### PR TITLE
[9.4] Fix histogram isNotNullFilter CSV test capabilities (#149308)

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/exponential_histogram.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/exponential_histogram.csv-spec
@@ -1105,6 +1105,7 @@ time:datetime            | count:long
 
 isNotNullFilter
 required_capability: ts_command_v0
+required_capability: count_of_histogram_types
 required_capability: fix_histogram_blockloaders_isnull
 
 TS exp_histo_sample

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/tdigest.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/tdigest.csv-spec
@@ -806,6 +806,7 @@ time:datetime            | first_count:long | last_count:long
 
 isNotNullFilter (timeseries mode)
 required_capability: ts_command_v0
+required_capability: count_of_histogram_types
 required_capability: fix_histogram_blockloaders_isnull
 
 TS tdigest_timeseries_index


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Fix histogram isNotNullFilter CSV test capabilities (#149308)](https://github.com/elastic/elasticsearch/pull/149308)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)