### PR TITLE
ESQL: Faster `BUCKET` eval floor convention

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/Rounding.java
+++ b/server/src/main/java/org/elasticsearch/common/Rounding.java
@@ -570,7 +570,7 @@ public abstract class Rounding implements Writeable {
             }
         }
 
-        private record Prepared(Rounding.Prepared delegate) implements Rounding.Prepared {
+        private record Prepared(Rounding.Prepared delegate, Long maxUtcMillis) implements Rounding.Prepared {
             @Override
             public long round(long utcMillis) {
                 return delegate.nextRoundingValue(prevLong(utcMillis));
@@ -608,7 +608,17 @@ public abstract class Rounding implements Writeable {
 
             @Override
             public long[] fixedRoundingPoints() {
-                return delegate.fixedRoundingPoints();
+                long[] points = delegate.fixedRoundingPoints();
+                if (points == null || maxUtcMillis == null) {
+                    return points;
+                }
+                long end = round(maxUtcMillis);
+                if (points.length == 0 || points[points.length - 1] >= end) {
+                    return points;
+                }
+                points = Arrays.copyOf(points, points.length + 1);
+                points[points.length - 1] = end;
+                return points;
             }
 
             @Override
@@ -632,17 +642,17 @@ public abstract class Rounding implements Writeable {
 
         @Override
         public Rounding.Prepared prepare(long minUtcMillis, long maxUtcMillis) {
-            return new ToUpperRounding.Prepared(next.prepare(prevLong(minUtcMillis), maxUtcMillis));
+            return new ToUpperRounding.Prepared(next.prepare(prevLong(minUtcMillis), maxUtcMillis), maxUtcMillis);
         }
 
         @Override
         public Rounding.Prepared prepareForUnknown() {
-            return new ToUpperRounding.Prepared(next.prepareForUnknown());
+            return new ToUpperRounding.Prepared(next.prepareForUnknown(), null);
         }
 
         @Override
         public Rounding.Prepared prepareJavaTime() {
-            return new ToUpperRounding.Prepared(next.prepareJavaTime());
+            return new ToUpperRounding.Prepared(next.prepareJavaTime(), null);
         }
 
         @Override
@@ -1737,8 +1747,15 @@ public abstract class Rounding implements Writeable {
 
         @Override
         public long[] fixedRoundingPoints() {
-            // TODO we can likely translate here
-            return null;
+            long[] delegatePoints = delegatePrepared.fixedRoundingPoints();
+            if (delegatePoints == null) {
+                return null;
+            }
+            long[] points = Arrays.copyOf(delegatePoints, delegatePoints.length);
+            for (int i = 0; i < points.length; i++) {
+                points[i] += offset;
+            }
+            return points;
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -964,10 +964,10 @@ public final class DateFieldMapper extends FieldMapper {
                     return new LongsBlockLoader(name());
                 }
                 return switch (cfg.function()) {
-                    case ROUND_TO -> new RoundToLongsFromDocValuesBlockLoader(
-                        name(),
-                        ((BlockLoaderFunctionConfig.RoundToLongs) cfg).points()
-                    );
+                    case ROUND_TO -> {
+                        BlockLoaderFunctionConfig.RoundToLongs roundTo = (BlockLoaderFunctionConfig.RoundToLongs) cfg;
+                        yield new RoundToLongsFromDocValuesBlockLoader(name(), roundTo.points(), roundTo.convention());
+                    }
                     default -> throw new UnsupportedOperationException("unknown fusion config [" + cfg.function() + "]");
                 };
             }

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -31,6 +31,7 @@ import org.apache.lucene.util.NumericUtils;
 import org.elasticsearch.cluster.routing.IndexRouting;
 import org.elasticsearch.common.Explicit;
 import org.elasticsearch.common.Numbers;
+import org.elasticsearch.common.Rounding;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
@@ -554,7 +555,7 @@ public class NumberFieldMapper extends FieldMapper {
             }
 
             @Override
-            BlockLoader blockLoaderFromDocValuesRoundTo(String fieldName, long[] points) {
+            BlockLoader blockLoaderFromDocValuesRoundTo(String fieldName, long[] points, Rounding.RoundingConvention convention) {
                 throw new UnsupportedOperationException("ROUND_TO not supported for half_float");
             }
         },
@@ -774,7 +775,7 @@ public class NumberFieldMapper extends FieldMapper {
             }
 
             @Override
-            BlockLoader blockLoaderFromDocValuesRoundTo(String fieldName, long[] points) {
+            BlockLoader blockLoaderFromDocValuesRoundTo(String fieldName, long[] points, Rounding.RoundingConvention convention) {
                 throw new UnsupportedOperationException("ROUND_TO not supported for float");
             }
         },
@@ -960,7 +961,7 @@ public class NumberFieldMapper extends FieldMapper {
             }
 
             @Override
-            BlockLoader blockLoaderFromDocValuesRoundTo(String fieldName, long[] points) {
+            BlockLoader blockLoaderFromDocValuesRoundTo(String fieldName, long[] points, Rounding.RoundingConvention convention) {
                 throw new UnsupportedOperationException("ROUND_TO not supported for double");
             }
         },
@@ -1110,7 +1111,7 @@ public class NumberFieldMapper extends FieldMapper {
             }
 
             @Override
-            BlockLoader blockLoaderFromDocValuesRoundTo(String fieldName, long[] points) {
+            BlockLoader blockLoaderFromDocValuesRoundTo(String fieldName, long[] points, Rounding.RoundingConvention convention) {
                 throw new UnsupportedOperationException("ROUND_TO not supported for byte");
             }
 
@@ -1260,7 +1261,7 @@ public class NumberFieldMapper extends FieldMapper {
             }
 
             @Override
-            BlockLoader blockLoaderFromDocValuesRoundTo(String fieldName, long[] points) {
+            BlockLoader blockLoaderFromDocValuesRoundTo(String fieldName, long[] points, Rounding.RoundingConvention convention) {
                 throw new UnsupportedOperationException("ROUND_TO not supported for short");
             }
 
@@ -1485,7 +1486,7 @@ public class NumberFieldMapper extends FieldMapper {
             }
 
             @Override
-            BlockLoader blockLoaderFromDocValuesRoundTo(String fieldName, long[] points) {
+            BlockLoader blockLoaderFromDocValuesRoundTo(String fieldName, long[] points, Rounding.RoundingConvention convention) {
                 throw new UnsupportedOperationException("ROUND_TO not supported for integer");
             }
         },
@@ -1690,8 +1691,8 @@ public class NumberFieldMapper extends FieldMapper {
             }
 
             @Override
-            BlockLoader blockLoaderFromDocValuesRoundTo(String fieldName, long[] points) {
-                return new RoundToLongsFromDocValuesBlockLoader(fieldName, points);
+            BlockLoader blockLoaderFromDocValuesRoundTo(String fieldName, long[] points, Rounding.RoundingConvention convention) {
+                return new RoundToLongsFromDocValuesBlockLoader(fieldName, points, convention);
             }
 
             private boolean isOutOfRange(Object value) {
@@ -1994,7 +1995,7 @@ public class NumberFieldMapper extends FieldMapper {
 
         abstract BlockLoader blockLoaderFromDocValuesMvMax(String fieldName);
 
-        abstract BlockLoader blockLoaderFromDocValuesRoundTo(String fieldName, long[] points);
+        abstract BlockLoader blockLoaderFromDocValuesRoundTo(String fieldName, long[] points, Rounding.RoundingConvention convention);
 
         // All values that fit into integer are returned as integers
         private static BlockLoader integerBlockLoaderFromFallbackSyntheticSource(
@@ -2276,7 +2277,10 @@ public class NumberFieldMapper extends FieldMapper {
                     case MV_MAX -> type.blockLoaderFromDocValuesMvMax(name());
                     case MV_MIN -> type.blockLoaderFromDocValuesMvMin(name());
                     case AMD_COUNT, AMD_DEFAULT, AMD_MAX, AMD_MIN, AMD_SUM -> type.blockLoaderFromDocValues(name());
-                    case ROUND_TO -> type.blockLoaderFromDocValuesRoundTo(name(), ((BlockLoaderFunctionConfig.RoundToLongs) cfg).points());
+                    case ROUND_TO -> {
+                        BlockLoaderFunctionConfig.RoundToLongs roundTo = (BlockLoaderFunctionConfig.RoundToLongs) cfg;
+                        yield type.blockLoaderFromDocValuesRoundTo(name(), roundTo.points(), roundTo.convention());
+                    }
                     default -> throw new UnsupportedOperationException("unknown fusion config [" + cfg.function() + "]");
                 };
             }

--- a/server/src/main/java/org/elasticsearch/index/mapper/blockloader/BlockLoaderFunctionConfig.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/blockloader/BlockLoaderFunctionConfig.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.index.mapper.blockloader;
 
+import org.elasticsearch.common.Rounding;
 import org.elasticsearch.index.mapper.MappedFieldType;
 
 import java.util.Arrays;
@@ -43,7 +44,8 @@ public interface BlockLoaderFunctionConfig {
     /**
      * Configuration for rounding long values to one of a sorted list of points.
      */
-    record RoundToLongs(long[] points) implements BlockLoaderFunctionConfig {
+    record RoundToLongs(long[] points, Rounding.RoundingConvention convention) implements BlockLoaderFunctionConfig {
+
         @Override
         public Function function() {
             return Function.ROUND_TO;
@@ -51,12 +53,12 @@ public interface BlockLoaderFunctionConfig {
 
         @Override
         public int hashCode() {
-            return Arrays.hashCode(points);
+            return 31 * Arrays.hashCode(points) + convention.hashCode();
         }
 
         @Override
         public boolean equals(Object o) {
-            return o instanceof RoundToLongs other && Arrays.equals(points, other.points);
+            return o instanceof RoundToLongs other && Arrays.equals(points, other.points) && convention == other.convention;
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/RoundToLongsFromDocValuesBlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/RoundToLongsFromDocValuesBlockLoader.java
@@ -12,6 +12,7 @@ package org.elasticsearch.index.mapper.blockloader.docvalues.fn;
 import org.apache.lucene.index.DocValuesSkipper;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.DocIdSetIterator;
+import org.elasticsearch.common.Rounding;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.mapper.blockloader.ConstantNull;
@@ -22,19 +23,23 @@ import org.elasticsearch.index.mapper.blockloader.docvalues.tracking.TrackingSor
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Objects;
 
 /**
- * Loads {@code long}s from doc values, rounding each value down to one of a sorted list of points.
+ * Loads {@code long}s from doc values, rounding each value to one of a sorted list of points
+ * according to the configured {@link Rounding.RoundingConvention}.
  * When a {@link DocValuesSkipper} is available, attempts to shortcircuit entire blocks by checking
  * whether the min and max values for the block's doc ID range round to the same point.
  */
 public class RoundToLongsFromDocValuesBlockLoader extends BlockDocValuesReader.DocValuesBlockLoader {
     final String fieldName;
     private final long[] points;
+    private final Rounding.RoundingConvention convention;
 
-    public RoundToLongsFromDocValuesBlockLoader(String fieldName, long[] points) {
+    public RoundToLongsFromDocValuesBlockLoader(String fieldName, long[] points, Rounding.RoundingConvention convention) {
         this.fieldName = fieldName;
-        this.points = points;
+        this.points = Objects.requireNonNull(points);
+        this.convention = Objects.requireNonNull(convention);
     }
 
     @Override
@@ -51,9 +56,9 @@ public class RoundToLongsFromDocValuesBlockLoader extends BlockDocValuesReader.D
         try {
             DocValuesSkipper skipper = context.reader().getDocValuesSkipper(fieldName);
             if (dv.singleton() != null) {
-                return new RoundToSingleton(dv.singleton(), points, skipper);
+                return new RoundToSingleton(dv.singleton(), points, convention, skipper);
             }
-            return new RoundToSorted(dv.sorted(), points, skipper);
+            return new RoundToSorted(dv.sorted(), points, convention, skipper);
         } catch (IOException e) {
             if (dv.singleton() != null) {
                 dv.singleton().close();
@@ -69,9 +74,12 @@ public class RoundToLongsFromDocValuesBlockLoader extends BlockDocValuesReader.D
         return "RoundToLongsFromDocValues[" + fieldName + "]";
     }
 
-    static long roundTo(long value, long[] points) {
+    static long roundTo(long value, long[] points, Rounding.RoundingConvention convention) {
         int idx = Arrays.binarySearch(points, value);
-        return points[idx >= 0 ? idx : Math.max(0, -idx - 2)];
+        return switch (convention) {
+            case DOWN -> points[idx >= 0 ? idx : Math.max(0, -idx - 2)];
+            case UP -> points[idx >= 0 ? idx : Math.min(points.length - 1, -idx - 1)];
+        };
     }
 
     /**
@@ -79,7 +87,14 @@ public class RoundToLongsFromDocValuesBlockLoader extends BlockDocValuesReader.D
      * Returns {@code null} if the optimization cannot be applied.
      */
     @Nullable
-    static Block tryConstantBlock(BlockFactory factory, Docs docs, int offset, long[] points, DocValuesSkipper skipper) throws IOException {
+    static Block tryConstantBlock(
+        BlockFactory factory,
+        Docs docs,
+        int offset,
+        long[] points,
+        Rounding.RoundingConvention convention,
+        DocValuesSkipper skipper
+    ) throws IOException {
         if (skipper == null || docs.count() - offset == 0) {
             return null;
         }
@@ -97,8 +112,8 @@ public class RoundToLongsFromDocValuesBlockLoader extends BlockDocValuesReader.D
                     // some docs are missing, so we have to go doc by doc to get the nulls right
                     return null;
                 }
-                long roundedMin = roundTo(skipper.minValue(level), points);
-                long roundedMax = roundTo(skipper.maxValue(level), points);
+                long roundedMin = roundTo(skipper.minValue(level), points, convention);
+                long roundedMax = roundTo(skipper.maxValue(level), points, convention);
                 if (roundedMin == roundedMax) {
                     return factory.constantLong(roundedMin, docs.count() - offset);
                 }
@@ -111,19 +126,26 @@ public class RoundToLongsFromDocValuesBlockLoader extends BlockDocValuesReader.D
     private static class RoundToSingleton extends BlockDocValuesReader {
         private final TrackingNumericDocValues numericDocValues;
         private final long[] points;
+        private final Rounding.RoundingConvention convention;
         @Nullable
         private final DocValuesSkipper skipper;
 
-        RoundToSingleton(TrackingNumericDocValues numericDocValues, long[] points, @Nullable DocValuesSkipper skipper) {
+        RoundToSingleton(
+            TrackingNumericDocValues numericDocValues,
+            long[] points,
+            Rounding.RoundingConvention convention,
+            @Nullable DocValuesSkipper skipper
+        ) {
             super(null);
             this.numericDocValues = numericDocValues;
             this.points = points;
+            this.convention = convention;
             this.skipper = skipper;
         }
 
         @Override
         public Block read(BlockFactory factory, Docs docs, int offset, boolean nullsFiltered) throws IOException {
-            Block constant = tryConstantBlock(factory, docs, offset, points, skipper);
+            Block constant = tryConstantBlock(factory, docs, offset, points, convention, skipper);
             if (constant != null) {
                 return constant;
             }
@@ -131,7 +153,7 @@ public class RoundToLongsFromDocValuesBlockLoader extends BlockDocValuesReader.D
                 for (int i = offset; i < docs.count(); i++) {
                     int doc = docs.get(i);
                     if (numericDocValues.docValues().advanceExact(doc)) {
-                        builder.appendLong(roundTo(numericDocValues.docValues().longValue(), points));
+                        builder.appendLong(roundTo(numericDocValues.docValues().longValue(), points, convention));
                     } else {
                         builder.appendNull();
                     }
@@ -159,19 +181,26 @@ public class RoundToLongsFromDocValuesBlockLoader extends BlockDocValuesReader.D
     private static class RoundToSorted extends BlockDocValuesReader {
         private final TrackingSortedNumericDocValues numericDocValues;
         private final long[] points;
+        private final Rounding.RoundingConvention convention;
         @Nullable
         private final DocValuesSkipper skipper;
 
-        RoundToSorted(TrackingSortedNumericDocValues numericDocValues, long[] points, @Nullable DocValuesSkipper skipper) {
+        RoundToSorted(
+            TrackingSortedNumericDocValues numericDocValues,
+            long[] points,
+            Rounding.RoundingConvention convention,
+            @Nullable DocValuesSkipper skipper
+        ) {
             super(null);
             this.numericDocValues = numericDocValues;
             this.points = points;
+            this.convention = convention;
             this.skipper = skipper;
         }
 
         @Override
         public Block read(BlockFactory factory, Docs docs, int offset, boolean nullsFiltered) throws IOException {
-            Block constant = tryConstantBlock(factory, docs, offset, points, skipper);
+            Block constant = tryConstantBlock(factory, docs, offset, points, convention, skipper);
             if (constant != null) {
                 return constant;
             }
@@ -191,12 +220,12 @@ public class RoundToLongsFromDocValuesBlockLoader extends BlockDocValuesReader.D
             }
             int count = numericDocValues.docValues().docValueCount();
             if (count == 1) {
-                builder.appendLong(roundTo(numericDocValues.docValues().nextValue(), points));
+                builder.appendLong(roundTo(numericDocValues.docValues().nextValue(), points, convention));
                 return;
             }
             builder.beginPositionEntry();
             for (int v = 0; v < count; v++) {
-                builder.appendLong(roundTo(numericDocValues.docValues().nextValue(), points));
+                builder.appendLong(roundTo(numericDocValues.docValues().nextValue(), points, convention));
             }
             builder.endPositionEntry();
         }

--- a/server/src/test/java/org/elasticsearch/common/RoundingTests.java
+++ b/server/src/test/java/org/elasticsearch/common/RoundingTests.java
@@ -1358,6 +1358,27 @@ public class RoundingTests extends ESTestCase {
         }
     }
 
+    public void testUpperIntervalRoundingWithOffsetFixedPoints() {
+        Rounding rounding = Rounding.ToUpperRounding.createRounding(
+            Rounding.builder(TimeValue.timeValueMinutes(2)).offset(TimeUnit.MINUTES.toMillis(1)).build()
+        );
+        assertFixedRoundingPoints(
+            rounding.prepare(time("2024-05-10T00:10:00"), time("2024-05-10T00:30:00")),
+            "2024-05-10T00:09:00",
+            "2024-05-10T00:11:00",
+            "2024-05-10T00:13:00",
+            "2024-05-10T00:15:00",
+            "2024-05-10T00:17:00",
+            "2024-05-10T00:19:00",
+            "2024-05-10T00:21:00",
+            "2024-05-10T00:23:00",
+            "2024-05-10T00:25:00",
+            "2024-05-10T00:27:00",
+            "2024-05-10T00:29:00",
+            "2024-05-10T00:31:00"
+        );
+    }
+
     public void testUpperIntervalReprepareWithOffsetMatchesDerivedFormula() {
         Rounding rounding = Rounding.builder(TimeValue.timeValueMinutes(2)).offset(TimeUnit.MINUTES.toMillis(1)).build();
         long min = time("2024-05-10T00:15:00");

--- a/server/src/test/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/RoundToLongsFromDocValuesBlockLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/RoundToLongsFromDocValuesBlockLoaderTests.java
@@ -18,6 +18,7 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.elasticsearch.common.Rounding;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.index.mapper.BlockLoader;
@@ -46,32 +47,34 @@ public class RoundToLongsFromDocValuesBlockLoaderTests extends AbstractNumericBl
 
     @Override
     protected void innerTest(CircuitBreaker breaker, LeafReaderContext ctx, int mvCount) throws IOException {
-        LongsBlockLoader longsLoader = new LongsBlockLoader("field");
-        RoundToLongsFromDocValuesBlockLoader roundToLoader = new RoundToLongsFromDocValuesBlockLoader("field", POINTS);
-        BlockLoader.Docs docs = TestBlock.docs(ctx);
+        for (Rounding.RoundingConvention convention : Rounding.RoundingConvention.values()) {
+            LongsBlockLoader longsLoader = new LongsBlockLoader("field");
+            RoundToLongsFromDocValuesBlockLoader roundToLoader = new RoundToLongsFromDocValuesBlockLoader("field", POINTS, convention);
+            BlockLoader.Docs docs = TestBlock.docs(ctx);
 
-        try (
-            BlockLoader.ColumnAtATimeReader longsReader = longsLoader.reader(breaker, ctx);
-            BlockLoader.ColumnAtATimeReader roundToReader = roundToLoader.reader(breaker, ctx)
-        ) {
-            assertThat(roundToReader, readerMatcher());
-            try (TestBlock longs = read(longsReader, docs); TestBlock rounded = read(roundToReader, docs)) {
-                checkBlocks(longs, rounded);
-            }
-        }
-
-        try (
-            BlockLoader.ColumnAtATimeReader longsReader = longsLoader.reader(breaker, ctx);
-            BlockLoader.ColumnAtATimeReader roundToReader = roundToLoader.reader(breaker, ctx)
-        ) {
-            for (int i = 0; i < ctx.reader().numDocs(); i += 10) {
-                int[] docsArray = new int[Math.min(10, ctx.reader().numDocs() - i)];
-                for (int d = 0; d < docsArray.length; d++) {
-                    docsArray[d] = i + d;
-                }
-                docs = TestBlock.docs(docsArray);
+            try (
+                BlockLoader.ColumnAtATimeReader longsReader = longsLoader.reader(breaker, ctx);
+                BlockLoader.ColumnAtATimeReader roundToReader = roundToLoader.reader(breaker, ctx)
+            ) {
+                assertThat(roundToReader, readerMatcher());
                 try (TestBlock longs = read(longsReader, docs); TestBlock rounded = read(roundToReader, docs)) {
-                    checkBlocks(longs, rounded);
+                    checkBlocks(longs, rounded, convention);
+                }
+            }
+
+            try (
+                BlockLoader.ColumnAtATimeReader longsReader = longsLoader.reader(breaker, ctx);
+                BlockLoader.ColumnAtATimeReader roundToReader = roundToLoader.reader(breaker, ctx)
+            ) {
+                for (int i = 0; i < ctx.reader().numDocs(); i += 10) {
+                    int[] docsArray = new int[Math.min(10, ctx.reader().numDocs() - i)];
+                    for (int d = 0; d < docsArray.length; d++) {
+                        docsArray[d] = i + d;
+                    }
+                    docs = TestBlock.docs(docsArray);
+                    try (TestBlock longs = read(longsReader, docs); TestBlock rounded = read(roundToReader, docs)) {
+                        checkBlocks(longs, rounded, convention);
+                    }
                 }
             }
         }
@@ -92,14 +95,17 @@ public class RoundToLongsFromDocValuesBlockLoaderTests extends AbstractNumericBl
             try (DirectoryReader dr = iw.getReader()) {
                 LeafReaderContext ctx = getOnlyLeafReader(dr).getContext();
                 assertNotNull(ctx.reader().getDocValuesSkipper("field"));
-                RoundToLongsFromDocValuesBlockLoader loader = new RoundToLongsFromDocValuesBlockLoader("field", points);
-                try (BlockLoader.ColumnAtATimeReader reader = loader.reader(breaker, ctx)) {
-                    BlockLoader.Docs docs = TestBlock.docs(ctx);
-                    try (TestBlock block = (TestBlock) reader.read(TestBlock.factory(), docs, 0, false)) {
-                        assertTrue("expected constant block from skipper optimization", block.isConstant());
-                        assertThat(block.size(), equalTo(docCount));
-                        for (int i = 0; i < docCount; i++) {
-                            assertThat(block.get(i), equalTo(100L));
+                for (Rounding.RoundingConvention convention : Rounding.RoundingConvention.values()) {
+                    RoundToLongsFromDocValuesBlockLoader loader = new RoundToLongsFromDocValuesBlockLoader("field", points, convention);
+                    try (BlockLoader.ColumnAtATimeReader reader = loader.reader(breaker, ctx)) {
+                        BlockLoader.Docs docs = TestBlock.docs(ctx);
+                        try (TestBlock block = (TestBlock) reader.read(TestBlock.factory(), docs, 0, false)) {
+                            assertTrue("expected constant block from skipper optimization", block.isConstant());
+                            assertThat(block.size(), equalTo(docCount));
+                            long expected = RoundToLongsFromDocValuesBlockLoader.roundTo(150, points, convention);
+                            for (int i = 0; i < docCount; i++) {
+                                assertThat(block.get(i), equalTo(expected));
+                            }
                         }
                     }
                 }
@@ -124,29 +130,34 @@ public class RoundToLongsFromDocValuesBlockLoaderTests extends AbstractNumericBl
                 LeafReaderContext ctx = getOnlyLeafReader(dr).getContext();
                 assertNotNull(ctx.reader().getDocValuesSkipper("field"));
 
-                // Derive expected rounded values from actual index state since
-                // RandomIndexWriter may reorder segments during merge.
-                SortedNumericDocValues dv = ctx.reader().getSortedNumericDocValues("field");
-                long[] expectedRounded = new long[docCount];
-                int bucket100Count = 0;
-                int bucket200Count = 0;
-                for (int i = 0; i < docCount; i++) {
-                    assertTrue("doc " + i + " should have a value", dv.advanceExact(i));
-                    expectedRounded[i] = RoundToLongsFromDocValuesBlockLoader.roundTo(dv.nextValue(), points);
-                    if (expectedRounded[i] == 100L) bucket100Count++;
-                    else bucket200Count++;
-                }
-                assertThat("docs rounding to 100", bucket100Count, equalTo(100));
-                assertThat("docs rounding to 200", bucket200Count, equalTo(100));
+                for (Rounding.RoundingConvention convention : Rounding.RoundingConvention.values()) {
+                    // Derive expected rounded values from actual index state since
+                    // RandomIndexWriter may reorder segments during merge.
+                    SortedNumericDocValues dv = ctx.reader().getSortedNumericDocValues("field");
+                    long[] expectedRounded = new long[docCount];
+                    int lowerBucketCount = 0;
+                    int upperBucketCount = 0;
+                    for (int i = 0; i < docCount; i++) {
+                        assertTrue("doc " + i + " should have a value", dv.advanceExact(i));
+                        expectedRounded[i] = RoundToLongsFromDocValuesBlockLoader.roundTo(dv.nextValue(), points, convention);
+                        if (expectedRounded[i] == RoundToLongsFromDocValuesBlockLoader.roundTo(150, points, convention)) {
+                            lowerBucketCount++;
+                        } else {
+                            upperBucketCount++;
+                        }
+                    }
+                    assertThat("lower bucket docs", lowerBucketCount, equalTo(100));
+                    assertThat("upper bucket docs", upperBucketCount, equalTo(100));
 
-                RoundToLongsFromDocValuesBlockLoader loader = new RoundToLongsFromDocValuesBlockLoader("field", points);
-                try (BlockLoader.ColumnAtATimeReader reader = loader.reader(breaker, ctx)) {
-                    BlockLoader.Docs docs = TestBlock.docs(ctx);
-                    try (TestBlock block = (TestBlock) reader.read(TestBlock.factory(), docs, 0, false)) {
-                        assertFalse("expected non-constant block when values span buckets", block.isConstant());
-                        assertThat(block.size(), equalTo(docCount));
-                        for (int i = 0; i < docCount; i++) {
-                            assertThat("doc " + i, block.get(i), equalTo(expectedRounded[i]));
+                    RoundToLongsFromDocValuesBlockLoader loader = new RoundToLongsFromDocValuesBlockLoader("field", points, convention);
+                    try (BlockLoader.ColumnAtATimeReader reader = loader.reader(breaker, ctx)) {
+                        BlockLoader.Docs docs = TestBlock.docs(ctx);
+                        try (TestBlock block = (TestBlock) reader.read(TestBlock.factory(), docs, 0, false)) {
+                            assertFalse("expected non-constant block when values span buckets", block.isConstant());
+                            assertThat(block.size(), equalTo(docCount));
+                            for (int i = 0; i < docCount; i++) {
+                                assertThat("doc " + i, block.get(i), equalTo(expectedRounded[i]));
+                            }
                         }
                     }
                 }
@@ -185,17 +196,20 @@ public class RoundToLongsFromDocValuesBlockLoaderTests extends AbstractNumericBl
                 }
                 assertThat("number of missing docs", missingCount, equalTo(20));
 
-                RoundToLongsFromDocValuesBlockLoader loader = new RoundToLongsFromDocValuesBlockLoader("field", points);
-                try (BlockLoader.ColumnAtATimeReader reader = loader.reader(breaker, ctx)) {
-                    BlockLoader.Docs docs = TestBlock.docs(ctx);
-                    try (TestBlock block = (TestBlock) reader.read(TestBlock.factory(), docs, 0, false)) {
-                        assertFalse("expected non-constant block when values are missing", block.isConstant());
-                        assertThat(block.size(), equalTo(docCount));
-                        for (int i = 0; i < docCount; i++) {
-                            if (docHasValue[i]) {
-                                assertThat("doc " + i, block.get(i), equalTo(100L));
-                            } else {
-                                assertThat("doc " + i, block.get(i), nullValue());
+                for (Rounding.RoundingConvention convention : Rounding.RoundingConvention.values()) {
+                    RoundToLongsFromDocValuesBlockLoader loader = new RoundToLongsFromDocValuesBlockLoader("field", points, convention);
+                    try (BlockLoader.ColumnAtATimeReader reader = loader.reader(breaker, ctx)) {
+                        BlockLoader.Docs docs = TestBlock.docs(ctx);
+                        try (TestBlock block = (TestBlock) reader.read(TestBlock.factory(), docs, 0, false)) {
+                            assertFalse("expected non-constant block when values are missing", block.isConstant());
+                            assertThat(block.size(), equalTo(docCount));
+                            long expected = RoundToLongsFromDocValuesBlockLoader.roundTo(150, points, convention);
+                            for (int i = 0; i < docCount; i++) {
+                                if (docHasValue[i]) {
+                                    assertThat("doc " + i, block.get(i), equalTo(expected));
+                                } else {
+                                    assertThat("doc " + i, block.get(i), nullValue());
+                                }
                             }
                         }
                     }
@@ -212,7 +226,7 @@ public class RoundToLongsFromDocValuesBlockLoaderTests extends AbstractNumericBl
     }
 
     @SuppressWarnings("unchecked")
-    private void checkBlocks(TestBlock longs, TestBlock rounded) {
+    private void checkBlocks(TestBlock longs, TestBlock rounded, Rounding.RoundingConvention convention) {
         for (int i = 0; i < longs.size(); i++) {
             Object v = longs.get(i);
             if (v == null) {
@@ -221,11 +235,11 @@ public class RoundToLongsFromDocValuesBlockLoaderTests extends AbstractNumericBl
             }
             if (v instanceof List<?> l) {
                 List<Long> expected = ((List<Long>) l).stream()
-                    .map(val -> RoundToLongsFromDocValuesBlockLoader.roundTo(val, POINTS))
+                    .map(val -> RoundToLongsFromDocValuesBlockLoader.roundTo(val, POINTS, convention))
                     .toList();
                 assertThat(rounded.get(i), equalTo(expected));
             } else {
-                assertThat(rounded.get(i), equalTo(RoundToLongsFromDocValuesBlockLoader.roundTo((Long) v, POINTS)));
+                assertThat(rounded.get(i), equalTo(RoundToLongsFromDocValuesBlockLoader.roundTo((Long) v, POINTS, convention)));
             }
         }
     }

--- a/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToDouble.java
+++ b/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToDouble.java
@@ -7,88 +7,140 @@
 
 package org.elasticsearch.xpack.esql.expression.function.scalar.math;
 
-// begin generated imports
+import org.elasticsearch.common.Rounding;
 import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.ann.Fixed;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.xpack.esql.core.tree.Source;
 
 import java.util.Arrays;
-// end generated imports
 
 /**
- * Implementations of {@link RoundTo} for specific types.
- * <p>
- *   We have specializations for when there are very few rounding points because
- *   those are very fast and quite common.
- * </p>
+ * Implementations of {@link RoundTo} for {@code double}.
  * This class is generated. Edit {@code X-RoundTo.java.st} instead.
  */
 class RoundToDouble {
-    static final RoundTo.Build BUILD = (source, field, points) -> {
-        double[] f = points.stream().mapToDouble(p -> p.doubleValue()).toArray();
-        return switch (f.length) {
-            // TODO should be a consistent way to do the 0 version - is CASE(MV_COUNT(f) == 1, f[0])
-            case 1 -> new RoundToDouble1Evaluator.Factory(source, field, f[0]);
+    static final RoundTo.Build BUILD = (source, field, points, convention) -> {
+        // TODO handle 0 points case - currently falls through to floorMany/ceilingMany and crashes
+        double[] p = points.stream().mapToDouble(n -> n.doubleValue()).toArray();
+        return switch (convention) {
+            case Rounding.RoundingConvention.DOWN -> floor(source, field, p);
+            case Rounding.RoundingConvention.UP -> ceiling(source, field, p);
+        };
+    };
+
+    private static ExpressionEvaluator.Factory floor(Source source, ExpressionEvaluator.Factory field, double[] p) {
+        return switch (p.length) {
+            case 1 -> new RoundToDoubleConstantEvaluator.Factory(source, field, p[0]);
             /*
              * These hand-unrolled implementations are even faster than the linear scan implementations.
              */
-            case 2 -> new RoundToDouble2Evaluator.Factory(source, field, f[0], f[1]);
-            case 3 -> new RoundToDouble3Evaluator.Factory(source, field, f[0], f[1], f[2]);
-            case 4 -> new RoundToDouble4Evaluator.Factory(source, field, f[0], f[1], f[2], f[3]);
-            case 5 -> new RoundToDouble5Evaluator.Factory(source, field, f[0], f[1], f[2], f[3], f[4]);
-            case 6 -> new RoundToDouble6Evaluator.Factory(source, field, f[0], f[1], f[2], f[3], f[4], f[5]);
-            case 7 -> new RoundToDouble7Evaluator.Factory(source, field, f[0], f[1], f[2], f[3], f[4], f[5], f[6]);
-            case 8 -> new RoundToDouble8Evaluator.Factory(source, field, f[0], f[1], f[2], f[3], f[4], f[5], f[6], f[7]);
-            case 9 -> new RoundToDouble9Evaluator.Factory(source, field, f[0], f[1], f[2], f[3], f[4], f[5], f[6], f[7], f[8]);
-            case 10 -> new RoundToDouble10Evaluator.Factory(source, field, f[0], f[1], f[2], f[3], f[4], f[5], f[6], f[7], f[8], f[9]);
+            case 2 -> new RoundToDoubleFloor2Evaluator.Factory(source, field, p[0], p[1]);
+            case 3 -> new RoundToDoubleFloor3Evaluator.Factory(source, field, p[0], p[1], p[2]);
+            case 4 -> new RoundToDoubleFloor4Evaluator.Factory(source, field, p[0], p[1], p[2], p[3]);
+            case 5 -> new RoundToDoubleFloor5Evaluator.Factory(source, field, p[0], p[1], p[2], p[3], p[4]);
+            case 6 -> new RoundToDoubleFloor6Evaluator.Factory(source, field, p[0], p[1], p[2], p[3], p[4], p[5]);
+            case 7 -> new RoundToDoubleFloor7Evaluator.Factory(source, field, p[0], p[1], p[2], p[3], p[4], p[5], p[6]);
+            case 8 -> new RoundToDoubleFloor8Evaluator.Factory(source, field, p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7]);
+            case 9 -> new RoundToDoubleFloor9Evaluator.Factory(source, field, p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7], p[8]);
+            case 10 -> new RoundToDoubleFloor10Evaluator.Factory(source, field, p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7], p[8], p[9]);
             /*
              * Break point of 10 experimentally derived on Nik's laptop (13th Gen Intel(R) Core(TM) i7-1370P)
              * on 2025-05-22.
              */
-            default -> {
-                yield new RoundToDoubleBinarySearchEvaluator.Factory(source, field, f);
-            }
+            default -> floorMany(source, field, p);
         };
-    };
-
-    @Evaluator(extraName = "BinarySearch")
-    static double process(double field, @Fixed(includeInToString = false) double[] points) {
-        int idx = Arrays.binarySearch(points, field);
-        return points[idx >= 0 ? idx : Math.max(0, -idx - 2)];
     }
 
-    @Evaluator(extraName = "1")
-    static double process(double field, @Fixed double p0) {
-        return p0;
+    private static ExpressionEvaluator.Factory ceiling(Source source, ExpressionEvaluator.Factory field, double[] p) {
+        return switch (p.length) {
+            case 1 -> new RoundToDoubleConstantEvaluator.Factory(source, field, p[0]);
+            /*
+             * These hand-unrolled implementations are even faster than the linear scan implementations.
+             */
+            case 2 -> new RoundToDoubleCeiling2Evaluator.Factory(source, field, p[0], p[1]);
+            case 3 -> new RoundToDoubleCeiling3Evaluator.Factory(source, field, p[0], p[1], p[2]);
+            case 4 -> new RoundToDoubleCeiling4Evaluator.Factory(source, field, p[0], p[1], p[2], p[3]);
+            case 5 -> new RoundToDoubleCeiling5Evaluator.Factory(source, field, p[0], p[1], p[2], p[3], p[4]);
+            case 6 -> new RoundToDoubleCeiling6Evaluator.Factory(source, field, p[0], p[1], p[2], p[3], p[4], p[5]);
+            case 7 -> new RoundToDoubleCeiling7Evaluator.Factory(source, field, p[0], p[1], p[2], p[3], p[4], p[5], p[6]);
+            case 8 -> new RoundToDoubleCeiling8Evaluator.Factory(source, field, p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7]);
+            case 9 -> new RoundToDoubleCeiling9Evaluator.Factory(source, field, p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7], p[8]);
+            case 10 -> new RoundToDoubleCeiling10Evaluator.Factory(
+                source,
+                field,
+                p[0],
+                p[1],
+                p[2],
+                p[3],
+                p[4],
+                p[5],
+                p[6],
+                p[7],
+                p[8],
+                p[9]
+            );
+            /*
+             * Break point of 10 experimentally derived on Nik's laptop (13th Gen Intel(R) Core(TM) i7-1370P)
+             * on 2025-05-22.
+             */
+            default -> ceilingMany(source, field, p);
+        };
     }
 
-    @Evaluator(extraName = "2")
-    static double process(double field, @Fixed double p0, @Fixed double p1) {
-        if (field < p1) {
+    private static ExpressionEvaluator.Factory floorMany(Source source, ExpressionEvaluator.Factory field, double[] p) {
+        return new RoundToDoubleFloorSearchEvaluator.Factory(source, field, p);
+    }
+
+    private static ExpressionEvaluator.Factory ceilingMany(Source source, ExpressionEvaluator.Factory field, double[] p) {
+        return new RoundToDoubleCeilingSearchEvaluator.Factory(source, field, p);
+    }
+
+    @Evaluator(extraName = "Constant")
+    static double constant(double v, @Fixed double p) {
+        return p;
+    }
+
+    @Evaluator(extraName = "FloorSearch")
+    static double floorSearch(double v, @Fixed(includeInToString = false) double[] p) {
+        int i = Arrays.binarySearch(p, v);
+        return p[i >= 0 ? i : Math.max(0, -i - 2)];
+    }
+
+    @Evaluator(extraName = "CeilingSearch")
+    static double ceilingSearch(double v, @Fixed(includeInToString = false) double[] p) {
+        int i = Arrays.binarySearch(p, v);
+        return p[i >= 0 ? i : Math.min(p.length - 1, -i - 1)];
+    }
+
+    @Evaluator(extraName = "Floor2")
+    static double floor2(double v, @Fixed double p0, @Fixed double p1) {
+        if (v < p1) {
             return p0;
         }
         return p1;
     }
 
-    @Evaluator(extraName = "3")
-    static double process(double field, @Fixed double p0, @Fixed double p1, @Fixed double p2) {
-        if (field < p1) {
+    @Evaluator(extraName = "Floor3")
+    static double floor3(double v, @Fixed double p0, @Fixed double p1, @Fixed double p2) {
+        if (v < p1) {
             return p0;
         }
-        if (field < p2) {
+        if (v < p2) {
             return p1;
         }
         return p2;
     }
 
-    @Evaluator(extraName = "4")
-    static double process(double field, @Fixed double p0, @Fixed double p1, @Fixed double p2, @Fixed double p3) {
-        if (field < p1) {
+    @Evaluator(extraName = "Floor4")
+    static double floor4(double v, @Fixed double p0, @Fixed double p1, @Fixed double p2, @Fixed double p3) {
+        if (v < p1) {
             return p0;
         }
-        if (field < p2) {
+        if (v < p2) {
             return p1;
         }
-        if (field < p3) {
+        if (v < p3) {
             return p2;
         }
         return p3;
@@ -97,18 +149,18 @@ class RoundToDouble {
     /*
      * Manual binary search for 5 rounding points, it is faster than linear search or array style binary search.
      */
-    @Evaluator(extraName = "5")
-    static double process(double field, @Fixed double p0, @Fixed double p1, @Fixed double p2, @Fixed double p3, @Fixed double p4) {
-        if (field < p2) {
-            if (field < p1) {
+    @Evaluator(extraName = "Floor5")
+    static double floor5(double v, @Fixed double p0, @Fixed double p1, @Fixed double p2, @Fixed double p3, @Fixed double p4) {
+        if (v < p2) {
+            if (v < p1) {
                 return p0;
             }
             return p1;
         }
-        if (field < p3) {
+        if (v < p3) {
             return p2;
         }
-        if (field < p4) {
+        if (v < p4) {
             return p3;
         }
         return p4;
@@ -117,9 +169,9 @@ class RoundToDouble {
     /*
      * Manual binary search for 6 rounding points, it is faster than linear search or array style binary search.
      */
-    @Evaluator(extraName = "6")
-    static double process(
-        double field,      // hack to keep the formatter happy.
+    @Evaluator(extraName = "Floor6")
+    static double floor6(
+        double v,          // hack to keep the formatter happy.
         @Fixed double p0,  // int is so short this should be on one line but double is not.
         @Fixed double p1,  // That's not compatible with the templates.
         @Fixed double p2,  // So we comment to make the formatter not try to change the line.
@@ -127,19 +179,19 @@ class RoundToDouble {
         @Fixed double p4,
         @Fixed double p5
     ) {
-        if (field < p2) {
-            if (field < p1) {
+        if (v < p2) {
+            if (v < p1) {
                 return p0;
             }
             return p1;
         }
-        if (field < p4) {
-            if (field < p3) {
+        if (v < p4) {
+            if (v < p3) {
                 return p2;
             }
             return p3;
         }
-        if (field < p5) {
+        if (v < p5) {
             return p4;
         }
         return p5;
@@ -148,9 +200,9 @@ class RoundToDouble {
     /*
      * Manual binary search for 7 rounding points, it is faster than linear search or array style binary search.
      */
-    @Evaluator(extraName = "7")
-    static double process(
-        double field,      // hack to keep the formatter happy.
+    @Evaluator(extraName = "Floor7")
+    static double floor7(
+        double v,          // hack to keep the formatter happy.
         @Fixed double p0,  // int is so short this should be on one line but double is not.
         @Fixed double p1,  // That's not compatible with the templates.
         @Fixed double p2,  // So we comment to make the formatter not try to change the line.
@@ -159,22 +211,22 @@ class RoundToDouble {
         @Fixed double p5,
         @Fixed double p6
     ) {
-        if (field < p3) {
-            if (field < p1) {
+        if (v < p3) {
+            if (v < p1) {
                 return p0;
             }
-            if (field < p2) {
+            if (v < p2) {
                 return p1;
             }
             return p2;
         }
-        if (field < p5) {
-            if (field < p4) {
+        if (v < p5) {
+            if (v < p4) {
                 return p3;
             }
             return p4;
         }
-        if (field < p6) {
+        if (v < p6) {
             return p5;
         }
         return p6;
@@ -183,37 +235,37 @@ class RoundToDouble {
     /*
      * Manual binary search for 8 rounding points, it is faster than linear search or array style binary search.
      */
-    @Evaluator(extraName = "8")
-    static double process(
-        double field,
-        @Fixed double p0,
-        @Fixed double p1,
-        @Fixed double p2,
+    @Evaluator(extraName = "Floor8")
+    static double floor8(
+        double v,          // hack to keep the formatter happy.
+        @Fixed double p0,  // int is so short this should be on one line but double is not.
+        @Fixed double p1,  // That's not compatible with the templates.
+        @Fixed double p2,  // So we comment to make the formatter not try to change the line.
         @Fixed double p3,
         @Fixed double p4,
         @Fixed double p5,
         @Fixed double p6,
         @Fixed double p7
     ) {
-        if (field < p3) {
-            if (field < p1) {
+        if (v < p3) {
+            if (v < p1) {
                 return p0;
             }
-            if (field < p2) {
+            if (v < p2) {
                 return p1;
             }
             return p2;
         }
-        if (field < p5) {
-            if (field < p4) {
+        if (v < p5) {
+            if (v < p4) {
                 return p3;
             }
             return p4;
         }
-        if (field < p6) {
+        if (v < p6) {
             return p5;
         }
-        if (field < p7) {
+        if (v < p7) {
             return p6;
         }
         return p7;
@@ -222,12 +274,12 @@ class RoundToDouble {
     /*
      * Manual binary search for 9 rounding points, it is faster than linear search or array style binary search.
      */
-    @Evaluator(extraName = "9")
-    static double process(
-        double field,
-        @Fixed double p0,
-        @Fixed double p1,
-        @Fixed double p2,
+    @Evaluator(extraName = "Floor9")
+    static double floor9(
+        double v,          // hack to keep the formatter happy.
+        @Fixed double p0,  // int is so short this should be on one line but double is not.
+        @Fixed double p1,  // That's not compatible with the templates.
+        @Fixed double p2,  // So we comment to make the formatter not try to change the line.
         @Fixed double p3,
         @Fixed double p4,
         @Fixed double p5,
@@ -235,28 +287,28 @@ class RoundToDouble {
         @Fixed double p7,
         @Fixed double p8
     ) {
-        if (field < p4) {
-            if (field < p1) {
+        if (v < p4) {
+            if (v < p1) {
                 return p0;
             }
-            if (field < p2) {
+            if (v < p2) {
                 return p1;
             }
-            if (field < p3) {
+            if (v < p3) {
                 return p2;
             }
             return p3;
         }
-        if (field < p6) {
-            if (field < p5) {
+        if (v < p6) {
+            if (v < p5) {
                 return p4;
             }
             return p5;
         }
-        if (field < p7) {
+        if (v < p7) {
             return p6;
         }
-        if (field < p8) {
+        if (v < p8) {
             return p7;
         }
         return p8;
@@ -265,12 +317,12 @@ class RoundToDouble {
     /*
      * Manual binary search for 10 rounding points, it is faster than linear search or array style binary search.
      */
-    @Evaluator(extraName = "10")
-    static double process(
-        double field,
-        @Fixed double p0,
-        @Fixed double p1,
-        @Fixed double p2,
+    @Evaluator(extraName = "Floor10")
+    static double floor10(
+        double v,          // hack to keep the formatter happy.
+        @Fixed double p0,  // int is so short this should be on one line but double is not.
+        @Fixed double p1,  // That's not compatible with the templates.
+        @Fixed double p2,  // So we comment to make the formatter not try to change the line.
         @Fixed double p3,
         @Fixed double p4,
         @Fixed double p5,
@@ -279,31 +331,279 @@ class RoundToDouble {
         @Fixed double p8,
         @Fixed double p9
     ) {
-        if (field < p4) {
-            if (field < p1) {
+        if (v < p4) {
+            if (v < p1) {
                 return p0;
             }
-            if (field < p2) {
+            if (v < p2) {
                 return p1;
             }
-            if (field < p3) {
+            if (v < p3) {
                 return p2;
             }
             return p3;
         }
-        if (field < p7) {
-            if (field < p5) {
+        if (v < p7) {
+            if (v < p5) {
                 return p4;
             }
-            if (field < p6) {
+            if (v < p6) {
                 return p5;
             }
             return p6;
         }
-        if (field < p8) {
+        if (v < p8) {
             return p7;
         }
-        if (field < p9) {
+        if (v < p9) {
+            return p8;
+        }
+        return p9;
+    }
+
+    @Evaluator(extraName = "Ceiling2")
+    static double ceiling2(double v, @Fixed double p0, @Fixed double p1) {
+        if (v <= p0) {
+            return p0;
+        }
+        return p1;
+    }
+
+    @Evaluator(extraName = "Ceiling3")
+    static double ceiling3(double v, @Fixed double p0, @Fixed double p1, @Fixed double p2) {
+        if (v <= p0) {
+            return p0;
+        }
+        if (v <= p1) {
+            return p1;
+        }
+        return p2;
+    }
+
+    @Evaluator(extraName = "Ceiling4")
+    static double ceiling4(double v, @Fixed double p0, @Fixed double p1, @Fixed double p2, @Fixed double p3) {
+        if (v <= p0) {
+            return p0;
+        }
+        if (v <= p1) {
+            return p1;
+        }
+        if (v <= p2) {
+            return p2;
+        }
+        return p3;
+    }
+
+    /*
+     * Manual binary search for 5 rounding points, it is faster than linear search or array style binary search.
+     */
+    @Evaluator(extraName = "Ceiling5")
+    static double ceiling5(double v, @Fixed double p0, @Fixed double p1, @Fixed double p2, @Fixed double p3, @Fixed double p4) {
+        if (v <= p1) {
+            if (v <= p0) {
+                return p0;
+            }
+            return p1;
+        }
+        if (v <= p2) {
+            return p2;
+        }
+        if (v <= p3) {
+            return p3;
+        }
+        return p4;
+    }
+
+    /*
+     * Manual binary search for 6 rounding points, it is faster than linear search or array style binary search.
+     */
+    @Evaluator(extraName = "Ceiling6")
+    static double ceiling6(
+        double v,          // hack to keep the formatter happy.
+        @Fixed double p0,  // int is so short this should be on one line but double is not.
+        @Fixed double p1,  // That's not compatible with the templates.
+        @Fixed double p2,  // So we comment to make the formatter not try to change the line.
+        @Fixed double p3,
+        @Fixed double p4,
+        @Fixed double p5
+    ) {
+        if (v <= p1) {
+            if (v <= p0) {
+                return p0;
+            }
+            return p1;
+        }
+        if (v <= p3) {
+            if (v <= p2) {
+                return p2;
+            }
+            return p3;
+        }
+        if (v <= p4) {
+            return p4;
+        }
+        return p5;
+    }
+
+    /*
+     * Manual binary search for 7 rounding points, it is faster than linear search or array style binary search.
+     */
+    @Evaluator(extraName = "Ceiling7")
+    static double ceiling7(
+        double v,          // hack to keep the formatter happy.
+        @Fixed double p0,  // int is so short this should be on one line but double is not.
+        @Fixed double p1,  // That's not compatible with the templates.
+        @Fixed double p2,  // So we comment to make the formatter not try to change the line.
+        @Fixed double p3,
+        @Fixed double p4,
+        @Fixed double p5,
+        @Fixed double p6
+    ) {
+        if (v <= p2) {
+            if (v <= p0) {
+                return p0;
+            }
+            if (v <= p1) {
+                return p1;
+            }
+            return p2;
+        }
+        if (v <= p4) {
+            if (v <= p3) {
+                return p3;
+            }
+            return p4;
+        }
+        if (v <= p5) {
+            return p5;
+        }
+        return p6;
+    }
+
+    /*
+     * Manual binary search for 8 rounding points, it is faster than linear search or array style binary search.
+     */
+    @Evaluator(extraName = "Ceiling8")
+    static double ceiling8(
+        double v,          // hack to keep the formatter happy.
+        @Fixed double p0,  // int is so short this should be on one line but double is not.
+        @Fixed double p1,  // That's not compatible with the templates.
+        @Fixed double p2,  // So we comment to make the formatter not try to change the line.
+        @Fixed double p3,
+        @Fixed double p4,
+        @Fixed double p5,
+        @Fixed double p6,
+        @Fixed double p7
+    ) {
+        if (v <= p2) {
+            if (v <= p0) {
+                return p0;
+            }
+            if (v <= p1) {
+                return p1;
+            }
+            return p2;
+        }
+        if (v <= p4) {
+            if (v <= p3) {
+                return p3;
+            }
+            return p4;
+        }
+        if (v <= p5) {
+            return p5;
+        }
+        if (v <= p6) {
+            return p6;
+        }
+        return p7;
+    }
+
+    /*
+     * Manual binary search for 9 rounding points, it is faster than linear search or array style binary search.
+     */
+    @Evaluator(extraName = "Ceiling9")
+    static double ceiling9(
+        double v,          // hack to keep the formatter happy.
+        @Fixed double p0,  // int is so short this should be on one line but double is not.
+        @Fixed double p1,  // That's not compatible with the templates.
+        @Fixed double p2,  // So we comment to make the formatter not try to change the line.
+        @Fixed double p3,
+        @Fixed double p4,
+        @Fixed double p5,
+        @Fixed double p6,
+        @Fixed double p7,
+        @Fixed double p8
+    ) {
+        if (v <= p3) {
+            if (v <= p0) {
+                return p0;
+            }
+            if (v <= p1) {
+                return p1;
+            }
+            if (v <= p2) {
+                return p2;
+            }
+            return p3;
+        }
+        if (v <= p5) {
+            if (v <= p4) {
+                return p4;
+            }
+            return p5;
+        }
+        if (v <= p6) {
+            return p6;
+        }
+        if (v <= p7) {
+            return p7;
+        }
+        return p8;
+    }
+
+    /*
+     * Manual binary search for 10 rounding points, it is faster than linear search or array style binary search.
+     */
+    @Evaluator(extraName = "Ceiling10")
+    static double ceiling10(
+        double v,          // hack to keep the formatter happy.
+        @Fixed double p0,  // int is so short this should be on one line but double is not.
+        @Fixed double p1,  // That's not compatible with the templates.
+        @Fixed double p2,  // So we comment to make the formatter not try to change the line.
+        @Fixed double p3,
+        @Fixed double p4,
+        @Fixed double p5,
+        @Fixed double p6,
+        @Fixed double p7,
+        @Fixed double p8,
+        @Fixed double p9
+    ) {
+        if (v <= p3) {
+            if (v <= p0) {
+                return p0;
+            }
+            if (v <= p1) {
+                return p1;
+            }
+            if (v <= p2) {
+                return p2;
+            }
+            return p3;
+        }
+        if (v <= p6) {
+            if (v <= p4) {
+                return p4;
+            }
+            if (v <= p5) {
+                return p5;
+            }
+            return p6;
+        }
+        if (v <= p7) {
+            return p7;
+        }
+        if (v <= p8) {
             return p8;
         }
         return p9;

--- a/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToInt.java
+++ b/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToInt.java
@@ -7,114 +7,171 @@
 
 package org.elasticsearch.xpack.esql.expression.function.scalar.math;
 
-// begin generated imports
+import org.elasticsearch.common.Rounding;
 import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.ann.Fixed;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.xpack.esql.core.tree.Source;
 
 import java.util.Arrays;
-// end generated imports
 
 /**
- * Implementations of {@link RoundTo} for specific types.
- * <p>
- *   We have specializations for when there are very few rounding points because
- *   those are very fast and quite common.
- * </p>
+ * Implementations of {@link RoundTo} for {@code int}.
  * This class is generated. Edit {@code X-RoundTo.java.st} instead.
  */
 class RoundToInt {
-    static final RoundTo.Build BUILD = (source, field, points) -> {
-        int[] f = points.stream().mapToInt(p -> p.intValue()).toArray();
-        return switch (f.length) {
-            // TODO should be a consistent way to do the 0 version - is CASE(MV_COUNT(f) == 1, f[0])
-            case 1 -> new RoundToInt1Evaluator.Factory(source, field, f[0]);
+    static final RoundTo.Build BUILD = (source, field, points, convention) -> {
+        // TODO handle 0 points case - currently falls through to floorMany/ceilingMany and crashes
+        int[] p = points.stream().mapToInt(n -> n.intValue()).toArray();
+        return switch (convention) {
+            case Rounding.RoundingConvention.DOWN -> floor(source, field, p);
+            case Rounding.RoundingConvention.UP -> ceiling(source, field, p);
+        };
+    };
+
+    private static ExpressionEvaluator.Factory floor(Source source, ExpressionEvaluator.Factory field, int[] p) {
+        return switch (p.length) {
+            case 1 -> new RoundToIntConstantEvaluator.Factory(source, field, p[0]);
             /*
              * These hand-unrolled implementations are even faster than the linear scan implementations.
              */
-            case 2 -> new RoundToInt2Evaluator.Factory(source, field, f[0], f[1]);
-            case 3 -> new RoundToInt3Evaluator.Factory(source, field, f[0], f[1], f[2]);
-            case 4 -> new RoundToInt4Evaluator.Factory(source, field, f[0], f[1], f[2], f[3]);
-            case 5 -> new RoundToInt5Evaluator.Factory(source, field, f[0], f[1], f[2], f[3], f[4]);
-            case 6 -> new RoundToInt6Evaluator.Factory(source, field, f[0], f[1], f[2], f[3], f[4], f[5]);
-            case 7 -> new RoundToInt7Evaluator.Factory(source, field, f[0], f[1], f[2], f[3], f[4], f[5], f[6]);
-            case 8 -> new RoundToInt8Evaluator.Factory(source, field, f[0], f[1], f[2], f[3], f[4], f[5], f[6], f[7]);
-            case 9 -> new RoundToInt9Evaluator.Factory(source, field, f[0], f[1], f[2], f[3], f[4], f[5], f[6], f[7], f[8]);
-            case 10 -> new RoundToInt10Evaluator.Factory(source, field, f[0], f[1], f[2], f[3], f[4], f[5], f[6], f[7], f[8], f[9]);
+            case 2 -> new RoundToIntFloor2Evaluator.Factory(source, field, p[0], p[1]);
+            case 3 -> new RoundToIntFloor3Evaluator.Factory(source, field, p[0], p[1], p[2]);
+            case 4 -> new RoundToIntFloor4Evaluator.Factory(source, field, p[0], p[1], p[2], p[3]);
+            case 5 -> new RoundToIntFloor5Evaluator.Factory(source, field, p[0], p[1], p[2], p[3], p[4]);
+            case 6 -> new RoundToIntFloor6Evaluator.Factory(source, field, p[0], p[1], p[2], p[3], p[4], p[5]);
+            case 7 -> new RoundToIntFloor7Evaluator.Factory(source, field, p[0], p[1], p[2], p[3], p[4], p[5], p[6]);
+            case 8 -> new RoundToIntFloor8Evaluator.Factory(source, field, p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7]);
+            case 9 -> new RoundToIntFloor9Evaluator.Factory(source, field, p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7], p[8]);
+            case 10 -> new RoundToIntFloor10Evaluator.Factory(source, field, p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7], p[8], p[9]);
             /*
              * Break point of 10 experimentally derived on Nik's laptop (13th Gen Intel(R) Core(TM) i7-1370P)
              * on 2025-05-22.
              */
-            default -> {
-                int interval = extractFixedInterval(f);
-                if (interval > 0) {
-                    yield new RoundToIntFixedIntervalEvaluator.Factory(source, field, f[0], f[f.length - 1], interval);
-                } else {
-                    yield new RoundToIntBinarySearchEvaluator.Factory(source, field, f);
-                }
-            }
+            default -> floorMany(source, field, p);
         };
-    };
-
-    @Evaluator(extraName = "BinarySearch")
-    static int process(int field, @Fixed(includeInToString = false) int[] points) {
-        int idx = Arrays.binarySearch(points, field);
-        return points[idx >= 0 ? idx : Math.max(0, -idx - 2)];
     }
 
-    private static int extractFixedInterval(int[] points) {
-        int interval = (points[points.length - 1] - points[0]) / (points.length - 1);
-        for (int i = 1; i < points.length; i++) {
-            if (points[i] - points[i - 1] != interval) {
+    private static ExpressionEvaluator.Factory ceiling(Source source, ExpressionEvaluator.Factory field, int[] p) {
+        return switch (p.length) {
+            case 1 -> new RoundToIntConstantEvaluator.Factory(source, field, p[0]);
+            /*
+             * These hand-unrolled implementations are even faster than the linear scan implementations.
+             */
+            case 2 -> new RoundToIntCeiling2Evaluator.Factory(source, field, p[0], p[1]);
+            case 3 -> new RoundToIntCeiling3Evaluator.Factory(source, field, p[0], p[1], p[2]);
+            case 4 -> new RoundToIntCeiling4Evaluator.Factory(source, field, p[0], p[1], p[2], p[3]);
+            case 5 -> new RoundToIntCeiling5Evaluator.Factory(source, field, p[0], p[1], p[2], p[3], p[4]);
+            case 6 -> new RoundToIntCeiling6Evaluator.Factory(source, field, p[0], p[1], p[2], p[3], p[4], p[5]);
+            case 7 -> new RoundToIntCeiling7Evaluator.Factory(source, field, p[0], p[1], p[2], p[3], p[4], p[5], p[6]);
+            case 8 -> new RoundToIntCeiling8Evaluator.Factory(source, field, p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7]);
+            case 9 -> new RoundToIntCeiling9Evaluator.Factory(source, field, p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7], p[8]);
+            case 10 -> new RoundToIntCeiling10Evaluator.Factory(source, field, p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7], p[8], p[9]);
+            /*
+             * Break point of 10 experimentally derived on Nik's laptop (13th Gen Intel(R) Core(TM) i7-1370P)
+             * on 2025-05-22.
+             */
+            default -> ceilingMany(source, field, p);
+        };
+    }
+
+    private static ExpressionEvaluator.Factory floorMany(Source source, ExpressionEvaluator.Factory field, int[] p) {
+        int interval = fixedInterval(p);
+        if (interval > 0) {
+            return new RoundToIntFloorIntervalEvaluator.Factory(source, field, p[0], p[p.length - 1], interval);
+        }
+        return new RoundToIntFloorSearchEvaluator.Factory(source, field, p);
+    }
+
+    private static ExpressionEvaluator.Factory ceilingMany(Source source, ExpressionEvaluator.Factory field, int[] p) {
+        int interval = fixedInterval(p);
+        if (interval > 0) {
+            return new RoundToIntCeilingIntervalEvaluator.Factory(source, field, p[0], p[p.length - 1], interval);
+        }
+        return new RoundToIntCeilingSearchEvaluator.Factory(source, field, p);
+    }
+
+    private static int fixedInterval(int[] p) {
+        int interval = (p[p.length - 1] - p[0]) / (p.length - 1);
+        for (int i = 1; i < p.length; i++) {
+            if (p[i] - p[i - 1] != interval) {
                 return -1;
             }
         }
         return interval;
     }
 
-    @Evaluator(extraName = "FixedInterval")
-    static int processFixed(int field, @Fixed int first, @Fixed int last, @Fixed int interval) {
-        if (field < first) {
-            return first; // almost never true in practice; predictor skips this
-        }
-        if (field > last) {
-            return last; // almost never true in practice; predictor skips this
-        }
-        return field - (field - first) % interval;
+    @Evaluator(extraName = "Constant")
+    static int constant(int v, @Fixed int p) {
+        return p;
     }
 
-    @Evaluator(extraName = "1")
-    static int process(int field, @Fixed int p0) {
-        return p0;
+    @Evaluator(extraName = "FloorSearch")
+    static int floorSearch(int v, @Fixed(includeInToString = false) int[] p) {
+        int i = Arrays.binarySearch(p, v);
+        return p[i >= 0 ? i : Math.max(0, -i - 2)];
     }
 
-    @Evaluator(extraName = "2")
-    static int process(int field, @Fixed int p0, @Fixed int p1) {
-        if (field < p1) {
+    @Evaluator(extraName = "CeilingSearch")
+    static int ceilingSearch(int v, @Fixed(includeInToString = false) int[] p) {
+        int i = Arrays.binarySearch(p, v);
+        return p[i >= 0 ? i : Math.min(p.length - 1, -i - 1)];
+    }
+
+    @Evaluator(extraName = "FloorInterval")
+    static int floorInterval(int v, @Fixed int lo, @Fixed int hi, @Fixed int interval) {
+        if (v < lo) {
+            return lo;
+        }
+        if (v > hi) {
+            return hi;
+        }
+        return v - (v - lo) % interval;
+    }
+
+    @Evaluator(extraName = "CeilingInterval")
+    static int ceilingInterval(int v, @Fixed int lo, @Fixed int hi, @Fixed int interval) {
+        if (v <= lo) {
+            return lo;
+        }
+        if (v > hi) {
+            return hi;
+        }
+        int r = (v - lo) % interval;
+        if (r == 0) {
+            return v;
+        }
+        return v + interval - r;
+    }
+
+    @Evaluator(extraName = "Floor2")
+    static int floor2(int v, @Fixed int p0, @Fixed int p1) {
+        if (v < p1) {
             return p0;
         }
         return p1;
     }
 
-    @Evaluator(extraName = "3")
-    static int process(int field, @Fixed int p0, @Fixed int p1, @Fixed int p2) {
-        if (field < p1) {
+    @Evaluator(extraName = "Floor3")
+    static int floor3(int v, @Fixed int p0, @Fixed int p1, @Fixed int p2) {
+        if (v < p1) {
             return p0;
         }
-        if (field < p2) {
+        if (v < p2) {
             return p1;
         }
         return p2;
     }
 
-    @Evaluator(extraName = "4")
-    static int process(int field, @Fixed int p0, @Fixed int p1, @Fixed int p2, @Fixed int p3) {
-        if (field < p1) {
+    @Evaluator(extraName = "Floor4")
+    static int floor4(int v, @Fixed int p0, @Fixed int p1, @Fixed int p2, @Fixed int p3) {
+        if (v < p1) {
             return p0;
         }
-        if (field < p2) {
+        if (v < p2) {
             return p1;
         }
-        if (field < p3) {
+        if (v < p3) {
             return p2;
         }
         return p3;
@@ -123,18 +180,18 @@ class RoundToInt {
     /*
      * Manual binary search for 5 rounding points, it is faster than linear search or array style binary search.
      */
-    @Evaluator(extraName = "5")
-    static int process(int field, @Fixed int p0, @Fixed int p1, @Fixed int p2, @Fixed int p3, @Fixed int p4) {
-        if (field < p2) {
-            if (field < p1) {
+    @Evaluator(extraName = "Floor5")
+    static int floor5(int v, @Fixed int p0, @Fixed int p1, @Fixed int p2, @Fixed int p3, @Fixed int p4) {
+        if (v < p2) {
+            if (v < p1) {
                 return p0;
             }
             return p1;
         }
-        if (field < p3) {
+        if (v < p3) {
             return p2;
         }
-        if (field < p4) {
+        if (v < p4) {
             return p3;
         }
         return p4;
@@ -143,9 +200,9 @@ class RoundToInt {
     /*
      * Manual binary search for 6 rounding points, it is faster than linear search or array style binary search.
      */
-    @Evaluator(extraName = "6")
-    static int process(
-        int field,      // hack to keep the formatter happy.
+    @Evaluator(extraName = "Floor6")
+    static int floor6(
+        int v,          // hack to keep the formatter happy.
         @Fixed int p0,  // int is so short this should be on one line but double is not.
         @Fixed int p1,  // That's not compatible with the templates.
         @Fixed int p2,  // So we comment to make the formatter not try to change the line.
@@ -153,19 +210,19 @@ class RoundToInt {
         @Fixed int p4,
         @Fixed int p5
     ) {
-        if (field < p2) {
-            if (field < p1) {
+        if (v < p2) {
+            if (v < p1) {
                 return p0;
             }
             return p1;
         }
-        if (field < p4) {
-            if (field < p3) {
+        if (v < p4) {
+            if (v < p3) {
                 return p2;
             }
             return p3;
         }
-        if (field < p5) {
+        if (v < p5) {
             return p4;
         }
         return p5;
@@ -174,9 +231,9 @@ class RoundToInt {
     /*
      * Manual binary search for 7 rounding points, it is faster than linear search or array style binary search.
      */
-    @Evaluator(extraName = "7")
-    static int process(
-        int field,      // hack to keep the formatter happy.
+    @Evaluator(extraName = "Floor7")
+    static int floor7(
+        int v,          // hack to keep the formatter happy.
         @Fixed int p0,  // int is so short this should be on one line but double is not.
         @Fixed int p1,  // That's not compatible with the templates.
         @Fixed int p2,  // So we comment to make the formatter not try to change the line.
@@ -185,22 +242,22 @@ class RoundToInt {
         @Fixed int p5,
         @Fixed int p6
     ) {
-        if (field < p3) {
-            if (field < p1) {
+        if (v < p3) {
+            if (v < p1) {
                 return p0;
             }
-            if (field < p2) {
+            if (v < p2) {
                 return p1;
             }
             return p2;
         }
-        if (field < p5) {
-            if (field < p4) {
+        if (v < p5) {
+            if (v < p4) {
                 return p3;
             }
             return p4;
         }
-        if (field < p6) {
+        if (v < p6) {
             return p5;
         }
         return p6;
@@ -209,37 +266,37 @@ class RoundToInt {
     /*
      * Manual binary search for 8 rounding points, it is faster than linear search or array style binary search.
      */
-    @Evaluator(extraName = "8")
-    static int process(
-        int field,
-        @Fixed int p0,
-        @Fixed int p1,
-        @Fixed int p2,
+    @Evaluator(extraName = "Floor8")
+    static int floor8(
+        int v,          // hack to keep the formatter happy.
+        @Fixed int p0,  // int is so short this should be on one line but double is not.
+        @Fixed int p1,  // That's not compatible with the templates.
+        @Fixed int p2,  // So we comment to make the formatter not try to change the line.
         @Fixed int p3,
         @Fixed int p4,
         @Fixed int p5,
         @Fixed int p6,
         @Fixed int p7
     ) {
-        if (field < p3) {
-            if (field < p1) {
+        if (v < p3) {
+            if (v < p1) {
                 return p0;
             }
-            if (field < p2) {
+            if (v < p2) {
                 return p1;
             }
             return p2;
         }
-        if (field < p5) {
-            if (field < p4) {
+        if (v < p5) {
+            if (v < p4) {
                 return p3;
             }
             return p4;
         }
-        if (field < p6) {
+        if (v < p6) {
             return p5;
         }
-        if (field < p7) {
+        if (v < p7) {
             return p6;
         }
         return p7;
@@ -248,12 +305,12 @@ class RoundToInt {
     /*
      * Manual binary search for 9 rounding points, it is faster than linear search or array style binary search.
      */
-    @Evaluator(extraName = "9")
-    static int process(
-        int field,
-        @Fixed int p0,
-        @Fixed int p1,
-        @Fixed int p2,
+    @Evaluator(extraName = "Floor9")
+    static int floor9(
+        int v,          // hack to keep the formatter happy.
+        @Fixed int p0,  // int is so short this should be on one line but double is not.
+        @Fixed int p1,  // That's not compatible with the templates.
+        @Fixed int p2,  // So we comment to make the formatter not try to change the line.
         @Fixed int p3,
         @Fixed int p4,
         @Fixed int p5,
@@ -261,28 +318,28 @@ class RoundToInt {
         @Fixed int p7,
         @Fixed int p8
     ) {
-        if (field < p4) {
-            if (field < p1) {
+        if (v < p4) {
+            if (v < p1) {
                 return p0;
             }
-            if (field < p2) {
+            if (v < p2) {
                 return p1;
             }
-            if (field < p3) {
+            if (v < p3) {
                 return p2;
             }
             return p3;
         }
-        if (field < p6) {
-            if (field < p5) {
+        if (v < p6) {
+            if (v < p5) {
                 return p4;
             }
             return p5;
         }
-        if (field < p7) {
+        if (v < p7) {
             return p6;
         }
-        if (field < p8) {
+        if (v < p8) {
             return p7;
         }
         return p8;
@@ -291,12 +348,12 @@ class RoundToInt {
     /*
      * Manual binary search for 10 rounding points, it is faster than linear search or array style binary search.
      */
-    @Evaluator(extraName = "10")
-    static int process(
-        int field,
-        @Fixed int p0,
-        @Fixed int p1,
-        @Fixed int p2,
+    @Evaluator(extraName = "Floor10")
+    static int floor10(
+        int v,          // hack to keep the formatter happy.
+        @Fixed int p0,  // int is so short this should be on one line but double is not.
+        @Fixed int p1,  // That's not compatible with the templates.
+        @Fixed int p2,  // So we comment to make the formatter not try to change the line.
         @Fixed int p3,
         @Fixed int p4,
         @Fixed int p5,
@@ -305,31 +362,279 @@ class RoundToInt {
         @Fixed int p8,
         @Fixed int p9
     ) {
-        if (field < p4) {
-            if (field < p1) {
+        if (v < p4) {
+            if (v < p1) {
                 return p0;
             }
-            if (field < p2) {
+            if (v < p2) {
                 return p1;
             }
-            if (field < p3) {
+            if (v < p3) {
                 return p2;
             }
             return p3;
         }
-        if (field < p7) {
-            if (field < p5) {
+        if (v < p7) {
+            if (v < p5) {
                 return p4;
             }
-            if (field < p6) {
+            if (v < p6) {
                 return p5;
             }
             return p6;
         }
-        if (field < p8) {
+        if (v < p8) {
             return p7;
         }
-        if (field < p9) {
+        if (v < p9) {
+            return p8;
+        }
+        return p9;
+    }
+
+    @Evaluator(extraName = "Ceiling2")
+    static int ceiling2(int v, @Fixed int p0, @Fixed int p1) {
+        if (v <= p0) {
+            return p0;
+        }
+        return p1;
+    }
+
+    @Evaluator(extraName = "Ceiling3")
+    static int ceiling3(int v, @Fixed int p0, @Fixed int p1, @Fixed int p2) {
+        if (v <= p0) {
+            return p0;
+        }
+        if (v <= p1) {
+            return p1;
+        }
+        return p2;
+    }
+
+    @Evaluator(extraName = "Ceiling4")
+    static int ceiling4(int v, @Fixed int p0, @Fixed int p1, @Fixed int p2, @Fixed int p3) {
+        if (v <= p0) {
+            return p0;
+        }
+        if (v <= p1) {
+            return p1;
+        }
+        if (v <= p2) {
+            return p2;
+        }
+        return p3;
+    }
+
+    /*
+     * Manual binary search for 5 rounding points, it is faster than linear search or array style binary search.
+     */
+    @Evaluator(extraName = "Ceiling5")
+    static int ceiling5(int v, @Fixed int p0, @Fixed int p1, @Fixed int p2, @Fixed int p3, @Fixed int p4) {
+        if (v <= p1) {
+            if (v <= p0) {
+                return p0;
+            }
+            return p1;
+        }
+        if (v <= p2) {
+            return p2;
+        }
+        if (v <= p3) {
+            return p3;
+        }
+        return p4;
+    }
+
+    /*
+     * Manual binary search for 6 rounding points, it is faster than linear search or array style binary search.
+     */
+    @Evaluator(extraName = "Ceiling6")
+    static int ceiling6(
+        int v,          // hack to keep the formatter happy.
+        @Fixed int p0,  // int is so short this should be on one line but double is not.
+        @Fixed int p1,  // That's not compatible with the templates.
+        @Fixed int p2,  // So we comment to make the formatter not try to change the line.
+        @Fixed int p3,
+        @Fixed int p4,
+        @Fixed int p5
+    ) {
+        if (v <= p1) {
+            if (v <= p0) {
+                return p0;
+            }
+            return p1;
+        }
+        if (v <= p3) {
+            if (v <= p2) {
+                return p2;
+            }
+            return p3;
+        }
+        if (v <= p4) {
+            return p4;
+        }
+        return p5;
+    }
+
+    /*
+     * Manual binary search for 7 rounding points, it is faster than linear search or array style binary search.
+     */
+    @Evaluator(extraName = "Ceiling7")
+    static int ceiling7(
+        int v,          // hack to keep the formatter happy.
+        @Fixed int p0,  // int is so short this should be on one line but double is not.
+        @Fixed int p1,  // That's not compatible with the templates.
+        @Fixed int p2,  // So we comment to make the formatter not try to change the line.
+        @Fixed int p3,
+        @Fixed int p4,
+        @Fixed int p5,
+        @Fixed int p6
+    ) {
+        if (v <= p2) {
+            if (v <= p0) {
+                return p0;
+            }
+            if (v <= p1) {
+                return p1;
+            }
+            return p2;
+        }
+        if (v <= p4) {
+            if (v <= p3) {
+                return p3;
+            }
+            return p4;
+        }
+        if (v <= p5) {
+            return p5;
+        }
+        return p6;
+    }
+
+    /*
+     * Manual binary search for 8 rounding points, it is faster than linear search or array style binary search.
+     */
+    @Evaluator(extraName = "Ceiling8")
+    static int ceiling8(
+        int v,          // hack to keep the formatter happy.
+        @Fixed int p0,  // int is so short this should be on one line but double is not.
+        @Fixed int p1,  // That's not compatible with the templates.
+        @Fixed int p2,  // So we comment to make the formatter not try to change the line.
+        @Fixed int p3,
+        @Fixed int p4,
+        @Fixed int p5,
+        @Fixed int p6,
+        @Fixed int p7
+    ) {
+        if (v <= p2) {
+            if (v <= p0) {
+                return p0;
+            }
+            if (v <= p1) {
+                return p1;
+            }
+            return p2;
+        }
+        if (v <= p4) {
+            if (v <= p3) {
+                return p3;
+            }
+            return p4;
+        }
+        if (v <= p5) {
+            return p5;
+        }
+        if (v <= p6) {
+            return p6;
+        }
+        return p7;
+    }
+
+    /*
+     * Manual binary search for 9 rounding points, it is faster than linear search or array style binary search.
+     */
+    @Evaluator(extraName = "Ceiling9")
+    static int ceiling9(
+        int v,          // hack to keep the formatter happy.
+        @Fixed int p0,  // int is so short this should be on one line but double is not.
+        @Fixed int p1,  // That's not compatible with the templates.
+        @Fixed int p2,  // So we comment to make the formatter not try to change the line.
+        @Fixed int p3,
+        @Fixed int p4,
+        @Fixed int p5,
+        @Fixed int p6,
+        @Fixed int p7,
+        @Fixed int p8
+    ) {
+        if (v <= p3) {
+            if (v <= p0) {
+                return p0;
+            }
+            if (v <= p1) {
+                return p1;
+            }
+            if (v <= p2) {
+                return p2;
+            }
+            return p3;
+        }
+        if (v <= p5) {
+            if (v <= p4) {
+                return p4;
+            }
+            return p5;
+        }
+        if (v <= p6) {
+            return p6;
+        }
+        if (v <= p7) {
+            return p7;
+        }
+        return p8;
+    }
+
+    /*
+     * Manual binary search for 10 rounding points, it is faster than linear search or array style binary search.
+     */
+    @Evaluator(extraName = "Ceiling10")
+    static int ceiling10(
+        int v,          // hack to keep the formatter happy.
+        @Fixed int p0,  // int is so short this should be on one line but double is not.
+        @Fixed int p1,  // That's not compatible with the templates.
+        @Fixed int p2,  // So we comment to make the formatter not try to change the line.
+        @Fixed int p3,
+        @Fixed int p4,
+        @Fixed int p5,
+        @Fixed int p6,
+        @Fixed int p7,
+        @Fixed int p8,
+        @Fixed int p9
+    ) {
+        if (v <= p3) {
+            if (v <= p0) {
+                return p0;
+            }
+            if (v <= p1) {
+                return p1;
+            }
+            if (v <= p2) {
+                return p2;
+            }
+            return p3;
+        }
+        if (v <= p6) {
+            if (v <= p4) {
+                return p4;
+            }
+            if (v <= p5) {
+                return p5;
+            }
+            return p6;
+        }
+        if (v <= p7) {
+            return p7;
+        }
+        if (v <= p8) {
             return p8;
         }
         return p9;

--- a/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLong.java
+++ b/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLong.java
@@ -7,114 +7,171 @@
 
 package org.elasticsearch.xpack.esql.expression.function.scalar.math;
 
-// begin generated imports
+import org.elasticsearch.common.Rounding;
 import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.ann.Fixed;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.xpack.esql.core.tree.Source;
 
 import java.util.Arrays;
-// end generated imports
 
 /**
- * Implementations of {@link RoundTo} for specific types.
- * <p>
- *   We have specializations for when there are very few rounding points because
- *   those are very fast and quite common.
- * </p>
+ * Implementations of {@link RoundTo} for {@code long}.
  * This class is generated. Edit {@code X-RoundTo.java.st} instead.
  */
 class RoundToLong {
-    static final RoundTo.Build BUILD = (source, field, points) -> {
-        long[] f = points.stream().mapToLong(p -> p.longValue()).toArray();
-        return switch (f.length) {
-            // TODO should be a consistent way to do the 0 version - is CASE(MV_COUNT(f) == 1, f[0])
-            case 1 -> new RoundToLong1Evaluator.Factory(source, field, f[0]);
+    static final RoundTo.Build BUILD = (source, field, points, convention) -> {
+        // TODO handle 0 points case - currently falls through to floorMany/ceilingMany and crashes
+        long[] p = points.stream().mapToLong(n -> n.longValue()).toArray();
+        return switch (convention) {
+            case Rounding.RoundingConvention.DOWN -> floor(source, field, p);
+            case Rounding.RoundingConvention.UP -> ceiling(source, field, p);
+        };
+    };
+
+    private static ExpressionEvaluator.Factory floor(Source source, ExpressionEvaluator.Factory field, long[] p) {
+        return switch (p.length) {
+            case 1 -> new RoundToLongConstantEvaluator.Factory(source, field, p[0]);
             /*
              * These hand-unrolled implementations are even faster than the linear scan implementations.
              */
-            case 2 -> new RoundToLong2Evaluator.Factory(source, field, f[0], f[1]);
-            case 3 -> new RoundToLong3Evaluator.Factory(source, field, f[0], f[1], f[2]);
-            case 4 -> new RoundToLong4Evaluator.Factory(source, field, f[0], f[1], f[2], f[3]);
-            case 5 -> new RoundToLong5Evaluator.Factory(source, field, f[0], f[1], f[2], f[3], f[4]);
-            case 6 -> new RoundToLong6Evaluator.Factory(source, field, f[0], f[1], f[2], f[3], f[4], f[5]);
-            case 7 -> new RoundToLong7Evaluator.Factory(source, field, f[0], f[1], f[2], f[3], f[4], f[5], f[6]);
-            case 8 -> new RoundToLong8Evaluator.Factory(source, field, f[0], f[1], f[2], f[3], f[4], f[5], f[6], f[7]);
-            case 9 -> new RoundToLong9Evaluator.Factory(source, field, f[0], f[1], f[2], f[3], f[4], f[5], f[6], f[7], f[8]);
-            case 10 -> new RoundToLong10Evaluator.Factory(source, field, f[0], f[1], f[2], f[3], f[4], f[5], f[6], f[7], f[8], f[9]);
+            case 2 -> new RoundToLongFloor2Evaluator.Factory(source, field, p[0], p[1]);
+            case 3 -> new RoundToLongFloor3Evaluator.Factory(source, field, p[0], p[1], p[2]);
+            case 4 -> new RoundToLongFloor4Evaluator.Factory(source, field, p[0], p[1], p[2], p[3]);
+            case 5 -> new RoundToLongFloor5Evaluator.Factory(source, field, p[0], p[1], p[2], p[3], p[4]);
+            case 6 -> new RoundToLongFloor6Evaluator.Factory(source, field, p[0], p[1], p[2], p[3], p[4], p[5]);
+            case 7 -> new RoundToLongFloor7Evaluator.Factory(source, field, p[0], p[1], p[2], p[3], p[4], p[5], p[6]);
+            case 8 -> new RoundToLongFloor8Evaluator.Factory(source, field, p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7]);
+            case 9 -> new RoundToLongFloor9Evaluator.Factory(source, field, p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7], p[8]);
+            case 10 -> new RoundToLongFloor10Evaluator.Factory(source, field, p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7], p[8], p[9]);
             /*
              * Break point of 10 experimentally derived on Nik's laptop (13th Gen Intel(R) Core(TM) i7-1370P)
              * on 2025-05-22.
              */
-            default -> {
-                long interval = extractFixedInterval(f);
-                if (interval > 0) {
-                    yield new RoundToLongFixedIntervalEvaluator.Factory(source, field, f[0], f[f.length - 1], interval);
-                } else {
-                    yield new RoundToLongBinarySearchEvaluator.Factory(source, field, f);
-                }
-            }
+            default -> floorMany(source, field, p);
         };
-    };
-
-    @Evaluator(extraName = "BinarySearch")
-    static long process(long field, @Fixed(includeInToString = false) long[] points) {
-        int idx = Arrays.binarySearch(points, field);
-        return points[idx >= 0 ? idx : Math.max(0, -idx - 2)];
     }
 
-    private static long extractFixedInterval(long[] points) {
-        long interval = (points[points.length - 1] - points[0]) / (points.length - 1);
-        for (int i = 1; i < points.length; i++) {
-            if (points[i] - points[i - 1] != interval) {
+    private static ExpressionEvaluator.Factory ceiling(Source source, ExpressionEvaluator.Factory field, long[] p) {
+        return switch (p.length) {
+            case 1 -> new RoundToLongConstantEvaluator.Factory(source, field, p[0]);
+            /*
+             * These hand-unrolled implementations are even faster than the linear scan implementations.
+             */
+            case 2 -> new RoundToLongCeiling2Evaluator.Factory(source, field, p[0], p[1]);
+            case 3 -> new RoundToLongCeiling3Evaluator.Factory(source, field, p[0], p[1], p[2]);
+            case 4 -> new RoundToLongCeiling4Evaluator.Factory(source, field, p[0], p[1], p[2], p[3]);
+            case 5 -> new RoundToLongCeiling5Evaluator.Factory(source, field, p[0], p[1], p[2], p[3], p[4]);
+            case 6 -> new RoundToLongCeiling6Evaluator.Factory(source, field, p[0], p[1], p[2], p[3], p[4], p[5]);
+            case 7 -> new RoundToLongCeiling7Evaluator.Factory(source, field, p[0], p[1], p[2], p[3], p[4], p[5], p[6]);
+            case 8 -> new RoundToLongCeiling8Evaluator.Factory(source, field, p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7]);
+            case 9 -> new RoundToLongCeiling9Evaluator.Factory(source, field, p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7], p[8]);
+            case 10 -> new RoundToLongCeiling10Evaluator.Factory(source, field, p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7], p[8], p[9]);
+            /*
+             * Break point of 10 experimentally derived on Nik's laptop (13th Gen Intel(R) Core(TM) i7-1370P)
+             * on 2025-05-22.
+             */
+            default -> ceilingMany(source, field, p);
+        };
+    }
+
+    private static ExpressionEvaluator.Factory floorMany(Source source, ExpressionEvaluator.Factory field, long[] p) {
+        long interval = fixedInterval(p);
+        if (interval > 0) {
+            return new RoundToLongFloorIntervalEvaluator.Factory(source, field, p[0], p[p.length - 1], interval);
+        }
+        return new RoundToLongFloorSearchEvaluator.Factory(source, field, p);
+    }
+
+    private static ExpressionEvaluator.Factory ceilingMany(Source source, ExpressionEvaluator.Factory field, long[] p) {
+        long interval = fixedInterval(p);
+        if (interval > 0) {
+            return new RoundToLongCeilingIntervalEvaluator.Factory(source, field, p[0], p[p.length - 1], interval);
+        }
+        return new RoundToLongCeilingSearchEvaluator.Factory(source, field, p);
+    }
+
+    private static long fixedInterval(long[] p) {
+        long interval = (p[p.length - 1] - p[0]) / (p.length - 1);
+        for (int i = 1; i < p.length; i++) {
+            if (p[i] - p[i - 1] != interval) {
                 return -1;
             }
         }
         return interval;
     }
 
-    @Evaluator(extraName = "FixedInterval")
-    static long processFixed(long field, @Fixed long first, @Fixed long last, @Fixed long interval) {
-        if (field < first) {
-            return first; // almost never true in practice; predictor skips this
-        }
-        if (field > last) {
-            return last; // almost never true in practice; predictor skips this
-        }
-        return field - (field - first) % interval;
+    @Evaluator(extraName = "Constant")
+    static long constant(long v, @Fixed long p) {
+        return p;
     }
 
-    @Evaluator(extraName = "1")
-    static long process(long field, @Fixed long p0) {
-        return p0;
+    @Evaluator(extraName = "FloorSearch")
+    static long floorSearch(long v, @Fixed(includeInToString = false) long[] p) {
+        int i = Arrays.binarySearch(p, v);
+        return p[i >= 0 ? i : Math.max(0, -i - 2)];
     }
 
-    @Evaluator(extraName = "2")
-    static long process(long field, @Fixed long p0, @Fixed long p1) {
-        if (field < p1) {
+    @Evaluator(extraName = "CeilingSearch")
+    static long ceilingSearch(long v, @Fixed(includeInToString = false) long[] p) {
+        int i = Arrays.binarySearch(p, v);
+        return p[i >= 0 ? i : Math.min(p.length - 1, -i - 1)];
+    }
+
+    @Evaluator(extraName = "FloorInterval")
+    static long floorInterval(long v, @Fixed long lo, @Fixed long hi, @Fixed long interval) {
+        if (v < lo) {
+            return lo;
+        }
+        if (v > hi) {
+            return hi;
+        }
+        return v - (v - lo) % interval;
+    }
+
+    @Evaluator(extraName = "CeilingInterval")
+    static long ceilingInterval(long v, @Fixed long lo, @Fixed long hi, @Fixed long interval) {
+        if (v <= lo) {
+            return lo;
+        }
+        if (v > hi) {
+            return hi;
+        }
+        long r = (v - lo) % interval;
+        if (r == 0) {
+            return v;
+        }
+        return v + interval - r;
+    }
+
+    @Evaluator(extraName = "Floor2")
+    static long floor2(long v, @Fixed long p0, @Fixed long p1) {
+        if (v < p1) {
             return p0;
         }
         return p1;
     }
 
-    @Evaluator(extraName = "3")
-    static long process(long field, @Fixed long p0, @Fixed long p1, @Fixed long p2) {
-        if (field < p1) {
+    @Evaluator(extraName = "Floor3")
+    static long floor3(long v, @Fixed long p0, @Fixed long p1, @Fixed long p2) {
+        if (v < p1) {
             return p0;
         }
-        if (field < p2) {
+        if (v < p2) {
             return p1;
         }
         return p2;
     }
 
-    @Evaluator(extraName = "4")
-    static long process(long field, @Fixed long p0, @Fixed long p1, @Fixed long p2, @Fixed long p3) {
-        if (field < p1) {
+    @Evaluator(extraName = "Floor4")
+    static long floor4(long v, @Fixed long p0, @Fixed long p1, @Fixed long p2, @Fixed long p3) {
+        if (v < p1) {
             return p0;
         }
-        if (field < p2) {
+        if (v < p2) {
             return p1;
         }
-        if (field < p3) {
+        if (v < p3) {
             return p2;
         }
         return p3;
@@ -123,18 +180,18 @@ class RoundToLong {
     /*
      * Manual binary search for 5 rounding points, it is faster than linear search or array style binary search.
      */
-    @Evaluator(extraName = "5")
-    static long process(long field, @Fixed long p0, @Fixed long p1, @Fixed long p2, @Fixed long p3, @Fixed long p4) {
-        if (field < p2) {
-            if (field < p1) {
+    @Evaluator(extraName = "Floor5")
+    static long floor5(long v, @Fixed long p0, @Fixed long p1, @Fixed long p2, @Fixed long p3, @Fixed long p4) {
+        if (v < p2) {
+            if (v < p1) {
                 return p0;
             }
             return p1;
         }
-        if (field < p3) {
+        if (v < p3) {
             return p2;
         }
-        if (field < p4) {
+        if (v < p4) {
             return p3;
         }
         return p4;
@@ -143,9 +200,9 @@ class RoundToLong {
     /*
      * Manual binary search for 6 rounding points, it is faster than linear search or array style binary search.
      */
-    @Evaluator(extraName = "6")
-    static long process(
-        long field,      // hack to keep the formatter happy.
+    @Evaluator(extraName = "Floor6")
+    static long floor6(
+        long v,          // hack to keep the formatter happy.
         @Fixed long p0,  // int is so short this should be on one line but double is not.
         @Fixed long p1,  // That's not compatible with the templates.
         @Fixed long p2,  // So we comment to make the formatter not try to change the line.
@@ -153,19 +210,19 @@ class RoundToLong {
         @Fixed long p4,
         @Fixed long p5
     ) {
-        if (field < p2) {
-            if (field < p1) {
+        if (v < p2) {
+            if (v < p1) {
                 return p0;
             }
             return p1;
         }
-        if (field < p4) {
-            if (field < p3) {
+        if (v < p4) {
+            if (v < p3) {
                 return p2;
             }
             return p3;
         }
-        if (field < p5) {
+        if (v < p5) {
             return p4;
         }
         return p5;
@@ -174,9 +231,9 @@ class RoundToLong {
     /*
      * Manual binary search for 7 rounding points, it is faster than linear search or array style binary search.
      */
-    @Evaluator(extraName = "7")
-    static long process(
-        long field,      // hack to keep the formatter happy.
+    @Evaluator(extraName = "Floor7")
+    static long floor7(
+        long v,          // hack to keep the formatter happy.
         @Fixed long p0,  // int is so short this should be on one line but double is not.
         @Fixed long p1,  // That's not compatible with the templates.
         @Fixed long p2,  // So we comment to make the formatter not try to change the line.
@@ -185,22 +242,22 @@ class RoundToLong {
         @Fixed long p5,
         @Fixed long p6
     ) {
-        if (field < p3) {
-            if (field < p1) {
+        if (v < p3) {
+            if (v < p1) {
                 return p0;
             }
-            if (field < p2) {
+            if (v < p2) {
                 return p1;
             }
             return p2;
         }
-        if (field < p5) {
-            if (field < p4) {
+        if (v < p5) {
+            if (v < p4) {
                 return p3;
             }
             return p4;
         }
-        if (field < p6) {
+        if (v < p6) {
             return p5;
         }
         return p6;
@@ -209,37 +266,37 @@ class RoundToLong {
     /*
      * Manual binary search for 8 rounding points, it is faster than linear search or array style binary search.
      */
-    @Evaluator(extraName = "8")
-    static long process(
-        long field,
-        @Fixed long p0,
-        @Fixed long p1,
-        @Fixed long p2,
+    @Evaluator(extraName = "Floor8")
+    static long floor8(
+        long v,          // hack to keep the formatter happy.
+        @Fixed long p0,  // int is so short this should be on one line but double is not.
+        @Fixed long p1,  // That's not compatible with the templates.
+        @Fixed long p2,  // So we comment to make the formatter not try to change the line.
         @Fixed long p3,
         @Fixed long p4,
         @Fixed long p5,
         @Fixed long p6,
         @Fixed long p7
     ) {
-        if (field < p3) {
-            if (field < p1) {
+        if (v < p3) {
+            if (v < p1) {
                 return p0;
             }
-            if (field < p2) {
+            if (v < p2) {
                 return p1;
             }
             return p2;
         }
-        if (field < p5) {
-            if (field < p4) {
+        if (v < p5) {
+            if (v < p4) {
                 return p3;
             }
             return p4;
         }
-        if (field < p6) {
+        if (v < p6) {
             return p5;
         }
-        if (field < p7) {
+        if (v < p7) {
             return p6;
         }
         return p7;
@@ -248,12 +305,12 @@ class RoundToLong {
     /*
      * Manual binary search for 9 rounding points, it is faster than linear search or array style binary search.
      */
-    @Evaluator(extraName = "9")
-    static long process(
-        long field,
-        @Fixed long p0,
-        @Fixed long p1,
-        @Fixed long p2,
+    @Evaluator(extraName = "Floor9")
+    static long floor9(
+        long v,          // hack to keep the formatter happy.
+        @Fixed long p0,  // int is so short this should be on one line but double is not.
+        @Fixed long p1,  // That's not compatible with the templates.
+        @Fixed long p2,  // So we comment to make the formatter not try to change the line.
         @Fixed long p3,
         @Fixed long p4,
         @Fixed long p5,
@@ -261,28 +318,28 @@ class RoundToLong {
         @Fixed long p7,
         @Fixed long p8
     ) {
-        if (field < p4) {
-            if (field < p1) {
+        if (v < p4) {
+            if (v < p1) {
                 return p0;
             }
-            if (field < p2) {
+            if (v < p2) {
                 return p1;
             }
-            if (field < p3) {
+            if (v < p3) {
                 return p2;
             }
             return p3;
         }
-        if (field < p6) {
-            if (field < p5) {
+        if (v < p6) {
+            if (v < p5) {
                 return p4;
             }
             return p5;
         }
-        if (field < p7) {
+        if (v < p7) {
             return p6;
         }
-        if (field < p8) {
+        if (v < p8) {
             return p7;
         }
         return p8;
@@ -291,12 +348,12 @@ class RoundToLong {
     /*
      * Manual binary search for 10 rounding points, it is faster than linear search or array style binary search.
      */
-    @Evaluator(extraName = "10")
-    static long process(
-        long field,
-        @Fixed long p0,
-        @Fixed long p1,
-        @Fixed long p2,
+    @Evaluator(extraName = "Floor10")
+    static long floor10(
+        long v,          // hack to keep the formatter happy.
+        @Fixed long p0,  // int is so short this should be on one line but double is not.
+        @Fixed long p1,  // That's not compatible with the templates.
+        @Fixed long p2,  // So we comment to make the formatter not try to change the line.
         @Fixed long p3,
         @Fixed long p4,
         @Fixed long p5,
@@ -305,31 +362,279 @@ class RoundToLong {
         @Fixed long p8,
         @Fixed long p9
     ) {
-        if (field < p4) {
-            if (field < p1) {
+        if (v < p4) {
+            if (v < p1) {
                 return p0;
             }
-            if (field < p2) {
+            if (v < p2) {
                 return p1;
             }
-            if (field < p3) {
+            if (v < p3) {
                 return p2;
             }
             return p3;
         }
-        if (field < p7) {
-            if (field < p5) {
+        if (v < p7) {
+            if (v < p5) {
                 return p4;
             }
-            if (field < p6) {
+            if (v < p6) {
                 return p5;
             }
             return p6;
         }
-        if (field < p8) {
+        if (v < p8) {
             return p7;
         }
-        if (field < p9) {
+        if (v < p9) {
+            return p8;
+        }
+        return p9;
+    }
+
+    @Evaluator(extraName = "Ceiling2")
+    static long ceiling2(long v, @Fixed long p0, @Fixed long p1) {
+        if (v <= p0) {
+            return p0;
+        }
+        return p1;
+    }
+
+    @Evaluator(extraName = "Ceiling3")
+    static long ceiling3(long v, @Fixed long p0, @Fixed long p1, @Fixed long p2) {
+        if (v <= p0) {
+            return p0;
+        }
+        if (v <= p1) {
+            return p1;
+        }
+        return p2;
+    }
+
+    @Evaluator(extraName = "Ceiling4")
+    static long ceiling4(long v, @Fixed long p0, @Fixed long p1, @Fixed long p2, @Fixed long p3) {
+        if (v <= p0) {
+            return p0;
+        }
+        if (v <= p1) {
+            return p1;
+        }
+        if (v <= p2) {
+            return p2;
+        }
+        return p3;
+    }
+
+    /*
+     * Manual binary search for 5 rounding points, it is faster than linear search or array style binary search.
+     */
+    @Evaluator(extraName = "Ceiling5")
+    static long ceiling5(long v, @Fixed long p0, @Fixed long p1, @Fixed long p2, @Fixed long p3, @Fixed long p4) {
+        if (v <= p1) {
+            if (v <= p0) {
+                return p0;
+            }
+            return p1;
+        }
+        if (v <= p2) {
+            return p2;
+        }
+        if (v <= p3) {
+            return p3;
+        }
+        return p4;
+    }
+
+    /*
+     * Manual binary search for 6 rounding points, it is faster than linear search or array style binary search.
+     */
+    @Evaluator(extraName = "Ceiling6")
+    static long ceiling6(
+        long v,          // hack to keep the formatter happy.
+        @Fixed long p0,  // int is so short this should be on one line but double is not.
+        @Fixed long p1,  // That's not compatible with the templates.
+        @Fixed long p2,  // So we comment to make the formatter not try to change the line.
+        @Fixed long p3,
+        @Fixed long p4,
+        @Fixed long p5
+    ) {
+        if (v <= p1) {
+            if (v <= p0) {
+                return p0;
+            }
+            return p1;
+        }
+        if (v <= p3) {
+            if (v <= p2) {
+                return p2;
+            }
+            return p3;
+        }
+        if (v <= p4) {
+            return p4;
+        }
+        return p5;
+    }
+
+    /*
+     * Manual binary search for 7 rounding points, it is faster than linear search or array style binary search.
+     */
+    @Evaluator(extraName = "Ceiling7")
+    static long ceiling7(
+        long v,          // hack to keep the formatter happy.
+        @Fixed long p0,  // int is so short this should be on one line but double is not.
+        @Fixed long p1,  // That's not compatible with the templates.
+        @Fixed long p2,  // So we comment to make the formatter not try to change the line.
+        @Fixed long p3,
+        @Fixed long p4,
+        @Fixed long p5,
+        @Fixed long p6
+    ) {
+        if (v <= p2) {
+            if (v <= p0) {
+                return p0;
+            }
+            if (v <= p1) {
+                return p1;
+            }
+            return p2;
+        }
+        if (v <= p4) {
+            if (v <= p3) {
+                return p3;
+            }
+            return p4;
+        }
+        if (v <= p5) {
+            return p5;
+        }
+        return p6;
+    }
+
+    /*
+     * Manual binary search for 8 rounding points, it is faster than linear search or array style binary search.
+     */
+    @Evaluator(extraName = "Ceiling8")
+    static long ceiling8(
+        long v,          // hack to keep the formatter happy.
+        @Fixed long p0,  // int is so short this should be on one line but double is not.
+        @Fixed long p1,  // That's not compatible with the templates.
+        @Fixed long p2,  // So we comment to make the formatter not try to change the line.
+        @Fixed long p3,
+        @Fixed long p4,
+        @Fixed long p5,
+        @Fixed long p6,
+        @Fixed long p7
+    ) {
+        if (v <= p2) {
+            if (v <= p0) {
+                return p0;
+            }
+            if (v <= p1) {
+                return p1;
+            }
+            return p2;
+        }
+        if (v <= p4) {
+            if (v <= p3) {
+                return p3;
+            }
+            return p4;
+        }
+        if (v <= p5) {
+            return p5;
+        }
+        if (v <= p6) {
+            return p6;
+        }
+        return p7;
+    }
+
+    /*
+     * Manual binary search for 9 rounding points, it is faster than linear search or array style binary search.
+     */
+    @Evaluator(extraName = "Ceiling9")
+    static long ceiling9(
+        long v,          // hack to keep the formatter happy.
+        @Fixed long p0,  // int is so short this should be on one line but double is not.
+        @Fixed long p1,  // That's not compatible with the templates.
+        @Fixed long p2,  // So we comment to make the formatter not try to change the line.
+        @Fixed long p3,
+        @Fixed long p4,
+        @Fixed long p5,
+        @Fixed long p6,
+        @Fixed long p7,
+        @Fixed long p8
+    ) {
+        if (v <= p3) {
+            if (v <= p0) {
+                return p0;
+            }
+            if (v <= p1) {
+                return p1;
+            }
+            if (v <= p2) {
+                return p2;
+            }
+            return p3;
+        }
+        if (v <= p5) {
+            if (v <= p4) {
+                return p4;
+            }
+            return p5;
+        }
+        if (v <= p6) {
+            return p6;
+        }
+        if (v <= p7) {
+            return p7;
+        }
+        return p8;
+    }
+
+    /*
+     * Manual binary search for 10 rounding points, it is faster than linear search or array style binary search.
+     */
+    @Evaluator(extraName = "Ceiling10")
+    static long ceiling10(
+        long v,          // hack to keep the formatter happy.
+        @Fixed long p0,  // int is so short this should be on one line but double is not.
+        @Fixed long p1,  // That's not compatible with the templates.
+        @Fixed long p2,  // So we comment to make the formatter not try to change the line.
+        @Fixed long p3,
+        @Fixed long p4,
+        @Fixed long p5,
+        @Fixed long p6,
+        @Fixed long p7,
+        @Fixed long p8,
+        @Fixed long p9
+    ) {
+        if (v <= p3) {
+            if (v <= p0) {
+                return p0;
+            }
+            if (v <= p1) {
+                return p1;
+            }
+            if (v <= p2) {
+                return p2;
+            }
+            return p3;
+        }
+        if (v <= p6) {
+            if (v <= p4) {
+                return p4;
+            }
+            if (v <= p5) {
+                return p5;
+            }
+            return p6;
+        }
+        if (v <= p7) {
+            return p7;
+        }
+        if (v <= p8) {
             return p8;
         }
         return p9;

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToDoubleCeiling10Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToDoubleCeiling10Evaluator.java
@@ -1,0 +1,191 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.math;
+
+import java.lang.IllegalArgumentException;
+import java.lang.Override;
+import java.lang.String;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.DoubleVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+/**
+ * {@link ExpressionEvaluator} implementation for {@link RoundToDouble}.
+ * This class is generated. Edit {@code EvaluatorImplementer} instead.
+ */
+public final class RoundToDoubleCeiling10Evaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(RoundToDoubleCeiling10Evaluator.class);
+
+  private final Source source;
+
+  private final ExpressionEvaluator v;
+
+  private final double p0;
+
+  private final double p1;
+
+  private final double p2;
+
+  private final double p3;
+
+  private final double p4;
+
+  private final double p5;
+
+  private final double p6;
+
+  private final double p7;
+
+  private final double p8;
+
+  private final double p9;
+
+  private final DriverContext driverContext;
+
+  private Warnings warnings;
+
+  public RoundToDoubleCeiling10Evaluator(Source source, ExpressionEvaluator v, double p0, double p1,
+      double p2, double p3, double p4, double p5, double p6, double p7, double p8, double p9,
+      DriverContext driverContext) {
+    this.source = source;
+    this.v = v;
+    this.p0 = p0;
+    this.p1 = p1;
+    this.p2 = p2;
+    this.p3 = p3;
+    this.p4 = p4;
+    this.p5 = p5;
+    this.p6 = p6;
+    this.p7 = p7;
+    this.p8 = p8;
+    this.p9 = p9;
+    this.driverContext = driverContext;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    try (DoubleBlock vBlock = (DoubleBlock) v.eval(page)) {
+      DoubleVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
+      }
+      return eval(page.getPositionCount(), vVector).asBlock();
+    }
+  }
+
+  @Override
+  public long baseRamBytesUsed() {
+    long baseRamBytesUsed = BASE_RAM_BYTES_USED;
+    baseRamBytesUsed += v.baseRamBytesUsed();
+    return baseRamBytesUsed;
+  }
+
+  public DoubleBlock eval(int positionCount, DoubleBlock vBlock) {
+    try(DoubleBlock.Builder result = driverContext.blockFactory().newDoubleBlockBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        switch (vBlock.getValueCount(p)) {
+          case 0:
+              result.appendNull();
+              continue position;
+          case 1:
+              break;
+          default:
+              warnings().registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+              result.appendNull();
+              continue position;
+        }
+        double v = vBlock.getDouble(vBlock.getFirstValueIndex(p));
+        result.appendDouble(RoundToDouble.ceiling10(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6, this.p7, this.p8, this.p9));
+      }
+      return result.build();
+    }
+  }
+
+  public DoubleVector eval(int positionCount, DoubleVector vVector) {
+    try(DoubleVector.FixedBuilder result = driverContext.blockFactory().newDoubleVectorFixedBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        double v = vVector.getDouble(p);
+        result.appendDouble(p, RoundToDouble.ceiling10(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6, this.p7, this.p8, this.p9));
+      }
+      return result.build();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "RoundToDoubleCeiling10Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + ", p7=" + p7 + ", p8=" + p8 + ", p9=" + p9 + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(v);
+  }
+
+  private Warnings warnings() {
+    if (warnings == null) {
+      this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+    }
+    return warnings;
+  }
+
+  static class Factory implements ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final ExpressionEvaluator.Factory v;
+
+    private final double p0;
+
+    private final double p1;
+
+    private final double p2;
+
+    private final double p3;
+
+    private final double p4;
+
+    private final double p5;
+
+    private final double p6;
+
+    private final double p7;
+
+    private final double p8;
+
+    private final double p9;
+
+    public Factory(Source source, ExpressionEvaluator.Factory v, double p0, double p1, double p2,
+        double p3, double p4, double p5, double p6, double p7, double p8, double p9) {
+      this.source = source;
+      this.v = v;
+      this.p0 = p0;
+      this.p1 = p1;
+      this.p2 = p2;
+      this.p3 = p3;
+      this.p4 = p4;
+      this.p5 = p5;
+      this.p6 = p6;
+      this.p7 = p7;
+      this.p8 = p8;
+      this.p9 = p9;
+    }
+
+    @Override
+    public RoundToDoubleCeiling10Evaluator get(DriverContext context) {
+      return new RoundToDoubleCeiling10Evaluator(source, v.get(context), p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, context);
+    }
+
+    @Override
+    public String toString() {
+      return "RoundToDoubleCeiling10Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + ", p7=" + p7 + ", p8=" + p8 + ", p9=" + p9 + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToDoubleCeiling2Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToDoubleCeiling2Evaluator.java
@@ -1,0 +1,141 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.math;
+
+import java.lang.IllegalArgumentException;
+import java.lang.Override;
+import java.lang.String;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.DoubleVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+/**
+ * {@link ExpressionEvaluator} implementation for {@link RoundToDouble}.
+ * This class is generated. Edit {@code EvaluatorImplementer} instead.
+ */
+public final class RoundToDoubleCeiling2Evaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(RoundToDoubleCeiling2Evaluator.class);
+
+  private final Source source;
+
+  private final ExpressionEvaluator v;
+
+  private final double p0;
+
+  private final double p1;
+
+  private final DriverContext driverContext;
+
+  private Warnings warnings;
+
+  public RoundToDoubleCeiling2Evaluator(Source source, ExpressionEvaluator v, double p0, double p1,
+      DriverContext driverContext) {
+    this.source = source;
+    this.v = v;
+    this.p0 = p0;
+    this.p1 = p1;
+    this.driverContext = driverContext;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    try (DoubleBlock vBlock = (DoubleBlock) v.eval(page)) {
+      DoubleVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
+      }
+      return eval(page.getPositionCount(), vVector).asBlock();
+    }
+  }
+
+  @Override
+  public long baseRamBytesUsed() {
+    long baseRamBytesUsed = BASE_RAM_BYTES_USED;
+    baseRamBytesUsed += v.baseRamBytesUsed();
+    return baseRamBytesUsed;
+  }
+
+  public DoubleBlock eval(int positionCount, DoubleBlock vBlock) {
+    try(DoubleBlock.Builder result = driverContext.blockFactory().newDoubleBlockBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        switch (vBlock.getValueCount(p)) {
+          case 0:
+              result.appendNull();
+              continue position;
+          case 1:
+              break;
+          default:
+              warnings().registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+              result.appendNull();
+              continue position;
+        }
+        double v = vBlock.getDouble(vBlock.getFirstValueIndex(p));
+        result.appendDouble(RoundToDouble.ceiling2(v, this.p0, this.p1));
+      }
+      return result.build();
+    }
+  }
+
+  public DoubleVector eval(int positionCount, DoubleVector vVector) {
+    try(DoubleVector.FixedBuilder result = driverContext.blockFactory().newDoubleVectorFixedBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        double v = vVector.getDouble(p);
+        result.appendDouble(p, RoundToDouble.ceiling2(v, this.p0, this.p1));
+      }
+      return result.build();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "RoundToDoubleCeiling2Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(v);
+  }
+
+  private Warnings warnings() {
+    if (warnings == null) {
+      this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+    }
+    return warnings;
+  }
+
+  static class Factory implements ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final ExpressionEvaluator.Factory v;
+
+    private final double p0;
+
+    private final double p1;
+
+    public Factory(Source source, ExpressionEvaluator.Factory v, double p0, double p1) {
+      this.source = source;
+      this.v = v;
+      this.p0 = p0;
+      this.p1 = p1;
+    }
+
+    @Override
+    public RoundToDoubleCeiling2Evaluator get(DriverContext context) {
+      return new RoundToDoubleCeiling2Evaluator(source, v.get(context), p0, p1, context);
+    }
+
+    @Override
+    public String toString() {
+      return "RoundToDoubleCeiling2Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToDoubleCeiling3Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToDoubleCeiling3Evaluator.java
@@ -1,0 +1,147 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.math;
+
+import java.lang.IllegalArgumentException;
+import java.lang.Override;
+import java.lang.String;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.DoubleVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+/**
+ * {@link ExpressionEvaluator} implementation for {@link RoundToDouble}.
+ * This class is generated. Edit {@code EvaluatorImplementer} instead.
+ */
+public final class RoundToDoubleCeiling3Evaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(RoundToDoubleCeiling3Evaluator.class);
+
+  private final Source source;
+
+  private final ExpressionEvaluator v;
+
+  private final double p0;
+
+  private final double p1;
+
+  private final double p2;
+
+  private final DriverContext driverContext;
+
+  private Warnings warnings;
+
+  public RoundToDoubleCeiling3Evaluator(Source source, ExpressionEvaluator v, double p0, double p1,
+      double p2, DriverContext driverContext) {
+    this.source = source;
+    this.v = v;
+    this.p0 = p0;
+    this.p1 = p1;
+    this.p2 = p2;
+    this.driverContext = driverContext;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    try (DoubleBlock vBlock = (DoubleBlock) v.eval(page)) {
+      DoubleVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
+      }
+      return eval(page.getPositionCount(), vVector).asBlock();
+    }
+  }
+
+  @Override
+  public long baseRamBytesUsed() {
+    long baseRamBytesUsed = BASE_RAM_BYTES_USED;
+    baseRamBytesUsed += v.baseRamBytesUsed();
+    return baseRamBytesUsed;
+  }
+
+  public DoubleBlock eval(int positionCount, DoubleBlock vBlock) {
+    try(DoubleBlock.Builder result = driverContext.blockFactory().newDoubleBlockBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        switch (vBlock.getValueCount(p)) {
+          case 0:
+              result.appendNull();
+              continue position;
+          case 1:
+              break;
+          default:
+              warnings().registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+              result.appendNull();
+              continue position;
+        }
+        double v = vBlock.getDouble(vBlock.getFirstValueIndex(p));
+        result.appendDouble(RoundToDouble.ceiling3(v, this.p0, this.p1, this.p2));
+      }
+      return result.build();
+    }
+  }
+
+  public DoubleVector eval(int positionCount, DoubleVector vVector) {
+    try(DoubleVector.FixedBuilder result = driverContext.blockFactory().newDoubleVectorFixedBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        double v = vVector.getDouble(p);
+        result.appendDouble(p, RoundToDouble.ceiling3(v, this.p0, this.p1, this.p2));
+      }
+      return result.build();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "RoundToDoubleCeiling3Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(v);
+  }
+
+  private Warnings warnings() {
+    if (warnings == null) {
+      this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+    }
+    return warnings;
+  }
+
+  static class Factory implements ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final ExpressionEvaluator.Factory v;
+
+    private final double p0;
+
+    private final double p1;
+
+    private final double p2;
+
+    public Factory(Source source, ExpressionEvaluator.Factory v, double p0, double p1, double p2) {
+      this.source = source;
+      this.v = v;
+      this.p0 = p0;
+      this.p1 = p1;
+      this.p2 = p2;
+    }
+
+    @Override
+    public RoundToDoubleCeiling3Evaluator get(DriverContext context) {
+      return new RoundToDoubleCeiling3Evaluator(source, v.get(context), p0, p1, p2, context);
+    }
+
+    @Override
+    public String toString() {
+      return "RoundToDoubleCeiling3Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToDoubleCeiling4Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToDoubleCeiling4Evaluator.java
@@ -1,0 +1,154 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.math;
+
+import java.lang.IllegalArgumentException;
+import java.lang.Override;
+import java.lang.String;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.DoubleVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+/**
+ * {@link ExpressionEvaluator} implementation for {@link RoundToDouble}.
+ * This class is generated. Edit {@code EvaluatorImplementer} instead.
+ */
+public final class RoundToDoubleCeiling4Evaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(RoundToDoubleCeiling4Evaluator.class);
+
+  private final Source source;
+
+  private final ExpressionEvaluator v;
+
+  private final double p0;
+
+  private final double p1;
+
+  private final double p2;
+
+  private final double p3;
+
+  private final DriverContext driverContext;
+
+  private Warnings warnings;
+
+  public RoundToDoubleCeiling4Evaluator(Source source, ExpressionEvaluator v, double p0, double p1,
+      double p2, double p3, DriverContext driverContext) {
+    this.source = source;
+    this.v = v;
+    this.p0 = p0;
+    this.p1 = p1;
+    this.p2 = p2;
+    this.p3 = p3;
+    this.driverContext = driverContext;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    try (DoubleBlock vBlock = (DoubleBlock) v.eval(page)) {
+      DoubleVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
+      }
+      return eval(page.getPositionCount(), vVector).asBlock();
+    }
+  }
+
+  @Override
+  public long baseRamBytesUsed() {
+    long baseRamBytesUsed = BASE_RAM_BYTES_USED;
+    baseRamBytesUsed += v.baseRamBytesUsed();
+    return baseRamBytesUsed;
+  }
+
+  public DoubleBlock eval(int positionCount, DoubleBlock vBlock) {
+    try(DoubleBlock.Builder result = driverContext.blockFactory().newDoubleBlockBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        switch (vBlock.getValueCount(p)) {
+          case 0:
+              result.appendNull();
+              continue position;
+          case 1:
+              break;
+          default:
+              warnings().registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+              result.appendNull();
+              continue position;
+        }
+        double v = vBlock.getDouble(vBlock.getFirstValueIndex(p));
+        result.appendDouble(RoundToDouble.ceiling4(v, this.p0, this.p1, this.p2, this.p3));
+      }
+      return result.build();
+    }
+  }
+
+  public DoubleVector eval(int positionCount, DoubleVector vVector) {
+    try(DoubleVector.FixedBuilder result = driverContext.blockFactory().newDoubleVectorFixedBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        double v = vVector.getDouble(p);
+        result.appendDouble(p, RoundToDouble.ceiling4(v, this.p0, this.p1, this.p2, this.p3));
+      }
+      return result.build();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "RoundToDoubleCeiling4Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(v);
+  }
+
+  private Warnings warnings() {
+    if (warnings == null) {
+      this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+    }
+    return warnings;
+  }
+
+  static class Factory implements ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final ExpressionEvaluator.Factory v;
+
+    private final double p0;
+
+    private final double p1;
+
+    private final double p2;
+
+    private final double p3;
+
+    public Factory(Source source, ExpressionEvaluator.Factory v, double p0, double p1, double p2,
+        double p3) {
+      this.source = source;
+      this.v = v;
+      this.p0 = p0;
+      this.p1 = p1;
+      this.p2 = p2;
+      this.p3 = p3;
+    }
+
+    @Override
+    public RoundToDoubleCeiling4Evaluator get(DriverContext context) {
+      return new RoundToDoubleCeiling4Evaluator(source, v.get(context), p0, p1, p2, p3, context);
+    }
+
+    @Override
+    public String toString() {
+      return "RoundToDoubleCeiling4Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToDoubleCeiling5Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToDoubleCeiling5Evaluator.java
@@ -1,0 +1,160 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.math;
+
+import java.lang.IllegalArgumentException;
+import java.lang.Override;
+import java.lang.String;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.DoubleVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+/**
+ * {@link ExpressionEvaluator} implementation for {@link RoundToDouble}.
+ * This class is generated. Edit {@code EvaluatorImplementer} instead.
+ */
+public final class RoundToDoubleCeiling5Evaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(RoundToDoubleCeiling5Evaluator.class);
+
+  private final Source source;
+
+  private final ExpressionEvaluator v;
+
+  private final double p0;
+
+  private final double p1;
+
+  private final double p2;
+
+  private final double p3;
+
+  private final double p4;
+
+  private final DriverContext driverContext;
+
+  private Warnings warnings;
+
+  public RoundToDoubleCeiling5Evaluator(Source source, ExpressionEvaluator v, double p0, double p1,
+      double p2, double p3, double p4, DriverContext driverContext) {
+    this.source = source;
+    this.v = v;
+    this.p0 = p0;
+    this.p1 = p1;
+    this.p2 = p2;
+    this.p3 = p3;
+    this.p4 = p4;
+    this.driverContext = driverContext;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    try (DoubleBlock vBlock = (DoubleBlock) v.eval(page)) {
+      DoubleVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
+      }
+      return eval(page.getPositionCount(), vVector).asBlock();
+    }
+  }
+
+  @Override
+  public long baseRamBytesUsed() {
+    long baseRamBytesUsed = BASE_RAM_BYTES_USED;
+    baseRamBytesUsed += v.baseRamBytesUsed();
+    return baseRamBytesUsed;
+  }
+
+  public DoubleBlock eval(int positionCount, DoubleBlock vBlock) {
+    try(DoubleBlock.Builder result = driverContext.blockFactory().newDoubleBlockBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        switch (vBlock.getValueCount(p)) {
+          case 0:
+              result.appendNull();
+              continue position;
+          case 1:
+              break;
+          default:
+              warnings().registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+              result.appendNull();
+              continue position;
+        }
+        double v = vBlock.getDouble(vBlock.getFirstValueIndex(p));
+        result.appendDouble(RoundToDouble.ceiling5(v, this.p0, this.p1, this.p2, this.p3, this.p4));
+      }
+      return result.build();
+    }
+  }
+
+  public DoubleVector eval(int positionCount, DoubleVector vVector) {
+    try(DoubleVector.FixedBuilder result = driverContext.blockFactory().newDoubleVectorFixedBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        double v = vVector.getDouble(p);
+        result.appendDouble(p, RoundToDouble.ceiling5(v, this.p0, this.p1, this.p2, this.p3, this.p4));
+      }
+      return result.build();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "RoundToDoubleCeiling5Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(v);
+  }
+
+  private Warnings warnings() {
+    if (warnings == null) {
+      this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+    }
+    return warnings;
+  }
+
+  static class Factory implements ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final ExpressionEvaluator.Factory v;
+
+    private final double p0;
+
+    private final double p1;
+
+    private final double p2;
+
+    private final double p3;
+
+    private final double p4;
+
+    public Factory(Source source, ExpressionEvaluator.Factory v, double p0, double p1, double p2,
+        double p3, double p4) {
+      this.source = source;
+      this.v = v;
+      this.p0 = p0;
+      this.p1 = p1;
+      this.p2 = p2;
+      this.p3 = p3;
+      this.p4 = p4;
+    }
+
+    @Override
+    public RoundToDoubleCeiling5Evaluator get(DriverContext context) {
+      return new RoundToDoubleCeiling5Evaluator(source, v.get(context), p0, p1, p2, p3, p4, context);
+    }
+
+    @Override
+    public String toString() {
+      return "RoundToDoubleCeiling5Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToDoubleCeiling6Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToDoubleCeiling6Evaluator.java
@@ -1,0 +1,166 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.math;
+
+import java.lang.IllegalArgumentException;
+import java.lang.Override;
+import java.lang.String;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.DoubleVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+/**
+ * {@link ExpressionEvaluator} implementation for {@link RoundToDouble}.
+ * This class is generated. Edit {@code EvaluatorImplementer} instead.
+ */
+public final class RoundToDoubleCeiling6Evaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(RoundToDoubleCeiling6Evaluator.class);
+
+  private final Source source;
+
+  private final ExpressionEvaluator v;
+
+  private final double p0;
+
+  private final double p1;
+
+  private final double p2;
+
+  private final double p3;
+
+  private final double p4;
+
+  private final double p5;
+
+  private final DriverContext driverContext;
+
+  private Warnings warnings;
+
+  public RoundToDoubleCeiling6Evaluator(Source source, ExpressionEvaluator v, double p0, double p1,
+      double p2, double p3, double p4, double p5, DriverContext driverContext) {
+    this.source = source;
+    this.v = v;
+    this.p0 = p0;
+    this.p1 = p1;
+    this.p2 = p2;
+    this.p3 = p3;
+    this.p4 = p4;
+    this.p5 = p5;
+    this.driverContext = driverContext;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    try (DoubleBlock vBlock = (DoubleBlock) v.eval(page)) {
+      DoubleVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
+      }
+      return eval(page.getPositionCount(), vVector).asBlock();
+    }
+  }
+
+  @Override
+  public long baseRamBytesUsed() {
+    long baseRamBytesUsed = BASE_RAM_BYTES_USED;
+    baseRamBytesUsed += v.baseRamBytesUsed();
+    return baseRamBytesUsed;
+  }
+
+  public DoubleBlock eval(int positionCount, DoubleBlock vBlock) {
+    try(DoubleBlock.Builder result = driverContext.blockFactory().newDoubleBlockBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        switch (vBlock.getValueCount(p)) {
+          case 0:
+              result.appendNull();
+              continue position;
+          case 1:
+              break;
+          default:
+              warnings().registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+              result.appendNull();
+              continue position;
+        }
+        double v = vBlock.getDouble(vBlock.getFirstValueIndex(p));
+        result.appendDouble(RoundToDouble.ceiling6(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5));
+      }
+      return result.build();
+    }
+  }
+
+  public DoubleVector eval(int positionCount, DoubleVector vVector) {
+    try(DoubleVector.FixedBuilder result = driverContext.blockFactory().newDoubleVectorFixedBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        double v = vVector.getDouble(p);
+        result.appendDouble(p, RoundToDouble.ceiling6(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5));
+      }
+      return result.build();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "RoundToDoubleCeiling6Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(v);
+  }
+
+  private Warnings warnings() {
+    if (warnings == null) {
+      this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+    }
+    return warnings;
+  }
+
+  static class Factory implements ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final ExpressionEvaluator.Factory v;
+
+    private final double p0;
+
+    private final double p1;
+
+    private final double p2;
+
+    private final double p3;
+
+    private final double p4;
+
+    private final double p5;
+
+    public Factory(Source source, ExpressionEvaluator.Factory v, double p0, double p1, double p2,
+        double p3, double p4, double p5) {
+      this.source = source;
+      this.v = v;
+      this.p0 = p0;
+      this.p1 = p1;
+      this.p2 = p2;
+      this.p3 = p3;
+      this.p4 = p4;
+      this.p5 = p5;
+    }
+
+    @Override
+    public RoundToDoubleCeiling6Evaluator get(DriverContext context) {
+      return new RoundToDoubleCeiling6Evaluator(source, v.get(context), p0, p1, p2, p3, p4, p5, context);
+    }
+
+    @Override
+    public String toString() {
+      return "RoundToDoubleCeiling6Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToDoubleCeiling7Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToDoubleCeiling7Evaluator.java
@@ -1,0 +1,172 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.math;
+
+import java.lang.IllegalArgumentException;
+import java.lang.Override;
+import java.lang.String;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.DoubleVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+/**
+ * {@link ExpressionEvaluator} implementation for {@link RoundToDouble}.
+ * This class is generated. Edit {@code EvaluatorImplementer} instead.
+ */
+public final class RoundToDoubleCeiling7Evaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(RoundToDoubleCeiling7Evaluator.class);
+
+  private final Source source;
+
+  private final ExpressionEvaluator v;
+
+  private final double p0;
+
+  private final double p1;
+
+  private final double p2;
+
+  private final double p3;
+
+  private final double p4;
+
+  private final double p5;
+
+  private final double p6;
+
+  private final DriverContext driverContext;
+
+  private Warnings warnings;
+
+  public RoundToDoubleCeiling7Evaluator(Source source, ExpressionEvaluator v, double p0, double p1,
+      double p2, double p3, double p4, double p5, double p6, DriverContext driverContext) {
+    this.source = source;
+    this.v = v;
+    this.p0 = p0;
+    this.p1 = p1;
+    this.p2 = p2;
+    this.p3 = p3;
+    this.p4 = p4;
+    this.p5 = p5;
+    this.p6 = p6;
+    this.driverContext = driverContext;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    try (DoubleBlock vBlock = (DoubleBlock) v.eval(page)) {
+      DoubleVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
+      }
+      return eval(page.getPositionCount(), vVector).asBlock();
+    }
+  }
+
+  @Override
+  public long baseRamBytesUsed() {
+    long baseRamBytesUsed = BASE_RAM_BYTES_USED;
+    baseRamBytesUsed += v.baseRamBytesUsed();
+    return baseRamBytesUsed;
+  }
+
+  public DoubleBlock eval(int positionCount, DoubleBlock vBlock) {
+    try(DoubleBlock.Builder result = driverContext.blockFactory().newDoubleBlockBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        switch (vBlock.getValueCount(p)) {
+          case 0:
+              result.appendNull();
+              continue position;
+          case 1:
+              break;
+          default:
+              warnings().registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+              result.appendNull();
+              continue position;
+        }
+        double v = vBlock.getDouble(vBlock.getFirstValueIndex(p));
+        result.appendDouble(RoundToDouble.ceiling7(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6));
+      }
+      return result.build();
+    }
+  }
+
+  public DoubleVector eval(int positionCount, DoubleVector vVector) {
+    try(DoubleVector.FixedBuilder result = driverContext.blockFactory().newDoubleVectorFixedBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        double v = vVector.getDouble(p);
+        result.appendDouble(p, RoundToDouble.ceiling7(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6));
+      }
+      return result.build();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "RoundToDoubleCeiling7Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(v);
+  }
+
+  private Warnings warnings() {
+    if (warnings == null) {
+      this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+    }
+    return warnings;
+  }
+
+  static class Factory implements ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final ExpressionEvaluator.Factory v;
+
+    private final double p0;
+
+    private final double p1;
+
+    private final double p2;
+
+    private final double p3;
+
+    private final double p4;
+
+    private final double p5;
+
+    private final double p6;
+
+    public Factory(Source source, ExpressionEvaluator.Factory v, double p0, double p1, double p2,
+        double p3, double p4, double p5, double p6) {
+      this.source = source;
+      this.v = v;
+      this.p0 = p0;
+      this.p1 = p1;
+      this.p2 = p2;
+      this.p3 = p3;
+      this.p4 = p4;
+      this.p5 = p5;
+      this.p6 = p6;
+    }
+
+    @Override
+    public RoundToDoubleCeiling7Evaluator get(DriverContext context) {
+      return new RoundToDoubleCeiling7Evaluator(source, v.get(context), p0, p1, p2, p3, p4, p5, p6, context);
+    }
+
+    @Override
+    public String toString() {
+      return "RoundToDoubleCeiling7Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToDoubleCeiling8Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToDoubleCeiling8Evaluator.java
@@ -1,0 +1,179 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.math;
+
+import java.lang.IllegalArgumentException;
+import java.lang.Override;
+import java.lang.String;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.DoubleVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+/**
+ * {@link ExpressionEvaluator} implementation for {@link RoundToDouble}.
+ * This class is generated. Edit {@code EvaluatorImplementer} instead.
+ */
+public final class RoundToDoubleCeiling8Evaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(RoundToDoubleCeiling8Evaluator.class);
+
+  private final Source source;
+
+  private final ExpressionEvaluator v;
+
+  private final double p0;
+
+  private final double p1;
+
+  private final double p2;
+
+  private final double p3;
+
+  private final double p4;
+
+  private final double p5;
+
+  private final double p6;
+
+  private final double p7;
+
+  private final DriverContext driverContext;
+
+  private Warnings warnings;
+
+  public RoundToDoubleCeiling8Evaluator(Source source, ExpressionEvaluator v, double p0, double p1,
+      double p2, double p3, double p4, double p5, double p6, double p7,
+      DriverContext driverContext) {
+    this.source = source;
+    this.v = v;
+    this.p0 = p0;
+    this.p1 = p1;
+    this.p2 = p2;
+    this.p3 = p3;
+    this.p4 = p4;
+    this.p5 = p5;
+    this.p6 = p6;
+    this.p7 = p7;
+    this.driverContext = driverContext;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    try (DoubleBlock vBlock = (DoubleBlock) v.eval(page)) {
+      DoubleVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
+      }
+      return eval(page.getPositionCount(), vVector).asBlock();
+    }
+  }
+
+  @Override
+  public long baseRamBytesUsed() {
+    long baseRamBytesUsed = BASE_RAM_BYTES_USED;
+    baseRamBytesUsed += v.baseRamBytesUsed();
+    return baseRamBytesUsed;
+  }
+
+  public DoubleBlock eval(int positionCount, DoubleBlock vBlock) {
+    try(DoubleBlock.Builder result = driverContext.blockFactory().newDoubleBlockBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        switch (vBlock.getValueCount(p)) {
+          case 0:
+              result.appendNull();
+              continue position;
+          case 1:
+              break;
+          default:
+              warnings().registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+              result.appendNull();
+              continue position;
+        }
+        double v = vBlock.getDouble(vBlock.getFirstValueIndex(p));
+        result.appendDouble(RoundToDouble.ceiling8(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6, this.p7));
+      }
+      return result.build();
+    }
+  }
+
+  public DoubleVector eval(int positionCount, DoubleVector vVector) {
+    try(DoubleVector.FixedBuilder result = driverContext.blockFactory().newDoubleVectorFixedBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        double v = vVector.getDouble(p);
+        result.appendDouble(p, RoundToDouble.ceiling8(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6, this.p7));
+      }
+      return result.build();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "RoundToDoubleCeiling8Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + ", p7=" + p7 + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(v);
+  }
+
+  private Warnings warnings() {
+    if (warnings == null) {
+      this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+    }
+    return warnings;
+  }
+
+  static class Factory implements ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final ExpressionEvaluator.Factory v;
+
+    private final double p0;
+
+    private final double p1;
+
+    private final double p2;
+
+    private final double p3;
+
+    private final double p4;
+
+    private final double p5;
+
+    private final double p6;
+
+    private final double p7;
+
+    public Factory(Source source, ExpressionEvaluator.Factory v, double p0, double p1, double p2,
+        double p3, double p4, double p5, double p6, double p7) {
+      this.source = source;
+      this.v = v;
+      this.p0 = p0;
+      this.p1 = p1;
+      this.p2 = p2;
+      this.p3 = p3;
+      this.p4 = p4;
+      this.p5 = p5;
+      this.p6 = p6;
+      this.p7 = p7;
+    }
+
+    @Override
+    public RoundToDoubleCeiling8Evaluator get(DriverContext context) {
+      return new RoundToDoubleCeiling8Evaluator(source, v.get(context), p0, p1, p2, p3, p4, p5, p6, p7, context);
+    }
+
+    @Override
+    public String toString() {
+      return "RoundToDoubleCeiling8Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + ", p7=" + p7 + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToDoubleCeiling9Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToDoubleCeiling9Evaluator.java
@@ -1,0 +1,185 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.math;
+
+import java.lang.IllegalArgumentException;
+import java.lang.Override;
+import java.lang.String;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.DoubleVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+/**
+ * {@link ExpressionEvaluator} implementation for {@link RoundToDouble}.
+ * This class is generated. Edit {@code EvaluatorImplementer} instead.
+ */
+public final class RoundToDoubleCeiling9Evaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(RoundToDoubleCeiling9Evaluator.class);
+
+  private final Source source;
+
+  private final ExpressionEvaluator v;
+
+  private final double p0;
+
+  private final double p1;
+
+  private final double p2;
+
+  private final double p3;
+
+  private final double p4;
+
+  private final double p5;
+
+  private final double p6;
+
+  private final double p7;
+
+  private final double p8;
+
+  private final DriverContext driverContext;
+
+  private Warnings warnings;
+
+  public RoundToDoubleCeiling9Evaluator(Source source, ExpressionEvaluator v, double p0, double p1,
+      double p2, double p3, double p4, double p5, double p6, double p7, double p8,
+      DriverContext driverContext) {
+    this.source = source;
+    this.v = v;
+    this.p0 = p0;
+    this.p1 = p1;
+    this.p2 = p2;
+    this.p3 = p3;
+    this.p4 = p4;
+    this.p5 = p5;
+    this.p6 = p6;
+    this.p7 = p7;
+    this.p8 = p8;
+    this.driverContext = driverContext;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    try (DoubleBlock vBlock = (DoubleBlock) v.eval(page)) {
+      DoubleVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
+      }
+      return eval(page.getPositionCount(), vVector).asBlock();
+    }
+  }
+
+  @Override
+  public long baseRamBytesUsed() {
+    long baseRamBytesUsed = BASE_RAM_BYTES_USED;
+    baseRamBytesUsed += v.baseRamBytesUsed();
+    return baseRamBytesUsed;
+  }
+
+  public DoubleBlock eval(int positionCount, DoubleBlock vBlock) {
+    try(DoubleBlock.Builder result = driverContext.blockFactory().newDoubleBlockBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        switch (vBlock.getValueCount(p)) {
+          case 0:
+              result.appendNull();
+              continue position;
+          case 1:
+              break;
+          default:
+              warnings().registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+              result.appendNull();
+              continue position;
+        }
+        double v = vBlock.getDouble(vBlock.getFirstValueIndex(p));
+        result.appendDouble(RoundToDouble.ceiling9(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6, this.p7, this.p8));
+      }
+      return result.build();
+    }
+  }
+
+  public DoubleVector eval(int positionCount, DoubleVector vVector) {
+    try(DoubleVector.FixedBuilder result = driverContext.blockFactory().newDoubleVectorFixedBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        double v = vVector.getDouble(p);
+        result.appendDouble(p, RoundToDouble.ceiling9(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6, this.p7, this.p8));
+      }
+      return result.build();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "RoundToDoubleCeiling9Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + ", p7=" + p7 + ", p8=" + p8 + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(v);
+  }
+
+  private Warnings warnings() {
+    if (warnings == null) {
+      this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+    }
+    return warnings;
+  }
+
+  static class Factory implements ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final ExpressionEvaluator.Factory v;
+
+    private final double p0;
+
+    private final double p1;
+
+    private final double p2;
+
+    private final double p3;
+
+    private final double p4;
+
+    private final double p5;
+
+    private final double p6;
+
+    private final double p7;
+
+    private final double p8;
+
+    public Factory(Source source, ExpressionEvaluator.Factory v, double p0, double p1, double p2,
+        double p3, double p4, double p5, double p6, double p7, double p8) {
+      this.source = source;
+      this.v = v;
+      this.p0 = p0;
+      this.p1 = p1;
+      this.p2 = p2;
+      this.p3 = p3;
+      this.p4 = p4;
+      this.p5 = p5;
+      this.p6 = p6;
+      this.p7 = p7;
+      this.p8 = p8;
+    }
+
+    @Override
+    public RoundToDoubleCeiling9Evaluator get(DriverContext context) {
+      return new RoundToDoubleCeiling9Evaluator(source, v.get(context), p0, p1, p2, p3, p4, p5, p6, p7, p8, context);
+    }
+
+    @Override
+    public String toString() {
+      return "RoundToDoubleCeiling9Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + ", p7=" + p7 + ", p8=" + p8 + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToDoubleCeilingSearchEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToDoubleCeilingSearchEvaluator.java
@@ -1,0 +1,135 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.math;
+
+import java.lang.IllegalArgumentException;
+import java.lang.Override;
+import java.lang.String;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.DoubleVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+/**
+ * {@link ExpressionEvaluator} implementation for {@link RoundToDouble}.
+ * This class is generated. Edit {@code EvaluatorImplementer} instead.
+ */
+public final class RoundToDoubleCeilingSearchEvaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(RoundToDoubleCeilingSearchEvaluator.class);
+
+  private final Source source;
+
+  private final ExpressionEvaluator v;
+
+  private final double[] p;
+
+  private final DriverContext driverContext;
+
+  private Warnings warnings;
+
+  public RoundToDoubleCeilingSearchEvaluator(Source source, ExpressionEvaluator v, double[] p,
+      DriverContext driverContext) {
+    this.source = source;
+    this.v = v;
+    this.p = p;
+    this.driverContext = driverContext;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    try (DoubleBlock vBlock = (DoubleBlock) v.eval(page)) {
+      DoubleVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
+      }
+      return eval(page.getPositionCount(), vVector).asBlock();
+    }
+  }
+
+  @Override
+  public long baseRamBytesUsed() {
+    long baseRamBytesUsed = BASE_RAM_BYTES_USED;
+    baseRamBytesUsed += v.baseRamBytesUsed();
+    return baseRamBytesUsed;
+  }
+
+  public DoubleBlock eval(int positionCount, DoubleBlock vBlock) {
+    try(DoubleBlock.Builder result = driverContext.blockFactory().newDoubleBlockBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        switch (vBlock.getValueCount(p)) {
+          case 0:
+              result.appendNull();
+              continue position;
+          case 1:
+              break;
+          default:
+              warnings().registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+              result.appendNull();
+              continue position;
+        }
+        double v = vBlock.getDouble(vBlock.getFirstValueIndex(p));
+        result.appendDouble(RoundToDouble.ceilingSearch(v, this.p));
+      }
+      return result.build();
+    }
+  }
+
+  public DoubleVector eval(int positionCount, DoubleVector vVector) {
+    try(DoubleVector.FixedBuilder result = driverContext.blockFactory().newDoubleVectorFixedBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        double v = vVector.getDouble(p);
+        result.appendDouble(p, RoundToDouble.ceilingSearch(v, this.p));
+      }
+      return result.build();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "RoundToDoubleCeilingSearchEvaluator[" + "v=" + v + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(v);
+  }
+
+  private Warnings warnings() {
+    if (warnings == null) {
+      this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+    }
+    return warnings;
+  }
+
+  static class Factory implements ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final ExpressionEvaluator.Factory v;
+
+    private final double[] p;
+
+    public Factory(Source source, ExpressionEvaluator.Factory v, double[] p) {
+      this.source = source;
+      this.v = v;
+      this.p = p;
+    }
+
+    @Override
+    public RoundToDoubleCeilingSearchEvaluator get(DriverContext context) {
+      return new RoundToDoubleCeilingSearchEvaluator(source, v.get(context), p, context);
+    }
+
+    @Override
+    public String toString() {
+      return "RoundToDoubleCeilingSearchEvaluator[" + "v=" + v + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToDoubleConstantEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToDoubleConstantEvaluator.java
@@ -1,0 +1,135 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.math;
+
+import java.lang.IllegalArgumentException;
+import java.lang.Override;
+import java.lang.String;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.DoubleVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+/**
+ * {@link ExpressionEvaluator} implementation for {@link RoundToDouble}.
+ * This class is generated. Edit {@code EvaluatorImplementer} instead.
+ */
+public final class RoundToDoubleConstantEvaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(RoundToDoubleConstantEvaluator.class);
+
+  private final Source source;
+
+  private final ExpressionEvaluator v;
+
+  private final double p;
+
+  private final DriverContext driverContext;
+
+  private Warnings warnings;
+
+  public RoundToDoubleConstantEvaluator(Source source, ExpressionEvaluator v, double p,
+      DriverContext driverContext) {
+    this.source = source;
+    this.v = v;
+    this.p = p;
+    this.driverContext = driverContext;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    try (DoubleBlock vBlock = (DoubleBlock) v.eval(page)) {
+      DoubleVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
+      }
+      return eval(page.getPositionCount(), vVector).asBlock();
+    }
+  }
+
+  @Override
+  public long baseRamBytesUsed() {
+    long baseRamBytesUsed = BASE_RAM_BYTES_USED;
+    baseRamBytesUsed += v.baseRamBytesUsed();
+    return baseRamBytesUsed;
+  }
+
+  public DoubleBlock eval(int positionCount, DoubleBlock vBlock) {
+    try(DoubleBlock.Builder result = driverContext.blockFactory().newDoubleBlockBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        switch (vBlock.getValueCount(p)) {
+          case 0:
+              result.appendNull();
+              continue position;
+          case 1:
+              break;
+          default:
+              warnings().registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+              result.appendNull();
+              continue position;
+        }
+        double v = vBlock.getDouble(vBlock.getFirstValueIndex(p));
+        result.appendDouble(RoundToDouble.constant(v, this.p));
+      }
+      return result.build();
+    }
+  }
+
+  public DoubleVector eval(int positionCount, DoubleVector vVector) {
+    try(DoubleVector.FixedBuilder result = driverContext.blockFactory().newDoubleVectorFixedBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        double v = vVector.getDouble(p);
+        result.appendDouble(p, RoundToDouble.constant(v, this.p));
+      }
+      return result.build();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "RoundToDoubleConstantEvaluator[" + "v=" + v + ", p=" + p + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(v);
+  }
+
+  private Warnings warnings() {
+    if (warnings == null) {
+      this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+    }
+    return warnings;
+  }
+
+  static class Factory implements ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final ExpressionEvaluator.Factory v;
+
+    private final double p;
+
+    public Factory(Source source, ExpressionEvaluator.Factory v, double p) {
+      this.source = source;
+      this.v = v;
+      this.p = p;
+    }
+
+    @Override
+    public RoundToDoubleConstantEvaluator get(DriverContext context) {
+      return new RoundToDoubleConstantEvaluator(source, v.get(context), p, context);
+    }
+
+    @Override
+    public String toString() {
+      return "RoundToDoubleConstantEvaluator[" + "v=" + v + ", p=" + p + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToDoubleFloor10Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToDoubleFloor10Evaluator.java
@@ -27,7 +27,7 @@ public final class RoundToDoubleFloor10Evaluator implements ExpressionEvaluator 
 
   private final Source source;
 
-  private final ExpressionEvaluator field;
+  private final ExpressionEvaluator v;
 
   private final double p0;
 
@@ -53,11 +53,11 @@ public final class RoundToDoubleFloor10Evaluator implements ExpressionEvaluator 
 
   private Warnings warnings;
 
-  public RoundToDoubleFloor10Evaluator(Source source, ExpressionEvaluator field, double p0, double p1,
+  public RoundToDoubleFloor10Evaluator(Source source, ExpressionEvaluator v, double p0, double p1,
       double p2, double p3, double p4, double p5, double p6, double p7, double p8, double p9,
       DriverContext driverContext) {
     this.source = source;
-    this.field = field;
+    this.v = v;
     this.p0 = p0;
     this.p1 = p1;
     this.p2 = p2;
@@ -73,26 +73,26 @@ public final class RoundToDoubleFloor10Evaluator implements ExpressionEvaluator 
 
   @Override
   public Block eval(Page page) {
-    try (DoubleBlock fieldBlock = (DoubleBlock) field.eval(page)) {
-      DoubleVector fieldVector = fieldBlock.asVector();
-      if (fieldVector == null) {
-        return eval(page.getPositionCount(), fieldBlock);
+    try (DoubleBlock vBlock = (DoubleBlock) v.eval(page)) {
+      DoubleVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
       }
-      return eval(page.getPositionCount(), fieldVector).asBlock();
+      return eval(page.getPositionCount(), vVector).asBlock();
     }
   }
 
   @Override
   public long baseRamBytesUsed() {
     long baseRamBytesUsed = BASE_RAM_BYTES_USED;
-    baseRamBytesUsed += field.baseRamBytesUsed();
+    baseRamBytesUsed += v.baseRamBytesUsed();
     return baseRamBytesUsed;
   }
 
-  public DoubleBlock eval(int positionCount, DoubleBlock fieldBlock) {
+  public DoubleBlock eval(int positionCount, DoubleBlock vBlock) {
     try(DoubleBlock.Builder result = driverContext.blockFactory().newDoubleBlockBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        switch (fieldBlock.getValueCount(p)) {
+        switch (vBlock.getValueCount(p)) {
           case 0:
               result.appendNull();
               continue position;
@@ -103,18 +103,18 @@ public final class RoundToDoubleFloor10Evaluator implements ExpressionEvaluator 
               result.appendNull();
               continue position;
         }
-        double field = fieldBlock.getDouble(fieldBlock.getFirstValueIndex(p));
-        result.appendDouble(RoundToDouble.process(field, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6, this.p7, this.p8, this.p9));
+        double v = vBlock.getDouble(vBlock.getFirstValueIndex(p));
+        result.appendDouble(RoundToDouble.floor10(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6, this.p7, this.p8, this.p9));
       }
       return result.build();
     }
   }
 
-  public DoubleVector eval(int positionCount, DoubleVector fieldVector) {
+  public DoubleVector eval(int positionCount, DoubleVector vVector) {
     try(DoubleVector.FixedBuilder result = driverContext.blockFactory().newDoubleVectorFixedBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        double field = fieldVector.getDouble(p);
-        result.appendDouble(p, RoundToDouble.process(field, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6, this.p7, this.p8, this.p9));
+        double v = vVector.getDouble(p);
+        result.appendDouble(p, RoundToDouble.floor10(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6, this.p7, this.p8, this.p9));
       }
       return result.build();
     }
@@ -122,12 +122,12 @@ public final class RoundToDoubleFloor10Evaluator implements ExpressionEvaluator 
 
   @Override
   public String toString() {
-    return "RoundToDoubleFloor10Evaluator[" + "field=" + field + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + ", p7=" + p7 + ", p8=" + p8 + ", p9=" + p9 + "]";
+    return "RoundToDoubleFloor10Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + ", p7=" + p7 + ", p8=" + p8 + ", p9=" + p9 + "]";
   }
 
   @Override
   public void close() {
-    Releasables.closeExpectNoException(field);
+    Releasables.closeExpectNoException(v);
   }
 
   private Warnings warnings() {
@@ -140,7 +140,7 @@ public final class RoundToDoubleFloor10Evaluator implements ExpressionEvaluator 
   static class Factory implements ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final ExpressionEvaluator.Factory field;
+    private final ExpressionEvaluator.Factory v;
 
     private final double p0;
 
@@ -162,10 +162,10 @@ public final class RoundToDoubleFloor10Evaluator implements ExpressionEvaluator 
 
     private final double p9;
 
-    public Factory(Source source, ExpressionEvaluator.Factory field, double p0, double p1,
-        double p2, double p3, double p4, double p5, double p6, double p7, double p8, double p9) {
+    public Factory(Source source, ExpressionEvaluator.Factory v, double p0, double p1, double p2,
+        double p3, double p4, double p5, double p6, double p7, double p8, double p9) {
       this.source = source;
-      this.field = field;
+      this.v = v;
       this.p0 = p0;
       this.p1 = p1;
       this.p2 = p2;
@@ -180,12 +180,12 @@ public final class RoundToDoubleFloor10Evaluator implements ExpressionEvaluator 
 
     @Override
     public RoundToDoubleFloor10Evaluator get(DriverContext context) {
-      return new RoundToDoubleFloor10Evaluator(source, field.get(context), p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, context);
+      return new RoundToDoubleFloor10Evaluator(source, v.get(context), p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, context);
     }
 
     @Override
     public String toString() {
-      return "RoundToDoubleFloor10Evaluator[" + "field=" + field + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + ", p7=" + p7 + ", p8=" + p8 + ", p9=" + p9 + "]";
+      return "RoundToDoubleFloor10Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + ", p7=" + p7 + ", p8=" + p8 + ", p9=" + p9 + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToDoubleFloor2Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToDoubleFloor2Evaluator.java
@@ -27,7 +27,7 @@ public final class RoundToDoubleFloor2Evaluator implements ExpressionEvaluator {
 
   private final Source source;
 
-  private final ExpressionEvaluator field;
+  private final ExpressionEvaluator v;
 
   private final double p0;
 
@@ -37,10 +37,10 @@ public final class RoundToDoubleFloor2Evaluator implements ExpressionEvaluator {
 
   private Warnings warnings;
 
-  public RoundToDoubleFloor2Evaluator(Source source, ExpressionEvaluator field, double p0, double p1,
+  public RoundToDoubleFloor2Evaluator(Source source, ExpressionEvaluator v, double p0, double p1,
       DriverContext driverContext) {
     this.source = source;
-    this.field = field;
+    this.v = v;
     this.p0 = p0;
     this.p1 = p1;
     this.driverContext = driverContext;
@@ -48,26 +48,26 @@ public final class RoundToDoubleFloor2Evaluator implements ExpressionEvaluator {
 
   @Override
   public Block eval(Page page) {
-    try (DoubleBlock fieldBlock = (DoubleBlock) field.eval(page)) {
-      DoubleVector fieldVector = fieldBlock.asVector();
-      if (fieldVector == null) {
-        return eval(page.getPositionCount(), fieldBlock);
+    try (DoubleBlock vBlock = (DoubleBlock) v.eval(page)) {
+      DoubleVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
       }
-      return eval(page.getPositionCount(), fieldVector).asBlock();
+      return eval(page.getPositionCount(), vVector).asBlock();
     }
   }
 
   @Override
   public long baseRamBytesUsed() {
     long baseRamBytesUsed = BASE_RAM_BYTES_USED;
-    baseRamBytesUsed += field.baseRamBytesUsed();
+    baseRamBytesUsed += v.baseRamBytesUsed();
     return baseRamBytesUsed;
   }
 
-  public DoubleBlock eval(int positionCount, DoubleBlock fieldBlock) {
+  public DoubleBlock eval(int positionCount, DoubleBlock vBlock) {
     try(DoubleBlock.Builder result = driverContext.blockFactory().newDoubleBlockBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        switch (fieldBlock.getValueCount(p)) {
+        switch (vBlock.getValueCount(p)) {
           case 0:
               result.appendNull();
               continue position;
@@ -78,18 +78,18 @@ public final class RoundToDoubleFloor2Evaluator implements ExpressionEvaluator {
               result.appendNull();
               continue position;
         }
-        double field = fieldBlock.getDouble(fieldBlock.getFirstValueIndex(p));
-        result.appendDouble(RoundToDouble.process(field, this.p0, this.p1));
+        double v = vBlock.getDouble(vBlock.getFirstValueIndex(p));
+        result.appendDouble(RoundToDouble.floor2(v, this.p0, this.p1));
       }
       return result.build();
     }
   }
 
-  public DoubleVector eval(int positionCount, DoubleVector fieldVector) {
+  public DoubleVector eval(int positionCount, DoubleVector vVector) {
     try(DoubleVector.FixedBuilder result = driverContext.blockFactory().newDoubleVectorFixedBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        double field = fieldVector.getDouble(p);
-        result.appendDouble(p, RoundToDouble.process(field, this.p0, this.p1));
+        double v = vVector.getDouble(p);
+        result.appendDouble(p, RoundToDouble.floor2(v, this.p0, this.p1));
       }
       return result.build();
     }
@@ -97,12 +97,12 @@ public final class RoundToDoubleFloor2Evaluator implements ExpressionEvaluator {
 
   @Override
   public String toString() {
-    return "RoundToDoubleFloor2Evaluator[" + "field=" + field + ", p0=" + p0 + ", p1=" + p1 + "]";
+    return "RoundToDoubleFloor2Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + "]";
   }
 
   @Override
   public void close() {
-    Releasables.closeExpectNoException(field);
+    Releasables.closeExpectNoException(v);
   }
 
   private Warnings warnings() {
@@ -115,27 +115,27 @@ public final class RoundToDoubleFloor2Evaluator implements ExpressionEvaluator {
   static class Factory implements ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final ExpressionEvaluator.Factory field;
+    private final ExpressionEvaluator.Factory v;
 
     private final double p0;
 
     private final double p1;
 
-    public Factory(Source source, ExpressionEvaluator.Factory field, double p0, double p1) {
+    public Factory(Source source, ExpressionEvaluator.Factory v, double p0, double p1) {
       this.source = source;
-      this.field = field;
+      this.v = v;
       this.p0 = p0;
       this.p1 = p1;
     }
 
     @Override
     public RoundToDoubleFloor2Evaluator get(DriverContext context) {
-      return new RoundToDoubleFloor2Evaluator(source, field.get(context), p0, p1, context);
+      return new RoundToDoubleFloor2Evaluator(source, v.get(context), p0, p1, context);
     }
 
     @Override
     public String toString() {
-      return "RoundToDoubleFloor2Evaluator[" + "field=" + field + ", p0=" + p0 + ", p1=" + p1 + "]";
+      return "RoundToDoubleFloor2Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToDoubleFloor3Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToDoubleFloor3Evaluator.java
@@ -27,7 +27,7 @@ public final class RoundToDoubleFloor3Evaluator implements ExpressionEvaluator {
 
   private final Source source;
 
-  private final ExpressionEvaluator field;
+  private final ExpressionEvaluator v;
 
   private final double p0;
 
@@ -39,10 +39,10 @@ public final class RoundToDoubleFloor3Evaluator implements ExpressionEvaluator {
 
   private Warnings warnings;
 
-  public RoundToDoubleFloor3Evaluator(Source source, ExpressionEvaluator field, double p0, double p1,
+  public RoundToDoubleFloor3Evaluator(Source source, ExpressionEvaluator v, double p0, double p1,
       double p2, DriverContext driverContext) {
     this.source = source;
-    this.field = field;
+    this.v = v;
     this.p0 = p0;
     this.p1 = p1;
     this.p2 = p2;
@@ -51,26 +51,26 @@ public final class RoundToDoubleFloor3Evaluator implements ExpressionEvaluator {
 
   @Override
   public Block eval(Page page) {
-    try (DoubleBlock fieldBlock = (DoubleBlock) field.eval(page)) {
-      DoubleVector fieldVector = fieldBlock.asVector();
-      if (fieldVector == null) {
-        return eval(page.getPositionCount(), fieldBlock);
+    try (DoubleBlock vBlock = (DoubleBlock) v.eval(page)) {
+      DoubleVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
       }
-      return eval(page.getPositionCount(), fieldVector).asBlock();
+      return eval(page.getPositionCount(), vVector).asBlock();
     }
   }
 
   @Override
   public long baseRamBytesUsed() {
     long baseRamBytesUsed = BASE_RAM_BYTES_USED;
-    baseRamBytesUsed += field.baseRamBytesUsed();
+    baseRamBytesUsed += v.baseRamBytesUsed();
     return baseRamBytesUsed;
   }
 
-  public DoubleBlock eval(int positionCount, DoubleBlock fieldBlock) {
+  public DoubleBlock eval(int positionCount, DoubleBlock vBlock) {
     try(DoubleBlock.Builder result = driverContext.blockFactory().newDoubleBlockBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        switch (fieldBlock.getValueCount(p)) {
+        switch (vBlock.getValueCount(p)) {
           case 0:
               result.appendNull();
               continue position;
@@ -81,18 +81,18 @@ public final class RoundToDoubleFloor3Evaluator implements ExpressionEvaluator {
               result.appendNull();
               continue position;
         }
-        double field = fieldBlock.getDouble(fieldBlock.getFirstValueIndex(p));
-        result.appendDouble(RoundToDouble.process(field, this.p0, this.p1, this.p2));
+        double v = vBlock.getDouble(vBlock.getFirstValueIndex(p));
+        result.appendDouble(RoundToDouble.floor3(v, this.p0, this.p1, this.p2));
       }
       return result.build();
     }
   }
 
-  public DoubleVector eval(int positionCount, DoubleVector fieldVector) {
+  public DoubleVector eval(int positionCount, DoubleVector vVector) {
     try(DoubleVector.FixedBuilder result = driverContext.blockFactory().newDoubleVectorFixedBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        double field = fieldVector.getDouble(p);
-        result.appendDouble(p, RoundToDouble.process(field, this.p0, this.p1, this.p2));
+        double v = vVector.getDouble(p);
+        result.appendDouble(p, RoundToDouble.floor3(v, this.p0, this.p1, this.p2));
       }
       return result.build();
     }
@@ -100,12 +100,12 @@ public final class RoundToDoubleFloor3Evaluator implements ExpressionEvaluator {
 
   @Override
   public String toString() {
-    return "RoundToDoubleFloor3Evaluator[" + "field=" + field + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + "]";
+    return "RoundToDoubleFloor3Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + "]";
   }
 
   @Override
   public void close() {
-    Releasables.closeExpectNoException(field);
+    Releasables.closeExpectNoException(v);
   }
 
   private Warnings warnings() {
@@ -118,7 +118,7 @@ public final class RoundToDoubleFloor3Evaluator implements ExpressionEvaluator {
   static class Factory implements ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final ExpressionEvaluator.Factory field;
+    private final ExpressionEvaluator.Factory v;
 
     private final double p0;
 
@@ -126,10 +126,9 @@ public final class RoundToDoubleFloor3Evaluator implements ExpressionEvaluator {
 
     private final double p2;
 
-    public Factory(Source source, ExpressionEvaluator.Factory field, double p0, double p1,
-        double p2) {
+    public Factory(Source source, ExpressionEvaluator.Factory v, double p0, double p1, double p2) {
       this.source = source;
-      this.field = field;
+      this.v = v;
       this.p0 = p0;
       this.p1 = p1;
       this.p2 = p2;
@@ -137,12 +136,12 @@ public final class RoundToDoubleFloor3Evaluator implements ExpressionEvaluator {
 
     @Override
     public RoundToDoubleFloor3Evaluator get(DriverContext context) {
-      return new RoundToDoubleFloor3Evaluator(source, field.get(context), p0, p1, p2, context);
+      return new RoundToDoubleFloor3Evaluator(source, v.get(context), p0, p1, p2, context);
     }
 
     @Override
     public String toString() {
-      return "RoundToDoubleFloor3Evaluator[" + "field=" + field + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + "]";
+      return "RoundToDoubleFloor3Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToDoubleFloor4Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToDoubleFloor4Evaluator.java
@@ -27,7 +27,7 @@ public final class RoundToDoubleFloor4Evaluator implements ExpressionEvaluator {
 
   private final Source source;
 
-  private final ExpressionEvaluator field;
+  private final ExpressionEvaluator v;
 
   private final double p0;
 
@@ -41,10 +41,10 @@ public final class RoundToDoubleFloor4Evaluator implements ExpressionEvaluator {
 
   private Warnings warnings;
 
-  public RoundToDoubleFloor4Evaluator(Source source, ExpressionEvaluator field, double p0, double p1,
+  public RoundToDoubleFloor4Evaluator(Source source, ExpressionEvaluator v, double p0, double p1,
       double p2, double p3, DriverContext driverContext) {
     this.source = source;
-    this.field = field;
+    this.v = v;
     this.p0 = p0;
     this.p1 = p1;
     this.p2 = p2;
@@ -54,26 +54,26 @@ public final class RoundToDoubleFloor4Evaluator implements ExpressionEvaluator {
 
   @Override
   public Block eval(Page page) {
-    try (DoubleBlock fieldBlock = (DoubleBlock) field.eval(page)) {
-      DoubleVector fieldVector = fieldBlock.asVector();
-      if (fieldVector == null) {
-        return eval(page.getPositionCount(), fieldBlock);
+    try (DoubleBlock vBlock = (DoubleBlock) v.eval(page)) {
+      DoubleVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
       }
-      return eval(page.getPositionCount(), fieldVector).asBlock();
+      return eval(page.getPositionCount(), vVector).asBlock();
     }
   }
 
   @Override
   public long baseRamBytesUsed() {
     long baseRamBytesUsed = BASE_RAM_BYTES_USED;
-    baseRamBytesUsed += field.baseRamBytesUsed();
+    baseRamBytesUsed += v.baseRamBytesUsed();
     return baseRamBytesUsed;
   }
 
-  public DoubleBlock eval(int positionCount, DoubleBlock fieldBlock) {
+  public DoubleBlock eval(int positionCount, DoubleBlock vBlock) {
     try(DoubleBlock.Builder result = driverContext.blockFactory().newDoubleBlockBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        switch (fieldBlock.getValueCount(p)) {
+        switch (vBlock.getValueCount(p)) {
           case 0:
               result.appendNull();
               continue position;
@@ -84,18 +84,18 @@ public final class RoundToDoubleFloor4Evaluator implements ExpressionEvaluator {
               result.appendNull();
               continue position;
         }
-        double field = fieldBlock.getDouble(fieldBlock.getFirstValueIndex(p));
-        result.appendDouble(RoundToDouble.process(field, this.p0, this.p1, this.p2, this.p3));
+        double v = vBlock.getDouble(vBlock.getFirstValueIndex(p));
+        result.appendDouble(RoundToDouble.floor4(v, this.p0, this.p1, this.p2, this.p3));
       }
       return result.build();
     }
   }
 
-  public DoubleVector eval(int positionCount, DoubleVector fieldVector) {
+  public DoubleVector eval(int positionCount, DoubleVector vVector) {
     try(DoubleVector.FixedBuilder result = driverContext.blockFactory().newDoubleVectorFixedBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        double field = fieldVector.getDouble(p);
-        result.appendDouble(p, RoundToDouble.process(field, this.p0, this.p1, this.p2, this.p3));
+        double v = vVector.getDouble(p);
+        result.appendDouble(p, RoundToDouble.floor4(v, this.p0, this.p1, this.p2, this.p3));
       }
       return result.build();
     }
@@ -103,12 +103,12 @@ public final class RoundToDoubleFloor4Evaluator implements ExpressionEvaluator {
 
   @Override
   public String toString() {
-    return "RoundToDoubleFloor4Evaluator[" + "field=" + field + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + "]";
+    return "RoundToDoubleFloor4Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + "]";
   }
 
   @Override
   public void close() {
-    Releasables.closeExpectNoException(field);
+    Releasables.closeExpectNoException(v);
   }
 
   private Warnings warnings() {
@@ -121,7 +121,7 @@ public final class RoundToDoubleFloor4Evaluator implements ExpressionEvaluator {
   static class Factory implements ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final ExpressionEvaluator.Factory field;
+    private final ExpressionEvaluator.Factory v;
 
     private final double p0;
 
@@ -131,10 +131,10 @@ public final class RoundToDoubleFloor4Evaluator implements ExpressionEvaluator {
 
     private final double p3;
 
-    public Factory(Source source, ExpressionEvaluator.Factory field, double p0, double p1,
-        double p2, double p3) {
+    public Factory(Source source, ExpressionEvaluator.Factory v, double p0, double p1, double p2,
+        double p3) {
       this.source = source;
-      this.field = field;
+      this.v = v;
       this.p0 = p0;
       this.p1 = p1;
       this.p2 = p2;
@@ -143,12 +143,12 @@ public final class RoundToDoubleFloor4Evaluator implements ExpressionEvaluator {
 
     @Override
     public RoundToDoubleFloor4Evaluator get(DriverContext context) {
-      return new RoundToDoubleFloor4Evaluator(source, field.get(context), p0, p1, p2, p3, context);
+      return new RoundToDoubleFloor4Evaluator(source, v.get(context), p0, p1, p2, p3, context);
     }
 
     @Override
     public String toString() {
-      return "RoundToDoubleFloor4Evaluator[" + "field=" + field + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + "]";
+      return "RoundToDoubleFloor4Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToDoubleFloor5Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToDoubleFloor5Evaluator.java
@@ -27,7 +27,7 @@ public final class RoundToDoubleFloor5Evaluator implements ExpressionEvaluator {
 
   private final Source source;
 
-  private final ExpressionEvaluator field;
+  private final ExpressionEvaluator v;
 
   private final double p0;
 
@@ -43,10 +43,10 @@ public final class RoundToDoubleFloor5Evaluator implements ExpressionEvaluator {
 
   private Warnings warnings;
 
-  public RoundToDoubleFloor5Evaluator(Source source, ExpressionEvaluator field, double p0, double p1,
+  public RoundToDoubleFloor5Evaluator(Source source, ExpressionEvaluator v, double p0, double p1,
       double p2, double p3, double p4, DriverContext driverContext) {
     this.source = source;
-    this.field = field;
+    this.v = v;
     this.p0 = p0;
     this.p1 = p1;
     this.p2 = p2;
@@ -57,26 +57,26 @@ public final class RoundToDoubleFloor5Evaluator implements ExpressionEvaluator {
 
   @Override
   public Block eval(Page page) {
-    try (DoubleBlock fieldBlock = (DoubleBlock) field.eval(page)) {
-      DoubleVector fieldVector = fieldBlock.asVector();
-      if (fieldVector == null) {
-        return eval(page.getPositionCount(), fieldBlock);
+    try (DoubleBlock vBlock = (DoubleBlock) v.eval(page)) {
+      DoubleVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
       }
-      return eval(page.getPositionCount(), fieldVector).asBlock();
+      return eval(page.getPositionCount(), vVector).asBlock();
     }
   }
 
   @Override
   public long baseRamBytesUsed() {
     long baseRamBytesUsed = BASE_RAM_BYTES_USED;
-    baseRamBytesUsed += field.baseRamBytesUsed();
+    baseRamBytesUsed += v.baseRamBytesUsed();
     return baseRamBytesUsed;
   }
 
-  public DoubleBlock eval(int positionCount, DoubleBlock fieldBlock) {
+  public DoubleBlock eval(int positionCount, DoubleBlock vBlock) {
     try(DoubleBlock.Builder result = driverContext.blockFactory().newDoubleBlockBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        switch (fieldBlock.getValueCount(p)) {
+        switch (vBlock.getValueCount(p)) {
           case 0:
               result.appendNull();
               continue position;
@@ -87,18 +87,18 @@ public final class RoundToDoubleFloor5Evaluator implements ExpressionEvaluator {
               result.appendNull();
               continue position;
         }
-        double field = fieldBlock.getDouble(fieldBlock.getFirstValueIndex(p));
-        result.appendDouble(RoundToDouble.process(field, this.p0, this.p1, this.p2, this.p3, this.p4));
+        double v = vBlock.getDouble(vBlock.getFirstValueIndex(p));
+        result.appendDouble(RoundToDouble.floor5(v, this.p0, this.p1, this.p2, this.p3, this.p4));
       }
       return result.build();
     }
   }
 
-  public DoubleVector eval(int positionCount, DoubleVector fieldVector) {
+  public DoubleVector eval(int positionCount, DoubleVector vVector) {
     try(DoubleVector.FixedBuilder result = driverContext.blockFactory().newDoubleVectorFixedBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        double field = fieldVector.getDouble(p);
-        result.appendDouble(p, RoundToDouble.process(field, this.p0, this.p1, this.p2, this.p3, this.p4));
+        double v = vVector.getDouble(p);
+        result.appendDouble(p, RoundToDouble.floor5(v, this.p0, this.p1, this.p2, this.p3, this.p4));
       }
       return result.build();
     }
@@ -106,12 +106,12 @@ public final class RoundToDoubleFloor5Evaluator implements ExpressionEvaluator {
 
   @Override
   public String toString() {
-    return "RoundToDoubleFloor5Evaluator[" + "field=" + field + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + "]";
+    return "RoundToDoubleFloor5Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + "]";
   }
 
   @Override
   public void close() {
-    Releasables.closeExpectNoException(field);
+    Releasables.closeExpectNoException(v);
   }
 
   private Warnings warnings() {
@@ -124,7 +124,7 @@ public final class RoundToDoubleFloor5Evaluator implements ExpressionEvaluator {
   static class Factory implements ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final ExpressionEvaluator.Factory field;
+    private final ExpressionEvaluator.Factory v;
 
     private final double p0;
 
@@ -136,10 +136,10 @@ public final class RoundToDoubleFloor5Evaluator implements ExpressionEvaluator {
 
     private final double p4;
 
-    public Factory(Source source, ExpressionEvaluator.Factory field, double p0, double p1,
-        double p2, double p3, double p4) {
+    public Factory(Source source, ExpressionEvaluator.Factory v, double p0, double p1, double p2,
+        double p3, double p4) {
       this.source = source;
-      this.field = field;
+      this.v = v;
       this.p0 = p0;
       this.p1 = p1;
       this.p2 = p2;
@@ -149,12 +149,12 @@ public final class RoundToDoubleFloor5Evaluator implements ExpressionEvaluator {
 
     @Override
     public RoundToDoubleFloor5Evaluator get(DriverContext context) {
-      return new RoundToDoubleFloor5Evaluator(source, field.get(context), p0, p1, p2, p3, p4, context);
+      return new RoundToDoubleFloor5Evaluator(source, v.get(context), p0, p1, p2, p3, p4, context);
     }
 
     @Override
     public String toString() {
-      return "RoundToDoubleFloor5Evaluator[" + "field=" + field + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + "]";
+      return "RoundToDoubleFloor5Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToDoubleFloor6Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToDoubleFloor6Evaluator.java
@@ -27,7 +27,7 @@ public final class RoundToDoubleFloor6Evaluator implements ExpressionEvaluator {
 
   private final Source source;
 
-  private final ExpressionEvaluator field;
+  private final ExpressionEvaluator v;
 
   private final double p0;
 
@@ -45,10 +45,10 @@ public final class RoundToDoubleFloor6Evaluator implements ExpressionEvaluator {
 
   private Warnings warnings;
 
-  public RoundToDoubleFloor6Evaluator(Source source, ExpressionEvaluator field, double p0, double p1,
+  public RoundToDoubleFloor6Evaluator(Source source, ExpressionEvaluator v, double p0, double p1,
       double p2, double p3, double p4, double p5, DriverContext driverContext) {
     this.source = source;
-    this.field = field;
+    this.v = v;
     this.p0 = p0;
     this.p1 = p1;
     this.p2 = p2;
@@ -60,26 +60,26 @@ public final class RoundToDoubleFloor6Evaluator implements ExpressionEvaluator {
 
   @Override
   public Block eval(Page page) {
-    try (DoubleBlock fieldBlock = (DoubleBlock) field.eval(page)) {
-      DoubleVector fieldVector = fieldBlock.asVector();
-      if (fieldVector == null) {
-        return eval(page.getPositionCount(), fieldBlock);
+    try (DoubleBlock vBlock = (DoubleBlock) v.eval(page)) {
+      DoubleVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
       }
-      return eval(page.getPositionCount(), fieldVector).asBlock();
+      return eval(page.getPositionCount(), vVector).asBlock();
     }
   }
 
   @Override
   public long baseRamBytesUsed() {
     long baseRamBytesUsed = BASE_RAM_BYTES_USED;
-    baseRamBytesUsed += field.baseRamBytesUsed();
+    baseRamBytesUsed += v.baseRamBytesUsed();
     return baseRamBytesUsed;
   }
 
-  public DoubleBlock eval(int positionCount, DoubleBlock fieldBlock) {
+  public DoubleBlock eval(int positionCount, DoubleBlock vBlock) {
     try(DoubleBlock.Builder result = driverContext.blockFactory().newDoubleBlockBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        switch (fieldBlock.getValueCount(p)) {
+        switch (vBlock.getValueCount(p)) {
           case 0:
               result.appendNull();
               continue position;
@@ -90,18 +90,18 @@ public final class RoundToDoubleFloor6Evaluator implements ExpressionEvaluator {
               result.appendNull();
               continue position;
         }
-        double field = fieldBlock.getDouble(fieldBlock.getFirstValueIndex(p));
-        result.appendDouble(RoundToDouble.process(field, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5));
+        double v = vBlock.getDouble(vBlock.getFirstValueIndex(p));
+        result.appendDouble(RoundToDouble.floor6(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5));
       }
       return result.build();
     }
   }
 
-  public DoubleVector eval(int positionCount, DoubleVector fieldVector) {
+  public DoubleVector eval(int positionCount, DoubleVector vVector) {
     try(DoubleVector.FixedBuilder result = driverContext.blockFactory().newDoubleVectorFixedBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        double field = fieldVector.getDouble(p);
-        result.appendDouble(p, RoundToDouble.process(field, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5));
+        double v = vVector.getDouble(p);
+        result.appendDouble(p, RoundToDouble.floor6(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5));
       }
       return result.build();
     }
@@ -109,12 +109,12 @@ public final class RoundToDoubleFloor6Evaluator implements ExpressionEvaluator {
 
   @Override
   public String toString() {
-    return "RoundToDoubleFloor6Evaluator[" + "field=" + field + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + "]";
+    return "RoundToDoubleFloor6Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + "]";
   }
 
   @Override
   public void close() {
-    Releasables.closeExpectNoException(field);
+    Releasables.closeExpectNoException(v);
   }
 
   private Warnings warnings() {
@@ -127,7 +127,7 @@ public final class RoundToDoubleFloor6Evaluator implements ExpressionEvaluator {
   static class Factory implements ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final ExpressionEvaluator.Factory field;
+    private final ExpressionEvaluator.Factory v;
 
     private final double p0;
 
@@ -141,10 +141,10 @@ public final class RoundToDoubleFloor6Evaluator implements ExpressionEvaluator {
 
     private final double p5;
 
-    public Factory(Source source, ExpressionEvaluator.Factory field, double p0, double p1,
-        double p2, double p3, double p4, double p5) {
+    public Factory(Source source, ExpressionEvaluator.Factory v, double p0, double p1, double p2,
+        double p3, double p4, double p5) {
       this.source = source;
-      this.field = field;
+      this.v = v;
       this.p0 = p0;
       this.p1 = p1;
       this.p2 = p2;
@@ -155,12 +155,12 @@ public final class RoundToDoubleFloor6Evaluator implements ExpressionEvaluator {
 
     @Override
     public RoundToDoubleFloor6Evaluator get(DriverContext context) {
-      return new RoundToDoubleFloor6Evaluator(source, field.get(context), p0, p1, p2, p3, p4, p5, context);
+      return new RoundToDoubleFloor6Evaluator(source, v.get(context), p0, p1, p2, p3, p4, p5, context);
     }
 
     @Override
     public String toString() {
-      return "RoundToDoubleFloor6Evaluator[" + "field=" + field + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + "]";
+      return "RoundToDoubleFloor6Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToDoubleFloor7Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToDoubleFloor7Evaluator.java
@@ -27,7 +27,7 @@ public final class RoundToDoubleFloor7Evaluator implements ExpressionEvaluator {
 
   private final Source source;
 
-  private final ExpressionEvaluator field;
+  private final ExpressionEvaluator v;
 
   private final double p0;
 
@@ -47,10 +47,10 @@ public final class RoundToDoubleFloor7Evaluator implements ExpressionEvaluator {
 
   private Warnings warnings;
 
-  public RoundToDoubleFloor7Evaluator(Source source, ExpressionEvaluator field, double p0, double p1,
+  public RoundToDoubleFloor7Evaluator(Source source, ExpressionEvaluator v, double p0, double p1,
       double p2, double p3, double p4, double p5, double p6, DriverContext driverContext) {
     this.source = source;
-    this.field = field;
+    this.v = v;
     this.p0 = p0;
     this.p1 = p1;
     this.p2 = p2;
@@ -63,26 +63,26 @@ public final class RoundToDoubleFloor7Evaluator implements ExpressionEvaluator {
 
   @Override
   public Block eval(Page page) {
-    try (DoubleBlock fieldBlock = (DoubleBlock) field.eval(page)) {
-      DoubleVector fieldVector = fieldBlock.asVector();
-      if (fieldVector == null) {
-        return eval(page.getPositionCount(), fieldBlock);
+    try (DoubleBlock vBlock = (DoubleBlock) v.eval(page)) {
+      DoubleVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
       }
-      return eval(page.getPositionCount(), fieldVector).asBlock();
+      return eval(page.getPositionCount(), vVector).asBlock();
     }
   }
 
   @Override
   public long baseRamBytesUsed() {
     long baseRamBytesUsed = BASE_RAM_BYTES_USED;
-    baseRamBytesUsed += field.baseRamBytesUsed();
+    baseRamBytesUsed += v.baseRamBytesUsed();
     return baseRamBytesUsed;
   }
 
-  public DoubleBlock eval(int positionCount, DoubleBlock fieldBlock) {
+  public DoubleBlock eval(int positionCount, DoubleBlock vBlock) {
     try(DoubleBlock.Builder result = driverContext.blockFactory().newDoubleBlockBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        switch (fieldBlock.getValueCount(p)) {
+        switch (vBlock.getValueCount(p)) {
           case 0:
               result.appendNull();
               continue position;
@@ -93,18 +93,18 @@ public final class RoundToDoubleFloor7Evaluator implements ExpressionEvaluator {
               result.appendNull();
               continue position;
         }
-        double field = fieldBlock.getDouble(fieldBlock.getFirstValueIndex(p));
-        result.appendDouble(RoundToDouble.process(field, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6));
+        double v = vBlock.getDouble(vBlock.getFirstValueIndex(p));
+        result.appendDouble(RoundToDouble.floor7(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6));
       }
       return result.build();
     }
   }
 
-  public DoubleVector eval(int positionCount, DoubleVector fieldVector) {
+  public DoubleVector eval(int positionCount, DoubleVector vVector) {
     try(DoubleVector.FixedBuilder result = driverContext.blockFactory().newDoubleVectorFixedBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        double field = fieldVector.getDouble(p);
-        result.appendDouble(p, RoundToDouble.process(field, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6));
+        double v = vVector.getDouble(p);
+        result.appendDouble(p, RoundToDouble.floor7(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6));
       }
       return result.build();
     }
@@ -112,12 +112,12 @@ public final class RoundToDoubleFloor7Evaluator implements ExpressionEvaluator {
 
   @Override
   public String toString() {
-    return "RoundToDoubleFloor7Evaluator[" + "field=" + field + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + "]";
+    return "RoundToDoubleFloor7Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + "]";
   }
 
   @Override
   public void close() {
-    Releasables.closeExpectNoException(field);
+    Releasables.closeExpectNoException(v);
   }
 
   private Warnings warnings() {
@@ -130,7 +130,7 @@ public final class RoundToDoubleFloor7Evaluator implements ExpressionEvaluator {
   static class Factory implements ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final ExpressionEvaluator.Factory field;
+    private final ExpressionEvaluator.Factory v;
 
     private final double p0;
 
@@ -146,10 +146,10 @@ public final class RoundToDoubleFloor7Evaluator implements ExpressionEvaluator {
 
     private final double p6;
 
-    public Factory(Source source, ExpressionEvaluator.Factory field, double p0, double p1,
-        double p2, double p3, double p4, double p5, double p6) {
+    public Factory(Source source, ExpressionEvaluator.Factory v, double p0, double p1, double p2,
+        double p3, double p4, double p5, double p6) {
       this.source = source;
-      this.field = field;
+      this.v = v;
       this.p0 = p0;
       this.p1 = p1;
       this.p2 = p2;
@@ -161,12 +161,12 @@ public final class RoundToDoubleFloor7Evaluator implements ExpressionEvaluator {
 
     @Override
     public RoundToDoubleFloor7Evaluator get(DriverContext context) {
-      return new RoundToDoubleFloor7Evaluator(source, field.get(context), p0, p1, p2, p3, p4, p5, p6, context);
+      return new RoundToDoubleFloor7Evaluator(source, v.get(context), p0, p1, p2, p3, p4, p5, p6, context);
     }
 
     @Override
     public String toString() {
-      return "RoundToDoubleFloor7Evaluator[" + "field=" + field + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + "]";
+      return "RoundToDoubleFloor7Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToDoubleFloor8Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToDoubleFloor8Evaluator.java
@@ -27,7 +27,7 @@ public final class RoundToDoubleFloor8Evaluator implements ExpressionEvaluator {
 
   private final Source source;
 
-  private final ExpressionEvaluator field;
+  private final ExpressionEvaluator v;
 
   private final double p0;
 
@@ -49,11 +49,11 @@ public final class RoundToDoubleFloor8Evaluator implements ExpressionEvaluator {
 
   private Warnings warnings;
 
-  public RoundToDoubleFloor8Evaluator(Source source, ExpressionEvaluator field, double p0, double p1,
+  public RoundToDoubleFloor8Evaluator(Source source, ExpressionEvaluator v, double p0, double p1,
       double p2, double p3, double p4, double p5, double p6, double p7,
       DriverContext driverContext) {
     this.source = source;
-    this.field = field;
+    this.v = v;
     this.p0 = p0;
     this.p1 = p1;
     this.p2 = p2;
@@ -67,26 +67,26 @@ public final class RoundToDoubleFloor8Evaluator implements ExpressionEvaluator {
 
   @Override
   public Block eval(Page page) {
-    try (DoubleBlock fieldBlock = (DoubleBlock) field.eval(page)) {
-      DoubleVector fieldVector = fieldBlock.asVector();
-      if (fieldVector == null) {
-        return eval(page.getPositionCount(), fieldBlock);
+    try (DoubleBlock vBlock = (DoubleBlock) v.eval(page)) {
+      DoubleVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
       }
-      return eval(page.getPositionCount(), fieldVector).asBlock();
+      return eval(page.getPositionCount(), vVector).asBlock();
     }
   }
 
   @Override
   public long baseRamBytesUsed() {
     long baseRamBytesUsed = BASE_RAM_BYTES_USED;
-    baseRamBytesUsed += field.baseRamBytesUsed();
+    baseRamBytesUsed += v.baseRamBytesUsed();
     return baseRamBytesUsed;
   }
 
-  public DoubleBlock eval(int positionCount, DoubleBlock fieldBlock) {
+  public DoubleBlock eval(int positionCount, DoubleBlock vBlock) {
     try(DoubleBlock.Builder result = driverContext.blockFactory().newDoubleBlockBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        switch (fieldBlock.getValueCount(p)) {
+        switch (vBlock.getValueCount(p)) {
           case 0:
               result.appendNull();
               continue position;
@@ -97,18 +97,18 @@ public final class RoundToDoubleFloor8Evaluator implements ExpressionEvaluator {
               result.appendNull();
               continue position;
         }
-        double field = fieldBlock.getDouble(fieldBlock.getFirstValueIndex(p));
-        result.appendDouble(RoundToDouble.process(field, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6, this.p7));
+        double v = vBlock.getDouble(vBlock.getFirstValueIndex(p));
+        result.appendDouble(RoundToDouble.floor8(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6, this.p7));
       }
       return result.build();
     }
   }
 
-  public DoubleVector eval(int positionCount, DoubleVector fieldVector) {
+  public DoubleVector eval(int positionCount, DoubleVector vVector) {
     try(DoubleVector.FixedBuilder result = driverContext.blockFactory().newDoubleVectorFixedBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        double field = fieldVector.getDouble(p);
-        result.appendDouble(p, RoundToDouble.process(field, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6, this.p7));
+        double v = vVector.getDouble(p);
+        result.appendDouble(p, RoundToDouble.floor8(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6, this.p7));
       }
       return result.build();
     }
@@ -116,12 +116,12 @@ public final class RoundToDoubleFloor8Evaluator implements ExpressionEvaluator {
 
   @Override
   public String toString() {
-    return "RoundToDoubleFloor8Evaluator[" + "field=" + field + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + ", p7=" + p7 + "]";
+    return "RoundToDoubleFloor8Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + ", p7=" + p7 + "]";
   }
 
   @Override
   public void close() {
-    Releasables.closeExpectNoException(field);
+    Releasables.closeExpectNoException(v);
   }
 
   private Warnings warnings() {
@@ -134,7 +134,7 @@ public final class RoundToDoubleFloor8Evaluator implements ExpressionEvaluator {
   static class Factory implements ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final ExpressionEvaluator.Factory field;
+    private final ExpressionEvaluator.Factory v;
 
     private final double p0;
 
@@ -152,10 +152,10 @@ public final class RoundToDoubleFloor8Evaluator implements ExpressionEvaluator {
 
     private final double p7;
 
-    public Factory(Source source, ExpressionEvaluator.Factory field, double p0, double p1,
-        double p2, double p3, double p4, double p5, double p6, double p7) {
+    public Factory(Source source, ExpressionEvaluator.Factory v, double p0, double p1, double p2,
+        double p3, double p4, double p5, double p6, double p7) {
       this.source = source;
-      this.field = field;
+      this.v = v;
       this.p0 = p0;
       this.p1 = p1;
       this.p2 = p2;
@@ -168,12 +168,12 @@ public final class RoundToDoubleFloor8Evaluator implements ExpressionEvaluator {
 
     @Override
     public RoundToDoubleFloor8Evaluator get(DriverContext context) {
-      return new RoundToDoubleFloor8Evaluator(source, field.get(context), p0, p1, p2, p3, p4, p5, p6, p7, context);
+      return new RoundToDoubleFloor8Evaluator(source, v.get(context), p0, p1, p2, p3, p4, p5, p6, p7, context);
     }
 
     @Override
     public String toString() {
-      return "RoundToDoubleFloor8Evaluator[" + "field=" + field + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + ", p7=" + p7 + "]";
+      return "RoundToDoubleFloor8Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + ", p7=" + p7 + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToDoubleFloor9Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToDoubleFloor9Evaluator.java
@@ -27,7 +27,7 @@ public final class RoundToDoubleFloor9Evaluator implements ExpressionEvaluator {
 
   private final Source source;
 
-  private final ExpressionEvaluator field;
+  private final ExpressionEvaluator v;
 
   private final double p0;
 
@@ -51,11 +51,11 @@ public final class RoundToDoubleFloor9Evaluator implements ExpressionEvaluator {
 
   private Warnings warnings;
 
-  public RoundToDoubleFloor9Evaluator(Source source, ExpressionEvaluator field, double p0, double p1,
+  public RoundToDoubleFloor9Evaluator(Source source, ExpressionEvaluator v, double p0, double p1,
       double p2, double p3, double p4, double p5, double p6, double p7, double p8,
       DriverContext driverContext) {
     this.source = source;
-    this.field = field;
+    this.v = v;
     this.p0 = p0;
     this.p1 = p1;
     this.p2 = p2;
@@ -70,26 +70,26 @@ public final class RoundToDoubleFloor9Evaluator implements ExpressionEvaluator {
 
   @Override
   public Block eval(Page page) {
-    try (DoubleBlock fieldBlock = (DoubleBlock) field.eval(page)) {
-      DoubleVector fieldVector = fieldBlock.asVector();
-      if (fieldVector == null) {
-        return eval(page.getPositionCount(), fieldBlock);
+    try (DoubleBlock vBlock = (DoubleBlock) v.eval(page)) {
+      DoubleVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
       }
-      return eval(page.getPositionCount(), fieldVector).asBlock();
+      return eval(page.getPositionCount(), vVector).asBlock();
     }
   }
 
   @Override
   public long baseRamBytesUsed() {
     long baseRamBytesUsed = BASE_RAM_BYTES_USED;
-    baseRamBytesUsed += field.baseRamBytesUsed();
+    baseRamBytesUsed += v.baseRamBytesUsed();
     return baseRamBytesUsed;
   }
 
-  public DoubleBlock eval(int positionCount, DoubleBlock fieldBlock) {
+  public DoubleBlock eval(int positionCount, DoubleBlock vBlock) {
     try(DoubleBlock.Builder result = driverContext.blockFactory().newDoubleBlockBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        switch (fieldBlock.getValueCount(p)) {
+        switch (vBlock.getValueCount(p)) {
           case 0:
               result.appendNull();
               continue position;
@@ -100,18 +100,18 @@ public final class RoundToDoubleFloor9Evaluator implements ExpressionEvaluator {
               result.appendNull();
               continue position;
         }
-        double field = fieldBlock.getDouble(fieldBlock.getFirstValueIndex(p));
-        result.appendDouble(RoundToDouble.process(field, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6, this.p7, this.p8));
+        double v = vBlock.getDouble(vBlock.getFirstValueIndex(p));
+        result.appendDouble(RoundToDouble.floor9(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6, this.p7, this.p8));
       }
       return result.build();
     }
   }
 
-  public DoubleVector eval(int positionCount, DoubleVector fieldVector) {
+  public DoubleVector eval(int positionCount, DoubleVector vVector) {
     try(DoubleVector.FixedBuilder result = driverContext.blockFactory().newDoubleVectorFixedBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        double field = fieldVector.getDouble(p);
-        result.appendDouble(p, RoundToDouble.process(field, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6, this.p7, this.p8));
+        double v = vVector.getDouble(p);
+        result.appendDouble(p, RoundToDouble.floor9(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6, this.p7, this.p8));
       }
       return result.build();
     }
@@ -119,12 +119,12 @@ public final class RoundToDoubleFloor9Evaluator implements ExpressionEvaluator {
 
   @Override
   public String toString() {
-    return "RoundToDoubleFloor9Evaluator[" + "field=" + field + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + ", p7=" + p7 + ", p8=" + p8 + "]";
+    return "RoundToDoubleFloor9Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + ", p7=" + p7 + ", p8=" + p8 + "]";
   }
 
   @Override
   public void close() {
-    Releasables.closeExpectNoException(field);
+    Releasables.closeExpectNoException(v);
   }
 
   private Warnings warnings() {
@@ -137,7 +137,7 @@ public final class RoundToDoubleFloor9Evaluator implements ExpressionEvaluator {
   static class Factory implements ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final ExpressionEvaluator.Factory field;
+    private final ExpressionEvaluator.Factory v;
 
     private final double p0;
 
@@ -157,10 +157,10 @@ public final class RoundToDoubleFloor9Evaluator implements ExpressionEvaluator {
 
     private final double p8;
 
-    public Factory(Source source, ExpressionEvaluator.Factory field, double p0, double p1,
-        double p2, double p3, double p4, double p5, double p6, double p7, double p8) {
+    public Factory(Source source, ExpressionEvaluator.Factory v, double p0, double p1, double p2,
+        double p3, double p4, double p5, double p6, double p7, double p8) {
       this.source = source;
-      this.field = field;
+      this.v = v;
       this.p0 = p0;
       this.p1 = p1;
       this.p2 = p2;
@@ -174,12 +174,12 @@ public final class RoundToDoubleFloor9Evaluator implements ExpressionEvaluator {
 
     @Override
     public RoundToDoubleFloor9Evaluator get(DriverContext context) {
-      return new RoundToDoubleFloor9Evaluator(source, field.get(context), p0, p1, p2, p3, p4, p5, p6, p7, p8, context);
+      return new RoundToDoubleFloor9Evaluator(source, v.get(context), p0, p1, p2, p3, p4, p5, p6, p7, p8, context);
     }
 
     @Override
     public String toString() {
-      return "RoundToDoubleFloor9Evaluator[" + "field=" + field + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + ", p7=" + p7 + ", p8=" + p8 + "]";
+      return "RoundToDoubleFloor9Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + ", p7=" + p7 + ", p8=" + p8 + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToDoubleFloorSearchEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToDoubleFloorSearchEvaluator.java
@@ -22,49 +22,49 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * {@link ExpressionEvaluator} implementation for {@link RoundToDouble}.
  * This class is generated. Edit {@code EvaluatorImplementer} instead.
  */
-public final class RoundToDoubleBinarySearchEvaluator implements ExpressionEvaluator {
-  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(RoundToDoubleBinarySearchEvaluator.class);
+public final class RoundToDoubleFloorSearchEvaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(RoundToDoubleFloorSearchEvaluator.class);
 
   private final Source source;
 
-  private final ExpressionEvaluator field;
+  private final ExpressionEvaluator v;
 
-  private final double[] points;
+  private final double[] p;
 
   private final DriverContext driverContext;
 
   private Warnings warnings;
 
-  public RoundToDoubleBinarySearchEvaluator(Source source, ExpressionEvaluator field,
-      double[] points, DriverContext driverContext) {
+  public RoundToDoubleFloorSearchEvaluator(Source source, ExpressionEvaluator v, double[] p,
+      DriverContext driverContext) {
     this.source = source;
-    this.field = field;
-    this.points = points;
+    this.v = v;
+    this.p = p;
     this.driverContext = driverContext;
   }
 
   @Override
   public Block eval(Page page) {
-    try (DoubleBlock fieldBlock = (DoubleBlock) field.eval(page)) {
-      DoubleVector fieldVector = fieldBlock.asVector();
-      if (fieldVector == null) {
-        return eval(page.getPositionCount(), fieldBlock);
+    try (DoubleBlock vBlock = (DoubleBlock) v.eval(page)) {
+      DoubleVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
       }
-      return eval(page.getPositionCount(), fieldVector).asBlock();
+      return eval(page.getPositionCount(), vVector).asBlock();
     }
   }
 
   @Override
   public long baseRamBytesUsed() {
     long baseRamBytesUsed = BASE_RAM_BYTES_USED;
-    baseRamBytesUsed += field.baseRamBytesUsed();
+    baseRamBytesUsed += v.baseRamBytesUsed();
     return baseRamBytesUsed;
   }
 
-  public DoubleBlock eval(int positionCount, DoubleBlock fieldBlock) {
+  public DoubleBlock eval(int positionCount, DoubleBlock vBlock) {
     try(DoubleBlock.Builder result = driverContext.blockFactory().newDoubleBlockBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        switch (fieldBlock.getValueCount(p)) {
+        switch (vBlock.getValueCount(p)) {
           case 0:
               result.appendNull();
               continue position;
@@ -75,18 +75,18 @@ public final class RoundToDoubleBinarySearchEvaluator implements ExpressionEvalu
               result.appendNull();
               continue position;
         }
-        double field = fieldBlock.getDouble(fieldBlock.getFirstValueIndex(p));
-        result.appendDouble(RoundToDouble.process(field, this.points));
+        double v = vBlock.getDouble(vBlock.getFirstValueIndex(p));
+        result.appendDouble(RoundToDouble.floorSearch(v, this.p));
       }
       return result.build();
     }
   }
 
-  public DoubleVector eval(int positionCount, DoubleVector fieldVector) {
+  public DoubleVector eval(int positionCount, DoubleVector vVector) {
     try(DoubleVector.FixedBuilder result = driverContext.blockFactory().newDoubleVectorFixedBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        double field = fieldVector.getDouble(p);
-        result.appendDouble(p, RoundToDouble.process(field, this.points));
+        double v = vVector.getDouble(p);
+        result.appendDouble(p, RoundToDouble.floorSearch(v, this.p));
       }
       return result.build();
     }
@@ -94,12 +94,12 @@ public final class RoundToDoubleBinarySearchEvaluator implements ExpressionEvalu
 
   @Override
   public String toString() {
-    return "RoundToDoubleBinarySearchEvaluator[" + "field=" + field + "]";
+    return "RoundToDoubleFloorSearchEvaluator[" + "v=" + v + "]";
   }
 
   @Override
   public void close() {
-    Releasables.closeExpectNoException(field);
+    Releasables.closeExpectNoException(v);
   }
 
   private Warnings warnings() {
@@ -112,24 +112,24 @@ public final class RoundToDoubleBinarySearchEvaluator implements ExpressionEvalu
   static class Factory implements ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final ExpressionEvaluator.Factory field;
+    private final ExpressionEvaluator.Factory v;
 
-    private final double[] points;
+    private final double[] p;
 
-    public Factory(Source source, ExpressionEvaluator.Factory field, double[] points) {
+    public Factory(Source source, ExpressionEvaluator.Factory v, double[] p) {
       this.source = source;
-      this.field = field;
-      this.points = points;
+      this.v = v;
+      this.p = p;
     }
 
     @Override
-    public RoundToDoubleBinarySearchEvaluator get(DriverContext context) {
-      return new RoundToDoubleBinarySearchEvaluator(source, field.get(context), points, context);
+    public RoundToDoubleFloorSearchEvaluator get(DriverContext context) {
+      return new RoundToDoubleFloorSearchEvaluator(source, v.get(context), p, context);
     }
 
     @Override
     public String toString() {
-      return "RoundToDoubleBinarySearchEvaluator[" + "field=" + field + "]";
+      return "RoundToDoubleFloorSearchEvaluator[" + "v=" + v + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToIntCeiling10Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToIntCeiling10Evaluator.java
@@ -1,0 +1,190 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.math;
+
+import java.lang.IllegalArgumentException;
+import java.lang.Override;
+import java.lang.String;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+/**
+ * {@link ExpressionEvaluator} implementation for {@link RoundToInt}.
+ * This class is generated. Edit {@code EvaluatorImplementer} instead.
+ */
+public final class RoundToIntCeiling10Evaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(RoundToIntCeiling10Evaluator.class);
+
+  private final Source source;
+
+  private final ExpressionEvaluator v;
+
+  private final int p0;
+
+  private final int p1;
+
+  private final int p2;
+
+  private final int p3;
+
+  private final int p4;
+
+  private final int p5;
+
+  private final int p6;
+
+  private final int p7;
+
+  private final int p8;
+
+  private final int p9;
+
+  private final DriverContext driverContext;
+
+  private Warnings warnings;
+
+  public RoundToIntCeiling10Evaluator(Source source, ExpressionEvaluator v, int p0, int p1, int p2,
+      int p3, int p4, int p5, int p6, int p7, int p8, int p9, DriverContext driverContext) {
+    this.source = source;
+    this.v = v;
+    this.p0 = p0;
+    this.p1 = p1;
+    this.p2 = p2;
+    this.p3 = p3;
+    this.p4 = p4;
+    this.p5 = p5;
+    this.p6 = p6;
+    this.p7 = p7;
+    this.p8 = p8;
+    this.p9 = p9;
+    this.driverContext = driverContext;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    try (IntBlock vBlock = (IntBlock) v.eval(page)) {
+      IntVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
+      }
+      return eval(page.getPositionCount(), vVector).asBlock();
+    }
+  }
+
+  @Override
+  public long baseRamBytesUsed() {
+    long baseRamBytesUsed = BASE_RAM_BYTES_USED;
+    baseRamBytesUsed += v.baseRamBytesUsed();
+    return baseRamBytesUsed;
+  }
+
+  public IntBlock eval(int positionCount, IntBlock vBlock) {
+    try(IntBlock.Builder result = driverContext.blockFactory().newIntBlockBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        switch (vBlock.getValueCount(p)) {
+          case 0:
+              result.appendNull();
+              continue position;
+          case 1:
+              break;
+          default:
+              warnings().registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+              result.appendNull();
+              continue position;
+        }
+        int v = vBlock.getInt(vBlock.getFirstValueIndex(p));
+        result.appendInt(RoundToInt.ceiling10(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6, this.p7, this.p8, this.p9));
+      }
+      return result.build();
+    }
+  }
+
+  public IntVector eval(int positionCount, IntVector vVector) {
+    try(IntVector.FixedBuilder result = driverContext.blockFactory().newIntVectorFixedBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        int v = vVector.getInt(p);
+        result.appendInt(p, RoundToInt.ceiling10(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6, this.p7, this.p8, this.p9));
+      }
+      return result.build();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "RoundToIntCeiling10Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + ", p7=" + p7 + ", p8=" + p8 + ", p9=" + p9 + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(v);
+  }
+
+  private Warnings warnings() {
+    if (warnings == null) {
+      this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+    }
+    return warnings;
+  }
+
+  static class Factory implements ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final ExpressionEvaluator.Factory v;
+
+    private final int p0;
+
+    private final int p1;
+
+    private final int p2;
+
+    private final int p3;
+
+    private final int p4;
+
+    private final int p5;
+
+    private final int p6;
+
+    private final int p7;
+
+    private final int p8;
+
+    private final int p9;
+
+    public Factory(Source source, ExpressionEvaluator.Factory v, int p0, int p1, int p2, int p3,
+        int p4, int p5, int p6, int p7, int p8, int p9) {
+      this.source = source;
+      this.v = v;
+      this.p0 = p0;
+      this.p1 = p1;
+      this.p2 = p2;
+      this.p3 = p3;
+      this.p4 = p4;
+      this.p5 = p5;
+      this.p6 = p6;
+      this.p7 = p7;
+      this.p8 = p8;
+      this.p9 = p9;
+    }
+
+    @Override
+    public RoundToIntCeiling10Evaluator get(DriverContext context) {
+      return new RoundToIntCeiling10Evaluator(source, v.get(context), p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, context);
+    }
+
+    @Override
+    public String toString() {
+      return "RoundToIntCeiling10Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + ", p7=" + p7 + ", p8=" + p8 + ", p9=" + p9 + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToIntCeiling2Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToIntCeiling2Evaluator.java
@@ -1,0 +1,141 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.math;
+
+import java.lang.IllegalArgumentException;
+import java.lang.Override;
+import java.lang.String;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+/**
+ * {@link ExpressionEvaluator} implementation for {@link RoundToInt}.
+ * This class is generated. Edit {@code EvaluatorImplementer} instead.
+ */
+public final class RoundToIntCeiling2Evaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(RoundToIntCeiling2Evaluator.class);
+
+  private final Source source;
+
+  private final ExpressionEvaluator v;
+
+  private final int p0;
+
+  private final int p1;
+
+  private final DriverContext driverContext;
+
+  private Warnings warnings;
+
+  public RoundToIntCeiling2Evaluator(Source source, ExpressionEvaluator v, int p0, int p1,
+      DriverContext driverContext) {
+    this.source = source;
+    this.v = v;
+    this.p0 = p0;
+    this.p1 = p1;
+    this.driverContext = driverContext;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    try (IntBlock vBlock = (IntBlock) v.eval(page)) {
+      IntVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
+      }
+      return eval(page.getPositionCount(), vVector).asBlock();
+    }
+  }
+
+  @Override
+  public long baseRamBytesUsed() {
+    long baseRamBytesUsed = BASE_RAM_BYTES_USED;
+    baseRamBytesUsed += v.baseRamBytesUsed();
+    return baseRamBytesUsed;
+  }
+
+  public IntBlock eval(int positionCount, IntBlock vBlock) {
+    try(IntBlock.Builder result = driverContext.blockFactory().newIntBlockBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        switch (vBlock.getValueCount(p)) {
+          case 0:
+              result.appendNull();
+              continue position;
+          case 1:
+              break;
+          default:
+              warnings().registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+              result.appendNull();
+              continue position;
+        }
+        int v = vBlock.getInt(vBlock.getFirstValueIndex(p));
+        result.appendInt(RoundToInt.ceiling2(v, this.p0, this.p1));
+      }
+      return result.build();
+    }
+  }
+
+  public IntVector eval(int positionCount, IntVector vVector) {
+    try(IntVector.FixedBuilder result = driverContext.blockFactory().newIntVectorFixedBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        int v = vVector.getInt(p);
+        result.appendInt(p, RoundToInt.ceiling2(v, this.p0, this.p1));
+      }
+      return result.build();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "RoundToIntCeiling2Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(v);
+  }
+
+  private Warnings warnings() {
+    if (warnings == null) {
+      this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+    }
+    return warnings;
+  }
+
+  static class Factory implements ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final ExpressionEvaluator.Factory v;
+
+    private final int p0;
+
+    private final int p1;
+
+    public Factory(Source source, ExpressionEvaluator.Factory v, int p0, int p1) {
+      this.source = source;
+      this.v = v;
+      this.p0 = p0;
+      this.p1 = p1;
+    }
+
+    @Override
+    public RoundToIntCeiling2Evaluator get(DriverContext context) {
+      return new RoundToIntCeiling2Evaluator(source, v.get(context), p0, p1, context);
+    }
+
+    @Override
+    public String toString() {
+      return "RoundToIntCeiling2Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToIntCeiling3Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToIntCeiling3Evaluator.java
@@ -1,0 +1,147 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.math;
+
+import java.lang.IllegalArgumentException;
+import java.lang.Override;
+import java.lang.String;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+/**
+ * {@link ExpressionEvaluator} implementation for {@link RoundToInt}.
+ * This class is generated. Edit {@code EvaluatorImplementer} instead.
+ */
+public final class RoundToIntCeiling3Evaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(RoundToIntCeiling3Evaluator.class);
+
+  private final Source source;
+
+  private final ExpressionEvaluator v;
+
+  private final int p0;
+
+  private final int p1;
+
+  private final int p2;
+
+  private final DriverContext driverContext;
+
+  private Warnings warnings;
+
+  public RoundToIntCeiling3Evaluator(Source source, ExpressionEvaluator v, int p0, int p1, int p2,
+      DriverContext driverContext) {
+    this.source = source;
+    this.v = v;
+    this.p0 = p0;
+    this.p1 = p1;
+    this.p2 = p2;
+    this.driverContext = driverContext;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    try (IntBlock vBlock = (IntBlock) v.eval(page)) {
+      IntVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
+      }
+      return eval(page.getPositionCount(), vVector).asBlock();
+    }
+  }
+
+  @Override
+  public long baseRamBytesUsed() {
+    long baseRamBytesUsed = BASE_RAM_BYTES_USED;
+    baseRamBytesUsed += v.baseRamBytesUsed();
+    return baseRamBytesUsed;
+  }
+
+  public IntBlock eval(int positionCount, IntBlock vBlock) {
+    try(IntBlock.Builder result = driverContext.blockFactory().newIntBlockBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        switch (vBlock.getValueCount(p)) {
+          case 0:
+              result.appendNull();
+              continue position;
+          case 1:
+              break;
+          default:
+              warnings().registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+              result.appendNull();
+              continue position;
+        }
+        int v = vBlock.getInt(vBlock.getFirstValueIndex(p));
+        result.appendInt(RoundToInt.ceiling3(v, this.p0, this.p1, this.p2));
+      }
+      return result.build();
+    }
+  }
+
+  public IntVector eval(int positionCount, IntVector vVector) {
+    try(IntVector.FixedBuilder result = driverContext.blockFactory().newIntVectorFixedBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        int v = vVector.getInt(p);
+        result.appendInt(p, RoundToInt.ceiling3(v, this.p0, this.p1, this.p2));
+      }
+      return result.build();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "RoundToIntCeiling3Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(v);
+  }
+
+  private Warnings warnings() {
+    if (warnings == null) {
+      this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+    }
+    return warnings;
+  }
+
+  static class Factory implements ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final ExpressionEvaluator.Factory v;
+
+    private final int p0;
+
+    private final int p1;
+
+    private final int p2;
+
+    public Factory(Source source, ExpressionEvaluator.Factory v, int p0, int p1, int p2) {
+      this.source = source;
+      this.v = v;
+      this.p0 = p0;
+      this.p1 = p1;
+      this.p2 = p2;
+    }
+
+    @Override
+    public RoundToIntCeiling3Evaluator get(DriverContext context) {
+      return new RoundToIntCeiling3Evaluator(source, v.get(context), p0, p1, p2, context);
+    }
+
+    @Override
+    public String toString() {
+      return "RoundToIntCeiling3Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToIntCeiling4Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToIntCeiling4Evaluator.java
@@ -1,0 +1,153 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.math;
+
+import java.lang.IllegalArgumentException;
+import java.lang.Override;
+import java.lang.String;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+/**
+ * {@link ExpressionEvaluator} implementation for {@link RoundToInt}.
+ * This class is generated. Edit {@code EvaluatorImplementer} instead.
+ */
+public final class RoundToIntCeiling4Evaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(RoundToIntCeiling4Evaluator.class);
+
+  private final Source source;
+
+  private final ExpressionEvaluator v;
+
+  private final int p0;
+
+  private final int p1;
+
+  private final int p2;
+
+  private final int p3;
+
+  private final DriverContext driverContext;
+
+  private Warnings warnings;
+
+  public RoundToIntCeiling4Evaluator(Source source, ExpressionEvaluator v, int p0, int p1, int p2,
+      int p3, DriverContext driverContext) {
+    this.source = source;
+    this.v = v;
+    this.p0 = p0;
+    this.p1 = p1;
+    this.p2 = p2;
+    this.p3 = p3;
+    this.driverContext = driverContext;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    try (IntBlock vBlock = (IntBlock) v.eval(page)) {
+      IntVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
+      }
+      return eval(page.getPositionCount(), vVector).asBlock();
+    }
+  }
+
+  @Override
+  public long baseRamBytesUsed() {
+    long baseRamBytesUsed = BASE_RAM_BYTES_USED;
+    baseRamBytesUsed += v.baseRamBytesUsed();
+    return baseRamBytesUsed;
+  }
+
+  public IntBlock eval(int positionCount, IntBlock vBlock) {
+    try(IntBlock.Builder result = driverContext.blockFactory().newIntBlockBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        switch (vBlock.getValueCount(p)) {
+          case 0:
+              result.appendNull();
+              continue position;
+          case 1:
+              break;
+          default:
+              warnings().registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+              result.appendNull();
+              continue position;
+        }
+        int v = vBlock.getInt(vBlock.getFirstValueIndex(p));
+        result.appendInt(RoundToInt.ceiling4(v, this.p0, this.p1, this.p2, this.p3));
+      }
+      return result.build();
+    }
+  }
+
+  public IntVector eval(int positionCount, IntVector vVector) {
+    try(IntVector.FixedBuilder result = driverContext.blockFactory().newIntVectorFixedBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        int v = vVector.getInt(p);
+        result.appendInt(p, RoundToInt.ceiling4(v, this.p0, this.p1, this.p2, this.p3));
+      }
+      return result.build();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "RoundToIntCeiling4Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(v);
+  }
+
+  private Warnings warnings() {
+    if (warnings == null) {
+      this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+    }
+    return warnings;
+  }
+
+  static class Factory implements ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final ExpressionEvaluator.Factory v;
+
+    private final int p0;
+
+    private final int p1;
+
+    private final int p2;
+
+    private final int p3;
+
+    public Factory(Source source, ExpressionEvaluator.Factory v, int p0, int p1, int p2, int p3) {
+      this.source = source;
+      this.v = v;
+      this.p0 = p0;
+      this.p1 = p1;
+      this.p2 = p2;
+      this.p3 = p3;
+    }
+
+    @Override
+    public RoundToIntCeiling4Evaluator get(DriverContext context) {
+      return new RoundToIntCeiling4Evaluator(source, v.get(context), p0, p1, p2, p3, context);
+    }
+
+    @Override
+    public String toString() {
+      return "RoundToIntCeiling4Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToIntCeiling5Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToIntCeiling5Evaluator.java
@@ -1,0 +1,160 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.math;
+
+import java.lang.IllegalArgumentException;
+import java.lang.Override;
+import java.lang.String;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+/**
+ * {@link ExpressionEvaluator} implementation for {@link RoundToInt}.
+ * This class is generated. Edit {@code EvaluatorImplementer} instead.
+ */
+public final class RoundToIntCeiling5Evaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(RoundToIntCeiling5Evaluator.class);
+
+  private final Source source;
+
+  private final ExpressionEvaluator v;
+
+  private final int p0;
+
+  private final int p1;
+
+  private final int p2;
+
+  private final int p3;
+
+  private final int p4;
+
+  private final DriverContext driverContext;
+
+  private Warnings warnings;
+
+  public RoundToIntCeiling5Evaluator(Source source, ExpressionEvaluator v, int p0, int p1, int p2,
+      int p3, int p4, DriverContext driverContext) {
+    this.source = source;
+    this.v = v;
+    this.p0 = p0;
+    this.p1 = p1;
+    this.p2 = p2;
+    this.p3 = p3;
+    this.p4 = p4;
+    this.driverContext = driverContext;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    try (IntBlock vBlock = (IntBlock) v.eval(page)) {
+      IntVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
+      }
+      return eval(page.getPositionCount(), vVector).asBlock();
+    }
+  }
+
+  @Override
+  public long baseRamBytesUsed() {
+    long baseRamBytesUsed = BASE_RAM_BYTES_USED;
+    baseRamBytesUsed += v.baseRamBytesUsed();
+    return baseRamBytesUsed;
+  }
+
+  public IntBlock eval(int positionCount, IntBlock vBlock) {
+    try(IntBlock.Builder result = driverContext.blockFactory().newIntBlockBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        switch (vBlock.getValueCount(p)) {
+          case 0:
+              result.appendNull();
+              continue position;
+          case 1:
+              break;
+          default:
+              warnings().registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+              result.appendNull();
+              continue position;
+        }
+        int v = vBlock.getInt(vBlock.getFirstValueIndex(p));
+        result.appendInt(RoundToInt.ceiling5(v, this.p0, this.p1, this.p2, this.p3, this.p4));
+      }
+      return result.build();
+    }
+  }
+
+  public IntVector eval(int positionCount, IntVector vVector) {
+    try(IntVector.FixedBuilder result = driverContext.blockFactory().newIntVectorFixedBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        int v = vVector.getInt(p);
+        result.appendInt(p, RoundToInt.ceiling5(v, this.p0, this.p1, this.p2, this.p3, this.p4));
+      }
+      return result.build();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "RoundToIntCeiling5Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(v);
+  }
+
+  private Warnings warnings() {
+    if (warnings == null) {
+      this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+    }
+    return warnings;
+  }
+
+  static class Factory implements ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final ExpressionEvaluator.Factory v;
+
+    private final int p0;
+
+    private final int p1;
+
+    private final int p2;
+
+    private final int p3;
+
+    private final int p4;
+
+    public Factory(Source source, ExpressionEvaluator.Factory v, int p0, int p1, int p2, int p3,
+        int p4) {
+      this.source = source;
+      this.v = v;
+      this.p0 = p0;
+      this.p1 = p1;
+      this.p2 = p2;
+      this.p3 = p3;
+      this.p4 = p4;
+    }
+
+    @Override
+    public RoundToIntCeiling5Evaluator get(DriverContext context) {
+      return new RoundToIntCeiling5Evaluator(source, v.get(context), p0, p1, p2, p3, p4, context);
+    }
+
+    @Override
+    public String toString() {
+      return "RoundToIntCeiling5Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToIntCeiling6Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToIntCeiling6Evaluator.java
@@ -1,0 +1,166 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.math;
+
+import java.lang.IllegalArgumentException;
+import java.lang.Override;
+import java.lang.String;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+/**
+ * {@link ExpressionEvaluator} implementation for {@link RoundToInt}.
+ * This class is generated. Edit {@code EvaluatorImplementer} instead.
+ */
+public final class RoundToIntCeiling6Evaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(RoundToIntCeiling6Evaluator.class);
+
+  private final Source source;
+
+  private final ExpressionEvaluator v;
+
+  private final int p0;
+
+  private final int p1;
+
+  private final int p2;
+
+  private final int p3;
+
+  private final int p4;
+
+  private final int p5;
+
+  private final DriverContext driverContext;
+
+  private Warnings warnings;
+
+  public RoundToIntCeiling6Evaluator(Source source, ExpressionEvaluator v, int p0, int p1, int p2,
+      int p3, int p4, int p5, DriverContext driverContext) {
+    this.source = source;
+    this.v = v;
+    this.p0 = p0;
+    this.p1 = p1;
+    this.p2 = p2;
+    this.p3 = p3;
+    this.p4 = p4;
+    this.p5 = p5;
+    this.driverContext = driverContext;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    try (IntBlock vBlock = (IntBlock) v.eval(page)) {
+      IntVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
+      }
+      return eval(page.getPositionCount(), vVector).asBlock();
+    }
+  }
+
+  @Override
+  public long baseRamBytesUsed() {
+    long baseRamBytesUsed = BASE_RAM_BYTES_USED;
+    baseRamBytesUsed += v.baseRamBytesUsed();
+    return baseRamBytesUsed;
+  }
+
+  public IntBlock eval(int positionCount, IntBlock vBlock) {
+    try(IntBlock.Builder result = driverContext.blockFactory().newIntBlockBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        switch (vBlock.getValueCount(p)) {
+          case 0:
+              result.appendNull();
+              continue position;
+          case 1:
+              break;
+          default:
+              warnings().registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+              result.appendNull();
+              continue position;
+        }
+        int v = vBlock.getInt(vBlock.getFirstValueIndex(p));
+        result.appendInt(RoundToInt.ceiling6(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5));
+      }
+      return result.build();
+    }
+  }
+
+  public IntVector eval(int positionCount, IntVector vVector) {
+    try(IntVector.FixedBuilder result = driverContext.blockFactory().newIntVectorFixedBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        int v = vVector.getInt(p);
+        result.appendInt(p, RoundToInt.ceiling6(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5));
+      }
+      return result.build();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "RoundToIntCeiling6Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(v);
+  }
+
+  private Warnings warnings() {
+    if (warnings == null) {
+      this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+    }
+    return warnings;
+  }
+
+  static class Factory implements ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final ExpressionEvaluator.Factory v;
+
+    private final int p0;
+
+    private final int p1;
+
+    private final int p2;
+
+    private final int p3;
+
+    private final int p4;
+
+    private final int p5;
+
+    public Factory(Source source, ExpressionEvaluator.Factory v, int p0, int p1, int p2, int p3,
+        int p4, int p5) {
+      this.source = source;
+      this.v = v;
+      this.p0 = p0;
+      this.p1 = p1;
+      this.p2 = p2;
+      this.p3 = p3;
+      this.p4 = p4;
+      this.p5 = p5;
+    }
+
+    @Override
+    public RoundToIntCeiling6Evaluator get(DriverContext context) {
+      return new RoundToIntCeiling6Evaluator(source, v.get(context), p0, p1, p2, p3, p4, p5, context);
+    }
+
+    @Override
+    public String toString() {
+      return "RoundToIntCeiling6Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToIntCeiling7Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToIntCeiling7Evaluator.java
@@ -1,0 +1,172 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.math;
+
+import java.lang.IllegalArgumentException;
+import java.lang.Override;
+import java.lang.String;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+/**
+ * {@link ExpressionEvaluator} implementation for {@link RoundToInt}.
+ * This class is generated. Edit {@code EvaluatorImplementer} instead.
+ */
+public final class RoundToIntCeiling7Evaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(RoundToIntCeiling7Evaluator.class);
+
+  private final Source source;
+
+  private final ExpressionEvaluator v;
+
+  private final int p0;
+
+  private final int p1;
+
+  private final int p2;
+
+  private final int p3;
+
+  private final int p4;
+
+  private final int p5;
+
+  private final int p6;
+
+  private final DriverContext driverContext;
+
+  private Warnings warnings;
+
+  public RoundToIntCeiling7Evaluator(Source source, ExpressionEvaluator v, int p0, int p1, int p2,
+      int p3, int p4, int p5, int p6, DriverContext driverContext) {
+    this.source = source;
+    this.v = v;
+    this.p0 = p0;
+    this.p1 = p1;
+    this.p2 = p2;
+    this.p3 = p3;
+    this.p4 = p4;
+    this.p5 = p5;
+    this.p6 = p6;
+    this.driverContext = driverContext;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    try (IntBlock vBlock = (IntBlock) v.eval(page)) {
+      IntVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
+      }
+      return eval(page.getPositionCount(), vVector).asBlock();
+    }
+  }
+
+  @Override
+  public long baseRamBytesUsed() {
+    long baseRamBytesUsed = BASE_RAM_BYTES_USED;
+    baseRamBytesUsed += v.baseRamBytesUsed();
+    return baseRamBytesUsed;
+  }
+
+  public IntBlock eval(int positionCount, IntBlock vBlock) {
+    try(IntBlock.Builder result = driverContext.blockFactory().newIntBlockBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        switch (vBlock.getValueCount(p)) {
+          case 0:
+              result.appendNull();
+              continue position;
+          case 1:
+              break;
+          default:
+              warnings().registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+              result.appendNull();
+              continue position;
+        }
+        int v = vBlock.getInt(vBlock.getFirstValueIndex(p));
+        result.appendInt(RoundToInt.ceiling7(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6));
+      }
+      return result.build();
+    }
+  }
+
+  public IntVector eval(int positionCount, IntVector vVector) {
+    try(IntVector.FixedBuilder result = driverContext.blockFactory().newIntVectorFixedBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        int v = vVector.getInt(p);
+        result.appendInt(p, RoundToInt.ceiling7(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6));
+      }
+      return result.build();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "RoundToIntCeiling7Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(v);
+  }
+
+  private Warnings warnings() {
+    if (warnings == null) {
+      this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+    }
+    return warnings;
+  }
+
+  static class Factory implements ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final ExpressionEvaluator.Factory v;
+
+    private final int p0;
+
+    private final int p1;
+
+    private final int p2;
+
+    private final int p3;
+
+    private final int p4;
+
+    private final int p5;
+
+    private final int p6;
+
+    public Factory(Source source, ExpressionEvaluator.Factory v, int p0, int p1, int p2, int p3,
+        int p4, int p5, int p6) {
+      this.source = source;
+      this.v = v;
+      this.p0 = p0;
+      this.p1 = p1;
+      this.p2 = p2;
+      this.p3 = p3;
+      this.p4 = p4;
+      this.p5 = p5;
+      this.p6 = p6;
+    }
+
+    @Override
+    public RoundToIntCeiling7Evaluator get(DriverContext context) {
+      return new RoundToIntCeiling7Evaluator(source, v.get(context), p0, p1, p2, p3, p4, p5, p6, context);
+    }
+
+    @Override
+    public String toString() {
+      return "RoundToIntCeiling7Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToIntCeiling8Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToIntCeiling8Evaluator.java
@@ -1,0 +1,178 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.math;
+
+import java.lang.IllegalArgumentException;
+import java.lang.Override;
+import java.lang.String;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+/**
+ * {@link ExpressionEvaluator} implementation for {@link RoundToInt}.
+ * This class is generated. Edit {@code EvaluatorImplementer} instead.
+ */
+public final class RoundToIntCeiling8Evaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(RoundToIntCeiling8Evaluator.class);
+
+  private final Source source;
+
+  private final ExpressionEvaluator v;
+
+  private final int p0;
+
+  private final int p1;
+
+  private final int p2;
+
+  private final int p3;
+
+  private final int p4;
+
+  private final int p5;
+
+  private final int p6;
+
+  private final int p7;
+
+  private final DriverContext driverContext;
+
+  private Warnings warnings;
+
+  public RoundToIntCeiling8Evaluator(Source source, ExpressionEvaluator v, int p0, int p1, int p2,
+      int p3, int p4, int p5, int p6, int p7, DriverContext driverContext) {
+    this.source = source;
+    this.v = v;
+    this.p0 = p0;
+    this.p1 = p1;
+    this.p2 = p2;
+    this.p3 = p3;
+    this.p4 = p4;
+    this.p5 = p5;
+    this.p6 = p6;
+    this.p7 = p7;
+    this.driverContext = driverContext;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    try (IntBlock vBlock = (IntBlock) v.eval(page)) {
+      IntVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
+      }
+      return eval(page.getPositionCount(), vVector).asBlock();
+    }
+  }
+
+  @Override
+  public long baseRamBytesUsed() {
+    long baseRamBytesUsed = BASE_RAM_BYTES_USED;
+    baseRamBytesUsed += v.baseRamBytesUsed();
+    return baseRamBytesUsed;
+  }
+
+  public IntBlock eval(int positionCount, IntBlock vBlock) {
+    try(IntBlock.Builder result = driverContext.blockFactory().newIntBlockBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        switch (vBlock.getValueCount(p)) {
+          case 0:
+              result.appendNull();
+              continue position;
+          case 1:
+              break;
+          default:
+              warnings().registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+              result.appendNull();
+              continue position;
+        }
+        int v = vBlock.getInt(vBlock.getFirstValueIndex(p));
+        result.appendInt(RoundToInt.ceiling8(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6, this.p7));
+      }
+      return result.build();
+    }
+  }
+
+  public IntVector eval(int positionCount, IntVector vVector) {
+    try(IntVector.FixedBuilder result = driverContext.blockFactory().newIntVectorFixedBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        int v = vVector.getInt(p);
+        result.appendInt(p, RoundToInt.ceiling8(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6, this.p7));
+      }
+      return result.build();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "RoundToIntCeiling8Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + ", p7=" + p7 + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(v);
+  }
+
+  private Warnings warnings() {
+    if (warnings == null) {
+      this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+    }
+    return warnings;
+  }
+
+  static class Factory implements ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final ExpressionEvaluator.Factory v;
+
+    private final int p0;
+
+    private final int p1;
+
+    private final int p2;
+
+    private final int p3;
+
+    private final int p4;
+
+    private final int p5;
+
+    private final int p6;
+
+    private final int p7;
+
+    public Factory(Source source, ExpressionEvaluator.Factory v, int p0, int p1, int p2, int p3,
+        int p4, int p5, int p6, int p7) {
+      this.source = source;
+      this.v = v;
+      this.p0 = p0;
+      this.p1 = p1;
+      this.p2 = p2;
+      this.p3 = p3;
+      this.p4 = p4;
+      this.p5 = p5;
+      this.p6 = p6;
+      this.p7 = p7;
+    }
+
+    @Override
+    public RoundToIntCeiling8Evaluator get(DriverContext context) {
+      return new RoundToIntCeiling8Evaluator(source, v.get(context), p0, p1, p2, p3, p4, p5, p6, p7, context);
+    }
+
+    @Override
+    public String toString() {
+      return "RoundToIntCeiling8Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + ", p7=" + p7 + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToIntCeiling9Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToIntCeiling9Evaluator.java
@@ -1,0 +1,184 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.math;
+
+import java.lang.IllegalArgumentException;
+import java.lang.Override;
+import java.lang.String;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+/**
+ * {@link ExpressionEvaluator} implementation for {@link RoundToInt}.
+ * This class is generated. Edit {@code EvaluatorImplementer} instead.
+ */
+public final class RoundToIntCeiling9Evaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(RoundToIntCeiling9Evaluator.class);
+
+  private final Source source;
+
+  private final ExpressionEvaluator v;
+
+  private final int p0;
+
+  private final int p1;
+
+  private final int p2;
+
+  private final int p3;
+
+  private final int p4;
+
+  private final int p5;
+
+  private final int p6;
+
+  private final int p7;
+
+  private final int p8;
+
+  private final DriverContext driverContext;
+
+  private Warnings warnings;
+
+  public RoundToIntCeiling9Evaluator(Source source, ExpressionEvaluator v, int p0, int p1, int p2,
+      int p3, int p4, int p5, int p6, int p7, int p8, DriverContext driverContext) {
+    this.source = source;
+    this.v = v;
+    this.p0 = p0;
+    this.p1 = p1;
+    this.p2 = p2;
+    this.p3 = p3;
+    this.p4 = p4;
+    this.p5 = p5;
+    this.p6 = p6;
+    this.p7 = p7;
+    this.p8 = p8;
+    this.driverContext = driverContext;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    try (IntBlock vBlock = (IntBlock) v.eval(page)) {
+      IntVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
+      }
+      return eval(page.getPositionCount(), vVector).asBlock();
+    }
+  }
+
+  @Override
+  public long baseRamBytesUsed() {
+    long baseRamBytesUsed = BASE_RAM_BYTES_USED;
+    baseRamBytesUsed += v.baseRamBytesUsed();
+    return baseRamBytesUsed;
+  }
+
+  public IntBlock eval(int positionCount, IntBlock vBlock) {
+    try(IntBlock.Builder result = driverContext.blockFactory().newIntBlockBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        switch (vBlock.getValueCount(p)) {
+          case 0:
+              result.appendNull();
+              continue position;
+          case 1:
+              break;
+          default:
+              warnings().registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+              result.appendNull();
+              continue position;
+        }
+        int v = vBlock.getInt(vBlock.getFirstValueIndex(p));
+        result.appendInt(RoundToInt.ceiling9(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6, this.p7, this.p8));
+      }
+      return result.build();
+    }
+  }
+
+  public IntVector eval(int positionCount, IntVector vVector) {
+    try(IntVector.FixedBuilder result = driverContext.blockFactory().newIntVectorFixedBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        int v = vVector.getInt(p);
+        result.appendInt(p, RoundToInt.ceiling9(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6, this.p7, this.p8));
+      }
+      return result.build();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "RoundToIntCeiling9Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + ", p7=" + p7 + ", p8=" + p8 + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(v);
+  }
+
+  private Warnings warnings() {
+    if (warnings == null) {
+      this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+    }
+    return warnings;
+  }
+
+  static class Factory implements ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final ExpressionEvaluator.Factory v;
+
+    private final int p0;
+
+    private final int p1;
+
+    private final int p2;
+
+    private final int p3;
+
+    private final int p4;
+
+    private final int p5;
+
+    private final int p6;
+
+    private final int p7;
+
+    private final int p8;
+
+    public Factory(Source source, ExpressionEvaluator.Factory v, int p0, int p1, int p2, int p3,
+        int p4, int p5, int p6, int p7, int p8) {
+      this.source = source;
+      this.v = v;
+      this.p0 = p0;
+      this.p1 = p1;
+      this.p2 = p2;
+      this.p3 = p3;
+      this.p4 = p4;
+      this.p5 = p5;
+      this.p6 = p6;
+      this.p7 = p7;
+      this.p8 = p8;
+    }
+
+    @Override
+    public RoundToIntCeiling9Evaluator get(DriverContext context) {
+      return new RoundToIntCeiling9Evaluator(source, v.get(context), p0, p1, p2, p3, p4, p5, p6, p7, p8, context);
+    }
+
+    @Override
+    public String toString() {
+      return "RoundToIntCeiling9Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + ", p7=" + p7 + ", p8=" + p8 + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToIntCeilingIntervalEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToIntCeilingIntervalEvaluator.java
@@ -1,0 +1,147 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.math;
+
+import java.lang.IllegalArgumentException;
+import java.lang.Override;
+import java.lang.String;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+/**
+ * {@link ExpressionEvaluator} implementation for {@link RoundToInt}.
+ * This class is generated. Edit {@code EvaluatorImplementer} instead.
+ */
+public final class RoundToIntCeilingIntervalEvaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(RoundToIntCeilingIntervalEvaluator.class);
+
+  private final Source source;
+
+  private final ExpressionEvaluator v;
+
+  private final int lo;
+
+  private final int hi;
+
+  private final int interval;
+
+  private final DriverContext driverContext;
+
+  private Warnings warnings;
+
+  public RoundToIntCeilingIntervalEvaluator(Source source, ExpressionEvaluator v, int lo, int hi,
+      int interval, DriverContext driverContext) {
+    this.source = source;
+    this.v = v;
+    this.lo = lo;
+    this.hi = hi;
+    this.interval = interval;
+    this.driverContext = driverContext;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    try (IntBlock vBlock = (IntBlock) v.eval(page)) {
+      IntVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
+      }
+      return eval(page.getPositionCount(), vVector).asBlock();
+    }
+  }
+
+  @Override
+  public long baseRamBytesUsed() {
+    long baseRamBytesUsed = BASE_RAM_BYTES_USED;
+    baseRamBytesUsed += v.baseRamBytesUsed();
+    return baseRamBytesUsed;
+  }
+
+  public IntBlock eval(int positionCount, IntBlock vBlock) {
+    try(IntBlock.Builder result = driverContext.blockFactory().newIntBlockBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        switch (vBlock.getValueCount(p)) {
+          case 0:
+              result.appendNull();
+              continue position;
+          case 1:
+              break;
+          default:
+              warnings().registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+              result.appendNull();
+              continue position;
+        }
+        int v = vBlock.getInt(vBlock.getFirstValueIndex(p));
+        result.appendInt(RoundToInt.ceilingInterval(v, this.lo, this.hi, this.interval));
+      }
+      return result.build();
+    }
+  }
+
+  public IntVector eval(int positionCount, IntVector vVector) {
+    try(IntVector.FixedBuilder result = driverContext.blockFactory().newIntVectorFixedBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        int v = vVector.getInt(p);
+        result.appendInt(p, RoundToInt.ceilingInterval(v, this.lo, this.hi, this.interval));
+      }
+      return result.build();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "RoundToIntCeilingIntervalEvaluator[" + "v=" + v + ", lo=" + lo + ", hi=" + hi + ", interval=" + interval + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(v);
+  }
+
+  private Warnings warnings() {
+    if (warnings == null) {
+      this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+    }
+    return warnings;
+  }
+
+  static class Factory implements ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final ExpressionEvaluator.Factory v;
+
+    private final int lo;
+
+    private final int hi;
+
+    private final int interval;
+
+    public Factory(Source source, ExpressionEvaluator.Factory v, int lo, int hi, int interval) {
+      this.source = source;
+      this.v = v;
+      this.lo = lo;
+      this.hi = hi;
+      this.interval = interval;
+    }
+
+    @Override
+    public RoundToIntCeilingIntervalEvaluator get(DriverContext context) {
+      return new RoundToIntCeilingIntervalEvaluator(source, v.get(context), lo, hi, interval, context);
+    }
+
+    @Override
+    public String toString() {
+      return "RoundToIntCeilingIntervalEvaluator[" + "v=" + v + ", lo=" + lo + ", hi=" + hi + ", interval=" + interval + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToIntCeilingSearchEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToIntCeilingSearchEvaluator.java
@@ -1,0 +1,135 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.math;
+
+import java.lang.IllegalArgumentException;
+import java.lang.Override;
+import java.lang.String;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+/**
+ * {@link ExpressionEvaluator} implementation for {@link RoundToInt}.
+ * This class is generated. Edit {@code EvaluatorImplementer} instead.
+ */
+public final class RoundToIntCeilingSearchEvaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(RoundToIntCeilingSearchEvaluator.class);
+
+  private final Source source;
+
+  private final ExpressionEvaluator v;
+
+  private final int[] p;
+
+  private final DriverContext driverContext;
+
+  private Warnings warnings;
+
+  public RoundToIntCeilingSearchEvaluator(Source source, ExpressionEvaluator v, int[] p,
+      DriverContext driverContext) {
+    this.source = source;
+    this.v = v;
+    this.p = p;
+    this.driverContext = driverContext;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    try (IntBlock vBlock = (IntBlock) v.eval(page)) {
+      IntVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
+      }
+      return eval(page.getPositionCount(), vVector).asBlock();
+    }
+  }
+
+  @Override
+  public long baseRamBytesUsed() {
+    long baseRamBytesUsed = BASE_RAM_BYTES_USED;
+    baseRamBytesUsed += v.baseRamBytesUsed();
+    return baseRamBytesUsed;
+  }
+
+  public IntBlock eval(int positionCount, IntBlock vBlock) {
+    try(IntBlock.Builder result = driverContext.blockFactory().newIntBlockBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        switch (vBlock.getValueCount(p)) {
+          case 0:
+              result.appendNull();
+              continue position;
+          case 1:
+              break;
+          default:
+              warnings().registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+              result.appendNull();
+              continue position;
+        }
+        int v = vBlock.getInt(vBlock.getFirstValueIndex(p));
+        result.appendInt(RoundToInt.ceilingSearch(v, this.p));
+      }
+      return result.build();
+    }
+  }
+
+  public IntVector eval(int positionCount, IntVector vVector) {
+    try(IntVector.FixedBuilder result = driverContext.blockFactory().newIntVectorFixedBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        int v = vVector.getInt(p);
+        result.appendInt(p, RoundToInt.ceilingSearch(v, this.p));
+      }
+      return result.build();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "RoundToIntCeilingSearchEvaluator[" + "v=" + v + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(v);
+  }
+
+  private Warnings warnings() {
+    if (warnings == null) {
+      this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+    }
+    return warnings;
+  }
+
+  static class Factory implements ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final ExpressionEvaluator.Factory v;
+
+    private final int[] p;
+
+    public Factory(Source source, ExpressionEvaluator.Factory v, int[] p) {
+      this.source = source;
+      this.v = v;
+      this.p = p;
+    }
+
+    @Override
+    public RoundToIntCeilingSearchEvaluator get(DriverContext context) {
+      return new RoundToIntCeilingSearchEvaluator(source, v.get(context), p, context);
+    }
+
+    @Override
+    public String toString() {
+      return "RoundToIntCeilingSearchEvaluator[" + "v=" + v + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToIntConstantEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToIntConstantEvaluator.java
@@ -1,0 +1,135 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.math;
+
+import java.lang.IllegalArgumentException;
+import java.lang.Override;
+import java.lang.String;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+/**
+ * {@link ExpressionEvaluator} implementation for {@link RoundToInt}.
+ * This class is generated. Edit {@code EvaluatorImplementer} instead.
+ */
+public final class RoundToIntConstantEvaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(RoundToIntConstantEvaluator.class);
+
+  private final Source source;
+
+  private final ExpressionEvaluator v;
+
+  private final int p;
+
+  private final DriverContext driverContext;
+
+  private Warnings warnings;
+
+  public RoundToIntConstantEvaluator(Source source, ExpressionEvaluator v, int p,
+      DriverContext driverContext) {
+    this.source = source;
+    this.v = v;
+    this.p = p;
+    this.driverContext = driverContext;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    try (IntBlock vBlock = (IntBlock) v.eval(page)) {
+      IntVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
+      }
+      return eval(page.getPositionCount(), vVector).asBlock();
+    }
+  }
+
+  @Override
+  public long baseRamBytesUsed() {
+    long baseRamBytesUsed = BASE_RAM_BYTES_USED;
+    baseRamBytesUsed += v.baseRamBytesUsed();
+    return baseRamBytesUsed;
+  }
+
+  public IntBlock eval(int positionCount, IntBlock vBlock) {
+    try(IntBlock.Builder result = driverContext.blockFactory().newIntBlockBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        switch (vBlock.getValueCount(p)) {
+          case 0:
+              result.appendNull();
+              continue position;
+          case 1:
+              break;
+          default:
+              warnings().registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+              result.appendNull();
+              continue position;
+        }
+        int v = vBlock.getInt(vBlock.getFirstValueIndex(p));
+        result.appendInt(RoundToInt.constant(v, this.p));
+      }
+      return result.build();
+    }
+  }
+
+  public IntVector eval(int positionCount, IntVector vVector) {
+    try(IntVector.FixedBuilder result = driverContext.blockFactory().newIntVectorFixedBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        int v = vVector.getInt(p);
+        result.appendInt(p, RoundToInt.constant(v, this.p));
+      }
+      return result.build();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "RoundToIntConstantEvaluator[" + "v=" + v + ", p=" + p + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(v);
+  }
+
+  private Warnings warnings() {
+    if (warnings == null) {
+      this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+    }
+    return warnings;
+  }
+
+  static class Factory implements ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final ExpressionEvaluator.Factory v;
+
+    private final int p;
+
+    public Factory(Source source, ExpressionEvaluator.Factory v, int p) {
+      this.source = source;
+      this.v = v;
+      this.p = p;
+    }
+
+    @Override
+    public RoundToIntConstantEvaluator get(DriverContext context) {
+      return new RoundToIntConstantEvaluator(source, v.get(context), p, context);
+    }
+
+    @Override
+    public String toString() {
+      return "RoundToIntConstantEvaluator[" + "v=" + v + ", p=" + p + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToIntFloor10Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToIntFloor10Evaluator.java
@@ -27,7 +27,7 @@ public final class RoundToIntFloor10Evaluator implements ExpressionEvaluator {
 
   private final Source source;
 
-  private final ExpressionEvaluator field;
+  private final ExpressionEvaluator v;
 
   private final int p0;
 
@@ -53,10 +53,10 @@ public final class RoundToIntFloor10Evaluator implements ExpressionEvaluator {
 
   private Warnings warnings;
 
-  public RoundToIntFloor10Evaluator(Source source, ExpressionEvaluator field, int p0, int p1, int p2,
+  public RoundToIntFloor10Evaluator(Source source, ExpressionEvaluator v, int p0, int p1, int p2,
       int p3, int p4, int p5, int p6, int p7, int p8, int p9, DriverContext driverContext) {
     this.source = source;
-    this.field = field;
+    this.v = v;
     this.p0 = p0;
     this.p1 = p1;
     this.p2 = p2;
@@ -72,26 +72,26 @@ public final class RoundToIntFloor10Evaluator implements ExpressionEvaluator {
 
   @Override
   public Block eval(Page page) {
-    try (IntBlock fieldBlock = (IntBlock) field.eval(page)) {
-      IntVector fieldVector = fieldBlock.asVector();
-      if (fieldVector == null) {
-        return eval(page.getPositionCount(), fieldBlock);
+    try (IntBlock vBlock = (IntBlock) v.eval(page)) {
+      IntVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
       }
-      return eval(page.getPositionCount(), fieldVector).asBlock();
+      return eval(page.getPositionCount(), vVector).asBlock();
     }
   }
 
   @Override
   public long baseRamBytesUsed() {
     long baseRamBytesUsed = BASE_RAM_BYTES_USED;
-    baseRamBytesUsed += field.baseRamBytesUsed();
+    baseRamBytesUsed += v.baseRamBytesUsed();
     return baseRamBytesUsed;
   }
 
-  public IntBlock eval(int positionCount, IntBlock fieldBlock) {
+  public IntBlock eval(int positionCount, IntBlock vBlock) {
     try(IntBlock.Builder result = driverContext.blockFactory().newIntBlockBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        switch (fieldBlock.getValueCount(p)) {
+        switch (vBlock.getValueCount(p)) {
           case 0:
               result.appendNull();
               continue position;
@@ -102,18 +102,18 @@ public final class RoundToIntFloor10Evaluator implements ExpressionEvaluator {
               result.appendNull();
               continue position;
         }
-        int field = fieldBlock.getInt(fieldBlock.getFirstValueIndex(p));
-        result.appendInt(RoundToInt.process(field, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6, this.p7, this.p8, this.p9));
+        int v = vBlock.getInt(vBlock.getFirstValueIndex(p));
+        result.appendInt(RoundToInt.floor10(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6, this.p7, this.p8, this.p9));
       }
       return result.build();
     }
   }
 
-  public IntVector eval(int positionCount, IntVector fieldVector) {
+  public IntVector eval(int positionCount, IntVector vVector) {
     try(IntVector.FixedBuilder result = driverContext.blockFactory().newIntVectorFixedBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        int field = fieldVector.getInt(p);
-        result.appendInt(p, RoundToInt.process(field, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6, this.p7, this.p8, this.p9));
+        int v = vVector.getInt(p);
+        result.appendInt(p, RoundToInt.floor10(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6, this.p7, this.p8, this.p9));
       }
       return result.build();
     }
@@ -121,12 +121,12 @@ public final class RoundToIntFloor10Evaluator implements ExpressionEvaluator {
 
   @Override
   public String toString() {
-    return "RoundToIntFloor10Evaluator[" + "field=" + field + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + ", p7=" + p7 + ", p8=" + p8 + ", p9=" + p9 + "]";
+    return "RoundToIntFloor10Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + ", p7=" + p7 + ", p8=" + p8 + ", p9=" + p9 + "]";
   }
 
   @Override
   public void close() {
-    Releasables.closeExpectNoException(field);
+    Releasables.closeExpectNoException(v);
   }
 
   private Warnings warnings() {
@@ -139,7 +139,7 @@ public final class RoundToIntFloor10Evaluator implements ExpressionEvaluator {
   static class Factory implements ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final ExpressionEvaluator.Factory field;
+    private final ExpressionEvaluator.Factory v;
 
     private final int p0;
 
@@ -161,10 +161,10 @@ public final class RoundToIntFloor10Evaluator implements ExpressionEvaluator {
 
     private final int p9;
 
-    public Factory(Source source, ExpressionEvaluator.Factory field, int p0, int p1, int p2, int p3,
+    public Factory(Source source, ExpressionEvaluator.Factory v, int p0, int p1, int p2, int p3,
         int p4, int p5, int p6, int p7, int p8, int p9) {
       this.source = source;
-      this.field = field;
+      this.v = v;
       this.p0 = p0;
       this.p1 = p1;
       this.p2 = p2;
@@ -179,12 +179,12 @@ public final class RoundToIntFloor10Evaluator implements ExpressionEvaluator {
 
     @Override
     public RoundToIntFloor10Evaluator get(DriverContext context) {
-      return new RoundToIntFloor10Evaluator(source, field.get(context), p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, context);
+      return new RoundToIntFloor10Evaluator(source, v.get(context), p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, context);
     }
 
     @Override
     public String toString() {
-      return "RoundToIntFloor10Evaluator[" + "field=" + field + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + ", p7=" + p7 + ", p8=" + p8 + ", p9=" + p9 + "]";
+      return "RoundToIntFloor10Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + ", p7=" + p7 + ", p8=" + p8 + ", p9=" + p9 + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToIntFloor2Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToIntFloor2Evaluator.java
@@ -27,7 +27,7 @@ public final class RoundToIntFloor2Evaluator implements ExpressionEvaluator {
 
   private final Source source;
 
-  private final ExpressionEvaluator field;
+  private final ExpressionEvaluator v;
 
   private final int p0;
 
@@ -37,10 +37,10 @@ public final class RoundToIntFloor2Evaluator implements ExpressionEvaluator {
 
   private Warnings warnings;
 
-  public RoundToIntFloor2Evaluator(Source source, ExpressionEvaluator field, int p0, int p1,
+  public RoundToIntFloor2Evaluator(Source source, ExpressionEvaluator v, int p0, int p1,
       DriverContext driverContext) {
     this.source = source;
-    this.field = field;
+    this.v = v;
     this.p0 = p0;
     this.p1 = p1;
     this.driverContext = driverContext;
@@ -48,26 +48,26 @@ public final class RoundToIntFloor2Evaluator implements ExpressionEvaluator {
 
   @Override
   public Block eval(Page page) {
-    try (IntBlock fieldBlock = (IntBlock) field.eval(page)) {
-      IntVector fieldVector = fieldBlock.asVector();
-      if (fieldVector == null) {
-        return eval(page.getPositionCount(), fieldBlock);
+    try (IntBlock vBlock = (IntBlock) v.eval(page)) {
+      IntVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
       }
-      return eval(page.getPositionCount(), fieldVector).asBlock();
+      return eval(page.getPositionCount(), vVector).asBlock();
     }
   }
 
   @Override
   public long baseRamBytesUsed() {
     long baseRamBytesUsed = BASE_RAM_BYTES_USED;
-    baseRamBytesUsed += field.baseRamBytesUsed();
+    baseRamBytesUsed += v.baseRamBytesUsed();
     return baseRamBytesUsed;
   }
 
-  public IntBlock eval(int positionCount, IntBlock fieldBlock) {
+  public IntBlock eval(int positionCount, IntBlock vBlock) {
     try(IntBlock.Builder result = driverContext.blockFactory().newIntBlockBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        switch (fieldBlock.getValueCount(p)) {
+        switch (vBlock.getValueCount(p)) {
           case 0:
               result.appendNull();
               continue position;
@@ -78,18 +78,18 @@ public final class RoundToIntFloor2Evaluator implements ExpressionEvaluator {
               result.appendNull();
               continue position;
         }
-        int field = fieldBlock.getInt(fieldBlock.getFirstValueIndex(p));
-        result.appendInt(RoundToInt.process(field, this.p0, this.p1));
+        int v = vBlock.getInt(vBlock.getFirstValueIndex(p));
+        result.appendInt(RoundToInt.floor2(v, this.p0, this.p1));
       }
       return result.build();
     }
   }
 
-  public IntVector eval(int positionCount, IntVector fieldVector) {
+  public IntVector eval(int positionCount, IntVector vVector) {
     try(IntVector.FixedBuilder result = driverContext.blockFactory().newIntVectorFixedBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        int field = fieldVector.getInt(p);
-        result.appendInt(p, RoundToInt.process(field, this.p0, this.p1));
+        int v = vVector.getInt(p);
+        result.appendInt(p, RoundToInt.floor2(v, this.p0, this.p1));
       }
       return result.build();
     }
@@ -97,12 +97,12 @@ public final class RoundToIntFloor2Evaluator implements ExpressionEvaluator {
 
   @Override
   public String toString() {
-    return "RoundToIntFloor2Evaluator[" + "field=" + field + ", p0=" + p0 + ", p1=" + p1 + "]";
+    return "RoundToIntFloor2Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + "]";
   }
 
   @Override
   public void close() {
-    Releasables.closeExpectNoException(field);
+    Releasables.closeExpectNoException(v);
   }
 
   private Warnings warnings() {
@@ -115,27 +115,27 @@ public final class RoundToIntFloor2Evaluator implements ExpressionEvaluator {
   static class Factory implements ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final ExpressionEvaluator.Factory field;
+    private final ExpressionEvaluator.Factory v;
 
     private final int p0;
 
     private final int p1;
 
-    public Factory(Source source, ExpressionEvaluator.Factory field, int p0, int p1) {
+    public Factory(Source source, ExpressionEvaluator.Factory v, int p0, int p1) {
       this.source = source;
-      this.field = field;
+      this.v = v;
       this.p0 = p0;
       this.p1 = p1;
     }
 
     @Override
     public RoundToIntFloor2Evaluator get(DriverContext context) {
-      return new RoundToIntFloor2Evaluator(source, field.get(context), p0, p1, context);
+      return new RoundToIntFloor2Evaluator(source, v.get(context), p0, p1, context);
     }
 
     @Override
     public String toString() {
-      return "RoundToIntFloor2Evaluator[" + "field=" + field + ", p0=" + p0 + ", p1=" + p1 + "]";
+      return "RoundToIntFloor2Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToIntFloor3Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToIntFloor3Evaluator.java
@@ -27,7 +27,7 @@ public final class RoundToIntFloor3Evaluator implements ExpressionEvaluator {
 
   private final Source source;
 
-  private final ExpressionEvaluator field;
+  private final ExpressionEvaluator v;
 
   private final int p0;
 
@@ -39,10 +39,10 @@ public final class RoundToIntFloor3Evaluator implements ExpressionEvaluator {
 
   private Warnings warnings;
 
-  public RoundToIntFloor3Evaluator(Source source, ExpressionEvaluator field, int p0, int p1, int p2,
+  public RoundToIntFloor3Evaluator(Source source, ExpressionEvaluator v, int p0, int p1, int p2,
       DriverContext driverContext) {
     this.source = source;
-    this.field = field;
+    this.v = v;
     this.p0 = p0;
     this.p1 = p1;
     this.p2 = p2;
@@ -51,26 +51,26 @@ public final class RoundToIntFloor3Evaluator implements ExpressionEvaluator {
 
   @Override
   public Block eval(Page page) {
-    try (IntBlock fieldBlock = (IntBlock) field.eval(page)) {
-      IntVector fieldVector = fieldBlock.asVector();
-      if (fieldVector == null) {
-        return eval(page.getPositionCount(), fieldBlock);
+    try (IntBlock vBlock = (IntBlock) v.eval(page)) {
+      IntVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
       }
-      return eval(page.getPositionCount(), fieldVector).asBlock();
+      return eval(page.getPositionCount(), vVector).asBlock();
     }
   }
 
   @Override
   public long baseRamBytesUsed() {
     long baseRamBytesUsed = BASE_RAM_BYTES_USED;
-    baseRamBytesUsed += field.baseRamBytesUsed();
+    baseRamBytesUsed += v.baseRamBytesUsed();
     return baseRamBytesUsed;
   }
 
-  public IntBlock eval(int positionCount, IntBlock fieldBlock) {
+  public IntBlock eval(int positionCount, IntBlock vBlock) {
     try(IntBlock.Builder result = driverContext.blockFactory().newIntBlockBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        switch (fieldBlock.getValueCount(p)) {
+        switch (vBlock.getValueCount(p)) {
           case 0:
               result.appendNull();
               continue position;
@@ -81,18 +81,18 @@ public final class RoundToIntFloor3Evaluator implements ExpressionEvaluator {
               result.appendNull();
               continue position;
         }
-        int field = fieldBlock.getInt(fieldBlock.getFirstValueIndex(p));
-        result.appendInt(RoundToInt.process(field, this.p0, this.p1, this.p2));
+        int v = vBlock.getInt(vBlock.getFirstValueIndex(p));
+        result.appendInt(RoundToInt.floor3(v, this.p0, this.p1, this.p2));
       }
       return result.build();
     }
   }
 
-  public IntVector eval(int positionCount, IntVector fieldVector) {
+  public IntVector eval(int positionCount, IntVector vVector) {
     try(IntVector.FixedBuilder result = driverContext.blockFactory().newIntVectorFixedBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        int field = fieldVector.getInt(p);
-        result.appendInt(p, RoundToInt.process(field, this.p0, this.p1, this.p2));
+        int v = vVector.getInt(p);
+        result.appendInt(p, RoundToInt.floor3(v, this.p0, this.p1, this.p2));
       }
       return result.build();
     }
@@ -100,12 +100,12 @@ public final class RoundToIntFloor3Evaluator implements ExpressionEvaluator {
 
   @Override
   public String toString() {
-    return "RoundToIntFloor3Evaluator[" + "field=" + field + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + "]";
+    return "RoundToIntFloor3Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + "]";
   }
 
   @Override
   public void close() {
-    Releasables.closeExpectNoException(field);
+    Releasables.closeExpectNoException(v);
   }
 
   private Warnings warnings() {
@@ -118,7 +118,7 @@ public final class RoundToIntFloor3Evaluator implements ExpressionEvaluator {
   static class Factory implements ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final ExpressionEvaluator.Factory field;
+    private final ExpressionEvaluator.Factory v;
 
     private final int p0;
 
@@ -126,9 +126,9 @@ public final class RoundToIntFloor3Evaluator implements ExpressionEvaluator {
 
     private final int p2;
 
-    public Factory(Source source, ExpressionEvaluator.Factory field, int p0, int p1, int p2) {
+    public Factory(Source source, ExpressionEvaluator.Factory v, int p0, int p1, int p2) {
       this.source = source;
-      this.field = field;
+      this.v = v;
       this.p0 = p0;
       this.p1 = p1;
       this.p2 = p2;
@@ -136,12 +136,12 @@ public final class RoundToIntFloor3Evaluator implements ExpressionEvaluator {
 
     @Override
     public RoundToIntFloor3Evaluator get(DriverContext context) {
-      return new RoundToIntFloor3Evaluator(source, field.get(context), p0, p1, p2, context);
+      return new RoundToIntFloor3Evaluator(source, v.get(context), p0, p1, p2, context);
     }
 
     @Override
     public String toString() {
-      return "RoundToIntFloor3Evaluator[" + "field=" + field + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + "]";
+      return "RoundToIntFloor3Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToIntFloor4Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToIntFloor4Evaluator.java
@@ -27,7 +27,7 @@ public final class RoundToIntFloor4Evaluator implements ExpressionEvaluator {
 
   private final Source source;
 
-  private final ExpressionEvaluator field;
+  private final ExpressionEvaluator v;
 
   private final int p0;
 
@@ -41,10 +41,10 @@ public final class RoundToIntFloor4Evaluator implements ExpressionEvaluator {
 
   private Warnings warnings;
 
-  public RoundToIntFloor4Evaluator(Source source, ExpressionEvaluator field, int p0, int p1, int p2,
+  public RoundToIntFloor4Evaluator(Source source, ExpressionEvaluator v, int p0, int p1, int p2,
       int p3, DriverContext driverContext) {
     this.source = source;
-    this.field = field;
+    this.v = v;
     this.p0 = p0;
     this.p1 = p1;
     this.p2 = p2;
@@ -54,26 +54,26 @@ public final class RoundToIntFloor4Evaluator implements ExpressionEvaluator {
 
   @Override
   public Block eval(Page page) {
-    try (IntBlock fieldBlock = (IntBlock) field.eval(page)) {
-      IntVector fieldVector = fieldBlock.asVector();
-      if (fieldVector == null) {
-        return eval(page.getPositionCount(), fieldBlock);
+    try (IntBlock vBlock = (IntBlock) v.eval(page)) {
+      IntVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
       }
-      return eval(page.getPositionCount(), fieldVector).asBlock();
+      return eval(page.getPositionCount(), vVector).asBlock();
     }
   }
 
   @Override
   public long baseRamBytesUsed() {
     long baseRamBytesUsed = BASE_RAM_BYTES_USED;
-    baseRamBytesUsed += field.baseRamBytesUsed();
+    baseRamBytesUsed += v.baseRamBytesUsed();
     return baseRamBytesUsed;
   }
 
-  public IntBlock eval(int positionCount, IntBlock fieldBlock) {
+  public IntBlock eval(int positionCount, IntBlock vBlock) {
     try(IntBlock.Builder result = driverContext.blockFactory().newIntBlockBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        switch (fieldBlock.getValueCount(p)) {
+        switch (vBlock.getValueCount(p)) {
           case 0:
               result.appendNull();
               continue position;
@@ -84,18 +84,18 @@ public final class RoundToIntFloor4Evaluator implements ExpressionEvaluator {
               result.appendNull();
               continue position;
         }
-        int field = fieldBlock.getInt(fieldBlock.getFirstValueIndex(p));
-        result.appendInt(RoundToInt.process(field, this.p0, this.p1, this.p2, this.p3));
+        int v = vBlock.getInt(vBlock.getFirstValueIndex(p));
+        result.appendInt(RoundToInt.floor4(v, this.p0, this.p1, this.p2, this.p3));
       }
       return result.build();
     }
   }
 
-  public IntVector eval(int positionCount, IntVector fieldVector) {
+  public IntVector eval(int positionCount, IntVector vVector) {
     try(IntVector.FixedBuilder result = driverContext.blockFactory().newIntVectorFixedBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        int field = fieldVector.getInt(p);
-        result.appendInt(p, RoundToInt.process(field, this.p0, this.p1, this.p2, this.p3));
+        int v = vVector.getInt(p);
+        result.appendInt(p, RoundToInt.floor4(v, this.p0, this.p1, this.p2, this.p3));
       }
       return result.build();
     }
@@ -103,12 +103,12 @@ public final class RoundToIntFloor4Evaluator implements ExpressionEvaluator {
 
   @Override
   public String toString() {
-    return "RoundToIntFloor4Evaluator[" + "field=" + field + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + "]";
+    return "RoundToIntFloor4Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + "]";
   }
 
   @Override
   public void close() {
-    Releasables.closeExpectNoException(field);
+    Releasables.closeExpectNoException(v);
   }
 
   private Warnings warnings() {
@@ -121,7 +121,7 @@ public final class RoundToIntFloor4Evaluator implements ExpressionEvaluator {
   static class Factory implements ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final ExpressionEvaluator.Factory field;
+    private final ExpressionEvaluator.Factory v;
 
     private final int p0;
 
@@ -131,10 +131,9 @@ public final class RoundToIntFloor4Evaluator implements ExpressionEvaluator {
 
     private final int p3;
 
-    public Factory(Source source, ExpressionEvaluator.Factory field, int p0, int p1, int p2,
-        int p3) {
+    public Factory(Source source, ExpressionEvaluator.Factory v, int p0, int p1, int p2, int p3) {
       this.source = source;
-      this.field = field;
+      this.v = v;
       this.p0 = p0;
       this.p1 = p1;
       this.p2 = p2;
@@ -143,12 +142,12 @@ public final class RoundToIntFloor4Evaluator implements ExpressionEvaluator {
 
     @Override
     public RoundToIntFloor4Evaluator get(DriverContext context) {
-      return new RoundToIntFloor4Evaluator(source, field.get(context), p0, p1, p2, p3, context);
+      return new RoundToIntFloor4Evaluator(source, v.get(context), p0, p1, p2, p3, context);
     }
 
     @Override
     public String toString() {
-      return "RoundToIntFloor4Evaluator[" + "field=" + field + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + "]";
+      return "RoundToIntFloor4Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToIntFloor5Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToIntFloor5Evaluator.java
@@ -27,7 +27,7 @@ public final class RoundToIntFloor5Evaluator implements ExpressionEvaluator {
 
   private final Source source;
 
-  private final ExpressionEvaluator field;
+  private final ExpressionEvaluator v;
 
   private final int p0;
 
@@ -43,10 +43,10 @@ public final class RoundToIntFloor5Evaluator implements ExpressionEvaluator {
 
   private Warnings warnings;
 
-  public RoundToIntFloor5Evaluator(Source source, ExpressionEvaluator field, int p0, int p1, int p2,
+  public RoundToIntFloor5Evaluator(Source source, ExpressionEvaluator v, int p0, int p1, int p2,
       int p3, int p4, DriverContext driverContext) {
     this.source = source;
-    this.field = field;
+    this.v = v;
     this.p0 = p0;
     this.p1 = p1;
     this.p2 = p2;
@@ -57,26 +57,26 @@ public final class RoundToIntFloor5Evaluator implements ExpressionEvaluator {
 
   @Override
   public Block eval(Page page) {
-    try (IntBlock fieldBlock = (IntBlock) field.eval(page)) {
-      IntVector fieldVector = fieldBlock.asVector();
-      if (fieldVector == null) {
-        return eval(page.getPositionCount(), fieldBlock);
+    try (IntBlock vBlock = (IntBlock) v.eval(page)) {
+      IntVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
       }
-      return eval(page.getPositionCount(), fieldVector).asBlock();
+      return eval(page.getPositionCount(), vVector).asBlock();
     }
   }
 
   @Override
   public long baseRamBytesUsed() {
     long baseRamBytesUsed = BASE_RAM_BYTES_USED;
-    baseRamBytesUsed += field.baseRamBytesUsed();
+    baseRamBytesUsed += v.baseRamBytesUsed();
     return baseRamBytesUsed;
   }
 
-  public IntBlock eval(int positionCount, IntBlock fieldBlock) {
+  public IntBlock eval(int positionCount, IntBlock vBlock) {
     try(IntBlock.Builder result = driverContext.blockFactory().newIntBlockBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        switch (fieldBlock.getValueCount(p)) {
+        switch (vBlock.getValueCount(p)) {
           case 0:
               result.appendNull();
               continue position;
@@ -87,18 +87,18 @@ public final class RoundToIntFloor5Evaluator implements ExpressionEvaluator {
               result.appendNull();
               continue position;
         }
-        int field = fieldBlock.getInt(fieldBlock.getFirstValueIndex(p));
-        result.appendInt(RoundToInt.process(field, this.p0, this.p1, this.p2, this.p3, this.p4));
+        int v = vBlock.getInt(vBlock.getFirstValueIndex(p));
+        result.appendInt(RoundToInt.floor5(v, this.p0, this.p1, this.p2, this.p3, this.p4));
       }
       return result.build();
     }
   }
 
-  public IntVector eval(int positionCount, IntVector fieldVector) {
+  public IntVector eval(int positionCount, IntVector vVector) {
     try(IntVector.FixedBuilder result = driverContext.blockFactory().newIntVectorFixedBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        int field = fieldVector.getInt(p);
-        result.appendInt(p, RoundToInt.process(field, this.p0, this.p1, this.p2, this.p3, this.p4));
+        int v = vVector.getInt(p);
+        result.appendInt(p, RoundToInt.floor5(v, this.p0, this.p1, this.p2, this.p3, this.p4));
       }
       return result.build();
     }
@@ -106,12 +106,12 @@ public final class RoundToIntFloor5Evaluator implements ExpressionEvaluator {
 
   @Override
   public String toString() {
-    return "RoundToIntFloor5Evaluator[" + "field=" + field + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + "]";
+    return "RoundToIntFloor5Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + "]";
   }
 
   @Override
   public void close() {
-    Releasables.closeExpectNoException(field);
+    Releasables.closeExpectNoException(v);
   }
 
   private Warnings warnings() {
@@ -124,7 +124,7 @@ public final class RoundToIntFloor5Evaluator implements ExpressionEvaluator {
   static class Factory implements ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final ExpressionEvaluator.Factory field;
+    private final ExpressionEvaluator.Factory v;
 
     private final int p0;
 
@@ -136,10 +136,10 @@ public final class RoundToIntFloor5Evaluator implements ExpressionEvaluator {
 
     private final int p4;
 
-    public Factory(Source source, ExpressionEvaluator.Factory field, int p0, int p1, int p2, int p3,
+    public Factory(Source source, ExpressionEvaluator.Factory v, int p0, int p1, int p2, int p3,
         int p4) {
       this.source = source;
-      this.field = field;
+      this.v = v;
       this.p0 = p0;
       this.p1 = p1;
       this.p2 = p2;
@@ -149,12 +149,12 @@ public final class RoundToIntFloor5Evaluator implements ExpressionEvaluator {
 
     @Override
     public RoundToIntFloor5Evaluator get(DriverContext context) {
-      return new RoundToIntFloor5Evaluator(source, field.get(context), p0, p1, p2, p3, p4, context);
+      return new RoundToIntFloor5Evaluator(source, v.get(context), p0, p1, p2, p3, p4, context);
     }
 
     @Override
     public String toString() {
-      return "RoundToIntFloor5Evaluator[" + "field=" + field + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + "]";
+      return "RoundToIntFloor5Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToIntFloor6Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToIntFloor6Evaluator.java
@@ -27,7 +27,7 @@ public final class RoundToIntFloor6Evaluator implements ExpressionEvaluator {
 
   private final Source source;
 
-  private final ExpressionEvaluator field;
+  private final ExpressionEvaluator v;
 
   private final int p0;
 
@@ -45,10 +45,10 @@ public final class RoundToIntFloor6Evaluator implements ExpressionEvaluator {
 
   private Warnings warnings;
 
-  public RoundToIntFloor6Evaluator(Source source, ExpressionEvaluator field, int p0, int p1, int p2,
+  public RoundToIntFloor6Evaluator(Source source, ExpressionEvaluator v, int p0, int p1, int p2,
       int p3, int p4, int p5, DriverContext driverContext) {
     this.source = source;
-    this.field = field;
+    this.v = v;
     this.p0 = p0;
     this.p1 = p1;
     this.p2 = p2;
@@ -60,26 +60,26 @@ public final class RoundToIntFloor6Evaluator implements ExpressionEvaluator {
 
   @Override
   public Block eval(Page page) {
-    try (IntBlock fieldBlock = (IntBlock) field.eval(page)) {
-      IntVector fieldVector = fieldBlock.asVector();
-      if (fieldVector == null) {
-        return eval(page.getPositionCount(), fieldBlock);
+    try (IntBlock vBlock = (IntBlock) v.eval(page)) {
+      IntVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
       }
-      return eval(page.getPositionCount(), fieldVector).asBlock();
+      return eval(page.getPositionCount(), vVector).asBlock();
     }
   }
 
   @Override
   public long baseRamBytesUsed() {
     long baseRamBytesUsed = BASE_RAM_BYTES_USED;
-    baseRamBytesUsed += field.baseRamBytesUsed();
+    baseRamBytesUsed += v.baseRamBytesUsed();
     return baseRamBytesUsed;
   }
 
-  public IntBlock eval(int positionCount, IntBlock fieldBlock) {
+  public IntBlock eval(int positionCount, IntBlock vBlock) {
     try(IntBlock.Builder result = driverContext.blockFactory().newIntBlockBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        switch (fieldBlock.getValueCount(p)) {
+        switch (vBlock.getValueCount(p)) {
           case 0:
               result.appendNull();
               continue position;
@@ -90,18 +90,18 @@ public final class RoundToIntFloor6Evaluator implements ExpressionEvaluator {
               result.appendNull();
               continue position;
         }
-        int field = fieldBlock.getInt(fieldBlock.getFirstValueIndex(p));
-        result.appendInt(RoundToInt.process(field, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5));
+        int v = vBlock.getInt(vBlock.getFirstValueIndex(p));
+        result.appendInt(RoundToInt.floor6(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5));
       }
       return result.build();
     }
   }
 
-  public IntVector eval(int positionCount, IntVector fieldVector) {
+  public IntVector eval(int positionCount, IntVector vVector) {
     try(IntVector.FixedBuilder result = driverContext.blockFactory().newIntVectorFixedBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        int field = fieldVector.getInt(p);
-        result.appendInt(p, RoundToInt.process(field, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5));
+        int v = vVector.getInt(p);
+        result.appendInt(p, RoundToInt.floor6(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5));
       }
       return result.build();
     }
@@ -109,12 +109,12 @@ public final class RoundToIntFloor6Evaluator implements ExpressionEvaluator {
 
   @Override
   public String toString() {
-    return "RoundToIntFloor6Evaluator[" + "field=" + field + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + "]";
+    return "RoundToIntFloor6Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + "]";
   }
 
   @Override
   public void close() {
-    Releasables.closeExpectNoException(field);
+    Releasables.closeExpectNoException(v);
   }
 
   private Warnings warnings() {
@@ -127,7 +127,7 @@ public final class RoundToIntFloor6Evaluator implements ExpressionEvaluator {
   static class Factory implements ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final ExpressionEvaluator.Factory field;
+    private final ExpressionEvaluator.Factory v;
 
     private final int p0;
 
@@ -141,10 +141,10 @@ public final class RoundToIntFloor6Evaluator implements ExpressionEvaluator {
 
     private final int p5;
 
-    public Factory(Source source, ExpressionEvaluator.Factory field, int p0, int p1, int p2, int p3,
+    public Factory(Source source, ExpressionEvaluator.Factory v, int p0, int p1, int p2, int p3,
         int p4, int p5) {
       this.source = source;
-      this.field = field;
+      this.v = v;
       this.p0 = p0;
       this.p1 = p1;
       this.p2 = p2;
@@ -155,12 +155,12 @@ public final class RoundToIntFloor6Evaluator implements ExpressionEvaluator {
 
     @Override
     public RoundToIntFloor6Evaluator get(DriverContext context) {
-      return new RoundToIntFloor6Evaluator(source, field.get(context), p0, p1, p2, p3, p4, p5, context);
+      return new RoundToIntFloor6Evaluator(source, v.get(context), p0, p1, p2, p3, p4, p5, context);
     }
 
     @Override
     public String toString() {
-      return "RoundToIntFloor6Evaluator[" + "field=" + field + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + "]";
+      return "RoundToIntFloor6Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToIntFloor7Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToIntFloor7Evaluator.java
@@ -27,7 +27,7 @@ public final class RoundToIntFloor7Evaluator implements ExpressionEvaluator {
 
   private final Source source;
 
-  private final ExpressionEvaluator field;
+  private final ExpressionEvaluator v;
 
   private final int p0;
 
@@ -47,10 +47,10 @@ public final class RoundToIntFloor7Evaluator implements ExpressionEvaluator {
 
   private Warnings warnings;
 
-  public RoundToIntFloor7Evaluator(Source source, ExpressionEvaluator field, int p0, int p1, int p2,
+  public RoundToIntFloor7Evaluator(Source source, ExpressionEvaluator v, int p0, int p1, int p2,
       int p3, int p4, int p5, int p6, DriverContext driverContext) {
     this.source = source;
-    this.field = field;
+    this.v = v;
     this.p0 = p0;
     this.p1 = p1;
     this.p2 = p2;
@@ -63,26 +63,26 @@ public final class RoundToIntFloor7Evaluator implements ExpressionEvaluator {
 
   @Override
   public Block eval(Page page) {
-    try (IntBlock fieldBlock = (IntBlock) field.eval(page)) {
-      IntVector fieldVector = fieldBlock.asVector();
-      if (fieldVector == null) {
-        return eval(page.getPositionCount(), fieldBlock);
+    try (IntBlock vBlock = (IntBlock) v.eval(page)) {
+      IntVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
       }
-      return eval(page.getPositionCount(), fieldVector).asBlock();
+      return eval(page.getPositionCount(), vVector).asBlock();
     }
   }
 
   @Override
   public long baseRamBytesUsed() {
     long baseRamBytesUsed = BASE_RAM_BYTES_USED;
-    baseRamBytesUsed += field.baseRamBytesUsed();
+    baseRamBytesUsed += v.baseRamBytesUsed();
     return baseRamBytesUsed;
   }
 
-  public IntBlock eval(int positionCount, IntBlock fieldBlock) {
+  public IntBlock eval(int positionCount, IntBlock vBlock) {
     try(IntBlock.Builder result = driverContext.blockFactory().newIntBlockBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        switch (fieldBlock.getValueCount(p)) {
+        switch (vBlock.getValueCount(p)) {
           case 0:
               result.appendNull();
               continue position;
@@ -93,18 +93,18 @@ public final class RoundToIntFloor7Evaluator implements ExpressionEvaluator {
               result.appendNull();
               continue position;
         }
-        int field = fieldBlock.getInt(fieldBlock.getFirstValueIndex(p));
-        result.appendInt(RoundToInt.process(field, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6));
+        int v = vBlock.getInt(vBlock.getFirstValueIndex(p));
+        result.appendInt(RoundToInt.floor7(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6));
       }
       return result.build();
     }
   }
 
-  public IntVector eval(int positionCount, IntVector fieldVector) {
+  public IntVector eval(int positionCount, IntVector vVector) {
     try(IntVector.FixedBuilder result = driverContext.blockFactory().newIntVectorFixedBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        int field = fieldVector.getInt(p);
-        result.appendInt(p, RoundToInt.process(field, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6));
+        int v = vVector.getInt(p);
+        result.appendInt(p, RoundToInt.floor7(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6));
       }
       return result.build();
     }
@@ -112,12 +112,12 @@ public final class RoundToIntFloor7Evaluator implements ExpressionEvaluator {
 
   @Override
   public String toString() {
-    return "RoundToIntFloor7Evaluator[" + "field=" + field + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + "]";
+    return "RoundToIntFloor7Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + "]";
   }
 
   @Override
   public void close() {
-    Releasables.closeExpectNoException(field);
+    Releasables.closeExpectNoException(v);
   }
 
   private Warnings warnings() {
@@ -130,7 +130,7 @@ public final class RoundToIntFloor7Evaluator implements ExpressionEvaluator {
   static class Factory implements ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final ExpressionEvaluator.Factory field;
+    private final ExpressionEvaluator.Factory v;
 
     private final int p0;
 
@@ -146,10 +146,10 @@ public final class RoundToIntFloor7Evaluator implements ExpressionEvaluator {
 
     private final int p6;
 
-    public Factory(Source source, ExpressionEvaluator.Factory field, int p0, int p1, int p2, int p3,
+    public Factory(Source source, ExpressionEvaluator.Factory v, int p0, int p1, int p2, int p3,
         int p4, int p5, int p6) {
       this.source = source;
-      this.field = field;
+      this.v = v;
       this.p0 = p0;
       this.p1 = p1;
       this.p2 = p2;
@@ -161,12 +161,12 @@ public final class RoundToIntFloor7Evaluator implements ExpressionEvaluator {
 
     @Override
     public RoundToIntFloor7Evaluator get(DriverContext context) {
-      return new RoundToIntFloor7Evaluator(source, field.get(context), p0, p1, p2, p3, p4, p5, p6, context);
+      return new RoundToIntFloor7Evaluator(source, v.get(context), p0, p1, p2, p3, p4, p5, p6, context);
     }
 
     @Override
     public String toString() {
-      return "RoundToIntFloor7Evaluator[" + "field=" + field + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + "]";
+      return "RoundToIntFloor7Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToIntFloor8Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToIntFloor8Evaluator.java
@@ -27,7 +27,7 @@ public final class RoundToIntFloor8Evaluator implements ExpressionEvaluator {
 
   private final Source source;
 
-  private final ExpressionEvaluator field;
+  private final ExpressionEvaluator v;
 
   private final int p0;
 
@@ -49,10 +49,10 @@ public final class RoundToIntFloor8Evaluator implements ExpressionEvaluator {
 
   private Warnings warnings;
 
-  public RoundToIntFloor8Evaluator(Source source, ExpressionEvaluator field, int p0, int p1, int p2,
+  public RoundToIntFloor8Evaluator(Source source, ExpressionEvaluator v, int p0, int p1, int p2,
       int p3, int p4, int p5, int p6, int p7, DriverContext driverContext) {
     this.source = source;
-    this.field = field;
+    this.v = v;
     this.p0 = p0;
     this.p1 = p1;
     this.p2 = p2;
@@ -66,26 +66,26 @@ public final class RoundToIntFloor8Evaluator implements ExpressionEvaluator {
 
   @Override
   public Block eval(Page page) {
-    try (IntBlock fieldBlock = (IntBlock) field.eval(page)) {
-      IntVector fieldVector = fieldBlock.asVector();
-      if (fieldVector == null) {
-        return eval(page.getPositionCount(), fieldBlock);
+    try (IntBlock vBlock = (IntBlock) v.eval(page)) {
+      IntVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
       }
-      return eval(page.getPositionCount(), fieldVector).asBlock();
+      return eval(page.getPositionCount(), vVector).asBlock();
     }
   }
 
   @Override
   public long baseRamBytesUsed() {
     long baseRamBytesUsed = BASE_RAM_BYTES_USED;
-    baseRamBytesUsed += field.baseRamBytesUsed();
+    baseRamBytesUsed += v.baseRamBytesUsed();
     return baseRamBytesUsed;
   }
 
-  public IntBlock eval(int positionCount, IntBlock fieldBlock) {
+  public IntBlock eval(int positionCount, IntBlock vBlock) {
     try(IntBlock.Builder result = driverContext.blockFactory().newIntBlockBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        switch (fieldBlock.getValueCount(p)) {
+        switch (vBlock.getValueCount(p)) {
           case 0:
               result.appendNull();
               continue position;
@@ -96,18 +96,18 @@ public final class RoundToIntFloor8Evaluator implements ExpressionEvaluator {
               result.appendNull();
               continue position;
         }
-        int field = fieldBlock.getInt(fieldBlock.getFirstValueIndex(p));
-        result.appendInt(RoundToInt.process(field, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6, this.p7));
+        int v = vBlock.getInt(vBlock.getFirstValueIndex(p));
+        result.appendInt(RoundToInt.floor8(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6, this.p7));
       }
       return result.build();
     }
   }
 
-  public IntVector eval(int positionCount, IntVector fieldVector) {
+  public IntVector eval(int positionCount, IntVector vVector) {
     try(IntVector.FixedBuilder result = driverContext.blockFactory().newIntVectorFixedBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        int field = fieldVector.getInt(p);
-        result.appendInt(p, RoundToInt.process(field, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6, this.p7));
+        int v = vVector.getInt(p);
+        result.appendInt(p, RoundToInt.floor8(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6, this.p7));
       }
       return result.build();
     }
@@ -115,12 +115,12 @@ public final class RoundToIntFloor8Evaluator implements ExpressionEvaluator {
 
   @Override
   public String toString() {
-    return "RoundToIntFloor8Evaluator[" + "field=" + field + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + ", p7=" + p7 + "]";
+    return "RoundToIntFloor8Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + ", p7=" + p7 + "]";
   }
 
   @Override
   public void close() {
-    Releasables.closeExpectNoException(field);
+    Releasables.closeExpectNoException(v);
   }
 
   private Warnings warnings() {
@@ -133,7 +133,7 @@ public final class RoundToIntFloor8Evaluator implements ExpressionEvaluator {
   static class Factory implements ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final ExpressionEvaluator.Factory field;
+    private final ExpressionEvaluator.Factory v;
 
     private final int p0;
 
@@ -151,10 +151,10 @@ public final class RoundToIntFloor8Evaluator implements ExpressionEvaluator {
 
     private final int p7;
 
-    public Factory(Source source, ExpressionEvaluator.Factory field, int p0, int p1, int p2, int p3,
+    public Factory(Source source, ExpressionEvaluator.Factory v, int p0, int p1, int p2, int p3,
         int p4, int p5, int p6, int p7) {
       this.source = source;
-      this.field = field;
+      this.v = v;
       this.p0 = p0;
       this.p1 = p1;
       this.p2 = p2;
@@ -167,12 +167,12 @@ public final class RoundToIntFloor8Evaluator implements ExpressionEvaluator {
 
     @Override
     public RoundToIntFloor8Evaluator get(DriverContext context) {
-      return new RoundToIntFloor8Evaluator(source, field.get(context), p0, p1, p2, p3, p4, p5, p6, p7, context);
+      return new RoundToIntFloor8Evaluator(source, v.get(context), p0, p1, p2, p3, p4, p5, p6, p7, context);
     }
 
     @Override
     public String toString() {
-      return "RoundToIntFloor8Evaluator[" + "field=" + field + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + ", p7=" + p7 + "]";
+      return "RoundToIntFloor8Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + ", p7=" + p7 + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToIntFloor9Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToIntFloor9Evaluator.java
@@ -27,7 +27,7 @@ public final class RoundToIntFloor9Evaluator implements ExpressionEvaluator {
 
   private final Source source;
 
-  private final ExpressionEvaluator field;
+  private final ExpressionEvaluator v;
 
   private final int p0;
 
@@ -51,10 +51,10 @@ public final class RoundToIntFloor9Evaluator implements ExpressionEvaluator {
 
   private Warnings warnings;
 
-  public RoundToIntFloor9Evaluator(Source source, ExpressionEvaluator field, int p0, int p1, int p2,
+  public RoundToIntFloor9Evaluator(Source source, ExpressionEvaluator v, int p0, int p1, int p2,
       int p3, int p4, int p5, int p6, int p7, int p8, DriverContext driverContext) {
     this.source = source;
-    this.field = field;
+    this.v = v;
     this.p0 = p0;
     this.p1 = p1;
     this.p2 = p2;
@@ -69,26 +69,26 @@ public final class RoundToIntFloor9Evaluator implements ExpressionEvaluator {
 
   @Override
   public Block eval(Page page) {
-    try (IntBlock fieldBlock = (IntBlock) field.eval(page)) {
-      IntVector fieldVector = fieldBlock.asVector();
-      if (fieldVector == null) {
-        return eval(page.getPositionCount(), fieldBlock);
+    try (IntBlock vBlock = (IntBlock) v.eval(page)) {
+      IntVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
       }
-      return eval(page.getPositionCount(), fieldVector).asBlock();
+      return eval(page.getPositionCount(), vVector).asBlock();
     }
   }
 
   @Override
   public long baseRamBytesUsed() {
     long baseRamBytesUsed = BASE_RAM_BYTES_USED;
-    baseRamBytesUsed += field.baseRamBytesUsed();
+    baseRamBytesUsed += v.baseRamBytesUsed();
     return baseRamBytesUsed;
   }
 
-  public IntBlock eval(int positionCount, IntBlock fieldBlock) {
+  public IntBlock eval(int positionCount, IntBlock vBlock) {
     try(IntBlock.Builder result = driverContext.blockFactory().newIntBlockBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        switch (fieldBlock.getValueCount(p)) {
+        switch (vBlock.getValueCount(p)) {
           case 0:
               result.appendNull();
               continue position;
@@ -99,18 +99,18 @@ public final class RoundToIntFloor9Evaluator implements ExpressionEvaluator {
               result.appendNull();
               continue position;
         }
-        int field = fieldBlock.getInt(fieldBlock.getFirstValueIndex(p));
-        result.appendInt(RoundToInt.process(field, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6, this.p7, this.p8));
+        int v = vBlock.getInt(vBlock.getFirstValueIndex(p));
+        result.appendInt(RoundToInt.floor9(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6, this.p7, this.p8));
       }
       return result.build();
     }
   }
 
-  public IntVector eval(int positionCount, IntVector fieldVector) {
+  public IntVector eval(int positionCount, IntVector vVector) {
     try(IntVector.FixedBuilder result = driverContext.blockFactory().newIntVectorFixedBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        int field = fieldVector.getInt(p);
-        result.appendInt(p, RoundToInt.process(field, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6, this.p7, this.p8));
+        int v = vVector.getInt(p);
+        result.appendInt(p, RoundToInt.floor9(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6, this.p7, this.p8));
       }
       return result.build();
     }
@@ -118,12 +118,12 @@ public final class RoundToIntFloor9Evaluator implements ExpressionEvaluator {
 
   @Override
   public String toString() {
-    return "RoundToIntFloor9Evaluator[" + "field=" + field + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + ", p7=" + p7 + ", p8=" + p8 + "]";
+    return "RoundToIntFloor9Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + ", p7=" + p7 + ", p8=" + p8 + "]";
   }
 
   @Override
   public void close() {
-    Releasables.closeExpectNoException(field);
+    Releasables.closeExpectNoException(v);
   }
 
   private Warnings warnings() {
@@ -136,7 +136,7 @@ public final class RoundToIntFloor9Evaluator implements ExpressionEvaluator {
   static class Factory implements ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final ExpressionEvaluator.Factory field;
+    private final ExpressionEvaluator.Factory v;
 
     private final int p0;
 
@@ -156,10 +156,10 @@ public final class RoundToIntFloor9Evaluator implements ExpressionEvaluator {
 
     private final int p8;
 
-    public Factory(Source source, ExpressionEvaluator.Factory field, int p0, int p1, int p2, int p3,
+    public Factory(Source source, ExpressionEvaluator.Factory v, int p0, int p1, int p2, int p3,
         int p4, int p5, int p6, int p7, int p8) {
       this.source = source;
-      this.field = field;
+      this.v = v;
       this.p0 = p0;
       this.p1 = p1;
       this.p2 = p2;
@@ -173,12 +173,12 @@ public final class RoundToIntFloor9Evaluator implements ExpressionEvaluator {
 
     @Override
     public RoundToIntFloor9Evaluator get(DriverContext context) {
-      return new RoundToIntFloor9Evaluator(source, field.get(context), p0, p1, p2, p3, p4, p5, p6, p7, p8, context);
+      return new RoundToIntFloor9Evaluator(source, v.get(context), p0, p1, p2, p3, p4, p5, p6, p7, p8, context);
     }
 
     @Override
     public String toString() {
-      return "RoundToIntFloor9Evaluator[" + "field=" + field + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + ", p7=" + p7 + ", p8=" + p8 + "]";
+      return "RoundToIntFloor9Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + ", p7=" + p7 + ", p8=" + p8 + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToIntFloorIntervalEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToIntFloorIntervalEvaluator.java
@@ -22,16 +22,16 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * {@link ExpressionEvaluator} implementation for {@link RoundToInt}.
  * This class is generated. Edit {@code EvaluatorImplementer} instead.
  */
-public final class RoundToIntFixedIntervalEvaluator implements ExpressionEvaluator {
-  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(RoundToIntFixedIntervalEvaluator.class);
+public final class RoundToIntFloorIntervalEvaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(RoundToIntFloorIntervalEvaluator.class);
 
   private final Source source;
 
-  private final ExpressionEvaluator field;
+  private final ExpressionEvaluator v;
 
-  private final int first;
+  private final int lo;
 
-  private final int last;
+  private final int hi;
 
   private final int interval;
 
@@ -39,38 +39,38 @@ public final class RoundToIntFixedIntervalEvaluator implements ExpressionEvaluat
 
   private Warnings warnings;
 
-  public RoundToIntFixedIntervalEvaluator(Source source, ExpressionEvaluator field, int first,
-      int last, int interval, DriverContext driverContext) {
+  public RoundToIntFloorIntervalEvaluator(Source source, ExpressionEvaluator v, int lo, int hi,
+      int interval, DriverContext driverContext) {
     this.source = source;
-    this.field = field;
-    this.first = first;
-    this.last = last;
+    this.v = v;
+    this.lo = lo;
+    this.hi = hi;
     this.interval = interval;
     this.driverContext = driverContext;
   }
 
   @Override
   public Block eval(Page page) {
-    try (IntBlock fieldBlock = (IntBlock) field.eval(page)) {
-      IntVector fieldVector = fieldBlock.asVector();
-      if (fieldVector == null) {
-        return eval(page.getPositionCount(), fieldBlock);
+    try (IntBlock vBlock = (IntBlock) v.eval(page)) {
+      IntVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
       }
-      return eval(page.getPositionCount(), fieldVector).asBlock();
+      return eval(page.getPositionCount(), vVector).asBlock();
     }
   }
 
   @Override
   public long baseRamBytesUsed() {
     long baseRamBytesUsed = BASE_RAM_BYTES_USED;
-    baseRamBytesUsed += field.baseRamBytesUsed();
+    baseRamBytesUsed += v.baseRamBytesUsed();
     return baseRamBytesUsed;
   }
 
-  public IntBlock eval(int positionCount, IntBlock fieldBlock) {
+  public IntBlock eval(int positionCount, IntBlock vBlock) {
     try(IntBlock.Builder result = driverContext.blockFactory().newIntBlockBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        switch (fieldBlock.getValueCount(p)) {
+        switch (vBlock.getValueCount(p)) {
           case 0:
               result.appendNull();
               continue position;
@@ -81,18 +81,18 @@ public final class RoundToIntFixedIntervalEvaluator implements ExpressionEvaluat
               result.appendNull();
               continue position;
         }
-        int field = fieldBlock.getInt(fieldBlock.getFirstValueIndex(p));
-        result.appendInt(RoundToInt.processFixed(field, this.first, this.last, this.interval));
+        int v = vBlock.getInt(vBlock.getFirstValueIndex(p));
+        result.appendInt(RoundToInt.floorInterval(v, this.lo, this.hi, this.interval));
       }
       return result.build();
     }
   }
 
-  public IntVector eval(int positionCount, IntVector fieldVector) {
+  public IntVector eval(int positionCount, IntVector vVector) {
     try(IntVector.FixedBuilder result = driverContext.blockFactory().newIntVectorFixedBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        int field = fieldVector.getInt(p);
-        result.appendInt(p, RoundToInt.processFixed(field, this.first, this.last, this.interval));
+        int v = vVector.getInt(p);
+        result.appendInt(p, RoundToInt.floorInterval(v, this.lo, this.hi, this.interval));
       }
       return result.build();
     }
@@ -100,12 +100,12 @@ public final class RoundToIntFixedIntervalEvaluator implements ExpressionEvaluat
 
   @Override
   public String toString() {
-    return "RoundToIntFixedIntervalEvaluator[" + "field=" + field + ", first=" + first + ", last=" + last + ", interval=" + interval + "]";
+    return "RoundToIntFloorIntervalEvaluator[" + "v=" + v + ", lo=" + lo + ", hi=" + hi + ", interval=" + interval + "]";
   }
 
   @Override
   public void close() {
-    Releasables.closeExpectNoException(field);
+    Releasables.closeExpectNoException(v);
   }
 
   private Warnings warnings() {
@@ -118,31 +118,30 @@ public final class RoundToIntFixedIntervalEvaluator implements ExpressionEvaluat
   static class Factory implements ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final ExpressionEvaluator.Factory field;
+    private final ExpressionEvaluator.Factory v;
 
-    private final int first;
+    private final int lo;
 
-    private final int last;
+    private final int hi;
 
     private final int interval;
 
-    public Factory(Source source, ExpressionEvaluator.Factory field, int first, int last,
-        int interval) {
+    public Factory(Source source, ExpressionEvaluator.Factory v, int lo, int hi, int interval) {
       this.source = source;
-      this.field = field;
-      this.first = first;
-      this.last = last;
+      this.v = v;
+      this.lo = lo;
+      this.hi = hi;
       this.interval = interval;
     }
 
     @Override
-    public RoundToIntFixedIntervalEvaluator get(DriverContext context) {
-      return new RoundToIntFixedIntervalEvaluator(source, field.get(context), first, last, interval, context);
+    public RoundToIntFloorIntervalEvaluator get(DriverContext context) {
+      return new RoundToIntFloorIntervalEvaluator(source, v.get(context), lo, hi, interval, context);
     }
 
     @Override
     public String toString() {
-      return "RoundToIntFixedIntervalEvaluator[" + "field=" + field + ", first=" + first + ", last=" + last + ", interval=" + interval + "]";
+      return "RoundToIntFloorIntervalEvaluator[" + "v=" + v + ", lo=" + lo + ", hi=" + hi + ", interval=" + interval + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToIntFloorSearchEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToIntFloorSearchEvaluator.java
@@ -22,49 +22,49 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * {@link ExpressionEvaluator} implementation for {@link RoundToInt}.
  * This class is generated. Edit {@code EvaluatorImplementer} instead.
  */
-public final class RoundToIntBinarySearchEvaluator implements ExpressionEvaluator {
-  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(RoundToIntBinarySearchEvaluator.class);
+public final class RoundToIntFloorSearchEvaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(RoundToIntFloorSearchEvaluator.class);
 
   private final Source source;
 
-  private final ExpressionEvaluator field;
+  private final ExpressionEvaluator v;
 
-  private final int[] points;
+  private final int[] p;
 
   private final DriverContext driverContext;
 
   private Warnings warnings;
 
-  public RoundToIntBinarySearchEvaluator(Source source, ExpressionEvaluator field, int[] points,
+  public RoundToIntFloorSearchEvaluator(Source source, ExpressionEvaluator v, int[] p,
       DriverContext driverContext) {
     this.source = source;
-    this.field = field;
-    this.points = points;
+    this.v = v;
+    this.p = p;
     this.driverContext = driverContext;
   }
 
   @Override
   public Block eval(Page page) {
-    try (IntBlock fieldBlock = (IntBlock) field.eval(page)) {
-      IntVector fieldVector = fieldBlock.asVector();
-      if (fieldVector == null) {
-        return eval(page.getPositionCount(), fieldBlock);
+    try (IntBlock vBlock = (IntBlock) v.eval(page)) {
+      IntVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
       }
-      return eval(page.getPositionCount(), fieldVector).asBlock();
+      return eval(page.getPositionCount(), vVector).asBlock();
     }
   }
 
   @Override
   public long baseRamBytesUsed() {
     long baseRamBytesUsed = BASE_RAM_BYTES_USED;
-    baseRamBytesUsed += field.baseRamBytesUsed();
+    baseRamBytesUsed += v.baseRamBytesUsed();
     return baseRamBytesUsed;
   }
 
-  public IntBlock eval(int positionCount, IntBlock fieldBlock) {
+  public IntBlock eval(int positionCount, IntBlock vBlock) {
     try(IntBlock.Builder result = driverContext.blockFactory().newIntBlockBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        switch (fieldBlock.getValueCount(p)) {
+        switch (vBlock.getValueCount(p)) {
           case 0:
               result.appendNull();
               continue position;
@@ -75,18 +75,18 @@ public final class RoundToIntBinarySearchEvaluator implements ExpressionEvaluato
               result.appendNull();
               continue position;
         }
-        int field = fieldBlock.getInt(fieldBlock.getFirstValueIndex(p));
-        result.appendInt(RoundToInt.process(field, this.points));
+        int v = vBlock.getInt(vBlock.getFirstValueIndex(p));
+        result.appendInt(RoundToInt.floorSearch(v, this.p));
       }
       return result.build();
     }
   }
 
-  public IntVector eval(int positionCount, IntVector fieldVector) {
+  public IntVector eval(int positionCount, IntVector vVector) {
     try(IntVector.FixedBuilder result = driverContext.blockFactory().newIntVectorFixedBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        int field = fieldVector.getInt(p);
-        result.appendInt(p, RoundToInt.process(field, this.points));
+        int v = vVector.getInt(p);
+        result.appendInt(p, RoundToInt.floorSearch(v, this.p));
       }
       return result.build();
     }
@@ -94,12 +94,12 @@ public final class RoundToIntBinarySearchEvaluator implements ExpressionEvaluato
 
   @Override
   public String toString() {
-    return "RoundToIntBinarySearchEvaluator[" + "field=" + field + "]";
+    return "RoundToIntFloorSearchEvaluator[" + "v=" + v + "]";
   }
 
   @Override
   public void close() {
-    Releasables.closeExpectNoException(field);
+    Releasables.closeExpectNoException(v);
   }
 
   private Warnings warnings() {
@@ -112,24 +112,24 @@ public final class RoundToIntBinarySearchEvaluator implements ExpressionEvaluato
   static class Factory implements ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final ExpressionEvaluator.Factory field;
+    private final ExpressionEvaluator.Factory v;
 
-    private final int[] points;
+    private final int[] p;
 
-    public Factory(Source source, ExpressionEvaluator.Factory field, int[] points) {
+    public Factory(Source source, ExpressionEvaluator.Factory v, int[] p) {
       this.source = source;
-      this.field = field;
-      this.points = points;
+      this.v = v;
+      this.p = p;
     }
 
     @Override
-    public RoundToIntBinarySearchEvaluator get(DriverContext context) {
-      return new RoundToIntBinarySearchEvaluator(source, field.get(context), points, context);
+    public RoundToIntFloorSearchEvaluator get(DriverContext context) {
+      return new RoundToIntFloorSearchEvaluator(source, v.get(context), p, context);
     }
 
     @Override
     public String toString() {
-      return "RoundToIntBinarySearchEvaluator[" + "field=" + field + "]";
+      return "RoundToIntFloorSearchEvaluator[" + "v=" + v + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLongCeiling10Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLongCeiling10Evaluator.java
@@ -1,0 +1,191 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.math;
+
+import java.lang.IllegalArgumentException;
+import java.lang.Override;
+import java.lang.String;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.LongVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+/**
+ * {@link ExpressionEvaluator} implementation for {@link RoundToLong}.
+ * This class is generated. Edit {@code EvaluatorImplementer} instead.
+ */
+public final class RoundToLongCeiling10Evaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(RoundToLongCeiling10Evaluator.class);
+
+  private final Source source;
+
+  private final ExpressionEvaluator v;
+
+  private final long p0;
+
+  private final long p1;
+
+  private final long p2;
+
+  private final long p3;
+
+  private final long p4;
+
+  private final long p5;
+
+  private final long p6;
+
+  private final long p7;
+
+  private final long p8;
+
+  private final long p9;
+
+  private final DriverContext driverContext;
+
+  private Warnings warnings;
+
+  public RoundToLongCeiling10Evaluator(Source source, ExpressionEvaluator v, long p0, long p1,
+      long p2, long p3, long p4, long p5, long p6, long p7, long p8, long p9,
+      DriverContext driverContext) {
+    this.source = source;
+    this.v = v;
+    this.p0 = p0;
+    this.p1 = p1;
+    this.p2 = p2;
+    this.p3 = p3;
+    this.p4 = p4;
+    this.p5 = p5;
+    this.p6 = p6;
+    this.p7 = p7;
+    this.p8 = p8;
+    this.p9 = p9;
+    this.driverContext = driverContext;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    try (LongBlock vBlock = (LongBlock) v.eval(page)) {
+      LongVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
+      }
+      return eval(page.getPositionCount(), vVector).asBlock();
+    }
+  }
+
+  @Override
+  public long baseRamBytesUsed() {
+    long baseRamBytesUsed = BASE_RAM_BYTES_USED;
+    baseRamBytesUsed += v.baseRamBytesUsed();
+    return baseRamBytesUsed;
+  }
+
+  public LongBlock eval(int positionCount, LongBlock vBlock) {
+    try(LongBlock.Builder result = driverContext.blockFactory().newLongBlockBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        switch (vBlock.getValueCount(p)) {
+          case 0:
+              result.appendNull();
+              continue position;
+          case 1:
+              break;
+          default:
+              warnings().registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+              result.appendNull();
+              continue position;
+        }
+        long v = vBlock.getLong(vBlock.getFirstValueIndex(p));
+        result.appendLong(RoundToLong.ceiling10(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6, this.p7, this.p8, this.p9));
+      }
+      return result.build();
+    }
+  }
+
+  public LongVector eval(int positionCount, LongVector vVector) {
+    try(LongVector.FixedBuilder result = driverContext.blockFactory().newLongVectorFixedBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        long v = vVector.getLong(p);
+        result.appendLong(p, RoundToLong.ceiling10(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6, this.p7, this.p8, this.p9));
+      }
+      return result.build();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "RoundToLongCeiling10Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + ", p7=" + p7 + ", p8=" + p8 + ", p9=" + p9 + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(v);
+  }
+
+  private Warnings warnings() {
+    if (warnings == null) {
+      this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+    }
+    return warnings;
+  }
+
+  static class Factory implements ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final ExpressionEvaluator.Factory v;
+
+    private final long p0;
+
+    private final long p1;
+
+    private final long p2;
+
+    private final long p3;
+
+    private final long p4;
+
+    private final long p5;
+
+    private final long p6;
+
+    private final long p7;
+
+    private final long p8;
+
+    private final long p9;
+
+    public Factory(Source source, ExpressionEvaluator.Factory v, long p0, long p1, long p2, long p3,
+        long p4, long p5, long p6, long p7, long p8, long p9) {
+      this.source = source;
+      this.v = v;
+      this.p0 = p0;
+      this.p1 = p1;
+      this.p2 = p2;
+      this.p3 = p3;
+      this.p4 = p4;
+      this.p5 = p5;
+      this.p6 = p6;
+      this.p7 = p7;
+      this.p8 = p8;
+      this.p9 = p9;
+    }
+
+    @Override
+    public RoundToLongCeiling10Evaluator get(DriverContext context) {
+      return new RoundToLongCeiling10Evaluator(source, v.get(context), p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, context);
+    }
+
+    @Override
+    public String toString() {
+      return "RoundToLongCeiling10Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + ", p7=" + p7 + ", p8=" + p8 + ", p9=" + p9 + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLongCeiling2Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLongCeiling2Evaluator.java
@@ -1,0 +1,141 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.math;
+
+import java.lang.IllegalArgumentException;
+import java.lang.Override;
+import java.lang.String;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.LongVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+/**
+ * {@link ExpressionEvaluator} implementation for {@link RoundToLong}.
+ * This class is generated. Edit {@code EvaluatorImplementer} instead.
+ */
+public final class RoundToLongCeiling2Evaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(RoundToLongCeiling2Evaluator.class);
+
+  private final Source source;
+
+  private final ExpressionEvaluator v;
+
+  private final long p0;
+
+  private final long p1;
+
+  private final DriverContext driverContext;
+
+  private Warnings warnings;
+
+  public RoundToLongCeiling2Evaluator(Source source, ExpressionEvaluator v, long p0, long p1,
+      DriverContext driverContext) {
+    this.source = source;
+    this.v = v;
+    this.p0 = p0;
+    this.p1 = p1;
+    this.driverContext = driverContext;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    try (LongBlock vBlock = (LongBlock) v.eval(page)) {
+      LongVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
+      }
+      return eval(page.getPositionCount(), vVector).asBlock();
+    }
+  }
+
+  @Override
+  public long baseRamBytesUsed() {
+    long baseRamBytesUsed = BASE_RAM_BYTES_USED;
+    baseRamBytesUsed += v.baseRamBytesUsed();
+    return baseRamBytesUsed;
+  }
+
+  public LongBlock eval(int positionCount, LongBlock vBlock) {
+    try(LongBlock.Builder result = driverContext.blockFactory().newLongBlockBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        switch (vBlock.getValueCount(p)) {
+          case 0:
+              result.appendNull();
+              continue position;
+          case 1:
+              break;
+          default:
+              warnings().registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+              result.appendNull();
+              continue position;
+        }
+        long v = vBlock.getLong(vBlock.getFirstValueIndex(p));
+        result.appendLong(RoundToLong.ceiling2(v, this.p0, this.p1));
+      }
+      return result.build();
+    }
+  }
+
+  public LongVector eval(int positionCount, LongVector vVector) {
+    try(LongVector.FixedBuilder result = driverContext.blockFactory().newLongVectorFixedBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        long v = vVector.getLong(p);
+        result.appendLong(p, RoundToLong.ceiling2(v, this.p0, this.p1));
+      }
+      return result.build();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "RoundToLongCeiling2Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(v);
+  }
+
+  private Warnings warnings() {
+    if (warnings == null) {
+      this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+    }
+    return warnings;
+  }
+
+  static class Factory implements ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final ExpressionEvaluator.Factory v;
+
+    private final long p0;
+
+    private final long p1;
+
+    public Factory(Source source, ExpressionEvaluator.Factory v, long p0, long p1) {
+      this.source = source;
+      this.v = v;
+      this.p0 = p0;
+      this.p1 = p1;
+    }
+
+    @Override
+    public RoundToLongCeiling2Evaluator get(DriverContext context) {
+      return new RoundToLongCeiling2Evaluator(source, v.get(context), p0, p1, context);
+    }
+
+    @Override
+    public String toString() {
+      return "RoundToLongCeiling2Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLongCeiling3Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLongCeiling3Evaluator.java
@@ -1,0 +1,147 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.math;
+
+import java.lang.IllegalArgumentException;
+import java.lang.Override;
+import java.lang.String;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.LongVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+/**
+ * {@link ExpressionEvaluator} implementation for {@link RoundToLong}.
+ * This class is generated. Edit {@code EvaluatorImplementer} instead.
+ */
+public final class RoundToLongCeiling3Evaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(RoundToLongCeiling3Evaluator.class);
+
+  private final Source source;
+
+  private final ExpressionEvaluator v;
+
+  private final long p0;
+
+  private final long p1;
+
+  private final long p2;
+
+  private final DriverContext driverContext;
+
+  private Warnings warnings;
+
+  public RoundToLongCeiling3Evaluator(Source source, ExpressionEvaluator v, long p0, long p1,
+      long p2, DriverContext driverContext) {
+    this.source = source;
+    this.v = v;
+    this.p0 = p0;
+    this.p1 = p1;
+    this.p2 = p2;
+    this.driverContext = driverContext;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    try (LongBlock vBlock = (LongBlock) v.eval(page)) {
+      LongVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
+      }
+      return eval(page.getPositionCount(), vVector).asBlock();
+    }
+  }
+
+  @Override
+  public long baseRamBytesUsed() {
+    long baseRamBytesUsed = BASE_RAM_BYTES_USED;
+    baseRamBytesUsed += v.baseRamBytesUsed();
+    return baseRamBytesUsed;
+  }
+
+  public LongBlock eval(int positionCount, LongBlock vBlock) {
+    try(LongBlock.Builder result = driverContext.blockFactory().newLongBlockBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        switch (vBlock.getValueCount(p)) {
+          case 0:
+              result.appendNull();
+              continue position;
+          case 1:
+              break;
+          default:
+              warnings().registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+              result.appendNull();
+              continue position;
+        }
+        long v = vBlock.getLong(vBlock.getFirstValueIndex(p));
+        result.appendLong(RoundToLong.ceiling3(v, this.p0, this.p1, this.p2));
+      }
+      return result.build();
+    }
+  }
+
+  public LongVector eval(int positionCount, LongVector vVector) {
+    try(LongVector.FixedBuilder result = driverContext.blockFactory().newLongVectorFixedBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        long v = vVector.getLong(p);
+        result.appendLong(p, RoundToLong.ceiling3(v, this.p0, this.p1, this.p2));
+      }
+      return result.build();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "RoundToLongCeiling3Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(v);
+  }
+
+  private Warnings warnings() {
+    if (warnings == null) {
+      this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+    }
+    return warnings;
+  }
+
+  static class Factory implements ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final ExpressionEvaluator.Factory v;
+
+    private final long p0;
+
+    private final long p1;
+
+    private final long p2;
+
+    public Factory(Source source, ExpressionEvaluator.Factory v, long p0, long p1, long p2) {
+      this.source = source;
+      this.v = v;
+      this.p0 = p0;
+      this.p1 = p1;
+      this.p2 = p2;
+    }
+
+    @Override
+    public RoundToLongCeiling3Evaluator get(DriverContext context) {
+      return new RoundToLongCeiling3Evaluator(source, v.get(context), p0, p1, p2, context);
+    }
+
+    @Override
+    public String toString() {
+      return "RoundToLongCeiling3Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLongCeiling4Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLongCeiling4Evaluator.java
@@ -1,0 +1,154 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.math;
+
+import java.lang.IllegalArgumentException;
+import java.lang.Override;
+import java.lang.String;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.LongVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+/**
+ * {@link ExpressionEvaluator} implementation for {@link RoundToLong}.
+ * This class is generated. Edit {@code EvaluatorImplementer} instead.
+ */
+public final class RoundToLongCeiling4Evaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(RoundToLongCeiling4Evaluator.class);
+
+  private final Source source;
+
+  private final ExpressionEvaluator v;
+
+  private final long p0;
+
+  private final long p1;
+
+  private final long p2;
+
+  private final long p3;
+
+  private final DriverContext driverContext;
+
+  private Warnings warnings;
+
+  public RoundToLongCeiling4Evaluator(Source source, ExpressionEvaluator v, long p0, long p1,
+      long p2, long p3, DriverContext driverContext) {
+    this.source = source;
+    this.v = v;
+    this.p0 = p0;
+    this.p1 = p1;
+    this.p2 = p2;
+    this.p3 = p3;
+    this.driverContext = driverContext;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    try (LongBlock vBlock = (LongBlock) v.eval(page)) {
+      LongVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
+      }
+      return eval(page.getPositionCount(), vVector).asBlock();
+    }
+  }
+
+  @Override
+  public long baseRamBytesUsed() {
+    long baseRamBytesUsed = BASE_RAM_BYTES_USED;
+    baseRamBytesUsed += v.baseRamBytesUsed();
+    return baseRamBytesUsed;
+  }
+
+  public LongBlock eval(int positionCount, LongBlock vBlock) {
+    try(LongBlock.Builder result = driverContext.blockFactory().newLongBlockBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        switch (vBlock.getValueCount(p)) {
+          case 0:
+              result.appendNull();
+              continue position;
+          case 1:
+              break;
+          default:
+              warnings().registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+              result.appendNull();
+              continue position;
+        }
+        long v = vBlock.getLong(vBlock.getFirstValueIndex(p));
+        result.appendLong(RoundToLong.ceiling4(v, this.p0, this.p1, this.p2, this.p3));
+      }
+      return result.build();
+    }
+  }
+
+  public LongVector eval(int positionCount, LongVector vVector) {
+    try(LongVector.FixedBuilder result = driverContext.blockFactory().newLongVectorFixedBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        long v = vVector.getLong(p);
+        result.appendLong(p, RoundToLong.ceiling4(v, this.p0, this.p1, this.p2, this.p3));
+      }
+      return result.build();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "RoundToLongCeiling4Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(v);
+  }
+
+  private Warnings warnings() {
+    if (warnings == null) {
+      this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+    }
+    return warnings;
+  }
+
+  static class Factory implements ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final ExpressionEvaluator.Factory v;
+
+    private final long p0;
+
+    private final long p1;
+
+    private final long p2;
+
+    private final long p3;
+
+    public Factory(Source source, ExpressionEvaluator.Factory v, long p0, long p1, long p2,
+        long p3) {
+      this.source = source;
+      this.v = v;
+      this.p0 = p0;
+      this.p1 = p1;
+      this.p2 = p2;
+      this.p3 = p3;
+    }
+
+    @Override
+    public RoundToLongCeiling4Evaluator get(DriverContext context) {
+      return new RoundToLongCeiling4Evaluator(source, v.get(context), p0, p1, p2, p3, context);
+    }
+
+    @Override
+    public String toString() {
+      return "RoundToLongCeiling4Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLongCeiling5Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLongCeiling5Evaluator.java
@@ -1,0 +1,160 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.math;
+
+import java.lang.IllegalArgumentException;
+import java.lang.Override;
+import java.lang.String;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.LongVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+/**
+ * {@link ExpressionEvaluator} implementation for {@link RoundToLong}.
+ * This class is generated. Edit {@code EvaluatorImplementer} instead.
+ */
+public final class RoundToLongCeiling5Evaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(RoundToLongCeiling5Evaluator.class);
+
+  private final Source source;
+
+  private final ExpressionEvaluator v;
+
+  private final long p0;
+
+  private final long p1;
+
+  private final long p2;
+
+  private final long p3;
+
+  private final long p4;
+
+  private final DriverContext driverContext;
+
+  private Warnings warnings;
+
+  public RoundToLongCeiling5Evaluator(Source source, ExpressionEvaluator v, long p0, long p1,
+      long p2, long p3, long p4, DriverContext driverContext) {
+    this.source = source;
+    this.v = v;
+    this.p0 = p0;
+    this.p1 = p1;
+    this.p2 = p2;
+    this.p3 = p3;
+    this.p4 = p4;
+    this.driverContext = driverContext;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    try (LongBlock vBlock = (LongBlock) v.eval(page)) {
+      LongVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
+      }
+      return eval(page.getPositionCount(), vVector).asBlock();
+    }
+  }
+
+  @Override
+  public long baseRamBytesUsed() {
+    long baseRamBytesUsed = BASE_RAM_BYTES_USED;
+    baseRamBytesUsed += v.baseRamBytesUsed();
+    return baseRamBytesUsed;
+  }
+
+  public LongBlock eval(int positionCount, LongBlock vBlock) {
+    try(LongBlock.Builder result = driverContext.blockFactory().newLongBlockBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        switch (vBlock.getValueCount(p)) {
+          case 0:
+              result.appendNull();
+              continue position;
+          case 1:
+              break;
+          default:
+              warnings().registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+              result.appendNull();
+              continue position;
+        }
+        long v = vBlock.getLong(vBlock.getFirstValueIndex(p));
+        result.appendLong(RoundToLong.ceiling5(v, this.p0, this.p1, this.p2, this.p3, this.p4));
+      }
+      return result.build();
+    }
+  }
+
+  public LongVector eval(int positionCount, LongVector vVector) {
+    try(LongVector.FixedBuilder result = driverContext.blockFactory().newLongVectorFixedBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        long v = vVector.getLong(p);
+        result.appendLong(p, RoundToLong.ceiling5(v, this.p0, this.p1, this.p2, this.p3, this.p4));
+      }
+      return result.build();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "RoundToLongCeiling5Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(v);
+  }
+
+  private Warnings warnings() {
+    if (warnings == null) {
+      this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+    }
+    return warnings;
+  }
+
+  static class Factory implements ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final ExpressionEvaluator.Factory v;
+
+    private final long p0;
+
+    private final long p1;
+
+    private final long p2;
+
+    private final long p3;
+
+    private final long p4;
+
+    public Factory(Source source, ExpressionEvaluator.Factory v, long p0, long p1, long p2, long p3,
+        long p4) {
+      this.source = source;
+      this.v = v;
+      this.p0 = p0;
+      this.p1 = p1;
+      this.p2 = p2;
+      this.p3 = p3;
+      this.p4 = p4;
+    }
+
+    @Override
+    public RoundToLongCeiling5Evaluator get(DriverContext context) {
+      return new RoundToLongCeiling5Evaluator(source, v.get(context), p0, p1, p2, p3, p4, context);
+    }
+
+    @Override
+    public String toString() {
+      return "RoundToLongCeiling5Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLongCeiling6Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLongCeiling6Evaluator.java
@@ -1,0 +1,166 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.math;
+
+import java.lang.IllegalArgumentException;
+import java.lang.Override;
+import java.lang.String;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.LongVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+/**
+ * {@link ExpressionEvaluator} implementation for {@link RoundToLong}.
+ * This class is generated. Edit {@code EvaluatorImplementer} instead.
+ */
+public final class RoundToLongCeiling6Evaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(RoundToLongCeiling6Evaluator.class);
+
+  private final Source source;
+
+  private final ExpressionEvaluator v;
+
+  private final long p0;
+
+  private final long p1;
+
+  private final long p2;
+
+  private final long p3;
+
+  private final long p4;
+
+  private final long p5;
+
+  private final DriverContext driverContext;
+
+  private Warnings warnings;
+
+  public RoundToLongCeiling6Evaluator(Source source, ExpressionEvaluator v, long p0, long p1,
+      long p2, long p3, long p4, long p5, DriverContext driverContext) {
+    this.source = source;
+    this.v = v;
+    this.p0 = p0;
+    this.p1 = p1;
+    this.p2 = p2;
+    this.p3 = p3;
+    this.p4 = p4;
+    this.p5 = p5;
+    this.driverContext = driverContext;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    try (LongBlock vBlock = (LongBlock) v.eval(page)) {
+      LongVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
+      }
+      return eval(page.getPositionCount(), vVector).asBlock();
+    }
+  }
+
+  @Override
+  public long baseRamBytesUsed() {
+    long baseRamBytesUsed = BASE_RAM_BYTES_USED;
+    baseRamBytesUsed += v.baseRamBytesUsed();
+    return baseRamBytesUsed;
+  }
+
+  public LongBlock eval(int positionCount, LongBlock vBlock) {
+    try(LongBlock.Builder result = driverContext.blockFactory().newLongBlockBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        switch (vBlock.getValueCount(p)) {
+          case 0:
+              result.appendNull();
+              continue position;
+          case 1:
+              break;
+          default:
+              warnings().registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+              result.appendNull();
+              continue position;
+        }
+        long v = vBlock.getLong(vBlock.getFirstValueIndex(p));
+        result.appendLong(RoundToLong.ceiling6(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5));
+      }
+      return result.build();
+    }
+  }
+
+  public LongVector eval(int positionCount, LongVector vVector) {
+    try(LongVector.FixedBuilder result = driverContext.blockFactory().newLongVectorFixedBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        long v = vVector.getLong(p);
+        result.appendLong(p, RoundToLong.ceiling6(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5));
+      }
+      return result.build();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "RoundToLongCeiling6Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(v);
+  }
+
+  private Warnings warnings() {
+    if (warnings == null) {
+      this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+    }
+    return warnings;
+  }
+
+  static class Factory implements ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final ExpressionEvaluator.Factory v;
+
+    private final long p0;
+
+    private final long p1;
+
+    private final long p2;
+
+    private final long p3;
+
+    private final long p4;
+
+    private final long p5;
+
+    public Factory(Source source, ExpressionEvaluator.Factory v, long p0, long p1, long p2, long p3,
+        long p4, long p5) {
+      this.source = source;
+      this.v = v;
+      this.p0 = p0;
+      this.p1 = p1;
+      this.p2 = p2;
+      this.p3 = p3;
+      this.p4 = p4;
+      this.p5 = p5;
+    }
+
+    @Override
+    public RoundToLongCeiling6Evaluator get(DriverContext context) {
+      return new RoundToLongCeiling6Evaluator(source, v.get(context), p0, p1, p2, p3, p4, p5, context);
+    }
+
+    @Override
+    public String toString() {
+      return "RoundToLongCeiling6Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLongCeiling7Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLongCeiling7Evaluator.java
@@ -1,0 +1,172 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.math;
+
+import java.lang.IllegalArgumentException;
+import java.lang.Override;
+import java.lang.String;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.LongVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+/**
+ * {@link ExpressionEvaluator} implementation for {@link RoundToLong}.
+ * This class is generated. Edit {@code EvaluatorImplementer} instead.
+ */
+public final class RoundToLongCeiling7Evaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(RoundToLongCeiling7Evaluator.class);
+
+  private final Source source;
+
+  private final ExpressionEvaluator v;
+
+  private final long p0;
+
+  private final long p1;
+
+  private final long p2;
+
+  private final long p3;
+
+  private final long p4;
+
+  private final long p5;
+
+  private final long p6;
+
+  private final DriverContext driverContext;
+
+  private Warnings warnings;
+
+  public RoundToLongCeiling7Evaluator(Source source, ExpressionEvaluator v, long p0, long p1,
+      long p2, long p3, long p4, long p5, long p6, DriverContext driverContext) {
+    this.source = source;
+    this.v = v;
+    this.p0 = p0;
+    this.p1 = p1;
+    this.p2 = p2;
+    this.p3 = p3;
+    this.p4 = p4;
+    this.p5 = p5;
+    this.p6 = p6;
+    this.driverContext = driverContext;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    try (LongBlock vBlock = (LongBlock) v.eval(page)) {
+      LongVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
+      }
+      return eval(page.getPositionCount(), vVector).asBlock();
+    }
+  }
+
+  @Override
+  public long baseRamBytesUsed() {
+    long baseRamBytesUsed = BASE_RAM_BYTES_USED;
+    baseRamBytesUsed += v.baseRamBytesUsed();
+    return baseRamBytesUsed;
+  }
+
+  public LongBlock eval(int positionCount, LongBlock vBlock) {
+    try(LongBlock.Builder result = driverContext.blockFactory().newLongBlockBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        switch (vBlock.getValueCount(p)) {
+          case 0:
+              result.appendNull();
+              continue position;
+          case 1:
+              break;
+          default:
+              warnings().registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+              result.appendNull();
+              continue position;
+        }
+        long v = vBlock.getLong(vBlock.getFirstValueIndex(p));
+        result.appendLong(RoundToLong.ceiling7(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6));
+      }
+      return result.build();
+    }
+  }
+
+  public LongVector eval(int positionCount, LongVector vVector) {
+    try(LongVector.FixedBuilder result = driverContext.blockFactory().newLongVectorFixedBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        long v = vVector.getLong(p);
+        result.appendLong(p, RoundToLong.ceiling7(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6));
+      }
+      return result.build();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "RoundToLongCeiling7Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(v);
+  }
+
+  private Warnings warnings() {
+    if (warnings == null) {
+      this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+    }
+    return warnings;
+  }
+
+  static class Factory implements ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final ExpressionEvaluator.Factory v;
+
+    private final long p0;
+
+    private final long p1;
+
+    private final long p2;
+
+    private final long p3;
+
+    private final long p4;
+
+    private final long p5;
+
+    private final long p6;
+
+    public Factory(Source source, ExpressionEvaluator.Factory v, long p0, long p1, long p2, long p3,
+        long p4, long p5, long p6) {
+      this.source = source;
+      this.v = v;
+      this.p0 = p0;
+      this.p1 = p1;
+      this.p2 = p2;
+      this.p3 = p3;
+      this.p4 = p4;
+      this.p5 = p5;
+      this.p6 = p6;
+    }
+
+    @Override
+    public RoundToLongCeiling7Evaluator get(DriverContext context) {
+      return new RoundToLongCeiling7Evaluator(source, v.get(context), p0, p1, p2, p3, p4, p5, p6, context);
+    }
+
+    @Override
+    public String toString() {
+      return "RoundToLongCeiling7Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLongCeiling8Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLongCeiling8Evaluator.java
@@ -1,0 +1,178 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.math;
+
+import java.lang.IllegalArgumentException;
+import java.lang.Override;
+import java.lang.String;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.LongVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+/**
+ * {@link ExpressionEvaluator} implementation for {@link RoundToLong}.
+ * This class is generated. Edit {@code EvaluatorImplementer} instead.
+ */
+public final class RoundToLongCeiling8Evaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(RoundToLongCeiling8Evaluator.class);
+
+  private final Source source;
+
+  private final ExpressionEvaluator v;
+
+  private final long p0;
+
+  private final long p1;
+
+  private final long p2;
+
+  private final long p3;
+
+  private final long p4;
+
+  private final long p5;
+
+  private final long p6;
+
+  private final long p7;
+
+  private final DriverContext driverContext;
+
+  private Warnings warnings;
+
+  public RoundToLongCeiling8Evaluator(Source source, ExpressionEvaluator v, long p0, long p1,
+      long p2, long p3, long p4, long p5, long p6, long p7, DriverContext driverContext) {
+    this.source = source;
+    this.v = v;
+    this.p0 = p0;
+    this.p1 = p1;
+    this.p2 = p2;
+    this.p3 = p3;
+    this.p4 = p4;
+    this.p5 = p5;
+    this.p6 = p6;
+    this.p7 = p7;
+    this.driverContext = driverContext;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    try (LongBlock vBlock = (LongBlock) v.eval(page)) {
+      LongVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
+      }
+      return eval(page.getPositionCount(), vVector).asBlock();
+    }
+  }
+
+  @Override
+  public long baseRamBytesUsed() {
+    long baseRamBytesUsed = BASE_RAM_BYTES_USED;
+    baseRamBytesUsed += v.baseRamBytesUsed();
+    return baseRamBytesUsed;
+  }
+
+  public LongBlock eval(int positionCount, LongBlock vBlock) {
+    try(LongBlock.Builder result = driverContext.blockFactory().newLongBlockBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        switch (vBlock.getValueCount(p)) {
+          case 0:
+              result.appendNull();
+              continue position;
+          case 1:
+              break;
+          default:
+              warnings().registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+              result.appendNull();
+              continue position;
+        }
+        long v = vBlock.getLong(vBlock.getFirstValueIndex(p));
+        result.appendLong(RoundToLong.ceiling8(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6, this.p7));
+      }
+      return result.build();
+    }
+  }
+
+  public LongVector eval(int positionCount, LongVector vVector) {
+    try(LongVector.FixedBuilder result = driverContext.blockFactory().newLongVectorFixedBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        long v = vVector.getLong(p);
+        result.appendLong(p, RoundToLong.ceiling8(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6, this.p7));
+      }
+      return result.build();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "RoundToLongCeiling8Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + ", p7=" + p7 + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(v);
+  }
+
+  private Warnings warnings() {
+    if (warnings == null) {
+      this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+    }
+    return warnings;
+  }
+
+  static class Factory implements ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final ExpressionEvaluator.Factory v;
+
+    private final long p0;
+
+    private final long p1;
+
+    private final long p2;
+
+    private final long p3;
+
+    private final long p4;
+
+    private final long p5;
+
+    private final long p6;
+
+    private final long p7;
+
+    public Factory(Source source, ExpressionEvaluator.Factory v, long p0, long p1, long p2, long p3,
+        long p4, long p5, long p6, long p7) {
+      this.source = source;
+      this.v = v;
+      this.p0 = p0;
+      this.p1 = p1;
+      this.p2 = p2;
+      this.p3 = p3;
+      this.p4 = p4;
+      this.p5 = p5;
+      this.p6 = p6;
+      this.p7 = p7;
+    }
+
+    @Override
+    public RoundToLongCeiling8Evaluator get(DriverContext context) {
+      return new RoundToLongCeiling8Evaluator(source, v.get(context), p0, p1, p2, p3, p4, p5, p6, p7, context);
+    }
+
+    @Override
+    public String toString() {
+      return "RoundToLongCeiling8Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + ", p7=" + p7 + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLongCeiling9Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLongCeiling9Evaluator.java
@@ -1,0 +1,184 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.math;
+
+import java.lang.IllegalArgumentException;
+import java.lang.Override;
+import java.lang.String;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.LongVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+/**
+ * {@link ExpressionEvaluator} implementation for {@link RoundToLong}.
+ * This class is generated. Edit {@code EvaluatorImplementer} instead.
+ */
+public final class RoundToLongCeiling9Evaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(RoundToLongCeiling9Evaluator.class);
+
+  private final Source source;
+
+  private final ExpressionEvaluator v;
+
+  private final long p0;
+
+  private final long p1;
+
+  private final long p2;
+
+  private final long p3;
+
+  private final long p4;
+
+  private final long p5;
+
+  private final long p6;
+
+  private final long p7;
+
+  private final long p8;
+
+  private final DriverContext driverContext;
+
+  private Warnings warnings;
+
+  public RoundToLongCeiling9Evaluator(Source source, ExpressionEvaluator v, long p0, long p1,
+      long p2, long p3, long p4, long p5, long p6, long p7, long p8, DriverContext driverContext) {
+    this.source = source;
+    this.v = v;
+    this.p0 = p0;
+    this.p1 = p1;
+    this.p2 = p2;
+    this.p3 = p3;
+    this.p4 = p4;
+    this.p5 = p5;
+    this.p6 = p6;
+    this.p7 = p7;
+    this.p8 = p8;
+    this.driverContext = driverContext;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    try (LongBlock vBlock = (LongBlock) v.eval(page)) {
+      LongVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
+      }
+      return eval(page.getPositionCount(), vVector).asBlock();
+    }
+  }
+
+  @Override
+  public long baseRamBytesUsed() {
+    long baseRamBytesUsed = BASE_RAM_BYTES_USED;
+    baseRamBytesUsed += v.baseRamBytesUsed();
+    return baseRamBytesUsed;
+  }
+
+  public LongBlock eval(int positionCount, LongBlock vBlock) {
+    try(LongBlock.Builder result = driverContext.blockFactory().newLongBlockBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        switch (vBlock.getValueCount(p)) {
+          case 0:
+              result.appendNull();
+              continue position;
+          case 1:
+              break;
+          default:
+              warnings().registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+              result.appendNull();
+              continue position;
+        }
+        long v = vBlock.getLong(vBlock.getFirstValueIndex(p));
+        result.appendLong(RoundToLong.ceiling9(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6, this.p7, this.p8));
+      }
+      return result.build();
+    }
+  }
+
+  public LongVector eval(int positionCount, LongVector vVector) {
+    try(LongVector.FixedBuilder result = driverContext.blockFactory().newLongVectorFixedBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        long v = vVector.getLong(p);
+        result.appendLong(p, RoundToLong.ceiling9(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6, this.p7, this.p8));
+      }
+      return result.build();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "RoundToLongCeiling9Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + ", p7=" + p7 + ", p8=" + p8 + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(v);
+  }
+
+  private Warnings warnings() {
+    if (warnings == null) {
+      this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+    }
+    return warnings;
+  }
+
+  static class Factory implements ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final ExpressionEvaluator.Factory v;
+
+    private final long p0;
+
+    private final long p1;
+
+    private final long p2;
+
+    private final long p3;
+
+    private final long p4;
+
+    private final long p5;
+
+    private final long p6;
+
+    private final long p7;
+
+    private final long p8;
+
+    public Factory(Source source, ExpressionEvaluator.Factory v, long p0, long p1, long p2, long p3,
+        long p4, long p5, long p6, long p7, long p8) {
+      this.source = source;
+      this.v = v;
+      this.p0 = p0;
+      this.p1 = p1;
+      this.p2 = p2;
+      this.p3 = p3;
+      this.p4 = p4;
+      this.p5 = p5;
+      this.p6 = p6;
+      this.p7 = p7;
+      this.p8 = p8;
+    }
+
+    @Override
+    public RoundToLongCeiling9Evaluator get(DriverContext context) {
+      return new RoundToLongCeiling9Evaluator(source, v.get(context), p0, p1, p2, p3, p4, p5, p6, p7, p8, context);
+    }
+
+    @Override
+    public String toString() {
+      return "RoundToLongCeiling9Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + ", p7=" + p7 + ", p8=" + p8 + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLongCeilingIntervalEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLongCeilingIntervalEvaluator.java
@@ -1,0 +1,147 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.math;
+
+import java.lang.IllegalArgumentException;
+import java.lang.Override;
+import java.lang.String;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.LongVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+/**
+ * {@link ExpressionEvaluator} implementation for {@link RoundToLong}.
+ * This class is generated. Edit {@code EvaluatorImplementer} instead.
+ */
+public final class RoundToLongCeilingIntervalEvaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(RoundToLongCeilingIntervalEvaluator.class);
+
+  private final Source source;
+
+  private final ExpressionEvaluator v;
+
+  private final long lo;
+
+  private final long hi;
+
+  private final long interval;
+
+  private final DriverContext driverContext;
+
+  private Warnings warnings;
+
+  public RoundToLongCeilingIntervalEvaluator(Source source, ExpressionEvaluator v, long lo, long hi,
+      long interval, DriverContext driverContext) {
+    this.source = source;
+    this.v = v;
+    this.lo = lo;
+    this.hi = hi;
+    this.interval = interval;
+    this.driverContext = driverContext;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    try (LongBlock vBlock = (LongBlock) v.eval(page)) {
+      LongVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
+      }
+      return eval(page.getPositionCount(), vVector).asBlock();
+    }
+  }
+
+  @Override
+  public long baseRamBytesUsed() {
+    long baseRamBytesUsed = BASE_RAM_BYTES_USED;
+    baseRamBytesUsed += v.baseRamBytesUsed();
+    return baseRamBytesUsed;
+  }
+
+  public LongBlock eval(int positionCount, LongBlock vBlock) {
+    try(LongBlock.Builder result = driverContext.blockFactory().newLongBlockBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        switch (vBlock.getValueCount(p)) {
+          case 0:
+              result.appendNull();
+              continue position;
+          case 1:
+              break;
+          default:
+              warnings().registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+              result.appendNull();
+              continue position;
+        }
+        long v = vBlock.getLong(vBlock.getFirstValueIndex(p));
+        result.appendLong(RoundToLong.ceilingInterval(v, this.lo, this.hi, this.interval));
+      }
+      return result.build();
+    }
+  }
+
+  public LongVector eval(int positionCount, LongVector vVector) {
+    try(LongVector.FixedBuilder result = driverContext.blockFactory().newLongVectorFixedBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        long v = vVector.getLong(p);
+        result.appendLong(p, RoundToLong.ceilingInterval(v, this.lo, this.hi, this.interval));
+      }
+      return result.build();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "RoundToLongCeilingIntervalEvaluator[" + "v=" + v + ", lo=" + lo + ", hi=" + hi + ", interval=" + interval + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(v);
+  }
+
+  private Warnings warnings() {
+    if (warnings == null) {
+      this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+    }
+    return warnings;
+  }
+
+  static class Factory implements ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final ExpressionEvaluator.Factory v;
+
+    private final long lo;
+
+    private final long hi;
+
+    private final long interval;
+
+    public Factory(Source source, ExpressionEvaluator.Factory v, long lo, long hi, long interval) {
+      this.source = source;
+      this.v = v;
+      this.lo = lo;
+      this.hi = hi;
+      this.interval = interval;
+    }
+
+    @Override
+    public RoundToLongCeilingIntervalEvaluator get(DriverContext context) {
+      return new RoundToLongCeilingIntervalEvaluator(source, v.get(context), lo, hi, interval, context);
+    }
+
+    @Override
+    public String toString() {
+      return "RoundToLongCeilingIntervalEvaluator[" + "v=" + v + ", lo=" + lo + ", hi=" + hi + ", interval=" + interval + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLongCeilingSearchEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLongCeilingSearchEvaluator.java
@@ -1,0 +1,135 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.math;
+
+import java.lang.IllegalArgumentException;
+import java.lang.Override;
+import java.lang.String;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.LongVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+/**
+ * {@link ExpressionEvaluator} implementation for {@link RoundToLong}.
+ * This class is generated. Edit {@code EvaluatorImplementer} instead.
+ */
+public final class RoundToLongCeilingSearchEvaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(RoundToLongCeilingSearchEvaluator.class);
+
+  private final Source source;
+
+  private final ExpressionEvaluator v;
+
+  private final long[] p;
+
+  private final DriverContext driverContext;
+
+  private Warnings warnings;
+
+  public RoundToLongCeilingSearchEvaluator(Source source, ExpressionEvaluator v, long[] p,
+      DriverContext driverContext) {
+    this.source = source;
+    this.v = v;
+    this.p = p;
+    this.driverContext = driverContext;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    try (LongBlock vBlock = (LongBlock) v.eval(page)) {
+      LongVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
+      }
+      return eval(page.getPositionCount(), vVector).asBlock();
+    }
+  }
+
+  @Override
+  public long baseRamBytesUsed() {
+    long baseRamBytesUsed = BASE_RAM_BYTES_USED;
+    baseRamBytesUsed += v.baseRamBytesUsed();
+    return baseRamBytesUsed;
+  }
+
+  public LongBlock eval(int positionCount, LongBlock vBlock) {
+    try(LongBlock.Builder result = driverContext.blockFactory().newLongBlockBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        switch (vBlock.getValueCount(p)) {
+          case 0:
+              result.appendNull();
+              continue position;
+          case 1:
+              break;
+          default:
+              warnings().registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+              result.appendNull();
+              continue position;
+        }
+        long v = vBlock.getLong(vBlock.getFirstValueIndex(p));
+        result.appendLong(RoundToLong.ceilingSearch(v, this.p));
+      }
+      return result.build();
+    }
+  }
+
+  public LongVector eval(int positionCount, LongVector vVector) {
+    try(LongVector.FixedBuilder result = driverContext.blockFactory().newLongVectorFixedBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        long v = vVector.getLong(p);
+        result.appendLong(p, RoundToLong.ceilingSearch(v, this.p));
+      }
+      return result.build();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "RoundToLongCeilingSearchEvaluator[" + "v=" + v + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(v);
+  }
+
+  private Warnings warnings() {
+    if (warnings == null) {
+      this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+    }
+    return warnings;
+  }
+
+  static class Factory implements ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final ExpressionEvaluator.Factory v;
+
+    private final long[] p;
+
+    public Factory(Source source, ExpressionEvaluator.Factory v, long[] p) {
+      this.source = source;
+      this.v = v;
+      this.p = p;
+    }
+
+    @Override
+    public RoundToLongCeilingSearchEvaluator get(DriverContext context) {
+      return new RoundToLongCeilingSearchEvaluator(source, v.get(context), p, context);
+    }
+
+    @Override
+    public String toString() {
+      return "RoundToLongCeilingSearchEvaluator[" + "v=" + v + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLongConstantEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLongConstantEvaluator.java
@@ -1,0 +1,135 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.math;
+
+import java.lang.IllegalArgumentException;
+import java.lang.Override;
+import java.lang.String;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.LongVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+/**
+ * {@link ExpressionEvaluator} implementation for {@link RoundToLong}.
+ * This class is generated. Edit {@code EvaluatorImplementer} instead.
+ */
+public final class RoundToLongConstantEvaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(RoundToLongConstantEvaluator.class);
+
+  private final Source source;
+
+  private final ExpressionEvaluator v;
+
+  private final long p;
+
+  private final DriverContext driverContext;
+
+  private Warnings warnings;
+
+  public RoundToLongConstantEvaluator(Source source, ExpressionEvaluator v, long p,
+      DriverContext driverContext) {
+    this.source = source;
+    this.v = v;
+    this.p = p;
+    this.driverContext = driverContext;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    try (LongBlock vBlock = (LongBlock) v.eval(page)) {
+      LongVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
+      }
+      return eval(page.getPositionCount(), vVector).asBlock();
+    }
+  }
+
+  @Override
+  public long baseRamBytesUsed() {
+    long baseRamBytesUsed = BASE_RAM_BYTES_USED;
+    baseRamBytesUsed += v.baseRamBytesUsed();
+    return baseRamBytesUsed;
+  }
+
+  public LongBlock eval(int positionCount, LongBlock vBlock) {
+    try(LongBlock.Builder result = driverContext.blockFactory().newLongBlockBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        switch (vBlock.getValueCount(p)) {
+          case 0:
+              result.appendNull();
+              continue position;
+          case 1:
+              break;
+          default:
+              warnings().registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+              result.appendNull();
+              continue position;
+        }
+        long v = vBlock.getLong(vBlock.getFirstValueIndex(p));
+        result.appendLong(RoundToLong.constant(v, this.p));
+      }
+      return result.build();
+    }
+  }
+
+  public LongVector eval(int positionCount, LongVector vVector) {
+    try(LongVector.FixedBuilder result = driverContext.blockFactory().newLongVectorFixedBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        long v = vVector.getLong(p);
+        result.appendLong(p, RoundToLong.constant(v, this.p));
+      }
+      return result.build();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "RoundToLongConstantEvaluator[" + "v=" + v + ", p=" + p + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(v);
+  }
+
+  private Warnings warnings() {
+    if (warnings == null) {
+      this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+    }
+    return warnings;
+  }
+
+  static class Factory implements ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final ExpressionEvaluator.Factory v;
+
+    private final long p;
+
+    public Factory(Source source, ExpressionEvaluator.Factory v, long p) {
+      this.source = source;
+      this.v = v;
+      this.p = p;
+    }
+
+    @Override
+    public RoundToLongConstantEvaluator get(DriverContext context) {
+      return new RoundToLongConstantEvaluator(source, v.get(context), p, context);
+    }
+
+    @Override
+    public String toString() {
+      return "RoundToLongConstantEvaluator[" + "v=" + v + ", p=" + p + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLongFloor10Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLongFloor10Evaluator.java
@@ -27,7 +27,7 @@ public final class RoundToLongFloor10Evaluator implements ExpressionEvaluator {
 
   private final Source source;
 
-  private final ExpressionEvaluator field;
+  private final ExpressionEvaluator v;
 
   private final long p0;
 
@@ -53,10 +53,11 @@ public final class RoundToLongFloor10Evaluator implements ExpressionEvaluator {
 
   private Warnings warnings;
 
-  public RoundToLongFloor10Evaluator(Source source, ExpressionEvaluator field, long p0, long p1, long p2,
-      long p3, long p4, long p5, long p6, long p7, long p8, long p9, DriverContext driverContext) {
+  public RoundToLongFloor10Evaluator(Source source, ExpressionEvaluator v, long p0, long p1,
+      long p2, long p3, long p4, long p5, long p6, long p7, long p8, long p9,
+      DriverContext driverContext) {
     this.source = source;
-    this.field = field;
+    this.v = v;
     this.p0 = p0;
     this.p1 = p1;
     this.p2 = p2;
@@ -72,26 +73,26 @@ public final class RoundToLongFloor10Evaluator implements ExpressionEvaluator {
 
   @Override
   public Block eval(Page page) {
-    try (LongBlock fieldBlock = (LongBlock) field.eval(page)) {
-      LongVector fieldVector = fieldBlock.asVector();
-      if (fieldVector == null) {
-        return eval(page.getPositionCount(), fieldBlock);
+    try (LongBlock vBlock = (LongBlock) v.eval(page)) {
+      LongVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
       }
-      return eval(page.getPositionCount(), fieldVector).asBlock();
+      return eval(page.getPositionCount(), vVector).asBlock();
     }
   }
 
   @Override
   public long baseRamBytesUsed() {
     long baseRamBytesUsed = BASE_RAM_BYTES_USED;
-    baseRamBytesUsed += field.baseRamBytesUsed();
+    baseRamBytesUsed += v.baseRamBytesUsed();
     return baseRamBytesUsed;
   }
 
-  public LongBlock eval(int positionCount, LongBlock fieldBlock) {
+  public LongBlock eval(int positionCount, LongBlock vBlock) {
     try(LongBlock.Builder result = driverContext.blockFactory().newLongBlockBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        switch (fieldBlock.getValueCount(p)) {
+        switch (vBlock.getValueCount(p)) {
           case 0:
               result.appendNull();
               continue position;
@@ -102,18 +103,18 @@ public final class RoundToLongFloor10Evaluator implements ExpressionEvaluator {
               result.appendNull();
               continue position;
         }
-        long field = fieldBlock.getLong(fieldBlock.getFirstValueIndex(p));
-        result.appendLong(RoundToLong.process(field, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6, this.p7, this.p8, this.p9));
+        long v = vBlock.getLong(vBlock.getFirstValueIndex(p));
+        result.appendLong(RoundToLong.floor10(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6, this.p7, this.p8, this.p9));
       }
       return result.build();
     }
   }
 
-  public LongVector eval(int positionCount, LongVector fieldVector) {
+  public LongVector eval(int positionCount, LongVector vVector) {
     try(LongVector.FixedBuilder result = driverContext.blockFactory().newLongVectorFixedBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        long field = fieldVector.getLong(p);
-        result.appendLong(p, RoundToLong.process(field, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6, this.p7, this.p8, this.p9));
+        long v = vVector.getLong(p);
+        result.appendLong(p, RoundToLong.floor10(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6, this.p7, this.p8, this.p9));
       }
       return result.build();
     }
@@ -121,12 +122,12 @@ public final class RoundToLongFloor10Evaluator implements ExpressionEvaluator {
 
   @Override
   public String toString() {
-    return "RoundToLongFloor10Evaluator[" + "field=" + field + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + ", p7=" + p7 + ", p8=" + p8 + ", p9=" + p9 + "]";
+    return "RoundToLongFloor10Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + ", p7=" + p7 + ", p8=" + p8 + ", p9=" + p9 + "]";
   }
 
   @Override
   public void close() {
-    Releasables.closeExpectNoException(field);
+    Releasables.closeExpectNoException(v);
   }
 
   private Warnings warnings() {
@@ -139,7 +140,7 @@ public final class RoundToLongFloor10Evaluator implements ExpressionEvaluator {
   static class Factory implements ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final ExpressionEvaluator.Factory field;
+    private final ExpressionEvaluator.Factory v;
 
     private final long p0;
 
@@ -161,10 +162,10 @@ public final class RoundToLongFloor10Evaluator implements ExpressionEvaluator {
 
     private final long p9;
 
-    public Factory(Source source, ExpressionEvaluator.Factory field, long p0, long p1, long p2,
-        long p3, long p4, long p5, long p6, long p7, long p8, long p9) {
+    public Factory(Source source, ExpressionEvaluator.Factory v, long p0, long p1, long p2, long p3,
+        long p4, long p5, long p6, long p7, long p8, long p9) {
       this.source = source;
-      this.field = field;
+      this.v = v;
       this.p0 = p0;
       this.p1 = p1;
       this.p2 = p2;
@@ -179,12 +180,12 @@ public final class RoundToLongFloor10Evaluator implements ExpressionEvaluator {
 
     @Override
     public RoundToLongFloor10Evaluator get(DriverContext context) {
-      return new RoundToLongFloor10Evaluator(source, field.get(context), p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, context);
+      return new RoundToLongFloor10Evaluator(source, v.get(context), p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, context);
     }
 
     @Override
     public String toString() {
-      return "RoundToLongFloor10Evaluator[" + "field=" + field + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + ", p7=" + p7 + ", p8=" + p8 + ", p9=" + p9 + "]";
+      return "RoundToLongFloor10Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + ", p7=" + p7 + ", p8=" + p8 + ", p9=" + p9 + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLongFloor2Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLongFloor2Evaluator.java
@@ -27,7 +27,7 @@ public final class RoundToLongFloor2Evaluator implements ExpressionEvaluator {
 
   private final Source source;
 
-  private final ExpressionEvaluator field;
+  private final ExpressionEvaluator v;
 
   private final long p0;
 
@@ -37,10 +37,10 @@ public final class RoundToLongFloor2Evaluator implements ExpressionEvaluator {
 
   private Warnings warnings;
 
-  public RoundToLongFloor2Evaluator(Source source, ExpressionEvaluator field, long p0, long p1,
+  public RoundToLongFloor2Evaluator(Source source, ExpressionEvaluator v, long p0, long p1,
       DriverContext driverContext) {
     this.source = source;
-    this.field = field;
+    this.v = v;
     this.p0 = p0;
     this.p1 = p1;
     this.driverContext = driverContext;
@@ -48,26 +48,26 @@ public final class RoundToLongFloor2Evaluator implements ExpressionEvaluator {
 
   @Override
   public Block eval(Page page) {
-    try (LongBlock fieldBlock = (LongBlock) field.eval(page)) {
-      LongVector fieldVector = fieldBlock.asVector();
-      if (fieldVector == null) {
-        return eval(page.getPositionCount(), fieldBlock);
+    try (LongBlock vBlock = (LongBlock) v.eval(page)) {
+      LongVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
       }
-      return eval(page.getPositionCount(), fieldVector).asBlock();
+      return eval(page.getPositionCount(), vVector).asBlock();
     }
   }
 
   @Override
   public long baseRamBytesUsed() {
     long baseRamBytesUsed = BASE_RAM_BYTES_USED;
-    baseRamBytesUsed += field.baseRamBytesUsed();
+    baseRamBytesUsed += v.baseRamBytesUsed();
     return baseRamBytesUsed;
   }
 
-  public LongBlock eval(int positionCount, LongBlock fieldBlock) {
+  public LongBlock eval(int positionCount, LongBlock vBlock) {
     try(LongBlock.Builder result = driverContext.blockFactory().newLongBlockBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        switch (fieldBlock.getValueCount(p)) {
+        switch (vBlock.getValueCount(p)) {
           case 0:
               result.appendNull();
               continue position;
@@ -78,18 +78,18 @@ public final class RoundToLongFloor2Evaluator implements ExpressionEvaluator {
               result.appendNull();
               continue position;
         }
-        long field = fieldBlock.getLong(fieldBlock.getFirstValueIndex(p));
-        result.appendLong(RoundToLong.process(field, this.p0, this.p1));
+        long v = vBlock.getLong(vBlock.getFirstValueIndex(p));
+        result.appendLong(RoundToLong.floor2(v, this.p0, this.p1));
       }
       return result.build();
     }
   }
 
-  public LongVector eval(int positionCount, LongVector fieldVector) {
+  public LongVector eval(int positionCount, LongVector vVector) {
     try(LongVector.FixedBuilder result = driverContext.blockFactory().newLongVectorFixedBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        long field = fieldVector.getLong(p);
-        result.appendLong(p, RoundToLong.process(field, this.p0, this.p1));
+        long v = vVector.getLong(p);
+        result.appendLong(p, RoundToLong.floor2(v, this.p0, this.p1));
       }
       return result.build();
     }
@@ -97,12 +97,12 @@ public final class RoundToLongFloor2Evaluator implements ExpressionEvaluator {
 
   @Override
   public String toString() {
-    return "RoundToLongFloor2Evaluator[" + "field=" + field + ", p0=" + p0 + ", p1=" + p1 + "]";
+    return "RoundToLongFloor2Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + "]";
   }
 
   @Override
   public void close() {
-    Releasables.closeExpectNoException(field);
+    Releasables.closeExpectNoException(v);
   }
 
   private Warnings warnings() {
@@ -115,27 +115,27 @@ public final class RoundToLongFloor2Evaluator implements ExpressionEvaluator {
   static class Factory implements ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final ExpressionEvaluator.Factory field;
+    private final ExpressionEvaluator.Factory v;
 
     private final long p0;
 
     private final long p1;
 
-    public Factory(Source source, ExpressionEvaluator.Factory field, long p0, long p1) {
+    public Factory(Source source, ExpressionEvaluator.Factory v, long p0, long p1) {
       this.source = source;
-      this.field = field;
+      this.v = v;
       this.p0 = p0;
       this.p1 = p1;
     }
 
     @Override
     public RoundToLongFloor2Evaluator get(DriverContext context) {
-      return new RoundToLongFloor2Evaluator(source, field.get(context), p0, p1, context);
+      return new RoundToLongFloor2Evaluator(source, v.get(context), p0, p1, context);
     }
 
     @Override
     public String toString() {
-      return "RoundToLongFloor2Evaluator[" + "field=" + field + ", p0=" + p0 + ", p1=" + p1 + "]";
+      return "RoundToLongFloor2Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLongFloor3Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLongFloor3Evaluator.java
@@ -27,7 +27,7 @@ public final class RoundToLongFloor3Evaluator implements ExpressionEvaluator {
 
   private final Source source;
 
-  private final ExpressionEvaluator field;
+  private final ExpressionEvaluator v;
 
   private final long p0;
 
@@ -39,10 +39,10 @@ public final class RoundToLongFloor3Evaluator implements ExpressionEvaluator {
 
   private Warnings warnings;
 
-  public RoundToLongFloor3Evaluator(Source source, ExpressionEvaluator field, long p0, long p1, long p2,
+  public RoundToLongFloor3Evaluator(Source source, ExpressionEvaluator v, long p0, long p1, long p2,
       DriverContext driverContext) {
     this.source = source;
-    this.field = field;
+    this.v = v;
     this.p0 = p0;
     this.p1 = p1;
     this.p2 = p2;
@@ -51,26 +51,26 @@ public final class RoundToLongFloor3Evaluator implements ExpressionEvaluator {
 
   @Override
   public Block eval(Page page) {
-    try (LongBlock fieldBlock = (LongBlock) field.eval(page)) {
-      LongVector fieldVector = fieldBlock.asVector();
-      if (fieldVector == null) {
-        return eval(page.getPositionCount(), fieldBlock);
+    try (LongBlock vBlock = (LongBlock) v.eval(page)) {
+      LongVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
       }
-      return eval(page.getPositionCount(), fieldVector).asBlock();
+      return eval(page.getPositionCount(), vVector).asBlock();
     }
   }
 
   @Override
   public long baseRamBytesUsed() {
     long baseRamBytesUsed = BASE_RAM_BYTES_USED;
-    baseRamBytesUsed += field.baseRamBytesUsed();
+    baseRamBytesUsed += v.baseRamBytesUsed();
     return baseRamBytesUsed;
   }
 
-  public LongBlock eval(int positionCount, LongBlock fieldBlock) {
+  public LongBlock eval(int positionCount, LongBlock vBlock) {
     try(LongBlock.Builder result = driverContext.blockFactory().newLongBlockBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        switch (fieldBlock.getValueCount(p)) {
+        switch (vBlock.getValueCount(p)) {
           case 0:
               result.appendNull();
               continue position;
@@ -81,18 +81,18 @@ public final class RoundToLongFloor3Evaluator implements ExpressionEvaluator {
               result.appendNull();
               continue position;
         }
-        long field = fieldBlock.getLong(fieldBlock.getFirstValueIndex(p));
-        result.appendLong(RoundToLong.process(field, this.p0, this.p1, this.p2));
+        long v = vBlock.getLong(vBlock.getFirstValueIndex(p));
+        result.appendLong(RoundToLong.floor3(v, this.p0, this.p1, this.p2));
       }
       return result.build();
     }
   }
 
-  public LongVector eval(int positionCount, LongVector fieldVector) {
+  public LongVector eval(int positionCount, LongVector vVector) {
     try(LongVector.FixedBuilder result = driverContext.blockFactory().newLongVectorFixedBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        long field = fieldVector.getLong(p);
-        result.appendLong(p, RoundToLong.process(field, this.p0, this.p1, this.p2));
+        long v = vVector.getLong(p);
+        result.appendLong(p, RoundToLong.floor3(v, this.p0, this.p1, this.p2));
       }
       return result.build();
     }
@@ -100,12 +100,12 @@ public final class RoundToLongFloor3Evaluator implements ExpressionEvaluator {
 
   @Override
   public String toString() {
-    return "RoundToLongFloor3Evaluator[" + "field=" + field + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + "]";
+    return "RoundToLongFloor3Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + "]";
   }
 
   @Override
   public void close() {
-    Releasables.closeExpectNoException(field);
+    Releasables.closeExpectNoException(v);
   }
 
   private Warnings warnings() {
@@ -118,7 +118,7 @@ public final class RoundToLongFloor3Evaluator implements ExpressionEvaluator {
   static class Factory implements ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final ExpressionEvaluator.Factory field;
+    private final ExpressionEvaluator.Factory v;
 
     private final long p0;
 
@@ -126,9 +126,9 @@ public final class RoundToLongFloor3Evaluator implements ExpressionEvaluator {
 
     private final long p2;
 
-    public Factory(Source source, ExpressionEvaluator.Factory field, long p0, long p1, long p2) {
+    public Factory(Source source, ExpressionEvaluator.Factory v, long p0, long p1, long p2) {
       this.source = source;
-      this.field = field;
+      this.v = v;
       this.p0 = p0;
       this.p1 = p1;
       this.p2 = p2;
@@ -136,12 +136,12 @@ public final class RoundToLongFloor3Evaluator implements ExpressionEvaluator {
 
     @Override
     public RoundToLongFloor3Evaluator get(DriverContext context) {
-      return new RoundToLongFloor3Evaluator(source, field.get(context), p0, p1, p2, context);
+      return new RoundToLongFloor3Evaluator(source, v.get(context), p0, p1, p2, context);
     }
 
     @Override
     public String toString() {
-      return "RoundToLongFloor3Evaluator[" + "field=" + field + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + "]";
+      return "RoundToLongFloor3Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLongFloor4Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLongFloor4Evaluator.java
@@ -27,7 +27,7 @@ public final class RoundToLongFloor4Evaluator implements ExpressionEvaluator {
 
   private final Source source;
 
-  private final ExpressionEvaluator field;
+  private final ExpressionEvaluator v;
 
   private final long p0;
 
@@ -41,10 +41,10 @@ public final class RoundToLongFloor4Evaluator implements ExpressionEvaluator {
 
   private Warnings warnings;
 
-  public RoundToLongFloor4Evaluator(Source source, ExpressionEvaluator field, long p0, long p1, long p2,
+  public RoundToLongFloor4Evaluator(Source source, ExpressionEvaluator v, long p0, long p1, long p2,
       long p3, DriverContext driverContext) {
     this.source = source;
-    this.field = field;
+    this.v = v;
     this.p0 = p0;
     this.p1 = p1;
     this.p2 = p2;
@@ -54,26 +54,26 @@ public final class RoundToLongFloor4Evaluator implements ExpressionEvaluator {
 
   @Override
   public Block eval(Page page) {
-    try (LongBlock fieldBlock = (LongBlock) field.eval(page)) {
-      LongVector fieldVector = fieldBlock.asVector();
-      if (fieldVector == null) {
-        return eval(page.getPositionCount(), fieldBlock);
+    try (LongBlock vBlock = (LongBlock) v.eval(page)) {
+      LongVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
       }
-      return eval(page.getPositionCount(), fieldVector).asBlock();
+      return eval(page.getPositionCount(), vVector).asBlock();
     }
   }
 
   @Override
   public long baseRamBytesUsed() {
     long baseRamBytesUsed = BASE_RAM_BYTES_USED;
-    baseRamBytesUsed += field.baseRamBytesUsed();
+    baseRamBytesUsed += v.baseRamBytesUsed();
     return baseRamBytesUsed;
   }
 
-  public LongBlock eval(int positionCount, LongBlock fieldBlock) {
+  public LongBlock eval(int positionCount, LongBlock vBlock) {
     try(LongBlock.Builder result = driverContext.blockFactory().newLongBlockBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        switch (fieldBlock.getValueCount(p)) {
+        switch (vBlock.getValueCount(p)) {
           case 0:
               result.appendNull();
               continue position;
@@ -84,18 +84,18 @@ public final class RoundToLongFloor4Evaluator implements ExpressionEvaluator {
               result.appendNull();
               continue position;
         }
-        long field = fieldBlock.getLong(fieldBlock.getFirstValueIndex(p));
-        result.appendLong(RoundToLong.process(field, this.p0, this.p1, this.p2, this.p3));
+        long v = vBlock.getLong(vBlock.getFirstValueIndex(p));
+        result.appendLong(RoundToLong.floor4(v, this.p0, this.p1, this.p2, this.p3));
       }
       return result.build();
     }
   }
 
-  public LongVector eval(int positionCount, LongVector fieldVector) {
+  public LongVector eval(int positionCount, LongVector vVector) {
     try(LongVector.FixedBuilder result = driverContext.blockFactory().newLongVectorFixedBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        long field = fieldVector.getLong(p);
-        result.appendLong(p, RoundToLong.process(field, this.p0, this.p1, this.p2, this.p3));
+        long v = vVector.getLong(p);
+        result.appendLong(p, RoundToLong.floor4(v, this.p0, this.p1, this.p2, this.p3));
       }
       return result.build();
     }
@@ -103,12 +103,12 @@ public final class RoundToLongFloor4Evaluator implements ExpressionEvaluator {
 
   @Override
   public String toString() {
-    return "RoundToLongFloor4Evaluator[" + "field=" + field + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + "]";
+    return "RoundToLongFloor4Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + "]";
   }
 
   @Override
   public void close() {
-    Releasables.closeExpectNoException(field);
+    Releasables.closeExpectNoException(v);
   }
 
   private Warnings warnings() {
@@ -121,7 +121,7 @@ public final class RoundToLongFloor4Evaluator implements ExpressionEvaluator {
   static class Factory implements ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final ExpressionEvaluator.Factory field;
+    private final ExpressionEvaluator.Factory v;
 
     private final long p0;
 
@@ -131,10 +131,10 @@ public final class RoundToLongFloor4Evaluator implements ExpressionEvaluator {
 
     private final long p3;
 
-    public Factory(Source source, ExpressionEvaluator.Factory field, long p0, long p1, long p2,
+    public Factory(Source source, ExpressionEvaluator.Factory v, long p0, long p1, long p2,
         long p3) {
       this.source = source;
-      this.field = field;
+      this.v = v;
       this.p0 = p0;
       this.p1 = p1;
       this.p2 = p2;
@@ -143,12 +143,12 @@ public final class RoundToLongFloor4Evaluator implements ExpressionEvaluator {
 
     @Override
     public RoundToLongFloor4Evaluator get(DriverContext context) {
-      return new RoundToLongFloor4Evaluator(source, field.get(context), p0, p1, p2, p3, context);
+      return new RoundToLongFloor4Evaluator(source, v.get(context), p0, p1, p2, p3, context);
     }
 
     @Override
     public String toString() {
-      return "RoundToLongFloor4Evaluator[" + "field=" + field + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + "]";
+      return "RoundToLongFloor4Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLongFloor5Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLongFloor5Evaluator.java
@@ -27,7 +27,7 @@ public final class RoundToLongFloor5Evaluator implements ExpressionEvaluator {
 
   private final Source source;
 
-  private final ExpressionEvaluator field;
+  private final ExpressionEvaluator v;
 
   private final long p0;
 
@@ -43,10 +43,10 @@ public final class RoundToLongFloor5Evaluator implements ExpressionEvaluator {
 
   private Warnings warnings;
 
-  public RoundToLongFloor5Evaluator(Source source, ExpressionEvaluator field, long p0, long p1, long p2,
+  public RoundToLongFloor5Evaluator(Source source, ExpressionEvaluator v, long p0, long p1, long p2,
       long p3, long p4, DriverContext driverContext) {
     this.source = source;
-    this.field = field;
+    this.v = v;
     this.p0 = p0;
     this.p1 = p1;
     this.p2 = p2;
@@ -57,26 +57,26 @@ public final class RoundToLongFloor5Evaluator implements ExpressionEvaluator {
 
   @Override
   public Block eval(Page page) {
-    try (LongBlock fieldBlock = (LongBlock) field.eval(page)) {
-      LongVector fieldVector = fieldBlock.asVector();
-      if (fieldVector == null) {
-        return eval(page.getPositionCount(), fieldBlock);
+    try (LongBlock vBlock = (LongBlock) v.eval(page)) {
+      LongVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
       }
-      return eval(page.getPositionCount(), fieldVector).asBlock();
+      return eval(page.getPositionCount(), vVector).asBlock();
     }
   }
 
   @Override
   public long baseRamBytesUsed() {
     long baseRamBytesUsed = BASE_RAM_BYTES_USED;
-    baseRamBytesUsed += field.baseRamBytesUsed();
+    baseRamBytesUsed += v.baseRamBytesUsed();
     return baseRamBytesUsed;
   }
 
-  public LongBlock eval(int positionCount, LongBlock fieldBlock) {
+  public LongBlock eval(int positionCount, LongBlock vBlock) {
     try(LongBlock.Builder result = driverContext.blockFactory().newLongBlockBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        switch (fieldBlock.getValueCount(p)) {
+        switch (vBlock.getValueCount(p)) {
           case 0:
               result.appendNull();
               continue position;
@@ -87,18 +87,18 @@ public final class RoundToLongFloor5Evaluator implements ExpressionEvaluator {
               result.appendNull();
               continue position;
         }
-        long field = fieldBlock.getLong(fieldBlock.getFirstValueIndex(p));
-        result.appendLong(RoundToLong.process(field, this.p0, this.p1, this.p2, this.p3, this.p4));
+        long v = vBlock.getLong(vBlock.getFirstValueIndex(p));
+        result.appendLong(RoundToLong.floor5(v, this.p0, this.p1, this.p2, this.p3, this.p4));
       }
       return result.build();
     }
   }
 
-  public LongVector eval(int positionCount, LongVector fieldVector) {
+  public LongVector eval(int positionCount, LongVector vVector) {
     try(LongVector.FixedBuilder result = driverContext.blockFactory().newLongVectorFixedBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        long field = fieldVector.getLong(p);
-        result.appendLong(p, RoundToLong.process(field, this.p0, this.p1, this.p2, this.p3, this.p4));
+        long v = vVector.getLong(p);
+        result.appendLong(p, RoundToLong.floor5(v, this.p0, this.p1, this.p2, this.p3, this.p4));
       }
       return result.build();
     }
@@ -106,12 +106,12 @@ public final class RoundToLongFloor5Evaluator implements ExpressionEvaluator {
 
   @Override
   public String toString() {
-    return "RoundToLongFloor5Evaluator[" + "field=" + field + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + "]";
+    return "RoundToLongFloor5Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + "]";
   }
 
   @Override
   public void close() {
-    Releasables.closeExpectNoException(field);
+    Releasables.closeExpectNoException(v);
   }
 
   private Warnings warnings() {
@@ -124,7 +124,7 @@ public final class RoundToLongFloor5Evaluator implements ExpressionEvaluator {
   static class Factory implements ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final ExpressionEvaluator.Factory field;
+    private final ExpressionEvaluator.Factory v;
 
     private final long p0;
 
@@ -136,10 +136,10 @@ public final class RoundToLongFloor5Evaluator implements ExpressionEvaluator {
 
     private final long p4;
 
-    public Factory(Source source, ExpressionEvaluator.Factory field, long p0, long p1, long p2,
-        long p3, long p4) {
+    public Factory(Source source, ExpressionEvaluator.Factory v, long p0, long p1, long p2, long p3,
+        long p4) {
       this.source = source;
-      this.field = field;
+      this.v = v;
       this.p0 = p0;
       this.p1 = p1;
       this.p2 = p2;
@@ -149,12 +149,12 @@ public final class RoundToLongFloor5Evaluator implements ExpressionEvaluator {
 
     @Override
     public RoundToLongFloor5Evaluator get(DriverContext context) {
-      return new RoundToLongFloor5Evaluator(source, field.get(context), p0, p1, p2, p3, p4, context);
+      return new RoundToLongFloor5Evaluator(source, v.get(context), p0, p1, p2, p3, p4, context);
     }
 
     @Override
     public String toString() {
-      return "RoundToLongFloor5Evaluator[" + "field=" + field + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + "]";
+      return "RoundToLongFloor5Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLongFloor6Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLongFloor6Evaluator.java
@@ -27,7 +27,7 @@ public final class RoundToLongFloor6Evaluator implements ExpressionEvaluator {
 
   private final Source source;
 
-  private final ExpressionEvaluator field;
+  private final ExpressionEvaluator v;
 
   private final long p0;
 
@@ -45,10 +45,10 @@ public final class RoundToLongFloor6Evaluator implements ExpressionEvaluator {
 
   private Warnings warnings;
 
-  public RoundToLongFloor6Evaluator(Source source, ExpressionEvaluator field, long p0, long p1, long p2,
+  public RoundToLongFloor6Evaluator(Source source, ExpressionEvaluator v, long p0, long p1, long p2,
       long p3, long p4, long p5, DriverContext driverContext) {
     this.source = source;
-    this.field = field;
+    this.v = v;
     this.p0 = p0;
     this.p1 = p1;
     this.p2 = p2;
@@ -60,26 +60,26 @@ public final class RoundToLongFloor6Evaluator implements ExpressionEvaluator {
 
   @Override
   public Block eval(Page page) {
-    try (LongBlock fieldBlock = (LongBlock) field.eval(page)) {
-      LongVector fieldVector = fieldBlock.asVector();
-      if (fieldVector == null) {
-        return eval(page.getPositionCount(), fieldBlock);
+    try (LongBlock vBlock = (LongBlock) v.eval(page)) {
+      LongVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
       }
-      return eval(page.getPositionCount(), fieldVector).asBlock();
+      return eval(page.getPositionCount(), vVector).asBlock();
     }
   }
 
   @Override
   public long baseRamBytesUsed() {
     long baseRamBytesUsed = BASE_RAM_BYTES_USED;
-    baseRamBytesUsed += field.baseRamBytesUsed();
+    baseRamBytesUsed += v.baseRamBytesUsed();
     return baseRamBytesUsed;
   }
 
-  public LongBlock eval(int positionCount, LongBlock fieldBlock) {
+  public LongBlock eval(int positionCount, LongBlock vBlock) {
     try(LongBlock.Builder result = driverContext.blockFactory().newLongBlockBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        switch (fieldBlock.getValueCount(p)) {
+        switch (vBlock.getValueCount(p)) {
           case 0:
               result.appendNull();
               continue position;
@@ -90,18 +90,18 @@ public final class RoundToLongFloor6Evaluator implements ExpressionEvaluator {
               result.appendNull();
               continue position;
         }
-        long field = fieldBlock.getLong(fieldBlock.getFirstValueIndex(p));
-        result.appendLong(RoundToLong.process(field, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5));
+        long v = vBlock.getLong(vBlock.getFirstValueIndex(p));
+        result.appendLong(RoundToLong.floor6(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5));
       }
       return result.build();
     }
   }
 
-  public LongVector eval(int positionCount, LongVector fieldVector) {
+  public LongVector eval(int positionCount, LongVector vVector) {
     try(LongVector.FixedBuilder result = driverContext.blockFactory().newLongVectorFixedBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        long field = fieldVector.getLong(p);
-        result.appendLong(p, RoundToLong.process(field, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5));
+        long v = vVector.getLong(p);
+        result.appendLong(p, RoundToLong.floor6(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5));
       }
       return result.build();
     }
@@ -109,12 +109,12 @@ public final class RoundToLongFloor6Evaluator implements ExpressionEvaluator {
 
   @Override
   public String toString() {
-    return "RoundToLongFloor6Evaluator[" + "field=" + field + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + "]";
+    return "RoundToLongFloor6Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + "]";
   }
 
   @Override
   public void close() {
-    Releasables.closeExpectNoException(field);
+    Releasables.closeExpectNoException(v);
   }
 
   private Warnings warnings() {
@@ -127,7 +127,7 @@ public final class RoundToLongFloor6Evaluator implements ExpressionEvaluator {
   static class Factory implements ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final ExpressionEvaluator.Factory field;
+    private final ExpressionEvaluator.Factory v;
 
     private final long p0;
 
@@ -141,10 +141,10 @@ public final class RoundToLongFloor6Evaluator implements ExpressionEvaluator {
 
     private final long p5;
 
-    public Factory(Source source, ExpressionEvaluator.Factory field, long p0, long p1, long p2,
-        long p3, long p4, long p5) {
+    public Factory(Source source, ExpressionEvaluator.Factory v, long p0, long p1, long p2, long p3,
+        long p4, long p5) {
       this.source = source;
-      this.field = field;
+      this.v = v;
       this.p0 = p0;
       this.p1 = p1;
       this.p2 = p2;
@@ -155,12 +155,12 @@ public final class RoundToLongFloor6Evaluator implements ExpressionEvaluator {
 
     @Override
     public RoundToLongFloor6Evaluator get(DriverContext context) {
-      return new RoundToLongFloor6Evaluator(source, field.get(context), p0, p1, p2, p3, p4, p5, context);
+      return new RoundToLongFloor6Evaluator(source, v.get(context), p0, p1, p2, p3, p4, p5, context);
     }
 
     @Override
     public String toString() {
-      return "RoundToLongFloor6Evaluator[" + "field=" + field + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + "]";
+      return "RoundToLongFloor6Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLongFloor7Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLongFloor7Evaluator.java
@@ -27,7 +27,7 @@ public final class RoundToLongFloor7Evaluator implements ExpressionEvaluator {
 
   private final Source source;
 
-  private final ExpressionEvaluator field;
+  private final ExpressionEvaluator v;
 
   private final long p0;
 
@@ -47,10 +47,10 @@ public final class RoundToLongFloor7Evaluator implements ExpressionEvaluator {
 
   private Warnings warnings;
 
-  public RoundToLongFloor7Evaluator(Source source, ExpressionEvaluator field, long p0, long p1, long p2,
+  public RoundToLongFloor7Evaluator(Source source, ExpressionEvaluator v, long p0, long p1, long p2,
       long p3, long p4, long p5, long p6, DriverContext driverContext) {
     this.source = source;
-    this.field = field;
+    this.v = v;
     this.p0 = p0;
     this.p1 = p1;
     this.p2 = p2;
@@ -63,26 +63,26 @@ public final class RoundToLongFloor7Evaluator implements ExpressionEvaluator {
 
   @Override
   public Block eval(Page page) {
-    try (LongBlock fieldBlock = (LongBlock) field.eval(page)) {
-      LongVector fieldVector = fieldBlock.asVector();
-      if (fieldVector == null) {
-        return eval(page.getPositionCount(), fieldBlock);
+    try (LongBlock vBlock = (LongBlock) v.eval(page)) {
+      LongVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
       }
-      return eval(page.getPositionCount(), fieldVector).asBlock();
+      return eval(page.getPositionCount(), vVector).asBlock();
     }
   }
 
   @Override
   public long baseRamBytesUsed() {
     long baseRamBytesUsed = BASE_RAM_BYTES_USED;
-    baseRamBytesUsed += field.baseRamBytesUsed();
+    baseRamBytesUsed += v.baseRamBytesUsed();
     return baseRamBytesUsed;
   }
 
-  public LongBlock eval(int positionCount, LongBlock fieldBlock) {
+  public LongBlock eval(int positionCount, LongBlock vBlock) {
     try(LongBlock.Builder result = driverContext.blockFactory().newLongBlockBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        switch (fieldBlock.getValueCount(p)) {
+        switch (vBlock.getValueCount(p)) {
           case 0:
               result.appendNull();
               continue position;
@@ -93,18 +93,18 @@ public final class RoundToLongFloor7Evaluator implements ExpressionEvaluator {
               result.appendNull();
               continue position;
         }
-        long field = fieldBlock.getLong(fieldBlock.getFirstValueIndex(p));
-        result.appendLong(RoundToLong.process(field, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6));
+        long v = vBlock.getLong(vBlock.getFirstValueIndex(p));
+        result.appendLong(RoundToLong.floor7(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6));
       }
       return result.build();
     }
   }
 
-  public LongVector eval(int positionCount, LongVector fieldVector) {
+  public LongVector eval(int positionCount, LongVector vVector) {
     try(LongVector.FixedBuilder result = driverContext.blockFactory().newLongVectorFixedBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        long field = fieldVector.getLong(p);
-        result.appendLong(p, RoundToLong.process(field, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6));
+        long v = vVector.getLong(p);
+        result.appendLong(p, RoundToLong.floor7(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6));
       }
       return result.build();
     }
@@ -112,12 +112,12 @@ public final class RoundToLongFloor7Evaluator implements ExpressionEvaluator {
 
   @Override
   public String toString() {
-    return "RoundToLongFloor7Evaluator[" + "field=" + field + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + "]";
+    return "RoundToLongFloor7Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + "]";
   }
 
   @Override
   public void close() {
-    Releasables.closeExpectNoException(field);
+    Releasables.closeExpectNoException(v);
   }
 
   private Warnings warnings() {
@@ -130,7 +130,7 @@ public final class RoundToLongFloor7Evaluator implements ExpressionEvaluator {
   static class Factory implements ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final ExpressionEvaluator.Factory field;
+    private final ExpressionEvaluator.Factory v;
 
     private final long p0;
 
@@ -146,10 +146,10 @@ public final class RoundToLongFloor7Evaluator implements ExpressionEvaluator {
 
     private final long p6;
 
-    public Factory(Source source, ExpressionEvaluator.Factory field, long p0, long p1, long p2,
-        long p3, long p4, long p5, long p6) {
+    public Factory(Source source, ExpressionEvaluator.Factory v, long p0, long p1, long p2, long p3,
+        long p4, long p5, long p6) {
       this.source = source;
-      this.field = field;
+      this.v = v;
       this.p0 = p0;
       this.p1 = p1;
       this.p2 = p2;
@@ -161,12 +161,12 @@ public final class RoundToLongFloor7Evaluator implements ExpressionEvaluator {
 
     @Override
     public RoundToLongFloor7Evaluator get(DriverContext context) {
-      return new RoundToLongFloor7Evaluator(source, field.get(context), p0, p1, p2, p3, p4, p5, p6, context);
+      return new RoundToLongFloor7Evaluator(source, v.get(context), p0, p1, p2, p3, p4, p5, p6, context);
     }
 
     @Override
     public String toString() {
-      return "RoundToLongFloor7Evaluator[" + "field=" + field + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + "]";
+      return "RoundToLongFloor7Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLongFloor8Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLongFloor8Evaluator.java
@@ -27,7 +27,7 @@ public final class RoundToLongFloor8Evaluator implements ExpressionEvaluator {
 
   private final Source source;
 
-  private final ExpressionEvaluator field;
+  private final ExpressionEvaluator v;
 
   private final long p0;
 
@@ -49,10 +49,10 @@ public final class RoundToLongFloor8Evaluator implements ExpressionEvaluator {
 
   private Warnings warnings;
 
-  public RoundToLongFloor8Evaluator(Source source, ExpressionEvaluator field, long p0, long p1, long p2,
+  public RoundToLongFloor8Evaluator(Source source, ExpressionEvaluator v, long p0, long p1, long p2,
       long p3, long p4, long p5, long p6, long p7, DriverContext driverContext) {
     this.source = source;
-    this.field = field;
+    this.v = v;
     this.p0 = p0;
     this.p1 = p1;
     this.p2 = p2;
@@ -66,26 +66,26 @@ public final class RoundToLongFloor8Evaluator implements ExpressionEvaluator {
 
   @Override
   public Block eval(Page page) {
-    try (LongBlock fieldBlock = (LongBlock) field.eval(page)) {
-      LongVector fieldVector = fieldBlock.asVector();
-      if (fieldVector == null) {
-        return eval(page.getPositionCount(), fieldBlock);
+    try (LongBlock vBlock = (LongBlock) v.eval(page)) {
+      LongVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
       }
-      return eval(page.getPositionCount(), fieldVector).asBlock();
+      return eval(page.getPositionCount(), vVector).asBlock();
     }
   }
 
   @Override
   public long baseRamBytesUsed() {
     long baseRamBytesUsed = BASE_RAM_BYTES_USED;
-    baseRamBytesUsed += field.baseRamBytesUsed();
+    baseRamBytesUsed += v.baseRamBytesUsed();
     return baseRamBytesUsed;
   }
 
-  public LongBlock eval(int positionCount, LongBlock fieldBlock) {
+  public LongBlock eval(int positionCount, LongBlock vBlock) {
     try(LongBlock.Builder result = driverContext.blockFactory().newLongBlockBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        switch (fieldBlock.getValueCount(p)) {
+        switch (vBlock.getValueCount(p)) {
           case 0:
               result.appendNull();
               continue position;
@@ -96,18 +96,18 @@ public final class RoundToLongFloor8Evaluator implements ExpressionEvaluator {
               result.appendNull();
               continue position;
         }
-        long field = fieldBlock.getLong(fieldBlock.getFirstValueIndex(p));
-        result.appendLong(RoundToLong.process(field, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6, this.p7));
+        long v = vBlock.getLong(vBlock.getFirstValueIndex(p));
+        result.appendLong(RoundToLong.floor8(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6, this.p7));
       }
       return result.build();
     }
   }
 
-  public LongVector eval(int positionCount, LongVector fieldVector) {
+  public LongVector eval(int positionCount, LongVector vVector) {
     try(LongVector.FixedBuilder result = driverContext.blockFactory().newLongVectorFixedBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        long field = fieldVector.getLong(p);
-        result.appendLong(p, RoundToLong.process(field, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6, this.p7));
+        long v = vVector.getLong(p);
+        result.appendLong(p, RoundToLong.floor8(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6, this.p7));
       }
       return result.build();
     }
@@ -115,12 +115,12 @@ public final class RoundToLongFloor8Evaluator implements ExpressionEvaluator {
 
   @Override
   public String toString() {
-    return "RoundToLongFloor8Evaluator[" + "field=" + field + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + ", p7=" + p7 + "]";
+    return "RoundToLongFloor8Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + ", p7=" + p7 + "]";
   }
 
   @Override
   public void close() {
-    Releasables.closeExpectNoException(field);
+    Releasables.closeExpectNoException(v);
   }
 
   private Warnings warnings() {
@@ -133,7 +133,7 @@ public final class RoundToLongFloor8Evaluator implements ExpressionEvaluator {
   static class Factory implements ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final ExpressionEvaluator.Factory field;
+    private final ExpressionEvaluator.Factory v;
 
     private final long p0;
 
@@ -151,10 +151,10 @@ public final class RoundToLongFloor8Evaluator implements ExpressionEvaluator {
 
     private final long p7;
 
-    public Factory(Source source, ExpressionEvaluator.Factory field, long p0, long p1, long p2,
-        long p3, long p4, long p5, long p6, long p7) {
+    public Factory(Source source, ExpressionEvaluator.Factory v, long p0, long p1, long p2, long p3,
+        long p4, long p5, long p6, long p7) {
       this.source = source;
-      this.field = field;
+      this.v = v;
       this.p0 = p0;
       this.p1 = p1;
       this.p2 = p2;
@@ -167,12 +167,12 @@ public final class RoundToLongFloor8Evaluator implements ExpressionEvaluator {
 
     @Override
     public RoundToLongFloor8Evaluator get(DriverContext context) {
-      return new RoundToLongFloor8Evaluator(source, field.get(context), p0, p1, p2, p3, p4, p5, p6, p7, context);
+      return new RoundToLongFloor8Evaluator(source, v.get(context), p0, p1, p2, p3, p4, p5, p6, p7, context);
     }
 
     @Override
     public String toString() {
-      return "RoundToLongFloor8Evaluator[" + "field=" + field + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + ", p7=" + p7 + "]";
+      return "RoundToLongFloor8Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + ", p7=" + p7 + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLongFloor9Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLongFloor9Evaluator.java
@@ -27,7 +27,7 @@ public final class RoundToLongFloor9Evaluator implements ExpressionEvaluator {
 
   private final Source source;
 
-  private final ExpressionEvaluator field;
+  private final ExpressionEvaluator v;
 
   private final long p0;
 
@@ -51,10 +51,10 @@ public final class RoundToLongFloor9Evaluator implements ExpressionEvaluator {
 
   private Warnings warnings;
 
-  public RoundToLongFloor9Evaluator(Source source, ExpressionEvaluator field, long p0, long p1, long p2,
+  public RoundToLongFloor9Evaluator(Source source, ExpressionEvaluator v, long p0, long p1, long p2,
       long p3, long p4, long p5, long p6, long p7, long p8, DriverContext driverContext) {
     this.source = source;
-    this.field = field;
+    this.v = v;
     this.p0 = p0;
     this.p1 = p1;
     this.p2 = p2;
@@ -69,26 +69,26 @@ public final class RoundToLongFloor9Evaluator implements ExpressionEvaluator {
 
   @Override
   public Block eval(Page page) {
-    try (LongBlock fieldBlock = (LongBlock) field.eval(page)) {
-      LongVector fieldVector = fieldBlock.asVector();
-      if (fieldVector == null) {
-        return eval(page.getPositionCount(), fieldBlock);
+    try (LongBlock vBlock = (LongBlock) v.eval(page)) {
+      LongVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
       }
-      return eval(page.getPositionCount(), fieldVector).asBlock();
+      return eval(page.getPositionCount(), vVector).asBlock();
     }
   }
 
   @Override
   public long baseRamBytesUsed() {
     long baseRamBytesUsed = BASE_RAM_BYTES_USED;
-    baseRamBytesUsed += field.baseRamBytesUsed();
+    baseRamBytesUsed += v.baseRamBytesUsed();
     return baseRamBytesUsed;
   }
 
-  public LongBlock eval(int positionCount, LongBlock fieldBlock) {
+  public LongBlock eval(int positionCount, LongBlock vBlock) {
     try(LongBlock.Builder result = driverContext.blockFactory().newLongBlockBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        switch (fieldBlock.getValueCount(p)) {
+        switch (vBlock.getValueCount(p)) {
           case 0:
               result.appendNull();
               continue position;
@@ -99,18 +99,18 @@ public final class RoundToLongFloor9Evaluator implements ExpressionEvaluator {
               result.appendNull();
               continue position;
         }
-        long field = fieldBlock.getLong(fieldBlock.getFirstValueIndex(p));
-        result.appendLong(RoundToLong.process(field, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6, this.p7, this.p8));
+        long v = vBlock.getLong(vBlock.getFirstValueIndex(p));
+        result.appendLong(RoundToLong.floor9(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6, this.p7, this.p8));
       }
       return result.build();
     }
   }
 
-  public LongVector eval(int positionCount, LongVector fieldVector) {
+  public LongVector eval(int positionCount, LongVector vVector) {
     try(LongVector.FixedBuilder result = driverContext.blockFactory().newLongVectorFixedBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        long field = fieldVector.getLong(p);
-        result.appendLong(p, RoundToLong.process(field, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6, this.p7, this.p8));
+        long v = vVector.getLong(p);
+        result.appendLong(p, RoundToLong.floor9(v, this.p0, this.p1, this.p2, this.p3, this.p4, this.p5, this.p6, this.p7, this.p8));
       }
       return result.build();
     }
@@ -118,12 +118,12 @@ public final class RoundToLongFloor9Evaluator implements ExpressionEvaluator {
 
   @Override
   public String toString() {
-    return "RoundToLongFloor9Evaluator[" + "field=" + field + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + ", p7=" + p7 + ", p8=" + p8 + "]";
+    return "RoundToLongFloor9Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + ", p7=" + p7 + ", p8=" + p8 + "]";
   }
 
   @Override
   public void close() {
-    Releasables.closeExpectNoException(field);
+    Releasables.closeExpectNoException(v);
   }
 
   private Warnings warnings() {
@@ -136,7 +136,7 @@ public final class RoundToLongFloor9Evaluator implements ExpressionEvaluator {
   static class Factory implements ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final ExpressionEvaluator.Factory field;
+    private final ExpressionEvaluator.Factory v;
 
     private final long p0;
 
@@ -156,10 +156,10 @@ public final class RoundToLongFloor9Evaluator implements ExpressionEvaluator {
 
     private final long p8;
 
-    public Factory(Source source, ExpressionEvaluator.Factory field, long p0, long p1, long p2,
-        long p3, long p4, long p5, long p6, long p7, long p8) {
+    public Factory(Source source, ExpressionEvaluator.Factory v, long p0, long p1, long p2, long p3,
+        long p4, long p5, long p6, long p7, long p8) {
       this.source = source;
-      this.field = field;
+      this.v = v;
       this.p0 = p0;
       this.p1 = p1;
       this.p2 = p2;
@@ -173,12 +173,12 @@ public final class RoundToLongFloor9Evaluator implements ExpressionEvaluator {
 
     @Override
     public RoundToLongFloor9Evaluator get(DriverContext context) {
-      return new RoundToLongFloor9Evaluator(source, field.get(context), p0, p1, p2, p3, p4, p5, p6, p7, p8, context);
+      return new RoundToLongFloor9Evaluator(source, v.get(context), p0, p1, p2, p3, p4, p5, p6, p7, p8, context);
     }
 
     @Override
     public String toString() {
-      return "RoundToLongFloor9Evaluator[" + "field=" + field + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + ", p7=" + p7 + ", p8=" + p8 + "]";
+      return "RoundToLongFloor9Evaluator[" + "v=" + v + ", p0=" + p0 + ", p1=" + p1 + ", p2=" + p2 + ", p3=" + p3 + ", p4=" + p4 + ", p5=" + p5 + ", p6=" + p6 + ", p7=" + p7 + ", p8=" + p8 + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLongFloorIntervalEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLongFloorIntervalEvaluator.java
@@ -22,16 +22,16 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * {@link ExpressionEvaluator} implementation for {@link RoundToLong}.
  * This class is generated. Edit {@code EvaluatorImplementer} instead.
  */
-public final class RoundToLongFixedIntervalEvaluator implements ExpressionEvaluator {
-  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(RoundToLongFixedIntervalEvaluator.class);
+public final class RoundToLongFloorIntervalEvaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(RoundToLongFloorIntervalEvaluator.class);
 
   private final Source source;
 
-  private final ExpressionEvaluator field;
+  private final ExpressionEvaluator v;
 
-  private final long first;
+  private final long lo;
 
-  private final long last;
+  private final long hi;
 
   private final long interval;
 
@@ -39,38 +39,38 @@ public final class RoundToLongFixedIntervalEvaluator implements ExpressionEvalua
 
   private Warnings warnings;
 
-  public RoundToLongFixedIntervalEvaluator(Source source, ExpressionEvaluator field, long first,
-      long last, long interval, DriverContext driverContext) {
+  public RoundToLongFloorIntervalEvaluator(Source source, ExpressionEvaluator v, long lo, long hi,
+      long interval, DriverContext driverContext) {
     this.source = source;
-    this.field = field;
-    this.first = first;
-    this.last = last;
+    this.v = v;
+    this.lo = lo;
+    this.hi = hi;
     this.interval = interval;
     this.driverContext = driverContext;
   }
 
   @Override
   public Block eval(Page page) {
-    try (LongBlock fieldBlock = (LongBlock) field.eval(page)) {
-      LongVector fieldVector = fieldBlock.asVector();
-      if (fieldVector == null) {
-        return eval(page.getPositionCount(), fieldBlock);
+    try (LongBlock vBlock = (LongBlock) v.eval(page)) {
+      LongVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
       }
-      return eval(page.getPositionCount(), fieldVector).asBlock();
+      return eval(page.getPositionCount(), vVector).asBlock();
     }
   }
 
   @Override
   public long baseRamBytesUsed() {
     long baseRamBytesUsed = BASE_RAM_BYTES_USED;
-    baseRamBytesUsed += field.baseRamBytesUsed();
+    baseRamBytesUsed += v.baseRamBytesUsed();
     return baseRamBytesUsed;
   }
 
-  public LongBlock eval(int positionCount, LongBlock fieldBlock) {
+  public LongBlock eval(int positionCount, LongBlock vBlock) {
     try(LongBlock.Builder result = driverContext.blockFactory().newLongBlockBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        switch (fieldBlock.getValueCount(p)) {
+        switch (vBlock.getValueCount(p)) {
           case 0:
               result.appendNull();
               continue position;
@@ -81,18 +81,18 @@ public final class RoundToLongFixedIntervalEvaluator implements ExpressionEvalua
               result.appendNull();
               continue position;
         }
-        long field = fieldBlock.getLong(fieldBlock.getFirstValueIndex(p));
-        result.appendLong(RoundToLong.processFixed(field, this.first, this.last, this.interval));
+        long v = vBlock.getLong(vBlock.getFirstValueIndex(p));
+        result.appendLong(RoundToLong.floorInterval(v, this.lo, this.hi, this.interval));
       }
       return result.build();
     }
   }
 
-  public LongVector eval(int positionCount, LongVector fieldVector) {
+  public LongVector eval(int positionCount, LongVector vVector) {
     try(LongVector.FixedBuilder result = driverContext.blockFactory().newLongVectorFixedBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        long field = fieldVector.getLong(p);
-        result.appendLong(p, RoundToLong.processFixed(field, this.first, this.last, this.interval));
+        long v = vVector.getLong(p);
+        result.appendLong(p, RoundToLong.floorInterval(v, this.lo, this.hi, this.interval));
       }
       return result.build();
     }
@@ -100,12 +100,12 @@ public final class RoundToLongFixedIntervalEvaluator implements ExpressionEvalua
 
   @Override
   public String toString() {
-    return "RoundToLongFixedIntervalEvaluator[" + "field=" + field + ", first=" + first + ", last=" + last + ", interval=" + interval + "]";
+    return "RoundToLongFloorIntervalEvaluator[" + "v=" + v + ", lo=" + lo + ", hi=" + hi + ", interval=" + interval + "]";
   }
 
   @Override
   public void close() {
-    Releasables.closeExpectNoException(field);
+    Releasables.closeExpectNoException(v);
   }
 
   private Warnings warnings() {
@@ -118,31 +118,30 @@ public final class RoundToLongFixedIntervalEvaluator implements ExpressionEvalua
   static class Factory implements ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final ExpressionEvaluator.Factory field;
+    private final ExpressionEvaluator.Factory v;
 
-    private final long first;
+    private final long lo;
 
-    private final long last;
+    private final long hi;
 
     private final long interval;
 
-    public Factory(Source source, ExpressionEvaluator.Factory field, long first, long last,
-        long interval) {
+    public Factory(Source source, ExpressionEvaluator.Factory v, long lo, long hi, long interval) {
       this.source = source;
-      this.field = field;
-      this.first = first;
-      this.last = last;
+      this.v = v;
+      this.lo = lo;
+      this.hi = hi;
       this.interval = interval;
     }
 
     @Override
-    public RoundToLongFixedIntervalEvaluator get(DriverContext context) {
-      return new RoundToLongFixedIntervalEvaluator(source, field.get(context), first, last, interval, context);
+    public RoundToLongFloorIntervalEvaluator get(DriverContext context) {
+      return new RoundToLongFloorIntervalEvaluator(source, v.get(context), lo, hi, interval, context);
     }
 
     @Override
     public String toString() {
-      return "RoundToLongFixedIntervalEvaluator[" + "field=" + field + ", first=" + first + ", last=" + last + ", interval=" + interval + "]";
+      return "RoundToLongFloorIntervalEvaluator[" + "v=" + v + ", lo=" + lo + ", hi=" + hi + ", interval=" + interval + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLongFloorSearchEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLongFloorSearchEvaluator.java
@@ -22,49 +22,49 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * {@link ExpressionEvaluator} implementation for {@link RoundToLong}.
  * This class is generated. Edit {@code EvaluatorImplementer} instead.
  */
-public final class RoundToLongBinarySearchEvaluator implements ExpressionEvaluator {
-  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(RoundToLongBinarySearchEvaluator.class);
+public final class RoundToLongFloorSearchEvaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(RoundToLongFloorSearchEvaluator.class);
 
   private final Source source;
 
-  private final ExpressionEvaluator field;
+  private final ExpressionEvaluator v;
 
-  private final long[] points;
+  private final long[] p;
 
   private final DriverContext driverContext;
 
   private Warnings warnings;
 
-  public RoundToLongBinarySearchEvaluator(Source source, ExpressionEvaluator field, long[] points,
+  public RoundToLongFloorSearchEvaluator(Source source, ExpressionEvaluator v, long[] p,
       DriverContext driverContext) {
     this.source = source;
-    this.field = field;
-    this.points = points;
+    this.v = v;
+    this.p = p;
     this.driverContext = driverContext;
   }
 
   @Override
   public Block eval(Page page) {
-    try (LongBlock fieldBlock = (LongBlock) field.eval(page)) {
-      LongVector fieldVector = fieldBlock.asVector();
-      if (fieldVector == null) {
-        return eval(page.getPositionCount(), fieldBlock);
+    try (LongBlock vBlock = (LongBlock) v.eval(page)) {
+      LongVector vVector = vBlock.asVector();
+      if (vVector == null) {
+        return eval(page.getPositionCount(), vBlock);
       }
-      return eval(page.getPositionCount(), fieldVector).asBlock();
+      return eval(page.getPositionCount(), vVector).asBlock();
     }
   }
 
   @Override
   public long baseRamBytesUsed() {
     long baseRamBytesUsed = BASE_RAM_BYTES_USED;
-    baseRamBytesUsed += field.baseRamBytesUsed();
+    baseRamBytesUsed += v.baseRamBytesUsed();
     return baseRamBytesUsed;
   }
 
-  public LongBlock eval(int positionCount, LongBlock fieldBlock) {
+  public LongBlock eval(int positionCount, LongBlock vBlock) {
     try(LongBlock.Builder result = driverContext.blockFactory().newLongBlockBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        switch (fieldBlock.getValueCount(p)) {
+        switch (vBlock.getValueCount(p)) {
           case 0:
               result.appendNull();
               continue position;
@@ -75,18 +75,18 @@ public final class RoundToLongBinarySearchEvaluator implements ExpressionEvaluat
               result.appendNull();
               continue position;
         }
-        long field = fieldBlock.getLong(fieldBlock.getFirstValueIndex(p));
-        result.appendLong(RoundToLong.process(field, this.points));
+        long v = vBlock.getLong(vBlock.getFirstValueIndex(p));
+        result.appendLong(RoundToLong.floorSearch(v, this.p));
       }
       return result.build();
     }
   }
 
-  public LongVector eval(int positionCount, LongVector fieldVector) {
+  public LongVector eval(int positionCount, LongVector vVector) {
     try(LongVector.FixedBuilder result = driverContext.blockFactory().newLongVectorFixedBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        long field = fieldVector.getLong(p);
-        result.appendLong(p, RoundToLong.process(field, this.points));
+        long v = vVector.getLong(p);
+        result.appendLong(p, RoundToLong.floorSearch(v, this.p));
       }
       return result.build();
     }
@@ -94,12 +94,12 @@ public final class RoundToLongBinarySearchEvaluator implements ExpressionEvaluat
 
   @Override
   public String toString() {
-    return "RoundToLongBinarySearchEvaluator[" + "field=" + field + "]";
+    return "RoundToLongFloorSearchEvaluator[" + "v=" + v + "]";
   }
 
   @Override
   public void close() {
-    Releasables.closeExpectNoException(field);
+    Releasables.closeExpectNoException(v);
   }
 
   private Warnings warnings() {
@@ -112,24 +112,24 @@ public final class RoundToLongBinarySearchEvaluator implements ExpressionEvaluat
   static class Factory implements ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final ExpressionEvaluator.Factory field;
+    private final ExpressionEvaluator.Factory v;
 
-    private final long[] points;
+    private final long[] p;
 
-    public Factory(Source source, ExpressionEvaluator.Factory field, long[] points) {
+    public Factory(Source source, ExpressionEvaluator.Factory v, long[] p) {
       this.source = source;
-      this.field = field;
-      this.points = points;
+      this.v = v;
+      this.p = p;
     }
 
     @Override
-    public RoundToLongBinarySearchEvaluator get(DriverContext context) {
-      return new RoundToLongBinarySearchEvaluator(source, field.get(context), points, context);
+    public RoundToLongFloorSearchEvaluator get(DriverContext context) {
+      return new RoundToLongFloorSearchEvaluator(source, v.get(context), p, context);
     }
 
     @Override
     public String toString() {
-      return "RoundToLongBinarySearchEvaluator[" + "field=" + field + "]";
+      return "RoundToLongFloorSearchEvaluator[" + "v=" + v + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/grouping/Bucket.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/grouping/Bucket.java
@@ -171,7 +171,7 @@ public class Bucket extends GroupingFunction.EvaluatableGroupingFunction
         }
     }
 
-    private final RoundingConvention roundingConvention;
+    private final RoundingConvention convention;
     private final Configuration configuration;
     private final Expression field;
     private final Expression buckets;
@@ -299,7 +299,7 @@ public class Bucket extends GroupingFunction.EvaluatableGroupingFunction
         ) Expression to,
         Configuration configuration
     ) {
-        this(source, field, buckets, from, to, configuration, 0L, DOWN);
+        this(source, field, buckets, from, to, configuration, 0L, null);
     }
 
     public Bucket(
@@ -310,7 +310,7 @@ public class Bucket extends GroupingFunction.EvaluatableGroupingFunction
         Expression to,
         Configuration configuration,
         long offset,
-        RoundingConvention roundingConvention
+        RoundingConvention convention
     ) {
         super(source, fields(field, buckets, from, to));
         this.field = field;
@@ -319,7 +319,7 @@ public class Bucket extends GroupingFunction.EvaluatableGroupingFunction
         this.to = to;
         this.configuration = configuration;
         this.offset = offset;
-        this.roundingConvention = roundingConvention;
+        this.convention = convention != null ? convention : DOWN;
     }
 
     private Bucket(StreamInput in) throws IOException {
@@ -333,7 +333,7 @@ public class Bucket extends GroupingFunction.EvaluatableGroupingFunction
             in.getTransportVersion().supports(ESQL_BUCKET_OFFSET) ? in.readZLong() : 0L,
             in.getTransportVersion().supports(ESQL_SUPPORT_EXPLICIT_BUCKET_ROUNDING_CONFIGURATION)
                 ? in.readEnum(RoundingConvention.class)
-                : DOWN
+                : null
         );
     }
 
@@ -369,8 +369,8 @@ public class Bucket extends GroupingFunction.EvaluatableGroupingFunction
         }
 
         if (transportVersion.supports(ESQL_SUPPORT_EXPLICIT_BUCKET_ROUNDING_CONFIGURATION)) {
-            out.writeEnum(roundingConvention);
-        } else if (roundingConvention != DOWN) {
+            out.writeEnum(convention);
+        } else if (convention != DOWN) {
             throw new EsqlIllegalArgumentException(
                 "bucket explicit rounding is not supported in peer node's version [{}]. Upgrade to version [{}] or newer.",
                 transportVersion,
@@ -433,7 +433,7 @@ public class Bucket extends GroupingFunction.EvaluatableGroupingFunction
             long f = foldToLong(foldContext, from);
             long t = foldToLong(foldContext, to);
             var rounding = new DateRoundingPicker(b, f, t, configuration.zoneId()).pickRounding();
-            if (UP.equals(roundingConvention)) {
+            if (UP.equals(convention)) {
                 rounding = Rounding.ToUpperRounding.createRounding(rounding);
             }
             if (min != null && max != null) {
@@ -444,7 +444,7 @@ public class Bucket extends GroupingFunction.EvaluatableGroupingFunction
         } else {
             // `buckets` is the bucket length, use it directly
             assert DataType.isTemporalAmount(buckets.dataType()) : "Unexpected span data type [" + buckets.dataType() + "]";
-            prepared = DateTrunc.createRounding(buckets.fold(foldContext), configuration.zoneId(), min, max, offset, roundingConvention);
+            prepared = DateTrunc.createRounding(buckets.fold(foldContext), configuration.zoneId(), min, max, offset, convention);
         }
 
         return prepared;
@@ -567,12 +567,12 @@ public class Bucket extends GroupingFunction.EvaluatableGroupingFunction
     public Expression replaceChildren(List<Expression> newChildren) {
         Expression from = newChildren.size() > 2 ? newChildren.get(2) : null;
         Expression to = newChildren.size() > 3 ? newChildren.get(3) : null;
-        return new Bucket(source(), newChildren.get(0), newChildren.get(1), from, to, configuration, offset, roundingConvention);
+        return new Bucket(source(), newChildren.get(0), newChildren.get(1), from, to, configuration, offset, convention);
     }
 
     @Override
     protected NodeInfo<? extends Expression> info() {
-        return NodeInfo.create(this, Bucket::new, field, buckets, from, to, configuration, offset, roundingConvention);
+        return NodeInfo.create(this, Bucket::new, field, buckets, from, to, configuration, offset, convention);
     }
 
     public Expression field() {
@@ -596,7 +596,7 @@ public class Bucket extends GroupingFunction.EvaluatableGroupingFunction
     }
 
     public RoundingConvention roundingConfiguration() {
-        return roundingConvention;
+        return convention;
     }
 
     public Configuration configuration() {
@@ -617,13 +617,13 @@ public class Bucket extends GroupingFunction.EvaluatableGroupingFunction
             + ", offset="
             + offset
             + "roundingConfiguration="
-            + roundingConvention
+            + convention
             + '}';
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getClass(), children(), configuration, offset, roundingConvention);
+        return Objects.hash(getClass(), children(), configuration, offset, convention);
     }
 
     @Override
@@ -633,7 +633,7 @@ public class Bucket extends GroupingFunction.EvaluatableGroupingFunction
         }
         Bucket other = (Bucket) obj;
 
-        return configuration.equals(other.configuration) && offset == other.offset && roundingConvention == other.roundingConvention;
+        return configuration.equals(other.configuration) && offset == other.offset && convention == other.convention;
     }
 
     protected Map<String, Object> getIntervalMetadata(FoldContext foldContext) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundTo.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundTo.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.expression.function.scalar.math;
 
+import org.elasticsearch.common.Rounding;
 import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -40,7 +41,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import static org.elasticsearch.common.logging.LoggerMessageFormat.format;
+import static org.elasticsearch.common.Rounding.RoundingConvention.DOWN;
 import static org.elasticsearch.xpack.esql.action.EsqlCapabilities.Cap.ROUND_TO_BLOCK_LOADER;
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isFoldable;
 import static org.elasticsearch.xpack.esql.core.type.DataType.DATETIME;
@@ -49,10 +50,11 @@ import static org.elasticsearch.xpack.esql.core.type.DataType.DOUBLE;
 import static org.elasticsearch.xpack.esql.core.type.DataType.INTEGER;
 import static org.elasticsearch.xpack.esql.core.type.DataType.LONG;
 import static org.elasticsearch.xpack.esql.core.type.DataType.UNSIGNED_LONG;
+import static org.elasticsearch.xpack.esql.expression.function.grouping.Bucket.ESQL_SUPPORT_EXPLICIT_BUCKET_ROUNDING_CONFIGURATION;
 import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.commonType;
 
 /**
- * Round down to one of a list of values.
+ * Round to one from the list of values.
  */
 public class RoundTo extends EsqlScalarFunction implements BlockLoaderExpression {
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(Expression.class, "RoundTo", RoundTo::new);
@@ -60,6 +62,7 @@ public class RoundTo extends EsqlScalarFunction implements BlockLoaderExpression
 
     private final Expression field;
     private final List<Expression> points;
+    private final Rounding.RoundingConvention convention;
 
     private DataType resultType;
 
@@ -83,16 +86,24 @@ public class RoundTo extends EsqlScalarFunction implements BlockLoaderExpression
             description = "Remaining rounding points. Must be constants."
         ) List<Expression> points
     ) {
+        this(source, field, points, null);
+    }
+
+    public RoundTo(Source source, Expression field, List<Expression> points, Rounding.RoundingConvention convention) {
         super(source, Iterators.toList(Iterators.concat(Iterators.single(field), points.iterator())));
         this.field = field;
         this.points = points;
+        this.convention = convention != null ? convention : DOWN;
     }
 
     private RoundTo(StreamInput in) throws IOException {
         this(
             Source.readFrom((PlanStreamInput) in),
             in.readNamedWriteable(Expression.class),
-            in.readNamedWriteableCollectionAsList(Expression.class)
+            in.readNamedWriteableCollectionAsList(Expression.class),
+            in.getTransportVersion().supports(ESQL_SUPPORT_EXPLICIT_BUCKET_ROUNDING_CONFIGURATION)
+                ? in.readEnum(Rounding.RoundingConvention.class)
+                : null
         );
     }
 
@@ -101,6 +112,9 @@ public class RoundTo extends EsqlScalarFunction implements BlockLoaderExpression
         source().writeTo(out);
         out.writeNamedWriteable(field);
         out.writeNamedWriteableCollection(points);
+        if (out.getTransportVersion().supports(ESQL_SUPPORT_EXPLICIT_BUCKET_ROUNDING_CONFIGURATION)) {
+            out.writeEnum(convention);
+        }
     }
 
     @Override
@@ -127,7 +141,7 @@ public class RoundTo extends EsqlScalarFunction implements BlockLoaderExpression
 
         DataType dataType = dataType();
         if (dataType == null || SIGNATURES.containsKey(dataType) == false) {
-            return new TypeResolution(format(null, "all arguments must be numeric, date, or data_nanos"));
+            return new TypeResolution("all arguments must be numeric, date, or data_nanos");
         }
 
         return TypeResolution.TYPE_RESOLVED;
@@ -165,12 +179,12 @@ public class RoundTo extends EsqlScalarFunction implements BlockLoaderExpression
 
     @Override
     public final Expression replaceChildren(List<Expression> newChildren) {
-        return new RoundTo(source(), newChildren.get(0), newChildren.subList(1, newChildren.size()));
+        return new RoundTo(source(), newChildren.get(0), newChildren.subList(1, newChildren.size()), convention);
     }
 
     @Override
     protected NodeInfo<? extends Expression> info() {
-        return NodeInfo.create(this, RoundTo::new, field(), points());
+        return NodeInfo.create(this, RoundTo::new, field(), points(), convention);
     }
 
     public Expression field() {
@@ -181,23 +195,32 @@ public class RoundTo extends EsqlScalarFunction implements BlockLoaderExpression
         return points;
     }
 
+    public Rounding.RoundingConvention roundingConvention() {
+        return convention;
+    }
+
     @Override
     public ExpressionEvaluator.Factory toEvaluator(ToEvaluator toEvaluator) {
         DataType dataType = dataType();
         Build build = SIGNATURES.get(dataType);
         if (build == null) {
-            throw new IllegalStateException("unsupported type");
+            throw new IllegalStateException("not supported for type " + dataType);
         }
 
         ExpressionEvaluator.Factory field = toEvaluator.apply(field());
         field = Cast.cast(source(), field().dataType(), dataType, field);
         List<Object> points = Iterators.toList(Iterators.map(points().iterator(), p -> Foldables.valueOf(toEvaluator.foldCtx(), p)));
         List<Number> sortedPoints = sortedRoundingPoints(points, dataType); // provide sorted points to the evaluator
-        return build.build(source(), field, sortedPoints);
+        return build.build(source(), field, sortedPoints, convention);
     }
 
     interface Build {
-        ExpressionEvaluator.Factory build(Source source, ExpressionEvaluator.Factory field, List<Number> points);
+        ExpressionEvaluator.Factory build(
+            Source source,
+            ExpressionEvaluator.Factory field,
+            List<Number> points,
+            Rounding.RoundingConvention convention
+        );
     }
 
     private static final Map<DataType, Build> SIGNATURES = Map.ofEntries(
@@ -245,7 +268,7 @@ public class RoundTo extends EsqlScalarFunction implements BlockLoaderExpression
             if (sortedPoints == null) {
                 return null;
             }
-            return new PushedBlockLoaderExpression(f, new BlockLoaderFunctionConfig.RoundToLongs(sortedPoints));
+            return new PushedBlockLoaderExpression(f, new BlockLoaderFunctionConfig.RoundToLongs(sortedPoints, convention));
         }
         return null;
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/X-RoundTo.java.st
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/X-RoundTo.java.st
@@ -7,120 +7,196 @@
 
 package org.elasticsearch.xpack.esql.expression.function.scalar.math;
 
-// begin generated imports
+import org.elasticsearch.common.Rounding;
 import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.ann.Fixed;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.xpack.esql.core.tree.Source;
 
 import java.util.Arrays;
-// end generated imports
 
 /**
- * Implementations of {@link RoundTo} for specific types.
- * <p>
- *   We have specializations for when there are very few rounding points because
- *   those are very fast and quite common.
- * </p>
+ * Implementations of {@link RoundTo} for {@code $type$}.
  * This class is generated. Edit {@code X-RoundTo.java.st} instead.
  */
 class RoundTo$Type$ {
-    static final RoundTo.Build BUILD = (source, field, points) -> {
-        $type$[] f = points.stream().mapTo$Type$(p -> p.$type$Value()).toArray();
-        return switch (f.length) {
-            // TODO should be a consistent way to do the 0 version - is CASE(MV_COUNT(f) == 1, f[0])
-            case 1 -> new RoundTo$Type$1Evaluator.Factory(source, field, f[0]);
+    static final RoundTo.Build BUILD = (source, field, points, convention) -> {
+        // TODO handle 0 points case - currently falls through to floorMany/ceilingMany and crashes
+        $type$[] p = points.stream().mapTo$Type$(n -> n.$type$Value()).toArray();
+        return switch (convention) {
+            case Rounding.RoundingConvention.DOWN -> floor(source, field, p);
+            case Rounding.RoundingConvention.UP -> ceiling(source, field, p);
+        };
+    };
+
+    private static ExpressionEvaluator.Factory floor(Source source, ExpressionEvaluator.Factory field, $type$[] p) {
+        return switch (p.length) {
+            case 1 -> new RoundTo$Type$ConstantEvaluator.Factory(source, field, p[0]);
             /*
              * These hand-unrolled implementations are even faster than the linear scan implementations.
              */
-            case 2 -> new RoundTo$Type$2Evaluator.Factory(source, field, f[0], f[1]);
-            case 3 -> new RoundTo$Type$3Evaluator.Factory(source, field, f[0], f[1], f[2]);
-            case 4 -> new RoundTo$Type$4Evaluator.Factory(source, field, f[0], f[1], f[2], f[3]);
-            case 5 -> new RoundTo$Type$5Evaluator.Factory(source, field, f[0], f[1], f[2], f[3], f[4]);
-            case 6 -> new RoundTo$Type$6Evaluator.Factory(source, field, f[0], f[1], f[2], f[3], f[4], f[5]);
-            case 7 -> new RoundTo$Type$7Evaluator.Factory(source, field, f[0], f[1], f[2], f[3], f[4], f[5], f[6]);
-            case 8 -> new RoundTo$Type$8Evaluator.Factory(source, field, f[0], f[1], f[2], f[3], f[4], f[5], f[6], f[7]);
-            case 9 -> new RoundTo$Type$9Evaluator.Factory(source, field, f[0], f[1], f[2], f[3], f[4], f[5], f[6], f[7], f[8]);
-            case 10 -> new RoundTo$Type$10Evaluator.Factory(source, field, f[0], f[1], f[2], f[3], f[4], f[5], f[6], f[7], f[8], f[9]);
+            case 2 -> new RoundTo$Type$Floor2Evaluator.Factory(source, field, p[0], p[1]);
+            case 3 -> new RoundTo$Type$Floor3Evaluator.Factory(source, field, p[0], p[1], p[2]);
+            case 4 -> new RoundTo$Type$Floor4Evaluator.Factory(source, field, p[0], p[1], p[2], p[3]);
+            case 5 -> new RoundTo$Type$Floor5Evaluator.Factory(source, field, p[0], p[1], p[2], p[3], p[4]);
+            case 6 -> new RoundTo$Type$Floor6Evaluator.Factory(source, field, p[0], p[1], p[2], p[3], p[4], p[5]);
+            case 7 -> new RoundTo$Type$Floor7Evaluator.Factory(source, field, p[0], p[1], p[2], p[3], p[4], p[5], p[6]);
+            case 8 -> new RoundTo$Type$Floor8Evaluator.Factory(source, field, p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7]);
+            case 9 -> new RoundTo$Type$Floor9Evaluator.Factory(source, field, p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7], p[8]);
+            case 10 -> new RoundTo$Type$Floor10Evaluator.Factory(source, field, p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7], p[8], p[9]);
             /*
              * Break point of 10 experimentally derived on Nik's laptop (13th Gen Intel(R) Core(TM) i7-1370P)
              * on 2025-05-22.
              */
-            default -> {
-$if(long||int)$
-                $type$ interval = extractFixedInterval(f);
-                if (interval > 0) {
-                    yield new RoundTo$Type$FixedIntervalEvaluator.Factory(source, field, f[0], f[f.length - 1], interval);
-                } else {
-                    yield new RoundTo$Type$BinarySearchEvaluator.Factory(source, field, f);
-                }
-$else$
-                yield new RoundTo$Type$BinarySearchEvaluator.Factory(source, field, f);
-$endif$
-            }
+            default -> floorMany(source, field, p);
         };
-    };
+    }
 
-    @Evaluator(extraName = "BinarySearch")
-    static $type$ process($type$ field, @Fixed(includeInToString = false) $type$[] points) {
-        int idx = Arrays.binarySearch(points, field);
-        return points[idx >= 0 ? idx : Math.max(0, -idx - 2)];
+    private static ExpressionEvaluator.Factory ceiling(Source source, ExpressionEvaluator.Factory field, $type$[] p) {
+        return switch (p.length) {
+            case 1 -> new RoundTo$Type$ConstantEvaluator.Factory(source, field, p[0]);
+            /*
+             * These hand-unrolled implementations are even faster than the linear scan implementations.
+             */
+            case 2 -> new RoundTo$Type$Ceiling2Evaluator.Factory(source, field, p[0], p[1]);
+            case 3 -> new RoundTo$Type$Ceiling3Evaluator.Factory(source, field, p[0], p[1], p[2]);
+            case 4 -> new RoundTo$Type$Ceiling4Evaluator.Factory(source, field, p[0], p[1], p[2], p[3]);
+            case 5 -> new RoundTo$Type$Ceiling5Evaluator.Factory(source, field, p[0], p[1], p[2], p[3], p[4]);
+            case 6 -> new RoundTo$Type$Ceiling6Evaluator.Factory(source, field, p[0], p[1], p[2], p[3], p[4], p[5]);
+            case 7 -> new RoundTo$Type$Ceiling7Evaluator.Factory(source, field, p[0], p[1], p[2], p[3], p[4], p[5], p[6]);
+            case 8 -> new RoundTo$Type$Ceiling8Evaluator.Factory(source, field, p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7]);
+            case 9 -> new RoundTo$Type$Ceiling9Evaluator.Factory(source, field, p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7], p[8]);
+$if(double)$
+            case 10 -> new RoundTo$Type$Ceiling10Evaluator.Factory(
+                source,
+                field,
+                p[0],
+                p[1],
+                p[2],
+                p[3],
+                p[4],
+                p[5],
+                p[6],
+                p[7],
+                p[8],
+                p[9]
+            );
+$else$
+            case 10 -> new RoundTo$Type$Ceiling10Evaluator.Factory(source, field, p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7], p[8], p[9]);
+$endif$
+            /*
+             * Break point of 10 experimentally derived on Nik's laptop (13th Gen Intel(R) Core(TM) i7-1370P)
+             * on 2025-05-22.
+             */
+            default -> ceilingMany(source, field, p);
+        };
+    }
+
+    private static ExpressionEvaluator.Factory floorMany(Source source, ExpressionEvaluator.Factory field, $type$[] p) {
+$if(long||int)$
+        $type$ interval = fixedInterval(p);
+        if (interval > 0) {
+            return new RoundTo$Type$FloorIntervalEvaluator.Factory(source, field, p[0], p[p.length - 1], interval);
+        }
+$endif$
+        return new RoundTo$Type$FloorSearchEvaluator.Factory(source, field, p);
+    }
+
+    private static ExpressionEvaluator.Factory ceilingMany(Source source, ExpressionEvaluator.Factory field, $type$[] p) {
+$if(long||int)$
+        $type$ interval = fixedInterval(p);
+        if (interval > 0) {
+            return new RoundTo$Type$CeilingIntervalEvaluator.Factory(source, field, p[0], p[p.length - 1], interval);
+        }
+$endif$
+        return new RoundTo$Type$CeilingSearchEvaluator.Factory(source, field, p);
     }
 
 $if(long||int)$
-    private static $type$ extractFixedInterval($type$[] points) {
-        $type$ interval = (points[points.length - 1] - points[0]) / (points.length - 1);
-        for (int i = 1; i < points.length; i++) {
-            if (points[i] - points[i - 1] != interval) {
+    private static $type$ fixedInterval($type$[] p) {
+        $type$ interval = (p[p.length - 1] - p[0]) / (p.length - 1);
+        for (int i = 1; i < p.length; i++) {
+            if (p[i] - p[i - 1] != interval) {
                 return -1;
             }
         }
         return interval;
     }
+$endif$
 
-    @Evaluator(extraName = "FixedInterval")
-    static $type$ processFixed($type$ field, @Fixed $type$ first, @Fixed $type$ last, @Fixed $type$ interval) {
-        if (field < first) {
-            return first; // almost never true in practice; predictor skips this
+    @Evaluator(extraName = "Constant")
+    static $type$ constant($type$ v, @Fixed $type$ p) {
+        return p;
+    }
+
+    @Evaluator(extraName = "FloorSearch")
+    static $type$ floorSearch($type$ v, @Fixed(includeInToString = false) $type$[] p) {
+        int i = Arrays.binarySearch(p, v);
+        return p[i >= 0 ? i : Math.max(0, -i - 2)];
+    }
+
+    @Evaluator(extraName = "CeilingSearch")
+    static $type$ ceilingSearch($type$ v, @Fixed(includeInToString = false) $type$[] p) {
+        int i = Arrays.binarySearch(p, v);
+        return p[i >= 0 ? i : Math.min(p.length - 1, -i - 1)];
+    }
+
+$if(long||int)$
+    @Evaluator(extraName = "FloorInterval")
+    static $type$ floorInterval($type$ v, @Fixed $type$ lo, @Fixed $type$ hi, @Fixed $type$ interval) {
+        if (v < lo) {
+            return lo;
         }
-        if (field > last) {
-            return last; // almost never true in practice; predictor skips this
+        if (v > hi) {
+            return hi;
         }
-        return field - (field - first) % interval;
+        return v - (v - lo) % interval;
+    }
+
+    @Evaluator(extraName = "CeilingInterval")
+    static $type$ ceilingInterval($type$ v, @Fixed $type$ lo, @Fixed $type$ hi, @Fixed $type$ interval) {
+        if (v <= lo) {
+            return lo;
+        }
+        if (v > hi) {
+            return hi;
+        }
+        $type$ r = (v - lo) % interval;
+        if (r == 0) {
+            return v;
+        }
+        return v + interval - r;
     }
 $endif$
 
-    @Evaluator(extraName = "1")
-    static $type$ process($type$ field, @Fixed $type$ p0) {
-        return p0;
-    }
-
-    @Evaluator(extraName = "2")
-    static $type$ process($type$ field, @Fixed $type$ p0, @Fixed $type$ p1) {
-        if (field < p1) {
+    @Evaluator(extraName = "Floor2")
+    static $type$ floor2($type$ v, @Fixed $type$ p0, @Fixed $type$ p1) {
+        if (v < p1) {
             return p0;
         }
         return p1;
     }
 
-    @Evaluator(extraName = "3")
-    static $type$ process($type$ field, @Fixed $type$ p0, @Fixed $type$ p1, @Fixed $type$ p2) {
-        if (field < p1) {
+    @Evaluator(extraName = "Floor3")
+    static $type$ floor3($type$ v, @Fixed $type$ p0, @Fixed $type$ p1, @Fixed $type$ p2) {
+        if (v < p1) {
             return p0;
         }
-        if (field < p2) {
+        if (v < p2) {
             return p1;
         }
         return p2;
     }
 
-    @Evaluator(extraName = "4")
-    static $type$ process($type$ field, @Fixed $type$ p0, @Fixed $type$ p1, @Fixed $type$ p2, @Fixed $type$ p3) {
-        if (field < p1) {
+    @Evaluator(extraName = "Floor4")
+    static $type$ floor4($type$ v, @Fixed $type$ p0, @Fixed $type$ p1, @Fixed $type$ p2, @Fixed $type$ p3) {
+        if (v < p1) {
             return p0;
         }
-        if (field < p2) {
+        if (v < p2) {
             return p1;
         }
-        if (field < p3) {
+        if (v < p3) {
             return p2;
         }
         return p3;
@@ -129,18 +205,18 @@ $endif$
     /*
      * Manual binary search for 5 rounding points, it is faster than linear search or array style binary search.
      */
-    @Evaluator(extraName = "5")
-    static $type$ process($type$ field, @Fixed $type$ p0, @Fixed $type$ p1, @Fixed $type$ p2, @Fixed $type$ p3, @Fixed $type$ p4) {
-        if (field < p2) {
-            if (field < p1) {
+    @Evaluator(extraName = "Floor5")
+    static $type$ floor5($type$ v, @Fixed $type$ p0, @Fixed $type$ p1, @Fixed $type$ p2, @Fixed $type$ p3, @Fixed $type$ p4) {
+        if (v < p2) {
+            if (v < p1) {
                 return p0;
             }
             return p1;
         }
-        if (field < p3) {
+        if (v < p3) {
             return p2;
         }
-        if (field < p4) {
+        if (v < p4) {
             return p3;
         }
         return p4;
@@ -149,9 +225,9 @@ $endif$
     /*
      * Manual binary search for 6 rounding points, it is faster than linear search or array style binary search.
      */
-    @Evaluator(extraName = "6")
-    static $type$ process(
-        $type$ field,      // hack to keep the formatter happy.
+    @Evaluator(extraName = "Floor6")
+    static $type$ floor6(
+        $type$ v,          // hack to keep the formatter happy.
         @Fixed $type$ p0,  // int is so short this should be on one line but double is not.
         @Fixed $type$ p1,  // That's not compatible with the templates.
         @Fixed $type$ p2,  // So we comment to make the formatter not try to change the line.
@@ -159,19 +235,19 @@ $endif$
         @Fixed $type$ p4,
         @Fixed $type$ p5
     ) {
-        if (field < p2) {
-            if (field < p1) {
+        if (v < p2) {
+            if (v < p1) {
                 return p0;
             }
             return p1;
         }
-        if (field < p4) {
-            if (field < p3) {
+        if (v < p4) {
+            if (v < p3) {
                 return p2;
             }
             return p3;
         }
-        if (field < p5) {
+        if (v < p5) {
             return p4;
         }
         return p5;
@@ -180,9 +256,9 @@ $endif$
     /*
      * Manual binary search for 7 rounding points, it is faster than linear search or array style binary search.
      */
-    @Evaluator(extraName = "7")
-    static $type$ process(
-        $type$ field,      // hack to keep the formatter happy.
+    @Evaluator(extraName = "Floor7")
+    static $type$ floor7(
+        $type$ v,          // hack to keep the formatter happy.
         @Fixed $type$ p0,  // int is so short this should be on one line but double is not.
         @Fixed $type$ p1,  // That's not compatible with the templates.
         @Fixed $type$ p2,  // So we comment to make the formatter not try to change the line.
@@ -191,22 +267,22 @@ $endif$
         @Fixed $type$ p5,
         @Fixed $type$ p6
     ) {
-        if (field < p3) {
-            if (field < p1) {
+        if (v < p3) {
+            if (v < p1) {
                 return p0;
             }
-            if (field < p2) {
+            if (v < p2) {
                 return p1;
             }
             return p2;
         }
-        if (field < p5) {
-            if (field < p4) {
+        if (v < p5) {
+            if (v < p4) {
                 return p3;
             }
             return p4;
         }
-        if (field < p6) {
+        if (v < p6) {
             return p5;
         }
         return p6;
@@ -215,37 +291,37 @@ $endif$
     /*
      * Manual binary search for 8 rounding points, it is faster than linear search or array style binary search.
      */
-    @Evaluator(extraName = "8")
-    static $type$ process(
-        $type$ field,
-        @Fixed $type$ p0,
-        @Fixed $type$ p1,
-        @Fixed $type$ p2,
+    @Evaluator(extraName = "Floor8")
+    static $type$ floor8(
+        $type$ v,          // hack to keep the formatter happy.
+        @Fixed $type$ p0,  // int is so short this should be on one line but double is not.
+        @Fixed $type$ p1,  // That's not compatible with the templates.
+        @Fixed $type$ p2,  // So we comment to make the formatter not try to change the line.
         @Fixed $type$ p3,
         @Fixed $type$ p4,
         @Fixed $type$ p5,
         @Fixed $type$ p6,
         @Fixed $type$ p7
     ) {
-        if (field < p3) {
-            if (field < p1) {
+        if (v < p3) {
+            if (v < p1) {
                 return p0;
             }
-            if (field < p2) {
+            if (v < p2) {
                 return p1;
             }
             return p2;
         }
-        if (field < p5) {
-            if (field < p4) {
+        if (v < p5) {
+            if (v < p4) {
                 return p3;
             }
             return p4;
         }
-        if (field < p6) {
+        if (v < p6) {
             return p5;
         }
-        if (field < p7) {
+        if (v < p7) {
             return p6;
         }
         return p7;
@@ -254,12 +330,12 @@ $endif$
     /*
      * Manual binary search for 9 rounding points, it is faster than linear search or array style binary search.
      */
-    @Evaluator(extraName = "9")
-    static $type$ process(
-        $type$ field,
-        @Fixed $type$ p0,
-        @Fixed $type$ p1,
-        @Fixed $type$ p2,
+    @Evaluator(extraName = "Floor9")
+    static $type$ floor9(
+        $type$ v,          // hack to keep the formatter happy.
+        @Fixed $type$ p0,  // int is so short this should be on one line but double is not.
+        @Fixed $type$ p1,  // That's not compatible with the templates.
+        @Fixed $type$ p2,  // So we comment to make the formatter not try to change the line.
         @Fixed $type$ p3,
         @Fixed $type$ p4,
         @Fixed $type$ p5,
@@ -267,28 +343,28 @@ $endif$
         @Fixed $type$ p7,
         @Fixed $type$ p8
     ) {
-        if (field < p4) {
-            if (field < p1) {
+        if (v < p4) {
+            if (v < p1) {
                 return p0;
             }
-            if (field < p2) {
+            if (v < p2) {
                 return p1;
             }
-            if (field < p3) {
+            if (v < p3) {
                 return p2;
             }
             return p3;
         }
-        if (field < p6) {
-            if (field < p5) {
+        if (v < p6) {
+            if (v < p5) {
                 return p4;
             }
             return p5;
         }
-        if (field < p7) {
+        if (v < p7) {
             return p6;
         }
-        if (field < p8) {
+        if (v < p8) {
             return p7;
         }
         return p8;
@@ -297,12 +373,12 @@ $endif$
     /*
      * Manual binary search for 10 rounding points, it is faster than linear search or array style binary search.
      */
-    @Evaluator(extraName = "10")
-    static $type$ process(
-        $type$ field,
-        @Fixed $type$ p0,
-        @Fixed $type$ p1,
-        @Fixed $type$ p2,
+    @Evaluator(extraName = "Floor10")
+    static $type$ floor10(
+        $type$ v,          // hack to keep the formatter happy.
+        @Fixed $type$ p0,  // int is so short this should be on one line but double is not.
+        @Fixed $type$ p1,  // That's not compatible with the templates.
+        @Fixed $type$ p2,  // So we comment to make the formatter not try to change the line.
         @Fixed $type$ p3,
         @Fixed $type$ p4,
         @Fixed $type$ p5,
@@ -311,31 +387,279 @@ $endif$
         @Fixed $type$ p8,
         @Fixed $type$ p9
     ) {
-        if (field < p4) {
-            if (field < p1) {
+        if (v < p4) {
+            if (v < p1) {
                 return p0;
             }
-            if (field < p2) {
+            if (v < p2) {
                 return p1;
             }
-            if (field < p3) {
+            if (v < p3) {
                 return p2;
             }
             return p3;
         }
-        if (field < p7) {
-            if (field < p5) {
+        if (v < p7) {
+            if (v < p5) {
                 return p4;
             }
-            if (field < p6) {
+            if (v < p6) {
                 return p5;
             }
             return p6;
         }
-        if (field < p8) {
+        if (v < p8) {
             return p7;
         }
-        if (field < p9) {
+        if (v < p9) {
+            return p8;
+        }
+        return p9;
+    }
+
+    @Evaluator(extraName = "Ceiling2")
+    static $type$ ceiling2($type$ v, @Fixed $type$ p0, @Fixed $type$ p1) {
+        if (v <= p0) {
+            return p0;
+        }
+        return p1;
+    }
+
+    @Evaluator(extraName = "Ceiling3")
+    static $type$ ceiling3($type$ v, @Fixed $type$ p0, @Fixed $type$ p1, @Fixed $type$ p2) {
+        if (v <= p0) {
+            return p0;
+        }
+        if (v <= p1) {
+            return p1;
+        }
+        return p2;
+    }
+
+    @Evaluator(extraName = "Ceiling4")
+    static $type$ ceiling4($type$ v, @Fixed $type$ p0, @Fixed $type$ p1, @Fixed $type$ p2, @Fixed $type$ p3) {
+        if (v <= p0) {
+            return p0;
+        }
+        if (v <= p1) {
+            return p1;
+        }
+        if (v <= p2) {
+            return p2;
+        }
+        return p3;
+    }
+
+    /*
+     * Manual binary search for 5 rounding points, it is faster than linear search or array style binary search.
+     */
+    @Evaluator(extraName = "Ceiling5")
+    static $type$ ceiling5($type$ v, @Fixed $type$ p0, @Fixed $type$ p1, @Fixed $type$ p2, @Fixed $type$ p3, @Fixed $type$ p4) {
+        if (v <= p1) {
+            if (v <= p0) {
+                return p0;
+            }
+            return p1;
+        }
+        if (v <= p2) {
+            return p2;
+        }
+        if (v <= p3) {
+            return p3;
+        }
+        return p4;
+    }
+
+    /*
+     * Manual binary search for 6 rounding points, it is faster than linear search or array style binary search.
+     */
+    @Evaluator(extraName = "Ceiling6")
+    static $type$ ceiling6(
+        $type$ v,          // hack to keep the formatter happy.
+        @Fixed $type$ p0,  // int is so short this should be on one line but double is not.
+        @Fixed $type$ p1,  // That's not compatible with the templates.
+        @Fixed $type$ p2,  // So we comment to make the formatter not try to change the line.
+        @Fixed $type$ p3,
+        @Fixed $type$ p4,
+        @Fixed $type$ p5
+    ) {
+        if (v <= p1) {
+            if (v <= p0) {
+                return p0;
+            }
+            return p1;
+        }
+        if (v <= p3) {
+            if (v <= p2) {
+                return p2;
+            }
+            return p3;
+        }
+        if (v <= p4) {
+            return p4;
+        }
+        return p5;
+    }
+
+    /*
+     * Manual binary search for 7 rounding points, it is faster than linear search or array style binary search.
+     */
+    @Evaluator(extraName = "Ceiling7")
+    static $type$ ceiling7(
+        $type$ v,          // hack to keep the formatter happy.
+        @Fixed $type$ p0,  // int is so short this should be on one line but double is not.
+        @Fixed $type$ p1,  // That's not compatible with the templates.
+        @Fixed $type$ p2,  // So we comment to make the formatter not try to change the line.
+        @Fixed $type$ p3,
+        @Fixed $type$ p4,
+        @Fixed $type$ p5,
+        @Fixed $type$ p6
+    ) {
+        if (v <= p2) {
+            if (v <= p0) {
+                return p0;
+            }
+            if (v <= p1) {
+                return p1;
+            }
+            return p2;
+        }
+        if (v <= p4) {
+            if (v <= p3) {
+                return p3;
+            }
+            return p4;
+        }
+        if (v <= p5) {
+            return p5;
+        }
+        return p6;
+    }
+
+    /*
+     * Manual binary search for 8 rounding points, it is faster than linear search or array style binary search.
+     */
+    @Evaluator(extraName = "Ceiling8")
+    static $type$ ceiling8(
+        $type$ v,          // hack to keep the formatter happy.
+        @Fixed $type$ p0,  // int is so short this should be on one line but double is not.
+        @Fixed $type$ p1,  // That's not compatible with the templates.
+        @Fixed $type$ p2,  // So we comment to make the formatter not try to change the line.
+        @Fixed $type$ p3,
+        @Fixed $type$ p4,
+        @Fixed $type$ p5,
+        @Fixed $type$ p6,
+        @Fixed $type$ p7
+    ) {
+        if (v <= p2) {
+            if (v <= p0) {
+                return p0;
+            }
+            if (v <= p1) {
+                return p1;
+            }
+            return p2;
+        }
+        if (v <= p4) {
+            if (v <= p3) {
+                return p3;
+            }
+            return p4;
+        }
+        if (v <= p5) {
+            return p5;
+        }
+        if (v <= p6) {
+            return p6;
+        }
+        return p7;
+    }
+
+    /*
+     * Manual binary search for 9 rounding points, it is faster than linear search or array style binary search.
+     */
+    @Evaluator(extraName = "Ceiling9")
+    static $type$ ceiling9(
+        $type$ v,          // hack to keep the formatter happy.
+        @Fixed $type$ p0,  // int is so short this should be on one line but double is not.
+        @Fixed $type$ p1,  // That's not compatible with the templates.
+        @Fixed $type$ p2,  // So we comment to make the formatter not try to change the line.
+        @Fixed $type$ p3,
+        @Fixed $type$ p4,
+        @Fixed $type$ p5,
+        @Fixed $type$ p6,
+        @Fixed $type$ p7,
+        @Fixed $type$ p8
+    ) {
+        if (v <= p3) {
+            if (v <= p0) {
+                return p0;
+            }
+            if (v <= p1) {
+                return p1;
+            }
+            if (v <= p2) {
+                return p2;
+            }
+            return p3;
+        }
+        if (v <= p5) {
+            if (v <= p4) {
+                return p4;
+            }
+            return p5;
+        }
+        if (v <= p6) {
+            return p6;
+        }
+        if (v <= p7) {
+            return p7;
+        }
+        return p8;
+    }
+
+    /*
+     * Manual binary search for 10 rounding points, it is faster than linear search or array style binary search.
+     */
+    @Evaluator(extraName = "Ceiling10")
+    static $type$ ceiling10(
+        $type$ v,          // hack to keep the formatter happy.
+        @Fixed $type$ p0,  // int is so short this should be on one line but double is not.
+        @Fixed $type$ p1,  // That's not compatible with the templates.
+        @Fixed $type$ p2,  // So we comment to make the formatter not try to change the line.
+        @Fixed $type$ p3,
+        @Fixed $type$ p4,
+        @Fixed $type$ p5,
+        @Fixed $type$ p6,
+        @Fixed $type$ p7,
+        @Fixed $type$ p8,
+        @Fixed $type$ p9
+    ) {
+        if (v <= p3) {
+            if (v <= p0) {
+                return p0;
+            }
+            if (v <= p1) {
+                return p1;
+            }
+            if (v <= p2) {
+                return p2;
+            }
+            return p3;
+        }
+        if (v <= p6) {
+            if (v <= p4) {
+                return p4;
+            }
+            if (v <= p5) {
+                return p5;
+            }
+            return p6;
+        }
+        if (v <= p7) {
+            return p7;
+        }
+        if (v <= p8) {
             return p8;
         }
         return p9;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/local/ReplaceDateTruncBucketWithRoundTo.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/local/ReplaceDateTruncBucketWithRoundTo.java
@@ -42,6 +42,7 @@ import org.elasticsearch.xpack.esql.stats.SearchStats;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.elasticsearch.common.Rounding.RoundingConvention.UP;
 import static org.elasticsearch.xpack.esql.core.type.DataType.isDateTime;
 import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.dateWithTypeToString;
 
@@ -74,10 +75,6 @@ public class ReplaceDateTruncBucketWithRoundTo extends ParameterizedRule<Logical
                 (interval, minValue, maxValue) -> DateTrunc.createRounding(interval, dateTrunc.zoneId(), minValue, maxValue)
             );
         } else if (e instanceof Bucket bucket) {
-            // TODO(sidosera): https://github.com/elastic/elasticsearch/issues/148306
-            if (bucket.roundingConfiguration() == Rounding.RoundingConvention.UP) {
-                return e;
-            }
             roundTo = maybeToRoundTo(
                 bucket.source(),
                 bucket.field(),
@@ -121,8 +118,8 @@ public class ReplaceDateTruncBucketWithRoundTo extends ParameterizedRule<Logical
             if (min != null && max != null && foldableTimeExpression.foldable() && min <= max) {
                 Object foldedInterval = foldableTimeExpression.fold(FoldContext.small() /* TODO remove me */);
                 Rounding.Prepared rounding = roundingFunction.apply(foldedInterval, min, max);
-                long[] roundingPoints = rounding.fixedRoundingPoints();
-                if (roundingPoints == null) {
+                RoundTo roundTo = createRoundTo(source, field, rounding);
+                if (roundTo == null) {
                     logger.trace(
                         "Fixed rounding point is null for field {}, minValue {} in string format {} and maxValue {} in string format {}",
                         fieldName,
@@ -133,12 +130,7 @@ public class ReplaceDateTruncBucketWithRoundTo extends ParameterizedRule<Logical
                     );
                     return null;
                 }
-
-                List<Expression> expressions = new ArrayList<>(roundingPoints.length);
-                for (long p : roundingPoints) {
-                    expressions.add(new Literal(Source.EMPTY, p, fieldType));
-                }
-                return new RoundTo(source, field, expressions);
+                return roundTo;
             }
         }
         return null;
@@ -194,5 +186,21 @@ public class ReplaceDateTruncBucketWithRoundTo extends ParameterizedRule<Logical
 
     private Long toLong(Object value) {
         return value instanceof Long l ? l : null;
+    }
+
+    private static RoundTo createRoundTo(Source source, Expression field, Rounding.Prepared rounding) {
+        long[] roundingPoints = rounding.fixedRoundingPoints();
+        if (roundingPoints == null) {
+            return null;
+        }
+        DataType fieldType = field.dataType();
+        List<Expression> literals = new ArrayList<>(roundingPoints.length);
+        for (long p : roundingPoints) {
+            literals.add(new Literal(Source.EMPTY, p, fieldType));
+        }
+        if (rounding.getUnprepared() instanceof Rounding.ToUpperRounding) {
+            return new RoundTo(source, field, literals, UP);
+        }
+        return new RoundTo(source, field, literals);
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/ReplaceRoundToWithQueryAndTags.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/ReplaceRoundToWithQueryAndTags.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.optimizer.rules.physical.local;
 
+import org.elasticsearch.common.Rounding;
 import org.elasticsearch.compute.lucene.query.DataPartitioning;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.query.BoolQueryBuilder;
@@ -36,8 +37,10 @@ import org.elasticsearch.xpack.esql.core.util.Queries;
 import org.elasticsearch.xpack.esql.expression.function.scalar.math.RoundTo;
 import org.elasticsearch.xpack.esql.expression.predicate.Range;
 import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNull;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThan;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThanOrEqual;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThan;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThanOrEqual;
 import org.elasticsearch.xpack.esql.optimizer.LocalPhysicalOptimizerContext;
 import org.elasticsearch.xpack.esql.optimizer.PhysicalOptimizerRules;
 import org.elasticsearch.xpack.esql.plan.physical.EsQueryExec;
@@ -420,26 +423,42 @@ public class ReplaceRoundToWithQueryAndTags extends PhysicalOptimizerRules.Param
         }
         List<EsQueryExec.QueryBuilderAndTags> queries = new ArrayList<>(count);
 
-        Object tag = points.get(0);
+        // RoundingConvention.UP uses right-closed buckets and ceiling lookup (smallest p >= t),
+        // producing buckets (p_(i-1), p_i] tagged p_i.
+        boolean upperBound = roundTo.roundingConvention() == Rounding.RoundingConvention.UP;
         if (points.size() == 1) { // if there is only one rounding point, just tag the main query
-            EsQueryExec.QueryBuilderAndTags queryBuilderAndTags = tagOnlyBucket(queryExec, tag);
+            EsQueryExec.QueryBuilderAndTags queryBuilderAndTags = tagOnlyBucket(queryExec, points.get(0));
             queries.add(queryBuilderAndTags);
         } else {
             Source source = roundTo.source();
             Object lower = null;
-            Object upper = null;
+            Object upper;
             Queries.Clause clause = queryExec.hasScoring() ? Queries.Clause.MUST : Queries.Clause.FILTER;
             ZoneId zoneId = ctx.configuration().zoneId();
-            for (int i = 1; i < count; i++) {
+            // DOWN: buckets are [p_i, p_(i+1)) tagged with p_i, head bucket "< p_1" tagged p_0,
+            // tail bucket ">= p_(n-1)" tagged p_(n-1).
+            // UP: buckets are (p_(i-1), p_i] tagged with p_i, head bucket "<= p_0" tagged p_0,
+            // tail bucket "> p_(n-2)" tagged p_(n-1).
+            int loopStart = upperBound ? 0 : 1;
+            int loopEnd = upperBound ? count - 1 : count;
+            Object tag = upperBound ? null : points.get(0);
+            for (int i = loopStart; i < loopEnd; i++) {
                 upper = points.get(i);
-                // build predicates and range queries for RoundTo ranges
-                queries.add(rangeBucket(source, field, dataType, lower, upper, tag, zoneId, queryExec, pushdownPredicates, clause));
+                if (upperBound) {
+                    tag = upper;
+                }
+                queries.add(
+                    rangeBucket(source, field, dataType, lower, upper, tag, upperBound, zoneId, queryExec, pushdownPredicates, clause)
+                );
                 lower = upper;
-                tag = upper;
+                if (upperBound == false) {
+                    tag = upper;
+                }
             }
-            // build the last/gte bucket
-            queries.add(rangeBucket(source, field, dataType, lower, null, lower, zoneId, queryExec, pushdownPredicates, clause));
-            // build null bucket
+            Object tailTag = upperBound ? points.get(count - 1) : lower;
+            queries.add(
+                rangeBucket(source, field, dataType, lower, null, tailTag, upperBound, zoneId, queryExec, pushdownPredicates, clause)
+            );
             queries.add(nullBucket(source, field, queryExec, pushdownPredicates, clause));
         }
         return queries;
@@ -467,17 +486,20 @@ public class ReplaceRoundToWithQueryAndTags extends PhysicalOptimizerRules.Param
         DataType dataType,
         Object lower,
         Object upper,
+        boolean upperBound,
         ZoneId zoneId
     ) {
         Literal lowerValue = new Literal(source, lower, dataType);
         Literal upperValue = new Literal(source, upper, dataType);
         if (lower == null) {
-            return new LessThan(source, field, upperValue, zoneId);
+            return upperBound ? new LessThanOrEqual(source, field, upperValue, zoneId) : new LessThan(source, field, upperValue, zoneId);
         } else if (upper == null) {
-            return new GreaterThanOrEqual(source, field, lowerValue, zoneId);
+            return upperBound
+                ? new GreaterThan(source, field, lowerValue, zoneId)
+                : new GreaterThanOrEqual(source, field, lowerValue, zoneId);
         } else {
-            // lower and upper should not be both null
-            return new Range(source, field, lowerValue, true, upperValue, false, dataType.isDate() ? zoneId : null);
+            // lower and upper should not be both null. UP mode uses (lower, upper]; DOWN uses [lower, upper).
+            return new Range(source, field, lowerValue, upperBound == false, upperValue, upperBound, dataType.isDate() ? zoneId : null);
         }
     }
 
@@ -505,12 +527,13 @@ public class ReplaceRoundToWithQueryAndTags extends PhysicalOptimizerRules.Param
         Object lower,
         Object upper,
         Object tag,
+        boolean upperBound,
         ZoneId zoneId,
         EsQueryExec queryExec,
         LucenePushdownPredicates pushdownPredicates,
         Queries.Clause clause
     ) {
-        Expression range = createRangeExpression(source, field, dataType, lower, upper, zoneId);
+        Expression range = createRangeExpression(source, field, dataType, lower, upper, upperBound, zoneId);
         return buildCombinedQueryAndTags(queryExec, pushdownPredicates, range, clause, List.of(tag));
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToTests.java
@@ -215,7 +215,7 @@ public class RoundToTests extends AbstractScalarFunctionTestCase {
                 }
             }
             return max;
-        }, "FixedInterval");
+        }, "FloorInterval");
     }
 
     private static TestCaseSupplier fixedIntervalInts(
@@ -233,7 +233,7 @@ public class RoundToTests extends AbstractScalarFunctionTestCase {
                 }
             }
             return max;
-        }, "FixedInterval");
+        }, "FloorInterval");
     }
 
     private static TestCaseSupplier supplier(double f, double expected, double... points) {
@@ -354,8 +354,11 @@ public class RoundToTests extends AbstractScalarFunctionTestCase {
     }
 
     private static <P> String specialization(int pointsSize, DataType dataType, List<P> points) {
+        if (pointsSize == 1) {
+            return "Constant";
+        }
         if (pointsSize < 11) {
-            return Integer.toString(pointsSize);
+            return "Floor" + pointsSize;
         }
         // fixed intervals?
         if (dataType == DataType.INTEGER || dataType == DataType.LONG || dataType == DataType.DATETIME || dataType == DataType.DATE_NANOS) {
@@ -365,12 +368,12 @@ public class RoundToTests extends AbstractScalarFunctionTestCase {
             long interval = (pn - p0) / (size - 1);
             for (int i = 1; i < size; i++) {
                 if (((Number) points.get(i)).longValue() - ((Number) points.get(i - 1)).longValue() != interval) {
-                    return "BinarySearch";
+                    return "FloorSearch";
                 }
             }
-            return "FixedInterval";
+            return "FloorInterval";
         }
-        return "BinarySearch";
+        return "FloorSearch";
     }
 
     private static DataType expectedType(List<DataType> types) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/local/ReplaceDateTruncBucketWithRoundToTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/local/ReplaceDateTruncBucketWithRoundToTests.java
@@ -282,11 +282,10 @@ public class ReplaceDateTruncBucketWithRoundToTests extends AbstractLocalLogical
     }
 
     /**
-     * TStep (upper-bound) buckets are NOT substituted with a {@link RoundTo}: ceiling lookup needs a
-     * specialized RoundTo path that does not exist yet, so the rule keeps the {@link Bucket} so the
-     * eval path uses the wrapped {@code Rounding.Prepared} directly.
+     * TStep (right-closed) buckets are substituted with a {@link RoundTo} carrying
+     * {@link org.elasticsearch.common.Rounding.RoundingConvention#UP} (smallest p &gt;= t, ceiling lookup).
      */
-    public void testRightClosedBucketIsNotSubstituted() {
+    public void testRightClosedBucketIsSubstitutedWithRoundToCeiling() {
         assumeTrue("TSTEP requires corresponding capability", EsqlCapabilities.Cap.TSTEP.isEnabled());
         assumeTrue("TSTEP explicit bounds requires corresponding capability", EsqlCapabilities.Cap.TSTEP_EXPLICIT_BOUNDS.isEnabled());
         String query = """
@@ -304,8 +303,9 @@ public class ReplaceDateTruncBucketWithRoundToTests extends AbstractLocalLogical
         assertEquals(1, fields.size());
         Alias a = fields.get(0);
         assertEquals("x", a.name());
-        Bucket bucket = as(a.child(), Bucket.class);
-        FieldAttribute fa = as(bucket.field(), FieldAttribute.class);
+        RoundTo roundTo = as(a.child(), RoundTo.class);
+        assertEquals(org.elasticsearch.common.Rounding.RoundingConvention.UP, roundTo.roundingConvention());
+        FieldAttribute fa = as(roundTo.field(), FieldAttribute.class);
         assertEquals("@timestamp", fa.name());
         assertEquals(DATETIME, fa.dataType());
     }


### PR DESCRIPTION
This change adds `RoundTo` specialization used by `TSTEP` lowering.

To address the "why" for `ReplaceDateTruncBucketWithRoundTo`, this benchmark compares `TSTEP` vs `TBUCKET` on `upstream/main` and this branch.

- On `upstream/main`, `TBUCKET` is lowered to `round_to`, while `TSTEP` stays on the slower path.
- This change enables the same `round_to` lowering for `TSTEP` when `TSTEP(bucket_count, from, to, ts)` has explicit bounds.

Benchmark command:

```bash
./gradlew -g /tmp/gradle-home -p benchmarks run --args 'EvalBenchmark -p operation=tstep(10),tbucket(10),tstep(99),tbucket(99) -wi 2 -i 4 -f 1'
```

Environment: macOS arm64, JDK 26.0.1, JMH 1.37

| Branch | # Buckets | TStep (ns/op) | TBucket (ns/op) |
|---|---:|---:|---:|
| upstream/main | 10 | 1.401 | 0.420 |
| upstream/main | 99 | 1.052 | 0.547 |
| sidosera:feature/esql-round-to-eval-one | 10 | 0.632 | 0.409 |
| sidosera:feature/esql-round-to-eval-one | 99 | 0.702 | 0.528 |

### Why this is faster

- `TSTEP` is lowered to a right-closed `Bucket` in UTC (`RoundingConvention.UP`) in `TStep.surrogate()`.
- `ReplaceDateTruncBucketWithRoundTo` then rewrites that `Bucket` to `RoundTo` when min/max bounds are known and fixed rounding points can be materialized.
- Without rewrite (`Bucket`/`DateTrunc` path), each row calls generic `Rounding.Prepared.round(...)`.
- With rewrite (`RoundTo` path), execution uses generated specializations selected by point shape:
  - small point counts: unrolled comparator evaluators,
  - evenly spaced points: modulo interval evaluator,
  - fallback: binary-search evaluator.
- For explicit-bounds `TSTEP`, points are evenly spaced, so it consistently hits the cheaper interval/unrolled `RoundTo` paths instead of generic per-row rounding.
