### PR TITLE
[9.4] Fix InvalidMappedField equals/hashCode and split out InvalidMappedTsField (#146117)

### DIFF
--- a/docs/changelog/146117.yaml
+++ b/docs/changelog/146117.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 145907
+pr: 146117
+summary: Fix `InvalidMappedField` equals/hashCode and lazy error message
+type: bug

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -55,6 +55,7 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.type.EsField;
 import org.elasticsearch.xpack.esql.core.type.InvalidMappedField;
+import org.elasticsearch.xpack.esql.core.type.InvalidMappedTsField;
 import org.elasticsearch.xpack.esql.core.type.MultiTypeEsField;
 import org.elasticsearch.xpack.esql.core.type.PotentiallyUnmappedKeywordEsField;
 import org.elasticsearch.xpack.esql.core.type.UnsupportedEsField;
@@ -472,9 +473,17 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                     t = new EsField(t.getName(), type, t.getProperties(), t.isAggregatable(), t.isAlias(), t.getTimeSeriesFieldType());
                 }
 
-                FieldAttribute attribute = t instanceof UnsupportedEsField uef
-                    ? new UnsupportedAttribute(source, name, uef)
-                    : new FieldAttribute(source, parentName, null, name, t);
+                FieldAttribute attribute;
+                if (t instanceof UnsupportedEsField uef) {
+                    attribute = new UnsupportedAttribute(source, name, uef);
+                } else if (t instanceof InvalidMappedTsField imtf) {
+                    // Convert the TS role conflict directly to an UnsupportedAttribute with a meaningful message.
+                    // The original types don't matter. We pass a custom error message, anyway, which will fail the query in the verifier.
+                    var carrier = new UnsupportedEsField(imtf.getName(), List.of(), null, imtf.getProperties());
+                    attribute = new UnsupportedAttribute(source, name, carrier, imtf.errorMessage());
+                } else {
+                    attribute = new FieldAttribute(source, parentName, null, name, t);
+                }
                 // primitive branch
                 if (DataType.isPrimitive(type)) {
                     list.add(attribute);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/type/EsField.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/type/EsField.java
@@ -103,7 +103,6 @@ public class EsField implements Writeable {
     private static Map<String, Reader<? extends EsField>> readers = Map.ofEntries(
         Map.entry("DateEsField", DateEsField::new),
         Map.entry("EsField", EsField::new),
-        Map.entry("InvalidMappedField", InvalidMappedField::new),
         Map.entry("KeywordEsField", KeywordEsField::new),
         Map.entry("MissingEsField", MissingEsField::new),
         Map.entry("MultiTypeEsField", MultiTypeEsField::new),

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/type/InvalidMappedField.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/type/InvalidMappedField.java
@@ -7,14 +7,9 @@
 
 package org.elasticsearch.xpack.esql.core.type;
 
-import org.elasticsearch.TransportVersion;
-import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
-import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
-import org.elasticsearch.xpack.esql.io.stream.PlanStreamOutput;
 
-import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -22,29 +17,29 @@ import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 /**
- * Representation of field mapped differently across indices; or being potentially unmapped in some, in which case it is treated as
- * {@link DataType#KEYWORD} in the indices where it is unmapped.
- * Used during mapping discovery only.
- * Note that the fields <code>typesToIndices</code> and <code>isPotentiallyUnmapped</code> are not serialized because that information is
- * not required through the cluster, only surviving as long as the Analyser phase of query planning.
- * It is used specifically for the 'union types' and 'unmapped fields' feature in ES|QL.
+ * Representation of a field mapped differently across indices. When {@code SET unmapped_fields="LOAD"} this also includes indices missing
+ * the field in their mappings, in which case it is treated as {@link DataType#KEYWORD}.
+ * <p>
+ * Used during analysis only; the analyzer's {@code UnionTypesCleanup} converts any {@link InvalidMappedField}s before the plan leaves
+ * the coordinator.
  */
 public class InvalidMappedField extends EsField {
 
-    private final String errorMessage;
     private final Map<String, Set<String>> typesToIndices;
     private final boolean isPotentiallyUnmapped;
-
-    public InvalidMappedField(String name, String errorMessage, Map<String, EsField> properties) {
-        this(name, errorMessage, properties, Map.of(), false, TimeSeriesFieldType.UNKNOWN);
-    }
-
-    public InvalidMappedField(String name, String errorMessage) {
-        this(name, errorMessage, new TreeMap<>());
-    }
+    /**
+     * Lazily derived from {@link #typesToIndices} and {@link #isPotentiallyUnmapped} on first access; not part of
+     * {@link #equals(Object)} / {@link #hashCode()}.
+     */
+    private String cachedErrorMessage;
 
     public InvalidMappedField(String name, Map<String, Set<String>> typesToIndices) {
-        this(name, makeErrorMessage(typesToIndices, false), new TreeMap<>(), typesToIndices, false, TimeSeriesFieldType.UNKNOWN);
+        // Use a mutable map: IndexResolver may add child fields into the properties of a conflicting parent field later.
+        this(name, new TreeMap<>(), typesToIndices, false, TimeSeriesFieldType.UNKNOWN);
+    }
+
+    public InvalidMappedField(String name, Map<String, Set<String>> typesToIndices, Map<String, EsField> properties) {
+        this(name, properties, typesToIndices, false, TimeSeriesFieldType.UNKNOWN);
     }
 
     /**
@@ -53,71 +48,49 @@ public class InvalidMappedField extends EsField {
      * unmapped fields as {@link DataType#KEYWORD}.
      */
     public static InvalidMappedField potentiallyUnmapped(String name, Map<String, Set<String>> typesToIndices) {
-        return new InvalidMappedField(
-            name,
-            makeErrorMessage(typesToIndices, true),
-            new TreeMap<>(),
-            typesToIndices,
-            true,
-            TimeSeriesFieldType.UNKNOWN
-        );
+        // Use a mutable map: IndexResolver may add child fields into the properties of a conflicting parent field later.
+        return new InvalidMappedField(name, new TreeMap<>(), typesToIndices, true, TimeSeriesFieldType.UNKNOWN);
     }
 
     private InvalidMappedField(
         String name,
-        String errorMessage,
         Map<String, EsField> properties,
         Map<String, Set<String>> typesToIndices,
         boolean isPotentiallyUnmapped,
         TimeSeriesFieldType type
     ) {
         super(name, DataType.UNSUPPORTED, properties, false, type);
-        this.errorMessage = errorMessage;
         this.typesToIndices = typesToIndices;
         this.isPotentiallyUnmapped = isPotentiallyUnmapped;
+        this.cachedErrorMessage = null;
     }
 
-    protected InvalidMappedField(StreamInput in) throws IOException {
-        this(
-            ((PlanStreamInput) in).readCachedString(),
-            in.readString(),
-            in.readImmutableMap(StreamInput::readString, EsField::readFrom),
-            Map.of(),
-            false,
-            readTimeSeriesFieldType(in)
-        );
+    @Override
+    public void writeContent(StreamOutput out) {
+        throw new UnsupportedOperationException("InvalidMappedField must never leave the coordinator");
     }
 
     public Set<DataType> types() {
         return typesToIndices.keySet().stream().map(DataType::fromTypeName).collect(Collectors.toSet());
     }
 
-    @Override
-    public void writeContent(StreamOutput out) throws IOException {
-        ((PlanStreamOutput) out).writeCachedString(getName());
-        out.writeString(errorMessage);
-        out.writeMap(getProperties(), (o, x) -> x.writeTo(out));
-        writeTimeSeriesFieldType(out);
-    }
-
-    public String getWriteableName(TransportVersion transportVersion) {
-        return "InvalidMappedField";
-    }
-
     public String errorMessage() {
-        return errorMessage;
+        if (cachedErrorMessage == null) {
+            cachedErrorMessage = makeErrorMessage(typesToIndices, isPotentiallyUnmapped);
+        }
+        return cachedErrorMessage;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), errorMessage);
+        return Objects.hash(super.hashCode(), typesToIndices, isPotentiallyUnmapped);
     }
 
     @Override
     public boolean equals(Object obj) {
         if (super.equals(obj)) {
             InvalidMappedField other = (InvalidMappedField) obj;
-            return Objects.equals(errorMessage, other.errorMessage);
+            return isPotentiallyUnmapped == other.isPotentiallyUnmapped && Objects.equals(typesToIndices, other.typesToIndices);
         }
 
         return false;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/type/InvalidMappedTsField.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/type/InvalidMappedTsField.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.core.type;
+
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
+
+/**
+ * Represents a field that has the same ES data type across all indices but conflicting time-series
+ * roles (e.g., {@code DIMENSION} in one index and {@code METRIC} in another).
+ * <p>
+ * Exists only during analysis and verification - it is not sent to data nodes.
+ * The analyzer converts this to an {@link UnsupportedEsField}-backed
+ * {@link org.elasticsearch.xpack.esql.core.expression.UnsupportedAttribute} via {@code mappingAsAttributes}.
+ * <p>
+ * Unlike {@link InvalidMappedField}, which carries a {@code typesToIndices} map and can participate in
+ * union-type casts (e.g., {@code field::double}), a role conflict cannot be resolved by any cast,
+ * so this class is intentionally <em>not</em> a subclass of {@link InvalidMappedField}.
+ * <p>
+ * Crucially, this class is also not an {@link UnsupportedEsField}. The field-hierarchy walk in
+ * {@code IndexResolver.mergedMappings} propagates unsupported status to child fields when it
+ * encounters an {@link UnsupportedEsField} parent. By using a distinct type here, subfields with
+ * non-conflicting, supported types remain accessible.
+ */
+public class InvalidMappedTsField extends EsField {
+
+    private final String errorMessage;
+
+    public InvalidMappedTsField(String name, String errorMessage) {
+        super(name, DataType.UNSUPPORTED, new TreeMap<>(), false, TimeSeriesFieldType.UNKNOWN);
+        this.errorMessage = errorMessage;
+    }
+
+    public InvalidMappedTsField(String name, String errorMessage, Map<String, EsField> properties) {
+        super(name, DataType.UNSUPPORTED, properties, false, TimeSeriesFieldType.UNKNOWN);
+        this.errorMessage = errorMessage;
+    }
+
+    @Override
+    public void writeContent(StreamOutput out) {
+        throw new UnsupportedOperationException("InvalidMappedTsField must never leave the coordinator");
+    }
+
+    /**
+     * Returns the human-readable error message describing the time-series role conflict.
+     */
+    public String errorMessage() {
+        return errorMessage;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), errorMessage);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (super.equals(obj)) {
+            InvalidMappedTsField other = (InvalidMappedTsField) obj;
+            return Objects.equals(errorMessage, other.errorMessage);
+        }
+        return false;
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/IndexResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/IndexResolver.java
@@ -33,6 +33,7 @@ import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.type.DateEsField;
 import org.elasticsearch.xpack.esql.core.type.EsField;
 import org.elasticsearch.xpack.esql.core.type.InvalidMappedField;
+import org.elasticsearch.xpack.esql.core.type.InvalidMappedTsField;
 import org.elasticsearch.xpack.esql.core.type.KeywordEsField;
 import org.elasticsearch.xpack.esql.core.type.SupportedVersion;
 import org.elasticsearch.xpack.esql.core.type.TextEsField;
@@ -484,10 +485,14 @@ public class IndexResolver {
         if (rest.isEmpty() == false) {
             if (fieldsInfo.hasTimeSeriesAggregation()) {
                 for (IndexFieldCapabilities fc : rest) {
+                    EsField.TimeSeriesFieldType next = EsField.TimeSeriesFieldType.fromIndexFieldCapabilities(fc);
                     try {
-                        timeSeriesFieldType = timeSeriesFieldType.merge(EsField.TimeSeriesFieldType.fromIndexFieldCapabilities(fc));
+                        timeSeriesFieldType = timeSeriesFieldType.merge(next);
                     } catch (IllegalArgumentException e) {
-                        return new InvalidMappedField(name, e.getMessage());
+                        // Surface time series metadata conflicts (dimension vs metric) as an InvalidMappedTsField.
+                        // Don't use UnsupportedEsField as subfields would also be marked as unsupported; also don't use InvalidMappedField
+                        // as this is for type conflicts that can be resolved by casting.
+                        return new InvalidMappedTsField(name, e.getMessage());
                     }
                 }
             }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
@@ -49,6 +49,7 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.type.EsField;
 import org.elasticsearch.xpack.esql.core.type.InvalidMappedField;
+import org.elasticsearch.xpack.esql.core.type.InvalidMappedTsField;
 import org.elasticsearch.xpack.esql.core.type.MultiTypeEsField;
 import org.elasticsearch.xpack.esql.core.type.PotentiallyUnmappedKeywordEsField;
 import org.elasticsearch.xpack.esql.enrich.ResolvedEnrichPolicy;
@@ -3501,8 +3502,9 @@ public class AnalyzerTests extends ESTestCase {
 
     /**
      * When a TS source is followed by STATS, the time series merge is enforced and conflicting
-     * dimension/metric types across indices produce an {@link InvalidMappedField}. The field
-     * resolves as {@link DataType#UNSUPPORTED} rather than the original KEYWORD type.
+     * dimension/metric roles across indices produce an {@link InvalidMappedTsField}. Because
+     * {@code mappingAsAttributes} converts it to an {@link UnsupportedAttribute} immediately,
+     * any query that references the field is rejected with a clear error message.
      */
     public void testTsStatsQueryWithConflictingTsTypesMarksFieldUnsupported() {
         FieldCapabilitiesResponse caps = buildCapsWithConflictingTsTypes();
@@ -3513,10 +3515,12 @@ public class AnalyzerTests extends ESTestCase {
             false,
             (p, r) -> Map.of()
         );
-        assertThat(resolution.get().mapping().get("status"), instanceOf(InvalidMappedField.class));
-        var plan = analyzer().addIndex(resolution).query("TS test | STATS avg(rate(bytes_in)) BY status");
-        var statusAttr = plan.output().stream().filter(a -> a.name().equals("status")).findFirst().orElseThrow();
-        assertThat(statusAttr.dataType(), equalTo(UNSUPPORTED));
+        assertThat(resolution.get().mapping().get("status"), instanceOf(InvalidMappedTsField.class));
+        analyzer().addIndex(resolution)
+            .error(
+                "TS test | STATS avg(rate(bytes_in)) BY status",
+                containsString("Time Series Metadata conflict.  Cannot merge [METRIC] with [DIMENSION].")
+            );
     }
 
     /**
@@ -3553,7 +3557,7 @@ public class AnalyzerTests extends ESTestCase {
             false,
             (p, r) -> Map.of()
         );
-        assertThat(resolution.get().mapping().get("status"), instanceOf(InvalidMappedField.class));
+        assertThat(resolution.get().mapping().get("status"), instanceOf(InvalidMappedTsField.class));
         var plan = analyzer().addIndex(resolution).query("""
             PROMQL index=test
                 step=5m start="2024-05-10T00:20:00.000Z" end="2024-05-10T00:25:00.000Z"

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/FieldAttributeTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/FieldAttributeTests.java
@@ -22,7 +22,9 @@ public class FieldAttributeTests extends AbstractNamedExpressionSerializationTes
         String parentName = maxDepth == 0 || randomBoolean() ? null : randomAlphaOfLength(3);
         String qualifier = randomBoolean() ? null : randomAlphaOfLength(3);
         String name = randomAlphaOfLength(5);
-        EsField field = onlyRepresentable ? randomRepresentableEsField(maxDepth) : AbstractEsFieldTypeTests.randomAnyEsField(maxDepth);
+        EsField field = onlyRepresentable
+            ? randomRepresentableEsField(maxDepth)
+            : AbstractEsFieldTypeTests.randomSerializableEsField(maxDepth);
         Nullability nullability = randomFrom(Nullability.values());
         boolean synthetic = randomBoolean();
         return new FieldAttribute(source, parentName, qualifier, name, field, nullability, new NameId(), synthetic);
@@ -31,7 +33,7 @@ public class FieldAttributeTests extends AbstractNamedExpressionSerializationTes
     private static EsField randomRepresentableEsField(int maxDepth) {
         return randomValueOtherThanMany(
             f -> false == DataType.isRepresentable(f.getDataType()),
-            () -> AbstractEsFieldTypeTests.randomAnyEsField(maxDepth)
+            () -> AbstractEsFieldTypeTests.randomSerializableEsField(maxDepth)
         );
     }
 
@@ -54,7 +56,7 @@ public class FieldAttributeTests extends AbstractNamedExpressionSerializationTes
             case 0 -> parentName = randomValueOtherThan(parentName, () -> randomBoolean() ? null : randomAlphaOfLength(2));
             case 1 -> qualifier = randomAlphaOfLength(qualifier == null ? 3 : qualifier.length() + 1);
             case 2 -> name = randomAlphaOfLength(name.length() + 1);
-            case 3 -> field = randomValueOtherThan(field, () -> AbstractEsFieldTypeTests.randomAnyEsField(3));
+            case 3 -> field = randomValueOtherThan(field, () -> AbstractEsFieldTypeTests.randomSerializableEsField(3));
             case 4 -> nullability = randomValueOtherThan(nullability, () -> randomFrom(Nullability.values()));
             case 5 -> id = new NameId();
             case 6 -> synthetic = false == synthetic;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/index/EsIndexGenerator.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/index/EsIndexGenerator.java
@@ -44,7 +44,7 @@ public class EsIndexGenerator {
         int size = ESTestCase.between(0, 10);
         Map<String, EsField> result = new HashMap<>(size);
         while (result.size() < size) {
-            result.put(randomIdentifier(), EsFieldTests.randomAnyEsField(1));
+            result.put(randomIdentifier(), EsFieldTests.randomSerializableEsField(1));
         }
         return result;
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/ExchangeSinkExecSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/ExchangeSinkExecSerializationTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.xpack.esql.SerializationTestUtils;
 import org.elasticsearch.xpack.esql.analysis.Analyzer;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -24,6 +25,7 @@ import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
 import org.elasticsearch.xpack.esql.io.stream.PlanStreamOutput;
 import org.elasticsearch.xpack.esql.plan.logical.EsRelation;
 import org.elasticsearch.xpack.esql.plan.logical.Limit;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.Project;
 
 import java.io.IOException;
@@ -88,8 +90,9 @@ public class ExchangeSinkExecSerializationTests extends AbstractPhysicalPlanSeri
          *  1026343b - added time series field type to EsField  #129649
          *  1033593b - added qualifier back to FieldAttribute #132925
          *  1033595b - added split indices to EsRelation #138396
+         *  1152296b - turn InvalidMappedFields into UnsupportedAttributes like in production #146117
          */
-        testManyTypeConflicts(false, ByteSizeValue.ofBytes(1033595));
+        testManyTypeConflicts(false, ByteSizeValue.ofBytes(1152296));
     }
 
     /**
@@ -111,8 +114,9 @@ public class ExchangeSinkExecSerializationTests extends AbstractPhysicalPlanSeri
          *  1971523b - added time series field type to EsField  #129649
          *  1986023b - added qualifier back to FieldAttribute #132925
          *  1986025b - added split indices to EsRelation #138396
+         *  2303919b - turn InvalidMappedFields into UnsupportedAttributes like in production #146117
          */
-        testManyTypeConflicts(true, ByteSizeValue.ofBytes(1986025));
+        testManyTypeConflicts(true, ByteSizeValue.ofBytes(2303919));
     }
 
     private void testManyTypeConflicts(boolean withParent, ByteSizeValue expected) throws IOException {
@@ -228,7 +232,15 @@ public class ExchangeSinkExecSerializationTests extends AbstractPhysicalPlanSeri
         );
         Limit limit = new Limit(randomSource(), new Literal(randomSource(), 10, DataType.INTEGER), relation);
         Project project = new Project(randomSource(), limit, limit.output());
-        FragmentExec fragmentExec = new FragmentExec(project);
+        // Mirror the analyzer's UnionTypesCleanup: convert any InvalidMappedField-backed FieldAttribute into an UnsupportedAttribute so
+        // that the serialized plan matches what production sends over the wire (and round-trip equality holds). The fixtures here only
+        // produce genuine type conflicts (no single-type potentially-unmapped fields), so flagTypeConflicts() is sufficient and we don't
+        // need the full cleanTypeConflicts(...) logic from UnionTypesCleanup.
+        LogicalPlan cleanedProject = project.transformUp(
+            LogicalPlan.class,
+            p -> p.transformExpressionsOnly(FieldAttribute.class, FieldAttribute::flagTypeConflicts)
+        );
+        FragmentExec fragmentExec = new FragmentExec(cleanedProject);
         ExchangeSinkExec exchangeSinkExec = new ExchangeSinkExec(randomSource(), fragmentExec.output(), false, fragmentExec);
         try (BytesStreamOutput out = new BytesStreamOutput(); PlanStreamOutput pso = new PlanStreamOutput(out, configuration())) {
             pso.writeNamedWriteable(exchangeSinkExec);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/session/EsqlCCSUtilsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/session/EsqlCCSUtilsTests.java
@@ -724,7 +724,7 @@ public class EsqlCCSUtilsTests extends ESTestCase {
         int size = between(0, 10);
         Map<String, EsField> result = new HashMap<>(size);
         while (result.size() < size) {
-            result.put(randomAlphaOfLength(5), EsFieldTests.randomAnyEsField(1));
+            result.put(randomAlphaOfLength(5), EsFieldTests.randomSerializableEsField(1));
         }
         return result;
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/type/AbstractEsFieldTypeTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/type/AbstractEsFieldTypeTests.java
@@ -26,14 +26,13 @@ import java.util.Map;
 import java.util.TreeMap;
 
 public abstract class AbstractEsFieldTypeTests<T extends EsField> extends AbstractWireTestCase<T> {
-    public static EsField randomAnyEsField(int maxDepth) {
-        return switch (between(0, 5)) {
+    public static EsField randomSerializableEsField(int maxDepth) {
+        return switch (between(0, 4)) {
             case 0 -> EsFieldTests.randomEsField(maxDepth);
             case 1 -> DateEsFieldTests.randomDateEsField(maxDepth);
-            case 2 -> InvalidMappedFieldTests.randomInvalidMappedField(maxDepth);
-            case 3 -> KeywordEsFieldTests.randomKeywordEsField(maxDepth);
-            case 4 -> TextEsFieldTests.randomTextEsField(maxDepth);
-            case 5 -> UnsupportedEsFieldTests.randomUnsupportedEsField(maxDepth);
+            case 2 -> KeywordEsFieldTests.randomKeywordEsField(maxDepth);
+            case 3 -> TextEsFieldTests.randomTextEsField(maxDepth);
+            case 4 -> UnsupportedEsFieldTests.randomUnsupportedEsField(maxDepth);
             default -> throw new IllegalArgumentException();
         };
     }
@@ -75,7 +74,7 @@ public abstract class AbstractEsFieldTypeTests<T extends EsField> extends Abstra
         int targetSize = between(1, 5);
         Map<String, EsField> properties = new TreeMap<>();
         while (properties.size() < targetSize) {
-            properties.put(randomAlphaOfLength(properties.size() + 1), randomAnyEsField(maxDepth - 1));
+            properties.put(randomAlphaOfLength(properties.size() + 1), randomSerializableEsField(maxDepth - 1));
         }
         return properties;
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/type/FunctionEsFieldTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/type/FunctionEsFieldTests.java
@@ -24,7 +24,7 @@ import java.io.IOException;
 public class FunctionEsFieldTests extends AbstractEsFieldTypeTests<FunctionEsField> {
     @Override
     protected FunctionEsField createTestInstance() {
-        EsField esField = randomAnyEsField(4);
+        EsField esField = randomSerializableEsField(4);
         DataType dataType = randomFrom(DataType.types());
         DenseVectorFieldMapper.VectorSimilarityFunctionConfig functionConfig = randomFunctionConfig();
         return new FunctionEsField(esField, dataType, functionConfig);
@@ -36,7 +36,7 @@ public class FunctionEsFieldTests extends AbstractEsFieldTypeTests<FunctionEsFie
         DataType dataType = instance.getDataType();
         BlockLoaderFunctionConfig functionConfig = instance.functionConfig();
         switch (between(0, 2)) {
-            case 0 -> esField = randomValueOtherThan(esField, () -> randomAnyEsField(4));
+            case 0 -> esField = randomValueOtherThan(esField, () -> randomSerializableEsField(4));
             case 1 -> dataType = randomValueOtherThan(dataType, () -> randomFrom(DataType.types()));
             case 2 -> functionConfig = randomValueOtherThan(functionConfig, this::randomFunctionConfig);
             default -> throw new IllegalArgumentException();

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/type/InvalidMappedFieldTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/type/InvalidMappedFieldTests.java
@@ -7,17 +7,42 @@
 
 package org.elasticsearch.xpack.esql.type;
 
+import org.elasticsearch.TransportVersion;
 import org.elasticsearch.xpack.esql.core.type.EsField;
 import org.elasticsearch.xpack.esql.core.type.InvalidMappedField;
 
 import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
 
 public class InvalidMappedFieldTests extends AbstractEsFieldTypeTests<InvalidMappedField> {
     static InvalidMappedField randomInvalidMappedField(int maxPropertiesDepth) {
         String name = randomAlphaOfLength(4);
-        String errorMessage = randomAlphaOfLengthBetween(1, 100);
+        Map<String, Set<String>> typesToIndices = randomTypesToIndices();
+        // potentiallyUnmapped always uses empty properties; the non-potentially-unmapped variant may carry properties.
+        if (randomBoolean()) {
+            return InvalidMappedField.potentiallyUnmapped(name, typesToIndices);
+        }
         Map<String, EsField> properties = randomProperties(maxPropertiesDepth);
-        return new InvalidMappedField(name, errorMessage, properties);
+        return properties.isEmpty() && randomBoolean()
+            ? new InvalidMappedField(name, typesToIndices)
+            : new InvalidMappedField(name, typesToIndices, properties);
+    }
+
+    static Map<String, Set<String>> randomTypesToIndices() {
+        int typeCount = between(1, 4);
+        Map<String, Set<String>> typesToIndices = new TreeMap<>();
+        while (typesToIndices.size() < typeCount) {
+            String type = randomAlphaOfLengthBetween(3, 8);
+            int indexCount = between(1, 3);
+            Set<String> indices = new TreeSet<>();
+            while (indices.size() < indexCount) {
+                indices.add(randomAlphaOfLengthBetween(3, 10));
+            }
+            typesToIndices.put(type, indices);
+        }
+        return typesToIndices;
     }
 
     @Override
@@ -26,16 +51,35 @@ public class InvalidMappedFieldTests extends AbstractEsFieldTypeTests<InvalidMap
     }
 
     @Override
+    protected InvalidMappedField copyInstance(InvalidMappedField instance, TransportVersion version) {
+        // writeContent throws UnsupportedOperationException; copy directly without going through the wire.
+        if (instance.isPotentiallyUnmapped()) {
+            return InvalidMappedField.potentiallyUnmapped(instance.getName(), instance.getTypesToIndices());
+        }
+        return new InvalidMappedField(instance.getName(), instance.getTypesToIndices(), instance.getProperties());
+    }
+
+    @Override
     protected InvalidMappedField mutateInstance(InvalidMappedField instance) {
         String name = instance.getName();
-        String errorMessage = instance.errorMessage();
         Map<String, EsField> properties = instance.getProperties();
-        switch (between(0, 2)) {
+        Map<String, Set<String>> typesToIndices = instance.getTypesToIndices();
+        boolean isPotentiallyUnmapped = instance.isPotentiallyUnmapped();
+        // Pick a mutation that's actually applicable: the potentiallyUnmapped variant always has empty properties, so we can't
+        // mutate properties on it without first flipping isPotentiallyUnmapped.
+        int max = isPotentiallyUnmapped ? 2 : 3;
+        switch (between(0, max)) {
             case 0 -> name = randomAlphaOfLength(name.length() + 1);
-            case 1 -> errorMessage = randomValueOtherThan(errorMessage, () -> randomAlphaOfLengthBetween(1, 100));
-            case 2 -> properties = randomValueOtherThan(properties, () -> randomProperties(4));
+            case 1 -> typesToIndices = randomValueOtherThan(typesToIndices, InvalidMappedFieldTests::randomTypesToIndices);
+            case 2 -> isPotentiallyUnmapped = isPotentiallyUnmapped == false;
+            case 3 -> properties = randomValueOtherThan(properties, () -> randomProperties(4));
             default -> throw new IllegalArgumentException();
         }
-        return new InvalidMappedField(name, errorMessage, properties);
+        if (isPotentiallyUnmapped) {
+            // Reconstruction discards properties on this variant; we only get here if properties was already empty (or we just flipped
+            // isPotentiallyUnmapped from false→true, in which case discarding any prior properties is intended).
+            return InvalidMappedField.potentiallyUnmapped(name, typesToIndices);
+        }
+        return new InvalidMappedField(name, typesToIndices, properties);
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/type/InvalidMappedTsFieldTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/type/InvalidMappedTsFieldTests.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.type;
+
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.xpack.esql.core.type.EsField;
+import org.elasticsearch.xpack.esql.core.type.InvalidMappedTsField;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TreeMap;
+
+public class InvalidMappedTsFieldTests extends AbstractEsFieldTypeTests<InvalidMappedTsField> {
+
+    static InvalidMappedTsField randomInvalidMappedTsField(int maxPropertiesDepth) {
+        String name = randomAlphaOfLength(4);
+        String errorMessage = randomAlphaOfLength(20);
+        Map<String, EsField> properties = randomProperties(maxPropertiesDepth);
+        return new InvalidMappedTsField(name, errorMessage, new TreeMap<>(properties));
+    }
+
+    @Override
+    protected InvalidMappedTsField createTestInstance() {
+        return randomInvalidMappedTsField(4);
+    }
+
+    @Override
+    protected InvalidMappedTsField copyInstance(InvalidMappedTsField instance, TransportVersion version) {
+        // writeContent throws UnsupportedOperationException; copy directly without going through the wire.
+        return new InvalidMappedTsField(instance.getName(), instance.errorMessage(), new TreeMap<>(instance.getProperties()));
+    }
+
+    @Override
+    protected InvalidMappedTsField mutateInstance(InvalidMappedTsField instance) {
+        String name = instance.getName();
+        String errorMessage = instance.errorMessage();
+        Map<String, EsField> properties = instance.getProperties();
+        switch (between(0, 2)) {
+            case 0 -> name = randomAlphaOfLength(name.length() + 1);
+            case 1 -> errorMessage = randomValueOtherThan(errorMessage, () -> randomAlphaOfLength(20));
+            case 2 -> properties = randomValueOtherThan(properties, () -> randomProperties(4));
+            default -> throw new IllegalArgumentException();
+        }
+        return new InvalidMappedTsField(name, errorMessage, new HashMap<>(properties));
+    }
+}


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Fix InvalidMappedField equals/hashCode and split out InvalidMappedTsField (#146117)