### PR TITLE
[ML] Stabilize MlMemoryIT.testMemoryStats

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -214,9 +214,6 @@ tests:
 - class: org.elasticsearch.index.mapper.IpOffsetDocValuesLoaderTests
   method: testOffsetArrayRandomHighCardinality
   issue: https://github.com/elastic/elasticsearch/issues/147086
-- class: org.elasticsearch.xpack.ml.integration.MlMemoryIT
-  method: testMemoryStats
-  issue: https://github.com/elastic/elasticsearch/issues/147122
 - class: org.elasticsearch.xpack.esql.tree.EsqlNodeSubclassTests
   method: testReplaceChildren {class org.elasticsearch.xpack.esql.plan.physical.ExchangeSinkExec}
   issue: https://github.com/elastic/elasticsearch/issues/147164

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlMemoryIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlMemoryIT.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.ml.integration;
 
+import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.unit.ByteSizeValue;
@@ -36,6 +37,8 @@ import org.junit.After;
 
 import java.util.Base64;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.elasticsearch.xpack.ml.integration.ClassificationIT.KEYWORD_FIELD;
 import static org.elasticsearch.xpack.ml.integration.PyTorchModelIT.BASE_64_ENCODED_MODEL;
@@ -64,13 +67,22 @@ public class MlMemoryIT extends MlNativeDataFrameAnalyticsIntegTestCase {
         String dfaJobId = "dfa";
         startDataFrameAnalyticsJob(dfaJobId);
 
-        MlMemoryAction.Response response = client().execute(MlMemoryAction.INSTANCE, new MlMemoryAction.Request("_all")).actionGet();
+        int expectedNodes = cluster().size();
+        assertBusy(() -> {
+            ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
+            assertThat(state.nodes().getSize(), equalTo(expectedNodes));
+        }, 30, TimeUnit.SECONDS);
 
-        assertThat(response.failures(), empty());
-
+        AtomicReference<MlMemoryAction.Response> responseRef = new AtomicReference<>();
+        assertBusy(() -> {
+            MlMemoryAction.Response memoryResponse = client().execute(MlMemoryAction.INSTANCE, new MlMemoryAction.Request("_all"))
+                .actionGet();
+            assertThat(memoryResponse.failures(), empty());
+            assertThat(memoryResponse.getNodes(), hasSize(expectedNodes));
+            responseRef.set(memoryResponse);
+        }, 30, TimeUnit.SECONDS);
+        MlMemoryAction.Response response = responseRef.get();
         List<MlMemoryStats> statsList = response.getNodes();
-        // There are 4 nodes: 3 in the external cluster plus the test harness
-        assertThat(statsList, hasSize(4));
 
         int mlNodes = 0;
         int nodesWithPytorchModel = 0;


### PR DESCRIPTION
## Summary

- Hardens `MlMemoryIT.testMemoryStats` against discovery races in the external multi-node test harness (#147122).
- Waits until cluster state contains the expected node count (`cluster().size()`: 3 external nodes + test client) before calling `MlMemoryAction`.
- Uses `assertBusy` until `MlMemoryAction` returns stats for all nodes with no failures, instead of a single immediate call.
- Unmutes `testMemoryStats`.

## Test plan

- [x] `./gradlew ":x-pack:plugin:ml:qa:native-multi-node-tests:javaRestTest" --tests "org.elasticsearch.xpack.ml.integration.MlMemoryIT.testMemoryStats" -Dtests.iters=100 -Dtests.timeoutSuite=3600000!` (100/100 passed locally)

Fixes #147122

Made with [Cursor](https://cursor.com)