### PR TITLE
Make flakiness-detection never report failure on GitHub

### DIFF
--- a/.buildkite/scripts/flakiness-detection/domain.ts
+++ b/.buildkite/scripts/flakiness-detection/domain.ts
@@ -137,12 +137,10 @@ export interface AgentConfig {
   agents: typeof AGENTS;
   timeoutInMinutes: number;
   groupName: string;
-  softFail: boolean;
 }
 
 export const DEFAULT_AGENT_CONFIG: AgentConfig = {
   agents: AGENTS,
   timeoutInMinutes: 60,
   groupName: "flakiness-detection",
-  softFail: true,
 };

--- a/.buildkite/scripts/flakiness-detection/runners/buildkite.test.ts
+++ b/.buildkite/scripts/flakiness-detection/runners/buildkite.test.ts
@@ -30,9 +30,10 @@ describe("toBuildkitePipeline end-to-end", () => {
     expect(step.key).toBe("flakiness-detection:unit");
     expect(step.parallelism).toBeUndefined();
     expect(step.env).toBeUndefined();
-    expect(step.command).toBe(
+    expect(step.command).toContain(
       ".ci/scripts/run-gradle.sh -Dtests.iters=100 -Dtests.timeoutSuite=3600000! :server:test --tests org.elasticsearch.index.IndexTests"
     );
+    expect(step.command).toContain("exit 0");
     expect(step.timeout_in_minutes).toBe(60);
     expect(step.agents.provider).toBe("gcp");
     expect(step.agents.machineType).toBe("n4-custom-32-98304");
@@ -64,6 +65,8 @@ describe("toBuildkitePipeline end-to-end", () => {
     expect(step.env).toBeDefined();
     expect(step.env!["BATCH_COMMAND_0"]).toContain("repeat-rest-test.sh");
     expect(step.env!["BATCH_COMMAND_1"]).toContain("repeat-rest-test.sh");
+    expect(step.env!["BATCH_COMMAND_0"]).toContain("exit 0");
+    expect(step.env!["BATCH_COMMAND_1"]).toContain("exit 0");
     expect(step.command).toContain("BUILDKITE_PARALLEL_JOB");
     // The `$$` escape prevents Buildkite pipeline interpolation from trying to
     // parse `${!VARNAME}` (bash indirect expansion) as a Buildkite variable,
@@ -137,8 +140,8 @@ describe("toBuildkitePipeline", () => {
     const pipeline = toBuildkitePipeline(cmds, DEFAULT_AGENT_CONFIG);
     const step = pipeline.steps[0].steps[0];
     expect(step.parallelism).toBe(3);
-    expect(step.env?.BATCH_COMMAND_0).toBe("cmd1");
-    expect(step.env?.BATCH_COMMAND_2).toBe("cmd3");
+    expect(step.env?.BATCH_COMMAND_0).toContain("cmd1");
+    expect(step.env?.BATCH_COMMAND_2).toContain("cmd3");
   });
 
   test("does not set parallelism for a single batch", () => {
@@ -148,7 +151,7 @@ describe("toBuildkitePipeline", () => {
     const pipeline = toBuildkitePipeline(cmds, DEFAULT_AGENT_CONFIG);
     const step = pipeline.steps[0].steps[0];
     expect(step.parallelism).toBeUndefined();
-    expect(step.command).toBe("only");
+    expect(step.command).toContain("only");
   });
 
   test("batch steps upload JUnit XML artifacts; analyze step downloads them", () => {

--- a/.buildkite/scripts/flakiness-detection/runners/buildkite.ts
+++ b/.buildkite/scripts/flakiness-detection/runners/buildkite.ts
@@ -14,11 +14,30 @@ interface PipelineStep {
   // Optional so the analyze step can inherit the parent PR pipeline's default
   // agent (which has npm). Batch steps still set this to the gradle-tuned image.
   agents?: AgentConfig["agents"];
-  soft_fail: boolean;
   parallelism?: number;
   env?: Record<string, string>;
   depends_on?: { step: string; allow_failure: boolean }[];
   artifact_paths?: string;
+}
+
+// Wraps a shell command so it always exits 0. If the wrapped command exits
+// non-zero, a Buildkite warning annotation is appended so the failure is still
+// visible on the build, but the step's state stays "passed" so that Buildkite's
+// per-step and group-aggregate GitHub commit statuses report success.
+//
+// soft_fail is not used because Buildkite's GitHub commit-status integration
+// mirrors step.state ("failed") and ignores the soft_failed flag, so a
+// soft_fail step that exits non-zero still surfaces as a red check on the PR.
+function wrapNeverFail(command: string, contextKey: string): string {
+  return [
+    "set +e",
+    command,
+    "rc=$?",
+    `if [ "$rc" -ne 0 ]; then`,
+    `  buildkite-agent annotate --style warning --context "${contextKey}-failures" --append "[$BUILDKITE_LABEL] (job $BUILDKITE_JOB_ID) exited with $rc - see job log"`,
+    "fi",
+    "exit 0",
+  ].join("\n");
 }
 
 // Each BK step runs on its own fresh agent — workspaces are not shared. To get
@@ -58,17 +77,16 @@ export function toBuildkitePipeline(
     const step: PipelineStep = {
       label: head.label,
       key,
-      command: head.command,
+      command: wrapNeverFail(head.command, key),
       timeout_in_minutes: cfg.timeoutInMinutes,
       agents: { ...cfg.agents },
-      soft_fail: cfg.softFail,
       artifact_paths: TEST_RESULTS_ARTIFACTS,
     };
 
     if (batches.length > 1) {
       const env: Record<string, string> = {};
       for (let i = 0; i < batches.length; i++) {
-        env[`BATCH_COMMAND_${i}`] = batches[i].command;
+        env[`BATCH_COMMAND_${i}`] = wrapNeverFail(batches[i].command, key);
       }
       step.command = 'VARNAME="BATCH_COMMAND_${BUILDKITE_PARALLEL_JOB}"; eval "$${!VARNAME}"';
       step.parallelism = batches.length;
@@ -86,17 +104,19 @@ export function toBuildkitePipeline(
       // then run the analyzer. The download preserves the upload paths so
       // the analyzer finds files at the same `*/build/test-results/...`
       // locations a local run would see.
-      command: [
-        "npm install -g bun@1.3.13",
-        `buildkite-agent artifact download "${TEST_RESULTS_ARTIFACTS}" .`,
-        "bun .buildkite/scripts/flakiness-detection/entrypoints/analyze.ts",
-      ].join("\n"),
+      command: wrapNeverFail(
+        [
+          "npm install -g bun@1.3.13",
+          `buildkite-agent artifact download "${TEST_RESULTS_ARTIFACTS}" .`,
+          "bun .buildkite/scripts/flakiness-detection/entrypoints/analyze.ts",
+        ].join("\n"),
+        "flakiness-detection:analyze"
+      ),
       timeout_in_minutes: 10,
       // Intentionally no `agents:` — the analyze step is lightweight markdown
       // rendering and should not pin to the gradle-tuned `cfg.agents` image
       // (that image lacks npm). Letting BK pick the parent pipeline default
       // gives us an agent with the standard Node toolchain available.
-      soft_fail: true,
       depends_on: deps,
     });
   }


### PR DESCRIPTION
## Why

The Buildkite group `flakiness-detection` (previously `repeat-changed-tests`) and each step inside it (`unit tests`, `java rest tests`, …) are configured with `soft_fail: true` so they don't fail the overall PR build. However, on PR #147287 (commit `975b207`, before the rename) GitHub still shows them as failed.

Verified via the GitHub Statuses API for that commit:

- `elasticsearch-ci/repeat-changed-tests` → `FAILURE` (target = build root; this is the group-aggregate commit status).
- `elasticsearch-ci/java rest tests` → `FAILURE` (target = specific job UUID; this is a per-step commit status).

Both report `FAILURE` despite `soft_fail: true`. In this pipeline's commit-status integration, Buildkite mirrors a step's underlying `state` (which is `failed` when the command exits non-zero) to GitHub; the `soft_failed` flag is only a side flag and is **not** honored when publishing the per-step or group-aggregate GitHub commit status. `soft_fail` only protects the overall *build* state in Buildkite — not the GitHub check.

We workaround that by having an additional commits check. With that, when all other (non "soft-fail") checks pass, every soft-failed check will be also set as passing. However, this is still confusing and engineers spend time looking at soft-failing steps.

Conclusion: as long as the step's command can exit non-zero, the PR check goes red. The only reliable fix is to make the command itself always exit 0, and surface real failures another way (build annotations + the existing flakiness-report annotation).

## What

Wraps every command emitted by `runners/buildkite.ts` in:

```sh
set +e
<original command>
rc=$?
if [ "$rc" -ne 0 ]; then
  buildkite-agent annotate --style warning --context "<key>-failures" --append "[\$BUILDKITE_LABEL] (job \$BUILDKITE_JOB_ID) exited with \$rc - see job log"
fi
exit 0
```

Result:

- `step.state` becomes `passed` → per-step and group-aggregate GitHub commit statuses go green.
- Real failures stay visible as Buildkite build annotations, in the job log, and in the existing `flakiness-detection:analyze` markdown report.

### Scope

Changes are confined to the `flakiness-detection` package:

- `runners/buildkite.ts` — add `wrapNeverFail`, apply to single-batch `head.command`, each `BATCH_COMMAND_\${i}` env value, and the trailing `flakiness-detection:analyze` step. Drop `soft_fail` from the emitted `PipelineStep` shape.
- `domain.ts` — drop `softFail` from `AgentConfig` / `DEFAULT_AGENT_CONFIG`.
- `runners/buildkite.test.ts` — loosen `command` / `BATCH_COMMAND_*` strict equalities to `toContain`, add `\"exit 0\"` assertions.

### Intentionally unchanged

- `runners/local.ts` — local runs must keep real exit codes so developers see failures.
- `commands.ts` / `commands.test.ts` — wrapping is a runner-boundary concern; `RunnableCommand` stays unwrapped.
- `pipelines/pull-request/flakiness-detection.yml` — the static `detect changed tests` bootstrap step keeps its `soft_fail: true`. If `bun install` or `entrypoints/pr.ts` blows up before uploading the sub-pipeline, the group aggregate \`elasticsearch-ci/flakiness-detection\` will still flip to FAILURE on the PR; real infra failures should be visible. Inlining the wrap in YAML is awkward; if we want full coverage, we can later move the command into a small `flakiness-detection-bootstrap.sh`.
- `pipelines/flakiness-detection-manual.yml` — already `soft_fail: false`, intentional.

## Further planned improvements

The next step is to stabilize the flakiness check so it won't produce false positives.
When the flakiness check is stable, the soft-fail solution, introduced here, will be removed. 
We may not be able to predict all failing scenarios so the planned solution is to fail only on a clear case of flakiness detected.