### PR TITLE
[8.19] Deep copy BytesRef when creating a constant vector block (#141242)

### DIFF
--- a/docs/changelog/141242.yaml
+++ b/docs/changelog/141242.yaml
@@ -1,0 +1,8 @@
+pr: 141242
+summary: Deep copy `BytesRef` when creating a constant vector block
+area: ES|QL
+type: bug
+issues:
+ - 140615
+ - 140809
+ - 140621

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantBytesRefVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantBytesRefVector.java
@@ -115,13 +115,13 @@ final class ConstantBytesRefVector extends AbstractVector implements BytesRefVec
         return true;
     }
 
-    public static long ramBytesUsed(BytesRef value) {
-        return BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOf(value.bytes);
+    public static long ramBytesUsedWithLength(BytesRef value) {
+        return BASE_RAM_BYTES_USED + RamUsageEstimator.alignObjectSize(RamUsageEstimator.NUM_BYTES_ARRAY_HEADER + value.length);
     }
 
     @Override
     public long ramBytesUsed() {
-        return ramBytesUsed(value);
+        return ramBytesUsedWithLength(value);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockFactory.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockFactory.java
@@ -413,15 +413,13 @@ public class BlockFactory {
     }
 
     public BytesRefBlock newConstantBytesRefBlockWith(BytesRef value, int positions) {
-        var b = new ConstantBytesRefVector(value, positions, this).asBlock();
-        adjustBreaker(b.ramBytesUsed());
-        return b;
+        return newConstantBytesRefVector(value, positions).asBlock();
     }
 
     public BytesRefVector newConstantBytesRefVector(BytesRef value, int positions) {
-        long preadjusted = ConstantBytesRefVector.ramBytesUsed(value);
+        long preadjusted = ConstantBytesRefVector.ramBytesUsedWithLength(value);
         adjustBreaker(preadjusted);
-        var v = new ConstantBytesRefVector(value, positions, this);
+        var v = new ConstantBytesRefVector(BytesRef.deepCopyOf(value), positions, this);
         assert v.ramBytesUsed() == preadjusted;
         return v;
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/SingletonOrdinalsBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/SingletonOrdinalsBuilder.java
@@ -58,6 +58,39 @@ public class SingletonOrdinalsBuilder implements BlockLoader.SingletonOrdinalsBu
         throw new UnsupportedOperationException("should only have one value per doc");
     }
 
+    private BytesRefBlock tryBuildConstantBlock() {
+        if (minOrd != maxOrd) {
+            return null;
+        }
+        for (int ord : ords) {
+            if (ord == -1) {
+                return null;
+            }
+        }
+        final BytesRef v;
+        try {
+            v = docValues.lookupOrd(minOrd);
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to lookup ordinals", e);
+        }
+        BytesRefVector bytes = null;
+        IntVector ordinals = null;
+        boolean success = false;
+        try {
+            bytes = blockFactory.newConstantBytesRefVector(v, 1);
+            ordinals = blockFactory.newConstantIntVector(0, ords.length);
+            // Ideally, we would return a ConstantBytesRefVector, but we return an ordinal constant block instead
+            // to ensure ordinal optimizations are applied when constant optimization is not available.
+            final var result = new OrdinalBytesRefBlock(ordinals.asBlock(), bytes);
+            success = true;
+            return result;
+        } finally {
+            if (success == false) {
+                Releasables.close(bytes, ordinals);
+            }
+        }
+    }
+
     BytesRefBlock buildOrdinal() {
         int valueCount = maxOrd - minOrd + 1;
         long breakerSize = ordsSize(valueCount);
@@ -166,6 +199,10 @@ public class SingletonOrdinalsBuilder implements BlockLoader.SingletonOrdinalsBu
 
     @Override
     public BytesRefBlock build() {
+        var constantBlock = tryBuildConstantBlock();
+        if (constantBlock != null) {
+            return constantBlock;
+        }
         return shouldBuildOrdinalsBlock() ? buildOrdinal() : buildRegularBlock();
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ConstantVector.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ConstantVector.java.st
@@ -179,13 +179,13 @@ $endif$
     }
 
 $if(BytesRef)$
-    public static long ramBytesUsed(BytesRef value) {
-        return BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOf(value.bytes);
+    public static long ramBytesUsedWithLength(BytesRef value) {
+        return BASE_RAM_BYTES_USED + RamUsageEstimator.alignObjectSize(RamUsageEstimator.NUM_BYTES_ARRAY_HEADER + value.length);
     }
 
     @Override
     public long ramBytesUsed() {
-        return ramBytesUsed(value);
+        return ramBytesUsedWithLength(value);
     }
 
 $else$

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicBlockTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicBlockTests.java
@@ -753,27 +753,34 @@ public class BasicBlockTests extends ESTestCase {
         for (int i = 0; i < 1000; i++) {
             int positionCount = randomIntBetween(1, 16 * 1024);
             BytesRef value = new BytesRef(randomByteArrayOfLength(between(1, 20)));
+            BytesRef originalValue = BytesRef.deepCopyOf(value);
             BytesRefBlock block = blockFactory.newConstantBytesRefBlockWith(value, positionCount);
+            // modify the value after creating the constant block
+            for (int b = 0; b < value.length; b++) {
+                if (randomBoolean()) {
+                    value.bytes[b] = randomByte();
+                }
+            }
             assertThat(block.getPositionCount(), is(positionCount));
 
             BytesRef bytes = new BytesRef();
             bytes = block.getBytesRef(0, bytes);
-            assertThat(bytes, is(value));
+            assertThat(bytes, is(originalValue));
             bytes = block.getBytesRef(positionCount - 1, bytes);
-            assertThat(bytes, is(value));
+            assertThat(bytes, is(originalValue));
             bytes = block.getBytesRef(randomPosition(positionCount), bytes);
-            assertThat(bytes, is(value));
+            assertThat(bytes, is(originalValue));
             assertSingleValueDenseBlock(block);
             if (positionCount > 2) {
                 assertLookup(
                     block,
                     positions(blockFactory, 1, 2, new int[] { 1, 2 }),
-                    List.of(List.of(value), List.of(value), List.of(value, value))
+                    List.of(List.of(originalValue), List.of(originalValue), List.of(originalValue, originalValue))
                 );
                 assertLookup(
                     block,
                     positions(blockFactory, 1, 2),
-                    List.of(List.of(value), List.of(value)),
+                    List.of(List.of(originalValue), List.of(originalValue)),
                     b -> assertThat(b.asVector(), instanceOf(ConstantBytesRefVector.class))
                 );
             }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Deep copy BytesRef when creating a constant vector block (#141242)](https://github.com/elastic/elasticsearch/pull/141242)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)