### PR TITLE
ESQL: Fix NPE in bucket_sort on unresolvable sort path

### DIFF
--- a/docs/changelog/149390.yaml
+++ b/docs/changelog/149390.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 136418
+pr: 149390
+summary: Fix NPE in `bucket_sort` on unresolvable sort path
+type: bug

--- a/modules/aggregations/src/main/java/org/elasticsearch/aggregations/pipeline/BucketSortPipelineAggregator.java
+++ b/modules/aggregations/src/main/java/org/elasticsearch/aggregations/pipeline/BucketSortPipelineAggregator.java
@@ -103,8 +103,13 @@ public class BucketSortPipelineAggregator extends PipelineAggregator {
                 if ("_key".equals(sortField)) {
                     resolved.put(sort, (Comparable<Object>) internalBucket.getKey());
                 } else {
+                    // BucketHelpers.resolveBucketValue returns null when the path cannot be resolved for this bucket
+                    // (e.g. it contains a bucket-key lookup like inner_agg['some_key'] that does not exist in this
+                    // bucket's data). Treat that the same as a missing value and let the gap policy decide, which is
+                    // how sibling pipeline aggregators (BucketScript, BucketMetrics, etc.) handle it. Previously the
+                    // null was unboxed by Double.isNaN and threw NPE.
                     Double bucketValue = BucketHelpers.resolveBucketValue(parentAgg, internalBucket, sortField, gapPolicy);
-                    if (gapPolicy.isSkippable && Double.isNaN(bucketValue)) {
+                    if (gapPolicy.isSkippable && (bucketValue == null || Double.isNaN(bucketValue))) {
                         continue;
                     }
                     resolved.put(sort, (Comparable<Object>) (Object) bucketValue);

--- a/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/bucket_sort.yml
+++ b/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/bucket_sort.yml
@@ -535,6 +535,13 @@ invalid path fails:
 
 ---
 missing bucket key at runtime applies gap_policy=skip:
+  - requires:
+      capabilities:
+        - method: POST
+          path: /_search
+          capabilities: [ bucket_sort_null_handles_missing_bucket ]
+      test_runner_features: [capabilities]
+      reason: "previously NPE'd; now treated as a missing value subject to gap_policy"
   - do:
       search:
         body:
@@ -556,6 +563,13 @@ missing bucket key at runtime applies gap_policy=skip:
 
 ---
 missing bucket key at runtime applies gap_policy=insert_zeros:
+  - requires:
+      capabilities:
+        - method: POST
+          path: /_search
+          capabilities: [ bucket_sort_null_handles_missing_bucket ]
+      test_runner_features: [capabilities]
+      reason: "previously NPE'd; now treated as a missing value subject to gap_policy"
   - do:
       search:
         body:

--- a/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/bucket_sort.yml
+++ b/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/bucket_sort.yml
@@ -534,6 +534,49 @@ invalid path fails:
                       - garbage
 
 ---
+missing bucket key at runtime applies gap_policy=skip:
+  - do:
+      search:
+        body:
+          aggs:
+            timestamp:
+              date_histogram:
+                field: "@timestamp"
+                fixed_interval: 1h
+              aggs:
+                inner_terms:
+                  terms:
+                    field: g
+                sort:
+                  bucket_sort:
+                    sort:
+                      - "inner_terms['nonexistent']._count": desc
+
+  - length: { aggregations.timestamp.buckets: 0 }
+
+---
+missing bucket key at runtime applies gap_policy=insert_zeros:
+  - do:
+      search:
+        body:
+          aggs:
+            timestamp:
+              date_histogram:
+                field: "@timestamp"
+                fixed_interval: 1h
+              aggs:
+                inner_terms:
+                  terms:
+                    field: g
+                sort:
+                  bucket_sort:
+                    gap_policy: insert_zeros
+                    sort:
+                      - "inner_terms['nonexistent']._count": desc
+
+  - length: { aggregations.timestamp.buckets: 3 }
+
+---
 top level fails:
   - do:
       catch: /bucket_sort aggregation \[bad\] must be declared inside of another aggregation/

--- a/server/src/main/java/org/elasticsearch/rest/action/search/SearchCapabilities.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/search/SearchCapabilities.java
@@ -58,6 +58,8 @@ public final class SearchCapabilities {
     private static final String KNN_FILTER_ON_NESTED_FIELDS_CAPABILITY = "knn_filter_on_nested_fields";
     private static final String BUCKET_SCRIPT_PARENT_MULTI_BUCKET_ERROR = "bucket_script_parent_multi_bucket_error";
     private static final String PIPELINE_AGGS_PARENT_MULTI_BUCKET_ERROR = "pipeline_aggs_parent_multi_bucket_error";
+    /** Treat unresolvable bucket_sort paths as missing values controlled by gap_policy instead of NPE'ing. */
+    private static final String BUCKET_SORT_NULL_HANDLES_MISSING_BUCKET = "bucket_sort_null_handles_missing_bucket";
     private static final String EXCLUDE_SOURCE_VECTORS_SETTING = "exclude_source_vectors_setting";
     private static final String CLUSTER_STATS_EXTENDED_USAGE = "extended-search-usage-stats";
     private static final String REJECT_INVALID_REVERSE_NESTING = "reject_invalid_reverse_nesting";
@@ -93,6 +95,7 @@ public final class SearchCapabilities {
         capabilities.add(KNN_FILTER_ON_NESTED_FIELDS_CAPABILITY);
         capabilities.add(BUCKET_SCRIPT_PARENT_MULTI_BUCKET_ERROR);
         capabilities.add(PIPELINE_AGGS_PARENT_MULTI_BUCKET_ERROR);
+        capabilities.add(BUCKET_SORT_NULL_HANDLES_MISSING_BUCKET);
         capabilities.add(EXCLUDE_SOURCE_VECTORS_SETTING);
         capabilities.add(CLUSTER_STATS_EXTENDED_USAGE);
         capabilities.add(REJECT_INVALID_REVERSE_NESTING);


### PR DESCRIPTION
Treat `null` from `resolveBucketValue` as a missing value and let the existing `gap_policy` decide, matching how sibling pipeline aggregators (`BucketScript`, `BucketMetrics`, `Derivative`, etc.) handle the same case.

Closes #136418.