### PR TITLE
Compress hot threads emitted by `IndicesClusterStateService`

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/HotThreadsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/HotThreadsIT.java
@@ -22,7 +22,6 @@ import org.elasticsearch.common.logging.ChunkedLoggingStreamTestUtils;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.monitor.jvm.HotThreads;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.hamcrest.Matcher;
 
@@ -32,7 +31,6 @@ import java.util.concurrent.ExecutionException;
 import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.index.query.QueryBuilders.termQuery;
-import static org.elasticsearch.test.MockLog.assertThatLogger;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -196,13 +194,14 @@ public class HotThreadsIT extends ESIntegTestCase {
     @TestLogging(reason = "testing logging at various levels", value = "org.elasticsearch.action.admin.HotThreadsIT:TRACE")
     public void testLogLocalHotThreads() {
         final var level = randomFrom(Level.TRACE, Level.DEBUG, Level.INFO, Level.WARN, Level.ERROR);
+        final var docs = randomFrom(ReferenceDocs.values());
         assertThat(
             ChunkedLoggingStreamTestUtils.getDecodedLoggedBody(
                 logger,
                 level,
                 getTestName(),
-                ReferenceDocs.LOGGING,
-                () -> HotThreads.logLocalHotThreads(logger, level, getTestName(), ReferenceDocs.LOGGING)
+                docs,
+                () -> HotThreads.logLocalHotThreads(logger, level, getTestName(), docs)
             ).utf8ToString(),
             allOf(
                 containsString("Hot threads at"),
@@ -215,22 +214,24 @@ public class HotThreadsIT extends ESIntegTestCase {
     }
 
     @TestLogging(reason = "testing logging at various levels", value = "org.elasticsearch.action.admin.HotThreadsIT:TRACE")
-    public void testLogLocalCurrentThreadsInPlainText() {
+    public void testLogLocalCurrentThreads() {
         final var level = randomFrom(Level.TRACE, Level.DEBUG, Level.INFO, Level.WARN, Level.ERROR);
-        assertThatLogger(
-            () -> HotThreads.logLocalCurrentThreads(logger, level, getTestName()),
-            HotThreadsIT.class,
-            new MockLog.SeenEventExpectation(
-                "Should log hot threads header in plain text",
-                HotThreadsIT.class.getCanonicalName(),
+        final var docs = randomFrom(ReferenceDocs.values());
+        assertThat(
+            ChunkedLoggingStreamTestUtils.getDecodedLoggedBody(
+                logger,
                 level,
-                "testLogLocalCurrentThreadsInPlainText: Hot threads at"
-            ),
-            new MockLog.SeenEventExpectation(
-                "Should log hot threads cpu usage in plain text",
-                HotThreadsIT.class.getCanonicalName(),
-                level,
-                "cpu usage by thread"
+                getTestName(),
+                docs,
+                () -> HotThreads.logLocalCurrentThreads(logger, level, getTestName(), docs)
+            ).utf8ToString(),
+            allOf(
+                containsString("Hot threads at"),
+                containsString("interval=500ms"),
+                containsString("busiestThreads=500"),
+                containsString("ignoreIdleThreads=true"),
+                containsString("cpu usage by thread"),
+                containsString("unique snapshot")
             )
         );
     }

--- a/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -39,6 +39,7 @@ import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.service.ClusterApplierService;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Priority;
+import org.elasticsearch.common.ReferenceDocs;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
@@ -768,7 +769,14 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
                 primaryTerm,
                 0,
                 0L,
-                new RunOnce(() -> HotThreads.logLocalCurrentThreads(logger, Level.WARN, shardId + ": acquire shard lock for create")),
+                new RunOnce(
+                    () -> HotThreads.logLocalCurrentThreads(
+                        logger,
+                        Level.WARN,
+                        shardId + ": acquire shard lock for create",
+                        ReferenceDocs.SHARD_LOCK_TROUBLESHOOTING
+                    )
+                ),
                 ActionListener.runBefore(new ActionListener<>() {
                     @Override
                     public void onResponse(Boolean success) {

--- a/server/src/main/java/org/elasticsearch/monitor/jvm/HotThreads.java
+++ b/server/src/main/java/org/elasticsearch/monitor/jvm/HotThreads.java
@@ -28,7 +28,6 @@ import org.elasticsearch.transport.Transports;
 
 import java.io.IOException;
 import java.io.OutputStreamWriter;
-import java.io.StringWriter;
 import java.io.Writer;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
@@ -108,23 +107,24 @@ public class HotThreads {
 
     /**
      * Capture and log the current threads on the local node. Unlike hot threads this does not sample and captures current state only.
-     * Useful for capturing stack traces for unexpectedly-slow operations in production. The resulting message might be large, so it is
-     * split per thread and logged as multiple entries.
+     * Useful for capturing stack traces for unexpectedly-slow operations in production. The resulting log message may be large, and
+     * contains significant whitespace, so it is compressed and base64-encoded using {@link ChunkedLoggingStream}.
      *
      * @param logger        The logger to use for the logging
      * @param level         The log level to use for the logging.
      * @param prefix        The prefix to emit on each chunk of the logging.
+     * @param referenceDocs A link to the docs describing how to decode the logging.
      */
-    public static void logLocalCurrentThreads(Logger logger, Level level, String prefix) {
+    public static void logLocalCurrentThreads(Logger logger, Level level, String prefix, ReferenceDocs referenceDocs) {
         if (logger.isEnabled(level) == false) {
             return;
         }
 
-        try (var writer = new StringWriter()) {
-            new HotThreads().busiestThreads(500).threadElementsSnapshotCount(1).detect(writer, () -> {
-                logger.log(level, "{}: {}", prefix, writer.toString());
-                writer.getBuffer().setLength(0);
-            });
+        try (
+            var stream = ChunkedLoggingStream.create(logger, level, prefix, referenceDocs);
+            var writer = new OutputStreamWriter(stream, StandardCharsets.UTF_8)
+        ) {
+            new HotThreads().busiestThreads(500).threadElementsSnapshotCount(1).detect(writer);
         } catch (Exception e) {
             logger.error(
                 () -> org.elasticsearch.common.Strings.format("failed to write local current threads with prefix [%s]", prefix),


### PR DESCRIPTION
Today `IndicesClusterStateService` emits a log message per thread when
shard lock acquisition takes too long, but these are hard to interpret
properly because of the loss of significant whitespace and the
difficulty in collecting together all the associated messages
afterwards.

This commit migrates these messages to use `ChunkedLoggingStream`
instead, aligning the output with other thread-dump logging.