### PR TITLE
Add test showing non-bosted data evicting boosted cache

### DIFF
--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/KeyMapping.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/KeyMapping.java
@@ -77,7 +77,8 @@ class KeyMapping<Key1, Key2, Value> {
         }
     }
 
-    public long countMatchingKey2s(Predicate<Key2> predicate) {
+    // used by tests
+    long countMatchingKey2s(Predicate<Key2> predicate) {
         long count = 0;
         for (ConcurrentHashMap<Key2, Value> map : mapping.values()) {
             count += countMatchingKey2s(map, predicate);

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/KeyMapping.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/KeyMapping.java
@@ -11,6 +11,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 /**
  * A 2 layer key mapping for the shared cache.
@@ -74,5 +75,18 @@ class KeyMapping<Key1, Key2, Value> {
         for (ConcurrentHashMap<Key2, Value> map : mapping.values()) {
             map.forEach(consumer);
         }
+    }
+
+    public long countMatchingKey2s(Predicate<Key2> predicate) {
+        long count = 0;
+        for (ConcurrentHashMap<Key2, Value> map : mapping.values()) {
+            count += countMatchingKey2s(map, predicate);
+        }
+        return count;
+    }
+
+    private static <Key2, Value> long countMatchingKey2s(ConcurrentHashMap<Key2, Value> map, Predicate<Key2> predicate) {
+        int parallelismThreshold = 500; // we don't want to overwhelm the JVM with too many threads
+        return map.reduceToLong(parallelismThreshold, (key, value) -> predicate.test(key) ? 1L : 0L, 0, Long::sum);
     }
 }

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
@@ -2435,13 +2435,7 @@ public class SharedBlobCacheService<KeyType extends SharedBlobCacheService.KeyBa
         }
 
         long countCachedRegions(Predicate<KeyType> predicate) {
-            long[] count = { 0L };
-            keyMapping.forEach((regionKey, entry) -> {
-                if (predicate.test(regionKey.file())) {
-                    count[0]++;
-                }
-            });
-            return count[0];
+            return keyMapping.countMatchingKey2s(regionKey -> predicate.test(regionKey.file()));
         }
 
         /**

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
@@ -768,6 +768,14 @@ public class SharedBlobCacheService<KeyType extends SharedBlobCacheService.KeyBa
         return false;
     }
 
+    // used by tests
+    public long countCachedRegions(Predicate<KeyType> predicate) {
+        if (cache instanceof LFUCache lfuCache) {
+            return lfuCache.countCachedRegions(predicate);
+        }
+        throw new UnsupportedOperationException("cache is not an LFUCache");
+    }
+
     private static void throwAlreadyClosed(String message) {
         throw new AlreadyClosedException(message);
     }
@@ -2424,6 +2432,16 @@ public class SharedBlobCacheService<KeyType extends SharedBlobCacheService.KeyBa
          */
         private void maybeScheduleDecayAndNewEpoch(long currentEpoch) {
             decayAndNewEpochTask.spawnIfNotRunning(currentEpoch);
+        }
+
+        long countCachedRegions(Predicate<KeyType> predicate) {
+            long[] count = { 0L };
+            keyMapping.forEach((regionKey, entry) -> {
+                if (predicate.test(regionKey.file())) {
+                    count[0]++;
+                }
+            });
+            return count[0];
         }
 
         /**

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
@@ -2434,6 +2434,7 @@ public class SharedBlobCacheService<KeyType extends SharedBlobCacheService.KeyBa
             decayAndNewEpochTask.spawnIfNotRunning(currentEpoch);
         }
 
+        // used by tests
         long countCachedRegions(Predicate<KeyType> predicate) {
             return keyMapping.countMatchingKey2s(regionKey -> predicate.test(regionKey.file()));
         }

--- a/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/KeyMappingTests.java
+++ b/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/KeyMappingTests.java
@@ -14,6 +14,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.IntStream;
 
+import static org.hamcrest.Matchers.is;
+
 public class KeyMappingTests extends ESTestCase {
 
     public void testBasics() {
@@ -49,6 +51,37 @@ public class KeyMappingTests extends ESTestCase {
         assertNotNull(mapping.get(k12, k2));
 
         assertFalse(mapping.remove(k1, k2, value));
+    }
+
+    public void testCountMatchingKey2S() {
+        final var mapping = new KeyMapping<String, String, String>();
+
+        // empty mapping always returns 0
+        assertThat(mapping.countMatchingKey2s(k2 -> true), is(0L));
+
+        // populate entries spread across multiple key1 values, with key2 values prefixed "match-" or "skip-"
+        final var matching = randomLongBetween(3, 30);
+        final var nonMatching = randomLongBetween(3, 30);
+        for (var i = 0; i < matching; i++) {
+            final var k1 = "k1-" + randomIntBetween(0, 4);
+            mapping.computeIfAbsent(k1, "match-" + i, kx -> randomAlphanumericOfLength(5));
+        }
+        for (var i = 0; i < nonMatching; i++) {
+            final var k1 = "k1-" + randomIntBetween(0, 4);
+            mapping.computeIfAbsent(k1, "skip-" + i, kx -> randomAlphanumericOfLength(5));
+        }
+
+        assertThat(mapping.countMatchingKey2s(k2 -> k2.startsWith("match-")), is(matching));
+        assertThat(mapping.countMatchingKey2s(k2 -> k2.startsWith("skip-")), is(nonMatching));
+        assertThat(mapping.countMatchingKey2s(k2 -> true), is(matching + nonMatching));
+        assertThat(mapping.countMatchingKey2s(k2 -> false), is(0L));
+
+        // remove one matching entry — count must drop by exactly 1
+        final var removedValue = mapping.get("k1-0", "match-0");
+        if (removedValue != null) {
+            assertThat(mapping.remove("k1-0", "match-0", removedValue), is(true));
+            assertThat(mapping.countMatchingKey2s(k2 -> k2.startsWith("match-")), is(matching - 1));
+        }
     }
 
     public void testMultiThreaded() {

--- a/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/KeyMappingTests.java
+++ b/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/KeyMappingTests.java
@@ -53,7 +53,7 @@ public class KeyMappingTests extends ESTestCase {
         assertFalse(mapping.remove(k1, k2, value));
     }
 
-    public void testCountMatchingKey2S() {
+    public void testCountMatchingKey2s() {
         final var mapping = new KeyMapping<String, String, String>();
 
         // empty mapping always returns 0

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/cache/BoostedDataEvictionIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/cache/BoostedDataEvictionIT.java
@@ -67,9 +67,9 @@ public class BoostedDataEvictionIT extends AbstractStatelessPluginIntegTestCase 
     private static final ByteSizeValue CACHE_SIZE = ByteSizeValue.ofKb(256);
     private static final long BOOST_WINDOW_MILLIS = TimeValue.timeValueDays(7).millis();
     private static final long ONE_DAY_MILLIS = TimeValue.timeValueDays(1).millis();
+    private static final long BOOST_WINDOW_END = Instant.parse("2026-01-01T00:00:00Z").toEpochMilli();
     private final String BOOSTED_IDX = randomIdentifier();
     private final String NON_BOOSTED_IDX = randomIdentifier();
-    private String masterAndIndexNode;
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
@@ -92,22 +92,34 @@ public class BoostedDataEvictionIT extends AbstractStatelessPluginIntegTestCase 
     }
 
     public void testNonBoostedSearchesEvictBoostedData() {
-        startNodes();
-        createIndexes(BOOSTED_IDX, NON_BOOSTED_IDX);
+        final Settings cacheSettings = Settings.builder()
+            .put(SHARED_CACHE_SIZE_SETTING.getKey(), CACHE_SIZE)
+            .put(SHARED_CACHE_REGION_SIZE_SETTING.getKey(), REGION_SIZE)
+            .put(SHARED_CACHE_RANGE_SIZE_SETTING.getKey(), REGION_SIZE)
+            .build();
+        final String masterAndIndexNodeName = startMasterAndIndexNode(cacheSettings);
+        startSearchNode(cacheSettings);
+        final Settings idxSettings = ESTestCase.indexSettings(1, 1)
+            .put(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(), MINUS_ONE)
+            .put(IndexSettings.MODE.getKey(), IndexMode.TIME_SERIES)
+            .put(IndexMetadata.INDEX_ROUTING_PATH.getKey(), "hostname")
+            .put(MergePolicyConfig.INDEX_MERGE_ENABLED, "false")
+            .build();
+
+        assertAcked(prepareCreate(BOOSTED_IDX).setSettings(idxSettings).setMapping(TIMESTAMP_MAPPING));
+        assertAcked(prepareCreate(NON_BOOSTED_IDX).setSettings(idxSettings).setMapping(TIMESTAMP_MAPPING));
+        ensureGreen(BOOSTED_IDX, NON_BOOSTED_IDX);
 
         // Fixed reference point + seeded random offset so failures are reproducible from the test seed,
         // and so the boost-window bounds can be asserted against compound-commit metadata below.
-        final long boostWindowEndInMillis = Instant.parse("2026-01-01T00:00:00Z").toEpochMilli() + randomLongBetween(
-            0,
-            TimeValue.timeValueDays(365).millis()
-        );
+        final long boostWindowEndInMillis = BOOST_WINDOW_END + randomLongBetween(0, TimeValue.timeValueDays(365).millis());
         final long boostWindowStartInMillis = boostWindowEndInMillis - BOOST_WINDOW_MILLIS + ONE_DAY_MILLIS;
         final long preBoostWindowEndInMillis = boostWindowEndInMillis - BOOST_WINDOW_MILLIS - 2 * ONE_DAY_MILLIS;
         final long preBoostWindowStartInMillis = preBoostWindowEndInMillis - 30L * ONE_DAY_MILLIS;
         // Non-boosted index is sized to exceed the cache: many segments ensure non-boosted searches
         // span more cache regions than the cache holds, so LFU eviction must displace every boosted region.
-        indexDocuments(10, NON_BOOSTED_IDX, 10_000, preBoostWindowStartInMillis, preBoostWindowEndInMillis);
-        indexDocuments(10, BOOSTED_IDX, 1_000, boostWindowStartInMillis, boostWindowEndInMillis);
+        indexDocuments(masterAndIndexNodeName, 10, NON_BOOSTED_IDX, 10_000, preBoostWindowStartInMillis, preBoostWindowEndInMillis);
+        indexDocuments(masterAndIndexNodeName, 10, BOOSTED_IDX, 1_000, boostWindowStartInMillis, boostWindowEndInMillis);
 
         final StatelessSharedBlobCacheService cacheService = getCacheService();
         logger.info(
@@ -167,41 +179,18 @@ public class BoostedDataEvictionIT extends AbstractStatelessPluginIntegTestCase 
         }
     }
 
-    private void startNodes() {
-        Settings cacheSettings = Settings.builder()
-            .put(SHARED_CACHE_SIZE_SETTING.getKey(), CACHE_SIZE)
-            .put(SHARED_CACHE_REGION_SIZE_SETTING.getKey(), REGION_SIZE)
-            .put(SHARED_CACHE_RANGE_SIZE_SETTING.getKey(), REGION_SIZE)
-            .build();
-        masterAndIndexNode = startMasterAndIndexNode(cacheSettings);
-        startSearchNode(cacheSettings);
-    }
-
-    private void createIndexes(String boostedIdx, String nonBoostedIdx) {
-        final Settings idxSettings = ESTestCase.indexSettings(1, 1)
-            .put(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(), MINUS_ONE)
-            .put(IndexSettings.MODE.getKey(), IndexMode.TIME_SERIES)
-            .put(IndexMetadata.INDEX_ROUTING_PATH.getKey(), "hostname")
-            .put(MergePolicyConfig.INDEX_MERGE_ENABLED, "false")
-            .build();
-
-        assertAcked(prepareCreate(boostedIdx).setSettings(idxSettings).setMapping(TIMESTAMP_MAPPING));
-        assertAcked(prepareCreate(nonBoostedIdx).setSettings(idxSettings).setMapping(TIMESTAMP_MAPPING));
-        ensureGreen(boostedIdx, nonBoostedIdx);
-    }
-
-    private void indexDocuments(int numBatches, String indexName, int numDocs, long startInMillis, long endInMillis) {
+    private void indexDocuments(String nodeName, int numBatches, String indexName, int numDocs, long startInMillis, long endInMillis) {
         range(0, numBatches).forEach(i -> indexDocumentsWithTimestamp(indexName, numDocs, startInMillis, endInMillis));
         // Verify the @timestamp values we generated actually propagate down to the compound commit metadata
         // (StatelessCompoundCommit#timestampFieldValueRange) — that range is what a future boost feature on
         // the search node will consult, so this asserts the test's "boost window" label is real, not just doc source.
-        assertTimestampRangePropagatedToCommits(indexName, startInMillis, endInMillis);
+        assertTimestampRangePropagatedToCommits(nodeName, indexName, startInMillis, endInMillis);
         flush(indexName);
     }
 
-    private void assertTimestampRangePropagatedToCommits(String indexName, long minBound, long maxBound) {
+    private void assertTimestampRangePropagatedToCommits(String nodeName, String indexName, long minBound, long maxBound) {
         final var shardId = findIndexShard(indexName).shardId();
-        final var commitService = internalCluster().getInstance(StatelessCommitService.class, masterAndIndexNode);
+        final var commitService = internalCluster().getInstance(StatelessCommitService.class, nodeName);
         final var virtualBcc = commitService.getCurrentVirtualBcc(shardId);
         assertThat("expected a pending virtual BCC for shard " + shardId, virtualBcc, notNullValue());
         final var pendingCommits = virtualBcc.getPendingCompoundCommits();

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/cache/BoostedDataEvictionIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/cache/BoostedDataEvictionIT.java
@@ -10,9 +10,11 @@ package org.elasticsearch.xpack.stateless.cache;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.blobcache.shared.SharedBlobCacheService;
 import org.elasticsearch.cluster.metadata.DataStream;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.MergePolicyConfig;
 import org.elasticsearch.index.shard.IndexShard;
@@ -36,12 +38,24 @@ import static org.elasticsearch.search.sort.SortOrder.ASC;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 
 public class BoostedDataEvictionIT extends AbstractStatelessPluginIntegTestCase {
 
     private static final String TIMESTAMP_MAPPING = """
-        {"properties":{"@timestamp":{"type":"date"}}}""";
+        {
+            "properties": {
+                "@timestamp": {
+                    "type":"date"
+                },
+                "hostname": {
+                    "type":"keyword",
+                    "time_series_dimension": true
+                }
+            }
+        }
+        """;
 
     // non-boosted doc-value reads (sort forces reading all values per segment) overflow it.
     private static final ByteSizeValue REGION_SIZE = ByteSizeValue.ofKb(4); // TODO randomisation
@@ -70,64 +84,60 @@ public class BoostedDataEvictionIT extends AbstractStatelessPluginIntegTestCase 
 
         final long boostWindowEndInMillis = System.currentTimeMillis();
         final long boostWindowStartInMillis = boostWindowEndInMillis - BOOST_WINDOW_MILLIS + ONE_DAY_MILLIS;
-        indexDocuments(10, BOOSTED_IDX, 1_000, boostWindowStartInMillis, boostWindowEndInMillis);
-
         final long preBoostWindowEndInMillis = boostWindowEndInMillis - BOOST_WINDOW_MILLIS - 2 * ONE_DAY_MILLIS;
         final long preBoostWindowStartInMillis = preBoostWindowEndInMillis - 30L * ONE_DAY_MILLIS;
-        indexDocuments(5, NON_BOOSTED_IDX, 10_000, preBoostWindowStartInMillis, preBoostWindowEndInMillis);
+        // Non-boosted index is sized to exceed the cache: many segments ensure non-boosted searches
+        // span more cache regions than the cache holds, so LFU eviction must displace every boosted region.
+        indexDocuments(10, NON_BOOSTED_IDX, 10_000, preBoostWindowStartInMillis, preBoostWindowEndInMillis);
+        indexDocuments(10, BOOSTED_IDX, 1_000, boostWindowStartInMillis, boostWindowEndInMillis);
 
         final StatelessSharedBlobCacheService cacheService = getCacheService();
-        cacheService.forceEvict(key -> true);
-        logger.info("cache after forceEvict: {}", cacheService.getStats());
+        logger.info("cache regions after ingesting docs: boosted={}, non-boosted={}",
+            cacheRegionsForIndex(cacheService, BOOSTED_IDX), cacheRegionsForIndex(cacheService, NON_BOOSTED_IDX));
 
         // Step 1 — populate the cache with boosted data via a single on-demand search.
         // All boosted regions start at LFU frequency 1 (written once, not yet promoted).
         searchBoostedData(BOOSTED_IDX);
 
         final SharedBlobCacheService.Stats statsAfterBoostSearch = cacheService.getStats();
-        logger.info("cache after boosted search: {}", statsAfterBoostSearch);
+        logger.info("boosted cache regions after searching boosted docs: boosted={}, non-boosted={}",
+            cacheRegionsForIndex(cacheService, BOOSTED_IDX), cacheRegionsForIndex(cacheService, NON_BOOSTED_IDX));
 
         assertThat("boosted data should have been loaded into the cache", statsAfterBoostSearch.writeBytes(), greaterThan(0L));
-        assertThat("boosted cache regions should be resident", statsAfterBoostSearch.numberOfRegions(), greaterThan(0));
+        assertThat("boosted cache regions should be resident", cacheRegionsForIndex(cacheService, BOOSTED_IDX), greaterThan(0L));
 
         // Step 2 — drive non-boosted searches. Sorting by @timestamp forces reading all doc-value
         // data per segment, generating enough blob-cache reads to overflow the small cache.
         // Both boosted and non-boosted regions compete at the same LFU frequency (1); the older
         // boosted regions are evicted first under the LFU clock.
-        final long evictCountBaseline = statsAfterBoostSearch.evictCount();
         searchNonBoostedData(NON_BOOSTED_IDX);
 
-        logger.info("cache after non-boosted searches: {}", cacheService.getStats());
+        logger.info("boosted cache regions after searching non-boosted docs: boosted={}, non-boosted={}",
+            cacheRegionsForIndex(cacheService, BOOSTED_IDX), cacheRegionsForIndex(cacheService, NON_BOOSTED_IDX));
         assertThat(
-            "non-boosted searches must have caused cache evictions",
-            cacheService.getStats().evictCount(),
-            greaterThan(evictCountBaseline)
+            "boosted regions must have been fully evicted by non-boosted searches",
+            cacheRegionsForIndex(cacheService, BOOSTED_IDX),
+            equalTo(0L)
         );
+    }
 
-        // Step 3 — re-search the boosted index. Evicted boosted regions must be re-fetched from
-        // the object store, proving that non-boosted traffic displaced the boosted cache data.
-        final SharedBlobCacheService.Stats statsBeforeReSearch = cacheService.getStats();
-        searchBoostedData(BOOSTED_IDX);
-
-        logger.info("cache after boosted re-search: {}", cacheService.getStats());
-        assertThat(
-            "re-search of boosted index must trigger cache misses because boosted regions were evicted",
-            cacheService.getStats().missCount(),
-            greaterThan(statsBeforeReSearch.missCount())
-        );
+    private long cacheRegionsForIndex(StatelessSharedBlobCacheService cacheService, String indexName) {
+        return cacheService.countCachedRegions(key -> key.shardId().getIndexName().equals(indexName));
     }
 
     private static void searchNonBoostedData(String nonBoostedIdx) {
         for (int i = 0; i < randomIntBetween(2, 4); i++) {
             assertResponse(
-                prepareSearch(nonBoostedIdx).setSize(1_000).addSort(DataStream.TIMESTAMP_FIELD_NAME, ASC),
+                prepareSearch(nonBoostedIdx).setSize(5_000).addSort(DataStream.TIMESTAMP_FIELD_NAME, ASC),
                 ElasticsearchAssertions::assertNoFailures
             );
         }
     }
 
     private static void searchBoostedData(String boostedIdx) {
-        assertResponse(prepareSearch(boostedIdx).setSize(1_000), ElasticsearchAssertions::assertNoFailures);
+        for (int i = 0; i < randomIntBetween(2, 4); i++) {
+            assertResponse(prepareSearch(boostedIdx).setSize(1_000), ElasticsearchAssertions::assertNoFailures);
+        }
     }
 
     private void startNodes() {
@@ -143,6 +153,8 @@ public class BoostedDataEvictionIT extends AbstractStatelessPluginIntegTestCase 
     private void createIndexes(String boostedIdx, String nonBoostedIdx) {
         final Settings idxSettings = ESTestCase.indexSettings(1, 1)
             .put(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(), MINUS_ONE)
+            .put(IndexSettings.MODE.getKey() , IndexMode.TIME_SERIES)
+            .put(IndexMetadata.INDEX_ROUTING_PATH.getKey(), "hostname")
             .put(MergePolicyConfig.INDEX_MERGE_ENABLED, "false")
             .build();
 
@@ -159,7 +171,11 @@ public class BoostedDataEvictionIT extends AbstractStatelessPluginIntegTestCase 
     private void indexDocumentsWithTimestamp(String indexName, int numDocs, long minTimestamp, long maxTimestamp) {
         var bulk = client().prepareBulk().setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
         range(0, numDocs).mapToObj(
-            i -> client().prepareIndex(indexName).setSource(DataStream.TIMESTAMP_FIELD_NAME, randomLongBetween(minTimestamp, maxTimestamp))
+            i -> client().prepareIndex(indexName)
+                .setSource(
+                    DataStream.TIMESTAMP_FIELD_NAME, randomLongBetween(minTimestamp, maxTimestamp),
+                    "hostname", "host-" + randomIntBetween(1, 5)
+                )
         ).forEach(bulk::add);
         assertNoFailures(bulk.get());
     }

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/cache/BoostedDataEvictionIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/cache/BoostedDataEvictionIT.java
@@ -97,8 +97,10 @@ public class BoostedDataEvictionIT extends AbstractStatelessPluginIntegTestCase 
 
         // Fixed reference point + seeded random offset so failures are reproducible from the test seed,
         // and so the boost-window bounds can be asserted against compound-commit metadata below.
-        final long boostWindowEndInMillis = Instant.parse("2026-01-01T00:00:00Z").toEpochMilli()
-            + randomLongBetween(0, TimeValue.timeValueDays(365).millis());
+        final long boostWindowEndInMillis = Instant.parse("2026-01-01T00:00:00Z").toEpochMilli() + randomLongBetween(
+            0,
+            TimeValue.timeValueDays(365).millis()
+        );
         final long boostWindowStartInMillis = boostWindowEndInMillis - BOOST_WINDOW_MILLIS + ONE_DAY_MILLIS;
         final long preBoostWindowEndInMillis = boostWindowEndInMillis - BOOST_WINDOW_MILLIS - 2 * ONE_DAY_MILLIS;
         final long preBoostWindowStartInMillis = preBoostWindowEndInMillis - 30L * ONE_DAY_MILLIS;

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/cache/BoostedDataEvictionIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/cache/BoostedDataEvictionIT.java
@@ -66,8 +66,7 @@ public class BoostedDataEvictionIT extends AbstractStatelessPluginIntegTestCase 
     @Override
     protected Settings.Builder nodeSettings() {
         // Disable all background warmers so nothing populates the cache between test steps
-        return super.nodeSettings()
-            .put(StatelessOnlinePrewarmingService.STATELESS_ONLINE_PREWARMING_ENABLED.getKey(), false)
+        return super.nodeSettings().put(StatelessOnlinePrewarmingService.STATELESS_ONLINE_PREWARMING_ENABLED.getKey(), false)
             .put(SearchCommitPrefetcherDynamicSettings.PREFETCH_COMMITS_UPON_NOTIFICATIONS_ENABLED_SETTING.getKey(), false)
             .put(SharedBlobCacheWarmingService.SEARCH_OFFLINE_WARMING_ENABLED_SETTING.getKey(), false);
     }
@@ -174,9 +173,7 @@ public class BoostedDataEvictionIT extends AbstractStatelessPluginIntegTestCase 
 
     private StatelessSharedBlobCacheService getCacheService() {
         final IndexShard boostedShard = findSearchShard(BOOSTED_IDX);
-        return BlobStoreCacheDirectoryTestUtils.getCacheService(
-            SearchDirectory.unwrapDirectory(boostedShard.store().directory())
-        );
+        return BlobStoreCacheDirectoryTestUtils.getCacheService(SearchDirectory.unwrapDirectory(boostedShard.store().directory()));
     }
 
 }

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/cache/BoostedDataEvictionIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/cache/BoostedDataEvictionIT.java
@@ -67,6 +67,7 @@ public class BoostedDataEvictionIT extends AbstractStatelessPluginIntegTestCase 
     private static final ByteSizeValue CACHE_SIZE = ByteSizeValue.ofKb(256);
     private static final long BOOST_WINDOW_MILLIS = TimeValue.timeValueDays(7).millis();
     private static final long ONE_DAY_MILLIS = TimeValue.timeValueDays(1).millis();
+    // we avoid current timestamp to ease potential test failures reproduction
     private static final long BOOST_WINDOW_END = Instant.parse("2026-01-01T00:00:00Z").toEpochMilli();
     private final String BOOSTED_IDX = randomIdentifier();
     private final String NON_BOOSTED_IDX = randomIdentifier();
@@ -77,18 +78,16 @@ public class BoostedDataEvictionIT extends AbstractStatelessPluginIntegTestCase 
     }
 
     @Override
-    public int getUploadMaxCommits() {
-        // Keep compound commits in the virtual BCC's pending list until we explicitly flush, so the
-        // timestampFieldValueRange assertion in indexDocuments has something to inspect.
-        return Integer.MAX_VALUE;
-    }
-
-    @Override
     protected Settings.Builder nodeSettings() {
         // Disable all background warmers so nothing populates the cache between test steps
-        return super.nodeSettings().put(StatelessOnlinePrewarmingService.STATELESS_ONLINE_PREWARMING_ENABLED.getKey(), false)
+        return super.nodeSettings()
+            .put(disableIndexingDiskAndMemoryControllersNodeSettings())
+            .put(StatelessOnlinePrewarmingService.STATELESS_ONLINE_PREWARMING_ENABLED.getKey(), false)
             .put(SearchCommitPrefetcherDynamicSettings.PREFETCH_COMMITS_UPON_NOTIFICATIONS_ENABLED_SETTING.getKey(), false)
-            .put(SharedBlobCacheWarmingService.SEARCH_OFFLINE_WARMING_ENABLED_SETTING.getKey(), false);
+            .put(SharedBlobCacheWarmingService.SEARCH_OFFLINE_WARMING_ENABLED_SETTING.getKey(), false)
+            .put(StatelessCommitService.STATELESS_UPLOAD_MAX_AMOUNT_COMMITS.getKey(), Integer.MAX_VALUE)
+            .put(StatelessCommitService.STATELESS_UPLOAD_MAX_SIZE.getKey(), ByteSizeValue.ofGb(1));
+
     }
 
     public void testNonBoostedSearchesEvictBoostedData() {
@@ -114,15 +113,15 @@ public class BoostedDataEvictionIT extends AbstractStatelessPluginIntegTestCase 
         // and so the boost-window bounds can be asserted against compound-commit metadata below.
         final long boostWindowEndInMillis = BOOST_WINDOW_END + randomLongBetween(0, TimeValue.timeValueDays(365).millis());
         final long boostWindowStartInMillis = boostWindowEndInMillis - BOOST_WINDOW_MILLIS + ONE_DAY_MILLIS;
-        final long preBoostWindowEndInMillis = boostWindowEndInMillis - BOOST_WINDOW_MILLIS - 2 * ONE_DAY_MILLIS;
-        final long preBoostWindowStartInMillis = preBoostWindowEndInMillis - 30L * ONE_DAY_MILLIS;
+        final long nonBoostWindowEndInMillis = boostWindowEndInMillis - BOOST_WINDOW_MILLIS - 2 * ONE_DAY_MILLIS;
+        final long nonBoostWindowStartInMillis = nonBoostWindowEndInMillis - 30L * ONE_DAY_MILLIS;
         // Non-boosted index is sized to exceed the cache: many segments ensure non-boosted searches
         // span more cache regions than the cache holds, so LFU eviction must displace every boosted region.
-        indexDocuments(masterAndIndexNodeName, 10, NON_BOOSTED_IDX, 10_000, preBoostWindowStartInMillis, preBoostWindowEndInMillis);
+        indexDocuments(masterAndIndexNodeName, 10, NON_BOOSTED_IDX, 10_000, nonBoostWindowStartInMillis, nonBoostWindowEndInMillis);
         indexDocuments(masterAndIndexNodeName, 10, BOOSTED_IDX, 1_000, boostWindowStartInMillis, boostWindowEndInMillis);
 
         final StatelessSharedBlobCacheService cacheService = getCacheService();
-        logger.info(
+        logger.debug(
             "cache regions after ingesting docs: boosted={}, non-boosted={}",
             cacheRegionsForIndex(cacheService, BOOSTED_IDX),
             cacheRegionsForIndex(cacheService, NON_BOOSTED_IDX)
@@ -133,7 +132,7 @@ public class BoostedDataEvictionIT extends AbstractStatelessPluginIntegTestCase 
         searchBoostedData(BOOSTED_IDX);
 
         final SharedBlobCacheService.Stats statsAfterBoostSearch = cacheService.getStats();
-        logger.info(
+        logger.debug(
             "boosted cache regions after searching boosted docs: boosted={}, non-boosted={}",
             cacheRegionsForIndex(cacheService, BOOSTED_IDX),
             cacheRegionsForIndex(cacheService, NON_BOOSTED_IDX)
@@ -148,11 +147,13 @@ public class BoostedDataEvictionIT extends AbstractStatelessPluginIntegTestCase 
         // boosted regions are evicted first under the LFU clock.
         searchNonBoostedData(NON_BOOSTED_IDX);
 
-        logger.info(
+        logger.debug(
             "boosted cache regions after searching non-boosted docs: boosted={}, non-boosted={}",
             cacheRegionsForIndex(cacheService, BOOSTED_IDX),
             cacheRegionsForIndex(cacheService, NON_BOOSTED_IDX)
         );
+
+        // TODO this is the current behavior we want to get rid off, as a part of caching infrastructure improvements
         assertThat(
             "boosted regions must have been fully evicted by non-boosted searches",
             cacheRegionsForIndex(cacheService, BOOSTED_IDX),

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/cache/BoostedDataEvictionIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/cache/BoostedDataEvictionIT.java
@@ -80,8 +80,7 @@ public class BoostedDataEvictionIT extends AbstractStatelessPluginIntegTestCase 
     @Override
     protected Settings.Builder nodeSettings() {
         // Disable all background warmers so nothing populates the cache between test steps
-        return super.nodeSettings()
-            .put(disableIndexingDiskAndMemoryControllersNodeSettings())
+        return super.nodeSettings().put(disableIndexingDiskAndMemoryControllersNodeSettings())
             .put(StatelessOnlinePrewarmingService.STATELESS_ONLINE_PREWARMING_ENABLED.getKey(), false)
             .put(SearchCommitPrefetcherDynamicSettings.PREFETCH_COMMITS_UPON_NOTIFICATIONS_ENABLED_SETTING.getKey(), false)
             .put(SharedBlobCacheWarmingService.SEARCH_OFFLINE_WARMING_ENABLED_SETTING.getKey(), false)

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/cache/BoostedDataEvictionIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/cache/BoostedDataEvictionIT.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.stateless.cache;
+
+import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.blobcache.shared.SharedBlobCacheService;
+import org.elasticsearch.cluster.metadata.DataStream;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.MergePolicyConfig;
+import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.InternalSettingsPlugin;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
+import org.elasticsearch.xpack.stateless.AbstractStatelessPluginIntegTestCase;
+import org.elasticsearch.xpack.stateless.lucene.BlobStoreCacheDirectoryTestUtils;
+import org.elasticsearch.xpack.stateless.lucene.SearchDirectory;
+
+import java.util.Collection;
+
+import static java.util.stream.IntStream.range;
+import static org.elasticsearch.blobcache.shared.SharedBlobCacheService.SHARED_CACHE_RANGE_SIZE_SETTING;
+import static org.elasticsearch.blobcache.shared.SharedBlobCacheService.SHARED_CACHE_REGION_SIZE_SETTING;
+import static org.elasticsearch.blobcache.shared.SharedBlobCacheService.SHARED_CACHE_SIZE_SETTING;
+import static org.elasticsearch.common.util.CollectionUtils.appendToCopy;
+import static org.elasticsearch.core.TimeValue.MINUS_ONE;
+import static org.elasticsearch.search.sort.SortOrder.ASC;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
+import static org.hamcrest.Matchers.greaterThan;
+
+/// Verifies that non-boosted searches (over data older than the boost window) can evict
+/// pre-warmed boosted data from the shared blob cache.
+///
+/// The shared blob cache is a single global LFU with no priority tier. Pre-warmed regions for
+/// in-window ("boosted") data compete on the same frequency ladder as on-demand reads for
+/// out-of-window ("non-boosted") data. When the cache is full, non-boosted search reads can
+/// promote new regions and evict previously-warmed boosted regions.
+public class BoostedDataEvictionIT extends AbstractStatelessPluginIntegTestCase {
+
+    private static final String TIMESTAMP_MAPPING = """
+        {"properties":{"@timestamp":{"type":"date"}}}""";
+
+    // non-boosted doc-value reads (sort forces reading all values per segment) overflow it.
+    private static final ByteSizeValue REGION_SIZE = ByteSizeValue.ofKb(4); // TODO randomisation
+    private static final ByteSizeValue CACHE_SIZE = ByteSizeValue.ofKb(256);
+    private static final long BOOST_WINDOW_MILLIS = TimeValue.timeValueDays(7).millis();
+    private static final long ONE_DAY_MILLIS = TimeValue.timeValueDays(1).millis();
+    private final String BOOSTED_IDX = randomIdentifier();
+    private final String NON_BOOSTED_IDX = randomIdentifier();
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return appendToCopy(super.nodePlugins(), InternalSettingsPlugin.class);
+    }
+
+    @Override
+    protected Settings.Builder nodeSettings() {
+        // Disable all background warmers so nothing populates the cache between test steps
+        return super.nodeSettings()
+            .put(StatelessOnlinePrewarmingService.STATELESS_ONLINE_PREWARMING_ENABLED.getKey(), false)
+            .put(SearchCommitPrefetcherDynamicSettings.PREFETCH_COMMITS_UPON_NOTIFICATIONS_ENABLED_SETTING.getKey(), false)
+            .put(SharedBlobCacheWarmingService.SEARCH_OFFLINE_WARMING_ENABLED_SETTING.getKey(), false);
+    }
+
+    public void testNonBoostedSearchesEvictBoostedData() {
+        startNodes();
+        createIndexes(BOOSTED_IDX, NON_BOOSTED_IDX);
+
+        final long boostWindowEndInMillis = System.currentTimeMillis();
+        final long boostWindowStartInMillis = boostWindowEndInMillis - BOOST_WINDOW_MILLIS + ONE_DAY_MILLIS;
+        indexDocuments(10, BOOSTED_IDX, 1_000, boostWindowStartInMillis, boostWindowEndInMillis);
+
+        final long preBoostWindowEndInMillis = boostWindowEndInMillis - BOOST_WINDOW_MILLIS - 2 * ONE_DAY_MILLIS;
+        final long preBoostWindowStartInMillis = preBoostWindowEndInMillis - 30L * ONE_DAY_MILLIS;
+        indexDocuments(5, NON_BOOSTED_IDX, 10_000, preBoostWindowStartInMillis, preBoostWindowEndInMillis);
+
+        final StatelessSharedBlobCacheService cacheService = getCacheService();
+        cacheService.forceEvict(key -> true);
+        logger.info("cache after forceEvict: {}", cacheService.getStats());
+
+        // Step 1 — populate the cache with boosted data via a single on-demand search.
+        // All boosted regions start at LFU frequency 1 (written once, not yet promoted).
+        searchBoostedData(BOOSTED_IDX);
+
+        final SharedBlobCacheService.Stats statsAfterBoostSearch = cacheService.getStats();
+        logger.info("cache after boosted search: {}", statsAfterBoostSearch);
+
+        assertThat("boosted data should have been loaded into the cache", statsAfterBoostSearch.writeBytes(), greaterThan(0L));
+        assertThat("boosted cache regions should be resident", statsAfterBoostSearch.numberOfRegions(), greaterThan(0));
+
+        // Step 2 — drive non-boosted searches. Sorting by @timestamp forces reading all doc-value
+        // data per segment, generating enough blob-cache reads to overflow the small cache.
+        // Both boosted and non-boosted regions compete at the same LFU frequency (1); the older
+        // boosted regions are evicted first under the LFU clock.
+        final long evictCountBaseline = statsAfterBoostSearch.evictCount();
+        searchNonBoostedData(NON_BOOSTED_IDX);
+
+        logger.info("cache after non-boosted searches: {}", cacheService.getStats());
+        assertThat(
+            "non-boosted searches must have caused cache evictions",
+            cacheService.getStats().evictCount(),
+            greaterThan(evictCountBaseline)
+        );
+
+        // Step 3 — re-search the boosted index. Evicted boosted regions must be re-fetched from
+        // the object store, proving that non-boosted traffic displaced the boosted cache data.
+        final SharedBlobCacheService.Stats statsBeforeReSearch = cacheService.getStats();
+        searchBoostedData(BOOSTED_IDX);
+
+        logger.info("cache after boosted re-search: {}", cacheService.getStats());
+        assertThat(
+            "re-search of boosted index must trigger cache misses because boosted regions were evicted",
+            cacheService.getStats().missCount(),
+            greaterThan(statsBeforeReSearch.missCount())
+        );
+    }
+
+    private static void searchNonBoostedData(String nonBoostedIdx) {
+        for (int i = 0; i < randomIntBetween(2, 4); i++) {
+            assertResponse(
+                prepareSearch(nonBoostedIdx).setSize(1_000).addSort(DataStream.TIMESTAMP_FIELD_NAME, ASC),
+                ElasticsearchAssertions::assertNoFailures
+            );
+        }
+    }
+
+    private static void searchBoostedData(String boostedIdx) {
+        assertResponse(prepareSearch(boostedIdx).setSize(1_000), ElasticsearchAssertions::assertNoFailures);
+    }
+
+    private void startNodes() {
+        Settings cacheSettings = Settings.builder()
+            .put(SHARED_CACHE_SIZE_SETTING.getKey(), CACHE_SIZE)
+            .put(SHARED_CACHE_REGION_SIZE_SETTING.getKey(), REGION_SIZE)
+            .put(SHARED_CACHE_RANGE_SIZE_SETTING.getKey(), REGION_SIZE)
+            .build();
+        startMasterAndIndexNode(cacheSettings);
+        startSearchNode(cacheSettings);
+    }
+
+    private void createIndexes(String boostedIdx, String nonBoostedIdx) {
+        final Settings idxSettings = ESTestCase.indexSettings(1, 1)
+            .put(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(), MINUS_ONE)
+            .put(MergePolicyConfig.INDEX_MERGE_ENABLED, "false")
+            .build();
+
+        assertAcked(prepareCreate(boostedIdx).setSettings(idxSettings).setMapping(TIMESTAMP_MAPPING));
+        assertAcked(prepareCreate(nonBoostedIdx).setSettings(idxSettings).setMapping(TIMESTAMP_MAPPING));
+        ensureGreen(boostedIdx, nonBoostedIdx);
+    }
+
+    private void indexDocuments(int numBatches, String indexName, int numDocs, long startInMillis, long endInMillis) {
+        range(0, numBatches).forEach(i -> indexDocumentsWithTimestamp(indexName, numDocs, startInMillis, endInMillis));
+        flush(indexName);
+    }
+
+    private void indexDocumentsWithTimestamp(String indexName, int numDocs, long minTimestamp, long maxTimestamp) {
+        var bulk = client().prepareBulk().setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+        range(0, numDocs).mapToObj(
+            i -> client().prepareIndex(indexName).setSource(DataStream.TIMESTAMP_FIELD_NAME, randomLongBetween(minTimestamp, maxTimestamp))
+        ).forEach(bulk::add);
+        assertNoFailures(bulk.get());
+    }
+
+    private StatelessSharedBlobCacheService getCacheService() {
+        final IndexShard boostedShard = findSearchShard(BOOSTED_IDX);
+        return BlobStoreCacheDirectoryTestUtils.getCacheService(
+            SearchDirectory.unwrapDirectory(boostedShard.store().directory())
+        );
+    }
+
+}

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/cache/BoostedDataEvictionIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/cache/BoostedDataEvictionIT.java
@@ -38,13 +38,6 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFa
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.hamcrest.Matchers.greaterThan;
 
-/// Verifies that non-boosted searches (over data older than the boost window) can evict
-/// pre-warmed boosted data from the shared blob cache.
-///
-/// The shared blob cache is a single global LFU with no priority tier. Pre-warmed regions for
-/// in-window ("boosted") data compete on the same frequency ladder as on-demand reads for
-/// out-of-window ("non-boosted") data. When the cache is full, non-boosted search reads can
-/// promote new regions and evict previously-warmed boosted regions.
 public class BoostedDataEvictionIT extends AbstractStatelessPluginIntegTestCase {
 
     private static final String TIMESTAMP_MAPPING = """

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/cache/BoostedDataEvictionIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/cache/BoostedDataEvictionIT.java
@@ -92,16 +92,22 @@ public class BoostedDataEvictionIT extends AbstractStatelessPluginIntegTestCase 
         indexDocuments(10, BOOSTED_IDX, 1_000, boostWindowStartInMillis, boostWindowEndInMillis);
 
         final StatelessSharedBlobCacheService cacheService = getCacheService();
-        logger.info("cache regions after ingesting docs: boosted={}, non-boosted={}",
-            cacheRegionsForIndex(cacheService, BOOSTED_IDX), cacheRegionsForIndex(cacheService, NON_BOOSTED_IDX));
+        logger.info(
+            "cache regions after ingesting docs: boosted={}, non-boosted={}",
+            cacheRegionsForIndex(cacheService, BOOSTED_IDX),
+            cacheRegionsForIndex(cacheService, NON_BOOSTED_IDX)
+        );
 
         // Step 1 — populate the cache with boosted data via a single on-demand search.
         // All boosted regions start at LFU frequency 1 (written once, not yet promoted).
         searchBoostedData(BOOSTED_IDX);
 
         final SharedBlobCacheService.Stats statsAfterBoostSearch = cacheService.getStats();
-        logger.info("boosted cache regions after searching boosted docs: boosted={}, non-boosted={}",
-            cacheRegionsForIndex(cacheService, BOOSTED_IDX), cacheRegionsForIndex(cacheService, NON_BOOSTED_IDX));
+        logger.info(
+            "boosted cache regions after searching boosted docs: boosted={}, non-boosted={}",
+            cacheRegionsForIndex(cacheService, BOOSTED_IDX),
+            cacheRegionsForIndex(cacheService, NON_BOOSTED_IDX)
+        );
 
         assertThat("boosted data should have been loaded into the cache", statsAfterBoostSearch.writeBytes(), greaterThan(0L));
         assertThat("boosted cache regions should be resident", cacheRegionsForIndex(cacheService, BOOSTED_IDX), greaterThan(0L));
@@ -112,8 +118,11 @@ public class BoostedDataEvictionIT extends AbstractStatelessPluginIntegTestCase 
         // boosted regions are evicted first under the LFU clock.
         searchNonBoostedData(NON_BOOSTED_IDX);
 
-        logger.info("boosted cache regions after searching non-boosted docs: boosted={}, non-boosted={}",
-            cacheRegionsForIndex(cacheService, BOOSTED_IDX), cacheRegionsForIndex(cacheService, NON_BOOSTED_IDX));
+        logger.info(
+            "boosted cache regions after searching non-boosted docs: boosted={}, non-boosted={}",
+            cacheRegionsForIndex(cacheService, BOOSTED_IDX),
+            cacheRegionsForIndex(cacheService, NON_BOOSTED_IDX)
+        );
         assertThat(
             "boosted regions must have been fully evicted by non-boosted searches",
             cacheRegionsForIndex(cacheService, BOOSTED_IDX),
@@ -153,7 +162,7 @@ public class BoostedDataEvictionIT extends AbstractStatelessPluginIntegTestCase 
     private void createIndexes(String boostedIdx, String nonBoostedIdx) {
         final Settings idxSettings = ESTestCase.indexSettings(1, 1)
             .put(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(), MINUS_ONE)
-            .put(IndexSettings.MODE.getKey() , IndexMode.TIME_SERIES)
+            .put(IndexSettings.MODE.getKey(), IndexMode.TIME_SERIES)
             .put(IndexMetadata.INDEX_ROUTING_PATH.getKey(), "hostname")
             .put(MergePolicyConfig.INDEX_MERGE_ENABLED, "false")
             .build();
@@ -173,8 +182,10 @@ public class BoostedDataEvictionIT extends AbstractStatelessPluginIntegTestCase 
         range(0, numDocs).mapToObj(
             i -> client().prepareIndex(indexName)
                 .setSource(
-                    DataStream.TIMESTAMP_FIELD_NAME, randomLongBetween(minTimestamp, maxTimestamp),
-                    "hostname", "host-" + randomIntBetween(1, 5)
+                    DataStream.TIMESTAMP_FIELD_NAME,
+                    randomLongBetween(minTimestamp, maxTimestamp),
+                    "hostname",
+                    "host-" + randomIntBetween(1, 5)
                 )
         ).forEach(bulk::add);
         assertNoFailures(bulk.get());

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/cache/BoostedDataEvictionIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/cache/BoostedDataEvictionIT.java
@@ -23,9 +23,11 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.InternalSettingsPlugin;
 import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.xpack.stateless.AbstractStatelessPluginIntegTestCase;
+import org.elasticsearch.xpack.stateless.commits.StatelessCommitService;
 import org.elasticsearch.xpack.stateless.lucene.BlobStoreCacheDirectoryTestUtils;
 import org.elasticsearch.xpack.stateless.lucene.SearchDirectory;
 
+import java.time.Instant;
 import java.util.Collection;
 
 import static java.util.stream.IntStream.range;
@@ -40,6 +42,9 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFa
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.notNullValue;
 
 public class BoostedDataEvictionIT extends AbstractStatelessPluginIntegTestCase {
 
@@ -64,10 +69,18 @@ public class BoostedDataEvictionIT extends AbstractStatelessPluginIntegTestCase 
     private static final long ONE_DAY_MILLIS = TimeValue.timeValueDays(1).millis();
     private final String BOOSTED_IDX = randomIdentifier();
     private final String NON_BOOSTED_IDX = randomIdentifier();
+    private String masterAndIndexNode;
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
         return appendToCopy(super.nodePlugins(), InternalSettingsPlugin.class);
+    }
+
+    @Override
+    public int getUploadMaxCommits() {
+        // Keep compound commits in the virtual BCC's pending list until we explicitly flush, so the
+        // timestampFieldValueRange assertion in indexDocuments has something to inspect.
+        return Integer.MAX_VALUE;
     }
 
     @Override
@@ -82,7 +95,10 @@ public class BoostedDataEvictionIT extends AbstractStatelessPluginIntegTestCase 
         startNodes();
         createIndexes(BOOSTED_IDX, NON_BOOSTED_IDX);
 
-        final long boostWindowEndInMillis = System.currentTimeMillis();
+        // Fixed reference point + seeded random offset so failures are reproducible from the test seed,
+        // and so the boost-window bounds can be asserted against compound-commit metadata below.
+        final long boostWindowEndInMillis = Instant.parse("2026-01-01T00:00:00Z").toEpochMilli()
+            + randomLongBetween(0, TimeValue.timeValueDays(365).millis());
         final long boostWindowStartInMillis = boostWindowEndInMillis - BOOST_WINDOW_MILLIS + ONE_DAY_MILLIS;
         final long preBoostWindowEndInMillis = boostWindowEndInMillis - BOOST_WINDOW_MILLIS - 2 * ONE_DAY_MILLIS;
         final long preBoostWindowStartInMillis = preBoostWindowEndInMillis - 30L * ONE_DAY_MILLIS;
@@ -155,7 +171,7 @@ public class BoostedDataEvictionIT extends AbstractStatelessPluginIntegTestCase 
             .put(SHARED_CACHE_REGION_SIZE_SETTING.getKey(), REGION_SIZE)
             .put(SHARED_CACHE_RANGE_SIZE_SETTING.getKey(), REGION_SIZE)
             .build();
-        startMasterAndIndexNode(cacheSettings);
+        masterAndIndexNode = startMasterAndIndexNode(cacheSettings);
         startSearchNode(cacheSettings);
     }
 
@@ -174,7 +190,26 @@ public class BoostedDataEvictionIT extends AbstractStatelessPluginIntegTestCase 
 
     private void indexDocuments(int numBatches, String indexName, int numDocs, long startInMillis, long endInMillis) {
         range(0, numBatches).forEach(i -> indexDocumentsWithTimestamp(indexName, numDocs, startInMillis, endInMillis));
+        // Verify the @timestamp values we generated actually propagate down to the compound commit metadata
+        // (StatelessCompoundCommit#timestampFieldValueRange) — that range is what a future boost feature on
+        // the search node will consult, so this asserts the test's "boost window" label is real, not just doc source.
+        assertTimestampRangePropagatedToCommits(indexName, startInMillis, endInMillis);
         flush(indexName);
+    }
+
+    private void assertTimestampRangePropagatedToCommits(String indexName, long minBound, long maxBound) {
+        final var shardId = findIndexShard(indexName).shardId();
+        final var commitService = internalCluster().getInstance(StatelessCommitService.class, masterAndIndexNode);
+        final var virtualBcc = commitService.getCurrentVirtualBcc(shardId);
+        assertThat("expected a pending virtual BCC for shard " + shardId, virtualBcc, notNullValue());
+        final var pendingCommits = virtualBcc.getPendingCompoundCommits();
+        assertThat("expected at least one pending compound commit", pendingCommits.size(), greaterThan(0));
+        for (final var pendingCC : pendingCommits) {
+            final var range = pendingCC.getStatelessCompoundCommit().timestampFieldValueRange();
+            assertThat("compound commit must carry a @timestamp range", range, notNullValue());
+            assertThat(range.minMillis(), greaterThanOrEqualTo(minBound));
+            assertThat(range.maxMillis(), lessThanOrEqualTo(maxBound));
+        }
     }
 
     private void indexDocumentsWithTimestamp(String indexName, int numDocs, long minTimestamp, long maxTimestamp) {


### PR DESCRIPTION
The test is about to prove the non-boosted data searches evict boosted data cache entries (the current behavior).

This test consist of 3 steps:
1. Search for boosted data to fill the cache
2. Search for non-boosted data to evict some cache entries
3. Search again for boosted data

Relates: #2849
