### PR TITLE
[8.19] Fix pragmas in CrossClusterQueryWithPartialResultsIT (#140110)

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterQueryWithPartialResultsIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterQueryWithPartialResultsIT.java
@@ -124,6 +124,7 @@ public class CrossClusterQueryWithPartialResultsIT extends AbstractCrossClusterT
         // Limit to one shard per batch to prevent all ok shards from being grouped with failed shards,
         // which could cause the ok shards to fail if a failed shard is processed first.
         request.pragmas(new QueryPragmas(Settings.builder().put(QueryPragmas.MAX_CONCURRENT_SHARDS_PER_NODE.getKey(), 1).build()));
+        request.acceptedPragmaRisks(true);
         try (var resp = runQuery(request)) {
             logger.info("--> response {}", resp);
             assertTrue(resp.isPartial());
@@ -158,6 +159,7 @@ public class CrossClusterQueryWithPartialResultsIT extends AbstractCrossClusterT
         // Limit to one shard per batch to prevent all ok shards from being grouped with failed shards,
         // which could cause the ok shards to fail if a failed shard is processed first.
         request.pragmas(new QueryPragmas(Settings.builder().put(QueryPragmas.MAX_CONCURRENT_SHARDS_PER_NODE.getKey(), 1).build()));
+        request.acceptedPragmaRisks(true);
         try (var resp = runQuery(request)) {
             logger.info("--> response {}", resp);
             assertTrue(resp.isPartial());


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Fix pragmas in CrossClusterQueryWithPartialResultsIT (#140110)](https://github.com/elastic/elasticsearch/pull/140110)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)