### PR TITLE
Fix neighborhoods after removing empty clusters

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -533,15 +533,6 @@ tests:
 - class: org.elasticsearch.xpack.inference.DefaultEndPointsIT
   method: testMultipleInferencesTriggeringDownloadAndDeploy
   issue: https://github.com/elastic/elasticsearch/issues/149130
-- class: org.elasticsearch.index.codec.vectors.diskbbq.es94.ES940DiskBBQVectorsFormatTests;
-  method: testOneRepeatedVector
-  issue: https://github.com/elastic/elasticsearch/issues/149168
-- class: org.elasticsearch.index.codec.vectors.diskbbq.es92.ES920DiskBBQVectorsFormatTests;
-  method: testOneRepeatedVector
-  issue: https://github.com/elastic/elasticsearch/issues/149168
-- class: org.elasticsearch.index.codec.vectors.diskbbq.next.ESNextDiskBBQVectorsFormatTests;
-  method: testOneRepeatedVector
-  issue: https://github.com/elastic/elasticsearch/issues/149168
 - class: org.elasticsearch.xpack.esql.qa.multi_node.GenerativeIT
   method: test
   issue: https://github.com/elastic/elasticsearch/issues/148339

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/cluster/ClusteringFloatVectorValues.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/cluster/ClusteringFloatVectorValues.java
@@ -283,6 +283,10 @@ public abstract sealed class ClusteringFloatVectorValues extends FloatVectorValu
         // Here, x is the document, c is the nearest centroid, and c_1 is the first
         // centroid the document was assigned to. The document is assigned to the
         // cluster with the smallest soar(x, c).
+
+        // Caveat: because of removals of empty clusters before SOAR,
+        // we may have neighborhoods.length > centroids.length.
+        // We should always use centroids.length as the correct value.
         float[] diffs = new float[dimension()];
         final float[] distances = new float[4];
         for (int i = startOrd; i < endOrd; i++) {

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/cluster/KMeansLocal.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/cluster/KMeansLocal.java
@@ -233,7 +233,7 @@ abstract class KMeansLocal {
             neighborhoods = computeNeighborhoods(centroids, clustersPerNeighborhood);
         }
         innerCluster(vectors, kMeansIntermediate, neighborhoods);
-        removeEmptyClusters(kMeansIntermediate);
+        removeEmptyClusters(kMeansIntermediate, neighborhoods);
         if (neighborAware && soarLambda >= 0) {
             assert kMeansIntermediate.soarAssignments().length == 0;
             kMeansIntermediate.setSoarAssignments(new int[vectors.size()]);
@@ -265,7 +265,7 @@ abstract class KMeansLocal {
         return MathUtils.sqrt(result / norm2);
     }
 
-    private static void removeEmptyClusters(KMeansIntermediate kMeansIntermediate) {
+    private static void removeEmptyClusters(KMeansIntermediate kMeansIntermediate, NeighborHood[] neighborhoods) {
         float[][] centroids = kMeansIntermediate.centroids();
         int[] assignments = kMeansIntermediate.assignments();
         int[] centroidVectorCount = kMeansIntermediate.clusterCounts();
@@ -298,6 +298,8 @@ abstract class KMeansLocal {
             return;
         }
 
+        // TODO eventually, we should get rid of this allocation by overhauling how centroids
+        //  are stored and handled in KMeansResult
         final float[][] newCentroids = new float[effectiveK][centroids[0].length];
         final int[] newClusterCounts = new int[effectiveK];
         final int[] centroidIndexMap = new int[centroids.length];
@@ -317,5 +319,19 @@ abstract class KMeansLocal {
             }
         }
         kMeansIntermediate.setCentroids(newCentroids, newClusterCounts);
+
+        if (neighborhoods != null) {
+            // This change will cause that neighborhoods.length > newCentroids.length.
+            // Doing it like this avoids more memory allocations and is fine as long as
+            // we do not use neighborhoods.length to get the number of clusters.
+            for (int c = 0; c < centroids.length; c++) {
+                neighborhoods[centroidIndexMap[c]] = neighborhoods[c];
+                int[] neighbors = neighborhoods[c].neighbors();
+                for (int i = 0; i < neighbors.length; i++) {
+                    neighbors[i] = centroidIndexMap[neighbors[i]];
+                }
+                neighborhoods[centroidIndexMap[c]] = neighborhoods[c];
+            }
+        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/cluster/KMeansLocal.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/cluster/KMeansLocal.java
@@ -299,7 +299,7 @@ abstract class KMeansLocal {
         }
 
         // TODO eventually, we should get rid of this allocation by overhauling how centroids
-        //  are stored and handled in KMeansResult
+        // are stored and handled in KMeansResult
         final float[][] newCentroids = new float[effectiveK][centroids[0].length];
         final int[] newClusterCounts = new int[effectiveK];
         final int[] centroidIndexMap = new int[centroids.length];


### PR DESCRIPTION
Addresses #149168. The cause of the bug was that after removing empty clusters, the neighborhoods were stale and SOAR assignments could fail. This PR updates the neighborhoods with the proper cluster indices.

This is a quick fix that avoids further memory copies. At some point, we should overhaul many of the data structures in the clustering code so that we can mutate them as needed without making new allocations. In particular, [this line](https://github.com/elastic/elasticsearch/blob/e18ad80ba05fd09ef3dd6b16642bce57e6d37b02/server/src/main/java/org/elasticsearch/index/codec/vectors/cluster/KMeansLocal.java#L301)
`final float[][] newCentroids = new float[effectiveK][centroids[0].length];`
is nasty during refinement, because we could be allocating a huge array. I added a TODO about this.