### PR TITLE
Write SQ format name for GPU INT8 SQ vector graphs

### DIFF
--- a/docs/changelog/148975.yaml
+++ b/docs/changelog/148975.yaml
@@ -1,0 +1,6 @@
+pr: 148975
+summary: Write the scalar-quantized format name for GPU INT8 SQ vector graphs
+area: Vector Search
+type: bug
+issues:
+ - 148975

--- a/libs/gpu-codec/src/main/java/org/elasticsearch/gpu/codec/ES92GpuHnswSQVectorsFormat.java
+++ b/libs/gpu-codec/src/main/java/org/elasticsearch/gpu/codec/ES92GpuHnswSQVectorsFormat.java
@@ -31,7 +31,11 @@ import static org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper.MAX_
  * HNSW graph is built on GPU, while scalar quantization and search is performed on CPU.
  */
 public class ES92GpuHnswSQVectorsFormat extends KnnVectorsFormat {
-    public static final String NAME = "Lucene99HnswVectorsFormat";
+    // Must match the format whose fieldsReader correctly reads the scalar-quantized flat data the GPU
+    // writer produces. Writing "Lucene99HnswVectorsFormat" here makes the on-disk segment info resolve
+    // to Lucene's built-in reader, which ignores the quantized vectors and falls back to float32
+    // scoring. See https://github.com/elastic/elasticsearch/issues/148975.
+    public static final String NAME = "ES814HnswScalarQuantizedVectorsFormat";
     static final int MAXIMUM_MAX_CONN = 512;
     static final int MAXIMUM_BEAM_WIDTH = 3200;
     private final int maxConn;


### PR DESCRIPTION
## Summary

`ES92GpuHnswSQVectorsFormat` declared `NAME = "Lucene99HnswVectorsFormat"`, so segments built by the GPU recorded that name in segment info. When the index is opened directly from the directory (the default in Elasticsearch), Lucene's `NamedSPILoader` resolves that name to the built-in `Lucene99HnswVectorsFormat`. Its `fieldsReader` uses `Lucene99FlatVectorsFormat` and has no knowledge of the scalar-quantized flat data the GPU writer produced via `ES814ScalarQuantizedVectorsFormat`, so the quantized vectors sit unused on disk and search silently falls back to float32 scoring.

The fix is the one Chris prescribed in the issue: set `NAME = "ES814HnswScalarQuantizedVectorsFormat"`. SPI then resolves to `ES814HnswScalarQuantizedVectorsFormat`, whose `fieldsReader` returns `new Lucene99HnswVectorsReader(state, ES814ScalarQuantizedVectorsFormat.fieldsReader(state))`. That matches the on-disk layout the GPU writer produces (the writer uses the same `Lucene99HnswVectorsFormatMeta` / `Lucene99HnswVectorsFormatIndex` file headers via `ES92GpuHnswVectorsWriter`, paired with SQ flat data from `ES814ScalarQuantizedVectorsFormat`).

The float32 sibling `ES92GpuHnswVectorsFormat` keeps `NAME = "Lucene99HnswVectorsFormat"` because in that case Lucene's built-in reader is the right one.

Closes #148975

## Test plan

- [x] `./gradlew :libs:gpu-codec:compileJava :libs:gpu-codec:compileTestJava` passes.
- [x] `./gradlew :libs:gpu-codec:test` passes (`ES92GpuHnswSQVectorsFormatTests` skips locally without CUDA, which is expected).
- [ ] Needs a GPU CI run to confirm: indices built with the GPU SQ codec now use the quantized scoring path during search and recall is maintained, per the issue's verification ask.