### PR TITLE
Fixing index mode serialization in stats

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/monitor/metrics/IndicesMetricsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/monitor/metrics/IndicesMetricsIT.java
@@ -29,10 +29,12 @@ import org.elasticsearch.xcontent.json.JsonXContent;
 import org.hamcrest.Matcher;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.elasticsearch.index.mapper.DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER;
 import static org.hamcrest.Matchers.equalTo;
@@ -396,6 +398,22 @@ public class IndicesMetricsIT extends ESIntegTestCase {
         verifyStatsPerIndexMode(
             Map.of(IndexMode.STANDARD, numStandardDocs, IndexMode.LOGSDB, numLogsdbDocs, IndexMode.TIME_SERIES, numTimeSeriesDocs)
         );
+    }
+
+    public void testStatsResponseIncludesOnlyAvailableModes() {
+        String indexNode = internalCluster().startNode();
+        ensureStableCluster(1);
+        createIndex("standard-test", Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1).build());
+        indexDoc("standard-test", "1", "f", "1");
+        flush("standard-test");
+        refresh("standard-test");
+
+        final var nodes = clusterService().state().nodes().stream().toArray(DiscoveryNode[]::new);
+        final var request = new IndexModeStatsActionType.StatsRequest(nodes);
+        final var response = client(indexNode).execute(IndexModeStatsActionType.TYPE, request).actionGet();
+        final var stats = response.stats();
+        final Set<IndexMode> expectedModes = Set.copyOf(Arrays.asList(IndexMode.availableModes()));
+        assertThat(stats.keySet(), equalTo(expectedModes));
     }
 
     void collectThenAssertMetrics(TestTelemetryPlugin telemetry, int times, Map<String, Matcher<Long>> matchers) {

--- a/server/src/main/java/org/elasticsearch/monitor/metrics/IndexModeStatsActionType.java
+++ b/server/src/main/java/org/elasticsearch/monitor/metrics/IndexModeStatsActionType.java
@@ -76,7 +76,7 @@ public final class IndexModeStatsActionType extends ActionType<IndexModeStatsAct
 
         public Map<IndexMode, IndexStats> stats() {
             final Map<IndexMode, IndexStats> stats = new EnumMap<>(IndexMode.class);
-            for (IndexMode mode : IndexMode.values()) {
+            for (IndexMode mode : IndexMode.availableModes()) {
                 stats.put(mode, new IndexStats());
             }
             for (NodeResponse node : getNodes()) {

--- a/server/src/main/java/org/elasticsearch/monitor/metrics/IndicesMetrics.java
+++ b/server/src/main/java/org/elasticsearch/monitor/metrics/IndicesMetrics.java
@@ -81,9 +81,12 @@ public class IndicesMetrics extends AbstractLifecycleComponent {
         ClusterService clusterService,
         SystemIndices systemIndices
     ) {
-        final int TOTAL_METRICS = 95;
-        List<AutoCloseable> metrics = new ArrayList<>(TOTAL_METRICS);
-        for (IndexMode indexMode : IndexMode.values()) {
+        final IndexMode[] availableModes = IndexMode.availableModes();
+        final int metricsPerIndexMode = 13;
+        final int sharedMetrics = 4;
+        final int totalMetrics = (availableModes.length * metricsPerIndexMode) + sharedMetrics;
+        List<AutoCloseable> metrics = new ArrayList<>(totalMetrics);
+        for (IndexMode indexMode : availableModes) {
             String name = indexMode.getName();
             metrics.add(
                 registry.registerLongGauge(
@@ -233,7 +236,7 @@ public class IndicesMetrics extends AbstractLifecycleComponent {
                 getTotalUserIndices(systemIndices, clusterState.getMetadata().projects().values().iterator().next())
             );
         }));
-        assert metrics.size() == TOTAL_METRICS : "total number of metrics has changed";
+        assert metrics.size() == totalMetrics : "total number of metrics has changed";
         return metrics;
     }
 

--- a/server/src/main/java/org/elasticsearch/monitor/metrics/IndicesMetrics.java
+++ b/server/src/main/java/org/elasticsearch/monitor/metrics/IndicesMetrics.java
@@ -317,7 +317,7 @@ public class IndicesMetrics extends AbstractLifecycleComponent {
 
     static Map<IndexMode, IndexStats> getStatsWithoutCache(IndicesService indicesService) {
         Map<IndexMode, IndexStats> stats = new EnumMap<>(IndexMode.class);
-        for (IndexMode mode : IndexMode.values()) {
+        for (IndexMode mode : IndexMode.availableModes()) {
             stats.put(mode, new IndexStats());
         }
         for (IndexService indexService : indicesService) {
@@ -351,7 +351,7 @@ public class IndicesMetrics extends AbstractLifecycleComponent {
         private static final Map<IndexMode, IndexStats> MISSING_STATS;
         static {
             MISSING_STATS = new EnumMap<>(IndexMode.class);
-            for (IndexMode value : IndexMode.values()) {
+            for (IndexMode value : IndexMode.availableModes()) {
                 MISSING_STATS.put(value, new IndexStats());
             }
         }

--- a/server/src/test/java/org/elasticsearch/monitor/metrics/IndexModeStatsActionTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/monitor/metrics/IndexModeStatsActionTypeTests.java
@@ -9,13 +9,11 @@
 
 package org.elasticsearch.monitor.metrics;
 
-import org.elasticsearch.TransportVersion;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.TransportVersionUtils;
 
 import java.io.IOException;
 import java.util.EnumMap;

--- a/server/src/test/java/org/elasticsearch/monitor/metrics/IndexModeStatsActionTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/monitor/metrics/IndexModeStatsActionTypeTests.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.monitor.metrics;
+
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.index.IndexMode;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.TransportVersionUtils;
+
+import java.io.IOException;
+import java.util.EnumMap;
+import java.util.Map;
+
+public class IndexModeStatsActionTypeTests extends ESTestCase {
+
+    public void testNodeResponseStats() throws IOException {
+        final Map<IndexMode, IndexStats> serializedStats = serializeAndReadStats();
+        for (var indexStats : IndexMode.availableModes()) {
+            assertTrue(serializedStats.containsKey(indexStats));
+        }
+    }
+
+    private static Map<IndexMode, IndexStats> serializeAndReadStats() throws IOException {
+        final Map<IndexMode, IndexStats> stats = new EnumMap<>(IndexMode.class);
+        for (IndexMode indexMode : IndexMode.availableModes()) {
+            stats.put(indexMode, new IndexStats());
+        }
+        final DiscoveryNode node = DiscoveryNodeUtils.create("node");
+        final var nodeResponse = new IndexModeStatsActionType.NodeResponse(node, stats);
+
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            nodeResponse.writeTo(out);
+            try (var in = out.bytes().streamInput()) {
+                new DiscoveryNode(in);
+                return in.readMap(IndexMode::readFrom, IndexStats::new);
+            }
+        }
+    }
+}


### PR DESCRIPTION
It seems like we are serializing index modes that are protected behind a feature flag. This doesn't seem right and it has caused some weirdness in rolling upgrades where stats calls will fail with the following, though no index has the mode set and the cluster never had the feature flag enabled:

```
java.lang.IllegalArgumentException: cannot send index mode [vectordb_document] to a node that does not support it
	at org.elasticsearch.server@9.5.0/org.elasticsearch.index.IndexMode.writeTo(IndexMode.java:880)
	at org.elasticsearch.server@9.5.0/org.elasticsearch.monitor.metrics.IndexModeStatsActionType$NodeResponse.lambda$writeTo$0(IndexModeStatsActionType.java:117)
	at org.elasticsearch.server@9.5.0/org.elasticsearch.common.io.stream.StreamOutput.writeMap(StreamOutput.java:646)
	at org.elasticsearch.server@9.5.0/org.elasticsearch.monitor.metrics.IndexModeStatsActionType$NodeResponse.writeTo(IndexModeStatsActionType.java:117)
	at org.elasticsearch.server@9.5.0/org.elasticsearch.transport.OutboundHandler.serializeMessageBody(OutboundHandler.java:372)
	at org.elasticsearch.server@9.5.0/org.elasticsearch.transport.OutboundHandler.serialize(OutboundHandler.java:313)
	at org.elasticsearch.server@9.5.0/org.elasticsearch.transport.OutboundHandler.sendMessage(OutboundHandler.java:238)
	at org.elasticsearch.server@9.5.0/org.elasticsearch.transport.OutboundHandler.sendResponse(OutboundHandler.java:150)
	at org.elasticsearch.server@9.5.0/org.elasticsearch.transport.TcpTransportChannel.sendResponse(TcpTransportChannel.java:57)
	at org.elasticsearch.server@9.5.0/org.elasticsearch.transport.TaskTransportChannel.sendResponse(TaskTransportChannel.java:35)
	at org.elasticsearch.server@9.5.0/org.elasticsearch.action.support.ChannelActionListener.onResponse(ChannelActionListener.java:33)
	at org.elasticsearch.server@9.5.0/org.elasticsearch.action.support.ChannelActionListener.onResponse(ChannelActionListener.java:20)
	at org.elasticsearch.server@9.5.0/org.elasticsearch.action.ActionListener.respondAndRelease(ActionListener.java:411)
	at
```