### PR TITLE
Correctly handle transient master failover exceptions

### DIFF
--- a/x-pack/plugin/dlm-frozen-transition/src/internalClusterTest/java/org/elasticsearch/xpack/dlm/frozen/DLMFrozenTransitionDisruptionIT.java
+++ b/x-pack/plugin/dlm-frozen-transition/src/internalClusterTest/java/org/elasticsearch/xpack/dlm/frozen/DLMFrozenTransitionDisruptionIT.java
@@ -57,6 +57,7 @@ import org.elasticsearch.xpack.searchablesnapshots.cache.full.CacheService;
 import org.junit.After;
 import org.junit.Before;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -440,6 +441,46 @@ public class DLMFrozenTransitionDisruptionIT extends ESIntegTestCase {
     }
 
     /**
+     * While the "take snapshot" phase is in progress (intercepted via {@link TransportGetSnapshotsAction}),
+     * stops the current master node to trigger a master failover.
+     * <p>
+     * Expected behaviour: the resulting transient master-failover exception is NOT recorded in the
+     * error store. Once a new master is elected the DLM service resumes and the frozen index
+     * eventually appears in the data stream.
+     */
+    public void testMasterFailoverDuringSnapshot() throws Exception {
+        String candidateIndex = setupClusterAndInfrastructure(3);
+
+        CountDownLatch latch = registerDisruptionInterceptor(TransportGetSnapshotsAction.TYPE.name(), () -> {
+            try {
+                internalCluster().stopCurrentMasterNode();
+            } catch (IOException e) {
+                logger.warn("Failed to stop current master node during disruption test", e);
+            }
+        }, true);
+        triggerRollover();
+
+        assertTrue("GetSnapshots request was never seen by the interceptor", latch.await(60, TimeUnit.SECONDS));
+        assertNoErrorRecorded(candidateIndex);
+
+        String expectedFrozenIndexName = DLMConvertToFrozen.SNAPSHOT_NAME_PREFIX + candidateIndex;
+        assertBusy(() -> {
+            var projectMetadata = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
+                .get()
+                .getState()
+                .metadata()
+                .getProject(Metadata.DEFAULT_PROJECT_ID);
+            assertThat(
+                "Frozen index should exist after master failover and transition retry",
+                projectMetadata.index(expectedFrozenIndexName),
+                notNullValue()
+            );
+        }, 120, TimeUnit.SECONDS);
+
+        logger.info("--> master-failover-during-snapshot disruption handled gracefully");
+    }
+
+    /**
      * While the frozen transition is in progress (force-merge phase), updates the lifecycle
      * policy to remove the frozenAfter setting. The service should not crash.
      */
