### PR TITLE
feat(tsdb): add `deltaOfDelta` stage for `@timestamp`

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/index/codec/tsdb/EncodePipelineBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/index/codec/tsdb/EncodePipelineBenchmark.java
@@ -48,26 +48,33 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 /**
- * Per-stage encode benchmark for the ES95 pipeline.
+ * Multi-stage pipeline encode benchmark for the ES95 pipeline.
  *
- * <p>Each {@code stage} parameter builds a minimal pipeline that contains only the named
- * transform plus the {@code bitpack} payload, so the throughput score isolates that stage's
- * contribution. The {@code pattern} parameter feeds inputs that exercise both the apply
- * path and the skip path of every transform, so a regression in any stage shows up as a
- * slowdown on the stage's row for the relevant pattern.
+ * <p>Sibling of {@link EncodePipelineStageBenchmark}, which isolates single transforms.
+ * This class runs full production-shaped pipelines so the per-pattern numbers can be
+ * compared against the realistic refresh workload and against design alternatives.
  *
- * <p>{@code full} runs the production {@code delta>offset>gcd>bitpack} pipeline so the
- * per-pattern numbers can be compared against the realistic refresh workload. For multi
- * stage {@code @timestamp} pipelines, see {@link EncodePipelineBenchmark}.
+ * <p>Reports average time per invocation in microseconds. Each invocation encodes
+ * {@code blocksPerInvocation} blocks, so multiply the score by
+ * {@code 1000 / blocksPerInvocation} to get nanoseconds per 128 value block. The
+ * latency framing matches how the codec is consumed (cost per encoded block) and
+ * lines up with the {@code bytesPerBlock} aux counter that reports compressed size
+ * on the same axis.
  *
- * <h2>Stages</h2>
+ * <p>{@code full} is the baseline production pipeline for non {@code @timestamp} fields.
+ * {@code fullTimestamp} is the production pipeline routed for the {@code @timestamp} field.
+ * {@code fullCascade} is the hypothetical alternative that would result from removing
+ * {@link org.elasticsearch.index.codec.tsdb.pipeline.numeric.stages.DeltaOfDeltaCodecStage}
+ * and applying {@link org.elasticsearch.index.codec.tsdb.pipeline.numeric.stages.DeltaCodecStage}
+ * twice instead. The pair {@code fullTimestamp} vs {@code fullCascade} measures the cost of
+ * running two sequential delta stages vs one dedicated stage, plus the downstream offset and
+ * gcd work.
+ *
+ * <h2>Pipelines</h2>
  * <ul>
- *   <li>{@code delta} - just {@code delta>bitpack}</li>
- *   <li>{@code deltaOfDelta} - just {@code deltaOfDelta>bitpack}</li>
- *   <li>{@code offset} - just {@code offset>bitpack}</li>
- *   <li>{@code gcd} - just {@code gcd>bitpack}</li>
- *   <li>{@code bitpackOnly} - just {@code bitpack}</li>
- *   <li>{@code full} - {@code delta>offset>gcd>bitpack} (production)</li>
+ *   <li>{@code full} - {@code delta>offset>gcd>bitpack} (baseline production)</li>
+ *   <li>{@code fullTimestamp} - {@code deltaOfDelta>offset>bitpack} ({@code @timestamp} production)</li>
+ *   <li>{@code fullCascade} - {@code delta>delta>offset>gcd>bitpack} (two sequential {@code delta} stages instead of one dedicated {@code deltaOfDelta})</li>
  * </ul>
  *
  * <h2>Patterns</h2>
@@ -81,49 +88,52 @@ import java.util.function.Supplier;
  *   <li>{@code lowCardinality} - small palette of values (bitpack uses few bits)</li>
  *   <li>{@code counterWithResets} - monotonic counter with occasional drops</li>
  *   <li>{@code nearConstant} - mostly the same value with rare outliers (offset case)</li>
- *   <li>{@code timestampLike} - timestamps with small jitter around a fixed delta</li>
- *   <li>{@code constantInterval} - timestamps spaced by a perfectly constant interval, no jitter</li>
- *   <li>{@code eventDriven} - irregular bursty timestamps, modeling event ingest (logs, traces)</li>
- *   <li>{@code constantRateOfChange} - timestamps whose interval grows by a fixed amount per step
- *       (jitter free; {@code deltaOfDelta} applies and both passes of a two stage delta cascade gate on)</li>
+ *   <li>{@code timestampLike} - timestamps with small jitter around a fixed delta
+ *       (the second {@code delta} stage of {@code fullCascade} gates off on jitter and skips
+ *       on this pattern)</li>
+ *   <li>{@code constantInterval} - timestamps spaced by a perfectly constant interval, no jitter
+ *       (idealized scrape input; {@code delta>offset} collapses to zeros, {@code deltaOfDelta}
+ *       reaches the same result in one stage)</li>
+ *   <li>{@code eventDriven} - irregular bursty timestamps, modeling event ingest (logs, traces)
+ *       where short bursts are separated by occasional longer gaps</li>
+ *   <li>{@code constantRateOfChange} - timestamps whose interval grows by a fixed amount per
+ *       step (jitter free; both {@code delta} stages of {@code fullCascade} gate on, exercising
+ *       the cost of running two sequential transforms vs one dedicated {@code deltaOfDelta})</li>
  * </ul>
  *
  * <h2>Ready to run commands</h2>
  *
  * <pre>{@code
- * # Full stage x pattern matrix (6 x 13 = 78 rows)
- * ./gradlew :benchmarks:run --args="EncodePipelineStageBenchmark"
+ * # Full pipeline x pattern matrix (3 x 13 = 39 rows)
+ * ./gradlew :benchmarks:run --args="EncodePipelineBenchmark"
  *
- * # Just the production pipeline across all patterns
- * ./gradlew :benchmarks:run --args="EncodePipelineStageBenchmark -p stage=full"
+ * # Realistic @timestamp shape (the second delta in fullCascade skips on jitter)
+ * ./gradlew :benchmarks:run --args="EncodePipelineBenchmark -p pattern=timestampLike"
  *
- * # Drill into a single stage (e.g. spot regressions in gcd)
- * ./gradlew :benchmarks:run --args="EncodePipelineStageBenchmark -p stage=gcd"
- *
- * # Compare gcd against a known-friendly input vs no common factor
- * ./gradlew :benchmarks:run --args="EncodePipelineStageBenchmark -p stage=gcd -p pattern=random,gcdFriendly"
+ * # Compare fullTimestamp vs fullCascade when both delta stages actually apply
+ * ./gradlew :benchmarks:run --args="EncodePipelineBenchmark -p pipeline=fullTimestamp,fullCascade -p pattern=constantRateOfChange"
  *
  * # Allocation rate per pattern (uses JMH built in GC profiler)
- * ./gradlew :benchmarks:run --args="EncodePipelineStageBenchmark -p stage=full -prof gc"
+ * ./gradlew :benchmarks:run --args="EncodePipelineBenchmark -prof gc"
  *
  * # Quick smoke (1 warmup, 1 measurement iteration, 1 fork)
- * ./gradlew :benchmarks:run --args="EncodePipelineStageBenchmark -wi 1 -i 1 -f 1 -w 1 -r 1"
+ * ./gradlew :benchmarks:run --args="EncodePipelineBenchmark -wi 1 -i 1 -f 1 -w 1 -r 1"
  * }</pre>
  */
 @Fork(1)
 @Warmup(iterations = 3, time = 1)
 @Measurement(iterations = 5, time = 2)
