### PR TITLE
Maintain array order for keyword fields in columnar mode

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldArrayContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldArrayContext.java
@@ -137,33 +137,30 @@ public class FieldArrayContext {
         boolean multiValue
     ) {
         var sourceKeepMode = fieldMapperBuilder.sourceKeepMode.orElse(indexSourceKeepMode);
-        if (context.isSourceSynthetic()
-            && sourceKeepMode == Mapper.SourceKeepMode.ARRAYS
-            && hasDocValues
+
+        if (context.isSourceSynthetic() && hasDocValues
+        // Skip stored, we will be synthesizing from stored fields, no point to keep track of the offsets
             && isStored == false
+            // Skip nested docs - we don't have per-nested-doc offset tracking
             && context.isInNestedContext() == false
+            // Skip copy_to and multi fields, supporting that requires more work. copy_to usage is rare in metrics and logging use cases.
             && fieldMapperBuilder.copyTo.copyToFields().isEmpty()
             && fieldMapperBuilder.multiFieldsBuilder.hasMultiFields() == false
             && indexVersionSupportStoringArraysNatively(indexCreatedVersion, minSupportedVersionMain)) {
-            // Skip stored, we will be synthesizing from stored fields, no point to keep track of the offsets
-            // Skip copy_to and multi fields, supporting that requires more work. However, copy_to usage is rare in metrics and
-            // logging use cases
 
-            // keep track of value offsets so that we can reconstruct arrays from doc values in order as was specified during indexing
-            // (if field is stored then there is no point of doing this)
-            return context.buildFullName(offsetsFieldName(fieldMapperBuilder.leafName()));
-        } else if (context.isSourceSynthetic()
-            && multiValue
-            && isColumnar
-            && hasDocValues
-            && isStored == false
-            && context.isInNestedContext() == false) {
-                // Columnar multi-value path: ordering preservation is implicit on every eligible field, so we don't require
-                // source_keep_mode=ARRAYS, copy_to to be empty, or multi-fields to be empty.
+            // source_keep_mode = ARRAYS path
+            if (sourceKeepMode == Mapper.SourceKeepMode.ARRAYS) {
                 return context.buildFullName(offsetsFieldName(fieldMapperBuilder.leafName()));
-            } else {
-                return null;
             }
+
+            // multi_value = true + columnar mode path
+            if (multiValue && isColumnar) {
+                return context.buildFullName(offsetsFieldName(fieldMapperBuilder.leafName()));
+            }
+        }
+
+        // Otherwise, offsets won't be recorded
+        return null;
     }
 
     private static boolean indexVersionSupportStoringArraysNatively(

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldArrayContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldArrayContext.java
@@ -138,7 +138,8 @@ public class FieldArrayContext {
     ) {
         var sourceKeepMode = fieldMapperBuilder.sourceKeepMode.orElse(indexSourceKeepMode);
 
-        if (context.isSourceSynthetic() && hasDocValues
+        // source_keep_mode = arrays path
+        if (sourceKeepMode == Mapper.SourceKeepMode.ARRAYS && context.isSourceSynthetic() && hasDocValues
         // Skip stored, we will be synthesizing from stored fields, no point to keep track of the offsets
             && isStored == false
             // Skip nested docs - we don't have per-nested-doc offset tracking
@@ -148,15 +149,18 @@ public class FieldArrayContext {
             && fieldMapperBuilder.multiFieldsBuilder.hasMultiFields() == false
             && indexVersionSupportStoringArraysNatively(indexCreatedVersion, minSupportedVersionMain)) {
 
-            // source_keep_mode = ARRAYS path
-            if (sourceKeepMode == Mapper.SourceKeepMode.ARRAYS) {
-                return context.buildFullName(offsetsFieldName(fieldMapperBuilder.leafName()));
-            }
+            return context.buildFullName(offsetsFieldName(fieldMapperBuilder.leafName()));
+        }
 
-            // multi_value = true + columnar mode path
-            if (multiValue && isColumnar) {
-                return context.buildFullName(offsetsFieldName(fieldMapperBuilder.leafName()));
-            }
+        // multi_value = true + columnar mode path
+        // Note, stored fields and nested docs will not be allowed in columnar mode - no need to check them explicitly
+        // Note, doc values cannot be disabled in columnar mode
+        if (multiValue && isColumnar && context.isSourceSynthetic()
+        // skip copy_to and multi fields for now - they wll be supported in a follow up
+            && fieldMapperBuilder.copyTo.copyToFields().isEmpty()
+            && fieldMapperBuilder.multiFieldsBuilder.hasMultiFields() == false) {
+
+            return context.buildFullName(offsetsFieldName(fieldMapperBuilder.leafName()));
         }
 
         // Otherwise, offsets won't be recorded

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -246,6 +246,8 @@ public final class KeywordFieldMapper extends FieldMapper {
         private final IndexSettings indexSettings;
         private final boolean storeIgnoredFieldsInBinaryDocValues;
 
+        private String offsetsFieldName;
+
         public Builder(final String name, final MappingParserContext mappingParserContext) {
             this(
                 name,
@@ -480,14 +482,16 @@ public final class KeywordFieldMapper extends FieldMapper {
             super.hasScript = script.get() != null;
             super.onScriptError = onScriptError.getValue();
 
-            String offsetsFieldName = getOffsetsFieldName(
+            this.offsetsFieldName = getOffsetsFieldName(
                 context,
                 indexSettings.sourceKeepMode(),
                 docValuesParameters().enabled(),
                 stored.getValue(),
                 this,
                 indexCreatedVersion,
-                IndexVersions.SYNTHETIC_SOURCE_STORE_ARRAYS_NATIVELY_KEYWORD
+                IndexVersions.SYNTHETIC_SOURCE_STORE_ARRAYS_NATIVELY_KEYWORD,
+                indexSettings.getMode().isColumnar(),
+                docValuesParameters().multiValue()
             );
             return new KeywordFieldMapper(
                 leafName(),
@@ -580,6 +584,7 @@ public final class KeywordFieldMapper extends FieldMapper {
         private final boolean usesBinaryDocValuesForIgnoredFields;
         private final DocValuesParameter.Values docValuesParams;
         private final IndexVersion indexVersion;
+        private final boolean readInArrayOrder;
 
         public KeywordFieldType(
             String name,
@@ -612,6 +617,9 @@ public final class KeywordFieldMapper extends FieldMapper {
             this.usesBinaryDocValuesForIgnoredFields = builder.storeIgnoredFieldsInBinaryDocValues;
             this.docValuesParams = builder.docValuesParameters();
             this.indexVersion = builder.indexSettings.getIndexVersionCreated();
+            this.readInArrayOrder = builder.offsetsFieldName != null
+                && builder.docValuesParameters().multiValue()
+                && builder.indexSettings.getMode().isColumnar();
         }
 
         public KeywordFieldType(String name) {
@@ -640,6 +648,7 @@ public final class KeywordFieldMapper extends FieldMapper {
             this.usesBinaryDocValuesForIgnoredFields = false;
             this.docValuesParams = null;
             this.indexVersion = IndexVersion.current();
+            this.readInArrayOrder = false;
         }
 
         public KeywordFieldType(String name, FieldType fieldType, boolean isSyntheticSource) {
@@ -662,6 +671,7 @@ public final class KeywordFieldMapper extends FieldMapper {
             this.usesBinaryDocValuesForIgnoredFields = false;
             this.docValuesParams = null;
             this.indexVersion = IndexVersion.current();
+            this.readInArrayOrder = false;
         }
 
         public KeywordFieldType(String name, NamedAnalyzer analyzer) {
@@ -684,6 +694,7 @@ public final class KeywordFieldMapper extends FieldMapper {
             this.usesBinaryDocValuesForIgnoredFields = false;
             this.docValuesParams = null;
             this.indexVersion = IndexVersion.current();
+            this.readInArrayOrder = false;
         }
 
         public boolean usesBinaryDocValues() {
@@ -924,10 +935,10 @@ public final class KeywordFieldMapper extends FieldMapper {
                         if (docValuesParams != null && docValuesParams.multiValue() == false) {
                             return new BytesRefsFromBinaryBlockLoader(name());
                         } else {
-                            return new BytesRefsFromBinaryMultiSeparateCountBlockLoader(name());
+                            return new BytesRefsFromBinaryMultiSeparateCountBlockLoader(name(), readInArrayOrder);
                         }
                     } else {
-                        return new BytesRefsFromOrdsBlockLoader(name(), blContext.ordinalsByteSize());
+                        return new BytesRefsFromOrdsBlockLoader(name(), blContext.ordinalsByteSize(), readInArrayOrder);
                     }
                 }
                 return switch (cfg.function()) {
@@ -1408,13 +1419,19 @@ public final class KeywordFieldMapper extends FieldMapper {
         }
 
         boolean indexed = indexValue(context, value);
-        if (offsetsFieldName != null && context.isImmediateParentAnArray() && context.canAddIgnoredField()) {
+        if (shouldRecordOffset(context)) {
             if (indexed) {
                 context.getOffSetContext().recordOffset(offsetsFieldName, value.bytes());
             } else if (value == null) {
                 context.getOffSetContext().recordNull(offsetsFieldName);
             }
         }
+    }
+
+    private boolean shouldRecordOffset(DocumentParserContext context) {
+        return offsetsFieldName != null && context.isImmediateParentAnArray()
+        // canAddIgnoreField is for source_keep_mode
+            && (context.canAddIgnoredField() || (docValuesParameters.multiValue() && indexSettings.getMode().isColumnar()));
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/index/mapper/FieldArrayContextTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FieldArrayContextTests.java
@@ -90,15 +90,6 @@ public class FieldArrayContextTests extends ESTestCase {
         FieldMapper.Builder builder = newTestBuilder("field");
         MapperBuilderContext syntheticRoot = MapperBuilderContext.root(true, false);
         MapperBuilderContext storedRoot = MapperBuilderContext.root(false, false);
-        MapperBuilderContext nestedSynthetic = new MapperBuilderContext(
-            null,
-            true,
-            false,
-            false,
-            ObjectMapper.Defaults.DYNAMIC,
-            MapperService.MergeReason.MAPPING_UPDATE,
-            true
-        );
 
         // not synthetic source
         assertNull(
@@ -140,48 +131,6 @@ public class FieldArrayContextTests extends ESTestCase {
                 IndexVersions.MINIMUM_COMPATIBLE,
                 true,
                 false
-            )
-        );
-        // no doc values
-        assertNull(
-            getOffsetsFieldName(
-                syntheticRoot,
-                Mapper.SourceKeepMode.NONE,
-                false,
-                false,
-                builder,
-                IndexVersion.current(),
-                IndexVersions.MINIMUM_COMPATIBLE,
-                true,
-                true
-            )
-        );
-        // stored
-        assertNull(
-            getOffsetsFieldName(
-                syntheticRoot,
-                Mapper.SourceKeepMode.NONE,
-                true,
-                true,
-                builder,
-                IndexVersion.current(),
-                IndexVersions.MINIMUM_COMPATIBLE,
-                true,
-                true
-            )
-        );
-        // nested context
-        assertNull(
-            getOffsetsFieldName(
-                nestedSynthetic,
-                Mapper.SourceKeepMode.NONE,
-                true,
-                false,
-                builder,
-                IndexVersion.current(),
-                IndexVersions.MINIMUM_COMPATIBLE,
-                true,
-                true
             )
         );
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/FieldArrayContextTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FieldArrayContextTests.java
@@ -186,13 +186,13 @@ public class FieldArrayContextTests extends ESTestCase {
         );
     }
 
-    public void testGetOffsetsFieldNameColumnarBranchIgnoresCopyToAndMultiFields() {
-        // copy_to set should not block the new branch
+    public void testGetOffsetsFieldNameColumnarBranchExcludesCopyToAndMultiFields() {
+        MapperBuilderContext context = MapperBuilderContext.root(true, false);
+
+        // copy_to blocks the columnar branch — the target's reconstructed source would mix copy_to values with direct writes
         FieldMapper.Builder withCopyTo = newTestBuilder("field");
         withCopyTo.copyTo = FieldMapper.CopyTo.empty().withAddedFields(List.of("target"));
-        MapperBuilderContext context = MapperBuilderContext.root(true, false);
-        assertEquals(
-            "field" + FieldArrayContext.OFFSETS_FIELD_NAME_SUFFIX,
+        assertNull(
             getOffsetsFieldName(
                 context,
                 Mapper.SourceKeepMode.NONE,
@@ -206,11 +206,10 @@ public class FieldArrayContextTests extends ESTestCase {
             )
         );
 
-        // multi-fields should not block the new branch
+        // multi-fields parents are blocked — the offsets sidecar on the parent would be wasted; sub-fields get their own offsets
         FieldMapper.Builder withMultiFields = newTestBuilder("field");
         withMultiFields.multiFieldsBuilder.add(newTestBuilder("sub"));
-        assertEquals(
-            "field" + FieldArrayContext.OFFSETS_FIELD_NAME_SUFFIX,
+        assertNull(
             getOffsetsFieldName(
                 context,
                 Mapper.SourceKeepMode.NONE,

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
@@ -1714,4 +1714,19 @@ public class KeywordFieldMapperTests extends MapperTestCase {
         ParsedDocument doc = mapper.parse(source);
         assertThat(doc.rootDoc().getFields("field"), empty());
     }
+
+    public void testColumnarKeywordArrayOrderRoundTrip() throws IOException {
+        Settings settings = Settings.builder().put(IndexSettings.MODE.getKey(), IndexMode.LOGSDB.name()).build();
+        DocumentMapper mapper = createMapperService(settings, mapping(b -> b.startObject("field").field("type", "keyword").endObject()))
+            .documentMapper();
+
+        String v1 = randomAlphanumericOfLength(4);
+        String v2 = randomAlphanumericOfLength(4);
+        String v3 = randomAlphanumericOfLength(4);
+        // Duplicate v2 — sorted-deduped doc-values order would collapse it; arrival order must be preserved.
+        assertThat(syntheticSource(mapper, b -> {
+            b.array("field", v2, v1, v3, v2);
+            b.field("@timestamp", Instant.now().toEpochMilli());
+        }), containsString("\"field\":[\"" + v2 + "\",\"" + v1 + "\",\"" + v3 + "\",\"" + v2 + "\"]"));
+    }
 }


### PR DESCRIPTION
In columnar mode, multi-valued keyword fields will maintain array order for both synthetic source and ESQL.

Note, the changes here are minimal - I want to land one field first to make sure nothing is broken. Follow up PRs will bundle more fields together.