### PR TITLE
Introduce RecoveryThrottlingQueue

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -154,6 +154,7 @@ import org.elasticsearch.indices.recovery.RecoveryFailedException;
 import org.elasticsearch.indices.recovery.RecoverySettings;
 import org.elasticsearch.indices.recovery.RecoveryState;
 import org.elasticsearch.indices.recovery.RecoveryTarget;
+import org.elasticsearch.indices.recovery.RecoveryThrottlingQueue;
 import org.elasticsearch.plugins.IndexStorePlugin;
 import org.elasticsearch.repositories.RepositoriesService;
 import org.elasticsearch.repositories.Repository;
@@ -3705,7 +3706,8 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         RepositoriesService repositoriesService,
         BiConsumer<MappingMetadata, ActionListener<Void>> mappingUpdateConsumer,
         IndicesService indicesService,
-        long clusterStateVersion
+        long clusterStateVersion,
+        RecoveryThrottlingQueue recoveryThrottlingQueue
     ) {
         // TODO: Create a proper object to encapsulate the recovery context
         // all of the current methods here follow a pattern of:
@@ -3729,12 +3731,20 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                 "from store",
                 recoveryState,
                 recoveryListener,
-                this::recoverFromStore
+                this::recoverFromStore,
+                recoveryThrottlingQueue
             );
             case PEER -> {
                 try {
                     markAsRecovering("from " + recoveryState.getSourceNode(), recoveryState);
-                    recoveryTargetService.startRecovery(this, recoveryState.getSourceNode(), clusterStateVersion, recoveryListener);
+                    recoveryThrottlingQueue.enqueue(
+                        () -> recoveryTargetService.startRecovery(
+                            this,
+                            recoveryState.getSourceNode(),
+                            clusterStateVersion,
+                            recoveryListener
+                        )
+                    );
                 } catch (Exception e) {
                     failShard("corrupted preexisting index", e);
                     recoveryListener.onRecoveryFailure(new RecoveryFailedException(recoveryState, null, e), true);
@@ -3748,7 +3758,8 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                     "from snapshot",
                     recoveryState,
                     recoveryListener,
-                    l -> restoreFromRepository(repositoriesService.repository(projectId, repo), l)
+                    l -> restoreFromRepository(repositoriesService.repository(projectId, repo), l),
+                    recoveryThrottlingQueue
                 );
             }
             case LOCAL_SHARDS -> {
@@ -3784,7 +3795,8 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                             mappingUpdateConsumer,
                             startedShards.stream().filter((s) -> requiredShards.contains(s.shardId())).toList(),
                             l
-                        )
+                        ),
+                        recoveryThrottlingQueue
                     );
                 } else {
                     final RuntimeException e;
@@ -3813,10 +3825,11 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         String reason,
         RecoveryState recoveryState,
         PeerRecoveryTargetService.RecoveryListener recoveryListener,
-        CheckedConsumer<ActionListener<Boolean>, Exception> action
+        CheckedConsumer<ActionListener<Boolean>, Exception> action,
+        RecoveryThrottlingQueue recoveryThrottlingQueue
     ) {
         markAsRecovering(reason, recoveryState); // mark the shard as recovering on the cluster state thread
-        threadPool.generic().execute(ActionRunnable.wrap(ActionListener.wrap(r -> {
+        recoveryThrottlingQueue.enqueue(ActionRunnable.wrap(ActionListener.wrap(r -> {
             if (r) {
                 recoveryListener.onRecoveryDone(recoveryState, getTimestampRange(), getEventIngestedRange());
             }

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -146,6 +146,7 @@ import org.elasticsearch.indices.cluster.IndicesClusterStateService;
 import org.elasticsearch.indices.fielddata.cache.IndicesFieldDataCache;
 import org.elasticsearch.indices.recovery.PeerRecoveryTargetService;
 import org.elasticsearch.indices.recovery.RecoveryState;
+import org.elasticsearch.indices.recovery.RecoveryThrottlingQueue;
 import org.elasticsearch.indices.store.CompositeIndexFoldersDeletionListener;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.plugins.FieldPredicate;
@@ -974,6 +975,7 @@ public class IndicesService extends AbstractLifecycleComponent
         final ProjectId projectId,
         final ShardRouting shardRouting,
         final PeerRecoveryTargetService recoveryTargetService,
+        final RecoveryThrottlingQueue recoveryThrottlingQueue,
         final PeerRecoveryTargetService.RecoveryListener recoveryListener,
         final RepositoriesService repositoriesService,
         final Consumer<IndexShard.ShardFailure> onShardFailure,
@@ -1011,7 +1013,8 @@ public class IndicesService extends AbstractLifecycleComponent
                     );
                 },
                 this,
-                clusterStateVersion
+                clusterStateVersion,
+                recoveryThrottlingQueue
             )
         );
     }

--- a/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -77,6 +77,7 @@ import org.elasticsearch.indices.recovery.PeerRecoverySourceService;
 import org.elasticsearch.indices.recovery.PeerRecoveryTargetService;
 import org.elasticsearch.indices.recovery.RecoveryFailedException;
 import org.elasticsearch.indices.recovery.RecoveryState;
+import org.elasticsearch.indices.recovery.RecoveryThrottlingQueue;
 import org.elasticsearch.injection.guice.Inject;
 import org.elasticsearch.monitor.jvm.HotThreads;
 import org.elasticsearch.repositories.RepositoriesService;
@@ -135,6 +136,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
     private final ClusterService clusterService;
     private final ThreadPool threadPool;
     private final PeerRecoveryTargetService recoveryTargetService;
+    private final RecoveryThrottlingQueue recoveryThrottlingQueue;
     private final ShardStateAction shardStateAction;
 
     private final Settings settings;
@@ -165,6 +167,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
         final ClusterService clusterService,
         final ThreadPool threadPool,
         final PeerRecoveryTargetService recoveryTargetService,
+        final RecoveryThrottlingQueue recoveryThrottlingQueue,
         final ShardStateAction shardStateAction,
         final RepositoriesService repositoriesService,
         final SearchService searchService,
@@ -180,6 +183,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
             clusterService,
             threadPool,
             recoveryTargetService,
+            recoveryThrottlingQueue,
             shardStateAction,
             repositoriesService,
             searchService,
@@ -198,6 +202,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
         final ClusterService clusterService,
         final ThreadPool threadPool,
         final PeerRecoveryTargetService recoveryTargetService,
+        final RecoveryThrottlingQueue recoveryThrottlingQueue,
         final ShardStateAction shardStateAction,
         final RepositoriesService repositoriesService,
         final SearchService searchService,
@@ -213,6 +218,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
         this.clusterService = clusterService;
         this.threadPool = threadPool;
         this.recoveryTargetService = recoveryTargetService;
+        this.recoveryThrottlingQueue = recoveryThrottlingQueue;
         this.shardStateAction = shardStateAction;
         this.repositoriesService = repositoriesService;
         this.primaryReplicaSyncer = primaryReplicaSyncer;
@@ -830,6 +836,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
                 originalState.metadata().projectFor(shardRouting.index()).id(),
                 shardRouting,
                 recoveryTargetService,
+                recoveryThrottlingQueue,
                 new RecoveryListener(shardRouting, primaryTerm),
                 repositoriesService,
                 failedShardHandler,
@@ -1405,6 +1412,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
             ProjectId projectId,
             ShardRouting shardRouting,
             PeerRecoveryTargetService recoveryTargetService,
+            RecoveryThrottlingQueue recoveryThrottlingQueue,
             PeerRecoveryTargetService.RecoveryListener recoveryListener,
             RepositoriesService repositoriesService,
             Consumer<IndexShard.ShardFailure> onShardFailure,

--- a/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
@@ -238,9 +238,8 @@ public class PeerRecoveryTargetService implements IndexEventListener {
             listener,
             snapshotFileDownloadsPermit
         );
-        // we fork off quickly here and go async but this is called from the cluster state applier thread too and that can cause
-        // assertions to trip if we executed it on the same thread hence we fork off to the generic threadpool.
-        threadPool.generic().execute(new RecoveryRunner(recoveryId));
+        // we've already forked off in RecoveryThrottlingQueue, so no need to do it again here
+        new RecoveryRunner(recoveryId).run();
     }
 
     protected void retryRecovery(final long recoveryId, final Throwable reason, TimeValue retryAfter) {

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryThrottlingQueue.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryThrottlingQueue.java
@@ -11,10 +11,16 @@ package org.elasticsearch.indices.recovery;
 
 import org.elasticsearch.threadpool.ThreadPool;
 
+import java.util.concurrent.ConcurrentLinkedQueue;
+
 public class RecoveryThrottlingQueue {
 
     private final ThreadPool threadPool;
     private final int maxConcurrentRecoveries;
+    private final ConcurrentLinkedQueue<RecoveryTask> pending = new ConcurrentLinkedQueue<>();
+    private final Object mutex = new Object();
+    // Protected by mutex
+    private int running;
 
     public RecoveryThrottlingQueue(ThreadPool threadPool, int maxConcurrentRecoveries) {
         this.threadPool = threadPool;
@@ -22,7 +28,37 @@ public class RecoveryThrottlingQueue {
     }
 
     public void enqueue(RecoveryTask recoveryTask) {
-        threadPool.generic().execute(recoveryTask);
+        synchronized (mutex) {
+            if (running < maxConcurrentRecoveries) {
+                running++;
+                dispatch(recoveryTask);
+            } else {
+                pending.add(recoveryTask);
+            }
+        }
+    }
+
+    private void dispatch(RecoveryTask recoveryTask) {
+        threadPool.generic().execute(() -> {
+            try {
+                recoveryTask.run();
+            } finally {
+                scheduleNext();
+            }
+        });
+    }
+
+    private void scheduleNext() {
+        RecoveryTask next;
+        synchronized (mutex) {
+            next = pending.poll();
+            if (next == null) {
+                running--;
+            }
+        }
+        if (next != null) {
+            dispatch(next);
+        }
     }
 
     @FunctionalInterface

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryThrottlingQueue.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryThrottlingQueue.java
@@ -9,31 +9,32 @@
 
 package org.elasticsearch.indices.recovery;
 
-import org.apache.logging.log4j.Logger;
+import org.elasticsearch.cluster.routing.allocation.decider.ThrottlingAllocationDecider;
 import org.elasticsearch.threadpool.ThreadPool;
 
-import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.ArrayDeque;
+import java.util.Queue;
 
 public class RecoveryThrottlingQueue {
 
     private final ThreadPool threadPool;
+    // todo: Introduce separate setting to control maxConcurrentRecoveries.
+    // Temporary defaults and unlimited for testing
+    public static final int DEFAULT = ThrottlingAllocationDecider.DEFAULT_CLUSTER_ROUTING_ALLOCATION_NODE_CONCURRENT_RECOVERIES;
+    public static final int UNLIMITED = -1;
     private final int maxConcurrentRecoveries;
-    // Logger useful for testing, might remove later
-    private final Logger logger;
-    private final ConcurrentLinkedQueue<RecoveryTask> pending = new ConcurrentLinkedQueue<>();
-    private final Object mutex = new Object();
-    // Protected by mutex
+    // 'pending' and 'running' both protected by synchronized(this)
+    private final Queue<Runnable> pending = new ArrayDeque<>();
     private int running;
 
-    public RecoveryThrottlingQueue(ThreadPool threadPool, int maxConcurrentRecoveries, Logger logger) {
+    public RecoveryThrottlingQueue(ThreadPool threadPool, int maxConcurrentRecoveries) {
         this.threadPool = threadPool;
         this.maxConcurrentRecoveries = maxConcurrentRecoveries;
-        this.logger = logger;
     }
 
-    public void enqueue(RecoveryTask recoveryTask) {
-        synchronized (mutex) {
-            if (running < maxConcurrentRecoveries) {
+    public void enqueue(Runnable recoveryTask) {
+        synchronized (this) {
+            if (running < maxConcurrentRecoveries || maxConcurrentRecoveries == UNLIMITED) {
                 running++;
                 dispatch(recoveryTask);
             } else {
@@ -42,7 +43,7 @@ public class RecoveryThrottlingQueue {
         }
     }
 
-    private void dispatch(RecoveryTask recoveryTask) {
+    private void dispatch(Runnable recoveryTask) {
         threadPool.generic().execute(() -> {
             try {
                 recoveryTask.run();
@@ -53,8 +54,8 @@ public class RecoveryThrottlingQueue {
     }
 
     private void scheduleNext() {
-        RecoveryTask next;
-        synchronized (mutex) {
+        Runnable next;
+        synchronized (this) {
             next = pending.poll();
             if (next == null) {
                 running--;
@@ -64,7 +65,4 @@ public class RecoveryThrottlingQueue {
             dispatch(next);
         }
     }
-
-    @FunctionalInterface
-    public interface RecoveryTask extends Runnable {}
 }

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryThrottlingQueue.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryThrottlingQueue.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.indices.recovery;
+
+import org.elasticsearch.threadpool.ThreadPool;
+
+public class RecoveryThrottlingQueue {
+
+    private final ThreadPool threadPool;
+    private final int maxConcurrentRecoveries;
+
+    public RecoveryThrottlingQueue(ThreadPool threadPool, int maxConcurrentRecoveries) {
+        this.threadPool = threadPool;
+        this.maxConcurrentRecoveries = maxConcurrentRecoveries;
+    }
+
+    public void enqueue(RecoveryTask recoveryTask) {
+        threadPool.generic().execute(recoveryTask);
+    }
+
+    @FunctionalInterface
+    public interface RecoveryTask extends Runnable {}
+}

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryThrottlingQueue.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryThrottlingQueue.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.indices.recovery;
 
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -17,14 +18,17 @@ public class RecoveryThrottlingQueue {
 
     private final ThreadPool threadPool;
     private final int maxConcurrentRecoveries;
+    // Logger useful for testing, might remove later
+    private final Logger logger;
     private final ConcurrentLinkedQueue<RecoveryTask> pending = new ConcurrentLinkedQueue<>();
     private final Object mutex = new Object();
     // Protected by mutex
     private int running;
 
-    public RecoveryThrottlingQueue(ThreadPool threadPool, int maxConcurrentRecoveries) {
+    public RecoveryThrottlingQueue(ThreadPool threadPool, int maxConcurrentRecoveries, Logger logger) {
         this.threadPool = threadPool;
         this.maxConcurrentRecoveries = maxConcurrentRecoveries;
+        this.logger = logger;
     }
 
     public void enqueue(RecoveryTask recoveryTask) {

--- a/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
@@ -152,6 +152,7 @@ import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.indices.recovery.PeerRecoverySourceService;
 import org.elasticsearch.indices.recovery.PeerRecoveryTargetService;
 import org.elasticsearch.indices.recovery.RecoverySettings;
+import org.elasticsearch.indices.recovery.RecoveryThrottlingQueue;
 import org.elasticsearch.indices.recovery.SnapshotFilesProvider;
 import org.elasticsearch.indices.recovery.plan.PeerOnlyRecoveryPlannerService;
 import org.elasticsearch.indices.recovery.plan.RecoveryPlannerService;
@@ -1371,6 +1372,7 @@ class NodeConstruction {
                         snapshotFilesProvider
                     )
                 );
+            b.bind(RecoveryThrottlingQueue.class).toInstance(new RecoveryThrottlingQueue(threadPool, RecoveryThrottlingQueue.DEFAULT));
         });
 
         modules.add(loadPluginComponents(pluginComponents));

--- a/server/src/test/java/org/elasticsearch/indices/cluster/IndicesClusterStateServiceRandomUpdatesTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/cluster/IndicesClusterStateServiceRandomUpdatesTests.java
@@ -46,6 +46,7 @@ import org.elasticsearch.index.seqno.RetentionLeaseSyncer;
 import org.elasticsearch.index.shard.PrimaryReplicaSyncer;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.recovery.PeerRecoveryTargetService;
+import org.elasticsearch.indices.recovery.RecoveryThrottlingQueue;
 import org.elasticsearch.indices.recovery.SnapshotFilesProvider;
 import org.elasticsearch.repositories.RepositoriesService;
 import org.elasticsearch.repositories.SnapshotMetrics;
@@ -565,6 +566,7 @@ public class IndicesClusterStateServiceRandomUpdatesTests extends AbstractIndice
             clusterService,
             mock(SnapshotFilesProvider.class)
         );
+        final RecoveryThrottlingQueue recoveryThrottlingQueue = new RecoveryThrottlingQueue(threadPool, RecoveryThrottlingQueue.UNLIMITED);
         final ShardStateAction shardStateAction = mock(ShardStateAction.class);
         final PrimaryReplicaSyncer primaryReplicaSyncer = mock(PrimaryReplicaSyncer.class);
         return new IndicesClusterStateService(
@@ -573,6 +575,7 @@ public class IndicesClusterStateServiceRandomUpdatesTests extends AbstractIndice
             clusterService,
             threadPool,
             recoveryTargetService,
+            recoveryThrottlingQueue,
             shardStateAction,
             repositoriesService,
             null,

--- a/server/src/test/java/org/elasticsearch/indices/cluster/IndicesClusterStateServiceShardsClosedListenersTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/cluster/IndicesClusterStateServiceShardsClosedListenersTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.index.shard.PrimaryReplicaSyncer;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.indices.recovery.PeerRecoverySourceService;
 import org.elasticsearch.indices.recovery.PeerRecoveryTargetService;
+import org.elasticsearch.indices.recovery.RecoveryThrottlingQueue;
 import org.elasticsearch.repositories.RepositoriesService;
 import org.elasticsearch.repositories.SnapshotShardContextFactory;
 import org.elasticsearch.search.SearchService;
@@ -150,6 +151,7 @@ public class IndicesClusterStateServiceShardsClosedListenersTests extends Abstra
                 new ClusterService(Settings.EMPTY, ClusterSettings.createBuiltInClusterSettings(), threadPool, null),
                 threadPool,
                 mock(PeerRecoveryTargetService.class),
+                mock(RecoveryThrottlingQueue.class),
                 mock(ShardStateAction.class),
                 mock(RepositoriesService.class),
                 mock(SearchService.class),

--- a/server/src/test/java/org/elasticsearch/indices/recovery/RecoveryThrottlingQueueTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/RecoveryThrottlingQueueTests.java
@@ -45,7 +45,7 @@ public class RecoveryThrottlingQueueTests extends ESTestCase {
 
     /** Enqueued work runs asynchronously (worker thread differs from enqueueing thread). */
     public void testTasksRunOutsideEnqueueingThread() throws Exception {
-        RecoveryThrottlingQueue queue = new RecoveryThrottlingQueue(threadPool, between(2, 4), logger);
+        RecoveryThrottlingQueue queue = new RecoveryThrottlingQueue(threadPool, between(2, 4));
         Thread caller = Thread.currentThread();
         AtomicReference<Thread> executionThread = new AtomicReference<>();
         CountDownLatch done = new CountDownLatch(1);
@@ -62,7 +62,7 @@ public class RecoveryThrottlingQueueTests extends ESTestCase {
      */
     public void testMaxConcurrencyBound() throws Exception {
         final int maxConcurrentRecoveries = between(2, 5);
-        RecoveryThrottlingQueue queue = new RecoveryThrottlingQueue(threadPool, maxConcurrentRecoveries, logger);
+        RecoveryThrottlingQueue queue = new RecoveryThrottlingQueue(threadPool, maxConcurrentRecoveries);
         AtomicInteger running = new AtomicInteger();
         AtomicInteger peakConcurrent = new AtomicInteger();
         CountDownLatch maxConcurrentReached = new CountDownLatch(maxConcurrentRecoveries);
@@ -70,7 +70,7 @@ public class RecoveryThrottlingQueueTests extends ESTestCase {
         int totalEnqueuedTasks = maxConcurrentRecoveries * 3;
         CountDownLatch allFinished = new CountDownLatch(totalEnqueuedTasks);
 
-        RecoveryThrottlingQueue.RecoveryTask recoveryTask = () -> {
+        Runnable recoveryTask = () -> {
             try {
                 int current = running.incrementAndGet();
                 peakConcurrent.accumulateAndGet(current, Integer::max);
@@ -111,7 +111,7 @@ public class RecoveryThrottlingQueueTests extends ESTestCase {
      * With a single execution slot, throttled backlog runs in enqueue order ({@linkplain ConcurrentLinkedQueue FIFO} semantics).
      */
     public void testFifoWhenThrottledToOneConcurrent() throws Exception {
-        RecoveryThrottlingQueue queue = new RecoveryThrottlingQueue(threadPool, 1, logger);
+        RecoveryThrottlingQueue queue = new RecoveryThrottlingQueue(threadPool, 1);
         int total = between(10, 20);
         List<Integer> startOrder = new CopyOnWriteArrayList<>();
         CountDownLatch allDone = new CountDownLatch(total);
@@ -143,7 +143,7 @@ public class RecoveryThrottlingQueueTests extends ESTestCase {
         final int maxConcurrentRecoveries = between(1, 20);
         final int highContentionBurstSizeMin = between(1, maxConcurrentRecoveries);
         final int highContentionBurstSizeMax = between(highContentionBurstSizeMin, maxConcurrentRecoveries * 2);
-        final RecoveryThrottlingQueue queue = new RecoveryThrottlingQueue(threadPool, maxConcurrentRecoveries, logger);
+        final RecoveryThrottlingQueue queue = new RecoveryThrottlingQueue(threadPool, maxConcurrentRecoveries);
         final AtomicInteger running = new AtomicInteger();
         final AtomicInteger peakRunning = new AtomicInteger();
         final AtomicInteger totalTasksEnqueued = new AtomicInteger();

--- a/server/src/test/java/org/elasticsearch/indices/recovery/RecoveryThrottlingQueueTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/RecoveryThrottlingQueueTests.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.indices.recovery;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.not;
+
+public class RecoveryThrottlingQueueTests extends ESTestCase {
+
+    private static TestThreadPool threadPool;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        threadPool = new TestThreadPool(RecoveryThrottlingQueueTests.class.getName());
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        threadPool.close();
+    }
+
+    /** Enqueued work runs asynchronously (worker thread differs from enqueueing thread). */
+    public void testTasksRunOutsideEnqueueingThread() throws Exception {
+        RecoveryThrottlingQueue queue = new RecoveryThrottlingQueue(threadPool, between(2, 4));
+        Thread caller = Thread.currentThread();
+        AtomicReference<Thread> executionThread = new AtomicReference<>();
+        CountDownLatch done = new CountDownLatch(1);
+        queue.enqueue(() -> {
+            executionThread.set(Thread.currentThread());
+            done.countDown();
+        });
+        assertTrue("recovery task never finished", done.await(10, TimeUnit.SECONDS));
+        assertThat("recovery task executed on enqueueing thread instead of asynchronously", executionThread.get(), not(equalTo(caller)));
+    }
+
+    /**
+     * Never more than {@code maxConcurrentRecoveries} runnable bodies may overlap; extra tasks stay pending until a slot frees.
+     */
+    public void testMaxConcurrencyBound() throws Exception {
+        final int maxConcurrentRecoveries = between(2, 5);
+        RecoveryThrottlingQueue queue = new RecoveryThrottlingQueue(threadPool, maxConcurrentRecoveries);
+        AtomicInteger running = new AtomicInteger();
+        AtomicInteger peakConcurrent = new AtomicInteger();
+        CountDownLatch maxConcurrentReached = new CountDownLatch(maxConcurrentRecoveries);
+        CountDownLatch unblock = new CountDownLatch(1);
+        int totalEnqueuedTasks = maxConcurrentRecoveries * 3;
+        CountDownLatch allFinished = new CountDownLatch(totalEnqueuedTasks);
+
+        RecoveryThrottlingQueue.RecoveryTask recoveryTask = () -> {
+            try {
+                int current = running.incrementAndGet();
+                peakConcurrent.accumulateAndGet(current, Integer::max);
+                maxConcurrentReached.countDown();
+                unblock.await();
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            } finally {
+                running.decrementAndGet();
+                allFinished.countDown();
+            }
+        };
+
+        int enqueued = 0;
+        for (; enqueued < maxConcurrentRecoveries; enqueued++) {
+            queue.enqueue(recoveryTask);
+        }
+
+        assertTrue(
+            "timed out waiting for expected number of concurrent tasks to execute",
+            maxConcurrentReached.await(10, TimeUnit.SECONDS)
+        );
+        assertThat(enqueued, equalTo(maxConcurrentRecoveries));
+        assertThat(running.get(), equalTo(maxConcurrentRecoveries));
+
+        for (; enqueued < totalEnqueuedTasks; enqueued++) {
+            queue.enqueue(recoveryTask);
+        }
+
+        unblock.countDown();
+
+        assertTrue("timed out waiting for tasks to finish", allFinished.await(10, TimeUnit.SECONDS));
+        assertThat(running.get(), equalTo(0));
+        assertThat(peakConcurrent.get(), lessThanOrEqualTo(maxConcurrentRecoveries));
+    }
+
+    /**
+     * With a single execution slot, throttled backlog runs in enqueue order ({@linkplain ConcurrentLinkedQueue FIFO} semantics).
+     */
+    public void testFifoWhenThrottledToOneConcurrent() throws Exception {
+        RecoveryThrottlingQueue queue = new RecoveryThrottlingQueue(threadPool, 1);
+        int total = between(10, 20);
+        List<Integer> startOrder = new CopyOnWriteArrayList<>();
+        CountDownLatch allDone = new CountDownLatch(total);
+
+        for (int i = 0; i < total; i++) {
+            final int sequence = i;
+            queue.enqueue(() -> {
+                startOrder.add(sequence);
+                allDone.countDown();
+            });
+        }
+
+        assertTrue(allDone.await(30, TimeUnit.SECONDS));
+        assertThat(startOrder.size(), equalTo(total));
+        for (int i = 0; i < total; i++) {
+            assertThat(startOrder.get(i), equalTo(Integer.valueOf(i)));
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/indices/recovery/RecoveryThrottlingQueueTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/RecoveryThrottlingQueueTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.threadpool.TestThreadPool;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -21,6 +22,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
@@ -42,7 +45,7 @@ public class RecoveryThrottlingQueueTests extends ESTestCase {
 
     /** Enqueued work runs asynchronously (worker thread differs from enqueueing thread). */
     public void testTasksRunOutsideEnqueueingThread() throws Exception {
-        RecoveryThrottlingQueue queue = new RecoveryThrottlingQueue(threadPool, between(2, 4));
+        RecoveryThrottlingQueue queue = new RecoveryThrottlingQueue(threadPool, between(2, 4), logger);
         Thread caller = Thread.currentThread();
         AtomicReference<Thread> executionThread = new AtomicReference<>();
         CountDownLatch done = new CountDownLatch(1);
@@ -59,7 +62,7 @@ public class RecoveryThrottlingQueueTests extends ESTestCase {
      */
     public void testMaxConcurrencyBound() throws Exception {
         final int maxConcurrentRecoveries = between(2, 5);
-        RecoveryThrottlingQueue queue = new RecoveryThrottlingQueue(threadPool, maxConcurrentRecoveries);
+        RecoveryThrottlingQueue queue = new RecoveryThrottlingQueue(threadPool, maxConcurrentRecoveries, logger);
         AtomicInteger running = new AtomicInteger();
         AtomicInteger peakConcurrent = new AtomicInteger();
         CountDownLatch maxConcurrentReached = new CountDownLatch(maxConcurrentRecoveries);
@@ -108,7 +111,7 @@ public class RecoveryThrottlingQueueTests extends ESTestCase {
      * With a single execution slot, throttled backlog runs in enqueue order ({@linkplain ConcurrentLinkedQueue FIFO} semantics).
      */
     public void testFifoWhenThrottledToOneConcurrent() throws Exception {
-        RecoveryThrottlingQueue queue = new RecoveryThrottlingQueue(threadPool, 1);
+        RecoveryThrottlingQueue queue = new RecoveryThrottlingQueue(threadPool, 1, logger);
         int total = between(10, 20);
         List<Integer> startOrder = new CopyOnWriteArrayList<>();
         CountDownLatch allDone = new CountDownLatch(total);
@@ -125,6 +128,135 @@ public class RecoveryThrottlingQueueTests extends ESTestCase {
         assertThat(startOrder.size(), equalTo(total));
         for (int i = 0; i < total; i++) {
             assertThat(startOrder.get(i), equalTo(Integer.valueOf(i)));
+        }
+    }
+
+    /**
+     * Stress one {@link RecoveryThrottlingQueue} from many producer threads for one second: alternating
+     * bursty submits (high contention on {@link RecoveryThrottlingQueue}) and idle periods (little
+     * to no contention). Verify that all tasks are finished and that no more maxConcurrentRecoveries run concurrently.
+     *
+     * By randomizing the burst sizes we exercise different queue pressure where in some executions we will always have
+     * tasks in the queue, and in other executions we manage to empty the queue of tasks during the idle periods.
+     */
+    public void testStressConcurrentEnqueueMaintainsBoundsFifoAndCompleteness() throws Exception {
+        final int maxConcurrentRecoveries = between(1, 20);
+        final int highContentionBurstSizeMin = between(1, maxConcurrentRecoveries);
+        final int highContentionBurstSizeMax = between(highContentionBurstSizeMin, maxConcurrentRecoveries * 2);
+        final RecoveryThrottlingQueue queue = new RecoveryThrottlingQueue(threadPool, maxConcurrentRecoveries, logger);
+        final AtomicInteger running = new AtomicInteger();
+        final AtomicInteger peakRunning = new AtomicInteger();
+        final AtomicInteger totalTasksEnqueued = new AtomicInteger();
+        final AtomicInteger totalTasksFinished = new AtomicInteger();
+        final DynamicTaskLatch taskLatch = new DynamicTaskLatch();
+
+        final long deadlineMillis = System.currentTimeMillis() + TimeUnit.MILLISECONDS.toMillis(1000);
+        final int producerThreads = between(1, 6);
+        final List<Thread> threads = new ArrayList<>(producerThreads);
+        for (int t = 0; t < producerThreads; t++) {
+            Thread thread = new Thread(() -> {
+                try {
+                    long phaseClock = System.currentTimeMillis();
+                    while (System.currentTimeMillis() < deadlineMillis) {
+                        long elapsedPhase = System.currentTimeMillis() - phaseClock;
+                        boolean highContention = (elapsedPhase / TimeUnit.MILLISECONDS.toMillis(100)) % 2 == 0;
+                        if (highContention) {
+                            int burst = between(highContentionBurstSizeMin, highContentionBurstSizeMax);
+                            for (int b = 0; b < burst && System.currentTimeMillis() < deadlineMillis; b++) {
+                                taskLatch.taskStarted();
+                                totalTasksEnqueued.incrementAndGet();
+                                queue.enqueue(() -> runStressTask(running, peakRunning, totalTasksFinished, taskLatch));
+                            }
+                        } else {
+                            int sleepMs = between(15, 80);
+                            Thread.sleep(sleepMs);
+                            if (System.currentTimeMillis() < deadlineMillis) {
+                                taskLatch.taskStarted();
+                                totalTasksEnqueued.incrementAndGet();
+                                queue.enqueue(() -> runStressTask(running, peakRunning, totalTasksFinished, taskLatch));
+                            }
+                        }
+                        // Sleep between each iteration
+                        Thread.sleep(between(1, 10));
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException(e);
+                }
+            }, "recovery-throttle-stress-" + "-" + t);
+            threads.add(thread);
+            thread.start();
+        }
+
+        for (Thread thread : threads) {
+            thread.join();
+        }
+
+        taskLatch.awaitZero();
+        assertThat(totalTasksFinished.get(), equalTo(totalTasksEnqueued.get()));
+        assertThat(peakRunning.get(), lessThanOrEqualTo(maxConcurrentRecoveries));
+        assertThat(running.get(), equalTo(0));
+    }
+
+    private void runStressTask(AtomicInteger running, AtomicInteger peakRunning, AtomicInteger totalTasksFinished, DynamicTaskLatch latch) {
+        int current = running.incrementAndGet();
+        peakRunning.accumulateAndGet(current, Integer::max);
+        try {
+            // Sleep to make sure scheduling threads also get to execute
+            Thread.sleep(1);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        } finally {
+            running.decrementAndGet();
+            totalTasksFinished.incrementAndGet();
+            latch.taskFinished();
+        }
+    }
+
+    public final class DynamicTaskLatch {
+        private final ReentrantLock lock = new ReentrantLock();
+        private final Condition zero = lock.newCondition();
+        private long count;
+
+        public void taskStarted() {
+            lock.lock();
+            try {
+                if (count == Long.MAX_VALUE) {
+                    throw new IllegalStateException("Too many active tasks");
+                }
+                count++;
+            } finally {
+                lock.unlock();
+            }
+        }
+
+        public void taskFinished() {
+            lock.lock();
+            try {
+                if (count == 0) {
+                    throw new IllegalStateException("taskFinished without taskStarted");
+                }
+
+                count--;
+
+                if (count == 0) {
+                    zero.signalAll();
+                }
+            } finally {
+                lock.unlock();
+            }
+        }
+
+        public void awaitZero() throws InterruptedException {
+            lock.lock();
+            try {
+                while (count != 0) {
+                    zero.await();
+                }
+            } finally {
+                lock.unlock();
+            }
         }
     }
 }

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTestHelper.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTestHelper.java
@@ -126,6 +126,7 @@ import org.elasticsearch.indices.cluster.IndicesClusterStateService;
 import org.elasticsearch.indices.recovery.PeerRecoverySourceService;
 import org.elasticsearch.indices.recovery.PeerRecoveryTargetService;
 import org.elasticsearch.indices.recovery.RecoverySettings;
+import org.elasticsearch.indices.recovery.RecoveryThrottlingQueue;
 import org.elasticsearch.indices.recovery.SnapshotFilesProvider;
 import org.elasticsearch.indices.recovery.plan.PeerOnlyRecoveryPlannerService;
 import org.elasticsearch.ingest.IngestService;
@@ -455,6 +456,8 @@ public class SnapshotResiliencyTestHelper {
 
             protected PeerRecoveryTargetService peerRecoveryTargetService;
 
+            protected RecoveryThrottlingQueue recoveryThrottlingQueue;
+
             private IndicesClusterStateService indicesClusterStateService;
 
             private final MasterService masterService;
@@ -696,6 +699,8 @@ public class SnapshotResiliencyTestHelper {
                     snapshotFilesProvider
                 );
 
+                recoveryThrottlingQueue = new RecoveryThrottlingQueue(threadPool, RecoveryThrottlingQueue.DEFAULT);
+
                 final ActionFilters actionFilters = new ActionFilters(emptySet());
                 final ActiveFetchPhaseTasks activeFetchPhaseTasks = new ActiveFetchPhaseTasks();
                 new TransportFetchPhaseResponseChunkAction(transportService, activeFetchPhaseTasks, namedWriteableRegistry);
@@ -773,6 +778,7 @@ public class SnapshotResiliencyTestHelper {
                     clusterService,
                     threadPool,
                     peerRecoveryTargetService,
+                    recoveryThrottlingQueue,
                     shardStateAction,
                     repositoriesService,
                     searchService,

--- a/test/framework/src/main/java/org/elasticsearch/indices/cluster/AbstractIndicesClusterStateServiceTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/indices/cluster/AbstractIndicesClusterStateServiceTestCase.java
@@ -38,6 +38,7 @@ import org.elasticsearch.indices.cluster.IndicesClusterStateService.AllocatedInd
 import org.elasticsearch.indices.cluster.IndicesClusterStateService.Shard;
 import org.elasticsearch.indices.recovery.PeerRecoveryTargetService;
 import org.elasticsearch.indices.recovery.RecoveryState;
+import org.elasticsearch.indices.recovery.RecoveryThrottlingQueue;
 import org.elasticsearch.repositories.RepositoriesService;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Before;
@@ -261,6 +262,7 @@ public abstract class AbstractIndicesClusterStateServiceTestCase extends ESTestC
             final ProjectId projectId,
             final ShardRouting shardRouting,
             final PeerRecoveryTargetService recoveryTargetService,
+            final RecoveryThrottlingQueue recoveryThrottlingQueue,
             final PeerRecoveryTargetService.RecoveryListener recoveryListener,
             final RepositoriesService repositoriesService,
             final Consumer<IndexShard.ShardFailure> onShardFailure,


### PR DESCRIPTION
A prototype for a recovery queue on data node. The idea was to introduce this queue as a minimal change. Where `IndexShard` would have forked to generic thread pool before, it now enqueues recovery tasks to the newly introduced `RecoveryThrottlingQueue`. At this point, the type of recovery has already been 

Another idea would be to move the enqueueing to `IndicesService`. I haven't explored that option yet so can't tell if it makes more sense.

All input is welcome!

Relates https://github.com/elastic/elasticsearch-team/issues/2808
Surpassed by https://github.com/elastic/elasticsearch/pull/149317