### PR TITLE
Mute MultiClusterSpecIT exponential_histogram.isNotNullFilter

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -572,3 +572,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
   method: test {csv-spec:tdigest.isNotNullFilter (timeseries mode)}
   issue: https://github.com/elastic/elasticsearch/issues/149293
+- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
+  method: test {csv-spec:exponential_histogram.isNotNullFilter}
+  issue: https://github.com/elastic/elasticsearch/issues/149291


### PR DESCRIPTION
## Summary
- Mutes `MultiClusterSpecIT.test {csv-spec:exponential_histogram.isNotNullFilter}` which fails in BWC suites against 9.3.5 nodes that don't support `COUNT` on `exponential_histogram` fields.
- Same root cause as #149291 (`MixedClusterEsqlSpecIT` variant).