### PR TITLE
[ESQL] tighten async external source coverage

### DIFF
--- a/docs/changelog/149491.yaml
+++ b/docs/changelog/149491.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 149491
+summary: Tighten async external source coverage
+type: enhancement

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalParquetMultiRowGroupCorrectnessIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalParquetMultiRowGroupCorrectnessIT.java
@@ -105,6 +105,9 @@ public class ExternalParquetMultiRowGroupCorrectnessIT extends AbstractEsqlInteg
 
         int rowCount = 50_000;
         int bucketCount = 8;
+        // Per-bucket assertion relies on exact integer division; otherwise truncation would
+        // silently change the expected count and surface as a confusing assertion failure.
+        assertEquals("rowCount must be evenly divisible by bucketCount for this test", 0, rowCount % bucketCount);
         // 50_000 rows of 512-byte payload at rowGroupSize=64 KiB forces many row groups even
         // uncompressed — that's the property this test relies on. The fixture is regenerated
         // every run, so a writer regression collapsing everything into one row group would

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalParquetMultiRowGroupCorrectnessIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalParquetMultiRowGroupCorrectnessIT.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.action;
+
+import org.apache.parquet.conf.PlainParquetConfiguration;
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.example.data.simple.SimpleGroupFactory;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.example.ExampleParquetWriter;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.io.OutputFile;
+import org.apache.parquet.io.PositionOutputStream;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Types;
+import org.elasticsearch.plugins.ExtensiblePlugin;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.xpack.core.esql.action.ColumnInfo;
+import org.elasticsearch.xpack.esql.datasource.http.HttpDataSourcePlugin;
+import org.elasticsearch.xpack.esql.datasource.parquet.ParquetDataSourcePlugin;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.getValuesList;
+import static org.elasticsearch.xpack.esql.action.EsqlCapabilities.Cap.EXTERNAL_COMMAND;
+import static org.elasticsearch.xpack.esql.action.EsqlQueryRequest.syncEsqlQueryRequest;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * End-to-end correctness check for the {@code EXTERNAL ... | STATS} pipeline against a
+ * Parquet file with many row groups. Generates a controlled fixture, runs
+ * {@code STATS COUNT(*) BY ...} (group-by prevents the {@code COUNT(*)} pushdown that
+ * {@link ExternalParquetCountPushdownIT} exercises), and asserts that the sum of the group
+ * counts and each per-bucket count match the exact number of rows written.
+ *
+ * <p>This is the regression net for the over-read / lost-wakeup class of bugs fixed in
+ * {@link org.elasticsearch.xpack.esql.datasources.AsyncExternalSourceBuffer}: a single
+ * shard or row group reading too many (or too few) pages, or a stalled driver, would
+ * surface here as a mismatched total. The grouped {@code COUNT(*)} shape is what keeps the
+ * test on the slow-scan path: both
+ * {@link org.elasticsearch.xpack.esql.optimizer.rules.physical.local.PushStatsToExternalSource}
+ * and
+ * {@link org.elasticsearch.xpack.esql.optimizer.rules.physical.local.PushAggregatesToExternalSource}
+ * bail out when {@code groupings()} is non-empty, so the rule for {@code COUNT(*)} pushdown
+ * exercised by {@link ExternalParquetCountPushdownIT} does not fire here.
+ *
+ * <p>The Parquet writer is configured {@code UNCOMPRESSED}. Compressed codecs require
+ * Parquet-MR's Hadoop-backed {@code CodecFactory} (and Woodstox/XML) on the writer side,
+ * while the plugin's Hadoop-free codec factory is package-private. The over-read bug
+ * class operates on decoded {@link org.elasticsearch.compute.data.Page}s — codec choice
+ * does not change the buffer/operator path under test. Codec-coverage tests already live
+ * in the parquet datasource module.
+ */
+public class ExternalParquetMultiRowGroupCorrectnessIT extends AbstractEsqlIntegTestCase {
+
+    /**
+     * Re-enables extension loading that {@link EsqlPluginWithEnterpriseOrTrialLicense} suppresses,
+     * so the Parquet and HTTP data source plugins are discovered.
+     */
+    public static final class EsqlEnterpriseWithDatasourceExtensions extends EsqlPluginWithEnterpriseOrTrialLicense {
+        @Override
+        public void loadExtensions(ExtensiblePlugin.ExtensionLoader loader) {
+            super.loadExtensions(loader);
+        }
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        List<Class<? extends Plugin>> plugins = new ArrayList<>(super.nodePlugins());
+        plugins.remove(EsqlPluginWithEnterpriseOrTrialLicense.class);
+        plugins.add(EsqlEnterpriseWithDatasourceExtensions.class);
+        plugins.add(HttpDataSourcePlugin.class);
+        plugins.add(ParquetDataSourcePlugin.class);
+        return plugins;
+    }
+
+    @Override
+    protected QueryPragmas getPragmas() {
+        return QueryPragmas.EMPTY;
+    }
+
+    /**
+     * STATS COUNT(*) BY ... over a multi-row-group Parquet file. The GROUP BY defeats both
+     * {@code COUNT(*)} pushdown rules so every row group is read through the async source
+     * operator. Both the sum of per-bucket counts and each individual per-bucket count must
+     * match the exact number of rows written, exercising the full ESQL plan (real planner,
+     * real Driver, real buffer) end-to-end.
+     */
+    public void testGroupedCountMatchesRowCountWithMultipleRowGroups() throws Exception {
+        assumeTrue("requires EXTERNAL command capability", EXTERNAL_COMMAND.isEnabled());
+
+        int rowCount = 50_000;
+        int bucketCount = 8;
+        // 50_000 rows of 512-byte payload at rowGroupSize=64 KiB forces many row groups even
+        // uncompressed — that's the property this test relies on. The fixture is regenerated
+        // every run, so a writer regression collapsing everything into one row group would
+        // still pass the count assertion but reduce the multi-row-group coverage; that is an
+        // acceptable graceful degradation rather than a hard prerequisite for the test.
+        Path parquetFile = writeMultiRowGroupParquetFile(rowCount, bucketCount);
+        try {
+            String query = "EXTERNAL \"" + StoragePath.fileUri(parquetFile) + "\" | STATS c = COUNT(*) BY bucket | KEEP c, bucket";
+            var request = syncEsqlQueryRequest(query);
+
+            try (var response = run(request)) {
+                List<? extends ColumnInfo> columns = response.columns();
+                assertThat("expected (c, bucket) columns, got " + columns, columns.size(), equalTo(2));
+                assertThat(columns.get(0).name(), equalTo("c"));
+                assertThat(columns.get(1).name(), equalTo("bucket"));
+
+                List<List<Object>> rows = getValuesList(response);
+                assertThat("expected one row per bucket key", (long) rows.size(), equalTo((long) bucketCount));
+
+                long total = 0;
+                long expectedPerBucket = (long) rowCount / bucketCount;
+                for (List<Object> row : rows) {
+                    long count = ((Number) row.get(0)).longValue();
+                    assertThat("per-bucket count must equal rowCount/bucketCount (row=" + row + ")", count, equalTo(expectedPerBucket));
+                    total += count;
+                }
+                assertThat("sum of grouped counts must equal the row count written", total, equalTo((long) rowCount));
+            }
+        } finally {
+            Files.deleteIfExists(parquetFile);
+        }
+    }
+
+    /**
+     * Writes an UNCOMPRESSED Parquet file with {@code rowCount} rows split evenly across
+     * {@code bucketCount} groups and a small row-group size to force multiple row groups. The
+     * 512-byte payload column is the row-size lever that makes 64 KiB row groups roll over
+     * many times for 50_000 rows.
+     */
+    private Path writeMultiRowGroupParquetFile(int rowCount, int bucketCount) throws IOException {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.INT32)
+            .named("bucket")
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("payload")
+            .named("external_multi_rg_schema");
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        OutputFile outputFile = createOutputFile(baos);
+        SimpleGroupFactory factory = new SimpleGroupFactory(schema);
+
+        String payload = "a".repeat(512);
+
+        try (
+            ParquetWriter<Group> writer = ExampleParquetWriter.builder(outputFile)
+                .withConf(new PlainParquetConfiguration())
+                .withType(schema)
+                .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
+                .withRowGroupSize(64L * 1024L)
+                .withPageSize(8 * 1024)
+                .build()
+        ) {
+            for (int i = 0; i < rowCount; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                g.add("bucket", i % bucketCount);
+                g.add("payload", payload);
+                writer.write(g);
+            }
+        }
+
+        Path tempFile = createTempDir().resolve("multi_rg_correctness.parquet");
+        Files.write(tempFile, baos.toByteArray());
+        return tempFile;
+    }
+
+    private static OutputFile createOutputFile(ByteArrayOutputStream baos) {
+        return new OutputFile() {
+            @Override
+            public PositionOutputStream create(long blockSizeHint) {
+                return new PositionOutputStream() {
+                    private long position = 0;
+
+                    @Override
+                    public long getPos() {
+                        return position;
+                    }
+
+                    @Override
+                    public void write(int b) throws IOException {
+                        baos.write(b);
+                        position++;
+                    }
+
+                    @Override
+                    public void write(byte[] b, int off, int len) throws IOException {
+                        baos.write(b, off, len);
+                        position += len;
+                    }
+                };
+            }
+
+            @Override
+            public PositionOutputStream createOrOverwrite(long blockSizeHint) {
+                return create(blockSizeHint);
+            }
+
+            @Override
+            public boolean supportsBlockSize() {
+                return false;
+            }
+
+            @Override
+            public long defaultBlockSize() {
+                return 0;
+            }
+        };
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncConnectorSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncConnectorSourceOperatorFactory.java
@@ -212,20 +212,7 @@ public class AsyncConnectorSourceOperatorFactory implements SourceOperator.Sourc
             }
             SubscribableListener<Void> space = buffer.waitForSpace();
             if (space.isDone() == false) {
-                space.addListener(ActionListener.wrap(v -> {
-                    try {
-                        executor.execute(() -> runProducerLoop(state, completionListener));
-                    } catch (Exception e) {
-                        closeCursorQuietly(state.cursor);
-                        state.cursor = null;
-                        completionListener.onFailure(e);
-                    }
-                }, e -> {
-                    closeCursorQuietly(state.cursor);
-                    state.cursor = null;
-                    completionListener.onFailure(e);
-                }));
-                return DrainResult.BLOCKED;
+                return parkUntilReady(space, state, completionListener);
             }
             if (buffer.noMoreInputs()) {
                 return DrainResult.DONE;
@@ -238,6 +225,35 @@ public class AsyncConnectorSourceOperatorFactory implements SourceOperator.Sourc
                 state.rowsRemaining -= rows;
             }
         }
