### PR TITLE
Rename AbstractAsyncBulkByScrollAction to AbstractAsyncBulkByPaginatedSearchAction

### DIFF
--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractAsyncBulkByPaginatedSearchAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractAsyncBulkByPaginatedSearchAction.java
@@ -91,7 +91,7 @@ import static org.elasticsearch.search.sort.SortBuilders.fieldSort;
  * Abstract base for scrolling across a search and executing bulk actions on all results. All package private methods are package private so
  * their tests can use them. Most methods run in the listener thread pool because they are meant to be fast and don't expect to block.
  */
-public abstract class AbstractAsyncBulkByScrollAction<
+public abstract class AbstractAsyncBulkByPaginatedSearchAction<
     Request extends AbstractBulkByPaginatedSearchRequest<Request>,
     Action extends TransportAction<Request, ?>> {
 
@@ -171,7 +171,7 @@ public abstract class AbstractAsyncBulkByScrollAction<
     private final CircuitBreaker circuitBreaker;
     private final String breakerLabel;
 
-    AbstractAsyncBulkByScrollAction(
+    AbstractAsyncBulkByPaginatedSearchAction(
         BulkByPaginatedSearchTask task,
         boolean needsSourceDocumentVersions,
         boolean needsSourceDocumentSeqNoAndPrimaryTerm,
@@ -215,7 +215,7 @@ public abstract class AbstractAsyncBulkByScrollAction<
         );
     }
 
-    AbstractAsyncBulkByScrollAction(
+    AbstractAsyncBulkByPaginatedSearchAction(
         BulkByPaginatedSearchTask task,
         boolean needsSourceDocumentVersions,
         boolean needsSourceDocumentSeqNoAndPrimaryTerm,
@@ -1307,7 +1307,7 @@ public abstract class AbstractAsyncBulkByScrollAction<
          * are read while another thread updates this field. {@link #consumeHits} uses a non-atomic
          * read-then-add on this value; {@code volatile} does not make that sequence atomic—callers rely
          * on at most one thread executing {@code consumeHits} per response, coordinated by
-         * {@link AbstractAsyncBulkByScrollAction#currentScrollResponse} CAS, not on this field alone.
+         * {@link AbstractAsyncBulkByPaginatedSearchAction#currentScrollResponse} CAS, not on this field alone.
          */
         private volatile int consumedOffset = 0;
         private final Releasable releaseRemainingHitsOnce;

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/AsyncDeleteByQueryAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/AsyncDeleteByQueryAction.java
@@ -25,7 +25,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 /**
  * Implementation of delete-by-query using scrolling and bulk.
  */
-public class AsyncDeleteByQueryAction extends AbstractAsyncBulkByScrollAction<DeleteByQueryRequest, TransportDeleteByQueryAction> {
+public class AsyncDeleteByQueryAction extends AbstractAsyncBulkByPaginatedSearchAction<DeleteByQueryRequest, TransportDeleteByQueryAction> {
 
     public AsyncDeleteByQueryAction(
         BulkByPaginatedSearchTask task,

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/Reindexer.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/Reindexer.java
@@ -941,7 +941,7 @@ public class Reindexer {
      * but this makes no attempt to do any of them so it can be as simple
      * possible.
      */
-    static class AsyncIndexBySearchAction extends AbstractAsyncBulkByScrollAction<ReindexRequest, TransportReindexAction> {
+    static class AsyncIndexBySearchAction extends AbstractAsyncBulkByPaginatedSearchAction<ReindexRequest, TransportReindexAction> {
         /**
          * Transformer for the {@code _id} of the destination index used to
          * normalize {@code _id}s landing in the index.

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/TransportUpdateByQueryAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/TransportUpdateByQueryAction.java
@@ -126,7 +126,9 @@ public class TransportUpdateByQueryAction extends HandledTransportAction<UpdateB
     /**
      * Simple implementation of update-by-query using scrolling and bulk.
      */
-    static class AsyncIndexBySearchAction extends AbstractAsyncBulkByScrollAction<UpdateByQueryRequest, TransportUpdateByQueryAction> {
+    static class AsyncIndexBySearchAction extends AbstractAsyncBulkByPaginatedSearchAction<
+        UpdateByQueryRequest,
+        TransportUpdateByQueryAction> {
 
         AsyncIndexBySearchAction(
             BulkByPaginatedSearchTask task,

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/AbstractAsyncBulkByPaginatedSearchActionMetadataTestCase.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/AbstractAsyncBulkByPaginatedSearchActionMetadataTestCase.java
@@ -13,7 +13,7 @@ import org.elasticsearch.index.reindex.AbstractAsyncBulkByScrollActionTestCase;
 import org.elasticsearch.index.reindex.AbstractBulkByPaginatedSearchRequest;
 import org.elasticsearch.index.reindex.BulkByScrollResponse;
 
-public abstract class AbstractAsyncBulkByScrollActionMetadataTestCase<
+public abstract class AbstractAsyncBulkByPaginatedSearchActionMetadataTestCase<
     Request extends AbstractBulkByPaginatedSearchRequest<Request>,
     Response extends BulkByScrollResponse> extends AbstractAsyncBulkByScrollActionTestCase<Request, Response> {
 
@@ -21,5 +21,5 @@ public abstract class AbstractAsyncBulkByScrollActionMetadataTestCase<
         return new PaginatedHitSource.BasicHit("index", "id", 0);
     }
 
-    protected abstract AbstractAsyncBulkByScrollAction<Request, ?> action();
+    protected abstract AbstractAsyncBulkByPaginatedSearchAction<Request, ?> action();
 }

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/AbstractAsyncBulkByPaginatedSearchActionMetadataTestCase.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/AbstractAsyncBulkByPaginatedSearchActionMetadataTestCase.java
@@ -9,13 +9,13 @@
 
 package org.elasticsearch.reindex;
 
-import org.elasticsearch.index.reindex.AbstractAsyncBulkByScrollActionTestCase;
+import org.elasticsearch.index.reindex.AbstractAsyncBulkByPaginatedSearchActionTestCase;
 import org.elasticsearch.index.reindex.AbstractBulkByPaginatedSearchRequest;
 import org.elasticsearch.index.reindex.BulkByScrollResponse;
 
 public abstract class AbstractAsyncBulkByPaginatedSearchActionMetadataTestCase<
     Request extends AbstractBulkByPaginatedSearchRequest<Request>,
-    Response extends BulkByScrollResponse> extends AbstractAsyncBulkByScrollActionTestCase<Request, Response> {
+    Response extends BulkByScrollResponse> extends AbstractAsyncBulkByPaginatedSearchActionTestCase<Request, Response> {
 
     protected PaginatedHitSource.BasicHit doc() {
         return new PaginatedHitSource.BasicHit("index", "id", 0);

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/AbstractAsyncBulkByPaginatedSearchActionPitKeepaliveHttpTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/AbstractAsyncBulkByPaginatedSearchActionPitKeepaliveHttpTests.java
@@ -26,11 +26,11 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.sameInstance;
 
 /**
- * Unit tests for {@link AbstractAsyncBulkByScrollAction#remapSearchFailures} and
- * {@link AbstractAsyncBulkByScrollAction#maybeWrapCatastrophicFailure}: how PIT keep-alive
+ * Unit tests for {@link AbstractAsyncBulkByPaginatedSearchAction#remapSearchFailures} and
+ * {@link AbstractAsyncBulkByPaginatedSearchAction#maybeWrapCatastrophicFailure}: how PIT keep-alive
  * semantics map {@link SearchContextMissingException} to {@link RestStatus} for HTTP-style failure handling.
  */
-public class AbstractAsyncBulkByScrollActionPitKeepaliveHttpTests extends ESTestCase {
+public class AbstractAsyncBulkByPaginatedSearchActionPitKeepaliveHttpTests extends ESTestCase {
 
     /**
      * Scroll pagination keeps the original failure list and {@link RestStatus#NOT_FOUND} for
@@ -40,7 +40,7 @@ public class AbstractAsyncBulkByScrollActionPitKeepaliveHttpTests extends ESTest
         PaginatedSearchFailure paginatedSearchFailure = new PaginatedSearchFailure(missingContext());
         assertThat(paginatedSearchFailure.getStatus(), equalTo(RestStatus.NOT_FOUND));
         List<PaginatedSearchFailure> originalSearchFailures = singletonList(paginatedSearchFailure);
-        List<PaginatedSearchFailure> remappedSearchFailures = AbstractAsyncBulkByScrollAction.remapSearchFailures(
+        List<PaginatedSearchFailure> remappedSearchFailures = AbstractAsyncBulkByPaginatedSearchAction.remapSearchFailures(
             false,
             true,
             originalSearchFailures
@@ -56,7 +56,7 @@ public class AbstractAsyncBulkByScrollActionPitKeepaliveHttpTests extends ESTest
     public void testRemapSearchFailuresPitDeadlineNotPassedLeavesListUntouched() {
         PaginatedSearchFailure paginatedSearchFailure = new PaginatedSearchFailure(missingContext());
         List<PaginatedSearchFailure> originalSearchFailures = singletonList(paginatedSearchFailure);
-        List<PaginatedSearchFailure> remappedSearchFailures = AbstractAsyncBulkByScrollAction.remapSearchFailures(
+        List<PaginatedSearchFailure> remappedSearchFailures = AbstractAsyncBulkByPaginatedSearchAction.remapSearchFailures(
             true,
             false,
             originalSearchFailures
@@ -70,7 +70,7 @@ public class AbstractAsyncBulkByScrollActionPitKeepaliveHttpTests extends ESTest
      */
     public void testRemapSearchFailuresPitPastDeadlineThrowsInternalServerError() {
         PaginatedSearchFailure paginatedSearchFailure = new PaginatedSearchFailure(missingContext());
-        List<PaginatedSearchFailure> remappedSearchFailures = AbstractAsyncBulkByScrollAction.remapSearchFailures(
+        List<PaginatedSearchFailure> remappedSearchFailures = AbstractAsyncBulkByPaginatedSearchAction.remapSearchFailures(
             true,
             true,
             singletonList(paginatedSearchFailure)
@@ -87,7 +87,7 @@ public class AbstractAsyncBulkByScrollActionPitKeepaliveHttpTests extends ESTest
     public void testRemapSearchFailuresPitPastDeadlineReturnsOriginalListForOtherFailures() {
         PaginatedSearchFailure paginatedSearchFailure = new PaginatedSearchFailure(new RuntimeException("other"));
         List<PaginatedSearchFailure> originalSearchFailures = singletonList(paginatedSearchFailure);
-        List<PaginatedSearchFailure> remappedSearchFailures = AbstractAsyncBulkByScrollAction.remapSearchFailures(
+        List<PaginatedSearchFailure> remappedSearchFailures = AbstractAsyncBulkByPaginatedSearchAction.remapSearchFailures(
             true,
             true,
             originalSearchFailures
@@ -97,7 +97,7 @@ public class AbstractAsyncBulkByScrollActionPitKeepaliveHttpTests extends ESTest
 
     /** A null catastrophic failure stays null regardless of PIT and deadline flags. */
     public void testMaybeWrapCatastrophicFailureReturnsNullForNullFailure() {
-        assertNull(AbstractAsyncBulkByScrollAction.maybeWrapCatastrophicFailure(true, true, null));
+        assertNull(AbstractAsyncBulkByPaginatedSearchAction.maybeWrapCatastrophicFailure(true, true, null));
     }
 
     /**
@@ -105,7 +105,7 @@ public class AbstractAsyncBulkByScrollActionPitKeepaliveHttpTests extends ESTest
      */
     public void testMaybeWrapCatastrophicFailureScrollPastDeadlinePreservesOriginalException() {
         Exception originalFailure = missingContext();
-        Exception maybeWrappedFailure = AbstractAsyncBulkByScrollAction.maybeWrapCatastrophicFailure(false, true, originalFailure);
+        Exception maybeWrappedFailure = AbstractAsyncBulkByPaginatedSearchAction.maybeWrapCatastrophicFailure(false, true, originalFailure);
         assertThat(maybeWrappedFailure, sameInstance(originalFailure));
     }
 
@@ -114,7 +114,7 @@ public class AbstractAsyncBulkByScrollActionPitKeepaliveHttpTests extends ESTest
      */
     public void testMaybeWrapCatastrophicFailurePitDeadlineNotPastPreservesOriginalException() {
         Exception originalFailure = missingContext();
-        Exception maybeWrappedFailure = AbstractAsyncBulkByScrollAction.maybeWrapCatastrophicFailure(true, false, originalFailure);
+        Exception maybeWrappedFailure = AbstractAsyncBulkByPaginatedSearchAction.maybeWrapCatastrophicFailure(true, false, originalFailure);
         assertThat(maybeWrappedFailure, sameInstance(originalFailure));
     }
 
@@ -124,7 +124,7 @@ public class AbstractAsyncBulkByScrollActionPitKeepaliveHttpTests extends ESTest
      */
     public void testMaybeWrapCatastrophicFailurePitPastDeadlineWrapsSearchContextMissing() {
         Exception originalFailure = missingContext();
-        Exception maybeWrappedFailure = AbstractAsyncBulkByScrollAction.maybeWrapCatastrophicFailure(true, true, originalFailure);
+        Exception maybeWrappedFailure = AbstractAsyncBulkByPaginatedSearchAction.maybeWrapCatastrophicFailure(true, true, originalFailure);
         assertThat(maybeWrappedFailure, instanceOf(ElasticsearchStatusException.class));
         ElasticsearchStatusException elasticsearchStatusException = (ElasticsearchStatusException) maybeWrappedFailure;
         assertThat(elasticsearchStatusException.status(), equalTo(RestStatus.INTERNAL_SERVER_ERROR));

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/AbstractAsyncBulkByPaginatedSearchActionScriptTestCase.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/AbstractAsyncBulkByPaginatedSearchActionScriptTestCase.java
@@ -12,7 +12,7 @@ package org.elasticsearch.reindex;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.index.IndexRequest;
-import org.elasticsearch.index.reindex.AbstractAsyncBulkByScrollActionTestCase;
+import org.elasticsearch.index.reindex.AbstractAsyncBulkByPaginatedSearchActionTestCase;
 import org.elasticsearch.index.reindex.AbstractBulkIndexByPaginatedSearchRequest;
 import org.elasticsearch.index.reindex.BulkByScrollResponse;
 import org.elasticsearch.reindex.AbstractAsyncBulkByPaginatedSearchAction.RequestWrapper;
@@ -35,7 +35,7 @@ import static org.mockito.Mockito.when;
 
 public abstract class AbstractAsyncBulkByPaginatedSearchActionScriptTestCase<
     Request extends AbstractBulkIndexByPaginatedSearchRequest<Request>,
-    Response extends BulkByScrollResponse> extends AbstractAsyncBulkByScrollActionTestCase<Request, Response> {
+    Response extends BulkByScrollResponse> extends AbstractAsyncBulkByPaginatedSearchActionTestCase<Request, Response> {
 
     protected ScriptService scriptService;
 

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/AbstractAsyncBulkByPaginatedSearchActionScriptTestCase.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/AbstractAsyncBulkByPaginatedSearchActionScriptTestCase.java
@@ -15,7 +15,7 @@ import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.index.reindex.AbstractAsyncBulkByScrollActionTestCase;
 import org.elasticsearch.index.reindex.AbstractBulkIndexByPaginatedSearchRequest;
 import org.elasticsearch.index.reindex.BulkByScrollResponse;
-import org.elasticsearch.reindex.AbstractAsyncBulkByScrollAction.RequestWrapper;
+import org.elasticsearch.reindex.AbstractAsyncBulkByPaginatedSearchAction.RequestWrapper;
 import org.elasticsearch.script.ReindexScript;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.script.UpdateByQueryScript;
@@ -33,7 +33,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public abstract class AbstractAsyncBulkByScrollActionScriptTestCase<
+public abstract class AbstractAsyncBulkByPaginatedSearchActionScriptTestCase<
     Request extends AbstractBulkIndexByPaginatedSearchRequest<Request>,
     Response extends BulkByScrollResponse> extends AbstractAsyncBulkByScrollActionTestCase<Request, Response> {
 
@@ -72,8 +72,8 @@ public abstract class AbstractAsyncBulkByScrollActionScriptTestCase<
                 }
             }
         );
-        AbstractAsyncBulkByScrollAction<Request, ?> action = action(scriptService, request().setScript(mockScript("")));
-        RequestWrapper<?> result = action.buildScriptApplier().apply(AbstractAsyncBulkByScrollAction.wrap(index), doc);
+        AbstractAsyncBulkByPaginatedSearchAction<Request, ?> action = action(scriptService, request().setScript(mockScript("")));
+        RequestWrapper<?> result = action.buildScriptApplier().apply(AbstractAsyncBulkByPaginatedSearchAction.wrap(index), doc);
         return (result != null) ? (T) result.self() : null;
     }
 
@@ -109,5 +109,5 @@ public abstract class AbstractAsyncBulkByScrollActionScriptTestCase<
         assertThat(e.getMessage(), equalTo("[op] must be one of delete, index, noop, not [unknown]"));
     }
 
-    protected abstract AbstractAsyncBulkByScrollAction<Request, ?> action(ScriptService scriptService, Request request);
+    protected abstract AbstractAsyncBulkByPaginatedSearchAction<Request, ?> action(ScriptService scriptService, Request request);
 }

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/AsyncBulkByScrollActionTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/AsyncBulkByScrollActionTests.java
@@ -125,7 +125,7 @@ import static org.apache.lucene.tests.util.TestUtil.randomSimpleString;
 import static org.elasticsearch.common.BackoffPolicy.constantBackoff;
 import static org.elasticsearch.core.TimeValue.timeValueMillis;
 import static org.elasticsearch.core.TimeValue.timeValueSeconds;
-import static org.elasticsearch.reindex.AbstractAsyncBulkByScrollAction.computeRelocationCooldownNanos;
+import static org.elasticsearch.reindex.AbstractAsyncBulkByPaginatedSearchAction.computeRelocationCooldownNanos;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.either;
@@ -204,7 +204,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
 
     private static final BytesArray TEST_PIT_ID = new BytesArray("test-pit-id".getBytes(StandardCharsets.UTF_8));
 
-    /** No-op batch release for tests that call {@link AbstractAsyncBulkByScrollAction#sendBulkRequest} with no hit refs. */
+    /** No-op batch release for tests that call {@link AbstractAsyncBulkByPaginatedSearchAction#sendBulkRequest} with no hit refs. */
     private static final Releasable NO_OP_RELEASE_BATCH_HITS = () -> {};
 
     /**
@@ -272,7 +272,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         action.onScrollResponse(
             lastBatchTime,
             lastBatchSize,
-            new AbstractAsyncBulkByScrollAction.ScrollConsumableHitsResponse(new PaginatedHitSource.AsyncResponse() {
+            new AbstractAsyncBulkByPaginatedSearchAction.ScrollConsumableHitsResponse(new PaginatedHitSource.AsyncResponse() {
                 @Override
                 public PaginatedHitSource.Response response() {
                     return response;
@@ -777,8 +777,8 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
 
     /**
      * Verifies that concurrent calls to {@code releaseRemainingHits()} release each unconsumed hit exactly once.
-     * This covers the race where {@link AbstractAsyncBulkByScrollAction#prepareBulkRequest} (via the
-     * {@code requestFinishing} path) and {@link AbstractAsyncBulkByScrollAction#finishHim} both hold a reference
+     * This covers the race where {@link AbstractAsyncBulkByPaginatedSearchAction#prepareBulkRequest} (via the
+     * {@code requestFinishing} path) and {@link AbstractAsyncBulkByPaginatedSearchAction#finishHim} both hold a reference
      * to the same response and call {@code releaseRemainingHits()} concurrently. Without the {@code releaseOnce}
      * guard the two threads would both iterate the same unconsumed range and double-release every remaining hit.
      */
@@ -798,8 +798,8 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
             scrollId(),
             null
         );
-        AbstractAsyncBulkByScrollAction.ScrollConsumableHitsResponse response =
-            new AbstractAsyncBulkByScrollAction.ScrollConsumableHitsResponse(new PaginatedHitSource.AsyncResponse() {
+        AbstractAsyncBulkByPaginatedSearchAction.ScrollConsumableHitsResponse response =
+            new AbstractAsyncBulkByPaginatedSearchAction.ScrollConsumableHitsResponse(new PaginatedHitSource.AsyncResponse() {
                 @Override
                 public PaginatedHitSource.Response response() {
                     return scrollResponse;
@@ -866,7 +866,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         boolean usePit = configurePitOrScroll();
         DummyAsyncBulkByScrollAction action = new DummyAsyncBulkByScrollAction() {
             @Override
-            protected AbstractAsyncBulkByScrollAction.RequestWrapper<?> buildRequest(Hit doc) {
+            protected AbstractAsyncBulkByPaginatedSearchAction.RequestWrapper<?> buildRequest(Hit doc) {
                 throw new RuntimeException("surprise");
             }
         };
@@ -1289,8 +1289,8 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
             usePit ? null : "scrollid",
             usePit ? new Object[] { "search_after" } : null
         );
-        final AbstractAsyncBulkByScrollAction.ScrollConsumableHitsResponse response =
-            new AbstractAsyncBulkByScrollAction.ScrollConsumableHitsResponse(new PaginatedHitSource.AsyncResponse() {
+        final AbstractAsyncBulkByPaginatedSearchAction.ScrollConsumableHitsResponse response =
+            new AbstractAsyncBulkByPaginatedSearchAction.ScrollConsumableHitsResponse(new PaginatedHitSource.AsyncResponse() {
                 @Override
                 public PaginatedHitSource.Response response() {
                     return scrollResponse;
@@ -1326,8 +1326,8 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
     }
 
     /**
-     * Exercises the window where {@link AbstractAsyncBulkByScrollAction#prepareBulkRequest} has CAS'd
-     * {@link AbstractAsyncBulkByScrollAction#currentScrollResponse} to {@code null} but has not yet restored the ref after
+     * Exercises the window where {@link AbstractAsyncBulkByPaginatedSearchAction#prepareBulkRequest} has CAS'd
+     * {@link AbstractAsyncBulkByPaginatedSearchAction#currentScrollResponse} to {@code null} but has not yet restored the ref after
      * {@code maxDocs} consumed a partial batch. A subclass blocks inside {@code consumeHits} until {@code finishHim} runs so
      * {@code finishHim}'s {@code getAndSet} sees {@code null} and does not release unconsumed hits; the {@code requestFinishing}
      * checks in {@code prepareBulkRequest} / {@code sendBulkRequest} must release the batch slice and remaining hits when prepare
@@ -1354,7 +1354,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         CountDownLatch firstConsumeReturnedFromSuper = new CountDownLatch(1);
         CountDownLatch resumePrepareAfterFinishHim = new CountDownLatch(1);
         AtomicInteger sendBulkInvocations = new AtomicInteger();
-        AbstractAsyncBulkByScrollAction.ScrollConsumableHitsResponse consumable = new ScrollConsumableHitsResponseGate(
+        AbstractAsyncBulkByPaginatedSearchAction.ScrollConsumableHitsResponse consumable = new ScrollConsumableHitsResponseGate(
             new PaginatedHitSource.AsyncResponse() {
                 @Override
                 public PaginatedHitSource.Response response() {
@@ -1370,8 +1370,8 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
 
         DummyAsyncBulkByScrollAction action = new DummyAsyncBulkByScrollAction() {
             @Override
-            protected AbstractAsyncBulkByScrollAction.RequestWrapper<?> buildRequest(Hit doc) {
-                return AbstractAsyncBulkByScrollAction.wrap(new IndexRequest().index("test").id(doc.getId()));
+            protected AbstractAsyncBulkByPaginatedSearchAction.RequestWrapper<?> buildRequest(Hit doc) {
+                return AbstractAsyncBulkByPaginatedSearchAction.wrap(new IndexRequest().index("test").id(doc.getId()));
             }
 
             @Override
@@ -1403,10 +1403,10 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
     }
 
     /**
-     * Complementary to {@link #testPartialScrollRequestFinishing}: {@link AbstractAsyncBulkByScrollAction#finishHim} runs first and
-     * wins {@link AbstractAsyncBulkByScrollAction#currentScrollResponse}'s {@code getAndSet(null)}, releasing unconsumed hits.
-     * A later {@link AbstractAsyncBulkByScrollAction#prepareBulkRequest} for the same
-     * {@link AbstractAsyncBulkByScrollAction.ScrollConsumableHitsResponse} must lose
+     * Complementary to {@link #testPartialScrollRequestFinishing}: {@link AbstractAsyncBulkByPaginatedSearchAction#finishHim} runs first
+     * and wins {@link AbstractAsyncBulkByPaginatedSearchAction#currentScrollResponse}'s {@code getAndSet(null)}, releasing unconsumed hits.
+     * A later {@link AbstractAsyncBulkByPaginatedSearchAction#prepareBulkRequest} for the same
+     * {@link AbstractAsyncBulkByPaginatedSearchAction.ScrollConsumableHitsResponse} must lose
      * the {@code compareAndSet(asyncResponse, null)} race and return without consuming or releasing again.
      */
     public void testPrepareBulkRequestNoOpsWhenFinishHimAlreadyClaimedScrollResponse() {
@@ -1426,8 +1426,8 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
             scrollId(),
             null
         );
-        AbstractAsyncBulkByScrollAction.ScrollConsumableHitsResponse consumable =
-            new AbstractAsyncBulkByScrollAction.ScrollConsumableHitsResponse(new PaginatedHitSource.AsyncResponse() {
+        AbstractAsyncBulkByPaginatedSearchAction.ScrollConsumableHitsResponse consumable =
+            new AbstractAsyncBulkByPaginatedSearchAction.ScrollConsumableHitsResponse(new PaginatedHitSource.AsyncResponse() {
                 @Override
                 public PaginatedHitSource.Response response() {
                     return scrollResponse;
@@ -1467,8 +1467,8 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
             usePit ? null : "scrollid",
             usePit ? new Object[] { "search_after" } : null
         );
-        final AbstractAsyncBulkByScrollAction.ScrollConsumableHitsResponse response =
-            new AbstractAsyncBulkByScrollAction.ScrollConsumableHitsResponse(new PaginatedHitSource.AsyncResponse() {
+        final AbstractAsyncBulkByPaginatedSearchAction.ScrollConsumableHitsResponse response =
+            new AbstractAsyncBulkByPaginatedSearchAction.ScrollConsumableHitsResponse(new PaginatedHitSource.AsyncResponse() {
                 @Override
                 public PaginatedHitSource.Response response() {
                     return scrollResponse;
@@ -1497,7 +1497,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
     }
 
     public void testEnableScrollByDefault() {
-        var preparedSearchRequest = AbstractAsyncBulkByScrollAction.prepareSearchRequest(testRequest, false, false, false, null);
+        var preparedSearchRequest = AbstractAsyncBulkByPaginatedSearchAction.prepareSearchRequest(testRequest, false, false, false, null);
         assertThat(preparedSearchRequest.scroll(), notNullValue());
     }
 
@@ -1505,7 +1505,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         testRequest.setMaxDocs(between(101, 1000));
         testRequest.getSearchRequest().source().size(100);
 
-        var preparedSearchRequest = AbstractAsyncBulkByScrollAction.prepareSearchRequest(testRequest, false, false, false, null);
+        var preparedSearchRequest = AbstractAsyncBulkByPaginatedSearchAction.prepareSearchRequest(testRequest, false, false, false, null);
 
         assertThat(preparedSearchRequest.scroll(), notNullValue());
     }
@@ -1514,7 +1514,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         testRequest.setMaxDocs(between(1, 100));
         testRequest.getSearchRequest().source().size(100);
 
-        var preparedSearchRequest = AbstractAsyncBulkByScrollAction.prepareSearchRequest(testRequest, false, false, false, null);
+        var preparedSearchRequest = AbstractAsyncBulkByPaginatedSearchAction.prepareSearchRequest(testRequest, false, false, false, null);
 
         assertThat(preparedSearchRequest.scroll(), nullValue());
     }
@@ -1529,7 +1529,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         testRequest.getSearchRequest().source().size(100);
         testRequest.getSearchRequest().source().slice(new SliceBuilder(IdFieldMapper.NAME, 0, 5));
 
-        var preparedSearchRequest = AbstractAsyncBulkByScrollAction.prepareSearchRequest(testRequest, false, false, false, null);
+        var preparedSearchRequest = AbstractAsyncBulkByPaginatedSearchAction.prepareSearchRequest(testRequest, false, false, false, null);
 
         assertThat(preparedSearchRequest.scroll(), notNullValue());
     }
@@ -1539,7 +1539,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         testRequest.getSearchRequest().source().size(100);
         testRequest.setAbortOnVersionConflict(false);
 
-        var preparedSearchRequest = AbstractAsyncBulkByScrollAction.prepareSearchRequest(testRequest, false, false, false, null);
+        var preparedSearchRequest = AbstractAsyncBulkByPaginatedSearchAction.prepareSearchRequest(testRequest, false, false, false, null);
 
         assertThat(preparedSearchRequest.scroll(), notNullValue());
     }
@@ -1549,7 +1549,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
      */
     public void testPrepareSearchRequestWithPITDisablesScrollAndSetsFromZero() {
         configurePitOrScroll(true);
-        var preparedSearchRequest = AbstractAsyncBulkByScrollAction.prepareSearchRequest(testRequest, false, false, false, null);
+        var preparedSearchRequest = AbstractAsyncBulkByPaginatedSearchAction.prepareSearchRequest(testRequest, false, false, false, null);
         assertThat(preparedSearchRequest.scroll(), nullValue());
         assertEquals(0, preparedSearchRequest.source().from());
     }
@@ -1560,7 +1560,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
      */
     public void testPrepareSearchRequestWithPITUsesShardDocSort() {
         configurePitOrScroll(true);
-        var preparedSearchRequest = AbstractAsyncBulkByScrollAction.prepareSearchRequest(testRequest, false, false, false, null);
+        var preparedSearchRequest = AbstractAsyncBulkByPaginatedSearchAction.prepareSearchRequest(testRequest, false, false, false, null);
         assertThat(preparedSearchRequest.source().sorts(), hasSize(1));
         assertThat(preparedSearchRequest.source().sorts().getFirst(), instanceOf(FieldSortBuilder.class));
         assertEquals(
@@ -1574,7 +1574,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
      */
     public void testPrepareSearchRequestWithPITUsesDocSortWhenRemoteBefore712() {
         configurePitOrScroll(true);
-        var preparedSearchRequest = AbstractAsyncBulkByScrollAction.prepareSearchRequest(
+        var preparedSearchRequest = AbstractAsyncBulkByPaginatedSearchAction.prepareSearchRequest(
             testRequest,
             false,
             false,
@@ -1595,7 +1595,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
      */
     public void testPrepareSearchRequestWithScrollUsesDocSort() {
         configurePitOrScroll(false);
-        var preparedSearchRequest = AbstractAsyncBulkByScrollAction.prepareSearchRequest(testRequest, false, false, false, null);
+        var preparedSearchRequest = AbstractAsyncBulkByPaginatedSearchAction.prepareSearchRequest(testRequest, false, false, false, null);
         assertThat(preparedSearchRequest.source().sorts(), hasSize(1));
         assertThat(preparedSearchRequest.source().sorts().getFirst(), instanceOf(FieldSortBuilder.class));
         assertEquals("_doc", ((FieldSortBuilder) preparedSearchRequest.source().sorts().getFirst()).getFieldName());
@@ -1608,7 +1608,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
     public void testPrepareSearchRequestPreservesUserSort() {
         configurePitOrScroll(true);
         testRequest.getSearchRequest().source().sort("timestamp");
-        var preparedSearchRequest = AbstractAsyncBulkByScrollAction.prepareSearchRequest(testRequest, false, false, false, null);
+        var preparedSearchRequest = AbstractAsyncBulkByPaginatedSearchAction.prepareSearchRequest(testRequest, false, false, false, null);
         assertThat(preparedSearchRequest.source().sorts(), hasSize(1));
         assertEquals("timestamp", ((FieldSortBuilder) preparedSearchRequest.source().sorts().getFirst()).getFieldName());
     }
@@ -1778,17 +1778,19 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         };
         action.setScroll(expectedScrollId);
 
-        final var asyncResponse = new AbstractAsyncBulkByScrollAction.ScrollConsumableHitsResponse(new PaginatedHitSource.AsyncResponse() {
-            @Override
-            public PaginatedHitSource.Response response() {
-                return createPaginatedResponse(false, false, emptyList(), 0, emptyList(), expectedScrollId, null);
-            }
+        final var asyncResponse = new AbstractAsyncBulkByPaginatedSearchAction.ScrollConsumableHitsResponse(
+            new PaginatedHitSource.AsyncResponse() {
+                @Override
+                public PaginatedHitSource.Response response() {
+                    return createPaginatedResponse(false, false, emptyList(), 0, emptyList(), expectedScrollId, null);
+                }
 
-            @Override
-            public void done(final TimeValue extraKeepAlive) {
-                fail("done() should not be called because it fetches more data");
+                @Override
+                public void done(final TimeValue extraKeepAlive) {
+                    fail("done() should not be called because it fetches more data");
+                }
             }
-        });
+        );
 
         action.notifyDone(System.nanoTime(), asyncResponse, 0);
 
@@ -1840,17 +1842,19 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         };
         action.setSearchAfterValues(expectedSearchAfter);
 
-        final var asyncResponse = new AbstractAsyncBulkByScrollAction.ScrollConsumableHitsResponse(new PaginatedHitSource.AsyncResponse() {
-            @Override
-            public PaginatedHitSource.Response response() {
-                return createPaginatedResponse(true, false, emptyList(), 0, emptyList(), null, expectedSearchAfter);
-            }
+        final var asyncResponse = new AbstractAsyncBulkByPaginatedSearchAction.ScrollConsumableHitsResponse(
+            new PaginatedHitSource.AsyncResponse() {
+                @Override
+                public PaginatedHitSource.Response response() {
+                    return createPaginatedResponse(true, false, emptyList(), 0, emptyList(), null, expectedSearchAfter);
+                }
 
-            @Override
-            public void done(final TimeValue extraKeepAlive) {
-                fail("done() should not be called because it fetches more data");
+                @Override
+                public void done(final TimeValue extraKeepAlive) {
+                    fail("done() should not be called because it fetches more data");
+                }
             }
-        });
+        );
 
         action.notifyDone(System.nanoTime(), asyncResponse, 0);
 
@@ -1881,17 +1885,19 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         action.setScroll(expectedScrollId);
 
         final AtomicBoolean doneCalled = new AtomicBoolean();
-        final var asyncResponse = new AbstractAsyncBulkByScrollAction.ScrollConsumableHitsResponse(new PaginatedHitSource.AsyncResponse() {
-            @Override
-            public PaginatedHitSource.Response response() {
-                return createPaginatedResponse(false, false, emptyList(), 0, emptyList(), expectedScrollId, null);
-            }
+        final var asyncResponse = new AbstractAsyncBulkByPaginatedSearchAction.ScrollConsumableHitsResponse(
+            new PaginatedHitSource.AsyncResponse() {
+                @Override
+                public PaginatedHitSource.Response response() {
+                    return createPaginatedResponse(false, false, emptyList(), 0, emptyList(), expectedScrollId, null);
+                }
 
-            @Override
-            public void done(final TimeValue extraKeepAlive) {
-                doneCalled.set(true);
+                @Override
+                public void done(final TimeValue extraKeepAlive) {
+                    doneCalled.set(true);
+                }
             }
-        });
+        );
         action.notifyDone(System.nanoTime(), asyncResponse, 0);
 
         assertTrue("asyncResponse.done() should be called for normal flow", doneCalled.get());
@@ -1911,17 +1917,19 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         action.setSearchAfterValues(expectedSearchAfter);
 
         final AtomicBoolean doneCalled = new AtomicBoolean();
-        final var asyncResponse = new AbstractAsyncBulkByScrollAction.ScrollConsumableHitsResponse(new PaginatedHitSource.AsyncResponse() {
-            @Override
-            public PaginatedHitSource.Response response() {
-                return createPaginatedResponse(true, false, emptyList(), 0, emptyList(), null, expectedSearchAfter);
-            }
+        final var asyncResponse = new AbstractAsyncBulkByPaginatedSearchAction.ScrollConsumableHitsResponse(
+            new PaginatedHitSource.AsyncResponse() {
+                @Override
+                public PaginatedHitSource.Response response() {
+                    return createPaginatedResponse(true, false, emptyList(), 0, emptyList(), null, expectedSearchAfter);
+                }
 
-            @Override
-            public void done(final TimeValue extraKeepAlive) {
-                doneCalled.set(true);
+                @Override
+                public void done(final TimeValue extraKeepAlive) {
+                    doneCalled.set(true);
+                }
             }
-        });
+        );
         action.notifyDone(System.nanoTime(), asyncResponse, 0);
 
         assertTrue("asyncResponse.done() should be called for normal flow", doneCalled.get());
@@ -1940,17 +1948,19 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         action.setScroll(expectedScrollId);
 
         final AtomicBoolean doneCalled = new AtomicBoolean();
-        final var asyncResponse = new AbstractAsyncBulkByScrollAction.ScrollConsumableHitsResponse(new PaginatedHitSource.AsyncResponse() {
-            @Override
-            public PaginatedHitSource.Response response() {
-                return createPaginatedResponse(false, false, emptyList(), 0, emptyList(), expectedScrollId, null);
-            }
+        final var asyncResponse = new AbstractAsyncBulkByPaginatedSearchAction.ScrollConsumableHitsResponse(
+            new PaginatedHitSource.AsyncResponse() {
+                @Override
+                public PaginatedHitSource.Response response() {
+                    return createPaginatedResponse(false, false, emptyList(), 0, emptyList(), expectedScrollId, null);
+                }
 
-            @Override
-            public void done(final TimeValue extraKeepAlive) {
-                doneCalled.set(true);
+                @Override
+                public void done(final TimeValue extraKeepAlive) {
+                    doneCalled.set(true);
+                }
             }
-        });
+        );
         action.notifyDone(System.nanoTime(), asyncResponse, 0);
 
         assertTrue("asyncResponse.done() should be called when relocation is not requested", doneCalled.get());
@@ -1969,17 +1979,19 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         action.setSearchAfterValues(expectedSearchAfter);
 
         final AtomicBoolean doneCalled = new AtomicBoolean();
-        final var asyncResponse = new AbstractAsyncBulkByScrollAction.ScrollConsumableHitsResponse(new PaginatedHitSource.AsyncResponse() {
-            @Override
-            public PaginatedHitSource.Response response() {
-                return createPaginatedResponse(true, false, emptyList(), 0, emptyList(), null, expectedSearchAfter);
-            }
+        final var asyncResponse = new AbstractAsyncBulkByPaginatedSearchAction.ScrollConsumableHitsResponse(
+            new PaginatedHitSource.AsyncResponse() {
+                @Override
+                public PaginatedHitSource.Response response() {
+                    return createPaginatedResponse(true, false, emptyList(), 0, emptyList(), null, expectedSearchAfter);
+                }
 
-            @Override
-            public void done(final TimeValue extraKeepAlive) {
-                doneCalled.set(true);
+                @Override
+                public void done(final TimeValue extraKeepAlive) {
+                    doneCalled.set(true);
+                }
             }
-        });
+        );
         action.notifyDone(System.nanoTime(), asyncResponse, 0);
 
         assertTrue("asyncResponse.done() should be called when relocation is not requested", doneCalled.get());
@@ -1998,7 +2010,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         final AtomicBoolean onScrollResponseCalled = new AtomicBoolean();
         final DummyAsyncBulkByScrollAction action = new DummyAsyncBulkByScrollAction() {
             @Override
-            void onScrollResponse(final AbstractAsyncBulkByScrollAction.ScrollConsumableHitsResponse asyncResponse) {
+            void onScrollResponse(final AbstractAsyncBulkByPaginatedSearchAction.ScrollConsumableHitsResponse asyncResponse) {
                 onScrollResponseCalled.set(true);
                 // don't call super - continues ingesting and listener might complete before assertions
             }
@@ -2009,17 +2021,19 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
             new PaginatedHitSource.BasicHit("index", "id-1", -1),
             new PaginatedHitSource.BasicHit("index", "id-2", -1)
         );
-        final var asyncResponse = new AbstractAsyncBulkByScrollAction.ScrollConsumableHitsResponse(new PaginatedHitSource.AsyncResponse() {
-            @Override
-            public PaginatedHitSource.Response response() {
-                return createPaginatedResponse(false, false, emptyList(), hits.size(), hits, expectedScrollId, null);
-            }
+        final var asyncResponse = new AbstractAsyncBulkByPaginatedSearchAction.ScrollConsumableHitsResponse(
+            new PaginatedHitSource.AsyncResponse() {
+                @Override
+                public PaginatedHitSource.Response response() {
+                    return createPaginatedResponse(false, false, emptyList(), hits.size(), hits, expectedScrollId, null);
+                }
 
-            @Override
-            public void done(final TimeValue extraKeepAlive) {
-                fail("done() should not be called when there are remaining hits to consume");
+                @Override
+                public void done(final TimeValue extraKeepAlive) {
+                    fail("done() should not be called when there are remaining hits to consume");
+                }
             }
-        });
+        );
 
         action.notifyDone(System.nanoTime(), asyncResponse, 0);
 
@@ -2040,7 +2054,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         final AtomicBoolean onScrollResponseCalled = new AtomicBoolean();
         final DummyAsyncBulkByScrollAction action = new DummyAsyncBulkByScrollAction() {
             @Override
-            void onScrollResponse(final AbstractAsyncBulkByScrollAction.ScrollConsumableHitsResponse asyncResponse) {
+            void onScrollResponse(final AbstractAsyncBulkByPaginatedSearchAction.ScrollConsumableHitsResponse asyncResponse) {
                 onScrollResponseCalled.set(true);
                 // don't call super - continues ingesting and listener might complete before assertions
             }
@@ -2051,17 +2065,19 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
             new PaginatedHitSource.BasicHit("index", "id-1", -1),
             new PaginatedHitSource.BasicHit("index", "id-2", -1)
         );
-        final var asyncResponse = new AbstractAsyncBulkByScrollAction.ScrollConsumableHitsResponse(new PaginatedHitSource.AsyncResponse() {
-            @Override
-            public PaginatedHitSource.Response response() {
-                return createPaginatedResponse(true, false, emptyList(), hits.size(), hits, null, expectedSearchAfter);
-            }
+        final var asyncResponse = new AbstractAsyncBulkByPaginatedSearchAction.ScrollConsumableHitsResponse(
+            new PaginatedHitSource.AsyncResponse() {
+                @Override
+                public PaginatedHitSource.Response response() {
+                    return createPaginatedResponse(true, false, emptyList(), hits.size(), hits, null, expectedSearchAfter);
+                }
 
-            @Override
-            public void done(final TimeValue extraKeepAlive) {
-                fail("done() should not be called when there are remaining hits to consume");
+                @Override
+                public void done(final TimeValue extraKeepAlive) {
+                    fail("done() should not be called when there are remaining hits to consume");
+                }
             }
-        });
+        );
 
         action.notifyDone(System.nanoTime(), asyncResponse, 0);
 
@@ -2079,17 +2095,19 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         worker.setNodeToRelocateToSupplier(() -> Optional.of("target-node"));
 
         final DummyAsyncBulkByScrollAction action = new DummyAsyncBulkByScrollAction();
-        final var asyncResponse = new AbstractAsyncBulkByScrollAction.ScrollConsumableHitsResponse(new PaginatedHitSource.AsyncResponse() {
-            @Override
-            public PaginatedHitSource.Response response() {
-                return createPaginatedResponse(true, false, emptyList(), 0, emptyList(), null, null);
-            }
+        final var asyncResponse = new AbstractAsyncBulkByPaginatedSearchAction.ScrollConsumableHitsResponse(
+            new PaginatedHitSource.AsyncResponse() {
+                @Override
+                public PaginatedHitSource.Response response() {
+                    return createPaginatedResponse(true, false, emptyList(), 0, emptyList(), null, null);
+                }
 
-            @Override
-            public void done(final TimeValue extraKeepAlive) {
-                fail("done() should not be called");
+                @Override
+                public void done(final TimeValue extraKeepAlive) {
+                    fail("done() should not be called");
+                }
             }
-        });
+        );
 
         IllegalStateException e = expectThrows(IllegalStateException.class, () -> action.notifyDone(System.nanoTime(), asyncResponse, 0));
         assertThat(e.getMessage(), containsString("PIT relocation requires search_after values from the last hit"));
@@ -2136,17 +2154,19 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         final DummyAsyncBulkByScrollAction action = new DummyAsyncBulkByScrollAction(TimeValue.timeValueHours(1));
 
         final AtomicBoolean doneCalled = new AtomicBoolean();
-        final var asyncResponse = new AbstractAsyncBulkByScrollAction.ScrollConsumableHitsResponse(new PaginatedHitSource.AsyncResponse() {
-            @Override
-            public PaginatedHitSource.Response response() {
-                return new PaginatedHitSource.Response(false, emptyList(), 0, emptyList(), scrollId());
-            }
+        final var asyncResponse = new AbstractAsyncBulkByPaginatedSearchAction.ScrollConsumableHitsResponse(
+            new PaginatedHitSource.AsyncResponse() {
+                @Override
+                public PaginatedHitSource.Response response() {
+                    return new PaginatedHitSource.Response(false, emptyList(), 0, emptyList(), scrollId());
+                }
 
-            @Override
-            public void done(final TimeValue extraKeepAlive) {
-                doneCalled.set(true);
+                @Override
+                public void done(final TimeValue extraKeepAlive) {
+                    doneCalled.set(true);
+                }
             }
-        });
+        );
         action.notifyDone(System.nanoTime(), asyncResponse, 0);
 
         assertTrue("asyncResponse.done() should be called because re-relocation was skipped", doneCalled.get());
@@ -2177,17 +2197,19 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         final DummyAsyncBulkByScrollAction action = new DummyAsyncBulkByScrollAction(task, TimeValue.ZERO);
         action.setScroll(expectedScrollId);
 
-        final var asyncResponse = new AbstractAsyncBulkByScrollAction.ScrollConsumableHitsResponse(new PaginatedHitSource.AsyncResponse() {
-            @Override
-            public PaginatedHitSource.Response response() {
-                return new PaginatedHitSource.Response(false, emptyList(), 0, emptyList(), scrollId);
-            }
+        final var asyncResponse = new AbstractAsyncBulkByPaginatedSearchAction.ScrollConsumableHitsResponse(
+            new PaginatedHitSource.AsyncResponse() {
+                @Override
+                public PaginatedHitSource.Response response() {
+                    return new PaginatedHitSource.Response(false, emptyList(), 0, emptyList(), scrollId);
+                }
 
-            @Override
-            public void done(final TimeValue extraKeepAlive) {
-                fail("done() should not be called because relocation should proceed");
+                @Override
+                public void done(final TimeValue extraKeepAlive) {
+                    fail("done() should not be called because relocation should proceed");
+                }
             }
-        });
+        );
         action.notifyDone(System.nanoTime(), asyncResponse, 0);
 
         assertTrue(listener.isDone());
@@ -2205,17 +2227,19 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         final DummyAsyncBulkByScrollAction action = new DummyAsyncBulkByScrollAction(TimeValue.timeValueHours(1));
         action.setScroll(expectedScrollId);
 
-        final var asyncResponse = new AbstractAsyncBulkByScrollAction.ScrollConsumableHitsResponse(new PaginatedHitSource.AsyncResponse() {
-            @Override
-            public PaginatedHitSource.Response response() {
-                return new PaginatedHitSource.Response(false, emptyList(), 0, emptyList(), scrollId);
-            }
+        final var asyncResponse = new AbstractAsyncBulkByPaginatedSearchAction.ScrollConsumableHitsResponse(
+            new PaginatedHitSource.AsyncResponse() {
+                @Override
+                public PaginatedHitSource.Response response() {
+                    return new PaginatedHitSource.Response(false, emptyList(), 0, emptyList(), scrollId);
+                }
 
-            @Override
-            public void done(final TimeValue extraKeepAlive) {
-                fail("done() should not be called because relocation should proceed");
+                @Override
+                public void done(final TimeValue extraKeepAlive) {
+                    fail("done() should not be called because relocation should proceed");
+                }
             }
-        });
+        );
         action.notifyDone(System.nanoTime(), asyncResponse, 0);
 
         assertTrue(listener.isDone());
@@ -2223,7 +2247,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         assertTrue(response.getTaskResumeInfo().isPresent());
     }
 
-    private class DummyAsyncBulkByScrollAction extends AbstractAsyncBulkByScrollAction<
+    private class DummyAsyncBulkByScrollAction extends AbstractAsyncBulkByPaginatedSearchAction<
         DummyAbstractBulkByPaginatedSearchRequest,
         DummyTransportAsyncBulkByScrollAction> {
 
@@ -2268,7 +2292,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         }
 
         @Override
-        protected AbstractAsyncBulkByScrollAction.RequestWrapper<?> buildRequest(Hit doc) {
+        protected AbstractAsyncBulkByPaginatedSearchAction.RequestWrapper<?> buildRequest(Hit doc) {
             throw new UnsupportedOperationException("Use another override to test this.");
         }
     }
@@ -2529,10 +2553,11 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
 
     /**
      * Blocks in {@code consumeHits} after {@code super} returns (first batch taken) until the test finishes {@code finishHim},
-     * so {@link AbstractAsyncBulkByScrollAction#currentScrollResponse} stays {@code null} across {@code finishHim}'s
+     * so {@link AbstractAsyncBulkByPaginatedSearchAction#currentScrollResponse} stays {@code null} across {@code finishHim}'s
      * {@code getAndSet} when {@code maxDocs} leaves a partial scroll batch.
      */
-    private static final class ScrollConsumableHitsResponseGate extends AbstractAsyncBulkByScrollAction.ScrollConsumableHitsResponse {
+    private static final class ScrollConsumableHitsResponseGate extends
+        AbstractAsyncBulkByPaginatedSearchAction.ScrollConsumableHitsResponse {
         private final CountDownLatch firstConsumeReturnedFromSuper;
         private final CountDownLatch resumePrepareAfterFinishHim;
 

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/AsyncBulkByScrollActionTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/AsyncBulkByScrollActionTests.java
@@ -756,7 +756,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         action.onScrollResponse(
             System.nanoTime(),
             0,
-            new AbstractAsyncBulkByScrollAction.ScrollConsumableHitsResponse(new PaginatedHitSource.AsyncResponse() {
+            new AbstractAsyncBulkByPaginatedSearchAction.ScrollConsumableHitsResponse(new PaginatedHitSource.AsyncResponse() {
                 @Override
                 public PaginatedHitSource.Response response() {
                     return response;
@@ -1615,14 +1615,14 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
 
     public void testPrepareSearchRequestEnablesAccurateTrackTotalHitsForPit() {
         configurePitOrScroll(true);
-        var preparedSearchRequest = AbstractAsyncBulkByScrollAction.prepareSearchRequest(testRequest, false, false, false, null);
+        var preparedSearchRequest = AbstractAsyncBulkByPaginatedSearchAction.prepareSearchRequest(testRequest, false, false, false, null);
         assertEquals(Integer.valueOf(Integer.MAX_VALUE), preparedSearchRequest.source().trackTotalHitsUpTo());
     }
 
     public void testPrepareSearchRequestDoesNotSetTrackTotalHitsForScroll() {
         configurePitOrScroll(false);
         assertNull(testRequest.getSearchRequest().source().trackTotalHitsUpTo());
-        var preparedSearchRequest = AbstractAsyncBulkByScrollAction.prepareSearchRequest(testRequest, false, false, false, null);
+        var preparedSearchRequest = AbstractAsyncBulkByPaginatedSearchAction.prepareSearchRequest(testRequest, false, false, false, null);
         assertNull(preparedSearchRequest.source().trackTotalHitsUpTo());
     }
 
@@ -1630,7 +1630,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         configurePitOrScroll(randomBoolean());
         int userTrackTotalHitsUpTo = randomIntBetween(1, 1000);
         testRequest.getSearchRequest().source().trackTotalHitsUpTo(userTrackTotalHitsUpTo);
-        var preparedSearchRequest = AbstractAsyncBulkByScrollAction.prepareSearchRequest(testRequest, false, false, false, null);
+        var preparedSearchRequest = AbstractAsyncBulkByPaginatedSearchAction.prepareSearchRequest(testRequest, false, false, false, null);
         assertEquals(Integer.valueOf(userTrackTotalHitsUpTo), preparedSearchRequest.source().trackTotalHitsUpTo());
     }
 
@@ -1638,7 +1638,13 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
     /// reporting the cached total in the response.
     public void testPitPaginatedHitSourceCachesTotalAndDisablesTrackOnSubsequentBatches() {
         configurePitOrScroll(true);
-        SearchRequest preparedSearchRequest = AbstractAsyncBulkByScrollAction.prepareSearchRequest(testRequest, false, false, false, null);
+        SearchRequest preparedSearchRequest = AbstractAsyncBulkByPaginatedSearchAction.prepareSearchRequest(
+            testRequest,
+            false,
+            false,
+            false,
+            null
+        );
         AtomicReference<PaginatedHitSource.AsyncResponse> capturedAsyncResponse = new AtomicReference<>();
         AtomicReference<Exception> capturedFailure = new AtomicReference<>();
         ClientPitPaginatedHitSource paginatedHitSource = new ClientPitPaginatedHitSource(
@@ -1669,7 +1675,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
             client.lastSearch.get().listener.onResponse(firstResponse);
             assertNotNull("first batch must be delivered", capturedAsyncResponse.get());
             assertEquals("first batch reports the accurate total", totalHits, capturedAsyncResponse.get().response().getTotalHits());
-            new AbstractAsyncBulkByScrollAction.ScrollConsumableHitsResponse(capturedAsyncResponse.get()).releaseRemainingHits();
+            new AbstractAsyncBulkByPaginatedSearchAction.ScrollConsumableHitsResponse(capturedAsyncResponse.get()).releaseRemainingHits();
             capturedAsyncResponse.set(null);
         } finally {
             firstResponse.decRef();
@@ -1703,7 +1709,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
                 totalHits,
                 capturedAsyncResponse.get().response().getTotalHits()
             );
-            new AbstractAsyncBulkByScrollAction.ScrollConsumableHitsResponse(capturedAsyncResponse.get()).releaseRemainingHits();
+            new AbstractAsyncBulkByPaginatedSearchAction.ScrollConsumableHitsResponse(capturedAsyncResponse.get()).releaseRemainingHits();
         } finally {
             secondResponse.decRef();
         }

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexIdTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexIdTests.java
@@ -25,7 +25,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersion;
-import org.elasticsearch.index.reindex.AbstractAsyncBulkByScrollActionTestCase;
+import org.elasticsearch.index.reindex.AbstractAsyncBulkByPaginatedSearchActionTestCase;
 import org.elasticsearch.index.reindex.BulkByScrollResponse;
 import org.elasticsearch.index.reindex.ReindexRequest;
 import org.elasticsearch.xcontent.XContentParseException;
@@ -44,7 +44,7 @@ import static org.mockito.Mockito.when;
 /**
  * Reindex tests for picking ids.
  */
-public class ReindexIdTests extends AbstractAsyncBulkByScrollActionTestCase<ReindexRequest, BulkByScrollResponse> {
+public class ReindexIdTests extends AbstractAsyncBulkByPaginatedSearchActionTestCase<ReindexRequest, BulkByScrollResponse> {
     public void testEmptyStateCopiesId() throws Exception {
         final ProjectState projectState = ClusterState.EMPTY_STATE.projectState(Metadata.DEFAULT_PROJECT_ID);
         assertThat(action(projectState).buildRequest(doc()).getId(), equalTo(doc().getId()));

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexMetadataTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexMetadataTests.java
@@ -21,10 +21,10 @@ import org.elasticsearch.reindex.PaginatedHitSource.Hit;
 /**
  * Reindex test for routing.
  */
-public class ReindexMetadataTests extends AbstractAsyncBulkByScrollActionMetadataTestCase<ReindexRequest, BulkByScrollResponse> {
+public class ReindexMetadataTests extends AbstractAsyncBulkByPaginatedSearchActionMetadataTestCase<ReindexRequest, BulkByScrollResponse> {
     public void testRoutingCopiedByDefault() throws Exception {
         IndexRequest index = new IndexRequest();
-        action().copyMetadata(AbstractAsyncBulkByScrollAction.wrap(index), doc().setRouting("foo"));
+        action().copyMetadata(AbstractAsyncBulkByPaginatedSearchAction.wrap(index), doc().setRouting("foo"));
         assertEquals("foo", index.routing());
     }
 
@@ -32,7 +32,7 @@ public class ReindexMetadataTests extends AbstractAsyncBulkByScrollActionMetadat
         TestAction action = action();
         action.mainRequest().getDestination().routing("keep");
         IndexRequest index = new IndexRequest();
-        action.copyMetadata(AbstractAsyncBulkByScrollAction.wrap(index), doc().setRouting("foo"));
+        action.copyMetadata(AbstractAsyncBulkByPaginatedSearchAction.wrap(index), doc().setRouting("foo"));
         assertEquals("foo", index.routing());
     }
 
@@ -40,7 +40,7 @@ public class ReindexMetadataTests extends AbstractAsyncBulkByScrollActionMetadat
         TestAction action = action();
         action.mainRequest().getDestination().routing("discard");
         IndexRequest index = new IndexRequest();
-        action.copyMetadata(AbstractAsyncBulkByScrollAction.wrap(index), doc().setRouting("foo"));
+        action.copyMetadata(AbstractAsyncBulkByPaginatedSearchAction.wrap(index), doc().setRouting("foo"));
         assertEquals(null, index.routing());
     }
 
@@ -48,7 +48,7 @@ public class ReindexMetadataTests extends AbstractAsyncBulkByScrollActionMetadat
         TestAction action = action();
         action.mainRequest().getDestination().routing("=cat");
         IndexRequest index = new IndexRequest();
-        action.copyMetadata(AbstractAsyncBulkByScrollAction.wrap(index), doc().setRouting("foo"));
+        action.copyMetadata(AbstractAsyncBulkByPaginatedSearchAction.wrap(index), doc().setRouting("foo"));
         assertEquals("cat", index.routing());
     }
 
@@ -56,7 +56,7 @@ public class ReindexMetadataTests extends AbstractAsyncBulkByScrollActionMetadat
         TestAction action = action();
         action.mainRequest().getDestination().routing("==]");
         IndexRequest index = new IndexRequest();
-        action.copyMetadata(AbstractAsyncBulkByScrollAction.wrap(index), doc().setRouting("foo"));
+        action.copyMetadata(AbstractAsyncBulkByPaginatedSearchAction.wrap(index), doc().setRouting("foo"));
         assertEquals("=]", index.routing());
     }
 
@@ -98,8 +98,8 @@ public class ReindexMetadataTests extends AbstractAsyncBulkByScrollActionMetadat
         }
 
         @Override
-        public AbstractAsyncBulkByScrollAction.RequestWrapper<?> copyMetadata(
-            AbstractAsyncBulkByScrollAction.RequestWrapper<?> request,
+        public AbstractAsyncBulkByPaginatedSearchAction.RequestWrapper<?> copyMetadata(
+            AbstractAsyncBulkByPaginatedSearchAction.RequestWrapper<?> request,
             Hit doc
         ) {
             return super.copyMetadata(request, doc);

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexScriptTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexScriptTests.java
@@ -27,7 +27,7 @@ import static org.hamcrest.Matchers.containsString;
 /**
  * Tests reindex with a script modifying the documents.
  */
-public class ReindexScriptTests extends AbstractAsyncBulkByScrollActionScriptTestCase<ReindexRequest, BulkByScrollResponse> {
+public class ReindexScriptTests extends AbstractAsyncBulkByPaginatedSearchActionScriptTestCase<ReindexRequest, BulkByScrollResponse> {
 
     public void testSetIndex() throws Exception {
         Object dest = randomFrom(new Object[] { 234, 234L, "pancake" });

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/UpdateByQueryCircuitBreakerTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/UpdateByQueryCircuitBreakerTests.java
@@ -32,7 +32,7 @@ import static org.hamcrest.Matchers.notNullValue;
  * CircuitBreakingException} to the client when that reservation can't fit.
  *
  * <p>This is the UBQ companion to {@link ReindexCircuitBreakerTests}; the two paths share the lifecycle in
- * {@link AbstractAsyncBulkByScrollAction} but each concrete action has its own breaker wiring with a distinct
+ * {@link AbstractAsyncBulkByPaginatedSearchAction} but each concrete action has its own breaker wiring with a distinct
  * label, so each needs its own end-to-end coverage to guard against wiring drift.
  */
 public class UpdateByQueryCircuitBreakerTests extends ESSingleNodeTestCase {

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/UpdateByQueryMetadataTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/UpdateByQueryMetadataTests.java
@@ -15,13 +15,13 @@ import org.elasticsearch.index.reindex.BulkByScrollResponse;
 import org.elasticsearch.index.reindex.UpdateByQueryRequest;
 import org.elasticsearch.reindex.PaginatedHitSource.Hit;
 
-public class UpdateByQueryMetadataTests extends AbstractAsyncBulkByScrollActionMetadataTestCase<
+public class UpdateByQueryMetadataTests extends AbstractAsyncBulkByPaginatedSearchActionMetadataTestCase<
     UpdateByQueryRequest,
     BulkByScrollResponse> {
 
     public void testRoutingIsCopied() {
         IndexRequest index = new IndexRequest();
-        action().copyMetadata(AbstractAsyncBulkByScrollAction.wrap(index), doc().setRouting("foo"));
+        action().copyMetadata(AbstractAsyncBulkByPaginatedSearchAction.wrap(index), doc().setRouting("foo"));
         assertEquals("foo", index.routing());
     }
 
@@ -53,8 +53,8 @@ public class UpdateByQueryMetadataTests extends AbstractAsyncBulkByScrollActionM
         }
 
         @Override
-        public AbstractAsyncBulkByScrollAction.RequestWrapper<?> copyMetadata(
-            AbstractAsyncBulkByScrollAction.RequestWrapper<?> request,
+        public AbstractAsyncBulkByPaginatedSearchAction.RequestWrapper<?> copyMetadata(
+            AbstractAsyncBulkByPaginatedSearchAction.RequestWrapper<?> request,
             Hit doc
         ) {
             return super.copyMetadata(request, doc);

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/UpdateByQueryVersionTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/UpdateByQueryVersionTests.java
@@ -14,7 +14,9 @@ import org.elasticsearch.index.reindex.BulkByScrollResponse;
 import org.elasticsearch.index.reindex.UpdateByQueryRequest;
 import org.elasticsearch.reindex.PaginatedHitSource.Hit;
 
-public class UpdateByQueryVersionTests extends AbstractAsyncBulkByScrollActionMetadataTestCase<UpdateByQueryRequest, BulkByScrollResponse> {
+public class UpdateByQueryVersionTests extends AbstractAsyncBulkByPaginatedSearchActionMetadataTestCase<
+    UpdateByQueryRequest,
+    BulkByScrollResponse> {
 
     UpdateByQueryRequest request;
 

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/UpdateByQueryWithScriptTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/UpdateByQueryWithScriptTests.java
@@ -27,7 +27,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class UpdateByQueryWithScriptTests extends AbstractAsyncBulkByScrollActionScriptTestCase<
+public class UpdateByQueryWithScriptTests extends AbstractAsyncBulkByPaginatedSearchActionScriptTestCase<
     UpdateByQueryRequest,
     BulkByScrollResponse> {
 

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/remote/RemoteRequestBuildersTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/remote/RemoteRequestBuildersTests.java
@@ -222,7 +222,7 @@ public class RemoteRequestBuildersTests extends ESTestCase {
 
         SearchRequest searchRequest = new SearchRequest();
         searchRequest.source(new SearchSourceBuilder());
-        // always set by AbstractAsyncBulkByScrollAction#prepareSearchRequest
+        // always set by AbstractAsyncBulkByPaginatedSearchAction#prepareSearchRequest
         searchRequest.source().excludeVectors(false);
         String query = "{\"match_all\":{}}";
         HttpEntity entity = initialSearch(searchRequest, new BytesArray(query), remoteVersion).getEntity();

--- a/server/src/main/java/org/elasticsearch/script/UpdateMetadata.java
+++ b/server/src/main/java/org/elasticsearch/script/UpdateMetadata.java
@@ -21,7 +21,7 @@ import java.util.stream.Collectors;
  * and read-write op that may be one of 'noop' or 'none' (legacy), 'index', 'delete' or null
  */
 public class UpdateMetadata extends Metadata {
-    // AbstractAsyncBulkByScrollAction.OpType uses 'noop' rather than 'none', so unify on 'noop' but allow 'none' in
+    // AbstractAsyncBulkByPaginatedSearchAction.OpType uses 'noop' rather than 'none', so unify on 'noop' but allow 'none' in
     // the ctx map
     protected static final String LEGACY_NOOP_STRING = "none";
 

--- a/test/framework/src/main/java/org/elasticsearch/index/reindex/AbstractAsyncBulkByPaginatedSearchActionTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/reindex/AbstractAsyncBulkByPaginatedSearchActionTestCase.java
@@ -19,7 +19,7 @@ import org.junit.Before;
 
 import java.util.Collections;
 
-public abstract class AbstractAsyncBulkByScrollActionTestCase<
+public abstract class AbstractAsyncBulkByPaginatedSearchActionTestCase<
     Request extends AbstractBulkByPaginatedSearchRequest<Request>,
     Response extends BulkByScrollResponse> extends ESTestCase {
     protected ThreadPool threadPool;


### PR DESCRIPTION
Renames `AbstractAsyncBulkByScrollAction` to `AbstractAsyncBulkByPaginatedSearchAction` now that scroll based search has been replaced by point-in-time search for reindexing. This is point 5 of https://github.com/elastic/elasticsearch-team/issues/2406.

Relates: https://github.com/elastic/elasticsearch-team/issues/2406 