### PR TITLE
Addres release test failures after introducing mapping.dynamic_strings.auto_text setting

### DIFF
--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/LogsDataStreamRestIT.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/LogsDataStreamRestIT.java
@@ -49,6 +49,7 @@ public class LogsDataStreamRestIT extends ESRestTestCase {
     public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
         .distribution(DistributionType.DEFAULT)
         .feature(FeatureFlag.COLUMNAR_INDEX_MODE_FEATURE_FLAG)
+        .feature(FeatureFlag.EXTENDED_DOC_VALUES_PARAMS)
         .setting("xpack.security.enabled", "false")
         .setting("xpack.license.self_generated.type", "trial")
         .build();


### PR DESCRIPTION
Set `EXTENDED_DOC_VALUES_PARAMS` feature flag in LogsDataStreamRestIT's test cluster.