### PR TITLE
[9.4] Reserve REQUEST circuit breaker for reindex bulk batches (#148656)

### DIFF
--- a/docs/changelog/148656.yaml
+++ b/docs/changelog/148656.yaml
@@ -1,0 +1,5 @@
+area: Reindex
+issues: []
+pr: 148656
+summary: Reserve REQUEST circuit breaker for reindex bulk batches
+type: bug

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractAsyncBulkByScrollAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractAsyncBulkByScrollAction.java
@@ -27,11 +27,14 @@ import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.action.support.broadcast.BroadcastResponse;
 import org.elasticsearch.client.internal.ParentTaskAssigningClient;
 import org.elasticsearch.common.BackoffPolicy;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.index.reindex.AbstractBulkByScrollRequest;
@@ -134,6 +137,11 @@ public abstract class AbstractAsyncBulkByScrollAction<
      */
     protected final Version remoteVersion;
 
+    private final ReindexSettings reindexSettings;
+    private final CircuitBreaker circuitBreaker;
+    private final String breakerLabel;
+
+
     AbstractAsyncBulkByScrollAction(
         BulkByScrollTask task,
         boolean needsSourceDocumentVersions,
@@ -146,7 +154,10 @@ public abstract class AbstractAsyncBulkByScrollAction<
         ActionListener<BulkByScrollResponse> listener,
         @Nullable ScriptService scriptService,
         @Nullable ReindexSslConfig sslConfig,
-        TimeValue maxTaskShutdownGracePeriod
+        TimeValue maxTaskShutdownGracePeriod,
+        ReindexSettings reindexSettings,
+        CircuitBreaker circuitBreaker,
+        String breakerLabel
     ) {
         this(
             task,
@@ -162,7 +173,10 @@ public abstract class AbstractAsyncBulkByScrollAction<
             scriptService,
             sslConfig,
             null,
-            maxTaskShutdownGracePeriod
+            maxTaskShutdownGracePeriod,
+            reindexSettings,
+            circuitBreaker,
+            breakerLabel
         );
     }
 
@@ -180,7 +194,10 @@ public abstract class AbstractAsyncBulkByScrollAction<
         @Nullable ScriptService scriptService,
         @Nullable ReindexSslConfig sslConfig,
         @Nullable Version remoteVersion,
-        TimeValue maxTaskShutdownGracePeriod
+        TimeValue maxTaskShutdownGracePeriod,
+        ReindexSettings reindexSettings,
+        CircuitBreaker circuitBreaker,
+        String breakerLabel
     ) {
         this.task = task;
         this.scriptService = scriptService;
@@ -205,6 +222,9 @@ public abstract class AbstractAsyncBulkByScrollAction<
             prepareSearchRequest(mainRequest, needsSourceDocumentVersions, needsSourceDocumentSeqNoAndPrimaryTerm, needsVectors)
         );
         scriptApplier = Objects.requireNonNull(buildScriptApplier(), "script applier must not be null");
+        this.reindexSettings = Objects.requireNonNull(reindexSettings);
+        this.circuitBreaker = Objects.requireNonNull(circuitBreaker);
+        this.breakerLabel = Objects.requireNonNull(breakerLabel);
     }
 
     /** Computes the minimum time a relocated task must run before it can be relocated again. Visible for testing. */
@@ -328,15 +348,26 @@ public abstract class AbstractAsyncBulkByScrollAction<
         return true;
     }
 
-    protected BulkRequest buildBulk(Iterable<? extends PaginatedHitSource.Hit> docs) {
+    protected BulkRequest buildBulk(Iterable<? extends PaginatedHitSource.Hit> docs, AtomicLong reservedBytes) {
         BulkRequest bulkRequest = new BulkRequest();
         for (PaginatedHitSource.Hit doc : docs) {
             if (accept(doc)) {
                 RequestWrapper<?> request = scriptApplier.apply(copyMetadata(buildRequest(doc), doc), doc);
                 if (request != null) {
                     bulkRequest.add(request.self());
+                    long delta = bulkRequest.estimatedSizeInBytes() - reservedBytes.get();
+                    if (delta >= reindexSettings.getMemoryAccountingThresholdInBytes()) {
+                        circuitBreaker.addEstimateBytesAndMaybeBreak(delta, breakerLabel);
+                        reservedBytes.set(bulkRequest.estimatedSizeInBytes());
+                    }
                 }
             }
+        }
+        // Reserve any bytes not yet covered by threshold checks above
+        long remaining = bulkRequest.estimatedSizeInBytes() - reservedBytes.get();
+        if (remaining > 0) {
+            circuitBreaker.addEstimateBytesAndMaybeBreak(remaining, breakerLabel);
+            reservedBytes.addAndGet(remaining);
         }
         return bulkRequest;
     }
@@ -493,23 +524,47 @@ public abstract class AbstractAsyncBulkByScrollAction<
             hits = asyncResponse.consumeRemainingHits();
         }
 
-        BulkRequest request = buildBulk(hits);
-        if (request.requests().isEmpty()) {
-            /*
-             * If we noop-ed the entire batch then just skip to the next batch or the BulkRequest would fail validation.
-             */
-            notifyDone(thisBatchStartTimeNS, asyncResponse, 0);
-            return;
+        // Reserve heap budget against the REQUEST breaker incrementally as docs are added in buildBulk,
+        // so oversized batches are rejected before all their source bytes land in memory. The reservation
+        // is released (via cleanup) when the bulk listener completes or if we return early for any reason.
+        final AtomicLong reservedBytes = new AtomicLong(0);
+        final Releasable cleanup = () -> {
+            long r = reservedBytes.getAndSet(0);
+            if (r > 0) circuitBreaker.addWithoutBreaking(-r);
+        };
+        boolean cleanupHandedOff = false;
+        try {
+            final BulkRequest request;
+            try {
+                request = buildBulk(hits, reservedBytes);
+            } catch (CircuitBreakingException e) {
+                finishHim(e);
+                return;
+            }
+            if (request.requests().isEmpty()) {
+                /*
+                 * If we noop-ed the entire batch then just skip to the next batch or the BulkRequest would fail validation.
+                 */
+                notifyDone(thisBatchStartTimeNS, asyncResponse, 0);
+                return;
+            }
+            request.timeout(mainRequest.getTimeout());
+            request.waitForActiveShards(mainRequest.getWaitForActiveShards());
+            sendBulkRequest(request, cleanup, () -> notifyDone(thisBatchStartTimeNS, asyncResponse, request.requests().size()));
+            cleanupHandedOff = true;
+        } finally {
+            if (cleanupHandedOff == false) {
+                cleanup.close();
+            }
         }
-        request.timeout(mainRequest.getTimeout());
-        request.waitForActiveShards(mainRequest.getWaitForActiveShards());
-        sendBulkRequest(request, () -> notifyDone(thisBatchStartTimeNS, asyncResponse, request.requests().size()));
     }
 
     /**
      * Send a bulk request, handling retries.
+     * The {@code cleanup} releasable is closed after the bulk completes (success or failure), releasing any
+     * circuit breaker reservation acquired during {@link #buildBulk}.
      */
