### PR TITLE
ESQL:DS: HeapAttack for Parquet

### DIFF
--- a/test/external-modules/esql-heap-attack/build.gradle
+++ b/test/external-modules/esql-heap-attack/build.gradle
@@ -11,6 +11,11 @@ apply plugin: 'elasticsearch.internal-java-rest-test'
 // Necessary to use tests in Serverless
 apply plugin: 'elasticsearch.internal-test-artifact'
 
+// Kept in sync with x-pack/plugin/esql-datasource-parquet/build.gradle, the only other consumer.
+versions << [
+  'hadoop' : '3.4.3',
+]
+
 esplugin {
   description = 'A test module that can trigger out of memory'
   classname ='org.elasticsearch.test.esql.heap_attack.HeapAttackPlugin'
@@ -20,12 +25,26 @@ dependencies {
   javaRestTestImplementation project(':x-pack:plugin:esql:compute')
   javaRestTestImplementation project(':libs:swisshash')
 
-  // EXTERNAL heap-attack suite: S3 fixture + qa server helpers (S3FixtureUtils), plus zstd-jni
-  // for compressing payloads in the test JVM. The cluster gets the matching datasource plugins
-  // from the default distribution's modules/ directory automatically.
+  // EXTERNAL heap-attack suite: S3 fixture + qa server helpers (S3FixtureUtils), parquet writer
+  // for payload generation, and zstd-jni for compressing payloads in the test JVM. The cluster
+  // gets the matching plugins via clusterPlugins / clusterModules below.
   javaRestTestImplementation project(':test:fixtures:s3-fixture')
   javaRestTestImplementation project(':test:fixtures:aws-fixture-utils')
   javaRestTestImplementation project(':x-pack:plugin:esql:qa:server')
+  // parquet-hadoop-bundle for the inline payload generator (ParquetWriter / SimpleGroup).
+  // parquet-mr's writer API references org.apache.hadoop.fs.Path on builder overloads, so
+  // Hadoop JARs are needed at compile time even though the test only uses the OutputFile path.
+  javaRestTestImplementation "org.apache.parquet:parquet-hadoop-bundle:${versions.parquet}"
+  // Hadoop JARs without transitives: parquet-mr's writer API references org.apache.hadoop.fs.Path
+  // on its builder overloads (compile-time only). At runtime we feed it a PlainParquetConfiguration
+  // so the actual Hadoop bootstrap path isn't taken — keeping the test classpath light and
+  // sidestepping dependency-verification updates for the full Hadoop transitive set.
+  javaRestTestImplementation("org.apache.hadoop:hadoop-common:${versions.hadoop}") {
+    transitive = false
+  }
+  javaRestTestImplementation("org.apache.hadoop:hadoop-mapreduce-client-core:${versions.hadoop}") {
+    transitive = false
+  }
   javaRestTestImplementation "com.github.luben:zstd-jni:${versions.zstdJni}"
 
   // Note: repository-s3 and the esql-datasource-{csv,ndjson,parquet,s3,zstd} plugins are
@@ -37,9 +56,7 @@ dependencies {
 tasks.named('javaRestTest') {
   usesDefaultDistribution("to be triaged")
   it.onlyIf("snapshot build") { buildParams.snapshotBuild }
-  // HeapAttackExternalIT materializes hundreds-of-MB NDJSON / CSV byte[] payloads inside the
-  // test JVM before pushing them into the in-memory S3 fixture. With pre-allocated buffers,
-  // retained-blob copies in the fixture, and the assertCircuitBreaks retry loop scaling each
-  // attempt, peak heap pressure adds up — 4 G is the smallest cap that survives the full suite.
+  // HeapAttackExternalIT materializes payloads (multi-GB Parquet/NDJSON/CSV byte arrays)
+  // inside the test JVM before pushing them into the in-memory S3 fixture.
   maxHeapSize = '4G'
 }

--- a/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/HeapAttackExternalFixtures.java
+++ b/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/HeapAttackExternalFixtures.java
@@ -7,7 +7,22 @@
 
 package org.elasticsearch.xpack.esql.heap_attack;
 
+import com.github.luben.zstd.Zstd;
 import com.github.luben.zstd.ZstdOutputStream;
+
+import org.apache.parquet.bytes.BytesInput;
+import org.apache.parquet.compression.CompressionCodecFactory;
+import org.apache.parquet.conf.PlainParquetConfiguration;
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.example.data.simple.SimpleGroupFactory;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.example.ExampleParquetWriter;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.io.OutputFile;
+import org.apache.parquet.io.PositionOutputStream;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Types;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -15,19 +30,14 @@ import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 
 /**
- * Payload generators for {@link HeapAttackExternalIT}. Produce raw bytes for NDJSON and CSV
- * inputs sized to exceed the cluster's request-breaker budget when materialized, and a helper
- * that wraps any payload in zstd framing so the test exercises the compression-layer
+ * Payload generators for {@link HeapAttackExternalIT}. Produce raw bytes for Parquet, NDJSON,
+ * and CSV inputs sized to exceed the cluster's request-breaker budget when materialized, and a
+ * helper that wraps any payload in zstd framing so the test exercises the compression-layer
  * allocations on the read side too.
  * <p>
  * All output is produced in the test JVM and pushed into the in-memory S3 fixture via
  * {@code S3FixtureUtils.addBlobToFixture}; the cluster reads it over the fixture's HTTP
  * endpoint exactly as it would a real S3 bucket.
- * <p>
- * Parquet support was scoped out together with the Parquet test scenarios — when those are
- * re-enabled, restore {@code parquetManyRows} (and the matching {@code Format.PARQUET} enum
- * value) here along with the parquet-mr/Hadoop {@code javaRestTestImplementation} deps in
- * {@code build.gradle}.
  */
 final class HeapAttackExternalFixtures {
 
@@ -45,6 +55,7 @@ final class HeapAttackExternalFixtures {
 
     /** Source formats the test exercises. */
     enum Format {
+        PARQUET("parquet"),
         NDJSON("ndjson"),
         CSV("csv");
 
@@ -58,10 +69,15 @@ final class HeapAttackExternalFixtures {
     private HeapAttackExternalFixtures() {}
 
     /**
-     * Wrap {@code raw} in the configured compression. {@link Compression#NONE} is a no-op.
+     * Wrap {@code raw} in the configured compression. For text formats (NDJSON / CSV) this is
+     * applied as a whole-file wrapper that the EXTERNAL command must unwrap before parsing.
+     * <p>
+     * Parquet has its own column-chunk compression baked into the writer (see
+     * {@link #parquetManyRows}); this method is a no-op for it on purpose, so the test attacks
+     * the parquet-internal codec path rather than double-wrapping the file.
      */
-    static byte[] maybeCompress(byte[] raw, Compression compression) throws IOException {
-        if (compression == Compression.NONE) {
+    static byte[] maybeCompress(byte[] raw, Format format, Compression compression) throws IOException {
+        if (format == Format.PARQUET || compression == Compression.NONE) {
             return raw;
         }
         ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -69,6 +85,54 @@ final class HeapAttackExternalFixtures {
             zstd.write(raw);
         }
         return out.toByteArray();
+    }
+
+    /**
+     * Object-key extension for the given format/compression pair: {@code .parquet} regardless of
+     * compression (the codec is internal to the parquet file), {@code .ndjson[.zst]} /
+     * {@code .csv[.zst]} for the text formats.
+     */
+    static String fileExtension(Format format, Compression compression) {
+        if (format == Format.PARQUET) {
+            return "." + format.extension;
+        }
+        return "." + format.extension + compression.extension;
+    }
+
+    /**
+     * Parquet file with one INT64 {@code id} column and {@code rowCount} rows, with column-chunk
+     * compression set to the codec corresponding to {@code compression}.
+     */
+    static byte[] parquetManyRows(int rowCount, int distinctKeys, Compression compression) throws IOException {
+        MessageType schema = new MessageType("schema", Types.optional(PrimitiveType.PrimitiveTypeName.INT64).named("id"));
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        OutputFile outputFile = inMemoryOutputFile(baos);
+        SimpleGroupFactory factory = new SimpleGroupFactory(schema);
+        try (
+            ParquetWriter<Group> writer = ExampleParquetWriter.builder(outputFile)
+                .withConf(new PlainParquetConfiguration())
+                // Custom factory bypasses parquet-mr's default Hadoop-backed codec resolution,
+                // which would otherwise require commons-collections4 / hadoop-thirdparty-guava on
+                // the test classpath (and the corresponding dependency-verification metadata).
+                .withCodecFactory(new InProcessCodecFactory())
+                .withType(schema)
+                .withCompressionCodec(parquetCodec(compression))
+                .build()
+        ) {
+            for (int i = 0; i < rowCount; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) (i % distinctKeys));
+                writer.write(g);
+            }
+        }
+        return baos.toByteArray();
+    }
+
+    private static CompressionCodecName parquetCodec(Compression compression) {
+        return switch (compression) {
+            case NONE -> CompressionCodecName.UNCOMPRESSED;
+            case ZSTD -> CompressionCodecName.ZSTD;
+        };
     }
 
     /**
@@ -105,12 +169,121 @@ final class HeapAttackExternalFixtures {
     }
 
     /**
-     * Format-dispatching wrapper for the many-rows scenarios.
+     * Format-dispatching wrapper for the many-rows scenarios. {@code compression} is only
+     * consumed by the Parquet path (internal column-chunk codec); for NDJSON / CSV the
+     * compression is applied later via {@link #maybeCompress} as a whole-file wrap.
      */
-    static byte[] manyRows(Format format, int rowCount, int distinctKeys) throws IOException {
+    static byte[] manyRows(Format format, int rowCount, int distinctKeys, Compression compression) throws IOException {
         return switch (format) {
+            case PARQUET -> parquetManyRows(rowCount, distinctKeys, compression);
             case NDJSON -> ndjsonManyRows(rowCount, distinctKeys);
             case CSV -> csvManyRows(rowCount, distinctKeys);
+        };
+    }
+
+    private static OutputFile inMemoryOutputFile(ByteArrayOutputStream baos) {
+        return new OutputFile() {
+            @Override
+            public PositionOutputStream create(long blockSizeHint) {
+                return positionStream(baos);
+            }
+
+            @Override
+            public PositionOutputStream createOrOverwrite(long blockSizeHint) {
+                return positionStream(baos);
+            }
+
+            @Override
+            public boolean supportsBlockSize() {
+                return false;
+            }
+
+            @Override
+            public long defaultBlockSize() {
+                return 0;
+            }
+        };
+    }
+
+    /**
+     * Minimal in-test parquet-mr {@link CompressionCodecFactory} supporting only the codecs the
+     * suite needs ({@code UNCOMPRESSED} and {@code ZSTD}). Mirrors the write-side logic from the
+     * (package-private) {@code PlainCompressionCodecFactory} in the parquet datasource plugin,
+     * so the test JVM can produce parquet files without dragging in Hadoop's codec resolution
+     * machinery (which would require commons-collections4 / hadoop-thirdparty on the classpath).
+     */
+    private static final class InProcessCodecFactory implements CompressionCodecFactory {
+
+        @Override
+        public BytesInputCompressor getCompressor(CompressionCodecName codec) {
+            return switch (codec) {
+                case UNCOMPRESSED -> new NoopCompressor();
+                case ZSTD -> new ZstdJniCompressor();
+                default -> throw new UnsupportedOperationException("Unsupported codec in heap-attack test fixtures: " + codec);
+            };
+        }
+
+        @Override
+        public BytesInputDecompressor getDecompressor(CompressionCodecName codec) {
+            // The fixtures only write parquet; no decompression happens in the test JVM.
+            throw new UnsupportedOperationException("decompression not implemented; the test JVM only writes parquet files");
+        }
+
+        @Override
+        public void release() {}
+    }
+
+    private static final class NoopCompressor implements CompressionCodecFactory.BytesInputCompressor {
+        @Override
+        public BytesInput compress(BytesInput bytes) {
+            return bytes;
+        }
+
+        @Override
+        public CompressionCodecName getCodecName() {
+            return CompressionCodecName.UNCOMPRESSED;
+        }
+
+        @Override
+        public void release() {}
+    }
+
+    private static final class ZstdJniCompressor implements CompressionCodecFactory.BytesInputCompressor {
+        @Override
+        public BytesInput compress(BytesInput bytes) throws IOException {
+            byte[] in = bytes.toByteArray();
+            return BytesInput.from(Zstd.compress(in));
+        }
+
+        @Override
+        public CompressionCodecName getCodecName() {
+            return CompressionCodecName.ZSTD;
+        }
+
+        @Override
+        public void release() {}
+    }
+
+    private static PositionOutputStream positionStream(ByteArrayOutputStream baos) {
+        return new PositionOutputStream() {
+            private long position = 0;
+
+            @Override
+            public long getPos() {
+                return position;
+            }
+
+            @Override
+            public void write(int b) {
+                baos.write(b);
+                position++;
+            }
+
+            @Override
+            public void write(byte[] b, int off, int len) {
+                baos.write(b, off, len);
+                position += len;
+            }
         };
     }
 }

--- a/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/HeapAttackExternalIT.java
+++ b/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/HeapAttackExternalIT.java
@@ -21,12 +21,14 @@ import org.elasticsearch.xpack.esql.datasources.S3FixtureUtils;
 import org.elasticsearch.xpack.esql.datasources.S3FixtureUtils.DataSourcesS3HttpFixture;
 import org.elasticsearch.xpack.esql.heap_attack.HeapAttackExternalFixtures.Compression;
 import org.elasticsearch.xpack.esql.heap_attack.HeapAttackExternalFixtures.Format;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
 import java.io.IOException;
+import java.util.Iterator;
 import java.util.Locale;
 import java.util.Map;
 
@@ -67,9 +69,11 @@ public class HeapAttackExternalIT extends HeapAttackRestHelpers {
      *  with {@code /{bucket}/{basePath}/}, where the fixture sets basePath = WAREHOUSE. */
     private static final String KEY_PREFIX = WAREHOUSE + "/heap-attack-external";
 
-    /** Hard cap on rows generated in the test JVM regardless of cluster heap, to keep the test-JVM
-     *  payload byte[] tractable (a 4&nbsp;G test heap can comfortably hold one ~300&nbsp;MB payload
-     *  plus framework overhead). Set well above what's needed to trip a 512&nbsp;MB-cluster breaker. */
+    /** Hard cap on rows generated in the test JVM regardless of cluster heap. With the cluster's
+     *  request-breaker pinned to 50% of a 512&nbsp;MB heap (~256&nbsp;MB) and STATS hash entries
+     *  costing ~64&nbsp;bytes apiece, ~5&nbsp;M distinct keys is already past the budget; 30&nbsp;M
+     *  rows gives the {@link #assertCircuitBreaks} retry-with-scaling loop room to land in trip
+     *  territory on the first attempt for every scenario. */
     private static final int MAX_ROWS = 30_000_000;
 
     /** Detected at test start from {@code _nodes/stats}; the min across nodes. */
@@ -85,6 +89,22 @@ public class HeapAttackExternalIT extends HeapAttackRestHelpers {
         assumeFalse("FIPS mode requires security enabled; this suite uses plain HTTP S3 fixtures", inFipsJvm());
         assumeTrue("EXTERNAL command required; skipping in release build", EsqlCapabilities.Cap.EXTERNAL_COMMAND.isEnabled());
         ensureHeapBudgetDiscovered();
+    }
+
+    /**
+     * Clear blobs left in the in-memory S3 fixture by this test method. Without this the fixture
+     * accumulates hundreds of MB of payloads across the test class (one per attempt × scenario)
+     * and the test JVM eventually OOMs while generating the next payload.
+     */
+    @After
+    public void clearTestBlobs() {
+        String prefix = "/" + BUCKET + "/" + KEY_PREFIX + "/" + getTestName() + "/";
+        Iterator<String> it = handler().blobs().keySet().iterator();
+        while (it.hasNext()) {
+            if (it.next().startsWith(prefix)) {
+                it.remove();
+            }
+        }
     }
 
     /**
@@ -144,15 +164,15 @@ public class HeapAttackExternalIT extends HeapAttackRestHelpers {
      * payload-generation problem is solved.
      */
 
-    /*
-     * Scenario 2: many-rows STATS BY high-cardinality key blows the hash table.
-     *
-     * Parquet variants are intentionally omitted here: a first run revealed that, with the
-     * current parquet reader + STATS interaction, this attack causes the cluster node to OOM
-     * rather than trip the request breaker (a real protection gap, not a test issue). Re-add
-     * the Parquet stats scenarios once the reader-side accounting catches the per-row-group
-     * decode pressure.
-     */
+    // Scenario 2: many-rows STATS BY high-cardinality key blows the hash table.
+
+    public void testStatsBlowupParquet() throws IOException {
+        runStatsBlowup(Format.PARQUET, Compression.NONE);
+    }
+
+    public void testStatsBlowupParquetZstd() throws IOException {
+        runStatsBlowup(Format.PARQUET, Compression.ZSTD);
+    }
 
     public void testStatsBlowupNdjson() throws IOException {
         runStatsBlowup(Format.NDJSON, Compression.NONE);
@@ -176,12 +196,15 @@ public class HeapAttackExternalIT extends HeapAttackRestHelpers {
         // upper bound at MAX_ROWS to keep the test-JVM byte[] payload tractable.
         int baseDistinctKeys = (int) Math.min(MAX_ROWS / 4, clusterHeapMax / 64L * 2);
         int baseRowCount = baseDistinctKeys * 4;
+        // Same key across attempts so the fixture's blob map holds at most one payload per test
+        // method — otherwise five attempts × ~200 MB pile up in the test JVM heap.
+        String key = scenarioKey("statsblowup", format, compression);
         assertCircuitBreaks(attempt -> {
             int distinctKeys = (int) Math.min(MAX_ROWS / 4, (long) baseDistinctKeys * attempt);
             int rowCount = (int) Math.min(MAX_ROWS, (long) baseRowCount * attempt);
-            String key = uniqueKey("statsblowup", format, compression, attempt);
             byte[] payload = HeapAttackExternalFixtures.maybeCompress(
-                HeapAttackExternalFixtures.manyRows(format, rowCount, distinctKeys),
+                HeapAttackExternalFixtures.manyRows(format, rowCount, distinctKeys, compression),
+                format,
                 compression
             );
             S3FixtureUtils.addBlobToFixture(handler(), key, payload);
@@ -204,17 +227,15 @@ public class HeapAttackExternalIT extends HeapAttackRestHelpers {
         return S3_FIXTURE.getHandler();
     }
 
-    private String uniqueKey(String scenario, Format format, Compression compression, int attempt) {
+    private String scenarioKey(String scenario, Format format, Compression compression) {
         return String.format(
             Locale.ROOT,
-            "%s/%s/%s-%s-a%d.%s%s",
+            "%s/%s/%s-%s%s",
             KEY_PREFIX,
             getTestName(),
             scenario,
             format.extension,
-            attempt,
-            format.extension,
-            compression.extension
+            HeapAttackExternalFixtures.fileExtension(format, compression)
         );
     }
 


### PR DESCRIPTION
This adds in HeapAttack tests for Parquet.

Related: #149197