### PR TITLE
Allow rerank in infer() method for Elastic and Elasticsearch services

### DIFF
--- a/docs/changelog/149427.yaml
+++ b/docs/changelog/149427.yaml
@@ -1,0 +1,5 @@
+area: Inference
+issues: []
+pr: 149427
+summary: Allow rerank in infer() method for Elastic and Elasticsearch services
+type: bug

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceService.java
@@ -100,7 +100,12 @@ public class ElasticInferenceService extends SenderService<ElasticInferenceServi
     /**
      * The task types that the {@link InferenceAction.Request} can accept.
      */
-    private static final EnumSet<TaskType> SUPPORTED_INFERENCE_ACTION_TASK_TYPES = EnumSet.of(SPARSE_EMBEDDING, COMPLETION, TEXT_EMBEDDING);
+    private static final EnumSet<TaskType> SUPPORTED_INFERENCE_ACTION_TASK_TYPES = EnumSet.of(
+        SPARSE_EMBEDDING,
+        COMPLETION,
+        RERANK,
+        TEXT_EMBEDDING
+    );
 
     private final CCMAuthenticationApplierFactory ccmAuthenticationApplierFactory;
     private ElasticInferenceServiceActionCreator actionCreator;

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalService.java
@@ -647,6 +647,8 @@ public class ElasticsearchInternalService extends BaseElasticsearchInternalServi
             var taskType = model.getConfigurations().getTaskType();
             if (TaskType.TEXT_EMBEDDING.equals(taskType)) {
                 inferTextEmbedding(esModel, input, inputType, timeout, listener);
+            } else if (TaskType.RERANK.equals(taskType)) {
+                inferRerank(esModel, query, input, returnDocuments, topN, inputType, timeout, taskSettings, listener);
             } else if (TaskType.SPARSE_EMBEDDING.equals(taskType)) {
                 inferSparseEmbedding(esModel, input, inputType, timeout, listener);
             } else {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceTests.java
@@ -580,7 +580,7 @@ public class ElasticInferenceServiceTests extends InferenceServiceTestCase {
                 thrownException.getMessage(),
                 is(
                     "Inference entity [model_id] does not support task type [chat_completion] "
-                        + "for inference, the task type must be one of [text_embedding, sparse_embedding, completion]. "
+                        + "for inference, the task type must be one of [text_embedding, sparse_embedding, rerank, completion]. "
                         + "The task type for the inference entity is chat_completion, "
                         + "please use the _inference/chat_completion/model_id/_stream URL."
                 )


### PR DESCRIPTION
Some code paths directly invoke InferenceAction with a TaskType of RERANK, which leads to the InferenceService.infer() method being called instead of InferenceService.rerankInfer().

Until these code paths are changed to use RerankAction, the Elastic and Elasticsearch services should continue to handle RERANK in the infer() method.
