### PR TITLE
[9.3] Do not enable doc-partitioning for count (#143544)

### DIFF
--- a/docs/changelog/143544.yaml
+++ b/docs/changelog/143544.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 134512
+pr: 143544
+summary: Do not enable doc-partitioning for count
+type: bug

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneCountOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneCountOperator.java
@@ -9,6 +9,9 @@ package org.elasticsearch.compute.lucene;
 
 import org.apache.lucene.search.DocIdStream;
 import org.apache.lucene.search.LeafCollector;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.MatchNoDocsQuery;
+import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Scorable;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Weight;
@@ -44,6 +47,7 @@ public class LuceneCountOperator extends LuceneOperator {
             IndexedByShardId<? extends ShardContext> contexts,
             Function<ShardContext, List<LuceneSliceQueue.QueryAndTags>> queryFunction,
             DataPartitioning dataPartitioning,
+            int docThresholdForAutoStrategy,
             int taskConcurrency,
             List<ElementType> tagTypes,
             int limit
@@ -51,8 +55,10 @@ public class LuceneCountOperator extends LuceneOperator {
             super(
                 contexts,
                 queryFunction,
-                dataPartitioning,
-                query -> LuceneSliceQueue.PartitioningStrategy.SHARD,
+                // don't enable doc-partitioning for count see #partitioningStrategyForCount
+                dataPartitioning == DataPartitioning.DOC ? DataPartitioning.AUTO : dataPartitioning,
+                LuceneCountOperator::partitioningStrategyForCount,
+                docThresholdForAutoStrategy,
                 taskConcurrency,
                 limit,
                 false,
@@ -139,19 +145,11 @@ public class LuceneCountOperator extends LuceneOperator {
         PerTagsState state = tagsToState.computeIfAbsent(scorer.tags(), t -> new PerTagsState());
         Weight weight = scorer.weight();
         var leafReaderContext = scorer.leafReaderContext();
-        // see org.apache.lucene.search.TotalHitCountCollector
         int leafCount = weight.count(leafReaderContext);
         if (leafCount != -1) {
-            // make sure to NOT multi count as the count _shortcut_ (which is segment wide)
-            // handle doc partitioning where the same leaf can be seen multiple times
-            // since the count is global, consider it only for the first partition and skip the rest
-            // SHARD, SEGMENT and the first DOC_ reader in data partitioning contain the first doc (position 0)
-            if (scorer.position() == 0) {
-                // check to not count over the desired number of docs/limit
-                var count = Math.min(leafCount, remainingDocs);
-                state.totalHits += count;
-                remainingDocs -= count;
-            }
+            var count = Math.min(leafCount, remainingDocs);
+            state.totalHits += count;
+            remainingDocs -= count;
             scorer.markAsDone();
         } else {
             // could not apply shortcut, trigger the search
@@ -248,5 +246,20 @@ public class LuceneCountOperator extends LuceneOperator {
                 totalHits++;
             }
         }
+    }
+
+    /**
+     * We can't use Weight.count() with doc-partitioning because if the query gets cached mid-way, the count becomes incorrect.
+     * Over-counting occurs when some parts are counted doc-by-doc while the first part is counted entirely via the cached shortcut.
+     * Under-counting occurs when the first part is not cached but later parts are, causing those parts to be skipped.
+     * To make doc-partitioning work properly for count, we would need coordination between threads.
+     */
+    static LuceneSliceQueue.PartitioningStrategy partitioningStrategyForCount(Query q) {
+        final Query unwrapped = LuceneSourceOperator.Factory.unwrapQuery(q);
+        return switch (unwrapped) {
+            case MatchAllDocsQuery unused -> LuceneSliceQueue.PartitioningStrategy.SHARD;
+            case MatchNoDocsQuery unused -> LuceneSliceQueue.PartitioningStrategy.SHARD;
+            default -> LuceneSliceQueue.PartitioningStrategy.SEGMENT;
+        };
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneMaxFactory.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneMaxFactory.java
@@ -127,6 +127,7 @@ public final class LuceneMaxFactory extends LuceneOperator.Factory {
             queryFunction,
             dataPartitioning,
             query -> LuceneSliceQueue.PartitioningStrategy.SHARD,
+            LuceneOperator.SMALL_INDEX_BOUNDARY,
             taskConcurrency,
             limit,
             false,

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneMinFactory.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneMinFactory.java
@@ -128,6 +128,7 @@ public final class LuceneMinFactory extends LuceneOperator.Factory {
             queryFunction,
             dataPartitioning,
             query -> LuceneSliceQueue.PartitioningStrategy.SHARD,
+            LuceneOperator.SMALL_INDEX_BOUNDARY,
             taskConcurrency,
             limit,
             false,

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneOperator.java
@@ -47,6 +47,12 @@ public abstract class LuceneOperator extends SourceOperator {
 
     public static final int NO_LIMIT = Integer.MAX_VALUE;
 
+    /**
+     * {@link DataPartitioning#AUTO} resolves to {@link LuceneSliceQueue.PartitioningStrategy#SHARD} for indices
+     * with fewer than this many documents.
+     */
+    public static final int SMALL_INDEX_BOUNDARY = LuceneSliceQueue.MAX_DOCS_PER_SLICE;
+
     protected final IndexedByShardId<? extends RefCounted> refCounteds;
     protected final BlockFactory blockFactory;
 
@@ -103,6 +109,7 @@ public abstract class LuceneOperator extends SourceOperator {
             Function<ShardContext, List<LuceneSliceQueue.QueryAndTags>> queryFunction,
             DataPartitioning dataPartitioning,
             Function<Query, LuceneSliceQueue.PartitioningStrategy> autoStrategy,
+            int docThresholdForAutoStrategy,
             int taskConcurrency,
             int limit,
             boolean needsScore,
@@ -115,6 +122,7 @@ public abstract class LuceneOperator extends SourceOperator {
                 queryFunction,
                 dataPartitioning,
                 autoStrategy,
+                docThresholdForAutoStrategy,
                 taskConcurrency,
                 scoreModeFunction
             );

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneSliceQueue.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneSliceQueue.java
@@ -182,6 +182,7 @@ public final class LuceneSliceQueue {
         Function<ShardContext, List<QueryAndTags>> queryFunction,
         DataPartitioning dataPartitioning,
         Function<Query, PartitioningStrategy> autoStrategy,
+        int docThresholdForAutoStrategy,
         int taskConcurrency,
         Function<ShardContext, ScoreMode> scoreModeFunction
     ) {
@@ -206,7 +207,7 @@ public final class LuceneSliceQueue {
                 } catch (IOException e) {
                     throw new UncheckedIOException(e);
                 }
-                PartitioningStrategy partitioning = PartitioningStrategy.pick(dataPartitioning, autoStrategy, ctx, query);
+                PartitioningStrategy partitioning = PartitioningStrategy.pick(dataPartitioning, autoStrategy, docThresholdForAutoStrategy, ctx, query);
                 partitioningStrategies.put(ctx.shardIdentifier(), partitioning);
                 List<List<PartialLeafReaderContext>> groups = partitioning.groups(ctx.searcher(), taskConcurrency);
                 Weight weight = weight(ctx, query, scoreMode);
@@ -291,6 +292,7 @@ public final class LuceneSliceQueue {
         private static PartitioningStrategy pick(
             DataPartitioning dataPartitioning,
             Function<Query, PartitioningStrategy> autoStrategy,
+            int docThresholdForAutoStrategy,
             ShardContext ctx,
             Query query
         ) {
@@ -298,18 +300,17 @@ public final class LuceneSliceQueue {
                 case SHARD -> PartitioningStrategy.SHARD;
                 case SEGMENT -> PartitioningStrategy.SEGMENT;
                 case DOC -> PartitioningStrategy.DOC;
-                case AUTO -> forAuto(autoStrategy, ctx, query);
+                case AUTO -> forAuto(autoStrategy, ctx, query, docThresholdForAutoStrategy);
             };
         }
 
-        /**
-         * {@link DataPartitioning#AUTO} resolves to {@link #SHARD} for indices
-         * with fewer than this many documents.
-         */
-        private static final int SMALL_INDEX_BOUNDARY = MAX_DOCS_PER_SLICE;
-
-        private static PartitioningStrategy forAuto(Function<Query, PartitioningStrategy> autoStrategy, ShardContext ctx, Query query) {
-            if (ctx.searcher().getIndexReader().maxDoc() < SMALL_INDEX_BOUNDARY) {
+        private static PartitioningStrategy forAuto(
+            Function<Query, PartitioningStrategy> autoStrategy,
+            ShardContext ctx,
+            Query query,
+            int docThresholdForAutoStrategy
+        ) {
+            if (ctx.searcher().getIndexReader().maxDoc() < docThresholdForAutoStrategy) {
                 return PartitioningStrategy.SHARD;
             }
             return autoStrategy.apply(query);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneSliceQueue.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneSliceQueue.java
@@ -207,7 +207,13 @@ public final class LuceneSliceQueue {
                 } catch (IOException e) {
                     throw new UncheckedIOException(e);
                 }
-                PartitioningStrategy partitioning = PartitioningStrategy.pick(dataPartitioning, autoStrategy, docThresholdForAutoStrategy, ctx, query);
+                PartitioningStrategy partitioning = PartitioningStrategy.pick(
+                    dataPartitioning,
+                    autoStrategy,
+                    docThresholdForAutoStrategy,
+                    ctx,
+                    query
+                );
                 partitioningStrategies.put(ctx.shardIdentifier(), partitioning);
                 List<List<PartialLeafReaderContext>> groups = partitioning.groups(ctx.searcher(), taskConcurrency);
                 Weight weight = weight(ctx, query, scoreMode);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneSourceOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneSourceOperator.java
@@ -81,6 +81,7 @@ public class LuceneSourceOperator extends LuceneOperator {
                 dataPartitioning == DataPartitioning.AUTO ? autoStrategy.pickStrategy(limit) : q -> {
                     throw new UnsupportedOperationException("locked in " + dataPartitioning);
                 },
+                LuceneOperator.SMALL_INDEX_BOUNDARY,
                 taskConcurrency,
                 limit,
                 needsScore,
@@ -154,7 +155,7 @@ public class LuceneSourceOperator extends LuceneOperator {
          * </ul>
          */
         private static PartitioningStrategy highSpeedAutoStrategy(Query query) {
-            Query unwrapped = unwrap(query);
+            Query unwrapped = unwrapQuery(query);
             log.trace("highSpeedAutoStrategy {} {}", query, unwrapped);
             return switch (unwrapped) {
                 case BooleanQuery q -> highSpeedAutoStrategyForBoolean(q);
@@ -164,7 +165,7 @@ public class LuceneSourceOperator extends LuceneOperator {
             };
         }
 
-        private static Query unwrap(Query query) {
+        static Query unwrapQuery(Query query) {
             while (true) {
                 switch (query) {
                     case BoostQuery q: {
@@ -194,7 +195,7 @@ public class LuceneSourceOperator extends LuceneOperator {
             List<PartitioningStrategy> clauses = new ArrayList<>(query.clauses().size());
             boolean allRequired = true;
             for (BooleanClause c : query) {
-                Query clauseQuery = unwrap(c.query());
+                Query clauseQuery = unwrapQuery(c.query());
                 log.trace("highSpeedAutoStrategyForBooleanClause {} {}", c.occur(), clauseQuery);
                 if ((c.isProhibited() && clauseQuery instanceof MatchAllDocsQuery)
                     || (c.isRequired() && clauseQuery instanceof MatchNoDocsQuery)) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneTopNSourceOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneTopNSourceOperator.java
@@ -74,6 +74,7 @@ public final class LuceneTopNSourceOperator extends LuceneOperator {
                 queryFunction,
                 dataPartitioning,
                 query -> LuceneSliceQueue.PartitioningStrategy.SHARD,
+                LuceneOperator.SMALL_INDEX_BOUNDARY,
                 taskConcurrency,
                 limit,
                 needsScore,

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/OperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/OperatorTests.java
@@ -512,6 +512,7 @@ public class OperatorTests extends MapperServiceTestCase {
             new IndexedByShardIdFromSingleton<>(searchContext),
             ctx -> queryAndTags,
             randomFrom(DataPartitioning.values()),
+            LuceneOperator.SMALL_INDEX_BOUNDARY,
             randomIntBetween(1, 10),
             tagTypes,
             LuceneOperator.NO_LIMIT

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/LuceneCountOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/LuceneCountOperatorTests.java
@@ -54,6 +54,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.matchesRegex;
 
@@ -93,6 +94,11 @@ public class LuceneCountOperatorTests extends SourceOperatorTestCase {
                     assertThat(count, equalTo((long) numDocs));
                 }
             }
+
+            @Override
+            LuceneSliceQueue.PartitioningStrategy expectedPartitioning() {
+                return LuceneSliceQueue.PartitioningStrategy.SHARD;
+            }
         },
         MATCH_0 {
             @Override
@@ -114,6 +120,11 @@ public class LuceneCountOperatorTests extends SourceOperatorTestCase {
                     count += getCount(p);
                 }
                 assertThat(count, equalTo((long) Math.min(numDocs, 1)));
+            }
+
+            @Override
+            LuceneSliceQueue.PartitioningStrategy expectedPartitioning() {
+                return LuceneSliceQueue.PartitioningStrategy.SEGMENT;
             }
         },
         MATCH_0_AND_1 {
@@ -141,6 +152,11 @@ public class LuceneCountOperatorTests extends SourceOperatorTestCase {
                     matcher = matcher.entry(456, 1L);
                 }
                 assertMap(counts, matcher);
+            }
+
+            @Override
+            LuceneSliceQueue.PartitioningStrategy expectedPartitioning() {
+                return LuceneSliceQueue.PartitioningStrategy.SEGMENT;
             }
         },
         LTE_100_GT_100 {
@@ -186,6 +202,11 @@ public class LuceneCountOperatorTests extends SourceOperatorTestCase {
                 assertThat(counts.keySet(), hasSize(either(equalTo(1)).or(equalTo(2))));
                 assertMap(counts, matcher);
             }
+
+            @Override
+            LuceneSliceQueue.PartitioningStrategy expectedPartitioning() {
+                return LuceneSliceQueue.PartitioningStrategy.SEGMENT;
+            }
         };
 
         abstract List<LuceneSliceQueue.QueryAndTags> queryAndExtra();
@@ -193,6 +214,8 @@ public class LuceneCountOperatorTests extends SourceOperatorTestCase {
         abstract List<ElementType> tagTypes();
 
         abstract void checkPages(int numDocs, int limit, List<Page> results);
+
+        abstract LuceneSliceQueue.PartitioningStrategy expectedPartitioning();
 
         // TODO check for the count of count shortcuts taken
     }
@@ -244,6 +267,7 @@ public class LuceneCountOperatorTests extends SourceOperatorTestCase {
             new IndexedByShardIdFromSingleton<>(ctx),
             queryFunction,
             dataPartitioning,
+            1,
             between(1, 8),
             testCase.tagTypes(),
             limit
@@ -314,6 +338,19 @@ public class LuceneCountOperatorTests extends SourceOperatorTestCase {
         OperatorTestCase.runDriver(drivers);
         assertThat(results.size(), lessThanOrEqualTo(taskConcurrency));
         testCase.checkPages(size, limit, results);
+        var expectedStrategy = switch (dataPartitioning) {
+            case SHARD -> LuceneSliceQueue.PartitioningStrategy.SHARD;
+            case SEGMENT -> LuceneSliceQueue.PartitioningStrategy.SEGMENT;
+            case AUTO, DOC -> size >= 1 ? testCase.expectedPartitioning() : LuceneSliceQueue.PartitioningStrategy.SHARD;
+        };
+        for (Driver driver : drivers) {
+            LuceneOperator.Status status = (LuceneOperator.Status) driver.status().completedOperators().get(0).status();
+            assertNotNull(status);
+            var strategies = status.partitioningStrategies();
+            for (var strategy : strategies.values()) {
+                assertThat(strategies.toString(), strategy, is(expectedStrategy));
+            }
+        }
     }
 
     private static long getCount(Page p) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
@@ -416,6 +416,7 @@ public class EsPhysicalOperationProviders extends AbstractPhysicalOperationProvi
             shardContexts,
             queryFunction,
             context.queryPragmas().dataPartitioning(plannerSettings.defaultDataPartitioning()),
+            LuceneOperator.SMALL_INDEX_BOUNDARY,
             context.queryPragmas().taskConcurrency(),
             tagTypes,
             limit == null ? NO_LIMIT : (Integer) limit.fold(context.foldCtx())


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Do not enable doc-partitioning for count (#143544)](https://github.com/elastic/elasticsearch/pull/143544)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)