-    void sendBulkRequest(BulkRequest request, Runnable onSuccess) {
+    void sendBulkRequest(BulkRequest request, Releasable cleanup, Runnable onSuccess) {
         final int requestSize = request.requests().size();
         if (logger.isDebugEnabled()) {
             logger.debug(
@@ -521,10 +576,11 @@ public abstract class AbstractAsyncBulkByScrollAction<
         }
         if (task.isCancelled()) {
             logger.debug("[{}]: finishing early because the task was cancelled", task.getId());
+            cleanup.close();
             finishHim(null);
             return;
         }
-        bulkRetry.withBackoff(bulkClient::bulk, request, new ActionListener<BulkResponse>() {
+        bulkRetry.withBackoff(bulkClient::bulk, request, ActionListener.releaseBefore(cleanup, new ActionListener<BulkResponse>() {
             @Override
             public void onResponse(BulkResponse response) {
                 logger.debug("[{}]: completed [{}] entry bulk request", task.getId(), requestSize);
@@ -535,7 +591,7 @@ public abstract class AbstractAsyncBulkByScrollAction<
             public void onFailure(Exception e) {
                 finishHim(e);
             }
-        });
+        }));
     }
 
     /**

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractAsyncBulkByScrollAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractAsyncBulkByScrollAction.java
@@ -141,7 +141,6 @@ public abstract class AbstractAsyncBulkByScrollAction<
     private final CircuitBreaker circuitBreaker;
     private final String breakerLabel;
 
-
     AbstractAsyncBulkByScrollAction(
         BulkByScrollTask task,
         boolean needsSourceDocumentVersions,

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/AsyncDeleteByQueryAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/AsyncDeleteByQueryAction.java
@@ -38,8 +38,23 @@ public class AsyncDeleteByQueryAction extends AbstractAsyncBulkByScrollAction<De
         ReindexSettings reindexSettings,
         CircuitBreaker requestBreaker
     ) {
-        super(task, false, true, false, logger, client, threadPool, request, listener, scriptService, null, maxTaskShutdownGracePeriod,
-            reindexSettings, requestBreaker, "delete_by_query_bulk_batch");
+        super(
+            task,
+            false,
+            true,
+            false,
+            logger,
+            client,
+            threadPool,
+            request,
+            listener,
+            scriptService,
+            null,
+            maxTaskShutdownGracePeriod,
+            reindexSettings,
+            requestBreaker,
+            "delete_by_query_bulk_batch"
+        );
     }
 
     @Override

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/AsyncDeleteByQueryAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/AsyncDeleteByQueryAction.java
@@ -13,6 +13,7 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.client.internal.ParentTaskAssigningClient;
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.reindex.BulkByScrollResponse;
 import org.elasticsearch.index.reindex.BulkByScrollTask;
@@ -33,9 +34,12 @@ public class AsyncDeleteByQueryAction extends AbstractAsyncBulkByScrollAction<De
         DeleteByQueryRequest request,
         ScriptService scriptService,
         ActionListener<BulkByScrollResponse> listener,
-        TimeValue maxTaskShutdownGracePeriod
+        TimeValue maxTaskShutdownGracePeriod,
+        ReindexSettings reindexSettings,
+        CircuitBreaker requestBreaker
     ) {
-        super(task, false, true, false, logger, client, threadPool, request, listener, scriptService, null, maxTaskShutdownGracePeriod);
+        super(task, false, true, false, logger, client, threadPool, request, listener, scriptService, null, maxTaskShutdownGracePeriod,
+            reindexSettings, requestBreaker, "delete_by_query_bulk_batch");
     }
 
     @Override

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/ReindexPlugin.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/ReindexPlugin.java
@@ -121,6 +121,7 @@ public class ReindexPlugin extends Plugin implements ActionPlugin, ExtensiblePlu
         final List<Setting<?>> settings = new ArrayList<>();
         settings.add(TransportReindexAction.REMOTE_CLUSTER_WHITELIST);
         settings.add(TransportReindexAction.REMOTE_CLUSTER_BLOCKLIST);
+        settings.add(ReindexSettings.REINDEX_MEMORY_ACCOUNTING_THRESHOLD_SETTING);
         settings.addAll(ReindexSslConfig.getSettings());
         return settings;
     }

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/ReindexSettings.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/ReindexSettings.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.reindex;
+
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Setting.Property;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.ByteSizeValue;
+
+/**
+ * Holds reindex-related dynamic cluster settings
+ */
+public final class ReindexSettings {
+
+    /**
+     * How many bytes must accumulate in a {@code BulkRequest} before reindex / update-by-query / delete-by-query
+     * consult the REQUEST circuit breaker for the in-flight reservation. Setting this very high (e.g. {@code 1pb})
+     * effectively disables the per-batch breaker check, which acts as a runtime escape hatch if the accounting
+     * logic ever misbehaves in production.
+     */
+    public static final Setting<ByteSizeValue> REINDEX_MEMORY_ACCOUNTING_THRESHOLD_SETTING = Setting.byteSizeSetting(
+        "cluster.reindex.memory_accounting_threshold",
+        ByteSizeValue.of(1, ByteSizeUnit.MB),
+        ByteSizeValue.of(1, ByteSizeUnit.MB),
+        ByteSizeValue.ofBytes(Long.MAX_VALUE),
+        Property.Dynamic,
+        Property.NodeScope
+    );
+
+    private volatile long memoryAccountingThresholdInBytes;
+
+    /**
+     * {@link ClusterSettings#initializeAndWatch} keeps the value of the settings updated
+     */
+    public ReindexSettings() {
+        // For nodes that do not load ReindexPlugin, the TransportEnrichReindexAction constructor, and some tests,
+        // still inject ReindexSettings for cross-module actions.
+        // This uses the static default and skips dynamic updates.
+        this.memoryAccountingThresholdInBytes = REINDEX_MEMORY_ACCOUNTING_THRESHOLD_SETTING.get(Settings.EMPTY).getBytes();
+    }
+
+    /**
+     * {@link ClusterSettings#initializeAndWatch} keeps the value of the settings updated
+     */
+    public ReindexSettings(ClusterSettings clusterSettings) {
+        clusterSettings.initializeAndWatch(REINDEX_MEMORY_ACCOUNTING_THRESHOLD_SETTING, this::setMemoryAccountingThreshold);
+    }
+
+    /**
+     * Byte threshold at which buildBulk consults the REQUEST circuit breaker during a batch.
+     */
+    public long getMemoryAccountingThresholdInBytes() {
+        return memoryAccountingThresholdInBytes;
+    }
+
+    private void setMemoryAccountingThreshold(ByteSizeValue memoryAccountingThreshold) {
+        this.memoryAccountingThresholdInBytes = memoryAccountingThreshold.getBytes();
+    }
+}

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/Reindexer.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/Reindexer.java
@@ -44,6 +44,7 @@ import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.BackoffPolicy;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.lucene.uid.Versions;
 import org.elasticsearch.common.settings.Settings;
@@ -68,6 +69,7 @@ import org.elasticsearch.index.reindex.ResumeInfo;
 import org.elasticsearch.index.reindex.ResumeReindexAction;
 import org.elasticsearch.index.reindex.TaskRelocatedException;
 import org.elasticsearch.index.reindex.WorkerBulkByScrollTaskState;
+import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.node.ShutdownPrepareService;
 import org.elasticsearch.reindex.remote.RemotePitPaginatedHitSource;
 import org.elasticsearch.reindex.remote.RemoteReindexingUtils;
@@ -119,6 +121,7 @@ public class Reindexer {
     private static final Logger logger = LogManager.getLogger(Reindexer.class);
 
     private final ClusterService clusterService;
+    private final ReindexSettings reindexSettings;
     private final ProjectResolver projectResolver;
     private final Client client;
     private final ThreadPool threadPool;
@@ -132,6 +135,7 @@ public class Reindexer {
     private final FeatureService featureService;
     private final TaskResultsService taskResultsService;
     private final TimeValue reindexShutdownGracePeriod;
+    private final CircuitBreaker requestBreaker;
 
     Reindexer(
         ClusterService clusterService,
@@ -144,9 +148,11 @@ public class Reindexer {
         TransportService transportService,
         ReindexRelocationNodePicker relocationNodePicker,
         FeatureService featureService,
-        TaskResultsService taskResultsService
+        TaskResultsService taskResultsService,
+        CircuitBreakerService circuitBreakerService
     ) {
         this.clusterService = clusterService;
+        this.reindexSettings = new ReindexSettings(clusterService.getClusterSettings());
         this.projectResolver = projectResolver;
         this.client = client;
         this.threadPool = threadPool;
@@ -159,6 +165,7 @@ public class Reindexer {
         this.featureService = featureService;
         this.taskResultsService = Objects.requireNonNull(taskResultsService);
         this.reindexShutdownGracePeriod = ShutdownPrepareService.MAXIMUM_REINDEXING_TIMEOUT_SETTING.get(clusterService.getSettings());
+        this.requestBreaker = Objects.requireNonNull(circuitBreakerService.getBreaker(CircuitBreaker.REQUEST));
     }
 
     public void initTask(BulkByScrollTask task, ReindexRequest request, ActionListener<Void> listener) {
@@ -278,7 +285,9 @@ public class Reindexer {
                 request,
                 listener,
                 remoteVersion,
-                reindexShutdownGracePeriod
+                reindexShutdownGracePeriod,
+                reindexSettings,
+                requestBreaker
             );
             searchAction.start();
         };
@@ -913,7 +922,9 @@ public class Reindexer {
             ReindexRequest request,
             ActionListener<BulkByScrollResponse> listener,
             @Nullable Version remoteVersion,
-            TimeValue maxTaskShutdownGracePeriod
+            TimeValue maxTaskShutdownGracePeriod,
+            ReindexSettings reindexSettings,
+            CircuitBreaker requestBreaker
         ) {
             super(
                 task,
@@ -933,7 +944,10 @@ public class Reindexer {
                 scriptService,
                 sslConfig,
                 remoteVersion,
-                maxTaskShutdownGracePeriod
+                maxTaskShutdownGracePeriod,
+                reindexSettings,
+                requestBreaker,
+                "reindex_bulk_batch"
             );
             this.destinationIndexIdMapper = destinationIndexMode(state).idFieldMapperWithoutFieldData();
         }

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/TransportDeleteByQueryAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/TransportDeleteByQueryAction.java
@@ -15,6 +15,7 @@ import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.client.internal.ParentTaskAssigningClient;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
@@ -22,6 +23,7 @@ import org.elasticsearch.index.reindex.BulkByScrollResponse;
 import org.elasticsearch.index.reindex.BulkByScrollTask;
 import org.elasticsearch.index.reindex.DeleteByQueryAction;
 import org.elasticsearch.index.reindex.DeleteByQueryRequest;
+import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.injection.guice.Inject;
 import org.elasticsearch.node.ShutdownPrepareService;
 import org.elasticsearch.script.ScriptService;
@@ -29,6 +31,7 @@ import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 public class TransportDeleteByQueryAction extends HandledTransportAction<DeleteByQueryRequest, BulkByScrollResponse> {
@@ -39,6 +42,8 @@ public class TransportDeleteByQueryAction extends HandledTransportAction<DeleteB
     private final ClusterService clusterService;
     private final DeleteByQueryMetrics deleteByQueryMetrics;
     private final TimeValue taskShutdownGracePeriod;
+    private final ReindexSettings reindexSettings;
+    private final CircuitBreaker requestBreaker;
 
     @Inject
     public TransportDeleteByQueryAction(
@@ -48,7 +53,9 @@ public class TransportDeleteByQueryAction extends HandledTransportAction<DeleteB
         TransportService transportService,
         ScriptService scriptService,
         ClusterService clusterService,
-        @Nullable DeleteByQueryMetrics deleteByQueryMetrics
+        @Nullable DeleteByQueryMetrics deleteByQueryMetrics,
+        ReindexSettings reindexSettings,
+        CircuitBreakerService circuitBreakerService
     ) {
         super(DeleteByQueryAction.NAME, transportService, actionFilters, DeleteByQueryRequest::new, EsExecutors.DIRECT_EXECUTOR_SERVICE);
         this.threadPool = threadPool;
@@ -59,6 +66,12 @@ public class TransportDeleteByQueryAction extends HandledTransportAction<DeleteB
         // todo: if relocations are added to delete-by-query and it gets its own timeout setting, this should be updated.
         // without this safe default, adding relocations to delete-by-query without updating this might open it up to race conditions.
         this.taskShutdownGracePeriod = ShutdownPrepareService.MAXIMUM_REINDEXING_TIMEOUT_SETTING.get(clusterService.getSettings());
+        this.reindexSettings = Objects.requireNonNull(reindexSettings);
+        Objects.requireNonNull(circuitBreakerService, "circuitBreakerService must not be null");
+        this.requestBreaker = Objects.requireNonNull(
+            circuitBreakerService.getBreaker(CircuitBreaker.REQUEST),
+            "REQUEST circuit breaker must be available — delete-by-query relies on it for per-batch heap reservations"
+        );
     }
 
     @Override
@@ -91,7 +104,9 @@ public class TransportDeleteByQueryAction extends HandledTransportAction<DeleteB
                             deleteByQueryMetrics.recordTookTime(elapsedTime);
                         }
                     }),
-                    taskShutdownGracePeriod
+                    taskShutdownGracePeriod,
+                    reindexSettings,
+                    requestBreaker
                 ).start();
             }
         );

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/TransportReindexAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/TransportReindexAction.java
@@ -27,6 +27,7 @@ import org.elasticsearch.index.reindex.BulkByScrollResponse;
 import org.elasticsearch.index.reindex.BulkByScrollTask;
 import org.elasticsearch.index.reindex.ReindexAction;
 import org.elasticsearch.index.reindex.ReindexRequest;
+import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.injection.guice.Inject;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.tasks.Task;
@@ -68,7 +69,8 @@ public class TransportReindexAction extends HandledTransportAction<ReindexReques
         @Nullable ReindexMetrics reindexMetrics,
         ReindexRelocationNodePicker relocationNodePicker,
         FeatureService featureService,
-        TaskResultsService taskResultsService
+        TaskResultsService taskResultsService,
+        CircuitBreakerService circuitBreakerService
     ) {
         this(
             ReindexAction.NAME,
@@ -86,7 +88,8 @@ public class TransportReindexAction extends HandledTransportAction<ReindexReques
             reindexMetrics,
             relocationNodePicker,
             featureService,
-            taskResultsService
+            taskResultsService,
+            circuitBreakerService
         );
     }
 
@@ -106,7 +109,8 @@ public class TransportReindexAction extends HandledTransportAction<ReindexReques
         @Nullable ReindexMetrics reindexMetrics,
         ReindexRelocationNodePicker relocationNodePicker,
         FeatureService featureService,
-        TaskResultsService taskResultsService
+        TaskResultsService taskResultsService,
+        CircuitBreakerService circuitBreakerService
     ) {
         super(name, transportService, actionFilters, ReindexRequest::new, EsExecutors.DIRECT_EXECUTOR_SERVICE);
         this.client = client;
@@ -128,7 +132,8 @@ public class TransportReindexAction extends HandledTransportAction<ReindexReques
             transportService,
             relocationNodePicker,
             featureService,
-            taskResultsService
+            taskResultsService,
+            circuitBreakerService
         );
     }
 

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/TransportUpdateByQueryAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/TransportUpdateByQueryAction.java
@@ -17,6 +17,7 @@ import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.client.internal.ParentTaskAssigningClient;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
@@ -25,6 +26,7 @@ import org.elasticsearch.index.reindex.BulkByScrollTask;
 import org.elasticsearch.index.reindex.UpdateByQueryAction;
 import org.elasticsearch.index.reindex.UpdateByQueryRequest;
 import org.elasticsearch.index.reindex.WorkerBulkByScrollTaskState;
