### PR TITLE
Do not merge patterns with exclusions

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/view/ViewResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/view/ViewResolver.java
@@ -289,7 +289,7 @@ public class ViewResolver {
         ActionListener<LogicalPlan> listener
     ) {
         // Avoid re-resolving wildcards preserved for non-view matches in subsequent transformDown visits.
-        var patterns = Arrays.stream(unresolvedRelation.indexPattern().indexPattern().split(","))
+        var patterns = Arrays.stream(patterns(unresolvedRelation))
             .filter(pattern -> Regex.isSimpleMatchPattern(pattern) == false || seenWildcards.contains(pattern) == false)
             .toArray(String[]::new);
         if (patterns.length == 0) {
@@ -311,7 +311,7 @@ public class ViewResolver {
         // non-CPS mode the shadow has no consumer, so we skip the bookkeeping entirely; the rest of
         // the resolver behaves as if shadows are simply not part of the tree.
         boolean cpsEnabled = crossProjectModeDecider.crossProjectEnabled();
-        String[] urPatterns = unresolvedRelation.indexPattern().indexPattern().split(",");
+        String[] urPatterns = patterns(unresolvedRelation);
 
         var req = new EsqlResolveViewAction.Request(REST_MASTER_TIMEOUT_DEFAULT);
         req.indices(patterns);
@@ -689,8 +689,17 @@ public class ViewResolver {
 
     /** Merge the unresolved relation unless the index patterns contain matching index names. */
     private static UnresolvedRelation mergeIfPossible(UnresolvedRelation main, UnresolvedRelation other) {
-        for (String mainPattern : main.indexPattern().indexPattern().split(",")) {
-            for (String otherPattern : other.indexPattern().indexPattern().split(",")) {
+        var mainPatterns = patterns(main);
+        var otherPatterns = patterns(other);
+
+        // can not merge if any contains exclusion. This risk expanding scope of exclusion to unrelated pattern
+        if (patternsContainsExclusion(mainPatterns) || patternsContainsExclusion(otherPatterns)) {
+            return null;
+        }
+
+        // can not merge if same expression is present in both patterns as it would be deduplicated by FieldCaps in the final result set
+        for (String mainPattern : mainPatterns) {
+            for (String otherPattern : otherPatterns) {
                 if (mainPattern.equals(otherPattern)) {
                     return null;
                 }
@@ -749,7 +758,7 @@ public class ViewResolver {
         // Parse the view query with the view name, which causes all Source objects
         // to be tagged with the view name during parsing
         LogicalPlan subquery = parser.apply(view.query(), view.name());
-        if (subquery instanceof UnresolvedRelation ur && containsExclusion(ur) == false) {
+        if (subquery instanceof UnresolvedRelation ur && patternsContainsExclusion(patterns(ur)) == false) {
             // Simple UnresolvedRelation subqueries are not kept as views, so we can compact them
             // together and avoid branched plans. But exclusion patterns must stay scoped to the
             // view body — a bare UnresolvedRelation with an exclusion that gets merged with sibling
@@ -764,12 +773,16 @@ public class ViewResolver {
         }
     }
 
-    private static boolean containsExclusion(UnresolvedRelation ur) {
-        for (String pattern : ur.indexPattern().indexPattern().split(",")) {
+    private static boolean patternsContainsExclusion(String[] patterns) {
+        for (String pattern : patterns) {
             if (patternIsExclusion(pattern)) {
                 return true;
             }
         }
         return false;
+    }
+
+    private static String[] patterns(UnresolvedRelation ur) {
+        return ur.indexPattern().indexPattern().split(",");
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/view/InMemoryViewServiceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/view/InMemoryViewServiceTests.java
@@ -185,7 +185,7 @@ public class InMemoryViewServiceTests extends AbstractStatementParserTests {
         addIndex("logs2");
         addIndex("logs3");
         LogicalPlan plan = query("FROM logs*,-logs3");
-        assertThat(replaceViews(plan), matchesPlan(query("FROM logs2,logs*,-logs3")));
+        assertThat(replaceViews(plan), matchesPlan(query("FROM (FROM logs2),(FROM logs*,-logs3)")));
     }
 
     /**
@@ -204,7 +204,7 @@ public class InMemoryViewServiceTests extends AbstractStatementParserTests {
         addIndex("data-view-extra");
         addView("data-view-origin", "FROM data-index-origin");
         LogicalPlan plan = query("FROM match-nothing-*,-*-view-*,data-view-*");
-        assertThat(replaceViews(plan), matchesPlan(query("FROM data-index-origin,-*-view-*,data-view-*")));
+        assertThat(replaceViews(plan), matchesPlan(query("FROM (FROM data-index-origin),(FROM -*-view-*,data-view-*)")));
     }
 
     /**
@@ -373,7 +373,7 @@ public class InMemoryViewServiceTests extends AbstractStatementParserTests {
         addIndex("viewX");
         addView("view1", "FROM emp1");
         LogicalPlan plan = query("FROM view*, -donotexist");
-        assertThat(replaceViews(plan), matchesPlan(query("FROM emp1,view*,-donotexist")));
+        assertThat(replaceViews(plan), matchesPlan(query("FROM (FROM emp1),(FROM view*,-donotexist)")));
     }
 
     public void testPositionalExclusion() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/view/InMemoryViewServiceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/view/InMemoryViewServiceTests.java
@@ -184,8 +184,8 @@ public class InMemoryViewServiceTests extends AbstractStatementParserTests {
         addView("logs1", "FROM logs2");
         addIndex("logs2");
         addIndex("logs3");
-        LogicalPlan plan = query("FROM logs*,-logs3");
-        assertThat(replaceViews(plan), matchesPlan(query("FROM (FROM logs2),(FROM logs*,-logs3)")));
+        assertThat(replaceViews(query("FROM logs*,-logs3")), matchesPlan(query("FROM (FROM logs2),(FROM logs*,-logs3)")));
+        assertThat(replaceViews(query("FROM logs*")), matchesPlan(query("FROM logs2,logs*")));
     }
 
     /**

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/view/InMemoryViewServiceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/view/InMemoryViewServiceTests.java
@@ -376,6 +376,15 @@ public class InMemoryViewServiceTests extends AbstractStatementParserTests {
         assertThat(replaceViews(plan), matchesPlan(query("FROM emp1,view*,-donotexist")));
     }
 
+    public void testPositionalExclusion() {
+        addIndex("data-ll");
+        addIndex("data-rr");
+        addView("data-l", "FROM index-l");
+        addView("data-r", "FROM index-r");
+        LogicalPlan plan = query("FROM -*l,data-*");
+        assertThat(replaceViews(plan), matchesPlan(query("FROM (FROM index-l,index-r),(FROM -*l,data-*)")));
+    }
+
     public void testFailureSelector() {
         addView("view1", "FROM emp1");
         addView("view2", "FROM emp2");


### PR DESCRIPTION
This change prevents merging unions into a single pattern if any of them contain exclusion.

For example with the following setup
```
        addIndex("data-ll");
        addIndex("data-rr");
        addView("data-l", "FROM index-l");
        addView("data-r", "FROM index-r");
```
A query `FROM -*l,data-*` 
was resolved as `FROM index-l,index-r,-*l,data-*`
where `index-l` was excluded by `-*l`.

Now it is correctly resolved as `FROM (FROM index-l,index-r),(FROM -*l,data-*)` containing the scope of `-*l` exclusion.