### PR TITLE
[9.3] Node-reduce driver should not release search contexts on failure (#145960)

### DIFF
--- a/docs/changelog/145960.yaml
+++ b/docs/changelog/145960.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 145509
+pr: 145960
+summary: Node-reduce driver should not release search contexts on failure
+type: bug

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
@@ -724,7 +724,9 @@ public class ComputeService {
                 ActionListener.releaseAfter(driverListener, () -> Releasables.close(drivers))
             );
         } catch (Exception e) {
-            Releasables.close(context.searchContexts().collection());
+            if (context.description().equals(DATA_DESCRIPTION)) {
+                Releasables.close(context.searchContexts().collection());
+            }
             LOGGER.debug("Error in ComputeService.runCompute for : " + context.description());
             listener.onFailure(e);
         }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Node-reduce driver should not release search contexts on failure (#145960)](https://github.com/elastic/elasticsearch/pull/145960)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)