+import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.injection.guice.Inject;
 import org.elasticsearch.node.ShutdownPrepareService;
 import org.elasticsearch.script.CtxMap;
@@ -37,6 +39,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 import java.util.function.LongSupplier;
@@ -49,6 +52,8 @@ public class TransportUpdateByQueryAction extends HandledTransportAction<UpdateB
     private final ClusterService clusterService;
     private final UpdateByQueryMetrics updateByQueryMetrics;
     private final TimeValue taskShutdownGracePeriod;
+    private final ReindexSettings reindexSettings;
+    private final CircuitBreaker requestBreaker;
 
     @Inject
     public TransportUpdateByQueryAction(
@@ -58,7 +63,9 @@ public class TransportUpdateByQueryAction extends HandledTransportAction<UpdateB
         TransportService transportService,
         ScriptService scriptService,
         ClusterService clusterService,
-        @Nullable UpdateByQueryMetrics updateByQueryMetrics
+        @Nullable UpdateByQueryMetrics updateByQueryMetrics,
+        ReindexSettings reindexSettings,
+        CircuitBreakerService circuitBreakerService
     ) {
         super(UpdateByQueryAction.NAME, transportService, actionFilters, UpdateByQueryRequest::new, EsExecutors.DIRECT_EXECUTOR_SERVICE);
         this.threadPool = threadPool;
@@ -69,6 +76,8 @@ public class TransportUpdateByQueryAction extends HandledTransportAction<UpdateB
         // todo: if relocations are added to update-by-query and it gets its own timeout setting, this should be updated.
         // without this safe default, adding relocations to update-by-query without updating this might open it up to race conditions.
         this.taskShutdownGracePeriod = ShutdownPrepareService.MAXIMUM_REINDEXING_TIMEOUT_SETTING.get(clusterService.getSettings());
+        this.reindexSettings = Objects.requireNonNull(reindexSettings);
+        this.requestBreaker = Objects.requireNonNull(circuitBreakerService.getBreaker(CircuitBreaker.REQUEST));
     }
 
     @Override
@@ -101,7 +110,9 @@ public class TransportUpdateByQueryAction extends HandledTransportAction<UpdateB
                             updateByQueryMetrics.recordTookTime(elapsedTime);
                         }
                     }),
-                    taskShutdownGracePeriod
+                    taskShutdownGracePeriod,
+                    reindexSettings,
+                    requestBreaker
                 ).start();
             }
         );
@@ -120,7 +131,9 @@ public class TransportUpdateByQueryAction extends HandledTransportAction<UpdateB
             ScriptService scriptService,
             UpdateByQueryRequest request,
             ActionListener<BulkByScrollResponse> listener,
