### PR TITLE
ESQL: fix FROM *_logs index name validation

### DIFF
--- a/docs/changelog/149395.yaml
+++ b/docs/changelog/149395.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 146073
+pr: 149395
+summary: Fix FROM *_logs index name validation
+type: bug

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/IdentifierBuilder.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/IdentifierBuilder.java
@@ -314,7 +314,8 @@ abstract class IdentifierBuilder extends AbstractBuilder {
             throwInvalidIndexNameException(index, BLANK_INDEX_ERROR_MESSAGE, ctx);
         }
 
-        hasSeenStar = hasSeenStar || index.contains(WILDCARD);
+        boolean currentPatternHasWildcard = index.contains(WILDCARD);
+        hasSeenStar = hasSeenStar || currentPatternHasWildcard;
         index = index.replace(WILDCARD, "").strip();
         if (index.isBlank()) {
             return;
@@ -337,6 +338,17 @@ abstract class IdentifierBuilder extends AbstractBuilder {
         } catch (InvalidIndexNameException e) {
             // ignore invalid index name if it has exclusions and there is an index with wildcard before it
             if (hasSeenStar && hasExclusion) {
+                return;
+            }
+
+            /*
+             * The "must not start with '_', '-', or '+'" rule restricts the first character of a literal
+             * index name; it does not restrict the first character of a wildcard pattern, since the
+             * wildcard can match any prefix (e.g. "*_logs" legitimately matches "app_logs", "nginx_logs").
+             * Don't reject patterns just because the literal portion left after stripping wildcards
+             * begins with one of those characters.
+             */
+            if (currentPatternHasWildcard && e.getMessage().contains("must not start with")) {
                 return;
             }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/IdentifierBuilder.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/IdentifierBuilder.java
@@ -314,8 +314,7 @@ abstract class IdentifierBuilder extends AbstractBuilder {
             throwInvalidIndexNameException(index, BLANK_INDEX_ERROR_MESSAGE, ctx);
         }
 
-        boolean currentPatternHasWildcard = index.contains(WILDCARD);
-        hasSeenStar = hasSeenStar || currentPatternHasWildcard;
+        hasSeenStar = hasSeenStar || index.contains(WILDCARD);
         index = index.replace(WILDCARD, "").strip();
         if (index.isBlank()) {
             return;
@@ -341,14 +340,8 @@ abstract class IdentifierBuilder extends AbstractBuilder {
                 return;
             }
 
-            /*
-             * The "must not start with '_', '-', or '+'" rule restricts the first character of a literal
-             * index name; it does not restrict the first character of a wildcard pattern, since the
-             * wildcard can match any prefix (e.g. "*_logs" legitimately matches "app_logs", "nginx_logs").
-             * Don't reject patterns just because the literal portion left after stripping wildcards
-             * begins with one of those characters.
-             */
-            if (currentPatternHasWildcard && e.getMessage().contains("must not start with")) {
+            // The "must not start with '_', '-', or '+'" rule does not apply if the pattern begins with '*'.
+            if (index.startsWith(WILDCARD) && e.getMessage().contains("must not start with")) {
                 return;
             }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/IdentifierBuilder.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/IdentifierBuilder.java
@@ -314,6 +314,7 @@ abstract class IdentifierBuilder extends AbstractBuilder {
             throwInvalidIndexNameException(index, BLANK_INDEX_ERROR_MESSAGE, ctx);
         }
 
+        boolean startsWithStar = index.startsWith("*");
         hasSeenStar = hasSeenStar || index.contains(WILDCARD);
         index = index.replace(WILDCARD, "").strip();
         if (index.isBlank()) {
@@ -340,8 +341,8 @@ abstract class IdentifierBuilder extends AbstractBuilder {
                 return;
             }
 
-            // The "must not start with '_', '-', or '+'" rule does not apply if the pattern begins with '*'.
-            if (index.startsWith(WILDCARD) && e.getMessage().contains("must not start with")) {
+            // The "must not start with ..." rules do not apply if the pattern begins with '*'.
+            if (startsWithStar && e.getMessage().contains("must not start with")) {
                 return;
             }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/StatementParserTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/StatementParserTests.java
@@ -996,6 +996,36 @@ public class StatementParserTests extends AbstractStatementParserTests {
         );
     }
 
+    /**
+     * Regression test for <a href="https://github.com/elastic/elasticsearch/issues/146073">#146073</a>.
+     * <p>
+     * Patterns containing a wildcard may have a literal portion abutting a reserved index-name
+     * prefix character ('_', '-', or '+'). The wildcard itself can match any prefix, so these
+     * patterns are valid: e.g. {@code *_logs} matches {@code app_logs}, {@code nginx_logs}, etc.
+     * Previously the parser stripped the wildcard and then validated the remainder as a literal
+     * index name, which incorrectly rejected the pattern with the misleading message
+     * {@code "Invalid index name [_logs], must not start with '_', '-', or '+'"}.
+     */
+    public void testWildcardPatternWithReservedPrefixChar() {
+        List<String> commands = new ArrayList<>();
+        commands.add("FROM");
+        if (Build.current().isSnapshot()) {
+            commands.add("TS");
+        }
+        for (String command : commands) {
+            assertStringAsIndexPattern("*_logs", command + " *_logs");
+            assertStringAsIndexPattern("*+logs", command + " *+logs");
+            assertStringAsIndexPattern("_logs*", command + " _logs*");
+            assertStringAsIndexPattern("+logs*", command + " +logs*");
+            assertStringAsIndexPattern("foo*_logs", command + " foo*_logs");
+            assertStringAsIndexPattern("*_logs,*_metrics", command + " *_logs,*_metrics");
+            assertStringAsIndexPattern("cluster:*_logs", command + " cluster:*_logs");
+            if (EsqlCapabilities.Cap.INDEX_COMPONENT_SELECTORS.isEnabled()) {
+                assertStringAsIndexPattern("*_logs::data", command + " *_logs::data");
+            }
+        }
+    }
+
     public void testInvalidQuotingAsFromIndexPattern() {
         expectError("FROM \"foo", ": token recognition error at: '\"foo'");
         expectError("FROM \"foo | LIMIT 1", ": token recognition error at: '\"foo | LIMIT 1'");

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/StatementParserTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/StatementParserTests.java
@@ -1016,7 +1016,7 @@ public class StatementParserTests extends AbstractStatementParserTests {
 
             String lineNumber = command.equals("FROM") ? "line 1:6: " : "line 1:4: ";
             expectError(command + " _logs*", lineNumber + "Invalid index name [_logs], must not start with '_', '-', or '+'");
-            expectError(command + " _*log", lineNumber + "Invalid index name [_log], must not start with '_', '-', or '+'");
+            expectError(command + " _*logs", lineNumber + "Invalid index name [_logs], must not start with '_', '-', or '+'");
             expectError(command + " +logs*", lineNumber + "Invalid index name [+logs], must not start with '_', '-', or '+'");
         }
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/StatementParserTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/StatementParserTests.java
@@ -996,16 +996,7 @@ public class StatementParserTests extends AbstractStatementParserTests {
         );
     }
 
-    /**
-     * Regression test for <a href="https://github.com/elastic/elasticsearch/issues/146073">#146073</a>.
-     * <p>
-     * Patterns containing a wildcard may have a literal portion abutting a reserved index-name
-     * prefix character ('_', '-', or '+'). The wildcard itself can match any prefix, so these
-     * patterns are valid: e.g. {@code *_logs} matches {@code app_logs}, {@code nginx_logs}, etc.
-     * Previously the parser stripped the wildcard and then validated the remainder as a literal
-     * index name, which incorrectly rejected the pattern with the misleading message
-     * {@code "Invalid index name [_logs], must not start with '_', '-', or '+'"}.
-     */
+    /** Regression test for <a href="https://github.com/elastic/elasticsearch/issues/146073">#146073</a>. */
     public void testWildcardPatternWithReservedPrefixChar() {
         List<String> commands = new ArrayList<>();
         commands.add("FROM");
@@ -1015,14 +1006,18 @@ public class StatementParserTests extends AbstractStatementParserTests {
         for (String command : commands) {
             assertStringAsIndexPattern("*_logs", command + " *_logs");
             assertStringAsIndexPattern("*+logs", command + " *+logs");
-            assertStringAsIndexPattern("_logs*", command + " _logs*");
-            assertStringAsIndexPattern("+logs*", command + " +logs*");
+            assertStringAsIndexPattern("**_logs", command + " **_logs");
             assertStringAsIndexPattern("foo*_logs", command + " foo*_logs");
             assertStringAsIndexPattern("*_logs,*_metrics", command + " *_logs,*_metrics");
             assertStringAsIndexPattern("cluster:*_logs", command + " cluster:*_logs");
             if (EsqlCapabilities.Cap.INDEX_COMPONENT_SELECTORS.isEnabled()) {
                 assertStringAsIndexPattern("*_logs::data", command + " *_logs::data");
             }
+
+            String lineNumber = command.equals("FROM") ? "line 1:6: " : "line 1:4: ";
+            expectError(command + " _logs*", lineNumber + "Invalid index name [_logs], must not start with '_', '-', or '+'");
+            expectError(command + " _*log", lineNumber + "Invalid index name [_log], must not start with '_', '-', or '+'");
+            expectError(command + " +logs*", lineNumber + "Invalid index name [+logs], must not start with '_', '-', or '+'");
         }
     }
 


### PR DESCRIPTION
Patterns like `*_logs` were rejected with `"Invalid index name [_logs], must not start with '_', '-', or '+'"`. The parser strips wildcards and validates the remainder as a literal index name, but the "must not start with" rule only restricts literal names; it does not restrict patterns whose wildcard can match any prefix.

Closes #146073
