### PR TITLE
Fix race condition in dynamic strings YAML tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -560,9 +560,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.csv.CsvFormatSpecIT
   method: test {csv-spec:csv-union-by-name.multiFileUnionByNameRecipeWithPruning [LOCAL]}
   issue: https://github.com/elastic/elasticsearch/issues/149352
-- class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
-  method: test {yaml=indices.create/40_dynamic_strings_auto_keyword/Dynamic string with auto text later disabled omits text subfield}
-  issue: https://github.com/elastic/elasticsearch/issues/149372
 - class: org.elasticsearch.index.mapper.DynamicMappingIT
   method: testDynamicStringMappingWithoutAutoTextSubfield
   issue: https://github.com/elastic/elasticsearch/issues/149374

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.create/40_dynamic_strings_auto_keyword.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.create/40_dynamic_strings_auto_keyword.yml
@@ -27,6 +27,10 @@ setup:
   - match: { test_dynamic_strings_default.defaults.index.mapping.dynamic_strings.auto_text: "true" }
 
   - do:
+      cluster.health:
+        wait_for_events: languid
+
+  - do:
       indices.get_mapping:
         index: test_dynamic_strings_default
 
@@ -55,6 +59,10 @@ setup:
         index: test_dynamic_strings_no_text
 
   - match: { test_dynamic_strings_no_text.settings.index.mapping.dynamic_strings.auto_text: "false" }
+
+  - do:
+      cluster.health:
+        wait_for_events: languid
 
   - do:
       indices.get_mapping:
@@ -88,6 +96,10 @@ setup:
   - match: { test_dynamic_strings.settings.index.mapping.dynamic_strings.auto_text: "true" }
 
   - do:
+      cluster.health:
+        wait_for_events: languid
+
+  - do:
       indices.get_mapping:
         index: test_dynamic_strings
 
@@ -112,6 +124,10 @@ setup:
         index: test_dynamic_strings
 
   - match: { test_dynamic_strings.settings.index.mapping.dynamic_strings.auto_text: "false" }
+
+  - do:
+      cluster.health:
+        wait_for_events: languid
 
   - do:
       indices.get_mapping:


### PR DESCRIPTION
Fixes a race condition in `40_dynamic_strings_auto_keyword`. When these tests run in a multi-node environment, we have to wait until the mapping updates have propagated to all nodes.

Fixes https://github.com/elastic/elasticsearch/issues/149372