-            TimeValue maxTaskShutdownGracePeriod
+            TimeValue maxTaskShutdownGracePeriod,
+            ReindexSettings reindexSettings,
+            CircuitBreaker requestBreaker
         ) {
             super(
                 task,
@@ -135,7 +148,10 @@ public class TransportUpdateByQueryAction extends HandledTransportAction<UpdateB
                 listener,
                 scriptService,
                 null,
-                maxTaskShutdownGracePeriod
+                maxTaskShutdownGracePeriod,
+                reindexSettings,
+                requestBreaker,
+                "update_by_query_bulk_batch"
             );
         }
 

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/AsyncBulkByScrollActionTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/AsyncBulkByScrollActionTests.java
@@ -48,12 +48,16 @@ import org.elasticsearch.client.internal.ParentTaskAssigningClient;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.common.BackoffPolicy;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.core.CheckedConsumer;
+import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.engine.VersionConflictEngineException;
@@ -103,6 +107,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.stream.IntStream;
@@ -134,6 +139,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class AsyncBulkByScrollActionTests extends ESTestCase {
+    /** No-op batch release for tests that call {@link AbstractAsyncBulkByScrollAction#sendBulkRequest} with no hit refs. */
+    private static final Releasable NO_OP_RELEASE_BATCH_HITS = () -> {};
+
     private MyMockClient client;
     private DummyAbstractBulkByScrollRequest testRequest;
     private PlainActionFuture<BulkByScrollResponse> listener;
@@ -645,6 +653,122 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
     }
 
     /**
+     * Verifies that when the REQUEST circuit breaker trips during {@code buildBulk} the reindex operation
+     * fails the listener with the exception, releases the batch hits, and never sends a bulk request.
+     */
+    public void testCircuitBreakerTripFailsBatchGracefully() throws Exception {
+        boolean usePit = configurePitOrScroll();
+        AtomicLong netBreakerBytes = new AtomicLong(0);
+
+        CircuitBreaker trippingBreaker = new NoopCircuitBreaker("test") {
+            @Override
+            public void addEstimateBytesAndMaybeBreak(long bytes, String label) {
+                throw new CircuitBreakingException("simulated breaker trip", bytes, 1L, CircuitBreaker.Durability.TRANSIENT);
+            }
+
+            @Override
+            public void addWithoutBreaking(long bytes) {
+                netBreakerBytes.addAndGet(bytes);
+            }
+        };
+
+        DummyAsyncBulkByScrollAction action = new DummyAsyncBulkByScrollAction(
+            testTask,
+            TimeValue.ZERO,
+            trippingBreaker,
+            "test_bulk_batch"
+        ) {
+            @Override
+            protected RequestWrapper<?> buildRequest(Hit doc) {
+                return wrap(new IndexRequest("test").id(doc.getId()).source(doc.getSource(), doc.getXContentType()));
+            }
+        };
+
+        List<PaginatedHitSource.BasicHit> hits = List.of(
+            new PaginatedHitSource.BasicHit("idx", "1", -1).setSource(new BytesArray(new byte[100]), XContentType.JSON),
+            new PaginatedHitSource.BasicHit("idx", "2", -1).setSource(new BytesArray(new byte[100]), XContentType.JSON)
+        );
+        PaginatedHitSource.Response response = createPaginatedResponse(usePit, false, emptyList(), hits.size(), hits, null, null);
+        simulatePaginatedResponse(action, System.nanoTime(), 0, response, usePit);
+
+        ExecutionException e = expectThrows(ExecutionException.class, () -> listener.get());
+        assertThat(e.getCause(), instanceOf(CircuitBreakingException.class));
+        assertThat(e.getCause().getMessage(), containsString("simulated breaker trip"));
+        assertEquals(0, client.bulksAttempts.get());
+        // No bytes were net-added to the breaker: the trip happened before any reservation landed.
+        assertEquals(0L, netBreakerBytes.get());
+    }
+
+    /**
+     * Verifies the per-batch reservation lifecycle: the circuit breaker accumulates bytes equal to
+     * {@code BulkRequest.estimatedSizeInBytes()} during {@code buildBulk}, and the reservation is fully
+     * released when the bulk listener completes.
+     */
+    public void testCircuitBreakerReservationMatchesBulkRequestSizeAndIsReleasedOnBulkComplete() throws Exception {
+        boolean usePit = configurePitOrScroll();
+        AtomicLong totalReserved = new AtomicLong(0);
+        AtomicLong totalReleased = new AtomicLong(0);
+
+        CircuitBreaker trackingBreaker = new NoopCircuitBreaker("test") {
+            @Override
+            public void addEstimateBytesAndMaybeBreak(long bytes, String label) {
+                if (bytes > 0) totalReserved.addAndGet(bytes);
+            }
+
+            @Override
+            public void addWithoutBreaking(long bytes) {
+                if (bytes < 0) totalReleased.addAndGet(-bytes);
+            }
+        };
+
+        DummyAsyncBulkByScrollAction action = new DummyAsyncBulkByScrollAction(
+            testTask,
+            TimeValue.ZERO,
+            trackingBreaker,
+            "test_bulk_batch"
+        ) {
+            @Override
+            protected RequestWrapper<?> buildRequest(Hit doc) {
+                return wrap(new IndexRequest("test").id(doc.getId()).source(doc.getSource(), doc.getXContentType()));
+            }
+        };
+
+        // Two docs × 100 bytes of source + 50 per-doc overhead = 300-byte BulkRequest.estimatedSizeInBytes().
+        List<PaginatedHitSource.BasicHit> hits = List.of(
+            new PaginatedHitSource.BasicHit("idx", "1", -1).setSource(new BytesArray(new byte[100]), XContentType.JSON),
+            new PaginatedHitSource.BasicHit("idx", "2", -1).setSource(new BytesArray(new byte[100]), XContentType.JSON)
+        );
+        PaginatedHitSource.Response response = createPaginatedResponse(usePit, false, emptyList(), hits.size(), hits, null, null);
+        // Inline the scroll response so done() is a no-op (rather than calling fail()) — the bulk completes
+        // but we don't want the action to try to fetch the next batch in this test.
+        if (usePit) {
+            action.setSearchAfterValues(new Object[] { "search_after_value" });
+        } else {
+            action.setScroll(scrollId());
+        }
+        action.onScrollResponse(
+            System.nanoTime(),
+            0,
+            new AbstractAsyncBulkByScrollAction.ScrollConsumableHitsResponse(new PaginatedHitSource.AsyncResponse() {
+                @Override
+                public PaginatedHitSource.Response response() {
+                    return response;
+                }
+
+                @Override
+                public void done(TimeValue extraKeepAlive) {
+                    // no-op: bulk has completed; we don't care about next-batch fetch in this test.
+                }
+            })
+        );
+
+        // Total reserved equals the full BulkRequest estimate (300 bytes); everything is released after the bulk.
+        assertBusy(() -> assertEquals(300L, totalReserved.get()));
+        assertBusy(() -> assertEquals(1, client.bulksAttempts.get()));
+        assertBusy(() -> assertEquals(totalReserved.get(), totalReleased.get()));
+    }
+
+    /**
      * Mimicks bulk indexing failures.
      */
     public void testBulkFailuresAbortRequest() throws Exception {
@@ -893,14 +1017,14 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
             request.add(new IndexRequest("index").id("id" + i));
         }
         if (failWithRejection) {
-            action.sendBulkRequest(request, Assert::fail);
+            action.sendBulkRequest(request, NO_OP_RELEASE_BATCH_HITS, Assert::fail);
             BulkByScrollResponse response = listener.get();
             assertThat(response.getBulkFailures(), hasSize(1));
             assertEquals(response.getBulkFailures().get(0).getStatus(), RestStatus.TOO_MANY_REQUESTS);
             assertThat(response.getSearchFailures(), empty());
             assertNull(response.getReasonCancelled());
         } else {
-            assertExactlyOnce(onSuccess -> action.sendBulkRequest(request, onSuccess));
+            assertExactlyOnce(onSuccess -> action.sendBulkRequest(request, NO_OP_RELEASE_BATCH_HITS, onSuccess));
         }
     }
 
