### PR TITLE
[9.4] ESQL: Fix "optimized incorrectly" error from project reorder (#149053)

### DIFF
--- a/docs/changelog/149053.yaml
+++ b/docs/changelog/149053.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 148612
+pr: 149053
+summary: Fix "optimized incorrectly" error from project reorder
+type: bug

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/limit.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/limit.csv-spec
@@ -1086,6 +1086,58 @@ emp_no:integer | language_code:integer | language_name:keyword
 10005          | 1                     | English
 ;
 
+// SORT key renamed by a Project lifted above a LOOKUP JOIN.
+// https://github.com/elastic/elasticsearch/issues/148612
+sortRenameSortKeyLimitByWithLookupJoin
+required_capability: fix_reorder_limit_project_and_order_by_preserves_refs
+required_capability: esql_topn_by
+required_capability: join_lookup_v12
+
+FROM employees
+| WHERE emp_no IN (10001, 10002, 10003, 10004, 10005)
+| RENAME salary AS pay
+| EVAL language_code = languages
+| LOOKUP JOIN languages_lookup ON language_code
+| SORT pay
+| LIMIT 5 BY language_code
+| KEEP emp_no, language_code, pay, language_name
+| SORT emp_no, language_code
+;
+
+emp_no:integer | language_code:integer | pay:integer | language_name:keyword
+10001          | 2                     | 57305       | French
+10002          | 5                     | 56371       | null
+10003          | 4                     | 61805       | German
+10004          | 5                     | 36174       | null
+10005          | 1                     | 63528       | English
+;
+
+
+// Companion positive test: the RENAME targets the join column, so the SORT key still survives the Project.
+// https://github.com/elastic/elasticsearch/issues/148612
+sortLimitByRenamingJoinKey
+required_capability: fix_reorder_limit_project_and_order_by_preserves_refs
+required_capability: esql_topn_by
+required_capability: join_lookup_v12
+
+FROM employees
+| WHERE emp_no IN (10001, 10002, 10003, 10004, 10005)
+| RENAME languages AS language_code
+| LOOKUP JOIN languages_lookup ON language_code
+| SORT salary
+| LIMIT 5 BY language_code
+| KEEP emp_no, language_code, salary, language_name
+| SORT emp_no, language_code
+;
+
+emp_no:integer | language_code:integer | salary:integer | language_name:keyword
+10001          | 2                     | 57305          | French
+10002          | 5                     | 56371          | null
+10003          | 4                     | 61805          | German
+10004          | 5                     | 36174          | null
+10005          | 1                     | 63528          | English
+;
+
 limitByWithEnrich
 required_capability: enrich_load
 required_capability: limit_by_enrich_fix

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -2561,6 +2561,16 @@ public class EsqlCapabilities {
          */
         FIX_HISTOGRAM_BLOCKLOADERS_ISNULL
 
+        /**
+         * Fix for {@code ReorderLimitProjectAndOrderBy} unconditionally lifting an {@code OrderBy} above a renaming/dropping
+         * {@code Project}: it now rewrites the {@code OrderBy}'s references through the {@code Project}'s aliases (so a sort on
+         * a renamed column stays valid) and bails out of the swap if a referenced column is dropped altogether.
+         * <p>
+         *     See <a href="https://github.com/elastic/elasticsearch/issues/148612">#148612</a>.
+         * </p>
+         */
+        FIX_REORDER_LIMIT_PROJECT_AND_ORDER_BY_PRESERVES_REFS,
+
         // Last capability should still have a comma for fewer merge conflicts when adding new ones :)
         // This comment prevents the semicolon from being on the previous capability when Spotless formats the file.
         ;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -2559,7 +2559,7 @@ public class EsqlCapabilities {
          * histogram field itself is present, so the null-filtered guarantee does not hold for them.
          * See <a href="https://github.com/elastic/elasticsearch/issues/147854">#147854</a>
          */
-        FIX_HISTOGRAM_BLOCKLOADERS_ISNULL
+        FIX_HISTOGRAM_BLOCKLOADERS_ISNULL,
 
         /**
          * Fix for {@code ReorderLimitProjectAndOrderBy} unconditionally lifting an {@code OrderBy} above a renaming/dropping

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReorderLimitProjectAndOrderBy.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReorderLimitProjectAndOrderBy.java
@@ -7,7 +7,11 @@
 
 package org.elasticsearch.xpack.esql.optimizer.rules.logical;
 
+import org.elasticsearch.xpack.esql.core.expression.Alias;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.AttributeMap;
 import org.elasticsearch.xpack.esql.core.expression.Expressions;
+import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.plan.logical.Limit;
 import org.elasticsearch.xpack.esql.plan.logical.LimitBy;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
@@ -37,14 +41,33 @@ public final class ReorderLimitProjectAndOrderBy extends OptimizerRules.Optimize
             && plan.child() instanceof Project proj
             && Expressions.references(limitBy.groupings()).subsetOf(proj.child().outputSet())) {
                 return proj.replaceChild(limitBy.replaceChild(proj.child()));
-                // If swapping Project and Limit / LimitBy was not possible, swap Project and OrderBy if possible
-                // Make sure all of the references OrderBy uses are included in the Project, because there could be re-aliasing there
-            } else if (plan instanceof Project proj
-                && plan.child() instanceof OrderBy orderBy
-                && Expressions.references(orderBy.expressions()).subsetOf(proj.child().outputSet())) {
-                    return orderBy.replaceChild(proj.replaceChild(orderBy.child()));
+                // If swapping Project and Limit / LimitBy was not possible, swap Project and OrderBy if possible.
+                // Make sure all the references OrderBy uses are included in the Project, because there could be re-aliasing there
+            } else if (plan instanceof Project proj && plan.child() instanceof OrderBy orderBy) {
+                // After the swap, OrderBy sits on top of the Project and reads from its output, so any reference to an
+                // attribute that the Project renames must be rewritten to the renamed name.
+                AttributeMap<Attribute> renamedInProject = renamedInputAttributes(proj);
+                OrderBy rewrittenOrderBy = renamedInProject.isEmpty()
+                    ? orderBy
+                    : (OrderBy) orderBy.transformExpressionsOnly(Attribute.class, a -> renamedInProject.resolve(a, a));
+                if (Expressions.references(rewrittenOrderBy.expressions()).subsetOf(proj.outputSet())) {
+                    return rewrittenOrderBy.replaceChild(proj.replaceChild(orderBy.child()));
                 }
+            }
 
         return plan;
+    }
+
+    /**
+     * Build a map from a {@link Project}'s input attributes to the output attributes that alias them.
+     */
+    private static AttributeMap<Attribute> renamedInputAttributes(Project proj) {
+        AttributeMap.Builder<Attribute> builder = AttributeMap.builder();
+        for (NamedExpression ne : proj.projections()) {
+            if (ne instanceof Alias alias && alias.child() instanceof Attribute inputAttr) {
+                builder.put(inputAttr, alias.toAttribute());
+            }
+        }
+        return builder.build();
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/OptimizerVerificationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/OptimizerVerificationTests.java
@@ -475,6 +475,61 @@ public class OptimizerVerificationTests extends AbstractLogicalPlanOptimizerTest
             it: either move the SORT after it, or add a LIMIT after the SORT"""));
     }
 
+    /**
+     * Renaming the sort key between an unbounded SORT and an MV_EXPAND used to make ReorderLimitProjectAndOrderBy lift the OrderBy
+     * above the renaming Project, leaving the OrderBy with a dangling reference to the dropped column and tripping the
+     * "optimized incorrectly" optimizer verifier.
+     * <p>
+     * The proper "unbounded SORT" message should be reported instead.
+     * <p>
+     * Same root cause as the DROP variant in <a href="https://github.com/elastic/elasticsearch/issues/148612">#148612</a>.
+     */
+    public void testDanglingOrderByInInlineStatsWithRenamedSortKey() {
+        assumeTrue("INLINE STATS must be enabled", INLINE_STATS.isEnabled());
+        var testAnalyzer = analyzer().addDefaultIndex().addLanguagesLookup().addTestLookup().addAnalysisTestsEnrichResolution();
+
+        var err = error(testAnalyzer.query("""
+            ROW a = 1
+            | SORT a DESC
+            | RENAME a AS b
+            | MV_EXPAND b
+            | INLINE STATS c = count(*)
+            """));
+
+        assertThat(err, is("""
+            2:3: Unbounded SORT not supported yet [SORT a DESC] please add a LIMIT
+            line 4:3: MV_EXPAND [MV_EXPAND b] cannot yet have an unbounded SORT [SORT a DESC] before it: either move the SORT after \
+            it, or add a LIMIT after the SORT
+            line 5:3: INLINE STATS [INLINE STATS c = count(*)] cannot yet have an unbounded SORT [SORT a DESC] before it: either move \
+            the SORT after it, or add a LIMIT after the SORT"""));
+    }
+
+    /**
+     * Dropping the sort key with a DROP between an unbounded SORT and an MV_EXPAND used to make ReorderLimitProjectAndOrderBy lift
+     * the OrderBy above the dropping Project, tripping the "optimized incorrectly" optimizer verifier.
+     * See <a href="https://github.com/elastic/elasticsearch/issues/148612">#148612</a>.
+     */
+    public void testDanglingOrderByInInlineStatsWithDroppedSortKey() {
+        assumeTrue("INLINE STATS must be enabled", INLINE_STATS.isEnabled());
+        var testAnalyzer = analyzer().addDefaultIndex().addLanguagesLookup().addTestLookup().addAnalysisTestsEnrichResolution();
+
+        var err = error(testAnalyzer.query("""
+            ROW x = "a b"
+            | DISSECT x "%{y}"
+            | SORT y
+            | DROP y
+            | MV_EXPAND x
+            | INLINE STATS c = count(*)
+            """));
+
+        assertThat(err, is("""
+            3:3: Unbounded SORT not supported yet [SORT y] please add a LIMIT
+            line 5:3: MV_EXPAND [MV_EXPAND x] cannot yet have an unbounded SORT [SORT y] before it: either move the SORT after it, \
+            or add a LIMIT after the SORT
+            line 6:3: INLINE STATS [INLINE STATS c = count(*)] cannot yet have an unbounded SORT [SORT y] before it: either move \
+            the SORT after it, or add a LIMIT after the SORT"""));
+    }
+
     public void testEnrichRemoteRejected() {
         assumeTrue("requires EXTERNAL command capability", EsqlCapabilities.Cap.EXTERNAL_COMMAND.isEnabled());
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/ReorderLimitProjectAndOrderByGoldenTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/ReorderLimitProjectAndOrderByGoldenTests.java
@@ -46,6 +46,23 @@ public class ReorderLimitProjectAndOrderByGoldenTests extends GoldenTestCase {
             """, STAGES);
     }
 
+    /**
+     * Project -> OrderBy swap when the Project renames the sort key. After the swap, the lifted OrderBy must
+     * reference the renamed attribute (here {@code pay}) rather than the dropped input {@code salary}.
+     * <p>
+     * Regression test for <a href="https://github.com/elastic/elasticsearch/issues/148612">#148612</a>.
+     */
+    public void testProjectAndOrderBySwappedRenamesSortKey() {
+        runGoldenTest("""
+            FROM employees
+            | RENAME salary AS pay, languages AS language_code
+            | LOOKUP JOIN languages_lookup ON language_code
+            | SORT pay
+            | LIMIT 5 BY language_code
+            | KEEP pay
+            """, STAGES);
+    }
+
     private static final EsqlTestUtils.TestSearchStatsWithMinMax STATS = new EsqlTestUtils.TestSearchStatsWithMinMax(
         Map.of("date", dateTimeToLong("2023-10-20T12:15:03.360Z")),
         Map.of("date", dateTimeToLong("2023-10-23T13:55:01.543Z"))

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/golden_tests/ReorderLimitProjectAndOrderByGoldenTests/testProjectAndOrderBySwappedRenamesSortKey/analysis.expected
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/golden_tests/ReorderLimitProjectAndOrderByGoldenTests/testProjectAndOrderBySwappedRenamesSortKey/analysis.expected
@@ -1,0 +1,8 @@
+Limit[1000[INTEGER],false,false]
+\_Project[[pay{r}#0]]
+  \_LimitBy[5[INTEGER],[language_code{r}#1],false]
+    \_OrderBy[[Order[pay{r}#0,ASC,LAST]]]
+      \_LookupJoin[LEFT,[language_code{r}#1],[language_code{f}#2],false,null]
+        |_Project[[avg_worked_seconds{f}#3, birth_date{f}#4, emp_no{f}#5, first_name{f}#6, gender{f}#7, height{f}#8, height.float{f}#9, height.half_float{f}#10, height.scaled_float{f}#11, hire_date{f}#12, is_rehired{f}#13, job_positions{f}#14, languages{f}#15 AS language_code#1, languages.byte{f}#16, languages.long{f}#17, languages.short{f}#18, last_name{f}#19, salary{f}#20 AS pay#0, salary_change{f}#21, salary_change.int{f}#22, salary_change.keyword{f}#23, salary_change.long{f}#24, still_hired{f}#25]]
+        | \_EsRelation[employees][avg_worked_seconds{f}#3, birth_date{f}#4, emp_no{f}#5, first_name{f}#6, gender{f}#7, height{f}#8, height.float{f}#9, height.half_float{f}#10, height.scaled_float{f}#11, hire_date{f}#12, is_rehired{f}#13, job_positions{f}#14, languages{f}#15, languages.byte{f}#16, languages.long{f}#17, languages.short{f}#18, last_name{f}#19, salary{f}#20, salary_change{f}#21, salary_change.int{f}#22, salary_change.keyword{f}#23, salary_change.long{f}#24, still_hired{f}#25]
+        \_EsRelation[languages_lookup][LOOKUP][language_code{f}#2, language_name{f}#26]

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/golden_tests/ReorderLimitProjectAndOrderByGoldenTests/testProjectAndOrderBySwappedRenamesSortKey/logical_optimization.expected
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/golden_tests/ReorderLimitProjectAndOrderByGoldenTests/testProjectAndOrderBySwappedRenamesSortKey/logical_optimization.expected
@@ -1,0 +1,7 @@
+Project[[pay{r}#0]]
+\_Limit[1000[INTEGER],false,false]
+  \_TopNBy[[Order[pay{r}#0,ASC,LAST]],5[INTEGER],[language_code{r}#1]]
+    \_Project[[languages{f}#2 AS language_code#1, salary{f}#3 AS pay#0]]
+      \_Join[LEFT,[languages{f}#2],[language_code{f}#4],null]
+        |_EsRelation[employees][avg_worked_seconds{f}#5, birth_date{f}#6, emp_no{f}#7, first_name{f}#8, gender{f}#9, height{f}#10, height.float{f}#11, height.half_float{f}#12, height.scaled_float{f}#13, hire_date{f}#14, is_rehired{f}#15, job_positions{f}#16, languages{f}#2, languages.byte{f}#17, languages.long{f}#18, languages.short{f}#19, last_name{f}#20, salary{f}#3, salary_change{f}#21, salary_change.int{f}#22, salary_change.keyword{f}#23, salary_change.long{f}#24, still_hired{f}#25]
+        \_EsRelation[languages_lookup][LOOKUP][language_code{f}#4]

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/golden_tests/ReorderLimitProjectAndOrderByGoldenTests/testProjectAndOrderBySwappedRenamesSortKey/query.esql
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/golden_tests/ReorderLimitProjectAndOrderByGoldenTests/testProjectAndOrderBySwappedRenamesSortKey/query.esql
@@ -1,0 +1,6 @@
+FROM employees
+| RENAME salary AS pay, languages AS language_code
+| LOOKUP JOIN languages_lookup ON language_code
+| SORT pay
+| LIMIT 5 BY language_code
+| KEEP pay


### PR DESCRIPTION
Manual 9.4 backport of https://github.com/elastic/elasticsearch/pull/149053