### PR TITLE
[9.4] Lucene TermsEnum and PostingsEnum may only be used from acquiring thread (#149297)

### DIFF
--- a/docs/changelog/149297.yaml
+++ b/docs/changelog/149297.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 149297
+summary: Lucene `TermsEnum` and `PostingsEnum` may only be used from acquiring thread
+type: bug

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/lookup/BulkKeywordLookup.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/lookup/BulkKeywordLookup.java
@@ -36,6 +36,7 @@ public class BulkKeywordLookup {
     private final Warnings warnings;
     private final String fieldName;
 
+    private Thread creationThread = null;
     private TermsEnum[] termsEnumCache = null;
     private PostingsEnum[] postingsCache = null;
     private final BytesRef scratch = new BytesRef();
@@ -61,6 +62,8 @@ public class BulkKeywordLookup {
         IntVector.Builder positionsBuilder
     ) {
         try {
+            initializeCaches(indexReader);
+
             final BytesRefBlock block = inputPage.getBlock(matchChannelOffset);
             final int valueCount = block.getValueCount(position);
             if (valueCount > 1) {
@@ -120,12 +123,16 @@ public class BulkKeywordLookup {
     }
 
     /**
-     * Initialize caches for the given index reader. This should be called once
-     * before the first processQuery call for a given index reader.
+     * Initialize caches for the given index reader as necessary.
+     * The current thread is tracked because Lucene only allows
+     * TermsEnum and PostingsEnum to be used from the thread that creates them.
+     * Note: postingsCache[i] filled in processQuery.
      */
     public void initializeCaches(IndexReader indexReader) throws IOException {
-        if (termsEnumCache == null) {
-            final int numLeaves = indexReader.leaves().size();
+        final Thread current = Thread.currentThread();
+        final int numLeaves = indexReader.leaves().size();
+        if (termsEnumCache == null || creationThread != current) {
+            creationThread = current;
             termsEnumCache = new TermsEnum[numLeaves];
             postingsCache = new PostingsEnum[numLeaves];
 


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Lucene TermsEnum and PostingsEnum may only be used from acquiring thread (#149297)