### PR TITLE
[ESQL] Unmute OrcFormatSpecIT external-basic.* [LOCAL]

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -232,8 +232,6 @@ tests:
 - class: org.elasticsearch.compute.aggregation.blockhash.BlockHashRandomizedTests
   method: test {forcePackedHash=false groups=2 maxValuesPerPosition=1 dups=0 allowedTypes=[Basic[elementType=LONG], Basic[elementType=INT]]}
   issue: https://github.com/elastic/elasticsearch/issues/147654
-- class: org.elasticsearch.xpack.esql.qa.orc.OrcFormatSpecIT
-  method: test {csv-spec:external-basic.* [LOCAL]}
 - class: org.elasticsearch.xpack.transform.integration.TransformCrossProjectIT
   method: testUpdateTransformWithProjectRouting
   issue: https://github.com/elastic/elasticsearch/issues/147655


### PR DESCRIPTION
The mute for OrcFormatSpecIT.test {csv-spec:external-basic.*
[LOCAL]} was added on 2026-04-28 (#147662) to silence a random
Windows-only Connection-reset failure tracked in #147660. The
issue is now closed and the underlying flakiness appears resolved
by intervening ORC and infra fixes (ORC tail caching, S3 receive
pooling, parsed-footer reuse).

The mute entry also lacks an issue link in muted-tests.yml, which
hides it from the failure-history dashboard and prevents triage
automation from re-attaching context. Without the link the mute
silently swallows the entire LOCAL backend group for this spec
(60+ test cases).

Drop the mute so CI can re-validate the LOCAL backend on Windows.
The full OrcFormatSpecIT suite passes consistently on macOS across
multiple runs (5 storage backends x ~60 cases per backend). If the
Windows flake recurs after this PR, a new dedicated mute can be
added with a fresh issue link so the failure is properly tracked.

Developed with AI-assisted tooling