### PR TITLE
ESQL|DS: restore cache + STATS_FILE_COUNT on UNION_BY_NAME / STRICT path

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
@@ -525,9 +525,7 @@ public class ExternalSourceResolver {
         return result;
     }
 
-    /** Cache-aware single-file resolve; mirrors the FFW cache pattern. Exceptions from the
-     *  cache layer or the underlying resolve propagate to the caller (same as FFW) so a real
-     *  cache bug fails loud instead of degrading silently to N footer reads per warm query. */
+    /** Cache-aware single-file resolve. Mirrors the FFW path — exceptions propagate (no catch). */
     private SourceMetadata cachedResolveSingleSource(StoragePath filePath, long mtime, Map<String, Object> config) throws Exception {
         String formatType = detectFormatType(filePath);
         SchemaCacheKey schemaKey = SchemaCacheKey.build(filePath.toString(), mtime, formatType, config);
@@ -544,14 +542,11 @@ public class ExternalSourceResolver {
      * then merges all maps using {@link SourceStatisticsSerializer#mergeStatistics}.
      * Returns {@code null} if any file lacks statistics (prevents incorrect partial results).
      */
-    // package-private for direct test coverage of the cached/uncached shape branch.
     @Nullable
     static Map<String, Object> aggregateFileStatistics(Collection<SourceMetadata> allMetadata) {
         List<Map<String, Object>> perFileFlatStats = new ArrayList<>(allMetadata.size());
         for (SourceMetadata meta : allMetadata) {
-            // Cached entries arrive with stats already embedded as flat keys in sourceMetadata();
-            // uncached entries arrive with typed statistics(). Accept either shape so callers
-            // don't need to know whether the metadata came through the schema cache.
+            // Cached entries embed stats in sourceMetadata(); uncached entries use typed statistics().
             Map<String, Object> base = meta.sourceMetadata();
             if (base != null && base.containsKey(SourceStatisticsSerializer.STATS_ROW_COUNT)) {
                 perFileFlatStats.add(base);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
@@ -525,20 +525,17 @@ public class ExternalSourceResolver {
         return result;
     }
 
-    /** Cache-aware single-file resolve; mirrors the FFW cache pattern. */
-    private SourceMetadata cachedResolveSingleSource(StoragePath filePath, long mtime, Map<String, Object> config) {
+    /** Cache-aware single-file resolve; mirrors the FFW cache pattern. Exceptions from the
+     *  cache layer or the underlying resolve propagate to the caller (same as FFW) so a real
+     *  cache bug fails loud instead of degrading silently to N footer reads per warm query. */
+    private SourceMetadata cachedResolveSingleSource(StoragePath filePath, long mtime, Map<String, Object> config) throws Exception {
         String formatType = detectFormatType(filePath);
         SchemaCacheKey schemaKey = SchemaCacheKey.build(filePath.toString(), mtime, formatType, config);
-        try {
-            SchemaCacheEntry entry = cacheService.getOrComputeSchema(
-                schemaKey,
-                k -> SchemaCacheEntry.from(resolveSingleSource(filePath.toString(), config))
-            );
-            return buildMetadataFromCache(entry, entry.toAttributes(), config);
-        } catch (Exception e) {
-            LOGGER.debug(() -> "Schema cache miss + fallback for [" + filePath + "]: " + e.getMessage());
-            return resolveSingleSource(filePath.toString(), config);
-        }
+        SchemaCacheEntry entry = cacheService.getOrComputeSchema(
+            schemaKey,
+            k -> SchemaCacheEntry.from(resolveSingleSource(filePath.toString(), config))
+        );
+        return buildMetadataFromCache(entry, entry.toAttributes(), config);
     }
 
     /**
@@ -547,8 +544,9 @@ public class ExternalSourceResolver {
      * then merges all maps using {@link SourceStatisticsSerializer#mergeStatistics}.
      * Returns {@code null} if any file lacks statistics (prevents incorrect partial results).
      */
+    // package-private for direct test coverage of the cached/uncached shape branch.
     @Nullable
-    private static Map<String, Object> aggregateFileStatistics(Collection<SourceMetadata> allMetadata) {
+    static Map<String, Object> aggregateFileStatistics(Collection<SourceMetadata> allMetadata) {
         List<Map<String, Object>> perFileFlatStats = new ArrayList<>(allMetadata.size());
         for (SourceMetadata meta : allMetadata) {
             // Cached entries arrive with stats already embedded as flat keys in sourceMetadata();

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
@@ -183,11 +183,7 @@ public class ExternalSourceResolver {
             String formatType = detectFormatType(storagePath);
             SchemaCacheKey schemaKey = SchemaCacheKey.build(storagePath.toString(), mtime, formatType, config);
             SchemaCacheEntry schemaEntry = cacheService.getOrComputeSchema(schemaKey, k -> {
-                SourceMetadata meta = resolveSingleSource(path, config);
-                Map<String, Object> enrichedMeta = meta.statistics()
-                    .map(stats -> SourceStatisticsSerializer.embedStatistics(meta.sourceMetadata(), stats))
-                    .orElse(meta.sourceMetadata());
-                return SchemaCacheEntry.from(meta.schema(), meta.sourceType(), meta.location(), enrichedMeta, meta.config());
+                return SchemaCacheEntry.from(resolveSingleSource(path, config));
             });
             List<Attribute> schema = schemaEntry.toAttributes();
             extMetadata = buildMetadataFromCache(schemaEntry, schema, config);
@@ -227,6 +223,7 @@ public class ExternalSourceResolver {
         StorageProvider provider = resolveProvider(storagePath, config);
 
         FormatReader.SchemaResolution schemaResolution = parseSchemaResolution(config);
+        boolean cacheable = isCacheable(provider);
 
         if (schemaResolution != FormatReader.SchemaResolution.FIRST_FILE_WINS) {
             int maxDiscoveredFiles = ExternalSourceSettings.MAX_DISCOVERED_FILES.get(settings);
@@ -237,10 +234,8 @@ public class ExternalSourceResolver {
             if (raw.fileCount() == 0) {
                 throw new IllegalArgumentException("Glob pattern matched no files: " + path);
             }
-            return resolveMultiFileWithReconciliation(raw, config, schemaResolution);
+            return resolveMultiFileWithReconciliation(raw, config, schemaResolution, cacheable);
         }
-
-        boolean cacheable = isCacheable(provider);
 
         FileList listing;
         if (cacheable) {
@@ -272,11 +267,7 @@ public class ExternalSourceResolver {
             String formatType = detectFormatType(anchorPath);
             SchemaCacheKey schemaKey = SchemaCacheKey.build(anchorPath.toString(), anchorMtime, formatType, config);
             SchemaCacheEntry schemaEntry = cacheService.getOrComputeSchema(schemaKey, k -> {
-                SourceMetadata meta = resolveSingleSource(anchorPath.toString(), config);
-                Map<String, Object> enrichedMeta = meta.statistics()
-                    .map(stats -> SourceStatisticsSerializer.embedStatistics(meta.sourceMetadata(), stats))
-                    .orElse(meta.sourceMetadata());
-                return SchemaCacheEntry.from(meta.schema(), meta.sourceType(), meta.location(), enrichedMeta, meta.config());
+                return SchemaCacheEntry.from(resolveSingleSource(anchorPath.toString(), config));
             });
             List<Attribute> schema = schemaEntry.toAttributes();
             extMetadata = buildMetadataFromCache(schemaEntry, schema, config);
@@ -469,10 +460,11 @@ public class ExternalSourceResolver {
     private ExternalSourceResolution.ResolvedSource resolveMultiFileWithReconciliation(
         FileList fileList,
         Map<String, Object> config,
-        FormatReader.SchemaResolution schemaResolution
+        FormatReader.SchemaResolution schemaResolution,
+        boolean cacheable
     ) throws Exception {
         long startNanos = System.nanoTime();
-        Map<StoragePath, SourceMetadata> allMetadata = readAllFileMetadata(fileList, config);
+        Map<StoragePath, SourceMetadata> allMetadata = readAllFileMetadata(fileList, config, cacheable);
         long durationMs = (System.nanoTime() - startNanos) / 1_000_000;
 
         LOGGER.debug("Schema reconciliation [{}]: scanned {} files in {}ms", schemaResolution, allMetadata.size(), durationMs);
@@ -487,8 +479,17 @@ public class ExternalSourceResolver {
 
         List<Attribute> unifiedSchema = result.unifiedSchema().attributes();
         SourceMetadata firstMeta = allMetadata.get(firstFile);
+        // Aggregate from the per-file metadata already fetched by readAllFileMetadata —
+        // no second cache or storage hit per file.
         Map<String, Object> aggregatedStats = aggregateFileStatistics(allMetadata.values());
         ExternalSourceMetadata extMetadata = buildUnifiedMetadata(firstMeta, unifiedSchema, config, aggregatedStats);
+
+        // Mirror the FFW invariants: file count enables canSkipSplitDiscovery; partial-stats
+        // marking is gated on fileCount > 1 (single-file globs have no "other file" missing stats).
+        extMetadata = enrichWithFileCount(extMetadata, fileList.fileCount());
+        if (aggregatedStats == null && fileList.fileCount() > 1) {
+            extMetadata = markStatsAsPartial(extMetadata);
+        }
 
         PartitionMetadata partitionMetadata = fileList.partitionMetadata();
         if (partitionMetadata != null && partitionMetadata.isEmpty() == false) {
@@ -499,30 +500,45 @@ public class ExternalSourceResolver {
         return new ExternalSourceResolution.ResolvedSource(extMetadata, fileList, schemaMap);
     }
 
-    /**
-     * Reads metadata from all files in parallel with bounded concurrency.
-     * Delegates to {@link BoundedParallelGather} which handles semaphore backpressure,
-     * fast-fail on error, and result ordering.
-     */
-    private Map<StoragePath, SourceMetadata> readAllFileMetadata(FileList fileList, Map<String, Object> config) throws Exception {
+    /** Per-file metadata, in parallel. When {@code cacheable} is true, each resolve goes through
+     *  the schema cache (keyed on path + mtime) so warm queries against the same paths hit cache. */
+    private Map<StoragePath, SourceMetadata> readAllFileMetadata(FileList fileList, Map<String, Object> config, boolean cacheable)
+        throws Exception {
         int fileCount = fileList.fileCount();
-        List<StoragePath> paths = new ArrayList<>(fileCount);
+        List<Integer> indices = new ArrayList<>(fileCount);
         for (int i = 0; i < fileCount; i++) {
-            paths.add(fileList.path(i));
+            indices.add(i);
         }
 
-        List<Map.Entry<StoragePath, SourceMetadata>> entries = BoundedParallelGather.gather(
-            paths,
-            filePath -> Map.entry(filePath, resolveSingleSource(filePath.toString(), config)),
-            MAX_PARALLEL_METADATA_READS,
-            executor
-        );
+        List<Map.Entry<StoragePath, SourceMetadata>> entries = BoundedParallelGather.gather(indices, i -> {
+            StoragePath filePath = fileList.path(i);
+            SourceMetadata meta = cacheable
+                ? cachedResolveSingleSource(filePath, fileList.lastModifiedMillis(i), config)
+                : resolveSingleSource(filePath.toString(), config);
+            return Map.entry(filePath, meta);
+        }, MAX_PARALLEL_METADATA_READS, executor);
 
         Map<StoragePath, SourceMetadata> result = new LinkedHashMap<>();
         for (Map.Entry<StoragePath, SourceMetadata> entry : entries) {
             result.put(entry.getKey(), entry.getValue());
         }
         return result;
+    }
+
+    /** Cache-aware single-file resolve; mirrors the FFW cache pattern. */
+    private SourceMetadata cachedResolveSingleSource(StoragePath filePath, long mtime, Map<String, Object> config) {
+        String formatType = detectFormatType(filePath);
+        SchemaCacheKey schemaKey = SchemaCacheKey.build(filePath.toString(), mtime, formatType, config);
+        try {
+            SchemaCacheEntry entry = cacheService.getOrComputeSchema(
+                schemaKey,
+                k -> SchemaCacheEntry.from(resolveSingleSource(filePath.toString(), config))
+            );
+            return buildMetadataFromCache(entry, entry.toAttributes(), config);
+        } catch (Exception e) {
+            LOGGER.debug(() -> "Schema cache miss + fallback for [" + filePath + "]: " + e.getMessage());
+            return resolveSingleSource(filePath.toString(), config);
+        }
     }
 
     /**
@@ -535,12 +551,18 @@ public class ExternalSourceResolver {
     private static Map<String, Object> aggregateFileStatistics(Collection<SourceMetadata> allMetadata) {
         List<Map<String, Object>> perFileFlatStats = new ArrayList<>(allMetadata.size());
         for (SourceMetadata meta : allMetadata) {
-            if (meta.statistics().isEmpty()) {
+            // Cached entries arrive with stats already embedded as flat keys in sourceMetadata();
+            // uncached entries arrive with typed statistics(). Accept either shape so callers
+            // don't need to know whether the metadata came through the schema cache.
+            Map<String, Object> base = meta.sourceMetadata();
+            if (base != null && base.containsKey(SourceStatisticsSerializer.STATS_ROW_COUNT)) {
+                perFileFlatStats.add(base);
+            } else if (meta.statistics().isPresent()) {
+                perFileFlatStats.add(SourceStatisticsSerializer.embedStatistics(base, meta.statistics().get()));
+            } else {
                 // At least one file has no statistics — cannot produce accurate global stats.
                 return null;
             }
-            Map<String, Object> flat = SourceStatisticsSerializer.embedStatistics(meta.sourceMetadata(), meta.statistics().get());
-            perFileFlatStats.add(flat);
         }
         return SourceStatisticsSerializer.mergeStatistics(perFileFlatStats);
     }
@@ -591,11 +613,7 @@ public class ExternalSourceResolver {
             SchemaCacheKey schemaKey = SchemaCacheKey.build(filePath.toString(), mtime, formatType, config);
             try {
                 SchemaCacheEntry entry = cacheService.getOrComputeSchema(schemaKey, k -> {
-                    SourceMetadata meta = resolveSingleSource(filePath.toString(), config);
-                    Map<String, Object> enrichedMeta = meta.statistics()
-                        .map(stats -> SourceStatisticsSerializer.embedStatistics(meta.sourceMetadata(), stats))
-                        .orElse(meta.sourceMetadata());
-                    return SchemaCacheEntry.from(meta.schema(), meta.sourceType(), meta.location(), enrichedMeta, meta.config());
+                    return SchemaCacheEntry.from(resolveSingleSource(filePath.toString(), config));
                 });
                 Map<String, Object> fileMeta = entry.safeMetadata();
                 if (fileMeta == null || fileMeta.containsKey(SourceStatisticsSerializer.STATS_ROW_COUNT) == false) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/SchemaCacheEntry.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/SchemaCacheEntry.java
@@ -12,6 +12,8 @@ import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.datasources.SourceStatisticsSerializer;
+import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -93,6 +95,15 @@ public record SchemaCacheEntry(
             );
         }
         return result;
+    }
+
+    /** Flattens a {@link SourceMetadata}'s stats into its metadata map. Replaces the
+     *  inlined flatten-and-build at the cache-loader call sites. */
+    public static SchemaCacheEntry from(SourceMetadata meta) {
+        Map<String, Object> enrichedMeta = meta.statistics()
+            .map(stats -> SourceStatisticsSerializer.embedStatistics(meta.sourceMetadata(), stats))
+            .orElse(meta.sourceMetadata());
+        return from(meta.schema(), meta.sourceType(), meta.location(), enrichedMeta, meta.config());
     }
 
     public long estimatedBytes() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolverTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolverTests.java
@@ -207,12 +207,11 @@ public class ExternalSourceResolverTests extends ESTestCase {
     // ===== Stats partial / file-count flag tests =====
 
     /**
-     * When no file reports statistics and there is more than one file, FFW reads the anchor's
-     * (empty) stats and then explicitly marks the result partial because the other files'
-     * stats are unknown. The reconciliation path's {@code aggregateFileStatistics} returns
-     * {@code null} on missing per-file stats and the resolver falls back to the anchor's
-     * (empty) stats without setting any partial-flag; this test pins that divergence so a
-     * future "always flag partial" alignment change shows up here.
+     * Invariant: every schema-resolution mode marks stats as partial when at least one file
+     * lacks statistics. {@code STATS_PARTIAL} is what tells downstream operators that aggregated
+     * stats are incomplete and must not be trusted for shortcuts like {@code canSkipSplitDiscovery}.
+     * Parameterized over {@link #MULTI_FILE_STRATEGIES} so any future {@code SchemaResolution}
+     * value inherits the invariant by construction.
      */
     public void testMultiFileStatsPartialFlagPerStrategy() throws Exception {
         List<Attribute> schema = List.of(attr("x", DataType.INTEGER));
@@ -233,18 +232,16 @@ public class ExternalSourceResolverTests extends ESTestCase {
             ExternalSourceResolution.ResolvedSource resolved = resolution.resolvedSource("s3://bucket/data/*.parquet");
             assertNotNull("[" + strategy + "] resolved source must not be null", resolved);
             Object partial = resolved.metadata().sourceMetadata().get(SourceStatisticsSerializer.STATS_PARTIAL);
-            if (strategy == FormatReader.SchemaResolution.FIRST_FILE_WINS) {
-                assertEquals("[FFW] STATS_PARTIAL must be true when only the anchor's stats are known", Boolean.TRUE, partial);
-            } else {
-                assertNull("[" + strategy + "] reconciliation path does not currently set STATS_PARTIAL", partial);
-            }
+            assertEquals("[" + strategy + "] STATS_PARTIAL must be true when not every file reports statistics", Boolean.TRUE, partial);
         }
     }
 
     /**
-     * STATS_FILE_COUNT is FFW-only: {@code enrichWithFileCount} runs on the FFW fast path and
-     * stamps the count of discovered files into the source metadata. The reconciliation path
-     * (UNION_BY_NAME / STRICT) does not currently populate it. This test pins both branches.
+     * Invariant: every schema-resolution mode stamps {@code STATS_FILE_COUNT} into the resolved
+     * source metadata. {@code ComputeService#canSkipSplitDiscovery} reads this field to short-circuit
+     * aggregate pushdown (COUNT/MIN/MAX) without scanning row groups; missing it forces Phase-2
+     * split discovery to run even when the answer is in metadata. Parameterized over
+     * {@link #MULTI_FILE_STRATEGIES} so any new mode inherits the invariant by construction.
      */
     public void testMultiFileFileCountPerStrategy() throws Exception {
         List<Attribute> schema = List.of(attr("x", DataType.INTEGER));
@@ -270,11 +267,7 @@ public class ExternalSourceResolverTests extends ESTestCase {
             ExternalSourceResolution.ResolvedSource resolved = resolution.resolvedSource("s3://bucket/data/*.parquet");
             assertNotNull("[" + strategy + "] resolved source must not be null", resolved);
             Object fileCount = resolved.metadata().sourceMetadata().get(SourceStatisticsSerializer.STATS_FILE_COUNT);
-            if (strategy == FormatReader.SchemaResolution.FIRST_FILE_WINS) {
-                assertEquals("[FFW] STATS_FILE_COUNT must equal the number of discovered files", 3L, fileCount);
-            } else {
-                assertNull("[" + strategy + "] reconciliation path does not currently set STATS_FILE_COUNT", fileCount);
-            }
+            assertEquals("[" + strategy + "] STATS_FILE_COUNT must equal the number of discovered files", 3L, fileCount);
         }
     }
 
@@ -469,12 +462,11 @@ public class ExternalSourceResolverTests extends ESTestCase {
     }
 
     /**
-     * When every file provides per-file row counts, both code paths must produce the same
-     * aggregated row count (sum across files) and must not flag the stats as partial.
-     * <p>
-     * STATS_FILE_COUNT differs by design: only the FFW path runs {@code enrichWithFileCount};
-     * the reconciliation path does not currently populate it. This test pins that divergence
-     * explicitly so a future change that aligns the paths shows up here.
+     * When every file provides per-file row counts, every code path must produce the same
+     * aggregated row count (sum across files), must not flag the stats as partial, and must
+     * stamp {@code STATS_FILE_COUNT}. The cross-mode {@code STATS_FILE_COUNT} invariant is
+     * pinned separately by {@link #testMultiFileFileCountPerStrategy}; here we assert all
+     * three (row count + not-partial + file count) together for the stats-available case.
      */
     public void testMultiFileAggregatesRowCountAcrossStrategiesWhenStatsAvailable() throws Exception {
         List<Attribute> schema = List.of(attr("x", DataType.INTEGER));
@@ -512,19 +504,11 @@ public class ExternalSourceResolverTests extends ESTestCase {
                 "[" + strategy + "] STATS_PARTIAL must be absent when every file has stats",
                 meta.get(SourceStatisticsSerializer.STATS_PARTIAL)
             );
-            // STATS_FILE_COUNT is FFW-only today; the reconciliation path does not enrich it.
-            if (strategy == FormatReader.SchemaResolution.FIRST_FILE_WINS) {
-                assertEquals(
-                    "[FFW] enrichWithFileCount must populate STATS_FILE_COUNT",
-                    3L,
-                    meta.get(SourceStatisticsSerializer.STATS_FILE_COUNT)
-                );
-            } else {
-                assertNull(
-                    "[" + strategy + "] reconciliation path does not currently set STATS_FILE_COUNT",
-                    meta.get(SourceStatisticsSerializer.STATS_FILE_COUNT)
-                );
-            }
+            assertEquals(
+                "[" + strategy + "] enrichWithFileCount must populate STATS_FILE_COUNT",
+                3L,
+                meta.get(SourceStatisticsSerializer.STATS_FILE_COUNT)
+            );
         }
     }
 
@@ -925,8 +909,9 @@ public class ExternalSourceResolverTests extends ESTestCase {
             .put("esql.source.cache.listing.ttl", "30s")
             .build();
 
-        // The listing/schema cache is only exercised on the FIRST_FILE_WINS fast path; multi-file
-        // reconciliation strategies read every file's metadata directly and bypass the cache.
+        // FFW-specific assertions of listing-cache + anchor-schema-cache reuse.
+        // The cross-mode cache invariant (every SchemaResolution strategy hits the cache on
+        // warm resolves) is covered separately by testMultiFileCacheReducesSchemaLoaderCallsPerStrategy.
         Map<String, Map<String, Object>> pathConfigs = Map.of(
             "s3://bucket/data/*.parquet",
             new HashMap<>(configFor(FormatReader.SchemaResolution.FIRST_FILE_WINS))
@@ -960,6 +945,63 @@ public class ExternalSourceResolverTests extends ESTestCase {
                 schemaCallsAfterFirst,
                 countingProvider.schemaCallCount.get()
             );
+        }
+    }
+
+    /**
+     * Invariant: every schema-resolution mode must consult the schema cache on the per-file
+     * resolve. A second resolve of the same glob across the same paths must add zero schema-loader
+     * calls. Parameterized over {@link #MULTI_FILE_STRATEGIES} so any new mode inherits the
+     * invariant by construction; the bug fixed by this PR (UNION_BY_NAME default flip in
+     * elastic/elasticsearch#149176) was that the reconciliation path bypassed the schema cache,
+     * so every warm multi-file query re-read N footers from storage.
+     */
+    public void testMultiFileCacheReducesSchemaLoaderCallsPerStrategy() throws Exception {
+        Settings cacheSettings = Settings.builder()
+            .put("esql.source.cache.size", "10mb")
+            .put("esql.source.cache.enabled", true)
+            .put("esql.source.cache.schema.ttl", "5m")
+            .put("esql.source.cache.listing.ttl", "30s")
+            .build();
+
+        for (FormatReader.SchemaResolution strategy : MULTI_FILE_STRATEGIES) {
+            List<Attribute> schema = List.of(attr("id", DataType.INTEGER), attr("name", DataType.KEYWORD));
+            Map<String, List<Attribute>> schemasByPath = new HashMap<>();
+            schemasByPath.put("s3://bucket/data/a.parquet", schema);
+            schemasByPath.put("s3://bucket/data/b.parquet", schema);
+            schemasByPath.put("s3://bucket/data/c.parquet", schema);
+
+            List<StorageEntry> listing = List.of(
+                entry("s3://bucket/data/a.parquet", 100),
+                entry("s3://bucket/data/b.parquet", 200),
+                entry("s3://bucket/data/c.parquet", 300)
+            );
+
+            CountingStorageProvider countingProvider = new CountingStorageProvider(Map.of("s3://bucket/data/", listing), schemasByPath);
+
+            Map<String, Map<String, Object>> pathConfigs = Map.of("s3://bucket/data/*.parquet", new HashMap<>(configFor(strategy)));
+
+            try (ExternalSourceCacheService cacheService = new ExternalSourceCacheService(cacheSettings)) {
+                ExternalSourceResolver resolver = createResolverWithCache(countingProvider, schemasByPath, cacheService);
+
+                PlainActionFuture<ExternalSourceResolution> f1 = new PlainActionFuture<>();
+                resolver.resolve(List.of("s3://bucket/data/*.parquet"), pathConfigs, f1);
+                ExternalSourceResolution res1 = f1.actionGet();
+                assertNotNull("[" + strategy + "] first resolve must produce a source", res1.resolvedSource("s3://bucket/data/*.parquet"));
+                int schemaCallsAfterFirst = countingProvider.schemaCallCount.get();
+                assertTrue("[" + strategy + "] schema loader must be invoked on first resolve", schemaCallsAfterFirst > 0);
+
+                PlainActionFuture<ExternalSourceResolution> f2 = new PlainActionFuture<>();
+                resolver.resolve(List.of("s3://bucket/data/*.parquet"), pathConfigs, f2);
+                ExternalSourceResolution res2 = f2.actionGet();
+                assertNotNull("[" + strategy + "] second resolve must produce a source", res2.resolvedSource("s3://bucket/data/*.parquet"));
+
+                assertEquals(
+                    "[" + strategy + "] schema loader must not be called again on second resolve (cache hit invariant)",
+                    schemaCallsAfterFirst,
+                    countingProvider.schemaCallCount.get()
+                );
+            }
         }
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolverTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolverTests.java
@@ -1005,6 +1005,107 @@ public class ExternalSourceResolverTests extends ESTestCase {
         }
     }
 
+    /**
+     * {@link ExternalSourceResolver#aggregateFileStatistics} accepts two distinct
+     * {@link SourceMetadata} shapes — cached entries arrive with stats already embedded as flat
+     * keys in {@code sourceMetadata()}, uncached entries arrive with typed {@code statistics()}
+     * — and merges both into a single flat stats map. Pinned independently of the full resolver
+     * flow so the shape branch (the load-bearing piece of the reconciliation fix) regresses
+     * loudly if either arm breaks.
+     */
+    public void testAggregateFileStatisticsAcceptsCachedAndUncachedShapes() {
+        long uncachedRowCount = 42L;
+        long cachedRowCount = 58L;
+
+        SourceMetadata uncached = new SourceMetadata() {
+            @Override
+            public List<Attribute> schema() {
+                return List.of();
+            }
+
+            @Override
+            public String sourceType() {
+                return "parquet";
+            }
+
+            @Override
+            public String location() {
+                return "s3://bucket/uncached.parquet";
+            }
+
+            @Override
+            public Optional<SourceStatistics> statistics() {
+                return Optional.of(statsOf(uncachedRowCount));
+            }
+        };
+
+        Map<String, Object> cachedFlatStats = SourceStatisticsSerializer.embedStatistics(Map.of(), statsOf(cachedRowCount));
+        SourceMetadata cached = new SourceMetadata() {
+            @Override
+            public List<Attribute> schema() {
+                return List.of();
+            }
+
+            @Override
+            public String sourceType() {
+                return "parquet";
+            }
+
+            @Override
+            public String location() {
+                return "s3://bucket/cached.parquet";
+            }
+
+            @Override
+            public Map<String, Object> sourceMetadata() {
+                return cachedFlatStats;
+            }
+        };
+
+        Map<String, Object> merged = ExternalSourceResolver.aggregateFileStatistics(List.of(uncached, cached));
+        assertNotNull("merging cached and uncached shapes must succeed", merged);
+        assertEquals(
+            "merged row count must sum both shapes",
+            uncachedRowCount + cachedRowCount,
+            ((Number) merged.get(SourceStatisticsSerializer.STATS_ROW_COUNT)).longValue()
+        );
+
+        SourceMetadata missing = new SourceMetadata() {
+            @Override
+            public List<Attribute> schema() {
+                return List.of();
+            }
+
+            @Override
+            public String sourceType() {
+                return "parquet";
+            }
+
+            @Override
+            public String location() {
+                return "s3://bucket/missing.parquet";
+            }
+        };
+        assertNull(
+            "aggregate must return null when any entry lacks both flat-embedded stats and typed statistics()",
+            ExternalSourceResolver.aggregateFileStatistics(List.of(uncached, cached, missing))
+        );
+    }
+
+    private static SourceStatistics statsOf(long rowCount) {
+        return new SourceStatistics() {
+            @Override
+            public OptionalLong rowCount() {
+                return OptionalLong.of(rowCount);
+            }
+
+            @Override
+            public OptionalLong sizeInBytes() {
+                return OptionalLong.empty();
+            }
+        };
+    }
+
     public void testSingleFileSchemaCacheHitAfterMiss() throws Exception {
         List<Attribute> schema = List.of(attr("id", DataType.INTEGER), attr("name", DataType.KEYWORD));
         Map<String, List<Attribute>> schemasByPath = new HashMap<>();

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolverTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolverTests.java
@@ -1106,6 +1106,140 @@ public class ExternalSourceResolverTests extends ESTestCase {
         };
     }
 
+    /**
+     * Column statistics (min/max/null_count) flow through {@code aggregateFileStatistics} via the
+     * same shape branch as row counts: cached entries carry them as flat {@code _stats.columns.*}
+     * keys in {@code sourceMetadata()}, uncached entries carry them as typed
+     * {@link SourceStatistics.ColumnStatistics}. The regression on {@code stats_min_max_eventdate}
+     * (21× slower at the bench baseline) makes column stats load-bearing, so pin the full
+     * round-trip: merged {@code null_count} sums across both shapes; merged {@code min}/{@code max}
+     * span the union; the implicit-nulls pass does not over-count when both files contain the
+     * column.
+     */
+    public void testAggregateFileStatisticsMergesColumnStatsAcrossShapes() {
+        String col = "eventDate";
+        long uncachedRowCount = 100L;
+        long cachedRowCount = 200L;
+        long uncachedNullCount = 5L;
+        long cachedNullCount = 3L;
+        long uncachedMin = 10L;
+        long uncachedMax = 100L;
+        long cachedMin = 50L;
+        long cachedMax = 200L;
+
+        SourceStatistics uncachedStats = statsWithColumn(uncachedRowCount, col, uncachedNullCount, uncachedMin, uncachedMax);
+        SourceMetadata uncached = new SourceMetadata() {
+            @Override
+            public List<Attribute> schema() {
+                return List.of();
+            }
+
+            @Override
+            public String sourceType() {
+                return "parquet";
+            }
+
+            @Override
+            public String location() {
+                return "s3://bucket/uncached.parquet";
+            }
+
+            @Override
+            public Optional<SourceStatistics> statistics() {
+                return Optional.of(uncachedStats);
+            }
+        };
+
+        Map<String, Object> cachedFlatStats = SourceStatisticsSerializer.embedStatistics(
+            Map.of(),
+            statsWithColumn(cachedRowCount, col, cachedNullCount, cachedMin, cachedMax)
+        );
+        SourceMetadata cached = new SourceMetadata() {
+            @Override
+            public List<Attribute> schema() {
+                return List.of();
+            }
+
+            @Override
+            public String sourceType() {
+                return "parquet";
+            }
+
+            @Override
+            public String location() {
+                return "s3://bucket/cached.parquet";
+            }
+
+            @Override
+            public Map<String, Object> sourceMetadata() {
+                return cachedFlatStats;
+            }
+        };
+
+        Map<String, Object> merged = ExternalSourceResolver.aggregateFileStatistics(List.of(uncached, cached));
+        assertNotNull("merging cached and uncached shapes with column stats must succeed", merged);
+        assertEquals(
+            "merged row count must sum both shapes",
+            uncachedRowCount + cachedRowCount,
+            ((Number) merged.get(SourceStatisticsSerializer.STATS_ROW_COUNT)).longValue()
+        );
+        assertEquals(
+            "merged null_count must sum across both shapes (no implicit nulls when column is present in every file)",
+            uncachedNullCount + cachedNullCount,
+            ((Number) merged.get(SourceStatisticsSerializer.columnNullCountKey(col))).longValue()
+        );
+        assertEquals(
+            "merged min must span the union",
+            uncachedMin,
+            ((Number) merged.get(SourceStatisticsSerializer.columnMinKey(col))).longValue()
+        );
+        assertEquals(
+            "merged max must span the union",
+            cachedMax,
+            ((Number) merged.get(SourceStatisticsSerializer.columnMaxKey(col))).longValue()
+        );
+    }
+
+    private static SourceStatistics statsWithColumn(long rowCount, String columnName, long nullCount, long min, long max) {
+        SourceStatistics.ColumnStatistics colStats = new SourceStatistics.ColumnStatistics() {
+            @Override
+            public OptionalLong nullCount() {
+                return OptionalLong.of(nullCount);
+            }
+
+            @Override
+            public OptionalLong distinctCount() {
+                return OptionalLong.empty();
+            }
+
+            @Override
+            public Optional<Object> minValue() {
+                return Optional.of(min);
+            }
+
+            @Override
+            public Optional<Object> maxValue() {
+                return Optional.of(max);
+            }
+        };
+        return new SourceStatistics() {
+            @Override
+            public OptionalLong rowCount() {
+                return OptionalLong.of(rowCount);
+            }
+
+            @Override
+            public OptionalLong sizeInBytes() {
+                return OptionalLong.empty();
+            }
+
+            @Override
+            public Optional<Map<String, ColumnStatistics>> columnStatistics() {
+                return Optional.of(Map.of(columnName, colStats));
+            }
+        };
+    }
+
     public void testSingleFileSchemaCacheHitAfterMiss() throws Exception {
         List<Attribute> schema = List.of(attr("id", DataType.INTEGER), attr("name", DataType.KEYWORD));
         Map<String, List<Attribute>> schemasByPath = new HashMap<>();

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolverTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolverTests.java
@@ -1005,14 +1005,6 @@ public class ExternalSourceResolverTests extends ESTestCase {
         }
     }
 
-    /**
-     * {@link ExternalSourceResolver#aggregateFileStatistics} accepts two distinct
-     * {@link SourceMetadata} shapes — cached entries arrive with stats already embedded as flat
-     * keys in {@code sourceMetadata()}, uncached entries arrive with typed {@code statistics()}
-     * — and merges both into a single flat stats map. Pinned independently of the full resolver
-     * flow so the shape branch (the load-bearing piece of the reconciliation fix) regresses
-     * loudly if either arm breaks.
-     */
     public void testAggregateFileStatisticsAcceptsCachedAndUncachedShapes() {
         long uncachedRowCount = 42L;
         long cachedRowCount = 58L;
@@ -1063,12 +1055,8 @@ public class ExternalSourceResolverTests extends ESTestCase {
         };
 
         Map<String, Object> merged = ExternalSourceResolver.aggregateFileStatistics(List.of(uncached, cached));
-        assertNotNull("merging cached and uncached shapes must succeed", merged);
-        assertEquals(
-            "merged row count must sum both shapes",
-            uncachedRowCount + cachedRowCount,
-            ((Number) merged.get(SourceStatisticsSerializer.STATS_ROW_COUNT)).longValue()
-        );
+        assertNotNull(merged);
+        assertEquals(uncachedRowCount + cachedRowCount, ((Number) merged.get(SourceStatisticsSerializer.STATS_ROW_COUNT)).longValue());
 
         SourceMetadata missing = new SourceMetadata() {
             @Override
@@ -1086,10 +1074,7 @@ public class ExternalSourceResolverTests extends ESTestCase {
                 return "s3://bucket/missing.parquet";
             }
         };
-        assertNull(
-            "aggregate must return null when any entry lacks both flat-embedded stats and typed statistics()",
-            ExternalSourceResolver.aggregateFileStatistics(List.of(uncached, cached, missing))
-        );
+        assertNull(ExternalSourceResolver.aggregateFileStatistics(List.of(uncached, cached, missing)));
     }
 
     private static SourceStatistics statsOf(long rowCount) {
@@ -1106,16 +1091,6 @@ public class ExternalSourceResolverTests extends ESTestCase {
         };
     }
 
-    /**
-     * Column statistics (min/max/null_count) flow through {@code aggregateFileStatistics} via the
-     * same shape branch as row counts: cached entries carry them as flat {@code _stats.columns.*}
-     * keys in {@code sourceMetadata()}, uncached entries carry them as typed
-     * {@link SourceStatistics.ColumnStatistics}. The regression on {@code stats_min_max_eventdate}
-     * (21× slower at the bench baseline) makes column stats load-bearing, so pin the full
-     * round-trip: merged {@code null_count} sums across both shapes; merged {@code min}/{@code max}
-     * span the union; the implicit-nulls pass does not over-count when both files contain the
-     * column.
-     */
     public void testAggregateFileStatisticsMergesColumnStatsAcrossShapes() {
         String col = "eventDate";
         long uncachedRowCount = 100L;
@@ -1177,27 +1152,14 @@ public class ExternalSourceResolverTests extends ESTestCase {
         };
 
         Map<String, Object> merged = ExternalSourceResolver.aggregateFileStatistics(List.of(uncached, cached));
-        assertNotNull("merging cached and uncached shapes with column stats must succeed", merged);
+        assertNotNull(merged);
+        assertEquals(uncachedRowCount + cachedRowCount, ((Number) merged.get(SourceStatisticsSerializer.STATS_ROW_COUNT)).longValue());
         assertEquals(
-            "merged row count must sum both shapes",
-            uncachedRowCount + cachedRowCount,
-            ((Number) merged.get(SourceStatisticsSerializer.STATS_ROW_COUNT)).longValue()
-        );
-        assertEquals(
-            "merged null_count must sum across both shapes (no implicit nulls when column is present in every file)",
             uncachedNullCount + cachedNullCount,
             ((Number) merged.get(SourceStatisticsSerializer.columnNullCountKey(col))).longValue()
         );
-        assertEquals(
-            "merged min must span the union",
-            uncachedMin,
-            ((Number) merged.get(SourceStatisticsSerializer.columnMinKey(col))).longValue()
-        );
-        assertEquals(
-            "merged max must span the union",
-            cachedMax,
-            ((Number) merged.get(SourceStatisticsSerializer.columnMaxKey(col))).longValue()
-        );
+        assertEquals(uncachedMin, ((Number) merged.get(SourceStatisticsSerializer.columnMinKey(col))).longValue());
+        assertEquals(cachedMax, ((Number) merged.get(SourceStatisticsSerializer.columnMaxKey(col))).longValue());
     }
 
     private static SourceStatistics statsWithColumn(long rowCount, String columnName, long nullCount, long min, long max) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/cache/SchemaCacheEntryTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/cache/SchemaCacheEntryTests.java
@@ -1,0 +1,269 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.cache;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.NameId;
+import org.elasticsearch.xpack.esql.core.expression.Nullability;
+import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.datasources.SourceStatisticsSerializer;
+import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
+import org.elasticsearch.xpack.esql.datasources.spi.SourceStatistics;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.Set;
+
+public class SchemaCacheEntryTests extends ESTestCase {
+
+    public void testFromSourceMetadataPreservesIdentityFields() {
+        List<Attribute> schema = List.of(attr("id", DataType.INTEGER), attr("name", DataType.KEYWORD));
+        SourceMetadata meta = meta(schema, "parquet", "s3://bucket/file.parquet", Map.of("k", "v"), Map.of("c", "d"), null);
+
+        SchemaCacheEntry entry = SchemaCacheEntry.from(meta);
+
+        assertEquals("parquet", entry.sourceType());
+        assertEquals("s3://bucket/file.parquet", entry.location());
+        assertEquals(Map.of("c", "d"), entry.connectorConfig());
+        List<Attribute> rebuilt = entry.toAttributes();
+        assertEquals(2, rebuilt.size());
+        assertEquals("id", rebuilt.get(0).name());
+        assertEquals(DataType.INTEGER, rebuilt.get(0).dataType());
+        assertEquals("name", rebuilt.get(1).name());
+        assertEquals(DataType.KEYWORD, rebuilt.get(1).dataType());
+    }
+
+    public void testFromSourceMetadataEmbedsStatisticsIntoSafeMetadata() {
+        SourceStatistics stats = new SourceStatistics() {
+            @Override
+            public OptionalLong rowCount() {
+                return OptionalLong.of(42_000L);
+            }
+
+            @Override
+            public OptionalLong sizeInBytes() {
+                return OptionalLong.of(99_000L);
+            }
+
+            @Override
+            public Optional<Map<String, ColumnStatistics>> columnStatistics() {
+                return Optional.empty();
+            }
+        };
+        SourceMetadata meta = meta(List.of(attr("x", DataType.LONG)), "parquet", "p", Map.of("orig", true), Map.of(), stats);
+
+        SchemaCacheEntry entry = SchemaCacheEntry.from(meta);
+
+        // Stats live as flat keys inside safeMetadata — same shape every existing reader expects.
+        assertEquals(42_000L, entry.safeMetadata().get(SourceStatisticsSerializer.STATS_ROW_COUNT));
+        assertEquals(99_000L, entry.safeMetadata().get(SourceStatisticsSerializer.STATS_SIZE_BYTES));
+        // Original metadata entries survive alongside.
+        assertEquals(true, entry.safeMetadata().get("orig"));
+    }
+
+    public void testFromSourceMetadataPassesSafeMetadataThroughWhenStatisticsAbsent() {
+        SourceMetadata meta = meta(List.of(attr("x", DataType.LONG)), "parquet", "p", Map.of("k", 1), Map.of(), null);
+
+        SchemaCacheEntry entry = SchemaCacheEntry.from(meta);
+
+        assertEquals(Map.of("k", 1), entry.safeMetadata());
+        assertNull(entry.safeMetadata().get(SourceStatisticsSerializer.STATS_ROW_COUNT));
+    }
+
+    public void testFromSourceMetadataEmbedsColumnStatistics() {
+        SourceStatistics stats = new SourceStatistics() {
+            @Override
+            public OptionalLong rowCount() {
+                return OptionalLong.of(10);
+            }
+
+            @Override
+            public OptionalLong sizeInBytes() {
+                return OptionalLong.empty();
+            }
+
+            @Override
+            public Optional<Map<String, ColumnStatistics>> columnStatistics() {
+                return Optional.of(Map.of("id", new ColumnStatistics() {
+                    @Override
+                    public OptionalLong nullCount() {
+                        return OptionalLong.of(3);
+                    }
+
+                    @Override
+                    public OptionalLong distinctCount() {
+                        return OptionalLong.empty();
+                    }
+
+                    @Override
+                    public Optional<Object> minValue() {
+                        return Optional.of(7L);
+                    }
+
+                    @Override
+                    public Optional<Object> maxValue() {
+                        return Optional.of(99L);
+                    }
+
+                    @Override
+                    public OptionalLong sizeInBytes() {
+                        return OptionalLong.of(40);
+                    }
+                }));
+            }
+        };
+        SourceMetadata meta = meta(List.of(attr("id", DataType.LONG)), "parquet", "p", Map.of(), Map.of(), stats);
+
+        SchemaCacheEntry entry = SchemaCacheEntry.from(meta);
+
+        assertEquals(Long.valueOf(3), SourceStatisticsSerializer.extractColumnNullCount(entry.safeMetadata(), "id"));
+        assertEquals(7L, SourceStatisticsSerializer.extractColumnMin(entry.safeMetadata(), "id"));
+        assertEquals(99L, SourceStatisticsSerializer.extractColumnMax(entry.safeMetadata(), "id"));
+        assertEquals(Long.valueOf(40), SourceStatisticsSerializer.extractColumnSizeBytes(entry.safeMetadata(), "id"));
+    }
+
+    public void testToAttributesReturnsFreshNameIdsOnEachCall() {
+        SchemaCacheEntry entry = SchemaCacheEntry.from(meta(List.of(attr("a", DataType.INTEGER)), "p", "x", Map.of(), Map.of(), null));
+
+        List<Attribute> first = entry.toAttributes();
+        List<Attribute> second = entry.toAttributes();
+
+        // Fresh ReferenceAttribute instances every call (avoids NameId sharing across queries —
+        // the load-bearing reason SchemaCacheEntry stores raw arrays, not List<Attribute>).
+        assertNotSame(first.get(0), second.get(0));
+        NameId firstId = first.get(0).id();
+        NameId secondId = second.get(0).id();
+        assertNotEquals(firstId, secondId);
+    }
+
+    public void testToAttributesPreservesNullabilityAndSyntheticFlags() {
+        SchemaCacheEntry entry = SchemaCacheEntry.from(
+            List.of(
+                new ReferenceAttribute(Source.EMPTY, null, "n", DataType.LONG, Nullability.TRUE, null, false),
+                new ReferenceAttribute(Source.EMPTY, null, "s", DataType.KEYWORD, Nullability.FALSE, null, true)
+            ),
+            "parquet",
+            "p",
+            Map.of(),
+            Map.of()
+        );
+
+        List<Attribute> rebuilt = entry.toAttributes();
+        assertEquals(Nullability.TRUE, rebuilt.get(0).nullable());
+        assertFalse(rebuilt.get(0).synthetic());
+        assertEquals(Nullability.FALSE, rebuilt.get(1).nullable());
+        assertTrue(rebuilt.get(1).synthetic());
+    }
+
+    public void testFromPrimitivesRejectsMismatchedColumnArrays() {
+        // Direct primitive factory: this validation lives in the record's compact constructor.
+        IllegalArgumentException ex = expectThrows(
+            IllegalArgumentException.class,
+            () -> new SchemaCacheEntry(
+                new String[] { "a", "b" },
+                new DataType[] { DataType.INTEGER },
+                new Nullability[] { Nullability.TRUE },
+                new boolean[] { false },
+                "parquet",
+                "p",
+                Map.of(),
+                Map.of(),
+                0L
+            )
+        );
+        assertTrue(ex.getMessage().contains("same length"));
+    }
+
+    public void testConstructorDefensivelyCopiesMaps() {
+        // safeMetadata + connectorConfig must be defensive-copied so mutating the caller's map
+        // after construction can't leak into cached state.
+        Map<String, Object> mutableMeta = new HashMap<>();
+        mutableMeta.put("k", "v");
+        Map<String, Object> mutableConfig = new HashMap<>();
+        mutableConfig.put("c", 1);
+
+        SchemaCacheEntry entry = SchemaCacheEntry.from(List.of(attr("x", DataType.INTEGER)), "p", "l", mutableMeta, mutableConfig);
+
+        mutableMeta.put("leaked", "v");
+        mutableConfig.put("leaked", 1);
+
+        assertEquals(Set.of("k"), entry.safeMetadata().keySet());
+        assertEquals(Set.of("c"), entry.connectorConfig().keySet());
+    }
+
+    public void testConstructorTreatsNullMapsAsEmpty() {
+        SchemaCacheEntry entry = SchemaCacheEntry.from(List.of(attr("x", DataType.INTEGER)), "p", "l", null, null);
+
+        assertEquals(Map.of(), entry.safeMetadata());
+        assertEquals(Map.of(), entry.connectorConfig());
+    }
+
+    public void testEstimatedBytesScalesWithColumnCount() {
+        SchemaCacheEntry small = SchemaCacheEntry.from(List.of(attr("a", DataType.INTEGER)), "p", "l", Map.of(), Map.of());
+        SchemaCacheEntry large = SchemaCacheEntry.from(
+            List.of(attr("a", DataType.INTEGER), attr("b", DataType.LONG), attr("c", DataType.KEYWORD)),
+            "p",
+            "l",
+            Map.of(),
+            Map.of()
+        );
+
+        assertTrue("estimatedBytes must grow with column count", large.estimatedBytes() > small.estimatedBytes());
+    }
+
+    private static Attribute attr(String name, DataType type) {
+        return new ReferenceAttribute(Source.EMPTY, null, name, type, null, null, false);
+    }
+
+    private static SourceMetadata meta(
+        List<Attribute> schema,
+        String sourceType,
+        String location,
+        Map<String, Object> sourceMetadata,
+        Map<String, Object> config,
+        SourceStatistics stats
+    ) {
+        return new SourceMetadata() {
+            @Override
+            public List<Attribute> schema() {
+                return schema;
+            }
+
+            @Override
+            public String sourceType() {
+                return sourceType;
+            }
+
+            @Override
+            public String location() {
+                return location;
+            }
+
+            @Override
+            public Map<String, Object> sourceMetadata() {
+                return sourceMetadata;
+            }
+
+            @Override
+            public Map<String, Object> config() {
+                return config;
+            }
+
+            @Override
+            public Optional<SourceStatistics> statistics() {
+                return Optional.ofNullable(stats);
+            }
+        };
+    }
+}


### PR DESCRIPTION
## What this is about

When the default schema resolution flipped from `FIRST_FILE_WINS` to `UNION_BY_NAME` in #149176, every multi-file glob started taking `ExternalSourceResolver.resolveMultiFileWithReconciliation`. That path has been bypassing three invariants the FFW path emits since #145220, and the regression became user-visible on 2026-05-15:

| query | layout | before #149176 | after #149176 | regression |
|---|---|---:|---:|---:|
| `count_hits` | zstd × 1rg-per-file | 8 ms | 273 ms | **34× slower** |
| `count_hits` | zstd × 50 files | 14 ms | 230 ms | 16× slower |
| `stats_min_max_eventdate` | zstd × 50 files | 9 ms | 190 ms | 21× slower |
| `stats_mobile_phone_users` | zstd × 1rg-per-file | 25 ms | 513 ms | 20× slower |

17 queries regressed on `50files`, 25 on `1rg-per-file`. Single-file globs were unaffected.

## What this PR does

Three coordinated edits in `ExternalSourceResolver`, plus a `SchemaCacheEntry.from(SourceMetadata)` static factory that names the flatten-and-build pattern duplicated at four cache-loader sites.

### Restore the three missing invariants in the reconciliation branch

1. **Schema cache.** `readAllFileMetadata` routes per-file resolve through `cacheService.getOrComputeSchema` when the provider is cacheable, via a new `cachedResolveSingleSource` helper that calls `buildMetadataFromCache` exactly the way the FFW single-file branch does. Exceptions from the cache layer or the underlying resolve propagate; no defensive try/catch hides a real cache bug behind a silent fallback to N footer reads per warm query.
2. **Single-fetch stats aggregation.** `resolveMultiFileWithReconciliation` calls `aggregateFileStatistics(allMetadata.values())` on the per-file metadata already fetched by `readAllFileMetadata`. No second cache or storage round-trip per file. `aggregateFileStatistics` accepts both cached entries (stats embedded as flat keys in `sourceMetadata()`) and uncached entries (typed `statistics()`), so callers don't need to know whether the metadata came through the schema cache.
3. **Metadata enrichment.** After `buildUnifiedMetadata`, call `enrichWithFileCount` and (when `fileCount > 1` and stats are partial) `markStatsAsPartial` — the same two enrichments FFW applies. `STATS_FILE_COUNT` is what lets `ComputeService.canSkipSplitDiscovery` short-circuit aggregate pushdown.

`cacheable = isCacheable(provider)` moves above the schema-resolution branch and threads through to `resolveMultiFileWithReconciliation` and `readAllFileMetadata`.

### `SchemaCacheEntry.from(SourceMetadata)`

Static factory overload that flattens `meta.statistics()` into the metadata map and constructs the entry. Pulls the pattern out of four inlined cache-loader sites (single-file FFW, multi-file FFW anchor, `readAndAggregateAllFileStatsWithCache`, and the new `cachedResolveSingleSource`). Same encoding, same behavior — one call site instead of four.

## Does it work

`./gradlew :x-pack:plugin:esql:test --tests org.elasticsearch.xpack.esql.datasources.*` — green.
`./gradlew :x-pack:plugin:esql:spotlessJavaCheck` — green.

`ExternalSourceResolverTests` covers the regression via parameterized invariant tests over `MULTI_FILE_STRATEGIES`. Any future `SchemaResolution` value inherits the invariants by construction:

- `testMultiFileStatsPartialFlagPerStrategy` — every mode marks partial when at least one file lacks statistics
- `testMultiFileFileCountPerStrategy` — every mode stamps `STATS_FILE_COUNT`
- `testMultiFileCacheReducesSchemaLoaderCallsPerStrategy` — a second resolve against the same paths adds zero schema-loader calls
- `testAggregateFileStatisticsAcceptsCachedAndUncachedShapes` — pins the shape branch directly; cached entries (flat-embedded stats) and uncached entries (typed `statistics()`) aggregate to the same merged result, and a missing-stats entry forces `null` to keep `markStatsAsPartial` honest

A new `SchemaCacheEntryTests` class covers the `from(SourceMetadata)` factory, the `toAttributes()` NameId-freshness invariant, defensive map copies, constructor validation, and `estimatedBytes` scaling.

### Reproducing the regression

The shape: two `STATS COUNT(*)` queries over the same multi-file glob, one with `schema_resolution=first_file_wins` (the pre-#149176 default), one without. On `main` today, the first stays in single-digit ms when warm; the second is 16–34× slower because every warm iter re-reads N parquet footers and `ComputeService.canSkipSplitDiscovery` can't fire (no `STATS_FILE_COUNT`).

```
# FFW route — answered from cached metadata, fast warm
POST _query
{ "query": "FROM EXTERNAL(\"s3://bucket/data/*.parquet\" WITH { \"schema_resolution\": \"first_file_wins\" }) | STATS COUNT(*)" }

# Default route post-#149176 — UNION_BY_NAME, no cache, no canSkipSplitDiscovery
POST _query
{ "query": "FROM EXTERNAL(\"s3://bucket/data/*.parquet\") | STATS COUNT(*)" }
```

Run each three times warm. The FFW variant shows zero `ParquetFileReader.readFooter` frames in a wall flame; the default variant shows N. The FFW response carries `STATS_FILE_COUNT` in its source metadata; the default one doesn't. After this PR, the two variants converge.


Closes elastic/esql-planning#792
