### PR TITLE
Tune merge policy for vectordb_document mode

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/IndexMode.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexMode.java
@@ -959,6 +959,31 @@ public enum IndexMode {
                 if (MergeSchedulerConfig.AUTO_THROTTLE_SETTING.exists(indexTemplateAndCreateRequestSettings) == false) {
                     additionalSettings.put(autoThrottleKey, false);
                 }
+
+                // Use a larger max merged segment to reduce segment count; fewer segments means fewer HNSW/IVF graphs
+                // to traverse per query, which is the dominant vector search cost.
+                // Only applied when the user has not set it explicitly.
+                String maxMergedSegmentKey = MergePolicyConfig.INDEX_MERGE_POLICY_MAX_MERGED_SEGMENT_SETTING.getKey();
+                if (MergePolicyConfig.INDEX_MERGE_POLICY_MAX_MERGED_SEGMENT_SETTING.exists(
+                    indexTemplateAndCreateRequestSettings
+                ) == false) {
+                    additionalSettings.put(maxMergedSegmentKey, "16gb");
+                }
+
+                // Raise the floor segment so that small post-flush segments are coalesced quickly.
+                // Only applied when the user has not set it explicitly.
+                String floorSegmentKey = MergePolicyConfig.INDEX_MERGE_POLICY_FLOOR_SEGMENT_SETTING.getKey();
+                if (MergePolicyConfig.INDEX_MERGE_POLICY_FLOOR_SEGMENT_SETTING.exists(indexTemplateAndCreateRequestSettings) == false) {
+                    additionalSettings.put(floorSegmentKey, "128mb");
+                }
+
+                // Lower segments per tier to keep the steady-state segment count small.
+                // Also implicitly clamps max_merge_at_once to 5 via MergePolicyConfig#adjustMaxMergeAtOnceIfNeeded.
+                // Only applied when the user has not set it explicitly.
+                String segmentsPerTierKey = MergePolicyConfig.INDEX_MERGE_POLICY_SEGMENTS_PER_TIER_SETTING.getKey();
+                if (MergePolicyConfig.INDEX_MERGE_POLICY_SEGMENTS_PER_TIER_SETTING.exists(indexTemplateAndCreateRequestSettings) == false) {
+                    additionalSettings.put(segmentsPerTierKey, 5.0);
+                }
             }
         }
 

--- a/server/src/test/java/org/elasticsearch/index/VectordbDocumentIndexModeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/VectordbDocumentIndexModeTests.java
@@ -58,6 +58,11 @@ public class VectordbDocumentIndexModeTests extends ESTestCase {
 
         // Merge IO auto-throttling is disabled by default.
         assertEquals("false", resolved.get(MergeSchedulerConfig.AUTO_THROTTLE_SETTING.getKey()));
+
+        // Merge policy is tuned for fewer, larger segments to reduce per-query HNSW/IVF graph traversal cost.
+        assertEquals("16gb", resolved.get(MergePolicyConfig.INDEX_MERGE_POLICY_MAX_MERGED_SEGMENT_SETTING.getKey()));
+        assertEquals("128mb", resolved.get(MergePolicyConfig.INDEX_MERGE_POLICY_FLOOR_SEGMENT_SETTING.getKey()));
+        assertEquals("5.0", resolved.get(MergePolicyConfig.INDEX_MERGE_POLICY_SEGMENTS_PER_TIER_SETTING.getKey()));
     }
 
     public void testProviderRejectsExplicitFalseExcludeSourceVectors() {
@@ -89,6 +94,9 @@ public class VectordbDocumentIndexModeTests extends ESTestCase {
             .putList(IndexModule.INDEX_STORE_PRE_LOAD_SETTING.getKey(), "vex")
             .put(IndexSettings.INTRA_MERGE_PARALLELISM_ENABLED_SETTING.getKey(), false)
             .put(MergeSchedulerConfig.AUTO_THROTTLE_SETTING.getKey(), true)
+            .put(MergePolicyConfig.INDEX_MERGE_POLICY_MAX_MERGED_SEGMENT_SETTING.getKey(), "5gb")
+            .put(MergePolicyConfig.INDEX_MERGE_POLICY_FLOOR_SEGMENT_SETTING.getKey(), "2mb")
+            .put(MergePolicyConfig.INDEX_MERGE_POLICY_SEGMENTS_PER_TIER_SETTING.getKey(), 10.0)
             .build();
         Settings.Builder additional = Settings.builder();
         runProvider(userSettings, additional);
@@ -105,6 +113,18 @@ public class VectordbDocumentIndexModeTests extends ESTestCase {
         assertNull(
             "should not override user-provided merge auto-throttle setting",
             resolved.get(MergeSchedulerConfig.AUTO_THROTTLE_SETTING.getKey())
+        );
+        assertNull(
+            "should not override user-provided max merged segment setting",
+            resolved.get(MergePolicyConfig.INDEX_MERGE_POLICY_MAX_MERGED_SEGMENT_SETTING.getKey())
+        );
+        assertNull(
+            "should not override user-provided floor segment setting",
+            resolved.get(MergePolicyConfig.INDEX_MERGE_POLICY_FLOOR_SEGMENT_SETTING.getKey())
+        );
+        assertNull(
+            "should not override user-provided segments per tier setting",
+            resolved.get(MergePolicyConfig.INDEX_MERGE_POLICY_SEGMENTS_PER_TIER_SETTING.getKey())
         );
     }
 


### PR DESCRIPTION
Set three TieredMergePolicy defaults for the vectordb_document index mode, overridable by the user at index creation time.

index.merge.policy.floor_segment: 2mb → 128mb
  Segments below this size are treated as extra-small: they are
  rounded up to the floor value in the tier-budget arithmetic.

index.merge.policy.max_merged_segment: 5gb → 16gb
  Ceiling on segment size produced by natural merges.
  Segments above half this value (8gb) are excluded from natural
  merging unless the global delete budget is exceeded.  16gb aligns
  cleanly with the tier geometry.

index.merge.policy.segments_per_tier: 10 → 5
  Maximum number of segments allowed in each geometric tier before
  a merge is triggered. Halving this value roughly halves the
  steady-state segment count. Alsosilently clamps
  max_merge_at_once from 10 → 5.

Tier structure with floor=128mb, max=16gb, segments_per_tier=5
  Each tier is segments_per_tier (5) times the size of the tier
  below.  A merge fires when a tier accumulates more than 5
  segments.

  Tier │ Segment size                        │ Max count
    ─┼─────────┼──────────
     0 │ ≤ 128 MB (floor)                    │ 5
     1 │ ~640 MB  (128 MB × 5)        │ 5
     2 │ ~3.2 GB  (640 MB × 5)         │ 5
     3 │ ~16 GB   (capped at max_merged_seg) │ unbounded — accumulates

  Once a segment exceeds 8 GB (the half-cap threshold) it is
  pinned and will not participate in further natural merges.
  forceMerge ignores this cap when maxNumSegments is specified.

Expected segment layout for 10 M vectors, 1024 dims, bfloat16
  Raw vector bytes: 10 000 000 × 1024 × 2 B ≈ 19 GB
  HNSW graph (M=16): ~1 GB
  Doc values / stored fields / term index: ~1–2 GB
  Estimated shard size: ~21–22 GB

  Total: ~3-16 segments for the full dataset, versus 8–45
  segments with the previous ES defaults (5gb cap / 2mb floor).

Negative implications
  Higher write amplification: the lower segments_per_tier (5 vs 10)
  causes merges to trigger more frequentl. High CPU and IO usage.