### PR TITLE
ESQL DS: fix race in testCancellationWhileWaitingOnWaitForSpace

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -196,12 +196,6 @@ tests:
 - class: org.elasticsearch.xpack.ml.integration.DatafeedJobsIT
   method: testStopLookback_forceTrue_closeJobFalse
   issue: https://github.com/elastic/elasticsearch/issues/146955
-- class: org.elasticsearch.xpack.esql.datasources.ExternalSourceDrainUtilsTests
-  method: testBudgetAccountingAcrossAsyncBoundaries
-  issue: https://github.com/elastic/elasticsearch/issues/147065
-- class: org.elasticsearch.xpack.esql.datasources.ExternalSourceDrainUtilsTests
-  method: testCancellationWhileWaitingOnWaitForSpace
-  issue: https://github.com/elastic/elasticsearch/issues/147073
 - class: org.elasticsearch.index.mapper.KeywordOffsetDocValuesLoaderTests
   method: testOffsetArrayRandomHighCardinality
   issue: https://github.com/elastic/elasticsearch/issues/147085

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceDrainUtilsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceDrainUtilsTests.java
@@ -746,18 +746,16 @@ public class ExternalSourceDrainUtilsTests extends ESTestCase {
             tracked,
             buffer,
             exec,
-            ActionListener.runAfter(ActionListener.wrap(v -> drainDone.countDown(), e -> {
-                drainError.set(e);
-                drainDone.countDown();
-            }), () -> {
+            ActionListener.runAfter(ActionListener.wrap(v -> {}, drainError::set), () -> {
                 closeQuietly(tracked);
                 cleanupRan.set(true);
+                // countDown after cleanup so the awaiting thread observes cleanupRan==true (avoid race).
+                drainDone.countDown();
             })
         );
 
         // Let the buffer fill up (producer should be blocked waiting for space)
-        Thread.sleep(200);
-        assertTrue("Buffer should have pages", buffer.size() > 0);
+        assertBusy(() -> assertTrue("Buffer should have pages", buffer.size() > 0), 5, TimeUnit.SECONDS);
 
         // Cancel the query
         buffer.finish(true);


### PR DESCRIPTION
## Summary

`testCancellationWhileWaitingOnWaitForSpace` was flaky because the latch the test thread waited on was counted down inside the wrapped `ActionListener` while the cleanup runnable ran immediately after on the producer thread. The test thread could therefore wake up and assert `cleanupRan` before the producer thread set it, occasionally tripping `AssertionError: Cleanup must run after cancellation`.

The fix moves `drainDone.countDown()` into the `ActionListener.runAfter` block so the awaiting thread always observes the cleanup state. The 200 ms `Thread.sleep` warmup is replaced with `assertBusy` so the precondition (`buffer.size() > 0`) holds under load.

The companion mute entry for `testBudgetAccountingAcrossAsyncBoundaries` is also removed: that test was deleted together with the budget drain variant in 75200bc2e966 and only the stale mute remained.

- **`x-pack/plugin/esql/.../ExternalSourceDrainUtilsTests`**: count down latch after cleanup; use `assertBusy` for buffer-fill precondition.
- **`muted-tests.yml`**: drop two stale `ExternalSourceDrainUtilsTests` mutes.

Closes #147065
Closes #147073