### PR TITLE
[9.3] Pre-allocate full capacity for first few buckets in HLL (#142363)

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/HyperLogLogPlusPlusTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/HyperLogLogPlusPlusTests.java
@@ -214,10 +214,11 @@ public class HyperLogLogPlusPlusTests extends ESTestCase {
 
     public void testDynamicGrowth() {
         int numGroups = between(1000, 10_000);
-        int numValuesPerGroup = between(1, 20);
+        int numValuesPerGroup = between(1, 14);
         long requiredBytesOneGroup = 32L * 4L + 48L + 8L; // 48 bytes overhead each group + 8L bytes for the object reference in the array
         long requiredBytes = requiredBytesOneGroup * numGroups;
         requiredBytes += 2 * PageCacheRecycler.PAGE_SIZE_IN_BYTES; // extra pages for the object array
+        requiredBytes += 10 * PageCacheRecycler.PAGE_SIZE_IN_BYTES; // full allocations for the first few groups
         CircuitBreaker breaker = new MockBigArrays.LimitedBreaker("test", ByteSizeValue.ofBytes(requiredBytes));
         BigArrays bigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, ByteSizeValue.ofBytes(requiredBytes));
         int precision = 14;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Pre-allocate full capacity for first few buckets in HLL (#142363)](https://github.com/elastic/elasticsearch/pull/142363)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)