### PR TITLE
Deprecate the indices.get_field_mapping API

### DIFF
--- a/docs/changelog/149354.yaml
+++ b/docs/changelog/149354.yaml
@@ -1,0 +1,21 @@
+pr: 149354
+issues:
+ - 118636
+summary: Deprecate the get field mapping API
+area: Mapping
+type: deprecation
+deprecation:
+  area: REST API
+  title: The get field mapping API is deprecated
+  details: |-
+    The get field mapping API (`GET /_mapping/field/<fields>` and
+    `GET /<index>/_mapping/field/<fields>`) is no longer maintained and does
+    not return mappings for field types that ship with internal synthetic
+    sub-fields (such as `search_as_you_type` and `join`). Requests now emit
+    a `Warning:` HTTP response header pointing callers at the get mapping
+    API (`GET /<index>/_mapping`).
+  impact: |-
+    Callers of the get field mapping API will receive a deprecation
+    `Warning:` HTTP response header. The endpoint continues to work for now;
+    migrate to the get mapping API (`GET /<index>/_mapping`) to retain
+    complete mapping information for all field types.

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_field_mapping.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_field_mapping.json
@@ -5,6 +5,10 @@
       "description": "Get mapping definitions"
     },
     "stability": "stable",
+    "deprecated": {
+      "version": "9.5.0",
+      "description": "The get field mapping API is no longer maintained. Use the get mapping API (`GET /<index>/_mapping`) instead."
+    },
     "visibility": "public",
     "headers": {
       "accept": [

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_field_mapping/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_field_mapping/10_basic.yml
@@ -1,5 +1,7 @@
 ---
 setup:
+  - requires:
+      test_runner_features: ["allowed_warnings"]
 
   - do:
         indices.create:
@@ -14,6 +16,8 @@ setup:
 "Get field mapping with no index":
 
   - do:
+      allowed_warnings:
+        - "The get field mapping API is no longer maintained. Use the get mapping API (`GET /<index>/_mapping`) instead."
       indices.get_field_mapping:
         fields: text
 
@@ -22,6 +26,8 @@ setup:
 ---
 "Get field mapping by index only":
   - do:
+      allowed_warnings:
+        - "The get field mapping API is no longer maintained. Use the get mapping API (`GET /<index>/_mapping`) instead."
       indices.get_field_mapping:
         index: test_index
         fields: text
@@ -32,6 +38,8 @@ setup:
 "Get field mapping by field, with another field that doesn't exist":
 
   - do:
+      allowed_warnings:
+        - "The get field mapping API is no longer maintained. Use the get mapping API (`GET /<index>/_mapping`) instead."
       indices.get_field_mapping:
         index: test_index
         fields: [ text , text1 ]
@@ -43,6 +51,8 @@ setup:
 "Get field mapping with include_defaults":
 
   - do:
+      allowed_warnings:
+        - "The get field mapping API is no longer maintained. Use the get mapping API (`GET /<index>/_mapping`) instead."
       indices.get_field_mapping:
         index: test_index
         fields: text

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_field_mapping/20_missing_field.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_field_mapping/20_missing_field.yml
@@ -1,5 +1,7 @@
 ---
 "Return empty object if field doesn't exist, but index does":
+  - requires:
+      test_runner_features: ["allowed_warnings"]
 
   - do:
         indices.create:
@@ -12,6 +14,8 @@
                   analyzer: whitespace
 
   - do:
+      allowed_warnings:
+        - "The get field mapping API is no longer maintained. Use the get mapping API (`GET /<index>/_mapping`) instead."
       indices.get_field_mapping:
         index: test_index
         fields: not_existent

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_field_mapping/40_missing_index.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_field_mapping/40_missing_index.yml
@@ -1,8 +1,12 @@
 ---
 "Raise 404 when index doesn't exist":
+  - requires:
+      test_runner_features: ["allowed_warnings"]
 
   - do:
       catch: missing
+      allowed_warnings:
+        - "The get field mapping API is no longer maintained. Use the get mapping API (`GET /<index>/_mapping`) instead."
       indices.get_field_mapping:
         index: test_index
         fields: field

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_field_mapping/50_field_wildcards.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_field_mapping/50_field_wildcards.yml
@@ -1,5 +1,7 @@
 ---
 setup:
+  - requires:
+      test_runner_features: ["allowed_warnings"]
 
   - do:
         indices.create:
@@ -43,6 +45,8 @@ setup:
 "Get field mapping with * for fields":
 
   - do:
+      allowed_warnings:
+        - "The get field mapping API is no longer maintained. Use the get mapping API (`GET /<index>/_mapping`) instead."
       indices.get_field_mapping:
         fields: "*"
 
@@ -56,6 +60,8 @@ setup:
 "Get field mapping with t* for fields":
 
   - do:
+      allowed_warnings:
+        - "The get field mapping API is no longer maintained. Use the get mapping API (`GET /<index>/_mapping`) instead."
       indices.get_field_mapping:
         index: test_index
         fields: "t*"
@@ -68,6 +74,8 @@ setup:
 "Get field mapping with *t1 for fields":
 
   - do:
+      allowed_warnings:
+        - "The get field mapping API is no longer maintained. Use the get mapping API (`GET /<index>/_mapping`) instead."
       indices.get_field_mapping:
         index: test_index
         fields: "*t1"
@@ -80,6 +88,8 @@ setup:
 "Get field mapping with wildcarded relative names":
 
   - do:
+      allowed_warnings:
+        - "The get field mapping API is no longer maintained. Use the get mapping API (`GET /<index>/_mapping`) instead."
       indices.get_field_mapping:
         index: test_index
         fields: "obj.i_*"
@@ -91,6 +101,8 @@ setup:
 "Get field mapping should work using '_all' for index":
 
   - do:
+      allowed_warnings:
+        - "The get field mapping API is no longer maintained. Use the get mapping API (`GET /<index>/_mapping`) instead."
       indices.get_field_mapping:
         index: _all
         fields: "t*"
@@ -105,6 +117,8 @@ setup:
 "Get field mapping should work using '*' for index":
 
   - do:
+      allowed_warnings:
+        - "The get field mapping API is no longer maintained. Use the get mapping API (`GET /<index>/_mapping`) instead."
       indices.get_field_mapping:
         index: '*'
         fields: "t*"
@@ -119,6 +133,8 @@ setup:
 "Get field mapping should work using comma_separated values for indices":
 
   - do:
+      allowed_warnings:
+        - "The get field mapping API is no longer maintained. Use the get mapping API (`GET /<index>/_mapping`) instead."
       indices.get_field_mapping:
         index: 'test_index,test_index_2'
         fields: "t*"

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetFieldMappingAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetFieldMappingAction.java
@@ -15,6 +15,8 @@ import org.elasticsearch.action.admin.indices.mapping.get.GetFieldMappingsRespon
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.core.RestApiVersion;
+import org.elasticsearch.core.UpdateForV10;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestResponse;
@@ -32,9 +34,16 @@ import static org.elasticsearch.rest.RestStatus.OK;
 
 public class RestGetFieldMappingAction extends BaseRestHandler {
 
+    static final String DEPRECATION_MESSAGE = "The get field mapping API is no longer maintained. "
+        + "Use the get mapping API (`GET /<index>/_mapping`) instead.";
+
     @Override
+    @UpdateForV10(owner = UpdateForV10.Owner.SEARCH_FOUNDATIONS)
     public List<Route> routes() {
-        return List.of(new Route(GET, "/_mapping/field/{fields}"), new Route(GET, "/{index}/_mapping/field/{fields}"));
+        return List.of(
+            Route.builder(GET, "/_mapping/field/{fields}").deprecatedForRemoval(DEPRECATION_MESSAGE, RestApiVersion.V_9).build(),
+            Route.builder(GET, "/{index}/_mapping/field/{fields}").deprecatedForRemoval(DEPRECATION_MESSAGE, RestApiVersion.V_9).build()
+        );
     }
 
     @Override

--- a/x-pack/plugin/apm-data/src/yamlRestTest/resources/rest-api-spec/test/20_metrics_mapping.yml
+++ b/x-pack/plugin/apm-data/src/yamlRestTest/resources/rest-api-spec/test/20_metrics_mapping.yml
@@ -42,6 +42,8 @@ setup:
       cluster.health:
         wait_for_events: languid
   - do:
+      allowed_warnings:
+        - "The get field mapping API is no longer maintained. Use the get mapping API (`GET /<index>/_mapping`) instead."
       indices.get_field_mapping:
         index: metrics-apm.app.svc1-testing
         fields: [double_metric, summary_metric, histogram_metric]

--- a/x-pack/plugin/apm-data/src/yamlRestTest/resources/rest-api-spec/test/30_custom_templates.yml
+++ b/x-pack/plugin/apm-data/src/yamlRestTest/resources/rest-api-spec/test/30_custom_templates.yml
@@ -57,6 +57,7 @@ setup:
   - do:
       allowed_warnings:
         - "Parameter [default_metric] is deprecated and will be removed in a future version"
+        - "The get field mapping API is no longer maintained. Use the get mapping API (`GET /<index>/_mapping`) instead."
       indices.get_field_mapping:
         index: metrics-apm.app.svc1-testing
         fields: custom_field*

--- a/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/10_semantic_text_field_mapping.yml
+++ b/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/10_semantic_text_field_mapping.yml
@@ -2,6 +2,7 @@ setup:
   - requires:
       cluster_features: "gte_v8.15.0"
       reason: semantic_text introduced in 8.15.0
+      test_runner_features: ["allowed_warnings"]
 
   - do:
       inference.put:
@@ -1400,6 +1401,8 @@ setup:
   - not_exists: test-index-options-sparse.mappings.semantic_field.mapping.index_options
 
   - do:
+      allowed_warnings:
+        - "The get field mapping API is no longer maintained. Use the get mapping API (`GET /<index>/_mapping`) instead."
       indices.get_field_mapping:
         index: test-index-options-sparse
         fields: semantic_field
@@ -1440,6 +1443,8 @@ setup:
   - match: { "test-index-options-sparse2.mappings.properties.semantic_field.index_options.sparse_vector.pruning_config.tokens_weight_threshold": 0.4 }
 
   - do:
+      allowed_warnings:
+        - "The get field mapping API is no longer maintained. Use the get mapping API (`GET /<index>/_mapping`) instead."
       indices.get_field_mapping:
         index: test-index-options-sparse2
         fields: semantic_field

--- a/x-pack/plugin/ml/qa/multi-cluster-tests-with-security/src/test/resources/rest-api-spec/test/multi_cluster/50_sparse_vector.yml
+++ b/x-pack/plugin/ml/qa/multi-cluster-tests-with-security/src/test/resources/rest-api-spec/test/multi_cluster/50_sparse_vector.yml
@@ -5,7 +5,7 @@ setup:
       cluster_features: [ "gte_v8.15.0" ]
       reason: "sparse_vector query introduced in 8.15.0"
   - skip:
-      features: headers
+      features: [headers, allowed_warnings]
 
   - do:
       headers:
@@ -266,6 +266,8 @@ teardown:
   - do:
       headers:
         Content-Type: application/json
+      allowed_warnings:
+        - "The get field mapping API is no longer maintained. Use the get mapping API (`GET /<index>/_mapping`) instead."
       indices.get_field_mapping:
         index: sparse_vector_pruning_test
         fields: ml.tokens
@@ -279,6 +281,8 @@ teardown:
   - do:
       headers:
         Content-Type: application/json
+      allowed_warnings:
+        - "The get field mapping API is no longer maintained. Use the get mapping API (`GET /<index>/_mapping`) instead."
       indices.get_field_mapping:
         index: sparse_vector_pruning_test
         fields: ml.tokens

--- a/x-pack/plugin/ml/qa/multi-cluster-tests-with-security/src/test/resources/rest-api-spec/test/remote_cluster/50_sparse_vector.yml
+++ b/x-pack/plugin/ml/qa/multi-cluster-tests-with-security/src/test/resources/rest-api-spec/test/remote_cluster/50_sparse_vector.yml
@@ -5,7 +5,7 @@ setup:
       cluster_features: [ "gte_v8.15.0" ]
       reason: "sparse_vector query introduced in 8.15.0"
   - skip:
-      features: headers
+      features: [headers, allowed_warnings]
   - do:
       headers:
         Authorization: "Basic dGVzdF91c2VyOngtcGFjay10ZXN0LXBhc3N3b3Jk" #test_user credentials
@@ -264,6 +264,8 @@ teardown:
   - do:
       headers:
         Content-Type: application/json
+      allowed_warnings:
+        - "The get field mapping API is no longer maintained. Use the get mapping API (`GET /<index>/_mapping`) instead."
       indices.get_field_mapping:
         index: sparse_vector_pruning_test
         fields: ml.tokens
@@ -277,6 +279,8 @@ teardown:
   - do:
       headers:
         Content-Type: application/json
+      allowed_warnings:
+        - "The get field mapping API is no longer maintained. Use the get mapping API (`GET /<index>/_mapping`) instead."
       indices.get_field_mapping:
         index: sparse_vector_pruning_test
         fields: ml.tokens

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/ml_anomalies_default_mappings.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/ml_anomalies_default_mappings.yml
@@ -1,6 +1,6 @@
 setup:
   - skip:
-      features: headers
+      features: [headers, allowed_warnings]
 ---
 "Test new fields are mapped as keyword":
 
@@ -40,6 +40,8 @@ setup:
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+      allowed_warnings:
+        - "The get field mapping API is no longer maintained. Use the get mapping API (`GET /<index>/_mapping`) instead."
       indices.get_field_mapping:
         index: .ml-anomalies-shared-000001
         fields: new_field

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/sparse_vector_search.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/sparse_vector_search.yml
@@ -5,7 +5,7 @@ setup:
       cluster_features: [ "gte_v8.15.0" ]
       reason: "sparse_vector query introduced in 8.15.0"
   - skip:
-      features: headers
+      features: [headers, allowed_warnings]
 
   - do:
       headers:
@@ -613,6 +613,8 @@ teardown:
   - do:
       headers:
         Content-Type: application/json
+      allowed_warnings:
+        - "The get field mapping API is no longer maintained. Use the get mapping API (`GET /<index>/_mapping`) instead."
       indices.get_field_mapping:
         index: sparse_vector_pruning_test
         fields: ml.tokens
@@ -626,6 +628,8 @@ teardown:
   - do:
       headers:
         Content-Type: application/json
+      allowed_warnings:
+        - "The get field mapping API is no longer maintained. Use the get mapping API (`GET /<index>/_mapping`) instead."
       indices.get_field_mapping:
         index: sparse_vector_pruning_test
         fields: ml.tokens


### PR DESCRIPTION
## Summary

Deprecate the `indices.get_field_mapping` REST API. All routes now emit a `Warning:` HTTP response header pointing users at the get mapping API (`GET /<index>/_mapping`) instead.

The API has been unmaintained — its handling of field types with internal synthetic sub-fields (`search_as_you_type`, `join`, etc.) produces incomplete results (see #118636). Per the discussion on #147905, the maintainer team opted to deprecate the endpoint rather than attempt to fix it.

Supersedes #147905. Refs #118636.

## What changed

- `RestGetFieldMappingAction`: routes are now built via `Route.builder().deprecatedForRemoval(DEPRECATION_MESSAGE, RestApiVersion.V_9).build()`. The `routes()` method is annotated `@UpdateForV10(owner = SEARCH_FOUNDATIONS)` so it surfaces when v10 work begins.
- `rest-api-spec/.../indices.get_field_mapping.json`: REST spec now carries a top-level `deprecated` block (version `9.5.0`, message matching the Java route message).
- 4 existing YAML REST tests under `indices.get_field_mapping/`: added `requires.test_runner_features: ["allowed_warnings"]` and an `allowed_warnings` entry to each `do.indices.get_field_mapping` block so they continue to pass against the new deprecation header.

## Test plan

- [x] `./gradlew :rest-api-spec:yamlRestTest --tests "*missing_field*" --tests "*missing_index*" --tests "*field_wildcards*" --tests "*10_basic*"` — 13 get_field_mapping tests pass with the new warning header, no failures across the 559 tests the wildcards matched.
- [ ] Follow-up commit will add `docs/changelog/<this-PR>.yaml` (type: `deprecation`) once the PR number is allocated.

## Notes

- The endpoint is preserved for now — only marked deprecated. The `@UpdateForV10` annotation flags it for follow-up when v10 work begins.
- Deprecation message is intentionally short so the HTTP `Warning:` header stays readable; the REST spec carries the same message.