@@ -974,7 +1098,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
     }
 
     public void testCancelBeforeSendBulkRequest() throws Exception {
-        cancelTaskCase((DummyAsyncBulkByScrollAction action) -> action.sendBulkRequest(new BulkRequest(), Assert::fail));
+        cancelTaskCase((DummyAsyncBulkByScrollAction action) -> action.sendBulkRequest(new BulkRequest(), NO_OP_RELEASE_BATCH_HITS, Assert::fail));
     }
 
     public void testCancelBeforeOnBulkResponse() throws Exception {
@@ -1787,6 +1911,15 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         }
 
         DummyAsyncBulkByScrollAction(BulkByScrollTask task, TimeValue maxTaskShutdownGracePeriod) {
+            this(task, maxTaskShutdownGracePeriod, new NoopCircuitBreaker("test"), "test_bulk_batch");
+        }
+
+        DummyAsyncBulkByScrollAction(
+            BulkByScrollTask task,
+            TimeValue maxTaskShutdownGracePeriod,
+            CircuitBreaker circuitBreaker,
+            String breakerLabel
+        ) {
             super(
                 task,
                 randomBoolean(),
@@ -1799,7 +1932,10 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
                 listener,
                 null,
                 null,
-                maxTaskShutdownGracePeriod
+                maxTaskShutdownGracePeriod,
+                new ReindexSettings(),
+                circuitBreaker,
+                breakerLabel
             );
         }
 

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/AsyncBulkByScrollActionTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/AsyncBulkByScrollActionTests.java
@@ -1098,7 +1098,9 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
     }
 
     public void testCancelBeforeSendBulkRequest() throws Exception {
-        cancelTaskCase((DummyAsyncBulkByScrollAction action) -> action.sendBulkRequest(new BulkRequest(), NO_OP_RELEASE_BATCH_HITS, Assert::fail));
+        cancelTaskCase(
+            (DummyAsyncBulkByScrollAction action) -> action.sendBulkRequest(new BulkRequest(), NO_OP_RELEASE_BATCH_HITS, Assert::fail)
+        );
     }
 
     public void testCancelBeforeOnBulkResponse() throws Exception {

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/DeleteByQueryCircuitBreakerTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/DeleteByQueryCircuitBreakerTests.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.reindex;
+
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.reindex.DeleteByQueryAction;
+import org.elasticsearch.index.reindex.DeleteByQueryRequest;
+import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.concurrent.ExecutionException;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.notNullValue;
+
+/**
+ * End-to-end check that delete-by-query reserves heap against the REQUEST circuit breaker for the {@link
+ * org.elasticsearch.action.bulk.BulkRequest} it is about to send, and surfaces a {@link
+ * CircuitBreakingException} to the client when that reservation can't fit.
+ *
+ * <p>DBQ's bulk request is unusually small — only {@code DeleteRequest}s with no body (DBQ disables
+ * {@code _source} fetching, see {@link DeleteByQueryRequest}), so each request contributes just the per-doc
+ * {@code BulkRequest.REQUEST_OVERHEAD} (~50 bytes). To trip the breaker on a realistic-sized batch we
+ * configure an unusually small breaker limit; in production the small reservation is correct precisely
+ * because DBQ's heap pressure is minimal.
+ *
+ * <p>Companion to {@link ReindexCircuitBreakerTests} and {@link UpdateByQueryCircuitBreakerTests}; each
+ * concrete action has its own breaker wiring with a distinct label so each needs its own end-to-end coverage
+ * to guard against wiring drift.
+ */
+public class DeleteByQueryCircuitBreakerTests extends ESSingleNodeTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return Arrays.asList(ReindexPlugin.class);
+    }
+
+    @Override
+    protected Settings nodeSettings() {
+        return Settings.builder()
+            .put(super.nodeSettings())
+            // DBQ's BulkRequest for 5 DeleteRequests is ≈ 5 × 50 = 250 bytes (no source bodies). Set the
+            // breaker just under that so the reservation in prepareBulkRequest trips.
+            .put(HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_LIMIT_SETTING.getKey(), "200b")
+            .build();
+    }
+
+    public void testDeleteByQueryFailsWhenBulkRequestSizeExceedsRequestBreakerLimit() {
+        int docCount = 5;
+        for (int i = 0; i < docCount; i++) {
+            prepareIndex("source").setId(Integer.toString(i)).setSource("data", "x".repeat(500)).get();
+        }
+        indicesAdmin().prepareRefresh("source").get();
+
+        DeleteByQueryRequest request = new DeleteByQueryRequest("source").setQuery(QueryBuilders.matchAllQuery());
+
+        ExecutionException thrown = expectThrows(
+            ExecutionException.class,
+            () -> client().execute(DeleteByQueryAction.INSTANCE, request).get()
+        );
+        Throwable circuitBreakingCause = ExceptionsHelper.unwrap(thrown, CircuitBreakingException.class);
+        assertThat("expected CircuitBreakingException in cause chain, got: " + thrown, circuitBreakingCause, notNullValue());
+        // The label is set by AsyncDeleteByQueryAction#reserveBatchAllocation.
+        assertThat(circuitBreakingCause.getMessage(), containsString("delete_by_query_bulk_batch"));
+
+        // No documents should have been deleted — no bulk request was issued.
+        assertHitCount(client().prepareSearch("source").setSize(0), docCount);
+    }
+}

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexCircuitBreakerTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexCircuitBreakerTests.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.reindex;
+
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.reindex.ReindexAction;
+import org.elasticsearch.index.reindex.ReindexRequest;
+import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.concurrent.ExecutionException;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.notNullValue;
+
+/**
+ * End-to-end check that reindex reserves heap against the REQUEST circuit breaker for the {@link
+ * org.elasticsearch.action.bulk.BulkRequest} it is about to send, and surfaces a {@link
+ * CircuitBreakingException} to the client when that reservation can't fit — without sending the oversized
+ * bulk request that would have pushed the node toward OOM.
+ *
+ * <p>The reservation/release lifecycle of the hooks themselves is covered by unit tests in
+ * {@code AsyncBulkByScrollActionTests}; this class verifies the production wiring (CircuitBreakerService →
+ * Reindexer → AsyncIndexBySearchAction) actually fires against a real breaker.
+ */
+public class ReindexCircuitBreakerTests extends ESSingleNodeTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return Arrays.asList(ReindexPlugin.class);
+    }
+
+    @Override
+    protected Settings nodeSettings() {
+        return Settings.builder()
+            .put(super.nodeSettings())
+            // Sized below the BulkRequest reservation the reindex will attempt (≈ 40 KiB) so the breaker
+            // trips when the action calls reserveBatchAllocation in prepareBulkRequest. Local search-side
+            // accounting for these 5 small-ish hits stays well under this limit.
+            .put(HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_LIMIT_SETTING.getKey(), "30kb")
+            .build();
+    }
+
+    public void testReindexFailsWhenBulkRequestSizeExceedsRequestBreakerLimit() {
+        // Pre-create dest so we can search it after the failure even though no bulk write reaches it.
+        assertAcked(indicesAdmin().prepareCreate("dest"));
+
+        // Five docs × ~8 000-byte source ⇒ BulkRequest.estimatedSizeInBytes() ≈ 5 × (8 000 + 50) ≈ 40 250
+        // bytes, which exceeds the 30 KiB breaker limit configured above.
+        int batchSize = 5;
+        int docCount = batchSize;
+        int sourceBytes = 8_000;
+        for (int i = 0; i < docCount; i++) {
+            prepareIndex("source").setId(Integer.toString(i)).setSource("data", "x".repeat(sourceBytes)).get();
+        }
+        indicesAdmin().prepareRefresh("source").get();
+
+        ReindexRequest request = new ReindexRequest().setSourceIndices("source");
+        request.setDestIndex("dest");
+        request.getSearchRequest().source().size(batchSize);
+
+        ExecutionException thrown = expectThrows(ExecutionException.class, () -> client().execute(ReindexAction.INSTANCE, request).get());
+        Throwable circuitBreakingCause = ExceptionsHelper.unwrap(thrown, CircuitBreakingException.class);
+        assertThat("expected CircuitBreakingException in cause chain, got: " + thrown, circuitBreakingCause, notNullValue());
+        // The label is set by Reindexer.AsyncIndexBySearchAction#reserveBatchAllocation and identifies the source.
+        assertThat(circuitBreakingCause.getMessage(), containsString("reindex_bulk_batch"));
+
+        // No bulk request should have been issued — destination remains empty.
+        assertHitCount(client().prepareSearch("dest").setSize(0), 0);
+    }
+}

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexIdTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexIdTests.java
@@ -18,7 +18,9 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.ProjectMetadata;
 import org.elasticsearch.cluster.metadata.Template;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
@@ -26,12 +28,18 @@ import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.reindex.AbstractAsyncBulkByScrollActionTestCase;
 import org.elasticsearch.index.reindex.BulkByScrollResponse;
 import org.elasticsearch.index.reindex.ReindexRequest;
+import org.elasticsearch.xcontent.XContentParseException;
 import org.elasticsearch.xcontent.XContentType;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.List;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Reindex tests for picking ids.
