### PR TITLE
[8.19] Fix alias id when drop all aggregates (#135247)

### DIFF
--- a/docs/changelog/135247.yaml
+++ b/docs/changelog/135247.yaml
@@ -1,0 +1,5 @@
+pr: 135247
+summary: Fix alias id when drop all aggregates
+area: ES|QL
+type: bug
+issues: []

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/eval.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/eval.csv-spec
@@ -777,3 +777,20 @@ row x = 1
 a:keyword | z:integer | x:integer
 foo       | 1         | 9
 ;
+
+evalAfterGroupingUsingSameName6
+required_capability: fix_alias_id_when_drop_all_aggregates
+from employees
+| stats sum=sum(salary) by last_name, year = bucket(birth_date, 1 year)
+| DROP sum
+| DROP last_name
+| eval year = 12
+| LIMIT 4
+;
+
+year:integer
+12
+12
+12
+12
+;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -1107,6 +1107,8 @@ public class EsqlCapabilities {
          * see <a href="https://github.com/elastic/elasticsearch/issues/146364">ES|QL: _index LIKE with ? #146364</a>
          */
         FIX_INDEX_LIKE_QUESTION_MARK_WILDCARD,
+
+        FIX_ALIAS_ID_WHEN_DROP_ALL_AGGREGATES,
         // Last capability should still have a comma for fewer merge conflicts when adding new ones :)
         // This comment prevents the semicolon from being on the previous capability when Spotless formats the file.
         ;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneColumns.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneColumns.java
@@ -75,9 +75,7 @@ public final class PruneColumns extends Rule<LogicalPlan, LogicalPlan> {
                                 // Aggs cannot produce pages with 0 columns, so retain one grouping.
                                 Attribute attribute = Expressions.attribute(aggregate.groupings().get(0));
                                 NamedExpression firstAggregate = aggregate.aggregates().get(0);
-                                remaining = List.of(
-                                    new Alias(firstAggregate.source(), firstAggregate.name(), attribute, attribute.id())
-                                );
+                                remaining = List.of(new Alias(firstAggregate.source(), firstAggregate.name(), attribute, attribute.id()));
                                 p = aggregate.with(aggregate.groupings(), remaining);
                             }
                         } else {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneColumns.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneColumns.java
@@ -76,7 +76,7 @@ public final class PruneColumns extends Rule<LogicalPlan, LogicalPlan> {
                                 Attribute attribute = Expressions.attribute(aggregate.groupings().get(0));
                                 NamedExpression firstAggregate = aggregate.aggregates().get(0);
                                 remaining = List.of(
-                                    new Alias(firstAggregate.source(), firstAggregate.name(), attribute, firstAggregate.id())
+                                    new Alias(firstAggregate.source(), firstAggregate.name(), attribute, attribute.id())
                                 );
                                 p = aggregate.with(aggregate.groupings(), remaining);
                             }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
@@ -279,6 +279,7 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
 
         assertThat(Expressions.names(agg.groupings()), contains("emp_no"));
         assertThat(Expressions.names(agg.aggregates()), contains("c"));
+        assertThat(agg.aggregates().get(0).id(), equalTo(Expressions.attribute(agg.groupings().get(0)).id()));
 
         var exprs = eval.fields();
         assertThat(exprs.size(), equalTo(1));


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Fix alias id when drop all aggregates (#135247)](https://github.com/elastic/elasticsearch/pull/135247)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)