@@ -482,7 +523,17 @@ public class DLMFrozenTransitionDisruptionIT extends ESIntegTestCase {
      * Returns the name of the first backing index (candidate for frozen transition after rollover).
      */
     private String setupClusterAndInfrastructure() {
-        internalCluster().startMasterOnlyNode();
+        return setupClusterAndInfrastructure(1);
+    }
+
+    /**
+     * Starts {@code numMasterNodes} master-eligible nodes plus 2 data nodes and 1 frozen node,
+     * then sets up the data stream infrastructure.
+     * Use {@code numMasterNodes >= 3} for master-failover tests so the cluster retains quorum
+     * after stopping the current master.
+     */
+    private String setupClusterAndInfrastructure(int numMasterNodes) {
+        internalCluster().startMasterOnlyNodes(numMasterNodes);
         internalCluster().startDataOnlyNodes(2);
         startFrozenOnlyNode();
         int numReplicas = 1; // avoid unassigned shards with only 1 data node

--- a/x-pack/plugin/dlm-frozen-transition/src/main/java/org/elasticsearch/xpack/dlm/frozen/DLMConvertToFrozen.java
+++ b/x-pack/plugin/dlm-frozen-transition/src/main/java/org/elasticsearch/xpack/dlm/frozen/DLMConvertToFrozen.java
@@ -47,8 +47,10 @@ import org.elasticsearch.action.support.master.MasterNodeRequest;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateObserver;
+import org.elasticsearch.cluster.NotMasterException;
 import org.elasticsearch.cluster.ProjectState;
 import org.elasticsearch.cluster.SnapshotsInProgress;
+import org.elasticsearch.cluster.coordination.FailedToCommitClusterStateException;
 import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.DataStreamAction;
 import org.elasticsearch.cluster.metadata.IndexAbstraction;
@@ -67,14 +69,18 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.datastreams.DataStreamsPlugin;
 import org.elasticsearch.datastreams.lifecycle.DataStreamLifecycleService;
+import org.elasticsearch.discovery.MasterNotDiscoveredException;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.license.LicenseUtils;
 import org.elasticsearch.license.XPackLicenseState;
+import org.elasticsearch.node.NodeClosedException;
 import org.elasticsearch.repositories.RepositoriesService;
 import org.elasticsearch.snapshots.RestoreInfo;
+import org.elasticsearch.snapshots.SnapshotException;
 import org.elasticsearch.snapshots.SnapshotInfo;
 import org.elasticsearch.snapshots.SnapshotMissingException;
 import org.elasticsearch.snapshots.SnapshotState;
+import org.elasticsearch.transport.ConnectTransportException;
 import org.elasticsearch.xpack.core.ilm.LifecycleSettings;
 import org.elasticsearch.xpack.core.searchablesnapshots.MountSearchableSnapshotAction;
 import org.elasticsearch.xpack.core.searchablesnapshots.MountSearchableSnapshotRequest;
@@ -840,13 +846,7 @@ public class DLMConvertToFrozen implements DLMFrozenTransitionRunnable {
 
                 @Override
                 public void onClusterServiceClose() {
-                    observerError.set(
-                        new ElasticsearchException(
-                            "Cluster service closed while waiting for DLM snapshot [{}] for index [{}]",
-                            snapshotName,
-                            indexName
-                        )
-                    );
+                    observerError.set(new NodeClosedException(clusterService.localNode()));
                     latch.countDown();
                 }
 
@@ -995,6 +995,31 @@ public class DLMConvertToFrozen implements DLMFrozenTransitionRunnable {
             depth++;
         }
         return current;
+    }
+
+    /**
+     * Returns {@code true} if the exception indicates a transient master-failover condition from which the DLM service
+     * will naturally recover on the next scheduler tick once a new master is elected.
+     * Such exceptions must not be recorded in the error store, as they are not indicative of a bug or a
+     * misconfiguration.
+     */
+    static boolean isTransientMasterFailoverException(Throwable t) {
+        Throwable unwrapped = ExceptionsHelper.unwrap(
+            t,
+            NotMasterException.class,
+            FailedToCommitClusterStateException.class,
+            NodeClosedException.class,
+            MasterNotDiscoveredException.class,
+            ConnectTransportException.class,
+            SnapshotException.class
+        );
+
+        if (unwrapped != null) {
+            return unwrapped instanceof SnapshotException == false
+                || (unwrapped.getMessage() != null && unwrapped.getMessage().endsWith("no longer master"));
+        }
+
+        return false;
     }
 
     /**

--- a/x-pack/plugin/dlm-frozen-transition/src/main/java/org/elasticsearch/xpack/dlm/frozen/DLMFrozenTransitionExecutor.java
+++ b/x-pack/plugin/dlm-frozen-transition/src/main/java/org/elasticsearch/xpack/dlm/frozen/DLMFrozenTransitionExecutor.java
@@ -181,13 +181,21 @@ class DLMFrozenTransitionExecutor implements Closeable {
                     null
                 );
             } catch (Exception ex) {
-                errorStore.recordAndLogError(
-                    task.getProjectId(),
-                    indexName,
-                    ex,
-                    Strings.format("Error executing transition for index [%s]", indexName),
-                    frozenTransitionSettings.getErrorRetryInterval()
-                );
+                if (DLMConvertToFrozen.isTransientMasterFailoverException(ex)) {
+                    logger.debug(
+                        "Transient master-failover exception during frozen transition for index [{}], will retry on next tick",
+                        indexName,
+                        ex
+                    );
+                } else {
+                    errorStore.recordAndLogError(
+                        task.getProjectId(),
+                        indexName,
+                        ex,
+                        Strings.format("Error executing transition for index [%s]", indexName),
+                        frozenTransitionSettings.getErrorRetryInterval()
+                    );
+                }
             } finally {
                 submittedTransitions.remove(indexName);
             }


### PR DESCRIPTION
This PR allows us to silently skip exceptions thrown during a transition that is interrupted by a master fail-over so the job can be retried when the cluster is stable again.