### PR TITLE
Increment metric when relocated reindex starts

### DIFF
--- a/modules/reindex-management/src/internalClusterTest/java/org/elasticsearch/reindex/management/ReindexRelocationIT.java
+++ b/modules/reindex-management/src/internalClusterTest/java/org/elasticsearch/reindex/management/ReindexRelocationIT.java
@@ -910,6 +910,11 @@ public class ReindexRelocationIT extends ESIntegTestCase {
         plugin.collect();
         assertThat(plugin.getLongCounterMeasurement(ReindexMetrics.REINDEX_COMPLETION_COUNTER), is(empty()));
         assertThat(plugin.getLongHistogramMeasurement(ReindexMetrics.REINDEX_TIME_HISTOGRAM), is(empty()));
+        assertThat(
+            "relocation started metric should not be updated on the node the reindex moved from " + nodeName,
+            plugin.getLongCounterMeasurement(ReindexMetrics.REINDEX_RELOCATION_STARTED_COUNTER),
+            is(empty())
+        );
         final var relocationCounter = plugin.getLongCounterMeasurement(ReindexMetrics.REINDEX_RELOCATION_COUNTER);
         assertThat("relocation metric updated", relocationCounter.size(), equalTo(1));
         assertThat("relocation metric updated", relocationCounter.getFirst().getLong(), equalTo(1L));
@@ -951,6 +956,10 @@ public class ReindexRelocationIT extends ESIntegTestCase {
             duration.attributes().get(ReindexMetrics.ATTRIBUTE_NAME_SLICING_MODE),
             equalTo(slicingMode.name().toLowerCase(Locale.ROOT))
         );
+        final var relocationStartedCounter = plugin.getLongCounterMeasurement(ReindexMetrics.REINDEX_RELOCATION_STARTED_COUNTER);
+        assertThat(relocationStartedCounter.size(), equalTo(1));
+        assertThat(relocationStartedCounter.getFirst().getLong(), equalTo(1L));
+        assertThat(relocationStartedCounter.getFirst().attributes().get(ReindexMetrics.ATTRIBUTE_NAME_ERROR_TYPE), is(nullValue()));
         assertThat("no relocation metric", plugin.getLongCounterMeasurement(ReindexMetrics.REINDEX_RELOCATION_COUNTER).size(), equalTo(0));
     }
 

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/ReindexMetrics.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/ReindexMetrics.java
@@ -25,6 +25,7 @@ public class ReindexMetrics {
     public static final String REINDEX_TIME_HISTOGRAM = "es.reindex.duration.histogram";
     public static final String REINDEX_COMPLETION_COUNTER = "es.reindex.completion.total";
     public static final String REINDEX_RELOCATION_COUNTER = "es.reindex.relocation.total";
+    public static final String REINDEX_RELOCATION_STARTED_COUNTER = "es.reindex.relocation.started";
 
     // refers to https://opentelemetry.io/docs/specs/semconv/registry/attributes/error/#error-type
     public static final String ATTRIBUTE_NAME_ERROR_TYPE = "error_type";
@@ -38,6 +39,7 @@ public class ReindexMetrics {
     private final LongHistogram reindexTimeSecsHistogram;
     private final LongCounter reindexCompletionCounter;
     private final LongCounter reindexRelocationCounter;
+    private final LongCounter reindexRelocationStartedCounter;
 
     public ReindexMetrics(MeterRegistry meterRegistry) {
         this.reindexTimeSecsHistogram = meterRegistry.registerLongHistogram(REINDEX_TIME_HISTOGRAM, "Time to reindex by search", "seconds");
@@ -49,6 +51,11 @@ public class ReindexMetrics {
         this.reindexRelocationCounter = meterRegistry.registerLongCounter(
             REINDEX_RELOCATION_COUNTER,
             "Number of attempted reindex relocations",
+            "unit"
+        );
+        this.reindexRelocationStartedCounter = meterRegistry.registerLongCounter(
+            REINDEX_RELOCATION_STARTED_COUNTER,
+            "Number of times relocated reindex operations have started",
             "unit"
         );
     }
@@ -95,6 +102,10 @@ public class ReindexMetrics {
         // attribute ATTRIBUTE_ERROR_TYPE being present indicates failure
         final Map<String, Object> attributes = Map.of(ATTRIBUTE_NAME_ERROR_TYPE, e.getClass().getTypeName());
         reindexRelocationCounter.incrementBy(1, attributes);
+    }
+
+    public void recordRelocationStarted() {
+        reindexRelocationStartedCounter.incrementBy(1);
     }
 
     public enum SlicingMode {

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/ReindexMetrics.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/ReindexMetrics.java
@@ -25,7 +25,7 @@ public class ReindexMetrics {
     public static final String REINDEX_TIME_HISTOGRAM = "es.reindex.duration.histogram";
     public static final String REINDEX_COMPLETION_COUNTER = "es.reindex.completion.total";
     public static final String REINDEX_RELOCATION_COUNTER = "es.reindex.relocation.total";
-    public static final String REINDEX_RELOCATION_STARTED_COUNTER = "es.reindex.relocation.started";
+    public static final String REINDEX_RELOCATION_STARTED_COUNTER = "es.reindex.relocation.started.total";
 
     // refers to https://opentelemetry.io/docs/specs/semconv/registry/attributes/error/#error-type
     public static final String ATTRIBUTE_NAME_ERROR_TYPE = "error_type";

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/TransportResumeReindexAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/TransportResumeReindexAction.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.reindex;
 
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -16,18 +17,23 @@ import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.index.reindex.ReindexAction;
 import org.elasticsearch.index.reindex.ReindexRequest;
 import org.elasticsearch.index.reindex.ResumeBulkByScrollRequest;
+import org.elasticsearch.index.reindex.ResumeBulkByScrollResponse;
 import org.elasticsearch.index.reindex.ResumeReindexAction;
 import org.elasticsearch.injection.guice.Inject;
+import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
 
 public class TransportResumeReindexAction extends AbstractResumeBulkByScrollAction<ReindexRequest> {
+
+    private final ReindexMetrics reindexMetrics;
 
     @Inject
     public TransportResumeReindexAction(
         TransportService transportService,
         ActionFilters actionFilters,
         ClusterService clusterService,
-        NodeClient nodeClient
+        NodeClient nodeClient,
+        ReindexMetrics reindexMetrics
     ) {
         super(
             ResumeReindexAction.NAME,
@@ -39,5 +45,12 @@ public class TransportResumeReindexAction extends AbstractResumeBulkByScrollActi
             ReindexAction.INSTANCE,
             nodeClient
         );
+        this.reindexMetrics = reindexMetrics;
+    }
+
+    @Override
+    protected void doExecute(Task task, ResumeBulkByScrollRequest request, ActionListener<ResumeBulkByScrollResponse> listener) {
+        reindexMetrics.recordRelocationStarted();
+        super.doExecute(task, request, listener);
     }
 }

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexMetricsTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexMetricsTests.java
@@ -32,6 +32,7 @@ import static org.elasticsearch.reindex.ReindexMetrics.ATTRIBUTE_VALUE_SOURCE_LO
 import static org.elasticsearch.reindex.ReindexMetrics.ATTRIBUTE_VALUE_SOURCE_REMOTE;
 import static org.elasticsearch.reindex.ReindexMetrics.REINDEX_COMPLETION_COUNTER;
 import static org.elasticsearch.reindex.ReindexMetrics.REINDEX_RELOCATION_COUNTER;
+import static org.elasticsearch.reindex.ReindexMetrics.REINDEX_RELOCATION_STARTED_COUNTER;
 import static org.elasticsearch.reindex.ReindexMetrics.REINDEX_TIME_HISTOGRAM;
 import static org.elasticsearch.reindex.ReindexMetrics.SlicingMode;
 
@@ -155,6 +156,26 @@ public class ReindexMetricsTests extends ESTestCase {
         assertNull(measurements.getFirst().attributes().get(ATTRIBUTE_NAME_ERROR_TYPE));
         assertEquals(1, measurements.get(1).getLong());
         assertEquals("java.io.IOException", measurements.get(1).attributes().get(ATTRIBUTE_NAME_ERROR_TYPE));
+    }
+
+    public void testRecordRelocationStarted() {
+        metrics.recordRelocationStarted();
+
+        List<Measurement> measurements = registry.getRecorder().getMeasurements(InstrumentType.LONG_COUNTER, REINDEX_RELOCATION_STARTED_COUNTER);
+        assertEquals(1, measurements.size());
+        assertEquals(1, measurements.getFirst().getLong());
+        assertNull(measurements.getFirst().attributes().get(ATTRIBUTE_NAME_ERROR_TYPE));
+
+        assertEquals(0, registry.getRecorder().getMeasurements(InstrumentType.LONG_COUNTER, REINDEX_RELOCATION_COUNTER).size());
+
+        metrics.recordRelocationStarted();
+
+        measurements = registry.getRecorder().getMeasurements(InstrumentType.LONG_COUNTER, REINDEX_RELOCATION_STARTED_COUNTER);
+        assertEquals(2, measurements.size());
+        assertEquals(1, measurements.get(1).getLong());
+        assertNull(measurements.get(1).attributes().get(ATTRIBUTE_NAME_ERROR_TYPE));
+
+        assertEquals(0, registry.getRecorder().getMeasurements(InstrumentType.LONG_COUNTER, REINDEX_RELOCATION_COUNTER).size());
     }
 
     public void testResolveSlicingModeNone() {

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexMetricsTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexMetricsTests.java
@@ -161,7 +161,8 @@ public class ReindexMetricsTests extends ESTestCase {
     public void testRecordRelocationStarted() {
         metrics.recordRelocationStarted();
 
-        List<Measurement> measurements = registry.getRecorder().getMeasurements(InstrumentType.LONG_COUNTER, REINDEX_RELOCATION_STARTED_COUNTER);
+        List<Measurement> measurements = registry.getRecorder()
+            .getMeasurements(InstrumentType.LONG_COUNTER, REINDEX_RELOCATION_STARTED_COUNTER);
         assertEquals(1, measurements.size());
         assertEquals(1, measurements.getFirst().getLong());
         assertNull(measurements.getFirst().attributes().get(ATTRIBUTE_NAME_ERROR_TYPE));


### PR DESCRIPTION
This metric is incremented on the new node, when the resume action is incremented. This should be collected more reliably than the metric incremented on the old node just before it shuts down.
