### PR TITLE
Repro and fix recoveryStats double decrement

### DIFF
--- a/docs/changelog/149348.yaml
+++ b/docs/changelog/149348.yaml
@@ -1,0 +1,5 @@
+area: Distributed
+issues: []
+pr: 149348
+summary: Repro and fix `recoveryStats` double decrement
+type: bug

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
@@ -1685,15 +1685,15 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         ensureGreen(INDEX_NAME);
 
         final int numOfDocs = scaledRandomIntBetween(10, 100);
-        try (BackgroundIndexer indexer = new BackgroundIndexer(INDEX_NAME, client(), numOfDocs)) {
+        try (final var indexer = new BackgroundIndexer(INDEX_NAME, client(), numOfDocs)) {
             waitForDocs(numOfDocs, indexer);
         }
 
         refresh(INDEX_NAME);
         assertHitCount(prepareSearch(INDEX_NAME).setSize(0), numOfDocs);
 
-        final CountDownLatch recoveryStartedLatch = new CountDownLatch(1);
-        final CountDownLatch allowRecoveryToCompleteLatch = new CountDownLatch(1);
+        final var recoveryStartedLatch = new CountDownLatch(1);
+        final var allowRecoveryToCompleteLatch = new CountDownLatch(1);
 
         final var transportService = MockTransportService.getInstance(node);
         transportService.addSendBehavior((connection, requestId, action, request, options) -> {
@@ -1710,10 +1710,10 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         safeAwait(recoveryStartedLatch);
 
         final Index index = resolveIndex(INDEX_NAME);
-        final IndicesService indicesServiceA = internalCluster().getInstance(IndicesService.class, node);
-        final IndexShard primaryShard = indicesServiceA.indexServiceSafe(index).getShard(0);
+        final var indicesService = internalCluster().getInstance(IndicesService.class, node);
+        final IndexShard primaryShard = indicesService.indexServiceSafe(index).getShard(0);
 
-        assertBusy(() -> assertThat(primaryShard.recoveryStats().currentAsSource(), equalTo(1)));
+        assertThat(primaryShard.recoveryStats().currentAsSource(), equalTo(1));
         indicesAdmin().prepareDelete(INDEX_NAME).get();
 
         allowRecoveryToCompleteLatch.countDown();

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
@@ -1679,6 +1679,53 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         });
     }
 
+    public void testCancelRecoveryUpdatesRecoveryStats() throws Exception {
+        final String node = internalCluster().startNode();
+        createIndex(INDEX_NAME, SHARD_COUNT_1, REPLICA_COUNT_0);
+        ensureGreen(INDEX_NAME);
+
+        final int numOfDocs = scaledRandomIntBetween(10, 100);
+        try (BackgroundIndexer indexer = new BackgroundIndexer(INDEX_NAME, client(), numOfDocs)) {
+            waitForDocs(numOfDocs, indexer);
+        }
+
+        refresh(INDEX_NAME);
+        assertHitCount(prepareSearch(INDEX_NAME).setSize(0), numOfDocs);
+
+        final CountDownLatch recoveryStartedLatch = new CountDownLatch(1);
+        final CountDownLatch allowRecoveryToCompleteLatch = new CountDownLatch(1);
+
+        final var transportService = MockTransportService.getInstance(node);
+        transportService.addSendBehavior((connection, requestId, action, request, options) -> {
+            if (PeerRecoveryTargetService.Actions.PREPARE_TRANSLOG.equals(action)) {
+                recoveryStartedLatch.countDown();
+                safeAwait(allowRecoveryToCompleteLatch);
+            }
+            connection.sendRequest(requestId, action, request, options);
+        });
+
+        internalCluster().startNode();
+        setReplicaCount(1, INDEX_NAME);
+
+        safeAwait(recoveryStartedLatch);
+
+        final Index index = resolveIndex(INDEX_NAME);
+        final IndicesService indicesServiceA = internalCluster().getInstance(IndicesService.class, node);
+        final IndexShard primaryShard = indicesServiceA.indexServiceSafe(index).getShard(0);
+
+        assertBusy(() -> assertThat(primaryShard.recoveryStats().currentAsSource(), equalTo(1)));
+        indicesAdmin().prepareDelete(INDEX_NAME).get();
+
+        allowRecoveryToCompleteLatch.countDown();
+        assertBusy(() -> {
+            for (PeerRecoverySourceService recoveryService : internalCluster().getDataNodeInstances(PeerRecoverySourceService.class)) {
+                assertThat(recoveryService.numberOfOngoingRecoveries(), equalTo(0));
+            }
+        });
+        assertThat(primaryShard.recoveryStats().currentAsSource(), equalTo(0));
+        transportService.clearAllRules();
+    }
+
     public void testReservesBytesDuringPeerRecoveryPhaseOne() throws Exception {
         internalCluster().startNode();
         final List<String> dataNodes = internalCluster().startDataOnlyNodes(2);

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
@@ -1685,7 +1685,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         ensureGreen(INDEX_NAME);
 
         final int numOfDocs = scaledRandomIntBetween(10, 100);
-        try (final var indexer = new BackgroundIndexer(INDEX_NAME, client(), numOfDocs)) {
+        try (var indexer = new BackgroundIndexer(INDEX_NAME, client(), numOfDocs)) {
             waitForDocs(numOfDocs, indexer);
         }
 

--- a/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoverySourceService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoverySourceService.java
@@ -283,8 +283,6 @@ public class PeerRecoverySourceService extends AbstractLifecycleComponent implem
                         handlers.cancel("shard is closed");
                     } catch (Exception ex) {
                         failures.add(ex);
-                    } finally {
-                        shard.recoveryStats().decCurrentAsSource();
                     }
                 }
                 ExceptionsHelper.maybeThrowRuntimeAndSuppress(failures);


### PR DESCRIPTION
Encountered while working on: https://github.com/elastic/elasticsearch/pull/149319. Relates to https://github.com/elastic/elasticsearch-team/issues/2809.

When `OngoingRecoveries.cancel(IndexShard)` is called during shard close, it decrements `recoveryStats.currentAsSource()` in a `finally` block for each active handler. However, since `cancel()` does not remove handlers from the internal map, they remain registered and are subsequently removed via their completion listeners, which call `OngoingRecoveries.remove()`, triggering a second decrement of the same counter and making the `currentAsSource` recovery stat go negative.

See repro in [gradle](https://gradle-enterprise.elastic.co/s/7nzrma2pz6jcc/tests/task/:server:internalClusterTest/details/org.elasticsearch.indices.recovery.IndexRecoveryIT/testCancelRecoveryUpdatesRecoveryStats?top-execution=1)