### PR TITLE
Add an EngineConfig.Builder and clean up tests

### DIFF
--- a/qa/evil-tests/src/test/java/org/elasticsearch/index/engine/EvilInternalEngineTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/index/engine/EvilInternalEngineTests.java
@@ -116,7 +116,7 @@ public class EvilInternalEngineTests extends EngineTestCase {
                 return new IndexWriter(directory, iwc);
             }, null, null)) {
                 // force segments to exist on disk
-                final ParsedDocument doc1 = testParsedDocument("1", null, testDocumentWithTextField(), B_1, null);
+                final ParsedDocument doc1 = testParsedDocument("1", null, testDocumentWithTextField(), B_1);
                 e.index(indexForDoc(doc1));
                 e.flush();
                 final List<SegmentCommitInfo> segments = StreamSupport.stream(e.getLastCommittedSegmentInfos().spliterator(), false)

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/ShardRoutingRoleIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/ShardRoutingRoleIT.java
@@ -46,8 +46,8 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.engine.EngineConfig;
 import org.elasticsearch.index.engine.EngineFactory;
-import org.elasticsearch.index.engine.EngineTestCase;
 import org.elasticsearch.index.engine.InternalEngine;
 import org.elasticsearch.index.engine.NoOpEngine;
 import org.elasticsearch.index.shard.IndexShard;
@@ -234,7 +234,7 @@ public class ShardRoutingRoleIT extends ESIntegTestCase {
                         throw new RuntimeException(e);
                     }
 
-                    return new NoOpEngine(EngineTestCase.copy(config, () -> -1L));
+                    return new NoOpEngine(EngineConfig.builder(config).globalCheckpointSupplier(() -> -1L).build());
                 }
             });
         }

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/engine/MergeWithFailureIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/engine/MergeWithFailureIT.java
@@ -102,9 +102,8 @@ public class MergeWithFailureIT extends ESIntegTestCase {
             }
             return Optional.of(
                 config -> new TestEngine(
-                    EngineTestCase.copy(
-                        config,
-                        new OneMergeWrappingMergePolicy(config.getMergePolicy(), toWrap -> new MergePolicy.OneMerge(toWrap) {
+                    EngineConfig.builder(config)
+                        .mergePolicy(new OneMergeWrappingMergePolicy(config.getMergePolicy(), toWrap -> new MergePolicy.OneMerge(toWrap) {
                             @Override
                             public CodecReader wrapForMerge(CodecReader reader) {
                                 return new FilterCodecReader(reader) {
@@ -135,8 +134,8 @@ public class MergeWithFailureIT extends ESIntegTestCase {
                                     }
                                 };
                             }
-                        })
-                    )
+                        }))
+                        .build()
                 )
             );
         }

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/IndexingMemoryControllerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/IndexingMemoryControllerIT.java
@@ -59,39 +59,10 @@ public class IndexingMemoryControllerIT extends ESSingleNodeTestCase {
                 .put("indices.memory.index_buffer_size", "10mb")
                 .build();
             IndexSettings indexSettings = new IndexSettings(config.getIndexSettings().getIndexMetadata(), settings);
-            return new EngineConfig(
-                config.getShardId(),
-                config.getThreadPool(),
-                config.getThreadPoolMergeExecutorService(),
-                indexSettings,
-                config.getWarmer(),
-                config.getStore(),
-                config.getMergePolicy(),
-                config.getAnalyzer(),
-                config.getSimilarity(),
-                new CodecService(null, BigArrays.NON_RECYCLING_INSTANCE, null),
-                config.getEventListener(),
-                config.getQueryCache(),
-                config.getQueryCachingPolicy(),
-                config.getTranslogConfig(),
-                config.getFlushMergesAfter(),
-                config.getExternalRefreshListener(),
-                config.getInternalRefreshListener(),
-                config.getIndexSort(),
-                config.getCircuitBreakerService(),
-                config.getGlobalCheckpointSupplier(),
-                config.retentionLeasesSupplier(),
-                config.getPrimaryTermSupplier(),
-                config.getSnapshotCommitSupplier(),
-                config.getLeafSorter(),
-                config.getRelativeTimeInNanosSupplier(),
-                config.getIndexCommitListener(),
-                config.isPromotableToPrimary(),
-                config.getMapperService(),
-                config.getEngineResetLock(),
-                config.getMergeMetrics(),
-                config.getIndexDeletionPolicyWrapper()
-            );
+            return EngineConfig.builder(config)
+                .indexSettings(indexSettings)
+                .codecProvider(new CodecService(null, BigArrays.NON_RECYCLING_INSTANCE, null))
+                .build();
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/engine/EngineConfig.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/EngineConfig.java
@@ -81,9 +81,7 @@ public final class EngineConfig {
     private final Engine.EventListener eventListener;
     private final QueryCache queryCache;
     private final QueryCachingPolicy queryCachingPolicy;
-    @Nullable
     private final List<ReferenceManager.RefreshListener> externalRefreshListener;
-    @Nullable
     private final List<ReferenceManager.RefreshListener> internalRefreshListener;
     @Nullable
     private final Sort indexSort;
@@ -526,8 +524,8 @@ public final class EngineConfig {
         private QueryCachingPolicy queryCachingPolicy;
         private TranslogConfig translogConfig;
         private TimeValue flushMergesAfter;
-        private List<ReferenceManager.RefreshListener> externalRefreshListener;
-        private List<ReferenceManager.RefreshListener> internalRefreshListener;
+        private List<ReferenceManager.RefreshListener> externalRefreshListener = List.of();
+        private List<ReferenceManager.RefreshListener> internalRefreshListener = List.of();
         private Sort indexSort;
         private CircuitBreakerService circuitBreakerService;
         private LongSupplier globalCheckpointSupplier;
@@ -655,12 +653,12 @@ public final class EngineConfig {
         }
 
         public Builder externalRefreshListener(List<ReferenceManager.RefreshListener> externalRefreshListener) {
-            this.externalRefreshListener = externalRefreshListener;
+            this.externalRefreshListener = Objects.requireNonNull(externalRefreshListener, "externalRefreshListener");
             return this;
         }
 
         public Builder internalRefreshListener(List<ReferenceManager.RefreshListener> internalRefreshListener) {
-            this.internalRefreshListener = internalRefreshListener;
+            this.internalRefreshListener = Objects.requireNonNull(internalRefreshListener, "internalRefreshListener");
             return this;
         }
 

--- a/server/src/main/java/org/elasticsearch/index/engine/EngineConfig.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/EngineConfig.java
@@ -52,6 +52,15 @@ import java.util.function.Supplier;
  * object will affect the {@link Engine} instance.
  */
 public final class EngineConfig {
+
+    public static EngineConfig.Builder builder() {
+        return new Builder();
+    }
+
+    public static EngineConfig.Builder builder(EngineConfig config) {
+        return new Builder(config);
+    }
+
     private final ShardId shardId;
     private final IndexSettings indexSettings;
     private final ByteSizeValue indexingBufferSize;
@@ -159,10 +168,7 @@ public final class EngineConfig {
      */
     private final Function<ElasticsearchIndexDeletionPolicy, ElasticsearchIndexDeletionPolicy> indexDeletionPolicyWrapper;
 
-    /**
-     * Creates a new {@link org.elasticsearch.index.engine.EngineConfig}
-     */
-    public EngineConfig(
+    private EngineConfig(
         ShardId shardId,
         ThreadPool threadPool,
         ThreadPoolMergeExecutorService threadPoolMergeExecutorService,
@@ -502,5 +508,268 @@ public final class EngineConfig {
      */
     public Function<ElasticsearchIndexDeletionPolicy, ElasticsearchIndexDeletionPolicy> getIndexDeletionPolicyWrapper() {
         return indexDeletionPolicyWrapper;
+    }
+
+    public static final class Builder {
+        private ShardId shardId;
+        private ThreadPool threadPool;
+        private ThreadPoolMergeExecutorService threadPoolMergeExecutorService;
+        private IndexSettings indexSettings;
+        private Engine.Warmer warmer;
+        private Store store;
+        private MergePolicy mergePolicy;
+        private Analyzer analyzer;
+        private Similarity similarity;
+        private CodecProvider codecProvider;
+        private Engine.EventListener eventListener;
+        private QueryCache queryCache;
+        private QueryCachingPolicy queryCachingPolicy;
+        private TranslogConfig translogConfig;
+        private TimeValue flushMergesAfter;
+        private List<ReferenceManager.RefreshListener> externalRefreshListener;
+        private List<ReferenceManager.RefreshListener> internalRefreshListener;
+        private Sort indexSort;
+        private CircuitBreakerService circuitBreakerService;
+        private LongSupplier globalCheckpointSupplier;
+        private Supplier<RetentionLeases> retentionLeasesSupplier;
+        private LongSupplier primaryTermSupplier;
+        private IndexStorePlugin.SnapshotCommitSupplier snapshotCommitSupplier;
+        private Comparator<LeafReader> leafSorter;
+        private LongSupplier relativeTimeInNanosSupplier;
+        private Engine.IndexCommitListener indexCommitListener;
+        private boolean promotableToPrimary;
+        private MapperService mapperService;
+        private EngineResetLock engineResetLock;
+        private MergeMetrics mergeMetrics;
+        private Function<ElasticsearchIndexDeletionPolicy, ElasticsearchIndexDeletionPolicy> indexDeletionPolicyWrapper;
+
+        Builder() {}
+
+        Builder(EngineConfig config) {
+            this.shardId = config.shardId;
+            this.threadPool = config.threadPool;
+            this.threadPoolMergeExecutorService = config.threadPoolMergeExecutorService;
+            this.indexSettings = config.indexSettings;
+            this.warmer = config.warmer;
+            this.store = config.store;
+            this.mergePolicy = config.mergePolicy;
+            this.analyzer = config.analyzer;
+            this.similarity = config.similarity;
+            this.codecProvider = config.codecProvider;
+            this.eventListener = config.eventListener;
+            this.queryCache = config.queryCache;
+            this.queryCachingPolicy = config.queryCachingPolicy;
+            this.translogConfig = config.translogConfig;
+            this.flushMergesAfter = config.flushMergesAfter;
+            this.externalRefreshListener = config.externalRefreshListener;
+            this.internalRefreshListener = config.internalRefreshListener;
+            this.indexSort = config.indexSort;
+            this.circuitBreakerService = config.circuitBreakerService;
+            this.globalCheckpointSupplier = config.globalCheckpointSupplier;
+            this.retentionLeasesSupplier = config.retentionLeasesSupplier;
+            this.primaryTermSupplier = config.primaryTermSupplier;
+            this.snapshotCommitSupplier = config.snapshotCommitSupplier;
+            this.leafSorter = config.leafSorter;
+            this.relativeTimeInNanosSupplier = config.relativeTimeInNanosSupplier;
+            this.indexCommitListener = config.indexCommitListener;
+            this.promotableToPrimary = config.promotableToPrimary;
+            this.mapperService = config.mapperService;
+            this.engineResetLock = config.engineResetLock;
+            this.mergeMetrics = config.mergeMetrics;
+            this.indexDeletionPolicyWrapper = config.indexDeletionPolicyWrapper;
+        }
+
+        public Builder shardId(ShardId shardId) {
+            this.shardId = shardId;
+            return this;
+        }
+
+        public Builder threadPool(ThreadPool threadPool) {
+            this.threadPool = threadPool;
+            return this;
+        }
+
+        public Builder threadPoolMergeExecutorService(ThreadPoolMergeExecutorService threadPoolMergeExecutorService) {
+            this.threadPoolMergeExecutorService = threadPoolMergeExecutorService;
+            return this;
+        }
+
+        public Builder indexSettings(IndexSettings indexSettings) {
+            this.indexSettings = indexSettings;
+            return this;
+        }
+
+        public Builder warmer(Engine.Warmer warmer) {
+            this.warmer = warmer;
+            return this;
+        }
+
+        public Builder store(Store store) {
+            this.store = store;
+            return this;
+        }
+
+        public Builder mergePolicy(MergePolicy mergePolicy) {
+            this.mergePolicy = mergePolicy;
+            return this;
+        }
+
+        public Builder analyzer(Analyzer analyzer) {
+            this.analyzer = analyzer;
+            return this;
+        }
+
+        public Builder similarity(Similarity similarity) {
+            this.similarity = similarity;
+            return this;
+        }
+
+        public Builder codecProvider(CodecProvider codecProvider) {
+            this.codecProvider = codecProvider;
+            return this;
+        }
+
+        public Builder eventListener(Engine.EventListener eventListener) {
+            this.eventListener = eventListener;
+            return this;
+        }
+
+        public Builder queryCache(QueryCache queryCache) {
+            this.queryCache = queryCache;
+            return this;
+        }
+
+        public Builder queryCachingPolicy(QueryCachingPolicy queryCachingPolicy) {
+            this.queryCachingPolicy = queryCachingPolicy;
+            return this;
+        }
+
+        public Builder translogConfig(TranslogConfig translogConfig) {
+            this.translogConfig = translogConfig;
+            return this;
+        }
+
+        public Builder flushMergesAfter(TimeValue flushMergesAfter) {
+            this.flushMergesAfter = flushMergesAfter;
+            return this;
+        }
+
+        public Builder externalRefreshListener(List<ReferenceManager.RefreshListener> externalRefreshListener) {
+            this.externalRefreshListener = externalRefreshListener;
+            return this;
+        }
+
+        public Builder internalRefreshListener(List<ReferenceManager.RefreshListener> internalRefreshListener) {
+            this.internalRefreshListener = internalRefreshListener;
+            return this;
+        }
+
+        public Builder indexSort(Sort indexSort) {
+            this.indexSort = indexSort;
+            return this;
+        }
+
+        public Builder circuitBreakerService(CircuitBreakerService circuitBreakerService) {
+            this.circuitBreakerService = circuitBreakerService;
+            return this;
+        }
+
+        public Builder globalCheckpointSupplier(LongSupplier globalCheckpointSupplier) {
+            this.globalCheckpointSupplier = globalCheckpointSupplier;
+            return this;
+        }
+
+        public Builder retentionLeasesSupplier(Supplier<RetentionLeases> retentionLeasesSupplier) {
+            this.retentionLeasesSupplier = retentionLeasesSupplier;
+            return this;
+        }
+
+        public Builder primaryTermSupplier(LongSupplier primaryTermSupplier) {
+            this.primaryTermSupplier = primaryTermSupplier;
+            return this;
+        }
+
+        public Builder snapshotCommitSupplier(IndexStorePlugin.SnapshotCommitSupplier snapshotCommitSupplier) {
+            this.snapshotCommitSupplier = snapshotCommitSupplier;
+            return this;
+        }
+
+        public Builder leafSorter(Comparator<LeafReader> leafSorter) {
+            this.leafSorter = leafSorter;
+            return this;
+        }
+
+        public Builder relativeTimeInNanosSupplier(LongSupplier relativeTimeInNanosSupplier) {
+            this.relativeTimeInNanosSupplier = relativeTimeInNanosSupplier;
+            return this;
+        }
+
+        public Builder indexCommitListener(Engine.IndexCommitListener indexCommitListener) {
+            this.indexCommitListener = indexCommitListener;
+            return this;
+        }
+
+        public Builder promotableToPrimary(boolean promotableToPrimary) {
+            this.promotableToPrimary = promotableToPrimary;
+            return this;
+        }
+
+        public Builder mapperService(MapperService mapperService) {
+            this.mapperService = mapperService;
+            return this;
+        }
+
+        public Builder engineResetLock(EngineResetLock engineResetLock) {
+            this.engineResetLock = engineResetLock;
+            return this;
+        }
+
+        public Builder mergeMetrics(MergeMetrics mergeMetrics) {
+            this.mergeMetrics = mergeMetrics;
+            return this;
+        }
+
+        public Builder indexDeletionPolicyWrapper(
+            Function<ElasticsearchIndexDeletionPolicy, ElasticsearchIndexDeletionPolicy> indexDeletionPolicyWrapper
+        ) {
+            this.indexDeletionPolicyWrapper = indexDeletionPolicyWrapper;
+            return this;
+        }
+
+        public EngineConfig build() {
+            return new EngineConfig(
+                shardId,
+                threadPool,
+                threadPoolMergeExecutorService,
+                indexSettings,
+                warmer,
+                store,
+                mergePolicy,
+                analyzer,
+                similarity,
+                codecProvider,
+                eventListener,
+                queryCache,
+                queryCachingPolicy,
+                translogConfig,
+                flushMergesAfter,
+                externalRefreshListener,
+                internalRefreshListener,
+                indexSort,
+                circuitBreakerService,
+                globalCheckpointSupplier,
+                retentionLeasesSupplier,
+                primaryTermSupplier,
+                snapshotCommitSupplier,
+                leafSorter,
+                relativeTimeInNanosSupplier,
+                indexCommitListener,
+                promotableToPrimary,
+                mapperService,
+                engineResetLock,
+                mergeMetrics,
+                indexDeletionPolicyWrapper
+            );
+        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -3949,39 +3949,39 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             }
         };
         final boolean isTimeBasedIndex = mapperService == null ? false : mapperService.mappingLookup().getTimestampFieldType() != null;
-        return new EngineConfig(
-            shardId,
-            threadPool,
-            threadPoolMergeExecutorService,
-            indexSettings,
-            warmer,
-            store,
-            indexSettings.getMergePolicy(isTimeBasedIndex),
-            buildIndexAnalyzer(mapperService),
-            similarityService.similarity(mapperService == null ? null : mapperService::fieldType),
-            codecService,
-            shardEventListener,
-            indexCache != null ? indexCache.query() : null,
-            cachingPolicy,
-            translogConfig,
-            IndexingMemoryController.SHARD_INACTIVE_TIME_SETTING.get(indexSettings.getSettings()),
-            List.of(refreshListeners, refreshPendingLocationListener, refreshFieldHasValueListener),
-            List.of(new RefreshMetricUpdater(refreshMetric), new RefreshShardFieldStatsListener()),
-            indexSort,
-            circuitBreakerService,
-            globalCheckpointSupplier,
-            replicationTracker::getRetentionLeases,
-            this::getOperationPrimaryTerm,
-            snapshotCommitSupplier,
-            isTimeBasedIndex ? TIMESERIES_LEAF_READERS_SORTER : null,
-            relativeTimeInNanosSupplier,
-            indexCommitListener,
-            routingEntry().isPromotableToPrimary(),
-            mapperService(),
-            engineResetLock,
-            mergeMetrics,
-            Function.identity()
-        );
+        return EngineConfig.builder()
+            .shardId(shardId)
+            .threadPool(threadPool)
+            .threadPoolMergeExecutorService(threadPoolMergeExecutorService)
+            .indexSettings(indexSettings)
+            .warmer(warmer)
+            .store(store)
+            .mergePolicy(indexSettings.getMergePolicy(isTimeBasedIndex))
+            .analyzer(buildIndexAnalyzer(mapperService))
+            .similarity(similarityService.similarity(mapperService == null ? null : mapperService::fieldType))
+            .codecProvider(codecService)
+            .eventListener(shardEventListener)
+            .queryCache(indexCache != null ? indexCache.query() : null)
+            .queryCachingPolicy(cachingPolicy)
+            .translogConfig(translogConfig)
+            .flushMergesAfter(IndexingMemoryController.SHARD_INACTIVE_TIME_SETTING.get(indexSettings.getSettings()))
+            .externalRefreshListener(List.of(refreshListeners, refreshPendingLocationListener, refreshFieldHasValueListener))
+            .internalRefreshListener(List.of(new RefreshMetricUpdater(refreshMetric), new RefreshShardFieldStatsListener()))
+            .indexSort(indexSort)
+            .circuitBreakerService(circuitBreakerService)
+            .globalCheckpointSupplier(globalCheckpointSupplier)
+            .retentionLeasesSupplier(replicationTracker::getRetentionLeases)
+            .primaryTermSupplier(this::getOperationPrimaryTerm)
+            .snapshotCommitSupplier(snapshotCommitSupplier)
+            .leafSorter(isTimeBasedIndex ? TIMESERIES_LEAF_READERS_SORTER : null)
+            .relativeTimeInNanosSupplier(relativeTimeInNanosSupplier)
+            .indexCommitListener(indexCommitListener)
+            .promotableToPrimary(routingEntry().isPromotableToPrimary())
+            .mapperService(mapperService())
+            .engineResetLock(engineResetLock)
+            .mergeMetrics(mergeMetrics)
+            .indexDeletionPolicyWrapper(Function.identity())
+            .build();
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -407,7 +407,7 @@ public class InternalEngineTests extends EngineTestCase {
         Sort indexSort = new Sort(new SortedSetSortField("field", false));
         try (
             Store store = createStore();
-            Engine engine = createEngine(defaultSettings, store, createTempDir(), NoMergePolicy.INSTANCE, null, null, null, indexSort, null)
+            Engine engine = createEngine(defaultSettings, store, createTempDir(), NoMergePolicy.INSTANCE, indexSort)
         ) {
             List<Segment> segments = engine.segments();
             assertThat(segments.isEmpty(), equalTo(true));
@@ -472,7 +472,7 @@ public class InternalEngineTests extends EngineTestCase {
         try (
             Store store = createStore();
             InternalEngine engine = createEngine(
-                config(defaultSettings, store, createTempDir(), NoMergePolicy.INSTANCE, null, null, globalCheckpoint::get)
+                config(defaultSettings, store, createTempDir(), NoMergePolicy.INSTANCE, globalCheckpoint::get)
             )
         ) {
             assertThat(engine.segments(), empty());
@@ -769,7 +769,7 @@ public class InternalEngineTests extends EngineTestCase {
     public void testRecoveryFromTranslogUpToSeqNo() throws IOException {
         final AtomicLong globalCheckpoint = new AtomicLong(SequenceNumbers.NO_OPS_PERFORMED);
         try (Store store = createStore()) {
-            EngineConfig config = config(defaultSettings, store, createTempDir(), newMergePolicy(), null, null, globalCheckpoint::get);
+            EngineConfig config = config(defaultSettings, store, createTempDir(), newMergePolicy(), globalCheckpoint::get);
             final long maxSeqNo;
             try (InternalEngine engine = createEngine(config)) {
                 final int docs = randomIntBetween(1, 100);
@@ -1307,7 +1307,7 @@ public class InternalEngineTests extends EngineTestCase {
         store = createStore();
         final AtomicLong globalCheckpoint = new AtomicLong(SequenceNumbers.NO_OPS_PERFORMED);
         final LongSupplier globalCheckpointSupplier = () -> globalCheckpoint.get();
-        engine = createEngine(config(defaultSettings, store, translogPath, newMergePolicy(), null, null, globalCheckpointSupplier));
+        engine = createEngine(config(defaultSettings, store, translogPath, newMergePolicy(), globalCheckpointSupplier));
         ParsedDocument doc = testParsedDocument("1", null, testDocumentWithTextField(), B_1, null);
         indexDoc(engine, indexForDoc(doc));
         boolean inSync = randomBoolean();
@@ -1339,7 +1339,7 @@ public class InternalEngineTests extends EngineTestCase {
         final Path translogPath = createTempDir();
         store = createStore();
         final AtomicLong globalCheckpoint = new AtomicLong(SequenceNumbers.NO_OPS_PERFORMED);
-        engine = createEngine(config(defaultSettings, store, translogPath, newMergePolicy(), null, null, globalCheckpoint::get));
+        engine = createEngine(config(defaultSettings, store, translogPath, newMergePolicy(), globalCheckpoint::get));
         List<Engine.Operation> ops = generateHistoryOnReplica(between(1, 50), false, randomBoolean(), randomBoolean());
         applyOperations(engine, ops);
         engine.flush(true, true);
@@ -1717,9 +1717,7 @@ public class InternalEngineTests extends EngineTestCase {
         final Set<String> liveDocs = new HashSet<>();
         try (
             Store store = createStore();
-            InternalEngine engine = createEngine(
-                config(defaultSettings, store, createTempDir(), newMergePolicy(), null, null, globalCheckpoint::get)
-            )
+            InternalEngine engine = createEngine(config(defaultSettings, store, createTempDir(), newMergePolicy(), globalCheckpoint::get))
         ) {
             int numDocs = scaledRandomIntBetween(10, 100);
             for (int i = 0; i < numDocs; i++) {
@@ -1747,9 +1745,7 @@ public class InternalEngineTests extends EngineTestCase {
         final Set<String> liveDocs = new HashSet<>();
         try (
             Store store = createStore();
-            InternalEngine engine = createEngine(
-                config(indexSettings, store, createTempDir(), newMergePolicy(), null, null, globalCheckpoint::get)
-            )
+            InternalEngine engine = createEngine(config(indexSettings, store, createTempDir(), newMergePolicy(), globalCheckpoint::get))
         ) {
             int numDocs = scaledRandomIntBetween(10, 100);
             for (int i = 0; i < numDocs; i++) {
@@ -1824,9 +1820,7 @@ public class InternalEngineTests extends EngineTestCase {
         final Set<String> liveDocsWithSource = new HashSet<>();
         try (
             Store store = createStore();
-            InternalEngine engine = createEngine(
-                config(indexSettings, store, createTempDir(), newMergePolicy(), null, null, globalCheckpoint::get)
-            )
+            InternalEngine engine = createEngine(config(indexSettings, store, createTempDir(), newMergePolicy(), globalCheckpoint::get))
         ) {
             int numDocs = scaledRandomIntBetween(10, 100);
             for (int i = 0; i < numDocs; i++) {
@@ -2784,7 +2778,7 @@ public class InternalEngineTests extends EngineTestCase {
         InternalEngine initialEngine = null;
 
         try {
-            initialEngine = createEngine(defaultSettings, store, createTempDir(), newLogMergePolicy(), null);
+            initialEngine = createEngine(defaultSettings, store, createTempDir(), newLogMergePolicy());
             final ShardRouting primary = shardRoutingBuilder(shardId, "node1", true, ShardRoutingState.STARTED).withAllocationId(
                 allocationId
             ).build();
@@ -2947,7 +2941,7 @@ public class InternalEngineTests extends EngineTestCase {
         List<Engine.IndexCommitRef> commits = new ArrayList<>();
         try (
             Store store = createStore();
-            InternalEngine engine = createEngine(config(defaultSettings, store, createTempDir(), newMergePolicy(), null))
+            InternalEngine engine = createEngine(config(defaultSettings, store, createTempDir(), newMergePolicy()))
         ) {
             final int numIndexingThreads = scaledRandomIntBetween(2, 4);
             final int numDocsPerThread = randomIntBetween(500, 1000);
@@ -3250,10 +3244,7 @@ public class InternalEngineTests extends EngineTestCase {
     }
 
     public void testEnableGcDeletes() throws Exception {
-        try (
-            Store store = createStore();
-            Engine engine = createEngine(config(defaultSettings, store, createTempDir(), newMergePolicy(), null))
-        ) {
+        try (Store store = createStore(); Engine engine = createEngine(config(defaultSettings, store, createTempDir(), newMergePolicy()))) {
             engine.config().setEnableGcDeletes(false);
 
             MapperService mapperService = createMapperService();
@@ -3465,7 +3456,7 @@ public class InternalEngineTests extends EngineTestCase {
     public void testCurrentTranslogUUIIDIsCommitted() throws IOException {
         final AtomicLong globalCheckpoint = new AtomicLong(SequenceNumbers.NO_OPS_PERFORMED);
         try (Store store = createStore()) {
-            EngineConfig config = config(defaultSettings, store, createTempDir(), newMergePolicy(), null, null, globalCheckpoint::get);
+            EngineConfig config = config(defaultSettings, store, createTempDir(), newMergePolicy(), globalCheckpoint::get);
 
             // create
             {
@@ -3570,7 +3561,7 @@ public class InternalEngineTests extends EngineTestCase {
         // when a new translog is created it should be ok
         final String translogUUID = Translog.createEmptyTranslog(primaryTranslogDir, UNASSIGNED_SEQ_NO, shardId, newPrimaryTerm);
         store.associateIndexWithNewTranslog(translogUUID);
-        EngineConfig config = config(defaultSettings, store, primaryTranslogDir, newMergePolicy(), null);
+        EngineConfig config = config(defaultSettings, store, primaryTranslogDir, newMergePolicy());
         engine = new InternalEngine(config);
     }
 
@@ -3646,7 +3637,7 @@ public class InternalEngineTests extends EngineTestCase {
             store.associateIndexWithNewTranslog(translogUUID);
             try (
                 InternalEngine engine = new InternalEngine(
-                    config(indexSettings, store, translogPath, newMergePolicy(), null, null, globalCheckpointSupplier)
+                    config(indexSettings, store, translogPath, newMergePolicy(), globalCheckpointSupplier)
                 ) {
 
                     @Override
@@ -3670,7 +3661,7 @@ public class InternalEngineTests extends EngineTestCase {
             }
             try (
                 InternalEngine engine = new InternalEngine(
-                    config(indexSettings, store, translogPath, newMergePolicy(), null, null, globalCheckpointSupplier)
+                    config(indexSettings, store, translogPath, newMergePolicy(), globalCheckpointSupplier)
                 )
             ) {
                 recoverFromTranslog(engine, translogHandler, Long.MAX_VALUE);
@@ -4117,7 +4108,7 @@ public class InternalEngineTests extends EngineTestCase {
                 .codecProvider(newCodecService())
                 .translogConfig(configTranslogConfig)
                 .build();
-            try (InternalEngine engine = createEngine(indexWriterFactory, null, null, config)) {
+            try (InternalEngine engine = createEngine(indexWriterFactory, config)) {
                 final ParsedDocument doc = testParsedDocument("1", null, testDocumentWithTextField(), SOURCE, null);
                 indexDoc(engine, indexForDoc(doc));
                 expectThrows(
@@ -4978,7 +4969,7 @@ public class InternalEngineTests extends EngineTestCase {
         Map<String, Engine.Operation> latestOps = new HashMap<>(); // id -> latest seq_no
         try (
             Store store = createStore();
-            InternalEngine engine = createEngine(config(defaultSettings, store, createTempDir(), newMergePolicy(), null))
+            InternalEngine engine = createEngine(config(defaultSettings, store, createTempDir(), newMergePolicy()))
         ) {
             CheckedRunnable<IOException> lookupAndCheck = () -> {
                 try (Engine.Searcher searcher = engine.acquireSearcher("test", Engine.SearcherScope.INTERNAL)) {
@@ -6055,9 +6046,7 @@ public class InternalEngineTests extends EngineTestCase {
         final AtomicLong globalCheckpoint = new AtomicLong(SequenceNumbers.NO_OPS_PERFORMED);
         try (
             Store store = createStore();
-            InternalEngine engine = createEngine(
-                config(defaultSettings, store, createTempDir(), newMergePolicy(), null, null, globalCheckpoint::get)
-            )
+            InternalEngine engine = createEngine(config(defaultSettings, store, createTempDir(), newMergePolicy(), globalCheckpoint::get))
         ) {
             final int numDocs = scaledRandomIntBetween(10, 100);
             for (int docId = 0; docId < numDocs; docId++) {
@@ -6462,7 +6451,7 @@ public class InternalEngineTests extends EngineTestCase {
         final List<Long> seqNos = LongStream.rangeClosed(0, maxSeqNo).boxed().collect(Collectors.toCollection(ArrayList::new));
         Collections.shuffle(seqNos, random());
         try (Store store = createStore()) {
-            EngineConfig config = config(defaultSettings, store, createTempDir(), newMergePolicy(), null, null, globalCheckpoint::get);
+            EngineConfig config = config(defaultSettings, store, createTempDir(), newMergePolicy(), globalCheckpoint::get);
             final List<Long> commitMaxSeqNo = new ArrayList<>();
             final long minTranslogGen;
             try (InternalEngine engine = createEngine(config)) {
@@ -6557,7 +6546,7 @@ public class InternalEngineTests extends EngineTestCase {
         Set<Long> expectedSeqNos = new HashSet<>();
         try (
             Store store = createStore();
-            Engine engine = createEngine(config(indexSettings, store, createTempDir(), keepSoftDeleteDocsMP, null))
+            Engine engine = createEngine(config(indexSettings, store, createTempDir(), keepSoftDeleteDocsMP))
         ) {
             for (Engine.Operation op : operations) {
                 if (op instanceof Engine.Index) {
@@ -6610,7 +6599,7 @@ public class InternalEngineTests extends EngineTestCase {
         Set<Long> existingSeqNos = new HashSet<>();
         store = createStore();
         engine = createEngine(
-            config(indexSettings, store, createTempDir(), newMergePolicy(), null, null, globalCheckpoint::get, retentionLeasesHolder::get)
+            config(indexSettings, store, createTempDir(), newMergePolicy(), globalCheckpoint::get, retentionLeasesHolder::get)
         );
         assertThat(engine.getMinRetainedSeqNo(), equalTo(0L));
         long lastMinRetainedSeqNo = engine.getMinRetainedSeqNo();
@@ -6792,7 +6781,7 @@ public class InternalEngineTests extends EngineTestCase {
         engine.close();
         try (
             Store store = createStore();
-            InternalEngine engine = createEngine(config(defaultSettings, store, createTempDir(), NoMergePolicy.INSTANCE, null))
+            InternalEngine engine = createEngine(config(defaultSettings, store, createTempDir(), NoMergePolicy.INSTANCE))
         ) {
             engine.close();
             expectThrows(
@@ -6806,7 +6795,7 @@ public class InternalEngineTests extends EngineTestCase {
         engine.close();
         try (
             Store store = createStore();
-            InternalEngine engine = createEngine(config(defaultSettings, store, createTempDir(), NoMergePolicy.INSTANCE, null))
+            InternalEngine engine = createEngine(config(defaultSettings, store, createTempDir(), NoMergePolicy.INSTANCE))
         ) {
             engine.close();
             expectThrows(AlreadyClosedException.class, () -> engine.delete(replicaDeleteForDoc("test", 42, 7, System.nanoTime())));
@@ -6857,7 +6846,7 @@ public class InternalEngineTests extends EngineTestCase {
         List<List<Engine.Operation>> commits = new ArrayList<>();
         commits.add(new ArrayList<>());
         try (Store store = createStore()) {
-            EngineConfig config = config(defaultSettings, store, translogPath, NoMergePolicy.INSTANCE, null, null, globalCheckpoint::get);
+            EngineConfig config = config(defaultSettings, store, translogPath, NoMergePolicy.INSTANCE, globalCheckpoint::get);
             final List<DocIdSeqNoAndSource> docs;
             try (InternalEngine engine = createEngine(config)) {
                 List<Engine.Operation> flushedOperations = new ArrayList<>();
@@ -6966,7 +6955,7 @@ public class InternalEngineTests extends EngineTestCase {
             IndexSettings indexSettings = IndexSettingsModule.newIndexSettings("test", settings);
             try (
                 Store store = createStore(indexSettings, newDirectory());
-                InternalEngine engine = createEngine(config(indexSettings, store, createTempDir(), NoMergePolicy.INSTANCE, null))
+                InternalEngine engine = createEngine(config(indexSettings, store, createTempDir(), NoMergePolicy.INSTANCE))
             ) {
                 ParsedDocument doc = testParsedDocument(
                     "1",
@@ -7122,7 +7111,7 @@ public class InternalEngineTests extends EngineTestCase {
         Path translogPath = createTempDir();
         List<Engine.Operation> operations = generateHistoryOnReplica(between(1, 500), randomBoolean(), randomBoolean(), randomBoolean());
         try (Store store = createStore()) {
-            EngineConfig config = config(defaultSettings, store, translogPath, newMergePolicy(), null, null, globalCheckpoint::get);
+            EngineConfig config = config(defaultSettings, store, translogPath, newMergePolicy(), globalCheckpoint::get);
             final List<DocIdSeqNoAndSource> docs;
             try (InternalEngine engine = createEngine(config)) {
                 for (Engine.Operation op : operations) {
@@ -7261,7 +7250,7 @@ public class InternalEngineTests extends EngineTestCase {
                 throw new IllegalArgumentException("fatal");
             }
 
-        }, null, null, config(defaultSettings, store, createTempDir(), NoMergePolicy.INSTANCE, null))) {
+        }, config(defaultSettings, store, createTempDir(), NoMergePolicy.INSTANCE))) {
             final Engine.NoOp op = new Engine.NoOp(0, 0, PRIMARY, System.currentTimeMillis(), "test");
             final IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> engine.noOp(op));
             assertThat(e.getMessage(), equalTo("fatal"));
@@ -7286,7 +7275,7 @@ public class InternalEngineTests extends EngineTestCase {
         try (Store store = createStore(); InternalEngine engine = createEngine((dir, iwc) -> {
             iw.set(new ThrowingIndexWriter(dir, iwc));
             return iw.get();
-        }, null, null, config(defaultSettings, store, createTempDir(), NoMergePolicy.INSTANCE, null))) {
+        }, config(defaultSettings, store, createTempDir(), NoMergePolicy.INSTANCE))) {
             indexDoc(engine, new Engine.Index(Uid.encodeId("0"), primaryTerm.get(), InternalEngineTests.createParsedDoc("0", null)));
             final Engine.Delete op = new Engine.Delete("0", Uid.encodeId("0"), primaryTerm.get());
             consumer.accept(engine, op);
@@ -7340,7 +7329,7 @@ public class InternalEngineTests extends EngineTestCase {
         final IndexSettings indexSettings = IndexSettingsModule.newIndexSettings(indexMetadata);
         try (
             Store store = createStore();
-            InternalEngine engine = createEngine(config(indexSettings, store, createTempDir(), newMergePolicy(), null))
+            InternalEngine engine = createEngine(config(indexSettings, store, createTempDir(), newMergePolicy()))
         ) {
             final List<DocIdSeqNoAndSource> prevDocs;
             final Engine.Index indexWithThrottlingCheck = indexForDoc(createParsedDoc("1", null));
@@ -7639,7 +7628,7 @@ public class InternalEngineTests extends EngineTestCase {
     public void testCurrentVersionIsCommitted() throws IOException {
         final AtomicLong globalCheckpoint = new AtomicLong(SequenceNumbers.NO_OPS_PERFORMED);
         try (Store store = createStore()) {
-            EngineConfig config = config(defaultSettings, store, createTempDir(), newMergePolicy(), null, null, globalCheckpoint::get);
+            EngineConfig config = config(defaultSettings, store, createTempDir(), newMergePolicy(), globalCheckpoint::get);
 
             store.createEmpty();
             final String translogUUID = Translog.createEmptyTranslog(
@@ -8041,7 +8030,7 @@ public class InternalEngineTests extends EngineTestCase {
         assertTrue(indexSettings.sequenceNumbersDisabled());
         try (
             Store store = createStore();
-            InternalEngine engine = createEngine(config(indexSettings, store, createTempDir(), NoMergePolicy.INSTANCE, null))
+            InternalEngine engine = createEngine(config(indexSettings, store, createTempDir(), NoMergePolicy.INSTANCE))
         ) {
             ParsedDocument doc = testParsedDocument("1", null, testDocumentWithTextField(), B_1, null);
             indexDoc(engine, indexForDoc(doc));

--- a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -179,7 +179,6 @@ import java.util.function.ToLongBiFunction;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 
-import static java.util.Collections.shuffle;
 import static org.elasticsearch.cluster.routing.TestShardRouting.shardRoutingBuilder;
 import static org.elasticsearch.common.lucene.Lucene.indexWriterConfigWithNoMerging;
 import static org.elasticsearch.index.engine.Engine.ES_VERSION;
@@ -2107,7 +2106,7 @@ public class InternalEngineTests extends EngineTestCase {
         // insert some duplicates
         randomSubsetOf(allOps).forEach(op -> allOps.add(seqNoUpdater.apply(op, op.seqNo())));
 
-        shuffle(allOps, random());
+        Collections.shuffle(allOps, random());
         concurrentlyApplyOps(allOps, engine);
 
         engine.refresh("test");
@@ -2406,7 +2405,7 @@ public class InternalEngineTests extends EngineTestCase {
         }
         // other version types don't support out of order processing.
         if (versionType == VersionType.EXTERNAL) {
-            shuffle(ops, random());
+            Collections.shuffle(ops, random());
         }
         long highestOpVersion = Versions.NOT_FOUND;
         long seqNo = -1;
@@ -2508,7 +2507,7 @@ public class InternalEngineTests extends EngineTestCase {
             // delete
             lastFieldValue = null;
         }
-        shuffle(ops, random());
+        Collections.shuffle(ops, random());
         concurrentlyApplyOps(ops, engine);
 
         assertVisibleCount(engine, lastFieldValue == null ? 0 : 1);
@@ -2799,7 +2798,7 @@ public class InternalEngineTests extends EngineTestCase {
             ReplicationTracker gcpTracker = (ReplicationTracker) initialEngine.config().getGlobalCheckpointSupplier();
             gcpTracker.updateFromMaster(
                 1L,
-                new HashSet<>(Collections.singletonList(primary.allocationId().getId())),
+                new HashSet<>(List.of(primary.allocationId().getId())),
                 new IndexShardRoutingTable.Builder(shardId).addShard(primary).build()
             );
             gcpTracker.activatePrimaryMode(primarySeqNo);
@@ -2814,7 +2813,7 @@ public class InternalEngineTests extends EngineTestCase {
             }
             gcpTracker.updateFromMaster(
                 2L,
-                new HashSet<>(Collections.singletonList(primary.allocationId().getId())),
+                new HashSet<>(List.of(primary.allocationId().getId())),
                 new IndexShardRoutingTable.Builder(shardId).addShard(primary).addShard(initializingReplica).build()
             );
             gcpTracker.initiateTracking(initializingReplica.allocationId().getId());
@@ -5817,7 +5816,7 @@ public class InternalEngineTests extends EngineTestCase {
                 seqID,
                 id,
                 "routing",
-                Collections.singletonList(document),
+                List.of(document),
                 source,
                 XContentType.JSON,
                 null,
@@ -6597,7 +6596,7 @@ public class InternalEngineTests extends EngineTestCase {
         final long primaryTerm = randomLongBetween(1, Long.MAX_VALUE);
         final AtomicLong retentionLeasesVersion = new AtomicLong();
         final AtomicReference<RetentionLeases> retentionLeasesHolder = new AtomicReference<>(
-            new RetentionLeases(primaryTerm, retentionLeasesVersion.get(), Collections.emptyList())
+            new RetentionLeases(primaryTerm, retentionLeasesVersion.get(), List.of())
         );
         final List<Engine.Operation> operations = generateSingleDocHistory(
             true,

--- a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -252,21 +252,14 @@ public class InternalEngineTests extends EngineTestCase {
             "1",
             null,
             testDocumentWithTextField("test"),
-            new BytesArray("{}".getBytes(Charset.defaultCharset())),
-            null
+            new BytesArray("{}".getBytes(Charset.defaultCharset()))
         );
         Engine.Index operation = randomBoolean()
             ? appendOnlyPrimary(doc, false, 1)
             : appendOnlyReplica(doc, false, 1, randomIntBetween(0, 5));
         indexDoc(engine, operation);
         assertFalse(engine.isSafeAccessRequired());
-        doc = testParsedDocument(
-            "1",
-            null,
-            testDocumentWithTextField("updated"),
-            new BytesArray("{}".getBytes(Charset.defaultCharset())),
-            null
-        );
+        doc = testParsedDocument("1", null, testDocumentWithTextField("updated"), new BytesArray("{}".getBytes(Charset.defaultCharset())));
         Engine.Index update = indexForDoc(doc);
         indexDoc(engine, update);
         assertTrue(engine.isSafeAccessRequired());
@@ -295,13 +288,7 @@ public class InternalEngineTests extends EngineTestCase {
             assertEquals("updated", luceneDoc.get("value"));
         }
 
-        doc = testParsedDocument(
-            "2",
-            null,
-            testDocumentWithTextField("test"),
-            new BytesArray("{}".getBytes(Charset.defaultCharset())),
-            null
-        );
+        doc = testParsedDocument("2", null, testDocumentWithTextField("test"), new BytesArray("{}".getBytes(Charset.defaultCharset())));
         operation = randomBoolean() ? appendOnlyPrimary(doc, false, 1) : appendOnlyReplica(doc, false, 1, generateNewSeqNo(engine));
         indexDoc(engine, operation);
         assertTrue("safe access should be required", engine.isSafeAccessRequired());
@@ -330,17 +317,17 @@ public class InternalEngineTests extends EngineTestCase {
             List<Segment> segments = engine.segments();
             assertThat(segments.isEmpty(), equalTo(true));
 
-            ParsedDocument doc = testParsedDocument("1", null, testDocumentWithTextField(), B_1, null);
+            ParsedDocument doc = testParsedDocument("1", null, testDocumentWithTextField(), B_1);
             indexDoc(engine, indexForDoc(doc));
             engine.refresh("test");
 
             segments = engine.segments();
             assertThat(segments.size(), equalTo(1));
 
-            ParsedDocument doc2 = testParsedDocument("2", null, testDocumentWithTextField(), B_2, null);
+            ParsedDocument doc2 = testParsedDocument("2", null, testDocumentWithTextField(), B_2);
             indexDoc(engine, indexForDoc(doc2));
             engine.refresh("test");
-            ParsedDocument doc3 = testParsedDocument("3", null, testDocumentWithTextField(), B_3, null);
+            ParsedDocument doc3 = testParsedDocument("3", null, testDocumentWithTextField(), B_3);
             indexDoc(engine, indexForDoc(doc3));
             engine.refresh("test");
 
@@ -351,12 +338,12 @@ public class InternalEngineTests extends EngineTestCase {
 
     public void testSegmentsWithMergeFlag() throws Exception {
         try (Store store = createStore(); Engine engine = createEngine(defaultSettings, store, createTempDir(), new TieredMergePolicy())) {
-            ParsedDocument doc = testParsedDocument("1", null, testDocument(), B_1, null);
+            ParsedDocument doc = testParsedDocument("1", null, testDocument(), B_1);
             Engine.Index index = indexForDoc(doc);
             indexDoc(engine, index);
             engine.flush();
             assertThat(engine.segments().size(), equalTo(1));
-            index = indexForDoc(testParsedDocument("2", null, testDocument(), B_1, null));
+            index = indexForDoc(testParsedDocument("2", null, testDocument(), B_1));
             indexDoc(engine, index);
             engine.flush();
             List<Segment> segments = engine.segments();
@@ -364,7 +351,7 @@ public class InternalEngineTests extends EngineTestCase {
             for (Segment segment : segments) {
                 assertThat(segment.getMergeId(), nullValue());
             }
-            index = indexForDoc(testParsedDocument("3", null, testDocument(), B_1, null));
+            index = indexForDoc(testParsedDocument("3", null, testDocument(), B_1));
             indexDoc(engine, index);
             engine.flush();
             segments = engine.segments();
@@ -412,7 +399,7 @@ public class InternalEngineTests extends EngineTestCase {
             List<Segment> segments = engine.segments();
             assertThat(segments.isEmpty(), equalTo(true));
 
-            ParsedDocument doc = testParsedDocument("1", null, testDocumentWithTextField(), B_1, null);
+            ParsedDocument doc = testParsedDocument("1", null, testDocumentWithTextField(), B_1);
             indexDoc(engine, indexForDoc(doc));
             engine.refresh("test");
 
@@ -420,10 +407,10 @@ public class InternalEngineTests extends EngineTestCase {
             assertThat(segments.size(), equalTo(1));
             assertThat(segments.get(0).getSegmentSort(), equalTo(indexSort));
 
-            ParsedDocument doc2 = testParsedDocument("2", null, testDocumentWithTextField(), B_2, null);
+            ParsedDocument doc2 = testParsedDocument("2", null, testDocumentWithTextField(), B_2);
             indexDoc(engine, indexForDoc(doc2));
             engine.refresh("test");
-            ParsedDocument doc3 = testParsedDocument("3", null, testDocumentWithTextField(), B_3, null);
+            ParsedDocument doc3 = testParsedDocument("3", null, testDocumentWithTextField(), B_3);
             indexDoc(engine, indexForDoc(doc3));
             engine.refresh("test");
 
@@ -439,7 +426,7 @@ public class InternalEngineTests extends EngineTestCase {
         try (Store store = createStore(); Engine engine = createEngine(defaultSettings, store, createTempDir(), NoMergePolicy.INSTANCE)) {
             assertThat(engine.segmentsStats(true, false).getFiles().size(), equalTo(0));
 
-            ParsedDocument doc = testParsedDocument("1", null, testDocumentWithTextField(), B_1, null);
+            ParsedDocument doc = testParsedDocument("1", null, testDocumentWithTextField(), B_1);
             indexDoc(engine, indexForDoc(doc));
             engine.refresh("test");
 
@@ -452,7 +439,7 @@ public class InternalEngineTests extends EngineTestCase {
                 assertThat(fileStats.getValue().getMax(), greaterThan(0L));
             }
 
-            ParsedDocument doc2 = testParsedDocument("2", null, testDocumentWithTextField(), B_2, null);
+            ParsedDocument doc2 = testParsedDocument("2", null, testDocumentWithTextField(), B_2);
             indexDoc(engine, indexForDoc(doc2));
             engine.refresh("test");
 
@@ -480,7 +467,7 @@ public class InternalEngineTests extends EngineTestCase {
             Set<String> liveDocsFirstSegment = new HashSet<>();
             for (int i = 0; i < numDocsFirstSegment; i++) {
                 String id = Integer.toString(i);
-                ParsedDocument doc = testParsedDocument(id, null, testDocument(), B_1, null);
+                ParsedDocument doc = testParsedDocument(id, null, testDocument(), B_1);
                 indexDoc(engine, indexForDoc(doc));
                 liveDocsFirstSegment.add(id);
             }
@@ -497,7 +484,7 @@ public class InternalEngineTests extends EngineTestCase {
             for (int i = 0; i < iterations && liveDocsFirstSegment.isEmpty() == false; i++) {
                 String idToUpdate = randomFrom(liveDocsFirstSegment);
                 liveDocsFirstSegment.remove(idToUpdate);
-                ParsedDocument doc = testParsedDocument(idToUpdate, null, testDocument(), B_1, null);
+                ParsedDocument doc = testParsedDocument(idToUpdate, null, testDocument(), B_1);
                 if (randomBoolean()) {
                     engine.delete(new Engine.Delete(doc.id(), newUid(doc), primaryTerm.get()));
                     deletes++;
@@ -506,7 +493,7 @@ public class InternalEngineTests extends EngineTestCase {
                     updates++;
                 }
                 if (randomBoolean()) {
-                    indexDoc(engine, indexForDoc(testParsedDocument(UUIDs.randomBase64UUID(), null, testDocument(), B_1, null)));
+                    indexDoc(engine, indexForDoc(testParsedDocument(UUIDs.randomBase64UUID(), null, testDocument(), B_1)));
                     appends++;
                 }
             }
@@ -585,7 +572,7 @@ public class InternalEngineTests extends EngineTestCase {
 
     public void testFlushIsDisabledDuringTranslogRecovery() throws IOException {
         engine.ensureCanFlush(); // recovered already
-        ParsedDocument doc = testParsedDocument("1", null, testDocumentWithTextField(), SOURCE, null);
+        ParsedDocument doc = testParsedDocument("1", null, testDocumentWithTextField(), SOURCE);
         indexDoc(engine, indexForDoc(doc));
         engine.close();
 
@@ -598,7 +585,7 @@ public class InternalEngineTests extends EngineTestCase {
             engine.skipTranslogRecovery();
         }
         engine.ensureCanFlush(); // ready
-        doc = testParsedDocument("2", null, testDocumentWithTextField(), SOURCE, null);
+        doc = testParsedDocument("2", null, testDocumentWithTextField(), SOURCE);
         indexDoc(engine, indexForDoc(doc));
         engine.flush();
     }
@@ -610,7 +597,7 @@ public class InternalEngineTests extends EngineTestCase {
         try {
             initialEngine = engine;
             for (int i = 0; i < ops; i++) {
-                final ParsedDocument doc = testParsedDocument("1", null, testDocumentWithTextField(), SOURCE, null);
+                final ParsedDocument doc = testParsedDocument("1", null, testDocumentWithTextField(), SOURCE);
                 if (randomBoolean()) {
                     final Engine.Index operation = new Engine.Index(
                         newUid(doc),
@@ -665,7 +652,7 @@ public class InternalEngineTests extends EngineTestCase {
             initialEngine = engine;
             for (int i = 0; i < docs; i++) {
                 final String id = Integer.toString(i);
-                final ParsedDocument doc = testParsedDocument(id, null, testDocumentWithTextField(), SOURCE, null);
+                final ParsedDocument doc = testParsedDocument(id, null, testDocumentWithTextField(), SOURCE);
                 indexDoc(initialEngine, indexForDoc(doc));
             }
         } finally {
@@ -718,7 +705,7 @@ public class InternalEngineTests extends EngineTestCase {
             engine.skipTranslogRecovery();
         }
         engine.ensureCanFlush(); // recovered already
-        ParsedDocument doc = testParsedDocument("1", null, testDocumentWithTextField(), SOURCE, null);
+        ParsedDocument doc = testParsedDocument("1", null, testDocumentWithTextField(), SOURCE);
         indexDoc(engine, indexForDoc(doc));
         engine.flush();
         assertThat(preCommitGen.get(), greaterThan(-1L));
@@ -745,7 +732,7 @@ public class InternalEngineTests extends EngineTestCase {
             );
             for (int i = 0; i < docs; i++) {
                 final String id = Integer.toString(i);
-                final ParsedDocument doc = testParsedDocument(id, null, testDocumentWithTextField(), SOURCE, null);
+                final ParsedDocument doc = testParsedDocument(id, null, testDocumentWithTextField(), SOURCE);
                 indexDoc(initialEngine, indexForDoc(doc));
                 if (rarely()) {
                     getTranslog(initialEngine).rollGeneration();
@@ -775,7 +762,7 @@ public class InternalEngineTests extends EngineTestCase {
                 final int docs = randomIntBetween(1, 100);
                 for (int i = 0; i < docs; i++) {
                     final String id = Integer.toString(i);
-                    final ParsedDocument doc = testParsedDocument(id, null, testDocumentWithTextField(), SOURCE, null);
+                    final ParsedDocument doc = testParsedDocument(id, null, testDocumentWithTextField(), SOURCE);
                     indexDoc(engine, indexForDoc(doc));
                     if (rarely()) {
                         engine.rollTranslogGeneration();
@@ -802,7 +789,7 @@ public class InternalEngineTests extends EngineTestCase {
     }
 
     public void testConcurrentGetAndFlush() throws Exception {
-        ParsedDocument doc = testParsedDocument("1", null, testDocumentWithTextField(), B_1, null);
+        ParsedDocument doc = testParsedDocument("1", null, testDocumentWithTextField(), B_1);
         indexDoc(engine, indexForDoc(doc));
 
         MapperService mapperService = createMapperService();
@@ -864,7 +851,7 @@ public class InternalEngineTests extends EngineTestCase {
         // create a document
         LuceneDocument document = testDocumentWithTextField();
         document.add(new Field(SourceFieldMapper.NAME, BytesReference.toBytes(B_1), SourceFieldMapper.Defaults.FIELD_TYPE));
-        ParsedDocument doc = testParsedDocument("1", null, document, B_1, null);
+        ParsedDocument doc = testParsedDocument("1", null, document, B_1);
         indexDoc(engine, indexForDoc(doc));
 
         // its not there...
@@ -946,7 +933,7 @@ public class InternalEngineTests extends EngineTestCase {
         document = testDocument();
         document.add(new TextField("value", "test1", Field.Store.YES));
         document.add(new Field(SourceFieldMapper.NAME, BytesReference.toBytes(SOURCE), SourceFieldMapper.Defaults.FIELD_TYPE));
-        doc = testParsedDocument("1", null, document, SOURCE, null);
+        doc = testParsedDocument("1", null, document, SOURCE);
         indexDoc(engine, indexForDoc(doc));
 
         // its not updated yet...
@@ -1038,7 +1025,7 @@ public class InternalEngineTests extends EngineTestCase {
         // add it back
         document = testDocumentWithTextField();
         document.add(new Field(SourceFieldMapper.NAME, BytesReference.toBytes(B_1), SourceFieldMapper.Defaults.FIELD_TYPE));
-        doc = testParsedDocument("1", null, document, B_1, null);
+        doc = testParsedDocument("1", null, document, B_1);
         indexDoc(engine, new Engine.Index(newUid(doc), primaryTerm.get(), doc, Versions.MATCH_DELETED));
 
         // its not there...
@@ -1091,7 +1078,7 @@ public class InternalEngineTests extends EngineTestCase {
         // now do an update
         document = testDocument();
         document.add(new TextField("value", "test1", Field.Store.YES));
-        doc = testParsedDocument("1", null, document, B_1, null);
+        doc = testParsedDocument("1", null, document, B_1);
         indexDoc(engine, indexForDoc(doc));
 
         // its not updated yet...
@@ -1261,7 +1248,7 @@ public class InternalEngineTests extends EngineTestCase {
         searchResult.close();
 
         // create a document
-        ParsedDocument doc = testParsedDocument("1", null, testDocumentWithTextField(), B_1, null);
+        ParsedDocument doc = testParsedDocument("1", null, testDocumentWithTextField(), B_1);
         indexDoc(engine, indexForDoc(doc));
 
         // its not there...
@@ -1308,7 +1295,7 @@ public class InternalEngineTests extends EngineTestCase {
         final AtomicLong globalCheckpoint = new AtomicLong(SequenceNumbers.NO_OPS_PERFORMED);
         final LongSupplier globalCheckpointSupplier = () -> globalCheckpoint.get();
         engine = createEngine(config(defaultSettings, store, translogPath, newMergePolicy(), globalCheckpointSupplier));
-        ParsedDocument doc = testParsedDocument("1", null, testDocumentWithTextField(), B_1, null);
+        ParsedDocument doc = testParsedDocument("1", null, testDocumentWithTextField(), B_1);
         indexDoc(engine, indexForDoc(doc));
         boolean inSync = randomBoolean();
         if (inSync) {
@@ -1383,7 +1370,7 @@ public class InternalEngineTests extends EngineTestCase {
             null,
             globalCheckpoint::get
         );
-        ParsedDocument doc = testParsedDocument("1", null, testDocumentWithTextField(), new BytesArray("{}"), null);
+        ParsedDocument doc = testParsedDocument("1", null, testDocumentWithTextField(), new BytesArray("{}"));
         indexDoc(engine, indexForDoc(doc));
         globalCheckpoint.set(0L);
         engine.flush();
@@ -1425,12 +1412,12 @@ public class InternalEngineTests extends EngineTestCase {
             null,
             globalCheckpoint::get
         );
-        ParsedDocument doc = testParsedDocument("1", null, testDocumentWithTextField(), new BytesArray("{}"), null);
+        ParsedDocument doc = testParsedDocument("1", null, testDocumentWithTextField(), new BytesArray("{}"));
         globalCheckpoint.set(engine.getProcessedLocalCheckpoint());
         indexDoc(engine, indexForDoc(doc));
         engine.flush();
         syncFlush(indexWriterHolder.get(), engine);
-        doc = testParsedDocument("2", null, testDocumentWithTextField(), new BytesArray("{}"), null);
+        doc = testParsedDocument("2", null, testDocumentWithTextField(), new BytesArray("{}"));
         indexDoc(engine, indexForDoc(doc));
         EngineConfig config = engine.config();
         engine.close();
@@ -1445,7 +1432,7 @@ public class InternalEngineTests extends EngineTestCase {
     }
 
     public void testVersioningNewCreate() throws IOException {
-        ParsedDocument doc = testParsedDocument("1", null, testDocument(), B_1, null);
+        ParsedDocument doc = testParsedDocument("1", null, testDocument(), B_1);
         Engine.Index create = new Engine.Index(newUid(doc), primaryTerm.get(), doc, Versions.MATCH_DELETED);
         Engine.IndexResult indexResult = indexDoc(engine, create);
         assertThat(indexResult.getVersion(), equalTo(1L));
@@ -1469,7 +1456,7 @@ public class InternalEngineTests extends EngineTestCase {
     }
 
     public void testReplicatedVersioningWithFlush() throws IOException {
-        ParsedDocument doc = testParsedDocument("1", null, testDocument(), B_1, null);
+        ParsedDocument doc = testParsedDocument("1", null, testDocument(), B_1);
         Engine.Index create = new Engine.Index(newUid(doc), primaryTerm.get(), doc, Versions.MATCH_DELETED);
         Engine.IndexResult indexResult = indexDoc(engine, create);
         assertThat(indexResult.getVersion(), equalTo(1L));
@@ -1541,7 +1528,7 @@ public class InternalEngineTests extends EngineTestCase {
         MappingLookup mappingLookup = mapperService.mappingLookup();
         DocumentParser documentParser = mapperService.documentParser();
 
-        ParsedDocument doc = testParsedDocument("1", null, testDocument(), B_1, null);
+        ParsedDocument doc = testParsedDocument("1", null, testDocument(), B_1);
         Engine.Index create = new Engine.Index(newUid(doc), primaryTerm.get(), doc, Versions.MATCH_DELETED);
         Engine.IndexResult indexResult = indexDoc(engine, create);
         assertThat(indexResult.getVersion(), equalTo(1L));
@@ -1595,7 +1582,7 @@ public class InternalEngineTests extends EngineTestCase {
         MapperService mapperService = createMapperService();
         MappingLookup mappingLookup = mapperService.mappingLookup();
         DocumentParser documentParser = mapperService.documentParser();
-        ParsedDocument doc = testParsedDocument("1", null, testDocument(), B_1, null);
+        ParsedDocument doc = testParsedDocument("1", null, testDocument(), B_1);
         Engine.Index create = new Engine.Index(newUid(doc), primaryTerm.get(), doc, Versions.MATCH_DELETED);
         Engine.IndexResult indexResult = indexDoc(engine, create);
         if (randomBoolean()) {
@@ -1652,7 +1639,7 @@ public class InternalEngineTests extends EngineTestCase {
     }
 
     public void testVersioningNewIndex() throws IOException {
-        ParsedDocument doc = testParsedDocument("1", null, testDocument(), B_1, null);
+        ParsedDocument doc = testParsedDocument("1", null, testDocument(), B_1);
         Engine.Index index = indexForDoc(doc);
         Engine.IndexResult indexResult = indexDoc(engine, index);
         assertThat(indexResult.getVersion(), equalTo(1L));
@@ -1721,13 +1708,13 @@ public class InternalEngineTests extends EngineTestCase {
         ) {
             int numDocs = scaledRandomIntBetween(10, 100);
             for (int i = 0; i < numDocs; i++) {
-                ParsedDocument doc = testParsedDocument(Integer.toString(i), null, testDocument(), B_1, null);
+                ParsedDocument doc = testParsedDocument(Integer.toString(i), null, testDocument(), B_1);
                 indexDoc(engine, indexForDoc(doc));
                 liveDocs.add(doc.id());
             }
 
             for (int i = 0; i < numDocs; i++) {
-                ParsedDocument doc = testParsedDocument(Integer.toString(i), null, testDocument(), B_1, null);
+                ParsedDocument doc = testParsedDocument(Integer.toString(i), null, testDocument(), B_1);
                 indexDoc(engine, indexForDoc(doc));
                 liveDocs.add(doc.id());
             }
@@ -1749,12 +1736,12 @@ public class InternalEngineTests extends EngineTestCase {
         ) {
             int numDocs = scaledRandomIntBetween(10, 100);
             for (int i = 0; i < numDocs; i++) {
-                ParsedDocument doc = testParsedDocument(Integer.toString(i), null, testDocument(), B_1, null);
+                ParsedDocument doc = testParsedDocument(Integer.toString(i), null, testDocument(), B_1);
                 indexDoc(engine, indexForDoc(doc));
                 liveDocs.add(doc.id());
             }
             for (int i = 0; i < numDocs; i++) {
-                ParsedDocument doc = testParsedDocument(Integer.toString(i), null, testDocument(), B_1, null);
+                ParsedDocument doc = testParsedDocument(Integer.toString(i), null, testDocument(), B_1);
                 if (randomBoolean()) {
                     String id = doc.id();
                     engine.delete(new Engine.Delete(doc.id(), Uid.encodeId(id), primaryTerm.get()));
@@ -1825,7 +1812,7 @@ public class InternalEngineTests extends EngineTestCase {
             int numDocs = scaledRandomIntBetween(10, 100);
             for (int i = 0; i < numDocs; i++) {
                 boolean useRecoverySource = randomBoolean() || omitSourceAllTheTime;
-                ParsedDocument doc = testParsedDocument(Integer.toString(i), null, testDocument(), B_1, null, useRecoverySource);
+                ParsedDocument doc = testParsedDocument(Integer.toString(i), testDocument(), B_1, useRecoverySource);
                 indexDoc(engine, indexForDoc(doc));
                 liveDocs.add(doc.id());
                 if (useRecoverySource == false) {
@@ -1834,7 +1821,7 @@ public class InternalEngineTests extends EngineTestCase {
             }
             for (int i = 0; i < numDocs; i++) {
                 boolean useRecoverySource = randomBoolean() || omitSourceAllTheTime;
-                ParsedDocument doc = testParsedDocument(Integer.toString(i), null, testDocument(), B_1, null, useRecoverySource);
+                ParsedDocument doc = testParsedDocument(Integer.toString(i), testDocument(), B_1, useRecoverySource);
                 if (randomBoolean()) {
                     String id = doc.id();
                     engine.delete(new Engine.Delete(doc.id(), Uid.encodeId(id), primaryTerm.get()));
@@ -1895,7 +1882,7 @@ public class InternalEngineTests extends EngineTestCase {
             }
             if (numSegments == 1) {
                 boolean useRecoverySource = randomBoolean() || omitSourceAllTheTime;
-                ParsedDocument doc = testParsedDocument("dummy", null, testDocument(), B_1, null, useRecoverySource);
+                ParsedDocument doc = testParsedDocument("dummy", testDocument(), B_1, useRecoverySource);
                 indexDoc(engine, indexForDoc(doc));
                 if (useRecoverySource == false) {
                     liveDocsWithSource.add(doc.id());
@@ -1935,7 +1922,7 @@ public class InternalEngineTests extends EngineTestCase {
                                 int numDocs = randomIntBetween(1, 20);
                                 for (int j = 0; j < numDocs; j++) {
                                     i++;
-                                    ParsedDocument doc = testParsedDocument(Integer.toString(i), null, testDocument(), B_1, null);
+                                    ParsedDocument doc = testParsedDocument(Integer.toString(i), null, testDocument(), B_1);
                                     Engine.Index index = indexForDoc(doc);
                                     indexDoc(engine, index);
                                 }
@@ -1970,7 +1957,7 @@ public class InternalEngineTests extends EngineTestCase {
     }
 
     public void testVersioningCreateExistsException() throws IOException {
-        ParsedDocument doc = testParsedDocument("1", null, testDocument(), B_1, null);
+        ParsedDocument doc = testParsedDocument("1", null, testDocument(), B_1);
         Engine.Index create = new Engine.Index(
             newUid(doc),
             doc,
@@ -2057,7 +2044,7 @@ public class InternalEngineTests extends EngineTestCase {
         BiFunction<Engine.Operation, Long, Engine.Operation> seqNoUpdater = (operation, newSeqNo) -> {
             if (operation instanceof Engine.Index index) {
                 LuceneDocument doc = testDocumentWithTextField(index.docs().get(0).get("value"));
-                ParsedDocument parsedDocument = testParsedDocument(index.id(), index.routing(), doc, index.source(), null);
+                ParsedDocument parsedDocument = testParsedDocument(index.id(), index.routing(), doc, index.source());
                 return new Engine.Index(
                     index.uid(),
                     parsedDocument,
@@ -2534,7 +2521,7 @@ public class InternalEngineTests extends EngineTestCase {
         }
         final AtomicInteger idGenerator = new AtomicInteger();
         final Queue<OpAndVersion> history = ConcurrentCollections.newQueue();
-        ParsedDocument doc = testParsedDocument("1", null, testDocument(), bytesArray(""), null);
+        ParsedDocument doc = testParsedDocument("1", null, testDocument(), bytesArray(""));
         final BytesRef uidTerm = newUid(doc);
         indexDoc(engine, indexForDoc(doc));
         startInParallel(randomIntBetween(3, 5), i -> {
@@ -2557,7 +2544,7 @@ public class InternalEngineTests extends EngineTestCase {
                     values.add(added);
                     Engine.Index index = new Engine.Index(
                         uidTerm,
-                        testParsedDocument("1", null, testDocument(), bytesArray(Strings.collectionToCommaDelimitedString(values)), null),
+                        testParsedDocument("1", null, testDocument(), bytesArray(Strings.collectionToCommaDelimitedString(values))),
                         UNASSIGNED_SEQ_NO,
                         2,
                         get.version(),
@@ -2609,7 +2596,7 @@ public class InternalEngineTests extends EngineTestCase {
     }
 
     public void testBasicCreatedFlag() throws IOException {
-        ParsedDocument doc = testParsedDocument("1", null, testDocument(), B_1, null);
+        ParsedDocument doc = testParsedDocument("1", null, testDocument(), B_1);
         Engine.Index index = indexForDoc(doc);
         Engine.IndexResult indexResult = indexDoc(engine, index);
         assertTrue(indexResult.isCreated());
@@ -2664,7 +2651,7 @@ public class InternalEngineTests extends EngineTestCase {
 
         try {
             // First, with DEBUG, which should NOT log IndexWriter output:
-            ParsedDocument doc = testParsedDocument("1", null, testDocumentWithTextField(), B_1, null);
+            ParsedDocument doc = testParsedDocument("1", null, testDocumentWithTextField(), B_1);
             indexDoc(engine, indexForDoc(doc));
             engine.flush();
             assertFalse(mockAppender.sawIndexWriterMessage);
@@ -2728,11 +2715,11 @@ public class InternalEngineTests extends EngineTestCase {
 
             try (Store store = createStore()) {
                 InternalEngine engine = createEngine(defaultSettings, store, createTempDir(), lmp);
-                indexDoc(engine, indexForDoc(testParsedDocument("1", null, testDocument(), B_1, null)));
-                indexDoc(engine, indexForDoc(testParsedDocument("2", null, testDocument(), B_1, null)));
+                indexDoc(engine, indexForDoc(testParsedDocument("1", null, testDocument(), B_1)));
+                indexDoc(engine, indexForDoc(testParsedDocument("2", null, testDocument(), B_1)));
                 engine.flush();
-                indexDoc(engine, indexForDoc(testParsedDocument("3", null, testDocument(), B_1, null)));
-                indexDoc(engine, indexForDoc(testParsedDocument("4", null, testDocument(), B_1, null)));
+                indexDoc(engine, indexForDoc(testParsedDocument("3", null, testDocument(), B_1)));
+                indexDoc(engine, indexForDoc(testParsedDocument("4", null, testDocument(), B_1)));
                 engine.forceMerge(true, 1, false, UUIDs.randomBase64UUID());
 
                 assertBusy(() -> {
@@ -2850,7 +2837,7 @@ public class InternalEngineTests extends EngineTestCase {
                 } else {
                     // index a document
                     id = randomFrom(ids);
-                    ParsedDocument doc = testParsedDocument(id, null, testDocumentWithTextField(), SOURCE, null);
+                    ParsedDocument doc = testParsedDocument(id, null, testDocumentWithTextField(), SOURCE);
                     final Engine.Index index = new Engine.Index(
                         newUid(doc),
                         doc,
@@ -2957,7 +2944,7 @@ public class InternalEngineTests extends EngineTestCase {
                         // index random number of docs
                         for (int i = 0; i < numDocsPerThread; i++) {
                             final String id = "thread" + threadIdx + "#" + i;
-                            ParsedDocument doc = testParsedDocument(id, null, testDocument(), B_1, null);
+                            ParsedDocument doc = testParsedDocument(id, null, testDocument(), B_1);
                             indexDoc(engine, indexForDoc(doc));
                         }
                     } catch (Exception e) {
@@ -3071,13 +3058,13 @@ public class InternalEngineTests extends EngineTestCase {
         for (int i = 0; i < nIterations; i++) {
             final String docA = Integer.toString(2 * i + 1);
             final String docB = Integer.toString(2 * i + 2);
-            indexDoc(engine, indexForDoc(testParsedDocument(docA, null, testDocumentWithTextField(), SOURCE, null)));
+            indexDoc(engine, indexForDoc(testParsedDocument(docA, null, testDocumentWithTextField(), SOURCE)));
             final long genBeforeFlush = engine.getLastCommittedSegmentInfos().getGeneration();
 
             final var concurrentFlushThread = new Thread(() -> {
                 try {
                     safeAwait(flushBarrier);
-                    indexDoc(engine, indexForDoc(testParsedDocument(docB, null, testDocumentWithTextField(), SOURCE, null)));
+                    indexDoc(engine, indexForDoc(testParsedDocument(docB, null, testDocumentWithTextField(), SOURCE)));
                     engine.flush(randomBoolean(), true);
                 } catch (Exception e) {
                     fail(e);
@@ -3145,7 +3132,7 @@ public class InternalEngineTests extends EngineTestCase {
         recoverFromTranslog(engine, translogHandler, Long.MAX_VALUE);
         engine.ensureCanFlush();
 
-        indexDoc(engine, indexForDoc(testParsedDocument("1", null, testDocumentWithTextField(), SOURCE, null)));
+        indexDoc(engine, indexForDoc(testParsedDocument("1", null, testDocumentWithTextField(), SOURCE)));
         shouldFail.set(true);
         expectThrows(ElasticsearchException.class, () -> engine.acquireLastIndexCommit(true));
         assertFalse("acquired commit should have been released on failure", hasAcquiredIndexCommitsForTesting(engine));
@@ -3223,7 +3210,7 @@ public class InternalEngineTests extends EngineTestCase {
 
         try {
             // First, with DEBUG, which should NOT log IndexWriter output:
-            ParsedDocument doc = testParsedDocument("1", null, testDocumentWithTextField(), B_1, null);
+            ParsedDocument doc = testParsedDocument("1", null, testDocumentWithTextField(), B_1);
             indexDoc(engine, indexForDoc(doc));
             engine.flush();
             assertFalse(mockAppender.sawIndexWriterMessage);
@@ -3255,7 +3242,7 @@ public class InternalEngineTests extends EngineTestCase {
             LuceneDocument document = testDocument();
             document.add(new TextField("value", "test1", Field.Store.YES));
 
-            ParsedDocument doc = testParsedDocument("1", null, document, B_2, null);
+            ParsedDocument doc = testParsedDocument("1", null, document, B_2);
             indexDoc(
                 engine,
                 new Engine.Index(
@@ -3468,7 +3455,7 @@ public class InternalEngineTests extends EngineTestCase {
                     primaryTerm.get()
                 );
                 store.associateIndexWithNewTranslog(translogUUID);
-                ParsedDocument doc = testParsedDocument(Integer.toString(0), null, testDocument(), new BytesArray("{}"), null);
+                ParsedDocument doc = testParsedDocument(Integer.toString(0), null, testDocument(), new BytesArray("{}"));
                 Engine.Index firstIndexRequest = new Engine.Index(
                     newUid(doc),
                     doc,
@@ -3572,7 +3559,7 @@ public class InternalEngineTests extends EngineTestCase {
             final int numDocs = randomIntBetween(1, 10);
             try (InternalEngine engine = createEngine(store, translogPath)) {
                 for (int i = 0; i < numDocs; i++) {
-                    ParsedDocument doc = testParsedDocument(Integer.toString(i), null, testDocument(), new BytesArray("{}"), null);
+                    ParsedDocument doc = testParsedDocument(Integer.toString(i), null, testDocument(), new BytesArray("{}"));
                     Engine.Index firstIndexRequest = new Engine.Index(
                         newUid(doc),
                         doc,
@@ -3650,7 +3637,7 @@ public class InternalEngineTests extends EngineTestCase {
                 }
             ) {
                 recoverFromTranslog(engine, translogHandler, Long.MAX_VALUE);
-                final ParsedDocument doc1 = testParsedDocument("1", null, testDocumentWithTextField(), SOURCE, null);
+                final ParsedDocument doc1 = testParsedDocument("1", null, testDocumentWithTextField(), SOURCE);
                 indexDoc(engine, indexForDoc(doc1));
                 engine.syncTranslog(); // to advance local checkpoint
                 assertEquals(engine.getProcessedLocalCheckpoint(), engine.getPersistedLocalCheckpoint());
@@ -3681,7 +3668,7 @@ public class InternalEngineTests extends EngineTestCase {
     public void testSkipTranslogReplay() throws IOException {
         final int numDocs = randomIntBetween(1, 10);
         for (int i = 0; i < numDocs; i++) {
-            ParsedDocument doc = testParsedDocument(Integer.toString(i), null, testDocument(), new BytesArray("{}"), null);
+            ParsedDocument doc = testParsedDocument(Integer.toString(i), null, testDocument(), new BytesArray("{}"));
             Engine.Index firstIndexRequest = new Engine.Index(
                 newUid(doc),
                 doc,
@@ -3715,7 +3702,7 @@ public class InternalEngineTests extends EngineTestCase {
         final LongSupplier inSyncGlobalCheckpointSupplier = () -> this.engine.getProcessedLocalCheckpoint();
         final int numDocs = randomIntBetween(1, 10);
         for (int i = 0; i < numDocs; i++) {
-            ParsedDocument doc = testParsedDocument(Integer.toString(i), null, testDocument(), new BytesArray("{}"), null);
+            ParsedDocument doc = testParsedDocument(Integer.toString(i), null, testDocument(), new BytesArray("{}"));
             Engine.Index firstIndexRequest = new Engine.Index(
                 newUid(doc),
                 doc,
@@ -3754,7 +3741,7 @@ public class InternalEngineTests extends EngineTestCase {
 
         final boolean flush = randomBoolean();
         int randomId = randomIntBetween(numDocs + 1, numDocs + 10);
-        ParsedDocument doc = testParsedDocument(Integer.toString(randomId), null, testDocument(), new BytesArray("{}"), null);
+        ParsedDocument doc = testParsedDocument(Integer.toString(randomId), null, testDocument(), new BytesArray("{}"));
         Engine.Index firstIndexRequest = new Engine.Index(
             newUid(doc),
             doc,
@@ -3776,7 +3763,7 @@ public class InternalEngineTests extends EngineTestCase {
             engine.refresh("test");
         }
 
-        doc = testParsedDocument(Integer.toString(randomId), null, testDocument(), new BytesArray("{}"), null);
+        doc = testParsedDocument(Integer.toString(randomId), null, testDocument(), new BytesArray("{}"));
         Engine.Index idxRequest = new Engine.Index(
             newUid(doc),
             doc,
@@ -3823,7 +3810,7 @@ public class InternalEngineTests extends EngineTestCase {
     public void testRecoverFromForeignTranslog() throws IOException {
         final int numDocs = randomIntBetween(1, 10);
         for (int i = 0; i < numDocs; i++) {
-            ParsedDocument doc = testParsedDocument(Integer.toString(i), null, testDocument(), new BytesArray("{}"), null);
+            ParsedDocument doc = testParsedDocument(Integer.toString(i), null, testDocument(), new BytesArray("{}"));
             Engine.Index firstIndexRequest = new Engine.Index(
                 newUid(doc),
                 doc,
@@ -4020,9 +4007,9 @@ public class InternalEngineTests extends EngineTestCase {
 
     public void testHandleDocumentFailure() throws Exception {
         try (Store store = createStore()) {
-            final ParsedDocument doc1 = testParsedDocument("1", null, testDocumentWithTextField(), B_1, null);
-            final ParsedDocument doc2 = testParsedDocument("2", null, testDocumentWithTextField(), B_1, null);
-            final ParsedDocument doc3 = testParsedDocument("3", null, testDocumentWithTextField(), B_1, null);
+            final ParsedDocument doc1 = testParsedDocument("1", null, testDocumentWithTextField(), B_1);
+            final ParsedDocument doc2 = testParsedDocument("2", null, testDocumentWithTextField(), B_1);
+            final ParsedDocument doc3 = testParsedDocument("3", null, testDocumentWithTextField(), B_1);
 
             AtomicReference<ThrowingIndexWriter> throwingIndexWriter = new AtomicReference<>();
             try (InternalEngine engine = createEngine(defaultSettings, store, createTempDir(), NoMergePolicy.INSTANCE, (directory, iwc) -> {
@@ -4109,7 +4096,7 @@ public class InternalEngineTests extends EngineTestCase {
                 .translogConfig(configTranslogConfig)
                 .build();
             try (InternalEngine engine = createEngine(indexWriterFactory, config)) {
-                final ParsedDocument doc = testParsedDocument("1", null, testDocumentWithTextField(), SOURCE, null);
+                final ParsedDocument doc = testParsedDocument("1", null, testDocumentWithTextField(), SOURCE);
                 indexDoc(engine, indexForDoc(doc));
                 expectThrows(
                     IllegalStateException.class,
@@ -4126,8 +4113,7 @@ public class InternalEngineTests extends EngineTestCase {
             "1",
             null,
             testDocumentWithTextField(),
-            new BytesArray("{}".getBytes(Charset.defaultCharset())),
-            null
+            new BytesArray("{}".getBytes(Charset.defaultCharset()))
         );
         final boolean create = randomBoolean();
         Engine.Index operation = appendOnlyPrimary(doc, false, 1, create);
@@ -4208,8 +4194,7 @@ public class InternalEngineTests extends EngineTestCase {
             "1",
             null,
             testDocumentWithTextField(),
-            new BytesArray("{}".getBytes(Charset.defaultCharset())),
-            null
+            new BytesArray("{}".getBytes(Charset.defaultCharset()))
         );
         Engine.Index operation = appendOnlyReplica(doc, false, 1, randomIntBetween(0, 5));
         Engine.Index retry = appendOnlyReplica(doc, true, 1, randomIntBetween(0, 5));
@@ -4266,8 +4251,7 @@ public class InternalEngineTests extends EngineTestCase {
             "1",
             null,
             testDocumentWithTextField(),
-            new BytesArray("{}".getBytes(Charset.defaultCharset())),
-            null
+            new BytesArray("{}".getBytes(Charset.defaultCharset()))
         );
         boolean replicaOperationIsRetry = randomBoolean();
         Engine.Index operation = appendOnlyReplica(doc.get(), replicaOperationIsRetry, 1, randomIntBetween(0, 5));
@@ -4330,8 +4314,7 @@ public class InternalEngineTests extends EngineTestCase {
             "1",
             null,
             testDocumentWithTextField(),
-            new BytesArray("{}".getBytes(Charset.defaultCharset())),
-            null
+            new BytesArray("{}".getBytes(Charset.defaultCharset()))
         );
         Engine.Index operation = replicaIndexForDoc(doc, 1, 20, false);
         Engine.Index duplicate = replicaIndexForDoc(doc, 1, 20, true);
@@ -4385,8 +4368,7 @@ public class InternalEngineTests extends EngineTestCase {
             "1",
             null,
             testDocumentWithTextField(),
-            new BytesArray("{}".getBytes(Charset.defaultCharset())),
-            null
+            new BytesArray("{}".getBytes(Charset.defaultCharset()))
         );
         boolean isRetry = false;
         long autoGeneratedIdTimestamp = 0;
@@ -4478,8 +4460,7 @@ public class InternalEngineTests extends EngineTestCase {
             "1",
             null,
             testDocumentWithTextField(),
-            new BytesArray("{}".getBytes(Charset.defaultCharset())),
-            null
+            new BytesArray("{}".getBytes(Charset.defaultCharset()))
         );
         boolean isRetry = true;
         long autoGeneratedIdTimestamp = 0;
@@ -4619,8 +4600,7 @@ public class InternalEngineTests extends EngineTestCase {
                 Integer.toString(i),
                 null,
                 testDocumentWithTextField(),
-                new BytesArray("{}".getBytes(Charset.defaultCharset())),
-                null
+                new BytesArray("{}".getBytes(Charset.defaultCharset()))
             );
             final Engine.Index originalIndex;
             final Engine.Index retryIndex;
@@ -4679,8 +4659,7 @@ public class InternalEngineTests extends EngineTestCase {
                 "1",
                 null,
                 testDocumentWithTextField(),
-                new BytesArray("{}".getBytes(Charset.defaultCharset())),
-                null
+                new BytesArray("{}".getBytes(Charset.defaultCharset()))
             );
             indexDoc(engine, appendOnlyPrimary(doc, true, timestamp1));
             assertEquals(timestamp1, engine.segmentsStats(false, false).getMaxUnsafeAutoIdTimestamp());
@@ -4693,8 +4672,7 @@ public class InternalEngineTests extends EngineTestCase {
                 "1",
                 null,
                 testDocumentWithTextField(),
-                new BytesArray("{}".getBytes(Charset.defaultCharset())),
-                null
+                new BytesArray("{}".getBytes(Charset.defaultCharset()))
             );
             indexDoc(engine, appendOnlyPrimary(doc, true, timestamp2, false));
             assertEquals(maxTimestamp12, engine.segmentsStats(false, false).getMaxUnsafeAutoIdTimestamp());
@@ -4729,8 +4707,7 @@ public class InternalEngineTests extends EngineTestCase {
                 Integer.toString(i),
                 null,
                 testDocumentWithTextField(),
-                new BytesArray("{}".getBytes(Charset.defaultCharset())),
-                null
+                new BytesArray("{}".getBytes(Charset.defaultCharset()))
             );
             Engine.Index index = primary ? appendOnlyPrimary(doc, false, i) : appendOnlyReplica(doc, false, i, i);
             docs.add(index);
@@ -4815,8 +4792,7 @@ public class InternalEngineTests extends EngineTestCase {
                 Integer.toString(docId),
                 null,
                 testDocumentWithTextField(),
-                new BytesArray("{}".getBytes(Charset.defaultCharset())),
-                null
+                new BytesArray("{}".getBytes(Charset.defaultCharset()))
             );
 
             Engine.Index index = randomBoolean() ? indexForDoc(doc) : randomAppendOnly(doc, false, docId);
@@ -4857,7 +4833,7 @@ public class InternalEngineTests extends EngineTestCase {
         // create a document
         LuceneDocument document = testDocumentWithTextField();
         document.add(new Field(SourceFieldMapper.NAME, BytesReference.toBytes(B_1), SourceFieldMapper.Defaults.FIELD_TYPE));
-        ParsedDocument doc = testParsedDocument("1", null, document, B_1, null);
+        ParsedDocument doc = testParsedDocument("1", null, document, B_1);
         indexDoc(engine, indexForDoc(doc));
         engine.refresh("test");
 
@@ -4869,7 +4845,7 @@ public class InternalEngineTests extends EngineTestCase {
         // Index the same document again
         document = testDocumentWithTextField();
         document.add(new Field(SourceFieldMapper.NAME, BytesReference.toBytes(B_1), SourceFieldMapper.Defaults.FIELD_TYPE));
-        doc = testParsedDocument("1", null, document, B_1, null);
+        doc = testParsedDocument("1", null, document, B_1);
         indexDoc(engine, indexForDoc(doc));
         engine.refresh("test");
 
@@ -4881,7 +4857,7 @@ public class InternalEngineTests extends EngineTestCase {
         // Index the same document for the third time, this time changing the primary term
         document = testDocumentWithTextField();
         document.add(new Field(SourceFieldMapper.NAME, BytesReference.toBytes(B_1), SourceFieldMapper.Defaults.FIELD_TYPE));
-        doc = testParsedDocument("1", null, document, B_1, null);
+        doc = testParsedDocument("1", null, document, B_1);
         indexDoc(
             engine,
             new Engine.Index(
@@ -5097,7 +5073,7 @@ public class InternalEngineTests extends EngineTestCase {
             final InternalEngine finalInitialEngine = initialEngine;
             for (int i = 0; i < docs; i++) {
                 final String id = Integer.toString(i);
-                final ParsedDocument doc = testParsedDocument(id, null, testDocumentWithTextField(), SOURCE, null);
+                final ParsedDocument doc = testParsedDocument(id, null, testDocumentWithTextField(), SOURCE);
 
                 stall.set(randomBoolean());
                 final Thread thread = new Thread(() -> {
@@ -5147,7 +5123,7 @@ public class InternalEngineTests extends EngineTestCase {
         final Supplier<ParsedDocument> doc = () -> {
             final LuceneDocument document = testDocumentWithTextField();
             document.add(new Field(SourceFieldMapper.NAME, BytesReference.toBytes(B_1), SourceFieldMapper.Defaults.FIELD_TYPE));
-            return testParsedDocument("1", null, document, B_1, null);
+            return testParsedDocument("1", null, document, B_1);
         };
         final BytesRef uid = Uid.encodeId("1");
         final BiFunction<String, Engine.SearcherScope, Engine.Searcher> searcherFactory = engine::acquireSearcher;
@@ -5239,7 +5215,7 @@ public class InternalEngineTests extends EngineTestCase {
      * </ul>
      */
     public void testVersionConflictIgnoreDeletedDoc() throws IOException {
-        ParsedDocument doc = testParsedDocument("1", null, testDocument(), new BytesArray("{}".getBytes(Charset.defaultCharset())), null);
+        ParsedDocument doc = testParsedDocument("1", null, testDocument(), new BytesArray("{}".getBytes(Charset.defaultCharset())));
         engine.delete(new Engine.Delete("1", Uid.encodeId("1"), 1));
         for (long seqNo : new long[] { 0, 1, randomNonNegativeLong() }) {
             assertDeletedVersionConflict(
@@ -5509,7 +5485,7 @@ public class InternalEngineTests extends EngineTestCase {
 
     private void index(final InternalEngine engine, final int id) throws IOException {
         final String docId = Integer.toString(id);
-        final ParsedDocument doc = testParsedDocument(docId, null, testDocumentWithTextField(), SOURCE, null);
+        final ParsedDocument doc = testParsedDocument(docId, null, testDocumentWithTextField(), SOURCE);
         indexDoc(engine, indexForDoc(doc));
     }
 
@@ -5559,7 +5535,7 @@ public class InternalEngineTests extends EngineTestCase {
                 engineConfig = engine.config();
                 for (final long seqNo : seqNos) {
                     final String id = Long.toString(seqNo);
-                    final ParsedDocument doc = testParsedDocument(id, null, testDocumentWithTextField(), SOURCE, null);
+                    final ParsedDocument doc = testParsedDocument(id, null, testDocumentWithTextField(), SOURCE);
                     indexDoc(engine, replicaIndexForDoc(doc, 1, seqNo, false));
                     if (rarely()) {
                         engine.rollTranslogGeneration();
@@ -5599,7 +5575,7 @@ public class InternalEngineTests extends EngineTestCase {
         try {
             for (int i = 0; i < docs; i++) {
                 final String docId = Integer.toString(i);
-                final ParsedDocument doc = testParsedDocument(docId, null, testDocumentWithTextField(), SOURCE, null);
+                final ParsedDocument doc = testParsedDocument(docId, null, testDocumentWithTextField(), SOURCE);
                 Engine.Index primaryResponse = indexForDoc(doc);
                 Engine.IndexResult indexResult = indexDoc(engine, primaryResponse);
                 if (randomBoolean()) {
@@ -5713,7 +5689,7 @@ public class InternalEngineTests extends EngineTestCase {
             }
             for (int i = 0; i < 10; i++) {
                 final String docId = Integer.toString(i);
-                final ParsedDocument doc = testParsedDocument(docId, null, testDocumentWithTextField(), SOURCE, null);
+                final ParsedDocument doc = testParsedDocument(docId, null, testDocumentWithTextField(), SOURCE);
                 Engine.Index primaryResponse = indexForDoc(doc);
                 indexDoc(engine, primaryResponse);
             }
@@ -5742,7 +5718,7 @@ public class InternalEngineTests extends EngineTestCase {
 
             // now ensure external refreshes are reflected on the internal reader
             final String docId = Integer.toString(10);
-            final ParsedDocument doc = testParsedDocument(docId, null, testDocumentWithTextField(), SOURCE, null);
+            final ParsedDocument doc = testParsedDocument(docId, null, testDocumentWithTextField(), SOURCE);
             Engine.Index primaryResponse = indexForDoc(doc);
             indexDoc(engine, primaryResponse);
 
@@ -5886,7 +5862,7 @@ public class InternalEngineTests extends EngineTestCase {
             for (int docId = 0; docId < numDocs; docId++) {
                 LuceneDocument document = testDocumentWithTextField();
                 document.add(new Field(SourceFieldMapper.NAME, BytesReference.toBytes(B_1), SourceFieldMapper.Defaults.FIELD_TYPE));
-                indexDoc(engine, indexForDoc(testParsedDocument(Integer.toString(docId), null, document, B_1, null)));
+                indexDoc(engine, indexForDoc(testParsedDocument(Integer.toString(docId), null, document, B_1)));
                 if (frequently()) {
                     globalCheckpoint.set(randomLongBetween(globalCheckpoint.get(), engine.getPersistedLocalCheckpoint()));
                     engine.syncTranslog();
@@ -5939,8 +5915,7 @@ public class InternalEngineTests extends EngineTestCase {
                         docID,
                         null,
                         testDocumentWithTextField(),
-                        new BytesArray("{}".getBytes(Charset.defaultCharset())),
-                        null
+                        new BytesArray("{}".getBytes(Charset.defaultCharset()))
                     );
                     Engine.Index operation = appendOnlyPrimary(doc, false, 1);
                     indexDoc(engine, operation);
@@ -5952,8 +5927,7 @@ public class InternalEngineTests extends EngineTestCase {
                             docID,
                             null,
                             testDocumentWithTextField("updated"),
-                            new BytesArray("{}".getBytes(Charset.defaultCharset())),
-                            null
+                            new BytesArray("{}".getBytes(Charset.defaultCharset()))
                         );
                         Engine.Index update = indexForDoc(doc);
                         indexDoc(engine, update);
@@ -6120,7 +6094,7 @@ public class InternalEngineTests extends EngineTestCase {
             - Translog.DEFAULT_HEADER_SIZE_IN_BYTES;
         int numDocs = between(10, 100);
         for (int id = 0; id < numDocs; id++) {
-            final ParsedDocument doc = testParsedDocument(Integer.toString(id), null, testDocumentWithTextField(), SOURCE, null);
+            final ParsedDocument doc = testParsedDocument(Integer.toString(id), null, testDocumentWithTextField(), SOURCE);
             indexDoc(engine, indexForDoc(doc));
         }
         assertThat("Not exceeded translog flush threshold yet", engine.shouldPeriodicallyFlush(), equalTo(false));
@@ -6145,7 +6119,7 @@ public class InternalEngineTests extends EngineTestCase {
         assertThat(uncommittedTranslogOperationsSinceLastCommit.getAsInt(), equalTo(0));
         // Stale operations skipped by Lucene but added to translog - still able to flush
         for (int id = 0; id < numDocs; id++) {
-            final ParsedDocument doc = testParsedDocument(Integer.toString(id), null, testDocumentWithTextField(), SOURCE, null);
+            final ParsedDocument doc = testParsedDocument(Integer.toString(id), null, testDocumentWithTextField(), SOURCE);
             final Engine.IndexResult result = indexDoc(engine, replicaIndexForDoc(doc, 1L, id, false));
             assertThat(result.isCreated(), equalTo(false));
         }
@@ -6162,7 +6136,7 @@ public class InternalEngineTests extends EngineTestCase {
             if (randomBoolean()) {
                 translog.rollGeneration();
             }
-            final ParsedDocument doc = testParsedDocument("new" + id, null, testDocumentWithTextField(), SOURCE, null);
+            final ParsedDocument doc = testParsedDocument("new" + id, null, testDocumentWithTextField(), SOURCE);
             indexDoc(engine, replicaIndexForDoc(doc, 2L, generateNewSeqNo(engine), false));
             if (engine.shouldPeriodicallyFlush()) {
                 engine.flush();
@@ -6192,7 +6166,7 @@ public class InternalEngineTests extends EngineTestCase {
         // Do not use MockRandomMergePolicy as it can cause a force merge performing two merges.
         engine = createEngine(EngineConfig.builder(engine.config()).mergePolicy(newMergePolicy(random(), false)).build());
         assertThat("Empty engine does not need flushing", engine.shouldPeriodicallyFlush(), equalTo(false));
-        ParsedDocument doc = testParsedDocument(Integer.toString(0), null, testDocumentWithTextField(), SOURCE, null);
+        ParsedDocument doc = testParsedDocument(Integer.toString(0), null, testDocumentWithTextField(), SOURCE);
         indexDoc(engine, indexForDoc(doc));
         engine.refresh("test");
         assertThat("Not exceeded translog flush threshold yet", engine.shouldPeriodicallyFlush(), equalTo(false));
@@ -6208,7 +6182,7 @@ public class InternalEngineTests extends EngineTestCase {
         engine.onSettingsChanged();
         assertThat(engine.getTranslog().stats().getUncommittedOperations(), equalTo(1));
         assertThat(engine.shouldPeriodicallyFlush(), equalTo(false));
-        doc = testParsedDocument(Integer.toString(1), null, testDocumentWithTextField(), SOURCE, null);
+        doc = testParsedDocument(Integer.toString(1), null, testDocumentWithTextField(), SOURCE);
         indexDoc(engine, indexForDoc(doc));
         assertThat(engine.getTranslog().stats().getUncommittedOperations(), equalTo(2));
         engine.refresh("test");
@@ -6239,7 +6213,7 @@ public class InternalEngineTests extends EngineTestCase {
         for (int i = 0; i < numOps; i++) {
             final long localCheckPoint = engine.getProcessedLocalCheckpoint();
             final long seqno = randomLongBetween(Math.max(0, localCheckPoint), localCheckPoint + 5);
-            final ParsedDocument doc = testParsedDocument(Long.toString(seqno), null, testDocumentWithTextField(), SOURCE, null);
+            final ParsedDocument doc = testParsedDocument(Long.toString(seqno), null, testDocumentWithTextField(), SOURCE);
             indexDoc(engine, replicaIndexForDoc(doc, 1L, seqno, false));
             if (rarely() && engine.getTranslog().shouldRollGeneration()) {
                 engine.rollTranslogGeneration();
@@ -6269,7 +6243,7 @@ public class InternalEngineTests extends EngineTestCase {
                     .build();
                 engine.engineConfig.getIndexSettings().updateIndexMetadata(indexMetadata);
                 engine.onSettingsChanged();
-                ParsedDocument document = testParsedDocument(Integer.toString(0), null, testDocumentWithTextField(), SOURCE, null);
+                ParsedDocument document = testParsedDocument(Integer.toString(0), null, testDocumentWithTextField(), SOURCE);
                 final Engine.Index doc = new Engine.Index(
                     newUid(document),
                     document,
@@ -6289,7 +6263,7 @@ public class InternalEngineTests extends EngineTestCase {
                 engine.delete(new Engine.Delete(doc.id(), doc.uid(), primaryTerm.get()));
 
                 // now index more append only docs and refresh so we re-enabel the optimization for unsafe version map
-                ParsedDocument document1 = testParsedDocument(Integer.toString(1), null, testDocumentWithTextField(), SOURCE, null);
+                ParsedDocument document1 = testParsedDocument(Integer.toString(1), null, testDocumentWithTextField(), SOURCE);
                 indexDoc(
                     engine,
                     new Engine.Index(
@@ -6308,7 +6282,7 @@ public class InternalEngineTests extends EngineTestCase {
                     )
                 );
                 engine.refresh("test");
-                ParsedDocument document2 = testParsedDocument(Integer.toString(2), null, testDocumentWithTextField(), SOURCE, null);
+                ParsedDocument document2 = testParsedDocument(Integer.toString(2), null, testDocumentWithTextField(), SOURCE);
                 indexDoc(
                     engine,
                     new Engine.Index(
@@ -6327,7 +6301,7 @@ public class InternalEngineTests extends EngineTestCase {
                     )
                 );
                 engine.refresh("test");
-                ParsedDocument document3 = testParsedDocument(Integer.toString(3), null, testDocumentWithTextField(), SOURCE, null);
+                ParsedDocument document3 = testParsedDocument(Integer.toString(3), null, testDocumentWithTextField(), SOURCE);
                 final Engine.Index doc3 = new Engine.Index(
                     newUid(document3),
                     document3,
@@ -6432,7 +6406,7 @@ public class InternalEngineTests extends EngineTestCase {
             if (randomBoolean()) {
                 indexDoc(
                     engine,
-                    replicaIndexForDoc(testParsedDocument("d", null, testDocumentWithTextField(), SOURCE, null), 1, gapSeqNo, false)
+                    replicaIndexForDoc(testParsedDocument("d", null, testDocumentWithTextField(), SOURCE), 1, gapSeqNo, false)
                 );
             } else {
                 engine.delete(
@@ -6456,7 +6430,7 @@ public class InternalEngineTests extends EngineTestCase {
             final long minTranslogGen;
             try (InternalEngine engine = createEngine(config)) {
                 for (int i = 0; i < seqNos.size(); i++) {
-                    ParsedDocument doc = testParsedDocument(Long.toString(seqNos.get(i)), null, testDocument(), new BytesArray("{}"), null);
+                    ParsedDocument doc = testParsedDocument(Long.toString(seqNos.get(i)), null, testDocument(), new BytesArray("{}"));
                     Engine.Index index = new Engine.Index(
                         newUid(doc),
                         doc,
@@ -6723,8 +6697,7 @@ public class InternalEngineTests extends EngineTestCase {
                     "id_" + seqNo,
                     null,
                     testDocumentWithTextField("test"),
-                    new BytesArray("{}".getBytes(Charset.defaultCharset())),
-                    null
+                    new BytesArray("{}".getBytes(Charset.defaultCharset()))
                 );
                 indexDoc(engine, replicaIndexForDoc(doc, 1, seqNo, randomBoolean()));
             }
@@ -6961,8 +6934,7 @@ public class InternalEngineTests extends EngineTestCase {
                     "1",
                     null,
                     new LuceneDocument(),
-                    new BytesArray("{}".getBytes(StandardCharsets.UTF_8)),
-                    null
+                    new BytesArray("{}".getBytes(StandardCharsets.UTF_8))
                 );
                 indexDoc(engine, appendOnlyPrimary(doc, false, 1));
                 engine.refresh("test");
@@ -6989,7 +6961,7 @@ public class InternalEngineTests extends EngineTestCase {
                 try {
                     String id = Long.toString(between(1, 50));
                     if (randomBoolean()) {
-                        ParsedDocument doc = testParsedDocument(id, null, testDocumentWithTextField(), SOURCE, null);
+                        ParsedDocument doc = testParsedDocument(id, null, testDocumentWithTextField(), SOURCE);
                         indexDoc(engine, replicaIndexForDoc(doc, 1L, seqNo, false));
                     } else {
                         engine.delete(replicaDeleteForDoc(id, 1L, seqNo, 0L));
@@ -7184,7 +7156,7 @@ public class InternalEngineTests extends EngineTestCase {
             Store store = createStore();
             InternalEngine engine = createEngine(defaultSettings, store, createTempDir(), NoMergePolicy.INSTANCE, indexWriterFactory)
         ) {
-            final ParsedDocument doc = testParsedDocument("1", null, testDocumentWithTextField(), SOURCE, null);
+            final ParsedDocument doc = testParsedDocument("1", null, testDocumentWithTextField(), SOURCE);
             Engine.Operation.Origin origin = randomFrom(REPLICA, LOCAL_RESET, PEER_RECOVERY);
             Engine.Index index = new Engine.Index(
                 newUid(doc),
@@ -7546,8 +7518,7 @@ public class InternalEngineTests extends EngineTestCase {
             "1",
             null,
             testDocumentWithTextField("test"),
-            new BytesArray("{}".getBytes(Charset.defaultCharset())),
-            null
+            new BytesArray("{}".getBytes(Charset.defaultCharset()))
         );
         Engine.Index operation = randomBoolean()
             ? appendOnlyPrimary(doc, false, 1)
@@ -7658,7 +7629,7 @@ public class InternalEngineTests extends EngineTestCase {
         };
         engine.skipTranslogRecovery();
 
-        ParsedDocument doc = testParsedDocument("1", null, testDocumentWithTextField(), SOURCE, null);
+        ParsedDocument doc = testParsedDocument("1", null, testDocumentWithTextField(), SOURCE);
         indexDoc(engine, indexForDoc(doc));
         engine.flush();
 
@@ -7685,7 +7656,7 @@ public class InternalEngineTests extends EngineTestCase {
 
             try (InternalEngine engine = createEngine(config)) {
                 for (Long seqNo : seqNos) {
-                    ParsedDocument doc = testParsedDocument(Long.toString(seqNo), null, testDocument(), new BytesArray("{}"), null);
+                    ParsedDocument doc = testParsedDocument(Long.toString(seqNo), null, testDocument(), new BytesArray("{}"));
                     Engine.Index index = new Engine.Index(
                         newUid(doc),
                         doc,
@@ -8032,7 +8003,7 @@ public class InternalEngineTests extends EngineTestCase {
             Store store = createStore();
             InternalEngine engine = createEngine(config(indexSettings, store, createTempDir(), NoMergePolicy.INSTANCE))
         ) {
-            ParsedDocument doc = testParsedDocument("1", null, testDocumentWithTextField(), B_1, null);
+            ParsedDocument doc = testParsedDocument("1", null, testDocumentWithTextField(), B_1);
             indexDoc(engine, indexForDoc(doc));
             engine.refresh("test");
 

--- a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -48,7 +48,6 @@ import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.index.TieredMergePolicy;
 import org.apache.lucene.search.DocIdSetIterator;
-import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.ReferenceManager;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortedSetSortField;
@@ -98,7 +97,6 @@ import org.elasticsearch.core.CheckedRunnable;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
-import org.elasticsearch.index.IndexModule;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.IndexVersions;
@@ -3750,7 +3748,7 @@ public class InternalEngineTests extends EngineTestCase {
 
         engine.close();
         // we need to reuse the engine config unless the parser.mappingModified won't work
-        engine = new InternalEngine(copy(engine.config(), inSyncGlobalCheckpointSupplier));
+        engine = new InternalEngine(EngineConfig.builder(engine.config()).globalCheckpointSupplier(inSyncGlobalCheckpointSupplier).build());
         recoverFromTranslog(engine, translogHandler, Long.MAX_VALUE);
         engine.refresh("warm_up");
 
@@ -3881,39 +3879,7 @@ public class InternalEngineTests extends EngineTestCase {
             BigArrays.NON_RECYCLING_INSTANCE
         );
 
-        EngineConfig brokenConfig = new EngineConfig(
-            shardId,
-            threadPool,
-            threadPoolMergeExecutorService,
-            config.getIndexSettings(),
-            null,
-            store,
-            newMergePolicy(),
-            config.getAnalyzer(),
-            config.getSimilarity(),
-            newCodecService(),
-            config.getEventListener(),
-            IndexSearcher.getDefaultQueryCache(),
-            IndexSearcher.getDefaultQueryCachingPolicy(),
-            translogConfig,
-            TimeValue.timeValueMinutes(5),
-            config.getExternalRefreshListener(),
-            config.getInternalRefreshListener(),
-            null,
-            new NoneCircuitBreakerService(),
-            () -> UNASSIGNED_SEQ_NO,
-            () -> RetentionLeases.EMPTY,
-            primaryTerm::get,
-            IndexModule.DEFAULT_SNAPSHOT_COMMIT_SUPPLIER,
-            null,
-            config.getRelativeTimeInNanosSupplier(),
-            null,
-            true,
-            config.getMapperService(),
-            config.getEngineResetLock(),
-            config.getMergeMetrics(),
-            Function.identity()
-        );
+        EngineConfig brokenConfig = EngineConfig.builder(config).translogConfig(translogConfig).build();
         expectThrows(EngineCreationFailureException.class, () -> new InternalEngine(brokenConfig));
 
         engine = createEngine(store, primaryTranslogDir); // and recover again!
@@ -4132,7 +4098,26 @@ public class InternalEngineTests extends EngineTestCase {
                     return super.softUpdateDocument(term, docIncludeExtraField, softDeletes);
                 }
             };
-            EngineConfig config = config(this.engine.config(), store, createTempDir());
+            Path translogPath = createTempDir();
+            IndexSettings configIndexSettings = IndexSettingsModule.newIndexSettings(
+                "test",
+                Settings.builder()
+                    .put(this.engine.config().getIndexSettings().getSettings())
+                    .put(IndexSettings.INDEX_SOFT_DELETES_SETTING.getKey(), true)
+                    .build()
+            );
+            TranslogConfig configTranslogConfig = new TranslogConfig(
+                shardId,
+                translogPath,
+                configIndexSettings,
+                BigArrays.NON_RECYCLING_INSTANCE
+            );
+            EngineConfig config = EngineConfig.builder(this.engine.config())
+                .indexSettings(configIndexSettings)
+                .store(store)
+                .codecProvider(newCodecService())
+                .translogConfig(configTranslogConfig)
+                .build();
             try (InternalEngine engine = createEngine(indexWriterFactory, null, null, config)) {
                 final ParsedDocument doc = testParsedDocument("1", null, testDocumentWithTextField(), SOURCE, null);
                 indexDoc(engine, indexForDoc(doc));
@@ -5330,14 +5315,15 @@ public class InternalEngineTests extends EngineTestCase {
                 maxSeqNo,
                 localCheckpoint
             );
-            EngineConfig noopEngineConfig = copy(
-                engine.config(),
-                new SoftDeletesRetentionMergePolicy(
-                    Lucene.SOFT_DELETES_FIELD,
-                    () -> Queries.ALL_DOCS_INSTANCE,
-                    engine.config().getMergePolicy()
+            EngineConfig noopEngineConfig = EngineConfig.builder(engine.config())
+                .mergePolicy(
+                    new SoftDeletesRetentionMergePolicy(
+                        Lucene.SOFT_DELETES_FIELD,
+                        () -> Queries.ALL_DOCS_INSTANCE,
+                        engine.config().getMergePolicy()
+                    )
                 )
-            );
+                .build();
             noOpEngine = new InternalEngine(noopEngineConfig, IndexWriter.MAX_DOCS, supplier) {
                 @Override
                 protected long doGenerateSeqNoForOperation(Operation operation) {
@@ -5647,7 +5633,9 @@ public class InternalEngineTests extends EngineTestCase {
             assertEquals(docs - 1, engine.getProcessedLocalCheckpoint());
             assertEquals(maxSeqIDOnReplica, replicaEngine.getSeqNoStats(-1).getMaxSeqNo());
             assertEquals(checkpointOnReplica, replicaEngine.getProcessedLocalCheckpoint());
-            recoveringEngine = new InternalEngine(copy(replicaEngine.config(), globalCheckpoint::get));
+            recoveringEngine = new InternalEngine(
+                EngineConfig.builder(replicaEngine.config()).globalCheckpointSupplier(globalCheckpoint::get).build()
+            );
             assertEquals(numDocsOnReplica, getTranslog(recoveringEngine).stats().getUncommittedOperations());
             recoverFromTranslog(recoveringEngine, translogHandler, Long.MAX_VALUE);
             assertEquals(maxSeqIDOnReplica, recoveringEngine.getSeqNoStats(-1).getMaxSeqNo());
@@ -5680,7 +5668,9 @@ public class InternalEngineTests extends EngineTestCase {
 
         // now do it again to make sure we preserve values etc.
         try {
-            recoveringEngine = new InternalEngine(copy(replicaEngine.config(), globalCheckpoint::get));
+            recoveringEngine = new InternalEngine(
+                EngineConfig.builder(replicaEngine.config()).globalCheckpointSupplier(globalCheckpoint::get).build()
+            );
             if (flushed) {
                 assertThat(recoveringEngine.getTranslogStats().getUncommittedOperations(), equalTo(0));
             }
@@ -6212,7 +6202,7 @@ public class InternalEngineTests extends EngineTestCase {
     public void testShouldPeriodicallyFlushAfterMerge() throws Exception {
         engine.close();
         // Do not use MockRandomMergePolicy as it can cause a force merge performing two merges.
-        engine = createEngine(copy(engine.config(), newMergePolicy(random(), false)));
+        engine = createEngine(EngineConfig.builder(engine.config()).mergePolicy(newMergePolicy(random(), false)).build());
         assertThat("Empty engine does not need flushing", engine.shouldPeriodicallyFlush(), equalTo(false));
         ParsedDocument doc = testParsedDocument(Integer.toString(0), null, testDocumentWithTextField(), SOURCE, null);
         indexDoc(engine, indexForDoc(doc));
@@ -7516,39 +7506,12 @@ public class InternalEngineTests extends EngineTestCase {
                 config.getTranslogConfig().getIndexSettings(),
                 config.getTranslogConfig().getBigArrays()
             );
-            EngineConfig configWithWarmer = new EngineConfig(
-                config.getShardId(),
-                config.getThreadPool(),
-                config.getThreadPoolMergeExecutorService(),
-                config.getIndexSettings(),
-                warmer,
-                store,
-                config.getMergePolicy(),
-                config.getAnalyzer(),
-                config.getSimilarity(),
-                newCodecService(),
-                config.getEventListener(),
-                config.getQueryCache(),
-                config.getQueryCachingPolicy(),
-                translogConfig,
-                config.getFlushMergesAfter(),
-                config.getExternalRefreshListener(),
-                config.getInternalRefreshListener(),
-                config.getIndexSort(),
-                config.getCircuitBreakerService(),
-                config.getGlobalCheckpointSupplier(),
-                config.retentionLeasesSupplier(),
-                config.getPrimaryTermSupplier(),
-                config.getSnapshotCommitSupplier(),
-                config.getLeafSorter(),
-                config.getRelativeTimeInNanosSupplier(),
-                config.getIndexCommitListener(),
-                config.isPromotableToPrimary(),
-                config.getMapperService(),
-                config.getEngineResetLock(),
-                config.getMergeMetrics(),
-                config.getIndexDeletionPolicyWrapper()
-            );
+            EngineConfig configWithWarmer = EngineConfig.builder(config)
+                .warmer(warmer)
+                .store(store)
+                .translogConfig(translogConfig)
+                .codecProvider(newCodecService())
+                .build();
             try (InternalEngine engine = createEngine(configWithWarmer)) {
                 assertThat(warmedUpReaders, empty());
                 assertThat(

--- a/server/src/test/java/org/elasticsearch/index/engine/NoOpEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/NoOpEngineTests.java
@@ -69,7 +69,7 @@ public class NoOpEngineTests extends EngineTestCase {
         tracker.updateFromMaster(1L, Collections.singleton(allocationId.getId()), table);
         tracker.activatePrimaryMode(SequenceNumbers.NO_OPS_PERFORMED);
         for (int i = 0; i < docs; i++) {
-            ParsedDocument doc = testParsedDocument("" + i, null, testDocumentWithTextField(), B_1, null);
+            ParsedDocument doc = testParsedDocument("" + i, null, testDocumentWithTextField(), B_1);
             engine.index(indexForDoc(doc));
             tracker.updateLocalCheckpoint(allocationId.getId(), i);
         }

--- a/server/src/test/java/org/elasticsearch/index/engine/NoOpEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/NoOpEngineTests.java
@@ -103,7 +103,7 @@ public class NoOpEngineTests extends EngineTestCase {
         final AtomicLong globalCheckpoint = new AtomicLong(SequenceNumbers.NO_OPS_PERFORMED);
         try (Store store = createStore()) {
             Path translogPath = createTempDir();
-            EngineConfig config = config(indexSettings, store, translogPath, NoMergePolicy.INSTANCE, null, null, globalCheckpoint::get);
+            EngineConfig config = config(indexSettings, store, translogPath, NoMergePolicy.INSTANCE, globalCheckpoint::get);
             final int numDocs = scaledRandomIntBetween(10, 3000);
             int deletions = 0;
             try (InternalEngine engine = createEngine(config)) {

--- a/server/src/test/java/org/elasticsearch/index/engine/ReadOnlyEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/ReadOnlyEngineTests.java
@@ -45,7 +45,7 @@ public class ReadOnlyEngineTests extends EngineTestCase {
         Engine readOnlyEngine = null;
         final AtomicLong globalCheckpoint = new AtomicLong(SequenceNumbers.NO_OPS_PERFORMED);
         try (Store store = createStore()) {
-            EngineConfig config = config(defaultSettings, store, createTempDir(), newMergePolicy(), null, null, globalCheckpoint::get);
+            EngineConfig config = config(defaultSettings, store, createTempDir(), newMergePolicy(), globalCheckpoint::get);
             int numDocs = scaledRandomIntBetween(10, 1000);
             final SeqNoStats lastSeqNoStats;
             final List<DocIdSeqNoAndSource> lastDocIds;
@@ -161,7 +161,7 @@ public class ReadOnlyEngineTests extends EngineTestCase {
         IOUtils.close(engine, store);
         final AtomicLong globalCheckpoint = new AtomicLong(SequenceNumbers.NO_OPS_PERFORMED);
         try (Store store = createStore()) {
-            EngineConfig config = config(defaultSettings, store, createTempDir(), newMergePolicy(), null, null, globalCheckpoint::get);
+            EngineConfig config = config(defaultSettings, store, createTempDir(), newMergePolicy(), globalCheckpoint::get);
             final int numDocs = scaledRandomIntBetween(10, 100);
             try (InternalEngine engine = createEngine(config)) {
                 long maxSeqNo = SequenceNumbers.NO_OPS_PERFORMED;
@@ -217,7 +217,7 @@ public class ReadOnlyEngineTests extends EngineTestCase {
         IOUtils.close(engine, store);
         final AtomicLong globalCheckpoint = new AtomicLong(SequenceNumbers.NO_OPS_PERFORMED);
         try (Store store = createStore()) {
-            EngineConfig config = config(defaultSettings, store, createTempDir(), newMergePolicy(), null, null, globalCheckpoint::get);
+            EngineConfig config = config(defaultSettings, store, createTempDir(), newMergePolicy(), globalCheckpoint::get);
             store.createEmpty();
             try (
                 ReadOnlyEngine readOnlyEngine = new ReadOnlyEngine(
@@ -248,7 +248,7 @@ public class ReadOnlyEngineTests extends EngineTestCase {
         IOUtils.close(engine, store);
         final AtomicLong globalCheckpoint = new AtomicLong(SequenceNumbers.NO_OPS_PERFORMED);
         try (Store store = createStore()) {
-            EngineConfig config = config(defaultSettings, store, createTempDir(), newMergePolicy(), null, null, globalCheckpoint::get);
+            EngineConfig config = config(defaultSettings, store, createTempDir(), newMergePolicy(), globalCheckpoint::get);
             store.createEmpty();
             try (
                 ReadOnlyEngine readOnlyEngine = new ReadOnlyEngine(
@@ -275,7 +275,7 @@ public class ReadOnlyEngineTests extends EngineTestCase {
         IOUtils.close(engine, store);
         final AtomicLong globalCheckpoint = new AtomicLong(SequenceNumbers.NO_OPS_PERFORMED);
         try (Store store = createStore()) {
-            EngineConfig config = config(defaultSettings, store, createTempDir(), newMergePolicy(), null, null, globalCheckpoint::get);
+            EngineConfig config = config(defaultSettings, store, createTempDir(), newMergePolicy(), globalCheckpoint::get);
             int numDocs = scaledRandomIntBetween(10, 100);
             int numSegments;
             try (InternalEngine engine = createEngine(config)) {
@@ -337,7 +337,7 @@ public class ReadOnlyEngineTests extends EngineTestCase {
         IOUtils.close(engine, store);
         final AtomicLong globalCheckpoint = new AtomicLong(SequenceNumbers.NO_OPS_PERFORMED);
         try (Store store = createStore()) {
-            EngineConfig config = config(defaultSettings, store, createTempDir(), newMergePolicy(), null, null, globalCheckpoint::get);
+            EngineConfig config = config(defaultSettings, store, createTempDir(), newMergePolicy(), globalCheckpoint::get);
             int numDocs = scaledRandomIntBetween(10, 1000);
             try (InternalEngine engine = createEngine(config)) {
                 for (int i = 0; i < numDocs; i++) {
@@ -379,7 +379,7 @@ public class ReadOnlyEngineTests extends EngineTestCase {
         IOUtils.close(engine, store);
         try (Store store = createStore()) {
             final AtomicLong globalCheckpoint = new AtomicLong(SequenceNumbers.NO_OPS_PERFORMED);
-            EngineConfig config = config(defaultSettings, store, createTempDir(), newMergePolicy(), null, null, globalCheckpoint::get);
+            EngineConfig config = config(defaultSettings, store, createTempDir(), newMergePolicy(), globalCheckpoint::get);
             final boolean softDeletesEnabled = config.getIndexSettings().isSoftDeleteEnabled();
             final int numDocs = frequently() ? scaledRandomIntBetween(10, 200) : 0;
             int uncommittedDocs = 0;
@@ -438,15 +438,7 @@ public class ReadOnlyEngineTests extends EngineTestCase {
         IOUtils.close(engine, store);
         AtomicLong globalCheckpoint = new AtomicLong(SequenceNumbers.NO_OPS_PERFORMED);
         try (Store store = createStore()) {
-            final EngineConfig config = config(
-                defaultSettings,
-                store,
-                createTempDir(),
-                NoMergePolicy.INSTANCE,
-                null,
-                null,
-                globalCheckpoint::get
-            );
+            final EngineConfig config = config(defaultSettings, store, createTempDir(), NoMergePolicy.INSTANCE, globalCheckpoint::get);
             String lastSearcherId;
             try (InternalEngine engine = createEngine(config)) {
                 lastSearcherId = ReadOnlyEngine.generateSearcherId(engine.getLastCommittedSegmentInfos());

--- a/server/src/test/java/org/elasticsearch/index/engine/ReadOnlyEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/ReadOnlyEngineTests.java
@@ -52,7 +52,7 @@ public class ReadOnlyEngineTests extends EngineTestCase {
             try (InternalEngine engine = createEngine(config)) {
                 Engine.Get get = null;
                 for (int i = 0; i < numDocs; i++) {
-                    ParsedDocument doc = testParsedDocument(Integer.toString(i), null, testDocument(), new BytesArray("{}"), null);
+                    ParsedDocument doc = testParsedDocument(Integer.toString(i), null, testDocument(), new BytesArray("{}"));
                     engine.index(
                         new Engine.Index(
                             newUid(doc),
@@ -166,7 +166,7 @@ public class ReadOnlyEngineTests extends EngineTestCase {
             try (InternalEngine engine = createEngine(config)) {
                 long maxSeqNo = SequenceNumbers.NO_OPS_PERFORMED;
                 for (int i = 0; i < numDocs; i++) {
-                    ParsedDocument doc = testParsedDocument(Integer.toString(i), null, testDocument(), new BytesArray("{}"), null);
+                    ParsedDocument doc = testParsedDocument(Integer.toString(i), null, testDocument(), new BytesArray("{}"));
                     engine.index(
                         new Engine.Index(
                             newUid(doc),
@@ -280,7 +280,7 @@ public class ReadOnlyEngineTests extends EngineTestCase {
             int numSegments;
             try (InternalEngine engine = createEngine(config)) {
                 for (int i = 0; i < numDocs; i++) {
-                    ParsedDocument doc = testParsedDocument(Integer.toString(i), null, testDocument(), new BytesArray("{}"), null);
+                    ParsedDocument doc = testParsedDocument(Integer.toString(i), null, testDocument(), new BytesArray("{}"));
                     engine.index(
                         new Engine.Index(
                             newUid(doc),
@@ -341,7 +341,7 @@ public class ReadOnlyEngineTests extends EngineTestCase {
             int numDocs = scaledRandomIntBetween(10, 1000);
             try (InternalEngine engine = createEngine(config)) {
                 for (int i = 0; i < numDocs; i++) {
-                    ParsedDocument doc = testParsedDocument(Integer.toString(i), null, testDocument(), new BytesArray("{}"), null);
+                    ParsedDocument doc = testParsedDocument(Integer.toString(i), null, testDocument(), new BytesArray("{}"));
                     engine.index(
                         new Engine.Index(
                             newUid(doc),
@@ -386,7 +386,7 @@ public class ReadOnlyEngineTests extends EngineTestCase {
 
             try (InternalEngine engine = createEngine(config)) {
                 for (int i = 0; i < numDocs; i++) {
-                    ParsedDocument doc = testParsedDocument(Integer.toString(i), null, testDocument(), new BytesArray("{}"), null);
+                    ParsedDocument doc = testParsedDocument(Integer.toString(i), null, testDocument(), new BytesArray("{}"));
                     engine.index(
                         new Engine.Index(
                             newUid(doc),

--- a/server/src/test/java/org/elasticsearch/index/engine/TranslogOperationAsserterTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/TranslogOperationAsserterTests.java
@@ -66,8 +66,7 @@ public class TranslogOperationAsserterTests extends EngineTestCase {
             new IndexSettings(imd, Settings.EMPTY),
             config.getStore(),
             config.getTranslogConfig().getTranslogPath(),
-            config.getMergePolicy(),
-            null
+            config.getMergePolicy()
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -5327,39 +5327,12 @@ public class IndexShardTests extends IndexShardTestCase {
                 safeAwait(warmerBlocking);
                 config.getWarmer().warm(reader);
             };
-            EngineConfig configWithWarmer = new EngineConfig(
-                config.getShardId(),
-                config.getThreadPool(),
-                config.getThreadPoolMergeExecutorService(),
-                config.getIndexSettings(),
-                warmer,
-                config.getStore(),
-                config.getMergePolicy(),
-                config.getAnalyzer(),
-                config.getSimilarity(),
-                new CodecService(null, BigArrays.NON_RECYCLING_INSTANCE, null),
-                config.getEventListener(),
-                config.getQueryCache(),
-                config.getQueryCachingPolicy(),
-                config.getTranslogConfig(),
-                config.getFlushMergesAfter(),
-                config.getExternalRefreshListener(),
-                config.getInternalRefreshListener(),
-                config.getIndexSort(),
-                config.getCircuitBreakerService(),
-                config.getGlobalCheckpointSupplier(),
-                config.retentionLeasesSupplier(),
-                config.getPrimaryTermSupplier(),
-                IndexModule.DEFAULT_SNAPSHOT_COMMIT_SUPPLIER,
-                config.getLeafSorter(),
-                config.getRelativeTimeInNanosSupplier(),
-                config.getIndexCommitListener(),
-                config.isPromotableToPrimary(),
-                config.getMapperService(),
-                config.getEngineResetLock(),
-                config.getMergeMetrics(),
-                Function.identity()
-            );
+            EngineConfig configWithWarmer = EngineConfig.builder(config)
+                .warmer(warmer)
+                .codecProvider(new CodecService(null, BigArrays.NON_RECYCLING_INSTANCE, null))
+                .snapshotCommitSupplier(IndexModule.DEFAULT_SNAPSHOT_COMMIT_SUPPLIER)
+                .indexDeletionPolicyWrapper(Function.identity())
+                .build();
             return new InternalEngine(configWithWarmer);
         });
         Thread recoveryThread = new Thread(() -> expectThrows(AlreadyClosedException.class, () -> recoverShardFromStore(shard)));
@@ -5676,39 +5649,12 @@ public class IndexShardTests extends IndexShardTestCase {
                 internalRefreshListeners.add(blockingRefreshListener);
                 internalRefreshListeners.addAll(config.getInternalRefreshListener());
 
-                var engineConfigWithBlockingRefreshListener = new EngineConfig(
-                    config.getShardId(),
-                    config.getThreadPool(),
-                    config.getThreadPoolMergeExecutorService(),
-                    config.getIndexSettings(),
-                    config.getWarmer(),
-                    config.getStore(),
-                    config.getMergePolicy(),
-                    config.getAnalyzer(),
-                    config.getSimilarity(),
-                    new CodecService(null, BigArrays.NON_RECYCLING_INSTANCE, null),
-                    config.getEventListener(),
-                    config.getQueryCache(),
-                    config.getQueryCachingPolicy(),
-                    config.getTranslogConfig(),
-                    config.getFlushMergesAfter(),
-                    config.getExternalRefreshListener(),
-                    internalRefreshListeners,
-                    config.getIndexSort(),
-                    config.getCircuitBreakerService(),
-                    config.getGlobalCheckpointSupplier(),
-                    config.retentionLeasesSupplier(),
-                    config.getPrimaryTermSupplier(),
-                    IndexModule.DEFAULT_SNAPSHOT_COMMIT_SUPPLIER,
-                    config.getLeafSorter(),
-                    config.getRelativeTimeInNanosSupplier(),
-                    config.getIndexCommitListener(),
-                    config.isPromotableToPrimary(),
-                    config.getMapperService(),
-                    config.getEngineResetLock(),
-                    config.getMergeMetrics(),
-                    Function.identity()
-                );
+                var engineConfigWithBlockingRefreshListener = EngineConfig.builder(config)
+                    .internalRefreshListener(internalRefreshListeners)
+                    .codecProvider(new CodecService(null, BigArrays.NON_RECYCLING_INSTANCE, null))
+                    .snapshotCommitSupplier(IndexModule.DEFAULT_SNAPSHOT_COMMIT_SUPPLIER)
+                    .indexDeletionPolicyWrapper(Function.identity())
+                    .build();
                 lazyEngineConfig.set(engineConfigWithBlockingRefreshListener);
                 return new InternalEngine(engineConfigWithBlockingRefreshListener) {
                     @Override

--- a/server/src/test/java/org/elasticsearch/index/shard/RefreshListenersTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/RefreshListenersTests.java
@@ -149,39 +149,35 @@ public class RefreshListenersTests extends ESTestCase {
             primaryTerm
         );
         store.associateIndexWithNewTranslog(translogUUID);
-        EngineConfig config = new EngineConfig(
-            shardId,
-            threadPool,
-            threadPoolMergeExecutorService,
-            indexSettings,
-            null,
-            store,
-            newMergePolicy(),
-            iwc.getAnalyzer(),
-            iwc.getSimilarity(),
-            new CodecService(null, BigArrays.NON_RECYCLING_INSTANCE, null),
-            eventListener,
-            IndexSearcher.getDefaultQueryCache(),
-            IndexSearcher.getDefaultQueryCachingPolicy(),
-            translogConfig,
-            TimeValue.timeValueMinutes(5),
-            Collections.singletonList(listeners),
-            Collections.emptyList(),
-            null,
-            new NoneCircuitBreakerService(),
-            () -> SequenceNumbers.NO_OPS_PERFORMED,
-            () -> RetentionLeases.EMPTY,
-            () -> primaryTerm,
-            IndexModule.DEFAULT_SNAPSHOT_COMMIT_SUPPLIER,
-            null,
-            System::nanoTime,
-            null,
-            true,
-            EngineTestCase.createMapperService(),
-            new EngineResetLock(),
-            MergeMetrics.NOOP,
-            Function.identity()
-        );
+        EngineConfig config = EngineConfig.builder()
+            .shardId(shardId)
+            .threadPool(threadPool)
+            .threadPoolMergeExecutorService(threadPoolMergeExecutorService)
+            .indexSettings(indexSettings)
+            .store(store)
+            .mergePolicy(newMergePolicy())
+            .analyzer(iwc.getAnalyzer())
+            .similarity(iwc.getSimilarity())
+            .codecProvider(new CodecService(null, BigArrays.NON_RECYCLING_INSTANCE, null))
+            .eventListener(eventListener)
+            .queryCache(IndexSearcher.getDefaultQueryCache())
+            .queryCachingPolicy(IndexSearcher.getDefaultQueryCachingPolicy())
+            .translogConfig(translogConfig)
+            .flushMergesAfter(TimeValue.timeValueMinutes(5))
+            .externalRefreshListener(Collections.singletonList(listeners))
+            .internalRefreshListener(Collections.emptyList())
+            .circuitBreakerService(new NoneCircuitBreakerService())
+            .globalCheckpointSupplier(() -> SequenceNumbers.NO_OPS_PERFORMED)
+            .retentionLeasesSupplier(() -> RetentionLeases.EMPTY)
+            .primaryTermSupplier(() -> primaryTerm)
+            .snapshotCommitSupplier(IndexModule.DEFAULT_SNAPSHOT_COMMIT_SUPPLIER)
+            .relativeTimeInNanosSupplier(System::nanoTime)
+            .promotableToPrimary(true)
+            .mapperService(EngineTestCase.createMapperService())
+            .engineResetLock(new EngineResetLock())
+            .mergeMetrics(MergeMetrics.NOOP)
+            .indexDeletionPolicyWrapper(Function.identity())
+            .build();
         engine = new InternalEngine(config);
         EngineTestCase.recoverFromTranslog(engine, (e, s) -> 0, Long.MAX_VALUE);
         listeners.setCurrentRefreshLocationSupplier(engine::getTranslogLastWriteLocation);

--- a/server/src/test/java/org/elasticsearch/index/shard/RefreshListenersTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/RefreshListenersTests.java
@@ -72,8 +72,6 @@ import org.junit.Before;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -164,8 +162,8 @@ public class RefreshListenersTests extends ESTestCase {
             .queryCachingPolicy(IndexSearcher.getDefaultQueryCachingPolicy())
             .translogConfig(translogConfig)
             .flushMergesAfter(TimeValue.timeValueMinutes(5))
-            .externalRefreshListener(Collections.singletonList(listeners))
-            .internalRefreshListener(Collections.emptyList())
+            .externalRefreshListener(List.of(listeners))
+            .internalRefreshListener(List.of())
             .circuitBreakerService(new NoneCircuitBreakerService())
             .globalCheckpointSupplier(() -> SequenceNumbers.NO_OPS_PERFORMED)
             .retentionLeasesSupplier(() -> RetentionLeases.EMPTY)
@@ -585,7 +583,7 @@ public class RefreshListenersTests extends ESTestCase {
             seqID,
             id,
             null,
-            Arrays.asList(document),
+            List.of(document),
             source,
             XContentType.JSON,
             null,

--- a/server/src/test/java/org/elasticsearch/index/shard/RefreshListenersTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/RefreshListenersTests.java
@@ -163,7 +163,6 @@ public class RefreshListenersTests extends ESTestCase {
             .translogConfig(translogConfig)
             .flushMergesAfter(TimeValue.timeValueMinutes(5))
             .externalRefreshListener(List.of(listeners))
-            .internalRefreshListener(List.of())
             .circuitBreakerService(new NoneCircuitBreakerService())
             .globalCheckpointSupplier(() -> SequenceNumbers.NO_OPS_PERFORMED)
             .retentionLeasesSupplier(() -> RetentionLeases.EMPTY)

--- a/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
@@ -144,8 +144,6 @@ import java.util.function.Supplier;
 import java.util.function.ToLongBiFunction;
 import java.util.stream.Collectors;
 
-import static java.util.Collections.emptyList;
-import static java.util.Collections.shuffle;
 import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 import static org.elasticsearch.index.engine.Engine.Operation.Origin.PEER_RECOVERY;
 import static org.elasticsearch.index.engine.Engine.Operation.Origin.PRIMARY;
@@ -416,7 +414,7 @@ public abstract class EngineTestCase extends ESTestCase {
             seqID,
             id,
             routing,
-            Arrays.asList(document),
+            List.of(document),
             source,
             XContentType.JSON,
             mappingUpdate,
@@ -774,12 +772,6 @@ public abstract class EngineTestCase extends ESTestCase {
         final IndexWriterConfig iwc = newIndexWriterConfig();
         final TranslogConfig translogConfig = new TranslogConfig(shardId, translogPath, indexSettings, BigArrays.NON_RECYCLING_INSTANCE);
         final Engine.EventListener eventListener = new Engine.EventListener() {}; // we don't need to notify anybody in this test
-        final List<ReferenceManager.RefreshListener> extRefreshListenerList = externalRefreshListener == null
-            ? emptyList()
-            : Collections.singletonList(externalRefreshListener);
-        final List<ReferenceManager.RefreshListener> intRefreshListenerList = internalRefreshListener == null
-            ? emptyList()
-            : Collections.singletonList(internalRefreshListener);
         final LongSupplier globalCheckpointSupplier;
         final Supplier<RetentionLeases> retentionLeasesSupplier;
         if (maybeGlobalCheckpointSupplier == null) {
@@ -817,8 +809,8 @@ public abstract class EngineTestCase extends ESTestCase {
             .queryCachingPolicy(IndexSearcher.getDefaultQueryCachingPolicy())
             .translogConfig(translogConfig)
             .flushMergesAfter(TimeValue.timeValueMinutes(5))
-            .externalRefreshListener(extRefreshListenerList)
-            .internalRefreshListener(intRefreshListenerList)
+            .externalRefreshListener(externalRefreshListener == null ? List.of() : List.of(externalRefreshListener))
+            .internalRefreshListener(internalRefreshListener == null ? List.of() : List.of(internalRefreshListener))
             .indexSort(indexSort)
             .circuitBreakerService(breakerService)
             .globalCheckpointSupplier(globalCheckpointSupplier)
@@ -1079,8 +1071,8 @@ public abstract class EngineTestCase extends ESTestCase {
                 firstOpWithSeqNo++;
             }
             // shuffle ops but make sure legacy ops are first
-            shuffle(ops.subList(0, firstOpWithSeqNo), random());
-            shuffle(ops.subList(firstOpWithSeqNo, ops.size()), random());
+            Collections.shuffle(ops.subList(0, firstOpWithSeqNo), random());
+            Collections.shuffle(ops.subList(firstOpWithSeqNo, ops.size()), random());
         }
         boolean firstOp = true;
         for (Engine.Operation op : ops) {

--- a/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
@@ -10,7 +10,6 @@
 package org.elasticsearch.index.engine;
 
 import org.apache.logging.log4j.Logger;
-import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.NumericDocValuesField;
@@ -291,150 +290,6 @@ public abstract class EngineTestCase extends ESTestCase {
         if (randomBoolean()) {
             engine.config().setEnableGcDeletes(false);
         }
-    }
-
-    public static EngineConfig copy(EngineConfig config, LongSupplier globalCheckpointSupplier) {
-        return new EngineConfig(
-            config.getShardId(),
-            config.getThreadPool(),
-            config.getThreadPoolMergeExecutorService(),
-            config.getIndexSettings(),
-            config.getWarmer(),
-            config.getStore(),
-            config.getMergePolicy(),
-            config.getAnalyzer(),
-            config.getSimilarity(),
-            config.getCodecProvider(),
-            config.getEventListener(),
-            config.getQueryCache(),
-            config.getQueryCachingPolicy(),
-            config.getTranslogConfig(),
-            config.getFlushMergesAfter(),
-            config.getExternalRefreshListener(),
-            Collections.emptyList(),
-            config.getIndexSort(),
-            config.getCircuitBreakerService(),
-            globalCheckpointSupplier,
-            config.retentionLeasesSupplier(),
-            config.getPrimaryTermSupplier(),
-            config.getSnapshotCommitSupplier(),
-            config.getLeafSorter(),
-            config.getRelativeTimeInNanosSupplier(),
-            config.getIndexCommitListener(),
-            config.isPromotableToPrimary(),
-            config.getMapperService(),
-            config.getEngineResetLock(),
-            config.getMergeMetrics(),
-            config.getIndexDeletionPolicyWrapper()
-        );
-    }
-
-    public EngineConfig copy(EngineConfig config, Analyzer analyzer) {
-        return new EngineConfig(
-            config.getShardId(),
-            config.getThreadPool(),
-            config.getThreadPoolMergeExecutorService(),
-            config.getIndexSettings(),
-            config.getWarmer(),
-            config.getStore(),
-            config.getMergePolicy(),
-            analyzer,
-            config.getSimilarity(),
-            config.getCodecProvider(),
-            config.getEventListener(),
-            config.getQueryCache(),
-            config.getQueryCachingPolicy(),
-            config.getTranslogConfig(),
-            config.getFlushMergesAfter(),
-            config.getExternalRefreshListener(),
-            Collections.emptyList(),
-            config.getIndexSort(),
-            config.getCircuitBreakerService(),
-            config.getGlobalCheckpointSupplier(),
-            config.retentionLeasesSupplier(),
-            config.getPrimaryTermSupplier(),
-            config.getSnapshotCommitSupplier(),
-            config.getLeafSorter(),
-            config.getRelativeTimeInNanosSupplier(),
-            config.getIndexCommitListener(),
-            config.isPromotableToPrimary(),
-            config.getMapperService(),
-            config.getEngineResetLock(),
-            config.getMergeMetrics(),
-            config.getIndexDeletionPolicyWrapper()
-        );
-    }
-
-    public static EngineConfig copy(EngineConfig config, MergePolicy mergePolicy) {
-        return new EngineConfig(
-            config.getShardId(),
-            config.getThreadPool(),
-            config.getThreadPoolMergeExecutorService(),
-            config.getIndexSettings(),
-            config.getWarmer(),
-            config.getStore(),
-            mergePolicy,
-            config.getAnalyzer(),
-            config.getSimilarity(),
-            config.getCodecProvider(),
-            config.getEventListener(),
-            config.getQueryCache(),
-            config.getQueryCachingPolicy(),
-            config.getTranslogConfig(),
-            config.getFlushMergesAfter(),
-            config.getExternalRefreshListener(),
-            Collections.emptyList(),
-            config.getIndexSort(),
-            config.getCircuitBreakerService(),
-            config.getGlobalCheckpointSupplier(),
-            config.retentionLeasesSupplier(),
-            config.getPrimaryTermSupplier(),
-            config.getSnapshotCommitSupplier(),
-            config.getLeafSorter(),
-            config.getRelativeTimeInNanosSupplier(),
-            config.getIndexCommitListener(),
-            config.isPromotableToPrimary(),
-            config.getMapperService(),
-            config.getEngineResetLock(),
-            config.getMergeMetrics(),
-            config.getIndexDeletionPolicyWrapper()
-        );
-    }
-
-    public static EngineConfig copy(EngineConfig config, MapperService mapperService) {
-        return new EngineConfig(
-            config.getShardId(),
-            config.getThreadPool(),
-            config.getThreadPoolMergeExecutorService(),
-            config.getIndexSettings(),
-            config.getWarmer(),
-            config.getStore(),
-            config.getMergePolicy(),
-            config.getAnalyzer(),
-            config.getSimilarity(),
-            config.getCodecProvider(),
-            config.getEventListener(),
-            config.getQueryCache(),
-            config.getQueryCachingPolicy(),
-            config.getTranslogConfig(),
-            config.getFlushMergesAfter(),
-            config.getExternalRefreshListener(),
-            config.getInternalRefreshListener(),
-            config.getIndexSort(),
-            config.getCircuitBreakerService(),
-            config.getGlobalCheckpointSupplier(),
-            config.retentionLeasesSupplier(),
-            config.getPrimaryTermSupplier(),
-            config.getSnapshotCommitSupplier(),
-            config.getLeafSorter(),
-            config.getRelativeTimeInNanosSupplier(),
-            config.getIndexCommitListener(),
-            config.isPromotableToPrimary(),
-            mapperService,
-            config.getEngineResetLock(),
-            config.getMergeMetrics(),
-            config.getIndexDeletionPolicyWrapper()
-        );
     }
 
     @Override
@@ -947,83 +802,37 @@ public abstract class EngineTestCase extends ESTestCase {
             globalCheckpointSupplier = maybeGlobalCheckpointSupplier;
             retentionLeasesSupplier = maybeRetentionLeasesSupplier;
         }
-        return new EngineConfig(
-            shardId,
-            threadPool,
-            threadPoolMergeExecutorService,
-            indexSettings,
-            null,
-            store,
-            mergePolicy,
-            iwc.getAnalyzer(),
-            iwc.getSimilarity(),
-            newCodecService(),
-            eventListener,
-            IndexSearcher.getDefaultQueryCache(),
-            IndexSearcher.getDefaultQueryCachingPolicy(),
-            translogConfig,
-            TimeValue.timeValueMinutes(5),
-            extRefreshListenerList,
-            intRefreshListenerList,
-            indexSort,
-            breakerService,
-            globalCheckpointSupplier,
-            retentionLeasesSupplier,
-            primaryTerm,
-            IndexModule.DEFAULT_SNAPSHOT_COMMIT_SUPPLIER,
-            null,
-            this::relativeTimeInNanos,
-            indexCommitListener,
-            true,
-            mapperService,
-            new EngineResetLock(),
-            mergeMetrics,
-            indexDeletionPolicyWrapper == null ? Function.identity() : indexDeletionPolicyWrapper
-        );
-    }
-
-    protected EngineConfig config(EngineConfig config, Store store, Path translogPath) {
-        IndexSettings indexSettings = IndexSettingsModule.newIndexSettings(
-            "test",
-            Settings.builder()
-                .put(config.getIndexSettings().getSettings())
-                .put(IndexSettings.INDEX_SOFT_DELETES_SETTING.getKey(), true)
-                .build()
-        );
-        TranslogConfig translogConfig = new TranslogConfig(shardId, translogPath, indexSettings, BigArrays.NON_RECYCLING_INSTANCE);
-        return new EngineConfig(
-            config.getShardId(),
-            config.getThreadPool(),
-            config.getThreadPoolMergeExecutorService(),
-            indexSettings,
-            config.getWarmer(),
-            store,
-            config.getMergePolicy(),
-            config.getAnalyzer(),
-            config.getSimilarity(),
-            newCodecService(),
-            config.getEventListener(),
-            config.getQueryCache(),
-            config.getQueryCachingPolicy(),
-            translogConfig,
-            config.getFlushMergesAfter(),
-            config.getExternalRefreshListener(),
-            config.getInternalRefreshListener(),
-            config.getIndexSort(),
-            config.getCircuitBreakerService(),
-            config.getGlobalCheckpointSupplier(),
-            config.retentionLeasesSupplier(),
-            config.getPrimaryTermSupplier(),
-            config.getSnapshotCommitSupplier(),
-            config.getLeafSorter(),
-            config.getRelativeTimeInNanosSupplier(),
-            config.getIndexCommitListener(),
-            config.isPromotableToPrimary(),
-            config.getMapperService(),
-            config.getEngineResetLock(),
-            config.getMergeMetrics(),
-            config.getIndexDeletionPolicyWrapper()
-        );
+        return EngineConfig.builder()
+            .shardId(shardId)
+            .threadPool(threadPool)
+            .threadPoolMergeExecutorService(threadPoolMergeExecutorService)
+            .indexSettings(indexSettings)
+            .store(store)
+            .mergePolicy(mergePolicy)
+            .analyzer(iwc.getAnalyzer())
+            .similarity(iwc.getSimilarity())
+            .codecProvider(newCodecService())
+            .eventListener(eventListener)
+            .queryCache(IndexSearcher.getDefaultQueryCache())
+            .queryCachingPolicy(IndexSearcher.getDefaultQueryCachingPolicy())
+            .translogConfig(translogConfig)
+            .flushMergesAfter(TimeValue.timeValueMinutes(5))
+            .externalRefreshListener(extRefreshListenerList)
+            .internalRefreshListener(intRefreshListenerList)
+            .indexSort(indexSort)
+            .circuitBreakerService(breakerService)
+            .globalCheckpointSupplier(globalCheckpointSupplier)
+            .retentionLeasesSupplier(retentionLeasesSupplier)
+            .primaryTermSupplier(primaryTerm)
+            .snapshotCommitSupplier(IndexModule.DEFAULT_SNAPSHOT_COMMIT_SUPPLIER)
+            .relativeTimeInNanosSupplier(this::relativeTimeInNanos)
+            .indexCommitListener(indexCommitListener)
+            .promotableToPrimary(true)
+            .mapperService(mapperService)
+            .engineResetLock(new EngineResetLock())
+            .mergeMetrics(mergeMetrics)
+            .indexDeletionPolicyWrapper(indexDeletionPolicyWrapper == null ? Function.identity() : indexDeletionPolicyWrapper)
+            .build();
     }
 
     protected EngineConfig noOpConfig(IndexSettings indexSettings, Store store, Path translogPath) {

--- a/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
@@ -473,7 +473,7 @@ public abstract class EngineTestCase extends ESTestCase {
     }
 
     protected InternalEngine createEngine(Store store, Path translogPath) throws IOException {
-        return createEngine(defaultSettings, store, translogPath, newMergePolicy(), null);
+        return createEngine(defaultSettings, store, translogPath, newMergePolicy());
     }
 
     protected InternalEngine createEngine(Store store, Path translogPath, LongSupplier globalCheckpointSupplier) throws IOException {
@@ -508,7 +508,7 @@ public abstract class EngineTestCase extends ESTestCase {
 
     protected InternalEngine createEngine(IndexSettings indexSettings, Store store, Path translogPath, MergePolicy mergePolicy)
         throws IOException {
-        return createEngine(indexSettings, store, translogPath, mergePolicy, null);
+        return createEngine(indexSettings, store, translogPath, mergePolicy, (IndexWriterFactory) null);
 
     }
 
@@ -582,6 +582,16 @@ public abstract class EngineTestCase extends ESTestCase {
         return createEngine(indexWriterFactory, localCheckpointTrackerSupplier, seqNoForOperation, config);
     }
 
+    protected InternalEngine createEngine(
+        IndexSettings indexSettings,
+        Store store,
+        Path translogPath,
+        MergePolicy mergePolicy,
+        @Nullable Sort indexSort
+    ) throws IOException {
+        return createEngine(indexSettings, store, translogPath, mergePolicy, null, null, null, indexSort, null);
+    }
+
     protected InternalEngine createEngine(EngineConfig config) throws IOException {
         return createEngine(null, null, null, config);
     }
@@ -610,13 +620,16 @@ public abstract class EngineTestCase extends ESTestCase {
         return internalEngine;
     }
 
+    protected InternalEngine createEngine(@Nullable IndexWriterFactory indexWriterFactory, EngineConfig config) throws IOException {
+        return createEngine(indexWriterFactory, null, null, config);
+    }
+
     public static InternalEngine createEngine(EngineConfig engineConfig, int maxDocs) {
         return new InternalEngine(engineConfig, maxDocs, LocalCheckpointTracker::new);
     }
 
     @FunctionalInterface
     public interface IndexWriterFactory {
-
         IndexWriter createWriter(Directory directory, IndexWriterConfig iwc) throws IOException;
     }
 
@@ -669,6 +682,20 @@ public abstract class EngineTestCase extends ESTestCase {
             };
         }
 
+    }
+
+    public EngineConfig config(IndexSettings indexSettings, Store store, Path translogPath, MergePolicy mergePolicy) {
+        return config(indexSettings, store, translogPath, mergePolicy, (ReferenceManager.RefreshListener) null);
+    }
+
+    public EngineConfig config(
+        IndexSettings indexSettings,
+        Store store,
+        Path translogPath,
+        MergePolicy mergePolicy,
+        LongSupplier globalCheckpointSupplier
+    ) {
+        return config(indexSettings, store, translogPath, mergePolicy, null, null, globalCheckpointSupplier);
     }
 
     public EngineConfig config(
@@ -726,6 +753,17 @@ public abstract class EngineTestCase extends ESTestCase {
             null,
             Function.identity()
         );
+    }
+
+    public EngineConfig config(
+        final IndexSettings indexSettings,
+        final Store store,
+        final Path translogPath,
+        final MergePolicy mergePolicy,
+        final LongSupplier globalCheckpointSupplier,
+        final Supplier<RetentionLeases> retentionLeasesSupplier
+    ) {
+        return config(indexSettings, store, translogPath, mergePolicy, null, null, globalCheckpointSupplier, retentionLeasesSupplier);
     }
 
     public EngineConfig config(
@@ -832,7 +870,7 @@ public abstract class EngineTestCase extends ESTestCase {
     }
 
     protected EngineConfig noOpConfig(IndexSettings indexSettings, Store store, Path translogPath, LongSupplier globalCheckpointSupplier) {
-        return config(indexSettings, store, translogPath, newMergePolicy(), null, null, globalCheckpointSupplier);
+        return config(indexSettings, store, translogPath, newMergePolicy(), globalCheckpointSupplier);
     }
 
     protected static final BytesReference B_1 = new BytesArray(new byte[] { 1 });

--- a/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
@@ -182,16 +182,6 @@ public abstract class EngineTestCase extends ESTestCase {
     protected final PrimaryTermSupplier primaryTerm = new PrimaryTermSupplier(1L);
     protected static SeqNoFieldMapper.SeqNoIndexOptions seqNoIndexOptions = SeqNoFieldMapper.SeqNoIndexOptions.POINTS_AND_DOC_VALUES;
 
-    protected static void assertVisibleCount(Engine engine, int numDocs, boolean refresh) throws IOException {
-        if (refresh) {
-            engine.refresh("test");
-        }
-        try (Engine.Searcher searcher = engine.acquireSearcher("test")) {
-            Integer totalHits = searcher.search(Queries.ALL_DOCS_INSTANCE, new TotalHitCountCollectorManager(searcher.getSlices()));
-            assertThat(totalHits, equalTo(numDocs));
-        }
-    }
-
     protected Settings indexSettings() {
         // TODO randomize more settings
         return Settings.builder()

--- a/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
@@ -58,7 +58,6 @@ import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.lucene.uid.Versions;
@@ -319,7 +318,7 @@ public abstract class EngineTestCase extends ESTestCase {
     }
 
     public static ParsedDocument createParsedDoc(String id, String routing) {
-        return testParsedDocument(id, routing, testDocumentWithTextField(), new BytesArray("{ \"value\" : \"test\" }"), null, false, false);
+        return testParsedDocument(id, routing, testDocumentWithTextField(), new BytesArray("{ \"value\" : \"test\" }"), false, false);
     }
 
     public static ParsedDocument createParsedDoc(String id, String routing, boolean recoverySource) {
@@ -332,20 +331,17 @@ public abstract class EngineTestCase extends ESTestCase {
             routing,
             testDocumentWithTextField(),
             new BytesArray("{ \"value\" : \"test\" }"),
-            null,
             recoverySource,
             syntheticId
         );
     }
 
-    protected ParsedDocument testParsedDocument(
-        String id,
-        String routing,
-        LuceneDocument document,
-        BytesReference source,
-        CompressedXContent mappingUpdate
-    ) {
-        return testParsedDocument(id, routing, document, source, mappingUpdate, false, false);
+    protected ParsedDocument testParsedDocument(String id, String routing, LuceneDocument document, BytesReference source) {
+        return testParsedDocument(id, routing, document, source, false, false);
+    }
+
+    protected static ParsedDocument testParsedDocument(String id, LuceneDocument document, BytesReference source, boolean recoverySource) {
+        return testParsedDocument(id, null, document, source, recoverySource, false);
     }
 
     protected static ParsedDocument testParsedDocument(
@@ -353,18 +349,6 @@ public abstract class EngineTestCase extends ESTestCase {
         String routing,
         LuceneDocument document,
         BytesReference source,
-        CompressedXContent mappingUpdate,
-        boolean recoverySource
-    ) {
-        return testParsedDocument(id, routing, document, source, mappingUpdate, recoverySource, false);
-    }
-
-    protected static ParsedDocument testParsedDocument(
-        String id,
-        String routing,
-        LuceneDocument document,
-        BytesReference source,
-        CompressedXContent mappingUpdate,
         boolean recoverySource,
         boolean syntheticId
     ) {
@@ -407,7 +391,7 @@ public abstract class EngineTestCase extends ESTestCase {
             List.of(document),
             source,
             XContentType.JSON,
-            mappingUpdate,
+            null,
             XContentMeteringParserDecorator.UNKNOWN_SIZE
         );
     }
@@ -954,7 +938,7 @@ public abstract class EngineTestCase extends ESTestCase {
             if (randomBoolean()) {
                 op = new Engine.Index(
                     id,
-                    testParsedDocument(docId, null, testDocumentWithTextField(valuePrefix + i), SOURCE, null, false),
+                    testParsedDocument(docId, testDocumentWithTextField(valuePrefix + i), SOURCE, false),
                     forReplica && i >= startWithSeqNo ? i * 2 : SequenceNumbers.UNASSIGNED_SEQ_NO,
                     forReplica && i >= startWithSeqNo && incrementTermWhenIntroducingSeqNo ? primaryTerm + 1 : primaryTerm,
                     version,

--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -146,7 +146,7 @@ import org.elasticsearch.index.MockEngineFactoryPlugin;
 import org.elasticsearch.index.codec.CodecService;
 import org.elasticsearch.index.engine.DocIdSeqNoAndSource;
 import org.elasticsearch.index.engine.Engine;
-import org.elasticsearch.index.engine.EngineTestCase;
+import org.elasticsearch.index.engine.EngineConfig;
 import org.elasticsearch.index.engine.NoOpEngine;
 import org.elasticsearch.index.engine.ReadOnlyEngine;
 import org.elasticsearch.index.engine.Segment;
@@ -1472,7 +1472,7 @@ public abstract class ESIntegTestCase extends ESTestCase {
                 try (
                     var tempEngine = new ReadOnlyEngine(
                         // Override the temporary engine configuration to use the correct mappers
-                        EngineTestCase.copy(engineConfig, indexService.mapperService()),
+                        EngineConfig.builder(engineConfig).mapperService(indexService.mapperService()).build(),
                         null,
                         new TranslogStats(0, 0, 0, 0, 0),
                         false,

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/index/engine/FollowingEngineTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/index/engine/FollowingEngineTests.java
@@ -254,44 +254,40 @@ public class FollowingEngineTests extends ESTestCase {
             BigArrays.NON_RECYCLING_INSTANCE
         );
         final MapperService mapperService = EngineTestCase.createMapperService(indexSettings.getSettings(), "{}");
-        return new EngineConfig(
-            shardIdValue,
-            threadPool,
-            threadPoolMergeExecutorService,
-            indexSettings,
-            null,
-            store,
-            newMergePolicy(),
-            indexWriterConfig.getAnalyzer(),
-            indexWriterConfig.getSimilarity(),
-            new CodecService(mapperService, BigArrays.NON_RECYCLING_INSTANCE, null),
-            new Engine.EventListener() {
+        return EngineConfig.builder()
+            .shardId(shardIdValue)
+            .threadPool(threadPool)
+            .threadPoolMergeExecutorService(threadPoolMergeExecutorService)
+            .indexSettings(indexSettings)
+            .store(store)
+            .mergePolicy(newMergePolicy())
+            .analyzer(indexWriterConfig.getAnalyzer())
+            .similarity(indexWriterConfig.getSimilarity())
+            .codecProvider(new CodecService(mapperService, BigArrays.NON_RECYCLING_INSTANCE, null))
+            .eventListener(new Engine.EventListener() {
                 @Override
                 public void onFailedEngine(String reason, Exception e) {
 
                 }
-            },
-            IndexSearcher.getDefaultQueryCache(),
-            IndexSearcher.getDefaultQueryCachingPolicy(),
-            translogConfig,
-            TimeValue.timeValueMinutes(5),
-            Collections.emptyList(),
-            Collections.emptyList(),
-            null,
-            new NoneCircuitBreakerService(),
-            globalCheckpoint::longValue,
-            () -> RetentionLeases.EMPTY,
-            () -> primaryTerm.get(),
-            IndexModule.DEFAULT_SNAPSHOT_COMMIT_SUPPLIER,
-            null,
-            System::nanoTime,
-            null,
-            true,
-            mapperService,
-            new EngineResetLock(),
-            MergeMetrics.NOOP,
-            Function.identity()
-        );
+            })
+            .queryCache(IndexSearcher.getDefaultQueryCache())
+            .queryCachingPolicy(IndexSearcher.getDefaultQueryCachingPolicy())
+            .translogConfig(translogConfig)
+            .flushMergesAfter(TimeValue.timeValueMinutes(5))
+            .externalRefreshListener(Collections.emptyList())
+            .internalRefreshListener(Collections.emptyList())
+            .circuitBreakerService(new NoneCircuitBreakerService())
+            .globalCheckpointSupplier(globalCheckpoint::longValue)
+            .retentionLeasesSupplier(() -> RetentionLeases.EMPTY)
+            .primaryTermSupplier(() -> primaryTerm.get())
+            .snapshotCommitSupplier(IndexModule.DEFAULT_SNAPSHOT_COMMIT_SUPPLIER)
+            .relativeTimeInNanosSupplier(System::nanoTime)
+            .promotableToPrimary(true)
+            .mapperService(mapperService)
+            .engineResetLock(new EngineResetLock())
+            .mergeMetrics(MergeMetrics.NOOP)
+            .indexDeletionPolicyWrapper(Function.identity())
+            .build();
     }
 
     private static Store createStore(final ShardId shardId, final IndexSettings indexSettings, final Directory directory) {

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/index/engine/FollowingEngineTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/index/engine/FollowingEngineTests.java
@@ -67,7 +67,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -274,8 +273,8 @@ public class FollowingEngineTests extends ESTestCase {
             .queryCachingPolicy(IndexSearcher.getDefaultQueryCachingPolicy())
             .translogConfig(translogConfig)
             .flushMergesAfter(TimeValue.timeValueMinutes(5))
-            .externalRefreshListener(Collections.emptyList())
-            .internalRefreshListener(Collections.emptyList())
+            .externalRefreshListener(List.of())
+            .internalRefreshListener(List.of())
             .circuitBreakerService(new NoneCircuitBreakerService())
             .globalCheckpointSupplier(globalCheckpoint::longValue)
             .retentionLeasesSupplier(() -> RetentionLeases.EMPTY)

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/index/engine/FollowingEngineTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/index/engine/FollowingEngineTests.java
@@ -273,8 +273,6 @@ public class FollowingEngineTests extends ESTestCase {
             .queryCachingPolicy(IndexSearcher.getDefaultQueryCachingPolicy())
             .translogConfig(translogConfig)
             .flushMergesAfter(TimeValue.timeValueMinutes(5))
-            .externalRefreshListener(List.of())
-            .internalRefreshListener(List.of())
             .circuitBreakerService(new NoneCircuitBreakerService())
             .globalCheckpointSupplier(globalCheckpoint::longValue)
             .retentionLeasesSupplier(() -> RetentionLeases.EMPTY)

--- a/x-pack/plugin/frozen-indices/src/test/java/org/elasticsearch/index/engine/frozen/FrozenEngineTests.java
+++ b/x-pack/plugin/frozen-indices/src/test/java/org/elasticsearch/index/engine/frozen/FrozenEngineTests.java
@@ -189,7 +189,7 @@ public class FrozenEngineTests extends EngineTestCase {
         int numDocsAdded = 0;
         for (int i = 0; i < numDocs; i++) {
             numDocsAdded++;
-            ParsedDocument doc = testParsedDocument(Integer.toString(i), null, testDocument(), new BytesArray("{}"), null);
+            ParsedDocument doc = testParsedDocument(Integer.toString(i), null, testDocument(), new BytesArray("{}"));
             engine.index(
                 new Engine.Index(
                     newUid(doc),

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/reshard/SnapshotsWithReshardingIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/reshard/SnapshotsWithReshardingIT.java
@@ -517,39 +517,9 @@ public class SnapshotsWithReshardingIT extends AbstractStatelessPluginIntegTestC
                     return snapshotCommitSupplier.acquireIndexCommitForSnapshot(engine);
                 };
 
-                EngineConfig customEngineConfig = new EngineConfig(
-                    engineConfig.getShardId(),
-                    engineConfig.getThreadPool(),
-                    engineConfig.getThreadPoolMergeExecutorService(),
-                    engineConfig.getIndexSettings(),
-                    engineConfig.getWarmer(),
-                    engineConfig.getStore(),
-                    engineConfig.getMergePolicy(),
-                    engineConfig.getAnalyzer(),
-                    engineConfig.getSimilarity(),
-                    engineConfig.getCodecProvider(),
-                    engineConfig.getEventListener(),
-                    engineConfig.getQueryCache(),
-                    engineConfig.getQueryCachingPolicy(),
-                    engineConfig.getTranslogConfig(),
-                    engineConfig.getFlushMergesAfter(),
-                    engineConfig.getExternalRefreshListener(),
-                    engineConfig.getInternalRefreshListener(),
-                    engineConfig.getIndexSort(),
-                    engineConfig.getCircuitBreakerService(),
-                    engineConfig.getGlobalCheckpointSupplier(),
-                    engineConfig.retentionLeasesSupplier(),
-                    engineConfig.getPrimaryTermSupplier(),
-                    customSnapshotCommitSupplier,
-                    engineConfig.getLeafSorter(),
-                    engineConfig.getRelativeTimeInNanosSupplier(),
-                    engineConfig.getIndexCommitListener(),
-                    engineConfig.isPromotableToPrimary(),
-                    engineConfig.getMapperService(),
-                    engineConfig.getEngineResetLock(),
-                    engineConfig.getMergeMetrics(),
-                    engineConfig.getIndexDeletionPolicyWrapper()
-                );
+                EngineConfig customEngineConfig = EngineConfig.builder(engineConfig)
+                    .snapshotCommitSupplier(customSnapshotCommitSupplier)
+                    .build();
 
                 return factory.newReadWriteEngine(customEngineConfig);
             });

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/snapshots/StatelessSnapshotIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/snapshots/StatelessSnapshotIT.java
@@ -1228,39 +1228,7 @@ public class StatelessSnapshotIT extends AbstractStatelessPluginIntegTestCase {
                     }
                     return commitRef;
                 };
-                final var wrappedConfig = new EngineConfig(
-                    engineConfig.getShardId(),
-                    engineConfig.getThreadPool(),
-                    engineConfig.getThreadPoolMergeExecutorService(),
-                    engineConfig.getIndexSettings(),
-                    engineConfig.getWarmer(),
-                    engineConfig.getStore(),
-                    engineConfig.getMergePolicy(),
-                    engineConfig.getAnalyzer(),
-                    engineConfig.getSimilarity(),
-                    engineConfig.getCodecProvider(),
-                    engineConfig.getEventListener(),
-                    engineConfig.getQueryCache(),
-                    engineConfig.getQueryCachingPolicy(),
-                    engineConfig.getTranslogConfig(),
-                    engineConfig.getFlushMergesAfter(),
-                    engineConfig.getExternalRefreshListener(),
-                    engineConfig.getInternalRefreshListener(),
-                    engineConfig.getIndexSort(),
-                    engineConfig.getCircuitBreakerService(),
-                    engineConfig.getGlobalCheckpointSupplier(),
-                    engineConfig.retentionLeasesSupplier(),
-                    engineConfig.getPrimaryTermSupplier(),
-                    wrappedCommitSupplier,
-                    engineConfig.getLeafSorter(),
-                    engineConfig.getRelativeTimeInNanosSupplier(),
-                    engineConfig.getIndexCommitListener(),
-                    engineConfig.isPromotableToPrimary(),
-                    engineConfig.getMapperService(),
-                    engineConfig.getEngineResetLock(),
-                    engineConfig.getMergeMetrics(),
-                    engineConfig.getIndexDeletionPolicyWrapper()
-                );
+                final var wrappedConfig = EngineConfig.builder(engineConfig).snapshotCommitSupplier(wrappedCommitSupplier).build();
                 return factory.newReadWriteEngine(wrappedConfig);
             });
         }

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/StatelessPlugin.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/StatelessPlugin.java
@@ -1553,13 +1553,8 @@ public class StatelessPlugin extends Plugin
                     false // translog is replicated to the object store, no need fsync that
                 );
 
-                var internalRefreshListeners = config.getInternalRefreshListener();
-                if (internalRefreshListeners == null) {
-                    internalRefreshListeners = List.of();
-                }
-
-                internalRefreshListeners = Stream.concat(
-                    internalRefreshListeners.stream(),
+                var internalRefreshListeners = Stream.concat(
+                    config.getInternalRefreshListener().stream(),
                     Stream.of(getUpdateMetricsRefreshListener(config))
                 ).toList();
 

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/StatelessPlugin.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/StatelessPlugin.java
@@ -1595,41 +1595,15 @@ public class StatelessPlugin extends Plugin
                     indexEngineDeletionPolicyCommitsListener = null;
                 }
 
-                EngineConfig newConfig = new EngineConfig(
-                    config.getShardId(),
-                    config.getThreadPool(),
-                    config.getThreadPoolMergeExecutorService(),
-                    config.getIndexSettings(),
-                    config.getWarmer(),
-                    config.getStore(),
-                    getMergePolicy(config),
-                    config.getAnalyzer(),
-                    config.getSimilarity(),
-                    getCodecProvider(config),
-                    config.getEventListener(),
-                    config.getQueryCache(),
-                    config.getQueryCachingPolicy(),
-                    newTranslogConfig,
-                    config.getFlushMergesAfter(),
-                    config.getExternalRefreshListener(),
-                    internalRefreshListeners,
-                    config.getIndexSort(),
-                    config.getCircuitBreakerService(),
-                    config.getGlobalCheckpointSupplier(),
-                    config.retentionLeasesSupplier(),
-                    config.getPrimaryTermSupplier(),
-                    config.getSnapshotCommitSupplier(),
-                    config.getLeafSorter(),
-                    config.getRelativeTimeInNanosSupplier(),
-                    config.getIndexCommitListener(),
-                    config.isPromotableToPrimary(),
-                    config.getMapperService(),
-                    config.getEngineResetLock(),
-                    config.getMergeMetrics(),
+                EngineConfig newConfig = EngineConfig.builder(config)
+                    .mergePolicy(getMergePolicy(config))
+                    .codecProvider(getCodecProvider(config))
+                    .translogConfig(newTranslogConfig)
+                    .internalRefreshListener(internalRefreshListeners)
                     // Here we pass an index deletion policy wrapper to the engine. This is the only way we have to pass the
                     // LocalCommitsRefs and the listener to the IndexWriter's policy, because the IndexWriter is created during
                     // InternalEngine construction, before IndexEngine class attributes are set.
-                    policy -> {
+                    .indexDeletionPolicyWrapper(policy -> {
                         if (hollowShardsEnabled) {
                             // If there is no default policy, we assume it is an hollow index engine
                             if (policy instanceof CombinedDeletionPolicy combinedDeletionPolicy) {
@@ -1645,8 +1619,8 @@ public class StatelessPlugin extends Plugin
                         } else {
                             return policy;
                         }
-                    }
-                );
+                    })
+                    .build();
 
                 final Engine engine = newHollowOrIndexEngine(indexSettings, newConfig);
 

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/engine/AbstractEngineTestCase.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/engine/AbstractEngineTestCase.java
@@ -118,7 +118,6 @@ import java.util.function.LongConsumer;
 import java.util.function.LongFunction;
 import java.util.function.LongSupplier;
 
-import static java.util.Collections.emptyList;
 import static org.elasticsearch.blobcache.shared.SharedBlobCacheService.SHARED_CACHE_REGION_SIZE_SETTING;
 import static org.elasticsearch.common.util.concurrent.EsExecutors.DIRECT_EXECUTOR_SERVICE;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
@@ -375,8 +374,8 @@ public abstract class AbstractEngineTestCase extends ESTestCase {
             .queryCachingPolicy(IndexSearcher.getDefaultQueryCachingPolicy())
             .translogConfig(translogConfig)
             .flushMergesAfter(IndexingMemoryController.SHARD_INACTIVE_TIME_SETTING.get(indexSettings.getSettings()))
-            .externalRefreshListener(emptyList())
-            .internalRefreshListener(emptyList())
+            .externalRefreshListener(List.of())
+            .internalRefreshListener(List.of())
             .circuitBreakerService(new NoneCircuitBreakerService())
             .globalCheckpointSupplier(() -> SequenceNumbers.NO_OPS_PERFORMED)
             .retentionLeasesSupplier(() -> RetentionLeases.EMPTY)

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/engine/AbstractEngineTestCase.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/engine/AbstractEngineTestCase.java
@@ -360,39 +360,36 @@ public abstract class AbstractEngineTestCase extends ESTestCase {
         );
         store.associateIndexWithNewTranslog(translogUuid);
 
-        return new EngineConfig(
-            shardId,
-            threadPool,
-            threadPoolMergeExecutorService,
-            indexSettings,
-            null,
-            store,
-            mergePolicy,
-            indexWriterConfig.getAnalyzer(),
-            indexWriterConfig.getSimilarity(),
-            new CodecService(null, BigArrays.NON_RECYCLING_INSTANCE, threadPool),
-            new CapturingEngineEventListener(),
-            IndexSearcher.getDefaultQueryCache(),
-            IndexSearcher.getDefaultQueryCachingPolicy(),
-            translogConfig,
-            IndexingMemoryController.SHARD_INACTIVE_TIME_SETTING.get(indexSettings.getSettings()),
-            emptyList(),
-            emptyList(),
-            null,
-            new NoneCircuitBreakerService(),
-            () -> SequenceNumbers.NO_OPS_PERFORMED,
-            () -> RetentionLeases.EMPTY,
-            primaryTermSupplier,
-            IndexModule.DEFAULT_SNAPSHOT_COMMIT_SUPPLIER,
-            null,
-            threadPool::relativeTimeInNanos,
-            new CapturingIndexCommitListener(),
-            true,
-            mapperService,
-            new EngineResetLock(),
-            MergeMetrics.NOOP,
-            Function.identity()
-        );
+        return EngineConfig.builder()
+            .shardId(shardId)
+            .threadPool(threadPool)
+            .threadPoolMergeExecutorService(threadPoolMergeExecutorService)
+            .indexSettings(indexSettings)
+            .store(store)
+            .mergePolicy(mergePolicy)
+            .analyzer(indexWriterConfig.getAnalyzer())
+            .similarity(indexWriterConfig.getSimilarity())
+            .codecProvider(new CodecService(null, BigArrays.NON_RECYCLING_INSTANCE, threadPool))
+            .eventListener(new CapturingEngineEventListener())
+            .queryCache(IndexSearcher.getDefaultQueryCache())
+            .queryCachingPolicy(IndexSearcher.getDefaultQueryCachingPolicy())
+            .translogConfig(translogConfig)
+            .flushMergesAfter(IndexingMemoryController.SHARD_INACTIVE_TIME_SETTING.get(indexSettings.getSettings()))
+            .externalRefreshListener(emptyList())
+            .internalRefreshListener(emptyList())
+            .circuitBreakerService(new NoneCircuitBreakerService())
+            .globalCheckpointSupplier(() -> SequenceNumbers.NO_OPS_PERFORMED)
+            .retentionLeasesSupplier(() -> RetentionLeases.EMPTY)
+            .primaryTermSupplier(primaryTermSupplier)
+            .snapshotCommitSupplier(IndexModule.DEFAULT_SNAPSHOT_COMMIT_SUPPLIER)
+            .relativeTimeInNanosSupplier(threadPool::relativeTimeInNanos)
+            .indexCommitListener(new CapturingIndexCommitListener())
+            .promotableToPrimary(true)
+            .mapperService(mapperService)
+            .engineResetLock(new EngineResetLock())
+            .mergeMetrics(MergeMetrics.NOOP)
+            .indexDeletionPolicyWrapper(Function.identity())
+            .build();
     }
 
     protected SearchEngine newSearchEngine() {
@@ -523,41 +520,23 @@ public abstract class AbstractEngineTestCase extends ESTestCase {
             )
         );
         var store = new Store(shardId, indexSettings, directory, new DummyShardLock(shardId));
-        final EngineConfig searchConfig = new EngineConfig(
-            shardId,
-            threadPool,
-            threadPoolMergeExecutorService,
-            indexSettings,
-            null,
-            store,
-            null,
-            null,
-            null,
-            null,
-            new CapturingEngineEventListener(),
-            null,
-            IndexSearcher.getDefaultQueryCachingPolicy(),
-            null,
-            null,
-            List.of(),
-            null,
-            null,
-            null,
-            null,
-            () -> {
+        final EngineConfig searchConfig = EngineConfig.builder()
+            .shardId(shardId)
+            .threadPool(threadPool)
+            .threadPoolMergeExecutorService(threadPoolMergeExecutorService)
+            .indexSettings(indexSettings)
+            .store(store)
+            .eventListener(new CapturingEngineEventListener())
+            .queryCachingPolicy(IndexSearcher.getDefaultQueryCachingPolicy())
+            .externalRefreshListener(List.of())
+            .retentionLeasesSupplier(() -> {
                 throw new AssertionError();
-            },
-            primaryTermSupplier,
-            null,
-            null,
-            null,
-            null,
-            false,
-            null,
-            new EngineResetLock(),
-            MergeMetrics.NOOP,
-            Function.identity()
-        );
+            })
+            .primaryTermSupplier(primaryTermSupplier)
+            .engineResetLock(new EngineResetLock())
+            .mergeMetrics(MergeMetrics.NOOP)
+            .indexDeletionPolicyWrapper(Function.identity())
+            .build();
         ClusterSettings clusterSettings = new ClusterSettings(
             Settings.EMPTY,
             Sets.addToCopy(
@@ -639,41 +618,23 @@ public abstract class AbstractEngineTestCase extends ESTestCase {
             )
         );
         var store = new Store(shardId, indexSettings, directory, new DummyShardLock(shardId));
-        return new EngineConfig(
-            shardId,
-            threadPool,
-            threadPoolMergeExecutorService,
-            indexSettings,
-            null,
-            store,
-            null,
-            null,
-            null,
-            null,
-            new CapturingEngineEventListener(),
-            null,
-            IndexSearcher.getDefaultQueryCachingPolicy(),
-            null,
-            null,
-            List.of(),
-            null,
-            null,
-            null,
-            null,
-            () -> {
+        return EngineConfig.builder()
+            .shardId(shardId)
+            .threadPool(threadPool)
+            .threadPoolMergeExecutorService(threadPoolMergeExecutorService)
+            .indexSettings(indexSettings)
+            .store(store)
+            .eventListener(new CapturingEngineEventListener())
+            .queryCachingPolicy(IndexSearcher.getDefaultQueryCachingPolicy())
+            .externalRefreshListener(List.of())
+            .retentionLeasesSupplier(() -> {
                 throw new AssertionError();
-            },
-            directory.getCurrentCommit()::primaryTerm,
-            null,
-            null,
-            null,
-            null,
-            false,
-            null,
-            new EngineResetLock(),
-            MergeMetrics.NOOP,
-            Function.identity()
-        );
+            })
+            .primaryTermSupplier(directory.getCurrentCommit()::primaryTerm)
+            .engineResetLock(new EngineResetLock())
+            .mergeMetrics(MergeMetrics.NOOP)
+            .indexDeletionPolicyWrapper(Function.identity())
+            .build();
     }
 
     protected static Engine.Index randomDoc(String id) throws IOException {

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/engine/AbstractEngineTestCase.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/engine/AbstractEngineTestCase.java
@@ -374,8 +374,6 @@ public abstract class AbstractEngineTestCase extends ESTestCase {
             .queryCachingPolicy(IndexSearcher.getDefaultQueryCachingPolicy())
             .translogConfig(translogConfig)
             .flushMergesAfter(IndexingMemoryController.SHARD_INACTIVE_TIME_SETTING.get(indexSettings.getSettings()))
-            .externalRefreshListener(List.of())
-            .internalRefreshListener(List.of())
             .circuitBreakerService(new NoneCircuitBreakerService())
             .globalCheckpointSupplier(() -> SequenceNumbers.NO_OPS_PERFORMED)
             .retentionLeasesSupplier(() -> RetentionLeases.EMPTY)
@@ -527,7 +525,6 @@ public abstract class AbstractEngineTestCase extends ESTestCase {
             .store(store)
             .eventListener(new CapturingEngineEventListener())
             .queryCachingPolicy(IndexSearcher.getDefaultQueryCachingPolicy())
-            .externalRefreshListener(List.of())
             .retentionLeasesSupplier(() -> {
                 throw new AssertionError();
             })
@@ -625,7 +622,6 @@ public abstract class AbstractEngineTestCase extends ESTestCase {
             .store(store)
             .eventListener(new CapturingEngineEventListener())
             .queryCachingPolicy(IndexSearcher.getDefaultQueryCachingPolicy())
-            .externalRefreshListener(List.of())
             .retentionLeasesSupplier(() -> {
                 throw new AssertionError();
             })

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/engine/HollowIndexEngineTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/engine/HollowIndexEngineTests.java
@@ -107,7 +107,7 @@ public class HollowIndexEngineTests extends EngineTestCase {
         IOUtils.close(engine, store);
         try (Store store = createStore()) {
             var globalCheckpoint = new AtomicLong(SequenceNumbers.NO_OPS_PERFORMED);
-            var engineConfig = config(defaultSettings, store, createTempDir(), NoMergePolicy.INSTANCE, null, null, globalCheckpoint::get);
+            var engineConfig = config(defaultSettings, store, createTempDir(), NoMergePolicy.INSTANCE, globalCheckpoint::get);
             int numDocs = randomIntBetween(8, 32);
 
             createEmptyStore(store, engineConfig);
@@ -136,7 +136,7 @@ public class HollowIndexEngineTests extends EngineTestCase {
         IOUtils.close(engine, store);
         try (Store store = createStore()) {
             var globalCheckpoint = new AtomicLong(SequenceNumbers.NO_OPS_PERFORMED);
-            var engineConfig = config(defaultSettings, store, createTempDir(), NoMergePolicy.INSTANCE, null, null, globalCheckpoint::get);
+            var engineConfig = config(defaultSettings, store, createTempDir(), NoMergePolicy.INSTANCE, globalCheckpoint::get);
             int numDocs = randomIntBetween(8, 32);
 
             createEmptyStore(store, engineConfig);
@@ -165,7 +165,7 @@ public class HollowIndexEngineTests extends EngineTestCase {
         IOUtils.close(engine, store);
         try (Store store = createStore()) {
             var globalCheckpoint = new AtomicLong(SequenceNumbers.NO_OPS_PERFORMED);
-            var engineConfig = config(defaultSettings, store, createTempDir(), NoMergePolicy.INSTANCE, null, null, globalCheckpoint::get);
+            var engineConfig = config(defaultSettings, store, createTempDir(), NoMergePolicy.INSTANCE, globalCheckpoint::get);
             int numDocs = randomIntBetween(8, 32);
 
             createEmptyStore(store, engineConfig);
@@ -194,7 +194,7 @@ public class HollowIndexEngineTests extends EngineTestCase {
         IOUtils.close(engine, store);
         try (Store store = createStore()) {
             var globalCheckpoint = new AtomicLong(SequenceNumbers.NO_OPS_PERFORMED);
-            var engineConfig = config(defaultSettings, store, createTempDir(), NoMergePolicy.INSTANCE, null, null, globalCheckpoint::get);
+            var engineConfig = config(defaultSettings, store, createTempDir(), NoMergePolicy.INSTANCE, globalCheckpoint::get);
             int numDocs = randomIntBetween(8, 32);
 
             createEmptyStore(store, engineConfig);
@@ -241,7 +241,7 @@ public class HollowIndexEngineTests extends EngineTestCase {
         IOUtils.close(engine, store);
         try (Store store = createStore()) {
             var globalCheckpoint = new AtomicLong(SequenceNumbers.NO_OPS_PERFORMED);
-            var engineConfig = config(defaultSettings, store, createTempDir(), NoMergePolicy.INSTANCE, null, null, globalCheckpoint::get);
+            var engineConfig = config(defaultSettings, store, createTempDir(), NoMergePolicy.INSTANCE, globalCheckpoint::get);
             var documentMapper = engineConfig.getMapperService().documentMapper();
             var mappingLookup = engineConfig.getMapperService().mappingLookup();
             int numDocs = randomIntBetween(8, 32);

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/snapshots/StatelessSnapshotResiliencyTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/snapshots/StatelessSnapshotResiliencyTests.java
@@ -1055,39 +1055,10 @@ public class StatelessSnapshotResiliencyTests extends SnapshotResiliencyTests {
                         false // translog is replicated to the object store, no need fsync that
                     );
 
-                    EngineConfig newConfig = new EngineConfig(
-                        config.getShardId(),
-                        config.getThreadPool(),
-                        config.getThreadPoolMergeExecutorService(),
-                        config.getIndexSettings(),
-                        config.getWarmer(),
-                        config.getStore(),
-                        config.getMergePolicy(),
-                        config.getAnalyzer(),
-                        config.getSimilarity(),
-                        config.getCodecProvider(),
-                        config.getEventListener(),
-                        config.getQueryCache(),
-                        config.getQueryCachingPolicy(),
-                        newTranslogConfig,
-                        config.getFlushMergesAfter(),
-                        config.getExternalRefreshListener(),
-                        config.getInternalRefreshListener(),
-                        config.getIndexSort(),
-                        config.getCircuitBreakerService(),
-                        config.getGlobalCheckpointSupplier(),
-                        config.retentionLeasesSupplier(),
-                        config.getPrimaryTermSupplier(),
-                        config.getSnapshotCommitSupplier(),
-                        config.getLeafSorter(),
-                        config.getRelativeTimeInNanosSupplier(),
-                        config.getIndexCommitListener(),
-                        config.isPromotableToPrimary(),
-                        config.getMapperService(),
-                        config.getEngineResetLock(),
-                        config.getMergeMetrics(),
-                        policy -> policy
-                    );
+                    EngineConfig newConfig = EngineConfig.builder(config)
+                        .translogConfig(newTranslogConfig)
+                        .indexDeletionPolicyWrapper(policy -> policy)
+                        .build();
 
                     return new IndexEngine(
                         newConfig,


### PR DESCRIPTION
This came up in https://github.com/elastic/elasticsearch/pull/149209 where I added a new call to the `EngineConfig` constructor. I thought it would be reasonable to take on cleaning that up on `main` and then merging an updated `main` into that other PR.

This is mostly pretty mechanical, and **_mostly_** it touches the tests, but there are some non-test changes, too, so don't just take my word for it.

Losing all the `copy(...)` methods in `EngineTestCase` should help demonstrate the value of this, I think.