### PR TITLE
[ESQL] Default schema resolution to UNION_BY_NAME

### DIFF
--- a/docs/changelog/149176.yaml
+++ b/docs/changelog/149176.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 149176
+summary: Default external source schema resolution to `UNION_BY_NAME`
+type: enhancement

--- a/docs/changelog/149176.yaml
+++ b/docs/changelog/149176.yaml
@@ -3,3 +3,21 @@ issues: []
 pr: 149176
 summary: Default external source schema resolution to `UNION_BY_NAME`
 type: enhancement
+highlight:
+  notable: true
+  title: Default ES|QL external source schema resolution to `UNION_BY_NAME`
+  body: |-
+    Multi-file ES|QL external source globs (the Tech Preview `EXTERNAL` command) now default
+    to `schema_resolution = union_by_name` instead of `first_file_wins`. Files in the same
+    glob no longer have to share the exact schema of the lex-smallest file: columns are merged
+    by name across all matched files, missing columns are null-filled per file, and types are
+    reconciled via conservative widening (`INTEGER` -> `LONG`, `INTEGER` -> `DOUBLE`,
+    `DATETIME` -> `DATE_NANOS`). Schemas that genuinely disagree on a column's type now fail
+    at planning time with a clear error instead of silently coercing data at read time.
+
+    To restore the previous behavior on a per-query basis, pass
+    `WITH { "schema_resolution": "first_file_wins" }` on the `EXTERNAL` command. Performance
+    note: the `UNION_BY_NAME` path reads every matched file's metadata in parallel (the FFW
+    path already did this for stats aggregation when more than one file matched) and
+    currently bypasses the listing/schema cache, so first-time and repeat-query latency is
+    higher for very large globs; this is being tracked as a follow-up.

--- a/x-pack/plugin/esql-datasource-csv/qa/src/javaRestTest/resources/csv-headerless.csv-spec
+++ b/x-pack/plugin/esql-datasource-csv/qa/src/javaRestTest/resources/csv-headerless.csv-spec
@@ -37,21 +37,23 @@ f1:keyword
 "10001"
 ;
 
-// End-to-end repro for the cross-file type-drift case. {{employees_multifile}} resolves to two
-// CSVs under iceberg-fixtures/multifile/:
+// End-to-end repro for the cross-file type-drift case under FIRST_FILE_WINS.
+// {{employees_multifile}} resolves to two CSVs under iceberg-fixtures/multifile/:
 //   multifile_a_anchor.csv (lex-smallest, anchor): col0 = "abc","xyz" → KEYWORD;       col1 = 1,2  → INTEGER
 //   multifile_b_other.csv:                          col0 = "10","20","30" → would-be INTEGER per-file
 // Without the fix, the non-anchor file's per-file inference would produce IntBlock for col0 and the
 // SORT would crash with "Expected [BYTES_REF] but was [INT]". With the fix, the planner-resolved
 // KEYWORD type is honored across files and SORT succeeds. The KEYWORD sort of "10","20","30","abc","xyz"
 // is lex-ordered: digits sort before letters.
+// This case is FFW-specific: under UNION_BY_NAME the KEYWORD/INTEGER col0 mismatch has no safe
+// supertype and would (correctly) be rejected as an unmergeable schema.
 multiFileHeaderlessReadSchemaPreventsTypeDrift
 required_capability: external_command
 required_capability: external_csv_header_row_option
 required_capability: external_source_read_schema
 required_capability: datasource_file_readers_no_text_type
 
-EXTERNAL "{{employees_multifile}}" WITH {"header_row": false}
+EXTERNAL "{{employees_multifile}}" WITH {"header_row": false, "schema_resolution": "first_file_wins"}
 | SORT col0 ASC
 | LIMIT 10
 ;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
