### PR TITLE
Add preconditions to hollowShards test function

### DIFF
--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/AbstractStatelessPluginIntegTestCase.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/AbstractStatelessPluginIntegTestCase.java
@@ -1279,10 +1279,44 @@ public abstract class AbstractStatelessPluginIntegTestCase extends ESIntegTestCa
         return indexingNodeSettingsBuilder.build();
     }
 
+    /**
+     * Relocate non-hollow index shards from {@code indexNodeA} to {@code indexNodeB} and hollow them on the target.
+     *
+     * Preconditions:
+     * <ul>
+     * <li>The cluster contains exactly two {@link DiscoveryNodeRole#INDEX_ROLE} nodes.</li>
+     * <li>{@code indexName} has {@code index.routing.allocation.exclude._name} setting set to {@code indexNodeB}. This is later
+     *     updated to indexNodeA to hollow the shards.</li>
+     * </ul>
+     */
     protected void hollowShards(String indexName, int numberOfShards, String indexNodeA, String indexNodeB) throws Exception {
-        var hollowShardsServiceA = internalCluster().getInstance(HollowShardsService.class, indexNodeA);
+        // assert cluster does not have more indexing nodes, and index settings exclude indexNodeB
+        final var state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).clear().setNodes(true).setMetadata(true).get().getState();
+        final Set<String> indexingNodeNames = new HashSet<>();
+        for (DiscoveryNode node : state.nodes()) {
+            if (node.hasRole(DiscoveryNodeRole.INDEX_ROLE.roleName())) {
+                indexingNodeNames.add(node.getName());
+            }
+        }
+        assertThat(
+            "we expect exactly two indexing nodes in the cluster (no other index-role nodes)",
+            indexingNodeNames,
+            equalTo(Set.of(indexNodeA, indexNodeB))
+        );
+
+        var indexMetadata = state.metadata().getProject().index(indexName);
+        assertThat("index [" + indexName + "] must exist", indexMetadata, notNullValue());
+        String excludeNames = indexMetadata.getSettings().get(IndexMetadata.INDEX_ROUTING_EXCLUDE_GROUP_PREFIX + "._name");
+        assertThat(
+            "index [" + indexName + "] must set [index.routing.allocation.exclude._name] so primaries stay off [" + indexNodeB + "]",
+            excludeNames,
+            equalTo(indexNodeB)
+        );
+
+        final var hollowShardsServiceA = internalCluster().getInstance(HollowShardsService.class, indexNodeA);
+        final var index = resolveIndex(indexName);
         for (int i = 0; i < numberOfShards; i++) {
-            var indexShard = findIndexShard(resolveIndex(indexName), 0);
+            var indexShard = findIndexShard(index, i);
             assertThat(indexShard.getEngineOrNull(), instanceOf(IndexEngine.class));
             var indexEngine = (IndexEngine) indexShard.getEngineOrNull();
             assertFalse(indexEngine.isLastCommitHollow());
@@ -1290,13 +1324,13 @@ public abstract class AbstractStatelessPluginIntegTestCase extends ESIntegTestCa
         }
 
         logger.debug("--> relocating {} hollowable shards from {} to {}", numberOfShards, indexNodeA, indexNodeB);
-        updateIndexSettings(Settings.builder().put("index.routing.allocation.exclude._name", indexNodeA), indexName);
+        updateIndexSettings(Settings.builder().put(IndexMetadata.INDEX_ROUTING_EXCLUDE_GROUP_PREFIX + "._name", indexNodeA), indexName);
         internalCluster().awaitNodesInclude(indexName, nodes -> nodes.contains(indexNodeA) == false && nodes.contains(indexNodeB));
         ensureGreen(indexName);
 
         var hollowShardsServiceB = internalCluster().getInstance(HollowShardsService.class, indexNodeB);
         for (int i = 0; i < numberOfShards; i++) {
-            var indexShard = findIndexShard(resolveIndex(indexName), i);
+            var indexShard = findIndexShard(index, i);
             assertThat(indexShard.getEngineOrNull(), instanceOf(HollowIndexEngine.class));
             hollowShardsServiceB.ensureHollowShard(indexShard.shardId(), true);
         }

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/StatelessFieldCapabilitiesIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/StatelessFieldCapabilitiesIT.java
@@ -11,15 +11,11 @@ import org.elasticsearch.action.NoShardAvailableActionException;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesBuilder;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
-import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider.Rebalance;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 
 import java.util.Map;
 
