### PR TITLE
[8.19] Skip spec tests when test cluster broken (#135862)

### DIFF
--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
@@ -136,8 +136,11 @@ public abstract class EsqlSpecTestCase extends ESRestTestCase {
         this.mode = mode;
     }
 
+    protected static boolean testClustersOk = true;
+
     @Before
     public void setup() throws IOException {
+        assumeTrue("test clusters were broken", testClustersOk);
         if (supportsInferenceTestService()) {
             createInferenceEndpoints(adminClient());
         }
@@ -153,6 +156,9 @@ public abstract class EsqlSpecTestCase extends ESRestTestCase {
 
     @AfterClass
     public static void wipeTestData() throws IOException {
+        if (testClustersOk == false) {
+            return;
+        }
         try {
             adminClient().performRequest(new Request("DELETE", "/*"));
         } catch (ResponseException e) {
@@ -174,11 +180,25 @@ public abstract class EsqlSpecTestCase extends ESRestTestCase {
             shouldSkipTest(testName);
             doTest();
         } catch (Exception e) {
+            ensureTestClustersAreOk(e);
             throw reworkException(e);
         }
     }
 
+    protected void ensureTestClustersAreOk(Exception failure) {
+        try {
+            ensureHealth(client(), "", (request) -> {
+                request.addParameter("wait_for_status", "yellow");
+                request.addParameter("level", "shards");
+            });
+        } catch (Exception inner) {
+            testClustersOk = false;
+            failure.addSuppressed(inner);
+        }
+    }
+
     protected void shouldSkipTest(String testName) throws IOException {
+        assumeTrue("test clusters were broken", testClustersOk);
         if (requiresInferenceEndpoint()) {
             assumeTrue("Inference test service needs to be supported", supportsInferenceTestService());
         }
@@ -406,7 +426,9 @@ public abstract class EsqlSpecTestCase extends ESRestTestCase {
     @Before
     @After
     public void assertRequestBreakerEmptyAfterTests() throws Exception {
-        assertRequestBreakerEmpty();
+        if (testClustersOk) {
+            assertRequestBreakerEmpty();
+        }
     }
 
     public static void assertRequestBreakerEmpty() throws Exception {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Skip spec tests when test cluster broken (#135862)](https://github.com/elastic/elasticsearch/pull/135862)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)