### PR TITLE
Update PostgreSQL connector documentation to clarify `track_commit_tmestamp` requirements and sync types

### DIFF
--- a/docs/reference/search-connectors/api-tutorial.md
+++ b/docs/reference/search-connectors/api-tutorial.md
@@ -139,7 +139,7 @@ The `album` table should contain **347** entries and the `artist` table should c
 ::::
 
 
-This tutorial uses a very basic setup. To use advanced functionality such as filtering rules and incremental syncs, enable `track_commit_timestamp` on your PostgreSQL database. Refer to postgresql-connector-client-tutorial for more details.
+This tutorial uses a very basic setup. Refer to postgresql-connector-client-tutorial for more details.
 
 Now it’s time for the real fun! We’ll set up a connector to create a searchable mirror of our PostgreSQL data in {{es}}.
 

--- a/docs/reference/search-connectors/es-connectors-postgresql.md
+++ b/docs/reference/search-connectors/es-connectors-postgresql.md
@@ -96,10 +96,6 @@ Refer to the [{{es}} API documentation](https://www.elastic.co/docs/api/doc/elas
 
 To use this connector as a **self-managed connector**, see [*Self-managed connectors*](/reference/search-connectors/self-managed-connectors.md).
 
-::::{tip}
-Users must set `track_commit_timestamp` to `on`. To do this, run `ALTER SYSTEM SET track_commit_timestamp = on;` in PostgreSQL server.
-
-::::
 
 
 For additional operations, see.
@@ -277,7 +273,12 @@ We also have a quickstart self-managed option using Docker Compose, so you can s
 
 * Tables must be owned by a PostgreSQL user.
 * Tables with no primary key defined are skipped.
-* To fetch the last updated time in PostgreSQL, `track_commit_timestamp` must be set to `on`. Otherwise, all data will be indexed in every sync.
+
+#### Sync types [es-connectors-postgresql-client-sync-types]
+
+[Full syncs](/reference/search-connectors/content-syncs.md#es-connectors-sync-types-full) are supported by default for all connectors.
+
+This connector does not currently support [incremental syncs](/reference/search-connectors/content-syncs.md#es-connectors-sync-types-incremental).
 
 ::::{note}
 * Files bigger than 10 MB won’t be extracted.

--- a/docs/reference/search-connectors/es-postgresql-connector-client-tutorial.md
+++ b/docs/reference/search-connectors/es-postgresql-connector-client-tutorial.md
@@ -28,7 +28,7 @@ Want to get started quickly testing a self-managed connector and a self-managed 
 You must satisfy the [prerequisites](/reference/search-connectors/self-managed-connectors.md#es-build-connector-prerequisites) for self-managed connectors.
 
 <!--
-TBD: If you're using {{es-serverless}}, you must have a `developer` or `admin` predefined role or an equivalent custom role to add the connector. 
+TBD: If you're using {{es-serverless}}, you must have a `developer` or `admin` predefined role or an equivalent custom role to add the connector.
 -->
 
 ### PostgreSQL prerequisites [es-postgresql-connector-client-tutorial-postgresql-prerequisites]
@@ -38,19 +38,6 @@ You need:
 * PostgreSQL version 11+.
 * Tables must be owned by a PostgreSQL user.
 * Database `superuser` privileges are required to index all database tables.
-
-::::{tip}
-You should enable recording of the commit time of PostgreSQL transactions. Otherwise, *all* data will be indexed in every sync. By default, `track_commit_timestamp` is `off`.
-
-Enable this by running the following command on the PosgreSQL server command line:
-
-```shell
-ALTER SYSTEM SET track_commit_timestamp = on;
-```
-
-Then restart the PostgreSQL server.
-
-::::
 
 ## Set up the connector
 
@@ -103,7 +90,7 @@ For this example, we’ll use the latter method:
         connector_id: "<YOUR-CONNECTOR-ID>"
         api_key: "<YOUR-API-KEY>" # Your scoped connector index API key (optional). If not provided, the top-level API key is used.
         service_type: "postgresql"
-    
+
     sources:
       # mongodb: connectors.sources.mongo:MongoDataSource
       # s3: connectors.sources.s3:S3DataSource


### PR DESCRIPTION
## Summary

PostgreSQL connector docs incorrectly implied that enabling `track_commit_timestamp` unlocks incremental syncs (and that without it, every sync re-indexes all data). The PostgreSQL connector does not support incremental syncs.

This PR removes that misleading guidance and states explicitly that only full syncs are supported.

## Changes

- **`es-connectors-postgresql.md`**: Remove `track_commit_timestamp` tip and the “last updated time” bullet; add a **Sync types** section noting incremental syncs are not supported.
- **`es-postgresql-connector-client-tutorial.md`**: Remove the prerequisites tip recommending `ALTER SYSTEM SET track_commit_timestamp = on`.
- **`api-tutorial.md`**: Remove the sentence linking `track_commit_timestamp` to filtering rules and incremental syncs.

The connector index table already lists `-` for PostgreSQL incremental syncs; no change there.

## Test plan

- [X] `./gradlew -p docs check`
- [x] Confirm docs preview renders the updated PostgreSQL pages correctly

Closes https://github.com/elastic/sdh-search/issues/1882