+    }
+
+    /**
+     * Register a single listener that resumes the producer loop when {@code signal} fires, and
+     * return synchronously. {@link DrainResult#BLOCKED} is returned immediately after listener
+     * registration; the producer resumes asynchronously when {@code signal} completes.
+     * <p>
+     * Both branches of the listener (success and failure) close the current cursor and route
+     * resume errors through {@code completionListener.onFailure}, matching the cleanup
+     * performed by the surrounding {@link #runProducerLoop} {@code catch} block.
+     *
+     * @param signal a not-done listener from {@code waitForSpace()}; callers must verify
+     *               {@code signal.isDone() == false} before invoking this helper.
+     */
+    private DrainResult parkUntilReady(SubscribableListener<Void> signal, ProducerState state, ActionListener<Void> completionListener) {
+        signal.addListener(ActionListener.wrap(v -> {
+            try {
+                executor.execute(() -> runProducerLoop(state, completionListener));
+            } catch (Exception e) {
+                closeCursorQuietly(state.cursor);
+                state.cursor = null;
+                completionListener.onFailure(e);
+            }
+        }, e -> {
+            closeCursorQuietly(state.cursor);
+            state.cursor = null;
+            completionListener.onFailure(e);
+        }));
+        return DrainResult.BLOCKED;
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncConnectorSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncConnectorSourceOperatorFactory.java
@@ -232,9 +232,17 @@ public class AsyncConnectorSourceOperatorFactory implements SourceOperator.Sourc
      * return synchronously. {@link DrainResult#BLOCKED} is returned immediately after listener
      * registration; the producer resumes asynchronously when {@code signal} completes.
      * <p>
-     * Both branches of the listener (success and failure) close the current cursor and route
-     * resume errors through {@code completionListener.onFailure}, matching the cleanup
-     * performed by the surrounding {@link #runProducerLoop} {@code catch} block.
+     * Cleanup semantics by branch:
+     * <ul>
+     * <li>Success branch (happy path): re-submits {@link #runProducerLoop} on {@code executor};
+     *     the current cursor stays open across the park. Only if {@code executor.execute()}
+     *     itself throws (e.g. shutting-down pool) is the cursor closed and the failure routed
+     *     through {@code completionListener.onFailure}.</li>
+     * <li>Failure branch: closes the current cursor and routes the signal's failure through
+     *     {@code completionListener.onFailure}.</li>
+     * </ul>
+     * Both cleanup paths match what the surrounding {@link #runProducerLoop} {@code catch} block
+     * does on a synchronous throw.
      *
      * @param signal a not-done listener from {@code waitForSpace()}; callers must verify
      *               {@code signal.isDone() == false} before invoking this helper.

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceBuffer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceBuffer.java
@@ -89,6 +89,7 @@ public final class AsyncExternalSourceBuffer {
                 }
             }
         }
+        assert invariantsHold() : "buffer invariants violated after addPage";
     }
 
     /**
@@ -100,6 +101,7 @@ public final class AsyncExternalSourceBuffer {
         Page page = queue.poll();
         if (page == null) {
             signalCompletionIfDrained();
+            assert invariantsHold() : "buffer invariants violated after pollPage (empty)";
             return null;
         }
         queueSize.decrementAndGet();
@@ -110,6 +112,7 @@ public final class AsyncExternalSourceBuffer {
         // orphaning notFullFuture. notifyNotFull() is a no-op when no listener is registered.
         notifyNotFull();
         signalCompletionIfDrained();
+        assert invariantsHold() : "buffer invariants violated after pollPage";
         return page;
     }
 
@@ -201,6 +204,7 @@ public final class AsyncExternalSourceBuffer {
             p.releaseBlocks();
         }
         bytesInBuffer.set(0);
+        assert invariantsHold() : "buffer invariants violated after discardPages";
     }
 
     /**
@@ -214,6 +218,7 @@ public final class AsyncExternalSourceBuffer {
         notifyNotEmpty();
         notifyNotFull(); // wake producers so they observe noMoreInputs and exit
         signalCompletionIfDrained();
+        assert invariantsHold() : "buffer invariants violated after finish";
     }
 
     /**
@@ -228,6 +233,7 @@ public final class AsyncExternalSourceBuffer {
         notifyNotEmpty();
         notifyNotFull();
         signalCompletionIfDrained();
+        assert invariantsHold() : "buffer invariants violated after onFailure";
     }
 
     public boolean isFinished() {
@@ -258,5 +264,39 @@ public final class AsyncExternalSourceBuffer {
      */
     public long bytesInBuffer() {
         return bytesInBuffer.get();
+    }
+
+    /**
+     * Verifies internal invariants under {@code -ea}. Called from each buffer mutator so that
+     * every existing test exercises the checks automatically without dedicated assertions.
+     * <p>
+     * Scope is intentionally narrow. The buffer is lock-free and counter updates are not atomic
+     * across fields, so several legitimate transient states cannot be asserted on without
+     * introducing flakiness:
+     * <ul>
+     * <li>{@link #addPage} updates {@code bytesInBuffer} before {@code queueSize}, so a
+     *     concurrent reader may briefly observe {@code bytes > 0 && size == 0}.</li>
+     * <li>{@link #pollPage} updates {@code queueSize} before {@code bytesInBuffer}, so a
+     *     concurrent reader may briefly observe {@code size < N && bytes} still reflecting
+     *     {@code N}.</li>
+     * <li>A race between {@link #discardPages()} (which sets {@code bytesInBuffer} to {@code 0}
+     *     wholesale) and the {@code noMoreInputs} cleanup branch of {@link #addPage} (which
+     *     subtracts its own page bytes) can transiently push counters below zero by an
+     *     unpredictable amount.</li>
+     * </ul>
+     * Hence the only invariant asserted here is the forward direction of completion
+     * consistency: if {@code completionFuture} has signalled success, then the buffer must
+     * already have observed {@code noMoreInputs}. This catches premature completion (signalling
+     * done before {@code finish} / {@code onFailure} was called). Lost-wakeup regressions — the
+     * bug class fixed in the unconditional {@code notifyNotEmpty}/{@code notifyNotFull} changes
+     * — leave counters and the completion future internally consistent and are not detected
+     * here; see {@code AsyncExternalSourceBufferTests#testNoLostWakeupUnderConcurrentAddAndPoll}
+     * for that coverage.
+     */
+    private boolean invariantsHold() {
+        if (completionFuture.isDone() && failure == null) {
+            assert noMoreInputs : "completionFuture done with no failure but noMoreInputs is false";
+        }
+        return true;
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceBuffer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceBuffer.java
@@ -64,6 +64,8 @@ public final class AsyncExternalSourceBuffer {
      */
     public void addPage(Page page) {
         if (failure != null) {
+            // Reject the page without touching buffer state, so the trailing invariantsHold()
+            // call is intentionally bypassed: nothing was mutated for it to check.
             page.releaseBlocks();
             return;
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
@@ -980,18 +980,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
             // immediately-completed listener and fall straight through.
             SubscribableListener<Void> ready = pages.waitForReady();
             if (ready.isDone() == false) {
-                ready.addListener(ActionListener.wrap(v -> {
-                    try {
-                        executor.execute(() -> runProducerLoop(state, completionListener));
-                    } catch (Exception e) {
-                        clearCurrentIterator(state);
-                        completionListener.onFailure(e);
-                    }
-                }, e -> {
-                    clearCurrentIterator(state);
-                    completionListener.onFailure(e);
-                }));
-                return DrainResult.BLOCKED;
+                return parkUntilReady(ready, state, completionListener);
             }
             if (pages.hasNext() == false) {
                 // Race: waitForReady reported done (page available or EOF), but by the time we
@@ -1005,33 +994,11 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                 if (recheck.isDone()) {
                     return DrainResult.EOF;
                 }
-                recheck.addListener(ActionListener.wrap(v -> {
-                    try {
-                        executor.execute(() -> runProducerLoop(state, completionListener));
-                    } catch (Exception e) {
-                        clearCurrentIterator(state);
-                        completionListener.onFailure(e);
-                    }
-                }, e -> {
-                    clearCurrentIterator(state);
-                    completionListener.onFailure(e);
-                }));
-                return DrainResult.BLOCKED;
+                return parkUntilReady(recheck, state, completionListener);
             }
             SubscribableListener<Void> space = buffer.waitForSpace();
             if (space.isDone() == false) {
-                space.addListener(ActionListener.wrap(v -> {
-                    try {
-                        executor.execute(() -> runProducerLoop(state, completionListener));
-                    } catch (Exception e) {
-                        clearCurrentIterator(state);
-                        completionListener.onFailure(e);
-                    }
-                }, e -> {
-                    clearCurrentIterator(state);
-                    completionListener.onFailure(e);
-                }));
-                return DrainResult.BLOCKED;
+                return parkUntilReady(space, state, completionListener);
             }
             if (buffer.noMoreInputs()) {
                 return DrainResult.DONE;
@@ -1044,6 +1011,37 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                 state.rowsRemaining -= rows;
             }
         }
+    }
+
+    /**
+     * Register a single listener that resumes the producer loop when {@code signal} fires, and
+     * return synchronously. {@link DrainResult#BLOCKED} is returned immediately after listener
+     * registration; the producer resumes asynchronously when {@code signal} completes.
+     * <p>
+     * Both branches of the listener (success and failure) route resume errors through
+     * {@code completionListener.onFailure} after calling {@link #clearCurrentIterator}, matching
+     * the cleanup performed by the surrounding {@link #runProducerLoop} {@code catch} block.
+     * <p>
+     * Collapses three structurally identical {@code addListener} blocks (page-ready, page-ready
+     * recheck, buffer-space) into one site, removing copy-paste drift risk between branches.
+     *
+     * @param signal a not-done listener from {@code waitForReady()} or {@code waitForSpace()};
+     *               callers must verify {@code signal.isDone() == false} before invoking this
+     *               helper, otherwise the producer will be re-submitted immediately.
+     */
+    private DrainResult parkUntilReady(SubscribableListener<Void> signal, ProducerState state, ActionListener<Void> completionListener) {
+        signal.addListener(ActionListener.wrap(v -> {
+            try {
+                executor.execute(() -> runProducerLoop(state, completionListener));
+            } catch (Exception e) {
+                clearCurrentIterator(state);
+                completionListener.onFailure(e);
+            }
+        }, e -> {
+            clearCurrentIterator(state);
+            completionListener.onFailure(e);
+        }));
+        return DrainResult.BLOCKED;
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
@@ -1018,9 +1018,17 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
      * return synchronously. {@link DrainResult#BLOCKED} is returned immediately after listener
      * registration; the producer resumes asynchronously when {@code signal} completes.
      * <p>
-     * Both branches of the listener (success and failure) route resume errors through
-     * {@code completionListener.onFailure} after calling {@link #clearCurrentIterator}, matching
-     * the cleanup performed by the surrounding {@link #runProducerLoop} {@code catch} block.
+     * Cleanup semantics by branch:
+     * <ul>
+     * <li>Success branch (happy path): re-submits {@link #runProducerLoop} on {@code executor};
+     *     the current iterator stays open across the park. Only if {@code executor.execute()}
+     *     itself throws (e.g. shutting-down pool) is the iterator cleared and the failure
+     *     routed through {@code completionListener.onFailure}.</li>
+     * <li>Failure branch: clears the current iterator and routes the signal's failure through
+     *     {@code completionListener.onFailure}.</li>
+     * </ul>
+     * Both cleanup paths match what the surrounding {@link #runProducerLoop} {@code catch} block
+     * does on a synchronous throw.
      * <p>
      * Collapses three structurally identical {@code addListener} blocks (page-ready, page-ready
      * recheck, buffer-space) into one site, removing copy-paste drift risk between branches.

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorRealDriverTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorRealDriverTests.java
@@ -1,0 +1,409 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.CloseableIterator;
+import org.elasticsearch.compute.operator.Driver;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.DriverRunner;
+import org.elasticsearch.compute.operator.DriverStatus;
+import org.elasticsearch.compute.operator.PageConsumerOperator;
+import org.elasticsearch.compute.operator.SourceOperator;
+import org.elasticsearch.compute.test.TestDriverFactory;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.FixedExecutorBuilder;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.type.EsField;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
+import org.elasticsearch.xpack.esql.datasources.spi.NoConfigFormatReader;
+import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageProvider;
+
+import java.io.InputStream;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * End-to-end tests that drive {@link AsyncExternalSourceOperator} through a real
+ * {@link Driver} + {@link DriverRunner}, so the consumer actually parks on the
+ * buffer's {@code waitForReading()} listener rather than busy-polling
+ * {@link SourceOperator#getOutput()} from a test thread.
+ *
+ * <p>This closes the operator-layer gap left by
+ * {@code AsyncExternalSourceOperatorFactoryTests}: those tests poll {@code getOutput} from
+ * a plain thread with {@code Thread.sleep(1)} retries and therefore never exercise the
+ * driver-parking code path that the lost-wakeup fix in
+ * {@code AsyncExternalSourceBuffer} guards. The buffer-layer regression test
+ * {@code AsyncExternalSourceBufferTests#testNoLostWakeupUnderConcurrentAddAndPoll}
+ * covers the buffer in isolation; this test class covers the integration with a
+ * real Driver where the consumer's blocked-status comes from
+ * {@code AsyncExternalSourceOperator#isBlocked()} and the driver yields its
+ * executor slot (recorded as {@code DriverStatus.Status.ASYNC} sleep) until the listener
+ * fires.
+ */
+public class AsyncExternalSourceOperatorRealDriverTests extends ESTestCase {
+
+    private static final BlockFactory TEST_BLOCK_FACTORY = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE)
+        .breaker(new NoopCircuitBreaker("none"))
+        .build();
+
+    private static final String DRIVER_POOL_NAME = "test-driver";
+
+    private ThreadPool driverThreadPool;
+    private ExecutorService producerExec;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        driverThreadPool = new TestThreadPool(
+            "real-driver-tests",
+            new FixedExecutorBuilder(
+                Settings.EMPTY,
+                DRIVER_POOL_NAME,
+                between(1, 4),
+                1024,
+                "real-driver-tests." + DRIVER_POOL_NAME,
+                EsExecutors.TaskTrackingConfig.DEFAULT
+            )
+        );
+        producerExec = Executors.newFixedThreadPool(2, EsExecutors.daemonThreadFactory("test", "real-driver-producer"));
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        try {
+            producerExec.shutdownNow();
+            assertTrue(producerExec.awaitTermination(10, TimeUnit.SECONDS));
+        } finally {
+            terminate(driverThreadPool);
+            super.tearDown();
+        }
+    }
+
+    /**
+     * Single Driver, slow producer (sleep on each {@code next()}), small buffer ({@code bufferSize=1}),
+     * pages large enough that two of them exceed buffer capacity. The Driver's consumer thread
+     * must park on the buffer's empty-listener between pages — proven by a non-zero
+     * {@code ASYNC} sleep count (driver records {@code ASYNC} for {@code isBlocked()} waits) with
+     * the buffer's reason on the driver status after completion. A pre-fix buffer that lost the
+     * empty-wakeup would hang here.
+     */
+    public void testRealDriverParksOnEmptyBuffer() throws Exception {
+        int totalPages = 50;
+        int bufferSize = 1;
+        long producerSleepMillis = 5L;
+        int pagesPerSplit = totalPages;
+
+        AtomicInteger readCount = new AtomicInteger();
+        FormatReader formatReader = new SlowMultiPageFormatReader(readCount, pagesPerSplit, producerSleepMillis);
+
+        ExternalSliceQueue sliceQueue = new ExternalSliceQueue(
+            List.of(new FileSplit("test", StoragePath.of("s3://bucket/slow.parquet"), 0, 100, "parquet", Map.of(), Map.of()))
+        );
+
+        DriverContext driverContext = new DriverContext(BigArrays.NON_RECYCLING_INSTANCE, TEST_BLOCK_FACTORY, null);
+        AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
+            new StubStorageProvider(),
+            formatReader,
+            StoragePath.of("s3://bucket/slow.parquet"),
+            singleIntAttribute(),
+            100,
+            bufferSize,
+            producerExec
+        ).sliceQueue(sliceQueue).build();
+
+        AtomicInteger pageCount = new AtomicInteger();
+        Driver driver = TestDriverFactory.create(driverContext, factory.get(driverContext), List.of(), new PageConsumerOperator(page -> {
+            pageCount.incrementAndGet();
+            page.releaseBlocks();
+        }));
+
+        runDriver(driver);
+
+        assertEquals("expected one slice read", 1, readCount.get());
+        assertEquals("driver must drain every page", totalPages, pageCount.get());
+        assertDriverParkedOnEmptyBuffer(driver);
+    }
+
+    /**
+     * Four real Drivers sharing one {@link ExternalSliceQueue}, each with its own
+     * {@link AsyncExternalSourceOperator}, distributing 20 splits with {@code pagesPerSplit=10}.
+     * The consumer threads are real driver executor slots that park on
+     * {@link AsyncExternalSourceBuffer#waitForReading()} when their per-driver buffer is empty.
+     * The total page count must equal {@code splits * pagesPerSplit}; no split may be lost or
+     * double-read across drivers.
+     */
+    public void testMultiDriverInterleavedRealDriver() throws Exception {
+        int driverCount = 4;
+        int splits = 20;
+        int pagesPerSplit = 10;
+        int bufferSize = 1;
+
+        List<FileSplit> queueEntries = new ArrayList<>();
+        for (int i = 0; i < splits; i++) {
+            queueEntries.add(
+                new FileSplit("test", StoragePath.of("s3://bucket/rg" + i + ".parquet"), 0, 100, "parquet", Map.of(), Map.of())
+            );
+        }
+        ExternalSliceQueue sliceQueue = new ExternalSliceQueue(List.copyOf(queueEntries));
+
+        AtomicInteger readCount = new AtomicInteger();
+        FormatReader formatReader = new SlowMultiPageFormatReader(readCount, pagesPerSplit, 1L);
+        StubStorageProvider storageProvider = new StubStorageProvider();
+
+        AtomicInteger pageCount = new AtomicInteger();
+        List<Driver> drivers = new ArrayList<>(driverCount);
+        for (int d = 0; d < driverCount; d++) {
+            DriverContext ctx = new DriverContext(BigArrays.NON_RECYCLING_INSTANCE, TEST_BLOCK_FACTORY, null);
+            AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
+                storageProvider,
+                formatReader,
+                StoragePath.of("s3://bucket/rg0.parquet"),
+                singleIntAttribute(),
+                100,
+                bufferSize,
+                producerExec
+            ).sliceQueue(sliceQueue).build();
+            drivers.add(TestDriverFactory.create(ctx, factory.get(ctx), List.of(), new PageConsumerOperator(page -> {
+                pageCount.incrementAndGet();
+                page.releaseBlocks();
+            })));
+        }
+
+        runDrivers(drivers);
+
+        assertEquals("every split must be read exactly once", splits, readCount.get());
+        assertEquals("total pages must be splits * pagesPerSplit", splits * pagesPerSplit, pageCount.get());
+    }
+
+    /**
+     * Asserts the driver parked at least once on the external-source buffer's empty-listener.
+     * The driver records {@link DriverStatus.Status#ASYNC} (not {@code WAITING}) for
+     * {@code isBlocked()} returns, and the sleep reason is the string registered by
+     * {@link AsyncExternalSourceBuffer#waitForReading()} on {@code IsBlockedResult}; any
+     * change to that reason string must update this assertion.
+     */
+    private static void assertDriverParkedOnEmptyBuffer(Driver driver) {
+        DriverStatus status = driver.status();
+        Long waits = status.sleeps().counts().get("async external source buffer empty");
+        assertNotNull("driver must have recorded at least one async-source park; sleeps were " + status.sleeps().counts(), waits);
+    }
+
+    private void runDriver(Driver driver) {
+        runDrivers(List.of(driver));
+    }
+
+    private void runDrivers(List<Driver> drivers) {
+        DriverRunner runner = new DriverRunner(driverThreadPool.getThreadContext()) {
+            @Override
+            protected void start(Driver driver, ActionListener<Void> driverListener) {
+                Driver.start(
+                    driverThreadPool.getThreadContext(),
+                    driverThreadPool.executor(DRIVER_POOL_NAME),
+                    driver,
+                    between(1, 10_000),
+                    driverListener
+                );
+            }
+        };
+        PlainActionFuture<Void> future = new PlainActionFuture<>();
+        runner.runToCompletion(drivers, future);
+        future.actionGet(TimeValue.timeValueSeconds(30));
+    }
+
+    private static List<Attribute> singleIntAttribute() {
+        return List.of(
+            new FieldAttribute(
+                Source.EMPTY,
+                "value",
+                new EsField("value", DataType.INTEGER, Map.of(), false, EsField.TimeSeriesFieldType.NONE)
+            )
+        );
+    }
+
+    /**
+     * Builds a page with enough rows that {@link Page#ramBytesUsedByBlocks()} exceeds
+     * {@link org.elasticsearch.compute.operator.Operator#TARGET_PAGE_SIZE} (256 KiB). This
+     * matters because the buffer's effective capacity is {@code bufferSize * TARGET_PAGE_SIZE}
+     * bytes — with tiny pages, {@code bufferSize=1} would still hold thousands of pages and
+     * the consumer would never observe an empty buffer.
+     */
+    private static Page createTestPage() {
+        // 96 KiB worth of int positions guarantees each page exceeds TARGET_PAGE_SIZE once block
+        // overhead is included (and even without overhead, three such pages overflow a
+        // bufferSize=1 buffer).
+        int positions = 96 * 1024;
+        var builder = TEST_BLOCK_FACTORY.newIntBlockBuilder(positions);
+        for (int i = 0; i < positions; i++) {
+            builder.appendInt(i);
+        }
+        IntBlock block = builder.build();
+        return new Page(block);
+    }
+
+    /**
+     * Format reader that returns a fixed number of pages per split, sleeping between each
+     * {@code next()} call so the consumer Driver is forced to park on
+     * {@link AsyncExternalSourceBuffer#waitForReading()} between pages.
+     */
+    private static class SlowMultiPageFormatReader implements NoConfigFormatReader {
+
+        private final AtomicInteger readCount;
+        private final int pagesPerRead;
+        private final long sleepMillis;
+
+        SlowMultiPageFormatReader(AtomicInteger readCount, int pagesPerRead, long sleepMillis) {
+            this.readCount = readCount;
+            this.pagesPerRead = pagesPerRead;
+            this.sleepMillis = sleepMillis;
+        }
+
+        @Override
+        public SourceMetadata metadata(StorageObject object) {
+            return null;
+        }
+
+        @Override
+        public CloseableIterator<Page> read(StorageObject object, FormatReadContext context) {
+            readCount.incrementAndGet();
+            return new CloseableIterator<>() {
+                private int remaining = pagesPerRead;
+
+                @Override
+                public boolean hasNext() {
+                    return remaining > 0;
+                }
+
+                @Override
+                public Page next() {
+                    if (remaining <= 0) {
+                        throw new NoSuchElementException();
+                    }
+                    remaining--;
+                    if (sleepMillis > 0) {
+                        try {
+                            Thread.sleep(sleepMillis);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            throw new RuntimeException(e);
+                        }
+                    }
+                    return createTestPage();
+                }
+
+                @Override
+                public void close() {}
+            };
+        }
+
+        @Override
+        public String formatName() {
+            return "test-slow-multi-page";
+        }
+
+        @Override
+        public List<String> fileExtensions() {
+            return List.of(".parquet");
+        }
+
+        @Override
+        public void close() {}
+    }
+
+    /**
+     * Minimal {@link StorageProvider} that returns trivial empty-stream objects. The reader
+     * stubs above ignore the storage object entirely, so we only need a stable instance to
+     * satisfy the operator's storage lookups.
+     */
+    private static class StubStorageProvider implements StorageProvider {
+        @Override
+        public StorageObject newObject(StoragePath path) {
+            return new StubStorageObject(path);
+        }
+
+        @Override
+        public StorageObject newObject(StoragePath path, long length) {
+            return new StubStorageObject(path);
+        }
+
+        @Override
+        public StorageObject newObject(StoragePath path, long length, Instant lastModified) {
+            return new StubStorageObject(path);
+        }
+
+        @Override
+        public StorageIterator listObjects(StoragePath prefix, boolean recursive) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean exists(StoragePath path) {
+            return true;
+        }
+
+        @Override
+        public List<String> supportedSchemes() {
+            return List.of("s3");
+        }
+
+        @Override
+        public void close() {}
+    }
+
+    private record StubStorageObject(StoragePath path) implements StorageObject {
+        @Override
+        public InputStream newStream() {
+            return InputStream.nullInputStream();
+        }
+
+        @Override
+        public InputStream newStream(long position, long length) {
+            return InputStream.nullInputStream();
+        }
+
+        @Override
+        public long length() {
+            return 0;
+        }
+
+        @Override
+        public Instant lastModified() {
+            return Instant.EPOCH;
+        }
+
+        @Override
+        public boolean exists() {
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Closes the three operator-layer gaps identified after the lost-wakeup
fix in AsyncExternalSourceBuffer:

- Add a real-Driver test for AsyncExternalSourceOperator that parks on
  waitForReading via a DriverRunner instead of busy-polling getOutput,
  filling the buffer-isolated regression test's blind spot at the
  operator layer.
- Add an end-to-end multi-row-group Parquet correctness IT that runs
  STATS COUNT(*) BY through the full ESQL plan and asserts exact
  per-bucket and total row counts, catching over-read regressions on
  multi-row-group scans.
- Encode buffer completion-direction invariants in
  AsyncExternalSourceBuffer so every -ea test exercises them, catching
  premature completion signalling without introducing flakiness on
  legitimate counter races.

Also collapses the three structurally identical addListener+BLOCKED
branches in AsyncExternalSourceOperatorFactory.drainHotPath (and the
matching branch in AsyncConnectorSourceOperatorFactory) into a single
parkUntilReady helper per class, removing copy-paste drift risk
without changing behaviour.

Developed with AI-assisted tooling