### PR TITLE
[9.4] Fix AIOOBE in date_histogram with hard_bounds outside data (#148765)

### DIFF
--- a/docs/changelog/148765.yaml
+++ b/docs/changelog/148765.yaml
@@ -1,0 +1,7 @@
+area: Aggregations
+issues:
+ - 148763
+pr: 148765
+summary: Fix `ArrayIndexOutOfBoundsException` in `date_histogram` with `hard_bounds`
+  outside data
+type: bug

--- a/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/date_histogram.yml
+++ b/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/date_histogram.yml
@@ -155,6 +155,51 @@ setup:
   - match: { aggregations.histo.buckets.12.doc_count: 1 }
 
 ---
+"date_histogram with hard_bounds outside data under a parent agg":
+  - requires:
+      cluster_features: ["search.aggs.date_histogram.hard_bounds_outside_data_fix"]
+      reason: "previously threw ArrayIndexOutOfBoundsException when hard_bounds excluded all rounding points"
+
+  - do:
+      indices.create:
+        index: hard_bounds_outside_data
+        body:
+          settings:
+            number_of_shards: 1
+          mappings:
+            properties:
+              date:
+                type: date
+
+  - do:
+      index:
+        index: hard_bounds_outside_data
+        refresh: true
+        body: { "date": "2020-06-15T00:00:00Z" }
+
+  - do:
+      search:
+        index: hard_bounds_outside_data
+        allow_partial_search_results: false
+        body:
+          size: 0
+          aggs:
+            outer:
+              filter:
+                match_all: {}
+              aggs:
+                histo:
+                  date_histogram:
+                    field: date
+                    fixed_interval: "1d"
+                    hard_bounds:
+                      "min": "2030-01-01"
+                      "max": "2030-01-02"
+
+  - match: { _shards.failed: 0 }
+  - length: { aggregations.outer.histo.buckets: 0 }
+
+---
 "date_histogram on date_nanos without timezone fixed interval":
   - requires:
       cluster_features: ["gte_v7.6.1"]

--- a/server/src/main/java/org/elasticsearch/search/SearchFeatures.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchFeatures.java
@@ -61,6 +61,13 @@ public final class SearchFeatures implements FeatureSpecification {
     );
     public static final NodeFeature EXPONENTIAL_HISTOGRAM_QUERYDSL_RANGE = new NodeFeature("search.exponential_histogram_querydsl_range");
     public static final NodeFeature DEFAULT_DISK_BBQ = new NodeFeature("search.default_disk_bbq");
+    /**
+     * A non-top-level {@code date_histogram} with {@code hard_bounds} that excludes every fixed rounding point
+     * produced from the data no longer throws {@code ArrayIndexOutOfBoundsException}; it returns an empty histogram.
+     */
+    public static final NodeFeature DATE_HISTOGRAM_HARD_BOUNDS_OUTSIDE_DATA_FIX = new NodeFeature(
+        "search.aggs.date_histogram.hard_bounds_outside_data_fix"
+    );
 
     @Override
     public Set<NodeFeature> getTestFeatures() {
@@ -89,7 +96,8 @@ public final class SearchFeatures implements FeatureSpecification {
             EXPONENTIAL_HISTOGRAM_QUERYDSL_BOXPLOT,
             EXPONENTIAL_HISTOGRAM_QUERYDSL_RANGE,
             EXPONENTIAL_HISTOGRAM_UPSCALING_REMOVED,
-            DEFAULT_DISK_BBQ
+            DEFAULT_DISK_BBQ,
+            DATE_HISTOGRAM_HARD_BOUNDS_OUTSIDE_DATA_FIX
         );
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregator.java
@@ -179,6 +179,13 @@ class DateHistogramAggregator extends BucketsAggregator implements SizedBucketAg
             return null;
         }
         RangeAggregator.Range[] ranges = ranges(hardBounds, fixedRoundingPoints);
+        if (ranges.length == 0) {
+            // hard_bounds excludes every fixed rounding point; fall back to the regular aggregator
+            // rather than adapting into a RangeAggregator with zero ranges, preserving the
+            // expected date_histogram behavior of producing an empty histogram.
+            logger.trace("couldn't adapt [{}], hard_bounds excludes all fixed rounding points", name);
+            return null;
+        }
         return new DateHistogramAggregator.FromDateRange(
             parent,
             factories,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregator.java
@@ -889,6 +889,9 @@ public abstract class RangeAggregator extends BucketsAggregator {
     }
 
     public static boolean hasOverlap(Range[] ranges) {
+        if (ranges.length == 0) {
+            return false;
+        }
         double lastEnd = ranges[0].to;
         for (int i = 1; i < ranges.length; ++i) {
             if (ranges[i].from < lastEnd) {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregatorTests.java
@@ -858,6 +858,24 @@ public class DateHistogramAggregatorTests extends DateHistogramAggregatorTestCas
         );
     }
 
+    /**
+     * Regression test for the case where {@code hard_bounds} excludes every fixed rounding point produced from the data,
+     * which previously caused {@link org.elasticsearch.search.aggregations.bucket.range.RangeAggregator#hasOverlap}
+     * to throw {@code ArrayIndexOutOfBoundsException} on an empty ranges array. The aggregation should fall back to the
+     * regular date-histogram aggregator and produce an empty result.
+     */
+    public void testHardBoundsOutsideDataDoesNotUseFromRange() throws IOException {
+        aggregationImplementationChoiceTestCase(
+            aggregableDateFieldType(false, true, DateFormatter.forPattern("yyyy")),
+            List.of("2017", "2018"),
+            List.of(),
+            new DateHistogramAggregationBuilder("test").field(AGGREGABLE_DATE)
+                .calendarInterval(DateHistogramInterval.YEAR)
+                .hardBounds(new LongBounds("2030", "2031")),
+            false
+        );
+    }
+
     public void testOneBucketOptimized() throws IOException {
         AggregationBuilder builder = new DateHistogramAggregationBuilder("d").field("f").calendarInterval(DateHistogramInterval.DAY);
         CheckedConsumer<RandomIndexWriter, IOException> buildIndex = iw -> {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Fix AIOOBE in date_histogram with hard_bounds outside data (#148765)](https://github.com/elastic/elasticsearch/pull/148765)