### PR TITLE
Mute Delete By Query Test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -485,6 +485,9 @@ tests:
 - class: org.elasticsearch.multiproject.test.CoreWithMultipleProjectsClientYamlTestSuiteIT
   method: test {yaml=data_stream/110_update_by_query/Update by query from data stream}
   issue: https://github.com/elastic/elasticsearch/issues/149042
+- class: org.elasticsearch.multiproject.test.CoreWithMultipleProjectsClientYamlTestSuiteIT
+  method: test {yaml=delete_by_query/10_basic/Response for version conflict with conflicts=proceed}
+  issue: https://github.com/elastic/elasticsearch/issues/145253
 - class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
   method: test {csv-spec:fuse.fuseWithRowRRFAndMultiValueGroupColumn}
   issue: https://github.com/elastic/elasticsearch/issues/149046


### PR DESCRIPTION
Mute `org.elasticsearch.multiproject.test.CoreWithMultipleProjectsClientYamlTestSuiteIT {yaml=delete_by_query/10_basic/Response for version conflict with conflicts=proceed}`

Relates: https://github.com/elastic/elasticsearch/issues/14525

