### PR TITLE
Add url.scheme, server.address, server.port to REST traces

### DIFF
--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpPipeliningHandler.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpPipeliningHandler.java
@@ -96,22 +96,26 @@ public class Netty4HttpPipeliningHandler extends ChannelDuplexHandler {
     private final Queue<WriteOperation> queuedWrites = new ArrayDeque<>();
 
     private final Netty4HttpServerTransport serverTransport;
+    private final String scheme;
 
     /**
      * Construct a new pipelining handler; this handler should be used downstream of HTTP decoding/aggregation.
      *
      * @param maxEventsHeld the maximum number of channel events that will be retained prior to aborting the channel connection; this is
      *                      required as events cannot queue up indefinitely
+     * @param scheme either {@code "http"} or {@code "https"} depending on whether TLS is enabled for this channel
      */
     public Netty4HttpPipeliningHandler(
         final int maxEventsHeld,
         final Netty4HttpServerTransport serverTransport,
-        final ThreadWatchdog.ActivityTracker activityTracker
+        final ThreadWatchdog.ActivityTracker activityTracker,
+        final String scheme
     ) {
         this.maxEventsHeld = maxEventsHeld;
         this.activityTracker = activityTracker;
         this.outboundHoldingQueue = new PriorityQueue<>(1, Comparator.comparingInt(t -> t.v1().getSequence()));
         this.serverTransport = serverTransport;
+        this.scheme = scheme;
     }
 
     @Override
@@ -130,12 +134,12 @@ public class Netty4HttpPipeliningHandler extends ChannelDuplexHandler {
                     } else {
                         nonError = (Exception) cause;
                     }
-                    netty4HttpRequest = new Netty4HttpRequest(readSequence++, request, nonError);
+                    netty4HttpRequest = new Netty4HttpRequest(readSequence++, request, nonError, scheme);
                 } else {
                     assert currentRequestStream == null : "current stream must be null for new request";
                     var contentStream = new Netty4HttpRequestBodyStream(ctx, serverTransport.getThreadPool().getThreadContext());
                     currentRequestStream = contentStream;
-                    netty4HttpRequest = new Netty4HttpRequest(readSequence++, request, contentStream);
+                    netty4HttpRequest = new Netty4HttpRequest(readSequence++, request, contentStream, scheme);
                     shouldRead = false;
                 }
                 handlePipelinedRequest(ctx, netty4HttpRequest);

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequest.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequest.java
@@ -46,13 +46,14 @@ public class Netty4HttpRequest implements HttpRequest {
     private final AtomicBoolean released;
     private final Exception inboundException;
     private final QueryStringDecoder queryStringDecoder;
+    private final String scheme;
 
-    public Netty4HttpRequest(int sequence, io.netty.handler.codec.http.HttpRequest nettyRequest, Exception exception) {
-        this(sequence, nettyRequest, HttpBody.empty(), new AtomicBoolean(false), exception);
+    public Netty4HttpRequest(int sequence, io.netty.handler.codec.http.HttpRequest nettyRequest, Exception exception, String scheme) {
+        this(sequence, nettyRequest, HttpBody.empty(), new AtomicBoolean(false), exception, scheme);
     }
 
-    public Netty4HttpRequest(int sequence, io.netty.handler.codec.http.HttpRequest nettyRequest, HttpBody content) {
-        this(sequence, nettyRequest, content, new AtomicBoolean(false), null);
+    public Netty4HttpRequest(int sequence, io.netty.handler.codec.http.HttpRequest nettyRequest, HttpBody content, String scheme) {
+        this(sequence, nettyRequest, content, new AtomicBoolean(false), null, scheme);
     }
 
     private Netty4HttpRequest(
@@ -60,7 +61,8 @@ public class Netty4HttpRequest implements HttpRequest {
         io.netty.handler.codec.http.HttpRequest nettyRequest,
         HttpBody content,
         AtomicBoolean released,
-        Exception inboundException
+        Exception inboundException,
+        String scheme
     ) {
         this.sequence = sequence;
         this.nettyRequest = nettyRequest;
@@ -70,10 +72,16 @@ public class Netty4HttpRequest implements HttpRequest {
         this.released = released;
         this.inboundException = inboundException;
         this.queryStringDecoder = new QueryStringDecoder(nettyRequest.uri());
+        this.scheme = scheme;
     }
 
     private static boolean hasContentHeader(io.netty.handler.codec.http.HttpRequest nettyRequest) {
         return HttpUtil.isTransferEncodingChunked(nettyRequest) || HttpUtil.getContentLength(nettyRequest, 0L) > 0;
+    }
+
+    @Override
+    public String getScheme() {
+        return scheme;
     }
 
     @Override
@@ -155,7 +163,7 @@ public class Netty4HttpRequest implements HttpRequest {
             nettyRequest.uri(),
             copiedHeadersWithout
         );
-        return new Netty4HttpRequest(sequence, requestWithoutHeader, content, released, null);
+        return new Netty4HttpRequest(sequence, requestWithoutHeader, content, released, null, scheme);
     }
 
     @Override

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
@@ -477,7 +477,12 @@ public class Netty4HttpServerTransport extends AbstractHttpServerTransport {
             ch.pipeline()
                 .addLast(
                     "pipelining",
-                    new Netty4HttpPipeliningHandler(transport.pipeliningMaxEvents, transport, threadWatchdogActivityTracker)
+                    new Netty4HttpPipeliningHandler(
+                        transport.pipeliningMaxEvents,
+                        transport,
+                        threadWatchdogActivityTracker,
+                        tlsConfig.isTLSEnabled() ? "https" : "http"
+                    )
                 );
             transport.serverAcceptedChannel(nettyHttpChannel);
 

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpPipeliningHandlerTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpPipeliningHandlerTests.java
@@ -140,7 +140,7 @@ public class Netty4HttpPipeliningHandlerTests extends ESTestCase {
 
     private EmbeddedChannel makeEmbeddedChannelWithSimulatedWork(int numberOfRequests) {
         return new EmbeddedChannel(
-            new Netty4HttpPipeliningHandler(numberOfRequests, httpServerTransport(), new ThreadWatchdog.ActivityTracker()) {
+            new Netty4HttpPipeliningHandler(numberOfRequests, httpServerTransport(), new ThreadWatchdog.ActivityTracker(), "http") {
                 @Override
                 protected void handlePipelinedRequest(ChannelHandlerContext ctx, Netty4HttpRequest pipelinedRequest) {
                     ctx.fireChannelRead(pipelinedRequest);
@@ -225,7 +225,7 @@ public class Netty4HttpPipeliningHandlerTests extends ESTestCase {
     public void testPipeliningRequestsAreReleased() {
         final int numberOfRequests = 10;
         final EmbeddedChannel embeddedChannel = new EmbeddedChannel(
-            new Netty4HttpPipeliningHandler(numberOfRequests + 1, httpServerTransport(), new ThreadWatchdog.ActivityTracker())
+            new Netty4HttpPipeliningHandler(numberOfRequests + 1, httpServerTransport(), new ThreadWatchdog.ActivityTracker(), "http")
         );
 
         for (int i = 0; i < numberOfRequests; i++) {
@@ -517,7 +517,7 @@ public class Netty4HttpPipeliningHandlerTests extends ESTestCase {
         final var watchdog = new ThreadWatchdog();
         final var activityTracker = watchdog.getActivityTrackerForCurrentThread();
         final var requestHandled = new AtomicBoolean();
-        final var handler = new Netty4HttpPipeliningHandler(Integer.MAX_VALUE, httpServerTransport(), activityTracker) {
+        final var handler = new Netty4HttpPipeliningHandler(Integer.MAX_VALUE, httpServerTransport(), activityTracker, "http") {
             @Override
             protected void handlePipelinedRequest(ChannelHandlerContext ctx, Netty4HttpRequest pipelinedRequest) {
                 // thread is not idle while handling the request
@@ -558,7 +558,7 @@ public class Netty4HttpPipeliningHandlerTests extends ESTestCase {
     }
 
     private Netty4HttpPipeliningHandler getTestHttpHandler() {
-        return new Netty4HttpPipeliningHandler(Integer.MAX_VALUE, httpServerTransport(), new ThreadWatchdog.ActivityTracker()) {
+        return new Netty4HttpPipeliningHandler(Integer.MAX_VALUE, httpServerTransport(), new ThreadWatchdog.ActivityTracker(), "http") {
             @Override
             protected void handlePipelinedRequest(ChannelHandlerContext ctx, Netty4HttpRequest pipelinedRequest) {
                 ctx.fireChannelRead(pipelinedRequest);

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpRequestTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpRequestTests.java
@@ -24,7 +24,12 @@ import org.elasticsearch.test.rest.FakeHttpBodyStream;
 public class Netty4HttpRequestTests extends ESTestCase {
 
     public void testEmptyFullContent() {
-        final var request = new Netty4HttpRequest(0, new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/"), HttpBody.empty());
+        final var request = new Netty4HttpRequest(
+            0,
+            new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/"),
+            HttpBody.empty(),
+            "http"
+        );
         assertFalse(request.hasContent());
     }
 
@@ -32,7 +37,8 @@ public class Netty4HttpRequestTests extends ESTestCase {
         final var request = new Netty4HttpRequest(
             0,
             new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/"),
-            new FakeHttpBodyStream()
+            new FakeHttpBodyStream(),
+            "http"
         );
         assertFalse(request.hasContent());
     }
@@ -47,7 +53,8 @@ public class Netty4HttpRequestTests extends ESTestCase {
                 "/",
                 new DefaultHttpHeaders().add(HttpHeaderNames.CONTENT_LENGTH, len)
             ),
-            HttpBody.fromBytesReference(new BytesArray(new byte[len]))
+            HttpBody.fromBytesReference(new BytesArray(new byte[len])),
+            "http"
         );
         assertTrue(request.hasContent());
     }
@@ -56,12 +63,12 @@ public class Netty4HttpRequestTests extends ESTestCase {
         final var len = between(1, 1024);
         final var nettyRequestWithLen = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/");
         HttpUtil.setContentLength(nettyRequestWithLen, len);
-        final var requestWithLen = new Netty4HttpRequest(0, nettyRequestWithLen, new FakeHttpBodyStream());
+        final var requestWithLen = new Netty4HttpRequest(0, nettyRequestWithLen, new FakeHttpBodyStream(), "http");
         assertTrue(requestWithLen.hasContent());
 
         final var nettyChunkedRequest = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/", new DefaultHttpHeaders());
         HttpUtil.setTransferEncodingChunked(nettyChunkedRequest, true);
-        final var chunkedRequest = new Netty4HttpRequest(0, nettyChunkedRequest, new FakeHttpBodyStream());
+        final var chunkedRequest = new Netty4HttpRequest(0, nettyChunkedRequest, new FakeHttpBodyStream(), "http");
         assertTrue(chunkedRequest.hasContent());
     }
 
@@ -69,7 +76,7 @@ public class Netty4HttpRequestTests extends ESTestCase {
         final var len = between(1, 1024);
         final var nettyRequestWithLen = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/");
         HttpUtil.setContentLength(nettyRequestWithLen, len);
-        final var streamRequest = new Netty4HttpRequest(0, nettyRequestWithLen, new FakeHttpBodyStream());
+        final var streamRequest = new Netty4HttpRequest(0, nettyRequestWithLen, new FakeHttpBodyStream(), "http");
 
         streamRequest.setBody(HttpBody.fromBytesReference(randomBytesReference(len)));
         assertTrue(streamRequest.hasContent());

--- a/server/src/main/java/org/elasticsearch/http/HttpRequest.java
+++ b/server/src/main/java/org/elasticsearch/http/HttpRequest.java
@@ -28,6 +28,11 @@ public interface HttpRequest extends HttpPreRequest {
         HTTP_1_1
     }
 
+    /** Returns the URI scheme for this request, either {@code "http"} or {@code "https"}. */
+    default String getScheme() {
+        return "http";
+    }
+
     HttpBody body();
 
     void setBody(HttpBody body);

--- a/server/src/main/java/org/elasticsearch/http/HttpRequest.java
+++ b/server/src/main/java/org/elasticsearch/http/HttpRequest.java
@@ -29,9 +29,7 @@ public interface HttpRequest extends HttpPreRequest {
     }
 
     /** Returns the URI scheme for this request, either {@code "http"} or {@code "https"}. */
-    default String getScheme() {
-        return "http";
-    }
+    String getScheme();
 
     HttpBody body();
 

--- a/server/src/main/java/org/elasticsearch/rest/RestController.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestController.java
@@ -615,12 +615,12 @@ public class RestController implements HttpServerTransport.Dispatcher {
         if (forwarded != null) {
             final String proto = extractForwardedParam(forwarded, "proto");
             if (proto != null) {
-                return proto;
+                return proto.toLowerCase(Locale.ROOT);
             }
         }
         final String xProto = firstHeaderValue(req, "X-Forwarded-Proto");
         if (xProto != null && xProto.isBlank() == false) {
-            return xProto.strip();
+            return xProto.strip().toLowerCase(Locale.ROOT);
         }
         return req.getHttpRequest().getScheme();
     }
@@ -689,7 +689,10 @@ public class RestController implements HttpServerTransport.Dispatcher {
         return values != null && values.isEmpty() == false ? values.get(0) : null;
     }
 
-    /** Extracts the value of the named directive from an RFC 7239 Forwarded header. */
+    /**
+     * Extracts the value of the named directive from an RFC 7239 Forwarded header.
+     * Note: quoted values containing {@code ';'} or {@code ','} are not fully supported.
+     */
     static String extractForwardedParam(String forwarded, String param) {
         final String prefix = param + "=";
         for (String entry : forwarded.split(",")) {

--- a/server/src/main/java/org/elasticsearch/rest/RestController.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestController.java
@@ -728,7 +728,8 @@ public class RestController implements HttpServerTransport.Dispatcher {
         if (colon < 0) {
             return new String[] { hostToken.isBlank() ? null : hostToken, null };
         }
-        return new String[] { hostToken.substring(0, colon), hostToken.substring(colon + 1) };
+        final String address = hostToken.substring(0, colon);
+        return new String[] { address.isBlank() ? null : address, hostToken.substring(colon + 1) };
     }
 
     /** Parses a port string. Returns null if {@code portStr} is null, not a valid integer, or outside [1, 65535]. */

--- a/server/src/main/java/org/elasticsearch/rest/RestController.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestController.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.common.io.stream.BytesStream;
 import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.network.NetworkAddress;
 import org.elasticsearch.common.path.PathTrie;
 import org.elasticsearch.common.recycler.Recycler;
 import org.elasticsearch.common.util.Maps;
@@ -35,6 +36,7 @@ import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.core.Streams;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.UpdateForV10;
+import org.elasticsearch.http.HttpChannel;
 import org.elasticsearch.http.HttpHeadersValidationException;
 import org.elasticsearch.http.HttpRouteStats;
 import org.elasticsearch.http.HttpRouteStatsTracker;
@@ -55,6 +57,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.InetSocketAddress;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Iterator;
@@ -562,38 +565,177 @@ public class RestController implements HttpServerTransport.Dispatcher {
             name = restPath;
         }
 
-        final Map<String, Object> attributes = Maps.newMapWithExpectedSize(req.getHeaders().size() + 3);
+        final Map<String, Object> traceAttributes = Maps.newMapWithExpectedSize(req.getHeaders().size() + 6);
         req.getHeaders().forEach((key, values) -> {
             final String lowerKey = key.toLowerCase(Locale.ROOT).replace('-', '_');
-            attributes.put("http.request.headers." + lowerKey, values == null ? "" : String.join("; ", values));
+            traceAttributes.put("http.request.headers." + lowerKey, values == null ? "" : String.join("; ", values));
         });
         String resolvedMethod = Objects.requireNonNullElse(method, "<unknown>");
         String resolvedUri = Objects.requireNonNullElse(req.uri(), "<unknown>");
-        attributes.put("http.method", resolvedMethod);
+        traceAttributes.put("http.method", resolvedMethod);
         // OTel HTTP server SemConv (https://opentelemetry.io/docs/specs/semconv/http/http-spans/):
         // http.request.method MUST be "_OTHER" for methods unknown to the instrumentation.
-        attributes.put("http.request.method", method != null ? method : "_OTHER");
-        attributes.put("http.url", resolvedUri);
-        attributes.put("url.full", resolvedUri);
+        traceAttributes.put("http.request.method", method != null ? method : "_OTHER");
+        traceAttributes.put("http.url", resolvedUri);
+        traceAttributes.put("url.full", resolvedUri);
         int queryIdx = resolvedUri.indexOf('?');
         if (queryIdx >= 0) {
-            attributes.put("url.path", resolvedUri.substring(0, queryIdx));
-            attributes.put("url.query", resolvedUri.substring(queryIdx + 1));
+            traceAttributes.put("url.path", resolvedUri.substring(0, queryIdx));
+            traceAttributes.put("url.query", resolvedUri.substring(queryIdx + 1));
         } else {
-            attributes.put("url.path", resolvedUri);
+            traceAttributes.put("url.path", resolvedUri);
         }
         switch (req.getHttpRequest().protocolVersion()) {
             case HTTP_1_0 -> {
-                attributes.put("http.flavour", "1.0");
-                attributes.put("network.protocol.version", "1.0");
+                traceAttributes.put("http.flavour", "1.0");
+                traceAttributes.put("network.protocol.version", "1.0");
             }
             case HTTP_1_1 -> {
-                attributes.put("http.flavour", "1.1");
-                attributes.put("network.protocol.version", "1.1");
+                traceAttributes.put("http.flavour", "1.1");
+                traceAttributes.put("network.protocol.version", "1.1");
+            }
+        }
+        final String forwarded = firstHeaderValue(req, "Forwarded");
+        traceAttributes.put("url.scheme", extractScheme(req, forwarded));
+        final HttpChannel httpChannel = req.getHttpChannel();
+        final String serverAddress = extractServerAddress(req, httpChannel, forwarded);
+        if (serverAddress != null) {
+            traceAttributes.put("server.address", serverAddress);
+            final Integer serverPort = extractServerPort(req, httpChannel, forwarded);
+            if (serverPort != null) {
+                traceAttributes.put("server.port", serverPort);
             }
         }
 
-        tracer.startTrace(threadContext, channel.request(), name, attributes);
+        tracer.startTrace(threadContext, channel.request(), name, traceAttributes);
+    }
+
+    /** Resolves the OTel HTTP server SemConv {@code url.scheme}: checks {@code Forwarded} proto= (RFC 7239), then {@code X-Forwarded-Proto}, then the transport scheme. */
+    static String extractScheme(RestRequest req, String forwarded) {
+        if (forwarded != null) {
+            final String proto = extractForwardedParam(forwarded, "proto");
+            if (proto != null) {
+                return proto;
+            }
+        }
+        final String xProto = firstHeaderValue(req, "X-Forwarded-Proto");
+        if (xProto != null && xProto.isBlank() == false) {
+            return xProto.strip();
+        }
+        return req.getHttpRequest().getScheme();
+    }
+
+    /** Extracts the OTel HTTP server SemConv {@code server.address}: checks {@code Forwarded} host= (RFC 7239), then {@code X-Forwarded-Host}, then {@code Host}, then the local socket. */
+    static String extractServerAddress(RestRequest req, HttpChannel httpChannel, String forwarded) {
+        if (forwarded != null) {
+            final String host = extractForwardedParam(forwarded, "host");
+            if (host != null) {
+                final String address = splitHostPort(host)[0];
+                if (address != null) return address;
+            }
+        }
+        final String xHost = firstHeaderValue(req, "X-Forwarded-Host");
+        if (xHost != null && xHost.isBlank() == false) {
+            final String address = splitHostPort(xHost.strip())[0];
+            if (address != null) return address;
+        }
+        final String hostHeader = firstHeaderValue(req, "Host");
+        if (hostHeader != null && hostHeader.isBlank() == false) {
+            final String address = splitHostPort(hostHeader.strip())[0];
+            if (address != null) return address;
+        }
+        if (httpChannel != null) {
+            final InetSocketAddress local = httpChannel.getLocalAddress();
+            if (local != null) return NetworkAddress.format(local.getAddress());
+        }
+        return null;
+    }
+
+    /**
+     * Extracts the OTel HTTP server SemConv {@code server.port}: checks {@code Forwarded} host= (RFC 7239), then {@code X-Forwarded-Host/Port}, then {@code Host}, then the local socket.
+     * When an address comes from a forwarding header without a port, the socket port is not used as a fallback.
+     */
+    static Integer extractServerPort(RestRequest req, HttpChannel httpChannel, String forwarded) {
+        if (forwarded != null) {
+            final String host = extractForwardedParam(forwarded, "host");
+            if (host != null) {
+                final String[] addrPort = splitHostPort(host);
+                if (addrPort[0] != null) return parsePortSafe(addrPort[1]);
+            }
+        }
+        final String xHost = firstHeaderValue(req, "X-Forwarded-Host");
+        if (xHost != null && xHost.isBlank() == false) {
+            final String[] addrPort = splitHostPort(xHost.strip());
+            if (addrPort[0] != null) {
+                final String xPort = firstHeaderValue(req, "X-Forwarded-Port");
+                return parsePortSafe(xPort != null ? xPort.strip() : addrPort[1]);
+            }
+        }
+        final String hostHeader = firstHeaderValue(req, "Host");
+        if (hostHeader != null && hostHeader.isBlank() == false) {
+            final String[] addrPort = splitHostPort(hostHeader.strip());
+            if (addrPort[0] != null) return parsePortSafe(addrPort[1]);
+        }
+        if (httpChannel != null) {
+            final InetSocketAddress local = httpChannel.getLocalAddress();
+            if (local != null) return local.getPort();
+        }
+        return null;
+    }
+
+    /** Returns the first value of the named request header, or {@code null} if absent. */
+    static String firstHeaderValue(RestRequest req, String name) {
+        final List<String> values = req.getHeaders().get(name);
+        return values != null && values.isEmpty() == false ? values.get(0) : null;
+    }
+
+    /** Extracts the value of the named directive from an RFC 7239 Forwarded header. */
+    static String extractForwardedParam(String forwarded, String param) {
+        final String prefix = param + "=";
+        for (String entry : forwarded.split(",")) {
+            for (String directive : entry.split(";")) {
+                final String token = directive.strip();
+                if (token.regionMatches(true, 0, prefix, 0, prefix.length())) {
+                    String value = token.substring(prefix.length()).strip();
+                    if (value.length() > 1 && value.startsWith("\"") && value.endsWith("\"")) {
+                        value = value.substring(1, value.length() - 1);
+                    }
+                    if (value.isBlank() == false) {
+                        return value;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    /** Splits a {@code host[:port]} token into a two-element {@code {address, port}} array; port may be null. */
+    static String[] splitHostPort(String hostToken) {
+        if (hostToken.startsWith("[")) {
+            final int close = hostToken.indexOf(']');
+            if (close < 0) {
+                return new String[] { hostToken, null };
+            }
+            final String address = hostToken.substring(1, close);
+            final String rest = hostToken.substring(close + 1);
+            return new String[] { address.isBlank() ? null : address, rest.startsWith(":") ? rest.substring(1) : null };
+        }
+        final int colon = hostToken.lastIndexOf(':');
+        if (colon < 0) {
+            return new String[] { hostToken.isBlank() ? null : hostToken, null };
+        }
+        return new String[] { hostToken.substring(0, colon), hostToken.substring(colon + 1) };
+    }
+
+    /** Parses a port string. Returns null if {@code portStr} is null, not a valid integer, or outside [1, 65535]. */
+    static Integer parsePortSafe(String portStr) {
+        if (portStr == null) return null;
+        try {
+            final int port = Integer.parseInt(portStr.strip());
+            return port > 0 && port <= 65535 ? port : null;
+        } catch (NumberFormatException e) {
+            return null;
+        }
     }
 
     private void traceException(RestChannel channel, Throwable e) {

--- a/server/src/main/java/org/elasticsearch/rest/RestController.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestController.java
@@ -654,6 +654,7 @@ public class RestController implements HttpServerTransport.Dispatcher {
     /**
      * Extracts the OTel HTTP server SemConv {@code server.port}: checks {@code Forwarded} host= (RFC 7239), then {@code X-Forwarded-Host/Port}, then {@code Host}, then the local socket.
      * When an address comes from a forwarding header without a port, the socket port is not used as a fallback.
+     * {@code X-Forwarded-Port} is only consulted when {@code X-Forwarded-Host} is also present; a standalone {@code X-Forwarded-Port} is ignored.
      */
     static Integer extractServerPort(RestRequest req, HttpChannel httpChannel, String forwarded) {
         if (forwarded != null) {

--- a/server/src/test/java/org/elasticsearch/http/TestHttpRequest.java
+++ b/server/src/test/java/org/elasticsearch/http/TestHttpRequest.java
@@ -73,6 +73,11 @@ public class TestHttpRequest implements HttpRequest {
     }
 
     @Override
+    public String getScheme() {
+        return "http";
+    }
+
+    @Override
     public HttpBody body() {
         return body;
     }

--- a/server/src/test/java/org/elasticsearch/rest/RestControllerTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/RestControllerTests.java
@@ -349,18 +349,6 @@ public class RestControllerTests extends ESTestCase {
         final RestController restController = new RestController(null, null, circuitBreakerService, usageService, telemetryProvider);
         final InetSocketAddress localAddress = new InetSocketAddress("127.0.0.1", 9200);
         RestRequest fakeRequest = new FakeRestRequest.Builder(xContentRegistry()).withLocalAddress(localAddress).withHttps(true).build();
-        final RestController spyRestController = spy(restController);
-        when(spyRestController.getAllHandlers(null, fakeRequest.rawPath())).thenReturn(new Iterator<>() {
-            @Override
-            public boolean hasNext() {
-                return false;
-            }
-
-            @Override
-            public MethodHandlers next() {
-                return new MethodHandlers("/").addMethod(GET, RestApiVersion.current(), (request, channel, client) -> {});
-            }
-        });
         AssertingChannel channel = new AssertingChannel(fakeRequest, randomBoolean(), RestStatus.BAD_REQUEST);
         restController.dispatchRequest(fakeRequest, channel, threadContext);
         verify(tracer).startTrace(

--- a/server/src/test/java/org/elasticsearch/rest/RestControllerTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/RestControllerTests.java
@@ -999,6 +999,11 @@ public class RestControllerTests extends ESTestCase {
             }
 
             @Override
+            public String getScheme() {
+                return "http";
+            }
+
+            @Override
             public HttpBody body() {
                 if (hasContent) {
                     return HttpBody.fromBytesReference(new BytesArray("test"));

--- a/server/src/test/java/org/elasticsearch/rest/RestControllerTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/RestControllerTests.java
@@ -58,6 +58,7 @@ import org.junit.After;
 import org.junit.Before;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -335,7 +336,128 @@ public class RestControllerTests extends ESTestCase {
                     "url.full",
                     "/",
                     "url.path",
-                    "/"
+                    "/",
+                    "url.scheme",
+                    "http"
+                )
+            )
+        );
+    }
+
+    public void testDispatchStartsTraceWithTls() {
+        final ThreadContext threadContext = client.threadPool().getThreadContext();
+        final RestController restController = new RestController(null, null, circuitBreakerService, usageService, telemetryProvider);
+        final InetSocketAddress localAddress = new InetSocketAddress("127.0.0.1", 9200);
+        RestRequest fakeRequest = new FakeRestRequest.Builder(xContentRegistry()).withLocalAddress(localAddress).withHttps(true).build();
+        final RestController spyRestController = spy(restController);
+        when(spyRestController.getAllHandlers(null, fakeRequest.rawPath())).thenReturn(new Iterator<>() {
+            @Override
+            public boolean hasNext() {
+                return false;
+            }
+
+            @Override
+            public MethodHandlers next() {
+                return new MethodHandlers("/").addMethod(GET, RestApiVersion.current(), (request, channel, client) -> {});
+            }
+        });
+        AssertingChannel channel = new AssertingChannel(fakeRequest, randomBoolean(), RestStatus.BAD_REQUEST);
+        restController.dispatchRequest(fakeRequest, channel, threadContext);
+        verify(tracer).startTrace(
+            eq(threadContext),
+            eq(channel.request()),
+            eq("GET /"),
+            eq(
+                Map.of(
+                    "http.method",
+                    "GET",
+                    "http.request.method",
+                    "GET",
+                    "http.flavour",
+                    "1.1",
+                    "network.protocol.version",
+                    "1.1",
+                    "http.url",
+                    "/",
+                    "url.full",
+                    "/",
+                    "url.path",
+                    "/",
+                    "url.scheme",
+                    "https",
+                    "server.address",
+                    "127.0.0.1",
+                    "server.port",
+                    9200
+                )
+            )
+        );
+    }
+
+    public void testDispatchStartsTraceWithForwardedHeaders() {
+        final ThreadContext threadContext = client.threadPool().getThreadContext();
+        final RestController restController = new RestController(null, null, circuitBreakerService, usageService, telemetryProvider);
+        RestRequest fakeRequest = new FakeRestRequest.Builder(xContentRegistry()).withHeaders(
+            Map.of("Forwarded", List.of("proto=https;host=proxy.example.com:8443"))
+        ).build();
+        AssertingChannel channel = new AssertingChannel(fakeRequest, randomBoolean(), RestStatus.BAD_REQUEST);
+        restController.dispatchRequest(fakeRequest, channel, threadContext);
+        verify(tracer).startTrace(
+            eq(threadContext),
+            eq(channel.request()),
+            eq("GET /"),
+            eq(
+                Map.ofEntries(
+                    Map.entry("http.method", "GET"),
+                    Map.entry("http.request.method", "GET"),
+                    Map.entry("http.request.headers.forwarded", "proto=https;host=proxy.example.com:8443"),
+                    Map.entry("http.flavour", "1.1"),
+                    Map.entry("network.protocol.version", "1.1"),
+                    Map.entry("http.url", "/"),
+                    Map.entry("url.full", "/"),
+                    Map.entry("url.path", "/"),
+                    Map.entry("url.scheme", "https"),
+                    Map.entry("server.address", "proxy.example.com"),
+                    Map.entry("server.port", 8443)
+                )
+            )
+        );
+    }
+
+    public void testDispatchStartsTraceWithXForwardedHeaders() {
+        final ThreadContext threadContext = client.threadPool().getThreadContext();
+        final RestController restController = new RestController(null, null, circuitBreakerService, usageService, telemetryProvider);
+        RestRequest fakeRequest = new FakeRestRequest.Builder(xContentRegistry()).withHeaders(
+            Map.of(
+                "X-Forwarded-Proto",
+                List.of("https"),
+                "X-Forwarded-Host",
+                List.of("proxy.example.com"),
+                "X-Forwarded-Port",
+                List.of("8443")
+            )
+        ).build();
+        AssertingChannel channel = new AssertingChannel(fakeRequest, randomBoolean(), RestStatus.BAD_REQUEST);
+        restController.dispatchRequest(fakeRequest, channel, threadContext);
+        verify(tracer).startTrace(
+            eq(threadContext),
+            eq(channel.request()),
+            eq("GET /"),
+            eq(
+                Map.ofEntries(
+                    Map.entry("http.method", "GET"),
+                    Map.entry("http.request.method", "GET"),
+                    Map.entry("http.request.headers.x_forwarded_proto", "https"),
+                    Map.entry("http.request.headers.x_forwarded_host", "proxy.example.com"),
+                    Map.entry("http.request.headers.x_forwarded_port", "8443"),
+                    Map.entry("http.flavour", "1.1"),
+                    Map.entry("network.protocol.version", "1.1"),
+                    Map.entry("http.url", "/"),
+                    Map.entry("url.full", "/"),
+                    Map.entry("url.path", "/"),
+                    Map.entry("url.scheme", "https"),
+                    Map.entry("server.address", "proxy.example.com"),
+                    Map.entry("server.port", 8443)
                 )
             )
         );

--- a/server/src/test/java/org/elasticsearch/rest/RestControllerTracingTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/RestControllerTracingTests.java
@@ -108,6 +108,11 @@ public class RestControllerTracingTests extends ESTestCase {
         assertEquals("https", RestController.extractScheme(req, forwarded(req)));
     }
 
+    public void testExtractSchemeForwardedNormalizesCase() {
+        final var req = requestWith(Map.of("Forwarded", List.of("proto=HTTPS")));
+        assertEquals("https", RestController.extractScheme(req, forwarded(req)));
+    }
+
     public void testExtractSchemeForwardedBeatsXForwardedProto() {
         final var req = requestWith(Map.of("Forwarded", List.of("proto=https"), "X-Forwarded-Proto", List.of("http")));
         assertEquals("https", RestController.extractScheme(req, forwarded(req)));
@@ -192,9 +197,14 @@ public class RestControllerTracingTests extends ESTestCase {
         assertEquals(Integer.valueOf(8443), RestController.extractServerPort(req, null, null));
     }
 
-    public void testExtractServerPortFromXForwardedPortAlone() {
+    public void testExtractServerPortFromXForwardedPortWhenXForwardedHostHasNoPort() {
         final var req = requestWith(Map.of("X-Forwarded-Host", List.of("proxy.com"), "X-Forwarded-Port", List.of("8443")));
         assertEquals(Integer.valueOf(8443), RestController.extractServerPort(req, null, null));
+    }
+
+    public void testXForwardedPortWithoutXForwardedHostIsIgnored() {
+        final var req = requestWith(Map.of("X-Forwarded-Port", List.of("8443")));
+        assertNull(RestController.extractServerPort(req, null, null));
     }
 
     public void testExtractServerPortFromHostHeader() {

--- a/server/src/test/java/org/elasticsearch/rest/RestControllerTracingTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/RestControllerTracingTests.java
@@ -173,6 +173,15 @@ public class RestControllerTracingTests extends ESTestCase {
         assertNull(RestController.extractServerPort(req, null, forwarded(req)));
     }
 
+    public void testForwardedHostWithoutPortAddressResolvedPortNotFallenBackToSocket() {
+        // Forwarded: host=proxy.com (no port) — address resolves, but socket port must NOT be used as fallback.
+        final var channel = new FakeRestRequest.FakeHttpChannel(null, new InetSocketAddress("127.0.0.1", 9200));
+        final var req = requestWith(Map.of("Forwarded", List.of("host=proxy.com")));
+        final var fwd = forwarded(req);
+        assertEquals("proxy.com", RestController.extractServerAddress(req, channel, fwd));
+        assertNull(RestController.extractServerPort(req, channel, fwd));
+    }
+
     public void testExtractServerPortFromXForwardedHostWithPort() {
         final var req = requestWith(Map.of("X-Forwarded-Host", List.of("proxy.com:8443")));
         assertEquals(Integer.valueOf(8443), RestController.extractServerPort(req, null, null));

--- a/server/src/test/java/org/elasticsearch/rest/RestControllerTracingTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/RestControllerTracingTests.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.rest;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.rest.FakeRestRequest;
+import org.elasticsearch.xcontent.NamedXContentRegistry;
+
+import java.net.InetSocketAddress;
+import java.util.List;
+import java.util.Map;
+
+public class RestControllerTracingTests extends ESTestCase {
+
+    public void testParsePortSafeNull() {
+        assertNull(RestController.parsePortSafe(null));
+    }
+
+    public void testParsePortSafeNonInteger() {
+        assertNull(RestController.parsePortSafe("abc"));
+    }
+
+    public void testParsePortSafeBoundaries() {
+        assertNull(RestController.parsePortSafe("0"));
+        assertEquals(Integer.valueOf(1), RestController.parsePortSafe("1"));
+        assertEquals(Integer.valueOf(65535), RestController.parsePortSafe("65535"));
+        assertNull(RestController.parsePortSafe("65536"));
+        assertNull(RestController.parsePortSafe("-1"));
+    }
+
+    public void testParsePortSafeTrimsWhitespace() {
+        assertEquals(Integer.valueOf(8080), RestController.parsePortSafe(" 8080 "));
+    }
+
+    public void testSplitHostPortIpv4WithPort() {
+        final var result = RestController.splitHostPort("192.168.1.1:8080");
+        assertEquals("192.168.1.1", result[0]);
+        assertEquals("8080", result[1]);
+    }
+
+    public void testSplitHostPortNameWithPort() {
+        final var result = RestController.splitHostPort("example.com:9200");
+        assertEquals("example.com", result[0]);
+        assertEquals("9200", result[1]);
+    }
+
+    public void testSplitHostPortNameWithoutPort() {
+        final var result = RestController.splitHostPort("example.com");
+        assertEquals("example.com", result[0]);
+        assertNull(result[1]);
+    }
+
+    public void testSplitHostPortIpv6WithPort() {
+        final var result = RestController.splitHostPort("[::1]:8080");
+        assertEquals("::1", result[0]);
+        assertEquals("8080", result[1]);
+    }
+
+    public void testSplitHostPortIpv6WithoutPort() {
+        final var result = RestController.splitHostPort("[::1]");
+        assertEquals("::1", result[0]);
+        assertNull(result[1]);
+    }
+
+    public void testSplitHostPortEmpty() {
+        final var result = RestController.splitHostPort("");
+        assertNull(result[0]);
+        assertNull(result[1]);
+    }
+
+    public void testExtractForwardedParamSimple() {
+        assertEquals("https", RestController.extractForwardedParam("proto=https", "proto"));
+    }
+
+    public void testExtractForwardedParamCaseInsensitiveKey() {
+        assertEquals("https", RestController.extractForwardedParam("PROTO=https", "proto"));
+    }
+
+    public void testExtractForwardedParamAmongSemicolonDirectives() {
+        assertEquals("https", RestController.extractForwardedParam("for=1.2.3.4;proto=https", "proto"));
+    }
+
+    public void testExtractForwardedParamMultiHopComma() {
+        assertEquals("https", RestController.extractForwardedParam("for=1.2.3.4, proto=https", "proto"));
+    }
+
+    public void testExtractForwardedParamQuotedValue() {
+        assertEquals("proxy.com:8443", RestController.extractForwardedParam("host=\"proxy.com:8443\"", "host"));
+    }
+
+    public void testExtractForwardedParamAbsent() {
+        assertNull(RestController.extractForwardedParam("for=1.2.3.4", "proto"));
+    }
+
+    public void testExtractForwardedParamEmptyValue() {
+        assertNull(RestController.extractForwardedParam("proto=", "proto"));
+    }
+
+    public void testExtractSchemeFromForwarded() {
+        final var req = requestWith(Map.of("Forwarded", List.of("proto=https")));
+        assertEquals("https", RestController.extractScheme(req, forwarded(req)));
+    }
+
+    public void testExtractSchemeForwardedBeatsXForwardedProto() {
+        final var req = requestWith(Map.of("Forwarded", List.of("proto=https"), "X-Forwarded-Proto", List.of("http")));
+        assertEquals("https", RestController.extractScheme(req, forwarded(req)));
+    }
+
+    public void testExtractSchemeForwardedWithoutProtoFallsThrough() {
+        final var req = requestWith(Map.of("Forwarded", List.of("for=1.2.3.4"), "X-Forwarded-Proto", List.of("https")));
+        assertEquals("https", RestController.extractScheme(req, forwarded(req)));
+    }
+
+    public void testExtractSchemeFromXForwardedProto() {
+        final var req = requestWith(Map.of("X-Forwarded-Proto", List.of("https")));
+        assertEquals("https", RestController.extractScheme(req, null));
+    }
+
+    public void testExtractSchemeBlankXForwardedProtoFallsThrough() {
+        final var req = requestWith(Map.of("X-Forwarded-Proto", List.of("  ")));
+        assertEquals("http", RestController.extractScheme(req, null));
+    }
+
+    public void testExtractSchemeFallsBackToTransportScheme() {
+        assertEquals("http", RestController.extractScheme(requestWith(Map.of()), null));
+        final var httpsReq = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withHttps(true).build();
+        assertEquals("https", RestController.extractScheme(httpsReq, null));
+    }
+
+    public void testExtractServerAddressFromForwarded() {
+        final var req = requestWith(Map.of("Forwarded", List.of("host=proxy.com:8443")));
+        assertEquals("proxy.com", RestController.extractServerAddress(req, null, forwarded(req)));
+    }
+
+    public void testExtractServerAddressForwardedBeatsXForwardedHost() {
+        final var req = requestWith(Map.of("Forwarded", List.of("host=proxy.com"), "X-Forwarded-Host", List.of("other.com")));
+        assertEquals("proxy.com", RestController.extractServerAddress(req, null, forwarded(req)));
+    }
+
+    public void testExtractServerAddressFromXForwardedHost() {
+        final var req = requestWith(Map.of("X-Forwarded-Host", List.of("proxy.com:8443")));
+        assertEquals("proxy.com", RestController.extractServerAddress(req, null, null));
+    }
+
+    public void testExtractServerAddressFromHostHeader() {
+        final var req = requestWith(Map.of("Host", List.of("example.com:9200")));
+        assertEquals("example.com", RestController.extractServerAddress(req, null, null));
+    }
+
+    public void testExtractServerAddressFromSocket() {
+        final var channel = new FakeRestRequest.FakeHttpChannel(null, new InetSocketAddress("127.0.0.1", 9200));
+        assertEquals("127.0.0.1", RestController.extractServerAddress(requestWith(Map.of()), channel, null));
+    }
+
+    public void testExtractServerAddressNullWhenNoSource() {
+        assertNull(RestController.extractServerAddress(requestWith(Map.of()), null, null));
+    }
+
+    public void testExtractServerPortFromForwarded() {
+        final var req = requestWith(Map.of("Forwarded", List.of("host=proxy.com:8443")));
+        assertEquals(Integer.valueOf(8443), RestController.extractServerPort(req, null, forwarded(req)));
+    }
+
+    public void testExtractServerPortForwardedHostWithoutPortIsNull() {
+        final var req = requestWith(Map.of("Forwarded", List.of("host=proxy.com")));
+        assertNull(RestController.extractServerPort(req, null, forwarded(req)));
+    }
+
+    public void testExtractServerPortFromXForwardedHostWithPort() {
+        final var req = requestWith(Map.of("X-Forwarded-Host", List.of("proxy.com:8443")));
+        assertEquals(Integer.valueOf(8443), RestController.extractServerPort(req, null, null));
+    }
+
+    public void testExtractServerPortXForwardedPortOverridesPortInXForwardedHost() {
+        final var req = requestWith(Map.of("X-Forwarded-Host", List.of("proxy.com:9999"), "X-Forwarded-Port", List.of("8443")));
+        assertEquals(Integer.valueOf(8443), RestController.extractServerPort(req, null, null));
+    }
+
+    public void testExtractServerPortFromXForwardedPortAlone() {
+        final var req = requestWith(Map.of("X-Forwarded-Host", List.of("proxy.com"), "X-Forwarded-Port", List.of("8443")));
+        assertEquals(Integer.valueOf(8443), RestController.extractServerPort(req, null, null));
+    }
+
+    public void testExtractServerPortFromHostHeader() {
+        final var req = requestWith(Map.of("Host", List.of("example.com:9200")));
+        assertEquals(Integer.valueOf(9200), RestController.extractServerPort(req, null, null));
+    }
+
+    public void testExtractServerPortFromSocket() {
+        final var channel = new FakeRestRequest.FakeHttpChannel(null, new InetSocketAddress("127.0.0.1", 9200));
+        assertEquals(Integer.valueOf(9200), RestController.extractServerPort(requestWith(Map.of()), channel, null));
+    }
+
+    public void testExtractServerPortNullWhenNoSource() {
+        assertNull(RestController.extractServerPort(requestWith(Map.of()), null, null));
+    }
+
+    private static RestRequest requestWith(Map<String, List<String>> headers) {
+        return new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withHeaders(headers).build();
+    }
+
+    private static String forwarded(RestRequest req) {
+        return RestController.firstHeaderValue(req, "Forwarded");
+    }
+}

--- a/server/src/test/java/org/elasticsearch/rest/RestControllerTracingTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/RestControllerTracingTests.java
@@ -75,6 +75,12 @@ public class RestControllerTracingTests extends ESTestCase {
         assertNull(result[1]);
     }
 
+    public void testSplitHostPortMalformedMissingAddress() {
+        final var result = RestController.splitHostPort(":8443");
+        assertNull(result[0]);
+        assertEquals("8443", result[1]);
+    }
+
     public void testExtractForwardedParamSimple() {
         assertEquals("https", RestController.extractForwardedParam("proto=https", "proto"));
     }

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/FakeRestRequest.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/FakeRestRequest.java
@@ -54,21 +54,35 @@ public class FakeRestRequest extends RestRequest {
         private final Map<String, List<String>> headers;
         private HttpBody body;
         private final Exception inboundException;
+        private final String scheme;
 
         public FakeHttpRequest(Method method, String uri, BytesReference body, Map<String, List<String>> headers) {
-            this(method, uri, body == null ? HttpBody.empty() : HttpBody.fromBytesReference(body), headers, null);
+            this(method, uri, body == null ? HttpBody.empty() : HttpBody.fromBytesReference(body), headers, null, "http");
         }
 
         public FakeHttpRequest(Method method, String uri, Map<String, List<String>> headers, HttpBody body) {
-            this(method, uri, body, headers, null);
+            this(method, uri, body, headers, null, "http");
         }
 
-        private FakeHttpRequest(Method method, String uri, HttpBody body, Map<String, List<String>> headers, Exception inboundException) {
+        private FakeHttpRequest(
+            Method method,
+            String uri,
+            HttpBody body,
+            Map<String, List<String>> headers,
+            Exception inboundException,
+            String scheme
+        ) {
             this.method = method;
             this.uri = uri;
             this.body = body;
             this.headers = headers;
             this.inboundException = inboundException;
+            this.scheme = scheme;
+        }
+
+        @Override
+        public String getScheme() {
+            return scheme;
         }
 
         @Override
@@ -110,7 +124,7 @@ public class FakeRestRequest extends RestRequest {
         public HttpRequest removeHeader(String header) {
             final var filteredHeaders = new HashMap<>(headers);
             filteredHeaders.remove(header);
-            return new FakeHttpRequest(method, uri, body, filteredHeaders, inboundException);
+            return new FakeHttpRequest(method, uri, body, filteredHeaders, inboundException, scheme);
         }
 
         public int contentLength() {
@@ -161,10 +175,16 @@ public class FakeRestRequest extends RestRequest {
     public static class FakeHttpChannel implements HttpChannel {
 
         private final InetSocketAddress remoteAddress;
+        private final InetSocketAddress localAddress;
         private final SubscribableListener<Void> closeFuture = new SubscribableListener<>();
 
         public FakeHttpChannel(InetSocketAddress remoteAddress) {
+            this(remoteAddress, null);
+        }
+
+        public FakeHttpChannel(InetSocketAddress remoteAddress, InetSocketAddress localAddress) {
             this.remoteAddress = remoteAddress;
+            this.localAddress = localAddress;
         }
 
         @Override
@@ -174,7 +194,7 @@ public class FakeRestRequest extends RestRequest {
 
         @Override
         public InetSocketAddress getLocalAddress() {
-            return null;
+            return localAddress;
         }
 
         @Override
@@ -212,6 +232,10 @@ public class FakeRestRequest extends RestRequest {
         private Method method = Method.GET;
 
         private InetSocketAddress address = null;
+
+        private InetSocketAddress localAddress = null;
+
+        private boolean secure = false;
 
         private Exception inboundException;
 
@@ -270,14 +294,31 @@ public class FakeRestRequest extends RestRequest {
             return this;
         }
 
+        public Builder withLocalAddress(InetSocketAddress localAddress) {
+            this.localAddress = localAddress;
+            return this;
+        }
+
+        public Builder withHttps(boolean secure) {
+            this.secure = secure;
+            return this;
+        }
+
         public Builder withInboundException(Exception exception) {
             this.inboundException = exception;
             return this;
         }
 
         public FakeRestRequest build() {
-            FakeHttpRequest fakeHttpRequest = new FakeHttpRequest(method, path, content, headers, inboundException);
-            return new FakeRestRequest(parserConfig, fakeHttpRequest, params, new FakeHttpChannel(address));
+            FakeHttpRequest fakeHttpRequest = new FakeHttpRequest(
+                method,
+                path,
+                content,
+                headers,
+                inboundException,
+                secure ? "https" : "http"
+            );
+            return new FakeRestRequest(parserConfig, fakeHttpRequest, params, new FakeHttpChannel(address, localAddress));
         }
     }
 


### PR DESCRIPTION
Closes #149020.

Adds the three remaining required OTel HTTP server SemConv attributes to REST traces. Scheme is read from the transport layer via a new `HttpRequest.getScheme()` default method, threaded through `Netty4HttpPipeliningHandler`. Server address and port respect the proxy-header priority order from RFC 7239: `Forwarded` → `X-Forwarded-{Proto,Host,Port}` → `Host` → local socket.
