### PR TITLE
Fix SnapshotMetricsIT#testSnapshotAPMMetrics flakiness

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -548,9 +548,6 @@ tests:
 - class: org.elasticsearch.index.codec.vectors.diskbbq.ES920DiskBBQVectorsFormatTests
   method: testOneRepeatedVector
   issue: https://github.com/elastic/elasticsearch/issues/149254
-- class: org.elasticsearch.repositories.SnapshotMetricsIT
-  method: testSnapshotAPMMetrics
-  issue: https://github.com/elastic/elasticsearch/issues/149256
 - class: org.elasticsearch.xpack.stateless.reshard.StatelessReshardingPitSearchIT
   method: testPitRelocationDuringReshard
   issue: https://github.com/elastic/elasticsearch/issues/149271

--- a/server/src/internalClusterTest/java/org/elasticsearch/repositories/SnapshotMetricsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/repositories/SnapshotMetricsIT.java
@@ -112,7 +112,7 @@ public class SnapshotMetricsIT extends AbstractSnapshotIntegTestCase {
         // Block the snapshot to test "snapshot shards in progress"
         blockAllDataNodes(repositoryName);
         final String snapshotName = randomIdentifier();
-        final long beforeCreateSnapshotNanos = System.nanoTime();
+        final long beforeCreateSnapshotMs = System.currentTimeMillis();
         final ActionFuture<CreateSnapshotResponse> snapshotFuture;
         try {
             snapshotFuture = clusterAdmin().prepareCreateSnapshot(TEST_REQUEST_TIMEOUT, repositoryName, snapshotName)
@@ -136,7 +136,7 @@ public class SnapshotMetricsIT extends AbstractSnapshotIntegTestCase {
 
         // wait for snapshot to finish to test the other metrics
         safeGet(snapshotFuture);
-        final TimeValue snapshotElapsedTime = TimeValue.timeValueNanos(System.nanoTime() - beforeCreateSnapshotNanos);
+        final TimeValue snapshotElapsedTime = TimeValue.timeValueMillis(System.currentTimeMillis() - beforeCreateSnapshotMs);
         final double maxHistogramDurationSeconds = snapshotElapsedTime.secondsFrac() + DOUBLE_HISTOGRAM_DURATION_UPPER_BOUND_SLACK_SEC;
         collectMetrics();
 


### PR DESCRIPTION
The snapshot duration metrics use System.currentTimeMillis() while the
test bound was measured with System.nanoTime(). These independent clocks
can drift relative to each other, causing the histogram value to exceed
the test bound by a fraction of a millisecond.

Switch to System.currentTimeMillis() for the elapsed time measurement so
both sides use the same clock.

Closes #149256
