### PR TITLE
Unmute histogram isNotNullFilter CSV tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -288,12 +288,6 @@ tests:
 - class: org.elasticsearch.smoketest.SmokeTestWatcherTestSuiteIT
   method: testMonitorClusterHealth
   issue: https://github.com/elastic/elasticsearch/issues/148615
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
-  method: test {csv-spec:exponential_histogram.isNotNullFilter}
-  issue: https://github.com/elastic/elasticsearch/issues/149291
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
-  method: test {csv-spec:tdigest.isNotNullFilter (timeseries mode)}
-  issue: https://github.com/elastic/elasticsearch/issues/149292
 
 # Examples:
 #


### PR DESCRIPTION
Unmutes the `tdigest` and `exponential_histogram` isNotNullFilter CSV tests on `9.4`, as they have been fixed via #149359.
