### PR TITLE
Enable index balance metrics serverless by default

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/IndexBalanceMetricsTaskExecutor.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/IndexBalanceMetricsTaskExecutor.java
@@ -59,7 +59,7 @@ public final class IndexBalanceMetricsTaskExecutor extends PersistentTasksExecut
 
     /**
      * Dynamic setting controlling whether the index balance metrics task is enabled.
-     * Intended for serverless deployments; defaults to false.
+     * Defaults to {@code false}.
      */
     public static final Setting<Boolean> INDEX_BALANCE_METRICS_ENABLED_SETTING = Setting.boolSetting(
         "cluster.routing.allocation.index_balance_metrics.enabled",

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/IndexBalanceMetricsTaskExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/IndexBalanceMetricsTaskExecutorTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.persistent.ClusterPersistentTasksCustomMetadata;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
@@ -58,6 +59,10 @@ public class IndexBalanceMetricsTaskExecutorTests extends ESTestCase {
     public void testFindTaskReturnsNullWhenNoPersistentTasks() {
         final var state = ClusterState.builder(ClusterName.DEFAULT).build();
         assertThat(IndexBalanceMetricsTaskExecutor.Task.findTask(state), nullValue());
+    }
+
+    public void testDefaultDisabled() {
+        assertThat(IndexBalanceMetricsTaskExecutor.INDEX_BALANCE_METRICS_ENABLED_SETTING.get(Settings.EMPTY), equalTo(false));
     }
 
     public void testFindTaskReturnsNullWhenTaskNotPresent() {

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -49,6 +49,7 @@ import org.elasticsearch.client.RestClientBuilder;
 import org.elasticsearch.client.WarningsHandler;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.ProjectId;
+import org.elasticsearch.cluster.routing.allocation.IndexBalanceMetricsTaskExecutor;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -705,7 +706,8 @@ public abstract class ESRestTestCase extends ESTestCase {
      * Wait for outstanding tasks to complete. The specified admin client is used to check the outstanding tasks and this is done using
      * {@link ESTestCase#assertBusy(CheckedRunnable)} to give a chance to any outstanding tasks to complete. The specified filter is used
      * to filter out outstanding tasks that are expected to be there. In addition to the expected tasks that are defined by the filter we
-     * expect the list task to be there since it is created by the call and the health node task which is always running on the background.
+     * expect the list task to be there since it is created by the call, the health node task, and the index balance metrics task which are
+     * always running in the background.
      *
      * @param restClient the admin client
      * @param taskFilter  predicate used to filter tasks that are expected to be there
@@ -734,6 +736,7 @@ public abstract class ESRestTestCase extends ESTestCase {
                             final String taskName = line.split("\\s+")[0];
                             if (taskName.startsWith(TransportListTasksAction.TYPE.name())
                                 || taskName.startsWith(HealthNode.TASK_NAME)
+                                || taskName.startsWith(IndexBalanceMetricsTaskExecutor.TASK_NAME)
                                 || taskName.startsWith(LEADER_CHECK_ACTION_NAME)
                                 || taskName.startsWith(FOLLOWER_CHECK_ACTION_NAME)
                                 || taskFilter.test(taskName)) {

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/StatelessPlugin.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/StatelessPlugin.java
@@ -43,6 +43,7 @@ import org.elasticsearch.cluster.routing.ShardRoutingRoleStrategy;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.allocation.ExistingShardsAllocator;
 import org.elasticsearch.cluster.routing.allocation.IndexBalanceConstraintSettings;
+import org.elasticsearch.cluster.routing.allocation.IndexBalanceMetricsTaskExecutor;
 import org.elasticsearch.cluster.routing.allocation.WriteLoadConstraintSettings;
 import org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllocator;
 import org.elasticsearch.cluster.routing.allocation.allocator.BalancerSettings;
@@ -673,6 +674,7 @@ public class StatelessPlugin extends Plugin
             /* Start reactive-balancing settings */
             .put(BalancedShardsAllocator.INDEX_BALANCE_FACTOR_SETTING.getKey(), 0)
             .put(IndexBalanceConstraintSettings.INDEX_BALANCE_DECIDER_ENABLED_SETTING.getKey(), true)
+            .put(IndexBalanceMetricsTaskExecutor.INDEX_BALANCE_METRICS_ENABLED_SETTING.getKey(), true)
             .put(InternalClusterInfoService.CLUSTER_ROUTING_ALLOCATION_ESTIMATED_HEAP_THRESHOLD_DECIDER_ENABLED.getKey(), true)
             .put(
                 WriteLoadConstraintSettings.WRITE_LOAD_DECIDER_ENABLED_SETTING.getKey(),

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/StatelessPluginSettingsTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/StatelessPluginSettingsTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.stateless;
 
 import org.elasticsearch.blobcache.shared.SharedBlobCacheService;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
+import org.elasticsearch.cluster.routing.allocation.IndexBalanceMetricsTaskExecutor;
 import org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllocator;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.node.NodeRoleSettings;
@@ -69,6 +70,19 @@ public class StatelessPluginSettingsTests extends ESTestCase {
         assertThat(
             statelessNode.additionalSettings().get(BalancedShardsAllocator.DISK_USAGE_BALANCE_FACTOR_SETTING.getKey()),
             equalTo("0")
+        );
+    }
+
+    public void testIndexBalanceMetricsEnabledForStateless() {
+        var statelessNode = new TestUtils.StatelessPluginWithTrialLicense(
+            Settings.builder()
+                .put(StatelessPlugin.STATELESS_ENABLED.getKey(), true)
+                .put(NodeRoleSettings.NODE_ROLES_SETTING.getKey(), DiscoveryNodeRole.SEARCH_ROLE.roleName())
+                .build()
+        );
+        assertThat(
+            statelessNode.additionalSettings().get(IndexBalanceMetricsTaskExecutor.INDEX_BALANCE_METRICS_ENABLED_SETTING.getKey()),
+            equalTo("true")
         );
     }
 }


### PR DESCRIPTION
Enable index balance metrics in serverless by default.