### PR TITLE
[8.19] Do not enable doc-partitioning for count (#143544)

### DIFF
--- a/docs/changelog/143544.yaml
+++ b/docs/changelog/143544.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 134512
+pr: 143544
+summary: Do not enable doc-partitioning for count
+type: bug

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneCountOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneCountOperator.java
@@ -9,6 +9,9 @@ package org.elasticsearch.compute.lucene;
 
 import org.apache.lucene.search.DocIdStream;
 import org.apache.lucene.search.LeafCollector;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.MatchNoDocsQuery;
+import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Scorable;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Weight;
@@ -45,14 +48,17 @@ public class LuceneCountOperator extends LuceneOperator {
             List<? extends ShardContext> contexts,
             Function<ShardContext, List<LuceneSliceQueue.QueryAndTags>> queryFunction,
             DataPartitioning dataPartitioning,
+            int docThresholdForAutoStrategy,
             int taskConcurrency,
             int limit
         ) {
             super(
                 contexts,
                 queryFunction,
-                dataPartitioning,
-                query -> LuceneSliceQueue.PartitioningStrategy.SHARD,
+                // don't enable doc-partitioning for count see #partitioningStrategyForCount
+                dataPartitioning == DataPartitioning.DOC ? DataPartitioning.AUTO : dataPartitioning,
+                LuceneCountOperator::partitioningStrategyForCount,
+                docThresholdForAutoStrategy,
                 taskConcurrency,
                 limit,
                 false,
@@ -128,16 +134,9 @@ public class LuceneCountOperator extends LuceneOperator {
                 // see org.apache.lucene.search.TotalHitCountCollector
                 int leafCount = weight.count(leafReaderContext);
                 if (leafCount != -1) {
-                    // make sure to NOT multi count as the count _shortcut_ (which is segment wide)
-                    // handle doc partitioning where the same leaf can be seen multiple times
-                    // since the count is global, consider it only for the first partition and skip the rest
-                    // SHARD, SEGMENT and the first DOC_ reader in data partitioning contain the first doc (position 0)
-                    if (scorer.position() == 0) {
-                        // check to not count over the desired number of docs/limit
-                        var count = Math.min(leafCount, remainingDocs);
-                        totalHits += count;
-                        remainingDocs -= count;
-                    }
+                    var count = Math.min(leafCount, remainingDocs);
+                    totalHits += count;
+                    remainingDocs -= count;
                     scorer.markAsDone();
                 } else {
                     // could not apply shortcut, trigger the search
@@ -170,5 +169,19 @@ public class LuceneCountOperator extends LuceneOperator {
     @Override
     protected void describe(StringBuilder sb) {
         sb.append(", remainingDocs=").append(remainingDocs);
+    }
+
+    /**
+     * We can't use Weight.count() with doc-partitioning because if the query gets cached mid-way, the count becomes incorrect.
+     * Over-counting occurs when some parts are counted doc-by-doc while the first part is counted entirely via the cached shortcut.
+     * Under-counting occurs when the first part is not cached but later parts are, causing those parts to be skipped.
+     * To make doc-partitioning work properly for count, we would need coordination between threads.
+     */
+    static LuceneSliceQueue.PartitioningStrategy partitioningStrategyForCount(Query q) {
+        final Query unwrapped = LuceneSourceOperator.Factory.unwrapQuery(q);
+        if (unwrapped instanceof MatchAllDocsQuery || unwrapped instanceof MatchNoDocsQuery) {
+            return LuceneSliceQueue.PartitioningStrategy.SHARD;
+        }
+        return LuceneSliceQueue.PartitioningStrategy.SEGMENT;
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneMaxFactory.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneMaxFactory.java
@@ -125,6 +125,7 @@ public final class LuceneMaxFactory extends LuceneOperator.Factory {
             queryFunction,
             dataPartitioning,
             query -> LuceneSliceQueue.PartitioningStrategy.SHARD,
+            LuceneOperator.SMALL_INDEX_BOUNDARY,
             taskConcurrency,
             limit,
             false,

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneMinFactory.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneMinFactory.java
@@ -125,6 +125,7 @@ public final class LuceneMinFactory extends LuceneOperator.Factory {
             queryFunction,
             dataPartitioning,
             query -> LuceneSliceQueue.PartitioningStrategy.SHARD,
+            LuceneOperator.SMALL_INDEX_BOUNDARY,
             taskConcurrency,
             limit,
             false,

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneOperator.java
@@ -48,6 +48,12 @@ public abstract class LuceneOperator extends SourceOperator {
 
     public static final int NO_LIMIT = Integer.MAX_VALUE;
 
+    /**
+     * {@link DataPartitioning#AUTO} resolves to {@link LuceneSliceQueue.PartitioningStrategy#SHARD} for indices
+     * with fewer than this many documents.
+     */
+    public static final int SMALL_INDEX_BOUNDARY = LuceneSliceQueue.MAX_DOCS_PER_SLICE;
+
     protected final BlockFactory blockFactory;
 
     /**
@@ -96,6 +102,7 @@ public abstract class LuceneOperator extends SourceOperator {
             Function<ShardContext, List<LuceneSliceQueue.QueryAndTags>> queryFunction,
             DataPartitioning dataPartitioning,
             Function<Query, LuceneSliceQueue.PartitioningStrategy> autoStrategy,
+            int docThresholdForAutoStrategy,
             int taskConcurrency,
             int limit,
             boolean needsScore,
@@ -108,6 +115,7 @@ public abstract class LuceneOperator extends SourceOperator {
                 queryFunction,
                 dataPartitioning,
                 autoStrategy,
+                docThresholdForAutoStrategy,
                 taskConcurrency,
                 scoreModeFunction
             );

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneSliceQueue.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneSliceQueue.java
@@ -106,6 +106,7 @@ public final class LuceneSliceQueue {
         Function<ShardContext, List<QueryAndTags>> queryFunction,
         DataPartitioning dataPartitioning,
         Function<Query, PartitioningStrategy> autoStrategy,
+        int docThresholdForAutoStrategy,
         int taskConcurrency,
         Function<ShardContext, ScoreMode> scoreModeFunction
     ) {
@@ -129,7 +130,7 @@ public final class LuceneSliceQueue {
                 } catch (IOException e) {
                     throw new UncheckedIOException(e);
                 }
-                PartitioningStrategy partitioning = PartitioningStrategy.pick(dataPartitioning, autoStrategy, ctx, query);
+                PartitioningStrategy partitioning = PartitioningStrategy.pick(dataPartitioning, autoStrategy, docThresholdForAutoStrategy, ctx, query);
                 partitioningStrategies.put(ctx.shardIdentifier(), partitioning);
                 List<List<PartialLeafReaderContext>> groups = partitioning.groups(ctx.searcher(), taskConcurrency);
                 Weight weight = weight(ctx, query, scoreMode);
@@ -247,6 +248,7 @@ public final class LuceneSliceQueue {
         private static PartitioningStrategy pick(
             DataPartitioning dataPartitioning,
             Function<Query, PartitioningStrategy> autoStrategy,
+            int docThresholdForAutoStrategy,
             ShardContext ctx,
             Query query
         ) {
@@ -254,18 +256,12 @@ public final class LuceneSliceQueue {
                 case SHARD -> PartitioningStrategy.SHARD;
                 case SEGMENT -> PartitioningStrategy.SEGMENT;
                 case DOC -> PartitioningStrategy.DOC;
-                case AUTO -> forAuto(autoStrategy, ctx, query);
+                case AUTO -> forAuto(autoStrategy, ctx, query, docThresholdForAutoStrategy);
             };
         }
 
-        /**
-         * {@link DataPartitioning#AUTO} resolves to {@link #SHARD} for indices
-         * with fewer than this many documents.
-         */
-        private static final int SMALL_INDEX_BOUNDARY = MAX_DOCS_PER_SLICE;
-
-        private static PartitioningStrategy forAuto(Function<Query, PartitioningStrategy> autoStrategy, ShardContext ctx, Query query) {
-            if (ctx.searcher().getIndexReader().maxDoc() < SMALL_INDEX_BOUNDARY) {
+        private static PartitioningStrategy forAuto(Function<Query, PartitioningStrategy> autoStrategy, ShardContext ctx, Query query, int docThresholdForAutoStrategy) {
+            if (ctx.searcher().getIndexReader().maxDoc() < docThresholdForAutoStrategy) {
                 return PartitioningStrategy.SHARD;
             }
             return autoStrategy.apply(query);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneSliceQueue.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneSliceQueue.java
@@ -130,7 +130,13 @@ public final class LuceneSliceQueue {
                 } catch (IOException e) {
                     throw new UncheckedIOException(e);
                 }
-                PartitioningStrategy partitioning = PartitioningStrategy.pick(dataPartitioning, autoStrategy, docThresholdForAutoStrategy, ctx, query);
+                PartitioningStrategy partitioning = PartitioningStrategy.pick(
+                    dataPartitioning,
+                    autoStrategy,
+                    docThresholdForAutoStrategy,
+                    ctx,
+                    query
+                );
                 partitioningStrategies.put(ctx.shardIdentifier(), partitioning);
                 List<List<PartialLeafReaderContext>> groups = partitioning.groups(ctx.searcher(), taskConcurrency);
                 Weight weight = weight(ctx, query, scoreMode);
@@ -260,7 +266,12 @@ public final class LuceneSliceQueue {
             };
         }
 
-        private static PartitioningStrategy forAuto(Function<Query, PartitioningStrategy> autoStrategy, ShardContext ctx, Query query, int docThresholdForAutoStrategy) {
+        private static PartitioningStrategy forAuto(
+            Function<Query, PartitioningStrategy> autoStrategy,
+            ShardContext ctx,
+            Query query,
+            int docThresholdForAutoStrategy
+        ) {
             if (ctx.searcher().getIndexReader().maxDoc() < docThresholdForAutoStrategy) {
                 return PartitioningStrategy.SHARD;
             }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneSourceOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneSourceOperator.java
@@ -77,6 +77,7 @@ public class LuceneSourceOperator extends LuceneOperator {
                 queryFunction,
                 dataPartitioning,
                 autoStrategy(limit),
+                LuceneOperator.SMALL_INDEX_BOUNDARY,
                 taskConcurrency,
                 limit,
                 needsScore,
@@ -149,7 +150,7 @@ public class LuceneSourceOperator extends LuceneOperator {
          * </ul>
          */
         private static PartitioningStrategy highSpeedAutoStrategy(Query query) {
-            Query unwrapped = unwrap(query);
+            Query unwrapped = unwrapQuery(query);
             log.trace("highSpeedAutoStrategy {} {}", query, unwrapped);
             if (unwrapped instanceof BooleanQuery q) {
                 return highSpeedAutoStrategyForBoolean(q);
@@ -163,7 +164,7 @@ public class LuceneSourceOperator extends LuceneOperator {
             return SEGMENT;
         }
 
-        private static Query unwrap(Query query) {
+        static Query unwrapQuery(Query query) {
             while (true) {
                 if (query instanceof BoostQuery q) {
                     query = q.getQuery();
@@ -190,7 +191,7 @@ public class LuceneSourceOperator extends LuceneOperator {
             List<PartitioningStrategy> clauses = new ArrayList<>(query.clauses().size());
             boolean allRequired = true;
             for (BooleanClause c : query) {
-                Query clauseQuery = unwrap(c.getQuery());
+                Query clauseQuery = unwrapQuery(c.getQuery());
                 log.trace("highSpeedAutoStrategyForBooleanClause {} {}", c.getOccur(), clauseQuery);
                 if ((c.isProhibited() && clauseQuery instanceof MatchAllDocsQuery)
                     || (c.isRequired() && clauseQuery instanceof MatchNoDocsQuery)) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneTopNSourceOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneTopNSourceOperator.java
@@ -74,6 +74,7 @@ public final class LuceneTopNSourceOperator extends LuceneOperator {
                 queryFunction,
                 dataPartitioning,
                 query -> LuceneSliceQueue.PartitioningStrategy.SHARD,
+                LuceneOperator.SMALL_INDEX_BOUNDARY,
                 taskConcurrency,
                 limit,
                 needsScore,

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/OperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/OperatorTests.java
@@ -49,6 +49,7 @@ import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.lucene.DataPartitioning;
+import org.elasticsearch.compute.lucene.LuceneCountOperator;
 import org.elasticsearch.compute.lucene.LuceneOperator;
 import org.elasticsearch.compute.lucene.LuceneSliceQueue;
 import org.elasticsearch.compute.lucene.LuceneSourceOperator;
@@ -596,6 +597,21 @@ public class OperatorTests extends MapperServiceTestCase {
             randomPageSize(),
             limit,
             false // no scoring
+        );
+    }
+
+    static LuceneOperator.Factory luceneCountOperatorFactory(
+        IndexReader reader,
+        List<LuceneSliceQueue.QueryAndTags> queryAndTags
+    ) {
+        final ShardContext searchContext = new LuceneSourceOperatorTests.MockShardContext(reader, 0);
+        return new LuceneCountOperator.Factory(
+            List.of(searchContext),
+            ctx -> queryAndTags,
+            randomFrom(DataPartitioning.values()),
+            LuceneOperator.SMALL_INDEX_BOUNDARY,
+            randomIntBetween(1, 10),
+            LuceneOperator.NO_LIMIT
         );
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/OperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/OperatorTests.java
@@ -600,10 +600,7 @@ public class OperatorTests extends MapperServiceTestCase {
         );
     }
 
-    static LuceneOperator.Factory luceneCountOperatorFactory(
-        IndexReader reader,
-        List<LuceneSliceQueue.QueryAndTags> queryAndTags
-    ) {
+    static LuceneOperator.Factory luceneCountOperatorFactory(IndexReader reader, List<LuceneSliceQueue.QueryAndTags> queryAndTags) {
         final ShardContext searchContext = new LuceneSourceOperatorTests.MockShardContext(reader, 0);
         return new LuceneCountOperator.Factory(
             List.of(searchContext),

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/LuceneCountOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/LuceneCountOperatorTests.java
@@ -93,6 +93,7 @@ public class LuceneCountOperatorTests extends AnyOperatorTestCase {
             List.of(ctx),
             c -> List.of(new LuceneSliceQueue.QueryAndTags(query, List.of())),
             dataPartitioning,
+            1,
             between(1, 8),
             limit
         );

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
@@ -252,6 +252,7 @@ public class EsPhysicalOperationProviders extends AbstractPhysicalOperationProvi
             shardContexts,
             querySupplier(queryBuilder),
             context.queryPragmas().dataPartitioning(physicalSettings.defaultDataPartitioning()),
+            LuceneOperator.SMALL_INDEX_BOUNDARY,
             context.queryPragmas().taskConcurrency(),
             limit == null ? NO_LIMIT : (Integer) limit.fold(context.foldCtx())
         );


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Do not enable doc-partitioning for count (#143544)](https://github.com/elastic/elasticsearch/pull/143544)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)