### PR TITLE
Allow gc of synonym rule strings after SynonymMap construction

### DIFF
--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SynonymGraphTokenFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SynonymGraphTokenFilterFactory.java
@@ -59,12 +59,7 @@ public class SynonymGraphTokenFilterFactory extends SynonymTokenFilterFactory {
         return buildChainedFactory(name(), synonyms, analysisMode, rulesReader.resource());
     }
 
-    static TokenFilterFactory buildChainedFactory(
-        String name,
-        SynonymMap synonyms,
-        AnalysisMode analysisMode,
-        String resourceName
-    ) {
+    static TokenFilterFactory buildChainedFactory(String name, SynonymMap synonyms, AnalysisMode analysisMode, String resourceName) {
         return new TokenFilterFactory() {
             @Override
             public String name() {

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SynonymGraphTokenFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SynonymGraphTokenFilterFactory.java
@@ -56,7 +56,15 @@ public class SynonymGraphTokenFilterFactory extends SynonymTokenFilterFactory {
         final Analyzer analyzer = buildSynonymAnalyzer(tokenizer, charFilters, previousTokenFilters);
         ReaderWithOrigin rulesReader = synonymsSource.getRulesReader(this, context);
         final SynonymMap synonyms = buildSynonyms(analyzer, rulesReader);
-        final String name = name();
+        return buildChainedFactory(name(), synonyms, analysisMode, rulesReader.resource());
+    }
+
+    static TokenFilterFactory buildChainedFactory(
+        String name,
+        SynonymMap synonyms,
+        AnalysisMode analysisMode,
+        String resourceName
+    ) {
         return new TokenFilterFactory() {
             @Override
             public String name() {
@@ -93,7 +101,7 @@ public class SynonymGraphTokenFilterFactory extends SynonymTokenFilterFactory {
 
             @Override
             public String getResourceName() {
-                return rulesReader.resource();
+                return resourceName;
             }
         };
     }

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SynonymGraphTokenFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SynonymGraphTokenFilterFactory.java
@@ -18,7 +18,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.index.IndexService.IndexCreationContext;
 import org.elasticsearch.index.IndexSettings;
-import org.elasticsearch.index.analysis.AnalysisMode;
 import org.elasticsearch.index.analysis.CharFilterFactory;
 import org.elasticsearch.index.analysis.TokenFilterFactory;
 import org.elasticsearch.index.analysis.TokenizerFactory;
@@ -56,48 +55,12 @@ public class SynonymGraphTokenFilterFactory extends SynonymTokenFilterFactory {
         final Analyzer analyzer = buildSynonymAnalyzer(tokenizer, charFilters, previousTokenFilters);
         ReaderWithOrigin rulesReader = synonymsSource.getRulesReader(this, context);
         final SynonymMap synonyms = buildSynonyms(analyzer, rulesReader);
-        return buildChainedFactory(name(), synonyms, analysisMode, rulesReader.resource());
-    }
-
-    static TokenFilterFactory buildChainedFactory(String name, SynonymMap synonyms, AnalysisMode analysisMode, String resourceName) {
-        return new TokenFilterFactory() {
-            @Override
-            public String name() {
-                return name;
-            }
-
-            @Override
-            public TokenStream create(TokenStream tokenStream) {
-                return synonyms.fst == null ? tokenStream : new SynonymGraphFilter(tokenStream, synonyms, false);
-            }
-
-            @Override
-            public TokenFilterFactory getSynonymFilter() {
-                // When building a synonym filter, we must prevent previous synonym filters in the chain
-                // from being active, as this would cause recursive synonym expansion during the building phase.
-                //
-                // Without this fix, when chaining multiple synonym filters (e.g., synonym_A → synonym_B → synonym_C),
-                // building synonym_C would use an analyzer containing active synonym_A and synonym_B filters.
-                // This causes:
-                // 1. Recursive synonym expansion when parsing synonym rules (e.g., synonyms are expanded via previous filters)
-                // 2. Each SynonymMap inflates since it applies all previous synonym rules again
-                // 3. Triggering O(n²) operations in SynonymGraphFilter.bufferOutputTokens()
-                // 4. Massive memory allocation during analyzer reload → OutOfMemoryError
-                //
-                // This matches the behavior of SynonymTokenFilterFactory and prevents OOM with chained
-                // synonym filters (critical for users with many chained synonym sets).
-                return IDENTITY_FILTER;
-            }
-
-            @Override
-            public AnalysisMode getAnalysisMode() {
-                return analysisMode;
-            }
-
-            @Override
-            public String getResourceName() {
-                return resourceName;
-            }
-        };
+        return buildChainedFactory(
+            name(),
+            synonyms,
+            analysisMode,
+            rulesReader.resource(),
+            ts -> new SynonymGraphFilter(ts, synonyms, false)
+        );
     }
 }

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SynonymTokenFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SynonymTokenFilterFactory.java
@@ -201,12 +201,7 @@ public class SynonymTokenFilterFactory extends AbstractTokenFilterFactory {
      * Static so the returned factory does not hold a reference to the outer instance,
      * allowing the outer factory's raw synonym rule strings to be GC'd after {@link SynonymMap} construction.
      */
-    static TokenFilterFactory buildChainedFactory(
-        String name,
-        SynonymMap synonyms,
-        AnalysisMode analysisMode,
-        String resourceName
-    ) {
+    static TokenFilterFactory buildChainedFactory(String name, SynonymMap synonyms, AnalysisMode analysisMode, String resourceName) {
         return new TokenFilterFactory() {
             @Override
             public String name() {

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SynonymTokenFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SynonymTokenFilterFactory.java
@@ -194,7 +194,19 @@ public class SynonymTokenFilterFactory extends AbstractTokenFilterFactory {
         final Analyzer analyzer = buildSynonymAnalyzer(tokenizer, charFilters, previousTokenFilters);
         ReaderWithOrigin rulesReader = synonymsSource.getRulesReader(this, context);
         final SynonymMap synonyms = buildSynonyms(analyzer, rulesReader);
-        final String name = name();
+        return buildChainedFactory(name(), synonyms, analysisMode, rulesReader.resource());
+    }
+
+    /**
+     * Static so the returned factory does not hold a reference to the outer instance,
+     * allowing the outer factory's raw synonym rule strings to be GC'd after {@link SynonymMap} construction.
+     */
+    static TokenFilterFactory buildChainedFactory(
+        String name,
+        SynonymMap synonyms,
+        AnalysisMode analysisMode,
+        String resourceName
+    ) {
         return new TokenFilterFactory() {
             @Override
             public String name() {
@@ -221,7 +233,7 @@ public class SynonymTokenFilterFactory extends AbstractTokenFilterFactory {
 
             @Override
             public String getResourceName() {
-                return rulesReader.resource();
+                return resourceName;
             }
         };
     }

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SynonymTokenFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SynonymTokenFilterFactory.java
@@ -194,14 +194,20 @@ public class SynonymTokenFilterFactory extends AbstractTokenFilterFactory {
         final Analyzer analyzer = buildSynonymAnalyzer(tokenizer, charFilters, previousTokenFilters);
         ReaderWithOrigin rulesReader = synonymsSource.getRulesReader(this, context);
         final SynonymMap synonyms = buildSynonyms(analyzer, rulesReader);
-        return buildChainedFactory(name(), synonyms, analysisMode, rulesReader.resource());
+        return buildChainedFactory(name(), synonyms, analysisMode, rulesReader.resource(), ts -> new SynonymFilter(ts, synonyms, false));
     }
 
     /**
      * Static so the returned factory does not hold a reference to the outer instance,
      * allowing the outer factory's raw synonym rule strings to be GC'd after {@link SynonymMap} construction.
      */
-    static TokenFilterFactory buildChainedFactory(String name, SynonymMap synonyms, AnalysisMode analysisMode, String resourceName) {
+    protected static TokenFilterFactory buildChainedFactory(
+        String name,
+        SynonymMap synonyms,
+        AnalysisMode analysisMode,
+        String resourceName,
+        Function<TokenStream, TokenStream> createFilter
+    ) {
         return new TokenFilterFactory() {
             @Override
             public String name() {
@@ -210,14 +216,24 @@ public class SynonymTokenFilterFactory extends AbstractTokenFilterFactory {
 
             @Override
             public TokenStream create(TokenStream tokenStream) {
-                return synonyms.fst == null ? tokenStream : new SynonymFilter(tokenStream, synonyms, false);
+                return synonyms.fst == null ? tokenStream : createFilter.apply(tokenStream);
             }
 
             @Override
             public TokenFilterFactory getSynonymFilter() {
-                // In order to allow chained synonym filters, we return IDENTITY here to
-                // ensure that synonyms don't get applied to the synonym map itself,
-                // which doesn't support stacked input tokens
+                // When building a synonym filter, we must prevent previous synonym filters in the chain
+                // from being active, as this would cause recursive synonym expansion during the building phase.
+                //
+                // Without this fix, when chaining multiple synonym filters (e.g., synonym_A → synonym_B → synonym_C),
+                // building synonym_C would use an analyzer containing active synonym_A and synonym_B filters.
+                // This causes:
+                // 1. Recursive synonym expansion when parsing synonym rules (e.g., synonyms are expanded via previous filters)
+                // 2. Each SynonymMap inflates since it applies all previous synonym rules again
+                // 3. Triggering O(n²) operations in SynonymGraphFilter.bufferOutputTokens()
+                // 4. Massive memory allocation during analyzer reload → OutOfMemoryError
+                //
+                // This matches the behavior of SynonymTokenFilterFactory and prevents OOM with chained
+                // synonym filters (critical for users with many chained synonym sets).
                 return IDENTITY_FILTER;
             }
 

--- a/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/SynonymsAnalysisTests.java
+++ b/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/SynonymsAnalysisTests.java
@@ -383,7 +383,7 @@ public class SynonymsAnalysisTests extends ESTestCase {
         );
     }
 
-    public void testManyChainedSynonymGraphFilters() throws IOException {
+    public void testManyChainedSynonymGraphFilters() throws IOException { // tmp ci trigger
         Settings.Builder settingsBuilder = Settings.builder()
             .put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current())
             .put("path.home", createTempDir().toString());

--- a/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/SynonymsAnalysisTests.java
+++ b/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/SynonymsAnalysisTests.java
@@ -383,7 +383,7 @@ public class SynonymsAnalysisTests extends ESTestCase {
         );
     }
 
-    public void testManyChainedSynonymGraphFilters() throws IOException { // tmp ci trigger
+    public void testManyChainedSynonymGraphFilters() throws IOException {
         Settings.Builder settingsBuilder = Settings.builder()
             .put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current())
             .put("path.home", createTempDir().toString());


### PR DESCRIPTION
Anonymous inner class kept a reference to the enclosing instance (and all the synonym rule strings), making the enclosing instance ineligible for GC. 

This affects inline synonyms, where lists of strings are kept in memory in the `settings` field in `SynonymTokenFilterFactory`.

On a laptop (ymmv), this failed 9 out of 20 times before this change:
```
./gradlew :modules:analysis-common:test \
    --tests "org.elasticsearch.analysis.common.SynonymsAnalysisTests.testManyChainedSynonymGraphFilters" \
    -Dtests.iters=20 \
    -Dtests.seed=87A4C60EC4A4202D \
    -Dtests.heap.size=448m \
    -Dtests.timestamp=$(date +%s)
```

This now passes 20/20.