### PR TITLE
ESQL: Clearer error message on nested aggregations

### DIFF
--- a/docs/changelog/149385.yaml
+++ b/docs/changelog/149385.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 149385
+summary: Clearer error message on nested aggregations
+type: bug

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Aggregate.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Aggregate.java
@@ -39,6 +39,7 @@ import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
 import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Consumer;
 
 import static java.util.Collections.emptyList;
 import static org.elasticsearch.xpack.esql.common.Failure.fail;
@@ -421,12 +422,13 @@ public class Aggregate extends UnaryPlan
         }
         // found an aggregate, constant or a group, bail out
         if (e instanceof AggregateFunction af && af instanceof Sparkline == false) {
-            af.field().forEachDown(AggregateFunction.class, f -> {
-                // rate aggregate is allowed to be inside another aggregate
+            Consumer<Expression> checkNested = arg -> arg.forEachDown(AggregateFunction.class, f -> {
                 if (f instanceof TimeSeriesAggregateFunction == false) {
                     failures.add(fail(f, "nested aggregations [{}] not allowed inside other aggregations [{}]", f, af));
                 }
             });
+            checkNested.accept(af.field());
+            af.parameters().forEach(checkNested);
         } else if (e instanceof GroupingFunction gf) {
             // optimizer will later unroll expressions with aggs and non-aggs with a grouping function into an EVAL, but that will no longer
             // be verified (by check above in checkAggregate()), so do it explicitly here

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
@@ -487,6 +487,10 @@ public class VerifierTests extends ESTestCase {
             equalTo("1:23: nested aggregations [max(salary)] not allowed inside other aggregations [max(max(salary))]")
         );
         defaultAnalyzer().error(
+            "from test | stats w_avg = weighted_avg(salary, count(*)) by first_name",
+            equalTo("1:48: nested aggregations [count(*)] not allowed inside other aggregations " + "[weighted_avg(salary, count(*))]")
+        );
+        defaultAnalyzer().error(
             "from test | stats count(avg(first_name)) by first_name",
             equalTo(
                 "1:25: argument of [avg(first_name)] must be [aggregate_metric_double,"


### PR DESCRIPTION
This PR replaces an internal error ("plan optimized incorrectly due to missing references") that happens with nested aggregations (e.g., `count` inside of `average`) with a proper 400 error, so the user would know what they did wrong, and this won't get flagged up as an internal error for on-callers.