### PR TITLE
[TEST]Unmute IndexCommitTimestampFieldRangeTests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -473,9 +473,6 @@ tests:
 - class: org.elasticsearch.xpack.stateless.commits.StatelessFileDeletionIT
   method: testDeleteIndexWhileNodeStopping
   issue: https://github.com/elastic/elasticsearch/issues/148807
-- class: org.elasticsearch.xpack.stateless.commits.IndexCommitTimestampFieldRangeTests
-  method: testFieldValueRangeForBatchedCompoundCommit
-  issue: https://github.com/elastic/elasticsearch/issues/148961
 - class: org.elasticsearch.upgrades.UpgradeClusterClientYamlTestSuiteIT
   method: test {p0=mixed_cluster/90_ml_data_frame_analytics_crud/Start and stop old regression job}
   issue: https://github.com/elastic/elasticsearch/issues/147516


### PR DESCRIPTION
Test failures don't reproduce, unmuting for now.

Fixes #148961
Fixes #148966