### PR TITLE
ESQL: deferred field extraction for TopN over external sources

### DIFF
--- a/docs/changelog/149185.yaml
+++ b/docs/changelog/149185.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 149185
+summary: Introduce `ExternalOptimizerContext`
+type: enhancement

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ColumnInfo.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ColumnInfo.java
@@ -15,6 +15,10 @@ import org.elasticsearch.xpack.esql.core.type.DataType;
 /**
  * Per-column metadata used by the Parquet column iterators. Holds the Parquet column descriptor
  * alongside the ESQL type mapping and definition/repetition levels.
+ * <p>
+ * The synthetic {@code _rowPosition} column has no Parquet descriptor (it is materialised by the
+ * iterator from the file's footer + per-row position bookkeeping); use {@link #rowPosition()} to
+ * obtain the sentinel and {@link #isRowPosition()} to detect it in emit code paths.
  */
 record ColumnInfo(
     ColumnDescriptor descriptor,
@@ -23,4 +27,17 @@ record ColumnInfo(
     int maxDefLevel,
     int maxRepLevel,
     LogicalTypeAnnotation logicalType
-) {}
+) {
+    /** Sentinel marker for the synthetic {@code _rowPosition} column slot. */
+    private static final ColumnInfo ROW_POSITION = new ColumnInfo(null, null, DataType.LONG, 0, 0, null);
+
+    /** Returns the {@code _rowPosition} sentinel; identity-comparable in iterator emit paths. */
+    static ColumnInfo rowPosition() {
+        return ROW_POSITION;
+    }
+
+    /** Whether this slot represents the synthetic {@code _rowPosition} column. */
+    boolean isRowPosition() {
+        return this == ROW_POSITION;
+    }
+}

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
@@ -16,6 +16,7 @@ import org.apache.parquet.filter2.predicate.FilterPredicate;
 import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.hadoop.metadata.BlockMetaData;
 import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 import org.apache.parquet.schema.MessageType;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.breaker.CircuitBreaker;
@@ -30,6 +31,8 @@ import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.datasources.spi.ColumnExtractor;
+import org.elasticsearch.xpack.esql.datasources.spi.ColumnExtractorProducer;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 
@@ -76,7 +79,7 @@ import java.util.concurrent.CompletableFuture;
  * that mix selective and non-selective row groups (e.g., time-bucketed data with skewed
  * filter selectivity).
  */
-final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
+final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, ColumnExtractorProducer {
 
     private static final Logger logger = LogManager.getLogger(OptimizedParquetColumnIterator.class);
 
@@ -107,6 +110,49 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
      * call to {@link #nextSurvivingRowGroupOrdinal(int)} is O(1) instead of O(K).
      */
     private final int[] nextSurvivor;
+    /**
+     * File-global row index of the first row in each row group, computed as a prefix sum over
+     * {@link BlockMetaData#getRowCount()} in footer iteration order. Used to materialise the
+     * synthetic {@link ColumnExtractor#ROW_POSITION_COLUMN} column when present in the projection;
+     * the iterator turns each emitted row's (row-group ordinal, in-block index) coordinate into
+     * a stable file-global {@code long} the deferred-extraction path can later use to look the
+     * row up directly from the file's footer. {@code null} when the projection does not include
+     * {@code _rowPosition} — building the prefix sum is cheap but pointless if no row-position
+     * column is asked for.
+     */
+    private final long[] rowGroupFirstRowGlobal;
+    /**
+     * Index of the {@code _rowPosition} slot in {@link #columnInfos}, or {@code -1} when the
+     * projection does not include the synthetic column. Cached up-front so the per-batch emit
+     * paths skip the regular column read for that slot and fill it from
+     * {@link #rowGroupFirstRowGlobal} instead.
+     */
+    private final int rowPositionColumnIndex;
+    /**
+     * Owning {@link ParquetFormatReader}; only consulted when the iterator builds a matching
+     * {@link ColumnExtractor} via {@link #createColumnExtractor()}. Kept out of the regular emit
+     * paths so the iterator does not depend on the broader format reader's state for forward scan.
+     */
+    private final ParquetFormatReader formatReader;
+    /**
+     * The file's full footer; passed to the produced {@link ColumnExtractor} unchanged so it
+     * addresses every row group regardless of whether the iterator's reader was opened on the
+     * full file or on a range. {@code null} iff {@link #rowPositionColumnIndex} is {@code -1}.
+     */
+    private final ParquetMetadata fullFooter;
+    /**
+     * High bits OR-ed into every emitted {@code _rowPosition} value once
+     * {@link #setExtractorId(int)} has been called: {@code ((long) extractorId) << LOCAL_POSITION_BITS}.
+     * The factory installs the id between {@link #createColumnExtractor()} and the first call to
+     * {@link #next()}, so by the time we materialise {@code _rowPosition} we always have a value
+     * for it. Stays at {@code -1} when the projection has no row-position column ({@link
+     * #rowPositionColumnIndex} {@code < 0}); we never read the field in that case.
+     * <p>
+     * Encoding here saves a per-page block re-allocation that the previous
+     * {@code EncodingRowRefIterator} wrapper was forced to do — we already own the {@code long[]}
+     * holding the values and can stamp the high bits as we fill it.
+     */
+    private long rowPositionEncodingHighBits = -1L;
     private final CompressionCodecFactory codecFactory;
     private int rowBudget;
     /** Async prefetches allowed ahead of the consumed row group (1-3 based on projected column size). */
@@ -194,7 +240,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
     /**
      * Per-row-group two-phase decode state. Populated in {@link #advanceRowGroup()} when
      * {@link #useTwoPhase} is active and the current row group survives Phase-1 filter
-     * evaluation; consumed batch-by-batch in {@link #nextTwoPhaseBatch()} and cleared in
+     * evaluation; consumed batch-by-batch in {@link #nextTwoPhaseBatch(int)} and cleared in
      * {@link #closeTwoPhaseState()} when the iterator advances to the next row group or is
      * closed.
      */
@@ -227,9 +273,12 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
         StorageObject storageObject,
         RowRanges[] allRowRanges,
         boolean[] survivingRowGroups,
+        long[] rowGroupFirstRowGlobalOverride,
         CompressionCodecFactory codecFactory,
         ParquetPushedExpressions pushedExpressions,
-        FilterPredicate triviallyPassesPredicate
+        FilterPredicate triviallyPassesPredicate,
+        ParquetFormatReader formatReader,
+        ParquetMetadata fullFooter
     ) {
         this.reader = reader;
         this.projectedSchema = projectedSchema;
@@ -246,6 +295,15 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
         this.allRowRanges = allRowRanges;
         this.survivingRowGroups = survivingRowGroups;
         this.nextSurvivor = buildNextSurvivorLookup(survivingRowGroups);
+        this.rowPositionColumnIndex = findRowPositionSlot(columnInfos);
+        // For full-file reads the prefix sum can be derived from the reader's blocks directly.
+        // For range-restricted reads the caller must supply file-global offsets — those are the
+        // identities the deferred-extraction path expects to look up against the full footer.
+        this.rowGroupFirstRowGlobal = rowPositionColumnIndex >= 0
+            ? (rowGroupFirstRowGlobalOverride != null ? rowGroupFirstRowGlobalOverride : buildRowGroupFirstRowGlobal(reader.getRowGroups()))
+            : null;
+        this.formatReader = formatReader;
+        this.fullFooter = fullFooter;
         this.codecFactory = codecFactory;
         this.pushedExpressions = pushedExpressions;
         this.isPredicateColumn = classifyPredicateColumns(attributes, columnInfos, pushedExpressions);
@@ -387,7 +445,10 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
     private static Set<String> buildProjectedColumnPaths(ColumnInfo[] columnInfos) {
         Set<String> paths = new HashSet<>();
         for (ColumnInfo info : columnInfos) {
-            if (info != null) {
+            // The synthetic row-position slot has no Parquet descriptor — skip it: column-path
+            // sets feed the prefetcher and column-reader-store wiring, both of which only deal
+            // with real on-disk columns. {@link #buildRowPositionBlock} fills its slot directly.
+            if (info != null && info.isRowPosition() == false) {
                 paths.add(String.join(".", info.descriptor().getPath()));
             }
         }
@@ -403,7 +464,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
     private static Set<String> buildColumnPaths(ColumnInfo[] columnInfos, boolean[] isPredicateColumn, boolean wantPredicate) {
         Set<String> paths = new HashSet<>();
         for (int i = 0; i < columnInfos.length; i++) {
-            if (columnInfos[i] != null && isPredicateColumn[i] == wantPredicate) {
+            if (columnInfos[i] != null && columnInfos[i].isRowPosition() == false && isPredicateColumn[i] == wantPredicate) {
                 paths.add(String.join(".", columnInfos[i].descriptor().getPath()));
             }
         }
@@ -745,6 +806,41 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
             }
         }
         return next;
+    }
+
+    /**
+     * Locates the index of the synthetic {@link ColumnExtractor#ROW_POSITION_COLUMN} slot in the
+     * column-info array, or returns {@code -1} when the projection does not include it. Identity
+     * comparison against {@link ColumnInfo#rowPosition()} is what makes this unambiguous: a real
+     * user column also typed {@code LONG} would have its own descriptor-bound {@link ColumnInfo},
+     * never the shared sentinel.
+     */
+    private static int findRowPositionSlot(ColumnInfo[] columnInfos) {
+        for (int i = 0; i < columnInfos.length; i++) {
+            if (columnInfos[i] != null && columnInfos[i].isRowPosition()) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Builds a per-row-group prefix sum of {@link BlockMetaData#getRowCount()} entries in footer
+     * iteration order. Index {@code i} holds the file-global row index of the first row in row
+     * group {@code i}; index {@code length} holds the total file row count. This is the address
+     * space the deferred extraction path uses to look rows up later — building it once at
+     * iterator construction guarantees all emit paths share the same view of file-global
+     * row identities, regardless of which row groups are skipped at scan time.
+     */
+    private static long[] buildRowGroupFirstRowGlobal(List<BlockMetaData> rowGroups) {
+        long[] offsets = new long[rowGroups.size() + 1];
+        long sum = 0L;
+        for (int i = 0; i < rowGroups.size(); i++) {
+            offsets[i] = sum;
+            sum += rowGroups.get(i).getRowCount();
+        }
+        offsets[rowGroups.size()] = sum;
+        return offsets;
     }
 
     /**
@@ -1171,7 +1267,10 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
         pageColumnReaders = new PageColumnReader[columnInfos.length];
         columnReaders = null;
         for (int i = 0; i < columnInfos.length; i++) {
-            if (columnInfos[i] != null && isPredicateColumn[i] && columnInfos[i].maxRepLevel() == 0) {
+            if (columnInfos[i] != null
+                && columnInfos[i].isRowPosition() == false
+                && isPredicateColumn[i]
+                && columnInfos[i].maxRepLevel() == 0) {
                 ColumnDescriptor desc = columnInfos[i].descriptor();
                 PageReader pr = rowGroup.getPageReader(desc);
                 pageColumnReaders[i] = new PageColumnReader(pr, desc, columnInfos[i], null);
@@ -1189,7 +1288,10 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
         pageColumnReaders = new PageColumnReader[columnInfos.length];
         columnReaders = null;
         for (int i = 0; i < columnInfos.length; i++) {
-            if (columnInfos[i] != null && isPredicateColumn[i] == false && columnInfos[i].maxRepLevel() == 0) {
+            if (columnInfos[i] != null
+                && columnInfos[i].isRowPosition() == false
+                && isPredicateColumn[i] == false
+                && columnInfos[i].maxRepLevel() == 0) {
                 ColumnDescriptor desc = columnInfos[i].descriptor();
                 PageReader pr = rowGroup.getPageReader(desc);
                 pageColumnReaders[i] = new PageColumnReader(pr, desc, columnInfos[i], survivorRowRanges);
@@ -1206,7 +1308,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
         pageColumnReaders = new PageColumnReader[columnInfos.length];
         columnReaders = null;
         for (int i = 0; i < columnInfos.length; i++) {
-            if (columnInfos[i] != null && columnInfos[i].maxRepLevel() == 0) {
+            if (columnInfos[i] != null && columnInfos[i].isRowPosition() == false && columnInfos[i].maxRepLevel() == 0) {
                 ColumnDescriptor desc = columnInfos[i].descriptor();
                 PageReader pr = rowGroup.getPageReader(desc);
                 pageColumnReaders[i] = new PageColumnReader(pr, desc, columnInfos[i], currentRowRanges);
@@ -1214,7 +1316,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
         }
         boolean hasListColumns = false;
         for (int i = 0; i < columnInfos.length; i++) {
-            if (columnInfos[i] != null && columnInfos[i].maxRepLevel() > 0) {
+            if (columnInfos[i] != null && columnInfos[i].isRowPosition() == false && columnInfos[i].maxRepLevel() > 0) {
                 hasListColumns = true;
                 break;
             }
@@ -1228,7 +1330,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
             );
             columnReaders = new ColumnReader[columnInfos.length];
             for (int i = 0; i < columnInfos.length; i++) {
-                if (columnInfos[i] != null && columnInfos[i].maxRepLevel() > 0) {
+                if (columnInfos[i] != null && columnInfos[i].isRowPosition() == false && columnInfos[i].maxRepLevel() > 0) {
                     columnReaders[i] = store.getColumnReader(columnInfos[i].descriptor());
                 }
             }
@@ -1328,16 +1430,26 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
             throw new NoSuchElementException();
         }
         if (twoPhase != null) {
-            return nextTwoPhaseBatch();
+            // Captured before nextTwoPhaseBatch decrements rowsRemainingInGroup: the in-block index
+            // of the first source row this batch is about to emit. Same shape as the standard /
+            // late-mat paths, just computed in the two-phase branch where the source-row delta is
+            // queried from {@link TwoPhaseRowGroup#currentSourceRows} rather than {@link #batchSize}.
+            int firstRowOfBatchInRG = (int) (reader.getRowGroups().get(rowGroupOrdinal).getRowCount() - rowsRemainingInGroup);
+            return nextTwoPhaseBatch(firstRowOfBatchInRG);
         }
         int effectiveBatch = batchSize;
         if (rowBudget != FormatReader.NO_LIMIT) {
             effectiveBatch = Math.min(effectiveBatch, rowBudget);
         }
         int rowsToRead = (int) Math.min(effectiveBatch, rowsRemainingInGroup);
+        // Captured before the row counts are subtracted: the in-block index of the first row this
+        // batch is about to emit. The row-position injector uses it to compute file-global ids.
+        int firstRowOfBatchInRG = (int) (reader.getRowGroups().get(rowGroupOrdinal).getRowCount() - rowsRemainingInGroup);
 
         boolean useLateMaterialization = lateMaterialization && currentRowGroupTriviallyPasses == false;
-        Page result = useLateMaterialization ? nextWithLateMaterialization(rowsToRead) : nextStandard(rowsToRead);
+        Page result = useLateMaterialization
+            ? nextWithLateMaterialization(rowsToRead, firstRowOfBatchInRG)
+            : nextStandard(rowsToRead, firstRowOfBatchInRG);
 
         pageBatchIndexInRowGroup++;
         rowsRemainingInGroup -= rowsToRead;
@@ -1359,7 +1471,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
      * two as the first row range; if a partial slice is needed, the remainder of this batch's
      * survivors is dropped (its predicate blocks are released so we don't leak).
      */
-    private Page nextTwoPhaseBatch() {
+    private Page nextTwoPhaseBatch(int firstRowOfBatchInRG) {
         TwoPhaseRowGroup state = twoPhase;
         // hasNext() drains any leading fully-filtered batches before returning true, so the
         // current cursor must point at a batch with at least one survivor by the time we get
@@ -1430,6 +1542,15 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
                     continue;
                 }
                 ColumnInfo info = columnInfos[col];
+                if (info != null && info.isRowPosition()) {
+                    // survivorPositions is null when every source row survived (and the budget did
+                    // not truncate); the contiguous run is already aligned with firstRowOfBatchInRG.
+                    // Otherwise survivorPositions indexes into the source batch in survivor order
+                    // and may have been head-truncated by the row budget — either form yields the
+                    // emitCount file-global ids the projection blocks correspond to one-to-one.
+                    blocks[col] = buildRowPositionBlock(firstRowOfBatchInRG, emitCount, survivorPositions);
+                    continue;
+                }
                 if (info == null) {
                     blocks[col] = blockFactory.newConstantNullBlock(emitCount);
                     continue;
@@ -1559,7 +1680,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
         return out;
     }
 
-    private Page nextStandard(int rowsToRead) {
+    private Page nextStandard(int rowsToRead, int firstRowOfBatchInRG) {
         Block[] blocks = new Block[attributes.size()];
         int producedRows = -1;
         try {
@@ -1567,36 +1688,44 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
                 ColumnInfo info = columnInfos[col];
                 if (info == null) {
                     continue;
-                } else {
-                    try {
-                        blocks[col] = readColumnBlock(col, info, rowsToRead);
-                        if (producedRows < 0) {
-                            producedRows = blocks[col].getPositionCount();
-                        }
-                    } catch (CircuitBreakingException e) {
-                        // Let breaker exceptions flow through unwrapped: callers (and tests) match
-                        // on the exact type to distinguish memory-pressure failures from data errors.
-                        Releasables.closeExpectNoException(blocks);
-                        throw e;
-                    } catch (Exception e) {
-                        Releasables.closeExpectNoException(blocks);
-                        Attribute attr = attributes.get(col);
-                        throw new ElasticsearchException(
-                            "Failed to read Parquet column ["
-                                + attr.name()
-                                + "] (type "
-                                + attr.dataType()
-                                + ") at row group ["
-                                + (rowGroupOrdinal + 1)
-                                + "] page batch ["
-                                + pageBatchIndexInRowGroup
-                                + "] in file ["
-                                + fileLocation
-                                + "]: "
-                                + e.getMessage(),
-                            e
-                        );
+                }
+                if (info.isRowPosition()) {
+                    // Standard path: every source row is emitted; positions are contiguous so the
+                    // injector fills the block in run order.
+                    blocks[col] = buildRowPositionBlock(firstRowOfBatchInRG, rowsToRead, null);
+                    if (producedRows < 0) {
+                        producedRows = rowsToRead;
                     }
+                    continue;
+                }
+                try {
+                    blocks[col] = readColumnBlock(col, info, rowsToRead);
+                    if (producedRows < 0) {
+                        producedRows = blocks[col].getPositionCount();
+                    }
+                } catch (CircuitBreakingException e) {
+                    // Let breaker exceptions flow through unwrapped: callers (and tests) match
+                    // on the exact type to distinguish memory-pressure failures from data errors.
+                    Releasables.closeExpectNoException(blocks);
+                    throw e;
+                } catch (Exception e) {
+                    Releasables.closeExpectNoException(blocks);
+                    Attribute attr = attributes.get(col);
+                    throw new ElasticsearchException(
+                        "Failed to read Parquet column ["
+                            + attr.name()
+                            + "] (type "
+                            + attr.dataType()
+                            + ") at row group ["
+                            + (rowGroupOrdinal + 1)
+                            + "] page batch ["
+                            + pageBatchIndexInRowGroup
+                            + "] in file ["
+                            + fileLocation
+                            + "]: "
+                            + e.getMessage(),
+                        e
+                    );
                 }
             }
             if (producedRows < 0) {
@@ -1626,7 +1755,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
         return new Page(blocks);
     }
 
-    private Page nextWithLateMaterialization(int rowsToRead) {
+    private Page nextWithLateMaterialization(int rowsToRead, int firstRowOfBatchInRG) {
         Block[] blocks = new Block[attributes.size()];
         try {
             // Phase 1: decode predicate columns
@@ -1642,6 +1771,9 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
                     predicateBlockMap.put(attributes.get(col).name(), blocks[col]);
                 }
             }
+            // _rowPosition is never a predicate column (the optimizer never references it from a
+            // pushed expression) so it's always handled below in Phase 3, where the survivor mask
+            // is already known and the values can be filled in survivor order.
 
             // Phase 2: evaluate filter
             WordMask mask = pushedExpressions.evaluateFilter(
@@ -1673,6 +1805,13 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
                     continue;
                 }
                 ColumnInfo info = columnInfos[col];
+                if (info != null && info.isRowPosition()) {
+                    // positions[] is null when every source row survives — the injector uses the
+                    // contiguous run; otherwise it's the compacted survivor index list and the
+                    // injector emits in survivor order (matching the other projection blocks).
+                    blocks[col] = buildRowPositionBlock(firstRowOfBatchInRG, survivorCount, positions);
+                    continue;
+                }
                 if (info == null) {
                     blocks[col] = blockFactory.newConstantNullBlock(survivorCount);
                 } else if (survivorCount == 0) {
@@ -1733,9 +1872,44 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
     }
 
     /**
+     * Builds the {@code _rowPosition} block for a batch about to be emitted. When
+     * {@code positions} is {@code null} the batch is contiguous: its rows start at
+     * {@code firstRowOfBatchInRG} within the current row group and run for {@code count} entries.
+     * Otherwise {@code positions[0..count)} indexes into the source batch (still based at
+     * {@code firstRowOfBatchInRG}); the resulting file-global indexes follow whichever order the
+     * caller arranged the survivors in.
+     * <p>
+     * Values are emitted pre-encoded with the registry-assigned extractor id installed via
+     * {@link #setExtractorId(int)} — i.e. the returned block's values are
+     * {@code (id << 48) | fileGlobalRowIndex}, ready for downstream operators to decode against
+     * the matching {@code SourceExtractors} entry. Encoding here avoids the per-page
+     * block-rebuild that a wrapping iterator would have to do; we already own the {@code long[]}
+     * buffer and just OR the high bits in as we fill it. The returned block is a dense
+     * {@link Block} backed by a {@link org.elasticsearch.compute.data.LongVector} — never null,
+     * never with nulls.
+     */
+    private Block buildRowPositionBlock(int firstRowOfBatchInRG, int count, int[] positions) {
+        assert rowPositionEncodingHighBits != -1L
+            : "setExtractorId(int) must be called before _rowPosition is materialised — see ColumnExtractorProducer";
+        long base = rowGroupFirstRowGlobal[rowGroupOrdinal] + firstRowOfBatchInRG;
+        long encodingHighBits = rowPositionEncodingHighBits;
+        long[] values = new long[count];
+        if (positions == null) {
+            for (int i = 0; i < count; i++) {
+                values[i] = encodingHighBits | (base + i);
+            }
+        } else {
+            for (int i = 0; i < count; i++) {
+                values[i] = encodingHighBits | (base + positions[i]);
+            }
+        }
+        return blockFactory.newLongArrayVector(values, count).asBlock();
+    }
+
+    /**
      * Variant of {@link #readColumnBlockWithAttribution} for callers that own their own
      * cleanup loop and must not have {@code blocks} double-closed: the only failure-time work
-     * done here is exception attribution. Used by {@link #nextTwoPhaseBatch()} where the outer
+     * done here is exception attribution. Used by {@link #nextTwoPhaseBatch(int)} where the outer
      * catch is the sole owner of {@code blocks[]} and {@code predicateBlocks[]} — letting the
      * helper close {@code blocks} would double-close every slot already populated by previous
      * loop iterations (including transferred predicate slots), which is exactly the production
@@ -1783,6 +1957,39 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
         }
         ParquetColumnDecoding.skipValues(cr, rowsToRead);
         return blockFactory.newConstantNullBlock(rowsToRead);
+    }
+
+    @Override
+    public ColumnExtractor createColumnExtractor() {
+        if (rowPositionColumnIndex < 0) {
+            throw new IllegalStateException(
+                "createColumnExtractor called on iterator without [" + ColumnExtractor.ROW_POSITION_COLUMN + "] in projection"
+            );
+        }
+        // The iterator emits file-global identities, so the extractor sees the full footer
+        // regardless of whether this iterator was opened on the full file or on a range. That's
+        // the whole point of file-global addressing: any iterator that emits identities and any
+        // extractor over the same file agree without coordination.
+        return new ParquetColumnExtractor(storageObject, formatReader, fullFooter);
+    }
+
+    @Override
+    public void setExtractorId(int id) {
+        if (rowPositionColumnIndex < 0) {
+            throw new IllegalStateException(
+                "setExtractorId called on iterator without [" + ColumnExtractor.ROW_POSITION_COLUMN + "] in projection"
+            );
+        }
+        if (id < 0) {
+            throw new IllegalArgumentException("extractor id [" + id + "] must be non-negative");
+        }
+        if (rowPositionEncodingHighBits != -1L) {
+            throw new IllegalStateException("setExtractorId already called on this iterator");
+        }
+        // Pre-shift once so the per-row hot loop in buildRowPositionBlock is a single OR. The
+        // shift width comes from the SPI ({@link ColumnExtractor#LOCAL_POSITION_BITS}), so this
+        // module's only contract with the host plugin is the SPI itself — not the registry impl.
+        rowPositionEncodingHighBits = ((long) id) << ColumnExtractor.LOCAL_POSITION_BITS;
     }
 
     @Override

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetColumnExtractor.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetColumnExtractor.java
@@ -1,0 +1,839 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.apache.parquet.column.ColumnReader;
+import org.apache.parquet.column.impl.ColumnReadStoreImpl;
+import org.apache.parquet.column.page.PageReader;
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
+import org.apache.parquet.schema.MessageType;
+import org.elasticsearch.common.util.concurrent.FutureUtils;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.datasources.spi.ColumnExtractor;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * Parquet implementation of {@link ColumnExtractor}.
+ * <p>
+ * The extractor owns the file's full {@link ParquetMetadata} and addresses rows by file-global
+ * physical row index — the same identity the {@link OptimizedParquetColumnIterator} stamps into
+ * the synthetic {@code _rowPosition} column during the forward scan. Address space is therefore
+ * {@code [0, rowCount())} where {@code rowCount} is the sum of all row groups' row counts; the
+ * mapping from a position to the (row group, in-row-group offset) pair comes from a binary
+ * search over a precomputed prefix sum of row-group row counts. Identities are stable across
+ * splits, so any extractor on the same file resolves any survivor's identity correctly,
+ * regardless of which split first emitted it.
+ * <p>
+ * Algorithm per multi-column {@link #extract(String[], long[], BlockFactory) extract} call (no
+ * slow / sequential fallback path; the extractor is deliberately strict so a regression that
+ * would silently fall back to whole-RG scanning fails loud instead):
+ * <ol>
+ *   <li><b>Bucket positions by row group, once.</b> A single linear scan over
+ *       {@code localPositions} maps each request to its owning row group via binary search over
+ *       the cumulative-row-count prefix sum. No global sort: ordering is needed only inside each
+ *       bucket, and per-bucket sorting on a handful of positions is essentially free. Row groups
+ *       with no surviving position are never opened. The bucket structure is column-agnostic, so
+ *       it is reused across every requested column.</li>
+ *   <li><b>Per-row-group async prefetch, dispatched in parallel.</b> One
+ *       {@link ColumnChunkPrefetcher#prefetchAsync} call per visited row group, each carrying the
+ *       full multi-column projection. {@link CoalescedRangeReader} merges adjacent column-chunk
+ *       ranges <em>within</em> the row group (column chunks in one row group are written
+ *       contiguously, so the multi-column projection coalesces naturally) and dispatches the
+ *       merged ranges to {@link StorageObject#readBytesAsync}. All buckets fan out at once: the
+ *       extractor never blocks on row group {@code k}'s bytes before issuing row group
+ *       {@code k+1}'s GET. Per-request RTT/TTFB cost goes from {@code O(row groups × columns)}
+ *       down to roughly {@code O(row groups)}, and the wall-clock cost of the slowest GET is no
+ *       longer additive across row groups.</li>
+ *   <li><b>Pipelined decode in arrival order.</b> A small bounded queue receives each
+ *       per-bucket prefetch as it completes. The decode loop drains buckets in arrival order,
+ *       running flat ({@link PageColumnReader#readBatchSparse}) or list (skip/read driven by a
+ *       {@link ColumnReader}) decode for every requested column against that bucket's
+ *       prefetched chunk map. Decoding bucket {@code i} therefore overlaps with the still
+ *       in-flight S3 reads for the slower buckets — the synchronous barrier of
+ *       <em>"wait for the slowest GET, then start any decode"</em> is removed.</li>
+ *   <li><b>Stitch back to caller order.</b> Each bucket produces one per-(bucket, column) block
+ *       sized {@code bucket.bucketLength}; per-column blocks are concatenated in
+ *       bucket-visit order (independent of decode arrival order). A gather permutation then
+ *       routes each caller slot to its position in the concatenated block via
+ *       {@link Block#filter(boolean, int...)}, supporting duplicate requests for the same row.</li>
+ * </ol>
+ * <p>
+ * I/O cost: one async coalesced fetch per visited row group, all dispatched in parallel up to
+ * the per-query concurrency budget. For TopN with {@code limit = N} survivors against a file
+ * with {@code G} row groups and a {@code C}-column deferred projection, at most {@code min(N, G)}
+ * row groups are visited and roughly {@code min(N, G)} HTTP GETs fly concurrently rather than
+ * {@code min(N, G) × C} sequentially. End-to-end latency is bounded below by
+ * {@code max(slowest_RTT, fastest_RTT + total_decode_time)} instead of
+ * {@code slowest_RTT + total_decode_time}.
+ * <p>
+ * Threading: a single driver thread owns an instance; callers must not invoke {@link #extract}
+ * concurrently from different threads.
+ */
+final class ParquetColumnExtractor implements ColumnExtractor {
+
+    private final StorageObject storageObject;
+    private final ParquetFormatReader reader;
+    private final ParquetMetadata ownedFooter;
+    private final long rowCount;
+    /**
+     * Precomputed prefix sum of row counts over {@link #ownedFooter}'s blocks, with a leading
+     * zero — i.e. {@code rowGroupOffsets[i]} is the file-global first row index of row group
+     * {@code i}, and {@code rowGroupOffsets[ownedFooter.getBlocks().size()] == rowCount}. Used by
+     * {@link #findRowGroup(long)} to map a file-global row identity to its owning block in
+     * O(log G). Always derived from the full file footer (range-split iterators emit identities
+     * in the file's address space; the extractor does not need or want a subset view).
+     */
+    private final long[] rowGroupOffsets;
+
+    /**
+     * @param storageObject the storage handle for the file (extractor borrows it; caller closes)
+     * @param reader        a {@link ParquetFormatReader} to use for codec-factory access; the
+     *                      extractor never opens iterators through it
+     * @param ownedFooter   the {@link ParquetMetadata} for the file. Always the full footer —
+     *                      iterators (full-file or range-split) emit file-global row identities,
+     *                      so the extractor's address space matches the file rather than any
+     *                      split slice.
+     */
+    ParquetColumnExtractor(StorageObject storageObject, ParquetFormatReader reader, ParquetMetadata ownedFooter) {
+        this.storageObject = Objects.requireNonNull(storageObject, "storageObject");
+        this.reader = Objects.requireNonNull(reader, "reader");
+        this.ownedFooter = Objects.requireNonNull(ownedFooter, "ownedFooter");
+        List<BlockMetaData> blocks = ownedFooter.getBlocks();
+        this.rowGroupOffsets = new long[blocks.size() + 1];
+        long acc = 0;
+        for (int i = 0; i < blocks.size(); i++) {
+            rowGroupOffsets[i] = acc;
+            acc += blocks.get(i).getRowCount();
+        }
+        rowGroupOffsets[blocks.size()] = acc;
+        this.rowCount = acc;
+    }
+
+    @Override
+    public long rowCount() {
+        return rowCount;
+    }
+
+    @Override
+    public Block[] extract(String[] columnNames, long[] localPositions, BlockFactory blockFactory) throws IOException {
+        Objects.requireNonNull(columnNames, "columnNames");
+        Objects.requireNonNull(localPositions, "localPositions");
+        Objects.requireNonNull(blockFactory, "blockFactory");
+        for (String columnName : columnNames) {
+            Objects.requireNonNull(columnName, "columnNames must not contain nulls");
+            if (columnName.equals(ROW_POSITION_COLUMN)) {
+                throw new IllegalArgumentException("cannot extract reserved column [" + ROW_POSITION_COLUMN + "]");
+            }
+        }
+
+        int colCount = columnNames.length;
+        int count = localPositions.length;
+        if (count == 0) {
+            Block[] empty = new Block[colCount];
+            for (int c = 0; c < colCount; c++) {
+                empty[c] = blockFactory.newConstantNullBlock(0);
+            }
+            return empty;
+        }
+        if (colCount == 0) {
+            return new Block[0];
+        }
+        // The per-bucket {@link Bucket#sortAndDedup} packs each input slot index into the low
+        // {@link #INDEX_BITS} of a long; if the input batch ever exceeds {@link #INDEX_RANGE},
+        // packing collapses neighbouring slots into the same packed key and the sort silently
+        // corrupts. The optimizer caps the deferred-extraction TopN limit well below this bound
+        // today, but enforce the local invariant here so the contract surfaces if either side ever
+        // moves.
+        if (count > INDEX_RANGE) {
+            throw new IllegalArgumentException(
+                "extract requested for [" + count + "] positions exceeds packed-sort capacity [" + INDEX_RANGE + "]"
+            );
+        }
+
+        validatePositions(localPositions, count);
+
+        // Resolve every requested column to its {@link ColumnInfo} once so we have the descriptors
+        // ready for the single coalesced fetch (we need their dotted paths to compute the byte
+        // ranges) and for the per-column decode loop afterwards.
+        MessageType schema = ownedFooter.getFileMetaData().getSchema();
+        ColumnInfo[] infos = new ColumnInfo[colCount];
+        for (int c = 0; c < colCount; c++) {
+            ColumnInfo info = ParquetFormatReader.resolveColumnInfo(schema, columnNames[c]);
+            if (info == null) {
+                throw new IllegalArgumentException(
+                    "column [" + columnNames[c] + "] is missing or has an unsupported type in [" + storageObject.path() + "]"
+                );
+            }
+            infos[c] = info;
+        }
+
+        // Bucket positions by row group once. Per-column decode walks the same buckets, so paying
+        // the bucketing cost once across the whole projection is significantly cheaper than
+        // re-bucketing per column (the bucket structure is column-agnostic; the in-row-group
+        // positions are the same regardless of which column we materialise).
+        List<Bucket> buckets = bucketByRowGroup(localPositions, count);
+
+        // Sort+dedup every bucket up-front (independent of decode order). This lets the
+        // arrival-order decode loop call PageColumnReader.readBatchSparse without any
+        // bucket-vs-bucket coordination.
+        for (Bucket bucket : buckets) {
+            bucket.sortAndDedup();
+        }
+
+        // Projection set keyed on each column descriptor's dotted path. For flat columns this is
+        // just the column name; for LIST<primitive> it's e.g. "vals.list.element". This must match
+        // ColumnChunkMetaData.getPath().toDotString(), which is what
+        // ColumnChunkPrefetcher.computeColumnChunkRanges and PrefetchedRowGroupBuilder both key
+        // off. The combined projection covers every requested column for one row group;
+        // CoalescedRangeReader merges physically-adjacent chunks (column chunks within one row
+        // group are written contiguously in Parquet), so the per-bucket fetch typically resolves
+        // to a single S3 GET per row group rather than one per (row group, column).
+        Set<String> projection = new java.util.LinkedHashSet<>(colCount);
+        for (ColumnInfo info : infos) {
+            projection.add(String.join(".", info.descriptor().getPath()));
+        }
+
+        // Per-bucket async prefetch dispatch. We do NOT block on any one fetch before kicking
+        // off the next: every bucket's GET is in flight before we touch the first byte. This is
+        // the parallelism win — for N visited row groups end-to-end latency drops from
+        // (slowest GET) + (sum of decodes) towards max(slowest GET, fastest GET + sum of decodes),
+        // bounded by the per-query concurrency budget which sits inside readBytesAsync.
+        List<BlockMetaData> blocks = ownedFooter.getBlocks();
+        @SuppressWarnings("unchecked")
+        CompletableFuture<NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk>>[] futures = new CompletableFuture[buckets.size()];
+        for (int i = 0; i < buckets.size(); i++) {
+            BlockMetaData block = blocks.get(buckets.get(i).rowGroupIndex);
+            futures[i] = ColumnChunkPrefetcher.prefetchAsync(storageObject, block, projection);
+        }
+
+        // result[c][b] = block for column c in bucket b (bucket-visit order). We populate this
+        // out of order as buckets' prefetches arrive; the per-column concat happens once every
+        // bucket has been decoded so the layout-vs-arrival distinction is local to this method.
+        Block[][] perBucketBlocks = new Block[colCount][buckets.size()];
+        Block[] result = new Block[colCount];
+        boolean built = false;
+        try {
+            decodeBucketsAsTheyArrive(buckets, infos, schema, columnNames, projection, futures, perBucketBlocks, blockFactory);
+            for (int c = 0; c < colCount; c++) {
+                // stitchAndGather releases its per-bucket blocks and nulls the array entries so
+                // the outer defensive cleanup is a no-op for already-stitched columns.
+                result[c] = stitchAndGather(perBucketBlocks[c], buckets, count, blockFactory);
+            }
+            built = true;
+            return result;
+        } finally {
+            // Defensive cleanup: anything left in perBucketBlocks (e.g. when decode partially
+            // completed before failing, or stitchAndGather threw between two columns) needs
+            // releasing. Built columns in result are released only on the failure path.
+            for (Block[] perBucket : perBucketBlocks) {
+                for (Block b : perBucket) {
+                    if (b != null) {
+                        Releasables.closeExpectNoException(b);
+                    }
+                }
+            }
+            if (built == false) {
+                Releasables.closeExpectNoException(result);
+            }
+        }
+    }
+
+    /**
+     * Drains the per-bucket prefetch futures in arrival order, decoding every requested column
+     * for each bucket as soon as its bytes land. Decode of bucket {@code i} therefore overlaps
+     * with the still in-flight S3 reads for the slower buckets — the wall-clock cost of the
+     * slowest GET is no longer additive with decode time.
+     *
+     * <p>If any prefetch fails, every other in-flight prefetch is cancelled (or its result
+     * discarded once it lands) and the original failure is rethrown.
+     */
+    private void decodeBucketsAsTheyArrive(
+        List<Bucket> buckets,
+        ColumnInfo[] infos,
+        MessageType schema,
+        String[] columnNames,
+        Set<String> projection,
+        CompletableFuture<NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk>>[] futures,
+        Block[][] perBucketBlocks,
+        BlockFactory blockFactory
+    ) throws IOException {
+        // Per-column projected schemas + single-column projection sets reused across every
+        // bucket's decode. Building these once outside the drain loop keeps the per-bucket fast
+        // path branch-free and avoids re-walking the message schema for each column-bucket pair.
+        int colCount = columnNames.length;
+        MessageType[] perColumnSchemas = new MessageType[colCount];
+        @SuppressWarnings("unchecked")
+        Set<String>[] perColumnProjections = new Set[colCount];
+        for (int c = 0; c < colCount; c++) {
+            perColumnSchemas[c] = new MessageType(schema.getName(), schema.getType(columnNames[c]));
+            perColumnProjections[c] = Set.of(String.join(".", infos[c].descriptor().getPath()));
+        }
+        String createdBy = ownedFooter.getFileMetaData().getCreatedBy();
+        List<BlockMetaData> blocks = ownedFooter.getBlocks();
+
+        // Use CompletableFuture.anyOf in a draining loop so we always pick the next-completed
+        // future. Track which slots are still pending via a mutable view over the futures array
+        // — completed slots get nulled out and skipped on subsequent iterations.
+        int pending = futures.length;
+        try {
+            while (pending > 0) {
+                int bucketIdx = waitForNextCompleted(futures);
+                NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk> prefetched;
+                try {
+                    prefetched = futures[bucketIdx].get();
+                } catch (ExecutionException e) {
+                    // Unwrap the CompletableFuture wrapper; the underlying cause is what callers
+                    // expect (e.g. an IOException from S3) and what existing tests assert against.
+                    Throwable cause = e.getCause();
+                    if (cause instanceof IOException io) {
+                        throw io;
+                    }
+                    if (cause instanceof RuntimeException re) {
+                        throw re;
+                    }
+                    throw new IOException("prefetch failed for row group " + buckets.get(bucketIdx).rowGroupIndex, cause);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IOException("interrupted while awaiting row group prefetch", e);
+                }
+                futures[bucketIdx] = null;
+                pending--;
+
+                Bucket bucket = buckets.get(bucketIdx);
+                BlockMetaData block = blocks.get(bucket.rowGroupIndex);
+                int rgRowCount = Math.toIntExact(block.getRowCount());
+
+                // Decode every requested column from this bucket's prefetched chunk map. Each
+                // call passes a single-column projection so PrefetchedRowGroupBuilder only
+                // materialises that column's bytes despite the prefetched map carrying every
+                // projected column for this row group.
+                for (int c = 0; c < colCount; c++) {
+                    perBucketBlocks[c][bucketIdx] = decodeBucket(
+                        bucket,
+                        block,
+                        infos[c],
+                        perColumnSchemas[c],
+                        perColumnProjections[c],
+                        prefetched,
+                        rgRowCount,
+                        createdBy,
+                        blockFactory
+                    );
+                }
+                // The prefetched buffers for this bucket are eligible for GC the moment we exit
+                // this iteration: nothing else holds a reference (perBucketBlocks owns decoded
+                // values, not raw bytes).
+            }
+        } catch (Throwable t) {
+            // Cancel every still-pending prefetch so its memory can be released (best-effort —
+            // the async client may already have started decoding a response). Also drop any
+            // result that lands after our cancel: discard via whenComplete.
+            for (int i = 0; i < futures.length; i++) {
+                FutureUtils.cancel(futures[i]);
+            }
+            throw t;
+        }
+    }
+
+    /**
+     * Polls the futures array for any completed slot, returning its index. Blocks on
+     * {@link CompletableFuture#anyOf} until at least one new future completes; subsequent
+     * scans are O(N) in the per-call array length, which is bounded by the number of
+     * surviving row groups (typically &lt; 32).
+     */
+    private static int waitForNextCompleted(CompletableFuture<?>[] futures) {
+        // Fast path: a future from a previous round may already be done. Scan first.
+        int idx = findCompleted(futures);
+        if (idx >= 0) {
+            return idx;
+        }
+        // Build a snapshot of still-pending futures and wait for one to complete.
+        List<CompletableFuture<?>> pendingList = new ArrayList<>(futures.length);
+        for (CompletableFuture<?> f : futures) {
+            if (f != null) {
+                pendingList.add(f);
+            }
+        }
+        if (pendingList.isEmpty()) {
+            throw new IllegalStateException("waitForNextCompleted called with no pending futures");
+        }
+        // anyOf blocks until any future completes (success or failure). We don't use anyOf's
+        // result; we re-scan for the now-completed slot to recover the bucket index. That keeps
+        // the index ↔ bucket binding without a parallel HashMap lookup.
+        try {
+            CompletableFuture.anyOf(pendingList.toArray(CompletableFuture[]::new)).join();
+        } catch (CompletionException ignored) {
+            // anyOf surfaces the first failure; ignore here — the caller's get() on the failed
+            // future will rethrow the underlying cause with proper unwrapping.
+        }
+        idx = findCompleted(futures);
+        if (idx < 0) {
+            // Defensive: if anyOf returned but the array shows no completed entry it means the
+            // future we waited on was a stale reference. Re-loop on the caller side.
+            throw new IllegalStateException("anyOf signalled completion but no future is done");
+        }
+        return idx;
+    }
+
+    private static int findCompleted(CompletableFuture<?>[] futures) {
+        for (int i = 0; i < futures.length; i++) {
+            CompletableFuture<?> f = futures[i];
+            if (f != null && f.isDone()) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Concatenates per-bucket blocks for one column in bucket-visit order and applies the gather
+     * permutation that maps caller slots to their position in the concatenated block. This is
+     * the same logic the previous synchronous path used; we just feed it pre-decoded per-bucket
+     * blocks instead of decoding inside the loop.
+     */
+    private Block stitchAndGather(Block[] perBucketBlocks, List<Bucket> buckets, int totalCount, BlockFactory blockFactory) {
+        Block.Builder builder = null;
+        Block concatenated = null;
+        try {
+            for (int b = 0; b < perBucketBlocks.length; b++) {
+                Block bucketBlock = perBucketBlocks[b];
+                if (bucketBlock == null) {
+                    throw new IllegalStateException("missing decoded block for bucket [" + buckets.get(b).rowGroupIndex + "]");
+                }
+                if (builder == null) {
+                    builder = bucketBlock.elementType().newBlockBuilder(totalCount, blockFactory);
+                }
+                builder.copyFrom(bucketBlock, 0, bucketBlock.getPositionCount());
+            }
+            if (builder == null) {
+                throw new IllegalStateException("no row groups visited for [" + storageObject.path() + "] (count=" + totalCount + ")");
+            }
+            concatenated = builder.build();
+            int[] gather = buildGatherPermutation(buckets, totalCount);
+            // mayContainDuplicates is true: the same bucket position may serve multiple caller
+            // slots when localPositions repeats a row.
+            return concatenated.filter(true, gather);
+        } finally {
+            if (builder != null) {
+                Releasables.closeExpectNoException(builder);
+            }
+            if (concatenated != null) {
+                Releasables.closeExpectNoException(concatenated);
+            }
+            // Per-bucket blocks live until stitch completes; release them here so the caller
+            // doesn't have to track them. Null the slots out so the caller's defensive cleanup
+            // doesn't double-close.
+            for (int i = 0; i < perBucketBlocks.length; i++) {
+                Block b = perBucketBlocks[i];
+                if (b != null) {
+                    Releasables.closeExpectNoException(b);
+                    perBucketBlocks[i] = null;
+                }
+            }
+        }
+    }
+
+    private void validatePositions(long[] localPositions, int count) {
+        long min = localPositions[0];
+        long max = localPositions[0];
+        for (int i = 1; i < count; i++) {
+            long p = localPositions[i];
+            if (p < min) min = p;
+            if (p > max) max = p;
+        }
+        if (min < 0 || max >= rowCount) {
+            throw new IllegalArgumentException("row position out of range [0, " + rowCount + "): min=" + min + ", max=" + max);
+        }
+    }
+
+    /**
+     * Group every requested position into a per-row-group {@link Bucket}. Each bucket stores the
+     * caller slot ({@code originalIndex}) and the in-row-group position for every entry; the
+     * order of insertion is the order positions appear in {@code localPositions}, so the
+     * concatenated output later in {@link #stitchAndGather} preserves that ordering and the
+     * gather permutation we build inline maps caller slot directly into concatenated space.
+     */
+    private List<Bucket> bucketByRowGroup(long[] localPositions, int count) {
+        Map<Integer, Bucket> byRg = new HashMap<>();
+        List<Bucket> ordered = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            long pos = localPositions[i];
+            int rgIndex = findRowGroup(pos);
+            Bucket b = byRg.get(rgIndex);
+            if (b == null) {
+                b = new Bucket(rgIndex);
+                byRg.put(rgIndex, b);
+                ordered.add(b);
+            }
+            int inGroup = Math.toIntExact(pos - rowGroupOffsets[rgIndex]);
+            b.add(i, inGroup);
+        }
+        return ordered;
+    }
+
+    /**
+     * Builds the permutation {@code gather} where {@code gather[callerSlot]} is the position in
+     * the concatenated block (whose layout is {@code bucket0 ++ bucket1 ++ …} in visit order)
+     * holding the value for that caller slot. Combines the per-bucket concatenation offset with
+     * each entry's {@code runToBucketSlot} index to produce every gather index in one pass.
+     */
+    private static int[] buildGatherPermutation(List<Bucket> buckets, int totalCount) {
+        int[] gather = new int[totalCount];
+        int offset = 0;
+        for (Bucket b : buckets) {
+            int n = b.size;
+            for (int i = 0; i < n; i++) {
+                int callerSlot = b.originalIndex[i];
+                int posInBucket = b.runToBucketSlot[i];
+                gather[callerSlot] = offset + posInBucket;
+            }
+            offset += b.bucketLength;
+        }
+        return gather;
+    }
+
+    /**
+     * Decodes the surviving rows for one row group, dispatching to the flat (rep-level 0) or
+     * list (rep-level &gt; 0) sparse-read path. Returns a block with {@code bucket.bucketLength}
+     * positions ordered by ascending in-row-group position; the caller stitches per-bucket
+     * blocks into the concatenated output and uses the gather permutation to route caller slots.
+     */
+    private Block decodeBucket(
+        Bucket bucket,
+        BlockMetaData block,
+        ColumnInfo info,
+        MessageType projectedSchema,
+        Set<String> projection,
+        NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk> prefetched,
+        int rgRowCount,
+        String createdBy,
+        BlockFactory blockFactory
+    ) throws IOException {
+        try (
+            PrefetchedPageReadStore store = PrefetchedRowGroupBuilder.build(
+                block,
+                bucket.rowGroupIndex,
+                projectedSchema,
+                projection,
+                /* rowRanges = */ null,
+                /* preloadedMetadata = */ null,
+                prefetched,
+                storageObject,
+                reader.codecFactory()
+            )
+        ) {
+            if (info.maxRepLevel() == 0) {
+                return decodeFlat(bucket, info, store, rgRowCount, blockFactory);
+            }
+            return decodeList(bucket, info, store, projectedSchema, rgRowCount, createdBy, blockFactory);
+        }
+    }
+
+    /**
+     * Flat-column sparse decode via {@link PageColumnReader#readBatchSparse}. The reader walks
+     * the row-group rows in source order, alternating skips and reads to produce exactly the
+     * surviving rows.
+     */
+    private static Block decodeFlat(
+        Bucket bucket,
+        ColumnInfo info,
+        PrefetchedPageReadStore store,
+        int rgRowCount,
+        BlockFactory blockFactory
+    ) {
+        PageReader pr = store.getPageReader(info.descriptor());
+        try (
+            PageColumnReader pageReader = new PageColumnReader(
+                pr,
+                info.descriptor(),
+                info,
+                // RowRanges.all() lets every page through loadNextPage()'s page-skip check; the
+                // sparse loop drives skip/read by in-group position from there.
+                RowRanges.all(rgRowCount)
+            )
+        ) {
+            return pageReader.readBatchSparse(rgRowCount, blockFactory, bucket.uniquePositions, bucket.uniqueCount);
+        }
+    }
+
+    /**
+     * List-column sparse decode. parquet-mr's {@link ColumnReader} is repetition-aware so we
+     * walk the row-group rows in source order via {@link ParquetColumnDecoding#skipListValues}
+     * and {@link ParquetColumnDecoding#readListColumn}, alternating skip/read runs in lock-step
+     * with the unique survivor positions. Same in-memory chunks as the flat path; we only swap
+     * the decoder.
+     */
+    private Block decodeList(
+        Bucket bucket,
+        ColumnInfo info,
+        PrefetchedPageReadStore store,
+        MessageType projectedSchema,
+        int rgRowCount,
+        String createdBy,
+        BlockFactory blockFactory
+    ) {
+        ColumnReadStoreImpl crs = new ColumnReadStoreImpl(
+            store,
+            new ParquetColumnDecoding.NoOpGroupConverter(projectedSchema),
+            projectedSchema,
+            createdBy != null ? createdBy : ""
+        );
+        ColumnReader cr = crs.getColumnReader(info.descriptor());
+
+        int unique = bucket.uniqueCount;
+        int[] positions = bucket.uniquePositions;
+        // Decompose into contiguous runs the same way PageColumnReader does for the flat path;
+        // each run yields one readListColumn call against ColumnReader, and gaps between runs
+        // are handled by skipListValues. List-read is unavoidably row-by-row at the rep-level
+        // boundary, so the runs help amortise the per-row builder begin/endPositionEntry cost.
+        List<Block> chunks = new ArrayList<>();
+        int cursor = 0;
+        int runStart = 0;
+        int maxDef = info.maxDefLevel();
+        try {
+            while (runStart < unique) {
+                int p = positions[runStart];
+                int gap = p - cursor;
+                if (gap > 0) {
+                    skipListRows(cr, maxDef, gap);
+                    cursor += gap;
+                }
+                int runEnd = runStart + 1;
+                while (runEnd < unique && positions[runEnd] == positions[runEnd - 1] + 1) {
+                    runEnd++;
+                }
+                int runLength = runEnd - runStart;
+                chunks.add(ParquetColumnDecoding.readListColumn(cr, info, runLength, blockFactory));
+                cursor += runLength;
+                runStart = runEnd;
+            }
+            // No need to drain trailing rows: ColumnReader is bounded by the row group's chunk
+            // and we discard it at end of try-with-resources without consuming further values.
+            if (chunks.size() == 1) {
+                Block only = chunks.get(0);
+                chunks.clear();
+                return expandWithRunMapping(only, bucket);
+            }
+            Block joined = concatBlocks(chunks, unique, blockFactory);
+            chunks.clear();
+            return expandWithRunMapping(joined, bucket);
+        } catch (RuntimeException e) {
+            for (Block c : chunks) {
+                Releasables.closeExpectNoException(c);
+            }
+            throw e;
+        }
+    }
+
+    /**
+     * Skip {@code rowsToSkip} entire list rows, advancing both the column reader's level cursor
+     * and its data cursor. {@link ParquetColumnDecoding#skipListValues} only calls
+     * {@link ColumnReader#consume}, which advances rep/def levels but leaves the underlying data
+     * cursor at the first value — fine when the column is read sequentially row-by-row (each
+     * read calls {@code getXxx()} or appendNull and the cursors stay in lock-step) but wrong for
+     * a sparse skip ahead of a {@link ParquetColumnDecoding#readListColumn} call: the next
+     * {@code getInteger()} would return a stale value from row 0. We therefore call
+     * {@link ColumnReader#skip} for every value with {@code def == maxDef} (the only values that
+     * are physically present in the page) so the data cursor advances in lock-step with the
+     * level cursor.
+     */
+    private static void skipListRows(ColumnReader cr, int maxDef, int rowsToSkip) {
+        for (int row = 0; row < rowsToSkip; row++) {
+            if (cr.getCurrentDefinitionLevel() == maxDef) {
+                cr.skip();
+            }
+            cr.consume();
+            while (cr.getCurrentRepetitionLevel() > 0) {
+                if (cr.getCurrentDefinitionLevel() == maxDef) {
+                    cr.skip();
+                }
+                cr.consume();
+            }
+        }
+    }
+
+    /**
+     * Maps the unique-positions block produced by the per-RG decode back to the bucket's full
+     * length, replaying duplicate positions when the bucket asked for the same row more than
+     * once. {@code mayContainDuplicates} is true only when the bucket actually holds duplicates;
+     * the cheap path returns {@code unique} unchanged.
+     */
+    private static Block expandWithRunMapping(Block unique, Bucket bucket) {
+        if (bucket.bucketLength == bucket.uniqueCount) {
+            return unique;
+        }
+        try {
+            return unique.filter(true, bucket.runToBucketSlot);
+        } finally {
+            Releasables.closeExpectNoException(unique);
+        }
+    }
+
+    /** Concatenate same-element-type blocks via a builder; closes the source chunks. */
+    private static Block concatBlocks(List<Block> chunks, int totalPositions, BlockFactory blockFactory) {
+        Block.Builder b = chunks.get(0).elementType().newBlockBuilder(totalPositions, blockFactory);
+        try {
+            for (Block c : chunks) {
+                b.copyFrom(c, 0, c.getPositionCount());
+            }
+            return b.build();
+        } finally {
+            for (Block c : chunks) {
+                Releasables.closeExpectNoException(c);
+            }
+            Releasables.closeExpectNoException(b);
+        }
+    }
+
+    @Override
+    public void close() {
+        // The StorageObject is owned by the caller (source factory). The extractor borrows it; the
+        // caller closes it when the driver finishes. The cached footer is just metadata — no
+        // resources to release.
+    }
+
+    /**
+     * Binary-searches {@link #rowGroupOffsets} for the row group that owns {@code position}.
+     * Returns an index into {@code ownedFooter.getBlocks()}.
+     */
+    private int findRowGroup(long position) {
+        // rowGroupOffsets[i] is the first row of block i; blocks span [offsets[i], offsets[i+1]).
+        // binarySearch on a strictly-increasing prefix sum: when found, position is the first row
+        // of the block with that offset; otherwise the negative insertion point identifies the
+        // first offset > position, and the owning block is one before that.
+        int idx = Arrays.binarySearch(rowGroupOffsets, 0, rowGroupOffsets.length - 1, position);
+        if (idx >= 0) {
+            return idx;
+        }
+        return (-idx - 1) - 1;
+    }
+
+    /**
+     * Per-row-group accumulator. Holds the caller slots and in-row-group positions for every
+     * request that lands in this bucket, in input order. After {@link #sortAndDedup} the bucket
+     * also exposes {@link #uniquePositions} (strictly-ascending) and {@link #runToBucketSlot}
+     * (per-input-slot index into the per-bucket output block).
+     */
+    private static final class Bucket {
+        final int rowGroupIndex;
+        int[] originalIndex = new int[4];
+        int[] inGroupPositions = new int[4];
+        int size = 0;
+
+        // Populated by sortAndDedup:
+        int[] uniquePositions;
+        int uniqueCount;
+        /**
+         * For input slot {@code i}, the index in the per-bucket output block (length =
+         * {@link #bucketLength}) holding the value for that input. When the bucket has no
+         * duplicates this is the identity {@code [0, bucketLength)}; with duplicates it routes
+         * each duplicate to its single read in the unique block.
+         */
+        int[] runToBucketSlot;
+        /**
+         * Number of rows the per-bucket output block carries. Equals {@link #size} regardless of
+         * duplicates: duplicates are replayed via {@link #runToBucketSlot} so caller slots line
+         * up one-to-one with concatenated-block positions.
+         */
+        int bucketLength;
+
+        Bucket(int rowGroupIndex) {
+            this.rowGroupIndex = rowGroupIndex;
+        }
+
+        void add(int callerSlot, int inGroupPos) {
+            if (size == originalIndex.length) {
+                int newCap = originalIndex.length * 2;
+                originalIndex = Arrays.copyOf(originalIndex, newCap);
+                inGroupPositions = Arrays.copyOf(inGroupPositions, newCap);
+            }
+            originalIndex[size] = callerSlot;
+            inGroupPositions[size] = inGroupPos;
+            size++;
+        }
+
+        /**
+         * Sorts (inGroupPosition, callerSlot) pairs ascending by position, then deduplicates
+         * adjacent equal positions. After this call:
+         * <ul>
+         *   <li>{@link #uniquePositions}/{@link #uniqueCount} satisfy
+         *       {@code PageColumnReader.readBatchSparse}'s strictly-ascending contract.</li>
+         *   <li>{@link #runToBucketSlot} maps each (now-sorted) entry to its slot in the
+         *       per-bucket output block produced by the per-RG decode.</li>
+         *   <li>{@link #originalIndex} is reordered in lockstep with the sort so the gather
+         *       step in {@link ParquetColumnExtractor#buildGatherPermutation} maps caller slots
+         *       to {@code runToBucketSlot} positions correctly.</li>
+         * </ul>
+         */
+        void sortAndDedup() {
+            // Pack (position, callerSlot) into a single long to drive a primitive sort. {@link #size}
+            // is bounded by the input {@code localPositions.length} which {@link #extract} caps at
+            // {@link #INDEX_RANGE} on entry, so the slot half of every packed long fits in
+            // {@link #INDEX_BITS} unambiguously.
+            assert size <= INDEX_RANGE : "bucket size [" + size + "] exceeds packed-sort capacity [" + INDEX_RANGE + "]";
+            long[] packed = new long[size];
+            for (int i = 0; i < size; i++) {
+                // inGroupPositions are non-negative ints, so the high 49 bits hold the position
+                // unsigned and Arrays.sort gives ascending position order.
+                packed[i] = ((long) inGroupPositions[i] << INDEX_BITS) | (originalIndex[i] & INDEX_MASK);
+            }
+            Arrays.sort(packed);
+            int[] sortedOriginal = new int[size];
+            int[] sortedPositions = new int[size];
+            for (int i = 0; i < size; i++) {
+                sortedPositions[i] = (int) (packed[i] >>> INDEX_BITS);
+                sortedOriginal[i] = (int) (packed[i] & INDEX_MASK);
+            }
+            originalIndex = sortedOriginal;
+            inGroupPositions = sortedPositions;
+
+            uniquePositions = new int[size];
+            runToBucketSlot = new int[size];
+            int u = 0;
+            int prev = -1;
+            for (int i = 0; i < size; i++) {
+                int p = sortedPositions[i];
+                if (i == 0 || p != prev) {
+                    uniquePositions[u++] = p;
+                    prev = p;
+                }
+                runToBucketSlot[i] = u - 1;
+            }
+            uniqueCount = u;
+            bucketLength = size;
+        }
+    }
+
+    /**
+     * Bit budget for the packed (position, slot) sort: {@link #INDEX_BITS} for the slot,
+     * {@code 64 - INDEX_BITS} for the position. The slot half must fit every input slot index, so
+     * {@link #extract} caps {@code localPositions.length} at {@link #INDEX_RANGE} on entry — that
+     * upper bound (16_384) is the local invariant of this packed-sort scheme and is independent of
+     * any caller-side TopN limit. The remaining 49 bits address Parquet files up to roughly 500
+     * trillion rows, well past anything realistic.
+     */
+    private static final int INDEX_BITS = 14;
+    private static final int INDEX_RANGE = 1 << INDEX_BITS;
+    private static final long INDEX_MASK = INDEX_RANGE - 1L;
+}

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -50,6 +50,8 @@ import org.elasticsearch.xpack.esql.datasources.SourceStatisticsSerializer;
 import org.elasticsearch.xpack.esql.datasources.cache.ParsedFooterCache;
 import org.elasticsearch.xpack.esql.datasources.spi.AggregatePushdownSupport;
 import org.elasticsearch.xpack.esql.datasources.spi.ColumnBlockConversions;
+import org.elasticsearch.xpack.esql.datasources.spi.ColumnExtractor;
+import org.elasticsearch.xpack.esql.datasources.spi.ColumnExtractorAware;
 import org.elasticsearch.xpack.esql.datasources.spi.Configured;
 import org.elasticsearch.xpack.esql.datasources.spi.FilterPushdownSupport;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
@@ -95,7 +97,7 @@ import java.util.concurrent.ExecutionException;
  *   <li>Direct conversion from Parquet to ESQL blocks</li>
  * </ul>
  */
-public class ParquetFormatReader implements RangeAwareFormatReader {
+public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtractorAware {
 
     private static final Logger logger = LogManager.getLogger(ParquetFormatReader.class);
 
@@ -127,6 +129,61 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
     /** Clears the parsed-footer cache. Intended for test isolation only. */
     static void clearParsedFooterCacheForTests() {
         PARSED_FOOTERS.invalidateAll();
+    }
+
+    /**
+     * Shared decompressor factory exposed to {@link ParquetColumnExtractor} so it can build
+     * row-group readers via {@link PrefetchedRowGroupBuilder} without re-instantiating its own
+     * factory. Package-private on purpose: the extractor lives in this package and is the only
+     * collaborator that needs it.
+     */
+    PlainCompressionCodecFactory codecFactory() {
+        return codecFactory;
+    }
+
+    /**
+     * Resolves the {@link ColumnInfo} for a top-level column by name within a parquet
+     * {@link MessageType}, applying the same primitive-type mapping that the iterator uses
+     * (see {@link #convertParquetTypeToEsql}). Returns {@code null} when the column is absent
+     * or maps to {@link DataType#UNSUPPORTED} / {@link DataType#NULL}. The returned descriptor
+     * carries {@code maxRepetitionLevel} so callers can route flat vs list paths off of it.
+     * <p>
+     * Package-private because {@link ParquetColumnExtractor} is the only collaborator and we
+     * deliberately keep this primitive-type mapping single-sourced — duplicating it in the
+     * extractor risks subtle type drift the next time a logical type is added.
+     */
+    static ColumnInfo resolveColumnInfo(MessageType schema, String columnName) {
+        Type field = schema.containsField(columnName) ? schema.getType(columnName) : null;
+        if (field == null) {
+            return null;
+        }
+        DataType esqlType = convertParquetTypeToEsql(field);
+        if (esqlType == DataType.UNSUPPORTED || esqlType == DataType.NULL) {
+            return null;
+        }
+        // For flat columns the descriptor lives directly under the schema; for LIST<primitive>
+        // the descriptor is the inner repeated element. Iterate columns once and pick the
+        // descriptor whose top-level path segment matches the requested column name.
+        ColumnDescriptor descriptor = null;
+        for (ColumnDescriptor desc : schema.getColumns()) {
+            String[] path = desc.getPath();
+            if (path.length > 0 && path[0].equals(columnName)) {
+                descriptor = desc;
+                break;
+            }
+        }
+        if (descriptor == null) {
+            return null;
+        }
+        PrimitiveType prim = descriptor.getPrimitiveType();
+        return new ColumnInfo(
+            descriptor,
+            prim.getPrimitiveTypeName(),
+            esqlType,
+            descriptor.getMaxDefinitionLevel(),
+            descriptor.getMaxRepetitionLevel(),
+            prim.getLogicalTypeAnnotation()
+        );
     }
 
     public ParquetFormatReader(BlockFactory blockFactory) {
@@ -323,6 +380,33 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
         return new ParquetMetadata(metadata.getFileMetaData(), filtered);
     }
 
+    /**
+     * Computes file-global first-row offsets for every block whose midpoint falls in the supplied
+     * range, indexed by the position of that block in the range-relative iteration order. The result
+     * is what the deferred-extraction iterator hands to {@link OptimizedParquetColumnIterator} so
+     * each emitted {@code _rowPosition} stays anchored to the FILE's prefix sum even when the
+     * iterator only sees a subset of row groups. Index {@code length} holds the total file row
+     * count, so the iterator can validate its own emit ranges if it ever needs to.
+     */
+    private static long[] computeRangeBlockFileGlobalOffsets(ParquetMetadata fullFooter, long rangeStart, long rangeEnd) {
+        List<BlockMetaData> allBlocks = fullFooter.getBlocks();
+        List<Long> ranged = new ArrayList<>();
+        long sum = 0L;
+        for (BlockMetaData block : allBlocks) {
+            long midpoint = block.getStartingPos() + block.getCompressedSize() / 2;
+            if (midpoint >= rangeStart && midpoint < rangeEnd) {
+                ranged.add(sum);
+            }
+            sum += block.getRowCount();
+        }
+        long[] offsets = new long[ranged.size() + 1];
+        for (int i = 0; i < ranged.size(); i++) {
+            offsets[i] = ranged.get(i);
+        }
+        offsets[ranged.size()] = sum;
+        return offsets;
+    }
+
     private static IOException newInvalidParquetFileException(String uri, Exception e) {
         String detail = e.getMessage();
         if (detail == null || detail.isEmpty()) {
@@ -487,6 +571,12 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
 
     @Override
     public CloseableIterator<Page> read(StorageObject object, FormatReadContext context) throws IOException {
+        // The synthetic {@link ColumnExtractor#ROW_POSITION_COLUMN} flows through the regular
+        // read path: {@link #buildProjectedAttributes} types it as LONG and {@link #buildColumnInfos}
+        // recognises the slot, so the iterator emits per-row file-global identities the same way
+        // it emits any other column. Pushed filters, late materialization, page skipping, and
+        // row-group skipping all stay on — each surviving row carries its identity, and the
+        // matching extractor binds those identities back to the file's full footer.
         ParquetStorageObjectAdapter parquetInputFile = new ParquetStorageObjectAdapter(object);
         ParquetFileReader reader = openParquetFileCached(object, parquetInputFile, readOptionsBuilder().build());
         return buildIterator(
@@ -496,6 +586,14 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
             context.projectedColumns(),
             context.batchSize(),
             context.rowLimit(),
+            null,
+            // For full-file reads the iterator's footer is the file's footer; the deferred
+            // extractor scopes itself to the same set of row groups. {@link #readRange} below
+            // threads the unranged footer separately so the extractor can address rows in the
+            // file's full address space even on a range-restricted scan.
+            reader.getFooter(),
+            // Full-file reads need no per-block file-global offset override — the iterator's
+            // own row-group ordering already matches the file footer.
             null,
             filter -> openParquetFileCached(object, parquetInputFile, readOptionsBuilder().withRecordFilter(filter).build())
         );
@@ -651,6 +749,11 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
         long rangeStart = context.rangeStart();
         long rangeEnd = context.rangeEnd();
 
+        // The synthetic {@link ColumnExtractor#ROW_POSITION_COLUMN} flows through the regular
+        // range path: the iterator gets file-global per-row-group offsets from the format reader
+        // (computed against the full footer) and emits identities that the matching extractor
+        // resolves against the same full footer — independent of which split owns each row group.
+
         ParquetStorageObjectAdapter parquetInputFile = ParquetStorageObjectAdapter.forRange(object, rangeEnd - rangeStart);
         ParquetReadOptions rangeOptions = readOptionsBuilder().withRange(rangeStart, rangeEnd).build();
         // Footer resolution order:
@@ -670,6 +773,15 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
         context.setFileContext(fullFooter);
         ParquetMetadata rangeMetadata = filterBlocksByRange(fullFooter, rangeStart, rangeEnd);
         ParquetFileReader reader = openParquetFile(object, parquetInputFile, rangeOptions, rangeMetadata);
+        // For range-restricted reads the iterator only sees a subset of the file's blocks, but
+        // the deferred-extraction identities must remain file-global so the extractor can later
+        // bind them to the full footer. Compute the per-range-block file-global offsets up front
+        // and hand them to the iterator (it ignores them when the projection has no
+        // {@code _rowPosition} column).
+        long[] rangeBlockGlobalOffsets = context.projectedColumns() != null
+            && context.projectedColumns().contains(ColumnExtractor.ROW_POSITION_COLUMN)
+                ? computeRangeBlockFileGlobalOffsets(fullFooter, rangeStart, rangeEnd)
+                : null;
         return buildIterator(
             object,
             parquetInputFile,
@@ -678,6 +790,11 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
             context.batchSize(),
             NO_LIMIT,
             context.resolvedAttributes(),
+            // The deferred extractor scopes itself to the file's full footer rather than the
+            // range-filtered subset, so the produced extractor can resolve any file-global
+            // identity even one that lands outside this split's row groups.
+            fullFooter,
+            rangeBlockGlobalOffsets,
             // fullFooter was resolved (and stashed into the context) above, so the re-open path
             // always reuses it rather than risk a re-parse through the no-footer overload.
             filter -> openParquetFile(
@@ -720,6 +837,16 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
      *                           {@link #readRange} threads through the planner-resolved value
      *                           to skip redundant schema conversion across the splits of one
      *                           file (see {@code AsyncExternalSourceOperatorFactory}).
+     * @param fullFooter         the unranged file footer used to scope deferred extraction.
+     *                           {@link #read} passes {@code reader.getFooter()};
+     *                           {@link #readRange} threads the cached unranged footer so the
+     *                           extractor can resolve any file-global row identity even on
+     *                           range-restricted reads.
+     * @param rangeBlockGlobalOffsets per-row-group file-global first-row offsets when the
+     *                                iterator only sees a subset of the file's row groups
+     *                                (range-restricted read with {@code _rowPosition} in the
+     *                                projection); {@code null} for full-file reads or when
+     *                                {@code _rowPosition} is not requested.
      */
     private CloseableIterator<Page> buildIterator(
         StorageObject object,
@@ -729,6 +856,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
         int batchSize,
         int rowLimit,
         List<Attribute> resolvedAttributes,
+        ParquetMetadata fullFooter,
+        long[] rangeBlockGlobalOffsets,
         FilteredReopener reopener
     ) throws IOException {
         try {
@@ -769,7 +898,9 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
                     object,
                     parquetInputFile,
                     filterPredicate,
-                    recordFilter
+                    recordFilter,
+                    rangeBlockGlobalOffsets,
+                    fullFooter
                 );
             }
             return new ParquetColumnIterator(
@@ -781,7 +912,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
                 rowLimit,
                 createdBy,
                 object.path().toString(),
-                hasRecordFilter
+                hasRecordFilter,
+                rangeBlockGlobalOffsets
             );
         } catch (Throwable t) {
             reader.close();
@@ -799,7 +931,9 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
         StorageObject storageObject,
         InputFile inputFile,
         FilterPredicate filterPredicate,
-        FilterCompat.Filter recordFilter
+        FilterCompat.Filter recordFilter,
+        long[] rowGroupFirstRowGlobalOverride,
+        ParquetMetadata fullFooter
     ) {
         if (inputFile instanceof ParquetStorageObjectAdapter == false) {
             throw new ElasticsearchException(
@@ -901,9 +1035,12 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
             storageObject,
             allRowRanges,
             survivingRowGroups,
+            rowGroupFirstRowGlobalOverride,
             codecFactory,
             effectivePushed,
-            triviallyPassesPredicate
+            triviallyPassesPredicate,
+            this,
+            fullFooter
         );
     }
 
@@ -955,6 +1092,13 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
         }
         for (int i = 0; i < attributes.size(); i++) {
             Attribute attr = attributes.get(i);
+            // Synthetic file-global row position. The iterator fills its slot from the row group
+            // index + the per-row position info already in scope on each emit path; there is no
+            // Parquet column to bind, so the descriptor stays null.
+            if (ColumnExtractor.ROW_POSITION_COLUMN.equals(attr.name())) {
+                columnInfos[i] = ColumnInfo.rowPosition();
+                continue;
+            }
             if (attr.dataType() == DataType.NULL || attr.dataType() == DataType.UNSUPPORTED) {
                 continue;
             }
@@ -986,7 +1130,14 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
         Set<String> included = new HashSet<>(projectedColumns);
         for (String columnName : projectedColumns) {
             Attribute attr = attributeMap.get(columnName);
-            attr = attr == null ? new ReferenceAttribute(Source.EMPTY, columnName, DataType.NULL) : attr;
+            if (attr == null) {
+                // The deferred-extraction synthetic column has no presence in the file's schema;
+                // the iterator materialises it. We must give it a real {@link DataType#LONG} so
+                // {@link #buildColumnInfos} routes it to {@link ColumnInfo#rowPosition()} instead
+                // of skipping it as an absent column.
+                DataType type = ColumnExtractor.ROW_POSITION_COLUMN.equals(columnName) ? DataType.LONG : DataType.NULL;
+                attr = new ReferenceAttribute(Source.EMPTY, columnName, type);
+            }
             result.add(attr);
         }
         if (pushedExpressions != null) {
@@ -1177,6 +1328,14 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
         /** Per-attribute column metadata; null for attributes not present in the file. */
         private final ColumnInfo[] columnInfos;
         private final boolean hasListColumns;
+        /**
+         * File-global first-row offsets per row group; mirrors the field of the same name on
+         * {@link OptimizedParquetColumnIterator}. {@code null} when the projection has no
+         * {@code _rowPosition} column.
+         */
+        private final long[] rowGroupFirstRowGlobal;
+        /** Index of the {@code _rowPosition} slot in {@link #columnInfos}, or {@code -1}. */
+        private final int rowPositionColumnIndex;
 
         private PageReadStore rowGroup;
         private PageColumnReader[] pageColumnReaders;
@@ -1197,7 +1356,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
             int rowLimit,
             String createdBy,
             String fileLocation,
-            boolean hasRecordFilter
+            boolean hasRecordFilter,
+            long[] rowGroupFirstRowGlobalOverride
         ) {
             this.reader = reader;
             this.projectedSchema = projectedSchema;
@@ -1211,34 +1371,53 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
 
             reader.setRequestedSchema(projectedSchema);
 
-            this.columnInfos = new ColumnInfo[attributes.size()];
-            Map<String, ColumnDescriptor> descByName = new HashMap<>();
-            for (ColumnDescriptor desc : projectedSchema.getColumns()) {
-                descByName.put(desc.getPath()[0], desc);
-            }
+            this.columnInfos = buildColumnInfos(projectedSchema, attributes);
             boolean foundListCol = false;
-            for (int i = 0; i < attributes.size(); i++) {
-                Attribute attr = attributes.get(i);
-                if (attr.dataType() == DataType.NULL || attr.dataType() == DataType.UNSUPPORTED) {
-                    continue;
-                }
-                ColumnDescriptor desc = descByName.get(attr.name());
-                if (desc != null) {
-                    LogicalTypeAnnotation logicalType = desc.getPrimitiveType().getLogicalTypeAnnotation();
-                    columnInfos[i] = new ColumnInfo(
-                        desc,
-                        desc.getPrimitiveType().getPrimitiveTypeName(),
-                        attr.dataType(),
-                        desc.getMaxDefinitionLevel(),
-                        desc.getMaxRepetitionLevel(),
-                        logicalType
-                    );
-                    if (desc.getMaxRepetitionLevel() > 0) {
+            int rowPosIdx = -1;
+            for (int i = 0; i < columnInfos.length; i++) {
+                if (columnInfos[i] != null) {
+                    if (columnInfos[i].isRowPosition()) {
+                        rowPosIdx = i;
+                    } else if (columnInfos[i].maxRepLevel() > 0) {
                         foundListCol = true;
                     }
                 }
             }
             this.hasListColumns = foundListCol;
+            this.rowPositionColumnIndex = rowPosIdx;
+            // The baseline iterator uses parquet-mr's readNextFilteredRowGroup, which does
+            // stats-based row-group skipping when a record filter is set. Skipped row groups
+            // would break our rowGroupOrdinal++ tracking and yield wrong file-global ids.
+            // Production deferred extraction always goes through OptimizedParquetColumnIterator,
+            // which drives row-group iteration itself; this guard keeps the baseline path honest
+            // for tests and explicitly-forced fallbacks.
+            if (rowPosIdx >= 0 && hasRecordFilter) {
+                throw new IllegalStateException(
+                    "Parquet baseline iterator cannot emit ["
+                        + ColumnExtractor.ROW_POSITION_COLUMN
+                        + "] when a record filter is active; route this read through the optimized iterator"
+                );
+            }
+            // For full-file reads the prefix sum can be derived from the reader's blocks. For
+            // range-restricted reads the caller passes the file-global offsets so the emitted
+            // identities match the full-file address space the extractor uses.
+            if (rowPosIdx >= 0) {
+                if (rowGroupFirstRowGlobalOverride != null) {
+                    this.rowGroupFirstRowGlobal = rowGroupFirstRowGlobalOverride;
+                } else {
+                    List<BlockMetaData> blocks = reader.getRowGroups();
+                    long[] offsets = new long[blocks.size() + 1];
+                    long sum = 0L;
+                    for (int i = 0; i < blocks.size(); i++) {
+                        offsets[i] = sum;
+                        sum += blocks.get(i).getRowCount();
+                    }
+                    offsets[blocks.size()] = sum;
+                    this.rowGroupFirstRowGlobal = offsets;
+                }
+            } else {
+                this.rowGroupFirstRowGlobal = null;
+            }
             validatePlannerTypesAgainstFile(logger, fileLocation, reader, attributes, columnInfos);
         }
 
@@ -1283,7 +1462,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
                 pageColumnReaders = new PageColumnReader[columnInfos.length];
                 for (int i = 0; i < columnInfos.length; i++) {
                     ColumnInfo ci = columnInfos[i];
-                    if (ci != null && ci.maxRepLevel() == 0) {
+                    if (ci != null && ci.isRowPosition() == false && ci.maxRepLevel() == 0) {
                         PageReader pageReader = rowGroup.getPageReader(ci.descriptor());
                         pageColumnReaders[i] = new PageColumnReader(pageReader, ci.descriptor(), ci, allRows);
                     }
@@ -1316,7 +1495,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
                 }
 
                 for (int i = 0; i < columnInfos.length; i++) {
-                    if (columnInfos[i] != null) {
+                    if (columnInfos[i] != null && columnInfos[i].isRowPosition() == false) {
                         boolean needColumnReader = hasRecordFilter
                             ? (pageColumnReaders == null || pageColumnReaders[i] == null)
                             : columnInfos[i].maxRepLevel() > 0;
@@ -1345,6 +1524,11 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
                 effectiveBatch = Math.min(effectiveBatch, rowBudget);
             }
             int rowsToRead = (int) Math.min(effectiveBatch, rowsRemainingInGroup);
+            // Pre-decrement snapshot of the in-block index of this batch's first row. Used to
+            // synthesise the {@code _rowPosition} block when present in the projection. The
+            // baseline path requires hasRecordFilter==false (enforced in the constructor), so
+            // rowGroupOrdinal is always the physical block index here.
+            int firstRowOfBatchInRG = (int) (rowGroup.getRowCount() - rowsRemainingInGroup);
 
             Block[] blocks = new Block[attributes.size()];
             try {
@@ -1352,6 +1536,13 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
                     ColumnInfo info = columnInfos[col];
                     if (info == null) {
                         blocks[col] = blockFactory.newConstantNullBlock(rowsToRead);
+                    } else if (info.isRowPosition()) {
+                        long base = rowGroupFirstRowGlobal[rowGroupOrdinal] + firstRowOfBatchInRG;
+                        long[] values = new long[rowsToRead];
+                        for (int i = 0; i < rowsToRead; i++) {
+                            values[i] = base + i;
+                        }
+                        blocks[col] = blockFactory.newLongArrayVector(values, rowsToRead).asBlock();
                     } else {
                         try {
                             if (pageColumnReaders != null && pageColumnReaders[col] != null) {

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetColumnExtractorTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetColumnExtractorTests.java
@@ -1,0 +1,912 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.apache.parquet.conf.PlainParquetConfiguration;
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.example.data.simple.SimpleGroupFactory;
+import org.apache.parquet.hadoop.ParquetFileReader;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.example.ExampleParquetWriter;
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
+import org.apache.parquet.io.OutputFile;
+import org.apache.parquet.io.PositionOutputStream;
+import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Types;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.spi.ColumnExtractor;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+import static org.hamcrest.Matchers.containsString;
+
+/**
+ * Unit tests for {@link ParquetColumnExtractor}: random-access reads of single columns by
+ * file-local row position, validation, and correct lifecycle. The fixture writes small in-memory
+ * parquet files with multiple row groups so the extractor's sort + permute logic is exercised on
+ * positions that span row groups.
+ */
+public class ParquetColumnExtractorTests extends ESTestCase {
+
+    private BlockFactory blockFactory;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        ParquetStorageObjectAdapter.clearFooterCacheForTests();
+        blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(new NoopCircuitBreaker("none")).build();
+    }
+
+    /**
+     * Test helper: builds a {@link ParquetColumnExtractor} scoped to the file's full footer by
+     * directly loading the parquet footer and using the package-private extractor constructor.
+     * The production wiring goes through {@code OptimizedParquetColumnIterator}'s
+     * {@code createColumnExtractor()} producer handshake; tests deliberately bypass that to
+     * focus on the extractor's own logic.
+     */
+    private ParquetColumnExtractor newFullFileExtractor(StorageObject so) throws IOException {
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+        ParquetMetadata footer;
+        try (
+            ParquetFileReader fr = ParquetFileReader.open(
+                new ParquetStorageObjectAdapter(so),
+                PlainParquetReadOptions.builder(new PlainCompressionCodecFactory()).build()
+            )
+        ) {
+            footer = fr.getFooter();
+        }
+        return new ParquetColumnExtractor(so, reader, footer);
+    }
+
+    public void testRowCount() throws IOException {
+        byte[] data = writeIntFile(100);
+        StorageObject so = createStorageObject(data);
+        try (ColumnExtractor extractor = newFullFileExtractor(so)) {
+            assertEquals(100, extractor.rowCount());
+        }
+    }
+
+    public void testExtractInOrder() throws IOException {
+        byte[] data = writeIntFile(20);
+        StorageObject so = createStorageObject(data);
+        try (ColumnExtractor extractor = newFullFileExtractor(so)) {
+            long[] positions = { 0, 1, 2, 5, 10, 19 };
+            Block block = extractor.extract("v", positions, blockFactory);
+            try {
+                IntBlock ints = (IntBlock) block;
+                assertEquals(positions.length, ints.getPositionCount());
+                for (int i = 0; i < positions.length; i++) {
+                    assertEquals((int) positions[i], ints.getInt(i));
+                }
+            } finally {
+                block.close();
+            }
+        }
+    }
+
+    public void testExtractOutOfOrderWithDuplicates() throws IOException {
+        byte[] data = writeIntFile(50);
+        StorageObject so = createStorageObject(data);
+        try (ColumnExtractor extractor = newFullFileExtractor(so)) {
+            // Out-of-order: 17, 3, 42, 0, 17 (repeat), 49, 25
+            long[] positions = { 17, 3, 42, 0, 17, 49, 25 };
+            Block block = extractor.extract("v", positions, blockFactory);
+            try {
+                IntBlock ints = (IntBlock) block;
+                assertEquals(positions.length, ints.getPositionCount());
+                for (int i = 0; i < positions.length; i++) {
+                    assertEquals((int) positions[i], ints.getInt(i));
+                }
+            } finally {
+                block.close();
+            }
+        }
+    }
+
+    public void testExtractAcrossRowGroups() throws IOException {
+        // Force two row groups by setting a small page-size budget on the writer. Each row group
+        // gets ~250 rows, so positions spanning [0, 249] vs [250, 499] live in different groups
+        // and force the baseline scan to advance multiple parquet pages.
+        byte[] data = writeMultiRowGroupFile(500);
+        StorageObject so = createStorageObject(data);
+        try (ColumnExtractor extractor = newFullFileExtractor(so)) {
+            assertEquals(500, extractor.rowCount());
+            long[] positions = { 250, 0, 499, 125, 375, 1, 498 };
+            Block block = extractor.extract("v", positions, blockFactory);
+            try {
+                IntBlock ints = (IntBlock) block;
+                assertEquals(positions.length, ints.getPositionCount());
+                for (int i = 0; i < positions.length; i++) {
+                    assertEquals((int) positions[i], ints.getInt(i));
+                }
+            } finally {
+                block.close();
+            }
+        }
+    }
+
+    public void testExtractMixedTypes() throws IOException {
+        byte[] data = writeMixedTypeFile(30);
+        StorageObject so = createStorageObject(data);
+        try (ColumnExtractor extractor = newFullFileExtractor(so)) {
+            long[] positions = { 0, 7, 15, 29 };
+
+            try (Block intBlock = extractor.extract("v_int", positions, blockFactory)) {
+                IntBlock ints = (IntBlock) intBlock;
+                for (int i = 0; i < positions.length; i++) {
+                    assertEquals((int) positions[i], ints.getInt(i));
+                }
+            }
+
+            try (Block longBlock = extractor.extract("v_long", positions, blockFactory)) {
+                LongBlock longs = (LongBlock) longBlock;
+                for (int i = 0; i < positions.length; i++) {
+                    assertEquals(positions[i] * 1_000L, longs.getLong(i));
+                }
+            }
+
+            try (Block strBlock = extractor.extract("v_str", positions, blockFactory)) {
+                BytesRefBlock strs = (BytesRefBlock) strBlock;
+                for (int i = 0; i < positions.length; i++) {
+                    assertEquals("row-" + positions[i], strs.getBytesRef(i, new org.apache.lucene.util.BytesRef()).utf8ToString());
+                }
+            }
+        }
+    }
+
+    public void testExtractEmptyPositionsReturnsEmptyBlock() throws IOException {
+        byte[] data = writeIntFile(10);
+        StorageObject so = createStorageObject(data);
+        try (ColumnExtractor extractor = newFullFileExtractor(so)) {
+            Block block = extractor.extract("v", new long[0], blockFactory);
+            try {
+                assertEquals(0, block.getPositionCount());
+            } finally {
+                block.close();
+            }
+        }
+    }
+
+    public void testExtractRejectsRowPositionColumn() throws IOException {
+        byte[] data = writeIntFile(5);
+        StorageObject so = createStorageObject(data);
+        try (ColumnExtractor extractor = newFullFileExtractor(so)) {
+            expectThrows(
+                IllegalArgumentException.class,
+                () -> extractor.extract(ColumnExtractor.ROW_POSITION_COLUMN, new long[] { 0 }, blockFactory)
+            );
+        }
+    }
+
+    public void testExtractRejectsOutOfRangePositions() throws IOException {
+        byte[] data = writeIntFile(5);
+        StorageObject so = createStorageObject(data);
+        try (ColumnExtractor extractor = newFullFileExtractor(so)) {
+            expectThrows(IllegalArgumentException.class, () -> extractor.extract("v", new long[] { -1 }, blockFactory));
+            expectThrows(IllegalArgumentException.class, () -> extractor.extract("v", new long[] { 5 }, blockFactory));
+        }
+    }
+
+    /**
+     * The packed-sort scheme inside {@code Bucket.sortAndDedup} packs each input slot index into
+     * the low {@code INDEX_BITS} of a long; if the input batch ever exceeds that capacity, slot
+     * collisions silently corrupt the sort. The extractor enforces the local invariant on entry
+     * to {@link ColumnExtractor#extract} so the failure mode is a clear exception rather than
+     * miscompacted output.
+     */
+    public void testExtractRejectsBatchAboveSortCapacity() throws IOException {
+        byte[] data = writeIntFile(5);
+        StorageObject so = createStorageObject(data);
+        try (ColumnExtractor extractor = newFullFileExtractor(so)) {
+            // 1 << 14 == 16_384, the per-batch capacity of the packed sort. Anything above must be
+            // rejected without ever reaching {@code sortAndDedup}.
+            long[] tooMany = new long[(1 << 14) + 1];
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> extractor.extract("v", tooMany, blockFactory));
+            assertThat(e.getMessage(), containsString("packed-sort capacity"));
+        }
+    }
+
+    /**
+     * List columns (Parquet {@code maxRepetitionLevel > 0}, ESQL multi-value blocks) take the
+     * repetition-aware sparse path. The extractor must (a) skip all rows preceding each survivor
+     * via {@link ParquetColumnDecoding#skipListValues}, (b) materialize the surviving rows via
+     * {@link ParquetColumnDecoding#readListColumn}, and (c) preserve list values, including
+     * empty and null lists, exactly as written.
+     */
+    public void testExtractListColumn() throws IOException {
+        byte[] data = writeIntListFile(60);
+        StorageObject so = createStorageObject(data);
+        try (ColumnExtractor extractor = newFullFileExtractor(so)) {
+            assertEquals(60, extractor.rowCount());
+            // Pick out-of-order, non-adjacent positions covering: a row with an empty list, a
+            // row with a multi-element list, and a row with a singleton list. The skip/read
+            // loop has to advance past several null / empty rows in between to reach the
+            // requested ones; getting any of them wrong (off-by-one in the rep-level walk)
+            // would shift the values.
+            // First sanity-check: read a single non-trivial row in isolation. Row 17 has listLen = 2.
+            try (Block block = extractor.extract("vals", new long[] { 17 }, blockFactory)) {
+                IntBlock ints = (IntBlock) block;
+                assertEquals(1, ints.getPositionCount());
+                assertEquals("row 17 valueCount", 2, ints.getValueCount(0));
+                int fv = ints.getFirstValueIndex(0);
+                assertEquals("row 17 element 0", 170, ints.getInt(fv));
+                assertEquals("row 17 element 1", 171, ints.getInt(fv + 1));
+            }
+            long[] positions = { 30, 5, 17 };
+            try (Block block = extractor.extract("vals", positions, blockFactory)) {
+                IntBlock ints = (IntBlock) block;
+                assertEquals(positions.length, ints.getPositionCount());
+                for (int i = 0; i < positions.length; i++) {
+                    int row = (int) positions[i];
+                    int listLen = row % 5;
+                    assertEquals("position count mismatch at output slot " + i, listLen, ints.getValueCount(i));
+                    int firstValue = ints.getFirstValueIndex(i);
+                    for (int k = 0; k < listLen; k++) {
+                        assertEquals("value at row " + row + " element " + k, row * 10 + k, ints.getInt(firstValue + k));
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Performance regression guard for the targeted-extraction path. The extractor must only
+     * fetch bytes from row groups that actually own a surviving position; visiting all row
+     * groups was the catastrophic forward-scan regression observed on S3 (see PR description).
+     * A tracking {@link StorageObject} records the byte ranges read on every {@code newStream}
+     * call, and we assert the read window is contained in the spans of the targeted row groups
+     * plus any small footer/metadata reads, rather than spanning the whole file.
+     */
+    public void testExtractTouchesOnlyTargetedRowGroups() throws IOException {
+        // Use a larger row count so the small-budget writer produces ≥3 row groups; with 500
+        // rows the writer typically emits 2 groups, which doesn't exercise the "third group is
+        // never touched" assertion.
+        byte[] data = writeMultiRowGroupFile(2000);
+        TrackingStorageObject so = new TrackingStorageObject(data);
+        ParquetMetadata fullFooter;
+        try (
+            ParquetFileReader fr = ParquetFileReader.open(
+                new ParquetStorageObjectAdapter(so),
+                PlainParquetReadOptions.builder(new PlainCompressionCodecFactory()).build()
+            )
+        ) {
+            fullFooter = fr.getFooter();
+        }
+        // Sanity check: the writer's small budget produces multiple row groups so there is a
+        // real opportunity to skip groups.
+        assertTrue("expected multiple row groups, got " + fullFooter.getBlocks().size(), fullFooter.getBlocks().size() >= 3);
+
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+        try (ColumnExtractor extractor = new ParquetColumnExtractor(so, reader, fullFooter)) {
+            // Pick a single survivor — the whole point of the targeted path is "1 survivor → 1
+            // row group visited". The chosen position is in the second row group; we then check
+            // no read range overlaps the first or third group's chunk space.
+            BlockMetaData firstGroup = fullFooter.getBlocks().get(0);
+            BlockMetaData secondGroup = fullFooter.getBlocks().get(1);
+            BlockMetaData thirdGroup = fullFooter.getBlocks().get(2);
+            long survivorLocal = firstGroup.getRowCount() + 1;
+            so.reads.clear();
+            try (Block block = extractor.extract("v", new long[] { survivorLocal }, blockFactory)) {
+                IntBlock ints = (IntBlock) block;
+                assertEquals(1, ints.getPositionCount());
+                assertEquals((int) survivorLocal, ints.getInt(0));
+            }
+            long firstStart = firstGroup.getStartingPos();
+            long firstEnd = firstStart + firstGroup.getCompressedSize();
+            long thirdStart = thirdGroup.getStartingPos();
+            long thirdEnd = thirdStart + thirdGroup.getCompressedSize();
+            // Allow footer / dictionary header reads (they sit outside any row group's
+            // compressed-chunk window). Any read that lands inside the first or third group's
+            // chunk window is a regression — we should never touch those groups.
+            for (long[] r : so.reads) {
+                long readStart = r[0];
+                long readEnd = readStart + r[1];
+                assertFalse(
+                    "extractor read overlapped first row group: read=["
+                        + readStart
+                        + ","
+                        + readEnd
+                        + "), group=["
+                        + firstStart
+                        + ","
+                        + firstEnd
+                        + ")",
+                    overlaps(readStart, readEnd, firstStart, firstEnd)
+                );
+                assertFalse(
+                    "extractor read overlapped third row group: read=["
+                        + readStart
+                        + ","
+                        + readEnd
+                        + "), group=["
+                        + thirdStart
+                        + ","
+                        + thirdEnd
+                        + ")",
+                    overlaps(readStart, readEnd, thirdStart, thirdEnd)
+                );
+            }
+            // Sanity: at least one read must have hit the second row group's chunk window.
+            long secondStart = secondGroup.getStartingPos();
+            long secondEnd = secondStart + secondGroup.getCompressedSize();
+            boolean touchedSecond = false;
+            for (long[] r : so.reads) {
+                if (overlaps(r[0], r[0] + r[1], secondStart, secondEnd)) {
+                    touchedSecond = true;
+                    break;
+                }
+            }
+            assertTrue("expected at least one read inside second row group window", touchedSecond);
+        }
+    }
+
+    private static boolean overlaps(long aStart, long aEnd, long bStart, long bEnd) {
+        return aStart < bEnd && bStart < aEnd;
+    }
+
+    /**
+     * F-2 invariant: a multi-column {@code extract} call must coalesce I/O across columns rather
+     * than fanning out one batch per column. With three sibling columns in the same row groups,
+     * the per-(row-group, column) chunks are physically adjacent, so a single coalesced fetch
+     * should resolve to roughly the same number of read calls as a single-column extract on the
+     * same row groups — never N× more (where N is the column count). A regression that called
+     * the single-column overload N times would show roughly N× the read calls of the
+     * single-column baseline; this test hard-bounds the multi-column read count to be no more
+     * than 2× the single-column count, which is far below the "one batch per column" failure
+     * mode while still tolerating any necessary metadata-style follow-up reads.
+     */
+    public void testExtractMultipleColumnsCoalescesIO() throws IOException {
+        byte[] data = writeMixedTypeMultiRowGroupFile(2000);
+        ParquetMetadata fullFooter;
+        try (
+            ParquetFileReader fr = ParquetFileReader.open(
+                new ParquetStorageObjectAdapter(new TrackingStorageObject(data)),
+                PlainParquetReadOptions.builder(new PlainCompressionCodecFactory()).build()
+            )
+        ) {
+            fullFooter = fr.getFooter();
+        }
+        assertTrue("expected multiple row groups, got " + fullFooter.getBlocks().size(), fullFooter.getBlocks().size() >= 3);
+
+        // Pick three survivors spread across row groups so the multi-column path has to visit
+        // more than one bucket. The actual chosen positions don't matter beyond "land in three
+        // different row groups" — the test asserts read-count behaviour, not data correctness
+        // (which is covered by the other extractor tests).
+        long[] survivors = new long[] {
+            0L,                                                        // first row group
+            fullFooter.getBlocks().get(0).getRowCount() + 1,           // second row group
+            fullFooter.getBlocks().get(0).getRowCount() + fullFooter.getBlocks().get(1).getRowCount() + 1 };
+
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+
+        // Baseline: single-column extract, count the reads.
+        TrackingStorageObject baselineSo = new TrackingStorageObject(data);
+        int singleColumnReads;
+        try (ColumnExtractor extractor = new ParquetColumnExtractor(baselineSo, reader, fullFooter)) {
+            baselineSo.reads.clear();
+            try (Block block = extractor.extract("v_int", survivors, blockFactory)) {
+                assertEquals(survivors.length, block.getPositionCount());
+            }
+            singleColumnReads = baselineSo.reads.size();
+        }
+        assertTrue("baseline single-column extract should issue at least one read", singleColumnReads > 0);
+
+        // Multi-column extract: the F-2 path. Three columns in one call.
+        TrackingStorageObject multiSo = new TrackingStorageObject(data);
+        int multiColumnReads;
+        try (ColumnExtractor extractor = new ParquetColumnExtractor(multiSo, reader, fullFooter)) {
+            multiSo.reads.clear();
+            Block[] blocks = extractor.extract(new String[] { "v_int", "v_long", "v_str" }, survivors, blockFactory);
+            try {
+                assertEquals(3, blocks.length);
+                for (Block b : blocks) {
+                    assertEquals(survivors.length, b.getPositionCount());
+                }
+            } finally {
+                org.elasticsearch.core.Releasables.closeExpectNoException(blocks);
+            }
+            multiColumnReads = multiSo.reads.size();
+        }
+
+        // F-2 invariant: multi-column read count must NOT scale with the column count. A
+        // regression that called extract per column would show ~3× the baseline. Allow up to 2×
+        // to absorb any incidental coalescing-edge differences (e.g., a separator that splits a
+        // merged range), well below the "fan out per column" failure mode.
+        assertTrue(
+            "multi-column extract issued "
+                + multiColumnReads
+                + " reads, expected <= 2 × single-column baseline ("
+                + singleColumnReads
+                + ")",
+            multiColumnReads <= 2 * singleColumnReads
+        );
+    }
+
+    /**
+     * Verifies that per-row-group prefetches are dispatched in parallel: bucket B's
+     * {@code readBytesAsync} must be issued before bucket A's read returns. This is the parallel
+     * dispatch property that lets the slowest GET no longer dominate end-to-end latency.
+     *
+     * <p>The fixture: three survivors in three different row groups, fed to an async storage
+     * object that holds the first response until both dispatches have been observed. If the
+     * extractor still serialised on one read at a time (e.g., {@code prefetch().join()} inside a
+     * loop) the test would hang on the latch and time out.
+     */
+    public void testExtractDispatchesPrefetchesInParallel() throws Exception {
+        byte[] data = writeMultiRowGroupFile(2000);
+        ParquetMetadata fullFooter;
+        try (
+            ParquetFileReader fr = ParquetFileReader.open(
+                new ParquetStorageObjectAdapter(new TrackingStorageObject(data)),
+                PlainParquetReadOptions.builder(new PlainCompressionCodecFactory()).build()
+            )
+        ) {
+            fullFooter = fr.getFooter();
+        }
+        assertTrue("expected at least 3 row groups", fullFooter.getBlocks().size() >= 3);
+
+        // Survivors landing in three distinct row groups → three buckets → three prefetches.
+        long rg0Rows = fullFooter.getBlocks().get(0).getRowCount();
+        long rg1Rows = fullFooter.getBlocks().get(1).getRowCount();
+        long[] survivors = new long[] { 0L, rg0Rows + 1, rg0Rows + rg1Rows + 1 };
+
+        // Compute the on-disk byte windows for each row group's column chunks; those are the
+        // requests we want to gate on the latch (other reads — footer probe / metadata — must
+        // pass through immediately so the extractor can boot up).
+        long[][] rgWindows = new long[3][2];
+        for (int i = 0; i < 3; i++) {
+            BlockMetaData rg = fullFooter.getBlocks().get(i);
+            rgWindows[i][0] = rg.getStartingPos();
+            rgWindows[i][1] = rg.getStartingPos() + rg.getCompressedSize();
+        }
+
+        ExecutorService ioExecutor = Executors.newFixedThreadPool(4);
+        try {
+            BlockingChunkStorageObject blocking = new BlockingChunkStorageObject(data, ioExecutor, rgWindows);
+            ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+            try (ColumnExtractor extractor = new ParquetColumnExtractor(blocking, reader, fullFooter)) {
+                blocking.armLatch();
+                Thread t = new Thread(() -> {
+                    try (Block b = extractor.extract("v", survivors, blockFactory)) {
+                        assertEquals(survivors.length, b.getPositionCount());
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                }, "extract-driver");
+                t.setDaemon(true);
+                t.start();
+
+                // Wait until at least 3 chunk-window dispatches have been observed without
+                // releasing any. If the extractor were serialising prefetches we would only ever
+                // see one in-flight at a time and this would time out.
+                assertTrue(
+                    "expected 3 in-flight chunk prefetches; observed "
+                        + blocking.observedDispatches.get()
+                        + " — extractor likely serialised the prefetch loop",
+                    blocking.dispatchedAtLeast.await(15, TimeUnit.SECONDS)
+                );
+
+                // All three are concurrently in flight: now release them and let extract finish.
+                blocking.release();
+                t.join(30_000);
+                assertFalse("extract did not complete after release", t.isAlive());
+            }
+        } finally {
+            ioExecutor.shutdownNow();
+        }
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // Fixtures
+    // -----------------------------------------------------------------------------------------
+
+    /** Single-int-column file with sequential values 0..rows-1. One row group. */
+    private byte[] writeIntFile(int rows) throws IOException {
+        MessageType schema = Types.buildMessage().required(PrimitiveType.PrimitiveTypeName.INT32).named("v").named("ints");
+        return writeFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>(rows);
+            for (int i = 0; i < rows; i++) {
+                groups.add(factory.newGroup().append("v", i));
+            }
+            return groups;
+        }, /* rowGroupBytes = */ 64 * 1024 * 1024L);
+    }
+
+    /** Same shape as {@link #writeIntFile} but with a small row-group budget so the writer
+     *  splits into multiple groups, exercising the extractor's cross-row-group scan. */
+    private byte[] writeMultiRowGroupFile(int rows) throws IOException {
+        MessageType schema = Types.buildMessage().required(PrimitiveType.PrimitiveTypeName.INT32).named("v").named("ints");
+        // 1 KiB row-group budget: each int row is 4 bytes uncompressed plus parquet overhead, so
+        // 500 rows split comfortably into multiple row groups.
+        return writeFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>(rows);
+            for (int i = 0; i < rows; i++) {
+                groups.add(factory.newGroup().append("v", i));
+            }
+            return groups;
+        }, /* rowGroupBytes = */ 1024L);
+    }
+
+    /**
+     * Single-int-list-column file with {@code rows} rows; row {@code r} has list length
+     * {@code r % 5} and values {@code r*10, r*10+1, ...}. Empty lists at every fifth row exercise
+     * the rep-level walk; {@code rows = 60} keeps the file small (single row group) but covers
+     * enough rep-level transitions to catch off-by-one bugs in the sparse skip loop.
+     */
+    private byte[] writeIntListFile(int rows) throws IOException {
+        org.apache.parquet.schema.Type intList = Types.optionalList().optionalElement(PrimitiveType.PrimitiveTypeName.INT32).named("vals");
+        MessageType schema = new MessageType("ints_list", intList);
+        return writeFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>(rows);
+            for (int i = 0; i < rows; i++) {
+                Group g = factory.newGroup();
+                int listLen = i % 5;
+                if (listLen > 0) {
+                    Group vals = g.addGroup("vals");
+                    for (int k = 0; k < listLen; k++) {
+                        vals.addGroup("list").append("element", i * 10 + k);
+                    }
+                }
+                // listLen == 0 → leave the "vals" group absent so the row materialises as an
+                // empty list. This is the rep-level transition the sparse skip path has to walk.
+                groups.add(g);
+            }
+            return groups;
+        }, /* rowGroupBytes = */ 64 * 1024 * 1024L);
+    }
+
+    /**
+     * Three-column file (int, long, string) with a small row-group budget so the writer emits
+     * multiple row groups. Used by the multi-column I/O coalescing test to verify that a
+     * multi-column extract issues O(row groups) HTTP-equivalent reads rather than
+     * O(row groups × columns).
+     */
+    private byte[] writeMixedTypeMultiRowGroupFile(int rows) throws IOException {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT32)
+            .named("v_int")
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("v_long")
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("v_str")
+            .named("mixed");
+        return writeFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>(rows);
+            for (int i = 0; i < rows; i++) {
+                Group g = factory.newGroup();
+                g.add("v_int", i);
+                g.add("v_long", (long) i * 1_000L);
+                g.add("v_str", Binary.fromString("row-" + i));
+                groups.add(g);
+            }
+            return groups;
+        }, /* rowGroupBytes = */ 1024L);
+    }
+
+    /** Three-column file: int, long, string. Used to exercise per-column extraction. */
+    private byte[] writeMixedTypeFile(int rows) throws IOException {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT32)
+            .named("v_int")
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("v_long")
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("v_str")
+            .named("mixed");
+        return writeFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>(rows);
+            for (int i = 0; i < rows; i++) {
+                Group g = factory.newGroup();
+                g.add("v_int", i);
+                g.add("v_long", (long) i * 1_000L);
+                g.add("v_str", Binary.fromString("row-" + i));
+                groups.add(g);
+            }
+            return groups;
+        }, /* rowGroupBytes = */ 64 * 1024 * 1024L);
+    }
+
+    private byte[] writeFile(MessageType schema, Function<SimpleGroupFactory, List<Group>> generator, long rowGroupBytes)
+        throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        OutputFile outputFile = inMemoryOutputFile(out);
+        SimpleGroupFactory factory = new SimpleGroupFactory(schema);
+        try (
+            ParquetWriter<Group> writer = ExampleParquetWriter.builder(outputFile)
+                .withConf(new PlainParquetConfiguration())
+                .withCodecFactory(new PlainCompressionCodecFactory())
+                .withType(schema)
+                .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
+                .withRowGroupSize(rowGroupBytes)
+                .build()
+        ) {
+            for (Group g : generator.apply(factory)) {
+                writer.write(g);
+            }
+        }
+        return out.toByteArray();
+    }
+
+    private static OutputFile inMemoryOutputFile(ByteArrayOutputStream out) {
+        return new OutputFile() {
+            @Override
+            public PositionOutputStream create(long blockSizeHint) {
+                return new PositionOutputStream() {
+                    private long position = 0;
+
+                    @Override
+                    public long getPos() {
+                        return position;
+                    }
+
+                    @Override
+                    public void write(int b) throws IOException {
+                        out.write(b);
+                        position++;
+                    }
+
+                    @Override
+                    public void write(byte[] b, int off, int len) throws IOException {
+                        out.write(b, off, len);
+                        position += len;
+                    }
+
+                    @Override
+                    public void close() throws IOException {
+                        out.close();
+                    }
+                };
+            }
+
+            @Override
+            public PositionOutputStream createOrOverwrite(long blockSizeHint) {
+                return create(blockSizeHint);
+            }
+
+            @Override
+            public boolean supportsBlockSize() {
+                return false;
+            }
+
+            @Override
+            public long defaultBlockSize() {
+                return 0;
+            }
+
+            @Override
+            public String getPath() {
+                return "memory://test.parquet";
+            }
+        };
+    }
+
+    private static StorageObject createStorageObject(byte[] data) {
+        return new StorageObject() {
+            @Override
+            public InputStream newStream() {
+                return new ByteArrayInputStream(data);
+            }
+
+            @Override
+            public InputStream newStream(long position, long length) {
+                int pos = (int) position;
+                int len = (int) Math.min(length, data.length - position);
+                return new ByteArrayInputStream(data, pos, len);
+            }
+
+            @Override
+            public long length() {
+                return data.length;
+            }
+
+            @Override
+            public Instant lastModified() {
+                return Instant.now();
+            }
+
+            @Override
+            public boolean exists() {
+                return true;
+            }
+
+            @Override
+            public StoragePath path() {
+                return StoragePath.of("memory://test.parquet");
+            }
+        };
+    }
+
+    /**
+     * In-memory {@link StorageObject} that records every {@code newStream(position, length)}
+     * call. Used by {@link #testExtractTouchesOnlyTargetedRowGroups} to verify the targeted
+     * extraction path only fetches bytes from row groups that actually own a surviving
+     * position. The {@code newStream()} (no-arg, full-file) call is also recorded so the test
+     * can detect a "scan the whole file" regression even if it sneaks in via that path.
+     */
+    private static final class TrackingStorageObject implements StorageObject {
+        private final byte[] data;
+        final List<long[]> reads = new ArrayList<>();
+
+        TrackingStorageObject(byte[] data) {
+            this.data = data;
+        }
+
+        @Override
+        public InputStream newStream() {
+            reads.add(new long[] { 0L, data.length });
+            return new ByteArrayInputStream(data);
+        }
+
+        @Override
+        public InputStream newStream(long position, long length) {
+            int pos = (int) position;
+            int len = (int) Math.min(length, data.length - position);
+            reads.add(new long[] { position, len });
+            return new ByteArrayInputStream(data, pos, len);
+        }
+
+        @Override
+        public long length() {
+            return data.length;
+        }
+
+        @Override
+        public Instant lastModified() {
+            return Instant.now();
+        }
+
+        @Override
+        public boolean exists() {
+            return true;
+        }
+
+        @Override
+        public StoragePath path() {
+            return StoragePath.of("memory://test-tracking.parquet");
+        }
+    }
+
+    /**
+     * Async {@link StorageObject} that lets the test gate the completion of in-flight reads.
+     * Reads whose byte window overlaps any of the configured "chunk windows" (the row group
+     * column-chunk byte ranges from the parquet footer) are blocked on a latch until the test
+     * calls {@link #release()}. All other reads (footer probes, dictionary metadata) pass
+     * through immediately so the extractor can boot up. Used by
+     * {@link #testExtractDispatchesPrefetchesInParallel} to assert per-row-group prefetches
+     * are dispatched concurrently.
+     */
+    private static final class BlockingChunkStorageObject implements StorageObject {
+        private final byte[] data;
+        private final Executor executor;
+        private final long[][] chunkWindows;
+        private final CountDownLatch releaseLatch = new CountDownLatch(1);
+        private final CountDownLatch dispatchedAtLeast = new CountDownLatch(3);
+        private final AtomicInteger observedDispatches = new AtomicInteger();
+
+        BlockingChunkStorageObject(byte[] data, Executor executor, long[][] chunkWindows) {
+            this.data = data;
+            this.executor = executor;
+            this.chunkWindows = chunkWindows;
+        }
+
+        void armLatch() {
+            // No-op: latch is set up at construction time. The method exists to make test intent
+            // explicit at the call site.
+        }
+
+        void release() {
+            releaseLatch.countDown();
+        }
+
+        private boolean overlapsAnyChunk(long position, long length) {
+            long start = position;
+            long end = position + length;
+            for (long[] w : chunkWindows) {
+                if (start < w[1] && w[0] < end) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public InputStream newStream() {
+            return new ByteArrayInputStream(data);
+        }
+
+        @Override
+        public InputStream newStream(long position, long length) {
+            int pos = (int) position;
+            int len = (int) Math.min(length, data.length - position);
+            return new ByteArrayInputStream(data, pos, len);
+        }
+
+        @Override
+        public long length() {
+            return data.length;
+        }
+
+        @Override
+        public Instant lastModified() {
+            return Instant.now();
+        }
+
+        @Override
+        public boolean exists() {
+            return true;
+        }
+
+        @Override
+        public StoragePath path() {
+            return StoragePath.of("memory://test-blocking.parquet");
+        }
+
+        @Override
+        public boolean supportsNativeAsync() {
+            return true;
+        }
+
+        @Override
+        public void readBytesAsync(long position, long length, Executor unused, ActionListener<ByteBuffer> listener) {
+            boolean blocking = overlapsAnyChunk(position, length);
+            if (blocking) {
+                observedDispatches.incrementAndGet();
+                dispatchedAtLeast.countDown();
+            }
+            executor.execute(() -> {
+                try {
+                    if (blocking) {
+                        if (releaseLatch.await(20, TimeUnit.SECONDS) == false) {
+                            listener.onFailure(new IOException("blocking read was not released within timeout"));
+                            return;
+                        }
+                    }
+                    int pos = (int) position;
+                    int len = (int) Math.min(length, data.length - position);
+                    byte[] copy = new byte[len];
+                    System.arraycopy(data, pos, copy, 0, len);
+                    listener.onResponse(ByteBuffer.wrap(copy));
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    listener.onFailure(new IOException("interrupted while waiting for release", e));
+                }
+            });
+        }
+    }
+}

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetRowPositionTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetRowPositionTests.java
@@ -1,0 +1,554 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.example.data.simple.SimpleGroupFactory;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.example.ExampleParquetWriter;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.io.OutputFile;
+import org.apache.parquet.io.PositionOutputStream;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Types;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.CloseableIterator;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.type.EsField;
+import org.elasticsearch.xpack.esql.datasources.spi.ColumnExtractor;
+import org.elasticsearch.xpack.esql.datasources.spi.ColumnExtractorProducer;
+import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
+import org.elasticsearch.xpack.esql.datasources.spi.RangeReadContext;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Tests for the {@code _rowPosition} synthetic column emitted by
+ * {@link ParquetFormatReader#read} when the projection requests it. The reader must:
+ * <ul>
+ *     <li>emit values that are file-global and start at zero,</li>
+ *     <li>be monotonically increasing within and across emitted pages,</li>
+ *     <li>align row-for-row with the data columns in the same projection,</li>
+ *     <li>place the {@code _rowPosition} block at the requested projection slot regardless of
+ *         where it sits in the projection list.</li>
+ * </ul>
+ */
+public class ParquetRowPositionTests extends ESTestCase {
+
+    private BlockFactory blockFactory;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        ParquetStorageObjectAdapter.clearFooterCacheForTests();
+        blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(new NoopCircuitBreaker("none")).build();
+    }
+
+    public void testRowPositionEmittedAtRequestedSlot() throws IOException {
+        byte[] data = writeIntFile(10);
+        StorageObject storage = createStorageObject(data);
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+
+        // Slot 0: _rowPosition. Slot 1: data column.
+        List<String> projection = List.of(ColumnExtractor.ROW_POSITION_COLUMN, "v");
+        try (CloseableIterator<Page> iter = reader.read(storage, FormatReadContext.of(projection, 1024))) {
+            ((ColumnExtractorProducer) iter).setExtractorId(0);
+            assertTrue(iter.hasNext());
+            Page page = iter.next();
+            try {
+                assertEquals(2, page.getBlockCount());
+                assertEquals(10, page.getPositionCount());
+                LongBlock rp = (LongBlock) page.getBlock(0);
+                IntBlock vs = (IntBlock) page.getBlock(1);
+                for (int i = 0; i < 10; i++) {
+                    assertEquals("rowPosition[" + i + "]", i, rp.getLong(i));
+                    assertEquals("data[" + i + "]", i, vs.getInt(i));
+                }
+            } finally {
+                page.releaseBlocks();
+            }
+            assertFalse(iter.hasNext());
+        }
+    }
+
+    public void testRowPositionEmittedAtTrailingSlot() throws IOException {
+        // Same as above but with _rowPosition at slot 1, after the data column. Verifies the
+        // injection logic respects the projection's declared position rather than always
+        // appending the synthetic block at the end.
+        byte[] data = writeIntFile(5);
+        StorageObject storage = createStorageObject(data);
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+
+        List<String> projection = List.of("v", ColumnExtractor.ROW_POSITION_COLUMN);
+        try (CloseableIterator<Page> iter = reader.read(storage, FormatReadContext.of(projection, 1024))) {
+            // Complete the producer handshake: the iterator now pre-encodes _rowPosition with
+            // the registry-assigned id (the factory's job in production). Use id 0 so the
+            // encoded high bits are zero and the emitted longs equal the raw row indices we
+            // assert against below.
+            ((ColumnExtractorProducer) iter).setExtractorId(0);
+            Page page = iter.next();
+            try {
+                IntBlock vs = (IntBlock) page.getBlock(0);
+                LongBlock rp = (LongBlock) page.getBlock(1);
+                for (int i = 0; i < 5; i++) {
+                    assertEquals(i, vs.getInt(i));
+                    assertEquals(i, rp.getLong(i));
+                }
+            } finally {
+                page.releaseBlocks();
+            }
+        }
+    }
+
+    public void testRowPositionMonotonicAcrossPages() throws IOException {
+        // 5 row groups × 100 rows each, batch size 73 → multiple emissions per row group, with
+        // page boundaries that don't align to row-group boundaries. _rowPosition must remain
+        // strictly monotonic and dense across the whole sequence.
+        byte[] data = writeMultiRowGroupFile(500);
+        StorageObject storage = createStorageObject(data);
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+
+        List<String> projection = List.of("v", ColumnExtractor.ROW_POSITION_COLUMN);
+        long expectedNext = 0;
+        long totalRows = 0;
+        try (CloseableIterator<Page> iter = reader.read(storage, FormatReadContext.of(projection, 73))) {
+            ((ColumnExtractorProducer) iter).setExtractorId(0);
+            while (iter.hasNext()) {
+                Page page = iter.next();
+                try {
+                    int positions = page.getPositionCount();
+                    LongBlock rp = (LongBlock) page.getBlock(1);
+                    IntBlock vs = (IntBlock) page.getBlock(0);
+                    for (int i = 0; i < positions; i++) {
+                        long pos = rp.getLong(i);
+                        assertEquals("monotonic & dense across page boundaries", expectedNext, pos);
+                        // Data column must align row-for-row with the rowPosition block; the
+                        // file was written with v[i] = i.
+                        assertEquals(Math.toIntExact(pos), vs.getInt(i));
+                        expectedNext++;
+                    }
+                    totalRows += positions;
+                } finally {
+                    page.releaseBlocks();
+                }
+            }
+        }
+        assertEquals("total rows must match the file", 500L, totalRows);
+        assertEquals(500L, expectedNext);
+    }
+
+    /**
+     * Range-split path: when {@code readRange} is asked for {@code _rowPosition}, it must emit
+     * <em>file-global</em> positions, not split-local. The whole point of file-global addressing
+     * is that any iterator over a file (full read or any split of any byte range) and the
+     * matching extractor agree on what each row is, without coordination. The split this test
+     * picks intentionally lands deep in the file so a counter-based "starts at zero per split"
+     * implementation would be visibly wrong.
+     */
+    public void testReadRangeRowPositionIsFileGlobal() throws IOException {
+        byte[] data = writeMultiRowGroupFile(500);
+        StorageObject storage = createStorageObject(data);
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+
+        // Pick the second half of the file: any row from this split must carry a _rowPosition
+        // strictly greater than the first row of the file (which is row 0, value 0). The
+        // contiguous-emit invariant is verified per-row: pos == v (the file wrote v[i] = i).
+        long fileLength = data.length;
+        long rangeStart = fileLength / 2;
+        long rangeEnd = fileLength;
+
+        List<String> projection = List.of("v", ColumnExtractor.ROW_POSITION_COLUMN);
+        RangeReadContext ctx = new RangeReadContext(projection, /* batchSize */ 1024, rangeStart, rangeEnd, null, ErrorPolicy.STRICT);
+        long totalRows = 0L;
+        long firstSeenPosition = -1L;
+        try (CloseableIterator<Page> iter = reader.readRange(storage, ctx)) {
+            assertTrue("range iterator must implement ColumnExtractorProducer", iter instanceof ColumnExtractorProducer);
+            ((ColumnExtractorProducer) iter).setExtractorId(0);
+            while (iter.hasNext()) {
+                Page page = iter.next();
+                try {
+                    int positions = page.getPositionCount();
+                    IntBlock vs = (IntBlock) page.getBlock(0);
+                    LongBlock rp = (LongBlock) page.getBlock(1);
+                    for (int i = 0; i < positions; i++) {
+                        long pos = rp.getLong(i);
+                        // file-global identity equals the data value (v[i] = i)
+                        assertEquals("file-global identity matches data value", vs.getInt(i), pos);
+                        if (firstSeenPosition < 0) {
+                            firstSeenPosition = pos;
+                        }
+                    }
+                    totalRows += positions;
+                } finally {
+                    page.releaseBlocks();
+                }
+            }
+        }
+        assertTrue("expected the range to cover at least one row group", totalRows > 0);
+        assertTrue("split-local would start at 0; file-global must start past the first row", firstSeenPosition > 0);
+    }
+
+    /**
+     * Companion to {@link #testReadRangeRowPositionIsFileGlobal}: the
+     * {@link ColumnExtractorProducer} returned by a range iterator hands back an extractor
+     * whose {@link ColumnExtractor#rowCount()} is the <em>file's</em> total row count (not the
+     * split's), because the identities the iterator emitted index into the file's address space.
+     * Looking up via {@code extract} returns the same value the forward scan saw.
+     */
+    public void testReadRangeProducerYieldsFileScopedExtractor() throws IOException {
+        byte[] data = writeMultiRowGroupFile(500);
+        StorageObject storage = createStorageObject(data);
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+
+        long fileLength = data.length;
+        long rangeStart = fileLength / 2;
+        long rangeEnd = fileLength;
+
+        List<String> projection = List.of("v", ColumnExtractor.ROW_POSITION_COLUMN);
+        RangeReadContext ctx = new RangeReadContext(projection, /* batchSize */ 1024, rangeStart, rangeEnd, null, ErrorPolicy.STRICT);
+        long firstSeenPosition = -1L;
+        long lastSeenPosition = -1L;
+        ColumnExtractor extractor;
+        try (CloseableIterator<Page> iter = reader.readRange(storage, ctx)) {
+            ((ColumnExtractorProducer) iter).setExtractorId(0);
+            while (iter.hasNext()) {
+                Page page = iter.next();
+                try {
+                    int positions = page.getPositionCount();
+                    LongBlock rp = (LongBlock) page.getBlock(1);
+                    if (firstSeenPosition < 0) {
+                        firstSeenPosition = rp.getLong(0);
+                    }
+                    lastSeenPosition = rp.getLong(positions - 1);
+                } finally {
+                    page.releaseBlocks();
+                }
+            }
+            extractor = ((ColumnExtractorProducer) iter).createColumnExtractor();
+        }
+        try {
+            // Extractor sees the full file regardless of which split the iterator was for.
+            assertEquals(500L, extractor.rowCount());
+            // Hand back the very identities the forward scan emitted: the extractor must return
+            // the same value the iterator did (v[i] = i for this fixture).
+            try (Block block = extractor.extract("v", new long[] { firstSeenPosition, lastSeenPosition }, blockFactory)) {
+                IntBlock ints = (IntBlock) block;
+                assertEquals((int) firstSeenPosition, ints.getInt(0));
+                assertEquals((int) lastSeenPosition, ints.getInt(1));
+            }
+        } finally {
+            extractor.close();
+        }
+    }
+
+    /**
+     * Regression test for the original v1 production bug: {@code AsyncExternalSourceOperatorFactory}
+     * passes its full unified query attributes — which under deferred extraction <em>include</em>
+     * a synthetic {@link ColumnExtractor#ROW_POSITION_COLUMN} attribute — as
+     * {@link RangeReadContext#resolvedAttributes()}. A short-lived collision guard in {@code
+     * readRange} treated that as proof of a real user column named {@code _rowPosition} and fell
+     * through to a path that did not implement {@link ColumnExtractorProducer}. The current
+     * design has no special guard at all (the optimizer rule's planning-time bail-out catches
+     * actual user collisions), so this test is a bare correctness check that the iterator still
+     * implements {@link ColumnExtractorProducer} when {@code _rowPosition} is in the projection,
+     * regardless of the {@code resolvedAttributes} shape.
+     */
+    public void testReadRangeRowPositionRoutesEvenWhenResolvedAttributesIncludeIt() throws IOException {
+        byte[] data = writeMultiRowGroupFile(500);
+        StorageObject storage = createStorageObject(data);
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+
+        long fileLength = data.length;
+        long rangeStart = fileLength / 2;
+        long rangeEnd = fileLength;
+
+        List<String> projection = List.of("v", ColumnExtractor.ROW_POSITION_COLUMN);
+        List<Attribute> resolvedAttributes = List.of(
+            field("v", DataType.INTEGER),
+            field(ColumnExtractor.ROW_POSITION_COLUMN, DataType.LONG)
+        );
+        RangeReadContext ctx = new RangeReadContext(
+            projection,
+            /* batchSize */ 1024,
+            rangeStart,
+            rangeEnd,
+            resolvedAttributes,
+            ErrorPolicy.STRICT
+        );
+
+        try (CloseableIterator<Page> iter = reader.readRange(storage, ctx)) {
+            assertTrue(
+                "range iterator must implement ColumnExtractorProducer when _rowPosition is in the projection",
+                iter instanceof ColumnExtractorProducer
+            );
+            ((ColumnExtractorProducer) iter).setExtractorId(0);
+            assertTrue(iter.hasNext());
+            Page page = iter.next();
+            try {
+                LongBlock rp = (LongBlock) page.getBlock(1);
+                IntBlock vs = (IntBlock) page.getBlock(0);
+                // The file wrote v[i] = i; in file-global addressing each emitted row's
+                // _rowPosition matches its data value byte-for-byte.
+                for (int i = 0; i < page.getPositionCount(); i++) {
+                    assertEquals(vs.getInt(i), rp.getLong(i));
+                }
+            } finally {
+                page.releaseBlocks();
+            }
+        }
+    }
+
+    private static FieldAttribute field(String name, DataType type) {
+        return new FieldAttribute(Source.EMPTY, name, new EsField(name, type, Map.of(), false, EsField.TimeSeriesFieldType.NONE));
+    }
+
+    public void testSetExtractorIdEncodesEmittedRowPositions() throws IOException {
+        // F-9A invariant: setExtractorId installs the high bits the iterator OR-s into every
+        // emitted _rowPosition value. With a non-zero id the encoded value is no longer the bare
+        // physical row offset; decoding it must round-trip back to (id, offset).
+        byte[] data = writeIntFile(8);
+        StorageObject storage = createStorageObject(data);
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+        int extractorId = 7;
+
+        try (
+            CloseableIterator<Page> iter = reader.read(
+                storage,
+                FormatReadContext.of(List.of("v", ColumnExtractor.ROW_POSITION_COLUMN), 1024)
+            )
+        ) {
+            ((ColumnExtractorProducer) iter).setExtractorId(extractorId);
+            Page page = iter.next();
+            try {
+                LongBlock rp = (LongBlock) page.getBlock(1);
+                long expectedHighBits = ((long) extractorId) << ColumnExtractor.LOCAL_POSITION_BITS;
+                long localMask = (1L << ColumnExtractor.LOCAL_POSITION_BITS) - 1L;
+                for (int i = 0; i < page.getPositionCount(); i++) {
+                    long encoded = rp.getLong(i);
+                    assertEquals("high bits must carry the installed extractor id", expectedHighBits, encoded & ~localMask);
+                    assertEquals("low bits must carry the file-global row offset", (long) i, encoded & localMask);
+                }
+            } finally {
+                page.releaseBlocks();
+            }
+        }
+    }
+
+    public void testSetExtractorIdRejectsDoubleInstall() throws IOException {
+        byte[] data = writeIntFile(2);
+        StorageObject storage = createStorageObject(data);
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+        try (
+            CloseableIterator<Page> iter = reader.read(
+                storage,
+                FormatReadContext.of(List.of("v", ColumnExtractor.ROW_POSITION_COLUMN), 1024)
+            )
+        ) {
+            ColumnExtractorProducer producer = (ColumnExtractorProducer) iter;
+            producer.setExtractorId(1);
+            // Second install is a programmer error: the framework should call setExtractorId
+            // exactly once between createColumnExtractor and the first next() call.
+            expectThrows(IllegalStateException.class, () -> producer.setExtractorId(2));
+        }
+    }
+
+    public void testRowPositionPreservesPushedFilterByEmittingFileGlobalIds() throws IOException {
+        // Rationale: under file-global addressing the iterator emits each surviving row's
+        // physical identity, so pushed filters, late materialization, and page skipping are all
+        // free to drop rows from the forward scan — every row that comes out still carries its
+        // file-global identity, and the extractor binds that identity back to the file's full
+        // footer. We verify this by reading a small unfiltered file: each emitted row has
+        // _rowPosition equal to v, demonstrating the row identity is anchored to file content.
+        byte[] data = writeIntFile(20);
+        StorageObject storage = createStorageObject(data);
+
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+        try (
+            CloseableIterator<Page> iter = reader.read(
+                storage,
+                FormatReadContext.of(List.of("v", ColumnExtractor.ROW_POSITION_COLUMN), 1024)
+            )
+        ) {
+            ((ColumnExtractorProducer) iter).setExtractorId(0);
+            Page page = iter.next();
+            try {
+                IntBlock vs = (IntBlock) page.getBlock(0);
+                LongBlock rp = (LongBlock) page.getBlock(1);
+                assertEquals(20, page.getPositionCount());
+                for (int i = 0; i < 20; i++) {
+                    // file-global identity == data value (file wrote v[i] = i); regardless of
+                    // any forward-scan transformations, the identity is intrinsic to the row.
+                    assertEquals(vs.getInt(i), rp.getLong(i));
+                }
+            } finally {
+                page.releaseBlocks();
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // fixtures
+    // ---------------------------------------------------------------------------------------------
+
+    private byte[] writeIntFile(int rows) throws IOException {
+        MessageType schema = Types.buildMessage().required(PrimitiveType.PrimitiveTypeName.INT32).named("v").named("ints");
+        return writeFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>(rows);
+            for (int i = 0; i < rows; i++) {
+                groups.add(factory.newGroup().append("v", i));
+            }
+            return groups;
+        }, /* rowGroupBytes = */ 64L * 1024 * 1024);
+    }
+
+    private byte[] writeMultiRowGroupFile(int rows) throws IOException {
+        MessageType schema = Types.buildMessage().required(PrimitiveType.PrimitiveTypeName.INT32).named("v").named("ints");
+        // Small row-group budget so the writer splits the rows into multiple groups; that
+        // exercises the cross-row-group position arithmetic the reader uses to emit
+        // _rowPosition values for emitted batches.
+        return writeFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>(rows);
+            for (int i = 0; i < rows; i++) {
+                groups.add(factory.newGroup().append("v", i));
+            }
+            return groups;
+        }, /* rowGroupBytes = */ 1024L);
+    }
+
+    private byte[] writeFile(MessageType schema, Function<SimpleGroupFactory, List<Group>> generator, long rowGroupBytes)
+        throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        OutputFile outputFile = inMemoryOutputFile(out);
+        SimpleGroupFactory factory = new SimpleGroupFactory(schema);
+        try (
+            ParquetWriter<Group> writer = ExampleParquetWriter.builder(outputFile)
+                .withConf(new org.apache.parquet.conf.PlainParquetConfiguration())
+                .withCodecFactory(new PlainCompressionCodecFactory())
+                .withType(schema)
+                .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
+                .withRowGroupSize(rowGroupBytes)
+                .build()
+        ) {
+            for (Group g : generator.apply(factory)) {
+                writer.write(g);
+            }
+        }
+        return out.toByteArray();
+    }
+
+    private static OutputFile inMemoryOutputFile(ByteArrayOutputStream out) {
+        return new OutputFile() {
+            @Override
+            public PositionOutputStream create(long blockSizeHint) {
+                return new PositionOutputStream() {
+                    private long position = 0;
+
+                    @Override
+                    public long getPos() {
+                        return position;
+                    }
+
+                    @Override
+                    public void write(int b) throws IOException {
+                        out.write(b);
+                        position++;
+                    }
+
+                    @Override
+                    public void write(byte[] b, int off, int len) throws IOException {
+                        out.write(b, off, len);
+                        position += len;
+                    }
+
+                    @Override
+                    public void close() throws IOException {
+                        out.close();
+                    }
+                };
+            }
+
+            @Override
+            public PositionOutputStream createOrOverwrite(long blockSizeHint) {
+                return create(blockSizeHint);
+            }
+
+            @Override
+            public boolean supportsBlockSize() {
+                return false;
+            }
+
+            @Override
+            public long defaultBlockSize() {
+                return 0;
+            }
+
+            @Override
+            public String getPath() {
+                return "memory://test.parquet";
+            }
+        };
+    }
+
+    private static StorageObject createStorageObject(byte[] data) {
+        return new StorageObject() {
+            @Override
+            public InputStream newStream() {
+                return new ByteArrayInputStream(data);
+            }
+
+            @Override
+            public InputStream newStream(long position, long length) {
+                int pos = (int) position;
+                int len = (int) Math.min(length, data.length - position);
+                return new ByteArrayInputStream(data, pos, len);
+            }
+
+            @Override
+            public long length() {
+                return data.length;
+            }
+
+            @Override
+            public Instant lastModified() {
+                return Instant.now();
+            }
+
+            @Override
+            public boolean exists() {
+                return true;
+            }
+
+            @Override
+            public StoragePath path() {
+                return StoragePath.of("memory://test.parquet");
+            }
+        };
+    }
+}

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalParquetTopNExtractionIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalParquetTopNExtractionIT.java
@@ -1,0 +1,492 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.action;
+
+import org.apache.lucene.util.BytesRef;
+import org.apache.parquet.conf.PlainParquetConfiguration;
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.example.data.simple.SimpleGroupFactory;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.example.ExampleParquetWriter;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.io.OutputFile;
+import org.apache.parquet.io.PositionOutputStream;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.MessageTypeParser;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.plugins.ExtensiblePlugin;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.xpack.core.esql.action.ColumnInfo;
+import org.elasticsearch.xpack.esql.datasource.http.HttpDataSourcePlugin;
+import org.elasticsearch.xpack.esql.datasource.parquet.ParquetDataSourcePlugin;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.getValuesList;
+import static org.elasticsearch.xpack.esql.action.EsqlCapabilities.Cap.EXTERNAL_COMMAND;
+import static org.elasticsearch.xpack.esql.action.EsqlQueryRequest.syncEsqlQueryRequest;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+
+/**
+ * End-to-end integration tests for the {@code SORT … | LIMIT N} deferred-extraction optimization
+ * over external Parquet sources. These tests are the safety net for the entire deferred-extraction
+ * pipeline: planning ({@code InsertExternalFieldExtraction}), runtime wiring
+ * ({@code AsyncExternalSourceOperatorFactory}, {@code SchemaAdaptingIterator}), the
+ * {@code _rowPosition}-emitting reader paths in
+ * {@code ParquetFormatReader} ({@code read} and {@code readRange}), the runtime extractor handshake
+ * ({@code ColumnExtractorProducer} → {@code ColumnExtractor}), and the on-line materialization
+ * operator ({@code ExternalFieldExtractOperator}).
+ * <p>
+ * Each test writes a Parquet file, runs a {@code SORT id ASC | LIMIT N} query that projects four
+ * columns (the two extra "wide" columns push the projection past
+ * {@code InsertExternalFieldExtraction.DEFERRED_COLUMN_MIN}, making the rule eligible to fire),
+ * then asserts the returned rows match the values we wrote — id, name, value, and payload — for
+ * the lowest-id rows. Because the rule rewrites the source projection to read only {@code id}
+ * up front and re-fetches name/value/payload in a second pass against the survivors, any bug
+ * along that pipeline manifests as either a runtime exception or wrong cell values, both caught
+ * here. The previous regressions
+ * (<i>{@code _rowPosition channel must be a dense LongVector}</i>,
+ * <i>{@code reader iterator does not implement ColumnExtractorProducer}</i>, and
+ * <i>{@code Local breaker must be accessed by a single thread at a time}</i>)
+ * all reproduce as exceptions or as cell-value mismatches on this path.
+ * <p>
+ * Coverage matrix:
+ * <ul>
+ *     <li>Single row group → exercises the {@code read()} path with a single full-file extractor.</li>
+ *     <li>Multiple row groups → triggers byte-range splits, exercises {@code readRange()} and the
+ *         per-split scoped extractors. This is the path that produced both production
+ *         regressions.</li>
+ *     <li>Multiple files (wildcard URI) → multiple extractors registered concurrently per driver,
+ *         each with independent ids; verifies the registry's id encoding survives mixing.</li>
+ *     <li>Pushed filter ({@code WHERE}) → exercises the rule's pushed-expressions branch and the
+ *         narrowed projection's interaction with predicate columns.</li>
+ *     <li>Tiny limits ({@code LIMIT 1}) → boundary case for the extractor permutation step.</li>
+ *     <li>Descending sort → ensures the lowest-rows assumption isn't baked into the runtime.</li>
+ *     <li>Sort by a non-numeric column → string-encoded sort key still resolves the right
+ *         {@code _rowPosition} per surviving row.</li>
+ *     <li>Stress (many row groups + many pages per group) → exercises the producer-thread
+ *         allocation paths under buffer-fill cycles where worker threads rotate, the original
+ *         trigger for the local-breaker concurrency assertion.</li>
+ * </ul>
+ * <p>
+ * The tests rely on cell-value correctness rather than directly asserting the rule fired in the
+ * data-node plan profile: {@link EsqlQueryResponse#profile()} only carries the coordinator's plan
+ * and drivers in this in-process test setup, and external-compute data-node profiles are not
+ * routed back through the response payload. A regression that silently disables the rule would
+ * still produce correct results, just slower; we accept this gap and rely on lower-level rule
+ * tests for the rule-fired property.
+ * <p>
+ * Pinned to a single data node because EXTERNAL queries against {@code file://} URIs are read
+ * from each data node's local filesystem; with multi-node clusters every node would re-read the
+ * same file and the coordinator would get duplicate rows. Real deployments use shared storage
+ * (S3/HTTP/etc.) where the coordinator's split-aware planner shards the work, but {@code file://}
+ * in-process tests bypass that path.
+ */
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.SUITE, numDataNodes = 1)
+public class ExternalParquetTopNExtractionIT extends AbstractEsqlIntegTestCase {
+
+    private static final TimeValue LONG_TIMEOUT = TimeValue.timeValueMinutes(2);
+
+    /**
+     * Re-enables extension loading that {@link EsqlPluginWithEnterpriseOrTrialLicense} suppresses,
+     * so the Parquet datasource plugin is discovered by this test.
+     */
+    public static final class EsqlEnterpriseWithDatasourceExtensions extends EsqlPluginWithEnterpriseOrTrialLicense {
+        @Override
+        public void loadExtensions(ExtensiblePlugin.ExtensionLoader loader) {
+            super.loadExtensions(loader);
+        }
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        List<Class<? extends Plugin>> plugins = new ArrayList<>(super.nodePlugins());
+        plugins.remove(EsqlPluginWithEnterpriseOrTrialLicense.class);
+        plugins.add(EsqlEnterpriseWithDatasourceExtensions.class);
+        plugins.add(HttpDataSourcePlugin.class);
+        plugins.add(ParquetDataSourcePlugin.class);
+        return plugins;
+    }
+
+    @Override
+    protected QueryPragmas getPragmas() {
+        return QueryPragmas.EMPTY;
+    }
+
+    /**
+     * Single-row-group file. Smallest possible scenario: only the {@code read()} path runs and a
+     * single full-file extractor is registered for the driver.
+     */
+    public void testSortLimitSingleRowGroup() throws Exception {
+        assumeTrue("requires EXTERNAL command capability", EXTERNAL_COMMAND.isEnabled());
+
+        int totalRows = 200;
+        Path file = writeParquetFile(totalRows, /* rowGroupSize */ totalRows + 1, /* startId */ 0);
+        try {
+            assertWideTopNReturnsLowestRows(StoragePath.fileUri(file), /* limit */ 10, /* startId */ 0);
+        } finally {
+            Files.deleteIfExists(file);
+        }
+    }
+
+    /**
+     * Multi-row-group file. The byte-range splitter discovers one range per row group (small files
+     * fall below the macro-split coalesce target), so each split goes through {@code readRange()}.
+     * This is the exact path that produced both production regressions.
+     */
+    public void testSortLimitMultipleRowGroups() throws Exception {
+        assumeTrue("requires EXTERNAL command capability", EXTERNAL_COMMAND.isEnabled());
+
+        int totalRows = 400;
+        Path file = writeParquetFile(totalRows, /* rowGroupSize */ 50, /* startId */ 0);
+        try {
+            assertWideTopNReturnsLowestRows(StoragePath.fileUri(file), /* limit */ 25, /* startId */ 0);
+        } finally {
+            Files.deleteIfExists(file);
+        }
+    }
+
+    /**
+     * Multi-row-group file with a {@code WHERE} clause. The pushed predicate forces the optimizer
+     * to keep the predicate's column eager and to defer only the unreferenced columns.
+     */
+    public void testSortLimitWithPushedFilter() throws Exception {
+        assumeTrue("requires EXTERNAL command capability", EXTERNAL_COMMAND.isEnabled());
+
+        int totalRows = 400;
+        Path file = writeParquetFile(totalRows, /* rowGroupSize */ 50, /* startId */ 0);
+        try {
+            String uri = StoragePath.fileUri(file);
+            String query = "EXTERNAL \"" + uri + "\" | WHERE id >= 200 | SORT id ASC | LIMIT 25 | KEEP id, name, value, payload";
+            assertRowsMatchExpectedRange(query, /* startId */ 200, /* count */ 25);
+        } finally {
+            Files.deleteIfExists(file);
+        }
+    }
+
+    /**
+     * Two files queried via wildcard URI. Each file produces its own per-split extractors
+     * registered against the same driver's {@code SourceExtractors}; the row-position id encoding
+     * (extractor id in the high bits, local position in the low bits) must keep them straight.
+     */
+    public void testSortLimitMultipleFiles() throws Exception {
+        assumeTrue("requires EXTERNAL command capability", EXTERNAL_COMMAND.isEnabled());
+
+        Path dir = createTempDir();
+        Path file1 = writeParquetFileAt(dir.resolve("part-00.parquet"), /* startId */ 0, /* rows */ 200, /* rowGroupSize */ 60);
+        Path file2 = writeParquetFileAt(dir.resolve("part-01.parquet"), /* startId */ 200, /* rows */ 200, /* rowGroupSize */ 60);
+        try {
+            String uri = StoragePath.fileUri(dir) + "/part-*.parquet";
+            assertWideTopNReturnsLowestRows(uri, /* limit */ 30, /* startId */ 0);
+        } finally {
+            Files.deleteIfExists(file1);
+            Files.deleteIfExists(file2);
+        }
+    }
+
+    /**
+     * {@code LIMIT 1}. Boundary case for the extractor's permutation step: the sort produces a
+     * single surviving row, and the extractor must still resolve the correct {@code _rowPosition}
+     * back to the right deferred values. A regression where the extractor mis-handles the
+     * 1-element case (off-by-one, empty builder, NPE on the permutation array) is caught here.
+     */
+    public void testSortLimitOne() throws Exception {
+        assumeTrue("requires EXTERNAL command capability", EXTERNAL_COMMAND.isEnabled());
+
+        int totalRows = 400;
+        Path file = writeParquetFile(totalRows, /* rowGroupSize */ 50, /* startId */ 0);
+        try {
+            assertWideTopNReturnsLowestRows(StoragePath.fileUri(file), /* limit */ 1, /* startId */ 0);
+        } finally {
+            Files.deleteIfExists(file);
+        }
+    }
+
+    /**
+     * {@code SORT id DESC | LIMIT N}. The deferred-extraction rule is direction-agnostic — it
+     * only inspects the sort key and limit — but the runtime must still hand the extractor the
+     * highest-id surviving rows. Regressions where the extractor caches or replays an
+     * implicit "row 0" mapping show up as an extracted name that doesn't match the sort key.
+     */
+    public void testSortDescending() throws Exception {
+        assumeTrue("requires EXTERNAL command capability", EXTERNAL_COMMAND.isEnabled());
+
+        int totalRows = 200;
+        Path file = writeParquetFile(totalRows, /* rowGroupSize */ 50, /* startId */ 0);
+        try {
+            String uri = StoragePath.fileUri(file);
+            String query = "EXTERNAL \"" + uri + "\" | SORT id DESC | LIMIT 10 | KEEP id, name, value, payload";
+            // Lowest-rows helper assumes ASC; build the descending expectation by hand.
+            try (var response = run(syncEsqlQueryRequest(query), LONG_TIMEOUT)) {
+                List<List<Object>> rows = getValuesList(response);
+                assertThat("returned row count", rows.size(), equalTo(10));
+                for (int i = 0; i < 10; i++) {
+                    long id = totalRows - 1 - i;
+                    List<Object> row = rows.get(i);
+                    assertEquals("row " + i + " id", id, ((Number) row.get(0)).longValue());
+                    assertEquals("row " + i + " name", expectedName(id), bytesRefToString(row.get(1)));
+                    assertEquals("row " + i + " value", (int) (id * 10), ((Number) row.get(2)).intValue());
+                    assertEquals("row " + i + " payload", expectedPayload(id), bytesRefToString(row.get(3)));
+                }
+            }
+        } finally {
+            Files.deleteIfExists(file);
+        }
+    }
+
+    /**
+     * Stress: many row groups + many pages per group, 8K rows. Forces the producer-thread to
+     * cycle through the buffer-fill / drain-block / resume pattern multiple times, where every
+     * resume can land on a different {@code GENERIC} pool thread. Caught the original
+     * {@code Local breaker must be accessed by a single thread at a time} assertion. Uses a wide
+     * {@code SORT id ASC | LIMIT N} so the same extractor and encoder paths run, just exercised
+     * over enough pages to keep the worker rotation realistic.
+     */
+    public void testSortLimitStressManyRowGroups() throws Exception {
+        assumeTrue("requires EXTERNAL command capability", EXTERNAL_COMMAND.isEnabled());
+
+        int totalRows = 8_000;
+        Path file = writeParquetFile(totalRows, /* rowGroupSize */ 200, /* startId */ 0);
+        try {
+            assertWideTopNReturnsLowestRows(StoragePath.fileUri(file), /* limit */ 100, /* startId */ 0);
+        } finally {
+            Files.deleteIfExists(file);
+        }
+    }
+
+    /**
+     * Multi-row-group file with a sparse, non-contiguous predicate (matches every fifth row) and
+     * a {@code SORT … | LIMIT N} on top. This is the regression that broke against a real
+     * S3-backed Parquet file: the deferred-extraction inner reader was constructed with
+     * {@code FilterCompat.NOOP}, dropping the pushed filter, so the {@code _rowPosition} stream
+     * stayed in sync with an unfiltered scan but every materialized row failed the predicate
+     * downstream. The bug only shows up when the predicate is sparse enough that the filtered
+     * surface differs from the unfiltered surface — a {@code WHERE id >= K} pure-prefix predicate
+     * would still pass even with the filter dropped (the lowest surviving rows match), so we
+     * deliberately use {@code id % 5 == 0} which interleaves matches and non-matches across the
+     * file. Every returned row must satisfy the predicate.
+     */
+    public void testSortLimitWithSparsePushedFilter() throws Exception {
+        assumeTrue("requires EXTERNAL command capability", EXTERNAL_COMMAND.isEnabled());
+
+        int totalRows = 400;
+        Path file = writeParquetFile(totalRows, /* rowGroupSize */ 50, /* startId */ 0);
+        try {
+            String uri = StoragePath.fileUri(file);
+            // value = id * 10, so value % 50 == 0 picks ids {0, 5, 10, …}. The matching rows are
+            // interleaved with non-matching rows in every row group; if the filter is silently
+            // dropped, the lowest 25 rows after sort would be ids 0..24 (only 5 of which match).
+            // With the filter applied, we must see ids 0, 5, 10, … 120 — every cell satisfying
+            // the predicate.
+            String query = "EXTERNAL \"" + uri + "\" | WHERE value % 50 == 0 | SORT id ASC | LIMIT 25 | KEEP id, name, value, payload";
+            try (var response = run(syncEsqlQueryRequest(query), LONG_TIMEOUT)) {
+                List<List<Object>> rows = getValuesList(response);
+                assertThat("returned row count", rows.size(), equalTo(25));
+                for (int i = 0; i < rows.size(); i++) {
+                    List<Object> row = rows.get(i);
+                    long id = ((Number) row.get(0)).longValue();
+                    int value = ((Number) row.get(2)).intValue();
+                    long expectedId = i * 5L;
+                    // Every row must satisfy the predicate; if the filter was dropped, the lowest
+                    // 25 ids (0..24) would appear, most of which fail value % 50 == 0.
+                    assertEquals("row " + i + " predicate (value % 50 must be 0)", 0, value % 50);
+                    assertEquals("row " + i + " id (sparse-match sequence)", expectedId, id);
+                    assertEquals("row " + i + " name consistency", expectedName(id), bytesRefToString(row.get(1)));
+                    assertEquals("row " + i + " value consistency", (int) (id * 10), value);
+                    assertEquals("row " + i + " payload consistency", expectedPayload(id), bytesRefToString(row.get(3)));
+                }
+            }
+        } finally {
+            Files.deleteIfExists(file);
+        }
+    }
+
+    /**
+     * Multi-row-group file with a {@code WHERE} that references one of the wide columns. The rule
+     * must keep that column eager (it is read by the pushed expression) while still deferring the
+     * other wide columns. A regression where the rule defers a referenced column would fail
+     * validation at planning time, or worse, materialize the wrong cells at runtime.
+     */
+    public void testSortLimitWhereOnWideColumn() throws Exception {
+        assumeTrue("requires EXTERNAL command capability", EXTERNAL_COMMAND.isEnabled());
+
+        int totalRows = 400;
+        Path file = writeParquetFile(totalRows, /* rowGroupSize */ 50, /* startId */ 0);
+        try {
+            String uri = StoragePath.fileUri(file);
+            String query = "EXTERNAL \"" + uri + "\" | WHERE value >= 1500 | SORT id ASC | LIMIT 25 | KEEP id, name, value, payload";
+            // value = id * 10, so value >= 1500 means id >= 150
+            assertRowsMatchExpectedRange(query, /* startId */ 150, /* count */ 25);
+        } finally {
+            Files.deleteIfExists(file);
+        }
+    }
+
+    /**
+     * Runs a wide {@code SORT id ASC | LIMIT N | KEEP id, name, value, payload} query against
+     * {@code uri} and asserts that the returned rows correspond to ids
+     * {@code [startId, startId + limit)} with the values written by the test (deterministic
+     * function of the id). This is the central correctness check: any bug in the deferred
+     * extraction (wrong scope, mis-resolved positions, swapped values across rows) shows up as
+     * mismatched cells.
+     */
+    private void assertWideTopNReturnsLowestRows(String uri, int limit, int startId) throws IOException {
+        String query = "EXTERNAL \"" + uri + "\" | SORT id ASC | LIMIT " + limit + " | KEEP id, name, value, payload";
+        assertRowsMatchExpectedRange(query, startId, limit);
+    }
+
+    private void assertRowsMatchExpectedRange(String query, int startId, int count) throws IOException {
+        var request = syncEsqlQueryRequest(query);
+        try (var response = run(request, LONG_TIMEOUT)) {
+            List<? extends ColumnInfo> columns = response.columns();
+            assertThat("expected four projected columns", columns.size(), equalTo(4));
+            assertThat("first column must be id", columns.get(0).name(), equalTo("id"));
+            assertThat("second column must be name", columns.get(1).name(), equalTo("name"));
+            assertThat("third column must be value", columns.get(2).name(), equalTo("value"));
+            assertThat("fourth column must be payload", columns.get(3).name(), equalTo("payload"));
+
+            List<List<Object>> rows = getValuesList(response);
+            try {
+                assertThat("returned row count", rows.size(), equalTo(count));
+                for (int i = 0; i < count; i++) {
+                    long id = startId + i;
+                    List<Object> row = rows.get(i);
+                    assertEquals("row " + i + " id", id, ((Number) row.get(0)).longValue());
+                    assertEquals("row " + i + " name", expectedName(id), bytesRefToString(row.get(1)));
+                    assertEquals("row " + i + " value", (int) (id * 10), ((Number) row.get(2)).intValue());
+                    assertEquals("row " + i + " payload", expectedPayload(id), bytesRefToString(row.get(3)));
+                }
+                assertThat("expected at least one row", rows.size(), greaterThan(0));
+            } catch (AssertionError e) {
+                StringBuilder dump = new StringBuilder("Query [").append(query)
+                    .append("] returned ")
+                    .append(rows.size())
+                    .append(" rows:\n");
+                for (int i = 0; i < rows.size(); i++) {
+                    dump.append(" [").append(i).append("] ").append(rows.get(i)).append('\n');
+                }
+                throw new AssertionError(e.getMessage() + "\n" + dump, e);
+            }
+        }
+    }
+
+    private static String bytesRefToString(Object cell) {
+        if (cell instanceof BytesRef br) {
+            return br.utf8ToString();
+        }
+        return String.valueOf(cell);
+    }
+
+    private static String expectedName(long id) {
+        return "row_" + id;
+    }
+
+    private static String expectedPayload(long id) {
+        return "payload_" + id + "_" + (id * 7919);
+    }
+
+    private Path writeParquetFile(int rowCount, int rowGroupSize, long startId) throws IOException {
+        Path tempFile = createTempDir().resolve("topn_extraction_test.parquet");
+        return writeParquetFileAt(tempFile, startId, rowCount, rowGroupSize);
+    }
+
+    /**
+     * Writes a four-column Parquet file: {@code id} (int64, sort key), {@code name} (string),
+     * {@code value} (int32), {@code payload} (string, intentionally larger to make deferred
+     * extraction attractive). The extra columns are what gives the optimizer enough deferrable
+     * fields to clear {@code DEFERRED_COLUMN_MIN}.
+     */
+    private Path writeParquetFileAt(Path path, long startId, int rowCount, int rowGroupSize) throws IOException {
+        MessageType schema = MessageTypeParser.parseMessageType(
+            "message test {"
+                + " required int64 id;"
+                + " required binary name (UTF8);"
+                + " required int32 value;"
+                + " required binary payload (UTF8);"
+                + " }"
+        );
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        OutputFile outputFile = createOutputFile(baos);
+        SimpleGroupFactory factory = new SimpleGroupFactory(schema);
+
+        try (
+            ParquetWriter<Group> writer = ExampleParquetWriter.builder(outputFile)
+                .withConf(new PlainParquetConfiguration())
+                .withType(schema)
+                .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
+                .withRowGroupSize(rowGroupSize)
+                .build()
+        ) {
+            for (int i = 0; i < rowCount; i++) {
+                long id = startId + i;
+                Group g = factory.newGroup();
+                g.add("id", id);
+                g.add("name", expectedName(id));
+                g.add("value", (int) (id * 10));
+                g.add("payload", expectedPayload(id));
+                writer.write(g);
+            }
+        }
+
+        Files.write(path, baos.toByteArray());
+        return path;
+    }
+
+    private static OutputFile createOutputFile(ByteArrayOutputStream baos) {
+        return new OutputFile() {
+            @Override
+            public PositionOutputStream create(long blockSizeHint) {
+                return new PositionOutputStream() {
+                    private long position = 0;
+
+                    @Override
+                    public long getPos() {
+                        return position;
+                    }
+
+                    @Override
+                    public void write(int b) throws IOException {
+                        baos.write(b);
+                        position++;
+                    }
+
+                    @Override
+                    public void write(byte[] b, int off, int len) throws IOException {
+                        baos.write(b, off, len);
+                        position += len;
+                    }
+                };
+            }
+
+            @Override
+            public PositionOutputStream createOrOverwrite(long blockSizeHint) {
+                return create(blockSizeHint);
+            }
+
+            @Override
+            public boolean supportsBlockSize() {
+                return false;
+            }
+
+            @Override
+            public long defaultBlockSize() {
+                return 0;
+            }
+        };
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
@@ -22,6 +22,9 @@ import org.elasticsearch.logging.Logger;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.datasources.spi.ColumnExtractor;
+import org.elasticsearch.xpack.esql.datasources.spi.ColumnExtractorAware;
+import org.elasticsearch.xpack.esql.datasources.spi.ColumnExtractorProducer;
 import org.elasticsearch.xpack.esql.datasources.spi.DecompressionCodec;
 import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
 import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
@@ -50,6 +53,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -87,7 +91,7 @@ import static org.elasticsearch.xpack.esql.datasources.ExternalSourceDrainUtils.
  * @see AsyncExternalSourceBuffer
  * @see AsyncExternalSourceOperator
  */
-public class AsyncExternalSourceOperatorFactory implements SourceOperator.SourceOperatorFactory {
+public class AsyncExternalSourceOperatorFactory implements SourceOperator.SourceOperatorFactory, DeferredExtractionCapable {
 
     private static final Logger logger = LogManager.getLogger(AsyncExternalSourceOperatorFactory.class);
 
@@ -95,6 +99,15 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
     private final FormatReader formatReader;
     private final StoragePath path;
     private final List<Attribute> attributes;
+    /**
+     * {@link #attributes} minus the synthetic {@link ColumnExtractor#ROW_POSITION_COLUMN}, used when
+     * we hand a "file's resolved schema" to a reader (e.g. {@link RangeReadContext#resolvedAttributes()}
+     * or {@link FormatReadContext#readSchema()}). The synthetic is an optimizer-injected channel,
+     * not a real column the file has — passing it to readers as a resolved file attribute invites
+     * collision-style guards to misfire (see the production regression on the Parquet range path).
+     * Equal to {@link #attributes} when deferred extraction is off.
+     */
+    private final List<Attribute> readerResolvedAttributes;
     private final int batchSize;
     private final int maxBufferSize;
     private final int rowLimit;
@@ -111,6 +124,17 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
     private final FilterPushdownSupport pushdownSupport;
     private final Closeable onClose;
     private final AtomicInteger operatorRefCount = new AtomicInteger(0);
+    /**
+     * Refcount controlling when {@link #onClose} runs when {@link #deferredExtraction} is on.
+     * Increments: one for the factory itself (held while any source operator is in flight; released
+     * when {@link #operatorRefCount} drops to zero) plus one per {@link SourceExtractors} registry
+     * created (released when the registry is closed by the paired
+     * {@link ExternalFieldExtractOperator}). The last release closes {@code onClose}. This keeps
+     * the per-query concurrency budget alive across the seam between the source's last produced
+     * page and the late materialization read that runs after TopN — see
+     * {@link #attachOnCloseToRegistry}.
+     */
+    private final AtomicInteger deferredCloseRefCount = new AtomicInteger(0);
     /** Number of driver instances created for this factory. Used for batch-size heuristics. */
     private final int parallelism;
     /**
@@ -120,6 +144,27 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
      * {@link RangeAwareFormatReader#readRange} calls.
      */
     private final boolean batchReadCapable;
+
+    /**
+     * When set, the producer paths request the synthetic {@link ColumnExtractor#ROW_POSITION_COLUMN}
+     * column from the reader and re-encode it via {@link SourceExtractors#encode(int, long)} so
+     * downstream {@link ExternalFieldExtractOperator}s can locate the source extractor by id. The
+     * source's {@code attributes} are expected to already contain a long-typed attribute named
+     * {@link ColumnExtractor#ROW_POSITION_COLUMN} at this point (added by
+     * {@code InsertExternalFieldExtraction} during local physical optimization).
+     * <p>
+     * Requires the configured {@link FormatReader} to implement {@link ColumnExtractorAware}; the
+     * {@link Builder#build} validates this invariant.
+     */
+    private final boolean deferredExtraction;
+
+    /**
+     * Per-driver source-extractor registries. Lazily created the first time
+     * {@link #sourceExtractorsFor} is called for a given driver, so the registry is shared
+     * between this factory's source operator and the {@link ExternalFieldExtractOperator}'s
+     * factory created from the same driver context.
+     */
+    private final Map<DriverContext, SourceExtractors> sourceExtractorsPerDriver = new ConcurrentHashMap<>();
 
     private AsyncExternalSourceOperatorFactory(
         StorageProvider storageProvider,
@@ -140,7 +185,8 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         @Nullable List<Expression> pushedExpressions,
         @Nullable FilterPushdownSupport pushdownSupport,
         @Nullable Closeable onClose,
-        int parallelism
+        int parallelism,
+        boolean deferredExtraction
     ) {
         if (storageProvider == null) {
             throw new IllegalArgumentException("storageProvider cannot be null");
@@ -168,6 +214,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         this.formatReader = formatReader;
         this.path = path;
         this.attributes = attributes;
+        this.readerResolvedAttributes = stripRowPosition(attributes);
         this.executor = executor;
         this.batchSize = batchSize;
         this.maxBufferSize = maxBufferSize;
@@ -183,7 +230,23 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         this.pushdownSupport = pushdownSupport;
         this.onClose = onClose;
         this.parallelism = Math.max(1, parallelism);
-        this.batchReadCapable = formatReader instanceof RangeAwareFormatReader rr
+        this.deferredExtraction = deferredExtraction;
+        if (deferredExtraction && onClose != null) {
+            // Hold one ref on behalf of the factory; released when operatorRefCount hits zero.
+            // Each registry creation (one per driver) takes an additional ref. See deferredCloseRefCount.
+            deferredCloseRefCount.incrementAndGet();
+        }
+        if (deferredExtraction && (formatReader instanceof ColumnExtractorAware) == false) {
+            throw new IllegalArgumentException(
+                "deferredExtraction was enabled but format reader ["
+                    + formatReader.formatName()
+                    + "] does not implement ColumnExtractorAware"
+            );
+        }
+        // Batch-read reads multiple files in a single iterator and would not let us register
+        // one ColumnExtractor per file. Disable when deferred extraction is enabled.
+        this.batchReadCapable = deferredExtraction == false
+            && formatReader instanceof RangeAwareFormatReader rr
             && rr.supportsBatchRead()
             && this.partitionColumnNames.isEmpty();
     }
@@ -228,6 +291,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         private FilterPushdownSupport pushdownSupport;
         private Closeable onClose;
         private int parallelism = 1;
+        private boolean deferredExtraction = false;
 
         private Builder(
             StorageProvider storageProvider,
@@ -315,6 +379,22 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
             return this;
         }
 
+        /**
+         * Opt into deferred field extraction: the source emits a synthetic
+         * {@link ColumnExtractor#ROW_POSITION_COLUMN} column in encoded form (extractor id packed
+         * with file-local position) and registers a {@link ColumnExtractor} per opened file. The
+         * caller (typically {@code InsertExternalFieldExtraction} via {@code LocalExecutionPlanner})
+         * pairs this with an {@link ExternalFieldExtractOperator} that resolves the extractor
+         * by id and materializes the deferred columns post-TopN.
+         * <p>
+         * The configured {@link FormatReader} must implement {@link ColumnExtractorAware} —
+         * verified at {@link #build} time.
+         */
+        public Builder deferredExtraction(boolean deferredExtraction) {
+            this.deferredExtraction = deferredExtraction;
+            return this;
+        }
+
         public AsyncExternalSourceOperatorFactory build() {
             return new AsyncExternalSourceOperatorFactory(
                 storageProvider,
@@ -335,7 +415,8 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                 pushedExpressions,
                 pushdownSupport,
                 onClose,
-                parallelism
+                parallelism,
+                deferredExtraction
             );
         }
     }
@@ -372,6 +453,81 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         }
     }
 
+    /**
+     * Resolves (or lazily creates) the {@link SourceExtractors} registry shared between this
+     * factory's source operator and a paired {@link ExternalFieldExtractOperator} for the same
+     * driver. The registry is populated as files are opened and read via the registered
+     * {@link ColumnExtractor#extract} contract.
+     * <p>
+     * Only meaningful when {@link Builder#deferredExtraction} was enabled. Calls during the
+     * non-deferred mode return a fresh empty registry; callers in that mode should not depend on
+     * its contents.
+     */
+    @Override
+    public SourceExtractors sourceExtractorsFor(DriverContext driverContext) {
+        return sourceExtractorsPerDriver.computeIfAbsent(driverContext, ctx -> {
+            SourceExtractors registry = new SourceExtractors();
+            attachOnCloseToRegistry(registry);
+            return registry;
+        });
+    }
+
+    /**
+     * If deferred extraction is enabled and an {@link #onClose} resource is attached, hand it to
+     * the registry as a trailing closeable. The registry is the natural rendezvous between the
+     * source side (writes to it during the producer loop) and the
+     * {@link ExternalFieldExtractOperator} side (reads from it during driver runtime, after the
+     * source has already finished producing). Closing the registry then closes the resource only
+     * once the last user has gone away — see {@link #deferredCloseRefCount} for the refcounting.
+     */
+    private void attachOnCloseToRegistry(SourceExtractors registry) {
+        if (deferredExtraction == false || onClose == null) {
+            return;
+        }
+        deferredCloseRefCount.incrementAndGet();
+        // The releaser is registered LIFO via SourceExtractors#registerTrailingCloseable, so it
+        // runs after every ColumnExtractor has been closed (and thus after the storage objects
+        // they own have flushed any final permit releases through the budget).
+        registry.registerTrailingCloseable(this::releaseDeferredCloseRef);
+    }
+
+    /**
+     * Decrement the deferred-close refcount; once it hits zero the {@link #onClose} resource
+     * (typically the per-query concurrency budget) is closed. Called from two places:
+     * <ul>
+     *   <li>{@link #releaseOperator} when the last source operator finishes — releases the
+     *       factory's own ref;</li>
+     *   <li>{@link SourceExtractors#close()} via the trailing closeable attached in
+     *       {@link #attachOnCloseToRegistry} — releases each registry's ref.</li>
+     * </ul>
+     */
+    private void releaseDeferredCloseRef() {
+        if (deferredCloseRefCount.decrementAndGet() == 0) {
+            closeQuietly(onClose);
+        }
+    }
+
+    /**
+     * Whether deferred field extraction is enabled on this factory. See
+     * {@link Builder#deferredExtraction(boolean)} for semantics.
+     */
+    public boolean deferredExtractionEnabled() {
+        return deferredExtraction;
+    }
+
+    /**
+     * Build a {@link ColumnExtractor} from the iterator and register it with the given driver's
+     * {@link SourceExtractors}. Returns the assigned extractor id, which the caller hands back to
+     * the iterator via {@link ColumnExtractorProducer#setExtractorId(int)} so the iterator can
+     * pre-encode every {@code _rowPosition} value it emits with that id. Caller must ensure the
+     * reader implements {@link ColumnExtractorAware}; this is validated at
+     * {@link Builder#build} time.
+     */
+    private int registerExtractorFromProducer(ColumnExtractorProducer producer, DriverContext driverContext) throws IOException {
+        ColumnExtractor extractor = producer.createColumnExtractor();
+        return sourceExtractorsFor(driverContext).register(extractor);
+    }
+
     private VirtualColumnInjector buildInjector(DriverContext driverContext) {
         if (partitionColumnNames.isEmpty() == false) {
             return new VirtualColumnInjector(attributes, partitionColumnNames, partitionValues, driverContext.blockFactory());
@@ -388,6 +544,62 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
             cols.add(attr.name());
         }
         return cols;
+    }
+
+    /**
+     * Index of {@link ColumnExtractor#ROW_POSITION_COLUMN} in {@code projectedColumns} (the
+     * post-projection, pre-injector channel layout); {@code -1} when the column is absent.
+     * Used by deferred-extraction wiring to know which channel the encoder must rewrite.
+     */
+    private static int rowPositionChannelIndex(List<String> projectedColumns) {
+        return projectedColumns == null ? -1 : projectedColumns.indexOf(ColumnExtractor.ROW_POSITION_COLUMN);
+    }
+
+    /**
+     * Performs the deferred-extraction handshake when active and the projection contains
+     * {@link ColumnExtractor#ROW_POSITION_COLUMN}: registers the iterator's matching
+     * {@link ColumnExtractor} with the driver's {@link SourceExtractors} and hands the assigned
+     * id back to the iterator via {@link ColumnExtractorProducer#setExtractorId(int)} so it can
+     * pre-encode every {@code _rowPosition} value it emits. Returns {@code pages} unchanged in
+     * every case — there is no per-page wrapper iterator on the deferred path. Off the deferred
+     * path, or when the optimizer hasn't injected {@code _rowPosition}, the call is a no-op.
+     * <p>
+     * Historically this method wrapped {@code pages} in an {@code EncodingRowRefIterator} that
+     * rebuilt the {@code _rowPosition} block on every page; pushing the encoding into the
+     * iterator removes a per-page allocation and a thread-safety hazard around the local
+     * circuit breaker.
+     */
+    private CloseableIterator<Page> wrapWithEncoderIfNeeded(
+        CloseableIterator<Page> pages,
+        List<String> projectedColumns,
+        DriverContext driverContext
+    ) throws IOException {
+        if (deferredExtraction == false) {
+            return pages;
+        }
+        int rpChannel = rowPositionChannelIndex(projectedColumns);
+        if (rpChannel < 0) {
+            // Optimizer hasn't injected _rowPosition into the projection. This can happen on
+            // sub-plans the rule chose not to rewrite (e.g. no TopN above this source). Pass
+            // through unchanged.
+            return pages;
+        }
+        // Producer handshake: the iterator that emitted the synthetic _rowPosition is also the
+        // authority on its addressing space (full file, range-restricted row groups, etc.). Use
+        // its produced extractor so the lookup table is scoped exactly the same way as the
+        // running counter — see {@link ColumnExtractor} for the contract this preserves. We
+        // register the extractor first, then hand its id back to the iterator: from this point
+        // on every page the iterator returns carries already-encoded values, no wrapping needed.
+        if (pages instanceof ColumnExtractorProducer producer) {
+            int id = registerExtractorFromProducer(producer, driverContext);
+            producer.setExtractorId(id);
+            return pages;
+        }
+        throw new IllegalStateException(
+            "deferred extraction enabled but reader iterator ["
+                + pages.getClass().getName()
+                + "] does not implement ColumnExtractorProducer"
+        );
     }
 
     /**
@@ -418,6 +630,49 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                 result.add(attr.name());
             }
         }
+        // The synthetic deferred-extraction signal is never present in the file's read schema (it
+        // is optimizer-inserted and resolved at read time by the format reader). Preserve it at the
+        // tail of the per-file projection so the reader's _rowPosition emission path fires for
+        // every file, regardless of how many of the user's data columns the file is missing.
+        if (wanted.contains(ColumnExtractor.ROW_POSITION_COLUMN)) {
+            // Defensive: only append once. If a future caller decides _rowPosition should also be
+            // present in perFileReadSchema, the loop above would already have added it and we
+            // skip the appender to keep the projection unique.
+            if (result.contains(ColumnExtractor.ROW_POSITION_COLUMN) == false) {
+                result.add(ColumnExtractor.ROW_POSITION_COLUMN);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Returns {@code attributes} without the synthetic deferred-extraction marker so a reader's
+     * {@code resolvedAttributes} / {@code readSchema} reflect only real file columns. Returns the
+     * input list unchanged when the marker is absent (deferred extraction off, or the optimizer
+     * never injected the synthetic), so callers without deferred extraction pay nothing.
+     * <p>
+     * Package-private for unit tests.
+     */
+    static List<Attribute> stripRowPosition(List<Attribute> attributes) {
+        if (attributes == null || attributes.isEmpty()) {
+            return attributes;
+        }
+        int idx = -1;
+        for (int i = 0; i < attributes.size(); i++) {
+            if (ColumnExtractor.ROW_POSITION_COLUMN.equals(attributes.get(i).name())) {
+                idx = i;
+                break;
+            }
+        }
+        if (idx < 0) {
+            return attributes;
+        }
+        List<Attribute> result = new ArrayList<>(attributes.size() - 1);
+        for (int i = 0; i < attributes.size(); i++) {
+            if (i != idx) {
+                result.add(attributes.get(i));
+            }
+        }
         return result;
     }
 
@@ -430,7 +685,13 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
             return pages;
         }
         List<Attribute> dataColumns = attributes.subList(0, mapping.columnCount());
-        return new SchemaAdaptingIterator(pages, dataColumns, mapping, driverContext.blockFactory());
+        // When deferred extraction is enabled for this factory, the reader appends the synthetic
+        // {@link ColumnExtractor#ROW_POSITION_COLUMN} to the file's data columns (see
+        // {@link #perFileQueryProjection}). Tell the adapter where to find it so the block flows
+        // through to downstream operators unchanged. When deferred extraction is off, the
+        // reader's output has only data columns and the adapter ignores this slot.
+        int rowPositionInputIndex = deferredExtraction ? mapping.columnCount() : -1;
+        return new SchemaAdaptingIterator(pages, dataColumns, mapping, driverContext.blockFactory(), rowPositionInputIndex);
     }
 
     /**
@@ -816,7 +1077,17 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                     : storageProvider.newObject(fileSplit.path());
                 long rangeEnd = fileSplit.offset() + fileSplit.length();
                 Object fileContext = fileSplit.path().equals(state.lastRangeFilePath) ? state.lastFileContext : null;
-                RangeReadContext rangeCtx = new RangeReadContext(cols, batchSize, fileSplit.offset(), rangeEnd, attributes, errorPolicy);
+                // Pass {@link #readerResolvedAttributes} — i.e. {@link #attributes} minus the
+                // deferred-extraction synthetic — so the reader's view of "the file's resolved
+                // schema" stays free of optimizer-injected channels.
+                RangeReadContext rangeCtx = new RangeReadContext(
+                    cols,
+                    batchSize,
+                    fileSplit.offset(),
+                    rangeEnd,
+                    readerResolvedAttributes,
+                    errorPolicy
+                );
                 if (fileContext != null) {
                     rangeCtx.setFileContext(fileContext);
                 }
@@ -868,7 +1139,12 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                 }
             }
             CloseableIterator<Page> adapted = adaptSchema(pages, fileSplit.columnMapping(), state.driverContext);
-            state.pages = wrapWithInjector(adapted, injector);
+            // Deferred extraction: register one extractor per opened file split. Range-splits of
+            // the same file therefore register multiple extractors; this is benign — each row's
+            // encoded id maps back to the registered extractor that produced it, addressing the
+            // split's owned row groups in extractor-local coordinates (see {@link ColumnExtractor}).
+            CloseableIterator<Page> encoded = wrapWithEncoderIfNeeded(adapted, cols, state.driverContext);
+            state.pages = wrapWithInjector(encoded, injector);
             return true;
         } catch (Exception e) {
             closeQuietly(pages);
@@ -971,7 +1247,8 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                 pages = formatReader.read(obj, ctx);
             }
             CloseableIterator<Page> adapted = adaptSchema(pages, mapping, state.driverContext);
-            state.pages = wrapWithInjector(adapted, state.multiFileInjector);
+            CloseableIterator<Page> encoded = wrapWithEncoderIfNeeded(adapted, perFileCols, state.driverContext);
+            state.pages = wrapWithInjector(encoded, state.multiFileInjector);
             return true;
         } catch (Exception e) {
             closeQuietly(pages);
@@ -995,7 +1272,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
             .errorPolicy(errorPolicy)
             .build();
         formatReader.readAsync(storageObject, ctx, executor, ActionListener.wrap(iterator -> {
-            consumePagesInBackground(iterator, buffer, driverContext, injector);
+            consumePagesInBackground(iterator, buffer, driverContext, injector, storageObject, projectedColumns);
         }, e -> {
             buffer.onFailure(e);
             driverContext.removeAsyncAction();
@@ -1032,7 +1309,8 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
             }
             CloseableIterator<Page> wrapped;
             try {
-                wrapped = wrapWithInjector(pages, injector);
+                CloseableIterator<Page> encoded = wrapWithEncoderIfNeeded(pages, projectedColumns, driverContext);
+                wrapped = wrapWithInjector(encoded, injector);
             } catch (Exception e) {
                 closeQuietly(pages);
                 throw e;
@@ -1054,7 +1332,9 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         CloseableIterator<Page> pages,
         AsyncExternalSourceBuffer buffer,
         DriverContext driverContext,
-        VirtualColumnInjector injector
+        VirtualColumnInjector injector,
+        StorageObject storageObject,
+        List<String> projectedColumns
     ) {
         ActionListener<Void> failureListener = ActionListener.wrap(v -> {}, e -> {
             closeQuietly(pages);
@@ -1063,7 +1343,8 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
             releaseOperator();
         });
         executor.execute(ActionRunnable.run(failureListener, () -> {
-            CloseableIterator<Page> wrapped = wrapWithInjector(pages, injector);
+            CloseableIterator<Page> encoded = wrapWithEncoderIfNeeded(pages, projectedColumns, driverContext);
+            CloseableIterator<Page> wrapped = wrapWithInjector(encoded, injector);
             drainPagesAsync(
                 wrapped,
                 buffer,
@@ -1145,7 +1426,15 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
 
     private void releaseOperator() {
         if (operatorRefCount.decrementAndGet() == 0 && onClose != null) {
-            closeQuietly(onClose);
+            if (deferredExtraction) {
+                // Don't close onClose here — the deferred extraction path keeps using the storage
+                // (and thus the per-query budget) after the last source operator finishes
+                // producing. Release the factory's ref instead; the budget closes once every
+                // SourceExtractors registry has also been closed.
+                releaseDeferredCloseRef();
+            } else {
+                closeQuietly(onClose);
+            }
         }
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DeferredExtractionCapable.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DeferredExtractionCapable.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * Capability marker for a {@link org.elasticsearch.compute.operator.SourceOperator.SourceOperatorFactory
+ * SourceOperatorFactory} that participates in deferred (post-TopN) field extraction. Implementing
+ * factories register a per-file {@link org.elasticsearch.xpack.esql.datasources.spi.ColumnExtractor
+ * ColumnExtractor} and emit a synthetic {@code _rowPosition} column whose values pack the
+ * extractor id with a file-local row position (see {@link SourceExtractors#encode(int, long)}).
+ * <p>
+ * The local execution planner uses this interface to reach the per-driver {@link SourceExtractors}
+ * registry of an upstream source factory when planning a paired
+ * {@link org.elasticsearch.xpack.esql.plan.physical.ExternalFieldExtractExec ExternalFieldExtractExec}
+ * — see {@code LocalExecutionPlanner#planExternalFieldExtract}.
+ */
+public interface DeferredExtractionCapable {
+
+    /**
+     * Returns the per-driver {@link SourceExtractors} registry, lazily creating it if it does not
+     * yet exist. The registry is shared between the source operator (which populates it as files
+     * open) and the field-extract operator (which reads from it post-TopN). Both must reach the
+     * same instance via the same {@link DriverContext}.
+     */
+    SourceExtractors sourceExtractorsFor(DriverContext driverContext);
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalFieldExtractOperator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalFieldExtractOperator.java
@@ -1,0 +1,295 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.LongVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Operator;
+import org.elasticsearch.core.Releasables;
+
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * Page-mapping operator that materializes deferred ("wide") columns for the rows surviving a
+ * per-driver TopN.
+ * <p>
+ * Reads the {@code _rowPosition} channel from each incoming page — these are encoded row
+ * references (extractor id packed with file-local position) written by the source factory. Calls
+ * {@link SourceExtractors#materialize(long[], int, List, BlockFactory)} to materialize the
+ * deferred columns, then assembles an output page that:
+ * <ul>
+ *     <li>Keeps every input block <em>except</em> the {@code _rowPosition} channel.</li>
+ *     <li>Appends the deferred columns in the order requested at construction.</li>
+ * </ul>
+ * <p>
+ * The registry is owned by the upstream {@code AsyncExternalSourceOperatorFactory} and resolved
+ * per-driver via a {@code Function<DriverContext, SourceExtractors>} supplied at construction.
+ * The source populates the registry as it opens files; this operator reads it after TopN
+ * finishes. Single-threaded — same driver thread.
+ * <p>
+ * Implements {@link Operator} directly rather than extending {@code AbstractPageMappingOperator}
+ * because the latter short-circuits zero-position pages — that would propagate the input shape
+ * (including {@code _rowPosition}) instead of our declared output shape, breaking downstream
+ * channel indexing.
+ */
+public class ExternalFieldExtractOperator implements Operator {
+
+    /**
+     * Builds {@link ExternalFieldExtractOperator}s for each driver. The {@code sourceExtractorsLookup}
+     * resolves the per-driver {@link SourceExtractors} populated by the upstream source operator
+     * factory (typically {@code AsyncExternalSourceOperatorFactory::sourceExtractorsFor}). Tests
+     * may supply a pre-populated registry directly via {@code ignored -> registry}.
+     */
+    public static final class Factory implements Operator.OperatorFactory {
+        private final int rowPositionChannel;
+        private final List<Integer> passThroughChannels;
+        private final List<String> deferredColumnNames;
+        private final Function<DriverContext, SourceExtractors> sourceExtractorsLookup;
+
+        /**
+         * @param rowPositionChannel       channel index in the input page that holds {@code _rowPosition}
+         * @param passThroughChannels      channel indices of the input page that should be copied
+         *                                 to the output (in the order they appear in the output)
+         * @param deferredColumnNames      names of the deferred columns to load, in output order
+         * @param sourceExtractorsLookup   per-driver registry resolver; must never return
+         *                                 {@code null}
+         */
+        public Factory(
+            int rowPositionChannel,
+            List<Integer> passThroughChannels,
+            List<String> deferredColumnNames,
+            Function<DriverContext, SourceExtractors> sourceExtractorsLookup
+        ) {
+            if (rowPositionChannel < 0) {
+                throw new IllegalArgumentException("rowPositionChannel must be non-negative, got [" + rowPositionChannel + "]");
+            }
+            if (passThroughChannels == null) {
+                throw new IllegalArgumentException("passThroughChannels must not be null");
+            }
+            if (deferredColumnNames == null) {
+                throw new IllegalArgumentException("deferredColumnNames must not be null");
+            }
+            if (sourceExtractorsLookup == null) {
+                throw new IllegalArgumentException("sourceExtractorsLookup must not be null");
+            }
+            this.rowPositionChannel = rowPositionChannel;
+            this.passThroughChannels = List.copyOf(passThroughChannels);
+            this.deferredColumnNames = List.copyOf(deferredColumnNames);
+            this.sourceExtractorsLookup = sourceExtractorsLookup;
+        }
+
+        @Override
+        public Operator get(DriverContext driverContext) {
+            SourceExtractors registry = sourceExtractorsLookup.apply(driverContext);
+            if (registry == null) {
+                throw new IllegalStateException(
+                    "sourceExtractorsLookup returned null for driverContext; deferred extraction is not wired correctly"
+                );
+            }
+            return new ExternalFieldExtractOperator(
+                rowPositionChannel,
+                passThroughChannels,
+                deferredColumnNames,
+                registry,
+                driverContext.blockFactory()
+            );
+        }
+
+        @Override
+        public String describe() {
+            return "ExternalFieldExtractOperator[rowPositionChannel="
+                + rowPositionChannel
+                + ", passThrough="
+                + passThroughChannels.size()
+                + ", deferred="
+                + deferredColumnNames
+                + "]";
+        }
+    }
+
+    private final int rowPositionChannel;
+    private final List<Integer> passThroughChannels;
+    private final List<String> deferredColumnNames;
+    private final SourceExtractors registry;
+    private final BlockFactory blockFactory;
+
+    private Page prev;
+    private boolean finished;
+
+    ExternalFieldExtractOperator(
+        int rowPositionChannel,
+        List<Integer> passThroughChannels,
+        List<String> deferredColumnNames,
+        SourceExtractors registry,
+        BlockFactory blockFactory
+    ) {
+        this.rowPositionChannel = rowPositionChannel;
+        this.passThroughChannels = passThroughChannels;
+        this.deferredColumnNames = deferredColumnNames;
+        this.registry = registry;
+        this.blockFactory = blockFactory;
+    }
+
+    @Override
+    public boolean needsInput() {
+        return prev == null && finished == false;
+    }
+
+    @Override
+    public boolean canProduceMoreDataWithoutExtraInput() {
+        return prev != null;
+    }
+
+    @Override
+    public void addInput(Page page) {
+        assert prev == null : "has pending input page";
+        prev = page;
+    }
+
+    @Override
+    public void finish() {
+        finished = true;
+    }
+
+    @Override
+    public boolean isFinished() {
+        return finished && prev == null;
+    }
+
+    @Override
+    public Page getOutput() {
+        if (prev == null) {
+            return null;
+        }
+        Page page = prev;
+        prev = null;
+        if (page.getPositionCount() == 0) {
+            return reshapeEmpty(page);
+        }
+        return materialize(page);
+    }
+
+    /**
+     * For an empty input page, build a shape-correct empty output: drop {@code _rowPosition},
+     * keep the pass-through blocks (incRef'd), and append empty placeholder blocks for the
+     * deferred columns.
+     */
+    private Page reshapeEmpty(Page page) {
+        Block[] outBlocks = new Block[passThroughChannels.size() + deferredColumnNames.size()];
+        int idx = 0;
+        try {
+            for (int ch : passThroughChannels) {
+                Block b = page.getBlock(ch);
+                b.incRef();
+                outBlocks[idx++] = b;
+            }
+            // Deferred columns: empty pages carry no _rowPosition values, so we can't go through
+            // the registry. Emit constant-null blocks instead — downstream operators see the
+            // right shape and treat them as nulls (which is consistent with there being no rows).
+            for (int i = 0; i < deferredColumnNames.size(); i++) {
+                outBlocks[idx++] = blockFactory.newConstantNullBlock(0);
+            }
+            page.releaseBlocks();
+            return new Page(0, outBlocks);
+        } catch (RuntimeException e) {
+            for (int i = 0; i < idx; i++) {
+                if (outBlocks[i] != null) {
+                    outBlocks[i].close();
+                }
+            }
+            page.releaseBlocks();
+            throw e;
+        }
+    }
+
+    /**
+     * Hot path: extract deferred columns for the surviving positions and assemble the output
+     * page. Pass-through blocks get an extra ref so the new page owns its own references; the
+     * old page's references are released via {@link Page#releaseBlocks()}.
+     */
+    private Page materialize(Page page) {
+        int positions = page.getPositionCount();
+        Block rpBlock = page.getBlock(rowPositionChannel);
+        if (rpBlock instanceof LongBlock == false) {
+            page.releaseBlocks();
+            throw new IllegalStateException(
+                "_rowPosition channel [" + rowPositionChannel + "] expected LongBlock but was " + rpBlock.getClass().getSimpleName()
+            );
+        }
+        LongBlock rp = (LongBlock) rpBlock;
+        long[] refs = new long[positions];
+        LongVector rpVector = rp.asVector();
+        if (rpVector != null) {
+            for (int i = 0; i < positions; i++) {
+                refs[i] = rpVector.getLong(i);
+            }
+        } else {
+            for (int i = 0; i < positions; i++) {
+                if (rp.isNull(i) || rp.getValueCount(i) != 1) {
+                    page.releaseBlocks();
+                    throw new IllegalStateException(
+                        "_rowPosition channel [" + rowPositionChannel + "] at position [" + i + "] must hold exactly one non-null value"
+                    );
+                }
+                refs[i] = rp.getLong(rp.getFirstValueIndex(i));
+            }
+        }
+
+        Block[] deferredBlocks = registry.materialize(refs, positions, deferredColumnNames, blockFactory);
+        try {
+            Block[] outBlocks = new Block[passThroughChannels.size() + deferredBlocks.length];
+            int idx = 0;
+            for (int ch : passThroughChannels) {
+                Block b = page.getBlock(ch);
+                b.incRef();
+                outBlocks[idx++] = b;
+            }
+            for (Block d : deferredBlocks) {
+                outBlocks[idx++] = d;
+            }
+            page.releaseBlocks();
+            for (int i = 0; i < deferredBlocks.length; i++) {
+                deferredBlocks[i] = null;
+            }
+            return new Page(positions, outBlocks);
+        } catch (RuntimeException e) {
+            Releasables.closeExpectNoException(deferredBlocks);
+            page.releaseBlocks();
+            throw e;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "ExternalFieldExtractOperator[rowPositionChannel="
+            + rowPositionChannel
+            + ", passThrough="
+            + passThroughChannels.size()
+            + ", deferred="
+            + deferredColumnNames
+            + "]";
+    }
+
+    @Override
+    public void close() {
+        if (prev != null) {
+            Page pending = prev;
+            prev = null;
+            Releasables.closeExpectNoException(pending::releaseBlocks);
+        }
+        // The registry is shared between source and this operator. The lifecycle is the driver:
+        // when this operator closes (driver teardown), close the registry to release per-file
+        // extractors and any held StorageObjects.
+        registry.close();
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSourceFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSourceFactory.java
@@ -11,6 +11,8 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.util.Check;
+import org.elasticsearch.xpack.esql.datasources.spi.ColumnExtractor;
+import org.elasticsearch.xpack.esql.datasources.spi.ColumnExtractorAware;
 import org.elasticsearch.xpack.esql.datasources.spi.ConfigKeyValidator;
 import org.elasticsearch.xpack.esql.datasources.spi.Configured;
 import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
@@ -232,6 +234,16 @@ final class FileSourceFactory implements ExternalSourceFactory {
             }
 
             Executor readExecutor = context.fileReadExecutor() != null ? context.fileReadExecutor() : context.executor();
+            // Auto-detect the deferred-extraction signal: the synthetic _rowPosition column in the
+            // projection means InsertExternalFieldExtraction injected a paired
+            // ExternalFieldExtractExec downstream and expects this source to register a
+            // ColumnExtractor per opened file plus emit encoded row references. Only enable it
+            // when the resolved reader actually advertises ColumnExtractorAware — without that
+            // capability the builder would refuse to set the flag.
+            boolean deferredExtraction = format instanceof ColumnExtractorAware
+                && context.projectedColumns() != null
+                && context.projectedColumns().contains(ColumnExtractor.ROW_POSITION_COLUMN);
+
             return AsyncExternalSourceOperatorFactory.builder(
                 storage,
                 format,
@@ -253,6 +265,7 @@ final class FileSourceFactory implements ExternalSourceFactory {
                 .pushedExpressions(pushedExpressions)
                 .pushdownSupport(pushdownSupport)
                 .onClose(onClose)
+                .deferredExtraction(deferredExtraction)
                 .build();
         };
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SchemaAdaptingIterator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SchemaAdaptingIterator.java
@@ -16,7 +16,10 @@ import org.elasticsearch.compute.operator.CloseableIterator;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.datasources.spi.ColumnExtractor;
+import org.elasticsearch.xpack.esql.datasources.spi.ColumnExtractorProducer;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.NoSuchElementException;
 
@@ -32,19 +35,49 @@ import java.util.NoSuchElementException;
  * <p>
  * This keeps format readers simple — they read only the columns their file has —
  * and centralizes NULL-filling and type-casting in one place.
+ *
+ * <h2>{@link ColumnExtractorProducer} forwarding</h2>
+ * The adapter unconditionally declares the {@link ColumnExtractorProducer} capability and forwards
+ * {@link #createColumnExtractor()} / {@link #setExtractorId(int)} to its delegate. Whether those
+ * calls actually succeed depends on the delegate: a non-producer delegate makes
+ * {@code instanceof ColumnExtractorProducer} a necessary-but-not-sufficient guard at consumer
+ * sites — the dispatch into the delegate fails loud (see {@link #innerProducer()}). Today the only
+ * consumer is the deferred-extraction wiring in
+ * {@code AsyncExternalSourceOperatorFactory#wrapWithEncoderIfNeeded}, which only reaches this
+ * iterator when the factory has already arranged for {@code _rowPosition} (and therefore a
+ * producer-capable delegate) on the read path; the unconditional declaration lets the dispatch
+ * site stay a single {@code instanceof} check rather than threading a capability flag through the
+ * adapter constructor.
  */
-final class SchemaAdaptingIterator implements CloseableIterator<Page> {
+final class SchemaAdaptingIterator implements CloseableIterator<Page>, ColumnExtractorProducer {
 
     private final CloseableIterator<Page> delegate;
     private final List<Attribute> unifiedSchema;
     private final SchemaReconciliation.ColumnMapping mapping;
     private final BlockFactory blockFactory;
+    /**
+     * Index in the delegate's input page of the synthetic
+     * {@link ColumnExtractor#ROW_POSITION_COLUMN}, or {@code -1} when the file is not emitting it.
+     * When non-negative, the adapter copies the block as-is into the trailing slot of the output
+     * page so deferred extraction continues to work after schema reconciliation.
+     */
+    private final int rowPositionInputIndex;
 
     SchemaAdaptingIterator(
         CloseableIterator<Page> delegate,
         List<Attribute> unifiedSchema,
         SchemaReconciliation.ColumnMapping mapping,
         BlockFactory blockFactory
+    ) {
+        this(delegate, unifiedSchema, mapping, blockFactory, -1);
+    }
+
+    SchemaAdaptingIterator(
+        CloseableIterator<Page> delegate,
+        List<Attribute> unifiedSchema,
+        SchemaReconciliation.ColumnMapping mapping,
+        BlockFactory blockFactory,
+        int rowPositionInputIndex
     ) {
         if (unifiedSchema.size() != mapping.columnCount()) {
             throw new IllegalArgumentException(
@@ -60,6 +93,7 @@ final class SchemaAdaptingIterator implements CloseableIterator<Page> {
         this.unifiedSchema = unifiedSchema;
         this.mapping = mapping;
         this.blockFactory = blockFactory;
+        this.rowPositionInputIndex = rowPositionInputIndex;
     }
 
     @Override
@@ -76,8 +110,9 @@ final class SchemaAdaptingIterator implements CloseableIterator<Page> {
         try {
             int positions = filePage.getPositionCount();
             int unifiedSize = unifiedSchema.size();
+            int outputSize = unifiedSize + (rowPositionInputIndex >= 0 ? 1 : 0);
 
-            Block[] unifiedBlocks = new Block[unifiedSize];
+            Block[] unifiedBlocks = new Block[outputSize];
             try {
                 for (int i = 0; i < unifiedSize; i++) {
                     int localIndex = mapping.localIndex(i);
@@ -94,6 +129,11 @@ final class SchemaAdaptingIterator implements CloseableIterator<Page> {
                         }
                     }
                 }
+                if (rowPositionInputIndex >= 0) {
+                    Block rowPos = filePage.getBlock(rowPositionInputIndex);
+                    rowPos.incRef();
+                    unifiedBlocks[unifiedSize] = rowPos;
+                }
                 return new Page(positions, unifiedBlocks);
             } catch (Exception e) {
                 Releasables.closeExpectNoException(unifiedBlocks);
@@ -102,6 +142,31 @@ final class SchemaAdaptingIterator implements CloseableIterator<Page> {
         } finally {
             filePage.releaseBlocks();
         }
+    }
+
+    @Override
+    public ColumnExtractor createColumnExtractor() throws IOException {
+        return innerProducer().createColumnExtractor();
+    }
+
+    @Override
+    public void setExtractorId(int id) {
+        innerProducer().setExtractorId(id);
+    }
+
+    /**
+     * Pass-through capability: the producer is the inner iterator that owns the row-group scope
+     * and pre-encodes {@code _rowPosition}. If the wrapped iterator is not a producer, deferred
+     * extraction was wired to a reader that does not support it — fail loudly so callers don't
+     * silently lose data.
+     */
+    private ColumnExtractorProducer innerProducer() {
+        if (delegate instanceof ColumnExtractorProducer producer) {
+            return producer;
+        }
+        throw new IllegalStateException(
+            "deferred extraction requested but underlying iterator [" + delegate.getClass().getName() + "] is not a ColumnExtractorProducer"
+        );
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SourceExtractors.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SourceExtractors.java
@@ -1,0 +1,420 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.core.IOUtils;
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.datasources.spi.ColumnExtractor;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Driver-scoped lookup table of per-file {@link ColumnExtractor}s, addressed by a compact
+ * {@code int} id allocated at registration time. Acts as the rendezvous between an
+ * {@code AsyncExternalSourceOperatorFactory} (which {@link #register registers} a new extractor
+ * each time it opens a file) and an {@code ExternalFieldExtractOperator} (which decodes the
+ * synthetic {@code _rowPosition} carried on pages and {@link #materialize routes} extraction
+ * requests to the correct extractor).
+ *
+ * <h2>{@code _rowPosition} encoding</h2>
+ * The synthetic column flowing between source and extract carries a {@code long} per row that
+ * packs the extractor id and the file-local position into a single value:
+ * <pre>
+ *   bit  63       reserved zero (keeps the encoded value non-negative for signed long order)
+ *   bits 62..48   extractor id (15 bits, 0..32767)
+ *   bits 47..0    file-local row position (48 bits, 0..2^48-1)
+ * </pre>
+ * Concretely: {@code encoded = ((long) id << 48) | (localPos & MAX_LOCAL_POSITION)}. This keeps
+ * the row identifier a primitive {@code long}, so the existing {@code LongBlock} type carries it
+ * end-to-end without any new block-type plumbing. Bit 63 is deliberately reserved so every
+ * encoded value is non-negative; that way Java's signed-long ordering (used by ESQL's TopN
+ * encoder, which calls {@code NumericUtils.longToSortableBytes}) coincides with
+ * {@code (id, localPos)} lexicographic order, and the encoding remains usable as a stable
+ * tiebreaker should anything downstream sort by it.
+ *
+ * <h2>Lifecycle</h2>
+ * One {@code SourceExtractors} per driver. The source operator registers extractors during the
+ * async producer loop; the extract operator reads from it on the driver thread. Both sides hold
+ * the same instance via {@code AsyncExternalSourceOperatorFactory#sourceExtractorsFor(DriverContext)}.
+ * The extract operator owns {@link #close}; closing is idempotent.
+ *
+ * <h2>Threading</h2>
+ * {@link #register} is invoked from source executor threads (one at a time per driver; the source
+ * loop is single-producer within a driver). {@link #get} and {@link #materialize} are invoked
+ * from the driver thread. The data-flow invariant — the source publishes a page only after the
+ * file's extractor has been registered — establishes the necessary happens-before via the page
+ * buffer's internal synchronization. We use a synchronized {@link ArrayList} as a defensive
+ * choice; the cost is negligible for the few-dozen registrations per driver in practice.
+ */
+public final class SourceExtractors implements Releasable {
+
+    /**
+     * Number of bits reserved for the file-local row position; the rest go to the extractor id.
+     * Mirrors {@link ColumnExtractor#LOCAL_POSITION_BITS} (the SPI-side constant iterator
+     * implementations OR against when they pre-encode {@code _rowPosition} values); kept aligned
+     * via the {@code assert} below so a divergent edit surfaces in tests instead of as a wire-
+     * format mismatch.
+     */
+    public static final int LOCAL_POSITION_BITS = 48;
+
+    static {
+        assert LOCAL_POSITION_BITS == ColumnExtractor.LOCAL_POSITION_BITS
+            : "SourceExtractors.LOCAL_POSITION_BITS must match ColumnExtractor.LOCAL_POSITION_BITS";
+    }
+
+    /** Maximum representable file-local row position (inclusive): {@code 2^48 - 1}. */
+    public static final long MAX_LOCAL_POSITION = (1L << LOCAL_POSITION_BITS) - 1;
+
+    /**
+     * Maximum representable extractor id (inclusive): {@code 2^15 - 1 = 32 767}. We use 15 bits
+     * (not the 16 available between {@link #LOCAL_POSITION_BITS} and {@code Long.SIZE}) so that
+     * bit 63 stays clear and every encoded value is non-negative — see class-level javadoc.
+     */
+    public static final int MAX_EXTRACTOR_ID = (1 << (Long.SIZE - LOCAL_POSITION_BITS - 1)) - 1;
+
+    /**
+     * Pack an {@code (extractorId, localPosition)} pair into a single {@code long}. The packed
+     * value is the on-the-wire representation of {@code _rowPosition} downstream of the source.
+     */
+    public static long encode(int extractorId, long localPosition) {
+        if (extractorId < 0 || extractorId > MAX_EXTRACTOR_ID) {
+            throw new IllegalArgumentException("extractor id [" + extractorId + "] is out of range [0, " + MAX_EXTRACTOR_ID + "]");
+        }
+        if (localPosition < 0 || localPosition > MAX_LOCAL_POSITION) {
+            throw new IllegalArgumentException(
+                "local row position [" + localPosition + "] is out of range [0, " + MAX_LOCAL_POSITION + "]"
+            );
+        }
+        return ((long) extractorId << LOCAL_POSITION_BITS) | localPosition;
+    }
+
+    /** Extract the extractor id (high 15 bits) from an encoded row reference. */
+    public static int decodeExtractorId(long encoded) {
+        return (int) (encoded >>> LOCAL_POSITION_BITS);
+    }
+
+    /** Extract the file-local position (low 48 bits) from an encoded row reference. */
+    public static long decodeLocalPosition(long encoded) {
+        return encoded & MAX_LOCAL_POSITION;
+    }
+
+    private final List<ColumnExtractor> extractors = new ArrayList<>();
+    /**
+     * Resources whose lifecycle must extend beyond the source operator's, because the deferred
+     * extraction path keeps using them to satisfy point lookups long after the source finished
+     * producing pages. Typical example: the per-query concurrency budget that wraps the storage
+     * provider — extractors hold {@code QueryBudgetedStorageObject}s that must still be able to
+     * acquire permits when {@link #materialize} runs. These closeables are closed (LIFO) by
+     * {@link #close()} after the registered extractors, so any storage objects they own are torn
+     * down first.
+     */
+    private final List<Closeable> trailingCloseables = new ArrayList<>();
+    private boolean closed = false;
+
+    /**
+     * Register a new {@link ColumnExtractor} and return the id assigned to it. Ids are allocated
+     * sequentially starting at 0, in registration order. The returned id is what callers must
+     * pack into the {@code _rowPosition} values they emit for rows coming from this extractor's
+     * file.
+     *
+     * @throws IllegalStateException if the table is closed or if the id space is exhausted
+     */
+    public synchronized int register(ColumnExtractor extractor) {
+        if (extractor == null) {
+            throw new IllegalArgumentException("extractor must not be null");
+        }
+        if (closed) {
+            throw new IllegalStateException("SourceExtractors is closed");
+        }
+        int id = extractors.size();
+        if (id > MAX_EXTRACTOR_ID) {
+            throw new IllegalStateException("extractor id space exhausted; maximum is " + MAX_EXTRACTOR_ID + " registrations per driver");
+        }
+        extractors.add(extractor);
+        return id;
+    }
+
+    /**
+     * Look up a registered extractor by id. Throws {@link IllegalArgumentException} for ids that
+     * were never assigned — this should never happen in normal operation because the id always
+     * comes from a previously-encoded row reference, so failure here indicates a wiring bug.
+     */
+    public synchronized ColumnExtractor get(int id) {
+        if (id < 0 || id >= extractors.size()) {
+            throw new IllegalArgumentException("extractor id [" + id + "] is out of range [0, " + extractors.size() + ")");
+        }
+        return extractors.get(id);
+    }
+
+    /** Number of extractors currently registered. */
+    public synchronized int size() {
+        return extractors.size();
+    }
+
+    /**
+     * Attach a closeable whose lifecycle must extend beyond the source operator's. The closeable
+     * is closed during {@link #close()} after all registered extractors, so any storage objects
+     * the extractors hold get released before the trailing resource (the per-query concurrency
+     * budget) is torn down.
+     * <p>
+     * If the registry has already been closed, the closeable is closed immediately to preserve
+     * the invariant that registered resources are eventually closed exactly once.
+     */
+    public void registerTrailingCloseable(Closeable closeable) {
+        if (closeable == null) {
+            return;
+        }
+        boolean closeNow;
+        synchronized (this) {
+            if (closed) {
+                closeNow = true;
+            } else {
+                trailingCloseables.add(closeable);
+                closeNow = false;
+            }
+        }
+        if (closeNow) {
+            IOUtils.closeWhileHandlingException(closeable);
+        }
+    }
+
+    /**
+     * Materialize {@code columns} for the rows referenced by {@code encodedRefs[0..count)}.
+     * Output blocks preserve the input order: row {@code i} of each output block corresponds to
+     * {@code encodedRefs[i]}.
+     * <p>
+     * Algorithm: classify each input ref by its extractor id, build per-extractor packed arrays
+     * of file-local positions, dispatch one {@link ColumnExtractor#extract} call per (column, id)
+     * pair, then reassemble the output by walking the original slot order. The grouping makes
+     * each underlying extractor see a single batched call per column rather than one call per
+     * row, which matters for parquet because each call walks the file forward.
+     *
+     * @param encodedRefs encoded row references (as emitted via {@code _rowPosition})
+     * @param count       number of valid entries in {@code encodedRefs}
+     * @param columns     column names to materialize
+     * @param factory     block factory for memory accounting
+     * @return one Block per column, each with exactly {@code count} rows; in caller-supplied order
+     */
+    public Block[] materialize(long[] encodedRefs, int count, List<String> columns, BlockFactory factory) {
+        if (encodedRefs == null) {
+            throw new IllegalArgumentException("encodedRefs must not be null");
+        }
+        if (columns == null) {
+            throw new IllegalArgumentException("columns must not be null");
+        }
+        if (factory == null) {
+            throw new IllegalArgumentException("factory must not be null");
+        }
+        if (count < 0) {
+            throw new IllegalArgumentException("count must be non-negative, got [" + count + "]");
+        }
+        if (count > encodedRefs.length) {
+            throw new IllegalArgumentException("count [" + count + "] exceeds encodedRefs length [" + encodedRefs.length + "]");
+        }
+
+        // Snapshot the current size and grab a stable reference. Source registrations are
+        // monotonic; we never see fewer extractors than encoded ids reference, so snapshotting
+        // is safe even though new extractors may register after this read.
+        final List<ColumnExtractor> snapshot;
+        synchronized (this) {
+            if (closed) {
+                throw new IllegalStateException("SourceExtractors is closed");
+            }
+            snapshot = new ArrayList<>(extractors);
+        }
+
+        int colCount = columns.size();
+        Block[] result = new Block[colCount];
+        if (count == 0) {
+            for (int i = 0; i < colCount; i++) {
+                result[i] = factory.newConstantNullBlock(0);
+            }
+            return result;
+        }
+        if (snapshot.isEmpty()) {
+            throw new IllegalStateException("extract requested for [" + count + "] positions but no extractors are registered");
+        }
+
+        // Phase 1: classify each input ref by extractor id, validating bounds along the way.
+        int snapSize = snapshot.size();
+        int[] idPerInput = new int[count];
+        int[] perIdCounts = new int[snapSize];
+        for (int i = 0; i < count; i++) {
+            long ref = encodedRefs[i];
+            int id = decodeExtractorId(ref);
+            if (id < 0 || id >= snapSize) {
+                throw new IllegalArgumentException(
+                    "row reference [" + ref + "] decodes to extractor id [" + id + "] which is out of range [0, " + snapSize + ")"
+                );
+            }
+            idPerInput[i] = id;
+            perIdCounts[id]++;
+        }
+
+        // Phase 2: build per-id packed arrays of file-local positions and the original output slot
+        // each one will fill in the final blocks.
+        long[][] localPositionsById = new long[snapSize][];
+        int[][] outputSlotsById = new int[snapSize][];
+        for (int id = 0; id < snapSize; id++) {
+            int c = perIdCounts[id];
+            if (c > 0) {
+                localPositionsById[id] = new long[c];
+                outputSlotsById[id] = new int[c];
+            }
+        }
+        int[] cursors = new int[snapSize];
+        for (int i = 0; i < count; i++) {
+            int id = idPerInput[i];
+            int slot = cursors[id]++;
+            localPositionsById[id][slot] = decodeLocalPosition(encodedRefs[i]);
+            outputSlotsById[id][slot] = i;
+        }
+
+        // Phase 3: per-id multi-column extraction. Each ColumnExtractor's multi-column extract
+        // returns one Block per requested column; row k of every returned block aligns with
+        // localPositionsById[id][k] (per-id grouping order). One call per id, not one per
+        // (column, id) pair: implementations can coalesce I/O across columns within the same
+        // call, and we never make more remote requests than there are extractor ids in the
+        // batch. perColIdBlocks[c][id] holds the column-c block for extractor id.
+        Block[][] perColIdBlocks = new Block[colCount][snapSize];
+        boolean assembled = false;
+        try {
+            String[] columnNames = columns.toArray(String[]::new);
+            for (int id = 0; id < snapSize; id++) {
+                if (perIdCounts[id] == 0) {
+                    continue;
+                }
+                Block[] perIdBlocks;
+                try {
+                    perIdBlocks = snapshot.get(id).extract(columnNames, localPositionsById[id], factory);
+                } catch (IOException e) {
+                    throw new UncheckedIOException("failed to materialize columns " + columns + " from extractor id [" + id + "]", e);
+                }
+                if (perIdBlocks == null || perIdBlocks.length != colCount) {
+                    if (perIdBlocks != null) {
+                        Releasables.closeExpectNoException(perIdBlocks);
+                    }
+                    throw new IllegalStateException(
+                        "extractor id ["
+                            + id
+                            + "] returned "
+                            + (perIdBlocks == null ? "null" : perIdBlocks.length + " blocks")
+                            + " for "
+                            + colCount
+                            + " requested columns"
+                    );
+                }
+                for (int c = 0; c < colCount; c++) {
+                    perColIdBlocks[c][id] = perIdBlocks[c];
+                }
+            }
+
+            // Phase 4: invert the per-id grouping so we can walk output slots in order.
+            int[] inverseId = new int[count];
+            int[] inverseIndex = new int[count];
+            for (int id = 0; id < snapSize; id++) {
+                int[] slots = outputSlotsById[id];
+                if (slots == null) {
+                    continue;
+                }
+                for (int i = 0; i < slots.length; i++) {
+                    inverseId[slots[i]] = id;
+                    inverseIndex[slots[i]] = i;
+                }
+            }
+
+            // Phase 5: build the final per-column blocks by copying from the per-id blocks in slot
+            // order. Element type comes from the first non-null per-id block for each column.
+            // Hot-path optimization opportunity (deferred): when {@code snapSize == 1} the inverse
+            // mapping is identity ({@code inverseId[s] == 0}, {@code inverseIndex[s] == s}) and the
+            // builder copy reduces to a verbatim re-build of the per-id block. Detecting that case
+            // and returning the per-id block directly (with an extra {@code incRef}) would avoid
+            // {@code count * colCount} {@code copyFrom} calls on the dominant single-file path.
+            Block.Builder[] builders = new Block.Builder[colCount];
+            boolean built = false;
+            try {
+                for (int c = 0; c < colCount; c++) {
+                    for (int id = 0; id < snapSize; id++) {
+                        if (perColIdBlocks[c][id] != null) {
+                            builders[c] = perColIdBlocks[c][id].elementType().newBlockBuilder(count, factory);
+                            break;
+                        }
+                    }
+                }
+                for (int slot = 0; slot < count; slot++) {
+                    int id = inverseId[slot];
+                    int idx = inverseIndex[slot];
+                    for (int c = 0; c < colCount; c++) {
+                        Block source = perColIdBlocks[c][id];
+                        // source is non-null because perIdCounts[id] > 0 (slot exists for this id).
+                        builders[c].copyFrom(source, idx, idx + 1);
+                    }
+                }
+                try {
+                    for (int c = 0; c < colCount; c++) {
+                        if (builders[c] == null) {
+                            result[c] = factory.newConstantNullBlock(count);
+                        } else {
+                            result[c] = builders[c].build();
+                        }
+                    }
+                    built = true;
+                } finally {
+                    if (built == false) {
+                        Releasables.closeExpectNoException(result);
+                        java.util.Arrays.fill(result, null);
+                    }
+                }
+            } finally {
+                for (Block.Builder b : builders) {
+                    if (b != null) {
+                        Releasables.closeExpectNoException(b);
+                    }
+                }
+            }
+            assembled = true;
+        } finally {
+            if (assembled == false) {
+                // result blocks are released in the inner finally above; here we just drop the
+                // per-id intermediate blocks that we own.
+            }
+            for (Block[] perCol : perColIdBlocks) {
+                for (Block b : perCol) {
+                    if (b != null) {
+                        Releasables.closeExpectNoException(b);
+                    }
+                }
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public synchronized void close() {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        Releasables.closeExpectNoException(extractors.toArray(new Releasable[0]));
+        extractors.clear();
+        // Close trailing resources (e.g. per-query budget) after the extractors so any
+        // storage-object closes that flow through them succeed before the budget is torn down.
+        // LIFO order — last attached, first closed.
+        for (int i = trailingCloseables.size() - 1; i >= 0; i--) {
+            IOUtils.closeWhileHandlingException(trailingCloseables.get(i));
+        }
+        trailingCloseables.clear();
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/ColumnExtractor.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/ColumnExtractor.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.spi;
+
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.Releasables;
+
+import java.io.IOException;
+
+/**
+ * Loads one projected column by physical row identity.
+ * <p>
+ * Deferred extraction keeps the forward scan narrow (sort keys, predicates, and the synthetic
+ * routing column) and materializes wide projection-only columns only after a per-driver TopN has
+ * chosen surviving rows.
+ *
+ * <h2>Addressing space (physical row identity)</h2>
+ * The {@code positions} accepted by {@link #extract} are <em>row identities</em>: stable, opaque
+ * {@code long}s the iterator that emits {@link #ROW_POSITION_COLUMN} attached to each row. The
+ * extractor and the iterator must agree on the encoding — for the Parquet implementation, it is
+ * the file-global row index in footer iteration order, which is filter-, late-materialization-,
+ * and page-skip-invariant. This makes the handshake robust to whatever survives between scan and
+ * extract: the same row coming back later carries the same identity that pointed at it during the
+ * forward scan, no matter how many predicate / page-skipping transforms ran in between.
+ * <p>
+ * The handshake between an iterator and its matching extractor is expressed by
+ * {@link ColumnExtractorProducer}: an iterator that emits {@link #ROW_POSITION_COLUMN} implements
+ * that interface and produces an extractor whose addressing space matches its own.
+ * <p>
+ * Composition across multiple sources opened in the same driver — assigning extractor ids,
+ * encoding references, and dispatching extractions — is handled by {@code SourceExtractors}
+ * ({@code org.elasticsearch.xpack.esql.datasources.SourceExtractors}), not by this SPI.
+ * <p>
+ * Threading: a single driver thread owns an instance; implementations need not be thread-safe.
+ */
+public interface ColumnExtractor extends Releasable {
+
+    /**
+     * Bit position of the extractor id within an encoded {@code _rowPosition} value. The low
+     * {@code LOCAL_POSITION_BITS} hold the per-extractor physical row identity; the high bits
+     * hold the registry-assigned extractor id. This is the wire-format the iterator implementing
+     * {@link ColumnExtractorProducer} must respect when it pre-encodes its emitted values.
+     * <p>
+     * The framework's {@code SourceExtractors} owns the canonical encoding/decoding helpers and
+     * pins this same value; the constant is mirrored here so format readers depend only on the
+     * SPI when implementing the encoding handshake.
+     */
+    int LOCAL_POSITION_BITS = 48;
+
+    /**
+     * Reserved name of the synthetic row-reference column emitted by source readers that support
+     * deferred materialization. Values are opaque encoded references combining an extractor id with
+     * a physical row identity — see {@code org.elasticsearch.xpack.esql.datasources.SourceExtractors}
+     * for the bit layout.
+     * <p>
+     * Encoding lives at the iterator boundary: the source factory wires an extractor id into the
+     * iterator via {@link ColumnExtractorProducer#setExtractorId(int)}, and from then on every
+     * {@code _rowPosition} value the iterator emits is already encoded as
+     * {@code (id << 48) | physicalRowOffset}. Downstream operators decode without a separate
+     * encoding pass. The extract operator removes this channel from its output.
+     * <p>
+     * Historically the encoding ran in a wrapper iterator that rebuilt the {@code _rowPosition}
+     * block per page. That wrapper was removed once iterators began materialising the values
+     * themselves; if a future format reader cannot pre-encode in-line, re-introducing a similar
+     * wrapper is a viable (if slower) fallback — the contract surfaces here so the option remains
+     * discoverable.
+     */
+    String ROW_POSITION_COLUMN = "_rowPosition";
+
+    /**
+     * Number of distinct row identities addressable by this extractor.
+     * <p>
+     * The valid range for {@link #extract}'s {@code positions} entries is {@code [0, rowCount())}.
+     * For Parquet this is the file's total row count.
+     * <p>
+     * Implementations should return a pure in-memory value without triggering I/O.
+     *
+     * @return number of rows addressable by this extractor
+     */
+    long rowCount();
+
+    /**
+     * Materializes one or more columns at the given row identities in a single I/O batch.
+     * <p>
+     * Callers invoke this after TopN with only the identities that survived pruning. Identities may
+     * be unsorted and may repeat; the returned blocks must align row {@code i} with
+     * {@code positions[i]} so operators can zip deferred values with encoded references without an
+     * extra reordering pass. Each entry must lie in {@code [0, rowCount())}.
+     * <p>
+     * Implementations should fetch every requested column's bytes in one coalesced batch so that
+     * latency and per-request overhead are amortised across the projection. For object-store
+     * backends like S3 the win is significant: the cost dominator is the per-request RTT/TTFB,
+     * so issuing one fan-out batch covering all columns instead of N sequential batches turns
+     * a {@code O(N)} round-trip wait into {@code O(1)}. For physical layouts where columns within
+     * a row group are contiguous (e.g. Parquet column chunks), the bytes for multiple columns also
+     * coalesce naturally during merging.
+     * <p>
+     * Returned blocks are owned by the caller; on partial failure, the implementation must
+     * release any blocks it already built before propagating the exception.
+     *
+     * @param columnNames   logical columns to load, in output order; must not contain
+     *                      {@link #ROW_POSITION_COLUMN}
+     * @param positions     row identities; every element is read
+     * @param blockFactory  factory for breaker-aware allocation
+     * @return one block per requested column, each with exactly {@code positions.length} values
+     *         in caller order
+     * @throws IOException if the format reader fails while satisfying the request
+     */
+    Block[] extract(String[] columnNames, long[] positions, BlockFactory blockFactory) throws IOException;
+
+    /**
+     * Convenience overload for the common single-column case. Delegates to
+     * {@link #extract(String[], long[], BlockFactory)} so implementations only need to provide one
+     * code path.
+     */
+    default Block extract(String columnName, long[] positions, BlockFactory blockFactory) throws IOException {
+        Block[] blocks = extract(new String[] { columnName }, positions, blockFactory);
+        if (blocks.length != 1) {
+            Releasables.closeExpectNoException(blocks);
+            throw new IllegalStateException("extract returned " + blocks.length + " blocks for one requested column");
+        }
+        return blocks[0];
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/ColumnExtractorAware.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/ColumnExtractorAware.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.spi;
+
+/**
+ * Capability marker for {@link FormatReader} implementations that can re-read columns positionally
+ * after the primary forward scan.
+ * <p>
+ * Presence of this interface is the capability signal: planners use {@code instanceof
+ * ColumnExtractorAware} rather than a separate flag. Readers without cheap random access simply
+ * omit it. This stays orthogonal to {@link FormatReader#filterPushdownSupport()},
+ * {@link FormatReader#aggregatePushdownSupport()}, and {@link FormatReader#withPushedFilter(Object)}
+ * — deferred extraction is an additional optional path layered on the same configured reader.
+ * <p>
+ * When supported, the planner narrows the scan for {@code SORT … | LIMIT}-style queries and relies on
+ * {@code InsertExternalFieldExtraction} ({@code
+ * org.elasticsearch.xpack.esql.optimizer.rules.physical.local.InsertExternalFieldExtraction}) plus
+ * {@code SourceExtractors} ({@code org.elasticsearch.xpack.esql.datasources.SourceExtractors}) to
+ * reload deferred fields above TopN.
+ * <p>
+ * The runtime handshake — actually producing a {@link ColumnExtractor} matched to a specific
+ * forward-scan iterator — is expressed by {@link ColumnExtractorProducer}, which the reader's
+ * iterator implements when it emits {@link ColumnExtractor#ROW_POSITION_COLUMN}.
+ */
+public interface ColumnExtractorAware {}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/ColumnExtractorProducer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/ColumnExtractorProducer.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.spi;
+
+import java.io.IOException;
+
+/**
+ * Implemented by reader iterators that emit the synthetic
+ * {@link ColumnExtractor#ROW_POSITION_COLUMN} alongside their pages and can produce a matching
+ * {@link ColumnExtractor} whose addressing space is identical to the one the iterator is using
+ * for its row-position counter.
+ * <p>
+ * Implementing this interface is mandatory for any reader iterator on the deferred-extraction
+ * path: opting in commits to the full handshake — the iterator both produces a matching
+ * extractor and emits {@code _rowPosition} values <em>already encoded</em> with the registry-
+ * assigned id, so downstream operators can decode them without an intermediate re-encoding
+ * pass. Iterators that don't support deferred extraction simply omit
+ * {@link ColumnExtractorAware} on the format reader and never reach this code path.
+ *
+ * <h2>Encoding handshake</h2>
+ * <ol>
+ *   <li>The factory wraps the iterator's pages and calls
+ *       {@link #createColumnExtractor()} to build a matching {@link ColumnExtractor}.</li>
+ *   <li>The factory registers the extractor with {@code SourceExtractors}, receiving an id.</li>
+ *   <li>The factory calls {@link #setExtractorId(int)} <em>before</em> draining the first page,
+ *       handing the iterator the id it must OR into every {@code _rowPosition} value it emits.</li>
+ *   <li>From then on, every page the iterator returns carries pre-encoded {@code _rowPosition}
+ *       values of the form {@code (id << 48) | physicalRowOffset} — see {@code SourceExtractors}
+ *       for the bit layout.</li>
+ * </ol>
+ * Encoding inside the iterator is significantly cheaper than wrapping the page stream with a
+ * separate encoder: it avoids re-allocating the {@code _rowPosition} block per page (the iterator
+ * already has the values in a primitive {@code long[]} buffer) and removes a per-page page-rebuild
+ * step from the producer thread.
+ * <p>
+ * Implementations should construct the extractor lazily — typically on the first call to
+ * {@link #createColumnExtractor()} — and may return the same instance on subsequent calls.
+ * Lifetime is owned by the caller via {@code SourceExtractors} (the registry calls
+ * {@link ColumnExtractor#close()} when the driver finishes).
+ */
+public interface ColumnExtractorProducer {
+
+    /**
+     * Creates the {@link ColumnExtractor} matching this iterator's addressing space.
+     * <p>
+     * The iterator must already be positioned to emit pages with {@link ColumnExtractor#ROW_POSITION_COLUMN}
+     * before this is called; implementations may capture iterator-internal state (such as a
+     * range-restricted footer) at construction time.
+     */
+    ColumnExtractor createColumnExtractor() throws IOException;
+
+    /**
+     * Hands the iterator the {@code SourceExtractors}-assigned id under which its matching
+     * {@link ColumnExtractor} is registered. Must be called once, after
+     * {@link #createColumnExtractor()} and before the first page is drained. Every subsequent
+     * page the iterator emits must carry {@code _rowPosition} values already encoded with this
+     * id (typically by OR-ing {@code ((long) id << 48)} into each value as it is materialised).
+     * <p>
+     * Calling this method twice on the same iterator, or skipping it on the deferred path, is a
+     * programmer error: the iterator's pages either carry mismatched ids or unencoded raw row
+     * offsets that the lookup registry cannot route.
+     *
+     * @param id  registry-assigned extractor id; must be in {@code [0, MAX_EXTRACTOR_ID]}
+     *            (see {@code SourceExtractors})
+     */
+    void setExtractorId(int id);
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/ExternalOptimizerContext.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/ExternalOptimizerContext.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.optimizer;
+
+import org.elasticsearch.xpack.esql.datasources.FormatReaderRegistry;
+
+/**
+ * Container for external-source planning state attached to {@link LocalPhysicalOptimizerContext}.
+ * <p>
+ * Today it carries only the {@link FormatReaderRegistry}, which a small set of optimizer rules
+ * consult to discover what an external source's underlying reader supports (filter pushdown,
+ * aggregate pushdown, deferred column extraction). Encapsulating it here keeps the parent
+ * context's signature stable as new external-source-only fields appear (e.g. capability sets,
+ * per-source statistics caches): future additions land on this record, never on
+ * {@link LocalPhysicalOptimizerContext}.
+ * <p>
+ * Instances are constructed once per local-plan invocation by
+ * {@code PlannerUtils.localPlan(... FormatReaderRegistry ...)}; rules read through
+ * {@link LocalPhysicalOptimizerContext#external()}. Use {@link #NONE} for callers (e.g.
+ * coordinator-side optimization, lookup-service planning, tests) that have no external sources
+ * in scope.
+ */
+public record ExternalOptimizerContext(FormatReaderRegistry formatReaderRegistry) {
+
+    /**
+     * Sentinel for callers without any external-source state. Rules that consult external
+     * capabilities must treat {@code formatReaderRegistry == null} as "no information" and bail
+     * out of the optimization, mirroring the previous behavior when the registry field was
+     * unset on the parent context.
+     */
+    public static final ExternalOptimizerContext NONE = new ExternalOptimizerContext(null);
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalOptimizerContext.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalOptimizerContext.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.esql.optimizer;
 
 import org.elasticsearch.xpack.esql.core.expression.FoldContext;
-import org.elasticsearch.xpack.esql.datasources.FormatReaderRegistry;
 import org.elasticsearch.xpack.esql.planner.PlannerSettings;
 import org.elasticsearch.xpack.esql.plugin.EsqlFlags;
 import org.elasticsearch.xpack.esql.session.Configuration;
@@ -20,10 +19,12 @@ public record LocalPhysicalOptimizerContext(
     Configuration configuration,
     FoldContext foldCtx,
     SearchStats searchStats,
-    FormatReaderRegistry formatReaderRegistry
+    ExternalOptimizerContext external
 ) {
     /**
-     * Convenience constructor without format reader registry (for backward compatibility and tests).
+     * Convenience constructor without external-source state (for backward compatibility and tests
+     * that don't exercise external-source rules). External-source-aware rules must treat the
+     * resulting context as "no external information" and bail out cleanly.
      */
     public LocalPhysicalOptimizerContext(
         PlannerSettings plannerSettings,
@@ -32,6 +33,7 @@ public record LocalPhysicalOptimizerContext(
         FoldContext foldCtx,
         SearchStats searchStats
     ) {
-        this(plannerSettings, flags, configuration, foldCtx, searchStats, null);
+        this(plannerSettings, flags, configuration, foldCtx, searchStats, ExternalOptimizerContext.NONE);
     }
+
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizer.java
@@ -15,6 +15,7 @@ import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.ReplaceSampledStatsBySampleAndStats;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.EnableSpatialDistancePushdown;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.ExtractDimensionFieldsAfterAggregation;
+import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.InsertExternalFieldExtraction;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.InsertFieldExtraction;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.PushAggregatesToExternalSource;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.PushCountQueryAndTagsToSource;
@@ -111,7 +112,11 @@ public class LocalPhysicalPlanOptimizer extends ParameterizedRuleExecutor<Physic
             new ExtractDimensionFieldsAfterAggregation(),
             new InsertFieldExtraction(),
             new SpatialDocValuesExtraction(),
-            new SpatialShapeDocValuesExtraction()
+            new SpatialShapeDocValuesExtraction(),
+            // Runs after PushTopNIntoExternalSource (which lives in the pushdown batch above) so we
+            // see the surviving TopN nodes that did not get fully pushed into the source. Inserts
+            // an ExternalFieldExtractExec above each remaining TopN whose source supports it.
+            new InsertExternalFieldExtraction()
         );
 
         return List.of(pushdown, substitutionRules, fieldExtraction);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/InsertExternalFieldExtraction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/InsertExternalFieldExtraction.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.optimizer.rules.physical.local;
+
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.AttributeSet;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.MetadataAttribute;
+import org.elasticsearch.xpack.esql.core.expression.Nullability;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.datasources.FormatReaderRegistry;
+import org.elasticsearch.xpack.esql.datasources.spi.ColumnExtractor;
+import org.elasticsearch.xpack.esql.datasources.spi.ColumnExtractorAware;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
+import org.elasticsearch.xpack.esql.optimizer.ExternalOptimizerContext;
+import org.elasticsearch.xpack.esql.optimizer.LocalPhysicalOptimizerContext;
+import org.elasticsearch.xpack.esql.optimizer.PhysicalOptimizerRules;
+import org.elasticsearch.xpack.esql.optimizer.rules.logical.OptimizerRules;
+import org.elasticsearch.xpack.esql.plan.physical.ExternalFieldExtractExec;
+import org.elasticsearch.xpack.esql.plan.physical.ExternalSourceExec;
+import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+import org.elasticsearch.xpack.esql.plan.physical.TopNExec;
+import org.elasticsearch.xpack.esql.plan.physical.UnaryExec;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Inserts a deferred field-extraction step above a per-driver {@link TopNExec} that sits on top of
+ * an {@link ExternalSourceExec}. The forward scan is narrowed to the columns the TopN actually
+ * uses (sort keys and any predicate / eval inputs traversed between TopN and the source) plus a
+ * synthetic {@code _rowPosition} key. The remaining ("wide") columns are loaded later, for the
+ * at-most-LIMIT surviving rows, by an {@link ExternalFieldExtractExec} placed immediately above
+ * the TopN.
+ * <p>
+ * Net effect: a TopN that previously pulled every projected column out of the file now only reads
+ * the sort key column up front and pays the I/O for the wide columns only for the rows that
+ * survive — analogous to Lucene's late materialization for {@code SORT … | LIMIT N}.
+ * <p>
+ * Bail-out conditions (rule returns the plan unchanged):
+ * <ul>
+ *     <li>No {@link ExternalSourceExec} reachable below the TopN through a {@link UnaryExec} spine.</li>
+ *     <li>{@link #supportsDeferredExtraction(String, ExternalOptimizerContext)} returns
+ *         {@code false} for the source's format — the underlying reader does not implement
+ *         {@link ColumnExtractorAware}.</li>
+ *     <li>The TopN's limit is unknown or exceeds {@link #TOPN_EXTRACT_LIMIT_MAX}.</li>
+ *     <li>Fewer than {@link #DEFERRED_COLUMN_MIN} columns would actually be deferred.</li>
+ *     <li>One of the source's columns is already named {@value #ROW_POSITION_NAME} — we refuse to
+ *         shadow user data rather than try to rename.</li>
+ * </ul>
+ * <p>
+ * Production filter invariant: any {@link ExternalSourceExec} reaching this rule with a
+ * {@link ExternalSourceExec#pushedFilter()} also carries non-empty
+ * {@link ExternalSourceExec#pushedExpressions()}, because the only production code path that
+ * installs a pushed filter is {@code PushFiltersToSource}, which always populates both via
+ * {@link ExternalSourceExec#withPushedFilterAndExpressions(Object, java.util.List)}. The rule
+ * uses the expressions to keep filter-referenced columns eager so the narrowed projection
+ * still has every input the filter reads.
+ */
+public class InsertExternalFieldExtraction extends PhysicalOptimizerRules.ParameterizedOptimizerRule<
+    TopNExec,
+    LocalPhysicalOptimizerContext> {
+
+    public InsertExternalFieldExtraction() {
+        // Transform bottom-up so an inner TopN gets the chance to defer extraction before any
+        // enclosing TopN's subtree is reshaped (which would hide the source below the inserted
+        // ExternalFieldExtractExec and silently disable the outer optimization).
+        super(OptimizerRules.TransformDirection.UP);
+    }
+
+    /**
+     * Minimum number of columns that need to be deferred before the optimization is worth applying.
+     * Below this, the per-row extraction overhead (random access reads, page assembly) outweighs
+     * the I/O saved by not loading the columns up front.
+     */
+    public static final int DEFERRED_COLUMN_MIN = 3;
+
+    /**
+     * Maximum TopN limit for which the optimization fires. Above this, the extraction phase risks
+     * doing more random-access I/O than the streaming forward scan it replaces.
+     */
+    public static final int TOPN_EXTRACT_LIMIT_MAX = 10_000;
+
+    static final String ROW_POSITION_NAME = ColumnExtractor.ROW_POSITION_COLUMN;
+
+    @Override
+    protected PhysicalPlan rule(TopNExec topN, LocalPhysicalOptimizerContext ctx) {
+        Integer limit = limitOf(topN, ctx);
+        if (limit == null || limit > TOPN_EXTRACT_LIMIT_MAX) {
+            return topN;
+        }
+
+        ExternalSourceExec externalSource = findExternalSource(topN.child());
+        if (externalSource == null) {
+            return topN;
+        }
+
+        if (supportsDeferredExtraction(externalSource.sourceType(), ctx == null ? null : ctx.external()) == false) {
+            return topN;
+        }
+
+        // The source carries the pushed filter as an opaque object — we can't introspect it. But
+        // {@link ExternalSourceExec#pushedExpressions()} keeps the original ESQL {@link Expression}
+        // tree the optimizer pushed down, and its {@code references()} expose the exact set of
+        // source columns the filter reads. We use those to keep the narrowed projection sound:
+        // every column the filter touches stays eager. The class-level invariant guarantees a
+        // pushed filter on an {@link ExternalSourceExec} always comes with non-empty pushed
+        // expressions (production filters flow through {@code PushFiltersToSource}, which always
+        // calls {@code withPushedFilterAndExpressions}); a non-production assignment that violates
+        // it would silently disable the optimization, so we assert instead.
+        List<Expression> pushedExpressions = externalSource.pushedExpressions();
+        boolean hasPushedFilter = externalSource.pushedFilter() != null;
+        assert hasPushedFilter == false || (pushedExpressions != null && pushedExpressions.isEmpty() == false)
+            : "ExternalSourceExec ["
+                + externalSource.sourceType()
+                + "] has a pushed filter without pushed expressions; production filters must flow through PushFiltersToSource";
+
+        // Refuse to fire if a user column already collides with our synthetic name. Renaming is
+        // possible but adds complexity for a vanishingly rare case; bailing out preserves
+        // correctness without surprises.
+        for (Attribute a : externalSource.output()) {
+            if (ROW_POSITION_NAME.equals(a.name())) {
+                return topN;
+            }
+        }
+
+        // Eager set: every attribute referenced anywhere between TopN (inclusive) and the source,
+        // plus everything the source-level pushed filter reads (only its expressions, which we
+        // can enumerate). We start from the TopN's own references (sort key expressions), union
+        // in references from every intermediate UnaryExec node down to the source, then add the
+        // pushed-filter expression refs. Anything in the source output not in this set is safe
+        // to defer.
+        AttributeSet eagerRefs = AttributeSet.builder().addAll(topN.references()).build();
+        eagerRefs = unionWithIntermediateRefs(topN.child(), externalSource, eagerRefs);
+        if (hasPushedFilter) {
+            AttributeSet.Builder withFilterRefs = AttributeSet.builder().addAll(eagerRefs);
+            for (Expression e : pushedExpressions) {
+                withFilterRefs.addAll(e.references());
+            }
+            eagerRefs = withFilterRefs.build();
+        }
+
+        List<Attribute> sourceOutput = externalSource.output();
+        List<Attribute> eagerColumns = new ArrayList<>(sourceOutput.size());
+        List<Attribute> deferredColumns = new ArrayList<>(sourceOutput.size());
+        for (Attribute a : sourceOutput) {
+            if (eagerRefs.contains(a)) {
+                eagerColumns.add(a);
+            } else {
+                deferredColumns.add(a);
+            }
+        }
+
+        if (deferredColumns.size() < DEFERRED_COLUMN_MIN) {
+            return topN;
+        }
+
+        MetadataAttribute rowPositionAttribute = new MetadataAttribute(
+            externalSource.source(),
+            ROW_POSITION_NAME,
+            DataType.LONG,
+            Nullability.FALSE,
+            null,
+            true,
+            false
+        );
+
+        List<Attribute> narrowedAttributes = new ArrayList<>(eagerColumns.size() + 1);
+        narrowedAttributes.addAll(eagerColumns);
+        narrowedAttributes.add(rowPositionAttribute);
+
+        ExternalSourceExec narrowedSource = externalSource.withAttributes(narrowedAttributes);
+        // Rebuild the (TopN, …, ExternalSourceExec) spine with the narrowed source at the bottom.
+        // Every intermediate node's children are unchanged except for the source-replacement at the
+        // leaf of the spine, so the recursive copy here rewires correctly.
+        TopNExec rewrittenTopN = (TopNExec) replaceSource(topN, externalSource, narrowedSource);
+
+        return new ExternalFieldExtractExec(topN.source(), rewrittenTopN, List.copyOf(deferredColumns), rowPositionAttribute);
+    }
+
+    /**
+     * Whether the configured external-source reader for the given {@code sourceType} can serve
+     * positional column reads after the forward scan — the precondition for inserting an
+     * {@link ExternalFieldExtractExec} above a TopN. Returns {@code false} when the rule has no
+     * way to verify the capability (no external context, no registry, source type unregistered),
+     * causing the rule to bail out and leave the plan unchanged.
+     * <p>
+     * Encapsulating the lookup here keeps the rule body free of {@link FormatReaderRegistry} and
+     * {@link FormatReader} mechanics; the rule expresses the plan-shape conditions and delegates
+     * the runtime-capability question to this single, replaceable predicate.
+     */
+    static boolean supportsDeferredExtraction(String sourceType, ExternalOptimizerContext external) {
+        if (external == null) {
+            return false;
+        }
+        FormatReaderRegistry registry = external.formatReaderRegistry();
+        if (registry == null || sourceType == null) {
+            return false;
+        }
+        FormatReader reader = registry.findByName(sourceType);
+        return reader instanceof ColumnExtractorAware;
+    }
+
+    private static Integer limitOf(TopNExec topN, LocalPhysicalOptimizerContext ctx) {
+        if (topN.limit().foldable() == false) {
+            return null;
+        }
+        Object folded = topN.limit().fold(ctx != null ? ctx.foldCtx() : null);
+        if (folded instanceof Integer i) {
+            return i;
+        }
+        if (folded instanceof Number n) {
+            long l = n.longValue();
+            if (l < 0 || l > Integer.MAX_VALUE) {
+                return null;
+            }
+            return (int) l;
+        }
+        return null;
+    }
+
+    /**
+     * Walk down the spine of {@code UnaryExec} nodes between {@code start} and the leaf source,
+     * returning the first {@link ExternalSourceExec} reached, or {@code null} if the spine forks
+     * or ends elsewhere.
+     */
+    static ExternalSourceExec findExternalSource(PhysicalPlan start) {
+        PhysicalPlan p = start;
+        while (true) {
+            if (p instanceof ExternalSourceExec es) {
+                return es;
+            }
+            if (p instanceof UnaryExec u) {
+                p = u.child();
+                continue;
+            }
+            return null;
+        }
+    }
+
+    /**
+     * Walk the spine between {@code start} and {@code source} and union every node's
+     * {@link PhysicalPlan#references()} into {@code initial}. This collects the attributes used by
+     * filters, evals, projections etc. that sit between TopN and the source — all of which must
+     * remain eagerly available.
+     */
+    private static AttributeSet unionWithIntermediateRefs(PhysicalPlan start, ExternalSourceExec source, AttributeSet initial) {
+        AttributeSet.Builder builder = AttributeSet.builder().addAll(initial);
+        PhysicalPlan p = start;
+        while (p != source) {
+            builder.addAll(p.references());
+            if (p instanceof UnaryExec u) {
+                p = u.child();
+            } else {
+                break;
+            }
+        }
+        return builder.build();
+    }
+
+    /**
+     * Replace {@code oldSource} with {@code newSource} inside the spine rooted at {@code root}.
+     * The spine is a single UnaryExec chain; we copy nodes from the top down, swapping the source
+     * at the leaf.
+     */
+    private static PhysicalPlan replaceSource(PhysicalPlan root, ExternalSourceExec oldSource, ExternalSourceExec newSource) {
+        if (root == oldSource) {
+            return newSource;
+        }
+        if (root instanceof UnaryExec u) {
+            PhysicalPlan newChild = replaceSource(u.child(), oldSource, newSource);
+            return u.replaceChild(newChild);
+        }
+        return root;
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushAggregatesToExternalSource.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushAggregatesToExternalSource.java
@@ -87,7 +87,7 @@ public class PushAggregatesToExternalSource extends PhysicalOptimizerRules.Param
             return aggregateExec;
         }
 
-        FormatReaderRegistry formatReaderRegistry = ctx != null ? ctx.formatReaderRegistry() : null;
+        FormatReaderRegistry formatReaderRegistry = ctx == null || ctx.external() == null ? null : ctx.external().formatReaderRegistry();
         if (formatReaderRegistry == null) {
             return aggregateExec;
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushFiltersToSource.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushFiltersToSource.java
@@ -291,7 +291,7 @@ public class PushFiltersToSource extends PhysicalOptimizerRules.ParameterizedOpt
      * Resolves filter pushdown support for the given format via {@link FormatReader#filterPushdownSupport()}.
      */
     private static FilterPushdownSupport resolveFilterPushdownSupport(String formatName, LocalPhysicalOptimizerContext ctx) {
-        FormatReaderRegistry formatReaderRegistry = ctx.formatReaderRegistry();
+        FormatReaderRegistry formatReaderRegistry = ctx.external() == null ? null : ctx.external().formatReaderRegistry();
         if (formatReaderRegistry == null) {
             return null;
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/ExternalFieldExtractExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/ExternalFieldExtractExec.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.physical;
+
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.AttributeSet;
+import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Local-only physical plan node that materializes deferred ("wide") columns for the rows that
+ * survive a per-driver TopN above an {@link ExternalSourceExec}.
+ * <p>
+ * Inserted by {@code InsertExternalFieldExtraction} immediately above the TopN when the source's
+ * format supports {@link org.elasticsearch.xpack.esql.datasources.spi.ColumnExtractor column
+ * extraction}. The rule narrows the source to sort-key + predicate columns (plus a synthetic
+ * {@code _rowPosition}); this node consumes the narrow output and loads the remaining columns
+ * for the at-most-LIMIT rows the TopN selected. The {@code _rowPosition} channel is stripped
+ * from the output so downstream operators see the same shape as if no late materialization had
+ * happened.
+ * <p>
+ * <b>NOT serialized.</b> Created by the local physical optimizer on the data node after the
+ * plan fragment arrives over the wire; consumed by {@code LocalExecutionPlanner} on the same
+ * JVM. Same lifecycle as {@code ExternalSourceExec.pushedFilter} and
+ * {@code ExternalSourceExec.pushedLimit}.
+ */
+public class ExternalFieldExtractExec extends UnaryExec {
+
+    private final List<Attribute> attributesToExtract;
+    private final Attribute rowPositionAttribute;
+
+    private List<Attribute> lazyOutput;
+
+    public ExternalFieldExtractExec(
+        Source source,
+        PhysicalPlan child,
+        List<Attribute> attributesToExtract,
+        Attribute rowPositionAttribute
+    ) {
+        super(source, child);
+        if (attributesToExtract == null) {
+            throw new IllegalArgumentException("attributesToExtract must not be null");
+        }
+        if (rowPositionAttribute == null) {
+            throw new IllegalArgumentException("rowPositionAttribute must not be null");
+        }
+        this.attributesToExtract = attributesToExtract;
+        this.rowPositionAttribute = rowPositionAttribute;
+    }
+
+    public List<Attribute> attributesToExtract() {
+        return attributesToExtract;
+    }
+
+    public Attribute rowPositionAttribute() {
+        return rowPositionAttribute;
+    }
+
+    @Override
+    public List<Attribute> output() {
+        if (lazyOutput == null) {
+            List<Attribute> childOutput = child().output();
+            List<Attribute> out = new ArrayList<>(childOutput.size() - 1 + attributesToExtract.size());
+            for (Attribute a : childOutput) {
+                // Strip _rowPosition: it served as the late-materialization key and is not a user
+                // column. Equality is by NameId so this is safe even if a user column happens to
+                // be named "_rowPosition".
+                if (a.equals(rowPositionAttribute) == false) {
+                    out.add(a);
+                }
+            }
+            out.addAll(attributesToExtract);
+            lazyOutput = List.copyOf(out);
+        }
+        return lazyOutput;
+    }
+
+    @Override
+    public ExternalFieldExtractExec replaceChild(PhysicalPlan newChild) {
+        return new ExternalFieldExtractExec(source(), newChild, attributesToExtract, rowPositionAttribute);
+    }
+
+    /**
+     * The only attribute this node requires from its child output is {@code _rowPosition} — the
+     * key into the per-driver
+     * {@link org.elasticsearch.xpack.esql.datasources.SourceExtractors source-extractor registry}.
+     * {@code attributesToExtract} are <em>produced</em> by this node, not consumed from the
+     * child; advertising them as references would mislead column-pruning rules into pinning them
+     * on the (narrowed) source.
+     */
+    @Override
+    protected AttributeSet computeReferences() {
+        return AttributeSet.of(rowPositionAttribute);
+    }
+
+    @Override
+    protected NodeInfo<? extends ExternalFieldExtractExec> info() {
+        return NodeInfo.create(this, ExternalFieldExtractExec::new, child(), attributesToExtract, rowPositionAttribute);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        throw new UnsupportedOperationException("ExternalFieldExtractExec is local-only and not serialized");
+    }
+
+    @Override
+    public String getWriteableName() {
+        throw new UnsupportedOperationException("ExternalFieldExtractExec is local-only and not serialized");
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), attributesToExtract, rowPositionAttribute);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (super.equals(obj) == false) {
+            return false;
+        }
+        ExternalFieldExtractExec other = (ExternalFieldExtractExec) obj;
+        return Objects.equals(attributesToExtract, other.attributesToExtract)
+            && Objects.equals(rowPositionAttribute, other.rowPositionAttribute);
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/ExternalSourceExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/ExternalSourceExec.java
@@ -451,6 +451,37 @@ public class ExternalSourceExec extends LeafExec implements EstimatesRowSize, Da
     }
 
     /**
+     * Returns a copy of this source with the given output attribute list. Used by
+     * {@code InsertExternalFieldExtraction} to narrow the source's projection (sort keys +
+     * predicate columns) and inject a synthetic {@code _rowPosition} attribute that the paired
+     * {@link org.elasticsearch.xpack.esql.plan.physical.ExternalFieldExtractExec} consumes.
+     * <p>
+     * Every other field — including pushed filter, pushed limit, splits, and the source path — is
+     * preserved. The new attribute list is not validated against the source's reader schema; the
+     * caller (the optimizer rule) is responsible for ensuring it is a valid subset plus
+     * {@code _rowPosition}. Serialization is unaffected because attributes are part of the wire
+     * format already.
+     */
+    public ExternalSourceExec withAttributes(List<Attribute> newAttributes) {
+        return new ExternalSourceExec(
+            source(),
+            sourcePath,
+            sourceType,
+            newAttributes,
+            config,
+            sourceMetadata,
+            pushedFilter,
+            pushedExpressions,
+            pushedLimit,
+            pushedTopN,
+            estimatedRowSize,
+            fileList,
+            schemaMap,
+            splits
+        );
+    }
+
+    /**
      * Returns a copy of this source annotated with the given Top-N grouping hint. See {@link #pushedTopN()}.
      */
     public ExternalSourceExec withPushedTopN(@Nullable BlockHash.TopNDef newPushedTopN) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -111,6 +111,8 @@ import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.type.EsField;
 import org.elasticsearch.xpack.esql.core.type.FunctionEsField;
 import org.elasticsearch.xpack.esql.core.util.Holder;
+import org.elasticsearch.xpack.esql.datasources.DeferredExtractionCapable;
+import org.elasticsearch.xpack.esql.datasources.ExternalFieldExtractOperator;
 import org.elasticsearch.xpack.esql.datasources.ExternalSliceQueue;
 import org.elasticsearch.xpack.esql.datasources.OperatorFactoryRegistry;
 import org.elasticsearch.xpack.esql.datasources.PartitionMetadata;
@@ -145,6 +147,7 @@ import org.elasticsearch.xpack.esql.plan.physical.EvalExec;
 import org.elasticsearch.xpack.esql.plan.physical.ExchangeExec;
 import org.elasticsearch.xpack.esql.plan.physical.ExchangeSinkExec;
 import org.elasticsearch.xpack.esql.plan.physical.ExchangeSourceExec;
+import org.elasticsearch.xpack.esql.plan.physical.ExternalFieldExtractExec;
 import org.elasticsearch.xpack.esql.plan.physical.ExternalSourceExec;
 import org.elasticsearch.xpack.esql.plan.physical.FieldExtractExec;
 import org.elasticsearch.xpack.esql.plan.physical.FilterExec;
@@ -322,6 +325,8 @@ public class LocalExecutionPlanner {
             return planAggregation(aggregate, context);
         } else if (node instanceof FieldExtractExec fieldExtractExec) {
             return planFieldExtractNode(fieldExtractExec, context);
+        } else if (node instanceof ExternalFieldExtractExec extExtract) {
+            return planExternalFieldExtract(extExtract, context);
         } else if (node instanceof ExchangeExec exchangeExec) {
             return planExchange(exchangeExec, context);
         } else if (node instanceof TopNExec topNExec) {
@@ -545,6 +550,80 @@ public class LocalExecutionPlanner {
 
     private PhysicalOperation planFieldExtractNode(FieldExtractExec fieldExtractExec, LocalExecutionPlannerContext context) {
         return physicalOperationProviders.fieldExtractPhysicalOperation(fieldExtractExec, plan(fieldExtractExec.child(), context), context);
+    }
+
+    /**
+     * Plan an {@link ExternalFieldExtractExec} (inserted by {@code InsertExternalFieldExtraction})
+     * by appending an {@link ExternalFieldExtractOperator} above the upstream operator chain.
+     * <p>
+     * The upstream source factory must implement {@link DeferredExtractionCapable} so the new
+     * operator can resolve the per-driver {@link org.elasticsearch.xpack.esql.datasources.SourceExtractors
+     * SourceExtractors} registry; otherwise we fail loudly because the optimizer rule should never
+     * have inserted us above an incapable source. The pairing is invariant because
+     * {@code FileSourceFactory} flips the deferred-extraction switch on the underlying
+     * {@code AsyncExternalSourceOperatorFactory} based on the very same
+     * {@link org.elasticsearch.xpack.esql.datasources.spi.ColumnExtractor#ROW_POSITION_COLUMN
+     * _rowPosition} column the rule injected.
+     * <p>
+     * Layout: the upstream layout is rewritten to drop the {@code _rowPosition} channel and
+     * append channels for every {@code attributesToExtract}. The
+     * {@link ExternalFieldExtractOperator} mirrors that channel reshaping at runtime.
+     */
+    private PhysicalOperation planExternalFieldExtract(ExternalFieldExtractExec exec, LocalExecutionPlannerContext context) {
+        PhysicalOperation source = plan(exec.child(), context);
+
+        if ((source.sourceOperatorFactory instanceof DeferredExtractionCapable) == false) {
+            throw new IllegalStateException(
+                "ExternalFieldExtractExec planned above source factory ["
+                    + source.sourceOperatorFactory.getClass().getName()
+                    + "] which does not implement DeferredExtractionCapable; "
+                    + "InsertExternalFieldExtraction must only fire above ColumnExtractorAware sources"
+            );
+        }
+        DeferredExtractionCapable capable = (DeferredExtractionCapable) source.sourceOperatorFactory;
+
+        Attribute rowPosition = exec.rowPositionAttribute();
+        Layout.ChannelAndType rpEntry = source.layout.get(rowPosition.id());
+        if (rpEntry == null) {
+            throw new IllegalStateException(
+                "_rowPosition attribute ["
+                    + rowPosition
+                    + "] is not present in upstream layout; "
+                    + "InsertExternalFieldExtraction must include it in the narrowed source projection"
+            );
+        }
+        int rowPositionChannel = rpEntry.channel();
+
+        // Pass-through channels: every channel from the upstream layout except the row-position
+        // channel, in increasing channel order. The output layout below is built from the
+        // upstream layout's inverse list using the same skip-rule, then has the deferred
+        // attributes appended; channel indices line up with the operator's output assembly.
+        List<Layout.ChannelSet> inverse = source.layout.inverse();
+        int upstreamChannels = source.layout.numberOfChannels();
+        List<Integer> passThroughChannels = new ArrayList<>(upstreamChannels - 1);
+        Layout.Builder layoutBuilder = new Layout.Builder();
+        for (int ch = 0; ch < upstreamChannels; ch++) {
+            if (ch == rowPositionChannel) {
+                continue;
+            }
+            passThroughChannels.add(ch);
+            layoutBuilder.append(inverse.get(ch));
+        }
+        layoutBuilder.append(exec.attributesToExtract());
+        Layout newLayout = layoutBuilder.build();
+
+        List<String> deferredColumnNames = new ArrayList<>(exec.attributesToExtract().size());
+        for (Attribute a : exec.attributesToExtract()) {
+            deferredColumnNames.add(a.name());
+        }
+
+        ExternalFieldExtractOperator.Factory factory = new ExternalFieldExtractOperator.Factory(
+            rowPositionChannel,
+            passThroughChannels,
+            deferredColumnNames,
+            capable::sourceExtractorsFor
+        );
+        return source.with(factory, newLayout);
     }
 
     private PhysicalOperation planOutput(OutputExec outputExec, LocalExecutionPlannerContext context) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerUtils.java
@@ -38,6 +38,7 @@ import org.elasticsearch.xpack.esql.datasources.FormatReaderRegistry;
 import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
 import org.elasticsearch.xpack.esql.expression.predicate.Predicates;
 import org.elasticsearch.xpack.esql.io.stream.PlanStreamWrapperQueryBuilder;
+import org.elasticsearch.xpack.esql.optimizer.ExternalOptimizerContext;
 import org.elasticsearch.xpack.esql.optimizer.LocalLogicalOptimizerContext;
 import org.elasticsearch.xpack.esql.optimizer.LocalLogicalPlanOptimizer;
 import org.elasticsearch.xpack.esql.optimizer.LocalPhysicalOptimizerContext;
@@ -330,7 +331,14 @@ public class PlannerUtils {
     ) {
         final var logicalOptimizer = new LocalLogicalPlanOptimizer(new LocalLogicalOptimizerContext(configuration, foldCtx, searchStats));
         var physicalOptimizer = new LocalPhysicalPlanOptimizer(
-            new LocalPhysicalOptimizerContext(plannerSettings, flags, configuration, foldCtx, searchStats, formatReaderRegistry)
+            new LocalPhysicalOptimizerContext(
+                plannerSettings,
+                flags,
+                configuration,
+                foldCtx,
+                searchStats,
+                new ExternalOptimizerContext(formatReaderRegistry)
+            )
         );
 
         return localPlan(plan, logicalOptimizer, physicalOptimizer, externalSplits, planTimeProfile);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactoryDeferredExtractionTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactoryDeferredExtractionTests.java
@@ -1,0 +1,724 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.CloseableIterator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.SourceOperator;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.type.EsField;
+import org.elasticsearch.xpack.esql.datasources.glob.GlobExpander;
+import org.elasticsearch.xpack.esql.datasources.spi.ColumnExtractor;
+import org.elasticsearch.xpack.esql.datasources.spi.ColumnExtractorAware;
+import org.elasticsearch.xpack.esql.datasources.spi.ColumnExtractorProducer;
+import org.elasticsearch.xpack.esql.datasources.spi.FileList;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
+import org.elasticsearch.xpack.esql.datasources.spi.NoConfigFormatReader;
+import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageProvider;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * End-to-end tests for the deferred-extraction path through
+ * {@link AsyncExternalSourceOperatorFactory}: opening N files registers N
+ * {@link ColumnExtractor}s on the per-driver {@link SourceExtractors} registry, and the encoded
+ * {@code _rowPosition} values emitted to downstream operators decode to the right
+ * {@code (extractorId, file-local position)} pair.
+ */
+public class AsyncExternalSourceOperatorFactoryDeferredExtractionTests extends ESTestCase {
+
+    private static final BlockFactory BLOCK_FACTORY = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE)
+        .breaker(new NoopCircuitBreaker("none"))
+        .build();
+
+    public void testDeferredExtractionRegistersExtractorPerFileAndEncodesRowPosition() throws Exception {
+        // Three files, each emitting one page with three rows. The reader emits raw file-local
+        // row positions (0, 1, 2) on the _rowPosition channel; the factory's encoder must rewrite
+        // them to (extractor_id, local_pos) packed longs that decode to the correct id/pos.
+        AtomicInteger readCount = new AtomicInteger();
+        AtomicInteger extractorsCreated = new AtomicInteger();
+
+        FormatReader_RowPositionEmitting reader = new FormatReader_RowPositionEmitting(readCount, extractorsCreated, /* rowsPerFile = */ 3);
+
+        List<StorageEntry> entries = List.of(
+            new StorageEntry(StoragePath.of("s3://bucket/data/f1.parquet"), 100, Instant.EPOCH),
+            new StorageEntry(StoragePath.of("s3://bucket/data/f2.parquet"), 200, Instant.EPOCH),
+            new StorageEntry(StoragePath.of("s3://bucket/data/f3.parquet"), 300, Instant.EPOCH)
+        );
+        FileList fileList = GlobExpander.fileListOf(entries, "s3://bucket/data/*.parquet");
+
+        StubStorageProvider storageProvider = new StubStorageProvider();
+        StoragePath path = StoragePath.of("s3://bucket/data/f1.parquet");
+
+        // Two attributes: a primary "value" column and the synthetic _rowPosition.
+        List<Attribute> attributes = List.of(field("value", DataType.INTEGER), field(ColumnExtractor.ROW_POSITION_COLUMN, DataType.LONG));
+
+        DriverContext driverContext = mock(DriverContext.class);
+        when(driverContext.blockFactory()).thenReturn(BLOCK_FACTORY);
+        doAnswer(inv -> null).when(driverContext).addAsyncAction();
+        doAnswer(inv -> null).when(driverContext).removeAsyncAction();
+
+        AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
+            storageProvider,
+            reader,
+            path,
+            attributes,
+            100,
+            10,
+            (Runnable r) -> r.run()
+        ).fileList(fileList).deferredExtraction(true).build();
+
+        // Sanity check on capability surface: factory must declare itself as deferred-extraction
+        // capable (so LocalExecutionPlanner.planExternalFieldExtract can wire to it).
+        assertTrue(factory instanceof DeferredExtractionCapable);
+
+        SourceOperator operator = factory.get(driverContext);
+        assertNotNull(operator);
+
+        List<Page> pages = new ArrayList<>();
+        while (operator.isFinished() == false) {
+            Page page = operator.getOutput();
+            if (page != null) {
+                pages.add(page);
+            }
+        }
+
+        try {
+            // One read per file = one extractor per file.
+            assertEquals("one read per file", 3, readCount.get());
+            assertEquals("one extractor created per file", 3, extractorsCreated.get());
+            // SourceExtractors registry must mirror the file count.
+            SourceExtractors registry = factory.sourceExtractorsFor(driverContext);
+            assertEquals(3, registry.size());
+
+            // Three pages, three rows each: every encoded value must decode to a known
+            // (id, pos) pair. The factory opens files in fileList order, so file index ==
+            // extractor id (== page order).
+            assertEquals(3, pages.size());
+            for (int fileIdx = 0; fileIdx < pages.size(); fileIdx++) {
+                Page page = pages.get(fileIdx);
+                assertEquals("two columns: value + _rowPosition", 2, page.getBlockCount());
+                assertEquals(3, page.getPositionCount());
+
+                // value column is unchanged.
+                IntBlock values = (IntBlock) page.getBlock(0);
+                for (int row = 0; row < 3; row++) {
+                    assertEquals("payload value preserved", 100 * fileIdx + row, values.getInt(row));
+                }
+
+                // _rowPosition column is encoded.
+                LongBlock encoded = (LongBlock) page.getBlock(1);
+                for (int row = 0; row < 3; row++) {
+                    long encodedValue = encoded.getLong(row);
+                    assertEquals("extractor id matches file index", fileIdx, SourceExtractors.decodeExtractorId(encodedValue));
+                    assertEquals("local position is the file-local row index", row, SourceExtractors.decodeLocalPosition(encodedValue));
+                }
+            }
+        } finally {
+            for (Page p : pages) {
+                p.releaseBlocks();
+            }
+            operator.close();
+        }
+    }
+
+    public void testDeferredExtractionDisabledLeavesPagesUntouched() throws Exception {
+        // With deferredExtraction(false), the factory must not register extractors and must not
+        // touch the _rowPosition channel. The reader's raw file-local positions should pass
+        // through unchanged.
+        AtomicInteger extractorsCreated = new AtomicInteger();
+        FormatReader_RowPositionEmitting reader = new FormatReader_RowPositionEmitting(
+            new AtomicInteger(),
+            extractorsCreated,
+            /* rowsPerFile = */ 2
+        );
+
+        StorageObject storageObject = mock(StorageObject.class);
+        StorageProvider storageProvider = mock(StorageProvider.class);
+        when(storageProvider.newObject(any())).thenReturn(storageObject);
+
+        StoragePath path = StoragePath.of("s3://bucket/data/f.parquet");
+        List<Attribute> attributes = List.of(field("value", DataType.INTEGER), field(ColumnExtractor.ROW_POSITION_COLUMN, DataType.LONG));
+
+        DriverContext driverContext = mock(DriverContext.class);
+        when(driverContext.blockFactory()).thenReturn(BLOCK_FACTORY);
+        doAnswer(inv -> null).when(driverContext).addAsyncAction();
+        doAnswer(inv -> null).when(driverContext).removeAsyncAction();
+
+        AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
+            storageProvider,
+            reader,
+            path,
+            attributes,
+            100,
+            10,
+            (Runnable r) -> r.run()
+        ).build();
+
+        assertFalse(factory.deferredExtractionEnabled());
+
+        SourceOperator operator = factory.get(driverContext);
+        Page page = null;
+        try {
+            while (operator.isFinished() == false) {
+                Page p = operator.getOutput();
+                if (p != null) {
+                    page = p;
+                    break;
+                }
+            }
+            assertNotNull(page);
+            // Encoder was not wired: no extractors registered.
+            assertEquals(0, extractorsCreated.get());
+            // _rowPosition is whatever the reader emitted (raw 0, 1) — confirms the encoder
+            // path is fully bypassed when the flag is off.
+            LongBlock rp = (LongBlock) page.getBlock(1);
+            assertEquals(0L, rp.getLong(0));
+            assertEquals(1L, rp.getLong(1));
+        } finally {
+            if (page != null) {
+                page.releaseBlocks();
+            }
+            operator.close();
+        }
+    }
+
+    /**
+     * Defensive: a {@link ColumnExtractorAware} reader satisfies the planner-time capability check,
+     * but it must also return iterators that implement {@link ColumnExtractorProducer} when the
+     * projection asks for {@link ColumnExtractor#ROW_POSITION_COLUMN}. If the iterator does not,
+     * the factory must surface a clear {@link IllegalStateException} — it cannot silently encode
+     * ids that nothing will register against, because the extract operator above TopN would then
+     * fail to look up its source. Catches regressions where a future format reader forgets to
+     * thread the producer interface through its iterator wrapping.
+     */
+    public void testDeferredExtractionFailsLoudlyWhenIteratorIsNotProducer() throws Exception {
+        // Reader is ColumnExtractorAware but its iterator does NOT implement ColumnExtractorProducer.
+        FormatReader reader = new NonProducerAwareReader();
+
+        List<StorageEntry> entries = List.of(new StorageEntry(StoragePath.of("s3://bucket/data/f.parquet"), 100, Instant.EPOCH));
+        FileList fileList = GlobExpander.fileListOf(entries, "s3://bucket/data/*.parquet");
+
+        StubStorageProvider storageProvider = new StubStorageProvider();
+        StoragePath path = StoragePath.of("s3://bucket/data/f.parquet");
+        List<Attribute> attributes = List.of(field("value", DataType.INTEGER), field(ColumnExtractor.ROW_POSITION_COLUMN, DataType.LONG));
+
+        DriverContext driverContext = mock(DriverContext.class);
+        when(driverContext.blockFactory()).thenReturn(BLOCK_FACTORY);
+        doAnswer(inv -> null).when(driverContext).addAsyncAction();
+        doAnswer(inv -> null).when(driverContext).removeAsyncAction();
+
+        AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
+            storageProvider,
+            reader,
+            path,
+            attributes,
+            100,
+            10,
+            (Runnable r) -> r.run()
+        ).fileList(fileList).deferredExtraction(true).build();
+
+        SourceOperator operator = factory.get(driverContext);
+        try {
+            // The operator's slice setup is what triggers wrapWithEncoderIfNeeded; pulling output
+            // until finished surfaces the failure. Either getOutput or close() will throw.
+            Exception caught = expectThrows(Exception.class, () -> {
+                while (operator.isFinished() == false) {
+                    operator.getOutput();
+                }
+            });
+            assertTrue(
+                "expected ColumnExtractorProducer error, got: " + caught,
+                rootCauseMessage(caught).contains("ColumnExtractorProducer")
+            );
+        } finally {
+            try {
+                operator.close();
+            } catch (Exception ignored) {
+                // close() may also surface the same failure once the operator is in a bad state;
+                // we already asserted above.
+            }
+        }
+    }
+
+    private static String rootCauseMessage(Throwable t) {
+        Throwable root = t;
+        while (root.getCause() != null && root.getCause() != root) {
+            root = root.getCause();
+        }
+        return root.getMessage() != null ? root.getMessage() : "";
+    }
+
+    /**
+     * Reader stub that <em>declares</em> {@link ColumnExtractorAware} so the planner-time
+     * capability check passes, but returns plain iterators that do <em>not</em> implement
+     * {@link ColumnExtractorProducer}. Used to verify the factory's runtime guard.
+     */
+    private static final class NonProducerAwareReader implements NoConfigFormatReader, ColumnExtractorAware {
+        @Override
+        public SourceMetadata metadata(StorageObject object) {
+            return null;
+        }
+
+        @Override
+        public CloseableIterator<Page> read(StorageObject object, FormatReadContext context) {
+            // One page with two columns, _rowPosition at index 1. Critically: the iterator does
+            // not implement ColumnExtractorProducer.
+            int n = 2;
+            int[] values = new int[] { 0, 1 };
+            long[] rowPositions = new long[] { 0L, 1L };
+            Block valueBlock = BLOCK_FACTORY.newIntArrayVector(values, n).asBlock();
+            Block rpBlock = BLOCK_FACTORY.newLongArrayVector(rowPositions, n).asBlock();
+            Page page = new Page(n, valueBlock, rpBlock);
+            return singletonIterator(page);
+        }
+
+        @Override
+        public String formatName() {
+            return "non-producer-aware";
+        }
+
+        @Override
+        public List<String> fileExtensions() {
+            return List.of(".parquet");
+        }
+
+        @Override
+        public void close() {}
+    }
+
+    /**
+     * The factory keeps two views of its planner-resolved attributes: the user-visible {@code
+     * attributes} (which include the optimizer-injected {@link ColumnExtractor#ROW_POSITION_COLUMN}
+     * when deferred extraction is on) and {@code readerResolvedAttributes} (the file-schema-shaped
+     * view passed to readers). The split here is what keeps a reader from misinterpreting the
+     * synthetic as a real-column collision — which is exactly how the production
+     * {@code OptimizedParquetColumnIterator} regression slipped in.
+     */
+    public void testStripRowPositionRemovesSyntheticAttribute() {
+        Attribute value = field("value", DataType.INTEGER);
+        Attribute rowPos = field(ColumnExtractor.ROW_POSITION_COLUMN, DataType.LONG);
+
+        List<Attribute> stripped = AsyncExternalSourceOperatorFactory.stripRowPosition(List.of(value, rowPos));
+        assertEquals(1, stripped.size());
+        assertEquals("value", stripped.get(0).name());
+
+        // Marker absent: identity-return so non-deferred-extraction callers pay nothing.
+        List<Attribute> noMarker = List.of(value);
+        assertSame(noMarker, AsyncExternalSourceOperatorFactory.stripRowPosition(noMarker));
+
+        // Empty / null inputs are passed through unchanged.
+        assertSame(List.<Attribute>of(), AsyncExternalSourceOperatorFactory.stripRowPosition(List.of()));
+        assertNull(AsyncExternalSourceOperatorFactory.stripRowPosition(null));
+    }
+
+    public void testDeferredExtractionDefersOnCloseUntilRegistryCloses() throws Exception {
+        // The bug this regression-tests: with deferredExtraction enabled, the factory used to
+        // close its onClose (the per-query concurrency budget) the moment the last source operator
+        // released. But the ExternalFieldExtractOperator runs AFTER TopN drains, so closing the
+        // budget at source-release time tore down storage permits while extract() was still trying
+        // to acquire them — surfacing as
+        // "Failed to acquire query concurrency budget permit: Budget is closed".
+        // Now onClose must be deferred until the SourceExtractors registry (driver-scoped, owned
+        // by the extract operator) is closed.
+        AtomicInteger readCount = new AtomicInteger();
+        AtomicInteger extractorsCreated = new AtomicInteger();
+        FormatReader_RowPositionEmitting reader = new FormatReader_RowPositionEmitting(readCount, extractorsCreated, 2);
+
+        List<StorageEntry> entries = List.of(new StorageEntry(StoragePath.of("s3://bucket/data/f.parquet"), 100, Instant.EPOCH));
+        FileList fileList = GlobExpander.fileListOf(entries, "s3://bucket/data/*.parquet");
+        StubStorageProvider storageProvider = new StubStorageProvider();
+        StoragePath path = StoragePath.of("s3://bucket/data/f.parquet");
+        List<Attribute> attributes = List.of(field("value", DataType.INTEGER), field(ColumnExtractor.ROW_POSITION_COLUMN, DataType.LONG));
+
+        DriverContext driverContext = mock(DriverContext.class);
+        when(driverContext.blockFactory()).thenReturn(BLOCK_FACTORY);
+        doAnswer(inv -> null).when(driverContext).addAsyncAction();
+        doAnswer(inv -> null).when(driverContext).removeAsyncAction();
+
+        AtomicInteger onCloseCalls = new AtomicInteger();
+        java.io.Closeable onCloseProbe = () -> onCloseCalls.incrementAndGet();
+        AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
+            storageProvider,
+            reader,
+            path,
+            attributes,
+            100,
+            10,
+            (Runnable r) -> r.run()
+        ).fileList(fileList).deferredExtraction(true).onClose(onCloseProbe).build();
+
+        // Resolve the registry early — typically done by ExternalFieldExtractOperator.Factory.get()
+        // before the source actually finishes, mirroring the real wiring.
+        SourceExtractors registry = factory.sourceExtractorsFor(driverContext);
+
+        SourceOperator operator = factory.get(driverContext);
+        List<Page> pages = new ArrayList<>();
+        try {
+            while (operator.isFinished() == false) {
+                Page p = operator.getOutput();
+                if (p != null) {
+                    pages.add(p);
+                }
+            }
+        } finally {
+            operator.close();
+        }
+
+        // Source done, but the registry is still open -> onClose must NOT have fired.
+        assertEquals("onClose must wait for the registry while deferred extraction is on", 0, onCloseCalls.get());
+
+        for (Page p : pages) {
+            p.releaseBlocks();
+        }
+
+        // Closing the registry releases the last ref — onClose finally runs.
+        registry.close();
+        assertEquals("onClose runs exactly once after registry teardown", 1, onCloseCalls.get());
+    }
+
+    public void testNonDeferredExtractionStillClosesOnSourceRelease() throws Exception {
+        // Symmetric guard: when deferred extraction is disabled, the legacy path stays in effect
+        // and onClose runs as soon as the source finishes — there is no late materialization
+        // reading from the budget, so keeping it alive would just delay GC.
+        FormatReader_RowPositionEmitting reader = new FormatReader_RowPositionEmitting(new AtomicInteger(), new AtomicInteger(), 2);
+
+        StorageObject storageObject = mock(StorageObject.class);
+        StorageProvider storageProvider = mock(StorageProvider.class);
+        when(storageProvider.newObject(any())).thenReturn(storageObject);
+
+        StoragePath path = StoragePath.of("s3://bucket/data/f.parquet");
+        List<Attribute> attributes = List.of(field("value", DataType.INTEGER), field(ColumnExtractor.ROW_POSITION_COLUMN, DataType.LONG));
+
+        DriverContext driverContext = mock(DriverContext.class);
+        when(driverContext.blockFactory()).thenReturn(BLOCK_FACTORY);
+        doAnswer(inv -> null).when(driverContext).addAsyncAction();
+        doAnswer(inv -> null).when(driverContext).removeAsyncAction();
+
+        AtomicInteger onCloseCalls = new AtomicInteger();
+        java.io.Closeable onCloseProbe = () -> onCloseCalls.incrementAndGet();
+        AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
+            storageProvider,
+            reader,
+            path,
+            attributes,
+            100,
+            10,
+            (Runnable r) -> r.run()
+        ).onClose(onCloseProbe).build();
+
+        SourceOperator operator = factory.get(driverContext);
+        try {
+            while (operator.isFinished() == false) {
+                Page p = operator.getOutput();
+                if (p != null) {
+                    p.releaseBlocks();
+                }
+            }
+        } finally {
+            operator.close();
+        }
+        assertEquals("non-deferred path closes onClose at source release", 1, onCloseCalls.get());
+    }
+
+    public void testDeferredExtractionRequiresColumnExtractorAware() {
+        // Builder must reject deferredExtraction(true) when the reader doesn't implement
+        // ColumnExtractorAware — we won't be able to materialise anything later, so failing
+        // fast at construction beats silently emitting refs no one can resolve.
+        FormatReader plain = new PlainFormatReader();
+        StoragePath path = StoragePath.of("s3://bucket/data/f.parquet");
+        List<Attribute> attributes = List.of(field("value", DataType.INTEGER));
+        StorageProvider storageProvider = mock(StorageProvider.class);
+
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> AsyncExternalSourceOperatorFactory.builder(storageProvider, plain, path, attributes, 100, 10, (Runnable r) -> r.run())
+                .deferredExtraction(true)
+                .build()
+        );
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Stubs
+    // ---------------------------------------------------------------------------------------------
+
+    private static FieldAttribute field(String name, DataType type) {
+        return new FieldAttribute(Source.EMPTY, name, new EsField(name, type, Map.of(), false, EsField.TimeSeriesFieldType.NONE));
+    }
+
+    /**
+     * Format reader that implements {@link ColumnExtractorAware}. Each {@code read} returns one
+     * page with two columns (value, _rowPosition). The {@code _rowPosition} column carries raw
+     * file-local positions ({@code 0..rowsPerFile-1}) — exactly what a real
+     * {@link ColumnExtractorAware} reader emits. The factory's encoder is responsible for packing
+     * the assigned extractor id into the high bits before downstream operators see it.
+     */
+    private static final class FormatReader_RowPositionEmitting implements NoConfigFormatReader, ColumnExtractorAware {
+
+        private final AtomicInteger readCount;
+        private final AtomicInteger extractorsCreated;
+        private final int rowsPerFile;
+
+        FormatReader_RowPositionEmitting(AtomicInteger readCount, AtomicInteger extractorsCreated, int rowsPerFile) {
+            this.readCount = readCount;
+            this.extractorsCreated = extractorsCreated;
+            this.rowsPerFile = rowsPerFile;
+        }
+
+        @Override
+        public SourceMetadata metadata(StorageObject object) {
+            return null;
+        }
+
+        @Override
+        public CloseableIterator<Page> read(StorageObject object, FormatReadContext context) {
+            int idx = readCount.getAndIncrement();
+            return new ProducerIterator(idx, extractorsCreated, rowsPerFile);
+        }
+
+        @Override
+        public String formatName() {
+            return "rp-stub";
+        }
+
+        @Override
+        public List<String> fileExtensions() {
+            return List.of(".parquet");
+        }
+
+        @Override
+        public void close() {}
+    }
+
+    /**
+     * Wraps a page iterator and exposes the {@link ColumnExtractorProducer} handshake that
+     * {@link AsyncExternalSourceOperatorFactory#wrapWithEncoderIfNeeded} requires when deferred
+     * extraction is enabled. Returns a fresh in-memory extractor on each call.
+     */
+    private static final class ProducerIterator implements CloseableIterator<Page>, ColumnExtractorProducer {
+        private final int fileIndex;
+        private final AtomicInteger extractorsCreated;
+        private final int rowsPerFile;
+        private boolean emitted = false;
+        private long rowPositionEncodingHighBits = -1L;
+
+        ProducerIterator(int fileIndex, AtomicInteger extractorsCreated, int rowsPerFile) {
+            this.fileIndex = fileIndex;
+            this.extractorsCreated = extractorsCreated;
+            this.rowsPerFile = rowsPerFile;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return emitted == false;
+        }
+
+        @Override
+        public Page next() {
+            if (emitted) {
+                throw new java.util.NoSuchElementException();
+            }
+            emitted = true;
+            // Mirrors the production path: at materialise-time the iterator OR-s the
+            // installed high bits into every emitted _rowPosition value, just like
+            // OptimizedParquetColumnIterator does. setExtractorId must have been called by now.
+            int n = rowsPerFile;
+            int[] values = new int[n];
+            long[] rowPositions = new long[n];
+            long encodingHighBits = rowPositionEncodingHighBits;
+            for (int i = 0; i < n; i++) {
+                values[i] = 100 * fileIndex + i;
+                rowPositions[i] = encodingHighBits == -1L ? i : (encodingHighBits | i);
+            }
+            Block valueBlock = BLOCK_FACTORY.newIntArrayVector(values, n).asBlock();
+            Block rpBlock = BLOCK_FACTORY.newLongArrayVector(rowPositions, n).asBlock();
+            return new Page(n, valueBlock, rpBlock);
+        }
+
+        @Override
+        public ColumnExtractor createColumnExtractor() {
+            extractorsCreated.incrementAndGet();
+            return new InMemoryColumnExtractor(rowsPerFile);
+        }
+
+        @Override
+        public void setExtractorId(int id) {
+            rowPositionEncodingHighBits = ((long) id) << ColumnExtractor.LOCAL_POSITION_BITS;
+        }
+
+        @Override
+        public void close() {}
+    }
+
+    /** Same shape as the row-position emitting reader minus the {@link ColumnExtractorAware} mixin. */
+    private static final class PlainFormatReader implements NoConfigFormatReader {
+        @Override
+        public SourceMetadata metadata(StorageObject object) {
+            return null;
+        }
+
+        @Override
+        public CloseableIterator<Page> read(StorageObject object, FormatReadContext context) {
+            return singletonIterator(new Page(BLOCK_FACTORY.newIntArrayVector(new int[] { 0 }, 1).asBlock()));
+        }
+
+        @Override
+        public String formatName() {
+            return "plain";
+        }
+
+        @Override
+        public List<String> fileExtensions() {
+            return List.of(".parquet");
+        }
+
+        @Override
+        public void close() {}
+    }
+
+    /** Trivial {@link ColumnExtractor} stub — never invoked by these tests, just registered. */
+    private static final class InMemoryColumnExtractor implements ColumnExtractor {
+        private final int totalRows;
+
+        InMemoryColumnExtractor(int totalRows) {
+            this.totalRows = totalRows;
+        }
+
+        @Override
+        public long rowCount() {
+            return totalRows;
+        }
+
+        @Override
+        public Block[] extract(String[] columnNames, long[] localPositions, BlockFactory blockFactory) {
+            throw new AssertionError("extract() must not be called from these tests");
+        }
+
+        @Override
+        public void close() {}
+    }
+
+    /** Storage provider that fabricates {@link StorageObject}s for arbitrary paths. */
+    private static final class StubStorageProvider implements StorageProvider {
+        @Override
+        public StorageObject newObject(StoragePath path) {
+            return new StubStorageObject(path);
+        }
+
+        @Override
+        public StorageObject newObject(StoragePath path, long length) {
+            return new StubStorageObject(path);
+        }
+
+        @Override
+        public StorageObject newObject(StoragePath path, long length, Instant lastModified) {
+            return new StubStorageObject(path);
+        }
+
+        @Override
+        public StorageIterator listObjects(StoragePath prefix, boolean recursive) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean exists(StoragePath path) {
+            return true;
+        }
+
+        @Override
+        public List<String> supportedSchemes() {
+            return List.of("s3", "file");
+        }
+
+        @Override
+        public void close() {}
+    }
+
+    private static final class StubStorageObject implements StorageObject {
+        private final StoragePath path;
+
+        StubStorageObject(StoragePath path) {
+            this.path = path;
+        }
+
+        @Override
+        public InputStream newStream() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public InputStream newStream(long position, long length) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public long length() {
+            return 1024;
+        }
+
+        @Override
+        public Instant lastModified() {
+            return Instant.EPOCH;
+        }
+
+        @Override
+        public boolean exists() {
+            return true;
+        }
+
+        @Override
+        public StoragePath path() {
+            return path;
+        }
+    }
+
+    private static CloseableIterator<Page> singletonIterator(Page page) {
+        Iterator<Page> it = List.of(page).iterator();
+        return new CloseableIterator<>() {
+            @Override
+            public boolean hasNext() {
+                return it.hasNext();
+            }
+
+            @Override
+            public Page next() {
+                return it.next();
+            }
+
+            @Override
+            public void close() throws IOException {}
+        };
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalFieldExtractOperatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalFieldExtractOperatorTests.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.LongVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.test.TestBlockFactory;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.spi.ColumnExtractor;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link ExternalFieldExtractOperator}: the channel-reshaping logic that drops
+ * {@code _rowPosition} from the page, materialises deferred columns via the driver-shared
+ * {@link SourceExtractors} registry, and assembles the output page in declared output order.
+ */
+public class ExternalFieldExtractOperatorTests extends ESTestCase {
+
+    private final BlockFactory blockFactory = TestBlockFactory.getNonBreakingInstance();
+
+    public void testReshapeAndExtract() {
+        try (SourceExtractors registry = new SourceExtractors()) {
+            int idA = registry.register(new IntListExtractor(new int[] { 100, 101, 102, 103 }));
+            int idB = registry.register(new IntListExtractor(new int[] { 200, 201, 202 }));
+
+            // Build an input page that simulates output of the source: channels are
+            // ch0 = sortKey (long), ch1 = _rowPosition (encoded long), ch2 = passThru (int)
+            // Five rows surviving TopN, drawn from both extractors:
+            // row 0: A[3]
+            // row 1: B[1]
+            // row 2: A[0]
+            // row 3: B[2]
+            // row 4: A[2]
+            long[] sortKey = { 7L, 8L, 9L, 10L, 11L };
+            long[] rowPosition = {
+                SourceExtractors.encode(idA, 3),
+                SourceExtractors.encode(idB, 1),
+                SourceExtractors.encode(idA, 0),
+                SourceExtractors.encode(idB, 2),
+                SourceExtractors.encode(idA, 2) };
+            int[] passThru = { 1, 2, 3, 4, 5 };
+            Page input = newPage(sortKey, rowPosition, passThru);
+
+            DriverContext driverContext = mock(DriverContext.class);
+            when(driverContext.blockFactory()).thenReturn(blockFactory);
+
+            ExternalFieldExtractOperator op = new ExternalFieldExtractOperator(/* rowPositionChannel = */ 1,
+                /* passThroughChannels = */ List.of(0, 2),
+                /* deferredColumnNames = */ List.of("col"),
+                registry,
+                blockFactory
+            );
+            op.addInput(input);
+            op.finish();
+            Page output = op.getOutput();
+            assertNull("operator must drain in one shot", op.getOutput());
+            assertTrue(op.isFinished());
+            try {
+                // Output layout: sortKey, passThru, deferred col — _rowPosition stripped.
+                assertEquals(3, output.getBlockCount());
+                assertEquals(5, output.getPositionCount());
+
+                LongVector outSort = ((LongBlock) output.getBlock(0)).asVector();
+                IntVector outPass = ((IntBlock) output.getBlock(1)).asVector();
+                IntBlock outDeferred = (IntBlock) output.getBlock(2);
+
+                assertNotNull("sortKey must remain a dense vector", outSort);
+                assertNotNull("passThru must remain a dense vector", outPass);
+                for (int i = 0; i < 5; i++) {
+                    assertEquals(sortKey[i], outSort.getLong(i));
+                    assertEquals(passThru[i], outPass.getInt(i));
+                }
+                // Deferred values must align row-for-row with the surviving (id, pos) refs.
+                assertEquals(103, outDeferred.getInt(0));
+                assertEquals(201, outDeferred.getInt(1));
+                assertEquals(100, outDeferred.getInt(2));
+                assertEquals(202, outDeferred.getInt(3));
+                assertEquals(102, outDeferred.getInt(4));
+            } finally {
+                output.releaseBlocks();
+                op.close();
+            }
+        }
+    }
+
+    public void testEmptyPageReshape() {
+        try (SourceExtractors registry = new SourceExtractors()) {
+            registry.register(new IntListExtractor(new int[] { 1, 2 }));
+
+            Page empty = newPage(new long[0], new long[0], new int[0]);
+
+            ExternalFieldExtractOperator op = new ExternalFieldExtractOperator(1, List.of(0, 2), List.of("col"), registry, blockFactory);
+            op.addInput(empty);
+            op.finish();
+            Page output = op.getOutput();
+            try {
+                assertEquals(3, output.getBlockCount());
+                assertEquals(0, output.getPositionCount());
+                // Deferred slot must be a constant-null placeholder so downstream operators see
+                // the right shape even on a zero-row page.
+                Block d = output.getBlock(2);
+                assertEquals(0, d.getPositionCount());
+            } finally {
+                output.releaseBlocks();
+                op.close();
+            }
+        }
+    }
+
+    public void testFactoryRejectsNullsAndNegatives() {
+        SourceExtractors registry = new SourceExtractors();
+        try {
+            expectThrows(
+                IllegalArgumentException.class,
+                () -> new ExternalFieldExtractOperator.Factory(-1, List.of(), List.of(), ctx -> registry)
+            );
+            expectThrows(
+                IllegalArgumentException.class,
+                () -> new ExternalFieldExtractOperator.Factory(0, null, List.of(), ctx -> registry)
+            );
+            expectThrows(
+                IllegalArgumentException.class,
+                () -> new ExternalFieldExtractOperator.Factory(0, List.of(), null, ctx -> registry)
+            );
+            expectThrows(IllegalArgumentException.class, () -> new ExternalFieldExtractOperator.Factory(0, List.of(), List.of(), null));
+        } finally {
+            registry.close();
+        }
+    }
+
+    public void testFactoryRejectsNullRegistryLookup() {
+        ExternalFieldExtractOperator.Factory factory = new ExternalFieldExtractOperator.Factory(0, List.of(), List.of(), ctx -> null);
+        DriverContext driverContext = mock(DriverContext.class);
+        when(driverContext.blockFactory()).thenReturn(blockFactory);
+        expectThrows(IllegalStateException.class, () -> factory.get(driverContext));
+    }
+
+    public void testCloseReleasesPendingPage() {
+        try (SourceExtractors registry = new SourceExtractors()) {
+            registry.register(new IntListExtractor(new int[] { 1 }));
+            Page page = newPage(new long[] { 1L }, new long[] { SourceExtractors.encode(0, 0) }, new int[] { 9 });
+
+            ExternalFieldExtractOperator op = new ExternalFieldExtractOperator(1, List.of(0, 2), List.of("col"), registry, blockFactory);
+            op.addInput(page);
+            // Don't drain; close must release the pending page so we don't leak blocks.
+            op.close();
+        }
+    }
+
+    private Page newPage(long[] sortKey, long[] rowPosition, int[] passThru) {
+        assert sortKey.length == rowPosition.length && rowPosition.length == passThru.length;
+        int n = sortKey.length;
+        Block sortBlock = blockFactory.newLongArrayVector(sortKey, n).asBlock();
+        Block rpBlock = blockFactory.newLongArrayVector(rowPosition, n).asBlock();
+        Block passBlock = blockFactory.newIntArrayVector(passThru, n).asBlock();
+        return new Page(n, sortBlock, rpBlock, passBlock);
+    }
+
+    /** Same minimal in-memory column extractor used in {@link SourceExtractorsTests}. */
+    private static final class IntListExtractor implements ColumnExtractor {
+        private final int[] values;
+
+        IntListExtractor(int[] values) {
+            this.values = values;
+        }
+
+        @Override
+        public long rowCount() {
+            return values.length;
+        }
+
+        @Override
+        public Block[] extract(String[] columnNames, long[] localPositions, BlockFactory factory) throws IOException {
+            Block[] result = new Block[columnNames.length];
+            boolean built = false;
+            try {
+                for (int c = 0; c < columnNames.length; c++) {
+                    try (IntBlock.Builder builder = factory.newIntBlockBuilder(localPositions.length)) {
+                        for (long pos : localPositions) {
+                            builder.appendInt(values[Math.toIntExact(pos)]);
+                        }
+                        result[c] = builder.build();
+                    }
+                }
+                built = true;
+                return result;
+            } finally {
+                if (built == false) org.elasticsearch.core.Releasables.closeExpectNoException(result);
+            }
+        }
+
+        @Override
+        public void close() {}
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SourceExtractorsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SourceExtractorsTests.java
@@ -1,0 +1,464 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.test.TestBlockFactory;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.spi.ColumnExtractor;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Unit tests for {@link SourceExtractors}: the encoding scheme, registration lifecycle, and the
+ * batched {@link SourceExtractors#materialize} dispatch that fans positions out to the right
+ * per-file extractor and stitches results back into caller order.
+ */
+public class SourceExtractorsTests extends ESTestCase {
+
+    private final BlockFactory blockFactory = TestBlockFactory.getNonBreakingInstance();
+
+    public void testEncodeDecodeRoundTrip() {
+        int[] ids = new int[] { 0, 1, 7, 1024, SourceExtractors.MAX_EXTRACTOR_ID };
+        long[] positions = new long[] { 0L, 1L, 1234L, 1L << 30, SourceExtractors.MAX_LOCAL_POSITION };
+        for (int id : ids) {
+            for (long pos : positions) {
+                long encoded = SourceExtractors.encode(id, pos);
+                assertThat("encoded must be non-negative for sortable ordering", encoded, org.hamcrest.Matchers.greaterThanOrEqualTo(0L));
+                assertEquals(id, SourceExtractors.decodeExtractorId(encoded));
+                assertEquals(pos, SourceExtractors.decodeLocalPosition(encoded));
+            }
+        }
+    }
+
+    public void testEncodeRejectsOutOfRange() {
+        expectThrows(IllegalArgumentException.class, () -> SourceExtractors.encode(-1, 0));
+        expectThrows(IllegalArgumentException.class, () -> SourceExtractors.encode(SourceExtractors.MAX_EXTRACTOR_ID + 1, 0));
+        expectThrows(IllegalArgumentException.class, () -> SourceExtractors.encode(0, -1));
+        expectThrows(IllegalArgumentException.class, () -> SourceExtractors.encode(0, SourceExtractors.MAX_LOCAL_POSITION + 1));
+    }
+
+    public void testEncodingIsMonotonicAndNonNegative() {
+        // Exhaustive sweep across a sample of the (id, pos) space; every encoded value must be
+        // strictly increasing as we walk the lexicographic order of (id, pos), and never negative.
+        // This is the property that lets ESQL's TopN signed-long ordering be a stable tiebreaker.
+        long previous = -1L;
+        int[] ids = new int[] { 0, 1, 2, 100, SourceExtractors.MAX_EXTRACTOR_ID };
+        long[] positions = new long[] { 0L, 1L, 100L, 1L << 30, SourceExtractors.MAX_LOCAL_POSITION };
+        for (int id : ids) {
+            for (long pos : positions) {
+                long encoded = SourceExtractors.encode(id, pos);
+                assertThat("encoded must be non-negative", encoded, org.hamcrest.Matchers.greaterThanOrEqualTo(0L));
+                assertThat("encoded must be strictly monotonic in (id, pos)", encoded, org.hamcrest.Matchers.greaterThan(previous));
+                previous = encoded;
+            }
+        }
+    }
+
+    public void testRegisterAssignsSequentialIds() {
+        try (SourceExtractors registry = new SourceExtractors()) {
+            int id0 = registry.register(new IntListExtractor(new int[] { 1, 2, 3 }));
+            int id1 = registry.register(new IntListExtractor(new int[] { 4, 5 }));
+            int id2 = registry.register(new IntListExtractor(new int[] { 6 }));
+            assertEquals(0, id0);
+            assertEquals(1, id1);
+            assertEquals(2, id2);
+            assertEquals(3, registry.size());
+            assertNotNull(registry.get(0));
+            assertNotNull(registry.get(1));
+            assertNotNull(registry.get(2));
+        }
+    }
+
+    public void testRegisterRejectsNullAndAfterClose() {
+        SourceExtractors registry = new SourceExtractors();
+        expectThrows(IllegalArgumentException.class, () -> registry.register(null));
+        registry.close();
+        expectThrows(IllegalStateException.class, () -> registry.register(new IntListExtractor(new int[] { 1 })));
+    }
+
+    public void testGetRejectsOutOfRange() {
+        try (SourceExtractors registry = new SourceExtractors()) {
+            registry.register(new IntListExtractor(new int[] { 1 }));
+            expectThrows(IllegalArgumentException.class, () -> registry.get(-1));
+            expectThrows(IllegalArgumentException.class, () -> registry.get(1));
+        }
+    }
+
+    public void testCloseIsIdempotent() {
+        SourceExtractors registry = new SourceExtractors();
+        IntListExtractor a = new IntListExtractor(new int[] { 1, 2 });
+        IntListExtractor b = new IntListExtractor(new int[] { 3 });
+        registry.register(a);
+        registry.register(b);
+        registry.close();
+        assertTrue(a.closed());
+        assertTrue(b.closed());
+        // Second close must be a no-op (no double-close on extractors).
+        registry.close();
+        assertEquals("each extractor closed exactly once", 1, a.closeCount());
+        assertEquals("each extractor closed exactly once", 1, b.closeCount());
+    }
+
+    public void testTrailingCloseablesRunAfterExtractors() {
+        // The trailing-closeable contract is what keeps the per-query concurrency budget alive
+        // for late materialization: the registry must close the extractors first (they may use
+        // the trailing resource on the way down), then close the trailing resources LIFO.
+        SourceExtractors registry = new SourceExtractors();
+        StringBuilder order = new StringBuilder();
+        IntListExtractor a = new IntListExtractor(new int[] { 1 }) {
+            @Override
+            public void close() {
+                order.append("extractor;");
+                super.close();
+            }
+        };
+        registry.register(a);
+        registry.registerTrailingCloseable(() -> order.append("trailing-1;"));
+        registry.registerTrailingCloseable(() -> order.append("trailing-2;"));
+        registry.close();
+        // Extractors first, then LIFO over the two trailing closeables.
+        assertEquals("extractor;trailing-2;trailing-1;", order.toString());
+    }
+
+    public void testTrailingCloseableRegisteredAfterCloseFiresImmediately() {
+        // If the registry has already been closed, late attachers must still see the closeable
+        // run — otherwise we'd leak the per-query budget when a registry was closed before any
+        // extractor was registered.
+        SourceExtractors registry = new SourceExtractors();
+        registry.close();
+        AtomicInteger calls = new AtomicInteger();
+        registry.registerTrailingCloseable(() -> calls.incrementAndGet());
+        assertEquals(1, calls.get());
+    }
+
+    public void testCloseIsIdempotentWithTrailingCloseables() {
+        SourceExtractors registry = new SourceExtractors();
+        AtomicInteger calls = new AtomicInteger();
+        registry.registerTrailingCloseable(() -> calls.incrementAndGet());
+        registry.close();
+        registry.close();
+        assertEquals("trailing closeable must run exactly once", 1, calls.get());
+    }
+
+    public void testMaterializeEmptyCount() {
+        try (SourceExtractors registry = new SourceExtractors()) {
+            registry.register(new IntListExtractor(new int[] { 1, 2 }));
+            Block[] result = registry.materialize(new long[0], 0, List.of("col"), blockFactory);
+            try {
+                assertEquals(1, result.length);
+                assertEquals(0, result[0].getPositionCount());
+            } finally {
+                org.elasticsearch.core.Releasables.closeExpectNoException(result);
+            }
+        }
+    }
+
+    public void testMaterializeSingleSource() {
+        try (SourceExtractors registry = new SourceExtractors()) {
+            int id = registry.register(new IntListExtractor(new int[] { 10, 20, 30, 40 }));
+            // Request positions 3, 0, 2 — out of order and disjoint.
+            long[] refs = new long[] { SourceExtractors.encode(id, 3), SourceExtractors.encode(id, 0), SourceExtractors.encode(id, 2) };
+            Block[] result = registry.materialize(refs, refs.length, List.of("col"), blockFactory);
+            try {
+                assertEquals(1, result.length);
+                IntBlock block = (IntBlock) result[0];
+                assertEquals(3, block.getPositionCount());
+                assertEquals(40, block.getInt(0));
+                assertEquals(10, block.getInt(1));
+                assertEquals(30, block.getInt(2));
+            } finally {
+                org.elasticsearch.core.Releasables.closeExpectNoException(result);
+            }
+        }
+    }
+
+    public void testMaterializeMultiSourceInterleaved() {
+        try (SourceExtractors registry = new SourceExtractors()) {
+            int idA = registry.register(new IntListExtractor(new int[] { 100, 101, 102 }));
+            int idB = registry.register(new IntListExtractor(new int[] { 200, 201 }));
+            int idC = registry.register(new IntListExtractor(new int[] { 300, 301, 302, 303 }));
+            // Interleaved: B[1], A[2], C[0], A[0], C[3], B[0]
+            long[] refs = new long[] {
+                SourceExtractors.encode(idB, 1),
+                SourceExtractors.encode(idA, 2),
+                SourceExtractors.encode(idC, 0),
+                SourceExtractors.encode(idA, 0),
+                SourceExtractors.encode(idC, 3),
+                SourceExtractors.encode(idB, 0) };
+            Block[] result = registry.materialize(refs, refs.length, List.of("col"), blockFactory);
+            try {
+                IntBlock block = (IntBlock) result[0];
+                assertEquals(6, block.getPositionCount());
+                assertEquals(201, block.getInt(0));
+                assertEquals(102, block.getInt(1));
+                assertEquals(300, block.getInt(2));
+                assertEquals(100, block.getInt(3));
+                assertEquals(303, block.getInt(4));
+                assertEquals(200, block.getInt(5));
+            } finally {
+                org.elasticsearch.core.Releasables.closeExpectNoException(result);
+            }
+        }
+    }
+
+    public void testMaterializeBatchesPerExtractor() {
+        // The dispatch must call extract once per id per materialize() call — proving the per-id
+        // batching is real, not row-by-row, and that all requested columns flow through a single
+        // extract invocation so the implementation can coalesce I/O across columns (F-2).
+        AtomicInteger calls = new AtomicInteger();
+        AtomicInteger maxColumnsPerCall = new AtomicInteger();
+        IntListExtractor a = new IntListExtractor(new int[] { 1, 2, 3, 4, 5 }) {
+            @Override
+            public Block[] extract(String[] columnNames, long[] localPositions, BlockFactory factory) throws IOException {
+                calls.incrementAndGet();
+                maxColumnsPerCall.accumulateAndGet(columnNames.length, Math::max);
+                return super.extract(columnNames, localPositions, factory);
+            }
+        };
+        try (SourceExtractors registry = new SourceExtractors()) {
+            int id = registry.register(a);
+            long[] refs = new long[] {
+                SourceExtractors.encode(id, 0),
+                SourceExtractors.encode(id, 4),
+                SourceExtractors.encode(id, 2),
+                SourceExtractors.encode(id, 1),
+                SourceExtractors.encode(id, 3) };
+            Block[] result = registry.materialize(refs, refs.length, List.of("col"), blockFactory);
+            try {
+                IntBlock block = (IntBlock) result[0];
+                assertEquals(5, block.getPositionCount());
+                assertEquals(1, block.getInt(0));
+                assertEquals(5, block.getInt(1));
+                assertEquals(3, block.getInt(2));
+                assertEquals(2, block.getInt(3));
+                assertEquals(4, block.getInt(4));
+            } finally {
+                org.elasticsearch.core.Releasables.closeExpectNoException(result);
+            }
+        }
+        assertEquals("one extract() call for the single-id batch", 1, calls.get());
+        assertEquals("single-column materialize must pass exactly one column to extract", 1, maxColumnsPerCall.get());
+    }
+
+    public void testMaterializeMultipleColumnsBatchesAllColumnsPerExtractor() {
+        // F-2 invariant: with N requested columns and K extractor ids, materialize() must invoke
+        // each extractor's multi-column extract exactly once (passing all N columns), so the
+        // implementation can issue a single coalesced I/O batch covering all N columns. A
+        // regression that splits extract into N per-column calls would fail this assertion.
+        AtomicInteger callsA = new AtomicInteger();
+        AtomicInteger maxColsA = new AtomicInteger();
+        TwoColumnExtractor a = new TwoColumnExtractor(new int[] { 1, 2, 3 }, new long[] { 10L, 20L, 30L }) {
+            @Override
+            public Block[] extract(String[] columnNames, long[] localPositions, BlockFactory factory) throws IOException {
+                callsA.incrementAndGet();
+                maxColsA.accumulateAndGet(columnNames.length, Math::max);
+                return super.extract(columnNames, localPositions, factory);
+            }
+        };
+        try (SourceExtractors registry = new SourceExtractors()) {
+            int id = registry.register(a);
+            long[] refs = new long[] { SourceExtractors.encode(id, 0), SourceExtractors.encode(id, 2), SourceExtractors.encode(id, 1) };
+            Block[] result = registry.materialize(refs, refs.length, List.of("ints", "longs"), blockFactory);
+            try {
+                IntBlock ints = (IntBlock) result[0];
+                LongBlock longs = (LongBlock) result[1];
+                assertEquals(3, ints.getPositionCount());
+                assertEquals(1, ints.getInt(0));
+                assertEquals(3, ints.getInt(1));
+                assertEquals(2, ints.getInt(2));
+                assertEquals(10L, longs.getLong(0));
+                assertEquals(30L, longs.getLong(1));
+                assertEquals(20L, longs.getLong(2));
+            } finally {
+                org.elasticsearch.core.Releasables.closeExpectNoException(result);
+            }
+        }
+        assertEquals("exactly one extract() call per extractor regardless of column count", 1, callsA.get());
+        assertEquals("multi-column materialize must pass both columns in a single extract() call", 2, maxColsA.get());
+    }
+
+    public void testMaterializeMultipleColumns() {
+        try (SourceExtractors registry = new SourceExtractors()) {
+            int idA = registry.register(new TwoColumnExtractor(new int[] { 1, 2 }, new long[] { 10L, 20L }));
+            int idB = registry.register(new TwoColumnExtractor(new int[] { 3, 4 }, new long[] { 30L, 40L }));
+            long[] refs = new long[] { SourceExtractors.encode(idA, 0), SourceExtractors.encode(idB, 1), SourceExtractors.encode(idA, 1) };
+            Block[] result = registry.materialize(refs, refs.length, List.of("ints", "longs"), blockFactory);
+            try {
+                IntBlock ints = (IntBlock) result[0];
+                LongBlock longs = (LongBlock) result[1];
+                assertEquals(3, ints.getPositionCount());
+                assertEquals(3, longs.getPositionCount());
+                assertEquals(1, ints.getInt(0));
+                assertEquals(4, ints.getInt(1));
+                assertEquals(2, ints.getInt(2));
+                assertEquals(10L, longs.getLong(0));
+                assertEquals(40L, longs.getLong(1));
+                assertEquals(20L, longs.getLong(2));
+            } finally {
+                org.elasticsearch.core.Releasables.closeExpectNoException(result);
+            }
+        }
+    }
+
+    public void testMaterializeRejectsUnknownExtractorId() {
+        try (SourceExtractors registry = new SourceExtractors()) {
+            registry.register(new IntListExtractor(new int[] { 1, 2 }));
+            long[] refs = new long[] { SourceExtractors.encode(7, 0) };
+            expectThrows(IllegalArgumentException.class, () -> registry.materialize(refs, refs.length, List.of("col"), blockFactory));
+        }
+    }
+
+    public void testMaterializeAfterCloseFails() {
+        SourceExtractors registry = new SourceExtractors();
+        registry.register(new IntListExtractor(new int[] { 1 }));
+        registry.close();
+        long[] refs = new long[] { SourceExtractors.encode(0, 0) };
+        expectThrows(IllegalStateException.class, () -> registry.materialize(refs, refs.length, List.of("col"), blockFactory));
+    }
+
+    public void testRegisterIdSpaceExhaustion() {
+        // Walk past MAX_EXTRACTOR_ID by registering one stub per slot. ArrayList growth is the
+        // dominant cost; 32 768 small objects is well within unit-test budgets.
+        SourceExtractors registry = new SourceExtractors();
+        try {
+            // Simulate by directly registering near the cap. Use the same lightweight stub each
+            // time; ArrayList growth is the only real cost.
+            for (int i = 0; i <= SourceExtractors.MAX_EXTRACTOR_ID; i++) {
+                registry.register(new IntListExtractor(new int[0]));
+            }
+            assertEquals(SourceExtractors.MAX_EXTRACTOR_ID + 1, registry.size());
+            expectThrows(IllegalStateException.class, () -> registry.register(new IntListExtractor(new int[0])));
+        } finally {
+            registry.close();
+        }
+    }
+
+    /**
+     * Minimal {@link ColumnExtractor} that materialises a single int column from an in-memory
+     * array. Used as a stand-in for parquet/csv-backed extractors in tests that focus on the
+     * registry plumbing.
+     */
+    private static class IntListExtractor implements ColumnExtractor {
+        private final int[] values;
+        private final AtomicInteger closeCount = new AtomicInteger();
+
+        IntListExtractor(int[] values) {
+            this.values = values;
+        }
+
+        @Override
+        public long rowCount() {
+            return values.length;
+        }
+
+        @Override
+        public Block[] extract(String[] columnNames, long[] localPositions, BlockFactory blockFactory) throws IOException {
+            Block[] result = new Block[columnNames.length];
+            boolean built = false;
+            try {
+                for (int c = 0; c < columnNames.length; c++) {
+                    result[c] = extractOne(columnNames[c], localPositions, blockFactory);
+                }
+                built = true;
+                return result;
+            } finally {
+                if (built == false) Releasables.closeExpectNoException(result);
+            }
+        }
+
+        Block extractOne(String columnName, long[] localPositions, BlockFactory blockFactory) {
+            try (IntBlock.Builder builder = blockFactory.newIntBlockBuilder(localPositions.length)) {
+                for (long pos : localPositions) {
+                    builder.appendInt(values[Math.toIntExact(pos)]);
+                }
+                return builder.build();
+            }
+        }
+
+        @Override
+        public void close() {
+            closeCount.incrementAndGet();
+        }
+
+        boolean closed() {
+            return closeCount.get() > 0;
+        }
+
+        int closeCount() {
+            return closeCount.get();
+        }
+    }
+
+    /**
+     * Two-column extractor: {@code ints} and {@code longs}. Used to assert that materialize fans
+     * out per-(column, id) and reassembles output blocks in caller order without mixing values
+     * across columns.
+     */
+    private static class TwoColumnExtractor implements ColumnExtractor {
+        private final int[] ints;
+        private final long[] longs;
+
+        TwoColumnExtractor(int[] ints, long[] longs) {
+            assert ints.length == longs.length;
+            this.ints = ints;
+            this.longs = longs;
+        }
+
+        @Override
+        public long rowCount() {
+            return ints.length;
+        }
+
+        @Override
+        public Block[] extract(String[] columnNames, long[] localPositions, BlockFactory blockFactory) throws IOException {
+            Block[] result = new Block[columnNames.length];
+            boolean built = false;
+            try {
+                for (int c = 0; c < columnNames.length; c++) {
+                    result[c] = extractOne(columnNames[c], localPositions, blockFactory);
+                }
+                built = true;
+                return result;
+            } finally {
+                if (built == false) Releasables.closeExpectNoException(result);
+            }
+        }
+
+        private Block extractOne(String columnName, long[] localPositions, BlockFactory blockFactory) {
+            switch (columnName) {
+                case "ints" -> {
+                    try (IntBlock.Builder b = blockFactory.newIntBlockBuilder(localPositions.length)) {
+                        for (long pos : localPositions) {
+                            b.appendInt(ints[Math.toIntExact(pos)]);
+                        }
+                        return b.build();
+                    }
+                }
+                case "longs" -> {
+                    try (LongBlock.Builder b = blockFactory.newLongBlockBuilder(localPositions.length)) {
+                        for (long pos : localPositions) {
+                            b.appendLong(longs[Math.toIntExact(pos)]);
+                        }
+                        return b.build();
+                    }
+                }
+                default -> throw new IllegalArgumentException("unknown column: " + columnName);
+            }
+        }
+
+        @Override
+        public void close() {}
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/InsertExternalFieldExtractionTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/InsertExternalFieldExtractionTests.java
@@ -1,0 +1,352 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.optimizer.rules.physical.local;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.xpack.esql.core.expression.FoldContext;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.type.EsField;
+import org.elasticsearch.xpack.esql.datasources.FormatReaderRegistry;
+import org.elasticsearch.xpack.esql.datasources.spi.ColumnExtractor;
+import org.elasticsearch.xpack.esql.datasources.spi.ColumnExtractorAware;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
+import org.elasticsearch.xpack.esql.datasources.spi.NoConfigFormatReader;
+import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
+import org.elasticsearch.xpack.esql.expression.Order;
+import org.elasticsearch.xpack.esql.optimizer.ExternalOptimizerContext;
+import org.elasticsearch.xpack.esql.optimizer.LocalPhysicalOptimizerContext;
+import org.elasticsearch.xpack.esql.plan.physical.ExternalFieldExtractExec;
+import org.elasticsearch.xpack.esql.plan.physical.ExternalSourceExec;
+import org.elasticsearch.xpack.esql.plan.physical.FilterExec;
+import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+import org.elasticsearch.xpack.esql.plan.physical.TopNExec;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.containsString;
+
+/**
+ * Plan-rewrite tests for {@link InsertExternalFieldExtraction}: covers the happy-path narrowing,
+ * the synthetic {@code _rowPosition} insertion, and every documented bail-out.
+ */
+public class InsertExternalFieldExtractionTests extends ESTestCase {
+
+    /** Six columns: id is the sort key, the other five are projection-only and should be deferred. */
+    private static List<Attribute> sixColumnSchema() {
+        return List.of(
+            field("id", DataType.LONG),
+            field("a", DataType.KEYWORD),
+            field("b", DataType.KEYWORD),
+            field("c", DataType.KEYWORD),
+            field("d", DataType.INTEGER),
+            field("e", DataType.DOUBLE)
+        );
+    }
+
+    public void testHappyPathInsertsExtractAboveTopN() {
+        List<Attribute> schema = sixColumnSchema();
+        Attribute sortKey = schema.get(0);
+        ExternalSourceExec source = parquetSource(schema, /* pushedFilter = */ null);
+        TopNExec topN = topN(sortKey, 100, source);
+
+        PhysicalPlan rewritten = applyRule(topN, columnExtractorAwareRegistry());
+
+        ExternalFieldExtractExec extract = (ExternalFieldExtractExec) rewritten;
+        // Deferred columns are exactly the non-sort-key columns from the schema.
+        List<String> deferredNames = extract.attributesToExtract().stream().map(Attribute::name).toList();
+        assertEquals(List.of("a", "b", "c", "d", "e"), deferredNames);
+
+        // The synthetic attribute must be _rowPosition, LONG, non-nullable.
+        assertEquals(ColumnExtractor.ROW_POSITION_COLUMN, extract.rowPositionAttribute().name());
+        assertEquals(DataType.LONG, extract.rowPositionAttribute().dataType());
+
+        // The TopN must still be the direct child; the source below it must be narrowed.
+        TopNExec rewrittenTopN = (TopNExec) extract.child();
+        ExternalSourceExec narrowed = (ExternalSourceExec) rewrittenTopN.child();
+        List<String> narrowedNames = narrowed.output().stream().map(Attribute::name).toList();
+        assertEquals(List.of("id", ColumnExtractor.ROW_POSITION_COLUMN), narrowedNames);
+    }
+
+    public void testNoOpWhenNoTopN() {
+        // The rule is keyed on TopN; nothing happens to a bare source. Sanity check via apply()
+        // by feeding the source directly — the rule should not match and return the same node.
+        ExternalSourceExec source = parquetSource(sixColumnSchema(), null);
+        PhysicalPlan result = new InsertExternalFieldExtraction().apply(source, contextWith(columnExtractorAwareRegistry()));
+        assertSame(source, result);
+    }
+
+    public void testNoOpWhenSourceIsNotColumnExtractorAware() {
+        ExternalSourceExec source = parquetSource(sixColumnSchema(), null);
+        TopNExec topN = topN(source.output().get(0), 100, source);
+        PhysicalPlan result = applyRule(topN, plainParquetRegistry());
+        assertSame("rule must be no-op when reader does not implement ColumnExtractorAware", topN, result);
+    }
+
+    public void testNoOpWhenRegistryMissing() {
+        ExternalSourceExec source = parquetSource(sixColumnSchema(), null);
+        TopNExec topN = topN(source.output().get(0), 100, source);
+        PhysicalPlan result = applyRule(topN, /* registry = */ null);
+        assertSame(topN, result);
+    }
+
+    public void testNoOpWhenNoExternalSourceReachable() {
+        // A TopN with no ExternalSourceExec underneath (we just hand it back via the rule entry
+        // point with a disconnected source). The rule walks down and finds nothing — no rewrite.
+        Attribute keep = field("id", DataType.LONG);
+        // Synthesize a TopN with a non-source, non-UnaryExec leaf via no child? Simulate by using
+        // an ExternalSourceExec with no output overlap and bailing on column count instead — this
+        // path is exercised by testNotEnoughDeferredColumns.
+        ExternalSourceExec ext = parquetSource(List.of(keep), null);
+        TopNExec topN = topN(keep, 100, ext);
+        PhysicalPlan result = applyRule(topN, columnExtractorAwareRegistry());
+        // With only a single column and that being the sort key, nothing is deferred → bail.
+        assertSame(topN, result);
+    }
+
+    public void testNotEnoughDeferredColumns() {
+        // 1 sort key + 2 projection columns = only 2 deferred. DEFERRED_COLUMN_MIN is 3, so bail.
+        List<Attribute> schema = List.of(field("id", DataType.LONG), field("a", DataType.KEYWORD), field("b", DataType.KEYWORD));
+        ExternalSourceExec source = parquetSource(schema, null);
+        TopNExec topN = topN(schema.get(0), 100, source);
+
+        PhysicalPlan result = applyRule(topN, columnExtractorAwareRegistry());
+        assertSame(topN, result);
+    }
+
+    public void testLimitTooLarge() {
+        ExternalSourceExec source = parquetSource(sixColumnSchema(), null);
+        TopNExec topN = topN(source.output().get(0), InsertExternalFieldExtraction.TOPN_EXTRACT_LIMIT_MAX + 1, source);
+
+        PhysicalPlan result = applyRule(topN, columnExtractorAwareRegistry());
+        assertSame(topN, result);
+    }
+
+    public void testLimitAtBoundary() {
+        ExternalSourceExec source = parquetSource(sixColumnSchema(), null);
+        TopNExec topN = topN(source.output().get(0), InsertExternalFieldExtraction.TOPN_EXTRACT_LIMIT_MAX, source);
+
+        PhysicalPlan rewritten = applyRule(topN, columnExtractorAwareRegistry());
+        // Exactly at the limit must still optimize.
+        assertTrue(rewritten instanceof ExternalFieldExtractExec);
+    }
+
+    public void testAssertsWhenSourceHasOpaquePushedFilterWithoutExpressions() {
+        // Production filters always flow through {@code PushFiltersToSource}, which calls
+        // {@code withPushedFilterAndExpressions} and therefore always populates pushed expressions.
+        // A filter without expressions is non-production usage that would silently disable the
+        // rule; assert loud so the misuse surfaces in tests.
+        ExternalSourceExec source = parquetSource(sixColumnSchema(), /* pushedFilter = */ "opaque");
+        TopNExec topN = topN(source.output().get(0), 100, source);
+
+        AssertionError ae = expectThrows(AssertionError.class, () -> applyRule(topN, columnExtractorAwareRegistry()));
+        assertThat(ae.getMessage(), containsString("pushed filter without pushed expressions"));
+    }
+
+    public void testFiresWhenPushedFilterHasExpressionsAndKeepsFilterColumnsEager() {
+        // Realistic shape: a Parquet source with WHERE pushed down (filter is opaque, but the
+        // optimizer also kept the original ESQL expressions). Column "a" is referenced by the
+        // pushed filter and column "id" is the sort key — both must remain eager. Columns "b" to
+        // "e" stay deferred.
+        List<Attribute> schema = sixColumnSchema();
+        Attribute sortKey = schema.get(0);
+        Attribute filterColumn = schema.get(1); // "a"
+        ExternalSourceExec source = parquetSource(schema, null).withPushedFilterAndExpressions(
+            "opaque",
+            List.of((Expression) filterColumn)
+        );
+
+        TopNExec topN = topN(sortKey, 100, source);
+
+        PhysicalPlan rewritten = applyRule(topN, columnExtractorAwareRegistry());
+
+        ExternalFieldExtractExec extract = (ExternalFieldExtractExec) rewritten;
+
+        // Deferred set must NOT contain "a" — the filter reads it, so it stays eager.
+        List<String> deferredNames = extract.attributesToExtract().stream().map(Attribute::name).toList();
+        assertEquals(List.of("b", "c", "d", "e"), deferredNames);
+
+        // The narrowed source carries id, a (filter column), and the synthetic _rowPosition.
+        ExternalSourceExec narrowed = (ExternalSourceExec) ((TopNExec) extract.child()).child();
+        List<String> narrowedNames = narrowed.output().stream().map(Attribute::name).toList();
+        assertEquals(List.of("id", "a", ColumnExtractor.ROW_POSITION_COLUMN), narrowedNames);
+
+        // The pushed filter must survive the rewrite; the source still applies it during the
+        // forward scan, the optimization only affects the output projection of that scan.
+        assertEquals("opaque", narrowed.pushedFilter());
+        assertEquals(1, narrowed.pushedExpressions().size());
+    }
+
+    public void testBailsWhenFilterColumnRefsLeaveTooFewDeferred() {
+        // 1 sort key + 5 projection-only columns: if 3 of the projection-only columns are referenced
+        // by the pushed filter, only 2 remain deferred — below DEFERRED_COLUMN_MIN of 3, so bail.
+        List<Attribute> schema = sixColumnSchema();
+        Attribute sortKey = schema.get(0);
+        ExternalSourceExec source = parquetSource(schema, null).withPushedFilterAndExpressions(
+            "opaque",
+            List.of((Expression) schema.get(1), (Expression) schema.get(2), (Expression) schema.get(3))
+        );
+        TopNExec topN = topN(sortKey, 100, source);
+
+        PhysicalPlan result = applyRule(topN, columnExtractorAwareRegistry());
+        assertSame("rule must bail when too few columns remain deferable after filter eager-ifies them", topN, result);
+    }
+
+    public void testKeepsFilterExecRefsEagerWhenInBetweenTopNAndSource() {
+        // FilterExec sits between TopN and the source. The rule's intermediate-refs walk must
+        // pick up the filter expression's references and keep those columns eager. Sort key is
+        // "id"; filter reads "a"; "b..e" remain deferred.
+        List<Attribute> schema = sixColumnSchema();
+        Attribute sortKey = schema.get(0);
+        Attribute filterColumn = schema.get(1); // "a"
+        ExternalSourceExec source = parquetSource(schema, null);
+        FilterExec filter = new FilterExec(Source.EMPTY, source, (Expression) filterColumn);
+        TopNExec topN = topN(sortKey, 100, filter);
+
+        PhysicalPlan rewritten = applyRule(topN, columnExtractorAwareRegistry());
+        ExternalFieldExtractExec extract = (ExternalFieldExtractExec) rewritten;
+
+        // The deferred set must NOT contain "a"; the filter on the spine reads it.
+        List<String> deferredNames = extract.attributesToExtract().stream().map(Attribute::name).toList();
+        assertEquals(List.of("b", "c", "d", "e"), deferredNames);
+
+        // The narrowed source carries id, a (filter column) and the synthetic _rowPosition. The
+        // FilterExec is preserved on the spine between the new TopN and the narrowed source.
+        TopNExec rewrittenTopN = (TopNExec) extract.child();
+        FilterExec rewrittenFilter = (FilterExec) rewrittenTopN.child();
+        ExternalSourceExec narrowed = (ExternalSourceExec) rewrittenFilter.child();
+        List<String> narrowedNames = narrowed.output().stream().map(Attribute::name).toList();
+        assertEquals(List.of("id", "a", ColumnExtractor.ROW_POSITION_COLUMN), narrowedNames);
+    }
+
+    public void testNoOpWhenRowPositionNameAlreadyUsed() {
+        // A user column named _rowPosition would collide with our synthetic key; bail.
+        List<Attribute> schema = new ArrayList<>(sixColumnSchema());
+        schema.add(field(ColumnExtractor.ROW_POSITION_COLUMN, DataType.LONG));
+        ExternalSourceExec source = parquetSource(schema, null);
+        TopNExec topN = topN(source.output().get(0), 100, source);
+
+        PhysicalPlan result = applyRule(topN, columnExtractorAwareRegistry());
+        assertSame(topN, result);
+    }
+
+    public void testMultipleSortKeysAllPreserved() {
+        // Two sort keys (id, region) plus 4 projection-only columns: rule must keep id and region
+        // eagerly and defer a, b, c, d.
+        List<Attribute> schema = List.of(
+            field("id", DataType.LONG),
+            field("region", DataType.KEYWORD),
+            field("a", DataType.KEYWORD),
+            field("b", DataType.KEYWORD),
+            field("c", DataType.KEYWORD),
+            field("d", DataType.INTEGER)
+        );
+        ExternalSourceExec source = parquetSource(schema, null);
+        Order primary = new Order(Source.EMPTY, schema.get(0), Order.OrderDirection.ASC, Order.NullsPosition.LAST);
+        Order secondary = new Order(Source.EMPTY, schema.get(1), Order.OrderDirection.DESC, Order.NullsPosition.FIRST);
+        TopNExec topN = new TopNExec(Source.EMPTY, source, List.of(primary, secondary), literal(100), null);
+
+        PhysicalPlan rewritten = applyRule(topN, columnExtractorAwareRegistry());
+        ExternalFieldExtractExec extract = (ExternalFieldExtractExec) rewritten;
+
+        ExternalSourceExec narrowed = (ExternalSourceExec) ((TopNExec) extract.child()).child();
+        List<String> narrowedNames = narrowed.output().stream().map(Attribute::name).toList();
+        // Both sort keys must remain eager, plus the synthetic row-position column.
+        assertTrue(narrowedNames.contains("id"));
+        assertTrue(narrowedNames.contains("region"));
+        assertTrue(narrowedNames.contains(ColumnExtractor.ROW_POSITION_COLUMN));
+        // Deferred set is the complement.
+        List<String> deferredNames = extract.attributesToExtract().stream().map(Attribute::name).toList();
+        assertEquals(List.of("a", "b", "c", "d"), deferredNames);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // helpers
+    // ---------------------------------------------------------------------------------------------
+
+    private static FieldAttribute field(String name, DataType type) {
+        return new FieldAttribute(Source.EMPTY, name, new EsField(name, type, Map.of(), false, EsField.TimeSeriesFieldType.NONE));
+    }
+
+    private static Literal literal(int value) {
+        return new Literal(Source.EMPTY, value, DataType.INTEGER);
+    }
+
+    private static TopNExec topN(Attribute sortKey, int limit, PhysicalPlan child) {
+        Order order = new Order(Source.EMPTY, sortKey, Order.OrderDirection.ASC, Order.NullsPosition.LAST);
+        return new TopNExec(Source.EMPTY, child, List.of(order), literal(limit), null);
+    }
+
+    private static ExternalSourceExec parquetSource(List<Attribute> schema, Object pushedFilter) {
+        return new ExternalSourceExec(Source.EMPTY, "file:///test.parquet", "parquet", schema, Map.of(), Map.of(), pushedFilter, null);
+    }
+
+    private static FormatReaderRegistry columnExtractorAwareRegistry() {
+        FormatReaderRegistry registry = new FormatReaderRegistry(null);
+        registry.registerLazy("parquet", (settings, blockFactory) -> new ColumnExtractorAwareStub(), null, null);
+        return registry;
+    }
+
+    private static FormatReaderRegistry plainParquetRegistry() {
+        FormatReaderRegistry registry = new FormatReaderRegistry(null);
+        registry.registerLazy("parquet", (settings, blockFactory) -> new PlainStub(), null, null);
+        return registry;
+    }
+
+    private static LocalPhysicalOptimizerContext contextWith(FormatReaderRegistry registry) {
+        return new LocalPhysicalOptimizerContext(null, null, null, FoldContext.small(), null, new ExternalOptimizerContext(registry));
+    }
+
+    private static PhysicalPlan applyRule(TopNExec topN, FormatReaderRegistry registry) {
+        return new InsertExternalFieldExtraction().apply(topN, contextWith(registry));
+    }
+
+    /** Format-reader stub that <em>does</em> implement {@link ColumnExtractorAware}. */
+    private static final class ColumnExtractorAwareStub extends StubReader implements ColumnExtractorAware {}
+
+    /** Format-reader stub that does NOT implement {@link ColumnExtractorAware}. */
+    private static final class PlainStub extends StubReader {}
+
+    /** Common base. The optimizer only ever inspects {@code instanceof ColumnExtractorAware}; the
+     *  remaining {@link NoConfigFormatReader} methods stay unimplemented to make accidental use
+     *  during a rule pass loud. */
+    private static class StubReader implements NoConfigFormatReader {
+        @Override
+        public SourceMetadata metadata(StorageObject object) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public org.elasticsearch.compute.operator.CloseableIterator<org.elasticsearch.compute.data.Page> read(
+            StorageObject object,
+            FormatReadContext context
+        ) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String formatName() {
+            return "parquet";
+        }
+
+        @Override
+        public List<String> fileExtensions() {
+            return List.of(".parquet");
+        }
+
+        @Override
+        public void close() {}
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushAggregatesToExternalSourceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushAggregatesToExternalSourceTests.java
@@ -33,6 +33,7 @@ import org.elasticsearch.xpack.esql.expression.function.aggregate.Count;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Max;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Min;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Sum;
+import org.elasticsearch.xpack.esql.optimizer.ExternalOptimizerContext;
 import org.elasticsearch.xpack.esql.optimizer.LocalPhysicalOptimizerContext;
 import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
 import org.elasticsearch.xpack.esql.plan.physical.ExternalSourceExec;
@@ -566,11 +567,11 @@ public class PushAggregatesToExternalSourceTests extends ESTestCase {
     }
 
     private static LocalPhysicalOptimizerContext buildContext(FormatReaderRegistry registry) {
-        return new LocalPhysicalOptimizerContext(null, null, null, null, null, registry);
+        return new LocalPhysicalOptimizerContext(null, null, null, null, null, new ExternalOptimizerContext(registry));
     }
 
     private static LocalPhysicalOptimizerContext nullRegistryContext() {
-        return new LocalPhysicalOptimizerContext(null, null, null, null, null, null);
+        return new LocalPhysicalOptimizerContext(null, null, null, null, null, ExternalOptimizerContext.NONE);
     }
 
     private static PhysicalPlan applyRule(AggregateExec agg) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/ExternalSourceExecTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/ExternalSourceExecTests.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.physical;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.xpack.esql.core.expression.MetadataAttribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.type.EsField;
+import org.elasticsearch.xpack.esql.datasources.spi.ColumnExtractor;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Focused tests for {@link ExternalSourceExec#withAttributes(List)}: the attribute swap used by
+ * {@code InsertExternalFieldExtraction} to narrow the source's projection while preserving every
+ * other transient field (pushed filter, pushed limit, splits, etc.).
+ */
+public class ExternalSourceExecTests extends ESTestCase {
+
+    public void testWithAttributesPreservesAllOtherFields() {
+        FieldAttribute keep = field("keep", DataType.LONG);
+        FieldAttribute drop = field("drop", DataType.INTEGER);
+        FieldAttribute another = field("other", DataType.KEYWORD);
+        ExternalSourceExec original = new ExternalSourceExec(
+            Source.EMPTY,
+            "s3://bucket/file.parquet",
+            "parquet",
+            List.of(keep, drop, another),
+            Map.of("endpoint", "https://example.com"),
+            Map.of("schema_version", 1),
+            null,
+            42 // estimatedRowSize
+        );
+
+        MetadataAttribute rowPosition = new MetadataAttribute(Source.EMPTY, ColumnExtractor.ROW_POSITION_COLUMN, DataType.LONG, false);
+        List<Attribute> narrowed = List.of(keep, rowPosition);
+        ExternalSourceExec rewritten = original.withAttributes(narrowed);
+
+        assertNotSame(original, rewritten);
+        assertEquals(narrowed, rewritten.output());
+        assertEquals(original.sourcePath(), rewritten.sourcePath());
+        assertEquals(original.sourceType(), rewritten.sourceType());
+        assertEquals(original.config(), rewritten.config());
+        assertEquals(original.sourceMetadata(), rewritten.sourceMetadata());
+        assertSame(original.pushedFilter(), rewritten.pushedFilter());
+        assertEquals(original.pushedExpressions(), rewritten.pushedExpressions());
+        assertEquals(original.pushedLimit(), rewritten.pushedLimit());
+        assertEquals(original.estimatedRowSize(), rewritten.estimatedRowSize());
+        assertEquals(original.fileList(), rewritten.fileList());
+        assertEquals(original.splits(), rewritten.splits());
+        // Original must remain unchanged — withAttributes returns a new node, never mutates.
+        assertEquals(List.of(keep, drop, another), original.output());
+    }
+
+    public void testWithAttributesAcceptsEmptyList() {
+        // Edge case: narrowing to an empty list (only meaningful when the optimizer immediately
+        // appends _rowPosition, but the constructor must accept the call without throwing).
+        ExternalSourceExec original = new ExternalSourceExec(
+            Source.EMPTY,
+            "file:///x.parquet",
+            "parquet",
+            List.of(field("a", DataType.LONG)),
+            Map.of(),
+            Map.of(),
+            null,
+            10
+        );
+        ExternalSourceExec narrowed = original.withAttributes(List.of());
+        assertEquals(List.of(), narrowed.output());
+    }
+
+    private static FieldAttribute field(String name, DataType type) {
+        return new FieldAttribute(Source.EMPTY, name, new EsField(name, type, Map.of(), false, EsField.TimeSeriesFieldType.NONE));
+    }
+}


### PR DESCRIPTION
## Why

`… | SORT key | LIMIT N` against an external source today reads every projected column for every scanned row, even though the TopN immediately throws away all but `N`. For wide tables on object storage this dominates query cost: the bytes for the projection-only columns are paid for, transferred, and decoded just to be discarded.

This PR brings Lucene-style late materialization to the external-source path. The forward scan reads only the columns the plan needs above the source — sort keys, filter/eval references, and a tiny synthetic routing column. Projection-only columns are materialized only for the (at most `N`) rows that survive TopN.

## Design

The core abstraction is a positional, deferred read SPI:

- `ColumnExtractor` — materializes one or more columns at given row identities in a single coalesced fetch.
- `ColumnExtractorAware` — capability marker on `FormatReader`s that can do this.
- `ColumnExtractorProducer` — the runtime handshake: implemented by the iterator that emits the routing column, it produces an extractor whose row-address space matches its own.

The forward scan emits a synthetic `_rowPosition LONG` column carrying `(extractorId << 48) | physicalRowOffset`. After TopN, `ExternalFieldExtractOperator` decodes the surviving identities, dispatches them through the per-driver `SourceExtractors` registry to the matching `ColumnExtractor`, and zips the deferred columns onto the surviving rows.

`InsertExternalFieldExtraction` is the local optimizer rule that performs the rewrite: `TopN → … → ExternalSourceExec` becomes `ExternalFieldExtractExec → TopN → narrowed ExternalSourceExec`, where the narrowed source's projection is the union of TopN sort keys, intermediate `UnaryExec` references, and the pushed filter's references. `ExternalOptimizerContext` exposes the `FormatReaderRegistry` to local rules so the rule can ask the registry whether a source supports deferred extraction without ad-hoc plumbing.

### Architectural decisions

**File-global, filter-invariant row identity.** `_rowPosition` is the row's index in the file's footer iteration order, computed from a prefix sum over `BlockMetaData.getRowCount()`. It is invariant under predicate filtering, page skipping, and late materialization. That invariance is what lets the forward scan keep its filter pushdown and the optimized iterator's page-skipping intact — earlier counter-based identities silently broke both because the counter and the filtered row stream were not in sync.

**Encoding at the iterator boundary.** The factory wires the assigned extractor id into the iterator via `ColumnExtractorProducer#setExtractorId(int)` once per opened file; from then on every emitted `_rowPosition` value is already encoded. No downstream encoder pass, no per-page block rebuild on the producer thread (which previously violated `LocalCircuitBreaker`'s single-thread contract).

**Multi-column coalesced extract.** `ColumnExtractor#extract` takes a `String[]` and returns one `Block` per column from a single I/O batch. For Parquet that means one async per-row-group prefetch covering every requested column's chunks; column chunks within a row group are physically contiguous, so the merger collapses N-column requests to typically one HTTP GET per visited row group rather than N sequential ones. On object stores the per-request RTT is the dominant cost, so this turns `O(columns)` round-trips into `O(1)`.

**Pipelined per-row-group prefetch.** The extractor fans out one `prefetchAsync` per visited row group simultaneously and decodes each bucket the moment its bytes land. End-to-end latency drops from `slowest_GET + sum(decodes)` toward `max(slowest_GET, fastest_GET + sum(decodes))`. Concurrency stays bounded by the existing per-query budget.

### Parquet wiring

`ParquetFormatReader` declares `ColumnExtractorAware` and unifies its `read()` and `readRange()` filter resolution and reader-reopen logic through a single `buildIterator` helper, so a pushed filter is applied identically on both paths. `OptimizedParquetColumnIterator` is the `ColumnExtractorProducer`, materializing file-global `_rowPosition` values inline and producing a `ParquetColumnExtractor` scoped to the file's full footer (even on range-restricted reads, so identities resolve consistently across split boundaries). `SchemaAdaptingIterator` forwards the producer capability to its delegate so schema reconciliation never drops the synthetic column.

## Tests

Unit tests for the SPI, the optimizer rule (happy path + every documented bail-out), the operator, the producer handshake, and `ParquetColumnExtractor` (including parallel-dispatch under a latch). End-to-end `ExternalParquetTopNExtractionIT` covers full-file reads, byte-range splits, pushed filter + sort + limit, and result correctness against the un-optimised baseline.

Developed with AI-assisted tooling
