### PR TITLE
Make PR CI merge-base resolution robust to non-local target refs

### DIFF
--- a/.buildkite/scripts/generate-pr-performance-benchmark.sh
+++ b/.buildkite/scripts/generate-pr-performance-benchmark.sh
@@ -15,7 +15,20 @@ set -euo pipefail
 
 env_id_baseline=$(python3 -c 'import uuid; print(uuid.uuid4())')
 env_id_contender=$(python3 -c 'import uuid; print(uuid.uuid4())')
-merge_base=$(git merge-base "origin/${GITHUB_PR_TARGET_BRANCH}" HEAD)
+
+resolve_merge_base_target() {
+  local target_branch="$1"
+  if git rev-parse --verify "${target_branch}^{commit}" >/dev/null 2>&1; then
+    printf '%s' "$target_branch"
+    return
+  fi
+
+  git fetch --no-tags origin "$target_branch"
+  printf '%s' "FETCH_HEAD"
+}
+
+target_ref=$(resolve_merge_base_target "${GITHUB_PR_TARGET_BRANCH}")
+merge_base=$(git merge-base "$target_ref" HEAD)
 
 # PR comment
 buildkite-agent meta-data set pr_comment:early_comment_job_id "$BUILDKITE_JOB_ID"

--- a/.buildkite/scripts/pull-request/pipeline.test.ts
+++ b/.buildkite/scripts/pull-request/pipeline.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 
-import { generatePipelines } from "./pipeline";
+import { generatePipelines, resolveMergeBaseTarget } from "./pipeline";
 import { setBwcVersionsPath, setSnapshotBwcVersionsPath } from "./bwc-versions";
 
 describe("generatePipelines", () => {
@@ -113,5 +113,39 @@ describe("generatePipelines", () => {
 
     expect(usingDefaults).toBeDefined();
     expect(usingDefaults!.pipeline.env?.["CUSTOM_ENV_VAR"]).toBe("value");
+  });
+});
+
+describe("resolveMergeBaseTarget", () => {
+  test("uses target branch directly when ref exists locally", () => {
+    const commands: string[] = [];
+    const runner = (command: string): Buffer => {
+      commands.push(command);
+      return Buffer.from("");
+    };
+
+    const result = resolveMergeBaseTarget("main", runner, "/repo");
+
+    expect(result).toBe("main");
+    expect(commands).toEqual(["git rev-parse --verify main^{commit}"]);
+  });
+
+  test("fetches remote target and falls back to FETCH_HEAD when ref is missing", () => {
+    const commands: string[] = [];
+    const runner = (command: string): Buffer => {
+      commands.push(command);
+      if (command.startsWith("git rev-parse")) {
+        throw new Error("missing ref");
+      }
+      return Buffer.from("");
+    };
+
+    const result = resolveMergeBaseTarget("spice/MattAlp/1/base", runner, "/repo");
+
+    expect(result).toBe("FETCH_HEAD");
+    expect(commands).toEqual([
+      "git rev-parse --verify spice/MattAlp/1/base^{commit}",
+      "git fetch --no-tags origin spice/MattAlp/1/base",
+    ]);
   });
 });

--- a/.buildkite/scripts/pull-request/pipeline.ts
+++ b/.buildkite/scripts/pull-request/pipeline.ts
@@ -229,16 +229,20 @@ export const generatePipelines = (
   return finalPipelines;
 };
 
+const shellQuote = (value: string): string => `'${value.replace(/'/g, `'\\''`)}'`;
+
 export function resolveMergeBaseTarget(
   targetBranch: string,
   run: CommandRunner = (command, options) => execSync(command, options),
   projectRoot: string = PROJECT_ROOT
 ): string {
+  const quotedTargetBranch = shellQuote(targetBranch);
+
   try {
-    run(`git rev-parse --verify ${targetBranch}^{commit}`, { cwd: projectRoot, stdio: "ignore" });
+    run(`git rev-parse --verify ${quotedTargetBranch}^{commit}`, { cwd: projectRoot, stdio: "ignore" });
     return targetBranch;
   } catch {
-    run(`git fetch --no-tags origin ${targetBranch}`, { cwd: projectRoot, stdio: "inherit" });
+    run(`git fetch --no-tags origin ${quotedTargetBranch}`, { cwd: projectRoot, stdio: "inherit" });
     return "FETCH_HEAD";
   }
 }

--- a/.buildkite/scripts/pull-request/pipeline.ts
+++ b/.buildkite/scripts/pull-request/pipeline.ts
@@ -25,6 +25,8 @@ const AUTO_RETRY_CONFIG: BuildkiteRetry = {
 
 const PROJECT_ROOT = resolve(`${import.meta.dir}/../../..`);
 
+type CommandRunner = (command: string, options: Parameters<typeof execSync>[1]) => Buffer;
+
 const getArray = (strOrArray: string | string[] | undefined): string[] => {
   if (typeof strOrArray === "undefined") {
     return [];
@@ -164,10 +166,12 @@ export const generatePipelines = (
 
   if (!changedFiles?.length) {
     console.log("Doing git fetch and getting merge-base");
-    const mergeBase = execSync(
-      `git fetch origin ${process.env["GITHUB_PR_TARGET_BRANCH"]}; git merge-base origin/${process.env["GITHUB_PR_TARGET_BRANCH"]} HEAD`,
-      { cwd: PROJECT_ROOT }
-    )
+    const targetBranch = process.env["GITHUB_PR_TARGET_BRANCH"];
+    if (!targetBranch) {
+      throw new Error("GITHUB_PR_TARGET_BRANCH environment variable is required");
+    }
+    const targetRef = resolveMergeBaseTarget(targetBranch);
+    const mergeBase = execSync(`git merge-base ${targetRef} HEAD`, { cwd: PROJECT_ROOT })
       .toString()
       .trim();
 
@@ -224,3 +228,17 @@ export const generatePipelines = (
 
   return finalPipelines;
 };
+
+export function resolveMergeBaseTarget(
+  targetBranch: string,
+  run: CommandRunner = (command, options) => execSync(command, options),
+  projectRoot: string = PROJECT_ROOT
+): string {
+  try {
+    run(`git rev-parse --verify ${targetBranch}^{commit}`, { cwd: projectRoot, stdio: "ignore" });
+    return targetBranch;
+  } catch {
+    run(`git fetch --no-tags origin ${targetBranch}`, { cwd: projectRoot, stdio: "inherit" });
+    return "FETCH_HEAD";
+  }
+}


### PR DESCRIPTION
Some PR workflows use target refs that are not present as local `origin/*` branches (for example synthetic stack refs). This updates PR CI scripts to resolve merge-base targets by first checking for a local commit ref and then falling back to fetching the target ref and using `FETCH_HEAD`.

It applies the same behavior in both pull-request pipeline generation and PR benchmark baseline selection, and adds test coverage for the fallback path.