### PR TITLE
[9.4] Override the merge policy in CompletionStatsCacheTests (#149288)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -279,9 +279,6 @@ tests:
 - class: org.elasticsearch.search.KnnSearchIT
   method: testKnnSearchWithScroll
   issue: https://github.com/elastic/elasticsearch/issues/148590
-- class: org.elasticsearch.index.engine.CompletionStatsCacheTests
-  method: testCompletionStatsCache
-  issue: https://github.com/elastic/elasticsearch/issues/148965
 - class: org.elasticsearch.reindex.ReindexBasicTests
   method: testReindexFailsWhenSourceIndexIsClosed
   issue: https://github.com/elastic/elasticsearch/issues/149234

--- a/server/src/test/java/org/elasticsearch/index/engine/CompletionStatsCacheTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/CompletionStatsCacheTests.java
@@ -13,6 +13,7 @@ import org.apache.lucene.document.Document;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.NoMergePolicy;
 import org.apache.lucene.search.suggest.document.Completion104PostingsFormat;
 import org.apache.lucene.search.suggest.document.SuggestField;
 import org.apache.lucene.store.Directory;
@@ -42,8 +43,10 @@ public class CompletionStatsCacheTests extends ESTestCase {
         assertThat(expectThrows(ElasticsearchException.class, completionStatsCache::get).getMessage(), equalTo("simulated 2"));
     }
 
-    public void testCompletionStatsCache() throws IOException, InterruptedException {
+    public void testCompletionStatsCache() throws Exception {
         final IndexWriterConfig indexWriterConfig = newIndexWriterConfig();
+        // override merge policy to prevent segments merging as assertions are based on number of segments after each flush
+        indexWriterConfig.setMergePolicy(NoMergePolicy.INSTANCE);
         final PostingsFormat postingsFormat = new Completion104PostingsFormat();
         indexWriterConfig.setCodec(TestUtil.alwaysPostingsFormat(postingsFormat)); // all fields are suggest fields
 
@@ -57,6 +60,7 @@ public class CompletionStatsCacheTests extends ESTestCase {
             document.add(new SuggestField("otherfield", "anotherval", 1));
             document.add(new SuggestField("otherfield", "yetmoreval", 1));
             indexWriter.addDocument(document);
+            // flush the first segment
             indexWriter.flush();
 
             final OpenCloseCounter openCloseCounter = new OpenCloseCounter();
@@ -146,6 +150,7 @@ public class CompletionStatsCacheTests extends ESTestCase {
             document2.add(new SuggestField("suggest2", "bar", 1));
             document2.add(new SuggestField("otherfield", "baz", 1));
             indexWriter.addDocument(document2);
+            // flush the second segment, next check that size in bytes increased
             indexWriter.flush();
             completionStatsCache.afterRefresh(true);
             final CompletionStats updatedStats = completionStatsCache.get();


### PR DESCRIPTION
testCompletionStatsCache relies on the number of segments, yet after a flush the two explicitly flushed segments may be immediately merged into one.

This commit forces no merge policy for this test to make sure that the two segments that the test needs never get merged away.

Closes #148965