### PR TITLE
[8.19] Fix flaky CCS IT on Windows connect errors (#149171)

### DIFF
--- a/qa/ccs-unavailable-clusters/src/javaRestTest/java/org/elasticsearch/search/CrossClusterSearchUnavailableClusterIT.java
+++ b/qa/ccs-unavailable-clusters/src/javaRestTest/java/org/elasticsearch/search/CrossClusterSearchUnavailableClusterIT.java
@@ -56,6 +56,7 @@ import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 
+import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 
@@ -375,21 +376,21 @@ public class CrossClusterSearchUnavailableClusterIT extends ESRestTestCase {
                 ResponseException.class,
                 () -> client().performRequest(new Request("POST", "/index,remote1:index/_search"))
             );
-            assertThat(exception.getMessage(), containsString("connect_exception"));
+            assertThat(exception.getMessage(), anyOf(containsString("connect_exception"), containsString("connect_timeout")));
         }
         {
             ResponseException exception = expectThrows(
                 ResponseException.class,
                 () -> client().performRequest(new Request("POST", "/remote1:index/_search"))
             );
-            assertThat(exception.getMessage(), containsString("connect_exception"));
+            assertThat(exception.getMessage(), anyOf(containsString("connect_exception"), containsString("connect_timeout")));
         }
         {
             ResponseException exception = expectThrows(
                 ResponseException.class,
                 () -> client().performRequest(new Request("POST", "/remote1:index/_search?scroll=1m"))
             );
-            assertThat(exception.getMessage(), containsString("connect_exception"));
+            assertThat(exception.getMessage(), anyOf(containsString("connect_exception"), containsString("connect_timeout")));
         }
     }
 


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Fix flaky CCS IT on Windows connect errors (#149171)