### PR TITLE
[Docs] Fix unnecessary backslash escaping in code spans

### DIFF
--- a/docs/reference/query-languages/query-dsl/query-dsl-percolate-query.md
+++ b/docs/reference/query-languages/query-dsl/query-dsl-percolate-query.md
@@ -540,7 +540,7 @@ The slightly different response:
 
 ## Named queries within percolator queries [_named_queries_within_percolator_queries]
 
-If a stored percolator query is a complex query, and you want to track which its sub-queries matched a percolated document, then you can use the `\_name` parameter for its sub-queries. In this case, in a response, each hit together with a `_percolator_document_slot` field contains `_percolator_document_slot_<slotNumber>_matched_queries` fields that show which sub-queries matched each percolated document.
+If a stored percolator query is a complex query, and you want to track which its sub-queries matched a percolated document, then you can use the `_name` parameter for its sub-queries. In this case, in a response, each hit together with a `_percolator_document_slot` field contains `_percolator_document_slot_<slotNumber>_matched_queries` fields that show which sub-queries matched each percolated document.
 
 For example:
 

--- a/docs/reference/query-languages/query-dsl/query-dsl-query-string-query.md
+++ b/docs/reference/query-languages/query-dsl/query-dsl-query-string-query.md
@@ -220,7 +220,7 @@ qu?ck bro*
 Be aware that wildcard queries can use an enormous amount of memory and perform very badly — just think how many terms need to be queried to match the query string `"a* b* c*"`.
 
 ::::{warning}
-Pure wildcards `\*` are rewritten to [`exists`](/reference/query-languages/query-dsl/query-dsl-exists-query.md) queries for efficiency. As a consequence, the wildcard `"field:*"` would match documents with an empty value like the following:
+Pure wildcards `*` are rewritten to [`exists`](/reference/query-languages/query-dsl/query-dsl-exists-query.md) queries for efficiency. As a consequence, the wildcard `"field:*"` would match documents with an empty value like the following:
 
 ```
 {

--- a/docs/reference/query-languages/query-dsl/query-dsl-simple-query-string-query.md
+++ b/docs/reference/query-languages/query-dsl/query-dsl-simple-query-string-query.md
@@ -169,7 +169,7 @@ The available flags are:
 :   Enables the `-` NOT operator.
 
 `OR`
-:   Enables the `\|` OR operator.
+:   Enables the `|` OR operator.
 
 `PHRASE`
 :   Enables the `"` quotes operator used to search for phrases.


### PR DESCRIPTION
## Summary

Removes unnecessary backslash escaping inside backtick code spans in three query DSL docs files. Special characters (`|`, `*`, `_`) do not need escaping inside code spans, and the backslashes were rendering visibly in the published docs.

- `query-dsl-simple-query-string-query.md`: `` `\|` `` → `` `|` `` in the `OR` flag description
- `query-dsl-query-string-query.md`: `` `\*` `` → `` `*` `` in the wildcard rewrite warning
- `query-dsl-percolate-query.md`: `` `\_name` `` → `` `_name` `` in the named queries section

Made with [Cursor](https://cursor.com)