### PR TITLE
[ESQL] Fix Windows glob path resolution in spec tests

### DIFF
--- a/docs/changelog/149469.yaml
+++ b/docs/changelog/149469.yaml
@@ -1,0 +1,8 @@
+area: ES|QL
+issues:
+ - 149126
+ - 149127
+ - 149352
+pr: 149469
+summary: Fix Windows glob path resolution in spec tests
+type: bug

--- a/docs/changelog/149469.yaml
+++ b/docs/changelog/149469.yaml
@@ -1,8 +1,0 @@
-area: ES|QL
-issues:
- - 149126
- - 149127
- - 149352
-pr: 149469
-summary: Fix Windows glob path resolution in spec tests
-type: bug

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -503,12 +503,6 @@ tests:
 - class: org.elasticsearch.xpack.stateless.StatelessCommitServiceIT
   method: testRetainCommitForReadersAfterShardMovedAway
   issue: https://github.com/elastic/elasticsearch/issues/149083
-- class: org.elasticsearch.xpack.esql.qa.csv.CsvFormatSpecIT
-  method: test {csv-spec:csv-headerless.multiFileHeaderlessReadSchemaPreventsTypeDrift [LOCAL]}
-  issue: https://github.com/elastic/elasticsearch/issues/149126
-- class: org.elasticsearch.xpack.esql.qa.csv.CsvFormatSpecIT
-  method: test {csv-spec:csv-union-by-name.multiFileUnionByNameRecipe [LOCAL]}
-  issue: https://github.com/elastic/elasticsearch/issues/149127
 - class: org.elasticsearch.xpack.inference.DefaultEndPointsIT
   method: testMultipleInferencesTriggeringDownloadAndDeploy
   issue: https://github.com/elastic/elasticsearch/issues/149130
@@ -587,9 +581,6 @@ tests:
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=index/100_field_name_length_limit/Test field name length limit array synthetic source}
   issue: https://github.com/elastic/elasticsearch/issues/149350
-- class: org.elasticsearch.xpack.esql.qa.csv.CsvFormatSpecIT
-  method: test {csv-spec:csv-union-by-name.multiFileUnionByNameRecipeWithPruning [LOCAL]}
-  issue: https://github.com/elastic/elasticsearch/issues/149352
 - class: org.elasticsearch.index.mapper.DynamicMappingIT
   method: testDynamicStringMappingWithoutAutoTextSubfield
   issue: https://github.com/elastic/elasticsearch/issues/149374

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/AbstractExternalSourceSpecTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/AbstractExternalSourceSpecTestCase.java
@@ -472,8 +472,7 @@ public abstract class AbstractExternalSourceSpecTestCase extends EsqlSpecTestCas
             case LOCAL:
                 // Local path: file:///absolute/path/to/iceberg-fixtures/standalone/employees.parquet
                 if (localFixturesPath != null) {
-                    Path localFile = localFixturesPath.resolve(relativePath);
-                    return localFile.toUri().toString();
+                    return resolveLocalUri(localFixturesPath, relativePath);
                 } else {
                     // Fallback to S3 if local path not available
                     logger.warn("Local fixtures path not available, falling back to S3");
@@ -496,6 +495,51 @@ public abstract class AbstractExternalSourceSpecTestCase extends EsqlSpecTestCas
             default:
                 throw new IllegalArgumentException("Unknown storage backend: " + storageBackend);
         }
