### PR TITLE
Bump ES|QL approximation capability

### DIFF
--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/GenerativeApproximationIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/GenerativeApproximationIT.java
@@ -27,7 +27,7 @@ public class GenerativeApproximationIT extends GenerativeApproximationRestTest {
 
     @Before
     public void checkCapability() {
-        assumeTrue("query approximation should be enabled", EsqlCapabilities.Cap.APPROXIMATION_V6.isEnabled());
+        assumeTrue("query approximation should be enabled", EsqlCapabilities.Cap.APPROXIMATION_V7.isEnabled());
     }
 
     @ClassRule

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/RestEsqlTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/RestEsqlTestCase.java
@@ -1951,7 +1951,7 @@ public abstract class RestEsqlTestCase extends ESRestTestCase {
     }
 
     public void testApproximationColumnMetadata() throws IOException {
-        assumeTrue("approximation support", EsqlCapabilities.Cap.APPROXIMATION_V6.isEnabled());
+        assumeTrue("approximation support", EsqlCapabilities.Cap.APPROXIMATION_V7.isEnabled());
         bulkLoadTestData(10);
 
         String query = "SET approximation=true; " + fromIndex() + " | STATS count=COUNT()";

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeApproximationRestTest.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeApproximationRestTest.java
@@ -17,7 +17,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.elasticsearch.xpack.esql.action.EsqlCapabilities.Cap.APPROXIMATION_V6;
+import static org.elasticsearch.xpack.esql.action.EsqlCapabilities.Cap.APPROXIMATION_V7;
 import static org.elasticsearch.xpack.esql.action.EsqlCapabilities.Cap.FIX_SUM_AGG_LONG_OVERFLOW;
 import static org.elasticsearch.xpack.esql.approximation.ApproximationPlan.CERTIFIED_COLUMN_PREFIX;
 import static org.elasticsearch.xpack.esql.approximation.ApproximationPlan.CONFIDENCE_INTERVAL_COLUMN_PREFIX;
@@ -101,7 +101,7 @@ public abstract class GenerativeApproximationRestTest extends EsqlSpecTestCase {
     @Override
     protected void shouldSkipTest(String testName) throws IOException {
         super.shouldSkipTest(testName);
-        assumeFalse("No approximation tests", testCase.requiredCapabilities.contains(APPROXIMATION_V6.capabilityName()));
+        assumeFalse("No approximation tests", testCase.requiredCapabilities.contains(APPROXIMATION_V7.capabilityName()));
         assumeFalse(
             "Approximation casts integer SUM to double, preventing long overflow",
             testCase.requiredCapabilities.contains(FIX_SUM_AGG_LONG_OVERFLOW.capabilityName())

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeForkRestTest.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeForkRestTest.java
@@ -15,7 +15,7 @@ import java.io.IOException;
 import java.util.List;
 
 import static org.elasticsearch.xpack.esql.CsvTestUtils.loadCsvSpecValues;
-import static org.elasticsearch.xpack.esql.action.EsqlCapabilities.Cap.APPROXIMATION_V6;
+import static org.elasticsearch.xpack.esql.action.EsqlCapabilities.Cap.APPROXIMATION_V7;
 import static org.elasticsearch.xpack.esql.action.EsqlCapabilities.Cap.ESQL_WITHOUT_GROUPING;
 import static org.elasticsearch.xpack.esql.action.EsqlCapabilities.Cap.FORK_V9;
 import static org.elasticsearch.xpack.esql.action.EsqlCapabilities.Cap.METRICS_GROUP_BY_ALL;
@@ -92,7 +92,7 @@ public abstract class GenerativeForkRestTest extends EsqlSpecTestCase {
 
         assumeFalse(
             "Tests using query approximation are skipped since query approximation is not supported with FORK",
-            testCase.requiredCapabilities.contains(APPROXIMATION_V6.capabilityName())
+            testCase.requiredCapabilities.contains(APPROXIMATION_V7.capabilityName())
         );
 
         assumeFalse(

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/generator/command/source/FromGenerator.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/generator/command/source/FromGenerator.java
@@ -59,7 +59,7 @@ public class FromGenerator implements CommandGenerator {
         if (useUnmappedFields) {
             result.append(SET_UNMAPPED_FIELDS_PREFIX);
         }
-        boolean setQueryApproximation = EsqlCapabilities.Cap.APPROXIMATION_V6.isEnabled()
+        boolean setQueryApproximation = EsqlCapabilities.Cap.APPROXIMATION_V7.isEnabled()
             && randomDouble() < QUERY_APPROXIMATION_SETTING_PROBABILITY;
         if (setQueryApproximation) {
             result.append(randomQueryApproximationSettings());

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/approximation.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/approximation.csv-spec
@@ -22,7 +22,7 @@
 
 
 No approximation
-required_capability: approximation_v6
+required_capability: approximation_v7
 request_stored: skip
 
 SET approximation=false\;
@@ -35,7 +35,7 @@ count:long
 
 
 No confidence intervals
-required_capability: approximation_v6
+required_capability: approximation_v7
 request_stored: skip
 
 SET approximation={"rows":10000, "confidence_level":null}\;
@@ -48,7 +48,7 @@ count:long     | sum:long
 
 
 Exact total row count
-required_capability: approximation_v6
+required_capability: approximation_v7
 request_stored: skip
 
 SET approximation={"rows":10000}\;
@@ -61,7 +61,7 @@ count:long | _approximation_confidence_interval(count):long | _approximation_cer
 
 
 Exact total single-valued field count
-required_capability: approximation_v6
+required_capability: approximation_v7
 request_stored: skip
 
 SET approximation={"rows":10000}\;
@@ -74,7 +74,7 @@ count:long | _approximation_confidence_interval(count):long | _approximation_cer
 
 
 Approximate total multi-valued field count
-required_capability: approximation_v6
+required_capability: approximation_v7
 request_stored: skip
 
 SET approximation={"rows":10000}\;
@@ -87,7 +87,7 @@ count:long       | _approximation_confidence_interval(count):long | _approximati
 
 
 Approximate stats on large single-valued data
-required_capability: approximation_v6
+required_capability: approximation_v7
 request_stored: skip
 
 SET approximation={"rows":10000}\;
@@ -100,7 +100,7 @@ count:long      | avg:double | sum:long            | _approximation_confidence_i
 
 
 Approximate stats on large multi-valued data
-required_capability: approximation_v6
+required_capability: approximation_v7
 request_stored: skip
 
 SET approximation=true\;
@@ -115,7 +115,7 @@ count:long       | avg:double | sum:long               | _approximation_confiden
 
 
 Exact stats on small single-valued data
-required_capability: approximation_v6
+required_capability: approximation_v7
 request_stored: skip
 
 SET approximation={"rows":10000}\;
@@ -130,7 +130,7 @@ count:long | avg:double | sum:long | _approximation_confidence_interval(count):l
 
 
 Exact stats on small multi-valued data
-required_capability: approximation_v6
+required_capability: approximation_v7
 request_stored: skip
 
 SET approximation={"rows":10000}\;
@@ -146,7 +146,7 @@ count:long | avg:double | sum:long | _approximation_confidence_interval(count):l
 
 
 Exact stats on large row data
-required_capability: approximation_v6
+required_capability: approximation_v7
 required_capability: approximation_fix_min_source_row_count
 request_stored: skip
 
@@ -169,7 +169,7 @@ SUM(a1):long    |  _approximation_confidence_interval(SUM(a1)):long | _approxima
 
 
 Multiple total counts
-required_capability: approximation_v6
+required_capability: approximation_v7
 request_stored: skip
 
 SET approximation={"rows":10000}\;
@@ -182,7 +182,7 @@ count:long     | count2:long    | countValue:long  | _approximation_confidence_i
 
 
 Exact count with where on single-valued data
-required_capability: approximation_v6
+required_capability: approximation_v7
 request_stored: skip
 
 SET approximation={"rows":10000}\;
@@ -197,7 +197,7 @@ count:long | _approximation_confidence_interval(count):long | _approximation_cer
 
 
 Approximate stats with where on multi-valued data
-required_capability: approximation_v6
+required_capability: approximation_v7
 request_stored: skip
 
 SET approximation={"rows":10000}\;
@@ -213,7 +213,7 @@ count:long      | avg:double | sum:long               | _approximation_confidenc
 
 
 Approximate stats with stats where
-required_capability: approximation_v6
+required_capability: approximation_v7
 request_stored: skip
 
 SET approximation={"rows":10000, "confidence_level":0.85}\;
@@ -230,7 +230,7 @@ count:long      | avg:double | sum:long               | _approximation_confidenc
 
 
 Approximate stats with sample
-required_capability: approximation_v6
+required_capability: approximation_v7
 request_stored: skip
 
 SET approximation={"rows":10000,"confidence_level":0.85}\;
@@ -245,7 +245,7 @@ count:long     | avg:double | sum:long            | _approximation_confidence_in
 
 
 Approximate stats with commands before stats
-required_capability: approximation_v6
+required_capability: approximation_v7
 request_stored: skip
 
 SET approximation={"rows":10000}\;
@@ -270,7 +270,7 @@ count:long       | avg:double | sum:long               | _approximation_confiden
 
 
 Approximate stats with commands after stats
-required_capability: approximation_v6
+required_capability: approximation_v7
 request_stored: skip
 
 SET approximation={"rows":10000}\;
@@ -289,7 +289,7 @@ avg:double | avg2:double | _approximation_confidence_interval(avg):double | _app
 
 
 Approximate stats with dependent variables that have confidence interval
-required_capability: approximation_v6
+required_capability: approximation_v7
 request_stored: skip
 
 SET approximation={"rows":10000}\;
@@ -309,7 +309,7 @@ y:integer | plus1:double     | _approximation_confidence_interval(plus1):double 
 
 
 Approximate stats with dependent string variable
-required_capability: approximation_v6
+required_capability: approximation_v7
 request_stored: skip
 
 SET approximation={"rows":10000}\;
@@ -326,7 +326,7 @@ from_str:double
 
 
 Approximate stats with dependent multi-valued variable
-required_capability: approximation_v6
+required_capability: approximation_v7
 request_stored: skip
 
 SET approximation={"rows":10000}\;
@@ -342,7 +342,7 @@ sv:double
 
 
 Approximate stats with dependent constant variable
-required_capability: approximation_v6
+required_capability: approximation_v7
 request_stored: skip
 
 SET approximation={"rows":10000}\;
@@ -357,7 +357,7 @@ avg:double | zero:double | _approximation_confidence_interval(avg):double | _app
 
 
 Approximate stats by with zero variance
-required_capability: approximation_v6
+required_capability: approximation_v7
 request_stored: skip
 
 SET approximation={"rows":100000}\;
@@ -379,7 +379,7 @@ avg:double               | median:double | one:double | mv:integer | _approximat
 
 
 Approximate stats by on large single-valued data
-required_capability: approximation_v6
+required_capability: approximation_v7
 request_stored: skip
 
 SET approximation={"rows":10000}\;
@@ -399,7 +399,7 @@ count:long | sv:integer | _approximation_confidence_interval(count):long | _appr
 
 
 Approximate stats by on large multi-valued data
-required_capability: approximation_v6
+required_capability: approximation_v7
 request_stored: skip
 
 SET approximation={"rows":100000}\;
@@ -420,7 +420,7 @@ count:long | mv:integer | _approximation_confidence_interval(count):long | _appr
 
 
 Exact stats by on small single-valued data
-required_capability: approximation_v6
+required_capability: approximation_v7
 request_stored: skip
 
 SET approximation={"rows":10000}\;
@@ -440,7 +440,7 @@ count:long | sv:integer | _approximation_confidence_interval(count):long | _appr
 
 
 Exact stats by on small multi-valued data
-required_capability: approximation_v6
+required_capability: approximation_v7
 request_stored: skip
 
 SET approximation={"rows":10000}\;
@@ -461,7 +461,7 @@ count:long | mv:integer | _approximation_confidence_interval(count):long | _appr
 
 
 Approximate stats by on mixed data
-required_capability: approximation_v6
+required_capability: approximation_v7
 request_stored: skip
 
 SET approximation={"rows":10000}\;
@@ -474,7 +474,7 @@ count:long     | _approximation_confidence_interval(count):long | _approximation
 
 
 Overwrite approximated column
-required_capability: approximation_v6
+required_capability: approximation_v7
 request_stored: skip
 
 SET approximation=true\;
@@ -489,7 +489,7 @@ sum:integer
 
 
 User-generated approximation column name
-required_capability: approximation_v6
+required_capability: approximation_v7
 request_stored: skip
 
 SET approximation=true\;
@@ -508,7 +508,7 @@ sum:long | _approximation_confidence_interval(sum):long | _approximation_certifi
 
 
 Rename stats group key
-required_capability: approximation_v6
+required_capability: approximation_v7
 request_stored: skip
 
 SET approximation={"rows":10000}\;
@@ -522,7 +522,7 @@ count:long | key:integer | _approximation_confidence_interval(count):long | _app
 
 
 Filter all rows
-required_capability: approximation_v6
+required_capability: approximation_v7
 request_stored: skip
 
 SET approximation={"rows":10000}\;
@@ -536,7 +536,7 @@ median:double | _approximation_confidence_interval(median):double | _approximati
 
 
 Row with duplicate aggs
-required_capability: approximation_v6
+required_capability: approximation_v7
 request_stored: skip
 
 SET approximation={"rows":10000}\;
@@ -551,7 +551,7 @@ a:long | b:long | c:long | x:long | _approximation_confidence_interval(a):long |
 
 
 Duplicate aggs with grouping
-required_capability: approximation_v6
+required_capability: approximation_v7
 request_stored: skip
 
 SET approximation={"rows":10000}\;
@@ -566,7 +566,7 @@ median:double | p50:double | key:keyword | _approximation_confidence_interval(me
 
 
 Sum of nulls
-required_capability: approximation_v6
+required_capability: approximation_v7
 request_stored: skip
 
 SET approximation=true\;
@@ -582,7 +582,7 @@ null
 
 
 Approximated column is null
-required_capability: approximation_v6
+required_capability: approximation_v7
 request_stored: skip
 
 SET approximation=true\;
@@ -595,7 +595,7 @@ null     | null                                         | null
 
 
 Approximated column and null
-required_capability: approximation_v6
+required_capability: approximation_v7
 request_stored: skip
 
 SET approximation=true\;
@@ -608,7 +608,7 @@ sum:long            | sum_null:long | _approximation_confidence_interval(sum):lo
 
 
 Mv_expand after duplicate aggs
-required_capability: approximation_v6
+required_capability: approximation_v7
 request_stored: skip
 
 SET approximation={"rows":10000}\;
@@ -620,7 +620,7 @@ a:long         | b:long         | _approximation_confidence_interval(a):long | _
 
 
 Exact dense vector count
-required_capability: approximation_v6
+required_capability: approximation_v7
 request_stored: skip
 
 SET approximation={"rows":10000}\;
@@ -634,7 +634,7 @@ count_vectors:long | _approximation_confidence_interval(count_vectors):long | _a
 
 
 Count by date bucket
-required_capability: approximation_v6
+required_capability: approximation_v7
 request_stored: skip
 
 SET approximation=true\;
@@ -653,7 +653,7 @@ c:long  |           b:date        | _approximation_confidence_interval(c):long |
 
 
 Warn on no stats
-required_capability: approximation_v6
+required_capability: approximation_v7
 request_stored: skip
 
 SET approximation=true\;
@@ -672,7 +672,7 @@ sv:integer
 
 
 Warn on max
-required_capability: approximation_v6
+required_capability: approximation_v7
 request_stored: skip
 
 SET approximation=true\;
@@ -690,7 +690,7 @@ max:integer | sv:integer
 
 
 Example boolean for docs
-required_capability: approximation_v6
+required_capability: approximation_v7
 request_stored: skip
 
 // tag::approximationBooleanForDocs[]
@@ -710,7 +710,7 @@ sum:long | _approximation_confidence_interval(sum):long | _approximation_certifi
 
 
 Example map for docs
-required_capability: approximation_v6
+required_capability: approximation_v7
 request_stored: skip
 
 // tag::approximationMapForDocs[]

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionIT.java
@@ -96,7 +96,7 @@ import static org.elasticsearch.test.ListMatcher.matchesList;
 import static org.elasticsearch.test.MapMatcher.assertMap;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.getValuesList;
-import static org.elasticsearch.xpack.esql.action.EsqlCapabilities.Cap.APPROXIMATION_V6;
+import static org.elasticsearch.xpack.esql.action.EsqlCapabilities.Cap.APPROXIMATION_V7;
 import static org.elasticsearch.xpack.esql.action.EsqlCapabilities.Cap.EXPLAIN;
 import static org.elasticsearch.xpack.esql.action.EsqlQueryRequest.syncEsqlQueryRequest;
 import static org.hamcrest.Matchers.allOf;
@@ -2524,7 +2524,7 @@ public class EsqlActionIT extends AbstractEsqlIntegTestCase {
      */
     public void testExplainWithApproximation() {
         assumeTrue("EXPLAIN requires the capability to be enabled", EXPLAIN.isEnabled());
-        assumeTrue("Approximation requires the capability to be enabled", APPROXIMATION_V6.isEnabled());
+        assumeTrue("Approximation requires the capability to be enabled", APPROXIMATION_V7.isEnabled());
 
         String indexName = "explain_approximation_test";
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -2207,7 +2207,7 @@ public class EsqlCapabilities {
         /**
          * Support query approximation.
          */
-        APPROXIMATION_V6,
+        APPROXIMATION_V7,
 
         /**
          * Create a ScoreOperator only when shard contexts are available


### PR DESCRIPTION
The capability `APPROXIMATION_V6` got renamed to `APPROXIMATION_V7` in `main` (9.5) in https://github.com/elastic/elasticsearch/pull/145980.

That shouldn't have happened. New capabilities to gate these features were introduced in https://github.com/elastic/elasticsearch/pull/146750.

However, the capabilities being out of sync between 9.5 and 9.4 lead to multi-cluster / mixed cluster tests not running, which is bad.

