### PR TITLE
Fix ConsumerAwareIpDatabaseDownloadIT cleanup crash when test is skipped

### DIFF
--- a/modules/ip-location/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/ConsumerAwareIpDatabaseDownloadIT.java
+++ b/modules/ip-location/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/ConsumerAwareIpDatabaseDownloadIT.java
@@ -73,9 +73,17 @@ public class ConsumerAwareIpDatabaseDownloadIT extends AbstractGeoIpIT {
      * any in-flight {@code runDownloader()} has returned), the DELETE runs against an idle index — no auto-create
      * race from a straggler bulk and therefore no shard left in {@code [starting shard]} state for
      * {@code InternalTestCluster#assertAfterTest} to time out on.
+     * <p>
+     * Guards against an empty cluster: if {@code assumeTrue} in the test body caused the test to be skipped before
+     * any nodes were started, there is nothing to clean up and attempting to do so would throw
+     * {@code AssertionError: Unable to get client, no node found}, which would turn the skip into a
+     * {@code TestCouldNotBeSkippedException}.
      */
     @After
     public void cleanUp() throws Exception {
+        if (internalCluster().size() == 0) {
+            return;
+        }
         updateClusterSettings(Settings.builder().putNull(GeoIpDownloaderTaskExecutor.ENABLED_SETTING.getKey()));
         assertBusy(
             () -> assertFalse(

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -564,9 +564,6 @@ tests:
 - class: org.elasticsearch.xpack.stateless.engine.translog.StatelessTranslogIT
   method: testTranslogLocalFailureOnlyStressRecoveryTest
   issue: https://github.com/elastic/elasticsearch/issues/149343
-- class: org.elasticsearch.ingest.geoip.ConsumerAwareIpDatabaseDownloadIT
-  method: testConsumerScopedDownloads
-  issue: https://github.com/elastic/elasticsearch/issues/149264
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=index/100_field_name_length_limit/Test field name length limit array synthetic source}
   issue: https://github.com/elastic/elasticsearch/issues/149350


### PR DESCRIPTION
  ## Summary

  `ConsumerAwareIpDatabaseDownloadIT.testConsumerScopedDownloads` uses
  `assumeTrue("only test with fixture...", getEndpoint() != null)` to skip
  when no geoip fixture is available. With `@ClusterScope(numDataNodes = 0)`
  no nodes are started automatically, so if the skip fires before the test
  body starts any nodes, the `@After cleanUp()` method crashes when it tries
  to call `updateClusterSettings` on an empty cluster:

  AssertionError: Unable to get client, no node found

  JUnit4 runs `@After` methods even after a skip, and the combination of the
  `AssumptionViolatedException` with the subsequent `AssertionError` produces
  a `TestCouldNotBeSkippedException`, turning a clean skip into a CI failure.

  **Fix:** guard `cleanUp()` with `internalCluster().size() == 0` and return
  early — there is nothing to clean up if no nodes were ever started.

  Closes #149264