### PR TITLE
[9.3] ESQL: fix FROM *_logs index name validation (#149395)

### DIFF
--- a/docs/changelog/149395.yaml
+++ b/docs/changelog/149395.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 146073
+pr: 149395
+summary: Fix FROM *_logs index name validation
+type: bug

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/IdentifierBuilder.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/IdentifierBuilder.java
@@ -332,6 +332,7 @@ abstract class IdentifierBuilder extends AbstractBuilder {
             throwInvalidIndexNameException(index, BLANK_INDEX_ERROR_MESSAGE, ctx);
         }
 
+        boolean startsWithStar = index.startsWith("*");
         hasSeenStar = hasSeenStar || index.contains(WILDCARD);
         index = index.replace(WILDCARD, "").strip();
         if (index.isBlank()) {
@@ -355,6 +356,11 @@ abstract class IdentifierBuilder extends AbstractBuilder {
         } catch (InvalidIndexNameException e) {
             // ignore invalid index name if it has exclusions and there is an index with wildcard before it
             if (hasSeenStar && hasExclusion) {
+                return;
+            }
+
+            // The "must not start with ..." rules do not apply if the pattern begins with '*'.
+            if (startsWithStar && e.getMessage().contains("must not start with")) {
                 return;
             }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/StatementParserTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/StatementParserTests.java
@@ -982,6 +982,31 @@ public class StatementParserTests extends AbstractStatementParserTests {
         );
     }
 
+    /** Regression test for <a href="https://github.com/elastic/elasticsearch/issues/146073">#146073</a>. */
+    public void testWildcardPatternWithReservedPrefixChar() {
+        List<String> commands = new ArrayList<>();
+        commands.add("FROM");
+        if (Build.current().isSnapshot()) {
+            commands.add("TS");
+        }
+        for (String command : commands) {
+            assertStringAsIndexPattern("*_logs", command + " *_logs");
+            assertStringAsIndexPattern("*+logs", command + " *+logs");
+            assertStringAsIndexPattern("**_logs", command + " **_logs");
+            assertStringAsIndexPattern("foo*_logs", command + " foo*_logs");
+            assertStringAsIndexPattern("*_logs,*_metrics", command + " *_logs,*_metrics");
+            assertStringAsIndexPattern("cluster:*_logs", command + " cluster:*_logs");
+            if (EsqlCapabilities.Cap.INDEX_COMPONENT_SELECTORS.isEnabled()) {
+                assertStringAsIndexPattern("*_logs::data", command + " *_logs::data");
+            }
+
+            String lineNumber = command.equals("FROM") ? "line 1:6: " : "line 1:4: ";
+            expectError(command + " _logs*", lineNumber + "Invalid index name [_logs], must not start with '_', '-', or '+'");
+            expectError(command + " _*logs", lineNumber + "Invalid index name [_logs], must not start with '_', '-', or '+'");
+            expectError(command + " +logs*", lineNumber + "Invalid index name [+logs], must not start with '_', '-', or '+'");
+        }
+    }
+
     public void testInvalidQuotingAsFromIndexPattern() {
         expectError("FROM \"foo", ": token recognition error at: '\"foo'");
         expectError("FROM \"foo | LIMIT 1", ": token recognition error at: '\"foo | LIMIT 1'");


### PR DESCRIPTION
Backports the following commits to 9.3:
 - ESQL: fix FROM *_logs index name validation (#149395)