@@ -57,6 +65,75 @@ public class ReindexIdTests extends AbstractAsyncBulkByScrollActionTestCase<Rein
     public void testMissingIndexWithTsdbTemplateClearsId() throws Exception {
         assertThat(action(stateWithTemplate(tsdbSettings())).buildRequest(doc()).getId(), nullValue());
     }
+
+    public void testConversionErrorContainsDocId() {
+        final PaginatedHitSource.BasicHit hit = new PaginatedHitSource.BasicHit("source_index", "doc_123", -1).setSource(
+            new BytesArray("not valid json"),
+            XContentType.JSON
+        );
+        final ReindexRequest req = request();
+        req.getDestination().source(new BytesArray("{}"), XContentType.CBOR);
+        final ProjectState projectState = ClusterState.EMPTY_STATE.projectState(Metadata.DEFAULT_PROJECT_ID);
+        final Reindexer.AsyncIndexBySearchAction action = new Reindexer.AsyncIndexBySearchAction(
+            task,
+            logger,
+            null,
+            null,
+            threadPool,
+            null,
+            projectState,
+            null,
+            req,
+            listener(),
+            null,
+            randomTimeValue(),
+            new ReindexSettings(),
+            new NoopCircuitBreaker("test")
+        );
+        expectThrows(
+            XContentParseException.class,
+            equalTo("[1:5] failed to convert hit [source_index][doc_123] from JSON to CBOR"),
+            () -> action.buildRequest(hit)
+        );
+    }
+
+    /**
+     * Simulates an I/O failure when opening the hit source stream so the {@link IOException} branch is exercised (not XContent parsing).
+     */
+    public void testConversionIoErrorContainsDocId() throws IOException {
+        final BytesReference source = mock(BytesReference.class);
+        when(source.hasArray()).thenReturn(false);
+        doThrow(new IOException(randomAlphaOfLength(8))).when(source).streamInput();
+        final PaginatedHitSource.BasicHit hit = new PaginatedHitSource.BasicHit("source_index", "doc_123", -1).setSource(
+            source,
+            XContentType.JSON
+        );
+        final ReindexRequest req = request();
+        req.getDestination().source(new BytesArray("{}"), XContentType.CBOR);
+        final ProjectState projectState = ClusterState.EMPTY_STATE.projectState(Metadata.DEFAULT_PROJECT_ID);
+        final Reindexer.AsyncIndexBySearchAction action = new Reindexer.AsyncIndexBySearchAction(
+            task,
+            logger,
+            null,
+            null,
+            threadPool,
+            null,
+            projectState,
+            null,
+            req,
+            listener(),
+            null,
+            randomTimeValue(),
+            new ReindexSettings(),
+            new NoopCircuitBreaker("test")
+        );
+        expectThrows(
+            UncheckedIOException.class,
+            equalTo("failed to convert hit [source_index][doc_123] from JSON to CBOR"),
+            () -> action.buildRequest(hit)
+        );
+    }
+
 
     private ProjectState stateWithTemplate(Settings.Builder settings) {
         final var projectId = randomProjectIdOrDefault();
@@ -121,7 +198,9 @@ public class ReindexIdTests extends AbstractAsyncBulkByScrollActionTestCase<Rein
             request(),
             listener(),
             randomBoolean() ? null : Version.CURRENT,
-            randomPositiveTimeValue()
+            randomPositiveTimeValue(),
+            new ReindexSettings(),
+            new NoopCircuitBreaker("test")
         );
     }
 }

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexIdTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexIdTests.java
@@ -134,7 +134,6 @@ public class ReindexIdTests extends AbstractAsyncBulkByScrollActionTestCase<Rein
         );
     }
 
-
     private ProjectState stateWithTemplate(Settings.Builder settings) {
         final var projectId = randomProjectIdOrDefault();
         ProjectMetadata.Builder projectBuilder = ProjectMetadata.builder(projectId);

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexMetadataTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexMetadataTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.index.reindex.BulkByScrollResponse;
 import org.elasticsearch.index.reindex.ReindexRequest;
 import org.elasticsearch.reindex.PaginatedHitSource.Hit;
@@ -85,7 +86,9 @@ public class ReindexMetadataTests extends AbstractAsyncBulkByScrollActionMetadat
                 request(),
                 listener(),
                 randomBoolean() ? null : Version.CURRENT,
-                randomPositiveTimeValue()
+                randomPositiveTimeValue(),
+                new ReindexSettings(),
+                new NoopCircuitBreaker("test")
             );
         }
 

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexScriptTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexScriptTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.lucene.uid.Versions;
 import org.elasticsearch.index.reindex.BulkByScrollResponse;
 import org.elasticsearch.index.reindex.ReindexRequest;
@@ -104,7 +105,9 @@ public class ReindexScriptTests extends AbstractAsyncBulkByScrollActionScriptTes
             request,
             listener(),
             randomBoolean() ? null : Version.CURRENT,
-            randomPositiveTimeValue()
+            randomPositiveTimeValue(),
+            new ReindexSettings(),
+            new NoopCircuitBreaker("test")
         );
     }
 }

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexSettingsTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexSettingsTests.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.reindex;
+
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.Set;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Unit tests for {@link ReindexSettings}: initialization from {@link ClusterSettings}, dynamic updates, and validation of
+ * {@link ReindexSettings#REINDEX_MEMORY_ACCOUNTING_THRESHOLD_SETTING}.
+ */
+public class ReindexSettingsTests extends ESTestCase {
+
+    /**
+     * After construction with empty node settings, {@link ReindexSettings#getMemoryAccountingThresholdInBytes()} matches the
+     * documented default of 1 MB.
+     */
+    public void testMemoryAccountingThresholdMatchesDefaultWhenNodeSettingsEmpty() {
+        ClusterSettings clusterSettings = clusterSettings(Settings.EMPTY);
+        ReindexSettings reindexSettings = new ReindexSettings(clusterSettings);
+        assertThat(reindexSettings.getMemoryAccountingThresholdInBytes(), equalTo(ByteSizeValue.of(1, ByteSizeUnit.MB).getBytes()));
+    }
+
+    /**
+     * The no-arg constructor (used by nodes that don't load ReindexPlugin and by some tests) falls back to the static default.
+     */
+    public void testMemoryAccountingThresholdUsesDefaultWhenSettingNotRegistered() {
+        ReindexSettings reindexSettings = new ReindexSettings();
+        assertThat(reindexSettings.getMemoryAccountingThresholdInBytes(), equalTo(ByteSizeValue.of(1, ByteSizeUnit.MB).getBytes()));
+    }
+
+    /**
+     * A dynamic cluster settings update propagates the new threshold into the cached value.
+     */
+    public void testMemoryAccountingThresholdUpdatesWhenClusterSettingApplied() {
+        ClusterSettings clusterSettings = clusterSettings(Settings.EMPTY);
+        ReindexSettings reindexSettings = new ReindexSettings(clusterSettings);
+
+        ByteSizeValue updated = ByteSizeValue.of(randomIntBetween(2, 512), ByteSizeUnit.MB);
+        clusterSettings.applySettings(
+            Settings.builder().put(ReindexSettings.REINDEX_MEMORY_ACCOUNTING_THRESHOLD_SETTING.getKey(), updated.getStringRep()).build()
+        );
+
+        assertThat(reindexSettings.getMemoryAccountingThresholdInBytes(), equalTo(updated.getBytes()));
+    }
+
+    /**
+     * Values strictly below the 1 MB minimum are rejected so the cached value is unchanged.
+     */
+    public void testMemoryAccountingThresholdRejectsBelowMinimum() {
+        String key = ReindexSettings.REINDEX_MEMORY_ACCOUNTING_THRESHOLD_SETTING.getKey();
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> ReindexSettings.REINDEX_MEMORY_ACCOUNTING_THRESHOLD_SETTING.get(Settings.builder().put(key, "512kb").build())
+        );
+        assertThat(e.getMessage(), containsString(key));
+    }
+
+    private static ClusterSettings clusterSettings(Settings nodeSettings) {
+        return new ClusterSettings(nodeSettings, Set.of(ReindexSettings.REINDEX_MEMORY_ACCOUNTING_THRESHOLD_SETTING));
+    }
+}

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexerTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexerTests.java
@@ -43,8 +43,11 @@ import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.cluster.project.TestProjectResolvers;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.core.TimeValue;
@@ -64,6 +67,7 @@ import org.elasticsearch.index.reindex.ResumeBulkByScrollResponse;
 import org.elasticsearch.index.reindex.ResumeInfo;
 import org.elasticsearch.index.reindex.ResumeReindexAction;
 import org.elasticsearch.index.reindex.TaskRelocatedException;
