### PR TITLE
[9.4] GPU codec: fall back to CPU graph build on flush when GPU is busy (#149373)

### DIFF
--- a/docs/changelog/149373.yaml
+++ b/docs/changelog/149373.yaml
@@ -1,0 +1,5 @@
+area: Vector Search
+issues: []
+pr: 149373
+summary: "GPU codec: fall back to CPU graph build on flush when GPU is busy"
+type: bug

--- a/libs/gpu-codec/src/main/java/org/elasticsearch/gpu/codec/CuVSResourceManager.java
+++ b/libs/gpu-codec/src/main/java/org/elasticsearch/gpu/codec/CuVSResourceManager.java
@@ -50,8 +50,22 @@ public interface CuVSResourceManager {
      * effect on GPU memory and compute usage to determine whether to give out
      * another resource or wait for a resources to be returned before giving out another.
      */
-    ManagedCuVSResources acquire(int numVectors, int dims, CuVSMatrix.DataType dataType, CagraIndexParams cagraIndexParams)
+    ManagedCuVSResources acquire(int numVectors, int dims, CuVSMatrix.DataType dataType, CagraIndexParams cagraIndexParams, String reason)
         throws InterruptedException, IOException;
+
+    /**
+     * Tries to acquire a resource from the manager.
+     *
+     * <p> Non-blocking variant of {@link #acquire}. Returns a locked resource immediately if
+     * one is available and there is sufficient GPU memory, or {@code null} if the GPU is busy.
+     */
+    ManagedCuVSResources tryAcquire(
+        int numVectors,
+        int dims,
+        CuVSMatrix.DataType dataType,
+        CagraIndexParams cagraIndexParams,
+        String reason
+    ) throws IOException;
 
     /** Marks the resources as finished with regard to compute. */
     void finishedComputation(ManagedCuVSResources resources);
@@ -148,23 +162,54 @@ public interface CuVSResourceManager {
         }
 
         @Override
-        public ManagedCuVSResources acquire(int numVectors, int dims, CuVSMatrix.DataType dataType, CagraIndexParams cagraIndexParams)
-            throws InterruptedException, IOException {
+        public ManagedCuVSResources acquire(
+            int numVectors,
+            int dims,
+            CuVSMatrix.DataType dataType,
+            CagraIndexParams cagraIndexParams,
+            String reason
+        ) throws InterruptedException, IOException {
+            return doAcquire(numVectors, dims, dataType, cagraIndexParams, false, reason);
+        }
+
+        @Override
+        public ManagedCuVSResources tryAcquire(
+            int numVectors,
+            int dims,
+            CuVSMatrix.DataType dataType,
+            CagraIndexParams cagraIndexParams,
+            String reason
+        ) throws IOException {
             try {
-                var started = System.nanoTime();
-                lock.lock();
+                return doAcquire(numVectors, dims, dataType, cagraIndexParams, true, reason);
+            } catch (InterruptedException e) {
+                throw new AssertionError("non-blocking acquire should never block", e);
+            }
+        }
+
+        /**
+         * Shared implementation for {@link #acquire} and {@link #tryAcquire}.
+         *
+         * @param nonBlocking if {@code true}, returns {@code null} instead of waiting when no
+         *                    resource or memory is available (tryAcquire semantics); if {@code false},
+         *                    blocks until a resource becomes available (acquire semantics).
+         */
+        private ManagedCuVSResources doAcquire(
+            int numVectors,
+            int dims,
+            CuVSMatrix.DataType dataType,
+            CagraIndexParams cagraIndexParams,
+            boolean nonBlocking,
+            String reason
+        ) throws InterruptedException, IOException {
+            var started = System.nanoTime();
+            lock.lock();
+            try {
+                long requiredMemoryInBytes = estimateRequiredMemory(numVectors, dims, dataType, cagraIndexParams);
+                logAcquireAttempt(reason, nonBlocking, numVectors, dims, dataType, requiredMemoryInBytes);
 
                 boolean allConditionsMet = false;
                 ManagedCuVSResources res = null;
-
-                long requiredMemoryInBytes = estimateRequiredMemory(numVectors, dims, dataType, cagraIndexParams);
-                logger.debug(
-                    "Estimated memory for [{}] vectors, [{}] dims of type [{}] is [{} B]",
-                    numVectors,
-                    dims,
-                    dataType.name(),
-                    requiredMemoryInBytes
-                );
 
                 while (allConditionsMet == false) {
                     res = getResourceFromPool();
@@ -173,42 +218,37 @@ public interface CuVSResourceManager {
                     if (res != null) {
                         // Check immutable constraints
                         long totalMemoryInBytes = gpuMemoryService.totalMemoryInBytes(res);
-                        if (requiredMemoryInBytes > totalMemoryInBytes) {
-                            String message = Strings.format(
-                                "Requested GPU memory for [%d] vectors, [%d] dims is greater than the GPU total memory [%d B]",
-                                numVectors,
-                                dims,
-                                totalMemoryInBytes
-                            );
-                            logger.error(message);
-                            throw new IllegalArgumentException(message);
-                        }
-
-                        // If no resource in the pool is locked, short circuit to avoid livelock
-                        if (numLockedResources() == 0) {
-                            logger.debug("No resources currently locked, proceeding");
-                            break;
-                        }
-
-                        // Check resources availability
                         long availableMemoryInBytes = gpuMemoryService.availableMemoryInBytes(res);
                         enoughMemory = requiredMemoryInBytes <= availableMemoryInBytes;
-                        logger.debug("Free device memory [{} B], enoughMemory[{}]", availableMemoryInBytes, enoughMemory);
+                        logMemoryCheck(availableMemoryInBytes, totalMemoryInBytes, requiredMemoryInBytes, enoughMemory);
+
+                        if (requiredMemoryInBytes > totalMemoryInBytes) {
+                            throw memoryExceededError(numVectors, dims, totalMemoryInBytes);
+                        }
+
+                        // If no resource in the pool is locked, we must proceed to avoid livelock
+                        if (enoughMemory == false && numLockedResources() == 0) {
+                            logLivelockBypass(availableMemoryInBytes, requiredMemoryInBytes);
+                            break;
+                        }
                     } else {
-                        if (createdCount == 0) {
+                        if (nonBlocking == false && createdCount == 0) {
                             throw new IOException("No GPU resources available and unable to create new ones");
                         }
                         logger.debug("No resources available in pool");
                         enoughMemory = false;
                     }
-                    // TODO: add enoughComputation / enoughComputationCondition here
-                    allConditionsMet = enoughMemory; // && enoughComputation
+
+                    allConditionsMet = enoughMemory;
                     if (allConditionsMet == false) {
+                        if (nonBlocking) {
+                            return null;
+                        }
+                        logger.debug("Waiting for GPU resources for [{}]", reason);
                         enoughResourcesCondition.await();
                     }
                 }
-                var elapsed = started - System.nanoTime();
-                logger.debug("Resource acquired in [{}ms]", elapsed / 1_000_000.0);
+                logAcquired(reason, started, requiredMemoryInBytes);
                 gpuMemoryService.reserveMemory(requiredMemoryInBytes);
                 res.lock(() -> gpuMemoryService.releaseMemory(requiredMemoryInBytes));
                 return res;
@@ -287,6 +327,61 @@ public interface CuVSResourceManager {
                 assert res != null;
                 res.delegate.close();
             }
+        }
+
+        private IllegalArgumentException memoryExceededError(int numVectors, int dims, long totalMemoryInBytes) {
+            String message = Strings.format(
+                "Requested GPU memory for [%d] vectors, [%d] dims is greater than the GPU total memory [%d B]",
+                numVectors,
+                dims,
+                totalMemoryInBytes
+            );
+            logger.error(message);
+            return new IllegalArgumentException(message);
+        }
+
+        private void logAcquireAttempt(
+            String reason,
+            boolean nonBlocking,
+            int numVectors,
+            int dims,
+            CuVSMatrix.DataType dataType,
+            long requiredMemoryInBytes
+        ) {
+            logger.debug(
+                "[{}] Try acquire(nonBlocking={}): [{}] vectors, dims={} type={}, estimated={}B, state:([{}] created, [{}] locked)",
+                reason,
+                nonBlocking,
+                numVectors,
+                dims,
+                dataType.name(),
+                requiredMemoryInBytes,
+                createdCount,
+                numLockedResources()
+            );
+        }
+
+        private void logMemoryCheck(long available, long total, long required, boolean enough) {
+            logger.debug("Memory check: available={}B, total={}B, required={}B, enough={}", available, total, required, enough);
+        }
+
+        private void logLivelockBypass(long available, long required) {
+            logger.warn(
+                "Insufficient GPU memory ({}B available, {}B required) but no locked resources; proceeding to avoid livelock",
+                available,
+                required
+            );
+        }
+
+        private void logAcquired(String reason, long startedNanos, long reservedBytes) {
+            logger.debug(
+                "[{}] acquired in {}ms, reserving {}B, state:([{}] created, [{}] locked)",
+                reason,
+                (System.nanoTime() - startedNanos) / 1_000_000.0,
+                reservedBytes,
+                createdCount,
+                numLockedResources() + 1
+            );
         }
     }
 

--- a/libs/gpu-codec/src/main/java/org/elasticsearch/gpu/codec/ES92GpuHnswVectorsWriter.java
+++ b/libs/gpu-codec/src/main/java/org/elasticsearch/gpu/codec/ES92GpuHnswVectorsWriter.java
@@ -37,6 +37,9 @@ import org.apache.lucene.store.MemorySegmentAccessInput;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.apache.lucene.util.hnsw.HnswGraph;
 import org.apache.lucene.util.hnsw.HnswGraph.NodesIterator;
+import org.apache.lucene.util.hnsw.HnswGraphBuilder;
+import org.apache.lucene.util.hnsw.NeighborArray;
+import org.apache.lucene.util.hnsw.OnHeapHnswGraph;
 import org.apache.lucene.util.hnsw.RandomVectorScorerSupplier;
 import org.apache.lucene.util.packed.DirectMonotonicWriter;
 import org.apache.lucene.util.quantization.ScalarQuantizer;
@@ -181,46 +184,39 @@ final class ES92GpuHnswVectorsWriter extends KnnVectorsWriter {
         logger.debug("Flush total time [{}ms]", elapsed / 1_000_000.0);
     }
 
-    private void flushFieldsWithoutMemoryMappedFile(Sorter.DocMap sortMap) throws IOException, InterruptedException {
+    private void flushFieldsWithoutMemoryMappedFile(Sorter.DocMap sortMap) throws IOException {
         // No tmp file written, or the file cannot be mmapped
         for (FieldWriter field : fields) {
             var started = System.nanoTime();
             var fieldInfo = field.fieldInfo;
+            int dims = fieldInfo.getVectorDimension();
 
             var originalVectors = field.flatFieldVectorsWriter.getVectors();
             final List<float[]> vectorsInSortedOrder = sortMap == null
                 ? originalVectors
                 : getVectorsInSortedOrder(field, sortMap, originalVectors);
             int numVectors = vectorsInSortedOrder.size();
-            CagraIndexParams cagraIndexParams = createCagraIndexParams(
-                fieldInfo.getVectorSimilarityFunction(),
-                numVectors,
-                fieldInfo.getVectorDimension()
-            );
+            CagraIndexParams cagraIndexParams = createCagraIndexParams(fieldInfo.getVectorSimilarityFunction(), numVectors, dims);
 
             if (numVectors < MIN_NUM_VECTORS_FOR_GPU_BUILD) {
                 logger.debug("Skip building carga index; vectors length {} < {} (min for GPU)", numVectors, MIN_NUM_VECTORS_FOR_GPU_BUILD);
                 // Will not be indexed on the GPU
                 generateMockGraphAndWriteMeta(fieldInfo, numVectors);
             } else {
-                try (
-                    var resourcesHolder = new ResourcesHolder(
-                        cuVSResourceManager,
-                        cuVSResourceManager.acquire(numVectors, fieldInfo.getVectorDimension(), CuVSMatrix.DataType.FLOAT, cagraIndexParams)
-                    )
-                ) {
-                    var builder = CuVSMatrix.deviceBuilder(
-                        resourcesHolder.resources(),
-                        numVectors,
-                        fieldInfo.getVectorDimension(),
-                        CuVSMatrix.DataType.FLOAT
-                    );
-                    for (var vector : vectorsInSortedOrder) {
-                        builder.addVector(vector);
+                var resource = cuVSResourceManager.tryAcquire(numVectors, dims, CuVSMatrix.DataType.FLOAT, cagraIndexParams, "flush");
+                if (resource != null) {
+                    try (var resourcesHolder = new ResourcesHolder(cuVSResourceManager, resource)) {
+                        var builder = CuVSMatrix.deviceBuilder(resourcesHolder.resources(), numVectors, dims, CuVSMatrix.DataType.FLOAT);
+                        for (var vector : vectorsInSortedOrder) {
+                            builder.addVector(vector);
+                        }
+                        try (var dataset = builder.build()) {
+                            generateGpuGraphAndWriteMeta(resourcesHolder, fieldInfo, dataset, cagraIndexParams);
+                        }
                     }
-                    try (var dataset = builder.build()) {
-                        generateGpuGraphAndWriteMeta(resourcesHolder, fieldInfo, dataset, cagraIndexParams);
-                    }
+                } else {
+                    logger.debug("GPU busy, building HNSW on CPU for [{}] vectors", numVectors);
+                    buildCpuGraphAndWriteMeta(fieldInfo, vectorsInSortedOrder, fieldInfo.getVectorSimilarityFunction());
                 }
             }
             var elapsed = System.nanoTime() - started;
@@ -580,6 +576,57 @@ final class ES92GpuHnswVectorsWriter extends KnnVectorsWriter {
         };
     }
 
+    private HnswGraph writeGraph(OnHeapHnswGraph graph, int[][] graphLevelNodeOffsets) throws IOException {
+        int countOnLevel0 = graph.size();
+        int[] scratch = new int[graph.maxConn() * 2];
+        for (int level = 0; level < graph.numLevels(); level++) {
+            NodesIterator nodesOnLevel = graph.getSortedNodes(level);
+            int nodeOffsetId = 0;
+            while (nodesOnLevel.hasNext()) {
+                NeighborArray neighbors = graph.getNeighbors(level, nodesOnLevel.next());
+                int size = neighbors.size();
+                long offsetStart = vectorIndex.getFilePointer();
+                int[] nnodes = neighbors.nodes();
+                Arrays.sort(nnodes, 0, size);
+                int actualSize = 0;
+                if (size > 0) {
+                    scratch[0] = nnodes[0];
+                    actualSize = 1;
+                }
+                for (int i = 1; i < size; i++) {
+                    assert nnodes[i] < countOnLevel0 : "node too large: " + nnodes[i] + ">=" + countOnLevel0;
+                    if (nnodes[i - 1] == nnodes[i]) {
+                        continue;
+                    }
+                    scratch[actualSize++] = nnodes[i] - nnodes[i - 1];
+                }
+                vectorIndex.writeVInt(actualSize);
+                vectorIndex.writeGroupVInts(scratch, actualSize);
+                graphLevelNodeOffsets[level][nodeOffsetId++] = Math.toIntExact(vectorIndex.getFilePointer() - offsetStart);
+            }
+        }
+        return graph;
+    }
+
+    private void buildCpuGraphAndWriteMeta(FieldInfo fieldInfo, List<float[]> vectors, VectorSimilarityFunction similarity)
+        throws IOException {
+        int numVectors = vectors.size();
+        int dims = fieldInfo.getVectorDimension();
+        var flatVectorsScorer = flatVectorWriter.getFlatVectorScorer();
+        var scorerSupplier = flatVectorsScorer.getRandomVectorScorerSupplier(similarity, FloatVectorValues.fromFloats(vectors, dims));
+        var graphBuilder = HnswGraphBuilder.create(scorerSupplier, M, beamWidth, HnswGraphBuilder.randSeed, numVectors);
+        OnHeapHnswGraph cpuGraph = graphBuilder.build(numVectors);
+
+        long vectorIndexOffset = vectorIndex.getFilePointer();
+        int[][] graphLevelNodeOffsets = new int[cpuGraph.numLevels()][];
+        for (int level = 0; level < cpuGraph.numLevels(); level++) {
+            graphLevelNodeOffsets[level] = new int[level == 0 ? numVectors : cpuGraph.getNodesOnLevel(level).size()];
+        }
+        HnswGraph graph = writeGraph(cpuGraph, graphLevelNodeOffsets);
+        long vectorIndexLength = vectorIndex.getFilePointer() - vectorIndexOffset;
+        writeMeta(fieldInfo, vectorIndexOffset, vectorIndexLength, numVectors, graph, graphLevelNodeOffsets);
+    }
+
     @Override
     public void mergeOneField(FieldInfo fieldInfo, MergeState mergeState) throws IOException {
         // Note: Merged raw vectors are already in sorted order. The flatVectorWriter and MergedVectorValues utilities
@@ -651,7 +698,7 @@ final class ES92GpuHnswVectorsWriter extends KnnVectorsWriter {
                 try (
                     var resourcesHolder = new ResourcesHolder(
                         cuVSResourceManager,
-                        cuVSResourceManager.acquire(numVectors, fieldInfo.getVectorDimension(), dataType, cagraIndexParams)
+                        cuVSResourceManager.acquire(numVectors, fieldInfo.getVectorDimension(), dataType, cagraIndexParams, "merge")
                     );
                     var packedSegmentHolder = getContiguousPackedMemorySegment(
                         memorySegmentAccessInput,
@@ -693,7 +740,7 @@ final class ES92GpuHnswVectorsWriter extends KnnVectorsWriter {
                     var dataset = builder.build();
                     var resourcesHolder = new ResourcesHolder(
                         cuVSResourceManager,
-                        cuVSResourceManager.acquire(numVectors, fieldInfo.getVectorDimension(), dataType, cagraIndexParams)
+                        cuVSResourceManager.acquire(numVectors, fieldInfo.getVectorDimension(), dataType, cagraIndexParams, "merge")
                     )
                 ) {
                     generateGpuGraphAndWriteMeta(resourcesHolder, fieldInfo, dataset, cagraIndexParams);
@@ -714,7 +761,7 @@ final class ES92GpuHnswVectorsWriter extends KnnVectorsWriter {
                 var dataset = builder.build();
                 var resourcesHolder = new ResourcesHolder(
                     cuVSResourceManager,
-                    cuVSResourceManager.acquire(numVectors, fieldInfo.getVectorDimension(), dataType, cagraIndexParams)
+                    cuVSResourceManager.acquire(numVectors, fieldInfo.getVectorDimension(), dataType, cagraIndexParams, "merge")
                 )
             ) {
                 generateGpuGraphAndWriteMeta(resourcesHolder, fieldInfo, dataset, cagraIndexParams);
@@ -747,7 +794,7 @@ final class ES92GpuHnswVectorsWriter extends KnnVectorsWriter {
                 try (
                     var resourcesHolder = new ResourcesHolder(
                         cuVSResourceManager,
-                        cuVSResourceManager.acquire(numVectors, fieldInfo.getVectorDimension(), dataType, cagraIndexParams)
+                        cuVSResourceManager.acquire(numVectors, fieldInfo.getVectorDimension(), dataType, cagraIndexParams, "merge")
                     );
                     var memorySegmentHolder = getContiguousMemorySegment(
                         memorySegmentAccessInput,
@@ -780,7 +827,7 @@ final class ES92GpuHnswVectorsWriter extends KnnVectorsWriter {
                     var dataset = builder.build();
                     var resourcesHolder = new ResourcesHolder(
                         cuVSResourceManager,
-                        cuVSResourceManager.acquire(numVectors, fieldInfo.getVectorDimension(), dataType, cagraIndexParams)
+                        cuVSResourceManager.acquire(numVectors, fieldInfo.getVectorDimension(), dataType, cagraIndexParams, "merge")
                     )
                 ) {
                     generateGpuGraphAndWriteMeta(resourcesHolder, fieldInfo, dataset, cagraIndexParams);
@@ -802,7 +849,7 @@ final class ES92GpuHnswVectorsWriter extends KnnVectorsWriter {
                 var dataset = builder.build();
                 var resourcesHolder = new ResourcesHolder(
                     cuVSResourceManager,
-                    cuVSResourceManager.acquire(numVectors, fieldInfo.getVectorDimension(), dataType, cagraIndexParams)
+                    cuVSResourceManager.acquire(numVectors, fieldInfo.getVectorDimension(), dataType, cagraIndexParams, "merge")
                 )
             ) {
                 generateGpuGraphAndWriteMeta(resourcesHolder, fieldInfo, dataset, cagraIndexParams);

--- a/libs/gpu-codec/src/test/java/org/elasticsearch/gpu/codec/CuVSResourceManagerTests.java
+++ b/libs/gpu-codec/src/test/java/org/elasticsearch/gpu/codec/CuVSResourceManagerTests.java
@@ -39,14 +39,14 @@ public class CuVSResourceManagerTests extends ESTestCase {
 
     private static void testBasic(CagraIndexParams params) throws Exception {
         var mgr = new MockPoolingCuVSResourceManager(2);
-        var res1 = mgr.acquire(0, 0, CuVSMatrix.DataType.FLOAT, params);
-        var res2 = mgr.acquire(0, 0, CuVSMatrix.DataType.FLOAT, params);
+        var res1 = mgr.acquire(0, 0, CuVSMatrix.DataType.FLOAT, params, "test");
+        var res2 = mgr.acquire(0, 0, CuVSMatrix.DataType.FLOAT, params, "test");
         assertThat(res1.toString(), containsString("id=0"));
         assertThat(res2.toString(), containsString("id=1"));
         mgr.release(res1);
         mgr.release(res2);
-        res1 = mgr.acquire(0, 0, CuVSMatrix.DataType.FLOAT, params);
-        res2 = mgr.acquire(0, 0, CuVSMatrix.DataType.FLOAT, params);
+        res1 = mgr.acquire(0, 0, CuVSMatrix.DataType.FLOAT, params, "test");
+        res2 = mgr.acquire(0, 0, CuVSMatrix.DataType.FLOAT, params, "test");
         assertThat(res1.toString(), containsString("id=0"));
         assertThat(res2.toString(), containsString("id=1"));
         mgr.release(res1);
@@ -64,16 +64,16 @@ public class CuVSResourceManagerTests extends ESTestCase {
 
     public void testMultipleAcquireRelease() throws Exception {
         var mgr = new MockPoolingCuVSResourceManager(2);
-        var res1 = mgr.acquire(16 * 1024, 1024, CuVSMatrix.DataType.FLOAT, createNnDescentParams());
-        var res2 = mgr.acquire(16 * 1024, 1024, CuVSMatrix.DataType.FLOAT, createIvfPqParams());
+        var res1 = mgr.acquire(16 * 1024, 1024, CuVSMatrix.DataType.FLOAT, createNnDescentParams(), "test");
+        var res2 = mgr.acquire(16 * 1024, 1024, CuVSMatrix.DataType.FLOAT, createIvfPqParams(), "test");
         assertThat(res1.toString(), containsString("id=0"));
         assertThat(res2.toString(), containsString("id=1"));
         assertThat(mgr.availableMemory(), lessThan(TOTAL_DEVICE_MEMORY_IN_BYTES / 2));
         mgr.release(res1);
         mgr.release(res2);
         assertThat(mgr.availableMemory(), equalTo(TOTAL_DEVICE_MEMORY_IN_BYTES));
-        res1 = mgr.acquire(16 * 1024, 1024, CuVSMatrix.DataType.FLOAT, createNnDescentParams());
-        res2 = mgr.acquire(16 * 1024, 1024, CuVSMatrix.DataType.FLOAT, createIvfPqParams());
+        res1 = mgr.acquire(16 * 1024, 1024, CuVSMatrix.DataType.FLOAT, createNnDescentParams(), "test");
+        res2 = mgr.acquire(16 * 1024, 1024, CuVSMatrix.DataType.FLOAT, createIvfPqParams(), "test");
         assertThat(res1.toString(), containsString("id=0"));
         assertThat(res2.toString(), containsString("id=1"));
         assertThat(mgr.availableMemory(), lessThan(TOTAL_DEVICE_MEMORY_IN_BYTES / 2));
@@ -85,13 +85,13 @@ public class CuVSResourceManagerTests extends ESTestCase {
 
     private static void testBlocking(CagraIndexParams params) throws Exception {
         var mgr = new MockPoolingCuVSResourceManager(2);
-        var res1 = mgr.acquire(0, 0, CuVSMatrix.DataType.FLOAT, params);
-        var res2 = mgr.acquire(0, 0, CuVSMatrix.DataType.FLOAT, params);
+        var res1 = mgr.acquire(0, 0, CuVSMatrix.DataType.FLOAT, params, "test");
+        var res2 = mgr.acquire(0, 0, CuVSMatrix.DataType.FLOAT, params, "test");
 
         AtomicReference<CuVSResources> holder = new AtomicReference<>();
         Thread t = new Thread(() -> {
             try {
-                var res3 = mgr.acquire(0, 0, CuVSMatrix.DataType.FLOAT, params);
+                var res3 = mgr.acquire(0, 0, CuVSMatrix.DataType.FLOAT, params, "test");
                 holder.set(res3);
             } catch (Exception e) {
                 throw new AssertionError(e);
@@ -115,12 +115,12 @@ public class CuVSResourceManagerTests extends ESTestCase {
     }
 
     private static void testBlockingOnInsufficientMemory(CagraIndexParams params, CuVSResourceManager mgr) throws Exception {
-        var res1 = mgr.acquire(16 * 1024, 1024, CuVSMatrix.DataType.FLOAT, params);
+        var res1 = mgr.acquire(16 * 1024, 1024, CuVSMatrix.DataType.FLOAT, params, "test");
 
         AtomicReference<CuVSResources> holder = new AtomicReference<>();
         Thread t = new Thread(() -> {
             try {
-                var res2 = mgr.acquire((16 * 1024) + 1, 1024, CuVSMatrix.DataType.FLOAT, params);
+                var res2 = mgr.acquire((16 * 1024) + 1, 1024, CuVSMatrix.DataType.FLOAT, params, "test");
                 holder.set(res2);
             } catch (Exception e) {
                 throw new AssertionError(e);
@@ -146,12 +146,12 @@ public class CuVSResourceManagerTests extends ESTestCase {
     }
 
     private static void testNotBlockingOnSufficientMemory(CagraIndexParams params, CuVSResourceManager mgr) throws Exception {
-        var res1 = mgr.acquire(16 * 1024, 1024, CuVSMatrix.DataType.FLOAT, params);
+        var res1 = mgr.acquire(16 * 1024, 1024, CuVSMatrix.DataType.FLOAT, params, "test");
 
         AtomicReference<CuVSResources> holder = new AtomicReference<>();
         Thread t = new Thread(() -> {
             try {
-                var res2 = mgr.acquire((16 * 1024) - 1000, 1024, CuVSMatrix.DataType.FLOAT, params);
+                var res2 = mgr.acquire((16 * 1024) - 1000, 1024, CuVSMatrix.DataType.FLOAT, params, "test");
                 holder.set(res2);
             } catch (Exception e) {
                 throw new AssertionError(e);
@@ -176,7 +176,7 @@ public class CuVSResourceManagerTests extends ESTestCase {
 
     public void testManagedResIsNotClosable() throws Exception {
         var mgr = new MockPoolingCuVSResourceManager(1);
-        var res = mgr.acquire(0, 0, CuVSMatrix.DataType.FLOAT, createNnDescentParams());
+        var res = mgr.acquire(0, 0, CuVSMatrix.DataType.FLOAT, createNnDescentParams(), "test");
         assertThrows(UnsupportedOperationException.class, res::close);
         mgr.release(res);
         mgr.shutdown();
@@ -185,13 +185,13 @@ public class CuVSResourceManagerTests extends ESTestCase {
     // Tests that a failed createNew() causes acquire to wait for an existing resource rather than crash with NPE.
     public void testCreateNewFailsAfterFirstResource() throws Exception {
         var mgr = new FailingAfterNMockPoolingCuVSResourceManager(2, 1);
-        var res1 = mgr.acquire(0, 0, CuVSMatrix.DataType.FLOAT, createNnDescentParams());
+        var res1 = mgr.acquire(0, 0, CuVSMatrix.DataType.FLOAT, createNnDescentParams(), "test");
         assertThat(res1.toString(), containsString("id=0"));
 
         AtomicReference<CuVSResourceManager.ManagedCuVSResources> holder = new AtomicReference<>();
         Thread t = new Thread(() -> {
             try {
-                var res2 = mgr.acquire(0, 0, CuVSMatrix.DataType.FLOAT, createNnDescentParams());
+                var res2 = mgr.acquire(0, 0, CuVSMatrix.DataType.FLOAT, createNnDescentParams(), "test");
                 holder.set(res2);
             } catch (Exception e) {
                 throw new AssertionError(e);
@@ -211,17 +211,109 @@ public class CuVSResourceManagerTests extends ESTestCase {
     // Tests that acquire throws IOException immediately if no resources exist and createNew() always fails.
     public void testCreateNewAlwaysFailsThrowsIOException() throws Exception {
         var mgr = new FailingAfterNMockPoolingCuVSResourceManager(2, 0);
-        expectThrows(java.io.IOException.class, () -> mgr.acquire(0, 0, CuVSMatrix.DataType.FLOAT, createNnDescentParams()));
+        expectThrows(java.io.IOException.class, () -> mgr.acquire(0, 0, CuVSMatrix.DataType.FLOAT, createNnDescentParams(), "test"));
         mgr.shutdown();
     }
 
     public void testDoubleRelease() throws Exception {
         var mgr = new MockPoolingCuVSResourceManager(2);
-        var res1 = mgr.acquire(0, 0, CuVSMatrix.DataType.FLOAT, createNnDescentParams());
-        var res2 = mgr.acquire(0, 0, CuVSMatrix.DataType.FLOAT, createNnDescentParams());
+        var res1 = mgr.acquire(0, 0, CuVSMatrix.DataType.FLOAT, createNnDescentParams(), "test");
+        var res2 = mgr.acquire(0, 0, CuVSMatrix.DataType.FLOAT, createNnDescentParams(), "test");
         mgr.release(res1);
         mgr.release(res2);
         assertThrows(AssertionError.class, () -> mgr.release(randomFrom(res1, res2)));
+        mgr.shutdown();
+    }
+
+    // tryAcquire returns null when all resources in the pool are locked
+    public void testTryAcquireReturnsNullWhenBusy() throws Exception {
+        var mgr = new MockPoolingCuVSResourceManager(1);
+        var res1 = mgr.acquire(0, 0, CuVSMatrix.DataType.FLOAT, createNnDescentParams(), "test");
+        assertNotNull(res1);
+        var res2 = mgr.tryAcquire(0, 0, CuVSMatrix.DataType.FLOAT, createNnDescentParams(), "test");
+        assertNull(res2);
+        mgr.release(res1);
+        mgr.shutdown();
+    }
+
+    // tryAcquire succeeds when resources are available in the pool
+    public void testTryAcquireSucceedsWhenFree() throws Exception {
+        var mgr = new MockPoolingCuVSResourceManager(2);
+        var res1 = mgr.tryAcquire(0, 0, CuVSMatrix.DataType.FLOAT, createNnDescentParams(), "test");
+        assertNotNull(res1);
+        assertThat(res1.toString(), containsString("id=0"));
+        var res2 = mgr.tryAcquire(0, 0, CuVSMatrix.DataType.FLOAT, createNnDescentParams(), "test");
+        assertNotNull(res2);
+        assertThat(res2.toString(), containsString("id=1"));
+        mgr.release(res1);
+        mgr.release(res2);
+        mgr.shutdown();
+    }
+
+    // tryAcquire returns null when available GPU memory is insufficient
+    public void testTryAcquireReturnsNullOnInsufficientMemory() throws Exception {
+        var mgr = new MockPoolingCuVSResourceManager(2);
+        var res1 = mgr.tryAcquire(16 * 1024, 1024, CuVSMatrix.DataType.FLOAT, createNnDescentParams(), "test");
+        assertNotNull(res1);
+        var res2 = mgr.tryAcquire((16 * 1024) + 1, 1024, CuVSMatrix.DataType.FLOAT, createNnDescentParams(), "test");
+        assertNull(res2);
+        mgr.release(res1);
+        mgr.shutdown();
+    }
+
+    // tryAcquire succeeds after a previously locked resource is released
+    public void testTryAcquireSucceedsAfterRelease() throws Exception {
+        var mgr = new MockPoolingCuVSResourceManager(1);
+        var res1 = mgr.tryAcquire(0, 0, CuVSMatrix.DataType.FLOAT, createNnDescentParams(), "test");
+        assertNotNull(res1);
+        assertNull(mgr.tryAcquire(0, 0, CuVSMatrix.DataType.FLOAT, createNnDescentParams(), "test"));
+        mgr.release(res1);
+        var res2 = mgr.tryAcquire(0, 0, CuVSMatrix.DataType.FLOAT, createNnDescentParams(), "test");
+        assertNotNull(res2);
+        assertThat(res2.toString(), containsString("id=0"));
+        mgr.release(res2);
+        mgr.shutdown();
+    }
+
+    // tryAcquire returns null (not IOException) when createNew fails and no existing resource is free
+    public void testTryAcquireReturnsNullWhenCreateNewFails() throws Exception {
+        var mgr = new FailingAfterNMockPoolingCuVSResourceManager(2, 0);
+        var res = mgr.tryAcquire(0, 0, CuVSMatrix.DataType.FLOAT, createNnDescentParams(), "test");
+        assertNull(res);
+        mgr.shutdown();
+    }
+
+    // N threads tryAcquire concurrently: exactly capacity succeed, the rest get null
+    public void testTryAcquireConcurrent() throws Exception {
+        int capacity = randomIntBetween(2, 4);
+        var mgr = new MockPoolingCuVSResourceManager(capacity);
+        int numThreads = randomIntBetween(8, 12);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(numThreads);
+        AtomicInteger successes = new AtomicInteger();
+        AtomicInteger nulls = new AtomicInteger();
+
+        for (int i = 0; i < numThreads; i++) {
+            new Thread(() -> {
+                try {
+                    startLatch.await();
+                    var res = mgr.tryAcquire(0, 0, CuVSMatrix.DataType.FLOAT, createNnDescentParams(), "test");
+                    if (res != null) {
+                        successes.incrementAndGet();
+                    } else {
+                        nulls.incrementAndGet();
+                    }
+                } catch (Exception e) {
+                    throw new AssertionError(e);
+                } finally {
+                    doneLatch.countDown();
+                }
+            }).start();
+        }
+        startLatch.countDown();
+        assertTrue(doneLatch.await(10, TimeUnit.SECONDS));
+        assertThat(successes.get(), equalTo(capacity));
+        assertThat(nulls.get(), equalTo(numThreads - capacity));
         mgr.shutdown();
     }
 

--- a/libs/gpu-codec/src/test/java/org/elasticsearch/gpu/codec/ES92GpuHnswMixedPathTests.java
+++ b/libs/gpu-codec/src/test/java/org/elasticsearch/gpu/codec/ES92GpuHnswMixedPathTests.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.gpu.codec;
+
+import com.nvidia.cuvs.CagraIndexParams;
+import com.nvidia.cuvs.CuVSMatrix;
+
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.index.VectorEncoding;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.tests.index.BaseKnnVectorsFormatTestCase;
+import org.apache.lucene.tests.util.TestUtil;
+import org.elasticsearch.common.logging.LogConfigurator;
+import org.elasticsearch.gpu.CuVSGPUSupport;
+import org.junit.BeforeClass;
+
+import java.io.IOException;
+import java.util.Random;
+
+import static org.elasticsearch.gpu.codec.ES92GpuHnswVectorsFormat.DEFAULT_BEAM_WIDTH;
+import static org.elasticsearch.gpu.codec.ES92GpuHnswVectorsFormat.DEFAULT_MAX_CONN;
+
+/**
+ * Exercises the GPU format with a resource manager that randomly fails {@code tryAcquire},
+ * forcing a mix of GPU and CPU fallback paths across flush calls within the same index.
+ * Requires a GPU — skipped on non-GPU nodes.
+ */
+public class ES92GpuHnswMixedPathTests extends BaseKnnVectorsFormatTestCase {
+
+    static {
+        LogConfigurator.configureESLogging();
+    }
+
+    static Codec codec;
+
+    @BeforeClass
+    public static void beforeClass() {
+        var gpuSupport = CuVSGPUSupport.instance();
+        assumeTrue("cuvs not supported", gpuSupport.isSupported());
+        codec = TestUtil.alwaysKnnVectorsFormat(
+            new ES92GpuHnswVectorsFormat(
+                () -> new RandomlyFailingResourceManager(CuVSResourceManager.pooling(), new Random(random().nextLong())),
+                gpuSupport.getTotalGpuMemory(),
+                DEFAULT_MAX_CONN,
+                DEFAULT_BEAM_WIDTH
+            )
+        );
+    }
+
+    @Override
+    protected Codec getCodec() {
+        return codec;
+    }
+
+    @Override
+    protected VectorSimilarityFunction randomSimilarity() {
+        return VectorSimilarityFunction.values()[random().nextInt(VectorSimilarityFunction.values().length)];
+    }
+
+    @Override
+    protected VectorEncoding randomVectorEncoding() {
+        return VectorEncoding.FLOAT32;
+    }
+
+    @Override
+    public void testRandomBytes() throws Exception {
+        // No bytes support
+    }
+
+    @Override
+    public void testSortedIndexBytes() throws Exception {
+        // No bytes support
+    }
+
+    @Override
+    public void testByteVectorScorerIteration() throws Exception {
+        // No bytes support
+    }
+
+    @Override
+    public void testEmptyByteVectorData() throws Exception {
+        // No bytes support
+    }
+
+    @Override
+    public void testMergingWithDifferentByteKnnFields() throws Exception {
+        // No bytes support
+    }
+
+    @Override
+    public void testMismatchedFields() throws Exception {
+        // No bytes support
+    }
+
+    @Override
+    protected boolean supportsFloatVectorFallback() {
+        return false;
+    }
+
+    /**
+     * A resource manager that randomly returns null from tryAcquire to simulate GPU contention,
+     * forcing some flushes to fall back to CPU graph building.
+     */
+    static class RandomlyFailingResourceManager implements CuVSResourceManager {
+        private final CuVSResourceManager delegate;
+        private final Random random;
+
+        RandomlyFailingResourceManager(CuVSResourceManager delegate, Random random) {
+            this.delegate = delegate;
+            this.random = random;
+        }
+
+        @Override
+        public ManagedCuVSResources acquire(
+            int numVectors,
+            int dims,
+            CuVSMatrix.DataType dataType,
+            CagraIndexParams cagraIndexParams,
+            String reason
+        ) throws InterruptedException, IOException {
+            return delegate.acquire(numVectors, dims, dataType, cagraIndexParams, reason);
+        }
+
+        @Override
+        public ManagedCuVSResources tryAcquire(
+            int numVectors,
+            int dims,
+            CuVSMatrix.DataType dataType,
+            CagraIndexParams cagraIndexParams,
+            String reason
+        ) throws IOException {
+            if (random.nextBoolean()) {
+                return null;
+            }
+            return delegate.tryAcquire(numVectors, dims, dataType, cagraIndexParams, reason);
+        }
+
+        @Override
+        public void finishedComputation(ManagedCuVSResources resources) {
+            delegate.finishedComputation(resources);
+        }
+
+        @Override
+        public void release(ManagedCuVSResources resources) {
+            delegate.release(resources);
+        }
+
+        @Override
+        public void shutdown() {
+            delegate.shutdown();
+        }
+    }
+}

--- a/libs/gpu-codec/src/test/java/org/elasticsearch/gpu/codec/ES92GpuHnswSQMixedPathTests.java
+++ b/libs/gpu-codec/src/test/java/org/elasticsearch/gpu/codec/ES92GpuHnswSQMixedPathTests.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.gpu.codec;
+
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.index.VectorEncoding;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.tests.index.BaseKnnVectorsFormatTestCase;
+import org.apache.lucene.tests.util.TestUtil;
+import org.elasticsearch.common.logging.LogConfigurator;
+import org.elasticsearch.gpu.CuVSGPUSupport;
+import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
+import org.junit.BeforeClass;
+
+import java.util.Random;
+
+import static org.elasticsearch.gpu.codec.ES92GpuHnswVectorsFormat.DEFAULT_BEAM_WIDTH;
+import static org.elasticsearch.gpu.codec.ES92GpuHnswVectorsFormat.DEFAULT_MAX_CONN;
+import static org.elasticsearch.test.ESTestCase.randomFrom;
+
+/**
+ * Exercises the GPU SQ format with a resource manager that randomly fails {@code tryAcquire},
+ * forcing a mix of GPU and CPU fallback paths across flush calls within the same index.
+ * Requires a GPU — skipped on non-GPU nodes.
+ */
+public class ES92GpuHnswSQMixedPathTests extends BaseKnnVectorsFormatTestCase {
+
+    static {
+        LogConfigurator.configureESLogging();
+    }
+
+    static Codec codec;
+
+    @BeforeClass
+    public static void beforeClass() {
+        var gpuSupport = CuVSGPUSupport.instance();
+        assumeTrue("cuvs not supported", gpuSupport.isSupported());
+        codec = TestUtil.alwaysKnnVectorsFormat(
+            new ES92GpuHnswSQVectorsFormat(
+                () -> new ES92GpuHnswMixedPathTests.RandomlyFailingResourceManager(
+                    CuVSResourceManager.pooling(),
+                    new Random(random().nextLong())
+                ),
+                gpuSupport.getTotalGpuMemory(),
+                DEFAULT_MAX_CONN,
+                DEFAULT_BEAM_WIDTH,
+                null,
+                7,
+                false
+            )
+        );
+    }
+
+    @Override
+    protected Codec getCodec() {
+        return codec;
+    }
+
+    @Override
+    protected VectorSimilarityFunction randomSimilarity() {
+        var randomGPUSupportedSimilarity = randomFrom(
+            DenseVectorFieldMapper.VectorSimilarity.L2_NORM,
+            DenseVectorFieldMapper.VectorSimilarity.COSINE,
+            DenseVectorFieldMapper.VectorSimilarity.DOT_PRODUCT
+        );
+        return randomGPUSupportedSimilarity.vectorSimilarityFunction(IndexVersion.current(), DenseVectorFieldMapper.ElementType.FLOAT);
+    }
+
+    @Override
+    protected VectorEncoding randomVectorEncoding() {
+        return VectorEncoding.FLOAT32;
+    }
+
+    @Override
+    public void testRandomBytes() {
+        // No bytes support
+    }
+
+    @Override
+    public void testSortedIndexBytes() {
+        // No bytes support
+    }
+
+    @Override
+    public void testByteVectorScorerIteration() {
+        // No bytes support
+    }
+
+    @Override
+    public void testEmptyByteVectorData() {
+        // No bytes support
+    }
+
+    @Override
+    public void testMergingWithDifferentByteKnnFields() {
+        // No bytes support
+    }
+
+    @Override
+    public void testMismatchedFields() {
+        // No bytes support
+    }
+
+    @Override
+    protected boolean supportsFloatVectorFallback() {
+        return false;
+    }
+}

--- a/libs/gpu-codec/src/test/java/org/elasticsearch/gpu/codec/ES92GpuHnswWriteGraphTests.java
+++ b/libs/gpu-codec/src/test/java/org/elasticsearch/gpu/codec/ES92GpuHnswWriteGraphTests.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.gpu.codec;
+
+import com.nvidia.cuvs.CagraIndexParams;
+import com.nvidia.cuvs.CuVSMatrix;
+
+import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.codecs.KnnVectorsFormat;
+import org.apache.lucene.codecs.KnnVectorsReader;
+import org.apache.lucene.codecs.KnnVectorsWriter;
+import org.apache.lucene.codecs.hnsw.HnswGraphProvider;
+import org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat;
+import org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsWriter;
+import org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.KnnFloatVectorField;
+import org.apache.lucene.index.CodecReader;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.SegmentWriteState;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.store.ChecksumIndexInput;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.util.TestUtil;
+import org.apache.lucene.util.hnsw.HnswGraph;
+import org.elasticsearch.common.logging.LogConfigurator;
+import org.elasticsearch.index.codec.vectors.ES814HnswScalarQuantizedVectorsFormat;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import static org.apache.lucene.tests.index.BaseKnnVectorsFormatTestCase.randomVector;
+import static org.elasticsearch.gpu.codec.ES92GpuHnswVectorsFormat.DEFAULT_BEAM_WIDTH;
+import static org.elasticsearch.gpu.codec.ES92GpuHnswVectorsFormat.DEFAULT_MAX_CONN;
+
+/**
+ * Validates that the CPU fallback path in {@link ES92GpuHnswVectorsWriter} produces graph
+ * data identical to Lucene's {@link Lucene99HnswVectorsFormat}. No GPU required.
+ */
+public class ES92GpuHnswWriteGraphTests extends ESTestCase {
+
+    static {
+        LogConfigurator.configureESLogging();
+    }
+
+    private static final String FIELD = "vec";
+    private int numVectors;
+    private int dims;
+    private VectorSimilarityFunction similarity;
+
+    @Before
+    public void setup() {
+        numVectors = randomIntBetween(100, 500);
+        dims = randomIntBetween(128, 1024);
+        similarity = randomSimilarity();
+    }
+
+    public void testCpuFallbackGraphMatchesLucene() throws Exception {
+        float[][] vectors = generateVectors(numVectors, dims);
+        var gpuFormat = new ES92GpuHnswVectorsFormat(() -> new NullResourceManager(), 0L, DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH);
+        var luceneFormat = new Lucene99HnswVectorsFormat(DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH, 0);
+
+        try (Directory gpuDir = newDirectory(); Directory luceneDir = newDirectory()) {
+            indexVectors(gpuDir, gpuFormat, vectors, similarity);
+            indexVectors(luceneDir, luceneFormat, vectors, similarity);
+            try (DirectoryReader gpuReader = DirectoryReader.open(gpuDir); DirectoryReader luceneReader = DirectoryReader.open(luceneDir)) {
+                HnswGraph gpuGraph = getGraph(gpuReader);
+                HnswGraph luceneGraph = getGraph(luceneReader);
+                assertGraphsEqual(gpuGraph, luceneGraph);
+                assertVexBytesEqual(gpuDir, luceneDir);
+            }
+        }
+    }
+
+    public void testCpuFallbackSQGraphMatchesLucene() throws Exception {
+        var sqSimilarity = randomValueOtherThan(
+            VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT,
+            ES92GpuHnswWriteGraphTests::randomSimilarity
+        );
+        float[][] vectors = generateVectors(numVectors, dims);
+        var gpuFormat = new ES92GpuHnswSQVectorsFormat(
+            () -> new NullResourceManager(),
+            0L,
+            DEFAULT_MAX_CONN,
+            DEFAULT_BEAM_WIDTH,
+            null,
+            7,
+            false
+        );
+        var luceneFormat = new ES814HnswScalarQuantizedRWVectorsFormat(DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH);
+
+        try (Directory gpuDir = newDirectory(); Directory luceneDir = newDirectory()) {
+            indexVectors(gpuDir, gpuFormat, vectors, sqSimilarity);
+            indexVectors(luceneDir, luceneFormat, vectors, sqSimilarity);
+            try (DirectoryReader gpuReader = DirectoryReader.open(gpuDir); DirectoryReader luceneReader = DirectoryReader.open(luceneDir)) {
+                HnswGraph gpuGraph = getGraph(gpuReader);
+                HnswGraph luceneGraph = getGraph(luceneReader);
+                assertGraphsEqual(gpuGraph, luceneGraph);
+                assertVexBytesEqual(gpuDir, luceneDir);
+            }
+        }
+    }
+
+    private void indexVectors(Directory dir, KnnVectorsFormat format, float[][] vectors, VectorSimilarityFunction similarity)
+        throws IOException {
+        IndexWriterConfig iwc = new IndexWriterConfig();
+        iwc.setCodec(TestUtil.alwaysKnnVectorsFormat(format));
+        iwc.setUseCompoundFile(false);
+        try (var writer = new IndexWriter(dir, iwc)) {
+            for (float[] vec : vectors) {
+                Document doc = new Document();
+                doc.add(new KnnFloatVectorField(FIELD, vec, similarity));
+                writer.addDocument(doc);
+            }
+        }
+    }
+
+    private static HnswGraph getGraph(DirectoryReader reader) throws IOException {
+        CodecReader codecReader = (CodecReader) getOnlyLeafReader(reader);
+        KnnVectorsReader knnReader = codecReader.getVectorReader();
+        while (knnReader instanceof PerFieldKnnVectorsFormat.FieldsReader perFieldReader) {
+            knnReader = perFieldReader.getFieldReader(FIELD);
+        }
+        return ((HnswGraphProvider) knnReader).getGraph(FIELD);
+    }
+
+    private void assertGraphsEqual(HnswGraph gpuGraph, HnswGraph luceneGraph) throws IOException {
+        assertEquals("numLevels", luceneGraph.numLevels(), gpuGraph.numLevels());
+        assertEquals("size", luceneGraph.size(), gpuGraph.size());
+        assertEquals("maxConn", luceneGraph.maxConn(), gpuGraph.maxConn());
+
+        for (int level = 0; level < luceneGraph.numLevels(); level++) {
+            var luceneNodes = luceneGraph.getNodesOnLevel(level);
+            var gpuNodes = gpuGraph.getNodesOnLevel(level);
+            assertEquals("nodes on level " + level, luceneNodes.size(), gpuNodes.size());
+
+            while (luceneNodes.hasNext()) {
+                assertTrue("gpu should have more nodes on level " + level, gpuNodes.hasNext());
+                int luceneNode = luceneNodes.nextInt();
+                int gpuNode = gpuNodes.nextInt();
+                assertEquals("node id on level " + level, luceneNode, gpuNode);
+
+                int[] luceneNeighbors = getSortedNeighbors(luceneGraph, level, luceneNode);
+                int[] gpuNeighbors = getSortedNeighbors(gpuGraph, level, gpuNode);
+                assertArrayEquals("neighbors of node " + luceneNode + " on level " + level, luceneNeighbors, gpuNeighbors);
+            }
+        }
+    }
+
+    private static int[] getSortedNeighbors(HnswGraph graph, int level, int node) throws IOException {
+        graph.seek(level, node);
+        int count = graph.neighborCount();
+        int[] neighbors = new int[count];
+        for (int i = 0; i < count; i++) {
+            neighbors[i] = graph.nextNeighbor();
+        }
+        Arrays.sort(neighbors);
+        return neighbors;
+    }
+
+    private void assertVexBytesEqual(Directory gpuDir, Directory luceneDir) throws IOException {
+        String gpuVex = findFileByExtension(gpuDir, "vex");
+        String luceneVex = findFileByExtension(luceneDir, "vex");
+        byte[] gpuBytes = readVexPayload(gpuDir, gpuVex);
+        byte[] luceneBytes = readVexPayload(luceneDir, luceneVex);
+        assertArrayEquals(".vex payload (graph + offsets) must be identical between GPU CPU-fallback and Lucene", luceneBytes, gpuBytes);
+    }
+
+    private static byte[] readVexPayload(Directory dir, String fileName) throws IOException {
+        try (ChecksumIndexInput input = dir.openChecksumInput(fileName)) {
+            CodecUtil.checkHeader(
+                input,
+                "Lucene99HnswVectorsFormatIndex",
+                Lucene99HnswVectorsFormat.VERSION_START,
+                Lucene99HnswVectorsFormat.VERSION_CURRENT
+            );
+            input.skipBytes(16);
+            int suffixLen = input.readByte() & 0xFF;
+            input.skipBytes(suffixLen);
+            long headerEnd = input.getFilePointer();
+            long payloadLen = input.length() - headerEnd - CodecUtil.footerLength();
+            assertTrue("vex file too small to contain header+footer", payloadLen >= 0);
+            byte[] bytes = new byte[(int) payloadLen];
+            input.readBytes(bytes, 0, bytes.length);
+            return bytes;
+        }
+    }
+
+    private static String findFileByExtension(Directory dir, String ext) throws IOException {
+        var l = Arrays.stream(dir.listAll()).filter(name -> name.endsWith(ext)).toList();
+        assert l.size() == 1 : "expected a list with a single element, got:" + l;
+        return l.getFirst();
+    }
+
+    private float[][] generateVectors(int count, int dims) {
+        float[][] vectors = new float[count][dims];
+        for (int i = 0; i < count; i++) {
+            vectors[i] = randomVector(dims);
+        }
+        return vectors;
+    }
+
+    private static VectorSimilarityFunction randomSimilarity() {
+        return VectorSimilarityFunction.values()[random().nextInt(VectorSimilarityFunction.values().length)];
+    }
+
+    /** A {@link CuVSResourceManager} whose {@code tryAcquire} always returns null, forcing the CPU fallback path. */
+    static class NullResourceManager implements CuVSResourceManager {
+        @Override
+        public ManagedCuVSResources acquire(
+            int numVectors,
+            int dims,
+            CuVSMatrix.DataType dataType,
+            CagraIndexParams cagraIndexParams,
+            String reason
+        ) {
+            throw new UnsupportedOperationException("NullResourceManager: acquire should not be called");
+        }
+
+        @Override
+        public ManagedCuVSResources tryAcquire(
+            int numVectors,
+            int dims,
+            CuVSMatrix.DataType dataType,
+            CagraIndexParams cagraIndexParams,
+            String reason
+        ) {
+            return null;
+        }
+
+        @Override
+        public void finishedComputation(ManagedCuVSResources resources) {
+            throw new UnsupportedOperationException("NullResourceManager: finishedComputation should not be called");
+        }
+
+        @Override
+        public void release(ManagedCuVSResources resources) {
+            throw new UnsupportedOperationException("NullResourceManager: release should not be called");
+        }
+
+        @Override
+        public void shutdown() {}
+    }
+
+    static class ES814HnswScalarQuantizedRWVectorsFormat extends ES814HnswScalarQuantizedVectorsFormat {
+        ES814HnswScalarQuantizedRWVectorsFormat(int maxConn, int beamWidth) {
+            super(maxConn, beamWidth, null, 7, false);
+        }
+
+        @Override
+        public KnnVectorsWriter fieldsWriter(SegmentWriteState state) throws IOException {
+            return new Lucene99HnswVectorsWriter(state, maxConn, beamWidth, flatVectorsFormat().fieldsWriter(state), 0, null, 0);
+        }
+    }
+}


### PR DESCRIPTION
Backport of #149373 to 9.4.