### PR TITLE
Gate MvSort FLATTENED tests by transport support

### DIFF
--- a/docs/changelog/149402.yaml
+++ b/docs/changelog/149402.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 149402
+summary: Gate `MvSort` FLATTENED tests by transport support
+type: bug

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvSortTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvSortTests.java
@@ -151,7 +151,11 @@ public class MvSortTests extends AbstractScalarFunctionTestCase {
     }
 
     private static void bytesRefs(List<TestCaseSupplier> suppliers) {
-        for (DataType type : List.of(DataType.KEYWORD, DataType.TEXT, DataType.IP, DataType.VERSION, DataType.FLATTENED)) {
+        var types = new ArrayList<>(List.of(DataType.KEYWORD, DataType.TEXT, DataType.IP, DataType.VERSION));
+        if (DataType.FLATTENED.supportedVersion().supportedLocally()) {
+            types.add(DataType.FLATTENED);
+        }
+        for (DataType type : types) {
             suppliers.add(new TestCaseSupplier(List.of(type, DataType.KEYWORD), () -> {
                 List<BytesRef> field = randomList(1, 10, () -> (BytesRef) randomLiteral(type).value());
                 boolean order = randomBoolean();


### PR DESCRIPTION
MvSortTests was generating FLATTENED test cases during mixed-version runs even when the target transport version does not support FLATTENED, which caused deterministic serialization failures. This change gates FLATTENED coverage on local transport support while keeping the rest of the test coverage unchanged.