+import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.mocksocket.MockHttpServer;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.SearchHits;
@@ -783,7 +787,8 @@ public class ReindexerTests extends ESTestCase {
                     mock(TransportService.class),
                     mock(ReindexRelocationNodePicker.class),
                     featureService,
-                    mock(TaskResultsService.class)
+                    mock(TaskResultsService.class),
+                    noopCircuitBreakerService()
                 );
 
                 // Simulate a worker request: PIT already set by leader, slice info from leader
@@ -1021,7 +1026,8 @@ public class ReindexerTests extends ESTestCase {
                 mock(TransportService.class),
                 mock(ReindexRelocationNodePicker.class),
                 featureService,
-                mock(TaskResultsService.class)
+                mock(TaskResultsService.class),
+                noopCircuitBreakerService()
             );
 
             final ReindexRequest request = new ReindexRequest();
@@ -1086,7 +1092,8 @@ public class ReindexerTests extends ESTestCase {
                     mock(TransportService.class),
                     mock(ReindexRelocationNodePicker.class),
                     featureService,
-                    mock(TaskResultsService.class)
+                    mock(TaskResultsService.class),
+                    noopCircuitBreakerService()
                 );
 
                 final ReindexRequest request = new ReindexRequest();
@@ -1160,7 +1167,8 @@ public class ReindexerTests extends ESTestCase {
                     mock(TransportService.class),
                     mock(ReindexRelocationNodePicker.class),
                     featureService,
-                    mock(TaskResultsService.class)
+                    mock(TaskResultsService.class),
+                    noopCircuitBreakerService()
                 );
 
                 final ReindexRequest request = new ReindexRequest();
@@ -1229,7 +1237,8 @@ public class ReindexerTests extends ESTestCase {
                     mock(TransportService.class),
                     mock(ReindexRelocationNodePicker.class),
                     featureService,
-                    mock(TaskResultsService.class)
+                    mock(TaskResultsService.class),
+                    noopCircuitBreakerService()
                 );
 
                 final var termQuery = QueryBuilders.termQuery("field", "value");
@@ -1298,7 +1307,8 @@ public class ReindexerTests extends ESTestCase {
                     mock(TransportService.class),
                     mock(ReindexRelocationNodePicker.class),
                     featureService,
-                    mock(TaskResultsService.class)
+                    mock(TaskResultsService.class),
+                    noopCircuitBreakerService()
                 );
 
                 final String projectRouting = "_alias:linked";
@@ -1369,7 +1379,8 @@ public class ReindexerTests extends ESTestCase {
                     mock(TransportService.class),
                     mock(ReindexRelocationNodePicker.class),
                     featureService,
-                    mock(TaskResultsService.class)
+                    mock(TaskResultsService.class),
+                    noopCircuitBreakerService()
                 );
 
                 // Simulate a worker request: PIT already set by leader, slice info from leader
@@ -1443,7 +1454,8 @@ public class ReindexerTests extends ESTestCase {
                     mock(TransportService.class),
                     mock(ReindexRelocationNodePicker.class),
                     featureService,
-                    mock(TaskResultsService.class)
+                    mock(TaskResultsService.class),
+                    noopCircuitBreakerService()
                 );
 
                 final ReindexRequest request = new ReindexRequest();
@@ -1513,7 +1525,8 @@ public class ReindexerTests extends ESTestCase {
                     mock(TransportService.class),
                     mock(ReindexRelocationNodePicker.class),
                     featureService,
-                    mock(TaskResultsService.class)
+                    mock(TaskResultsService.class),
+                    noopCircuitBreakerService()
                 );
 
                 final ReindexRequest request = new ReindexRequest();
@@ -1583,7 +1596,8 @@ public class ReindexerTests extends ESTestCase {
                     mock(TransportService.class),
                     mock(ReindexRelocationNodePicker.class),
                     featureService,
-                    mock(TaskResultsService.class)
+                    mock(TaskResultsService.class),
+                    noopCircuitBreakerService()
                 );
 
                 final ReindexRequest request = new ReindexRequest();
@@ -1688,7 +1702,8 @@ public class ReindexerTests extends ESTestCase {
                     transportService,
                     mock(ReindexRelocationNodePicker.class),
                     featureService,
-                    mock(TaskResultsService.class)
+                    mock(TaskResultsService.class),
+                    noopCircuitBreakerService()
                 );
                 reindexerRef.set(reindexer);
 
@@ -1803,7 +1818,8 @@ public class ReindexerTests extends ESTestCase {
                     mock(TransportService.class),
                     mock(ReindexRelocationNodePicker.class),
                     featureService,
-                    mock(TaskResultsService.class)
+                    mock(TaskResultsService.class),
+                    noopCircuitBreakerService()
                 );
 
                 final int scrollMinutes = randomIntBetween(3, 20);
@@ -1873,7 +1889,8 @@ public class ReindexerTests extends ESTestCase {
                     mock(TransportService.class),
                     mock(ReindexRelocationNodePicker.class),
                     featureService,
-                    mock(TaskResultsService.class)
+                    mock(TaskResultsService.class),
+                    noopCircuitBreakerService()
                 );
 
                 final ReindexRequest request = new ReindexRequest();
@@ -1941,7 +1958,8 @@ public class ReindexerTests extends ESTestCase {
                     mock(TransportService.class),
                     mock(ReindexRelocationNodePicker.class),
                     featureService,
-                    mock(TaskResultsService.class)
+                    mock(TaskResultsService.class),
+                    noopCircuitBreakerService()
                 );
 
                 final IndicesOptions indicesOptions = IndicesOptions.lenientExpandOpen();
@@ -2009,7 +2027,8 @@ public class ReindexerTests extends ESTestCase {
                     mock(TransportService.class),
                     mock(ReindexRelocationNodePicker.class),
                     featureService,
-                    mock(TaskResultsService.class)
+                    mock(TaskResultsService.class),
+                    noopCircuitBreakerService()
                 );
 
                 final ReindexRequest request = new ReindexRequest();
@@ -2126,7 +2145,8 @@ public class ReindexerTests extends ESTestCase {
                     mock(TransportService.class),
                     mock(ReindexRelocationNodePicker.class),
                     featureService,
-                    mock(TaskResultsService.class)
+                    mock(TaskResultsService.class),
+                    noopCircuitBreakerService()
                 );
 
                 ReindexRequest request = new ReindexRequest();
@@ -2230,7 +2250,8 @@ public class ReindexerTests extends ESTestCase {
             mock(TransportService.class),
             mock(ReindexRelocationNodePicker.class),
             mock(FeatureService.class),
-            mock(TaskResultsService.class)
+            mock(TaskResultsService.class),
+            noopCircuitBreakerService()
         );
         RestClient restClient = mock(RestClient.class);
         IOException ioException = new IOException("simulated close failure");
@@ -2562,7 +2583,8 @@ public class ReindexerTests extends ESTestCase {
                 mock(TransportService.class),
                 mock(ReindexRelocationNodePicker.class),
                 featureService,
-                mock(TaskResultsService.class)
+                mock(TaskResultsService.class),
+                noopCircuitBreakerService()
             );
 
             BulkByScrollTask task = new BulkByScrollTask(
@@ -2696,6 +2718,12 @@ public class ReindexerTests extends ESTestCase {
         );
     }
 