+    }
+
+    /**
+     * Build a {@code file://} URI for a relative path under {@code base}, tolerating glob
+     * characters like {@code *} that are illegal in filesystem path components on Windows.
+     * <p>
+     * {@link Path#resolve(String)} delegates to the filesystem provider, which on Windows
+     * (NTFS) rejects {@code *} because it is a reserved filename character. The downstream
+     * local file loader expands the glob itself, so the URI we produce here only needs to
+     * be a syntactically valid {@code file://} URI - we don't have to round-trip through
+     * {@link Path}. We split the relative path on the first glob meta-character, resolve
+     * the literal prefix via {@link Path#resolve(String)} (which is portable), and append
+     * the glob suffix to the resulting URI as-is. {@code *} is a valid URI sub-delim
+     * character per RFC 3986 and does not require percent-encoding.
+     */
+    static String resolveLocalUri(Path base, String relativePath) {
+        int globIdx = indexOfGlobMeta(relativePath);
+        if (globIdx < 0) {
+            return base.resolve(relativePath).toUri().toString();
+        }
+        // Find the last path separator before the glob meta-character so the literal portion
+        // we feed to Path.resolve() contains no glob characters.
+        int splitIdx = relativePath.lastIndexOf('/', globIdx);
+        if (splitIdx < 0) {
+            // Glob meta-character in the first path segment - resolve the base itself.
+            return appendGlobSuffix(base.toUri().toString(), relativePath);
+        }
+        String literalPrefix = relativePath.substring(0, splitIdx);
+        String globSuffix = relativePath.substring(splitIdx + 1);
+        Path literalParent = base.resolve(literalPrefix);
+        return appendGlobSuffix(literalParent.toUri().toString(), globSuffix);
+    }
+
+    private static int indexOfGlobMeta(String s) {
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            if (c == '*' || c == '?') {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static String appendGlobSuffix(String baseUri, String suffix) {
+        return baseUri.endsWith("/") ? baseUri + suffix : baseUri + "/" + suffix;
     }
 
     @Override

--- a/x-pack/plugin/esql/qa/server/src/test/java/org/elasticsearch/xpack/esql/qa/rest/AbstractExternalSourceSpecTestCaseTests.java
+++ b/x-pack/plugin/esql/qa/server/src/test/java/org/elasticsearch/xpack/esql/qa/rest/AbstractExternalSourceSpecTestCaseTests.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.qa.rest;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Unit tests for path resolution helpers in {@link AbstractExternalSourceSpecTestCase}.
+ * The interesting case is glob path resolution on Windows: {@link Path#resolve(String)}
+ * rejects {@code *} on NTFS because it is a reserved filename character, so multi-file
+ * fixture paths like {@code multifile/*.csv} must not be round-tripped through
+ * {@link Path}.
+ */
+public class AbstractExternalSourceSpecTestCaseTests extends ESTestCase {
+
+    public void testResolveLocalUriHandlesLiteralPath() {
+        Path base = Paths.get("/tmp/fixtures").toAbsolutePath();
+        String uri = AbstractExternalSourceSpecTestCase.resolveLocalUri(base, "standalone/employees.csv");
+        assertTrue("expected file:// URI, was: " + uri, uri.startsWith("file:"));
+        assertTrue("expected path tail in URI, was: " + uri, uri.endsWith("/standalone/employees.csv"));
+    }
+
+    public void testResolveLocalUriHandlesGlobInLeafSegment() {
+        Path base = Paths.get("/tmp/fixtures").toAbsolutePath();
+        String uri = AbstractExternalSourceSpecTestCase.resolveLocalUri(base, "multifile/*.csv");
+        assertTrue("expected file:// URI, was: " + uri, uri.startsWith("file:"));
+        assertTrue("expected glob to be preserved in URI, was: " + uri, uri.endsWith("/multifile/*.csv"));
+    }
+
+    public void testResolveLocalUriHandlesDoubleGlob() {
+        Path base = Paths.get("/tmp/fixtures").toAbsolutePath();
+        String uri = AbstractExternalSourceSpecTestCase.resolveLocalUri(base, "hive-partitioned/**/*.csv");
+        assertTrue("expected file:// URI, was: " + uri, uri.startsWith("file:"));
+        assertTrue("expected glob to be preserved in URI, was: " + uri, uri.endsWith("/hive-partitioned/**/*.csv"));
+    }
+
+    public void testResolveLocalUriHandlesGlobInFirstSegment() {
+        Path base = Paths.get("/tmp/fixtures").toAbsolutePath();
+        String uri = AbstractExternalSourceSpecTestCase.resolveLocalUri(base, "*.csv");
+        assertTrue("expected file:// URI, was: " + uri, uri.startsWith("file:"));
+        assertTrue("expected glob to be preserved in URI, was: " + uri, uri.endsWith("/*.csv"));
+    }
+
+    public void testResolveLocalUriHandlesQuestionMarkGlob() {
+        Path base = Paths.get("/tmp/fixtures").toAbsolutePath();
+        String uri = AbstractExternalSourceSpecTestCase.resolveLocalUri(base, "multifile/file?.csv");
+        assertTrue("expected file:// URI, was: " + uri, uri.startsWith("file:"));
+        assertTrue("expected glob to be preserved in URI, was: " + uri, uri.endsWith("/multifile/file?.csv"));
+    }
+}


### PR DESCRIPTION
## Summary

Multi-file CSV/Parquet fixture templates resolve to relative paths like `multifile/*.csv` and `hive-partitioned/**/*.csv`. The LOCAL storage backend in `AbstractExternalSourceSpecTestCase` called `Path.resolve(relativePath)`, which delegates to the filesystem provider — on Windows (NTFS) `*` and `?` are reserved filename characters, so `Path.resolve` threw `InvalidPathException: Illegal char <*>`. Linux/macOS tolerated `*` silently.

Extract a `resolveLocalUri` helper that splits the relative path at the last separator before the first glob meta-character, resolves the literal prefix through `Path.resolve` (portable), and appends the glob suffix to the resulting `file://` URI as a plain string. `*` and `?` are valid URI sub-delim characters per RFC 3986, so no percent-encoding is needed. The downstream local file loader expands the glob itself.

- **`AbstractExternalSourceSpecTestCase`**: new `resolveLocalUri` helper; LOCAL backend routes glob paths through it
- **`AbstractExternalSourceSpecTestCaseTests`**: new unit test covering literal paths, leaf-segment globs, double-globs, first-segment globs, and `?` wildcards
- **`muted-tests.yml`**: unmute the three Windows-failing tests whose stack traces all show `InvalidPathException` on `multifile_ubn/*.csv` or `multifile/*.csv`

Closes #149126
Closes #149127
Closes #149352

> Note on #149352: the issue body reports a `ConnectionClosedException`, but the Windows build-scan stack traces show the same `InvalidPathException` as #149126/#149127 — the test triage automation picked up the wrong stack frame. There is also a rare Linux single-processor `ConnectionClosedException` flake (1/90 in periodic) that is a distinct issue with no captured server-side log; if it persists after this lands, a new dedicated mute can be added.

Developed with AI-assisted tooling