### PR TITLE
[9.2] Fix testUpdateKeepAlive (#146023)

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/AsyncEsqlQueryActionIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/AsyncEsqlQueryActionIT.java
@@ -276,6 +276,7 @@ public class AsyncEsqlQueryActionIT extends AbstractPausableIntegTestCase {
             .keepAlive(keepAlive);
         final String asyncId;
         long currentExpiration;
+        scriptPermits.drainPermits();
         try {
             try (EsqlQueryResponse initialResponse = client().execute(EsqlQueryAction.INSTANCE, request).actionGet(60, TimeUnit.SECONDS)) {
                 assertThat(initialResponse.isRunning(), is(true));
@@ -390,7 +391,7 @@ public class AsyncEsqlQueryActionIT extends AbstractPausableIntegTestCase {
 
     private static long getExpirationFromDoc(String asyncId) {
         String docId = AsyncExecutionId.decode(asyncId).getDocId();
-        GetResponse doc = client().prepareGet().setIndex(XPackPlugin.ASYNC_RESULTS_INDEX).setId(docId).get();
+        GetResponse doc = client().prepareGet().setIndex(XPackPlugin.ASYNC_RESULTS_INDEX).setId(docId).setRealtime(true).get();
         assertTrue(doc.isExists());
         return ((Number) doc.getSource().get(AsyncTaskIndexService.EXPIRATION_TIME_FIELD)).longValue();
     }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [Fix testUpdateKeepAlive (#146023)](https://github.com/elastic/elasticsearch/pull/146023)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)