-@BenchmarkMode(Mode.Throughput)
+@BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 @State(Scope.Benchmark)
-public class EncodePipelineStageBenchmark {
+public class EncodePipelineBenchmark {
 
     private static final int SEED = 17;
     private static final int EXTRA_METADATA_SIZE = 64;
     private static final int RANDOM_INTEGER_BITS = 32;
 
-    @Param({ "delta", "deltaOfDelta", "offset", "gcd", "bitpackOnly", "full" })
-    private String stage;
+    @Param({ "full", "fullTimestamp", "fullCascade" })
+    private String pipeline;
 
     @Param(
         {
@@ -165,7 +175,7 @@ public class EncodePipelineStageBenchmark {
             outputs[i] = new ByteArrayDataOutput(outputBuffers[i]);
         }
 
-        final PipelineConfig config = configFor(stage, blockSize);
+        final PipelineConfig config = configFor(pipeline, blockSize);
         final NumericEncoder encoder = NumericCodecFactory.DEFAULT.createEncoder(config);
         blockEncoder = encoder.newBlockEncoder();
     }
@@ -182,8 +192,8 @@ public class EncodePipelineStageBenchmark {
     }
 
     /**
-     * Reports the encoded size per 128 value block alongside the throughput score. The size is
-     * deterministic given the stage and pattern, so every invocation overwrites the same value
+     * Reports the encoded size per 128 value block alongside the average time score. The size is
+     * deterministic given the pipeline and pattern, so every invocation overwrites the same value
      * and JMH reports it as the final per iteration reading.
      */
     @AuxCounters(AuxCounters.Type.EVENTS)
@@ -192,15 +202,12 @@ public class EncodePipelineStageBenchmark {
         public int bytesPerBlock;
     }
 
-    private static PipelineConfig configFor(final String stage, final int blockSize) {
-        return switch (stage) {
-            case "delta" -> PipelineConfig.forLongs(blockSize).delta().bitPack();
-            case "deltaOfDelta" -> PipelineConfig.forLongs(blockSize).deltaOfDelta().bitPack();
-            case "offset" -> PipelineConfig.forLongs(blockSize).offset().bitPack();
-            case "gcd" -> PipelineConfig.forLongs(blockSize).gcd().bitPack();
-            case "bitpackOnly" -> PipelineConfig.forLongs(blockSize).bitPack();
+    private static PipelineConfig configFor(final String pipeline, final int blockSize) {
+        return switch (pipeline) {
             case "full" -> PipelineConfig.forLongs(blockSize).delta().offset().gcd().bitPack();
-            default -> throw new IllegalArgumentException("Unknown stage: " + stage);
+            case "fullTimestamp" -> PipelineConfig.forLongs(blockSize).deltaOfDelta().offset().bitPack();
+            case "fullCascade" -> PipelineConfig.forLongs(blockSize).delta().delta().offset().gcd().bitPack();
+            default -> throw new IllegalArgumentException("Unknown pipeline: " + pipeline);
         };
     }
 

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/index/codec/tsdb/internal/ConstantIntervalSupplier.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/index/codec/tsdb/internal/ConstantIntervalSupplier.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.benchmark.index.codec.tsdb.internal;
+
+import java.util.Random;
+import java.util.function.Supplier;
+
+/**
+ * Generates strictly monotonic timestamps spaced by a perfectly constant interval, with no jitter.
+ *
+ * <p>Models the idealized common case for scrape based metric ingestion at the source: every value
+ * is exactly {@code baseDelta} ticks apart from the previous one. After a single {@code delta}
+ * stage the array becomes uniform; after {@code offset} it is all zeros and {@code bitpack} pays
+ * zero bits. {@code deltaOfDelta} reaches the same zero array with one stage instead of two.
+ *
+ * <p>Companion to {@link TimestampLikeSupplier} (same shape with small random jitter) and
+ * {@link ConstantRateOfChangeSupplier} (intervals that grow by a fixed amount per step).
+ */
+public class ConstantIntervalSupplier implements Supplier<long[]> {
+
+    private final Random random;
+    private final int size;
+    private final long baseDelta;
+
+    private ConstantIntervalSupplier(Builder builder) {
+        this.random = new Random(builder.seed);
+        this.size = builder.size;
+        this.baseDelta = builder.baseDelta;
+    }
+
+    /**
+     * Returns a new builder for this supplier.
+     *
+     * @param seed random seed for the starting offset
+     * @param size number of values to generate
+     * @return a new builder instance
+     */
+    public static Builder builder(int seed, int size) {
+        return new Builder(seed, size);
+    }
+
+    @Override
+    public long[] get() {
+        final long[] data = new long[size];
+        long current = random.nextLong(1_000_000L);
+        for (int i = 0; i < size; i++) {
+            data[i] = current;
+            current += baseDelta;
+        }
+        return data;
+    }
+
+    /** Builder for {@link ConstantIntervalSupplier}. */
+    public static class Builder {
+        private final int seed;
+        private final int size;
+        private long baseDelta = 1000L;
+
+        private Builder(int seed, int size) {
+            assert size >= 1 : "size must be positive";
+            this.seed = seed;
+            this.size = size;
+        }
+
+        /**
+         * Sets the constant interval between consecutive timestamps.
+         *
+         * @param baseDelta the interval value (must be positive)
+         * @return this builder
+         */
+        public Builder withBaseDelta(long baseDelta) {
+            assert baseDelta >= 1 : "baseDelta must be positive";
+            this.baseDelta = baseDelta;
+            return this;
+        }
+
+        /**
+         * Builds the supplier.
+         *
+         * @return the configured supplier
+         */
+        public ConstantIntervalSupplier build() {
+            return new ConstantIntervalSupplier(this);
+        }
+    }
+}

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/index/codec/tsdb/internal/ConstantRateOfChangeSupplier.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/index/codec/tsdb/internal/ConstantRateOfChangeSupplier.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.benchmark.index.codec.tsdb.internal;
+
+import java.util.Random;
+import java.util.function.Supplier;
+
+/**
+ * Generates strictly monotonic sequences where the interval between consecutive values grows
+ * by a fixed amount at each step, so the second order difference is a constant.
+ *
+ * <p>Sequence shape: {@code data[i] = T_0 + i * d_0 + i * (i - 1) / 2 * dd}, equivalent to
+ * walking from a starting value with an interval that begins at {@code firstDelta} and grows
+ * by {@code rateOfChange} on every step.
+ *
+ * <p>Useful for benchmarks that need to exercise the {@code deltaOfDelta} apply path under a
+ * clean, jitter free input. Unlike {@link TimestampLikeSupplier}, both passes of a
+ * {@code delta>delta} cascade gate on here (the intervals themselves are also strictly
+ * monotonic), so this is the right pattern to compare a single dedicated
+ * {@code deltaOfDelta} stage against the full cost of two cascaded {@code delta} stages.
+ */
+public class ConstantRateOfChangeSupplier implements Supplier<long[]> {
+
+    private final Random random;
+    private final int size;
+    private final long firstDelta;
+    private final long rateOfChange;
+
+    private ConstantRateOfChangeSupplier(Builder builder) {
+        this.random = new Random(builder.seed);
+        this.size = builder.size;
+        this.firstDelta = builder.firstDelta;
+        this.rateOfChange = builder.rateOfChange;
+    }
+
+    /**
+     * Returns a new builder for this supplier.
+     *
+     * @param seed random seed for the starting offset
+     * @param size number of values to generate
+     * @return a new builder instance
+     */
+    public static Builder builder(int seed, int size) {
+        return new Builder(seed, size);
+    }
+
+    @Override
+    public long[] get() {
+        final long[] data = new long[size];
+        long current = random.nextLong(1_000_000L);
+        long interval = firstDelta;
+        for (int i = 0; i < size; i++) {
+            data[i] = current;
+            current += interval;
+            interval += rateOfChange;
+        }
+        return data;
+    }
+
+    /** Builder for {@link ConstantRateOfChangeSupplier}. */
+    public static class Builder {
+        private final int seed;
+        private final int size;
+        private long firstDelta = 1000L;
+        private long rateOfChange = 10L;
+
+        private Builder(int seed, int size) {
+            assert size >= 1 : "size must be positive";
+            this.seed = seed;
+            this.size = size;
+        }
+
+        /**
+         * Sets the first interval between consecutive values.
+         *
+         * @param firstDelta the starting interval value
+         * @return this builder
+         */
+        public Builder withFirstDelta(long firstDelta) {
+            this.firstDelta = firstDelta;
+            return this;
+        }
+
+        /**
+         * Sets the constant amount the interval grows by at each step. May be negative for
+         * decelerating sequences.
+         *
+         * @param rateOfChange interval increment per step
+         * @return this builder
+         */
+        public Builder withRateOfChange(long rateOfChange) {
+            this.rateOfChange = rateOfChange;
+            return this;
+        }
+
+        /**
+         * Builds the supplier.
+         *
+         * @return the configured supplier
+         */
+        public ConstantRateOfChangeSupplier build() {
+            return new ConstantRateOfChangeSupplier(this);
+        }
+    }
+}

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/index/codec/tsdb/internal/EventDrivenSupplier.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/index/codec/tsdb/internal/EventDrivenSupplier.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.benchmark.index.codec.tsdb.internal;
+
+import java.util.Random;
+import java.util.function.Supplier;
+
+/**
+ * Generates strictly monotonic timestamps with irregular bursty intervals, modeling event driven
+ * workloads such as logs, traces, and security events.
+ *
+ * <p>Each step draws either a short interval (the burst path, with probability {@code burstProbability})
+ * or a long interval (the quiet gap path). The mixture produces clusters of close together
+ * timestamps separated by occasional larger gaps, which is the typical shape of event ingest:
+ * traffic spikes followed by quieter periods.
+ *
+ * <p>The pattern stresses both {@code delta} and {@code deltaOfDelta} differently from regular
+ * scrape data: timestamps are still strictly monotonic so the gate passes, but the post {@code delta}
+ * interval array has a wide value range, leaving more work for {@code offset} and {@code bitpack}
+ * than constant interval inputs do.
+ */
+public class EventDrivenSupplier implements Supplier<long[]> {
+
+    private final Random random;
+    private final int size;
+    private final long burstMin;
+    private final long burstMax;
+    private final long gapMin;
+    private final long gapMax;
+    private final double burstProbability;
+
+    private EventDrivenSupplier(Builder builder) {
+        this.random = new Random(builder.seed);
+        this.size = builder.size;
+        this.burstMin = builder.burstMin;
+        this.burstMax = builder.burstMax;
+        this.gapMin = builder.gapMin;
+        this.gapMax = builder.gapMax;
+        this.burstProbability = builder.burstProbability;
+    }
+
+    /**
+     * Returns a new builder for this supplier.
+     *
+     * @param seed random seed
+     * @param size number of values to generate
+     * @return a new builder instance
+     */
+    public static Builder builder(int seed, int size) {
+        return new Builder(seed, size);
+    }
+
+    @Override
+    public long[] get() {
+        final long[] data = new long[size];
+        long current = random.nextLong(1_000_000L);
+        for (int i = 0; i < size; i++) {
+            data[i] = current;
+            final long interval;
+            if (random.nextDouble() < burstProbability) {
+                interval = burstMin + random.nextLong(burstMax - burstMin + 1);
+            } else {
+                interval = gapMin + random.nextLong(gapMax - gapMin + 1);
+            }
+            current += interval;
+        }
+        return data;
+    }
+
+    /** Builder for {@link EventDrivenSupplier}. */
+    public static class Builder {
+        private final int seed;
+        private final int size;
+        private long burstMin = 1L;
+        private long burstMax = 100L;
+        private long gapMin = 1000L;
+        private long gapMax = 10000L;
+        private double burstProbability = 0.8;
+
+        private Builder(int seed, int size) {
+            assert size >= 1 : "size must be positive";
+            this.seed = seed;
+            this.size = size;
+        }
+
+        /**
+         * Sets the range of short burst intervals.
+         *
+         * @param min lower bound (inclusive, must be positive)
+         * @param max upper bound (inclusive, must be at least {@code min})
+         * @return this builder
+         */
+        public Builder withBurstRange(long min, long max) {
+            assert min >= 1 : "min must be positive";
+            assert max >= min : "max must be at least min";
+            this.burstMin = min;
+            this.burstMax = max;
+            return this;
+        }
+
+        /**
+         * Sets the range of long gap intervals between bursts.
+         *
+         * @param min lower bound (inclusive, must be positive)
+         * @param max upper bound (inclusive, must be at least {@code min})
+         * @return this builder
+         */
+        public Builder withGapRange(long min, long max) {
+            assert min >= 1 : "min must be positive";
+            assert max >= min : "max must be at least min";
+            this.gapMin = min;
+            this.gapMax = max;
+            return this;
+        }
+
+        /**
+         * Sets the probability of drawing a short burst interval on each step. The complement is the
+         * probability of drawing a long gap interval.
+         *
+         * @param burstProbability probability in [0.0, 1.0]
+         * @return this builder
+         */
+        public Builder withBurstProbability(double burstProbability) {
+            assert burstProbability >= 0.0 && burstProbability <= 1.0 : "burstProbability must be in [0.0, 1.0]";
+            this.burstProbability = burstProbability;
+            return this;
+        }
+
+        /**
+         * Builds the supplier.
+         *
+         * @return the configured supplier
+         */
+        public EventDrivenSupplier build() {
+            return new EventDrivenSupplier(this);
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/PipelineConfig.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/PipelineConfig.java
@@ -130,6 +130,17 @@ public record PipelineConfig(
         }
 
         /**
+         * Adds a delta-of-delta encoding stage. Targets near-constant-rate sequences
+         * (e.g. {@code @timestamp}) where second-order differences are zero or small noise.
+         *
+         * @return this builder
+         */
+        public LongBuilder deltaOfDelta() {
+            transforms.add(new StageSpec.DeltaOfDeltaStage());
+            return this;
+        }
+
+        /**
          * Adds a bit-packing payload and builds the configuration.
          *
          * @return the pipeline configuration

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/StageId.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/StageId.java
@@ -29,6 +29,8 @@ public enum StageId {
     OFFSET_STAGE((byte) 0x02, "offset"),
     /** GCD factoring transform stage. */
     GCD_STAGE((byte) 0x03, "gcd"),
+    /** Delta-of-delta encoding transform stage. */
+    DELTA_OF_DELTA_STAGE((byte) 0x04, "deltaOfDelta"),
 
     /** Bit-packing terminal payload stage. */
     BITPACK_PAYLOAD((byte) 0xA1, "bitPack");
@@ -60,6 +62,7 @@ public enum StageId {
             case (byte) 0x01 -> DELTA_STAGE;
             case (byte) 0x02 -> OFFSET_STAGE;
             case (byte) 0x03 -> GCD_STAGE;
+            case (byte) 0x04 -> DELTA_OF_DELTA_STAGE;
             case (byte) 0xA1 -> BITPACK_PAYLOAD;
             default -> throw new IllegalArgumentException("Unknown stage ID: 0x" + Integer.toHexString(id & 0xFF));
         };

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/StageSpec.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/StageSpec.java
@@ -54,6 +54,14 @@ public sealed interface StageSpec {
         }
     }
 
+    /** Delta-of-delta encoding: stores second-order differences for near-constant-rate sequences. */
+    record DeltaOfDeltaStage() implements TransformSpec {
+        @Override
+        public StageId stageId() {
+            return StageId.DELTA_OF_DELTA_STAGE;
+        }
+    }
+
     /** Bit-packing payload: packs values using the minimum number of bits. */
     record BitPackPayload() implements PayloadSpec {
         @Override

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/StaticPipelineConfigResolver.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/StaticPipelineConfigResolver.java
@@ -10,30 +10,45 @@
 package org.elasticsearch.index.codec.tsdb.pipeline;
 
 /**
- * A {@link PipelineConfigResolver} that returns the same pipeline for all fields:
- * {@code delta > offset > gcd > bitpack}. This matches the ES819 baseline
- * encoding and is the default for ES95.
+ * A {@link PipelineConfigResolver} that selects an encoding pipeline by field name.
  *
- * <p>The two production block sizes ({@code 128} and {@code 512}, see
+ * <p>The data stream timestamp field ({@code @timestamp}) is routed to
+ * {@code deltaOfDelta > offset > bitpack}. All other fields use the ES819 baseline
+ * pipeline {@code delta > offset > gcd > bitpack}.
+ *
+ * <p>Both pipelines have their {@link PipelineConfig} precomputed at class load
+ * for the two production block sizes ({@code 128} and {@code 512}, see
  * {@code ES95TSDBDocValuesFormat.NUMERIC_BLOCK_SHIFT} and
- * {@code NUMERIC_LARGE_BLOCK_SHIFT}) have their {@link PipelineConfig} precomputed
- * at class load so the per-field write path reuses a single instance instead of
- * rebuilding the same builder chain on every call. Unknown block sizes (e.g.
- * those used by unit tests) fall back to a fresh build.
+ * {@code NUMERIC_LARGE_BLOCK_SHIFT}) so the per-field write path reuses a single
+ * instance instead of rebuilding the same builder chain on every call. Unknown
+ * block sizes (e.g. those used by unit tests) fall back to a fresh build.
  */
 public final class StaticPipelineConfigResolver implements PipelineConfigResolver {
 
     /** Shared stateless instance; mirrors the {@code INSTANCE} pattern used by stage classes. */
     public static final StaticPipelineConfigResolver INSTANCE = new StaticPipelineConfigResolver();
 
+    static final String TIMESTAMP_FIELD_NAME = "@timestamp";
+
     private static final PipelineConfig BLOCK_128 = build(128);
     private static final PipelineConfig BLOCK_512 = build(512);
+    private static final PipelineConfig TIMESTAMP_128 = buildTimestamp(128);
+    private static final PipelineConfig TIMESTAMP_512 = buildTimestamp(512);
 
     private StaticPipelineConfigResolver() {}
 
     @Override
     public PipelineConfig resolve(final FieldContext context) {
         final int blockSize = context.blockSize();
+        if (TIMESTAMP_FIELD_NAME.equals(context.fieldName())) {
+            if (blockSize == 128) {
+                return TIMESTAMP_128;
+            }
+            if (blockSize == 512) {
+                return TIMESTAMP_512;
+            }
+            return buildTimestamp(blockSize);
+        }
         if (blockSize == 128) {
             return BLOCK_128;
         }
@@ -45,5 +60,9 @@ public final class StaticPipelineConfigResolver implements PipelineConfigResolve
 
     private static PipelineConfig build(final int blockSize) {
         return PipelineConfig.forLongs(blockSize).delta().offset().gcd().bitPack();
+    }
+
+    private static PipelineConfig buildTimestamp(final int blockSize) {
+        return PipelineConfig.forLongs(blockSize).deltaOfDelta().offset().bitPack();
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/StaticPipelineConfigResolver.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/StaticPipelineConfigResolver.java
@@ -63,6 +63,6 @@ public final class StaticPipelineConfigResolver implements PipelineConfigResolve
     }
 
     private static PipelineConfig buildTimestamp(final int blockSize) {
-        return PipelineConfig.forLongs(blockSize).deltaOfDelta().offset().bitPack();
+        return PipelineConfig.forLongs(blockSize).deltaOfDelta().offset().gcd().bitPack();
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/NumericDecodePipeline.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/NumericDecodePipeline.java
@@ -16,6 +16,7 @@ import org.elasticsearch.index.codec.tsdb.pipeline.PipelineDescriptor;
 import org.elasticsearch.index.codec.tsdb.pipeline.StageId;
 import org.elasticsearch.index.codec.tsdb.pipeline.StageSpec;
 import org.elasticsearch.index.codec.tsdb.pipeline.numeric.stages.DeltaCodecStage;
+import org.elasticsearch.index.codec.tsdb.pipeline.numeric.stages.DeltaOfDeltaCodecStage;
 import org.elasticsearch.index.codec.tsdb.pipeline.numeric.stages.GcdCodecStage;
 import org.elasticsearch.index.codec.tsdb.pipeline.numeric.stages.OffsetCodecStage;
 
@@ -95,6 +96,12 @@ public final class NumericDecodePipeline {
                     case DELTA_STAGE -> DeltaCodecStage.decodeStatic((DeltaCodecStage) transformStages[i], values, count, context);
                     case OFFSET_STAGE -> OffsetCodecStage.decodeStatic((OffsetCodecStage) transformStages[i], values, count, context);
                     case GCD_STAGE -> GcdCodecStage.decodeStatic((GcdCodecStage) transformStages[i], values, count, context);
+                    case DELTA_OF_DELTA_STAGE -> DeltaOfDeltaCodecStage.decodeStatic(
+                        (DeltaOfDeltaCodecStage) transformStages[i],
+                        values,
+                        count,
+                        context
+                    );
                     default -> throw new IllegalStateException("Unexpected decode stage: " + stageIds[i]);
                 }
             }

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/NumericEncodePipeline.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/NumericEncodePipeline.java
@@ -18,6 +18,7 @@ import org.elasticsearch.index.codec.tsdb.pipeline.PipelineDescriptor;
 import org.elasticsearch.index.codec.tsdb.pipeline.StageId;
 import org.elasticsearch.index.codec.tsdb.pipeline.StageSpec;
 import org.elasticsearch.index.codec.tsdb.pipeline.numeric.stages.DeltaCodecStage;
+import org.elasticsearch.index.codec.tsdb.pipeline.numeric.stages.DeltaOfDeltaCodecStage;
 import org.elasticsearch.index.codec.tsdb.pipeline.numeric.stages.GcdCodecStage;
 import org.elasticsearch.index.codec.tsdb.pipeline.numeric.stages.OffsetCodecStage;
 
@@ -118,6 +119,12 @@ public final class NumericEncodePipeline {
                     context
                 );
                 case GCD_STAGE -> GcdCodecStage.encodeStatic((GcdCodecStage) transformStages[i], values, context.valueCount(), context);
+                case DELTA_OF_DELTA_STAGE -> DeltaOfDeltaCodecStage.encodeStatic(
+                    (DeltaOfDeltaCodecStage) transformStages[i],
+                    values,
+                    context.valueCount(),
+                    context
+                );
                 default -> throw new IllegalStateException("Unexpected encode stage: " + stageIds[i]);
             }
         }

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/StageFactory.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/StageFactory.java
@@ -16,6 +16,7 @@ import org.elasticsearch.index.codec.tsdb.pipeline.StageId;
 import org.elasticsearch.index.codec.tsdb.pipeline.StageSpec;
 import org.elasticsearch.index.codec.tsdb.pipeline.numeric.stages.BitPackCodecStage;
 import org.elasticsearch.index.codec.tsdb.pipeline.numeric.stages.DeltaCodecStage;
+import org.elasticsearch.index.codec.tsdb.pipeline.numeric.stages.DeltaOfDeltaCodecStage;
 import org.elasticsearch.index.codec.tsdb.pipeline.numeric.stages.GcdCodecStage;
 import org.elasticsearch.index.codec.tsdb.pipeline.numeric.stages.OffsetCodecStage;
 
@@ -44,6 +45,7 @@ public final class StageFactory {
             case StageSpec.DeltaStage ignored -> DeltaCodecStage.INSTANCE;
             case StageSpec.OffsetStage ignored -> OffsetCodecStage.INSTANCE;
             case StageSpec.GcdStage ignored -> GcdCodecStage.INSTANCE;
+            case StageSpec.DeltaOfDeltaStage ignored -> DeltaOfDeltaCodecStage.INSTANCE;
             default -> throw new IllegalArgumentException("Not a transform stage: " + spec);
         };
     }
@@ -77,6 +79,7 @@ public final class StageFactory {
             case DELTA_STAGE -> new StageSpec.DeltaStage();
             case OFFSET_STAGE -> new StageSpec.OffsetStage();
             case GCD_STAGE -> new StageSpec.GcdStage();
+            case DELTA_OF_DELTA_STAGE -> new StageSpec.DeltaOfDeltaStage();
             case BITPACK_PAYLOAD -> new StageSpec.BitPackPayload();
         };
     }

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/stages/DeltaOfDeltaCodecStage.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/stages/DeltaOfDeltaCodecStage.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.tsdb.pipeline.numeric.stages;
+
+import org.elasticsearch.index.codec.tsdb.pipeline.DecodingContext;
+import org.elasticsearch.index.codec.tsdb.pipeline.EncodingContext;
+import org.elasticsearch.index.codec.tsdb.pipeline.StageId;
+import org.elasticsearch.index.codec.tsdb.pipeline.numeric.NumericCodecStage;
+
+import java.io.IOException;
+
+/**
+ * Second order difference transform stage. Targets sequences where the rate of change
+ * itself is roughly constant (linearly growing or shrinking intervals).
+ *
+ * <h2>Effectiveness</h2>
+ * <p>Applied when the sequence is strictly monotonic (at least 2 increases with 0 decreases,
+ * or at least 2 decreases with 0 increases), the same gate as {@link DeltaCodecStage}. The
+ * gate naturally rejects {@code valueCount < 3}, the minimum size at which a second order
+ * difference is defined.
+ *
+ * <p>Sharing the gate with {@link DeltaCodecStage} is intentional: when this stage's gate
+ * fails on non monotonic input, {@code DeltaCodecStage}'s gate would fail on the same input,
+ * so there is no scenario where this stage skips but a single delta fallback could still
+ * apply. The pipeline degrades to {@code offset > bitPack} on raw values either way, the
+ * same outcome a {@code delta > offset > bitPack} pipeline would produce on the same input.
+ *
+ * <h2>Example</h2>
+ * <p>Monotonic ascending {@code [1000, 1100, 1210, 1330, 1460]} (intervals 100, 110, 120, 130)
+ * produces second order differences {@code [10, 10, 10, 10, 10]} in the values array. First value
+ * 1000 and first interval 100 are stored as metadata; the downstream offset stage then subtracts
+ * the constant 10, leaving zeros for bitPack.
+ *
+ * <h2>Metadata layout</h2>
+ * <p>Written to the stage metadata section (see {@link org.elasticsearch.index.codec.tsdb.pipeline.BlockFormat}):
+ * <pre>
+ *   +---------------------+
+ *   | ZLong(first)        |  1 to 10 bytes, zigzag encoded first value
+ *   +---------------------+
+ *   | ZLong(firstDelta)   |  1 to 10 bytes, zigzag encoded first interval
+ *   +---------------------+
+ * </pre>
+ * <p>Storing the first value {@code T_0} and the first interval {@code d_0} in metadata, plus
+ * overwriting positions 0 and 1 with the first second order difference (see encode), keeps the
+ * values array uniform on constant rate input. Without these moves {@code T_0} and {@code T_1}
+ * would remain in the values array, spanning a wide range relative to the small second order
+ * residuals, and {@link OffsetCodecStage} would skip via its {@code |min| < |max|/4} heuristic,
+ * forcing bitPack to encode the full original range.
+ *
+ * <h2>Decode performance</h2>
+ * <p>Decoding is two independent forward prefix sums over the values array, each with the
+ * same shape as {@link DeltaCodecStage#decode}. The two passes are independent (no
+ * interleaved accumulators) so each can be vectorized by the JIT as a standard prefix
+ * sum scan.
+ */
+public final class DeltaOfDeltaCodecStage implements NumericCodecStage {
+
+    /** Singleton instance. */
+    public static final DeltaOfDeltaCodecStage INSTANCE = new DeltaOfDeltaCodecStage();
+
+    private DeltaOfDeltaCodecStage() {}
+
+    @Override
+    public byte id() {
+        return StageId.DELTA_OF_DELTA_STAGE.id;
+    }
+
+    @Override
+    public void encode(final long[] values, final int valueCount, final EncodingContext context) {
+        assert valueCount >= 1 : "valueCount must be at least 1";
+        if (isMonotonic(values, valueCount) == false) {
+            return;
+        }
+        assert valueCount >= 3 : "isMonotonic must reject valueCount < 3 (two strict transitions require at least three values)";
+
+        final long first = values[0];
+        final long firstDelta = values[1] - values[0];
+
+        for (int i = valueCount - 1; i >= 2; i--) {
+            final long previous = values[i - 1];
+            values[i] = (values[i] - previous) - (previous - values[i - 2]);
+        }
+
+        values[0] = values[2];
+        values[1] = values[2];
+
+        context.metadata().writeZLong(first - values[2]);
+        context.metadata().writeZLong(firstDelta);
+    }
+
+    @Override
+    public void decode(final long[] values, final int valueCount, final DecodingContext context) throws IOException {
+        assert valueCount >= 3 : "valueCount must be at least 3 for delta-of-delta decode";
+        final long first = context.metadata().readZLong();
+        final long firstDelta = context.metadata().readZLong();
+
+        values[1] = firstDelta;
+        long delta = firstDelta;
+        for (int i = 2; i < valueCount; i++) {
+            delta += values[i];
+            values[i] = delta;
+        }
+
+        long sum = first;
+        for (int i = 0; i < valueCount; i++) {
+            sum += values[i];
+            values[i] = sum;
+        }
+    }
+
+    public static void encodeStatic(final DeltaOfDeltaCodecStage stage, final long[] values, int valueCount, final EncodingContext context)
+        throws IOException {
+        stage.encode(values, valueCount, context);
+    }
+
+    public static void decodeStatic(final DeltaOfDeltaCodecStage stage, final long[] values, int valueCount, final DecodingContext context)
+        throws IOException {
+        stage.decode(values, valueCount, context);
+    }
+
+    private static boolean isMonotonic(final long[] values, final int valueCount) {
+        int increases = 0;
+        int decreases = 0;
+        for (int i = 1; i < valueCount; i++) {
+            if (values[i] > values[i - 1]) {
+                if (decreases > 0) {
+                    return false;
+                }
+                increases++;
+            } else if (values[i] < values[i - 1]) {
+                if (increases > 0) {
+                    return false;
+                }
+                decreases++;
+            }
+        }
+        return increases >= 2 || decreases >= 2;
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/pipeline/StageSpecTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/pipeline/StageSpecTests.java
@@ -17,6 +17,7 @@ public class StageSpecTests extends ESTestCase {
         assertNotNull(new StageSpec.DeltaStage().stageId());
         assertNotNull(new StageSpec.OffsetStage().stageId());
         assertNotNull(new StageSpec.GcdStage().stageId());
+        assertNotNull(new StageSpec.DeltaOfDeltaStage().stageId());
         assertNotNull(new StageSpec.BitPackPayload().stageId());
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/pipeline/StaticPipelineConfigResolverTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/pipeline/StaticPipelineConfigResolverTests.java
@@ -11,50 +11,63 @@ package org.elasticsearch.index.codec.tsdb.pipeline;
 
 import org.elasticsearch.test.ESTestCase;
 
+import java.util.List;
+
 public class StaticPipelineConfigResolverTests extends ESTestCase {
 
-    public void testResolvesBaselinePipelineShape() {
+    public void testTimestampFieldRoutesToDeltaOfDeltaPipeline() {
         final StaticPipelineConfigResolver resolver = StaticPipelineConfigResolver.INSTANCE;
-        final PipelineConfig config = resolver.resolve(new FieldContext(randomBlockSize(), randomFieldName()));
+        final PipelineConfig config = resolver.resolve(new FieldContext(randomBlockSize(), "@timestamp"));
 
-        assertEquals("delta>offset>gcd>bitPack", config.describeStages());
-        assertEquals(PipelineDescriptor.DataType.LONG, config.dataType());
-        assertEquals(3, config.transforms().size());
-        assertNotNull(config.payload());
+        assertEquals(
+            List.of(StageId.DELTA_OF_DELTA_STAGE, StageId.OFFSET_STAGE, StageId.BITPACK_PAYLOAD),
+            config.specs().stream().map(StageSpec::stageId).toList()
+        );
+    }
+
+    public void testNonTimestampFieldRoutesToBaselinePipeline() {
+        final StaticPipelineConfigResolver resolver = StaticPipelineConfigResolver.INSTANCE;
+        final PipelineConfig config = resolver.resolve(new FieldContext(randomBlockSize(), randomAlphaOfLengthBetween(1, 16)));
+
+        assertEquals(
+            List.of(StageId.DELTA_STAGE, StageId.OFFSET_STAGE, StageId.GCD_STAGE, StageId.BITPACK_PAYLOAD),
+            config.specs().stream().map(StageSpec::stageId).toList()
+        );
     }
 
     public void testPropagatesBlockSizeFromContext() {
         final StaticPipelineConfigResolver resolver = StaticPipelineConfigResolver.INSTANCE;
         final int blockSize = randomBlockSize();
 
-        final PipelineConfig config = resolver.resolve(new FieldContext(blockSize, randomFieldName()));
-
-        assertEquals(blockSize, config.blockSize());
+        assertEquals(blockSize, resolver.resolve(new FieldContext(blockSize, "@timestamp")).blockSize());
+        assertEquals(blockSize, resolver.resolve(new FieldContext(blockSize, randomAlphaOfLengthBetween(1, 16))).blockSize());
     }
 
-    public void testIgnoresFieldName() {
+    public void testTimestampNameIsCaseSensitive() {
         final StaticPipelineConfigResolver resolver = StaticPipelineConfigResolver.INSTANCE;
-        final int blockSize = randomBlockSize();
+        final PipelineConfig config = resolver.resolve(new FieldContext(randomBlockSize(), "@TIMESTAMP"));
 
-        final PipelineConfig first = resolver.resolve(new FieldContext(blockSize, "@timestamp"));
-        final PipelineConfig second = resolver.resolve(new FieldContext(blockSize, "metric.value"));
-
-        assertEquals(first, second);
-    }
-
-    public void testRepeatedResolveReturnsEqualConfigs() {
-        final StaticPipelineConfigResolver resolver = StaticPipelineConfigResolver.INSTANCE;
-        final FieldContext context = new FieldContext(randomBlockSize(), randomFieldName());
-
-        assertEquals(resolver.resolve(context), resolver.resolve(context));
+        assertEquals(
+            List.of(StageId.DELTA_STAGE, StageId.OFFSET_STAGE, StageId.GCD_STAGE, StageId.BITPACK_PAYLOAD),
+            config.specs().stream().map(StageSpec::stageId).toList()
+        );
     }
 
     public void testCachedBlockSizesReturnSameInstance() {
         final StaticPipelineConfigResolver resolver = StaticPipelineConfigResolver.INSTANCE;
         final int blockSize = randomFrom(128, 512);
 
-        final PipelineConfig first = resolver.resolve(new FieldContext(blockSize, randomFieldName()));
-        final PipelineConfig second = resolver.resolve(new FieldContext(blockSize, randomFieldName()));
+        final PipelineConfig first = resolver.resolve(new FieldContext(blockSize, randomAlphaOfLengthBetween(1, 16)));
+        final PipelineConfig second = resolver.resolve(new FieldContext(blockSize, randomAlphaOfLengthBetween(1, 16)));
+        assertSame(first, second);
+    }
+
+    public void testTimestampCachedBlockSizesReturnSameInstance() {
+        final StaticPipelineConfigResolver resolver = StaticPipelineConfigResolver.INSTANCE;
+        final int blockSize = randomFrom(128, 512);
+
+        final PipelineConfig first = resolver.resolve(new FieldContext(blockSize, "@timestamp"));
+        final PipelineConfig second = resolver.resolve(new FieldContext(blockSize, "@timestamp"));
         assertSame(first, second);
     }
 
@@ -62,16 +75,12 @@ public class StaticPipelineConfigResolverTests extends ESTestCase {
         final StaticPipelineConfigResolver resolver = StaticPipelineConfigResolver.INSTANCE;
         final int blockSize = 1 << randomIntBetween(4, 6);
 
-        final PipelineConfig config = resolver.resolve(new FieldContext(blockSize, randomFieldName()));
+        final PipelineConfig config = resolver.resolve(new FieldContext(blockSize, randomAlphaOfLengthBetween(1, 16)));
         assertEquals(blockSize, config.blockSize());
         assertEquals("delta>offset>gcd>bitPack", config.describeStages());
     }
 
     private static int randomBlockSize() {
-        return 1 << randomIntBetween(4, 10);
-    }
-
-    private static String randomFieldName() {
-        return randomAlphaOfLengthBetween(1, 16);
+        return 1 << randomIntBetween(7, 9);
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/pipeline/StaticPipelineConfigResolverTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/pipeline/StaticPipelineConfigResolverTests.java
@@ -20,7 +20,7 @@ public class StaticPipelineConfigResolverTests extends ESTestCase {
         final PipelineConfig config = resolver.resolve(new FieldContext(randomBlockSize(), "@timestamp"));
 
         assertEquals(
-            List.of(StageId.DELTA_OF_DELTA_STAGE, StageId.OFFSET_STAGE, StageId.BITPACK_PAYLOAD),
+            List.of(StageId.DELTA_OF_DELTA_STAGE, StageId.OFFSET_STAGE, StageId.GCD_STAGE, StageId.BITPACK_PAYLOAD),
             config.specs().stream().map(StageSpec::stageId).toList()
         );
     }

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/NumericPipelineDeltaOfDeltaRoundTripTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/NumericPipelineDeltaOfDeltaRoundTripTests.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.tsdb.pipeline.numeric;
+
+import org.apache.lucene.store.ByteBuffersDataInput;
+import org.apache.lucene.store.ByteBuffersDataOutput;
+import org.apache.lucene.store.ByteBuffersIndexOutput;
+import org.apache.lucene.store.IndexOutput;
+import org.elasticsearch.index.codec.tsdb.pipeline.PipelineConfig;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+public class NumericPipelineDeltaOfDeltaRoundTripTests extends ESTestCase {
+
+    private static int randomBlockSize() {
+        return 1 << randomIntBetween(7, 9);
+    }
+
+    public void testConstantIntervalMonotonicRoundTrip() throws IOException {
+        final int blockSize = randomBlockSize();
+        final long[] values = new long[blockSize];
+        final long base = randomLongBetween(0, 1_000_000);
+        final long interval = randomLongBetween(1, 10_000);
+        for (int i = 0; i < blockSize; i++) {
+            values[i] = base + (long) i * interval;
+        }
+        assertRoundTrip(values, blockSize, blockSize);
+    }
+
+    public void testConstantRateOfChangeRoundTrip() throws IOException {
+        final int blockSize = randomBlockSize();
+        final long[] values = new long[blockSize];
+        final long base = randomLongBetween(0, 1_000_000);
+        final long firstInterval = randomLongBetween(1, 10_000);
+        final long rateOfChange = randomLongBetween(1, 100);
+        values[0] = base;
+        long interval = firstInterval;
+        for (int i = 1; i < blockSize; i++) {
+            values[i] = values[i - 1] + interval;
+            interval += rateOfChange;
+        }
+        assertRoundTrip(values, blockSize, blockSize);
+    }
+
+    public void testJitteryIntervalsRoundTrip() throws IOException {
+        final int blockSize = randomBlockSize();
+        final long[] values = new long[blockSize];
+        final long base = randomLongBetween(0, 1_000_000);
+        final long meanInterval = randomLongBetween(100, 10_000);
+        long current = base;
+        for (int i = 0; i < blockSize; i++) {
+            values[i] = current;
+            current += meanInterval + randomLongBetween(-5, 5);
+        }
+        assertRoundTrip(values, blockSize, blockSize);
+    }
+
+    public void testNonMonotonicRoundTrip() throws IOException {
+        final int blockSize = randomBlockSize();
+        final long[] values = new long[blockSize];
+        for (int i = 0; i < blockSize; i++) {
+            values[i] = randomLong();
+        }
+        assertRoundTrip(values, blockSize, blockSize);
+    }
+
+    public void testZerosRoundTrip() throws IOException {
+        final int blockSize = randomBlockSize();
+        assertRoundTrip(new long[blockSize], blockSize, blockSize);
+    }
+
+    public void testPartialBlockRoundTrip() throws IOException {
+        final int blockSize = randomBlockSize();
+        final int count = randomIntBetween(1, blockSize - 1);
+        final long[] values = new long[blockSize];
+        final long base = randomLongBetween(0, 1_000_000);
+        for (int i = 0; i < count; i++) {
+            values[i] = base + (long) i * 10;
+        }
+        assertRoundTrip(values, blockSize, count);
+    }
+
+    public void testMultipleBlocksRoundTrip() throws IOException {
+        final int blockSize = randomBlockSize();
+        final int numBlocks = randomIntBetween(2, 10);
+        final PipelineConfig config = PipelineConfig.forLongs(blockSize).deltaOfDelta().offset().bitPack();
+        final NumericEncoder encoder = NumericCodecFactory.DEFAULT.createEncoder(config);
+        final NumericBlockEncoder blockEncoder = encoder.newBlockEncoder();
+
+        final ByteBuffersDataOutput bufferOut = new ByteBuffersDataOutput();
+        final IndexOutput out = new ByteBuffersIndexOutput(bufferOut, "test", "test");
+
+        final long[][] allValues = new long[numBlocks][];
+        for (int b = 0; b < numBlocks; b++) {
+            allValues[b] = new long[blockSize];
+            final long base = randomLongBetween(0, 1_000_000);
+            final long interval = randomLongBetween(1, 1000);
+            for (int i = 0; i < blockSize; i++) {
+                allValues[b][i] = base + (long) i * interval;
+            }
+            final long[] copy = Arrays.copyOf(allValues[b], blockSize);
+            blockEncoder.encode(copy, blockSize, out);
+        }
+        out.close();
+
+        final NumericDecoder decoder = NumericCodecFactory.DEFAULT.createDecoder(encoder.descriptor());
+        final NumericBlockDecoder blockDecoder = decoder.newBlockDecoder();
+        final ByteBuffersDataInput in = bufferOut.toDataInput();
+
+        for (int b = 0; b < numBlocks; b++) {
+            final long[] decoded = new long[blockSize];
+            blockDecoder.decode(decoded, blockSize, in);
+            assertArrayEquals("block " + b, allValues[b], decoded);
+        }
+    }
+
+    public void testConstantIntervalProducesMinimalOutput() throws IOException {
+        final int blockSize = 128;
+        final long base = 1000;
+        final long interval = 10;
+        final long[] values = new long[blockSize];
+        for (int i = 0; i < blockSize; i++) {
+            values[i] = base + (long) i * interval;
+        }
+        final long encodedSize = assertRoundTripAndReturnSize(values, blockSize, blockSize);
+        assertTrue("constant interval should compress tightly, was " + encodedSize + " bytes", encodedSize <= 8);
+    }
+
+    public void testConstantRateOfChangeProducesMinimalOutput() throws IOException {
+        final int blockSize = 128;
+        final long base = 1000;
+        final long firstInterval = 100;
+        final long rateOfChange = 10;
+        final long[] values = new long[blockSize];
+        values[0] = base;
+        long interval = firstInterval;
+        for (int i = 1; i < blockSize; i++) {
+            values[i] = values[i - 1] + interval;
+            interval += rateOfChange;
+        }
+        final long encodedSize = assertRoundTripAndReturnSize(values, blockSize, blockSize);
+        assertTrue("constant rate of change should compress tightly, was " + encodedSize + " bytes", encodedSize <= 8);
+    }
+
+    private void assertRoundTrip(long[] values, int blockSize, int count) throws IOException {
+        assertRoundTripAndReturnSize(values, blockSize, count);
+    }
+
+    private long assertRoundTripAndReturnSize(long[] values, int blockSize, int count) throws IOException {
+        final PipelineConfig config = PipelineConfig.forLongs(blockSize).deltaOfDelta().offset().bitPack();
+        final NumericEncoder encoder = NumericCodecFactory.DEFAULT.createEncoder(config);
+        final NumericBlockEncoder blockEncoder = encoder.newBlockEncoder();
+
+        final ByteBuffersDataOutput bufferOut = new ByteBuffersDataOutput();
+        final IndexOutput out = new ByteBuffersIndexOutput(bufferOut, "test", "test");
+        final long[] original = Arrays.copyOf(values, values.length);
+        blockEncoder.encode(values, count, out);
+        out.close();
+
+        final NumericDecoder decoder = NumericCodecFactory.DEFAULT.createDecoder(encoder.descriptor());
+        final NumericBlockDecoder blockDecoder = decoder.newBlockDecoder();
+        final long[] decoded = new long[blockSize];
+        blockDecoder.decode(decoded, count, bufferOut.toDataInput());
+
+        for (int i = 0; i < count; i++) {
+            assertEquals("index " + i, original[i], decoded[i]);
+        }
+        return bufferOut.size();
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/NumericPipelineDeltaOfDeltaRoundTripTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/NumericPipelineDeltaOfDeltaRoundTripTests.java
@@ -92,7 +92,7 @@ public class NumericPipelineDeltaOfDeltaRoundTripTests extends ESTestCase {
     public void testMultipleBlocksRoundTrip() throws IOException {
         final int blockSize = randomBlockSize();
         final int numBlocks = randomIntBetween(2, 10);
-        final PipelineConfig config = PipelineConfig.forLongs(blockSize).deltaOfDelta().offset().bitPack();
+        final PipelineConfig config = PipelineConfig.forLongs(blockSize).deltaOfDelta().offset().gcd().bitPack();
         final NumericEncoder encoder = NumericCodecFactory.DEFAULT.createEncoder(config);
         final NumericBlockEncoder blockEncoder = encoder.newBlockEncoder();
 
@@ -156,7 +156,7 @@ public class NumericPipelineDeltaOfDeltaRoundTripTests extends ESTestCase {
     }
 
     private long assertRoundTripAndReturnSize(long[] values, int blockSize, int count) throws IOException {
-        final PipelineConfig config = PipelineConfig.forLongs(blockSize).deltaOfDelta().offset().bitPack();
+        final PipelineConfig config = PipelineConfig.forLongs(blockSize).deltaOfDelta().offset().gcd().bitPack();
         final NumericEncoder encoder = NumericCodecFactory.DEFAULT.createEncoder(config);
         final NumericBlockEncoder blockEncoder = encoder.newBlockEncoder();
 

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/StageFactoryTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/StageFactoryTests.java
@@ -23,7 +23,11 @@ public class StageFactoryTests extends ESTestCase {
     }
 
     public void testTransformStageCreationMatchesSpec() {
-        final StageSpec.TransformSpec[] specs = { new StageSpec.DeltaStage(), new StageSpec.OffsetStage(), new StageSpec.GcdStage() };
+        final StageSpec.TransformSpec[] specs = {
+            new StageSpec.DeltaStage(),
+            new StageSpec.OffsetStage(),
+            new StageSpec.GcdStage(),
+            new StageSpec.DeltaOfDeltaStage() };
         for (StageSpec.TransformSpec spec : specs) {
             final NumericCodecStage stage = StageFactory.newTransformStage(spec);
             assertEquals(spec.stageId().id, stage.id());
@@ -40,7 +44,11 @@ public class StageFactoryTests extends ESTestCase {
     }
 
     public void testNewPayloadStageRejectsTransformSpec() {
-        final StageSpec.TransformSpec[] specs = { new StageSpec.DeltaStage(), new StageSpec.OffsetStage(), new StageSpec.GcdStage() };
+        final StageSpec.TransformSpec[] specs = {
+            new StageSpec.DeltaStage(),
+            new StageSpec.OffsetStage(),
+            new StageSpec.GcdStage(),
+            new StageSpec.DeltaOfDeltaStage() };
         for (StageSpec.TransformSpec spec : specs) {
             expectThrows(IllegalArgumentException.class, () -> StageFactory.newPayloadStage(spec, 128));
         }

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/stages/DeltaOfDeltaCodecStageTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/stages/DeltaOfDeltaCodecStageTests.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.tsdb.pipeline.numeric.stages;
+
+import org.elasticsearch.index.codec.tsdb.pipeline.StageId;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+public class DeltaOfDeltaCodecStageTests extends AbstractTransformStageTestCase {
+
+    public void testIdMatchesStageId() {
+        assertEquals(StageId.DELTA_OF_DELTA_STAGE.id, DeltaOfDeltaCodecStage.INSTANCE.id());
+    }
+
+    public void testNonMonotonicSkips() {
+        final int blockSize = randomBlockSize();
+        final long[] values = new long[blockSize];
+        for (int i = 0; i < blockSize; i++) {
+            values[i] = randomLong();
+        }
+        values[0] = 0;
+        values[1] = 100;
+        values[2] = 200;
+        values[3] = 50;
+        values[4] = -10;
+
+        assertStageSkipped(DeltaOfDeltaCodecStage.INSTANCE, values, blockSize);
+    }
+
+    public void testAllSameValuesSkips() {
+        final int blockSize = randomBlockSize();
+        final long[] values = new long[blockSize];
+        Arrays.fill(values, randomLong());
+
+        assertStageSkipped(DeltaOfDeltaCodecStage.INSTANCE, values, blockSize);
+    }
+
+    public void testTooFewMonotonicValuesSkips() {
+        assertStageSkipped(DeltaOfDeltaCodecStage.INSTANCE, new long[] { 10, 20 }, 2);
+        assertStageSkipped(DeltaOfDeltaCodecStage.INSTANCE, new long[] { 10, 20, 20 }, 3);
+    }
+
+    public void testRoundTripMonotonicIncreasing() throws IOException {
+        for (int i = 0; i < 10; i++) {
+            assertTransformRoundTrip(DeltaOfDeltaCodecStage.INSTANCE, randomMonotonicIncreasing(randomBlockSize()));
+        }
+    }
+
+    public void testRoundTripMonotonicDecreasing() throws IOException {
+        for (int i = 0; i < 10; i++) {
+            assertTransformRoundTrip(DeltaOfDeltaCodecStage.INSTANCE, randomMonotonicDecreasing(randomBlockSize()));
+        }
+    }
+
+    public void testRoundTripConstantInterval() throws IOException {
+        final int blockSize = randomBlockSize();
+        final long base = randomLongBetween(0, 1_000_000);
+        final long interval = randomLongBetween(1, 10_000);
+        final long[] values = new long[blockSize];
+        for (int i = 0; i < blockSize; i++) {
+            values[i] = base + (long) i * interval;
+        }
+        assertTransformRoundTrip(DeltaOfDeltaCodecStage.INSTANCE, values);
+    }
+
+    public void testRoundTripConstantRateOfChange() throws IOException {
+        final int blockSize = randomBlockSize();
+        final long base = randomLongBetween(0, 1_000_000);
+        final long firstInterval = randomLongBetween(1, 10_000);
+        final long rateOfChange = randomLongBetween(1, 100);
+        final long[] values = new long[blockSize];
+        values[0] = base;
+        long interval = firstInterval;
+        for (int i = 1; i < blockSize; i++) {
+            values[i] = values[i - 1] + interval;
+            interval += rateOfChange;
+        }
+        assertTransformRoundTrip(DeltaOfDeltaCodecStage.INSTANCE, values);
+    }
+
+    public void testMultiBlockRoundTripWithArrayReuse() throws IOException {
+        final int blockSize = randomBlockSize();
+        final int numBlocks = randomIntBetween(2, 5);
+        final long[][] blocks = new long[numBlocks][];
+        for (int b = 0; b < numBlocks; b++) {
+            blocks[b] = randomBoolean() ? randomMonotonicIncreasing(blockSize) : randomMonotonicDecreasing(blockSize);
+        }
+        assertMultiBlockTransformRoundTrip(DeltaOfDeltaCodecStage.INSTANCE, blocks);
+    }
+}


### PR DESCRIPTION
## Summary

Adds `DeltaOfDeltaCodecStage`, a transform stage that encodes second order differences for sequences whose rate of change is itself roughly constant. Routes `@timestamp` through it via `StaticPipelineConfigResolver`. Other fields keep the `ES819` baseline.

`delta().delta()` compiles and round trips, but it is the wrong design for timestamps. Three considerations drive the dedicated stage.

### 1. Second delta skips on jittery data

`DeltaCodecStage` gates on `isMonotonic`, which requires every step to go strictly in the same direction. After the first delta the array holds inter arrival intervals; for real ingestion those jitter in both directions, so the gate returns false and the second delta skips. `delta().delta()` collapses to a single delta. `DeltaOfDeltaCodecStage` checks `isMonotonic` on the original timestamps instead, so it applies on realistic `@timestamp` input where `delta().delta()` would not. This does not make `DeltaCodecStage` obsolete: single delta remains the right choice for other monotonic fields whose intervals do not carry constant rate structure (event driven counters, irregularly sampled metrics). `deltaOfDelta` is tuned for `@timestamp`'s near constant rate shape specifically.

Worked example, 6 value snippet with jittery intervals `100, 103, 98, 105, 99` ms:

```
input:                  [1000, 1100, 1203, 1301, 1406, 1505, ...]
after 1st delta():      [ 100,  100,  103,   98,  105,   99, ...]
isMonotonic gate:       sees both up and down steps, returns false
2nd delta():            SKIPPED, array unchanged
```

When `deltaOfDelta`'s gate itself fails (non monotonic input), single delta's gate fails on the same input because the two stages use an identical `isMonotonic` check. There is no scenario where `deltaOfDelta` skips but a single delta fallback could still apply, so the pipeline degrades to `offset > bitPack` on raw values either way.

### 2. `delta>delta` leaves a leading zero pair when both stages apply

When both passes do apply (perfectly constant rate of change inputs), applying the `values[0] = values[1]` trick across two `delta` stages leaves a leading zero pair in the values array. The first delta produces `[d_0, d_0, d_1, d_2, ...]`, the second delta then computes `values[1] -= values[0] = 0` against the flat leading pair, applies the same trick, and produces `[0, 0, r, r, ..., r]`. `OffsetCodecStage` sees `min == 0` and skips, so bitPack has to encode the full residual range. `deltaOfDelta` writes the first second order residual to positions `0` and `1` instead, leaving the array uniform so `OffsetCodecStage` applies and bitPack pays zero bits.

Worked example, 128 value block where `T_0 = 1000`, the first interval is `100`, and each interval grows by `10`:

```
input:                  [1000, 1100, 1210, 1330, 1460, ...]

delta().delta() path
  after 1st delta():    [ 100,  100,  110,  120,  130, ...]
  after 2nd delta():    [   0,    0,   10,   10,   10, ...]

deltaOfDelta() path
  after stage:          [  10,   10,   10,   10,   10, ...]
```

After `delta().delta()`, `OffsetCodecStage.encode` computes `min = 0, max = 10` and hits its first useful skip, `if (min == 0) return;`. The array passes through unchanged and bitPack encodes the full `0..10` range; with `gcd` dividing by 10 first this lands at 1 bit per value. `deltaOfDelta` produces a uniform array, `OffsetCodecStage` subtracts 10, and bitPack pays 0 bits. Savings are **16 bytes per 128 value block** relative to `delta().delta() > offset > gcd > bitPack` (see section 3 for the measured numbers). On jittery real timestamp blocks the two paths produce comparable storage; Rally will validate the realistic mix.

### 3. Single stage is cheaper across CPU, cache, and dispatch

Measured with `EncodePipelineBenchmark` (JMH 1.37, JDK 26, `Mode.AverageTime`, 3 forks, 3 warmup plus 5 measurement iterations, ± is the 99.9% confidence interval propagated from the JMH score error). Four timestamp regimes are shown: an idealized scrape (perfectly constant interval), a realistic scrape (constant interval with small jitter), an event ingest shape (bursty), and a synthetic shape that exercises `deltaOfDelta`'s algebra (linearly growing intervals).

Encode CPU cost in ns per 128 value block, lower is better:

| pipeline                                                  | `constantInterval` | `timestampLike`    | `eventDriven`      | `constantRateOfChange` |
|-----------------------------------------------------------|--------------------|--------------------|--------------------|------------------------|
| `delta>offset>gcd>bitpack` (default)                      | 208.2 ± 1.1 ns     | 407.1 ± 8.0 ns     | 370.4 ± 2.1 ns     | 514.9 ± 3.2 ns         |
| `deltaOfDelta>offset>bitpack` (`@timestamp` routing)      | **137.1 ± 1.9 ns** | **216.6 ± 4.1 ns** | **218.5 ± 1.0 ns** | **178.9 ± 1.9 ns**     |
| `delta>delta>offset>gcd>bitpack` (without dedicated stage) | 255.6 ± 2.3 ns     | 472.0 ± 15.5 ns    | 434.1 ± 8.2 ns     | 501.5 ± 6.7 ns         |

Encoded size per block (input is fixed at 1024 bytes = 128 longs × 8 bytes, lower is better):

| pipeline                                                  | `constantInterval` | `timestampLike` | `eventDriven` | `constantRateOfChange` |
|-----------------------------------------------------------|--------------------|-----------------|---------------|------------------------|
| `delta>offset>gcd>bitpack` (default)                      | 7 B                | 119 B           | 229 B         | 120 B                  |
| `deltaOfDelta>offset>bitpack` (`@timestamp` routing)      | 7 B                | 120 B           | 249 B         | **8 B**                |
| `delta>delta>offset>gcd>bitpack` (without dedicated stage) | 7 B                | 119 B           | 229 B         | 24 B                   |

Across the three realistic regimes, the `@timestamp` routing is 1.5x to 1.9x faster on CPU. Storage is tied in two of them and 9% larger on `eventDriven` (`gcd` in the default pipeline finds a small common factor that the routing skips). On the synthetic `constantRateOfChange` regime the routing wins on both axes: 2.88x faster on CPU and 15x smaller on storage, because that is the only input shape where `deltaOfDelta`'s algebra reduces to a uniform residual array that `offset` then collapses to zeros.

The cascade alternative `delta>delta>offset>gcd>bitpack` is the slowest of the three on every regime and never beats the routing on storage either, so it is not a viable substitute for the dedicated stage.

The CPU numbers cover only the in memory encode cost; IO and the rest of the refresh path will be validated by Rally on a realistic ingestion mix. The storage numbers are deterministic in either setting since the encoded size depends only on the input and the pipeline.

The mechanism: the dedicated stage runs one backward pass, writes one metadata section, and dispatches once through the `NumericEncodePipeline.encode` switch. `delta().delta()` doubles all three.

```
per 128 value block:
  delta().delta()       2 backward passes    2 metadata writes    2 switch dispatches
  deltaOfDelta()        1 backward pass      1 metadata write     1 switch dispatch
```

Neither path allocates per block and the wire format is identical (two `ZLong` metadata entries either way), so the saving is purely CPU and cache. For TSDB metric data `@timestamp` is present on every document, so this constant per block saving applies to every block in every segment of the index.

Part of #141118. Builds on the static resolver PR.

## What is included

* `DeltaOfDeltaCodecStage`: new transform stage, byte ID `0x04`, display name `deltaOfDelta`.
* `StageId.DELTA_OF_DELTA_STAGE`: wire format identifier, locked once shipped.
* `StageSpec.DeltaOfDeltaStage`: record in the sealed stage spec hierarchy.
* `PipelineConfig.LongBuilder.deltaOfDelta()`: fluent builder hook.
* `StaticPipelineConfigResolver`: routes `@timestamp` to `deltaOfDelta > offset > bitPack`. Other fields keep `delta > offset > gcd > bitPack`.

## Design highlights

* Stateless singleton via `INSTANCE`, mirroring other transform stages.
* Encode is a single backward pass: three array reads per iteration, no multiplication, no loop carried dependency. Decode is two forward prefix sums, vectorizable by the JIT.
* Positions `0` and `1` carry the first second order difference (not zero) so the residual array stays uniform on constant rate input; metadata `first` is adjusted to compensate so decode reconstructs `T_0` correctly.
* Same monotonicity gate as `DeltaCodecStage`; naturally skips for `valueCount < 3` and non monotonic input.

## Testing

* `DeltaOfDeltaCodecStageTests`: stage round trip and skip cases, mirroring `DeltaCodecStageTests`.
* `NumericPipelineDeltaOfDeltaRoundTripTests`: end to end round trip plus size budget assertions on two compression patterns.
* `StaticPipelineConfigResolverTests`: per field routing, block size propagation, case sensitivity.
* Updated `StageFactoryTests`, `StageSpecTests`: cover the new stage in existing iteration tests.

```bash
./gradlew :server:test --tests "*pipeline*" --tests "*ES95*"
```