@@ -664,11 +664,11 @@ public class ExternalSourceResolver {
 
     static FormatReader.SchemaResolution parseSchemaResolution(@Nullable Map<String, Object> config) {
         if (config == null) {
-            return FormatReader.SchemaResolution.UNION_BY_NAME;
+            return FormatReader.DEFAULT_SCHEMA_RESOLUTION;
         }
         Object value = config.get(CONFIG_SCHEMA_RESOLUTION);
         if (value == null) {
-            return FormatReader.SchemaResolution.UNION_BY_NAME;
+            return FormatReader.DEFAULT_SCHEMA_RESOLUTION;
         }
         return switch (value.toString().toLowerCase(Locale.ROOT)) {
             case "first_file_wins" -> FormatReader.SchemaResolution.FIRST_FILE_WINS;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
@@ -664,11 +664,11 @@ public class ExternalSourceResolver {
 
     static FormatReader.SchemaResolution parseSchemaResolution(@Nullable Map<String, Object> config) {
         if (config == null) {
-            return FormatReader.SchemaResolution.FIRST_FILE_WINS;
+            return FormatReader.SchemaResolution.UNION_BY_NAME;
         }
         Object value = config.get(CONFIG_SCHEMA_RESOLUTION);
         if (value == null) {
-            return FormatReader.SchemaResolution.FIRST_FILE_WINS;
+            return FormatReader.SchemaResolution.UNION_BY_NAME;
         }
         return switch (value.toString().toLowerCase(Locale.ROOT)) {
             case "first_file_wins" -> FormatReader.SchemaResolution.FIRST_FILE_WINS;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/FormatReader.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/FormatReader.java
@@ -54,8 +54,28 @@ public interface FormatReader extends Closeable {
         UNION_BY_NAME
     }
 
+    /**
+     * Cluster-wide default schema resolution strategy when a query does not specify one.
+     * <p>
+     * This is the single source of truth: it is consulted both by this SPI's
+     * {@link #defaultSchemaResolution()} and by {@code ExternalSourceResolver.parseSchemaResolution}
+     * when no {@code schema_resolution} key is present in the per-query config. The format
+     * detected at glob-expansion time is not yet known when the resolver decides whether to
+     * take the read-all-and-reconcile path versus the FFW fast path, so there is no format
+     * dispatch here today; if per-format defaults become desirable in the future the resolver
+     * will need to peek at the lex-smallest file's format first, and this constant becomes the
+     * fallback only.
+     */
+    SchemaResolution DEFAULT_SCHEMA_RESOLUTION = SchemaResolution.UNION_BY_NAME;
+
+    /**
+     * Returns the cluster-wide default schema resolution for this reader. Format implementations
+     * may override this to advertise a different preferred default, but the resolver does not
+     * consult it today (see {@link #DEFAULT_SCHEMA_RESOLUTION} for the rationale). Override is
+     * effectively informational until that wiring exists.
+     */
     default SchemaResolution defaultSchemaResolution() {
-        return SchemaResolution.UNION_BY_NAME;
+        return DEFAULT_SCHEMA_RESOLUTION;
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/FormatReader.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/FormatReader.java
@@ -48,14 +48,14 @@ public interface FormatReader extends Closeable {
     enum SchemaResolution {
         /** Use the schema from the first file; ignore differences in subsequent files. */
         FIRST_FILE_WINS,
-        // TODO: implement strict schema validation across files
+        /** Require all files to share the exact same schema (modulo nullability). */
         STRICT,
-        // TODO: implement union-by-name schema merging across files
+        /** Merge schemas from all files by column name, with safe type widening. */
         UNION_BY_NAME
     }
 
     default SchemaResolution defaultSchemaResolution() {
-        return SchemaResolution.FIRST_FILE_WINS;
+        return SchemaResolution.UNION_BY_NAME;
     }
 
     /**

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolverTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolverTests.java
@@ -81,14 +81,15 @@ public class ExternalSourceResolverTests extends ESTestCase {
         schemasByPath.put("s3://bucket/data/file2.parquet", schema2);
         schemasByPath.put("s3://bucket/data/file3.parquet", schema3);
 
-        ExternalSourceResolution resolution = resolveMultiFile(
+        ExternalSourceResolution resolution = resolveMultiFileWithConfig(
             "s3://bucket/data/*.parquet",
             schemasByPath,
             List.of(
                 entry("s3://bucket/data/file1.parquet", 100),
                 entry("s3://bucket/data/file2.parquet", 200),
                 entry("s3://bucket/data/file3.parquet", 300)
-            )
+            ),
+            firstFileWinsConfig()
         );
 
         ExternalSourceResolution.ResolvedSource resolved = resolution.resolvedSource("s3://bucket/data/*.parquet");
@@ -109,14 +110,15 @@ public class ExternalSourceResolverTests extends ESTestCase {
         schemasByPath.put("s3://bucket/data/f2.parquet", schema2);
         schemasByPath.put("s3://bucket/data/f3.parquet", schema3);
 
-        ExternalSourceResolution resolution = resolveMultiFile(
+        ExternalSourceResolution resolution = resolveMultiFileWithConfig(
             "s3://bucket/data/*.parquet",
             schemasByPath,
             List.of(
                 entry("s3://bucket/data/f1.parquet", 10),
                 entry("s3://bucket/data/f2.parquet", 20),
                 entry("s3://bucket/data/f3.parquet", 30)
-            )
+            ),
+            firstFileWinsConfig()
         );
 
         ExternalSourceResolution.ResolvedSource resolved = resolution.resolvedSource("s3://bucket/data/*.parquet");
@@ -133,10 +135,11 @@ public class ExternalSourceResolverTests extends ESTestCase {
         Map<String, List<Attribute>> schemasByPath = new HashMap<>();
         schemasByPath.put("s3://bucket/data/only.parquet", schema);
 
-        ExternalSourceResolution resolution = resolveMultiFile(
+        ExternalSourceResolution resolution = resolveMultiFileWithConfig(
             "s3://bucket/data/*.parquet",
             schemasByPath,
-            List.of(entry("s3://bucket/data/only.parquet", 500))
+            List.of(entry("s3://bucket/data/only.parquet", 500)),
+            firstFileWinsConfig()
         );
 
         ExternalSourceResolution.ResolvedSource resolved = resolution.resolvedSource("s3://bucket/data/*.parquet");
@@ -156,10 +159,11 @@ public class ExternalSourceResolverTests extends ESTestCase {
         schemasByPath.put("s3://bucket/data/a.parquet", schema);
         schemasByPath.put("s3://bucket/data/b.parquet", schema);
 
-        ExternalSourceResolution resolution = resolveMultiFile(
+        ExternalSourceResolution resolution = resolveMultiFileWithConfig(
             "s3://bucket/data/*.parquet",
             schemasByPath,
-            List.of(entry("s3://bucket/data/a.parquet", 100), entry("s3://bucket/data/b.parquet", 200))
+            List.of(entry("s3://bucket/data/a.parquet", 100), entry("s3://bucket/data/b.parquet", 200)),
+            firstFileWinsConfig()
         );
 
         ExternalSourceResolution.ResolvedSource resolved = resolution.resolvedSource("s3://bucket/data/*.parquet");
@@ -175,14 +179,15 @@ public class ExternalSourceResolverTests extends ESTestCase {
         schemasByPath.put("s3://bucket/data/b.parquet", schema);
         schemasByPath.put("s3://bucket/data/c.parquet", schema);
 
-        ExternalSourceResolution resolution = resolveMultiFile(
+        ExternalSourceResolution resolution = resolveMultiFileWithConfig(
             "s3://bucket/data/*.parquet",
             schemasByPath,
             List.of(
                 entry("s3://bucket/data/a.parquet", 100),
                 entry("s3://bucket/data/b.parquet", 200),
                 entry("s3://bucket/data/c.parquet", 300)
-            )
+            ),
+            firstFileWinsConfig()
         );
 
         ExternalSourceResolution.ResolvedSource resolved = resolution.resolvedSource("s3://bucket/data/*.parquet");
@@ -204,14 +209,15 @@ public class ExternalSourceResolverTests extends ESTestCase {
         schemasByPath.put("s3://bucket/data/b.parquet", List.of(attr("col0", DataType.INTEGER), attr("col1", DataType.INTEGER)));
         schemasByPath.put("s3://bucket/data/c.parquet", List.of(attr("col0", DataType.INTEGER), attr("col1", DataType.KEYWORD)));
 
-        ExternalSourceResolution resolution = resolveMultiFile(
+        ExternalSourceResolution resolution = resolveMultiFileWithConfig(
             "s3://bucket/data/*.parquet",
             schemasByPath,
             List.of(
                 entry("s3://bucket/data/a.parquet", 100),
                 entry("s3://bucket/data/b.parquet", 200),
                 entry("s3://bucket/data/c.parquet", 300)
-            )
+            ),
+            firstFileWinsConfig()
         );
 
         ExternalSourceResolution.ResolvedSource resolved = resolution.resolvedSource("s3://bucket/data/*.parquet");
@@ -240,10 +246,11 @@ public class ExternalSourceResolverTests extends ESTestCase {
         Map<String, List<Attribute>> schemasByPath = new HashMap<>();
         schemasByPath.put("s3://bucket/data/only.parquet", schema);
 
-        ExternalSourceResolution resolution = resolveMultiFile(
+        ExternalSourceResolution resolution = resolveMultiFileWithConfig(
             "s3://bucket/data/*.parquet",
             schemasByPath,
-            List.of(entry("s3://bucket/data/only.parquet", 100))
+            List.of(entry("s3://bucket/data/only.parquet", 100)),
+            firstFileWinsConfig()
         );
 
         ExternalSourceResolution.ResolvedSource resolved = resolution.resolvedSource("s3://bucket/data/*.parquet");
@@ -276,7 +283,8 @@ public class ExternalSourceResolverTests extends ESTestCase {
                 entry("s3://bucket/data/a.parquet", 100),
                 entry("s3://bucket/data/b.parquet", 200),
                 entry("s3://bucket/data/c.parquet", 300)
-            )
+            ),
+            firstFileWinsConfig()
         );
 
         ExternalSourceResolution.ResolvedSource resolved = resolution.resolvedSource("s3://bucket/data/*.parquet");
@@ -416,9 +424,9 @@ public class ExternalSourceResolverTests extends ESTestCase {
 
     // ===== Default schema resolution strategy =====
 
-    public void testDefaultSchemaResolutionIsFirstFileWins() {
+    public void testDefaultSchemaResolutionIsUnionByName() {
         FormatReader reader = new StubFormatReader(Map.of());
-        assertEquals(FormatReader.SchemaResolution.FIRST_FILE_WINS, reader.defaultSchemaResolution());
+        assertEquals(FormatReader.SchemaResolution.UNION_BY_NAME, reader.defaultSchemaResolution());
     }
 
     // ===== Multiple paths resolution =====
@@ -669,11 +677,14 @@ public class ExternalSourceResolverTests extends ESTestCase {
             .put("esql.source.cache.listing.ttl", "30s")
             .build();
 
+        // The listing/schema cache is only exercised on the FIRST_FILE_WINS fast path; multi-file
+        // reconciliation strategies read every file's metadata directly and bypass the cache.
+        Map<String, Map<String, Object>> pathConfigs = Map.of("s3://bucket/data/*.parquet", new HashMap<>(firstFileWinsConfig()));
         try (ExternalSourceCacheService cacheService = new ExternalSourceCacheService(settings)) {
             ExternalSourceResolver resolver = createResolverWithCache(countingProvider, schemasByPath, cacheService);
 
             PlainActionFuture<ExternalSourceResolution> f1 = new PlainActionFuture<>();
-            resolver.resolve(List.of("s3://bucket/data/*.parquet"), Map.of(), f1);
+            resolver.resolve(List.of("s3://bucket/data/*.parquet"), pathConfigs, f1);
             ExternalSourceResolution res1 = f1.actionGet();
             assertNotNull(res1.resolvedSource("s3://bucket/data/*.parquet"));
             assertEquals(2, res1.resolvedSource("s3://bucket/data/*.parquet").fileList().fileCount());
@@ -683,7 +694,7 @@ public class ExternalSourceResolverTests extends ESTestCase {
             assertTrue("schema loader should have been called at least once", schemaCallsAfterFirst > 0);
 
             PlainActionFuture<ExternalSourceResolution> f2 = new PlainActionFuture<>();
-            resolver.resolve(List.of("s3://bucket/data/*.parquet"), Map.of(), f2);
+            resolver.resolve(List.of("s3://bucket/data/*.parquet"), pathConfigs, f2);
             ExternalSourceResolution res2 = f2.actionGet();
             assertNotNull(res2.resolvedSource("s3://bucket/data/*.parquet"));
             assertEquals(2, res2.resolvedSource("s3://bucket/data/*.parquet").fileList().fileCount());
@@ -895,6 +906,16 @@ public class ExternalSourceResolverTests extends ESTestCase {
         Map<String, Long> rowCountsByPath,
         List<StorageEntry> listing
     ) throws Exception {
+        return resolveMultiFileWithStats(globPattern, schemasByPath, rowCountsByPath, listing, Map.of());
+    }
+
+    private ExternalSourceResolution resolveMultiFileWithStats(
+        String globPattern,
+        Map<String, List<Attribute>> schemasByPath,
+        Map<String, Long> rowCountsByPath,
+        List<StorageEntry> listing,
+        Map<String, Object> config
+    ) throws Exception {
         Map<String, List<StorageEntry>> listingsByPrefix = new HashMap<>();
         StoragePath sp = StoragePath.of(globPattern);
         listingsByPrefix.put(sp.patternPrefix().toString(), listing);
@@ -936,8 +957,13 @@ public class ExternalSourceResolverTests extends ESTestCase {
 
         ExternalSourceResolver resolver = new ExternalSourceResolver(EsExecutors.DIRECT_EXECUTOR_SERVICE, module);
         PlainActionFuture<ExternalSourceResolution> future = new PlainActionFuture<>();
-        resolver.resolve(List.of(globPattern), Map.of(), future);
+        Map<String, Map<String, Object>> pathConfigs = config.isEmpty() ? Map.of() : Map.of(globPattern, new HashMap<>(config));
+        resolver.resolve(List.of(globPattern), pathConfigs, future);
         return future.actionGet();
+    }
+
+    private static Map<String, Object> firstFileWinsConfig() {
+        return Map.of("schema_resolution", "first_file_wins");
     }
 
     private ExternalSourceResolution resolveSingleFile(String path, Map<String, List<Attribute>> schemasByPath) throws Exception {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolverTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolverTests.java
@@ -608,9 +608,30 @@ public class ExternalSourceResolverTests extends ESTestCase {
 
     // ===== Default schema resolution strategy =====
 
-    public void testDefaultSchemaResolutionIsUnionByName() {
+    /**
+     * Both the SPI default ({@link FormatReader#defaultSchemaResolution()}) and the resolver's
+     * config-parse fallback ({@code parseSchemaResolution(null/missing)}) must derive from the
+     * same constant — keeping them in lockstep is the whole point of
+     * {@link FormatReader#DEFAULT_SCHEMA_RESOLUTION}. This test catches a drift between the two
+     * (which previously had to be kept in sync by convention).
+     */
+    public void testDefaultSchemaResolutionIsSingleSourceOfTruth() {
         FormatReader reader = new StubFormatReader(Map.of());
-        assertEquals(FormatReader.SchemaResolution.UNION_BY_NAME, reader.defaultSchemaResolution());
+        assertEquals(
+            "SPI default must equal the FormatReader.DEFAULT_SCHEMA_RESOLUTION constant",
+            FormatReader.DEFAULT_SCHEMA_RESOLUTION,
+            reader.defaultSchemaResolution()
+        );
+        assertEquals(
+            "Resolver's null-config fallback must equal the FormatReader.DEFAULT_SCHEMA_RESOLUTION constant",
+            FormatReader.DEFAULT_SCHEMA_RESOLUTION,
+            ExternalSourceResolver.parseSchemaResolution(null)
+        );
+        assertEquals(
+            "Resolver's missing-key fallback must equal the FormatReader.DEFAULT_SCHEMA_RESOLUTION constant",
+            FormatReader.DEFAULT_SCHEMA_RESOLUTION,
+            ExternalSourceResolver.parseSchemaResolution(Map.of())
+        );
     }
 
     // ===== Multiple paths resolution =====
@@ -1074,12 +1095,10 @@ public class ExternalSourceResolverTests extends ESTestCase {
         ExternalSourceResolver resolver = createResolver(schemasByPath, listingsByPrefix);
         PlainActionFuture<ExternalSourceResolution> future = new PlainActionFuture<>();
 
-        Map<String, Map<String, Object>> pathConfigs = new HashMap<>();
-        if (config.isEmpty() == false) {
-            pathConfigs.put(globPattern, new HashMap<>(config));
-        }
-
-        resolver.resolve(List.of(globPattern), pathConfigs, future);
+        // The resolver treats a missing path key and a present-but-empty config map identically
+        // (see ExternalSourceResolver.resolve: pathConfigs.getOrDefault(path, Map.of())), so
+        // always forward the per-path config — no special-casing the empty case.
+        resolver.resolve(List.of(globPattern), Map.of(globPattern, new HashMap<>(config)), future);
         return future.actionGet();
     }
 
@@ -1144,8 +1163,10 @@ public class ExternalSourceResolverTests extends ESTestCase {
 
         ExternalSourceResolver resolver = new ExternalSourceResolver(EsExecutors.DIRECT_EXECUTOR_SERVICE, module);
         PlainActionFuture<ExternalSourceResolution> future = new PlainActionFuture<>();
-        Map<String, Map<String, Object>> pathConfigs = config.isEmpty() ? Map.of() : Map.of(globPattern, new HashMap<>(config));
-        resolver.resolve(List.of(globPattern), pathConfigs, future);
+        // The resolver treats a missing path key and a present-but-empty config map identically
+        // (see ExternalSourceResolver.resolve: pathConfigs.getOrDefault(path, Map.of())), so
+        // always forward the per-path config — no special-casing the empty case.
+        resolver.resolve(List.of(globPattern), Map.of(globPattern, new HashMap<>(config)), future);
         return future.actionGet();
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolverTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolverTests.java
@@ -44,6 +44,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -55,9 +56,16 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 
 /**
- * Tests for ExternalSourceResolver schema resolution behavior.
- * Validates FIRST_FILE_WINS (current behavior) and future STRICT / UNION_BY_NAME strategies
- * using mock FormatReader instances that return controlled schemas per StorageObject.
+ * Tests for {@link ExternalSourceResolver} multi-file schema resolution behavior.
+ * <p>
+ * Multi-file globs route through two distinct code paths inside
+ * {@code resolveMultiFileSource}: a {@code FIRST_FILE_WINS} fast path that reads only the
+ * lex-smallest anchor's metadata and pins it for every file, and a reconciliation path
+ * (shared by {@code UNION_BY_NAME} and {@code STRICT}) that reads every file's metadata
+ * up front and merges/validates schemas. Tests that exercise behavior invariant across
+ * the two paths are parameterized over {@link #MULTI_FILE_STRATEGIES} so every CI run
+ * walks both code paths; tests that lock down path-specific contracts (anchor schema
+ * pinning, file count enrichment, stats-partial flag) stay path-scoped.
  */
 public class ExternalSourceResolverTests extends ESTestCase {
 
@@ -71,7 +79,19 @@ public class ExternalSourceResolverTests extends ESTestCase {
 
     // ===== FIRST_FILE_WINS tests (current behavior) =====
 
-    public void testFirstFileWinsUsesFirstSchema() throws Exception {
+    /**
+     * Multi-file glob with three files whose schemas widen across files: the anchor (file1) has
+     * a strict subset of file2's columns, and file3 has a strict subset of file1's columns.
+     * The two strategies must produce different but equally well-defined schemas:
+     * <ul>
+     *   <li>FFW pins the anchor's columns ([emp_no, name]); columns present only in non-anchor
+     *       files (extra) are dropped, columns missing from non-anchor files are filled at read
+     *       time.</li>
+     *   <li>UNION_BY_NAME unions all columns in first-seen order ([emp_no, name, extra]); types
+     *       are preserved verbatim since each column's type is consistent across files.</li>
+     * </ul>
+     */
+    public void testMultiFileResolvedSchemaPerStrategy() throws Exception {
         List<Attribute> schema1 = List.of(attr("emp_no", DataType.INTEGER), attr("name", DataType.KEYWORD));
         List<Attribute> schema2 = List.of(attr("emp_no", DataType.INTEGER), attr("name", DataType.KEYWORD), attr("extra", DataType.LONG));
         List<Attribute> schema3 = List.of(attr("emp_no", DataType.INTEGER));
@@ -81,26 +101,41 @@ public class ExternalSourceResolverTests extends ESTestCase {
         schemasByPath.put("s3://bucket/data/file2.parquet", schema2);
         schemasByPath.put("s3://bucket/data/file3.parquet", schema3);
 
-        ExternalSourceResolution resolution = resolveMultiFileWithConfig(
-            "s3://bucket/data/*.parquet",
-            schemasByPath,
-            List.of(
-                entry("s3://bucket/data/file1.parquet", 100),
-                entry("s3://bucket/data/file2.parquet", 200),
-                entry("s3://bucket/data/file3.parquet", 300)
-            ),
-            firstFileWinsConfig()
+        List<StorageEntry> listing = List.of(
+            entry("s3://bucket/data/file1.parquet", 100),
+            entry("s3://bucket/data/file2.parquet", 200),
+            entry("s3://bucket/data/file3.parquet", 300)
         );
 
-        ExternalSourceResolution.ResolvedSource resolved = resolution.resolvedSource("s3://bucket/data/*.parquet");
-        assertNotNull(resolved);
-        List<Attribute> resolvedSchema = resolved.metadata().schema();
-        assertEquals(2, resolvedSchema.size());
-        assertEquals("emp_no", resolvedSchema.get(0).name());
-        assertEquals("name", resolvedSchema.get(1).name());
+        Map<FormatReader.SchemaResolution, List<String>> expectedColumnNames = Map.of(
+            FormatReader.SchemaResolution.FIRST_FILE_WINS,
+            List.of("emp_no", "name"),
+            FormatReader.SchemaResolution.UNION_BY_NAME,
+            List.of("emp_no", "name", "extra")
+        );
+
+        for (FormatReader.SchemaResolution strategy : MULTI_FILE_STRATEGIES) {
+            ExternalSourceResolution resolution = resolveMultiFileWithConfig(
+                "s3://bucket/data/*.parquet",
+                schemasByPath,
+                listing,
+                configFor(strategy)
+            );
+
+            ExternalSourceResolution.ResolvedSource resolved = resolution.resolvedSource("s3://bucket/data/*.parquet");
+            assertNotNull("[" + strategy + "] resolved source must not be null", resolved);
+            List<String> resolvedNames = resolved.metadata().schema().stream().map(Attribute::name).toList();
+            assertEquals("[" + strategy + "] resolved schema columns", expectedColumnNames.get(strategy), resolvedNames);
+        }
     }
 
-    public void testFirstFileWinsIgnoresMismatch() throws Exception {
+    /**
+     * Same shape as {@link #testMultiFileResolvedSchemaPerStrategy} but with no column types
+     * that could widen — under UBN, every union column keeps its original type. Locks in that
+     * FFW drops extra non-anchor columns ({@code c:LONG}) while UBN preserves them in
+     * first-seen order.
+     */
+    public void testMultiFileMismatchedSchemasPerStrategy() throws Exception {
         List<Attribute> schema1 = List.of(attr("a", DataType.KEYWORD), attr("b", DataType.INTEGER));
         List<Attribute> schema2 = List.of(attr("a", DataType.KEYWORD), attr("b", DataType.INTEGER), attr("c", DataType.LONG));
         List<Attribute> schema3 = List.of(attr("a", DataType.KEYWORD));
@@ -110,68 +145,108 @@ public class ExternalSourceResolverTests extends ESTestCase {
         schemasByPath.put("s3://bucket/data/f2.parquet", schema2);
         schemasByPath.put("s3://bucket/data/f3.parquet", schema3);
 
-        ExternalSourceResolution resolution = resolveMultiFileWithConfig(
-            "s3://bucket/data/*.parquet",
-            schemasByPath,
-            List.of(
-                entry("s3://bucket/data/f1.parquet", 10),
-                entry("s3://bucket/data/f2.parquet", 20),
-                entry("s3://bucket/data/f3.parquet", 30)
-            ),
-            firstFileWinsConfig()
+        List<StorageEntry> listing = List.of(
+            entry("s3://bucket/data/f1.parquet", 10),
+            entry("s3://bucket/data/f2.parquet", 20),
+            entry("s3://bucket/data/f3.parquet", 30)
         );
 
-        ExternalSourceResolution.ResolvedSource resolved = resolution.resolvedSource("s3://bucket/data/*.parquet");
-        assertNotNull(resolved);
-        List<Attribute> resolvedSchema = resolved.metadata().schema();
-        assertEquals(2, resolvedSchema.size());
-        assertEquals("a", resolvedSchema.get(0).name());
-        assertEquals("b", resolvedSchema.get(1).name());
+        Map<FormatReader.SchemaResolution, List<String>> expectedColumnNames = Map.of(
+            FormatReader.SchemaResolution.FIRST_FILE_WINS,
+            List.of("a", "b"),
+            FormatReader.SchemaResolution.UNION_BY_NAME,
+            List.of("a", "b", "c")
+        );
+
+        for (FormatReader.SchemaResolution strategy : MULTI_FILE_STRATEGIES) {
+            ExternalSourceResolution resolution = resolveMultiFileWithConfig(
+                "s3://bucket/data/*.parquet",
+                schemasByPath,
+                listing,
+                configFor(strategy)
+            );
+
+            ExternalSourceResolution.ResolvedSource resolved = resolution.resolvedSource("s3://bucket/data/*.parquet");
+            assertNotNull("[" + strategy + "] resolved source must not be null", resolved);
+            List<String> resolvedNames = resolved.metadata().schema().stream().map(Attribute::name).toList();
+            assertEquals("[" + strategy + "] resolved schema columns", expectedColumnNames.get(strategy), resolvedNames);
+        }
     }
 
-    public void testFirstFileWinsSingleFile() throws Exception {
+    /**
+     * Single-file glob expands to one entry. Both strategies must produce an identical
+     * user-observable schema: the file's columns, in declaration order, with the same types.
+     * The FFW path skips the multi-file stats-aggregation branch entirely; the UBN path runs
+     * the reconciliation loop on a single-entry map and ends up unifying the schema with itself.
+     */
+    public void testSingleFileGlobSchemaInvariantAcrossStrategies() throws Exception {
         List<Attribute> schema = List.of(attr("id", DataType.LONG), attr("value", DataType.DOUBLE));
 
         Map<String, List<Attribute>> schemasByPath = new HashMap<>();
         schemasByPath.put("s3://bucket/data/only.parquet", schema);
 
-        ExternalSourceResolution resolution = resolveMultiFileWithConfig(
-            "s3://bucket/data/*.parquet",
-            schemasByPath,
-            List.of(entry("s3://bucket/data/only.parquet", 500)),
-            firstFileWinsConfig()
-        );
+        for (FormatReader.SchemaResolution strategy : MULTI_FILE_STRATEGIES) {
+            ExternalSourceResolution resolution = resolveMultiFileWithConfig(
+                "s3://bucket/data/*.parquet",
+                schemasByPath,
+                List.of(entry("s3://bucket/data/only.parquet", 500)),
+                configFor(strategy)
+            );
 
-        ExternalSourceResolution.ResolvedSource resolved = resolution.resolvedSource("s3://bucket/data/*.parquet");
-        assertNotNull(resolved);
-        List<Attribute> resolvedSchema = resolved.metadata().schema();
-        assertEquals(2, resolvedSchema.size());
-        assertEquals("id", resolvedSchema.get(0).name());
-        assertEquals("value", resolvedSchema.get(1).name());
+            ExternalSourceResolution.ResolvedSource resolved = resolution.resolvedSource("s3://bucket/data/*.parquet");
+            assertNotNull("[" + strategy + "] resolved source must not be null", resolved);
+            List<Attribute> resolvedSchema = resolved.metadata().schema();
+            assertEquals("[" + strategy + "] resolved schema width", 2, resolvedSchema.size());
+            assertEquals("[" + strategy + "] resolved column 0 name", "id", resolvedSchema.get(0).name());
+            assertEquals("[" + strategy + "] resolved column 1 name", "value", resolvedSchema.get(1).name());
+            assertEquals("[" + strategy + "] resolved column 0 type", DataType.LONG, resolvedSchema.get(0).dataType());
+            assertEquals("[" + strategy + "] resolved column 1 type", DataType.DOUBLE, resolvedSchema.get(1).dataType());
+        }
     }
 
-    // ===== Stats partial flag tests =====
+    // ===== Stats partial / file-count flag tests =====
 
-    public void testMultiFileFirstFileWinsSetsStatsPartial() throws Exception {
+    /**
+     * When no file reports statistics and there is more than one file, FFW reads the anchor's
+     * (empty) stats and then explicitly marks the result partial because the other files'
+     * stats are unknown. The reconciliation path's {@code aggregateFileStatistics} returns
+     * {@code null} on missing per-file stats and the resolver falls back to the anchor's
+     * (empty) stats without setting any partial-flag; this test pins that divergence so a
+     * future "always flag partial" alignment change shows up here.
+     */
+    public void testMultiFileStatsPartialFlagPerStrategy() throws Exception {
         List<Attribute> schema = List.of(attr("x", DataType.INTEGER));
 
         Map<String, List<Attribute>> schemasByPath = new HashMap<>();
         schemasByPath.put("s3://bucket/data/a.parquet", schema);
         schemasByPath.put("s3://bucket/data/b.parquet", schema);
 
-        ExternalSourceResolution resolution = resolveMultiFileWithConfig(
-            "s3://bucket/data/*.parquet",
-            schemasByPath,
-            List.of(entry("s3://bucket/data/a.parquet", 100), entry("s3://bucket/data/b.parquet", 200)),
-            firstFileWinsConfig()
-        );
+        List<StorageEntry> listing = List.of(entry("s3://bucket/data/a.parquet", 100), entry("s3://bucket/data/b.parquet", 200));
 
-        ExternalSourceResolution.ResolvedSource resolved = resolution.resolvedSource("s3://bucket/data/*.parquet");
-        assertNotNull(resolved);
-        assertEquals(Boolean.TRUE, resolved.metadata().sourceMetadata().get(SourceStatisticsSerializer.STATS_PARTIAL));
+        for (FormatReader.SchemaResolution strategy : MULTI_FILE_STRATEGIES) {
+            ExternalSourceResolution resolution = resolveMultiFileWithConfig(
+                "s3://bucket/data/*.parquet",
+                schemasByPath,
+                listing,
+                configFor(strategy)
+            );
+            ExternalSourceResolution.ResolvedSource resolved = resolution.resolvedSource("s3://bucket/data/*.parquet");
+            assertNotNull("[" + strategy + "] resolved source must not be null", resolved);
+            Object partial = resolved.metadata().sourceMetadata().get(SourceStatisticsSerializer.STATS_PARTIAL);
+            if (strategy == FormatReader.SchemaResolution.FIRST_FILE_WINS) {
+                assertEquals("[FFW] STATS_PARTIAL must be true when only the anchor's stats are known", Boolean.TRUE, partial);
+            } else {
+                assertNull("[" + strategy + "] reconciliation path does not currently set STATS_PARTIAL", partial);
+            }
+        }
     }
 
-    public void testMultiFileFirstFileWinsSetsFileCount() throws Exception {
+    /**
+     * STATS_FILE_COUNT is FFW-only: {@code enrichWithFileCount} runs on the FFW fast path and
+     * stamps the count of discovered files into the source metadata. The reconciliation path
+     * (UNION_BY_NAME / STRICT) does not currently populate it. This test pins both branches.
+     */
+    public void testMultiFileFileCountPerStrategy() throws Exception {
         List<Attribute> schema = List.of(attr("x", DataType.INTEGER));
 
         Map<String, List<Attribute>> schemasByPath = new HashMap<>();
@@ -179,90 +254,183 @@ public class ExternalSourceResolverTests extends ESTestCase {
         schemasByPath.put("s3://bucket/data/b.parquet", schema);
         schemasByPath.put("s3://bucket/data/c.parquet", schema);
 
-        ExternalSourceResolution resolution = resolveMultiFileWithConfig(
-            "s3://bucket/data/*.parquet",
-            schemasByPath,
-            List.of(
-                entry("s3://bucket/data/a.parquet", 100),
-                entry("s3://bucket/data/b.parquet", 200),
-                entry("s3://bucket/data/c.parquet", 300)
-            ),
-            firstFileWinsConfig()
+        List<StorageEntry> listing = List.of(
+            entry("s3://bucket/data/a.parquet", 100),
+            entry("s3://bucket/data/b.parquet", 200),
+            entry("s3://bucket/data/c.parquet", 300)
         );
 
-        ExternalSourceResolution.ResolvedSource resolved = resolution.resolvedSource("s3://bucket/data/*.parquet");
-        assertNotNull(resolved);
-        assertEquals(3L, resolved.metadata().sourceMetadata().get(SourceStatisticsSerializer.STATS_FILE_COUNT));
-    }
-
-    /**
-     * FFW resolution must populate schemaMap with one identity-mapped FileSchemaInfo entry per
-     * discovered file, each carrying the anchor schema verbatim. Closest-layer assertion that the
-     * planner's per-file pinning is wired correctly: this is what {@code FileSplitProvider} reads
-     * to bake {@code FileSplit.readSchema} for every split, which in turn pins the reader.
-     */
-    public void testFirstFileWinsPopulatesSchemaMapForEveryFile() throws Exception {
-        List<Attribute> anchorSchema = List.of(attr("col0", DataType.KEYWORD), attr("col1", DataType.INTEGER));
-
-        Map<String, List<Attribute>> schemasByPath = new HashMap<>();
-        schemasByPath.put("s3://bucket/data/a.parquet", anchorSchema);
-        schemasByPath.put("s3://bucket/data/b.parquet", List.of(attr("col0", DataType.INTEGER), attr("col1", DataType.INTEGER)));
-        schemasByPath.put("s3://bucket/data/c.parquet", List.of(attr("col0", DataType.INTEGER), attr("col1", DataType.KEYWORD)));
-
-        ExternalSourceResolution resolution = resolveMultiFileWithConfig(
-            "s3://bucket/data/*.parquet",
-            schemasByPath,
-            List.of(
-                entry("s3://bucket/data/a.parquet", 100),
-                entry("s3://bucket/data/b.parquet", 200),
-                entry("s3://bucket/data/c.parquet", 300)
-            ),
-            firstFileWinsConfig()
-        );
-
-        ExternalSourceResolution.ResolvedSource resolved = resolution.resolvedSource("s3://bucket/data/*.parquet");
-        assertNotNull(resolved);
-        Map<StoragePath, SchemaReconciliation.FileSchemaInfo> schemaMap = resolved.schemaMap();
-        assertEquals("schemaMap must have one entry per matched file", 3, schemaMap.size());
-        for (Map.Entry<StoragePath, SchemaReconciliation.FileSchemaInfo> e : schemaMap.entrySet()) {
-            assertEquals(
-                "every FFW per-file entry carries the anchor schema verbatim, regardless of the file's own inference",
-                anchorSchema,
-                e.getValue().fileSchema()
+        for (FormatReader.SchemaResolution strategy : MULTI_FILE_STRATEGIES) {
+            ExternalSourceResolution resolution = resolveMultiFileWithConfig(
+                "s3://bucket/data/*.parquet",
+                schemasByPath,
+                listing,
+                configFor(strategy)
             );
-            SchemaReconciliation.ColumnMapping mapping = e.getValue().mapping();
-            assertNotNull("FFW entries carry an identity ColumnMapping", mapping);
-            assertEquals("identity mapping length matches anchor schema width", anchorSchema.size(), mapping.columnCount());
-            for (int i = 0; i < mapping.columnCount(); i++) {
-                assertEquals("identity mapping localIndex(" + i + ") = " + i, i, mapping.localIndex(i));
-                assertNull("identity mapping has no casts at position " + i, mapping.cast(i));
+            ExternalSourceResolution.ResolvedSource resolved = resolution.resolvedSource("s3://bucket/data/*.parquet");
+            assertNotNull("[" + strategy + "] resolved source must not be null", resolved);
+            Object fileCount = resolved.metadata().sourceMetadata().get(SourceStatisticsSerializer.STATS_FILE_COUNT);
+            if (strategy == FormatReader.SchemaResolution.FIRST_FILE_WINS) {
+                assertEquals("[FFW] STATS_FILE_COUNT must equal the number of discovered files", 3L, fileCount);
+            } else {
+                assertNull("[" + strategy + "] reconciliation path does not currently set STATS_FILE_COUNT", fileCount);
             }
         }
     }
 
-    public void testSingleFileFirstFileWinsDoesNotSetStatsPartial() throws Exception {
+    /**
+     * The schemaMap contract differs by code path and is asserted here under both:
+     * <ul>
+     *   <li>FFW: every entry's {@code fileSchema} is the anchor's schema <em>verbatim</em>
+     *       (the planner pins the anchor down for every split), and the mapping is identity.</li>
+     *   <li>UNION_BY_NAME: every entry's {@code fileSchema} is the file's own schema, and the
+     *       mapping rewrites the unified schema into that file's local layout — including
+     *       {@code -1} placeholders for columns the file is missing.</li>
+     * </ul>
+     * <p>
+     * Schemas here are intentionally compatible (no widening conflicts) so the UBN path can
+     * actually run end-to-end; type-conflict rejection is covered by SchemaReconciliationTests.
+     */
+    public void testMultiFileSchemaMapContractPerStrategy() throws Exception {
+        List<Attribute> anchorSchema = List.of(attr("col0", DataType.KEYWORD), attr("col1", DataType.INTEGER));
+        List<Attribute> schemaB = List.of(attr("col0", DataType.KEYWORD), attr("col1", DataType.INTEGER), attr("col2", DataType.LONG));
+        List<Attribute> schemaC = List.of(attr("col0", DataType.KEYWORD));
+
+        Map<String, List<Attribute>> schemasByPath = new HashMap<>();
+        schemasByPath.put("s3://bucket/data/a.parquet", anchorSchema);
+        schemasByPath.put("s3://bucket/data/b.parquet", schemaB);
+        schemasByPath.put("s3://bucket/data/c.parquet", schemaC);
+
+        List<StorageEntry> listing = List.of(
+            entry("s3://bucket/data/a.parquet", 100),
+            entry("s3://bucket/data/b.parquet", 200),
+            entry("s3://bucket/data/c.parquet", 300)
+        );
+
+        for (FormatReader.SchemaResolution strategy : MULTI_FILE_STRATEGIES) {
+            ExternalSourceResolution resolution = resolveMultiFileWithConfig(
+                "s3://bucket/data/*.parquet",
+                schemasByPath,
+                listing,
+                configFor(strategy)
+            );
+
+            ExternalSourceResolution.ResolvedSource resolved = resolution.resolvedSource("s3://bucket/data/*.parquet");
+            assertNotNull("[" + strategy + "] resolved source must not be null", resolved);
+            Map<StoragePath, SchemaReconciliation.FileSchemaInfo> schemaMap = resolved.schemaMap();
+            assertEquals("[" + strategy + "] schemaMap must have one entry per matched file", 3, schemaMap.size());
+
+            if (strategy == FormatReader.SchemaResolution.FIRST_FILE_WINS) {
+                // FFW pins the anchor schema down for every file with an identity mapping.
+                for (Map.Entry<StoragePath, SchemaReconciliation.FileSchemaInfo> e : schemaMap.entrySet()) {
+                    assertEquals(
+                        "[FFW] " + e.getKey() + ": entry must carry the anchor schema verbatim",
+                        anchorSchema,
+                        e.getValue().fileSchema()
+                    );
+                    SchemaReconciliation.ColumnMapping mapping = e.getValue().mapping();
+                    assertNotNull("[FFW] " + e.getKey() + ": ColumnMapping must be set", mapping);
+                    assertEquals(
+                        "[FFW] " + e.getKey() + ": identity mapping length matches anchor schema width",
+                        anchorSchema.size(),
+                        mapping.columnCount()
+                    );
+                    for (int i = 0; i < mapping.columnCount(); i++) {
+                        assertEquals("[FFW] " + e.getKey() + ": localIndex(" + i + ") = " + i, i, mapping.localIndex(i));
+                        assertNull("[FFW] " + e.getKey() + ": no casts at position " + i, mapping.cast(i));
+                    }
+                }
+            } else {
+                // UNION_BY_NAME: each entry's fileSchema is the file's own schema, and the
+                // mapping rewrites the unified schema [col0, col1, col2] into the file's local
+                // column order, with -1 for columns the file is missing.
+                List<Attribute> unifiedSchema = resolved.metadata().schema();
+                assertEquals(
+                    "[" + strategy + "] unified schema columns",
+                    List.of("col0", "col1", "col2"),
+                    unifiedSchema.stream().map(Attribute::name).toList()
+                );
+
+                Map<String, int[]> expectedLocalIndices = Map.of(
+                    "s3://bucket/data/a.parquet",
+                    new int[] { 0, 1, -1 },
+                    "s3://bucket/data/b.parquet",
+                    new int[] { 0, 1, 2 },
+                    "s3://bucket/data/c.parquet",
+                    new int[] { 0, -1, -1 }
+                );
+                Map<String, List<Attribute>> expectedFileSchemas = Map.of(
+                    "s3://bucket/data/a.parquet",
+                    anchorSchema,
+                    "s3://bucket/data/b.parquet",
+                    schemaB,
+                    "s3://bucket/data/c.parquet",
+                    schemaC
+                );
+
+                for (Map.Entry<StoragePath, SchemaReconciliation.FileSchemaInfo> e : schemaMap.entrySet()) {
+                    String pathStr = e.getKey().toString();
+                    assertEquals(
+                        "[" + strategy + "] " + pathStr + ": fileSchema must equal the file's own schema",
+                        expectedFileSchemas.get(pathStr),
+                        e.getValue().fileSchema()
+                    );
+                    SchemaReconciliation.ColumnMapping mapping = e.getValue().mapping();
+                    assertNotNull("[" + strategy + "] " + pathStr + ": ColumnMapping must be set", mapping);
+                    int[] expected = expectedLocalIndices.get(pathStr);
+                    assertEquals(
+                        "[" + strategy + "] " + pathStr + ": mapping width = unified schema width",
+                        unifiedSchema.size(),
+                        mapping.columnCount()
+                    );
+                    for (int i = 0; i < mapping.columnCount(); i++) {
+                        assertEquals("[" + strategy + "] " + pathStr + ": localIndex(" + i + ")", expected[i], mapping.localIndex(i));
+                        // No type drift in this fixture → no casts under UBN.
+                        assertNull("[" + strategy + "] " + pathStr + ": no casts at position " + i, mapping.cast(i));
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * A single-file glob match must never set STATS_PARTIAL: there are no other files whose
+     * statistics could be missing. Holds under both code paths — FFW skips the
+     * multi-file stats branch entirely; UBN's reconciliation aggregates the single file's
+     * (empty) stats and leaves the flag absent.
+     */
+    public void testSingleFileGlobDoesNotSetStatsPartialAcrossStrategies() throws Exception {
         List<Attribute> schema = List.of(attr("x", DataType.INTEGER));
 
         Map<String, List<Attribute>> schemasByPath = new HashMap<>();
         schemasByPath.put("s3://bucket/data/only.parquet", schema);
 
-        ExternalSourceResolution resolution = resolveMultiFileWithConfig(
-            "s3://bucket/data/*.parquet",
-            schemasByPath,
-            List.of(entry("s3://bucket/data/only.parquet", 100)),
-            firstFileWinsConfig()
-        );
+        for (FormatReader.SchemaResolution strategy : MULTI_FILE_STRATEGIES) {
+            ExternalSourceResolution resolution = resolveMultiFileWithConfig(
+                "s3://bucket/data/*.parquet",
+                schemasByPath,
+                List.of(entry("s3://bucket/data/only.parquet", 100)),
+                configFor(strategy)
+            );
 
-        ExternalSourceResolution.ResolvedSource resolved = resolution.resolvedSource("s3://bucket/data/*.parquet");
-        assertNotNull(resolved);
-        assertNull(resolved.metadata().sourceMetadata().get(SourceStatisticsSerializer.STATS_PARTIAL));
+            ExternalSourceResolution.ResolvedSource resolved = resolution.resolvedSource("s3://bucket/data/*.parquet");
+            assertNotNull("[" + strategy + "] resolved source must not be null", resolved);
+            assertNull(
+                "[" + strategy + "] STATS_PARTIAL must be absent for single-file matches",
+                resolved.metadata().sourceMetadata().get(SourceStatisticsSerializer.STATS_PARTIAL)
+            );
+        }
     }
 
     /**
-     * When all files provide per-file row counts, multi-file FIRST_FILE_WINS resolution
-     * should aggregate statistics and NOT set STATS_PARTIAL.
+     * When every file provides per-file row counts, both code paths must produce the same
+     * aggregated row count (sum across files) and must not flag the stats as partial.
+     * <p>
+     * STATS_FILE_COUNT differs by design: only the FFW path runs {@code enrichWithFileCount};
+     * the reconciliation path does not currently populate it. This test pins that divergence
+     * explicitly so a future change that aligns the paths shows up here.
      */
-    public void testMultiFileFirstFileWinsAggregatesRowCountWhenStatsAvailable() throws Exception {
+    public void testMultiFileAggregatesRowCountAcrossStrategiesWhenStatsAvailable() throws Exception {
         List<Attribute> schema = List.of(attr("x", DataType.INTEGER));
 
         Map<String, List<Attribute>> schemasByPath = new HashMap<>();
@@ -275,27 +443,43 @@ public class ExternalSourceResolverTests extends ESTestCase {
         rowCountsByPath.put("s3://bucket/data/b.parquet", 2000L);
         rowCountsByPath.put("s3://bucket/data/c.parquet", 3000L);
 
-        ExternalSourceResolution resolution = resolveMultiFileWithStats(
-            "s3://bucket/data/*.parquet",
-            schemasByPath,
-            rowCountsByPath,
-            List.of(
-                entry("s3://bucket/data/a.parquet", 100),
-                entry("s3://bucket/data/b.parquet", 200),
-                entry("s3://bucket/data/c.parquet", 300)
-            ),
-            firstFileWinsConfig()
+        List<StorageEntry> listing = List.of(
+            entry("s3://bucket/data/a.parquet", 100),
+            entry("s3://bucket/data/b.parquet", 200),
+            entry("s3://bucket/data/c.parquet", 300)
         );
 
-        ExternalSourceResolution.ResolvedSource resolved = resolution.resolvedSource("s3://bucket/data/*.parquet");
-        assertNotNull(resolved);
-        Map<String, Object> meta = resolved.metadata().sourceMetadata();
-        // Aggregated row count should be the sum across all files.
-        assertEquals(6000L, meta.get(SourceStatisticsSerializer.STATS_ROW_COUNT));
-        // No STATS_PARTIAL — stats cover all files.
-        assertNull(meta.get(SourceStatisticsSerializer.STATS_PARTIAL));
-        // File count should still be present.
-        assertEquals(3L, meta.get(SourceStatisticsSerializer.STATS_FILE_COUNT));
+        for (FormatReader.SchemaResolution strategy : MULTI_FILE_STRATEGIES) {
+            ExternalSourceResolution resolution = resolveMultiFileWithStats(
+                "s3://bucket/data/*.parquet",
+                schemasByPath,
+                rowCountsByPath,
+                listing,
+                configFor(strategy)
+            );
+
+            ExternalSourceResolution.ResolvedSource resolved = resolution.resolvedSource("s3://bucket/data/*.parquet");
+            assertNotNull("[" + strategy + "] resolved source must not be null", resolved);
+            Map<String, Object> meta = resolved.metadata().sourceMetadata();
+            assertEquals("[" + strategy + "] aggregated row count", 6000L, meta.get(SourceStatisticsSerializer.STATS_ROW_COUNT));
+            assertNull(
+                "[" + strategy + "] STATS_PARTIAL must be absent when every file has stats",
+                meta.get(SourceStatisticsSerializer.STATS_PARTIAL)
+            );
+            // STATS_FILE_COUNT is FFW-only today; the reconciliation path does not enrich it.
+            if (strategy == FormatReader.SchemaResolution.FIRST_FILE_WINS) {
+                assertEquals(
+                    "[FFW] enrichWithFileCount must populate STATS_FILE_COUNT",
+                    3L,
+                    meta.get(SourceStatisticsSerializer.STATS_FILE_COUNT)
+                );
+            } else {
+                assertNull(
+                    "[" + strategy + "] reconciliation path does not currently set STATS_FILE_COUNT",
+                    meta.get(SourceStatisticsSerializer.STATS_FILE_COUNT)
+                );
+            }
+        }
     }
 
     // ===== GenericFileList threading tests =====
@@ -679,7 +863,10 @@ public class ExternalSourceResolverTests extends ESTestCase {
 
         // The listing/schema cache is only exercised on the FIRST_FILE_WINS fast path; multi-file
         // reconciliation strategies read every file's metadata directly and bypass the cache.
-        Map<String, Map<String, Object>> pathConfigs = Map.of("s3://bucket/data/*.parquet", new HashMap<>(firstFileWinsConfig()));
+        Map<String, Map<String, Object>> pathConfigs = Map.of(
+            "s3://bucket/data/*.parquet",
+            new HashMap<>(configFor(FormatReader.SchemaResolution.FIRST_FILE_WINS))
+        );
         try (ExternalSourceCacheService cacheService = new ExternalSourceCacheService(settings)) {
             ExternalSourceResolver resolver = createResolverWithCache(countingProvider, schemasByPath, cacheService);
 
@@ -962,8 +1149,18 @@ public class ExternalSourceResolverTests extends ESTestCase {
         return future.actionGet();
     }
 
-    private static Map<String, Object> firstFileWinsConfig() {
-        return Map.of("schema_resolution", "first_file_wins");
+    /**
+     * The two multi-file schema resolution strategies whose code paths (FFW fast path vs.
+     * read-all-and-reconcile path) are covered in this suite. STRICT shares the
+     * read-all-and-reconcile path with UNION_BY_NAME, so it is not parameterized here.
+     */
+    private static final List<FormatReader.SchemaResolution> MULTI_FILE_STRATEGIES = List.of(
+        FormatReader.SchemaResolution.FIRST_FILE_WINS,
+        FormatReader.SchemaResolution.UNION_BY_NAME
+    );
+
+    private static Map<String, Object> configFor(FormatReader.SchemaResolution strategy) {
+        return Map.of("schema_resolution", strategy.name().toLowerCase(Locale.ROOT));
     }
 
     private ExternalSourceResolution resolveSingleFile(String path, Map<String, List<Attribute>> schemasByPath) throws Exception {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SchemaReconciliationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SchemaReconciliationTests.java
@@ -326,11 +326,11 @@ public class SchemaReconciliationTests extends ESTestCase {
     // === Config parsing tests ===
 
     public void testParseSchemaResolutionNull() {
-        assertThat(ExternalSourceResolver.parseSchemaResolution(null), equalTo(FormatReader.SchemaResolution.FIRST_FILE_WINS));
+        assertThat(ExternalSourceResolver.parseSchemaResolution(null), equalTo(FormatReader.SchemaResolution.UNION_BY_NAME));
     }
 
     public void testParseSchemaResolutionEmpty() {
-        assertThat(ExternalSourceResolver.parseSchemaResolution(Map.of()), equalTo(FormatReader.SchemaResolution.FIRST_FILE_WINS));
+        assertThat(ExternalSourceResolver.parseSchemaResolution(Map.of()), equalTo(FormatReader.SchemaResolution.UNION_BY_NAME));
     }
 
     public void testParseSchemaResolutionFirstFileWins() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SchemaReconciliationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SchemaReconciliationTests.java
@@ -326,11 +326,11 @@ public class SchemaReconciliationTests extends ESTestCase {
     // === Config parsing tests ===
 
     public void testParseSchemaResolutionNull() {
-        assertThat(ExternalSourceResolver.parseSchemaResolution(null), equalTo(FormatReader.SchemaResolution.UNION_BY_NAME));
+        assertThat(ExternalSourceResolver.parseSchemaResolution(null), equalTo(FormatReader.DEFAULT_SCHEMA_RESOLUTION));
     }
 
     public void testParseSchemaResolutionEmpty() {
-        assertThat(ExternalSourceResolver.parseSchemaResolution(Map.of()), equalTo(FormatReader.SchemaResolution.UNION_BY_NAME));
+        assertThat(ExternalSourceResolver.parseSchemaResolution(Map.of()), equalTo(FormatReader.DEFAULT_SCHEMA_RESOLUTION));
     }
 
     public void testParseSchemaResolutionFirstFileWins() {


### PR DESCRIPTION
The external source resolver previously defaulted multi-file globs to
`FIRST_FILE_WINS`, which silently masks per-file schema drift: the lex-
smallest file's schema is pinned and all other files are forced into it,
discarding columns that only exist elsewhere and risking type mismatches
at read time. `UNION_BY_NAME` is the safer, more useful default: it merges
columns by name across files, null-fills missing ones, and applies the
conservative widening rules already implemented in `SchemaReconciliation`.
Files that genuinely disagree on type now surface a clear planning-time
error instead of producing wrong rows.

`FormatReader.DEFAULT_SCHEMA_RESOLUTION` is now the single source of truth
for the cluster-wide default. Both `FormatReader.defaultSchemaResolution()`
(SPI) and `ExternalSourceResolver.parseSchemaResolution(...)` (config
parser) read from it; the lockstep between the two is asserted by
`testDefaultSchemaResolutionIsSingleSourceOfTruth` so a future drift fails
at test time. `FIRST_FILE_WINS` remains available via
`schema_resolution = "first_file_wins"`; the csv-headerless type-drift
spec and the cache-behavior resolver test opt in explicitly so they keep
exercising the FFW fast path (listing/schema cache, single-anchor metadata
read).

### Behavioral change for existing queries

Existing multi-file queries that relied on the implicit `FIRST_FILE_WINS`
default will now:

- get **additional columns** (null-filled per file) from files whose
  schemas have columns missing in others;
- **fail at planning time** if files genuinely disagree on a column's
  type with no safe supertype (e.g. `KEYWORD` vs `INTEGER`), instead of
  silently coercing data at read time.

A `highlight` block in the changelog calls this out and documents the
per-query opt-back via `WITH { "schema_resolution": "first_file_wins" }`.
The feature is in Tech Preview, so this is intentionally not labelled
`type: breaking`.

### Performance trade-off

For multi-file globs, the existing `FIRST_FILE_WINS` path **already**
reads every matched file's footer in parallel during Phase 1 to aggregate
stats (see the long comment in `resolveMultiFileSource` and #148086); the
delta versus `UNION_BY_NAME` is therefore narrower than "anchor-only
metadata read vs. all-files-metadata read". The actual differences are:

- The reconciliation path **bypasses the listing/schema cache**, so
  repeat queries against the same glob pay the full N-footer read every
  time (the FFW path serves both from cache when available).
- The reconciliation path does **not** call `enrichWithFileCount` nor
  `markStatsAsPartial`, so the result metadata lacks `STATS_FILE_COUNT`
  and never advertises partial stats. The unit suite pins this divergence
  in `testMultiFileFileCountPerStrategy` and
  `testMultiFileStatsPartialFlagPerStrategy` so any future alignment
  surfaces at test time.

Aligning the reconciliation path with the FFW cache and stats enrichment
is a worthwhile follow-up, tracked separately. For first-time queries the
on-the-wire cost is roughly the same as before.

### Test parameterization

The eight resolver tests that exercise schema-resolution-sensitive code
paths now loop over both `FIRST_FILE_WINS` and `UNION_BY_NAME` via a
`MULTI_FILE_STRATEGIES` constant, with per-strategy expectations: path-
invariant behavior (single-file glob schema, row-count aggregation) is
asserted identically under both strategies, while path-divergent
behavior (`STATS_PARTIAL`, `STATS_FILE_COUNT`, schemaMap contract, multi-
file resolved schema) is pinned per strategy in one place each.

Developed with AI-assisted tooling
