### PR TITLE
Update documentation for Gmail connector to describe include_full_raw_message toggle

### DIFF
--- a/docs/reference/search-connectors/es-connectors-gmail.md
+++ b/docs/reference/search-connectors/es-connectors-gmail.md
@@ -155,6 +155,9 @@ The following configuration fields are required:
 `Include spam and trash emails`
 :   Toggle to fetch spam and trash emails. Also works with DLS.
 
+`Index full raw email (including headers)`
+:   Toggle to index the full raw RFC 822 message. Disabled by default: only the email body (preferring `text/plain` over `text/html`) and a minimal set of headers (`Subject`, `From`, `Reply-To`, `To`, `Cc`, `Bcc`, `Date`, `Message-ID`) are indexed; routing/authentication headers and binary attachments are dropped. Enable to restore the passthrough behavior for edge cases where body extraction misses content.
+
 `Enable document level security`
 :   Toggle to enable [document level security (DLS](/reference/search-connectors/document-level-security.md). DLS is supported for the GMail connector. When enabled:
 


### PR DESCRIPTION
## Summary

Documents the new `include_full_raw_message` toggle added to the Gmail connector in elastic/connectors#4031.

A single entry is added to the **Configuration** section of `docs/reference/search-connectors/es-connectors-gmail.md`, placed between the existing `Include spam and trash emails` and `Enable document level security` toggles to match its `order: 5` position in the connector code.

## Related

- Connector PR: elastic/connectors#4031
- Issue: elastic/connectors#1369

## Preview

> `Index full raw email (including headers)`
> : Toggle to index the full raw RFC 822 message. Disabled by default: only the email body (preferring `text/plain` over `text/html`) and a minimal set of headers (`Subject`, `From`, `Reply-To`, `To`, `Cc`, `Bcc`, `Date`, `Message-ID`) are indexed; routing/authentication headers and binary attachments are dropped. Enable to restore the passthrough behavior for edge cases where body extraction misses content.

## Original issue https://github.com/elastic/connectors/issues/1369