-import static org.elasticsearch.cluster.InternalClusterInfoService.CLUSTER_ROUTING_ALLOCATION_ESTIMATED_HEAP_THRESHOLD_DECIDER_ENABLED;
-import static org.elasticsearch.cluster.routing.allocation.IndexBalanceConstraintSettings.INDEX_BALANCE_DECIDER_ENABLED_SETTING;
-import static org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider.CLUSTER_ROUTING_REBALANCE_ENABLE_SETTING;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.xpack.stateless.commits.HollowShardsService.SETTING_HOLLOW_INGESTION_TTL;
 import static org.elasticsearch.xpack.stateless.commits.HollowShardsService.STATELESS_HOLLOW_INDEX_SHARDS_ENABLED;
@@ -60,37 +56,29 @@ public class StatelessFieldCapabilitiesIT extends AbstractStatelessPluginIntegTe
         assertFieldCaps(indexName);
     }
 
-    @Override
-    protected Settings.Builder nodeSettings() {
-        return super.nodeSettings()
-            // disable rebalancing to avoid spurious shard movements that might cause premature hollowing
-            .put(CLUSTER_ROUTING_REBALANCE_ENABLE_SETTING.getKey(), Rebalance.NONE)
-            // disable index balance decider to avoid spurious shard movements that might cause premature hollowing
-            .put(INDEX_BALANCE_DECIDER_ENABLED_SETTING.getKey(), false)
-            // disable estimated heap decider to avoid spurious shard movements that might cause premature hollowing
-            .put(CLUSTER_ROUTING_ALLOCATION_ESTIMATED_HEAP_THRESHOLD_DECIDER_ENABLED.getKey(), false);
-    }
-
     public void testFieldCapsForHollowShards() throws Exception {
         startMasterOnlyNode();
-        var indexNodeSettings = Settings.builder()
+        final var indexNodeSettings = Settings.builder()
             .put(STATELESS_HOLLOW_INDEX_SHARDS_ENABLED.getKey(), true)
             .put(SETTING_HOLLOW_INGESTION_TTL.getKey(), TimeValue.timeValueMillis(1))
             .build();
-        var indexNodeA = startIndexNode(indexNodeSettings);
+        final var indexNodeA = startIndexNode(indexNodeSettings);
+        final var indexNodeB = startIndexNode(indexNodeSettings);
         startSearchNode();
-        ensureStableCluster(3);
+        ensureStableCluster(4);
 
         var indexName = randomIndexName();
         int numberOfShards = randomIntBetween(1, 5);
-        assertAcked(prepareCreate(indexName).setMapping(mapping).setSettings(indexSettings(numberOfShards, 1)));
+        assertAcked(
+            prepareCreate(indexName).setMapping(mapping)
+                .setSettings(indexSettings(numberOfShards, 1).put("index.routing.allocation.exclude._name", indexNodeB))
+        );
         ensureGreen(indexName);
         insertDocs(indexName);
         flush(indexName);
 
         assertFieldCaps(indexName);
 
-        String indexNodeB = startIndexNode(indexNodeSettings);
         hollowShards(indexName, numberOfShards, indexNodeA, indexNodeB);
 
         assertFieldCaps(indexName);


### PR DESCRIPTION
In #149113 we understood shards may relocate and/or become hollow before/while hollowShards executes.

This PR ensures the preconditions of hollowShards are met.