### PR TITLE
Update MMROperatorTests to handle multiple pages

### DIFF
--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/MMROperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/MMROperatorTests.java
@@ -72,7 +72,6 @@ public class MMROperatorTests extends OperatorTestCase {
                     throw new RuntimeException(e);
                 }
 
-                finish();
                 return new Page(blocks);
             }
         };
@@ -80,16 +79,16 @@ public class MMROperatorTests extends OperatorTestCase {
 
     @Override
     protected void assertSimpleOutput(List<Page> input, List<Page> results) {
-        assertEquals(1, input.size());
+        int totalInputPositions = input.stream().mapToInt(Page::getPositionCount).sum();
+        int expectedLimit = Math.min(totalInputPositions, testLimitValue);
 
-        int expectedLimit = Math.min(input.getFirst().getPositionCount(), testLimitValue);
+        int totalResultPositions = results.stream().mapToInt(Page::getPositionCount).sum();
+        assertEquals(expectedLimit, totalResultPositions);
 
-        var firstResultPage = results.getFirst();
-        assertEquals(expectedLimit, firstResultPage.getPositionCount());
-
-        assertEquals(1, firstResultPage.getBlockCount());
-
-        assertThat(firstResultPage.getBlock(0).elementType(), equalTo(ElementType.FLOAT));
+        for (Page page : results) {
+            assertEquals(1, page.getBlockCount());
+            assertThat(page.getBlock(0).elementType(), equalTo(ElementType.FLOAT));
+        }
     }
 
     @Override


### PR DESCRIPTION
Updates `MMROperatorTests` handle multiple pages.

Previously, this test called `finish()` in `createPage`, always limiting the output to a single page. This was done to simplify the checks in `assertSimpleOutput`. However, this creates problems when [AbstractBlockSourceOperator#getOutput generates a page of length 0](https://github.com/Mikep86/elasticsearch/blob/10eb5390d693b129ed269cce1ed604cb8eece8a2/x-pack/plugin/esql/compute/test/src/main/java/org/elasticsearch/compute/test/operator/blocksource/AbstractBlockSourceOperator.java#L42-L52). When this happens, some tests fail, as shown by https://github.com/elastic/elasticsearch/issues/149275.

The fix is to allow multiple pages to be generated, enough to satisfy the `size` passed to `simpleInput`. 0-length pages are discarded. This aligns `MMROperatorTests` with other implementations of `OperatorTestCase`.

Fixes https://github.com/elastic/elasticsearch/issues/149275