### PR TITLE
[9.3] Normalize `_timeseries` to JSON for stored source (#148716)

### DIFF
--- a/docs/changelog/148716.yaml
+++ b/docs/changelog/148716.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 148414
+pr: 148716
+summary: Normalize `_timeseries` to JSON for stored source
+type: bug

--- a/server/src/main/java/org/elasticsearch/index/mapper/TimeSeriesMetadataFieldBlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TimeSeriesMetadataFieldBlockLoader.java
@@ -12,8 +12,16 @@ package org.elasticsearch.index.mapper;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SortedSetDocValues;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.search.fetch.StoredFieldsSpec;
+import org.elasticsearch.search.lookup.Source;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentFactory;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentParserConfiguration;
+import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.LinkedHashSet;
@@ -65,7 +73,32 @@ public final class TimeSeriesMetadataFieldBlockLoader implements BlockLoader {
         @Override
         public void read(int docId, StoredFields storedFields, Builder builder) throws IOException {
             // TODO support appending BytesReference
-            ((BytesRefBuilder) builder).appendBytesRef(storedFields.source().internalSourceRef().toBytesRef());
+            ((BytesRefBuilder) builder).appendBytesRef(toJson(storedFields.source()).toBytesRef());
+        }
+
+        /**
+         * The {@code _timeseries} keyword column is documented to contain a JSON-encoded object with the dimension
+         * key/value pairs identifying each group. {@link Source#internalSourceRef()} returns bytes in whatever XContent
+         * type the underlying {@code _source} happens to use: synthetic source always reconstructs as JSON, but stored
+         * source preserves the original encoding (e.g. CBOR for documents written via the Prometheus remote-write
+         * endpoint, which builds {@link org.elasticsearch.xcontent.XContentFactory#cborBuilder} requests). Normalize
+         * to JSON so the value is a valid keyword regardless of how {@code _source} is stored. When the underlying
+         * encoding is already JSON we return the bytes unchanged to avoid a parser/builder round-trip.
+         */
+        private static BytesReference toJson(Source source) throws IOException {
+            BytesReference bytes = source.internalSourceRef();
+            XContentType type = source.sourceContentType();
+            if (type == XContentType.JSON) {
+                return bytes;
+            }
+            try (
+                XContentParser parser = XContentHelper.createParserNotCompressed(XContentParserConfiguration.EMPTY, bytes, type);
+                XContentBuilder json = XContentFactory.jsonBuilder()
+            ) {
+                parser.nextToken();
+                json.copyCurrentStructure(parser);
+                return BytesReference.bytes(json);
+            }
         }
 
         @Override

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
@@ -174,7 +174,7 @@ public class CsvTestsDataLoader {
         "k8s-downsampled-mappings.json",
         "k8s-downsampled.csv"
     ).withSetting("k8s-downsampled-settings.json");
-    private static final TestDataset K8S_STORED_SOURCE = new TestDataset("k8s_stored_source", "k8s-mappings.json", "k8s.csv").withSetting(
+    private static final TestDataset STORED_SOURCE_K8S = new TestDataset("stored_source_k8s", "k8s-mappings.json", "k8s.csv").withSetting(
         "k8s-stored-source-settings.json"
     );
     private static final TestDataset ADDRESSES = new TestDataset("addresses");
@@ -258,7 +258,7 @@ public class CsvTestsDataLoader {
         Map.entry(K8S.indexName, K8S),
         Map.entry(K8S_DATENANOS.indexName, K8S_DATENANOS),
         Map.entry(K8S_DOWNSAMPLED.indexName, K8S_DOWNSAMPLED),
-        Map.entry(K8S_STORED_SOURCE.indexName, K8S_STORED_SOURCE),
+        Map.entry(STORED_SOURCE_K8S.indexName, STORED_SOURCE_K8S),
         Map.entry(DISTANCES.indexName, DISTANCES),
         Map.entry(ADDRESSES.indexName, ADDRESSES),
         Map.entry(BOOKS.indexName, BOOKS),

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
@@ -174,6 +174,9 @@ public class CsvTestsDataLoader {
         "k8s-downsampled-mappings.json",
         "k8s-downsampled.csv"
     ).withSetting("k8s-downsampled-settings.json");
+    private static final TestDataset K8S_STORED_SOURCE = new TestDataset("k8s_stored_source", "k8s-mappings.json", "k8s.csv").withSetting(
+        "k8s-stored-source-settings.json"
+    );
     private static final TestDataset ADDRESSES = new TestDataset("addresses");
     private static final TestDataset BOOKS = new TestDataset("books").withSetting("books-settings.json");
     private static final TestDataset SEMANTIC_TEXT = new TestDataset("semantic_text").withInferenceEndpoint(true);
@@ -255,6 +258,7 @@ public class CsvTestsDataLoader {
         Map.entry(K8S.indexName, K8S),
         Map.entry(K8S_DATENANOS.indexName, K8S_DATENANOS),
         Map.entry(K8S_DOWNSAMPLED.indexName, K8S_DOWNSAMPLED),
+        Map.entry(K8S_STORED_SOURCE.indexName, K8S_STORED_SOURCE),
         Map.entry(DISTANCES.indexName, DISTANCES),
         Map.entry(ADDRESSES.indexName, ADDRESSES),
         Map.entry(BOOKS.indexName, BOOKS),

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-stored-source-settings.json
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-stored-source-settings.json
@@ -1,0 +1,15 @@
+{
+  "index": {
+    "mode": "time_series",
+    "routing_path": ["cluster", "pod"],
+    "time_series": {
+      "start_time": "2024-05-10T00:00:00Z",
+      "end_time": "2024-05-20T00:00:00Z"
+    },
+    "mapping": {
+      "source": {
+        "mode": "stored"
+      }
+    }
+  }
+}

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-stored-source.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-stored-source.csv-spec
@@ -1,0 +1,57 @@
+// Tests for `_timeseries` against a TSDB index that uses `index.mapping.source.mode: stored`.
+//
+// The synthetic-source variant in k8s-timeseries.csv-spec already covers richer time series functions; the
+// purpose of this fixture is to make sure the `_timeseries` keyword column is emitted as JSON regardless of
+// how `_source` is encoded on disk. With stored source the index keeps the original `_source` bytes (the
+// Prometheus remote-write endpoint produces CBOR), so the block loader must normalize them to JSON before
+// emitting them as a keyword.
+//
+// Stored source preserves the original `_source` field order (cluster, region, pod — see k8s.csv), unlike
+// synthetic source which reconstructs in alphabetical/mapping order. This is why the `_timeseries` values
+// here differ from those in k8s-timeseries.csv-spec.
+
+storedSourceTimeseriesGroupByAllImplicitly
+required_capability: ts_command_v0
+required_capability: metrics_group_by_all
+required_capability: metrics_group_by_all_with_ts_dimensions
+
+TS k8s_stored_source
+| STATS avg = avg_over_time(network.cost)
+| SORT avg DESC
+;
+ignoreOrder:true
+
+avg:double         | _timeseries:keyword
+8.375              | "{""cluster"":""prod"",""region"":[""eu"",""us""],""pod"":""three""}"
+7.262931034482759  | "{""cluster"":""qa"",""pod"":""one""}"
+6.870689655172414  | "{""cluster"":""qa"",""pod"":""two""}"
+6.635416666666667  | "{""cluster"":""qa"",""pod"":""three""}"
+6.46875            | "{""cluster"":""staging"",""region"":""us"",""pod"":""two""}"
+5.869791666666667  | "{""cluster"":""staging"",""region"":""us"",""pod"":""three""}"
+5.586956521739131  | "{""cluster"":""prod"",""region"":[""eu"",""us""],""pod"":""one""}"
+5.1826923076923075 | "{""cluster"":""staging"",""region"":""us"",""pod"":""one""}"
+4.0703125          | "{""cluster"":""prod"",""region"":[""eu"",""us""],""pod"":""two""}"
+;
+
+storedSourceTimeseriesCountOverTime
+required_capability: ts_command_v0
+required_capability: metrics_group_by_all
+required_capability: metrics_group_by_all_with_ts_dimensions
+
+TS k8s_stored_source
+| STATS count = count_over_time(network.cost)
+| SORT count ASC
+;
+ignoreOrder:true
+
+count:long | _timeseries:keyword
+13         | "{""cluster"":""staging"",""region"":""us"",""pod"":""one""}"
+16         | "{""cluster"":""prod"",""region"":[""eu"",""us""],""pod"":""two""}"
+20         | "{""cluster"":""staging"",""region"":""us"",""pod"":""two""}"
+22         | "{""cluster"":""prod"",""region"":[""eu"",""us""],""pod"":""three""}"
+23         | "{""cluster"":""prod"",""region"":[""eu"",""us""],""pod"":""one""}"
+24         | "{""cluster"":""staging"",""region"":""us"",""pod"":""three""}"
+24         | "{""cluster"":""qa"",""pod"":""three""}"
+29         | "{""cluster"":""qa"",""pod"":""one""}"
+29         | "{""cluster"":""qa"",""pod"":""two""}"
+;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-stored-source.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-stored-source.csv-spec
@@ -15,7 +15,7 @@ required_capability: ts_command_v0
 required_capability: metrics_group_by_all
 required_capability: metrics_group_by_all_with_ts_dimensions
 
-TS k8s_stored_source
+TS stored_source_k8s
 | STATS avg = avg_over_time(network.cost)
 | SORT avg DESC
 ;
@@ -38,7 +38,7 @@ required_capability: ts_command_v0
 required_capability: metrics_group_by_all
 required_capability: metrics_group_by_all_with_ts_dimensions
 
-TS k8s_stored_source
+TS stored_source_k8s
 | STATS count = count_over_time(network.cost)
 | SORT count ASC
 ;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Normalize `_timeseries` to JSON for stored source (#148716)](https://github.com/elastic/elasticsearch/pull/148716)

<!--- Backport version: 12.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)