+    private static CircuitBreakerService noopCircuitBreakerService() {
+        CircuitBreakerService service = mock(CircuitBreakerService.class);
+        when(service.getBreaker(CircuitBreaker.REQUEST)).thenReturn(new NoopCircuitBreaker(CircuitBreaker.REQUEST));
+        return service;
+    }
+
     private static Reindexer reindexerWithRelocation() {
         final TaskManager taskManager = mock(TaskManager.class);
         final TransportService transportService = mock(TransportService.class);
@@ -2715,6 +2743,7 @@ public class ReindexerTests extends ESTestCase {
         final ThreadPool threadPool = mock(ThreadPool.class);
         when(threadPool.generic()).thenReturn(mock(ExecutorService.class));
         when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettingsForReindexPit(Settings.EMPTY));
         return new Reindexer(
             clusterService,
             mock(ProjectResolver.class),
@@ -2727,7 +2756,8 @@ public class ReindexerTests extends ESTestCase {
             mock(ReindexRelocationNodePicker.class),
             // Will default REINDEX_PIT_SEARCH_FEATURE to false
             mock(FeatureService.class),
-            taskResultsService
+            taskResultsService,
+            noopCircuitBreakerService()
         );
     }
 
@@ -2753,6 +2783,15 @@ public class ReindexerTests extends ESTestCase {
         when(clusterService.state()).thenReturn(ClusterState.EMPTY_STATE);
         when(clusterService.localNode()).thenReturn(localNode);
         when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettingsForReindexPit(Settings.EMPTY));
         return clusterService;
+    }
+
+    private static ClusterSettings clusterSettingsForReindexPit(Settings nodeSettings) {
+        return new ClusterSettings(nodeSettings, Set.of(ReindexSettings.REINDEX_MEMORY_ACCOUNTING_THRESHOLD_SETTING));
+    }
+
+    private static ReindexSettings reindexSettingsFor(ClusterService clusterService) {
+        return new ReindexSettings(clusterService.getClusterSettings());
     }
 }

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/UpdateByQueryCircuitBreakerTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/UpdateByQueryCircuitBreakerTests.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.reindex;
+
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.reindex.UpdateByQueryAction;
+import org.elasticsearch.index.reindex.UpdateByQueryRequest;
+import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.concurrent.ExecutionException;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.notNullValue;
+
+/**
+ * End-to-end check that update-by-query reserves heap against the REQUEST circuit breaker for the {@link
+ * org.elasticsearch.action.bulk.BulkRequest} it is about to send, and surfaces a {@link
+ * CircuitBreakingException} to the client when that reservation can't fit.
+ *
+ * <p>This is the UBQ companion to {@link ReindexCircuitBreakerTests}; the two paths share the lifecycle in
+ * {@link AbstractAsyncBulkByScrollAction} but each concrete action has its own breaker wiring with a distinct
+ * label, so each needs its own end-to-end coverage to guard against wiring drift.
+ */
+public class UpdateByQueryCircuitBreakerTests extends ESSingleNodeTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return Arrays.asList(ReindexPlugin.class);
+    }
+
+    @Override
+    protected Settings nodeSettings() {
+        return Settings.builder()
+            .put(super.nodeSettings())
+            // Sized below the BulkRequest reservation UBQ will attempt (≈ 40 KiB) so the breaker trips
+            // when the action calls reserveBatchAllocation in prepareBulkRequest.
+            .put(HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_LIMIT_SETTING.getKey(), "30kb")
+            .build();
+    }
+
+    public void testUpdateByQueryFailsWhenBulkRequestSizeExceedsRequestBreakerLimit() {
+        // Five docs × ~8 000-byte source ⇒ BulkRequest.estimatedSizeInBytes() ≈ 5 × (8 000 + 50) ≈ 40 250
+        // bytes, which exceeds the 30 KiB breaker limit configured above.
+        int batchSize = 5;
+        int docCount = batchSize;
+        int sourceBytes = 8_000;
+        for (int i = 0; i < docCount; i++) {
+            prepareIndex("source").setId(Integer.toString(i)).setSource("data", "x".repeat(sourceBytes)).get();
+        }
+        indicesAdmin().prepareRefresh("source").get();
+
+        UpdateByQueryRequest request = new UpdateByQueryRequest("source");
+        request.getSearchRequest().source().size(batchSize);
+
+        ExecutionException thrown = expectThrows(
+            ExecutionException.class,
+            () -> client().execute(UpdateByQueryAction.INSTANCE, request).get()
+        );
+        Throwable circuitBreakingCause = ExceptionsHelper.unwrap(thrown, CircuitBreakingException.class);
+        assertThat("expected CircuitBreakingException in cause chain, got: " + thrown, circuitBreakingCause, notNullValue());
+        // The label is set by TransportUpdateByQueryAction.AsyncIndexBySearchAction#reserveBatchAllocation.
+        assertThat(circuitBreakingCause.getMessage(), containsString("update_by_query_bulk_batch"));
+
+        // Source documents should remain unchanged — no bulk request was issued.
+        // assertHitCount handles SearchResponse refcount release; calling .get() and dropping the response
+        // would leak it and trip the test framework's LeakTracker on the next GC.
+        assertHitCount(client().prepareSearch("source").setSize(0), docCount);
+    }
+}

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/UpdateByQueryMetadataTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/UpdateByQueryMetadataTests.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.reindex;
 
 import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.index.reindex.BulkByScrollResponse;
 import org.elasticsearch.index.reindex.UpdateByQueryRequest;
 import org.elasticsearch.reindex.PaginatedHitSource.Hit;
@@ -44,7 +45,9 @@ public class UpdateByQueryMetadataTests extends AbstractAsyncBulkByScrollActionM
                 null,
                 request(),
                 listener(),
-                randomPositiveTimeValue()
+                randomPositiveTimeValue(),
+                new ReindexSettings(),
+                new NoopCircuitBreaker("test")
             );
         }
 

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/UpdateByQueryVersionTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/UpdateByQueryVersionTests.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.reindex;
 
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.index.reindex.BulkByScrollResponse;
 import org.elasticsearch.index.reindex.UpdateByQueryRequest;
 import org.elasticsearch.reindex.PaginatedHitSource.Hit;
@@ -54,7 +55,9 @@ public class UpdateByQueryVersionTests extends AbstractAsyncBulkByScrollActionMe
                 null,
                 request(),
                 listener(),
-                randomPositiveTimeValue()
+                randomPositiveTimeValue(),
+                new ReindexSettings(),
+                new NoopCircuitBreaker("test")
             );
         }
 

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/UpdateByQueryWithScriptTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/UpdateByQueryWithScriptTests.java
@@ -11,9 +11,11 @@ package org.elasticsearch.reindex;
 
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.reindex.BulkByScrollResponse;
 import org.elasticsearch.index.reindex.UpdateByQueryRequest;
+import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.transport.TransportService;
 
@@ -58,6 +60,10 @@ public class UpdateByQueryWithScriptTests extends AbstractAsyncBulkByScrollActio
         ClusterService clusterService = mock(ClusterService.class);
         when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
 
+        CircuitBreakerService circuitBreakerService = mock(CircuitBreakerService.class);
+        when(circuitBreakerService.getBreaker(org.elasticsearch.common.breaker.CircuitBreaker.REQUEST)).thenReturn(
+            new NoopCircuitBreaker("test")
+        );
         TransportUpdateByQueryAction transportAction = new TransportUpdateByQueryAction(
             threadPool,
             new ActionFilters(Collections.emptySet()),
@@ -65,7 +71,9 @@ public class UpdateByQueryWithScriptTests extends AbstractAsyncBulkByScrollActio
             transportService,
             scriptService,
             clusterService,
-            null
+            null,
+            new ReindexSettings(),
+            circuitBreakerService
         );
         return new TransportUpdateByQueryAction.AsyncIndexBySearchAction(
             task,
@@ -75,7 +83,9 @@ public class UpdateByQueryWithScriptTests extends AbstractAsyncBulkByScrollActio
             scriptService,
             request,
             listener(),
-            randomPositiveTimeValue()
+            randomPositiveTimeValue(),
+            new ReindexSettings(),
+            new NoopCircuitBreaker("test")
         );
     }
 }

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/TransportEnrichReindexAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/TransportEnrichReindexAction.java
@@ -19,6 +19,7 @@ import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.index.reindex.ReindexRequest;
+import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.injection.guice.Inject;
 import org.elasticsearch.reindex.ReindexPlugin;
 import org.elasticsearch.reindex.ReindexSslConfig;
@@ -55,7 +56,8 @@ public class TransportEnrichReindexAction extends TransportReindexAction {
         Environment environment,
         ResourceWatcherService watcherService,
         FeatureService featureService,
-        TaskResultsService taskResultsService
+        TaskResultsService taskResultsService,
+        CircuitBreakerService circuitBreakerService
     ) {
         super(
             EnrichReindexAction.NAME,
@@ -74,7 +76,8 @@ public class TransportEnrichReindexAction extends TransportReindexAction {
             // can't be injected due to different classloaders between enrich and reindex (enrich doesn't extend reindex).
             ReindexPlugin.getReindexRelocationNodePicker(environment),
             featureService,
-            taskResultsService
+            taskResultsService,
+            circuitBreakerService
         );
         this.bulkClient = new OriginSettingClient(client, ENRICH_ORIGIN);
     }


### PR DESCRIPTION
# Backport

This is a backport of PR #148656 onto branch `9.4`.

### Original description

Reserve REQUEST circuit breaker for reindex bulk batches.

> **Note:** Conflicts were resolved manually. The `9.4` branch had diverged from `main` — `ReindexSettings.java` did not yet exist and several reindex files had structural differences. The circuit breaker changes were applied cleanly to the 9.4 versions of those files.