### PR TITLE
[9.4] Node-reduce driver should not release search contexts on failure (#145960)

### DIFF
--- a/docs/changelog/145960.yaml
+++ b/docs/changelog/145960.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 145509
+pr: 145960
+summary: Node-reduce driver should not release search contexts on failure
+type: bug

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
@@ -1171,7 +1171,9 @@ public class ComputeService {
                 ActionListener.releaseAfter(driverListener, () -> Releasables.close(drivers))
             );
         } catch (Exception e) {
-            Releasables.close(context.searchContexts().iterable());
+            if (context.description().equals(DATA_DESCRIPTION)) {
+                Releasables.close(context.searchContexts().iterable());
+            }
             LOGGER.debug("Error in ComputeService.runCompute for : " + context.description());
             listener.onFailure(e);
         }


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Node-reduce driver should not release search contexts on failure (#145960)