### PR TITLE
[ESQL] Fix UBN COUNT/MIN/MAX pushdown for absent columns

### DIFF
--- a/docs/changelog/149279.yaml
+++ b/docs/changelog/149279.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 149279
+summary: Fix UBN COUNT/MIN/MAX pushdown for absent columns
+type: enhancement

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/MergedSplitStats.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/MergedSplitStats.java
@@ -81,9 +81,11 @@ public final class MergedSplitStats implements org.elasticsearch.xpack.esql.data
     }
 
     /**
-     * Returns the sum of null counts across children for the named column.
-     * Returns {@code -1} if any child returns an unknown null count for the column,
-     * or if the column is not present in any child.
+     * Returns the sum of null counts across children for the named column under the SPI's
+     * "implicit nulls" contract: a child whose split lacks the column contributes its full
+     * row count (every row is an implicit null), and explicit nulls in present columns are
+     * summed normally. Returns {@code -1} only if a child returns {@code -1}, which signals
+     * the rare "column physically present but stats unknown" case (Parquet stats disabled).
      */
     @Override
     public long columnNullCount(String name) {
@@ -99,19 +101,35 @@ public final class MergedSplitStats implements org.elasticsearch.xpack.esql.data
     }
 
     /**
-     * Returns the minimum of children's min values for the named column.
-     * Returns {@code null} if any child returns null for the column min, or if
-     * the column is not present in any child. Cross-type numeric widening is applied
-     * via {@link SplitStats#mergedMin}.
+     * Returns the minimum of children's min values for the named column under the SPI's
+     * "implicit nulls" contract:
+     * <ul>
+     *   <li>A child with {@code columnNullCount(name) == child.rowCount()} contributes no candidate
+     *       min — the column is either absent from that file or its rows are all null. We
+     *       <b>skip</b> that child rather than poison.</li>
+     *   <li>A child with {@code columnNullCount(name) < 0} represents the rare "present but stats
+     *       unknown" case (Parquet stats disabled) and <b>poisons</b> the aggregate; we cannot
+     *       know whether that child has a smaller value than the running min.</li>
+     *   <li>A child with a known, finite null count and a non-null min participates in the merge
+     *       via {@link SplitStats#mergedMin}; incompatible numeric types poison defensively.</li>
+     * </ul>
+     * Returns {@code null} when poisoned or when no child contributes a value.
      */
     @Override
     @Nullable
     public Object columnMin(String name) {
         Object result = null;
         for (org.elasticsearch.xpack.esql.datasources.spi.SplitStats child : children) {
+            long nc = child.columnNullCount(name);
+            if (nc < 0) {
+                return null;
+            }
+            if (nc == child.rowCount()) {
+                continue;
+            }
             Object childMin = child.columnMin(name);
             if (childMin == null) {
-                // Unknown min in any child poisons the aggregate
+                // Present, not all-null, but reader produced no min — inconsistent; poison defensively.
                 return null;
             }
             result = SplitStats.mergedMin(result, childMin);
@@ -124,24 +142,29 @@ public final class MergedSplitStats implements org.elasticsearch.xpack.esql.data
     }
 
     /**
-     * Returns the maximum of children's max values for the named column.
-     * Returns {@code null} if any child returns null for the column max, or if
-     * the column is not present in any child. Cross-type numeric widening is applied
-     * via {@link SplitStats#mergedMax}.
+     * Returns the maximum of children's max values for the named column under the SPI's
+     * "implicit nulls" contract. Mirrors {@link #columnMin} — children whose null count equals
+     * their row count have no max value to contribute and are skipped; only an explicit
+     * unknown ({@code columnNullCount &lt; 0}) poisons the aggregate.
      */
     @Override
     @Nullable
     public Object columnMax(String name) {
         Object result = null;
         for (org.elasticsearch.xpack.esql.datasources.spi.SplitStats child : children) {
+            long nc = child.columnNullCount(name);
+            if (nc < 0) {
+                return null;
+            }
+            if (nc == child.rowCount()) {
+                continue;
+            }
             Object childMax = child.columnMax(name);
             if (childMax == null) {
-                // Unknown max in any child poisons the aggregate
                 return null;
             }
             result = SplitStats.mergedMax(result, childMax);
             if (result == null) {
-                // Incompatible types — clear the stat
                 return null;
             }
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SourceStatisticsSerializer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SourceStatisticsSerializer.java
@@ -225,10 +225,11 @@ public final class SourceStatisticsSerializer {
         Set<String> poisonedNullCounts = new HashSet<>();
         // Tracks (per per-file map) the row count and the set of columns physically present in
         // that file so we can fold absent-column rows into implicit nulls in a second pass.
-        List<long[]> perFileRowCounts = new ArrayList<>(splitStats.size());
+        long[] perFileRowCounts = new long[splitStats.size()];
         List<Set<String>> perFileColumns = new ArrayList<>(splitStats.size());
         Set<String> allColumns = new LinkedHashSet<>();
 
+        int fileIndex = 0;
         for (Map<String, Object> stats : splitStats) {
             if (stats == null || stats.containsKey(STATS_ROW_COUNT) == false) {
                 return null;
@@ -248,7 +249,7 @@ public final class SourceStatisticsSerializer {
             // any _stats.columns.<col>.* key is in the map (matches SplitStats.of's logic).
             Set<String> columnsInThisFile = new HashSet<>();
             // Track which present columns of this file emitted a null_count value, so we can
-            // detect the rare present-but-statless case after the column-family scan.
+            // detect the rare present-but-stats-less case after the column-family scan.
             Set<String> nullCountSeenInThisFile = new HashSet<>();
             for (Map.Entry<String, Object> entry : stats.entrySet()) {
                 String key = entry.getKey();
@@ -307,7 +308,7 @@ public final class SourceStatisticsSerializer {
                     poisonedNullCounts.add(present);
                 }
             }
-            perFileRowCounts.add(new long[] { fileRowCount });
+            perFileRowCounts[fileIndex++] = fileRowCount;
             perFileColumns.add(columnsInThisFile);
             allColumns.addAll(columnsInThisFile);
         }
@@ -320,7 +321,7 @@ public final class SourceStatisticsSerializer {
             String key = columnNullCountKey(colName);
             for (int i = 0; i < perFileColumns.size(); i++) {
                 if (perFileColumns.get(i).contains(colName) == false) {
-                    long fileRowCount = perFileRowCounts.get(i)[0];
+                    long fileRowCount = perFileRowCounts[i];
                     nullCounts.merge(key, new long[] { fileRowCount }, (a, b) -> {
                         a[0] += b[0];
                         return a;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SourceStatisticsSerializer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SourceStatisticsSerializer.java
@@ -10,8 +10,10 @@ package org.elasticsearch.xpack.esql.datasources;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceStatistics;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -178,6 +180,27 @@ public final class SourceStatisticsSerializer {
         return sourceMetadata != null ? asBoxedLong(sourceMetadata.get(columnSizeBytesKey(columnName))) : null;
     }
 
+    /**
+     * Merges per-file {@code _stats.*} maps into a single dataset-wide map.
+     * <p>
+     * Implements the "implicit nulls" contract for UNION_BY_NAME aggregate pushdown: a column
+     * absent from a per-file map (no {@code _stats.columns.<col>.*} keys at all) means the
+     * column is physically absent from that file, so its entire row count is folded into the
+     * merged {@code null_count} accumulator for that column. This makes
+     * {@code Count(col) = totalRowCount - mergedNullCount} correct downstream in
+     * {@link org.elasticsearch.xpack.esql.optimizer.rules.physical.local.PushAggregatesToExternalSource}.
+     * <p>
+     * Format-reader ground truth: Parquet always writes {@code size_bytes} for present columns
+     * and ORC always writes {@code null_count}, so any column-family key in a per-file map is
+     * sufficient to mark the column as physically present in that file. The rare exception is
+     * Parquet writing a column with stats disabled — present, with {@code size_bytes}, but no
+     * {@code null_count}. We refuse to fabricate a null count in that case: the merged map
+     * drops the {@code null_count} entry entirely (via {@code poisonedNullCounts}), so
+     * downstream consumers see "unknown" and fall back rather than under-count.
+     * <p>
+     * Min/max/size_bytes accumulators are unchanged: they only sum across files where the
+     * column is present, which is the correct semantics regardless of implicit nulls.
+     */
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public static Map<String, Object> mergeStatistics(List<Map<String, Object>> splitStats) {
         if (splitStats == null || splitStats.isEmpty()) {
@@ -196,24 +219,47 @@ public final class SourceStatisticsSerializer {
         Map<String, long[]> colSizeBytes = new HashMap<>();
         Set<String> poisonedMins = new HashSet<>();
         Set<String> poisonedMaxs = new HashSet<>();
+        // Columns that any file showed as physically present (any column-family key seen) but
+        // that lack a null_count value in that same file. We cannot fabricate a count for
+        // those rows, so we drop the merged null_count entry to signal "unknown" downstream.
+        Set<String> poisonedNullCounts = new HashSet<>();
+        // Tracks (per per-file map) the row count and the set of columns physically present in
+        // that file so we can fold absent-column rows into implicit nulls in a second pass.
+        List<long[]> perFileRowCounts = new ArrayList<>(splitStats.size());
+        List<Set<String>> perFileColumns = new ArrayList<>(splitStats.size());
+        Set<String> allColumns = new LinkedHashSet<>();
 
         for (Map<String, Object> stats : splitStats) {
             if (stats == null || stats.containsKey(STATS_ROW_COUNT) == false) {
                 return null;
             }
             Object rc = stats.get(STATS_ROW_COUNT);
+            long fileRowCount;
             if (rc instanceof Number rcNum) {
-                totalRows += rcNum.longValue();
+                fileRowCount = rcNum.longValue();
+                totalRows += fileRowCount;
             } else {
                 return null;
             }
             Object sb = stats.get(STATS_SIZE_BYTES);
             if (sb instanceof Number sbNum) totalSize += sbNum.longValue();
 
+            // Probe which columns this file physically contains. The column is "present" iff
+            // any _stats.columns.<col>.* key is in the map (matches SplitStats.of's logic).
+            Set<String> columnsInThisFile = new HashSet<>();
+            // Track which present columns of this file emitted a null_count value, so we can
+            // detect the rare present-but-statless case after the column-family scan.
+            Set<String> nullCountSeenInThisFile = new HashSet<>();
             for (Map.Entry<String, Object> entry : stats.entrySet()) {
                 String key = entry.getKey();
                 if (key.startsWith(STATS_COL_PREFIX) == false) continue;
+                String rest = key.substring(STATS_COL_PREFIX.length());
+                int dotIdx = rest.lastIndexOf('.');
+                if (dotIdx <= 0) continue;
+                String colName = rest.substring(0, dotIdx);
+                columnsInThisFile.add(colName);
                 if (key.endsWith(NULL_COUNT_SUFFIX) && entry.getValue() instanceof Number ncNum) {
+                    nullCountSeenInThisFile.add(colName);
                     nullCounts.merge(key, new long[] { ncNum.longValue() }, (a, b) -> {
                         a[0] += b[0];
                         return a;
@@ -254,6 +300,33 @@ public final class SourceStatisticsSerializer {
                     });
                 }
             }
+            // Any column physically present in this file but lacking a null_count value
+            // poisons that column's merged null_count: we cannot reconstruct it later.
+            for (String present : columnsInThisFile) {
+                if (nullCountSeenInThisFile.contains(present) == false) {
+                    poisonedNullCounts.add(present);
+                }
+            }
+            perFileRowCounts.add(new long[] { fileRowCount });
+            perFileColumns.add(columnsInThisFile);
+            allColumns.addAll(columnsInThisFile);
+        }
+
+        // Implicit-nulls pass: for every column ever seen, fold the row count of files that
+        // do not physically contain the column into that column's null_count accumulator.
+        // This only adds value when there are at least two files; the size==1 fast path above
+        // returns the single map verbatim and never reaches here.
+        for (String colName : allColumns) {
+            String key = columnNullCountKey(colName);
+            for (int i = 0; i < perFileColumns.size(); i++) {
+                if (perFileColumns.get(i).contains(colName) == false) {
+                    long fileRowCount = perFileRowCounts.get(i)[0];
+                    nullCounts.merge(key, new long[] { fileRowCount }, (a, b) -> {
+                        a[0] += b[0];
+                        return a;
+                    });
+                }
+            }
         }
 
         Map<String, Object> merged = new HashMap<>();
@@ -261,7 +334,12 @@ public final class SourceStatisticsSerializer {
         if (totalSize > 0) {
             merged.put(STATS_SIZE_BYTES, totalSize);
         }
-        nullCounts.forEach((k, v) -> merged.put(k, v[0]));
+        nullCounts.forEach((k, v) -> {
+            String colName = k.substring(STATS_COL_PREFIX.length(), k.length() - NULL_COUNT_SUFFIX.length());
+            if (poisonedNullCounts.contains(colName) == false) {
+                merged.put(k, v[0]);
+            }
+        });
         mins.forEach((k, v) -> merged.put(k, v[0]));
         maxs.forEach((k, v) -> merged.put(k, v[0]));
         colSizeBytes.forEach((k, v) -> merged.put(k, v[0]));

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SplitStats.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SplitStats.java
@@ -253,13 +253,26 @@ public final class SplitStats implements org.elasticsearch.xpack.esql.datasource
     }
 
     /**
-     * Returns the null count for the column with the given name, or {@code -1} if the column
-     * is not found or its null count is unknown.
+     * Returns the null count for the column with the given name under the SPI's "implicit nulls"
+     * contract: a column physically absent from this split contributes {@code rowCount} implicit
+     * nulls, since every row would deserialize as {@code null}. Format readers (Parquet, ORC)
+     * emit at least one column-family stat key (e.g. {@code size_bytes}/{@code null_count}) for
+     * every column they physically contain, so {@link #findColumn} returning {@code -1} is
+     * equivalent to "column is not in this file/split".
+     * <p>
+     * Returns {@code -1} only in the rare case where the column is physically present but the
+     * reader could not extract a null count (e.g. Parquet stats disabled at write time). Callers
+     * such as {@link org.elasticsearch.xpack.esql.optimizer.rules.physical.local.PushAggregatesToExternalSource}
+     * rely on this contract so that {@code Count(col) = rowCount - columnNullCount} is correct
+     * across UNION_BY_NAME mixes where some files lack the column.
      */
     @Override
     public long columnNullCount(String name) {
         int col = findColumn(name);
-        return col >= 0 ? nullCounts[col] : -1;
+        if (col < 0) {
+            return rowCount;
+        }
+        return nullCounts[col];
     }
 
     /** Returns the min value for the column with the given name, or {@code null} if not found. */

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/SplitStats.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/SplitStats.java
@@ -43,12 +43,19 @@ public interface SplitStats {
      * a column that is physically absent from this split contributes {@code rowCount()}
      * implicit nulls (every row would deserialize as {@code null}). Returns {@code -1}
      * only when the column is physically present in the split but the reader could not
-     * extract a null count (the rare Parquet present-but-statless case; ORC always emits one).
+     * extract a null count (the rare Parquet present-but-stats-less case; ORC always emits one).
      * <p>
      * This contract makes {@code Count(col) = rowCount - columnNullCount} correct for
      * UNION_BY_NAME pushdown across files where some files lack the column, and lets
      * {@code IS NULL}/{@code IS NOT NULL} classifiers treat absent-column splits as
      * unconditionally null without needing a separate "column present?" probe.
+     * <p>
+     * <b>Producer contract:</b> implementations must mark a column as physically present
+     * by carrying at least one column-family stat (e.g. {@code size_bytes}, a min/max value,
+     * or a null count). Both Parquet and ORC readers satisfy this — Parquet always emits
+     * {@code size_bytes} and ORC always emits {@code null_count}. Producers that build
+     * stats by hand must follow the same rule, otherwise this method will silently report
+     * a present column as absent and inflate the implicit-null contribution.
      */
     long columnNullCount(String name);
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/SplitStats.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/SplitStats.java
@@ -39,8 +39,16 @@ public interface SplitStats {
     }
 
     /**
-     * Number of null values in the named column, or {@code -1} if unknown or the
-     * column is not present in this split's statistics.
+     * Number of null values in the named column under the "implicit nulls" contract:
+     * a column that is physically absent from this split contributes {@code rowCount()}
+     * implicit nulls (every row would deserialize as {@code null}). Returns {@code -1}
+     * only when the column is physically present in the split but the reader could not
+     * extract a null count (the rare Parquet present-but-statless case; ORC always emits one).
+     * <p>
+     * This contract makes {@code Count(col) = rowCount - columnNullCount} correct for
+     * UNION_BY_NAME pushdown across files where some files lack the column, and lets
+     * {@code IS NULL}/{@code IS NOT NULL} classifiers treat absent-column splits as
+     * unconditionally null without needing a separate "column present?" probe.
      */
     long columnNullCount(String name);
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushAggregatesToExternalSource.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushAggregatesToExternalSource.java
@@ -170,6 +170,28 @@ public class PushAggregatesToExternalSource extends PhysicalOptimizerRules.Param
         return true;
     }
 
+    /**
+     * Resolves the value of an ungrouped aggregate purely from split-level statistics.
+     * <p>
+     * For {@code COUNT(col)} we use {@code rowCount - columnNullCount(col)}. This relies on the
+     * {@link org.elasticsearch.xpack.esql.datasources.spi.SplitStats} "implicit nulls" contract:
+     * {@code columnNullCount} already includes both explicit nulls in files that contain the
+     * column and rows in files that do not contain the column at all (those count as nulls
+     * because every row would deserialize as {@code null}). When the column is fully absent
+     * from a scope, {@code columnNullCount == rowCount}, so {@code COUNT(col) == 0} for that
+     * scope — exactly the right answer for UNION_BY_NAME mixes.
+     * <p>
+     * The only short-circuit is the rare "column present but stats unknown" case, where
+     * {@code columnNullCount} returns {@code -1} and we bail out so the engine falls back to a
+     * regular scan.
+     * <p>
+     * For {@code MIN}/{@code MAX} we read {@code columnMin}/{@code columnMax} verbatim. Under the
+     * SPI's "implicit nulls" contract, {@link org.elasticsearch.xpack.esql.datasources.MergedSplitStats}
+     * skips children whose null count equals their row count (absent column or all rows null) and
+     * only poisons on a genuine unknown ({@code columnNullCount &lt; 0}). Result of {@code null} therefore
+     * means either "no child contributed a candidate value" or "incompatible/unknown stats" — both are
+     * correct fall-back signals, the rule does not pushdown.
+     */
     private Object resolveFromStats(Expression aggFunction, org.elasticsearch.xpack.esql.datasources.spi.SplitStats stats) {
         if (aggFunction instanceof Count count) {
             if (count.hasFilter()) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushStatsToExternalSource.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushStatsToExternalSource.java
@@ -175,7 +175,7 @@ public class PushStatsToExternalSource extends PhysicalOptimizerRules.OptimizerR
      * "implicit nulls" contract: {@code columnNullCount} includes rows from files where the column
      * is physically absent (each such row is an implicit null), so the formula is correct for
      * UNION_BY_NAME mixes where some files lack the column. A return of {@code -1} from
-     * {@code columnNullCount} signals the rare present-but-statless case and we bail out.
+     * {@code columnNullCount} signals the rare present-but-stats-less case and we bail out.
      */
     private static Object resolveCount(Count count, org.elasticsearch.xpack.esql.datasources.spi.SplitStats stats) {
         if (count.hasFilter()) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushStatsToExternalSource.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushStatsToExternalSource.java
@@ -169,6 +169,14 @@ public class PushStatsToExternalSource extends PhysicalOptimizerRules.OptimizerR
         return null;
     }
 
+    /**
+     * Resolves {@code COUNT(col)} from split-level statistics as {@code rowCount - columnNullCount}.
+     * Correctness depends on the {@link org.elasticsearch.xpack.esql.datasources.spi.SplitStats}
+     * "implicit nulls" contract: {@code columnNullCount} includes rows from files where the column
+     * is physically absent (each such row is an implicit null), so the formula is correct for
+     * UNION_BY_NAME mixes where some files lack the column. A return of {@code -1} from
+     * {@code columnNullCount} signals the rare present-but-statless case and we bail out.
+     */
     private static Object resolveCount(Count count, org.elasticsearch.xpack.esql.datasources.spi.SplitStats stats) {
         if (count.hasFilter()) {
             return null;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/MergedSplitStatsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/MergedSplitStatsTests.java
@@ -68,10 +68,59 @@ public class MergedSplitStatsTests extends ESTestCase {
         assertEquals(-1, merged.columnNullCount("age"));
     }
 
-    public void testColumnNullCountReturnsMinusOneForMissingColumn() {
+    public void testColumnNullCountReturnsRowCountForMissingColumn() {
+        // Under the SPI's "implicit nulls" contract, a column absent from a child
+        // contributes that child's full row count as implicit nulls (not -1).
         SplitStats a = splitStatsWithColumn("age", 5L, 10, 90, 400);
         MergedSplitStats merged = new MergedSplitStats(List.of(a));
-        assertEquals(-1, merged.columnNullCount("name"));
+        assertEquals("absent column contributes rowCount, not -1", a.rowCount(), merged.columnNullCount("name"));
+    }
+
+    public void testColumnNullCountWithAbsentChildrenSumsCorrectly() {
+        // Child A: 100 rows, has bonus with 5 explicit nulls.
+        // Child B: 200 rows, no bonus column at all -> contributes 200 implicit nulls.
+        // Sum: 5 + 200 = 205.
+        SplitStats a = splitStatsRowCountWithColumn(100, "bonus", 5L, 10, 90, 400);
+        SplitStats b = splitStatsRowCountWithColumn(200, "age", 0L, 1, 2, 100);
+        MergedSplitStats merged = new MergedSplitStats(List.of(a, b));
+        assertEquals(205L, merged.columnNullCount("bonus"));
+    }
+
+    public void testColumnMinSkipsChildrenWithoutColumnValue() {
+        // Child A: has bonus, min=10. Child B: no bonus. Child C: has bonus, min=20.
+        // Skip B rather than poison; result is 10.
+        SplitStats a = splitStatsRowCountWithColumn(100, "bonus", 0L, 10, 90, 400);
+        SplitStats b = splitStatsRowCountWithColumn(50, "age", 0L, 1, 2, 100);
+        SplitStats c = splitStatsRowCountWithColumn(100, "bonus", 0L, 20, 80, 400);
+        MergedSplitStats merged = new MergedSplitStats(List.of(a, b, c));
+        assertEquals(10, merged.columnMin("bonus"));
+        assertEquals(90, merged.columnMax("bonus"));
+    }
+
+    public void testColumnMinSkipsAllNullChildren() {
+        // Child A: has bonus, min=10 (some rows non-null). Child B: has bonus but every row is null.
+        // Child C: has bonus, min=20. B contributes no candidate value and must be skipped.
+        SplitStats a = splitStatsRowCountWithColumn(100, "bonus", 5L, 10, 90, 400);
+        // B has bonus column but nullCount == rowCount (all rows null) and no min/max stat.
+        SplitStats.Builder bb = new SplitStats.Builder().rowCount(50);
+        bb.addColumn("bonus", 50L, null, null, 200);
+        SplitStats b = bb.build();
+        SplitStats c = splitStatsRowCountWithColumn(100, "bonus", 0L, 20, 80, 400);
+        MergedSplitStats merged = new MergedSplitStats(List.of(a, b, c));
+        assertEquals(10, merged.columnMin("bonus"));
+        assertEquals(90, merged.columnMax("bonus"));
+    }
+
+    public void testColumnMinPoisonedByPresentButStatlessChild() {
+        // Child A: has bonus with full stats. Child B: column physically present (column added)
+        // but null count is unknown (-1). Defensive: poison rather than fabricate.
+        SplitStats a = splitStatsRowCountWithColumn(100, "bonus", 0L, 10, 90, 400);
+        SplitStats.Builder bb = new SplitStats.Builder().rowCount(50);
+        bb.addColumn("bonus", -1L, null, null, 200);
+        SplitStats b = bb.build();
+        MergedSplitStats merged = new MergedSplitStats(List.of(a, b));
+        assertNull("present-but-statless child must poison the min", merged.columnMin("bonus"));
+        assertNull("present-but-statless child must poison the max", merged.columnMax("bonus"));
     }
 
     // -- columnMin --
@@ -181,6 +230,12 @@ public class MergedSplitStatsTests extends ESTestCase {
 
     private static SplitStats splitStatsWithColumn(String name, long nullCount, int min, int max, long sizeBytes) {
         SplitStats.Builder b = new SplitStats.Builder().rowCount(100);
+        b.addColumn(name, nullCount, min, max, sizeBytes);
+        return b.build();
+    }
+
+    private static SplitStats splitStatsRowCountWithColumn(long rowCount, String name, long nullCount, int min, int max, long sizeBytes) {
+        SplitStats.Builder b = new SplitStats.Builder().rowCount(rowCount);
         b.addColumn(name, nullCount, min, max, sizeBytes);
         return b.build();
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/MergedSplitStatsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/MergedSplitStatsTests.java
@@ -111,7 +111,7 @@ public class MergedSplitStatsTests extends ESTestCase {
         assertEquals(90, merged.columnMax("bonus"));
     }
 
-    public void testColumnMinPoisonedByPresentButStatlessChild() {
+    public void testColumnMinPoisonedByPresentButStatsLessChild() {
         // Child A: has bonus with full stats. Child B: column physically present (column added)
         // but null count is unknown (-1). Defensive: poison rather than fabricate.
         SplitStats a = splitStatsRowCountWithColumn(100, "bonus", 0L, 10, 90, 400);
@@ -119,8 +119,8 @@ public class MergedSplitStatsTests extends ESTestCase {
         bb.addColumn("bonus", -1L, null, null, 200);
         SplitStats b = bb.build();
         MergedSplitStats merged = new MergedSplitStats(List.of(a, b));
-        assertNull("present-but-statless child must poison the min", merged.columnMin("bonus"));
-        assertNull("present-but-statless child must poison the max", merged.columnMax("bonus"));
+        assertNull("present-but-stats-less child must poison the min", merged.columnMin("bonus"));
+        assertNull("present-but-stats-less child must poison the max", merged.columnMax("bonus"));
     }
 
     // -- columnMin --

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SourceStatisticsSerializerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SourceStatisticsSerializerTests.java
@@ -189,6 +189,89 @@ public class SourceStatisticsSerializerTests extends ESTestCase {
         assertNull("once poisoned, max must stay cleared", result.get(SourceStatisticsSerializer.columnMaxKey("val")));
     }
 
+    public void testMergeStatisticsAddsImplicitNullsForAbsentColumns() {
+        // File A: 100 rows, has bonus with 5 explicit nulls.
+        Map<String, Object> a = new HashMap<>();
+        a.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 100L);
+        a.put(SourceStatisticsSerializer.columnNullCountKey("bonus"), 5L);
+        a.put(SourceStatisticsSerializer.columnMinKey("bonus"), 10);
+        a.put(SourceStatisticsSerializer.columnMaxKey("bonus"), 50);
+        a.put(SourceStatisticsSerializer.columnSizeBytesKey("bonus"), 800L);
+
+        // File B: 200 rows, no bonus column at all (no _stats.columns.bonus.* keys).
+        Map<String, Object> b = new HashMap<>();
+        b.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 200L);
+
+        // File C: 700 rows, has bonus with 10 explicit nulls.
+        Map<String, Object> c = new HashMap<>();
+        c.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 700L);
+        c.put(SourceStatisticsSerializer.columnNullCountKey("bonus"), 10L);
+        c.put(SourceStatisticsSerializer.columnMinKey("bonus"), 20);
+        c.put(SourceStatisticsSerializer.columnMaxKey("bonus"), 70);
+        c.put(SourceStatisticsSerializer.columnSizeBytesKey("bonus"), 5600L);
+
+        Map<String, Object> result = SourceStatisticsSerializer.mergeStatistics(List.of(a, b, c));
+        assertNotNull(result);
+        assertEquals(1000L, result.get(SourceStatisticsSerializer.STATS_ROW_COUNT));
+        // 5 (A explicit) + 10 (C explicit) + 200 (B implicit, every row counts as null) = 215.
+        assertEquals(215L, result.get(SourceStatisticsSerializer.columnNullCountKey("bonus")));
+        // Min/max/size_bytes only consider files where the column is present.
+        assertEquals(10, result.get(SourceStatisticsSerializer.columnMinKey("bonus")));
+        assertEquals(70, result.get(SourceStatisticsSerializer.columnMaxKey("bonus")));
+        assertEquals(6400L, result.get(SourceStatisticsSerializer.columnSizeBytesKey("bonus")));
+    }
+
+    public void testMergeStatisticsImplicitNullsAcrossMultipleColumns() {
+        // File A has only "x"; file B has only "y". Each file's row count flows to the other column.
+        Map<String, Object> a = new HashMap<>();
+        a.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 100L);
+        a.put(SourceStatisticsSerializer.columnNullCountKey("x"), 0L);
+
+        Map<String, Object> b = new HashMap<>();
+        b.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 250L);
+        b.put(SourceStatisticsSerializer.columnNullCountKey("y"), 7L);
+
+        Map<String, Object> result = SourceStatisticsSerializer.mergeStatistics(List.of(a, b));
+        assertNotNull(result);
+        assertEquals(350L, result.get(SourceStatisticsSerializer.STATS_ROW_COUNT));
+        // x absent in B (250 rows): 0 + 250 = 250.
+        assertEquals(250L, result.get(SourceStatisticsSerializer.columnNullCountKey("x")));
+        // y absent in A (100 rows): 7 + 100 = 107.
+        assertEquals(107L, result.get(SourceStatisticsSerializer.columnNullCountKey("y")));
+    }
+
+    public void testMergeStatisticsPoisonsNullCountWhenAnyFilePresentsColumnWithoutNullCount() {
+        // File A: bonus with full stats.
+        Map<String, Object> a = new HashMap<>();
+        a.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 100L);
+        a.put(SourceStatisticsSerializer.columnNullCountKey("bonus"), 5L);
+        a.put(SourceStatisticsSerializer.columnMinKey("bonus"), 10);
+        a.put(SourceStatisticsSerializer.columnMaxKey("bonus"), 50);
+        a.put(SourceStatisticsSerializer.columnSizeBytesKey("bonus"), 800L);
+
+        // File B: bonus is physically present (size_bytes set) but reader produced no null_count
+        // (rare Parquet path with stats disabled). We must not invent a count for those rows.
+        Map<String, Object> b = new HashMap<>();
+        b.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 200L);
+        b.put(SourceStatisticsSerializer.columnSizeBytesKey("bonus"), 1600L);
+
+        // File C: bonus absent entirely.
+        Map<String, Object> c = new HashMap<>();
+        c.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 700L);
+
+        Map<String, Object> result = SourceStatisticsSerializer.mergeStatistics(List.of(a, b, c));
+        assertNotNull(result);
+        assertEquals(1000L, result.get(SourceStatisticsSerializer.STATS_ROW_COUNT));
+        assertFalse(
+            "null_count must be dropped when any present file lacks a null_count value",
+            result.containsKey(SourceStatisticsSerializer.columnNullCountKey("bonus"))
+        );
+        // Min/max/size_bytes are still informative from file A (and B for size_bytes).
+        assertEquals(10, result.get(SourceStatisticsSerializer.columnMinKey("bonus")));
+        assertEquals(50, result.get(SourceStatisticsSerializer.columnMaxKey("bonus")));
+        assertEquals(2400L, result.get(SourceStatisticsSerializer.columnSizeBytesKey("bonus")));
+    }
+
     public void testMergeStatistics_sumsSizeBytes() {
         Map<String, Object> s1 = new HashMap<>();
         s1.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 100L);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SplitStatsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SplitStatsTests.java
@@ -189,7 +189,7 @@ public class SplitStatsTests extends ESTestCase {
         assertEquals(-1L, stats.columnSizeBytes("bonus"));
     }
 
-    public void testColumnNullCountReturnsMinusOneWhenColumnPresentButStatless() {
+    public void testColumnNullCountReturnsMinusOneWhenColumnPresentButStatsLess() {
         // Defensive: a column physically present but with an unknown null count must keep
         // returning -1 (callers bail out rather than fabricate). This mirrors the rare
         // Parquet path where stats were not written.
@@ -197,7 +197,7 @@ public class SplitStatsTests extends ESTestCase {
         b.addColumn("bonus");
         SplitStats stats = b.build();
 
-        assertEquals("present-but-statless column must keep -1 sentinel", -1L, stats.columnNullCount("bonus"));
+        assertEquals("present-but-stats-less column must keep -1 sentinel", -1L, stats.columnNullCount("bonus"));
     }
 
     public void testFindColumn() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SplitStatsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SplitStatsTests.java
@@ -176,6 +176,30 @@ public class SplitStatsTests extends ESTestCase {
         assertFalse(map.containsKey(SourceStatisticsSerializer.columnSizeBytesKey("x")));
     }
 
+    public void testColumnNullCountReturnsRowCountWhenColumnAbsent() {
+        // Per-file SplitStats with no "bonus" column at all. Under the SPI's "implicit nulls"
+        // contract, every row of this file counts as a null for "bonus".
+        SplitStats.Builder b = new SplitStats.Builder().rowCount(100);
+        b.addColumn("age", 5L, 18, 65, 400);
+        SplitStats stats = b.build();
+
+        assertEquals("absent column should return rowCount as implicit nulls", 100L, stats.columnNullCount("bonus"));
+        assertNull(stats.columnMin("bonus"));
+        assertNull(stats.columnMax("bonus"));
+        assertEquals(-1L, stats.columnSizeBytes("bonus"));
+    }
+
+    public void testColumnNullCountReturnsMinusOneWhenColumnPresentButStatless() {
+        // Defensive: a column physically present but with an unknown null count must keep
+        // returning -1 (callers bail out rather than fabricate). This mirrors the rare
+        // Parquet path where stats were not written.
+        SplitStats.Builder b = new SplitStats.Builder().rowCount(100);
+        b.addColumn("bonus");
+        SplitStats stats = b.build();
+
+        assertEquals("present-but-statless column must keep -1 sentinel", -1L, stats.columnNullCount("bonus"));
+    }
+
     public void testFindColumn() {
         SplitStats.Builder b = new SplitStats.Builder().rowCount(50);
         b.addColumn("a.b.c", 0L, null, null, -1);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushAggregatesToExternalSourceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushAggregatesToExternalSourceTests.java
@@ -260,12 +260,17 @@ public class PushAggregatesToExternalSourceTests extends ESTestCase {
         as(result, AggregateExec.class);
     }
 
-    public void testCountFieldWithoutNullCountNotPushed() {
+    public void testCountFieldWithoutColumnEntriesPushedAsImplicitNullCount() {
+        // The merged metadata map carries a row count but no _stats.columns.age.* entries.
+        // Under the SplitStats SPI's "implicit nulls" contract, the column is treated as
+        // absent from this scope, so columnNullCount("age") == rowCount and COUNT(age) == 0.
+        // The rule pushes down a LocalSourceExec with value 0 rather than bailing out.
         Map<String, Object> metadata = new HashMap<>();
         metadata.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 1000L);
         var agg = aggregateExec(AggregatorMode.SINGLE, externalSource(metadata), countFieldAlias(AGE));
 
-        as(applyRule(agg), AggregateExec.class);
+        LocalSourceExec local = as(applyRule(agg), LocalSourceExec.class);
+        assertEquals(0L, as(local.supplier().get().getBlock(0), LongBlock.class).getLong(0));
     }
 
     public void testMinWithoutColumnStatsNotPushed() {
@@ -420,6 +425,91 @@ public class PushAggregatesToExternalSourceTests extends ESTestCase {
         assertEquals(100.5, as(maxLocal.supplier().get().getBlock(0), DoubleBlock.class).getDouble(0), 0.0001);
     }
 
+    public void testCountOverPartiallyPresentColumnUsesImplicitNulls() {
+        // Metadata-fast-path scenario (single sourceMetadata map, no per-split stats).
+        // The map already encodes the merged null_count under the new contract:
+        // 600 implicit nulls (rows from files lacking the column) + 10 explicit nulls = 610.
+        // Pushdown computes Count(bonus) = rowCount - columnNullCount = 1000 - 610 = 390.
+        // Pre-fix the merger would have produced null_count=10 and the result would be 990.
+        ReferenceAttribute bonus = referenceAttribute("bonus", DataType.INTEGER);
+        Map<String, Object> metadata = statsMetadata(1000L, "bonus", 610L);
+        ExternalSourceExec ext = new ExternalSourceExec(
+            Source.EMPTY,
+            "file:///test.parquet",
+            "parquet",
+            List.of(referenceAttribute("x", DataType.INTEGER), AGE, SCORE, bonus),
+            Map.of(),
+            metadata,
+            null
+        );
+        var agg = aggregateExec(AggregatorMode.SINGLE, ext, countFieldAlias(bonus));
+
+        LocalSourceExec local = as(applyRule(agg), LocalSourceExec.class);
+        assertEquals(390L, as(local.supplier().get().getBlock(0), LongBlock.class).getLong(0));
+    }
+
+    public void testPushdownAcrossSplitsWithMissingColumnInOneSplit() {
+        // Per-split path: split 1 has full bonus stats (100 rows, 5 nulls, min=1, max=99);
+        // split 2 has 200 rows but no bonus column at all.
+        // Under the implicit-nulls contract:
+        // COUNT(bonus) = (100 + 200) - (5 + 200) = 95 (split 2 contributes 200 implicit nulls).
+        // MIN(bonus) = 1 (split 2 has no candidate, gets skipped rather than poisoning).
+        // MAX(bonus) = 99 (same logic).
+        ReferenceAttribute bonus = referenceAttribute("bonus", DataType.INTEGER);
+        Map<String, Object> withBonus = new HashMap<>();
+        withBonus.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 100L);
+        withBonus.put(SourceStatisticsSerializer.columnNullCountKey("bonus"), 5L);
+        withBonus.put(SourceStatisticsSerializer.columnMinKey("bonus"), 1);
+        withBonus.put(SourceStatisticsSerializer.columnMaxKey("bonus"), 99);
+        withBonus.put(SourceStatisticsSerializer.columnSizeBytesKey("bonus"), 800L);
+
+        Map<String, Object> withoutBonus = new HashMap<>();
+        withoutBonus.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 200L);
+
+        // ExternalSourceExec with custom output that includes bonus in its attributes.
+        List<Attribute> attrs = List.of(referenceAttribute("x", DataType.INTEGER), AGE, SCORE, bonus);
+
+        ExternalSourceExec extCount = externalSourceWithSplitsAndAttrs(attrs, Map.of(), withBonus, withoutBonus);
+        var countAgg = aggregateExec(AggregatorMode.SINGLE, extCount, countFieldAlias(bonus));
+        LocalSourceExec countLocal = as(applyRule(countAgg), LocalSourceExec.class);
+        assertEquals(95L, as(countLocal.supplier().get().getBlock(0), LongBlock.class).getLong(0));
+
+        ExternalSourceExec extMin = externalSourceWithSplitsAndAttrs(attrs, Map.of(), withBonus, withoutBonus);
+        var minAgg = aggregateExec(AggregatorMode.SINGLE, extMin, alias("mn", new Min(Source.EMPTY, bonus)));
+        LocalSourceExec minLocal = as(applyRule(minAgg), LocalSourceExec.class);
+        assertEquals(1, as(minLocal.supplier().get().getBlock(0), IntBlock.class).getInt(0));
+
+        ExternalSourceExec extMax = externalSourceWithSplitsAndAttrs(attrs, Map.of(), withBonus, withoutBonus);
+        var maxAgg = aggregateExec(AggregatorMode.SINGLE, extMax, alias("mx", new Max(Source.EMPTY, bonus)));
+        LocalSourceExec maxLocal = as(applyRule(maxAgg), LocalSourceExec.class);
+        assertEquals(99, as(maxLocal.supplier().get().getBlock(0), IntBlock.class).getInt(0));
+    }
+
+    public void testCountFieldNotPushedWhenMergedNullCountPoisoned() {
+        // Defensive end-to-end check for the present-but-statless poison path:
+        // mergeStatistics drops null_count for `bonus` when any present file lacks it, so the
+        // sourceMetadata reaching the optimizer has no _stats.columns.bonus.null_count entry,
+        // even though _stats.columns.bonus.size_bytes is set (column is physically present
+        // somewhere). columnNullCount must return -1 and the rule must bail out.
+        ReferenceAttribute bonus = referenceAttribute("bonus", DataType.INTEGER);
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 1000L);
+        metadata.put(SourceStatisticsSerializer.columnSizeBytesKey("bonus"), 4000L);
+        // No _stats.columns.bonus.null_count -> SplitStats.of treats nullCount as -1 (unknown).
+        ExternalSourceExec ext = new ExternalSourceExec(
+            Source.EMPTY,
+            "file:///test.parquet",
+            "parquet",
+            List.of(referenceAttribute("x", DataType.INTEGER), AGE, SCORE, bonus),
+            Map.of(),
+            metadata,
+            null
+        );
+        var agg = aggregateExec(AggregatorMode.SINGLE, ext, countFieldAlias(bonus));
+
+        as(applyRule(agg), AggregateExec.class);
+    }
+
     public void testNotPushedWithMultipleSplitsWithoutStats() {
         ExternalSourceExec ext = externalSourceWithSplits(statsMetadata(1000L, null, null), (Map<String, Object>[]) null);
         var agg = aggregateExec(AggregatorMode.SINGLE, ext, countStarAlias());
@@ -460,6 +550,32 @@ public class PushAggregatesToExternalSourceTests extends ESTestCase {
     }
 
     // --- helpers ---
+
+    @SafeVarargs
+    @SuppressWarnings("varargs")
+    private static ExternalSourceExec externalSourceWithSplitsAndAttrs(
+        List<Attribute> attrs,
+        Map<String, Object> sourceMetadata,
+        Map<String, Object>... perSplitStats
+    ) {
+        List<ExternalSplit> splits = new ArrayList<>(perSplitStats.length);
+        for (int i = 0; i < perSplitStats.length; i++) {
+            splits.add(fileSplit(i, perSplitStats[i]));
+        }
+        return new ExternalSourceExec(
+            Source.EMPTY,
+            "file:///test.parquet",
+            "parquet",
+            attrs,
+            Map.of(),
+            sourceMetadata,
+            null,
+            -1,
+            null,
+            null,
+            splits
+        );
+    }
 
     @SafeVarargs
     @SuppressWarnings("varargs")

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushAggregatesToExternalSourceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushAggregatesToExternalSourceTests.java
@@ -486,7 +486,7 @@ public class PushAggregatesToExternalSourceTests extends ESTestCase {
     }
 
     public void testCountFieldNotPushedWhenMergedNullCountPoisoned() {
-        // Defensive end-to-end check for the present-but-statless poison path:
+        // Defensive end-to-end check for the present-but-stats-less poison path:
         // mergeStatistics drops null_count for `bonus` when any present file lacks it, so the
         // sourceMetadata reaching the optimizer has no _stats.columns.bonus.null_count entry,
         // even though _stats.columns.bonus.size_bytes is set (column is physically present

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushStatsToExternalSourceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushStatsToExternalSourceTests.java
@@ -84,12 +84,16 @@ public class PushStatsToExternalSourceTests extends ESTestCase {
         assertEquals(950L, as(local.supplier().get().getBlock(0), LongBlock.class).getLong(0));
     }
 
-    public void testCountFieldWithoutNullCountNotPushed() {
+    public void testCountFieldWithoutColumnEntriesPushedAsImplicitNullCount() {
+        // Under the "implicit nulls" contract, a metadata map with rowCount but no
+        // _stats.columns.age.* entries means the column is absent from this scope:
+        // columnNullCount("age") returns rowCount and COUNT(age) resolves to 0.
         Map<String, Object> metadata = new HashMap<>();
         metadata.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 1000L);
         var agg = aggregateExec(externalSource(metadata), countFieldAlias(AGE));
 
-        as(applyRule(agg), AggregateExec.class);
+        LocalSourceExec local = as(applyRule(agg), LocalSourceExec.class);
+        assertEquals(0L, as(local.supplier().get().getBlock(0), LongBlock.class).getLong(0));
     }
 
     public void testMinPushedDown() {


### PR DESCRIPTION
## Summary

Two related bugs share one root cause: the per-file `SplitStats.columnNullCount(name)` SPI conflated "column physically absent from this split" with "stats unknown for this column". That conflation caused:

1. **Wrong COUNT on the metadata-only fast path.** `Count(col) = rowCount - columnNullCount(col)` over-counted on UNION_BY_NAME mixes where some files lacked the column, because `rowCount` summed all files but `columnNullCount` only summed across files that contained the column.
2. **Missed pushdown on the per-split path.** `MergedSplitStats.columnMin/Max/NullCount` poisoned as soon as any child returned the "absent" sentinel, falling back to a full scan even when stats were perfectly resolvable.

This PR redefines `columnNullCount(name)` to include implicit nulls from absent-in-file rows. Every existing consumer becomes correct without an SPI surface change.

## Changes

- **`SplitStats.columnNullCount`** now returns `rowCount` when the column is physically absent (every row would deserialize as `null`); `-1` is reserved for the rare Parquet "present but stats disabled" case.
- **`SourceStatisticsSerializer.mergeStatistics`** does a two-pass merge: explicit nulls from per-file maps, then implicit nulls (each absent file's `row_count`) folded into the merged `null_count`. Columns that any file shows as present-but-statless poison the merged `null_count` so consumers see "unknown" rather than under-counting.
- **`MergedSplitStats.columnMin/Max`** distinguish "no candidate value" (skip) from "genuinely unknown" (poison). All-null or absent-from-file children are skipped; only `columnNullCount < 0` poisons.
- **Optimizer rule javadocs** in `PushAggregatesToExternalSource` / `PushStatsToExternalSource` document the new contract — the `rowCount - columnNullCount` formula is unchanged but now provably correct under UBN.


Developed with AI-assisted tooling