### PR TITLE
[9.4] Use search threadpool for coordination in ES|QL (#149034)

### DIFF
--- a/docs/changelog/149034.yaml
+++ b/docs/changelog/149034.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 149034
+summary: Use search threadpool for coordination in ES|QL
+type: bug

--- a/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/Clusters.java
+++ b/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/Clusters.java
@@ -14,6 +14,8 @@ import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 
 public class Clusters {
+    public static final int HEAP_SIZE_IN_MB = 512;
+
     static ElasticsearchCluster buildCluster() {
         var spec = ElasticsearchCluster.local()
             .distribution(DistributionType.DEFAULT)
@@ -23,7 +25,7 @@ public class Clusters {
             .setting("xpack.license.self_generated.type", "trial")
             .setting("esql.query.allow_partial_results", "false")
             .setting("logger.org.elasticsearch.compute.lucene.read", "DEBUG")
-            .jvmArg("-Xmx512m");
+            .jvmArg("-Xmx" + HEAP_SIZE_IN_MB + "m");
         String javaVersion = JvmInfo.jvmInfo().version();
         if (javaVersion.equals("20") || javaVersion.equals("21")) {
             // see https://github.com/elastic/elasticsearch/issues/99592

--- a/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/ManyRequestsIT.java
+++ b/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/ManyRequestsIT.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.xpack.esql.heap_attack;
+
+import org.apache.http.HttpStatus;
+import org.apache.http.util.EntityUtils;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.xcontent.support.XContentMapValues;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class ManyRequestsIT extends HeapAttackTestCase {
+
+    /**
+     * Submit as many requests as possible, then the cluster should reject instead of OOM
+     */
+    public void testManyRequests() throws Exception {
+        createPausableIndex();
+        blockPauseField();
+        int queueSize = getSearchQueueSize();
+        long queryLength = ByteSizeValue.ofMb(Clusters.HEAP_SIZE_IN_MB).getBytes() / queueSize;
+        List<String> asyncIds = new ArrayList<>();
+        logger.info("queue size {}", queueSize);
+        try {
+            int totalRequests = queueSize * 5;
+            for (int i = 0; i < totalRequests; i++) {
+                String comment = "q" + i + " ";
+                String pad = comment.repeat(Math.toIntExact(queryLength / comment.length()));
+                String query = query(pad);
+                try {
+                    String id = submitAsyncQuery(query);
+                    logger.info("--> submitted query={} length={} id={}", i, query.length(), id);
+                    asyncIds.add(id);
+                } catch (ResponseException ex) {
+                    int statusCode = ex.getResponse().getStatusLine().getStatusCode();
+                    String resp = EntityUtils.toString(ex.getResponse().getEntity());
+                    logger.info("--> failed to submit query {} response {} status {}", i, resp, statusCode);
+                    assertThat(resp, statusCode, equalTo(HttpStatus.SC_TOO_MANY_REQUESTS));
+                    break;
+                }
+            }
+        } finally {
+            unblockPauseField();
+            for (int i = 0; i < asyncIds.size(); i++) {
+                String id = asyncIds.get(i);
+                logger.info("--> stopping query={} id={}", i, id);
+                deleteAsyncQuery(id);
+            }
+            for (String id : asyncIds) {
+                ensureAsyncQueryCompleted(id);
+            }
+        }
+    }
+
+    /**
+     * Cancelling tail requests should not have to wait for requests ahead in the queue.
+     */
+    public void testCancelTailRequest() throws Exception {
+        createPausableIndex();
+        blockPauseField();
+        int batchSize = between(100, 200);
+        List<String> asyncIds = new ArrayList<>();
+        try {
+            for (int i = 0; i < batchSize; i++) {
+                String query = query("q-" + i);
+                String id = submitAsyncQuery(query);
+                asyncIds.add(id);
+            }
+            // cancelling requests in the queue should not wait for the running requests or those ahead in the queue
+            int tailRequests = between(10, 20);
+            for (int i = batchSize - tailRequests; i < batchSize; i++) {
+                String id = asyncIds.get(i);
+                logger.info("--> cancelling query={} id={}", i, id);
+                deleteAsyncQuery(id);
+            }
+            for (int i = batchSize - tailRequests; i < batchSize; i++) {
+                String id = asyncIds.get(i);
+                ensureAsyncQueryCompleted(id);
+            }
+        } finally {
+            unblockPauseField();
+            for (int i = 0; i < asyncIds.size(); i++) {
+                String id = asyncIds.get(i);
+                logger.info("--> stopping query={} id={}", i, id);
+                deleteAsyncQuery(id);
+            }
+            for (String id : asyncIds) {
+                ensureAsyncQueryCompleted(id);
+            }
+        }
+    }
+
+    private void createPausableIndex() throws IOException {
+        Request createIndex = new Request("PUT", "/pause_test");
+        createIndex.setJsonEntity("""
+            {
+                "settings": {
+                    "number_of_shards": 1
+                },
+                "mappings": {
+                    "runtime": {
+                        "pause_long_field": {
+                            "type": "long",
+                            "script": {
+                                "source": "",
+                                "lang": "pause"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "tag": {
+                            "type": "keyword"
+                        }
+                    }
+                }
+            }""");
+        client().performRequest(createIndex);
+        Request bulk = new Request("POST", "/pause_test/_bulk?refresh=true");
+        StringBuilder body = new StringBuilder();
+        for (int i = 0; i < 10; i++) {
+            body.append("{\"index\":{}}\n").append("{\"tag\":\"tag-").append(i).append("\"}\n");
+        }
+        bulk.setJsonEntity(body.toString());
+        client().performRequest(bulk);
+    }
+
+    private String query(String comment) {
+        return "FROM pause_test | STATS SUM(pause_long_field) | LIMIT 1 /* " + comment + " */";
+    }
+
+    private String submitAsyncQuery(String query) throws IOException {
+        Request request = new Request("POST", "/_query/async");
+        request.setJsonEntity("{\"query\": \"" + query + "\", \"wait_for_completion_timeout\": \"10ms\", \"keep_on_completion\": false}");
+        Response response = client().performRequest(request);
+        Map<String, Object> responseMap = entityAsMap(response);
+        return (String) responseMap.get("id");
+    }
+
+    private void deleteAsyncQuery(String id) throws Exception {
+        assertBusy(() -> {
+            try {
+                client().performRequest(new Request("DELETE", "/_query/async/" + id));
+            } catch (ResponseException ex) {
+                int statusCode = ex.getResponse().getStatusLine().getStatusCode();
+                if (statusCode != HttpStatus.SC_NOT_FOUND) {
+                    throw ex;
+                }
+            }
+        });
+    }
+
+    private void ensureAsyncQueryCompleted(String id) throws Exception {
+        assertBusy(() -> {
+            try {
+                client().performRequest(new Request("GET", "/_query/async/" + id));
+                fail("expected async query [" + id + "] to be gone");
+            } catch (ResponseException ex) {
+                int statusCode = ex.getResponse().getStatusLine().getStatusCode();
+                // the request might have been rejected (429) or already deleted
+                if (statusCode != HttpStatus.SC_TOO_MANY_REQUESTS && statusCode != HttpStatus.SC_NOT_FOUND) {
+                    throw ex;
+                }
+            }
+        });
+    }
+
+    private void blockPauseField() throws IOException {
+        client().performRequest(new Request("POST", "/_pause_field/block"));
+    }
+
+    private void unblockPauseField() throws IOException {
+        client().performRequest(new Request("POST", "/_pause_field/unblock"));
+    }
+
+    @SuppressWarnings("unchecked")
+    private int getSearchQueueSize() throws IOException {
+        Response response = client().performRequest(new Request("GET", "/_nodes/thread_pool"));
+        Map<String, Object> nodes = (Map<String, Object>) entityAsMap(response).get("nodes");
+        Map<String, Object> firstNode = (Map<String, Object>) nodes.values().iterator().next();
+        return (int) XContentMapValues.extractValue("thread_pool.search.queue_size", firstNode);
+    }
+}

--- a/test/external-modules/esql-heap-attack/src/main/java/org/elasticsearch/test/esql/heap_attack/HeapAttackPlugin.java
+++ b/test/external-modules/esql-heap-attack/src/main/java/org/elasticsearch/test/esql/heap_attack/HeapAttackPlugin.java
@@ -7,13 +7,6 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-/*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0; you may not use this file except in compliance with the Elastic License
- * 2.0.
- */
-
 package org.elasticsearch.test.esql.heap_attack;
 
 import org.elasticsearch.cluster.node.DiscoveryNodes;
@@ -23,20 +16,33 @@ import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.plugins.ActionPlugin;
 import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.plugins.ScriptPlugin;
 import org.elasticsearch.rest.RestHandler;
+import org.elasticsearch.script.LongFieldScript;
+import org.elasticsearch.script.ScriptContext;
+import org.elasticsearch.script.ScriptEngine;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
-public class HeapAttackPlugin extends Plugin implements ActionPlugin {
+public class HeapAttackPlugin extends Plugin implements ActionPlugin, ScriptPlugin {
+
+    @Override
+    public Collection<ActionHandler> getActions() {
+        return List.of(new ActionHandler(TransportPauseFieldAction.TYPE, TransportPauseFieldAction.class));
+    }
+
     @Override
     public List<RestHandler> getRestHandlers(
         RestHandlersServices restHandlersServices,
         Supplier<DiscoveryNodes> nodesInCluster,
         Predicate<NodeFeature> clusterSupportsFeature
     ) {
-        return List.of(new RestTriggerOutOfMemoryAction());
+        return List.of(new RestTriggerOutOfMemoryAction(), new RestPauseFieldAction());
     }
 
     // Deliberately unregistered, only used in unit tests. Copied to AbstractSimpleTransportTestCase#IGNORE_DESERIALIZATION_ERRORS_SETTING
@@ -55,5 +61,44 @@ public class HeapAttackPlugin extends Plugin implements ActionPlugin {
     @Override
     public Settings additionalSettings() {
         return Settings.builder().put(super.additionalSettings()).put(IGNORE_DESERIALIZATION_ERRORS_SETTING.getKey(), true).build();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public ScriptEngine getScriptEngine(Settings settings, Collection<ScriptContext<?>> contexts) {
+        return new ScriptEngine() {
+            @Override
+            public String getType() {
+                return "pause";
+            }
+
+            @Override
+            public <FactoryType> FactoryType compile(
+                String name,
+                String code,
+                ScriptContext<FactoryType> context,
+                Map<String, String> params
+            ) {
+                if (context == LongFieldScript.CONTEXT) {
+                    return (FactoryType) (LongFieldScript.Factory) (
+                        fieldName,
+                        p,
+                        searchLookup,
+                        onScriptError) -> ctx -> new LongFieldScript(fieldName, p, searchLookup, onScriptError, ctx) {
+                            @Override
+                            public void execute() {
+                                PausableField.waitForExecutionPermit();
+                                emit(1);
+                            }
+                        };
+                }
+                throw new IllegalStateException("unsupported type " + context);
+            }
+
+            @Override
+            public Set<ScriptContext<?>> getSupportedContexts() {
+                return Set.of(LongFieldScript.CONTEXT);
+            }
+        };
     }
 }

--- a/test/external-modules/esql-heap-attack/src/main/java/org/elasticsearch/test/esql/heap_attack/PausableField.java
+++ b/test/external-modules/esql-heap-attack/src/main/java/org/elasticsearch/test/esql/heap_attack/PausableField.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.test.esql.heap_attack;
+
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+final class PausableField {
+    private static final AtomicReference<CountDownLatch> blockingRef = new AtomicReference<>();
+    private static final Logger LOGGER = LogManager.getLogger(PausableField.class);
+
+    private PausableField() {}
+
+    static void blockExecution() {
+        CountDownLatch prev = blockingRef.getAndSet(new CountDownLatch(1));
+        if (prev != null) {
+            prev.countDown();
+        }
+    }
+
+    static void unblockExecution() {
+        CountDownLatch prev = blockingRef.getAndSet(null);
+        if (prev != null) {
+            prev.countDown();
+        }
+    }
+
+    static void waitForExecutionPermit() {
+        CountDownLatch latch = blockingRef.get();
+        if (latch != null) {
+            LOGGER.info("--> waiting for the latch of pausable field");
+            try {
+                if (latch.await(5, TimeUnit.MINUTES) == false) {
+                    throw new AssertionError("timed out waiting for the latch of a pausable field");
+                }
+            } catch (InterruptedException e) {
+                throw new AssertionError(e);
+            }
+        }
+    }
+}

--- a/test/external-modules/esql-heap-attack/src/main/java/org/elasticsearch/test/esql/heap_attack/RestPauseFieldAction.java
+++ b/test/external-modules/esql-heap-attack/src/main/java/org/elasticsearch/test/esql/heap_attack/RestPauseFieldAction.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.test.esql.heap_attack;
+
+import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.RestResponse;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.rest.Scope;
+import org.elasticsearch.rest.ServerlessScope;
+import org.elasticsearch.rest.action.RestActionListener;
+import org.elasticsearch.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.elasticsearch.rest.RestRequest.Method.POST;
+
+@ServerlessScope(Scope.PUBLIC)
+public class RestPauseFieldAction extends BaseRestHandler {
+    @Override
+    public String getName() {
+        return "pause_field";
+    }
+
+    @Override
+    public List<Route> routes() {
+        return List.of(new Route(POST, "/_pause_field/block"), new Route(POST, "/_pause_field/unblock"));
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+        boolean block = request.path().endsWith("/block");
+        return channel -> client.admin()
+            .cluster()
+            .execute(TransportPauseFieldAction.TYPE, new TransportPauseFieldAction.Request(block), new RestActionListener<>(channel) {
+                @Override
+                protected void processResponse(TransportPauseFieldAction.Response response) throws Exception {
+                    try (XContentBuilder builder = channel.newBuilder()) {
+                        builder.startObject().field("acknowledged", true).endObject();
+                        channel.sendResponse(new RestResponse(RestStatus.OK, builder));
+                    }
+                }
+            });
+    }
+}

--- a/test/external-modules/esql-heap-attack/src/main/java/org/elasticsearch/test/esql/heap_attack/TransportPauseFieldAction.java
+++ b/test/external-modules/esql-heap-attack/src/main/java/org/elasticsearch/test/esql/heap_attack/TransportPauseFieldAction.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.test.esql.heap_attack;
+
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.FailedNodeException;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.TransportAction;
+import org.elasticsearch.action.support.nodes.BaseNodeResponse;
+import org.elasticsearch.action.support.nodes.BaseNodesRequest;
+import org.elasticsearch.action.support.nodes.BaseNodesResponse;
+import org.elasticsearch.action.support.nodes.TransportNodesAction;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.injection.guice.Inject;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.AbstractTransportRequest;
+import org.elasticsearch.transport.TransportService;
+
+import java.io.IOException;
+import java.util.List;
+
+public class TransportPauseFieldAction extends TransportNodesAction<
+    TransportPauseFieldAction.Request,
+    TransportPauseFieldAction.Response,
+    TransportPauseFieldAction.NodeRequest,
+    TransportPauseFieldAction.NodeResponse,
+    Void> {
+
+    public static final ActionType<Response> TYPE = new ActionType<>("cluster:monitor/test/pause_field");
+
+    @Inject
+    public TransportPauseFieldAction(
+        ClusterService clusterService,
+        TransportService transportService,
+        ActionFilters actionFilters,
+        ThreadPool threadPool
+    ) {
+        super(
+            TYPE.name(),
+            clusterService,
+            transportService,
+            actionFilters,
+            NodeRequest::new,
+            threadPool.executor(ThreadPool.Names.MANAGEMENT)
+        );
+    }
+
+    @Override
+    protected Response newResponse(Request request, List<NodeResponse> nodeResponses, List<FailedNodeException> failures) {
+        return new Response(clusterService.getClusterName(), nodeResponses, failures);
+    }
+
+    @Override
+    protected NodeRequest newNodeRequest(Request request) {
+        return new NodeRequest(request.block);
+    }
+
+    @Override
+    protected NodeResponse newNodeResponse(StreamInput in, DiscoveryNode node) throws IOException {
+        return new NodeResponse(in, node);
+    }
+
+    @Override
+    protected NodeResponse nodeOperation(NodeRequest request, Task task) {
+        if (request.block) {
+            PausableField.blockExecution();
+        } else {
+            PausableField.unblockExecution();
+        }
+        return new NodeResponse(transportService.getLocalNode());
+    }
+
+    public static class Request extends BaseNodesRequest {
+        private final boolean block;
+
+        public Request(boolean block) {
+            super(Strings.EMPTY_ARRAY);
+            this.block = block;
+        }
+    }
+
+    public static class NodeRequest extends AbstractTransportRequest {
+        private final boolean block;
+
+        NodeRequest(boolean block) {
+            this.block = block;
+        }
+
+        NodeRequest(StreamInput in) throws IOException {
+            super(in);
+            this.block = in.readBoolean();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeBoolean(block);
+        }
+    }
+
+    public static class Response extends BaseNodesResponse<NodeResponse> {
+        protected Response(ClusterName clusterName, List<NodeResponse> nodes, List<FailedNodeException> failures) {
+            super(clusterName, nodes, failures);
+        }
+
+        @Override
+        protected List<NodeResponse> readNodesFrom(StreamInput in) throws IOException {
+            return in.readCollectionAsList(NodeResponse::new);
+        }
+
+        @Override
+        protected void writeNodesTo(StreamOutput out, List<NodeResponse> nodes) {
+            TransportAction.localOnly();
+        }
+    }
+
+    public static class NodeResponse extends BaseNodeResponse {
+        protected NodeResponse(DiscoveryNode node) {
+            super(node);
+        }
+
+        protected NodeResponse(StreamInput in) throws IOException {
+            super(in);
+        }
+
+        protected NodeResponse(StreamInput in, DiscoveryNode node) throws IOException {
+            super(in, node);
+        }
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/DriverTaskRunner.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/DriverTaskRunner.java
@@ -36,24 +36,31 @@ import java.util.concurrent.Executor;
 public class DriverTaskRunner {
     public static final String ACTION_NAME = "indices:data/read/esql/compute";
     private final TransportService transportService;
+    private final Executor searchExecutor;
 
-    public DriverTaskRunner(TransportService transportService, Executor executor) {
+    public DriverTaskRunner(TransportService transportService, Executor searchExecutor) {
         this.transportService = transportService;
-        transportService.registerRequestHandler(ACTION_NAME, executor, DriverRequest::new, new DriverRequestHandler(transportService));
+        this.searchExecutor = searchExecutor;
+        transportService.registerRequestHandler(
+            ACTION_NAME,
+            searchExecutor,
+            DriverRequest::new,
+            new DriverRequestHandler(transportService)
+        );
     }
 
-    public void executeDrivers(Task parentTask, List<Driver> drivers, Executor executor, ActionListener<Void> listener) {
+    public void executeDrivers(Task parentTask, List<Driver> drivers, Executor workerExecutor, ActionListener<Void> listener) {
         var runner = new DriverRunner(transportService.getThreadPool().getThreadContext()) {
             @Override
             protected void start(Driver driver, ActionListener<Void> driverListener) {
                 transportService.sendChildRequest(
                     transportService.getLocalNode(),
                     ACTION_NAME,
-                    new DriverRequest(driver, executor),
+                    new DriverRequest(driver, workerExecutor),
                     parentTask,
                     TransportRequestOptions.EMPTY,
                     TransportResponseHandler.empty(
-                        executor,
+                        searchExecutor,
                         // The TransportResponseHandler can be notified while the Driver is still running during node shutdown
                         // or the Driver hasn't started when the parent task is canceled. In such cases, we should abort
                         // the Driver and wait for it to finish.

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/ExchangeSourceHandler.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/ExchangeSourceHandler.java
@@ -212,7 +212,7 @@ public final class ExchangeSourceHandler {
                         } else {
                             future.listener().addListener(ActionListener.wrap(unused -> {
                                 if (loopControl.tryResume() == false) {
-                                    fetchPage();
+                                    fetchExecutor.execute(this::fetchPage);
                                 }
                             }, this::onSinkFailed));
                         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/AbstractLookupService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/AbstractLookupService.java
@@ -197,7 +197,7 @@ public abstract class AbstractLookupService<R extends AbstractLookupService.Requ
         this.plannerSettings = plannerSettings;
         transportService.registerRequestHandler(
             actionName,
-            transportService.getThreadPool().executor(EsqlPlugin.ESQL_WORKER_THREAD_POOL_NAME),
+            transportService.getThreadPool().executor(ThreadPool.Names.SEARCH),
             in -> readRequest.apply(in, blockFactory),
             new TransportHandler()
         );

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ClusterComputeHandler.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ClusterComputeHandler.java
@@ -50,22 +50,22 @@ final class ClusterComputeHandler implements TransportRequestHandler<ClusterComp
     private final ComputeService computeService;
     private final ExchangeService exchangeService;
     private final TransportService transportService;
-    private final Executor esqlExecutor;
+    private final Executor searchExecutor;
     private final DataNodeComputeHandler dataNodeComputeHandler;
 
     ClusterComputeHandler(
         ComputeService computeService,
         ExchangeService exchangeService,
         TransportService transportService,
-        Executor esqlExecutor,
+        Executor searchExecutor,
         DataNodeComputeHandler dataNodeComputeHandler
     ) {
         this.computeService = computeService;
         this.exchangeService = exchangeService;
-        this.esqlExecutor = esqlExecutor;
+        this.searchExecutor = searchExecutor;
         this.transportService = transportService;
         this.dataNodeComputeHandler = dataNodeComputeHandler;
-        transportService.registerRequestHandler(ComputeService.CLUSTER_ACTION_NAME, esqlExecutor, ClusterComputeRequest::new, this);
+        transportService.registerRequestHandler(ComputeService.CLUSTER_ACTION_NAME, searchExecutor, ClusterComputeRequest::new, this);
     }
 
     void startComputeOnRemoteCluster(
@@ -105,7 +105,7 @@ final class ClusterComputeHandler implements TransportRequestHandler<ClusterComp
             cluster.connection,
             childSessionId,
             queryPragmas.exchangeBufferSize(),
-            esqlExecutor,
+            searchExecutor,
             listener.delegateFailure((l, unused) -> {
                 final CancellableTask groupTask;
                 final Runnable onGroupFailure;
@@ -139,7 +139,7 @@ final class ClusterComputeHandler implements TransportRequestHandler<ClusterComp
                         clusterRequest,
                         groupTask,
                         TransportRequestOptions.EMPTY,
-                        new ActionListenerResponseHandler<>(clusterListener, ComputeResponse::new, esqlExecutor)
+                        new ActionListenerResponseHandler<>(clusterListener, ComputeResponse::new, searchExecutor)
                     );
                     var remoteSink = exchangeService.newRemoteSink(groupTask, childSessionId, transportService, cluster.connection);
                     exchangeSource.addRemoteSink(

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
@@ -97,6 +97,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -175,6 +176,7 @@ public class ComputeService {
     private final OperatorFactoryRegistry operatorFactoryRegistry;
     private final FilterPushdownRegistry filterPushdownRegistry;
     private final FormatReaderRegistry formatReaderRegistry;
+    private final Executor searchExecutor;
 
     @SuppressWarnings("this-escape")
     public ComputeService(
@@ -193,8 +195,8 @@ public class ComputeService {
         this.exchangeService = transportActionServices.exchangeService();
         this.bigArrays = bigArrays.withCircuitBreaking();
         this.blockFactory = blockFactory;
-        var esqlExecutor = threadPool.executor(ThreadPool.Names.SEARCH);
-        this.driverRunner = new DriverTaskRunner(transportService, esqlExecutor);
+        this.searchExecutor = threadPool.executor(ThreadPool.Names.SEARCH);
+        this.driverRunner = new DriverTaskRunner(transportService, searchExecutor);
         this.enrichLookupService = enrichLookupService;
         this.lookupFromIndexService = lookupFromIndexService;
         this.inferenceService = transportActionServices.inferenceService();
@@ -208,13 +210,13 @@ public class ComputeService {
             searchService,
             transportService,
             exchangeService,
-            esqlExecutor
+            searchExecutor
         );
         this.clusterComputeHandler = new ClusterComputeHandler(
             this,
             exchangeService,
             transportService,
-            esqlExecutor,
+            searchExecutor,
             dataNodeComputeHandler
         );
         this.plannerSettings = transportActionServices.plannerSettings();
@@ -371,7 +373,6 @@ public class ComputeService {
         ActionListener<Result> listener
     ) {
         assert ThreadPool.assertCurrentThreadPool(
-            ESQL_WORKER_THREAD_POOL_NAME,
             ThreadPool.Names.SYSTEM_READ,
             ThreadPool.Names.SEARCH,
             ThreadPool.Names.SEARCH_COORDINATION
@@ -419,10 +420,7 @@ public class ComputeService {
         var mainSessionId = newChildSession(sessionId);
         QueryPragmas queryPragmas = configuration.pragmas();
 
-        ExchangeSourceHandler mainExchangeSource = new ExchangeSourceHandler(
-            queryPragmas.exchangeBufferSize(),
-            transportService.getThreadPool().executor(ThreadPool.Names.SEARCH)
-        );
+        ExchangeSourceHandler mainExchangeSource = new ExchangeSourceHandler(queryPragmas.exchangeBufferSize(), searchExecutor);
 
         exchangeService.addExchangeSourceHandler(mainSessionId, mainExchangeSource);
         var finalListener = ActionListener.runBefore(listener, () -> exchangeService.removeExchangeSourceHandler(sessionId));
@@ -727,10 +725,7 @@ public class ComputeService {
          * entire plan.
          */
         List<Attribute> outputAttributes = resolvedPlan.output();
-        var exchangeSource = new ExchangeSourceHandler(
-            configuration.pragmas().exchangeBufferSize(),
-            transportService.getThreadPool().executor(ThreadPool.Names.SEARCH)
-        );
+        var exchangeSource = new ExchangeSourceHandler(configuration.pragmas().exchangeBufferSize(), searchExecutor);
         listener = ActionListener.runBefore(listener, () -> exchangeService.removeExchangeSourceHandler(sessionId));
         exchangeService.addExchangeSourceHandler(sessionId, exchangeSource);
         try (
@@ -904,10 +899,7 @@ public class ComputeService {
         ActionListener<Result> listener
     ) {
         List<Attribute> outputAttributes = resolvedPlan.output();
-        var exchangeSource = new ExchangeSourceHandler(
-            configuration.pragmas().exchangeBufferSize(),
-            transportService.getThreadPool().executor(ThreadPool.Names.SEARCH)
-        );
+        var exchangeSource = new ExchangeSourceHandler(configuration.pragmas().exchangeBufferSize(), searchExecutor);
         listener = ActionListener.runBefore(listener, () -> exchangeService.removeExchangeSourceHandler(sessionId));
         exchangeService.addExchangeSourceHandler(sessionId, exchangeSource);
         try (

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeComputeHandler.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeComputeHandler.java
@@ -71,8 +71,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.elasticsearch.xpack.esql.plugin.EsqlPlugin.ESQL_WORKER_THREAD_POOL_NAME;
-
 /**
  * Handles computes within a single cluster by dispatching {@link DataNodeRequest} to data nodes
  * and executing these computes on the data nodes.
@@ -89,7 +87,7 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
     private final ProjectResolver projectResolver;
     private final TransportService transportService;
     private final ExchangeService exchangeService;
-    private final Executor esqlExecutor;
+    private final Executor searchExecutor;
     private final ThreadPool threadPool;
 
     DataNodeComputeHandler(
@@ -99,7 +97,7 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
         SearchService searchService,
         TransportService transportService,
         ExchangeService exchangeService,
-        Executor esqlExecutor
+        Executor searchExecutor
     ) {
         this.computeService = computeService;
         this.clusterService = clusterService;
@@ -107,9 +105,9 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
         this.searchService = searchService;
         this.transportService = transportService;
         this.exchangeService = exchangeService;
-        this.esqlExecutor = esqlExecutor;
+        this.searchExecutor = searchExecutor;
         this.threadPool = transportService.getThreadPool();
-        transportService.registerRequestHandler(ComputeService.DATA_ACTION_NAME, esqlExecutor, DataNodeRequest::new, this);
+        transportService.registerRequestHandler(ComputeService.DATA_ACTION_NAME, searchExecutor, DataNodeRequest::new, this);
     }
 
     void startComputeOnDataNodes(
@@ -131,7 +129,7 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
             clusterService,
             projectResolver,
             transportService,
-            esqlExecutor,
+            searchExecutor,
             parentTask,
             originalIndices,
             PlannerUtils.canMatchFilter(flags, configuration, clusterService.state().getMinTransportVersion(), dataNodePlan),
@@ -170,7 +168,7 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
                     connection,
                     childSessionId,
                     queryPragmas.exchangeBufferSize(),
-                    esqlExecutor,
+                    searchExecutor,
                     listener.delegateFailureAndWrap((l, unused) -> {
                         final Runnable onGroupFailure;
                         final CancellableTask groupTask;
@@ -223,7 +221,7 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
                                 new ActionListenerResponseHandler<>(computeListener.acquireCompute().map(r -> {
                                     nodeResponseRef.set(r);
                                     return r.completionInfo();
-                                }), DataNodeComputeResponse::new, esqlExecutor)
+                                }), DataNodeComputeResponse::new, searchExecutor)
                             );
                             final var remoteSink = exchangeService.newRemoteSink(groupTask, childSessionId, transportService, connection);
                             exchangeSource.addRemoteSink(
@@ -374,7 +372,7 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
                             new ActionListenerResponseHandler<>(
                                 computeListener.acquireCompute().map(r -> r.completionInfo()),
                                 DataNodeComputeResponse::new,
-                                esqlExecutor
+                                searchExecutor
                             )
                         );
                         var remoteSink = exchangeService.newRemoteSink(groupTask, childSessionId, transportService, connection);
@@ -410,7 +408,7 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
                         connection,
                         childSessionId,
                         queryPragmas.exchangeBufferSize(),
-                        esqlExecutor,
+                        searchExecutor,
                         openExchangeListenerWithNodeCompletion
                     );
                 } catch (Exception e) {
@@ -553,7 +551,7 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
                 configuration,
                 request.aliasFilters(),
                 ActionListener.wrap(acquiredSearchContexts -> {
-                    assert ThreadPool.assertCurrentThreadPool(ThreadPool.Names.SEARCH, ESQL_WORKER_THREAD_POOL_NAME);
+                    assert ThreadPool.assertCurrentThreadPool(ThreadPool.Names.SEARCH);
                     if (acquiredSearchContexts.isEmpty()) {
                         batchListener.onResponse(DriverCompletionInfo.EMPTY);
                         return;
@@ -635,7 +633,7 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
             final AtomicBoolean waitedForRefreshes = new AtomicBoolean();
             try (RefCountingRunnable refs = new RefCountingRunnable(() -> {
                 if (waitedForRefreshes.get()) {
-                    esqlExecutor.execute(doAcquire);
+                    searchExecutor.execute(doAcquire);
                 } else {
                     doAcquire.run();
                 }
@@ -719,7 +717,7 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
                 );
                 dataNodeRequestExecutor.start();
                 // run the node-level reduction
-                var exchangeSource = new ExchangeSourceHandler(1, esqlExecutor);
+                var exchangeSource = new ExchangeSourceHandler(1, searchExecutor);
                 exchangeSource.addRemoteSink(internalSink::fetchPageAsync, true, () -> {}, 1, ActionListener.noop());
                 var reductionListener = computeListener.acquireCompute();
                 computeService.runCompute(

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeRequestSender.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeRequestSender.java
@@ -87,7 +87,7 @@ abstract class DataNodeRequestSender {
     private final ClusterService clusterService;
     private final ProjectResolver projectResolver;
     private final TransportService transportService;
-    private final Executor esqlExecutor;
+    private final Executor searchExecutor;
     private final CancellableTask rootTask;
 
     private final String clusterAlias;
@@ -109,7 +109,7 @@ abstract class DataNodeRequestSender {
         ClusterService clusterService,
         ProjectResolver projectResolver,
         TransportService transportService,
-        Executor esqlExecutor,
+        Executor searchExecutor,
         CancellableTask rootTask,
         OriginalIndices originalIndices,
         QueryBuilder requestFilter,
@@ -121,7 +121,7 @@ abstract class DataNodeRequestSender {
         this.clusterService = clusterService;
         this.projectResolver = projectResolver;
         this.transportService = transportService;
-        this.esqlExecutor = esqlExecutor;
+        this.searchExecutor = searchExecutor;
         this.rootTask = rootTask;
         this.originalIndices = originalIndices;
         this.requestFilter = requestFilter;
@@ -135,7 +135,6 @@ abstract class DataNodeRequestSender {
 
     final void startComputeOnDataNodes(Set<String> concreteIndices, Runnable runOnTaskFailure, ActionListener<ComputeResponse> listener) {
         assert ThreadPool.assertCurrentThreadPool(
-            EsqlPlugin.ESQL_WORKER_THREAD_POOL_NAME,
             ThreadPool.Names.SYSTEM_READ,
             ThreadPool.Names.SEARCH,
             ThreadPool.Names.SEARCH_COORDINATION
@@ -196,7 +195,7 @@ abstract class DataNodeRequestSender {
     }
 
     private void trySendingRequestsForPendingShards(TargetShards targetShards, ComputeListener computeListener) {
-        assert ThreadPool.assertCurrentThreadPool(EsqlPlugin.ESQL_WORKER_THREAD_POOL_NAME, ThreadPool.Names.SEARCH);
+        assert ThreadPool.assertCurrentThreadPool(ThreadPool.Names.SEARCH);
         changed.set(true);
         final ActionListener<Void> listener = computeListener.acquireAvoid();
         try {
@@ -540,7 +539,7 @@ abstract class DataNodeRequestSender {
             searchShardsRequest,
             rootTask,
             TransportRequestOptions.EMPTY,
-            new ActionListenerResponseHandler<>(searchShardsListener, SearchShardsResponse::new, esqlExecutor)
+            new ActionListenerResponseHandler<>(searchShardsListener, SearchShardsResponse::new, searchExecutor)
         );
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/DataNodeRequestSenderTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/DataNodeRequestSenderTests.java
@@ -28,12 +28,14 @@ import org.elasticsearch.compute.test.ComputeTestCase;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.ShardNotFoundException;
+import org.elasticsearch.node.Node;
 import org.elasticsearch.search.internal.AliasFilter;
 import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.TaskId;
+import org.elasticsearch.telemetry.metric.MeterRegistry;
 import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.threadpool.FixedExecutorBuilder;
-import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.esql.plugin.DataNodeRequestSender.NodeListener;
 import org.junit.After;
@@ -79,7 +81,7 @@ import static org.hamcrest.Matchers.not;
 
 public class DataNodeRequestSenderTests extends ComputeTestCase {
 
-    private TestThreadPool threadPool;
+    private ThreadPool threadPool;
     private Executor executor = null;
 
     private final DiscoveryNode node1 = DiscoveryNodeUtils.builder("node-1").roles(Set.of(DATA_HOT_NODE_ROLE)).build();
@@ -99,18 +101,13 @@ public class DataNodeRequestSenderTests extends ComputeTestCase {
     @Before
     public void setThreadPool() {
         int numThreads = randomBoolean() ? 1 : between(2, 16);
-        threadPool = new TestThreadPool(
-            "test",
-            new FixedExecutorBuilder(
-                Settings.EMPTY,
-                EsqlPlugin.ESQL_WORKER_THREAD_POOL_NAME,
-                numThreads,
-                1024,
-                "esql",
-                EsExecutors.TaskTrackingConfig.DEFAULT
-            )
+        threadPool = new ThreadPool(
+            Settings.builder().put(Node.NODE_NAME_SETTING.getKey(), "TransportActionTests").build(),
+            MeterRegistry.NOOP,
+            (settings, allocatedProcessors) -> Map.of(),
+            new FixedExecutorBuilder(Settings.EMPTY, ThreadPool.Names.SEARCH, numThreads, 1024, "", EsExecutors.TaskTrackingConfig.DEFAULT)
         );
-        executor = threadPool.executor(EsqlPlugin.ESQL_WORKER_THREAD_POOL_NAME);
+        executor = threadPool.executor(ThreadPool.Names.SEARCH);
     }
 
     @After

--- a/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/OperatorPrivilegesIT.java
+++ b/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/OperatorPrivilegesIT.java
@@ -181,6 +181,8 @@ public class OperatorPrivilegesIT extends ESRestTestCase {
         Set<String> allActions = Set.copyOf((List<String>) response.get("actions"));
         final HashSet<String> labelledActions = new HashSet<>(DefaultOperatorOnlyRegistry.SIMPLE_ACTIONS);
         labelledActions.addAll(Constants.NON_OPERATOR_ACTIONS);
+        // test-only actions
+        labelledActions.add("cluster:monitor/test/pause_field");
 
         final Set<String> unlabelled = Sets.difference(allActions, labelledActions);
         assertTrue("Actions are neither operator-only nor non-operator: [" + unlabelled + "]. " + message, unlabelled.isEmpty());


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Use search threadpool for coordination in ES|QL (#149034)