### PR TITLE
Partitioned memory prototype

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/IndexingPressure.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexingPressure.java
@@ -141,6 +141,13 @@ public class IndexingPressure implements IndexingPressureMonitor {
         this.primaryLimit = limits.primaryLimitBytes();
         this.replicaLimit = limits.replicaLimitBytes();
         this.operationLimit = limits.operationLimitBytes();
+        logger.debug(
+            "Indexing pressure limits: coordinating={}, primary={}, replica={}, operation={}",
+            ByteSizeValue.ofBytes(coordinatingLimit),
+            ByteSizeValue.ofBytes(primaryLimit),
+            ByteSizeValue.ofBytes(replicaLimit),
+            ByteSizeValue.ofBytes(operationLimit)
+        );
     }
 
     public IndexingPressure(Settings settings) {

--- a/server/src/main/java/org/elasticsearch/index/IndexingPressure.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexingPressure.java
@@ -18,6 +18,7 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.index.stats.IndexingPressureStats;
+import org.elasticsearch.indices.IndexingMemoryLimits;
 
 import java.util.List;
 import java.util.Optional;
@@ -131,15 +132,19 @@ public class IndexingPressure implements IndexingPressureMonitor {
 
     private final List<IndexingPressureListener> listeners = new CopyOnWriteArrayList<>();
 
-    public IndexingPressure(Settings settings) {
+    public IndexingPressure(IndexingMemoryLimits limits, Settings settings) {
         this.lowWatermark = SPLIT_BULK_LOW_WATERMARK.get(settings).getBytes();
         this.lowWatermarkSize = SPLIT_BULK_LOW_WATERMARK_SIZE.get(settings).getBytes();
         this.highWatermark = SPLIT_BULK_HIGH_WATERMARK.get(settings).getBytes();
         this.highWatermarkSize = SPLIT_BULK_HIGH_WATERMARK_SIZE.get(settings).getBytes();
-        this.coordinatingLimit = MAX_COORDINATING_BYTES.get(settings).getBytes();
-        this.primaryLimit = MAX_PRIMARY_BYTES.get(settings).getBytes();
-        this.replicaLimit = MAX_REPLICA_BYTES.get(settings).getBytes();
-        this.operationLimit = MAX_OPERATION_SIZE.get(settings).getBytes();
+        this.coordinatingLimit = limits.coordinatingLimitBytes();
+        this.primaryLimit = limits.primaryLimitBytes();
+        this.replicaLimit = limits.replicaLimitBytes();
+        this.operationLimit = limits.operationLimitBytes();
+    }
+
+    public IndexingPressure(Settings settings) {
+        this(IndexingMemoryLimits.fromSettings(settings), settings);
     }
 
     private static Releasable wrapReleasable(Releasable releasable) {

--- a/server/src/main/java/org/elasticsearch/indices/IndexingMemoryController.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndexingMemoryController.java
@@ -126,32 +126,13 @@ public class IndexingMemoryController implements IndexingOperationListener, Clos
     private final Set<IndexShard> pendingWriteIndexingBufferSet = ConcurrentCollections.newConcurrentSet();
     private final Deque<IndexShard> pendingWriteIndexingBufferQueue = new ConcurrentLinkedDeque<>();
 
-    IndexingMemoryController(Settings settings, ThreadPool threadPool, Iterable<IndexShard> indexServices) {
+    IndexingMemoryController(IndexingMemoryLimits limits, Settings settings, ThreadPool threadPool, Iterable<IndexShard> indexServices) {
         this.indexShards = indexServices;
-
-        ByteSizeValue indexingBuffer = INDEX_BUFFER_SIZE_SETTING.get(settings);
-
-        String indexingBufferSetting = settings.get(INDEX_BUFFER_SIZE_SETTING.getKey());
-        // null means we used the default (10%)
-        if (indexingBufferSetting == null || indexingBufferSetting.endsWith("%")) {
-            // We only apply the min/max when % value was used for the index buffer:
-            ByteSizeValue minIndexingBuffer = MIN_INDEX_BUFFER_SIZE_SETTING.get(settings);
-            ByteSizeValue maxIndexingBuffer = MAX_INDEX_BUFFER_SIZE_SETTING.get(settings);
-            if (indexingBuffer.getBytes() < minIndexingBuffer.getBytes()) {
-                indexingBuffer = minIndexingBuffer;
-            }
-            if (maxIndexingBuffer.getBytes() != -1 && indexingBuffer.getBytes() > maxIndexingBuffer.getBytes()) {
-                indexingBuffer = maxIndexingBuffer;
-            }
-        }
-        this.indexingBuffer = indexingBuffer.getBytes();
-
+        this.indexingBuffer = limits.indexBufferBytes();
         this.inactiveTime = SHARD_INACTIVE_TIME_SETTING.get(settings);
         // we need to have this relatively small to free up heap quickly enough
         this.interval = SHARD_MEMORY_INTERVAL_TIME_SETTING.get(settings);
-
         this.statusChecker = new ShardsIndicesStatusChecker();
-
         logger.debug(
             "using indexing buffer size [{}] with {} [{}], {} [{}]",
             this.indexingBuffer,
@@ -161,9 +142,12 @@ public class IndexingMemoryController implements IndexingOperationListener, Clos
             this.interval
         );
         this.scheduler = scheduleTask(threadPool);
-
         // Need to save this so we can later launch async "write indexing buffer to disk" on shards:
         this.threadPool = threadPool;
+    }
+
+    IndexingMemoryController(Settings settings, ThreadPool threadPool, Iterable<IndexShard> indexServices) {
+        this(IndexingMemoryLimits.fromSettings(settings), settings, threadPool, indexServices);
     }
 
     protected Cancellable scheduleTask(ThreadPool threadPool) {

--- a/server/src/main/java/org/elasticsearch/indices/IndexingMemoryLimits.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndexingMemoryLimits.java
@@ -1,9 +1,10 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
 package org.elasticsearch.indices;

--- a/server/src/main/java/org/elasticsearch/indices/IndexingMemoryLimits.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndexingMemoryLimits.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.indices;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexingPressure;
+
+/**
+ * Memory limits applied to indexing-related workloads on a node.
+ * The default implementation derives limits from the existing {@link IndexingPressure} and
+ * {@link IndexingMemoryController} settings. Stateless deployments replace this with a
+ * partition-based implementation so that back-pressure and buffer limits are driven by the
+ * configured partition fractions rather than independent settings.
+ *
+ * <p>Limits are computed once at node startup and are fixed for the node's lifetime.
+ */
+public interface IndexingMemoryLimits {
+
+    /** Max bytes for in-flight coordinating indexing operations before back-pressure is applied. */
+    long coordinatingLimitBytes();
+
+    /** Max bytes for in-flight primary indexing operations before back-pressure is applied. */
+    long primaryLimitBytes();
+
+    /** Max bytes for in-flight replica indexing operations before back-pressure is applied. */
+    long replicaLimitBytes();
+
+    /** Max bytes for a single indexing operation; larger operations are rejected. */
+    long operationLimitBytes();
+
+    /** Bytes allocated for Lucene indexing buffers; shards flush when this is approached. */
+    long indexBufferBytes();
+
+    /**
+     * Returns an {@link IndexingMemoryLimits} derived from the standard
+     * {@link IndexingPressure} and {@link IndexingMemoryController} settings.
+     */
+    static IndexingMemoryLimits fromSettings(Settings settings) {
+        return new SettingsBasedIndexingMemoryLimits(settings);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -318,7 +318,11 @@ public class IndicesService extends AbstractLifecycleComponent
         this.indicesQueryCache = new IndicesQueryCache(settings);
         this.mapperRegistry = builder.mapperRegistry;
         this.namedWriteableRegistry = builder.namedWriteableRegistry;
+        IndexingMemoryLimits indexingMemoryLimits = builder.indexingMemoryLimits != null
+            ? builder.indexingMemoryLimits
+            : IndexingMemoryLimits.fromSettings(settings);
         indexingMemoryController = new IndexingMemoryController(
+            indexingMemoryLimits,
             settings,
             threadPool,
             // ensure we pull an iter with new shards - flatten makes a copy

--- a/server/src/main/java/org/elasticsearch/indices/IndicesServiceBuilder.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesServiceBuilder.java
@@ -59,6 +59,7 @@ import java.util.stream.Collectors;
 
 public class IndicesServiceBuilder {
     Settings settings;
+    IndexingMemoryLimits indexingMemoryLimits;
     PluginsService pluginsService;
     NodeEnvironment nodeEnv;
     NamedXContentRegistry xContentRegistry;
@@ -94,6 +95,11 @@ public class IndicesServiceBuilder {
 
     public IndicesServiceBuilder settings(Settings settings) {
         this.settings = settings;
+        return this;
+    }
+
+    public IndicesServiceBuilder indexingMemoryLimits(IndexingMemoryLimits indexingMemoryLimits) {
+        this.indexingMemoryLimits = indexingMemoryLimits;
         return this;
     }
 

--- a/server/src/main/java/org/elasticsearch/indices/SettingsBasedIndexingMemoryLimits.java
+++ b/server/src/main/java/org/elasticsearch/indices/SettingsBasedIndexingMemoryLimits.java
@@ -1,9 +1,10 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
 package org.elasticsearch.indices;

--- a/server/src/main/java/org/elasticsearch/indices/SettingsBasedIndexingMemoryLimits.java
+++ b/server/src/main/java/org/elasticsearch/indices/SettingsBasedIndexingMemoryLimits.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.indices;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.index.IndexingPressure;
+
+/**
+ * Settings-derived implementation of {@link IndexingMemoryLimits}, preserving the existing
+ * {@link IndexingPressure} and {@link IndexingMemoryController} behaviour for stateful clusters.
+ */
+class SettingsBasedIndexingMemoryLimits implements IndexingMemoryLimits {
+
+    private final long coordinatingLimitBytes;
+    private final long primaryLimitBytes;
+    private final long replicaLimitBytes;
+    private final long operationLimitBytes;
+    private final long indexBufferBytes;
+
+    SettingsBasedIndexingMemoryLimits(Settings settings) {
+        this.coordinatingLimitBytes = IndexingPressure.MAX_COORDINATING_BYTES.get(settings).getBytes();
+        this.primaryLimitBytes = IndexingPressure.MAX_PRIMARY_BYTES.get(settings).getBytes();
+        this.replicaLimitBytes = IndexingPressure.MAX_REPLICA_BYTES.get(settings).getBytes();
+        this.operationLimitBytes = IndexingPressure.MAX_OPERATION_SIZE.get(settings).getBytes();
+        this.indexBufferBytes = resolveIndexBufferBytes(settings);
+    }
+
+    private static long resolveIndexBufferBytes(Settings settings) {
+        ByteSizeValue indexingBuffer = IndexingMemoryController.INDEX_BUFFER_SIZE_SETTING.get(settings);
+        String indexingBufferSetting = settings.get(IndexingMemoryController.INDEX_BUFFER_SIZE_SETTING.getKey());
+        if (indexingBufferSetting == null || indexingBufferSetting.endsWith("%")) {
+            ByteSizeValue min = IndexingMemoryController.MIN_INDEX_BUFFER_SIZE_SETTING.get(settings);
+            ByteSizeValue max = IndexingMemoryController.MAX_INDEX_BUFFER_SIZE_SETTING.get(settings);
+            if (indexingBuffer.getBytes() < min.getBytes()) {
+                return min.getBytes();
+            }
+            if (max.getBytes() != -1 && indexingBuffer.getBytes() > max.getBytes()) {
+                return max.getBytes();
+            }
+        }
+        return indexingBuffer.getBytes();
+    }
+
+    @Override
+    public long coordinatingLimitBytes() {
+        return coordinatingLimitBytes;
+    }
+
+    @Override
+    public long primaryLimitBytes() {
+        return primaryLimitBytes;
+    }
+
+    @Override
+    public long replicaLimitBytes() {
+        return replicaLimitBytes;
+    }
+
+    @Override
+    public long operationLimitBytes() {
+        return operationLimitBytes;
+    }
+
+    @Override
+    public long indexBufferBytes() {
+        return indexBufferBytes;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
@@ -138,6 +138,7 @@ import org.elasticsearch.index.mapper.SourceFieldMetrics;
 import org.elasticsearch.index.search.stats.ShardSearchPhaseAPMMetrics;
 import org.elasticsearch.index.shard.SearchOperationListener;
 import org.elasticsearch.indices.ExecutorSelector;
+import org.elasticsearch.indices.IndexingMemoryLimits;
 import org.elasticsearch.indices.IndicesModule;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.indices.IndicesServiceBuilder;
@@ -182,6 +183,7 @@ import org.elasticsearch.plugins.ClusterCoordinationPlugin;
 import org.elasticsearch.plugins.ClusterPlugin;
 import org.elasticsearch.plugins.DiscoveryPlugin;
 import org.elasticsearch.plugins.HealthPlugin;
+import org.elasticsearch.plugins.IndexingMemoryPlugin;
 import org.elasticsearch.plugins.IngestPlugin;
 import org.elasticsearch.plugins.IpLocationServiceProvider;
 import org.elasticsearch.plugins.MapperPlugin;
@@ -923,6 +925,10 @@ class NodeConstruction {
             }
         };
 
+        final IndexingMemoryLimits indexingMemoryLimits = getSinglePlugin(IndexingMemoryPlugin.class).map(
+            p -> p.getIndexingMemoryLimits(settings)
+        ).orElseGet(() -> IndexingMemoryLimits.fromSettings(settings));
+
         IndicesService indicesService = new IndicesServiceBuilder().settings(settings)
             .pluginsService(pluginsService)
             .nodeEnvironment(nodeEnvironment)
@@ -946,6 +952,7 @@ class NodeConstruction {
             .mergeMetrics(mergeMetrics)
             .searchOperationListeners(searchOperationListeners)
             .loggingFieldsProvider(loggingFieldsProvider)
+            .indexingMemoryLimits(indexingMemoryLimits)
             .build();
 
         final var parameters = new IndexSettingProvider.Parameters(clusterService, indicesService::createIndexMapperServiceForValidation);
@@ -1001,7 +1008,7 @@ class NodeConstruction {
             dataStreamGlobalRetentionSettings
         );
 
-        final IndexingPressure indexingLimits = new IndexingPressure(settings);
+        final IndexingPressure indexingLimits = new IndexingPressure(indexingMemoryLimits, settings);
 
         final var linkedProjectConfigService = pluginsService.loadSingletonServiceProvider(
             LinkedProjectConfigService.Provider.class,

--- a/server/src/main/java/org/elasticsearch/plugins/IndexingMemoryPlugin.java
+++ b/server/src/main/java/org/elasticsearch/plugins/IndexingMemoryPlugin.java
@@ -1,9 +1,10 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
 package org.elasticsearch.plugins;

--- a/server/src/main/java/org/elasticsearch/plugins/IndexingMemoryPlugin.java
+++ b/server/src/main/java/org/elasticsearch/plugins/IndexingMemoryPlugin.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.plugins;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.indices.IndexingMemoryLimits;
+
+/**
+ * Plugin interface for overriding the memory limits applied to indexing-related workloads.
+ * At most one installed plugin may implement this interface.
+ *
+ * <p>Implement this to replace the default settings-based limits ({@link IndexingMemoryLimits#fromSettings})
+ * with partition-derived limits, as stateless deployments do via their partitioned memory model.
+ */
+public interface IndexingMemoryPlugin {
+
+    /**
+     * Returns the {@link IndexingMemoryLimits} to use for this node, given the node-level settings.
+     * Called once during node construction; the returned limits are used for the lifetime of the node.
+     */
+    IndexingMemoryLimits getIndexingMemoryLimits(Settings settings);
+}

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/StatelessPlugin.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/StatelessPlugin.java
@@ -178,11 +178,19 @@ import org.elasticsearch.xpack.stateless.lucene.IndexDirectory;
 import org.elasticsearch.xpack.stateless.lucene.SearchDirectory;
 import org.elasticsearch.xpack.stateless.lucene.StatelessCommitRef;
 import org.elasticsearch.xpack.stateless.memory.HeapMemoryUsagePublisher;
+import org.elasticsearch.xpack.stateless.memory.IndexingTierPartitionMetrics;
 import org.elasticsearch.xpack.stateless.memory.ShardsMappingSizeCollector;
 import org.elasticsearch.xpack.stateless.memory.StatelessMemoryMetricsService;
 import org.elasticsearch.xpack.stateless.memory.TransportPublishHeapMemoryMetrics;
 import org.elasticsearch.xpack.stateless.memory.TransportPublishIndexingOperationsHeapMemoryRequirements;
 import org.elasticsearch.xpack.stateless.memory.TransportPublishMergeMemoryEstimate;
+import org.elasticsearch.xpack.stateless.memory.partition.HeadroomPartition;
+import org.elasticsearch.xpack.stateless.memory.partition.HostedShardsPartition;
+import org.elasticsearch.xpack.stateless.memory.partition.IndexBuffersPartition;
+import org.elasticsearch.xpack.stateless.memory.partition.IndexMetadataPartition;
+import org.elasticsearch.xpack.stateless.memory.partition.IndexingPressurePartition;
+import org.elasticsearch.xpack.stateless.memory.partition.MergePartition;
+import org.elasticsearch.xpack.stateless.memory.partition.PartitionedMemoryModel;
 import org.elasticsearch.xpack.stateless.objectstore.ObjectStoreService;
 import org.elasticsearch.xpack.stateless.objectstore.gc.ObjectStoreGCTask;
 import org.elasticsearch.xpack.stateless.objectstore.gc.ObjectStoreGCTaskExecutor;
@@ -919,6 +927,18 @@ public class StatelessPlugin extends Plugin
         this.statelessMemoryMetricsService.set(memoryMetricsService);
         components.add(memoryMetricsService);
 
+        var partitionedMemoryModel = new PartitionedMemoryModel(
+            List.of(
+                new IndexMetadataPartition(clusterService.getClusterSettings()),
+                new IndexingPressurePartition(clusterService.getClusterSettings()),
+                new IndexBuffersPartition(clusterService.getClusterSettings()),
+                new MergePartition(clusterService.getClusterSettings()),
+                new HostedShardsPartition(clusterService.getClusterSettings()),
+                new HeadroomPartition(clusterService.getClusterSettings())
+            )
+        );
+        IndexingTierPartitionMetrics.create(services.telemetryProvider().getMeterRegistry(), partitionedMemoryModel, memoryMetricsService);
+
         var heapMemoryUsagePublisher = new HeapMemoryUsagePublisher(client);
         components.add(heapMemoryUsagePublisher);
         var shardsMappingSizeCollector = ShardsMappingSizeCollector.create(
@@ -1298,6 +1318,12 @@ public class StatelessPlugin extends Plugin
             StatelessMemoryMetricsService.ADAPTIVE_EXTRA_OVERHEAD_SETTING,
             StatelessMemoryMetricsService.ADAPTIVE_SHARD_MEMORY_ESTIMATION_MIN_THRESHOLD_ENABLED_SETTING,
             StatelessMemoryMetricsService.SELF_REPORTED_SHARD_MEMORY_OVERHEAD_ENABLED_SETTING,
+            IndexMetadataPartition.FRACTION_SETTING,
+            IndexingPressurePartition.FRACTION_SETTING,
+            IndexBuffersPartition.FRACTION_SETTING,
+            MergePartition.FRACTION_SETTING,
+            HostedShardsPartition.FRACTION_SETTING,
+            HeadroomPartition.FRACTION_SETTING,
             ShardsMappingSizeCollector.PUBLISHING_FREQUENCY_SETTING,
             ShardsMappingSizeCollector.CUT_OFF_TIMEOUT_SETTING,
             ShardsMappingSizeCollector.RETRY_INITIAL_DELAY_SETTING,

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/StatelessPlugin.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/StatelessPlugin.java
@@ -297,6 +297,11 @@ public class StatelessPlugin extends Plugin
         TimeValue.timeValueSeconds(30),
         Setting.Property.NodeScope
     );
+    public static final Setting<Boolean> PARTITIONED_MEMORY_ENABLED = Setting.boolSetting(
+        "stateless.partitioned_memory.enabled",
+        false,
+        Setting.Property.NodeScope
+    );
 
     public static final Set<DiscoveryNodeRole> STATELESS_ROLES = Set.of(DiscoveryNodeRole.INDEX_ROLE, DiscoveryNodeRole.SEARCH_ROLE);
 
@@ -1116,7 +1121,11 @@ public class StatelessPlugin extends Plugin
 
     @Override
     public IndexingMemoryLimits getIndexingMemoryLimits(Settings settings) {
-        return PartitionBasedIndexingMemoryLimits.fromSettings(settings);
+        if (PARTITIONED_MEMORY_ENABLED.get(settings)) {
+            return PartitionBasedIndexingMemoryLimits.fromSettings(settings);
+        } else {
+            return IndexingMemoryLimits.fromSettings(settings);
+        }
     }
 
     public IndicesService getIndicesService() {

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/StatelessPlugin.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/StatelessPlugin.java
@@ -87,6 +87,7 @@ import org.elasticsearch.index.store.PluggableDirectoryMetricsHolder;
 import org.elasticsearch.index.store.Store;
 import org.elasticsearch.index.store.ThreadLocalDirectoryMetricHolder;
 import org.elasticsearch.index.translog.TranslogConfig;
+import org.elasticsearch.indices.IndexingMemoryLimits;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
 import org.elasticsearch.indices.cluster.IndexRemovalReason;
@@ -109,6 +110,7 @@ import org.elasticsearch.plugins.ClusterPlugin;
 import org.elasticsearch.plugins.EnginePlugin;
 import org.elasticsearch.plugins.ExtensiblePlugin;
 import org.elasticsearch.plugins.HealthPlugin;
+import org.elasticsearch.plugins.IndexingMemoryPlugin;
 import org.elasticsearch.plugins.PersistentTaskPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.internal.DocumentParsingProvider;
@@ -179,6 +181,7 @@ import org.elasticsearch.xpack.stateless.lucene.SearchDirectory;
 import org.elasticsearch.xpack.stateless.lucene.StatelessCommitRef;
 import org.elasticsearch.xpack.stateless.memory.HeapMemoryUsagePublisher;
 import org.elasticsearch.xpack.stateless.memory.IndexingTierPartitionMetrics;
+import org.elasticsearch.xpack.stateless.memory.PartitionBasedIndexingMemoryLimits;
 import org.elasticsearch.xpack.stateless.memory.ShardsMappingSizeCollector;
 import org.elasticsearch.xpack.stateless.memory.StatelessMemoryMetricsService;
 import org.elasticsearch.xpack.stateless.memory.TransportPublishHeapMemoryMetrics;
@@ -267,6 +270,7 @@ public class StatelessPlugin extends Plugin
         ClusterCoordinationPlugin,
         ExtensiblePlugin,
         HealthPlugin,
+        IndexingMemoryPlugin,
         PersistentTaskPlugin {
 
     private static final Logger logger = LogManager.getLogger(StatelessPlugin.class);
@@ -1108,6 +1112,11 @@ public class StatelessPlugin extends Plugin
 
     public StatelessMemoryMetricsService getStatelessMemoryMetricsService() {
         return Objects.requireNonNull(statelessMemoryMetricsService.get());
+    }
+
+    @Override
+    public IndexingMemoryLimits getIndexingMemoryLimits(Settings settings) {
+        return PartitionBasedIndexingMemoryLimits.fromSettings(settings);
     }
 
     public IndicesService getIndicesService() {

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/IndexingTierPartitionMetrics.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/IndexingTierPartitionMetrics.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.stateless.memory;
+
+import org.elasticsearch.telemetry.metric.LongGauge;
+import org.elasticsearch.telemetry.metric.LongWithAttributes;
+import org.elasticsearch.telemetry.metric.MeterRegistry;
+import org.elasticsearch.xpack.stateless.memory.partition.MemoryPartition;
+import org.elasticsearch.xpack.stateless.memory.partition.PartitionContext;
+import org.elasticsearch.xpack.stateless.memory.partition.PartitionedMemoryModel;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * APM gauges for the indexing-tier partitioned memory model.
+ * Registers one {@code node_heap_requirement} gauge per partition (the minimum node heap
+ * implied by that partition's workload, or 0 for fixed-size partitions) plus aggregate
+ * {@code node_estimate} and {@code tier_estimate} gauges.
+ */
+public record IndexingTierPartitionMetrics(List<LongGauge> partitionGauges, LongGauge nodeEstimateGauge, LongGauge tierEstimateGauge) {
+
+    static final String METRIC_PREFIX = "es.stateless.memory.partition.";
+    static final String NODE_ESTIMATE_METRIC = "es.stateless.memory.node_estimate.bytes";
+    static final String TIER_ESTIMATE_METRIC = "es.stateless.memory.tier_estimate.bytes";
+
+    public static IndexingTierPartitionMetrics create(
+        MeterRegistry meterRegistry,
+        PartitionedMemoryModel model,
+        StatelessMemoryMetricsService memoryMetricsService
+    ) {
+        List<LongGauge> gauges = new ArrayList<>(model.partitions().size());
+        for (MemoryPartition partition : model.partitions()) {
+            gauges.add(
+                meterRegistry.registerLongGauge(
+                    METRIC_PREFIX + partition.name() + ".node_heap_requirement.bytes",
+                    "Minimum node heap implied by the " + partition.name() + " partition",
+                    "bytes",
+                    () -> {
+                        PartitionContext ctx = memoryMetricsService.buildPartitionContext();
+                        return new LongWithAttributes(partition.nodeHeapRequirementBytes(ctx).orElse(0L));
+                    }
+                )
+            );
+        }
+        var nodeEstimateGauge = meterRegistry.registerLongGauge(
+            NODE_ESTIMATE_METRIC,
+            "Partitioned memory model node heap estimate: MAX across all partition requirements",
+            "bytes",
+            () -> new LongWithAttributes(model.nodeEstimateBytes(memoryMetricsService.buildPartitionContext()))
+        );
+        var tierEstimateGauge = meterRegistry.registerLongGauge(
+            TIER_ESTIMATE_METRIC,
+            "Partitioned memory model tier estimate: total hosted-shard memory across the cluster",
+            "bytes",
+            () -> new LongWithAttributes(model.tierEstimateBytes(memoryMetricsService.buildPartitionContext()))
+        );
+        return new IndexingTierPartitionMetrics(List.copyOf(gauges), nodeEstimateGauge, tierEstimateGauge);
+    }
+}

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/PartitionBasedIndexingMemoryLimits.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/PartitionBasedIndexingMemoryLimits.java
@@ -68,8 +68,8 @@ public class PartitionBasedIndexingMemoryLimits implements IndexingMemoryLimits 
     /** Constructs limits from the partition fraction settings present in {@code settings}. */
     public static PartitionBasedIndexingMemoryLimits fromSettings(org.elasticsearch.common.settings.Settings settings) {
         return new PartitionBasedIndexingMemoryLimits(
-            IndexingPressurePartition.FRACTION_SETTING.get(settings),
-            IndexBuffersPartition.FRACTION_SETTING.get(settings),
+            IndexingPressurePartition.FRACTION_SETTING.get(settings).getAsRatio(),
+            IndexBuffersPartition.FRACTION_SETTING.get(settings).getAsRatio(),
             IndexingPressure.MAX_OPERATION_SIZE.get(settings).getBytes()
         );
     }

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/PartitionBasedIndexingMemoryLimits.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/PartitionBasedIndexingMemoryLimits.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.stateless.memory;
+
+import org.elasticsearch.index.IndexingPressure;
+import org.elasticsearch.indices.IndexingMemoryLimits;
+import org.elasticsearch.monitor.jvm.JvmInfo;
+import org.elasticsearch.xpack.stateless.memory.partition.IndexBuffersPartition;
+import org.elasticsearch.xpack.stateless.memory.partition.IndexingPressurePartition;
+
+/**
+ * Partition-based implementation of {@link IndexingMemoryLimits} for stateless deployments.
+ * Back-pressure limits for {@link IndexingPressure} are set to
+ * {@code IndexingPressurePartition.fraction × heapMax}, and the Lucene indexing buffer
+ * size is set to {@code IndexBuffersPartition.fraction × heapMax}.
+ *
+ * <p>The single-operation limit ({@link #operationLimitBytes()}) retains the standard
+ * settings-based value, as it is also used as the autoscaling signal denominator.
+ */
+public class PartitionBasedIndexingMemoryLimits implements IndexingMemoryLimits {
+
+    private final long coordinatingLimitBytes;
+    private final long primaryLimitBytes;
+    private final long replicaLimitBytes;
+    private final long operationLimitBytes;
+    private final long indexBufferBytes;
+
+    public PartitionBasedIndexingMemoryLimits(double indexingPressureFraction, double indexBuffersFraction, long operationLimitBytes) {
+        long heapMaxBytes = JvmInfo.jvmInfo().getMem().getHeapMax().getBytes();
+        long pressureLimit = (long) (heapMaxBytes * indexingPressureFraction);
+        this.coordinatingLimitBytes = pressureLimit;
+        this.primaryLimitBytes = pressureLimit;
+        this.replicaLimitBytes = (long) (pressureLimit * 1.5);
+        this.operationLimitBytes = operationLimitBytes;
+        this.indexBufferBytes = (long) (heapMaxBytes * indexBuffersFraction);
+    }
+
+    @Override
+    public long coordinatingLimitBytes() {
+        return coordinatingLimitBytes;
+    }
+
+    @Override
+    public long primaryLimitBytes() {
+        return primaryLimitBytes;
+    }
+
+    @Override
+    public long replicaLimitBytes() {
+        return replicaLimitBytes;
+    }
+
+    @Override
+    public long operationLimitBytes() {
+        return operationLimitBytes;
+    }
+
+    @Override
+    public long indexBufferBytes() {
+        return indexBufferBytes;
+    }
+
+    /** Constructs limits from the partition fraction settings present in {@code settings}. */
+    public static PartitionBasedIndexingMemoryLimits fromSettings(org.elasticsearch.common.settings.Settings settings) {
+        return new PartitionBasedIndexingMemoryLimits(
+            IndexingPressurePartition.FRACTION_SETTING.get(settings),
+            IndexBuffersPartition.FRACTION_SETTING.get(settings),
+            IndexingPressure.MAX_OPERATION_SIZE.get(settings).getBytes()
+        );
+    }
+}

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/PartitionBasedIndexingMemoryLimits.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/PartitionBasedIndexingMemoryLimits.java
@@ -7,9 +7,6 @@
 
 package org.elasticsearch.xpack.stateless.memory;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.index.IndexingPressure;
 import org.elasticsearch.indices.IndexingMemoryLimits;
 import org.elasticsearch.monitor.jvm.JvmInfo;
@@ -26,8 +23,6 @@ import org.elasticsearch.xpack.stateless.memory.partition.IndexingPressurePartit
  * settings-based value, as it is also used as the autoscaling signal denominator.
  */
 public class PartitionBasedIndexingMemoryLimits implements IndexingMemoryLimits {
-
-    private static final Logger logger = LogManager.getLogger(PartitionBasedIndexingMemoryLimits.class);
 
     private final long coordinatingLimitBytes;
     private final long primaryLimitBytes;
@@ -54,14 +49,6 @@ public class PartitionBasedIndexingMemoryLimits implements IndexingMemoryLimits 
             org/elasticsearch/indices/IndexingMemoryController.java:402)
          */
         this.indexBufferBytes = (long) (heapMaxBytes * indexBuffersFraction) * 2 / 3;
-        logger.info(
-            "Indexing limits: coordinating={}, primary={}, replica={}, operation={}, buffers={}",
-            ByteSizeValue.ofBytes(coordinatingLimitBytes),
-            ByteSizeValue.ofBytes(primaryLimitBytes),
-            ByteSizeValue.ofBytes(replicaLimitBytes),
-            ByteSizeValue.ofBytes(operationLimitBytes),
-            ByteSizeValue.ofBytes(indexBufferBytes)
-        );
     }
 
     @Override

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/PartitionBasedIndexingMemoryLimits.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/PartitionBasedIndexingMemoryLimits.java
@@ -7,6 +7,9 @@
 
 package org.elasticsearch.xpack.stateless.memory;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.index.IndexingPressure;
 import org.elasticsearch.indices.IndexingMemoryLimits;
 import org.elasticsearch.monitor.jvm.JvmInfo;
@@ -24,6 +27,8 @@ import org.elasticsearch.xpack.stateless.memory.partition.IndexingPressurePartit
  */
 public class PartitionBasedIndexingMemoryLimits implements IndexingMemoryLimits {
 
+    private static final Logger logger = LogManager.getLogger(PartitionBasedIndexingMemoryLimits.class);
+
     private final long coordinatingLimitBytes;
     private final long primaryLimitBytes;
     private final long replicaLimitBytes;
@@ -32,12 +37,31 @@ public class PartitionBasedIndexingMemoryLimits implements IndexingMemoryLimits 
 
     public PartitionBasedIndexingMemoryLimits(double indexingPressureFraction, double indexBuffersFraction, long operationLimitBytes) {
         long heapMaxBytes = JvmInfo.jvmInfo().getMem().getHeapMax().getBytes();
-        long pressureLimit = (long) (heapMaxBytes * indexingPressureFraction);
-        this.coordinatingLimitBytes = pressureLimit;
-        this.primaryLimitBytes = pressureLimit;
-        this.replicaLimitBytes = (long) (pressureLimit * 1.5);
+        /*
+            For consistency with the old setting defaults, the replica limit
+            uses the entire partition, and the coordinating and primary
+            limits are 2/3 of that.
+         */
+        long indexingPressurePartitionSizeBytes = (long) (heapMaxBytes * indexingPressureFraction);
+        this.coordinatingLimitBytes = indexingPressurePartitionSizeBytes * 2 / 3;
+        this.primaryLimitBytes = indexingPressurePartitionSizeBytes * 2 / 3;
+        this.replicaLimitBytes = indexingPressurePartitionSizeBytes;
         this.operationLimitBytes = operationLimitBytes;
-        this.indexBufferBytes = (long) (heapMaxBytes * indexBuffersFraction);
+        /*
+            For consistency with the old setting defaults, the buffer size is
+            2/3 of the partition size, so there is room for the limit to
+            be exceeded (we only throttle at 1.5x the buffer size, see
+            org/elasticsearch/indices/IndexingMemoryController.java:402)
+         */
+        this.indexBufferBytes = (long) (heapMaxBytes * indexBuffersFraction) * 2 / 3;
+        logger.info(
+            "Indexing limits: coordinating={}, primary={}, replica={}, operation={}, buffers={}",
+            ByteSizeValue.ofBytes(coordinatingLimitBytes),
+            ByteSizeValue.ofBytes(primaryLimitBytes),
+            ByteSizeValue.ofBytes(replicaLimitBytes),
+            ByteSizeValue.ofBytes(operationLimitBytes),
+            ByteSizeValue.ofBytes(indexBufferBytes)
+        );
     }
 
     @Override

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/StatelessMemoryMetricsService.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/StatelessMemoryMetricsService.java
@@ -39,6 +39,7 @@ import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.telemetry.metric.LongWithAttributes;
 import org.elasticsearch.xpack.stateless.MetricQuality;
+import org.elasticsearch.xpack.stateless.memory.partition.PartitionContext;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -845,6 +846,31 @@ public class StatelessMemoryMetricsService implements ClusterStateListener {
             MetricQuality.MISSING,
             null,
             updateTimestampNanos
+        );
+    }
+
+    /**
+     * Builds a {@link PartitionContext} snapshot from the current state of this service.
+     * The shard cost fields are computed by iterating {@link #shardMemoryMetrics}: each shard's
+     * cost is {@link #computeShardHeapUsage} (shard-level infrastructure, excluding index-level
+     * mapping overhead which is the responsibility of {@code IndexMetadataPartition}).
+     */
+    public PartitionContext buildPartitionContext() {
+        long largestShardCostBytes = 0;
+        long totalShardCostBytes = 0;
+        for (ShardMemoryMetrics metrics : shardMemoryMetrics.values()) {
+            long cost = computeShardHeapUsage(metrics);
+            if (cost > largestShardCostBytes) {
+                largestShardCostBytes = cost;
+            }
+            totalShardCostBytes += cost;
+        }
+        return new PartitionContext(
+            totalIndices,
+            mergeMemoryEstimation(),
+            minimumRequiredHeapForAcceptingLargeIndexingOps(),
+            largestShardCostBytes,
+            totalShardCostBytes
         );
     }
 

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/partition/HeadroomPartition.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/partition/HeadroomPartition.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.stateless.memory.partition;
+
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Setting;
+
+import java.util.OptionalLong;
+
+/**
+ * Reserves a fixed slice of heap as headroom for JVM overhead and small untracked workloads.
+ * Does not drive autoscaling. May be reduced over time as the other partitions are refined
+ * and cover more of the actual heap consumers.
+ */
+public class HeadroomPartition implements MemoryPartition {
+
+    public static final String NAME = "headroom";
+    public static final double DEFAULT_FRACTION = 0.20;
+    public static final Setting<Double> FRACTION_SETTING = Setting.doubleSetting(
+        "memory_metrics.partition.headroom.fraction",
+        DEFAULT_FRACTION,
+        0.001,
+        1.0,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    private volatile double fraction;
+
+    public HeadroomPartition(ClusterSettings clusterSettings) {
+        clusterSettings.initializeAndWatch(FRACTION_SETTING, v -> this.fraction = v);
+    }
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public double fraction() {
+        return fraction;
+    }
+
+    @Override
+    public OptionalLong nodeHeapRequirementBytes(PartitionContext ctx) {
+        return OptionalLong.empty();
+    }
+}

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/partition/HeadroomPartition.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/partition/HeadroomPartition.java
@@ -26,14 +26,13 @@ public class HeadroomPartition implements MemoryPartition {
         DEFAULT_FRACTION,
         0.001,
         1.0,
-        Setting.Property.Dynamic,
         Setting.Property.NodeScope
     );
 
-    private volatile double fraction;
+    private final double fraction;
 
     public HeadroomPartition(ClusterSettings clusterSettings) {
-        clusterSettings.initializeAndWatch(FRACTION_SETTING, v -> this.fraction = v);
+        this.fraction = clusterSettings.get(FRACTION_SETTING);
     }
 
     @Override

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/partition/HeadroomPartition.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/partition/HeadroomPartition.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.stateless.memory.partition;
 
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.unit.RatioValue;
 
 import java.util.OptionalLong;
 
@@ -20,19 +21,17 @@ import java.util.OptionalLong;
 public class HeadroomPartition implements MemoryPartition {
 
     public static final String NAME = "headroom";
-    public static final double DEFAULT_FRACTION = 0.20;
-    public static final Setting<Double> FRACTION_SETTING = Setting.doubleSetting(
+    public static final Setting<RatioValue> FRACTION_SETTING = new Setting<>(
         "memory_metrics.partition.headroom.fraction",
-        DEFAULT_FRACTION,
-        0.001,
-        1.0,
+        "20%",
+        RatioValue::parseRatioValue,
         Setting.Property.NodeScope
     );
 
     private final double fraction;
 
     public HeadroomPartition(ClusterSettings clusterSettings) {
-        this.fraction = clusterSettings.get(FRACTION_SETTING);
+        this.fraction = clusterSettings.get(FRACTION_SETTING).getAsRatio();
     }
 
     @Override

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/partition/HostedShardsPartition.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/partition/HostedShardsPartition.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.stateless.memory.partition;
 
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.unit.RatioValue;
 
 import java.util.OptionalLong;
 
@@ -28,19 +29,17 @@ import java.util.OptionalLong;
 public class HostedShardsPartition implements MemoryPartition {
 
     public static final String NAME = "hosted_shards";
-    public static final double DEFAULT_FRACTION = 0.30;
-    public static final Setting<Double> FRACTION_SETTING = Setting.doubleSetting(
+    public static final Setting<RatioValue> FRACTION_SETTING = new Setting<>(
         "memory_metrics.partition.hosted_shards.fraction",
-        DEFAULT_FRACTION,
-        0.001,
-        1.0,
+        "30%",
+        RatioValue::parseRatioValue,
         Setting.Property.NodeScope
     );
 
     private final double fraction;
 
     public HostedShardsPartition(ClusterSettings clusterSettings) {
-        this.fraction = clusterSettings.get(FRACTION_SETTING);
+        this.fraction = clusterSettings.get(FRACTION_SETTING).getAsRatio();
     }
 
     @Override

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/partition/HostedShardsPartition.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/partition/HostedShardsPartition.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.stateless.memory.partition;
+
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Setting;
+
+import java.util.OptionalLong;
+
+/**
+ * Reserves heap for the indexing infrastructure of shards hosted on each node.
+ *
+ * <p>This is the only partition that contributes to the tier estimate (the total migratable
+ * workload memory across the cluster). It drives two autoscaling signals:
+ * <ul>
+ *   <li>The tier estimate ({@link #tierEstimateBytes}) — the sum of all shard hosting costs
+ *       in the cluster, which grows horizontally as more shards are added.</li>
+ *   <li>A node estimate floor ({@link #nodeHeapRequirementBytes}) — derived from the largest
+ *       single shard cost, ensuring every node can host at least one shard of that size.
+ *       This prevents the autoscaler from choosing nodes too small to host the largest shard.</li>
+ * </ul>
+ */
+public class HostedShardsPartition implements MemoryPartition {
+
+    public static final String NAME = "hosted_shards";
+    public static final double DEFAULT_FRACTION = 0.30;
+    public static final Setting<Double> FRACTION_SETTING = Setting.doubleSetting(
+        "memory_metrics.partition.hosted_shards.fraction",
+        DEFAULT_FRACTION,
+        0.001,
+        1.0,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    private volatile double fraction;
+
+    public HostedShardsPartition(ClusterSettings clusterSettings) {
+        clusterSettings.initializeAndWatch(FRACTION_SETTING, v -> this.fraction = v);
+    }
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public double fraction() {
+        return fraction;
+    }
+
+    @Override
+    public OptionalLong nodeHeapRequirementBytes(PartitionContext ctx) {
+        long largestShard = ctx.largestShardCostBytes();
+        if (largestShard == 0) {
+            return OptionalLong.empty();
+        }
+        return OptionalLong.of((long) (largestShard / fraction));
+    }
+
+    @Override
+    public OptionalLong tierEstimateBytes(PartitionContext ctx) {
+        return OptionalLong.of(ctx.totalShardCostBytes());
+    }
+
+    @Override
+    public boolean hasTierEstimate() {
+        return true;
+    }
+}

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/partition/HostedShardsPartition.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/partition/HostedShardsPartition.java
@@ -34,14 +34,13 @@ public class HostedShardsPartition implements MemoryPartition {
         DEFAULT_FRACTION,
         0.001,
         1.0,
-        Setting.Property.Dynamic,
         Setting.Property.NodeScope
     );
 
-    private volatile double fraction;
+    private final double fraction;
 
     public HostedShardsPartition(ClusterSettings clusterSettings) {
-        clusterSettings.initializeAndWatch(FRACTION_SETTING, v -> this.fraction = v);
+        this.fraction = clusterSettings.get(FRACTION_SETTING);
     }
 
     @Override

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/partition/IndexBuffersPartition.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/partition/IndexBuffersPartition.java
@@ -27,14 +27,13 @@ public class IndexBuffersPartition implements MemoryPartition {
         DEFAULT_FRACTION,
         0.001,
         1.0,
-        Setting.Property.Dynamic,
         Setting.Property.NodeScope
     );
 
-    private volatile double fraction;
+    private final double fraction;
 
     public IndexBuffersPartition(ClusterSettings clusterSettings) {
-        clusterSettings.initializeAndWatch(FRACTION_SETTING, v -> this.fraction = v);
+        this.fraction = clusterSettings.get(FRACTION_SETTING);
     }
 
     @Override

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/partition/IndexBuffersPartition.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/partition/IndexBuffersPartition.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.stateless.memory.partition;
 
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.unit.RatioValue;
 
 import java.util.OptionalLong;
 
@@ -21,19 +22,17 @@ import java.util.OptionalLong;
 public class IndexBuffersPartition implements MemoryPartition {
 
     public static final String NAME = "index_buffers";
-    public static final double DEFAULT_FRACTION = 0.15;
-    public static final Setting<Double> FRACTION_SETTING = Setting.doubleSetting(
+    public static final Setting<RatioValue> FRACTION_SETTING = new Setting<>(
         "memory_metrics.partition.index_buffers.fraction",
-        DEFAULT_FRACTION,
-        0.001,
-        1.0,
+        "15%",
+        RatioValue::parseRatioValue,
         Setting.Property.NodeScope
     );
 
     private final double fraction;
 
     public IndexBuffersPartition(ClusterSettings clusterSettings) {
-        this.fraction = clusterSettings.get(FRACTION_SETTING);
+        this.fraction = clusterSettings.get(FRACTION_SETTING).getAsRatio();
     }
 
     @Override

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/partition/IndexBuffersPartition.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/partition/IndexBuffersPartition.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.stateless.memory.partition;
+
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Setting;
+
+import java.util.OptionalLong;
+
+/**
+ * Reserves a fixed slice of heap for Lucene indexing buffers, managed by
+ * {@code IndexingMemoryController} which flushes to disk as the buffer fills.
+ * Because this is a fixed reservation with no observable workload signal, it
+ * does not drive autoscaling.
+ */
+public class IndexBuffersPartition implements MemoryPartition {
+
+    public static final String NAME = "index_buffers";
+    public static final double DEFAULT_FRACTION = 0.15;
+    public static final Setting<Double> FRACTION_SETTING = Setting.doubleSetting(
+        "memory_metrics.partition.index_buffers.fraction",
+        DEFAULT_FRACTION,
+        0.001,
+        1.0,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    private volatile double fraction;
+
+    public IndexBuffersPartition(ClusterSettings clusterSettings) {
+        clusterSettings.initializeAndWatch(FRACTION_SETTING, v -> this.fraction = v);
+    }
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public double fraction() {
+        return fraction;
+    }
+
+    @Override
+    public OptionalLong nodeHeapRequirementBytes(PartitionContext ctx) {
+        return OptionalLong.empty();
+    }
+}

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/partition/IndexMetadataPartition.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/partition/IndexMetadataPartition.java
@@ -27,14 +27,13 @@ public class IndexMetadataPartition implements MemoryPartition {
         DEFAULT_FRACTION,
         0.001,
         1.0,
-        Setting.Property.Dynamic,
         Setting.Property.NodeScope
     );
 
-    private volatile double fraction;
+    private final double fraction;
 
     public IndexMetadataPartition(ClusterSettings clusterSettings) {
-        clusterSettings.initializeAndWatch(FRACTION_SETTING, v -> this.fraction = v);
+        this.fraction = clusterSettings.get(FRACTION_SETTING);
     }
 
     @Override

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/partition/IndexMetadataPartition.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/partition/IndexMetadataPartition.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.stateless.memory.partition;
 
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.unit.RatioValue;
 import org.elasticsearch.xpack.stateless.memory.StatelessMemoryMetricsService;
 
 import java.util.OptionalLong;
@@ -21,19 +22,17 @@ import java.util.OptionalLong;
 public class IndexMetadataPartition implements MemoryPartition {
 
     public static final String NAME = "index_metadata";
-    public static final double DEFAULT_FRACTION = 0.10;
-    public static final Setting<Double> FRACTION_SETTING = Setting.doubleSetting(
+    public static final Setting<RatioValue> FRACTION_SETTING = new Setting<>(
         "memory_metrics.partition.index_metadata.fraction",
-        DEFAULT_FRACTION,
-        0.001,
-        1.0,
+        "10%",
+        RatioValue::parseRatioValue,
         Setting.Property.NodeScope
     );
 
     private final double fraction;
 
     public IndexMetadataPartition(ClusterSettings clusterSettings) {
-        this.fraction = clusterSettings.get(FRACTION_SETTING);
+        this.fraction = clusterSettings.get(FRACTION_SETTING).getAsRatio();
     }
 
     @Override

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/partition/IndexMetadataPartition.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/partition/IndexMetadataPartition.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.stateless.memory.partition;
+
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.xpack.stateless.memory.StatelessMemoryMetricsService;
+
+import java.util.OptionalLong;
+
+/**
+ * Reserves heap for index metadata held in cluster state on every node (~350 KB per index).
+ * Index creation is not back-pressured, so this partition drives autoscaling by publishing
+ * {@code totalIndices * INDEX_MEMORY_OVERHEAD / fraction} as its implied node heap requirement.
+ */
+public class IndexMetadataPartition implements MemoryPartition {
+
+    public static final String NAME = "index_metadata";
+    public static final double DEFAULT_FRACTION = 0.10;
+    public static final Setting<Double> FRACTION_SETTING = Setting.doubleSetting(
+        "memory_metrics.partition.index_metadata.fraction",
+        DEFAULT_FRACTION,
+        0.001,
+        1.0,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    private volatile double fraction;
+
+    public IndexMetadataPartition(ClusterSettings clusterSettings) {
+        clusterSettings.initializeAndWatch(FRACTION_SETTING, v -> this.fraction = v);
+    }
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public double fraction() {
+        return fraction;
+    }
+
+    @Override
+    public OptionalLong nodeHeapRequirementBytes(PartitionContext ctx) {
+        if (ctx.totalIndices() == 0) {
+            return OptionalLong.empty();
+        }
+        long workload = (long) ctx.totalIndices() * StatelessMemoryMetricsService.INDEX_MEMORY_OVERHEAD;
+        return OptionalLong.of((long) (workload / fraction));
+    }
+}

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/partition/IndexingPressurePartition.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/partition/IndexingPressurePartition.java
@@ -32,14 +32,13 @@ public class IndexingPressurePartition implements MemoryPartition {
         DEFAULT_FRACTION,
         0.001,
         1.0,
-        Setting.Property.Dynamic,
         Setting.Property.NodeScope
     );
 
-    private volatile double fraction;
+    private final double fraction;
 
     public IndexingPressurePartition(ClusterSettings clusterSettings) {
-        clusterSettings.initializeAndWatch(FRACTION_SETTING, v -> this.fraction = v);
+        this.fraction = clusterSettings.get(FRACTION_SETTING);
     }
 
     @Override

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/partition/IndexingPressurePartition.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/partition/IndexingPressurePartition.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.stateless.memory.partition;
+
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Setting;
+
+import java.util.OptionalLong;
+
+/**
+ * Reserves heap for the working memory used to process ingestion requests, aligned with
+ * the existing {@code IndexingPressure} limits.
+ *
+ * <p>The autoscaling signal is {@code minimumRequiredHeapForIndexingOpsBytes} from
+ * {@link org.elasticsearch.xpack.stateless.memory.StatelessMemoryMetricsService}, which is
+ * already expressed as a heap requirement derived from the IndexingPressure 10%
+ * single-document constraint ({@code largest_doc / 0.10}). This value is used directly
+ * as the node heap requirement — not divided by this partition's own fraction — because
+ * the 10% constraint is the operative limit, not the 15% reservation.
+ */
+public class IndexingPressurePartition implements MemoryPartition {
+
+    public static final String NAME = "indexing_pressure";
+    public static final double DEFAULT_FRACTION = 0.15;
+    public static final Setting<Double> FRACTION_SETTING = Setting.doubleSetting(
+        "memory_metrics.partition.indexing_pressure.fraction",
+        DEFAULT_FRACTION,
+        0.001,
+        1.0,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    private volatile double fraction;
+
+    public IndexingPressurePartition(ClusterSettings clusterSettings) {
+        clusterSettings.initializeAndWatch(FRACTION_SETTING, v -> this.fraction = v);
+    }
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public double fraction() {
+        return fraction;
+    }
+
+    @Override
+    public OptionalLong nodeHeapRequirementBytes(PartitionContext ctx) {
+        long requirement = ctx.minimumRequiredHeapForIndexingOpsBytes();
+        if (requirement == 0) {
+            return OptionalLong.empty();
+        }
+        return OptionalLong.of(requirement);
+    }
+}

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/partition/IndexingPressurePartition.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/partition/IndexingPressurePartition.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.stateless.memory.partition;
 
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.unit.RatioValue;
 
 import java.util.OptionalLong;
 
@@ -26,19 +27,17 @@ import java.util.OptionalLong;
 public class IndexingPressurePartition implements MemoryPartition {
 
     public static final String NAME = "indexing_pressure";
-    public static final double DEFAULT_FRACTION = 0.15;
-    public static final Setting<Double> FRACTION_SETTING = Setting.doubleSetting(
+    public static final Setting<RatioValue> FRACTION_SETTING = new Setting<>(
         "memory_metrics.partition.indexing_pressure.fraction",
-        DEFAULT_FRACTION,
-        0.001,
-        1.0,
+        "15%",
+        RatioValue::parseRatioValue,
         Setting.Property.NodeScope
     );
 
     private final double fraction;
 
     public IndexingPressurePartition(ClusterSettings clusterSettings) {
-        this.fraction = clusterSettings.get(FRACTION_SETTING);
+        this.fraction = clusterSettings.get(FRACTION_SETTING).getAsRatio();
     }
 
     @Override

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/partition/MemoryPartition.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/partition/MemoryPartition.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.stateless.memory.partition;
+
+import java.util.OptionalLong;
+
+/**
+ * A named slice of the available JVM heap reserved for a specific workload category.
+ * Each partition is allocated a fixed fraction of the heap and may optionally publish
+ * the minimum node size implied by its current workload (driving autoscaling) and/or
+ * a tier-level memory estimate (for migratable workloads distributed across nodes).
+ */
+public interface MemoryPartition {
+
+    /** Unique name used in metric names and logging, e.g. {@code "index_metadata"}. */
+    String name();
+
+    /** Fraction of total heap reserved for this partition, e.g. {@code 0.10} for 10%. */
+    double fraction();
+
+    /**
+     * The minimum node heap (in bytes) implied by this partition's current workload.
+     * Derived as {@code workload_requirement / fraction()} unless the partition has
+     * its own constraint (e.g. the indexing pressure 10% single-document rule).
+     *
+     * <p>Returns {@link OptionalLong#empty()} for fixed-size partitions that reserve a
+     * slice of heap without an observable workload signal, such as index buffers and headroom.
+     */
+    OptionalLong nodeHeapRequirementBytes(PartitionContext ctx);
+
+    /**
+     * The bytes this partition contributes to the tier estimate (the total migratable
+     * workload memory distributed across nodes). Non-empty only for partitions whose
+     * workload can be spread by adding more nodes, i.e. {@code HostedShardsPartition}.
+     */
+    default OptionalLong tierEstimateBytes(PartitionContext ctx) {
+        return OptionalLong.empty();
+    }
+
+    /**
+     * Whether this partition contributes to the tier estimate regardless of context.
+     * Used by {@link PartitionedMemoryModel#maxTierPercent()} to compute the
+     * {@code max_tier_percentage} field in the autoscaler payload.
+     */
+    default boolean hasTierEstimate() {
+        return false;
+    }
+}

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/partition/MergePartition.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/partition/MergePartition.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.stateless.memory.partition;
 
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.unit.RatioValue;
 
 import java.util.OptionalLong;
 
@@ -22,19 +23,17 @@ import java.util.OptionalLong;
 public class MergePartition implements MemoryPartition {
 
     public static final String NAME = "merge";
-    public static final double DEFAULT_FRACTION = 0.10;
-    public static final Setting<Double> FRACTION_SETTING = Setting.doubleSetting(
+    public static final Setting<RatioValue> FRACTION_SETTING = new Setting<>(
         "memory_metrics.partition.merge.fraction",
-        DEFAULT_FRACTION,
-        0.001,
-        1.0,
+        "10%",
+        RatioValue::parseRatioValue,
         Setting.Property.NodeScope
     );
 
     private final double fraction;
 
     public MergePartition(ClusterSettings clusterSettings) {
-        this.fraction = clusterSettings.get(FRACTION_SETTING);
+        this.fraction = clusterSettings.get(FRACTION_SETTING).getAsRatio();
     }
 
     @Override

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/partition/MergePartition.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/partition/MergePartition.java
@@ -28,14 +28,13 @@ public class MergePartition implements MemoryPartition {
         DEFAULT_FRACTION,
         0.001,
         1.0,
-        Setting.Property.Dynamic,
         Setting.Property.NodeScope
     );
 
-    private volatile double fraction;
+    private final double fraction;
 
     public MergePartition(ClusterSettings clusterSettings) {
-        clusterSettings.initializeAndWatch(FRACTION_SETTING, v -> this.fraction = v);
+        this.fraction = clusterSettings.get(FRACTION_SETTING);
     }
 
     @Override

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/partition/MergePartition.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/partition/MergePartition.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.stateless.memory.partition;
+
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Setting;
+
+import java.util.OptionalLong;
+
+/**
+ * Reserves heap for concurrent Lucene segment merges. Merges that would exceed the
+ * partition are delayed. The autoscaling signal is the largest active or queued merge
+ * size, published by nodes via
+ * {@code TransportPublishMergeMemoryEstimate} and tracked in
+ * {@code StatelessMemoryMetricsService}.
+ */
+public class MergePartition implements MemoryPartition {
+
+    public static final String NAME = "merge";
+    public static final double DEFAULT_FRACTION = 0.10;
+    public static final Setting<Double> FRACTION_SETTING = Setting.doubleSetting(
+        "memory_metrics.partition.merge.fraction",
+        DEFAULT_FRACTION,
+        0.001,
+        1.0,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    private volatile double fraction;
+
+    public MergePartition(ClusterSettings clusterSettings) {
+        clusterSettings.initializeAndWatch(FRACTION_SETTING, v -> this.fraction = v);
+    }
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public double fraction() {
+        return fraction;
+    }
+
+    @Override
+    public OptionalLong nodeHeapRequirementBytes(PartitionContext ctx) {
+        long largestMerge = ctx.largestMergeEstimateBytes();
+        if (largestMerge == 0) {
+            return OptionalLong.empty();
+        }
+        return OptionalLong.of((long) (largestMerge / fraction));
+    }
+}

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/partition/PartitionContext.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/partition/PartitionContext.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.stateless.memory.partition;
+
+/**
+ * A snapshot of the raw signals used by {@link MemoryPartition} implementations to compute
+ * their node heap requirements. Built by {@code StatelessMemoryMetricsService.buildPartitionContext()}.
+ *
+ * @param totalIndices                            Total number of indices in the cluster.
+ * @param largestMergeEstimateBytes               Memory estimate for the largest active or queued merge.
+ * @param minimumRequiredHeapForIndexingOpsBytes  Minimum heap required to accept the largest recent
+ *                                               indexing operation, already expressed as a heap
+ *                                               requirement (i.e. largest_doc / 0.10 per the
+ *                                               IndexingPressure single-document constraint).
+ * @param largestShardCostBytes                   Memory cost of the most expensive single shard to host.
+ * @param totalShardCostBytes                     Total memory cost of all shards in the cluster
+ *                                               (the tier-level workload).
+ */
+public record PartitionContext(
+    int totalIndices,
+    long largestMergeEstimateBytes,
+    long minimumRequiredHeapForIndexingOpsBytes,
+    long largestShardCostBytes,
+    long totalShardCostBytes
+) {}

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/partition/PartitionedMemoryModel.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/partition/PartitionedMemoryModel.java
@@ -26,6 +26,10 @@ public final class PartitionedMemoryModel {
 
     public PartitionedMemoryModel(List<MemoryPartition> partitions) {
         this.partitions = List.copyOf(partitions);
+        double sum = this.partitions.stream().mapToDouble(MemoryPartition::fraction).sum();
+        if (Math.abs(sum - 1.0) > 1e-9) {
+            throw new IllegalArgumentException("Memory partition fractions must sum to 1.0 but sum to " + sum);
+        }
     }
 
     public List<MemoryPartition> partitions() {

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/partition/PartitionedMemoryModel.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/partition/PartitionedMemoryModel.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.stateless.memory.partition;
+
+import java.util.List;
+
+/**
+ * Orchestrates a set of {@link MemoryPartition} instances to produce the three values needed
+ * for the partitioned autoscaler payload:
+ * <ul>
+ *   <li>{@link #nodeEstimateBytes} – the minimum node heap implied by the current workload,
+ *       computed as the MAX across all partitions' {@link MemoryPartition#nodeHeapRequirementBytes}.</li>
+ *   <li>{@link #tierEstimateBytes} – total migratable workload memory across the cluster.</li>
+ *   <li>{@link #maxTierPercent} – the percentage of node heap available for the tier workload,
+ *       equal to the sum of fractions of tier-contributing partitions.</li>
+ * </ul>
+ */
+public final class PartitionedMemoryModel {
+
+    private final List<MemoryPartition> partitions;
+
+    public PartitionedMemoryModel(List<MemoryPartition> partitions) {
+        this.partitions = List.copyOf(partitions);
+    }
+
+    public List<MemoryPartition> partitions() {
+        return partitions;
+    }
+
+    /** Minimum node heap in bytes: {@code MAX(partition.nodeHeapRequirementBytes())} across all partitions. */
+    public long nodeEstimateBytes(PartitionContext ctx) {
+        return partitions.stream()
+            .map(p -> p.nodeHeapRequirementBytes(ctx))
+            .flatMapToLong(o -> o.isPresent() ? java.util.stream.LongStream.of(o.getAsLong()) : java.util.stream.LongStream.empty())
+            .max()
+            .orElse(0L);
+    }
+
+    /** Total tier workload bytes: sum of {@link MemoryPartition#tierEstimateBytes} across all partitions. */
+    public long tierEstimateBytes(PartitionContext ctx) {
+        return partitions.stream().mapToLong(p -> p.tierEstimateBytes(ctx).orElse(0L)).sum();
+    }
+
+    /**
+     * Percentage of node heap available for the tier workload, as an integer 0–100.
+     * Equal to the sum of {@link MemoryPartition#fraction()} for tier-contributing partitions,
+     * multiplied by 100 and rounded.
+     */
+    public int maxTierPercent() {
+        double sum = partitions.stream().filter(MemoryPartition::hasTierEstimate).mapToDouble(MemoryPartition::fraction).sum();
+        return (int) Math.round(sum * 100);
+    }
+}


### PR DESCRIPTION
Just some code to demonstrate the partitioned memory approach (generated by Claude from the proposal doc and some prompting)

This PR 
- Implements some generic "partitioned memory model" infrastructure 
- Implements the proposed partition definitions for the indexing tier
- Uses the partition config as limits for indexing pressure and index buffers
- Publishes the partition contributions as APM metrics

To keep things simple and illustrative, this PR does not
- Actually return the partitioned memory estimate to the autoscaler
- Update the heap decider to restrict based on the hosted shards partition rather than the entire heap
- Allow the partitioned model to be enabled/disabled
- Implement the merge back-pressure based on the merge partition size