### PR TITLE
Ignore relocation pit tests when feature is not on

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -557,15 +557,6 @@ tests:
 - class: org.elasticsearch.repositories.SnapshotMetricsIT
   method: testSnapshotAPMMetrics
   issue: https://github.com/elastic/elasticsearch/issues/149256
-- class: org.elasticsearch.xpack.stateless.reshard.StatelessReshardingPitSearchIT
-  method: testPitRelocationDuringReshard
-  issue: https://github.com/elastic/elasticsearch/issues/149271
-- class: org.elasticsearch.xpack.stateless.reshard.StatelessReshardingPitSearchIT
-  method: testLongLivedPitRelocation
-  issue: https://github.com/elastic/elasticsearch/issues/149272
-- class: org.elasticsearch.xpack.stateless.reshard.StatelessReshardingPitSearchIT
-  method: testReshardedLongLivedPitRelocation
-  issue: https://github.com/elastic/elasticsearch/issues/149273
 - class: org.elasticsearch.ingest.geoip.GeoIpDownloaderCliIT
   method: testIpLocationServiceLifecycle
   issue: https://github.com/elastic/elasticsearch/issues/149284

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/reshard/StatelessReshardingPitSearchIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/reshard/StatelessReshardingPitSearchIT.java
@@ -41,6 +41,7 @@ import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.elasticsearch.index.IndexSettings.INDEX_REFRESH_INTERVAL_SETTING;
+import static org.elasticsearch.search.SearchService.PIT_RELOCATION_FEATURE_FLAG;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.elasticsearch.xpack.stateless.reshard.ReshardingTestHelpers.indexMetadata;
 import static org.elasticsearch.xpack.stateless.reshard.ReshardingTestHelpers.makeIdThatRoutesToShard;
@@ -218,6 +219,7 @@ public class StatelessReshardingPitSearchIT extends AbstractStatelessPluginInteg
     }
 
     public void testPitRelocationDuringReshard() {
+        assumeTrue("pit relocation must be enabled", PIT_RELOCATION_FEATURE_FLAG.isEnabled());
         var masterNode = startMasterOnlyNode();
         String indexNode = startIndexNode();
         startSearchNode();
@@ -297,6 +299,7 @@ public class StatelessReshardingPitSearchIT extends AbstractStatelessPluginInteg
     }
 
     public void testLongLivedPitRelocation() {
+        assumeTrue("pit relocation must be enabled", PIT_RELOCATION_FEATURE_FLAG.isEnabled());
         var masterNode = startMasterOnlyNode();
         startIndexNode();
         startSearchNode();
@@ -347,6 +350,7 @@ public class StatelessReshardingPitSearchIT extends AbstractStatelessPluginInteg
     }
 
     public void testReshardedLongLivedPitRelocation() {
+        assumeTrue("pit relocation must be enabled", PIT_RELOCATION_FEATURE_FLAG.isEnabled());
         var masterNode = startMasterOnlyNode();
         String indexNode = startIndexNode();
         startSearchNode();


### PR DESCRIPTION
These tests need the PIT_RELOCATION_FEATURE_FLAG enabled, which may be disabled if it's not a snapshot build.

Closes #149271
Closes #149272
Closes #149273