### PR TITLE
ESQL CSV: prefix-XOR boundary scanner, opt-in via flag

### DIFF
--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvBoundaryScanner.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvBoundaryScanner.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.csv;
+
+/**
+ * Quote-aware record-boundary scanning over a contiguous {@code byte[]}.
+ * <p>
+ * Two implementations live side by side:
+ * <ul>
+ *   <li>{@link #PREFIX_XOR} — bit-parallel prefix-XOR over 64-byte blocks. The production default.</li>
+ *   <li>{@link #REFERENCE} — per-byte scalar scanner, behaviourally identical to the original
+ *       {@code findLastRecordBoundaryQuotedFieldsOnly} in {@code CsvFormatReader}. Used as the
+ *       equivalence oracle in {@code CsvBoundaryScannerTests}; also reachable as an emergency
+ *       kill-switch via {@value #FAST_PATH_PROPERTY} at JVM start.</li>
+ * </ul>
+ * <p>
+ * The choice between the two is made <b>once</b>, by {@code CsvFormatReader} at class-init time —
+ * the active implementation is held in a {@code static final} field on {@code CsvFormatReader}, so
+ * the JIT sees a constant {@link Impl} reference at every dispatch site and inlines through it.
+ * <p>
+ * Both implementations honour:
+ * <ul>
+ *   <li><b>Open-tail rule</b>: when the buffer ends mid-quote, the last record terminator before
+ *       the open region is returned (or {@code -1}). Never an offset inside the open region.</li>
+ *   <li><b>RFC 4180 doubled-quote escape</b>: {@code ""} inside a quoted field is a literal quote;
+ *       the run stays open across the pair.</li>
+ *   <li><b>Configurable quote character</b>: any single byte; threaded through both paths.</li>
+ * </ul>
+ * <p>
+ * Out of scope: the bracket-multi-value-cell state machine ({@code [..]}-bounded regions in
+ * {@code findNextRecordBoundaryBracketCommaMvc}). That path stays on the SPI default polyloop in
+ * {@code CsvFormatReader}.
+ */
+public final class CsvBoundaryScanner {
+
+    /** Number of bytes processed per prefix-XOR block in the fast path. */
+    static final int BLOCK = 64;
+
+    /**
+     * System property controlling which implementation {@code CsvFormatReader} resolves at class
+     * init. {@code true} (the default) selects {@link #PREFIX_XOR}; {@code false} selects
+     * {@link #REFERENCE}. Read once at JVM start by {@code CsvFormatReader}; flipping it at
+     * runtime has no effect on already-loaded readers.
+     */
+    public static final String FAST_PATH_PROPERTY = "esql.csv.fast_boundary_scanner";
+
+    /** Bit-parallel prefix-XOR implementation. Stateless, thread-safe. */
+    public static final Impl PREFIX_XOR = new PrefixXorImpl();
+
+    /** Per-byte scalar reference, byte-for-byte equivalent to the original scanner. Stateless, thread-safe. */
+    public static final Impl REFERENCE = new ReferenceImpl();
+
+    private CsvBoundaryScanner() {}
+
+    /**
+     * Quote-aware record-boundary scanner. Both implementations must agree byte-for-byte on every
+     * input the original {@code findLastRecordBoundaryQuotedFieldsOnly} handled correctly — that
+     * contract is the property test in {@code CsvBoundaryScannerTests}.
+     */
+    public interface Impl {
+
+        /**
+         * Offset (relative to {@code off}) of the last {@code \n} byte that is outside any quoted
+         * field within {@code buf[off..off+len)}, or {@code -1} if no such byte exists. Honours the
+         * open-tail rule (see class-level javadoc).
+         */
+        int findLastRealTerminator(byte[] buf, int off, int len, byte quoteChar);
+
+        /**
+         * Count of {@code \n} bytes outside any quoted field within {@code buf[off..off+len)}.
+         * Threads {@code carryIn} as the entering in-quote state ({@code 0L} = outside,
+         * {@code -1L} = inside) and writes the exit state into {@code carryOut[0]} when
+         * {@code carryOut != null}. Designed for streaming use across multiple buffer reads.
+         */
+        long countRealTerminators(byte[] buf, int off, int len, byte quoteChar, long carryIn, long[] carryOut);
+    }
+
+    // -------- Fast path: prefix-XOR over 64-byte blocks ----------------------------------------
+
+    private static final class PrefixXorImpl implements Impl {
+
+        @Override
+        public int findLastRealTerminator(byte[] buf, int off, int len, byte quoteChar) {
+            if (len <= 0) {
+                return -1;
+            }
+            long carry = 0L;
+            int lastBoundary = -1;
+            int i = 0;
+            while (i + BLOCK <= len) {
+                long quoteBits = byteMask(buf, off + i, quoteChar);
+                long newlineBits = byteMask(buf, off + i, (byte) '\n');
+
+                long inQuote = prefixXor(quoteBits) ^ carry;
+                long realTerminators = newlineBits & ~inQuote;
+                if (realTerminators != 0L) {
+                    int highBit = 63 - Long.numberOfLeadingZeros(realTerminators);
+                    lastBoundary = i + highBit;
+                }
+                carry = -((inQuote >>> 63) & 1L);
+                i += BLOCK;
+            }
+
+            // Tail: 0..63 leftover bytes. Per-byte scan, seeded by the in-quote carry from the
+            // last full block.
+            boolean inQuoteScalar = (carry != 0L);
+            while (i < len) {
+                byte b = buf[off + i];
+                if (b == quoteChar) {
+                    if (inQuoteScalar) {
+                        if (i + 1 < len && buf[off + i + 1] == quoteChar) {
+                            i++; // RFC 4180 doubled-quote: literal, stay in run.
+                        } else {
+                            inQuoteScalar = false;
+                        }
+                    } else {
+                        inQuoteScalar = true;
+                    }
+                } else if (b == '\n' && inQuoteScalar == false) {
+                    lastBoundary = i;
+                }
+                i++;
+            }
+            return lastBoundary;
+        }
+
+        @Override
+        public long countRealTerminators(byte[] buf, int off, int len, byte quoteChar, long carryIn, long[] carryOut) {
+            if (len <= 0) {
+                if (carryOut != null) {
+                    carryOut[0] = carryIn;
+                }
+                return 0L;
+            }
+            long carry = carryIn;
+            long count = 0L;
+            int i = 0;
+            while (i + BLOCK <= len) {
+                long quoteBits = byteMask(buf, off + i, quoteChar);
+                long newlineBits = byteMask(buf, off + i, (byte) '\n');
+
+                long inQuote = prefixXor(quoteBits) ^ carry;
+                count += Long.bitCount(newlineBits & ~inQuote);
+                carry = -((inQuote >>> 63) & 1L);
+                i += BLOCK;
+            }
+            boolean inQuoteScalar = (carry != 0L);
+            while (i < len) {
+                byte b = buf[off + i];
+                if (b == quoteChar) {
+                    if (inQuoteScalar) {
+                        if (i + 1 < len && buf[off + i + 1] == quoteChar) {
+                            i++;
+                        } else {
+                            inQuoteScalar = false;
+                        }
+                    } else {
+                        inQuoteScalar = true;
+                    }
+                } else if (b == '\n' && inQuoteScalar == false) {
+                    count++;
+                }
+                i++;
+            }
+            if (carryOut != null) {
+                carryOut[0] = inQuoteScalar ? -1L : 0L;
+            }
+            return count;
+        }
+
+        /**
+         * Build a bitmap of {@link #BLOCK} bits: bit {@code j} set iff {@code buf[off + j] == target}.
+         * Pure scalar — the Vector API variant in a follow-up commit replaces this method with a
+         * parallel byte-compare.
+         */
+        private static long byteMask(byte[] buf, int off, byte target) {
+            long mask = 0L;
+            for (int j = 0; j < BLOCK; j++) {
+                if (buf[off + j] == target) {
+                    mask |= 1L << j;
+                }
+            }
+            return mask;
+        }
+
+        /** Hillis-Steele prefix-XOR scan on a 64-bit word. */
+        private static long prefixXor(long x) {
+            x ^= x << 1;
+            x ^= x << 2;
+            x ^= x << 4;
+            x ^= x << 8;
+            x ^= x << 16;
+            x ^= x << 32;
+            return x;
+        }
+    }
+
+    // -------- Reference path: per-byte scalar (the original scanner, preserved) ----------------
+
+    private static final class ReferenceImpl implements Impl {
+
+        @Override
+        public int findLastRealTerminator(byte[] buf, int off, int len, byte quoteChar) {
+            if (len <= 0) {
+                return -1;
+            }
+            int lastBoundary = -1;
+            boolean inQuotes = false;
+            for (int i = 0; i < len; i++) {
+                byte b = buf[off + i];
+                if (b == quoteChar) {
+                    if (inQuotes) {
+                        if (i + 1 < len && buf[off + i + 1] == quoteChar) {
+                            // Doubled quote inside a quoted field — RFC 4180 literal, stay in quotes.
+                            i++;
+                        } else {
+                            inQuotes = false;
+                        }
+                    } else {
+                        inQuotes = true;
+                    }
+                } else if (b == '\n' && inQuotes == false) {
+                    lastBoundary = i;
+                }
+            }
+            return lastBoundary;
+        }
+
+        @Override
+        public long countRealTerminators(byte[] buf, int off, int len, byte quoteChar, long carryIn, long[] carryOut) {
+            long count = 0L;
+            boolean inQuotes = (carryIn != 0L);
+            for (int i = 0; i < len; i++) {
+                byte b = buf[off + i];
+                if (b == quoteChar) {
+                    if (inQuotes) {
+                        if (i + 1 < len && buf[off + i + 1] == quoteChar) {
+                            i++;
+                        } else {
+                            inQuotes = false;
+                        }
+                    } else {
+                        inQuotes = true;
+                    }
+                } else if (b == '\n' && inQuotes == false) {
+                    count++;
+                }
+            }
+            if (carryOut != null) {
+                carryOut[0] = inQuotes ? -1L : 0L;
+            }
+            return count;
+        }
+    }
+}

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
@@ -207,6 +207,14 @@ public class CsvFormatReader implements SegmentableFormatReader {
      */
     private final ErrorPolicy effectivePolicy;
 
+    /**
+     * Boundary-scanner strategy chosen at construction. Held as a {@code final} field so the JIT
+     * sees a stable {@link CsvBoundaryScanner.Impl} at every dispatch site on this reader — in
+     * production every reader is built with the same default ({@link CsvBoundaryScanner#PREFIX_XOR}),
+     * so the call site is monomorphic and inlines through the interface.
+     */
+    private final CsvBoundaryScanner.Impl boundaryScanner;
+
     public CsvFormatReader(BlockFactory blockFactory) {
         this(
             blockFactory,
@@ -215,16 +223,64 @@ public class CsvFormatReader implements SegmentableFormatReader {
             List.of(".csv", ".tsv"),
             null,
             CsvSchemaInferrer.DEFAULT_SAMPLE_SIZE,
-            ErrorPolicy.STRICT
+            ErrorPolicy.STRICT,
+            defaultBoundaryScanner()
         );
     }
 
     public CsvFormatReader(BlockFactory blockFactory, String format, List<String> extensions) {
-        this(blockFactory, CsvFormatOptions.DEFAULT, format, extensions, null, CsvSchemaInferrer.DEFAULT_SAMPLE_SIZE, ErrorPolicy.STRICT);
+        this(
+            blockFactory,
+            CsvFormatOptions.DEFAULT,
+            format,
+            extensions,
+            null,
+            CsvSchemaInferrer.DEFAULT_SAMPLE_SIZE,
+            ErrorPolicy.STRICT,
+            defaultBoundaryScanner()
+        );
     }
 
     public CsvFormatReader(BlockFactory blockFactory, CsvFormatOptions options, String format, List<String> extensions) {
-        this(blockFactory, options, format, extensions, null, CsvSchemaInferrer.DEFAULT_SAMPLE_SIZE, ErrorPolicy.STRICT);
+        this(
+            blockFactory,
+            options,
+            format,
+            extensions,
+            null,
+            CsvSchemaInferrer.DEFAULT_SAMPLE_SIZE,
+            ErrorPolicy.STRICT,
+            defaultBoundaryScanner()
+        );
+    }
+
+    /**
+     * Test-only entry point: build a reader with an explicit boundary-scanner strategy. Lets
+     * equivalence tests compare {@link CsvBoundaryScanner#PREFIX_XOR} and
+     * {@link CsvBoundaryScanner#REFERENCE} end-to-end through the public reader API.
+     */
+    CsvFormatReader(BlockFactory blockFactory, CsvBoundaryScanner.Impl boundaryScanner) {
+        this(
+            blockFactory,
+            CsvFormatOptions.DEFAULT,
+            "csv",
+            List.of(".csv", ".tsv"),
+            null,
+            CsvSchemaInferrer.DEFAULT_SAMPLE_SIZE,
+            ErrorPolicy.STRICT,
+            boundaryScanner
+        );
+    }
+
+    /** Test-only: same as the four-arg public constructor plus an explicit boundary-scanner. */
+    CsvFormatReader(
+        BlockFactory blockFactory,
+        CsvFormatOptions options,
+        String format,
+        List<String> extensions,
+        CsvBoundaryScanner.Impl boundaryScanner
+    ) {
+        this(blockFactory, options, format, extensions, null, CsvSchemaInferrer.DEFAULT_SAMPLE_SIZE, ErrorPolicy.STRICT, boundaryScanner);
     }
 
     private CsvFormatReader(
@@ -234,7 +290,8 @@ public class CsvFormatReader implements SegmentableFormatReader {
         List<String> extensions,
         List<Attribute> resolvedSchema,
         int schemaSampleSize,
-        ErrorPolicy effectivePolicy
+        ErrorPolicy effectivePolicy,
+        CsvBoundaryScanner.Impl boundaryScanner
     ) {
         this.blockFactory = blockFactory;
         this.options = options;
@@ -243,7 +300,20 @@ public class CsvFormatReader implements SegmentableFormatReader {
         this.resolvedSchema = resolvedSchema;
         this.schemaSampleSize = schemaSampleSize;
         this.effectivePolicy = effectivePolicy;
+        this.boundaryScanner = boundaryScanner;
         this.sharedCsvMapper = createMapper(options);
+    }
+
+    /**
+     * Resolves the production default boundary-scanner strategy. Defaults to the per-byte scalar
+     * {@link CsvBoundaryScanner#REFERENCE} — behaviourally identical to the original scanner, so
+     * landing this PR changes nothing for existing deployments. Opt into the prefix-XOR fast path
+     * by setting {@code -D}{@value CsvBoundaryScanner#FAST_PATH_PROPERTY}{@code =true} at JVM
+     * start. A follow-up will flip the default once both implementations have soaked.
+     */
+    private static CsvBoundaryScanner.Impl defaultBoundaryScanner() {
+        String prop = System.getProperty(CsvBoundaryScanner.FAST_PATH_PROPERTY);
+        return Boolean.parseBoolean(prop) ? CsvBoundaryScanner.PREFIX_XOR : CsvBoundaryScanner.REFERENCE;
     }
 
     private static CsvMapper createMapper(CsvFormatOptions opts) {
@@ -407,12 +477,21 @@ public class CsvFormatReader implements SegmentableFormatReader {
     }
 
     public CsvFormatReader withOptions(CsvFormatOptions newOptions) {
-        return new CsvFormatReader(blockFactory, newOptions, format, extensions, resolvedSchema, schemaSampleSize, effectivePolicy);
+        return new CsvFormatReader(
+            blockFactory,
+            newOptions,
+            format,
+            extensions,
+            resolvedSchema,
+            schemaSampleSize,
+            effectivePolicy,
+            boundaryScanner
+        );
     }
 
     @Override
     public CsvFormatReader withSchema(List<Attribute> schema) {
-        return new CsvFormatReader(blockFactory, options, format, extensions, schema, schemaSampleSize, effectivePolicy);
+        return new CsvFormatReader(blockFactory, options, format, extensions, schema, schemaSampleSize, effectivePolicy, boundaryScanner);
     }
 
     @Override
@@ -433,7 +512,8 @@ public class CsvFormatReader implements SegmentableFormatReader {
                 result.extensions,
                 result.resolvedSchema,
                 newSampleSize,
-                resolvedPolicy
+                resolvedPolicy,
+                result.boundaryScanner
             );
         }
         return Configured.fromKnownSubset(result, config, RECOGNIZED_KEYS);
@@ -846,32 +926,14 @@ public class CsvFormatReader implements SegmentableFormatReader {
      * An unpaired opening quote leaves {@code inQuotes == true} for the rest of the buffer, so
      * any {@code \n} inside the unterminated tail is skipped and the returned offset stays before
      * the open region — the open-tail rule the segmentator's grow loop requires.
+     * <p>
+     * Implementation delegates to the {@link CsvBoundaryScanner.Impl} chosen at construction
+     * (defaults to {@link CsvBoundaryScanner#PREFIX_XOR}, which batches the per-byte state machine
+     * into bit-parallel operations on 64-byte blocks; falls back to {@link CsvBoundaryScanner#REFERENCE}
+     * when {@code -D}{@value CsvBoundaryScanner#FAST_PATH_PROPERTY}{@code =false} is set).
      */
     private int findLastRecordBoundaryQuotedFieldsOnly(byte[] buf, int length) {
-        if (length <= 0) {
-            return -1;
-        }
-        int lastBoundary = -1;
-        boolean inQuotes = false;
-        byte quoteAsByte = (byte) options.quoteChar();
-        for (int i = 0; i < length; i++) {
-            byte b = buf[i];
-            if (b == quoteAsByte) {
-                if (inQuotes) {
-                    if (i + 1 < length && buf[i + 1] == quoteAsByte) {
-                        // Doubled quote inside a quoted field — RFC 4180 literal, stay in quotes.
-                        i++;
-                    } else {
-                        inQuotes = false;
-                    }
-                } else {
-                    inQuotes = true;
-                }
-            } else if (b == '\n' && inQuotes == false) {
-                lastBoundary = i;
-            }
-        }
-        return lastBoundary;
+        return boundaryScanner.findLastRealTerminator(buf, 0, length, (byte) options.quoteChar());
     }
 
     /**

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/AbstractCsvBoundaryScannerTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/AbstractCsvBoundaryScannerTests.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.csv;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Regression suite that runs against any {@link CsvBoundaryScanner.Impl}. Each scanner — the
+ * prefix-XOR fast path and the per-byte scalar reference — has a one-line concrete subclass that
+ * supplies the {@link #impl()} under test, so every scenario below executes on both
+ * implementations.
+ * <p>
+ * The randomized cross-implementation equivalence check lives separately in
+ * {@code CsvBoundaryScannerEquivalenceTests} — that one structurally needs both implementations
+ * in scope and doesn't fit the parameterized pattern.
+ */
+public abstract class AbstractCsvBoundaryScannerTests extends ESTestCase {
+
+    protected static final byte QUOTE = (byte) '"';
+
+    /** The scanner under test. Each concrete subclass returns one of {@link CsvBoundaryScanner}'s impls. */
+    protected abstract CsvBoundaryScanner.Impl impl();
+
+    // -------- findLastRealTerminator regressions ----------------------------------------------
+
+    public void testSimpleTwoLines() {
+        byte[] data = "a,b\nc,d\n".getBytes(StandardCharsets.UTF_8);
+        assertEquals(data.length - 1, impl().findLastRealTerminator(data, 0, data.length, QUOTE));
+    }
+
+    public void testSingleTrailingLineNoTerminator() {
+        byte[] data = "a,b\nc,d".getBytes(StandardCharsets.UTF_8);
+        assertEquals(3, impl().findLastRealTerminator(data, 0, data.length, QUOTE));
+    }
+
+    public void testEmptyBuffer() {
+        assertEquals(-1, impl().findLastRealTerminator(new byte[0], 0, 0, QUOTE));
+    }
+
+    public void testAllInsideQuotedField() {
+        // Open quote, body with newlines, never closed: open-tail rule → -1.
+        byte[] data = "\"foo\nbar\nbaz".getBytes(StandardCharsets.UTF_8);
+        assertEquals(-1, impl().findLastRealTerminator(data, 0, data.length, QUOTE));
+    }
+
+    public void testSkipsEmbeddedNewlineInQuotedField() {
+        byte[] data = "a,\"foo\nbar\",c\nd,e,f\n".getBytes(StandardCharsets.UTF_8);
+        assertEquals(data.length - 1, impl().findLastRealTerminator(data, 0, data.length, QUOTE));
+    }
+
+    public void testEmbeddedNewlineFollowedByUnterminatedTail() {
+        byte[] data = "a,b\n\"foo\nbar".getBytes(StandardCharsets.UTF_8);
+        assertEquals(3, impl().findLastRealTerminator(data, 0, data.length, QUOTE));
+    }
+
+    public void testCRLF() {
+        byte[] data = "a,b\r\nc,d\r\n".getBytes(StandardCharsets.UTF_8);
+        assertEquals(data.length - 1, impl().findLastRealTerminator(data, 0, data.length, QUOTE));
+    }
+
+    public void testDoubledQuoteEscape() {
+        // "foo""bar" is one quoted field with a literal " in the middle; the trailing \n closes the
+        // record.
+        byte[] data = "\"foo\"\"bar\"\n".getBytes(StandardCharsets.UTF_8);
+        assertEquals(data.length - 1, impl().findLastRealTerminator(data, 0, data.length, QUOTE));
+    }
+
+    public void testLengthSubsetOfBuffer() {
+        byte[] data = "a,b\nc,d\nEXTRA".getBytes(StandardCharsets.UTF_8);
+        assertEquals(3, impl().findLastRealTerminator(data, 0, 7, QUOTE));
+    }
+
+    public void testOffsetRespectedDoesNotReadBefore() {
+        byte[] data = "PREFIX\na,b\nc,d\n".getBytes(StandardCharsets.UTF_8);
+        // From offset 7 onwards. Last real terminator at relative offset 7 (= absolute 14).
+        assertEquals(7, impl().findLastRealTerminator(data, 7, data.length - 7, QUOTE));
+    }
+
+    public void testCrossBlockBoundaryQuoteStaysOpen() {
+        // 71 bytes: open quote, 68 a's, closing quote, \n. The quote run spans block 0 (64 bytes);
+        // the in-quote carry must propagate to the tail where the \n at byte 70 is the terminator.
+        StringBuilder sb = new StringBuilder("\"");
+        for (int i = 0; i < 68; i++)
+            sb.append('a');
+        sb.append('"');
+        sb.append('\n');
+        byte[] data = sb.toString().getBytes(StandardCharsets.UTF_8);
+        assertEquals(71, data.length);
+        assertEquals(70, impl().findLastRealTerminator(data, 0, data.length, QUOTE));
+    }
+
+    public void testNewlineInsideQuoteSpanningBlockBoundary() {
+        // \n at exact block boundary (byte 64) inside the still-open quote — NOT a real terminator.
+        StringBuilder sb = new StringBuilder("\"");
+        for (int i = 0; i < 63; i++)
+            sb.append('a');
+        sb.append('\n'); // byte 64
+        for (int i = 0; i < 5; i++)
+            sb.append('b');
+        sb.append('"');
+        sb.append('\n'); // the real terminator
+        byte[] data = sb.toString().getBytes(StandardCharsets.UTF_8);
+        assertEquals(data.length - 1, impl().findLastRealTerminator(data, 0, data.length, QUOTE));
+    }
+
+    public void testDoubledQuoteStraddlesBlockBoundary() {
+        // First " at byte 63 (end of block 0), second " at byte 64 (start of block 1) — RFC 4180
+        // escape pair across the block boundary. The run stays open; the \n at byte 70 is inside.
+        StringBuilder sb = new StringBuilder("\"");
+        for (int i = 0; i < 62; i++)
+            sb.append('a'); // bytes 1..62
+        sb.append('"'); // byte 63
+        sb.append('"'); // byte 64
+        sb.append('x');
+        sb.append('y');
+        sb.append('z');
+        sb.append('w');
+        sb.append('v');
+        sb.append('\n'); // byte 70 — INSIDE the still-open run
+        sb.append('"'); // byte 71 — closes the run
+        sb.append('\n'); // byte 72 — the terminator
+        byte[] data = sb.toString().getBytes(StandardCharsets.UTF_8);
+        assertEquals(data.length - 1, impl().findLastRealTerminator(data, 0, data.length, QUOTE));
+    }
+
+    // -------- countRealTerminators regressions ------------------------------------------------
+
+    public void testCountTwoRecords() {
+        byte[] data = "a,b\nc,d\n".getBytes(StandardCharsets.UTF_8);
+        long[] carryOut = new long[1];
+        assertEquals(2L, impl().countRealTerminators(data, 0, data.length, QUOTE, 0L, carryOut));
+        assertEquals(0L, carryOut[0]);
+    }
+
+    public void testCountIgnoresEmbeddedNewlines() {
+        byte[] data = "a,\"foo\nbar\",c\nd,e,f\n".getBytes(StandardCharsets.UTF_8);
+        assertEquals(2L, impl().countRealTerminators(data, 0, data.length, QUOTE, 0L, null));
+    }
+
+    public void testCountPropagatesCarryAcrossBuffers() {
+        // First buffer opens a quote that doesn't close — carry-out must be -1L (inside-quote).
+        byte[] first = "a,b,\"foo\n".getBytes(StandardCharsets.UTF_8);
+        long[] mid = new long[1];
+        assertEquals(0L, impl().countRealTerminators(first, 0, first.length, QUOTE, 0L, mid));
+        assertEquals(-1L, mid[0]);
+
+        // Second buffer: enters inside-quote, closing " toggles out, trailing \n is the terminator.
+        byte[] second = "bar\nbaz\",g,h\n".getBytes(StandardCharsets.UTF_8);
+        long[] end = new long[1];
+        assertEquals(1L, impl().countRealTerminators(second, 0, second.length, QUOTE, mid[0], end));
+        assertEquals(0L, end[0]);
+    }
+
+    public void testCountEmptyBufferPreservesCarry() {
+        long[] carryOut = new long[1];
+        assertEquals(0L, impl().countRealTerminators(new byte[0], 0, 0, QUOTE, -1L, carryOut));
+        assertEquals(-1L, carryOut[0]);
+    }
+}

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvBoundaryScannerEquivalenceTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvBoundaryScannerEquivalenceTests.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.csv;
+
+import org.elasticsearch.test.ESTestCase;
+
+/**
+ * Randomised property test: on every input, {@link CsvBoundaryScanner#PREFIX_XOR} and
+ * {@link CsvBoundaryScanner#REFERENCE} must produce identical {@code findLastRealTerminator} and
+ * {@code countRealTerminators} results. Sits separately from {@link AbstractCsvBoundaryScannerTests}
+ * because it structurally compares both implementations rather than running each in isolation.
+ */
+public class CsvBoundaryScannerEquivalenceTests extends ESTestCase {
+
+    private static final byte QUOTE = (byte) '"';
+
+    public void testRandomizedEquivalence() {
+        int iterations = 5000;
+        for (int it = 0; it < iterations; it++) {
+            int len = randomIntBetween(0, 400);
+            byte[] data = generateRandomCsvBytes(len);
+
+            int xorBoundary = CsvBoundaryScanner.PREFIX_XOR.findLastRealTerminator(data, 0, data.length, QUOTE);
+            int refBoundary = CsvBoundaryScanner.REFERENCE.findLastRealTerminator(data, 0, data.length, QUOTE);
+            if (xorBoundary != refBoundary) {
+                fail(
+                    "findLastRealTerminator mismatch at it="
+                        + it
+                        + " prefixXor="
+                        + xorBoundary
+                        + " reference="
+                        + refBoundary
+                        + " for input: "
+                        + bytesToReadable(data)
+                );
+            }
+
+            long[] xorCarry = new long[1];
+            long[] refCarry = new long[1];
+            long xorCount = CsvBoundaryScanner.PREFIX_XOR.countRealTerminators(data, 0, data.length, QUOTE, 0L, xorCarry);
+            long refCount = CsvBoundaryScanner.REFERENCE.countRealTerminators(data, 0, data.length, QUOTE, 0L, refCarry);
+            if (xorCount != refCount || xorCarry[0] != refCarry[0]) {
+                fail(
+                    "countRealTerminators mismatch at it="
+                        + it
+                        + " prefixXor=(count="
+                        + xorCount
+                        + ",carry="
+                        + xorCarry[0]
+                        + ") reference=(count="
+                        + refCount
+                        + ",carry="
+                        + refCarry[0]
+                        + ") for input: "
+                        + bytesToReadable(data)
+                );
+            }
+        }
+    }
+
+    /**
+     * Same as above but threads a non-zero carry-in, exercising the cross-buffer state transition
+     * path that {@code countRealTerminators} uses for streaming reads. The randomised input simulates
+     * the bytes between two reads of the same logical file.
+     */
+    public void testRandomizedEquivalenceWithCarryIn() {
+        int iterations = 5000;
+        for (int it = 0; it < iterations; it++) {
+            int len = randomIntBetween(0, 400);
+            byte[] data = generateRandomCsvBytes(len);
+            long carryIn = randomBoolean() ? -1L : 0L;
+
+            long[] xorCarry = new long[1];
+            long[] refCarry = new long[1];
+            long xorCount = CsvBoundaryScanner.PREFIX_XOR.countRealTerminators(data, 0, data.length, QUOTE, carryIn, xorCarry);
+            long refCount = CsvBoundaryScanner.REFERENCE.countRealTerminators(data, 0, data.length, QUOTE, carryIn, refCarry);
+            if (xorCount != refCount || xorCarry[0] != refCarry[0]) {
+                fail(
+                    "countRealTerminators(carry="
+                        + carryIn
+                        + ") mismatch at it="
+                        + it
+                        + " prefixXor=(count="
+                        + xorCount
+                        + ",carry="
+                        + xorCarry[0]
+                        + ") reference=(count="
+                        + refCount
+                        + ",carry="
+                        + refCarry[0]
+                        + ") for input: "
+                        + bytesToReadable(data)
+                );
+            }
+        }
+    }
+
+    private byte[] generateRandomCsvBytes(int len) {
+        byte[] out = new byte[len];
+        for (int i = 0; i < len; i++) {
+            int roll = randomIntBetween(0, 99);
+            if (roll < 5) {
+                out[i] = (byte) '"';
+            } else if (roll < 15) {
+                out[i] = (byte) '\n';
+            } else if (roll < 25) {
+                out[i] = (byte) ',';
+            } else if (roll < 28) {
+                out[i] = (byte) '\r';
+            } else {
+                out[i] = (byte) ('a' + randomIntBetween(0, 25));
+            }
+        }
+        return out;
+    }
+
+    private static String bytesToReadable(byte[] data) {
+        StringBuilder sb = new StringBuilder("[" + data.length + "]");
+        for (byte b : data) {
+            if (b == '\n') sb.append("\\n");
+            else if (b == '\r') sb.append("\\r");
+            else if (b == '"') sb.append("\\\"");
+            else sb.append((char) (b & 0xff));
+        }
+        return sb.toString();
+    }
+}

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvBoundaryScannerPrefixXorTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvBoundaryScannerPrefixXorTests.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.csv;
+
+/** Runs the shared {@link AbstractCsvBoundaryScannerTests} suite against {@link CsvBoundaryScanner#PREFIX_XOR}. */
+public class CsvBoundaryScannerPrefixXorTests extends AbstractCsvBoundaryScannerTests {
+
+    @Override
+    protected CsvBoundaryScanner.Impl impl() {
+        return CsvBoundaryScanner.PREFIX_XOR;
+    }
+}

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvBoundaryScannerReferenceTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvBoundaryScannerReferenceTests.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.csv;
+
+/** Runs the shared {@link AbstractCsvBoundaryScannerTests} suite against {@link CsvBoundaryScanner#REFERENCE}. */
+public class CsvBoundaryScannerReferenceTests extends AbstractCsvBoundaryScannerTests {
+
+    @Override
+    protected CsvBoundaryScanner.Impl impl() {
+        return CsvBoundaryScanner.REFERENCE;
+    }
+}

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderReferenceTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderReferenceTests.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.csv;
+
+/**
+ * Re-runs the entire {@link CsvFormatReaderTests} suite against
+ * {@link CsvBoundaryScanner#REFERENCE} — the per-byte scalar scanner — instead of the prefix-XOR
+ * fast path the base class uses by default. Together these two suites enforce that both
+ * implementations behave byte-for-byte identically end-to-end through the public reader API.
+ */
+public class CsvFormatReaderReferenceTests extends CsvFormatReaderTests {
+
+    @Override
+    protected CsvBoundaryScanner.Impl scannerImpl() {
+        return CsvBoundaryScanner.REFERENCE;
+    }
+}

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
@@ -65,6 +65,22 @@ public class CsvFormatReaderTests extends ESTestCase {
     }
 
     /**
+     * Boundary-scanner strategy under test. The base class returns {@link CsvBoundaryScanner#PREFIX_XOR}
+     * so this suite — every regression below — runs against the new fast path. The sibling
+     * {@code CsvFormatReaderReferenceTests} overrides this to {@link CsvBoundaryScanner#REFERENCE},
+     * re-running every test against the preserved scalar scanner. The two suites together enforce
+     * byte-for-byte equivalence at the reader level, not just at the kernel level.
+     */
+    protected CsvBoundaryScanner.Impl scannerImpl() {
+        return CsvBoundaryScanner.PREFIX_XOR;
+    }
+
+    /** Build a default-options CSV reader that honours {@link #scannerImpl()}. */
+    protected CsvFormatReader newReader() {
+        return new CsvFormatReader(blockFactory, scannerImpl());
+    }
+
+    /**
      * Several tests below exercise non-strict {@link ErrorPolicy} paths which now emit response-header
      * warnings via {@link HeaderWarning#addWarning(String, Object[])}. Drop them here so the parent
      * {@code ensureNoWarnings} post-check passes; tests that want to assert on them call
@@ -88,7 +104,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             """;
 
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         List<Attribute> schema = reader.schema(object);
 
@@ -114,7 +130,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             """;
 
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         List<Attribute> schema = reader.schema(object);
 
@@ -134,7 +150,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             """;
 
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         List<Attribute> schema = reader.schema(object);
 
@@ -152,7 +168,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             """;
 
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -183,7 +199,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             """;
 
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         // Project only name and score
         try (CloseableIterator<Page> iterator = reader.read(object, List.of("name", "score"), 10)) {
@@ -205,7 +221,7 @@ public class CsvFormatReaderTests extends ESTestCase {
         }
 
         StorageObject object = createStorageObject(csv.toString());
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         int batchSize = 10;
         int totalRows = 0;
@@ -244,7 +260,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             """;
 
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -279,7 +295,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             """;
 
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -293,12 +309,12 @@ public class CsvFormatReaderTests extends ESTestCase {
     }
 
     public void testFormatName() {
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
         assertEquals("csv", reader.formatName());
     }
 
     public void testFileExtensions() {
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
         List<String> extensions = reader.fileExtensions();
         assertEquals(2, extensions.size());
         assertTrue(extensions.contains(".csv"));
@@ -308,7 +324,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testPlainHeaderTreatedAsColumnName() throws IOException {
         String csv = "column_name\nsome_value\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         List<Attribute> schema = reader.schema(object);
         assertEquals(1, schema.size());
@@ -319,7 +335,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testQuotedColumnNameWithColon() throws IOException {
         String csv = "\"host:port\",status\n\"localhost:9200\",200\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         List<Attribute> schema = reader.schema(object);
         assertEquals(2, schema.size());
@@ -334,7 +350,7 @@ public class CsvFormatReaderTests extends ESTestCase {
         String csv = "id:long,ts:datetime\n1," + epochMillis + "\n";
 
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -348,7 +364,7 @@ public class CsvFormatReaderTests extends ESTestCase {
         String csv = "id:long,ts:datetime\n1,1953-09-02T00:00:00.000Z\n2,2021-01-01T00:00:00Z\n";
 
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -364,7 +380,7 @@ public class CsvFormatReaderTests extends ESTestCase {
         String csv = "id:long,ts:datetime\n1," + epochMillis + "\n2,1953-09-02T00:00:00.000Z\n";
 
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -383,7 +399,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             """;
 
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         List<Attribute> schema = reader.schema(object);
 
@@ -403,7 +419,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             """;
 
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -437,7 +453,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             """;
 
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         List<Attribute> schema = reader.schema(object);
 
@@ -452,7 +468,7 @@ public class CsvFormatReaderTests extends ESTestCase {
         String csv = "pkg:keyword,ver:v\nlucene,9.10.0\n";
 
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         List<Attribute> schema = reader.schema(object);
 
@@ -468,7 +484,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             """;
 
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -510,7 +526,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT_COLUMN_PREFIX
         );
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
+        CsvFormatReader reader = newReader().withOptions(options);
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -533,7 +549,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             """;
 
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         List<Attribute> schema = reader.schema(object);
 
@@ -548,7 +564,7 @@ public class CsvFormatReaderTests extends ESTestCase {
         String csv = "event:keyword,ts:dn\nlogin,2024-01-15T12:34:56.123456789Z\n";
 
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         List<Attribute> schema = reader.schema(object);
 
@@ -564,7 +580,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             """;
 
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -589,7 +605,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             bad,not-a-date
             """;
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
         ErrorPolicy permissive = new ErrorPolicy(ErrorPolicy.Mode.NULL_FIELD, 100, 0.0, false);
 
         try (
@@ -610,14 +626,14 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testUnsupportedType() {
         String csv = "id:unsupported_type\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         EsqlIllegalArgumentException e = expectThrows(EsqlIllegalArgumentException.class, () -> reader.schema(object));
         assertTrue(e.getMessage().contains("illegal data type"));
     }
 
     public void testDefaultErrorPolicyIsStrict() {
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
         assertEquals(ErrorPolicy.STRICT, reader.defaultErrorPolicy());
         assertTrue(reader.defaultErrorPolicy().isStrict());
     }
@@ -631,7 +647,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             """;
 
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         ParsingException e = expectThrows(ParsingException.class, () -> {
             try (
@@ -662,7 +678,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             """;
 
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
         ErrorPolicy lenient = new ErrorPolicy(10, true);
 
         try (
@@ -690,7 +706,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             """;
 
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
         ErrorPolicy limited = new ErrorPolicy(2, false);
 
         ParsingException e = expectThrows(ParsingException.class, () -> {
@@ -718,7 +734,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             """;
 
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
         ErrorPolicy lenient = new ErrorPolicy(10, true);
 
         try (
@@ -743,7 +759,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             """;
 
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
         ErrorPolicy lenient = new ErrorPolicy(100, true);
 
         try (
@@ -764,7 +780,7 @@ public class CsvFormatReaderTests extends ESTestCase {
         }
 
         StorageObject object = createStorageObject(csv.toString());
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
         ErrorPolicy lenient = new ErrorPolicy(100, false);
 
         int totalRows = 0;
@@ -790,7 +806,7 @@ public class CsvFormatReaderTests extends ESTestCase {
         }
 
         StorageObject object = createStorageObject(csv.toString());
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
         ErrorPolicy ratioPolicy = new ErrorPolicy(Long.MAX_VALUE, 0.3, true);
 
         ParsingException e = expectThrows(ParsingException.class, () -> {
@@ -820,7 +836,7 @@ public class CsvFormatReaderTests extends ESTestCase {
         }
 
         StorageObject object = createStorageObject(csv.toString());
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
         ErrorPolicy ratioPolicy = new ErrorPolicy(Long.MAX_VALUE, 0.1, false);
 
         int totalRows = 0;
@@ -843,7 +859,7 @@ public class CsvFormatReaderTests extends ESTestCase {
         String csv = "id:long,data:keyword\n1,\"value;with;semicolons\"\n2,normal\n";
 
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -857,7 +873,7 @@ public class CsvFormatReaderTests extends ESTestCase {
         String csv = "id:long,data:keyword\n1,\"col1|col2|col3\"\n2,simple\n";
 
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -873,7 +889,7 @@ public class CsvFormatReaderTests extends ESTestCase {
         String csv = "id:long,name:keyword\n1,\"Smith, John\"\n2,\"Doe, Jane\"\n";
 
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -888,7 +904,7 @@ public class CsvFormatReaderTests extends ESTestCase {
         String csv = "id:long,description:keyword\n1,\"line1\nline2\"\n2,\"simple\"\n";
 
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -902,7 +918,7 @@ public class CsvFormatReaderTests extends ESTestCase {
         String csv = "id:long,name:keyword\n1,\"She said \\\"hello\\\"\"\n2,normal\n";
 
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -917,7 +933,7 @@ public class CsvFormatReaderTests extends ESTestCase {
         String csv = "id:long,name:keyword,score:double\n1,,95.5\n2,Bob,\n";
 
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -932,7 +948,7 @@ public class CsvFormatReaderTests extends ESTestCase {
         String csv = "id:long,name:keyword\n1,null\n2,Bob\n";
 
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -949,7 +965,7 @@ public class CsvFormatReaderTests extends ESTestCase {
         String csv = "id:long,name:keyword,score:double\n1,Alice\n2,Bob,87.3\n";
 
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -966,7 +982,7 @@ public class CsvFormatReaderTests extends ESTestCase {
         String csv = "id:long,name:keyword\n 1 , Alice \n 2 , Bob \n";
 
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -984,7 +1000,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             + "42,9999999999,3.14,hello,world,true,2021-01-01T00:00:00Z,\n";
 
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -1001,7 +1017,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             + "1,2,3.0,kw,str,text,false,2021-01-01T00:00:00Z,2021-01-01T00:00:00Z,\n";
 
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -1015,7 +1031,7 @@ public class CsvFormatReaderTests extends ESTestCase {
 
     public void testEmptyFile() throws IOException {
         StorageObject object = createStorageObject("");
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertFalse(iterator.hasNext());
@@ -1025,7 +1041,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testSchemaOnlyNoData() throws IOException {
         String csv = "id:long,name:keyword\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertFalse(iterator.hasNext());
@@ -1046,7 +1062,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             """;
 
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
         ErrorPolicy lenient = new ErrorPolicy(100, true);
 
         int totalRows = 0;
@@ -1075,7 +1091,7 @@ public class CsvFormatReaderTests extends ESTestCase {
         }
 
         StorageObject object = createStorageObject(csv.toString());
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
         ErrorPolicy lenient = new ErrorPolicy(100, false);
 
         int totalRows = 0;
@@ -1094,7 +1110,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testTsvPreset() throws IOException {
         String tsv = "id:long\tname:keyword\tvalue:integer\n1\tAlice\t100\n2\tBob\t200\n";
         StorageObject object = createStorageObject(tsv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(CsvFormatOptions.TSV);
+        CsvFormatReader reader = newReader().withOptions(CsvFormatOptions.TSV);
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -1126,7 +1142,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT_COLUMN_PREFIX
         );
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
+        CsvFormatReader reader = newReader().withOptions(options);
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -1154,7 +1170,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT_COLUMN_PREFIX
         );
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
+        CsvFormatReader reader = newReader().withOptions(options);
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -1198,7 +1214,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT_COLUMN_PREFIX
         );
         StorageObject object = createStorageObject(schema.append(data).toString());
-        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
+        CsvFormatReader reader = newReader().withOptions(options);
 
         int totalRows = 0;
         try (CloseableIterator<Page> iterator = reader.read(object, null, between(2, 10))) {
@@ -1232,7 +1248,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT_COLUMN_PREFIX
         );
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
+        CsvFormatReader reader = newReader().withOptions(options);
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -1259,7 +1275,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT_COLUMN_PREFIX
         );
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
+        CsvFormatReader reader = newReader().withOptions(options);
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -1286,7 +1302,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT_COLUMN_PREFIX
         );
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
+        CsvFormatReader reader = newReader().withOptions(options);
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -1322,7 +1338,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT_COLUMN_PREFIX
         );
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
+        CsvFormatReader reader = newReader().withOptions(options);
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -1356,7 +1372,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT_COLUMN_PREFIX
         );
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
+        CsvFormatReader reader = newReader().withOptions(options);
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -1385,7 +1401,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT_COLUMN_PREFIX
         );
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
+        CsvFormatReader reader = newReader().withOptions(options);
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -1412,7 +1428,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT_COLUMN_PREFIX
         );
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
+        CsvFormatReader reader = newReader().withOptions(options);
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -1434,7 +1450,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             """;
 
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
         ErrorPolicy permissive = new ErrorPolicy(ErrorPolicy.Mode.NULL_FIELD, 100, 0.0, false);
 
         try (
@@ -1467,7 +1483,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             """;
 
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
         ErrorPolicy permissive = new ErrorPolicy(ErrorPolicy.Mode.NULL_FIELD, 100, 0.0, false);
 
         try (
@@ -1495,7 +1511,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             """;
 
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
         ErrorPolicy permissive = new ErrorPolicy(ErrorPolicy.Mode.NULL_FIELD, 1, 0.0, false);
 
         ParsingException e = expectThrows(ParsingException.class, () -> {
@@ -1523,7 +1539,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             """;
 
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
         ErrorPolicy permissive = new ErrorPolicy(ErrorPolicy.Mode.NULL_FIELD, 100, 0.0, false);
 
         try (
@@ -1568,7 +1584,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT_COLUMN_PREFIX
         );
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
+        CsvFormatReader reader = newReader().withOptions(options);
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -1584,7 +1600,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testWithConfigDelimiter() throws IOException {
         String csv = "id:long|name:keyword\n1|Alice\n2|Bob\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader baseReader = new CsvFormatReader(blockFactory);
+        CsvFormatReader baseReader = newReader();
         FormatReader configured = baseReader.withConfig(Map.of("delimiter", "|"));
 
         try (CloseableIterator<Page> iterator = configured.read(object, null, 10)) {
@@ -1599,8 +1615,13 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testTsvWithConfigHeaderRowFalseKeepsTabDelimiter() throws IOException {
         String tsv = "a\tb\tc\n1\t2\t3\n";
         StorageObject object = createStorageObject(tsv);
-        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory, CsvFormatOptions.TSV, "tsv", List.of(".tsv"))
-            .withConfig(Map.of("header_row", false));
+        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(
+            blockFactory,
+            CsvFormatOptions.TSV,
+            "tsv",
+            List.of(".tsv"),
+            scannerImpl()
+        ).withConfig(Map.of("header_row", false));
 
         List<Attribute> schema = reader.schema(object);
         assertEquals(3, schema.size());
@@ -1616,7 +1637,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testCsvWithConfigHeaderRowFalseKeepsCommaDelimiter() throws IOException {
         String csv = "10,20\n30,40\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(Map.of("header_row", false));
+        CsvFormatReader reader = (CsvFormatReader) newReader().withConfig(Map.of("header_row", false));
 
         List<Attribute> schema = reader.schema(object);
         assertEquals(2, schema.size());
@@ -1641,7 +1662,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             "9110818468285196903","1","baz"
             """;
         StorageObject object = createStorageObject(csv);
-        var reader = new CsvFormatReader(blockFactory).withConfig(Map.of("header_row", false));
+        var reader = newReader().withConfig(Map.of("header_row", false));
 
         int rowCount = 0;
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
@@ -1657,7 +1678,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testWithConfigMultipleOptions() throws IOException {
         String csv = "id:long;name:keyword\n1;N/A\n2;Bob\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader baseReader = new CsvFormatReader(blockFactory);
+        CsvFormatReader baseReader = newReader();
         FormatReader configured = baseReader.withConfig(Map.of("delimiter", ";", "null_value", "N/A", "comment", "#"));
 
         try (CloseableIterator<Page> iterator = configured.read(object, null, 10)) {
@@ -1670,13 +1691,13 @@ public class CsvFormatReaderTests extends ESTestCase {
     }
 
     public void testWithConfigEmptyReturnsSameReader() {
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
         FormatReader result = reader.withConfig(Map.of());
         assertSame(reader, result);
     }
 
     public void testWithConfigNullReturnsSameReader() {
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
         FormatReader result = reader.withConfig(null);
         assertSame(reader, result);
     }
@@ -1684,7 +1705,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testWithConfigMultiValueSyntax() throws IOException {
         String csv = "id:integer,values:integer\n1,\"[1,2,3]\"\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader baseReader = new CsvFormatReader(blockFactory);
+        CsvFormatReader baseReader = newReader();
         FormatReader configured = baseReader.withConfig(Map.of("multi_value_syntax", "brackets"));
 
         try (CloseableIterator<Page> iterator = configured.read(object, null, 10)) {
@@ -1702,7 +1723,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testWithConfigMultiValueSyntaxNone() {
         String csv = "id:integer,values:integer\n1,\"[1,2]\"\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader baseReader = new CsvFormatReader(blockFactory);
+        CsvFormatReader baseReader = newReader();
         FormatReader configured = baseReader.withConfig(Map.of("multi_value_syntax", "none"));
 
         ParsingException e = expectThrows(ParsingException.class, () -> {
@@ -1722,7 +1743,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             csv.append(i).append(",text_").append(i).append("\n");
         }
         StorageObject object = createStorageObject(csv.toString());
-        CsvFormatReader baseReader = new CsvFormatReader(blockFactory);
+        CsvFormatReader baseReader = newReader();
         FormatReader configured = baseReader.withConfig(Map.of("schema_sample_size", "50"));
         try (CloseableIterator<Page> iterator = configured.read(object, null, 1000)) {
             assertTrue(iterator.hasNext());
@@ -1732,17 +1753,17 @@ public class CsvFormatReaderTests extends ESTestCase {
     }
 
     public void testWithConfigSchemaSampleSizeZeroIsRejected() {
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
         expectThrows(QlIllegalArgumentException.class, () -> reader.withConfig(Map.of("schema_sample_size", "0")));
     }
 
     public void testWithConfigSchemaSampleSizeNegativeIsRejected() {
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
         expectThrows(QlIllegalArgumentException.class, () -> reader.withConfig(Map.of("schema_sample_size", "-1")));
     }
 
     public void testWithConfigSchemaSampleSizeInvalidIsRejected() {
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
         expectThrows(IllegalArgumentException.class, () -> reader.withConfig(Map.of("schema_sample_size", "abc")));
     }
 
@@ -1764,7 +1785,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT_COLUMN_PREFIX
         );
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
+        CsvFormatReader reader = newReader().withOptions(options);
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -1797,7 +1818,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT_COLUMN_PREFIX
         );
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
+        CsvFormatReader reader = newReader().withOptions(options);
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -1827,7 +1848,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT_COLUMN_PREFIX
         );
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
+        CsvFormatReader reader = newReader().withOptions(options);
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -1858,7 +1879,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT_COLUMN_PREFIX
         );
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
+        CsvFormatReader reader = newReader().withOptions(options);
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -1887,7 +1908,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT_COLUMN_PREFIX
         );
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
+        CsvFormatReader reader = newReader().withOptions(options);
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -1916,7 +1937,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT_COLUMN_PREFIX
         );
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
+        CsvFormatReader reader = newReader().withOptions(options);
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -1944,7 +1965,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT_COLUMN_PREFIX
         );
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
+        CsvFormatReader reader = newReader().withOptions(options);
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -1972,7 +1993,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT_COLUMN_PREFIX
         );
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
+        CsvFormatReader reader = newReader().withOptions(options);
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -1992,7 +2013,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testEscapedDelimiterInLine() throws IOException {
         String csv = "id:long,data:keyword\n1,a\\,b\n2,normal\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -2011,7 +2032,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testEscapedDelimiterInQuotedField() throws IOException {
         String csv = "id:long,data:keyword\n1,\"a\\,b\"\n2,normal\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -2038,7 +2059,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT_COLUMN_PREFIX
         );
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
+        CsvFormatReader reader = newReader().withOptions(options);
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -2054,7 +2075,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testMultiValueEnabledByDefault() throws IOException {
         String csv = "id:integer,values:integer\n1,\"[1,2]\"\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -2083,7 +2104,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             true,
             CsvFormatOptions.DEFAULT_COLUMN_PREFIX
         );
-        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
+        CsvFormatReader reader = newReader().withOptions(options);
 
         ParsingException e = expectThrows(ParsingException.class, () -> {
             try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
@@ -2098,7 +2119,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testMultiValueBracketsQuotedStrings() throws IOException {
         String csv = "id:integer,names:keyword\n1,\"[\"\"foo\"\",\"\"bar\"\"]\"\n2,\"[\"\"hello world\"\",\"\"test\"\"]\"\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -2121,7 +2142,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testEmployeesCsvWithMultiValues() throws IOException {
         String csv = new String(CsvTestsDataLoader.getResourceStream("/data/employees.csv").readAllBytes(), StandardCharsets.UTF_8);
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         List<Attribute> schema = reader.schema(object);
         assertEquals(23, schema.size());
@@ -2144,7 +2165,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testMultiValueBracketsInMultiColumnRow() throws IOException {
         String csv = "prefix:keyword,tags:keyword,suffix:keyword\nx,[hello,world],y\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -2168,7 +2189,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testBracketAwareOpenBracketWithoutMvcCloseIsLiteralColumnSplit() throws IOException {
         String csv = "id:integer,title:keyword,dt:keyword\n1,[6:42) literal title text,2013-07-20\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -2189,7 +2210,7 @@ public class CsvFormatReaderTests extends ESTestCase {
      */
     public void testMetadataSchemaColumnCountUsesBracketAwareHeaderSplit() throws IOException {
         String csv = "id:integer,title:keyword\n1,[[37]]\n2,[hello,world]\n";
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
         assertEquals(2, reader.metadata(createStorageObject(csv)).schema().size());
         try (CloseableIterator<Page> iterator = reader.read(createStorageObject(csv), null, 10)) {
             int rows = 0;
@@ -2207,7 +2228,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testBracketAwareNestedBracketsStaySingleCell() throws IOException {
         String csv = "prefix:keyword,mid:keyword,suffix:keyword\nx,[[37]],y\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -2225,7 +2246,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testMultiValueBracketsQuotedElements() throws IOException {
         String csv = "id:integer,names:keyword\n1,\"[\"\"hello\"\",\"\"world\"\"]\"\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -2241,7 +2262,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testMultiValueBracketsMixedQuotedUnquoted() throws IOException {
         String csv = "id:integer,data:keyword\n1,\"[hello,\"\"world,world\"\"]\"\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -2257,7 +2278,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testMultiValueBracketsQuotedWithEscapedQuote() throws IOException {
         String csv = "id:integer,data:keyword\n1,\"[\"\"say \"\"\"\"hi\"\"\"\"\"\"]\"\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -2272,7 +2293,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testMultiValueBracketsLong() throws IOException {
         String csv = "id:integer,values:long\n1,\"[100000000000,200000000000]\"\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -2301,7 +2322,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT_COLUMN_PREFIX
         );
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
+        CsvFormatReader reader = newReader().withOptions(options);
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -2334,7 +2355,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT_COLUMN_PREFIX
         );
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
+        CsvFormatReader reader = newReader().withOptions(options);
         ErrorPolicy permissive = new ErrorPolicy(ErrorPolicy.Mode.NULL_FIELD, 100, 0.0, false);
 
         try (
@@ -2368,7 +2389,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT_COLUMN_PREFIX
         );
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
+        CsvFormatReader reader = newReader().withOptions(options);
         ErrorPolicy skipRow = new ErrorPolicy(10, true);
 
         try (
@@ -2419,7 +2440,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT_COLUMN_PREFIX
         );
         StorageObject object = createStorageObject(schema.append(data).toString());
-        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
+        CsvFormatReader reader = newReader().withOptions(options);
 
         int totalRows = 0;
         try (CloseableIterator<Page> iterator = reader.read(object, null, batchSize)) {
@@ -2448,7 +2469,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             }
         }
         StorageObject object = createStorageObject(csv.toString());
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
         ErrorPolicy dropMalformed = new ErrorPolicy(numBad + 10, false);
 
         int totalRows = 0;
@@ -2477,7 +2498,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             }
         }
         StorageObject object = createStorageObject(csv.toString());
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
         ErrorPolicy permissive = new ErrorPolicy(ErrorPolicy.Mode.NULL_FIELD, 100, 0.0, false);
 
         int totalRows = 0;
@@ -2506,20 +2527,20 @@ public class CsvFormatReaderTests extends ESTestCase {
     // --- findNextRecordBoundary tests ---
 
     public void testFindNextRecordBoundarySimpleNewline() throws IOException {
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
         byte[] data = "field1,field2\n".getBytes(StandardCharsets.UTF_8);
         assertEquals(data.length, reader.findNextRecordBoundary(new ByteArrayInputStream(data)));
     }
 
     public void testFindNextRecordBoundaryCRLF() throws IOException {
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
         byte[] data = "field1,field2\r\n".getBytes(StandardCharsets.UTF_8);
         long boundary = reader.findNextRecordBoundary(new ByteArrayInputStream(data));
         assertEquals("field1,field2\r\n".indexOf('\n') + 1, boundary);
     }
 
     public void testFindNextRecordBoundaryNewlineInsideQuotes() throws IOException {
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
         byte[] data = "\"field\nwith\nnewlines\",other\nreal_boundary\n".getBytes(StandardCharsets.UTF_8);
         long boundary = reader.findNextRecordBoundary(new ByteArrayInputStream(data));
         int expected = "\"field\nwith\nnewlines\",other\n".length();
@@ -2527,7 +2548,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     }
 
     public void testFindNextRecordBoundaryEscapedQuotes() throws IOException {
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
         byte[] data = "\"value with \"\"escaped\"\" quotes\"\nrest\n".getBytes(StandardCharsets.UTF_8);
         long boundary = reader.findNextRecordBoundary(new ByteArrayInputStream(data));
         int expected = "\"value with \"\"escaped\"\" quotes\"\n".length();
@@ -2535,18 +2556,18 @@ public class CsvFormatReaderTests extends ESTestCase {
     }
 
     public void testFindNextRecordBoundaryEofNoNewline() throws IOException {
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
         byte[] data = "field1,field2".getBytes(StandardCharsets.UTF_8);
         assertEquals(-1, reader.findNextRecordBoundary(new ByteArrayInputStream(data)));
     }
 
     public void testFindNextRecordBoundaryEmptyStream() throws IOException {
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
         assertEquals(-1, reader.findNextRecordBoundary(new ByteArrayInputStream(new byte[0])));
     }
 
     public void testFindNextRecordBoundaryQuotedNewlineAcrossSplitBoundary() throws IOException {
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
         // Simulate a split boundary landing inside a quoted field with embedded newlines.
         // The boundary finder must skip past the quoted field to find the real record boundary.
         byte[] data = "partial,\"quoted\nfield\nwith\nnewlines\",end\nnext_record,b,c\n".getBytes(StandardCharsets.UTF_8);
@@ -2561,7 +2582,7 @@ public class CsvFormatReaderTests extends ESTestCase {
         // turns the trailing text into a phantom extra column → "row has [N+1] columns" failures.
         String csv = "id:long,text:keyword,when:keyword\n1,[37] Title with text,2013-07-29\n2,plain,2013-07-30\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -2587,7 +2608,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             + "1,[some text\",1,2013-07-15 13:51:28,2013-07-15,38,177794517],ok\n"
             + "2,[plain],ok\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -2607,7 +2628,7 @@ public class CsvFormatReaderTests extends ESTestCase {
         // open quote, glue the second row's bytes onto it, and report 6 columns instead of 3.
         String csv = "id:long,title:keyword,value:long\n1,Inch \" mark,42\n2,plain,7\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -2624,7 +2645,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     }
 
     public void testFindNextRecordBoundaryStrayQuoteIsNotAQuoteOpener() throws IOException {
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
         // Stray `"` inside an unquoted cell must not switch the scanner into quote mode; otherwise the
         // first `\n` is skipped and the segment boundary lands far past the next record.
         byte[] data = "1,Inch \" mark,42\n2,plain,7\n".getBytes(StandardCharsets.UTF_8);
@@ -2633,21 +2654,21 @@ public class CsvFormatReaderTests extends ESTestCase {
     }
 
     public void testFindNextRecordBoundaryNewlineInsideBracketMvc() throws IOException {
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
         byte[] data = "before,[line1\nline2\nline3],after\nnext\n".getBytes(StandardCharsets.UTF_8);
         long boundary = reader.findNextRecordBoundary(new ByteArrayInputStream(data));
         assertEquals("before,[line1\nline2\nline3],after\n".length(), boundary);
     }
 
     public void testFindNextRecordBoundaryNestedBracketMvcWithEmbeddedNewlines() throws IOException {
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
         byte[] data = "a,[[cell\ninner]],b\nz\n".getBytes(StandardCharsets.UTF_8);
         long boundary = reader.findNextRecordBoundary(new ByteArrayInputStream(data));
         assertEquals("a,[[cell\ninner]],b\n".length(), boundary);
     }
 
     public void testFindNextRecordBoundaryMultiValueSyntaxNoneDoesNotTreatBracketsAsMvc() throws IOException {
-        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(Map.of("multi_value_syntax", "none"));
+        CsvFormatReader reader = (CsvFormatReader) newReader().withConfig(Map.of("multi_value_syntax", "none"));
         byte[] data = "before,[not\nmvc],after\nnext\n".getBytes(StandardCharsets.UTF_8);
         long boundary = reader.findNextRecordBoundary(new ByteArrayInputStream(data));
         assertEquals("before,[not\n".length(), boundary);
@@ -2656,33 +2677,33 @@ public class CsvFormatReaderTests extends ESTestCase {
     // --- findLastRecordBoundary tests ---
 
     public void testFindLastRecordBoundarySimpleTwoLines() throws IOException {
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
         byte[] data = "a,b\nc,d\n".getBytes(StandardCharsets.UTF_8);
         int boundary = reader.findLastRecordBoundary(data, data.length);
         assertEquals(data.length - 1, boundary);
     }
 
     public void testFindLastRecordBoundarySingleTrailingLineNoTerminator() throws IOException {
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
         byte[] data = "a,b\nc,d".getBytes(StandardCharsets.UTF_8);
         int boundary = reader.findLastRecordBoundary(data, data.length);
         assertEquals(3, boundary);
     }
 
     public void testFindLastRecordBoundaryEmpty() throws IOException {
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
         assertEquals(-1, reader.findLastRecordBoundary(new byte[0], 0));
     }
 
     public void testFindLastRecordBoundaryAllInsideQuotedField() throws IOException {
         // Unterminated quoted cell: no boundary; caller must grow.
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
         byte[] data = "\"line one\nline two\nline three\n".getBytes(StandardCharsets.UTF_8);
         assertEquals(-1, reader.findLastRecordBoundary(data, data.length));
     }
 
     public void testFindLastRecordBoundarySkipsEmbeddedNewlineInQuotedField() throws IOException {
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
         byte[] data = "\"row1\nwith\nembedded\",a\nrow2,b\n".getBytes(StandardCharsets.UTF_8);
         int boundary = reader.findLastRecordBoundary(data, data.length);
         assertEquals(data.length - 1, boundary);
@@ -2690,7 +2711,7 @@ public class CsvFormatReaderTests extends ESTestCase {
 
     public void testFindLastRecordBoundaryEmbeddedNewlineFollowedByUnterminatedTail() throws IOException {
         // Complete row, then an unterminated quoted field whose closing quote is in the next chunk.
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
         byte[] data = "row1,a\n\"row2 starts here\nstill inside quote".getBytes(StandardCharsets.UTF_8);
         int boundary = reader.findLastRecordBoundary(data, data.length);
         assertEquals("row1,a\n".length() - 1, boundary);
@@ -2698,14 +2719,14 @@ public class CsvFormatReaderTests extends ESTestCase {
 
     public void testFindLastRecordBoundaryRespectsBracketMvc() throws IOException {
         // Embedded \n inside [..] must not be a boundary.
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
         byte[] data = "a,[v1\nv2\nv3],b\nrow2,plain,c\n".getBytes(StandardCharsets.UTF_8);
         int boundary = reader.findLastRecordBoundary(data, data.length);
         assertEquals(data.length - 1, boundary);
     }
 
     public void testFindLastRecordBoundaryLengthSubsetOfBuffer() throws IOException {
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
         byte[] body = "a,b\nc,d\n".getBytes(StandardCharsets.UTF_8);
         byte[] padded = new byte[body.length + 64];
         System.arraycopy(body, 0, padded, 0, body.length);
@@ -2715,7 +2736,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     }
 
     public void testFindLastRecordBoundaryCRLF() throws IOException {
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
         byte[] data = "a,b\r\nc,d\r\n".getBytes(StandardCharsets.UTF_8);
         int boundary = reader.findLastRecordBoundary(data, data.length);
         assertEquals(data.length - 1, boundary);
@@ -2724,7 +2745,7 @@ public class CsvFormatReaderTests extends ESTestCase {
 
     public void testFindLastRecordBoundaryDoubledQuoteEscape() throws IOException {
         // RFC 4180: "" is a literal quote inside a quoted field, not close-then-reopen.
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
         byte[] data = "\"value with \"\"escaped\"\" quotes\"\nrest\n".getBytes(StandardCharsets.UTF_8);
         int boundary = reader.findLastRecordBoundary(data, data.length);
         assertEquals(data.length - 1, boundary);
@@ -2733,12 +2754,12 @@ public class CsvFormatReaderTests extends ESTestCase {
 
     // --- findLastRecordBoundary tests for the QuotedFieldsOnly override path (TSV / non-bracket-MVC CSV) ---
 
-    private static CsvFormatReader tsvReader(BlockFactory bf) {
-        return (CsvFormatReader) new CsvFormatReader(bf).withConfig(Map.of("delimiter", "\t"));
+    private CsvFormatReader tsvReader(BlockFactory bf) {
+        return (CsvFormatReader) new CsvFormatReader(bf, scannerImpl()).withConfig(Map.of("delimiter", "\t"));
     }
 
-    private static CsvFormatReader noMvcReader(BlockFactory bf) {
-        return (CsvFormatReader) new CsvFormatReader(bf).withConfig(Map.of("multi_value_syntax", "none"));
+    private CsvFormatReader noMvcReader(BlockFactory bf) {
+        return (CsvFormatReader) new CsvFormatReader(bf, scannerImpl()).withConfig(Map.of("multi_value_syntax", "none"));
     }
 
     public void testFindLastRecordBoundaryQuotedFieldsOnlyTsvSimpleTwoLines() throws IOException {
@@ -3116,7 +3137,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testBracketAwareLeadingWhitespaceBeforeBracketOpensMvc() throws IOException {
         String csv = "prefix:keyword,mid:keyword,suffix:keyword\nx,  [[37]],y\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
             Page page = iterator.next();
@@ -3129,7 +3150,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     }
 
     public void testFindNextRecordBoundaryAtBufferBoundary() throws IOException {
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
         byte[] padding = new byte[8191];
         Arrays.fill(padding, (byte) 'x');
         byte[] suffix = "\nmore\n".getBytes(StandardCharsets.UTF_8);
@@ -3141,7 +3162,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     }
 
     public void testFindNextRecordBoundaryQuoteAtBufferEdge() throws IOException {
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
         byte[] padding = new byte[8191];
         Arrays.fill(padding, (byte) 'a');
         padding[0] = (byte) '"';
@@ -3166,7 +3187,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             """;
 
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
         ErrorPolicy lenient = new ErrorPolicy(100, true);
 
         try (
@@ -3193,7 +3214,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             """;
 
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
         ErrorPolicy permissive = new ErrorPolicy(ErrorPolicy.Mode.NULL_FIELD, 100, 0.0, false);
 
         try (
@@ -3222,7 +3243,7 @@ public class CsvFormatReaderTests extends ESTestCase {
         }
 
         StorageObject object = createStorageObject(csv.toString());
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
         ErrorPolicy lenient = new ErrorPolicy(100, false);
 
         try (
@@ -3260,7 +3281,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testBooleanCapitalizedTrue() throws IOException {
         String csv = "active:boolean\nTrue\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -3273,7 +3294,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testBooleanUpperCase() throws IOException {
         String csv = "active:boolean\nTRUE\nFALSE\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -3287,7 +3308,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testBooleanMixedCase() throws IOException {
         String csv = "active:boolean\ntrue\nFalse\nTRUE\nfalse\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -3305,7 +3326,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testDatetimeDateOnly() throws IOException {
         String csv = "ts:datetime\n2021-01-01\n2022-06-15\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -3319,7 +3340,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testDatetimeZoneless() throws IOException {
         String csv = "ts:datetime\n2021-01-01T10:30:00\n2022-06-15T08:00:00\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -3333,7 +3354,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testDatetimeWhitespaceSeparator() throws IOException {
         String csv = "ts:datetime\n2021-01-01 10:30:00\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -3347,7 +3368,7 @@ public class CsvFormatReaderTests extends ESTestCase {
         long epoch = 1609459200000L;
         String csv = "ts:datetime\n" + epoch + "\n2021-01-01T00:00:00Z\n2021-06-15\n2022-03-01T12:00:00\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -3365,7 +3386,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testFloatAlias() throws IOException {
         String csv = "val:float\n3.14\n2.71\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         List<Attribute> schema = reader.schema(object);
         assertEquals(1, schema.size());
@@ -3382,7 +3403,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testShortAlias() throws IOException {
         String csv = "val:short\n42\n-7\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         List<Attribute> schema = reader.schema(object);
         assertEquals(1, schema.size());
@@ -3399,7 +3420,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testByteAlias() throws IOException {
         String csv = "val:byte\n1\n2\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         List<Attribute> schema = reader.schema(object);
         assertEquals(1, schema.size());
@@ -3409,7 +3430,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testHalfFloatAlias() throws IOException {
         String csv = "val:half_float\n1.5\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         List<Attribute> schema = reader.schema(object);
         assertEquals(1, schema.size());
@@ -3419,7 +3440,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testScaledFloatAlias() throws IOException {
         String csv = "val:scaled_float\n99.99\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         List<Attribute> schema = reader.schema(object);
         assertEquals(1, schema.size());
@@ -3429,7 +3450,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testFloatShorthandAlias() throws IOException {
         String csv = "val:f\n1.0\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         List<Attribute> schema = reader.schema(object);
         assertEquals(DataType.DOUBLE, schema.get(0).dataType());
@@ -3440,7 +3461,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testPlainHeaderInfersKeyword() throws IOException {
         String csv = "name,city\nAlice,London\nBob,Paris\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         List<Attribute> schema = reader.schema(object);
         assertEquals(2, schema.size());
@@ -3453,7 +3474,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testPlainHeaderInfersInteger() throws IOException {
         String csv = "name,age\nAlice,30\nBob,25\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         List<Attribute> schema = reader.schema(object);
         assertEquals(2, schema.size());
@@ -3464,7 +3485,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testPlainHeaderInfersMultipleTypes() throws IOException {
         String csv = "name,age,score,active,created\nAlice,30,95.5,true,2021-01-01T00:00:00Z\nBob,25,87.3,false,2022-06-15T12:00:00Z\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         List<Attribute> schema = reader.schema(object);
         assertEquals(5, schema.size());
@@ -3478,7 +3499,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testPlainHeaderReadsData() throws IOException {
         String csv = "name,age,active\nAlice,30,true\nBob,25,false\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -3497,7 +3518,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testPlainHeaderWithNulls() throws IOException {
         String csv = "name,age\nAlice,30\nBob,\nCharlie,25\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         List<Attribute> schema = reader.schema(object);
         assertEquals(DataType.INTEGER, schema.get(1).dataType());
@@ -3515,7 +3536,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testPlainHeaderWidensIntegerToLong() throws IOException {
         String csv = "id,big_number\n1,9999999999\n2,42\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         List<Attribute> schema = reader.schema(object);
         assertEquals(DataType.INTEGER, schema.get(0).dataType());
@@ -3525,7 +3546,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testPlainHeaderWidensIntegerToDouble() throws IOException {
         String csv = "id,value\n1,3.14\n2,42\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         List<Attribute> schema = reader.schema(object);
         assertEquals(DataType.DOUBLE, schema.get(1).dataType());
@@ -3534,7 +3555,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testPlainHeaderBooleanSkipsToKeyword() throws IOException {
         String csv = "flag\ntrue\nnot_a_bool\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         List<Attribute> schema = reader.schema(object);
         assertEquals(DataType.KEYWORD, schema.get(0).dataType());
@@ -3543,7 +3564,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testPlainHeaderDatetimeSkipsToKeyword() throws IOException {
         String csv = "ts\n2021-01-01T00:00:00Z\nnot_a_date\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         List<Attribute> schema = reader.schema(object);
         assertEquals(DataType.KEYWORD, schema.get(0).dataType());
@@ -3552,7 +3573,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testPlainHeaderAllNullsInferKeyword() throws IOException {
         String csv = "col\nnull\n\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         List<Attribute> schema = reader.schema(object);
         assertEquals(DataType.KEYWORD, schema.get(0).dataType());
@@ -3561,7 +3582,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testPlainHeaderSmallFile() throws IOException {
         String csv = "x\n42\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         List<Attribute> schema = reader.schema(object);
         assertEquals(DataType.INTEGER, schema.get(0).dataType());
@@ -3577,7 +3598,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testPlainHeaderProjectedColumns() throws IOException {
         String csv = "name,age,active\nAlice,30,true\nBob,25,false\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         try (CloseableIterator<Page> iterator = reader.read(object, List.of("age", "active"), 10)) {
             assertTrue(iterator.hasNext());
@@ -3595,7 +3616,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             csv.append(i).append(",").append(i * 10).append("\n");
         }
         StorageObject object = createStorageObject(csv.toString());
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         List<Attribute> schema = reader.schema(object);
         assertEquals(DataType.INTEGER, schema.get(0).dataType());
@@ -3613,7 +3634,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testPlainHeaderDateOnlyInference() throws IOException {
         String csv = "event,when\nlaunch,2021-01-01\nrelease,2022-06-15\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         List<Attribute> schema = reader.schema(object);
         assertEquals(DataType.KEYWORD, schema.get(0).dataType());
@@ -3623,7 +3644,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testPlainHeaderCaseInsensitiveBooleanInference() throws IOException {
         String csv = "flag\nTrue\nFalse\nTRUE\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         List<Attribute> schema = reader.schema(object);
         assertEquals(DataType.BOOLEAN, schema.get(0).dataType());
@@ -3636,7 +3657,7 @@ public class CsvFormatReaderTests extends ESTestCase {
         String csv = "9110818468285196899,0,\"\",1,2013-07-14T20:38:47Z,42.5,true\n"
             + "9110818468285196900,0,\"\",0,2013-07-14T20:38:48Z,17.0,false\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(Map.of("header_row", false));
+        CsvFormatReader reader = (CsvFormatReader) newReader().withConfig(Map.of("header_row", false));
 
         List<Attribute> schema = reader.schema(object);
 
@@ -3657,9 +3678,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testTsvFirstRowWithDatetimeFallsToInferenceNotTypedSchema() throws IOException {
         String tsv = "2021-01-01T00:00:00Z\t42\n2021-01-01T00:00:01Z\t43\n";
         StorageObject object = createStorageObject(tsv);
-        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(
-            Map.of("delimiter", "\t", "header_row", false)
-        );
+        CsvFormatReader reader = (CsvFormatReader) newReader().withConfig(Map.of("delimiter", "\t", "header_row", false));
 
         List<Attribute> schema = reader.schema(object);
         assertEquals(2, schema.size());
@@ -3675,9 +3694,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             1234567890\t0\tWorld\t2013-07-15 10:47:34\t15901
             """;
         StorageObject object = createStorageObject(tsv);
-        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(
-            Map.of("delimiter", "\t", "header_row", false)
-        );
+        CsvFormatReader reader = (CsvFormatReader) newReader().withConfig(Map.of("delimiter", "\t", "header_row", false));
 
         List<Attribute> schema = reader.schema(object);
 
@@ -3697,9 +3714,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testHeaderlessSchemaUsesCustomPrefix() throws IOException {
         String csv = "1,2\n3,4\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(
-            Map.of("header_row", false, "column_prefix", "f_")
-        );
+        CsvFormatReader reader = (CsvFormatReader) newReader().withConfig(Map.of("header_row", false, "column_prefix", "f_"));
 
         List<Attribute> schema = reader.schema(object);
 
@@ -3713,9 +3728,7 @@ public class CsvFormatReaderTests extends ESTestCase {
         // in ES|QL. The reader does not reject this, so verify the names are exactly the digits.
         String csv = "1,2\n3,4\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(
-            Map.of("header_row", false, "column_prefix", "")
-        );
+        CsvFormatReader reader = (CsvFormatReader) newReader().withConfig(Map.of("header_row", false, "column_prefix", ""));
 
         List<Attribute> schema = reader.schema(object);
         assertEquals(2, schema.size());
@@ -3727,7 +3740,7 @@ public class CsvFormatReaderTests extends ESTestCase {
         // Without header_row=false this would have lost row 0 to the header.
         String csv = "10,20\n30,40\n50,60\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(Map.of("header_row", false));
+        CsvFormatReader reader = (CsvFormatReader) newReader().withConfig(Map.of("header_row", false));
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -3747,7 +3760,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testHeaderlessSkipsCommentLines() throws IOException {
         String csv = "// a comment header\n1,2\n3,4\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(Map.of("header_row", false));
+        CsvFormatReader reader = (CsvFormatReader) newReader().withConfig(Map.of("header_row", false));
 
         List<Attribute> schema = reader.schema(object);
         assertEquals(2, schema.size());
@@ -3757,7 +3770,7 @@ public class CsvFormatReaderTests extends ESTestCase {
 
     public void testHeaderlessEmptyInputThrows() {
         StorageObject object = createStorageObject("");
-        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(Map.of("header_row", false));
+        CsvFormatReader reader = (CsvFormatReader) newReader().withConfig(Map.of("header_row", false));
 
         IOException ex = expectThrows(IOException.class, () -> reader.schema(object));
         assertThat(ex.getMessage().toLowerCase(Locale.ROOT), Matchers.containsString("no data rows"));
@@ -3766,7 +3779,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testHeaderlessCommentsOnlyInputThrows() {
         // Filtered by comment prefix so no data rows remain — must surface the same clean IOException.
         StorageObject object = createStorageObject("// only comments\n// another\n");
-        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(Map.of("header_row", false));
+        CsvFormatReader reader = (CsvFormatReader) newReader().withConfig(Map.of("header_row", false));
 
         IOException ex = expectThrows(IOException.class, () -> reader.schema(object));
         assertThat(ex.getMessage().toLowerCase(Locale.ROOT), Matchers.containsString("no data rows"));
@@ -3776,7 +3789,7 @@ public class CsvFormatReaderTests extends ESTestCase {
         // Bad value rejected at config parse time, not deferred to read.
         IllegalArgumentException ex = expectThrows(
             IllegalArgumentException.class,
-            () -> new CsvFormatReader(blockFactory).withConfig(Map.of("header_row", "not_a_bool"))
+            () -> newReader().withConfig(Map.of("header_row", "not_a_bool"))
         );
         assertThat(ex.getMessage(), Matchers.containsString("Invalid boolean value"));
         assertThat(ex.getMessage(), Matchers.containsString("header_row"));
@@ -3786,7 +3799,7 @@ public class CsvFormatReaderTests extends ESTestCase {
         // With header_row=false, a row that LOOKS like a typed header (name:type) is data, not schema.
         String csv = "id:long,age:int\n1,30\n2,25\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(Map.of("header_row", false));
+        CsvFormatReader reader = (CsvFormatReader) newReader().withConfig(Map.of("header_row", false));
 
         List<Attribute> schema = reader.schema(object);
         assertEquals(2, schema.size());
@@ -3815,7 +3828,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             csv.append(i).append(',').append(i * 10).append('\n');
         }
         StorageObject object = createStorageObject(csv.toString());
-        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(Map.of("header_row", false));
+        CsvFormatReader reader = (CsvFormatReader) newReader().withConfig(Map.of("header_row", false));
 
         int totalRows = 0;
         try (CloseableIterator<Page> iterator = reader.read(object, null, 7)) {
@@ -3836,7 +3849,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testHeaderlessProjectedColumns() throws IOException {
         String csv = "10,20,30\n40,50,60\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(Map.of("header_row", false));
+        CsvFormatReader reader = (CsvFormatReader) newReader().withConfig(Map.of("header_row", false));
 
         // Project col2 first then col0 to exercise reordering.
         try (CloseableIterator<Page> iterator = reader.read(object, List.of("col2", "col0"), 10)) {
@@ -3856,9 +3869,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testHeaderlessCustomPrefixViaReadPath() throws IOException {
         String csv = "1,2\n3,4\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(
-            Map.of("header_row", false, "column_prefix", "f_")
-        );
+        CsvFormatReader reader = (CsvFormatReader) newReader().withConfig(Map.of("header_row", false, "column_prefix", "f_"));
 
         // Project by the synthesized name to confirm the runtime path uses the same prefix.
         try (CloseableIterator<Page> iterator = reader.read(object, List.of("f_1"), 10)) {
@@ -3882,9 +3893,7 @@ public class CsvFormatReaderTests extends ESTestCase {
         csv.append("not_a_number,42\n");
         csv.append("99,9900\n");
         StorageObject object = createStorageObject(csv.toString());
-        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(
-            Map.of("header_row", false, "schema_sample_size", 10)
-        );
+        CsvFormatReader reader = (CsvFormatReader) newReader().withConfig(Map.of("header_row", false, "schema_sample_size", 10));
         ErrorPolicy skipRow = new ErrorPolicy(ErrorPolicy.Mode.SKIP_ROW, 10, 1.0, false);
 
         int totalRows = 0;
@@ -3906,7 +3915,7 @@ public class CsvFormatReaderTests extends ESTestCase {
         // ReferenceAttributes that the post-optimizer verifier rejects with a 500.
         String csv = "x,x,y\n1,2,3\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         ParsingException ex = expectThrows(ParsingException.class, () -> reader.schema(object));
         assertThat(ex.getMessage(), Matchers.containsString("duplicate column names"));
@@ -3919,7 +3928,7 @@ public class CsvFormatReaderTests extends ESTestCase {
         // like ",a," would be String.split-stripped and not hit this guard.)
         String csv = ",,a\n1,2,3\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         ParsingException ex = expectThrows(ParsingException.class, () -> reader.schema(object));
         assertThat(ex.getMessage(), Matchers.containsString("duplicate column names"));
@@ -3929,7 +3938,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testDuplicateTypedHeaderNamesThrowParsingException() {
         String csv = "id:long,id:long\n1,2\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         ParsingException ex = expectThrows(ParsingException.class, () -> reader.schema(object));
         assertThat(ex.getMessage(), Matchers.containsString("duplicate column names"));
@@ -3989,7 +3998,7 @@ public class CsvFormatReaderTests extends ESTestCase {
         StorageObject object = createStorageObject(csv);
         // Jackson path requires bracketMultiValues=false: use NONE multi-value syntax.
         Map<String, Object> config = Map.of("multi_value_syntax", "NONE");
-        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(config);
+        CsvFormatReader reader = (CsvFormatReader) newReader().withConfig(config);
         ErrorPolicy lenient = new ErrorPolicy(10, true);
 
         List<Long> ids = new ArrayList<>();
@@ -4022,7 +4031,7 @@ public class CsvFormatReaderTests extends ESTestCase {
 
         StorageObject object = createStorageObject(csv);
         Map<String, Object> config = Map.of("multi_value_syntax", "NONE");
-        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(config);
+        CsvFormatReader reader = (CsvFormatReader) newReader().withConfig(config);
 
         ParsingException e = expectThrows(ParsingException.class, () -> {
             try (
@@ -4052,7 +4061,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             """;
 
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
         ErrorPolicy lenient = new ErrorPolicy(10, true);
 
         try (
@@ -4077,7 +4086,7 @@ public class CsvFormatReaderTests extends ESTestCase {
 
         StorageObject object = createStorageObject(csv.toString());
         Map<String, Object> config = Map.of("multi_value_syntax", "NONE");
-        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(config);
+        CsvFormatReader reader = (CsvFormatReader) newReader().withConfig(config);
         ErrorPolicy budgetOf2 = new ErrorPolicy(2, false);
 
         ParsingException e = expectThrows(ParsingException.class, () -> {
@@ -4110,7 +4119,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             """;
 
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         try (
             CloseableIterator<Page> iterator = reader.read(
@@ -4135,7 +4144,7 @@ public class CsvFormatReaderTests extends ESTestCase {
         }
 
         StorageObject object = createStorageObject(csv.toString());
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         try (
             CloseableIterator<Page> iterator = reader.read(
@@ -4164,7 +4173,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             """;
 
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
         ErrorPolicy lenient = new ErrorPolicy(10, true);
 
         try (
@@ -4189,9 +4198,7 @@ public class CsvFormatReaderTests extends ESTestCase {
         // The wider row exceeds the inferred schema width and is rejected via onRowError.
         String csv = "1,Alice\n2,Bob\n3,Charlie,extra\n4,Dina\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(
-            Map.of("header_row", false, "schema_sample_size", 2)
-        );
+        CsvFormatReader reader = (CsvFormatReader) newReader().withConfig(Map.of("header_row", false, "schema_sample_size", 2));
         ErrorPolicy lenient = new ErrorPolicy(10, true);
 
         try (
@@ -4221,7 +4228,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             """;
 
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         try (CloseableIterator<Page> iterator = reader.read(object, FormatReadContext.builder().batchSize(10).build())) {
             assertTrue(iterator.hasNext());
@@ -4253,7 +4260,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             new ReferenceAttribute(Source.EMPTY, null, "id", DataType.LONG, Nullability.TRUE, null, false),
             new ReferenceAttribute(Source.EMPTY, null, "name", DataType.KEYWORD, Nullability.TRUE, null, false)
         );
-        CsvFormatReader reader = new CsvFormatReader(blockFactory).withSchema(schema);
+        CsvFormatReader reader = newReader().withSchema(schema);
 
         FormatReadContext ctx = FormatReadContext.builder().batchSize(10).firstSplit(false).recordAligned(true).build();
         try (CloseableIterator<Page> iterator = reader.read(object, ctx)) {
@@ -4279,7 +4286,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             new ReferenceAttribute(Source.EMPTY, null, "id", DataType.LONG, Nullability.TRUE, null, false),
             new ReferenceAttribute(Source.EMPTY, null, "name", DataType.KEYWORD, Nullability.TRUE, null, false)
         );
-        CsvFormatReader reader = new CsvFormatReader(blockFactory).withSchema(schema);
+        CsvFormatReader reader = newReader().withSchema(schema);
 
         // recordAligned defaults to false, matching legacy macro-split semantics.
         FormatReadContext ctx = FormatReadContext.builder().batchSize(10).firstSplit(false).build();
@@ -4318,7 +4325,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             new ReferenceAttribute(Source.EMPTY, null, "id", DataType.LONG),
             new ReferenceAttribute(Source.EMPTY, null, "name", DataType.KEYWORD)
         );
-        FormatReader baseReader = new CsvFormatReader(blockFactory);
+        FormatReader baseReader = newReader();
         FormatReader boundReader = baseReader.withSchema(bound);
 
         try (
@@ -4348,7 +4355,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             new ReferenceAttribute(Source.EMPTY, null, "col0", DataType.LONG),
             new ReferenceAttribute(Source.EMPTY, null, "col1", DataType.KEYWORD)
         );
-        FormatReader headerless = new CsvFormatReader(blockFactory).withConfig(Map.of("header_row", false));
+        FormatReader headerless = newReader().withConfig(Map.of("header_row", false));
         FormatReader bound2 = headerless.withSchema(bound);
 
         try (
@@ -4394,7 +4401,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             new ReferenceAttribute(Source.EMPTY, null, "id", DataType.LONG),
             new ReferenceAttribute(Source.EMPTY, null, "name", DataType.KEYWORD)
         );
-        FormatReader boundReader = new CsvFormatReader(blockFactory).withSchema(projectedAttrs);
+        FormatReader boundReader = newReader().withSchema(projectedAttrs);
 
         try (
             CloseableIterator<Page> iterator = boundReader.read(
@@ -4430,7 +4437,7 @@ public class CsvFormatReaderTests extends ESTestCase {
         // Row 2 has an unclosed quote — Jackson throws on it.
         String csv = "1,Alice\n2,\"Bob\n3,Charlie\n4,Dave\n";
         StorageObject object = createStorageObject(csv);
-        FormatReader reader = new CsvFormatReader(blockFactory).withConfig(
+        FormatReader reader = newReader().withConfig(
             Map.of("header_row", false, "multi_value_syntax", "NONE", "error_mode", "skip_row", "max_errors", 100)
         );
 
@@ -4455,7 +4462,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             csv.append(i).append(",\"unterminated\n");
         }
         StorageObject object = createStorageObject(csv.toString());
-        FormatReader reader = new CsvFormatReader(blockFactory).withConfig(Map.of("header_row", false, "multi_value_syntax", "NONE"));
+        FormatReader reader = newReader().withConfig(Map.of("header_row", false, "multi_value_syntax", "NONE"));
 
         ParsingException e = expectThrows(ParsingException.class, () -> {
             try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
@@ -4483,7 +4490,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             csv.append(i).append(",\"unterminated\n");
         }
         StorageObject object = createStorageObject(csv.toString());
-        FormatReader reader = new CsvFormatReader(blockFactory).withConfig(
+        FormatReader reader = newReader().withConfig(
             Map.of("header_row", false, "multi_value_syntax", "NONE", "error_mode", "skip_row", "max_errors", 5)
         );
 
@@ -4509,7 +4516,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             csv.append(i).append(",\"unterminated\n");
         }
         StorageObject object = createStorageObject(csv.toString());
-        FormatReader reader = new CsvFormatReader(blockFactory).withConfig(
+        FormatReader reader = newReader().withConfig(
             Map.of("header_row", false, "multi_value_syntax", "NONE", "error_mode", "skip_row", "max_errors", Long.MAX_VALUE)
         );
 
@@ -4536,7 +4543,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             not_a_number,Bob
             """;
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        CsvFormatReader reader = newReader();
 
         ParsingException e = expectThrows(ParsingException.class, () -> {
             try (
@@ -4566,7 +4573,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             """;
         StorageObject object = createStorageObject(csv);
         // Bracket parsing disabled so the Jackson tokeniser fires the structural error.
-        FormatReader reader = new CsvFormatReader(blockFactory).withConfig(Map.of("multi_value_syntax", "NONE"));
+        FormatReader reader = newReader().withConfig(Map.of("multi_value_syntax", "NONE"));
 
         ParsingException e = expectThrows(ParsingException.class, () -> {
             try (
@@ -4631,7 +4638,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             new ReferenceAttribute(Source.EMPTY, null, "col0", DataType.LONG),
             new ReferenceAttribute(Source.EMPTY, null, "col1", DataType.KEYWORD)
         );
-        FormatReader headerless = new CsvFormatReader(blockFactory).withConfig(Map.of("header_row", false, "multi_value_syntax", "NONE"));
+        FormatReader headerless = newReader().withConfig(Map.of("header_row", false, "multi_value_syntax", "NONE"));
         FormatReader bound2 = headerless.withSchema(bound);
 
         // SKIP_ROW so the malformed row is dropped and the rest of the file flows through.
@@ -4673,7 +4680,7 @@ public class CsvFormatReaderTests extends ESTestCase {
         // reflect the bound types, not the inferred ones.
         String csv = "10,20\n30,40\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(Map.of("header_row", false));
+        CsvFormatReader reader = (CsvFormatReader) newReader().withConfig(Map.of("header_row", false));
 
         List<Attribute> boundSchema = List.of(
             new ReferenceAttribute(Source.EMPTY, null, "col1", DataType.KEYWORD, Nullability.TRUE, null, false),
@@ -4703,7 +4710,7 @@ public class CsvFormatReaderTests extends ESTestCase {
         // slot is opt-in: existing call sites that don't set readSchema get the existing behavior.
         String csv = "10,20\n30,40\n";
         StorageObject object = createStorageObject(csv);
-        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(Map.of("header_row", false));
+        CsvFormatReader reader = (CsvFormatReader) newReader().withConfig(Map.of("header_row", false));
 
         FormatReadContext ctx = FormatReadContext.builder().batchSize(10).build();
         assertNull("readSchema must default to null", ctx.readSchema());
@@ -4729,7 +4736,7 @@ public class CsvFormatReaderTests extends ESTestCase {
         // the type-mismatch crash that TopN otherwise catches goes away.
         String fileB = "10,20\n30,40\n"; // would infer col1 as INTEGER without a bound read schema
         StorageObject fileBObject = createStorageObject(fileB);
-        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(Map.of("header_row", false));
+        CsvFormatReader reader = (CsvFormatReader) newReader().withConfig(Map.of("header_row", false));
 
         List<Attribute> readSchema = List.of(
             new ReferenceAttribute(Source.EMPTY, null, "col1", DataType.KEYWORD, Nullability.TRUE, null, false),


### PR DESCRIPTION
## What this is about

`findLastRecordBoundaryQuotedFieldsOnly` walks one byte at a time tracking quote state. On the slow-query flames it carries 12–26% of CPU as `findNextRecordBoundaryBracketCommaMvc`'s sibling; on `count_hits` the per-byte cost is what makes the bench 1438× ClickHouse. We replace the per-byte state machine with a 64-byte bit-parallel scan, but only when the operator opts in.

## What this PR does

Adds a `CsvBoundaryScanner` with two `Impl` strategies that live side by side:

- **`PREFIX_XOR`** — the new fast path. Per 64-byte block: parallel `eq('"')` and `eq('\n')` byte-masks, Hillis-Steele prefix-XOR on the quote bitmap to derive the in-quote run mask, AND-NOT with newlines to extract real record terminators, one-bit carry threading in-quote state across blocks. RFC 4180 doubled-quote escape is handled because two adjacent toggles cancel. Tail bytes < 64 fall through a scalar loop seeded by the carry.
- **`REFERENCE`** — the original per-byte scalar scanner, lifted verbatim from `CsvFormatReader.findLastRecordBoundaryQuotedFieldsOnly` so existing behaviour is preserved as an oracle and operational kill-switch.

`CsvFormatReader` takes its `Impl` at construction. Production default is `REFERENCE` — landing this PR changes nothing for existing deployments. Opt into `PREFIX_XOR` by setting `-Desql.csv.fast_boundary_scanner=true` at JVM start. A follow-up flips the default once both implementations have soaked.

## Does it work?

Three layers of equivalence:

- **Kernel-level** (`AbstractCsvBoundaryScannerTests`): hand-crafted regressions — RFC 4180 doubled-quote, open-tail rule, `\r\n` endings, cross-block-boundary quote runs, doubled-quote pairs straddling block boundaries — all run against both `Impl`s via two thin subclasses.
- **Reader-level** (`CsvFormatReaderTests` + `CsvFormatReaderReferenceTests`): the entire existing `CsvFormatReaderTests` suite (~200 tests) runs twice, once with each `Impl`, by parameterising on a `scannerImpl()` hook.
- **Randomised cross-impl** (`CsvBoundaryScannerEquivalenceTests`): 10k randomised CSV-shaped inputs (5k with carry-in=0, 5k with random carry-in) compare both `Impl`s byte-for-byte on `findLastRealTerminator` and `countRealTerminators`.

`StreamingParallelParsingCoordinatorTests` is unaffected by construction.

## What's in the diff

- `CsvBoundaryScanner.java` — interface + two static `Impl` instances.
- `CsvFormatReader.java` — new `final Impl boundaryScanner` field threaded through every constructor and copy method; `findLastRecordBoundaryQuotedFieldsOnly` delegates to it.
- `AbstractCsvBoundaryScannerTests` + two `Impl`-specific subclasses + `CsvBoundaryScannerEquivalenceTests` — new test surface.
- `CsvFormatReaderTests` — `scannerImpl()` hook + helper methods; all `new CsvFormatReader(blockFactory)` call sites routed through the helper. `CsvFormatReaderReferenceTests` extends to flip the `Impl`.

## What's out of scope

- The bracket-comma MVC scanner (`findNextRecordBoundaryBracketCommaMvc`). Different state machine — bracket-region tracking with `mark`/`reset` — doesn't fit bit-mask SIMD cleanly. Stays on the SPI default polyloop for now.
- `findNextRecordBoundary(InputStream)` (the per-record forward scanner). Hot path is `findLastRecordBoundary(byte[])` per the segmentator profile.
- `SourceStatistics.rowCount` plumbing in `CsvFormatReader.metadata`. Will use this PR's `countRealTerminators` once the kernel has soaked.
- Vector API port. Will replace the scalar `byteMask` primitive in `PrefixXorImpl` with a `ByteVector.eq(...).toLong()` call; algorithm structure stays identical.

## What's still to do

- [ ] Soak via CI on both `Impl`s, confirm `CsvFormatReaderReferenceTests` and `CsvFormatReaderTests` pass identically.
- [ ] Microbench `PREFIX_XOR` vs `REFERENCE` on a 14 GB `hits.csv` (separate PR).
- [ ] Vector API port of `byteMask` (separate PR).
- [ ] `SourceStatistics.rowCount` plumbing (separate PR).
- [ ] Flip production default to `PREFIX_XOR` once the above have soaked (separate PR).

## Why this is in draft

Cooked overnight; want bench results and a careful pass over the equivalence test seeds before unmarking. Closes #770 / #773 functionally; tracking ticket is elastic/esql-planning#772.


Closes elastic/esql-planning#770
Closes elastic/esql-planning#772
