### PR TITLE
[Test] Restrict test build to PluginProcessor

### DIFF
--- a/test/framework/build.gradle
+++ b/test/framework/build.gradle
@@ -65,6 +65,14 @@ sourceSets {
   }
 }
 
+// log4j-core registers both the PluginProcessor and GraalVmProcessor on the processor path; we only want the former
+tasks.named("compileJava").configure {
+  options.compilerArgs.addAll(
+    "-processor",
+    "org.apache.logging.log4j.core.config.plugins.processor.PluginProcessor",
+  )
+}
+
 // the main files are actually test files, so use the appropriate forbidden api sigs
 tasks.named('forbiddenApisMain').configure {
   replaceSignatureFiles 'jdk-signatures', 'es-all-signatures', 'es-test-signatures'


### PR DESCRIPTION
Apply the same restriction for log4j2 PluginProcessor in server to test. Earlier branches, 9.3, 8.19, require this change to compile. It is added as part of the backport for #149132, i.e. #149147 and #149148. Although it is not needed for main and 9.4 due to wider suppression added in #144798. It is better to have parity between server and test builds.

Relates #149132
