### PR TITLE
Add HttpServerInstrumentation interface with OTel HTTP server semconv attributes

### DIFF
--- a/modules/apm/build.gradle
+++ b/modules/apm/build.gradle
@@ -15,6 +15,7 @@ esplugin {
 
 def otelVersion = '1.60.1'
 def otelInstrumentationVersion = '2.26.1-alpha'
+def otelInstrumentationStableVersion = '2.26.1'
 
 dependencies {
   implementation "io.opentelemetry:opentelemetry-api:${otelVersion}"
@@ -25,6 +26,7 @@ dependencies {
     exclude group: 'io.opentelemetry', module: 'opentelemetry-exporter-sender-okhttp'
   }
   implementation "io.opentelemetry.instrumentation:opentelemetry-runtime-telemetry:${otelInstrumentationVersion}"
+  implementation "io.opentelemetry.instrumentation:opentelemetry-instrumentation-api:${otelInstrumentationStableVersion}"
 
   implementation "io.opentelemetry:opentelemetry-sdk-common:${otelVersion}"
   implementation "io.opentelemetry:opentelemetry-sdk-trace:${otelVersion}"

--- a/modules/apm/src/main/java/module-info.java
+++ b/modules/apm/src/main/java/module-info.java
@@ -20,6 +20,7 @@ module org.elasticsearch.telemetry.apm {
     requires io.opentelemetry.sdk.trace;
     requires io.opentelemetry.exporter.otlp;
     requires io.opentelemetry.instrumentation.runtime_telemetry;
+    requires io.opentelemetry.instrumentation_api;
     requires io.opentelemetry.sdk.common;
     requires org.elasticsearch.logging;
 

--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/APMTelemetryProvider.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/APMTelemetryProvider.java
@@ -12,20 +12,29 @@ package org.elasticsearch.telemetry.apm.internal;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.telemetry.TelemetryProvider;
 import org.elasticsearch.telemetry.apm.APMMeterRegistry;
+import org.elasticsearch.telemetry.apm.internal.instrumentation.APMHttpServerInstrumentation;
 import org.elasticsearch.telemetry.apm.internal.tracing.APMTracer;
+import org.elasticsearch.telemetry.instrumentation.HttpServerInstrumentation;
 
 public class APMTelemetryProvider implements TelemetryProvider {
     private final APMTracer apmTracer;
     private final APMMeterService apmMeterService;
+    private final APMHttpServerInstrumentation httpServerInstrumentation;
 
     public APMTelemetryProvider(Settings settings) {
         apmTracer = new APMTracer(settings);
         apmMeterService = new APMMeterService(settings);
+        httpServerInstrumentation = new APMHttpServerInstrumentation(apmTracer);
     }
 
     @Override
     public APMTracer getTracer() {
         return apmTracer;
+    }
+
+    @Override
+    public HttpServerInstrumentation getHttpServerInstrumentation() {
+        return httpServerInstrumentation;
     }
 
     public APMMeterService getMeterService() {

--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/instrumentation/APMHttpServerInstrumentation.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/instrumentation/APMHttpServerInstrumentation.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.telemetry.apm.internal.instrumentation;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
+import io.opentelemetry.instrumentation.api.semconv.http.HttpServerAttributesExtractor;
+import io.opentelemetry.instrumentation.api.semconv.http.HttpSpanNameExtractor;
+
+import org.elasticsearch.common.util.Maps;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.RestResponse;
+import org.elasticsearch.telemetry.apm.internal.tracing.APMTracer;
+import org.elasticsearch.telemetry.instrumentation.HttpServerInstrumentation;
+import org.elasticsearch.telemetry.instrumentation.HttpServerSemConvAttributes;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * APM-backed {@link HttpServerInstrumentation} that uses the OTel {@code instrumentation-api}
+ * library to compute spec-compliant HTTP server semconv attributes.
+ * <p>
+ * The OTel {@code Instrumenter} API is intentionally NOT used because it is incompatible with
+ * ES's custom span-lifecycle management in {@link APMTracer}. Instead, only
+ * {@link AttributesExtractor} and {@link SpanNameExtractor} are used for attribute computation
+ * while span start/stop/error are delegated to the existing {@link APMTracer}.
+ * <p>
+ * Backward-compatible legacy attributes ({@code http.method}, {@code http.url}, {@code http.flavour},
+ * {@code http.status_code}, {@code http.request/response.headers.*}) are dual-written alongside
+ * the new OTel semconv attributes so that existing APM dashboards continue to function.
+ */
+public class APMHttpServerInstrumentation implements HttpServerInstrumentation {
+
+    private final APMTracer tracer;
+    private final SpanNameExtractor<RequestAndRoute> spanNameExtractor;
+    private final AttributesExtractor<RequestAndRoute, RestResponse> httpServerAttributesExtractor;
+
+    public APMHttpServerInstrumentation(APMTracer tracer) {
+        this.tracer = tracer;
+        final var getter = new OtelAttributesGetter();
+        this.spanNameExtractor = HttpSpanNameExtractor.builder(getter).build();
+        this.httpServerAttributesExtractor = HttpServerAttributesExtractor.builder(getter).build();
+    }
+
+    @Override
+    public void start(ThreadContext threadContext, RestRequest request, String matchedRoute) {
+        final var req = new RequestAndRoute(request, matchedRoute);
+        final String spanName = spanNameExtractor.extract(req);
+
+        // Legacy attributes — kept for backward compat with existing APM dashboards.
+        // These also trigger SpanKind.SERVER detection in APMTracer (keys starting with "http.").
+        tracer.startTrace(threadContext, request, spanName, legacyRequestAttributes(request));
+
+        // OTel semconv attributes (url.*, http.request.method, network.protocol.*, server.*, http.route)
+        final var otelAttrs = Attributes.builder();
+        httpServerAttributesExtractor.onStart(otelAttrs, Context.root(), req);
+
+        // server.address / server.port: HttpServerAttributesGetter does not extend ServerAttributesGetter,
+        // so the extractor cannot derive these. Resolve them here with proxy-header priority.
+        final String forwarded = HttpServerSemConvAttributes.firstHeaderValue(request, "Forwarded");
+        final String serverAddress = HttpServerSemConvAttributes.extractServerAddress(request, request.getHttpChannel(), forwarded);
+        if (serverAddress != null) {
+            otelAttrs.put(AttributeKey.stringKey("server.address"), serverAddress);
+            final Integer serverPort = HttpServerSemConvAttributes.extractServerPort(request, request.getHttpChannel(), forwarded);
+            if (serverPort != null) {
+                otelAttrs.put(AttributeKey.longKey("server.port"), (long) serverPort);
+            }
+        }
+
+        tracer.setAttributes(request, otelAttrs.build());
+    }
+
+    @Override
+    public void recordException(RestRequest request, Throwable t) {
+        tracer.addError(request, t);
+    }
+
+    @Override
+    public void end(RestRequest request, RestResponse response) {
+        final var req = new RequestAndRoute(request, null);
+
+        // OTel semconv response attributes (http.response.status_code, http.response.headers.*)
+        final var otelAttrs = Attributes.builder();
+        httpServerAttributesExtractor.onEnd(otelAttrs, Context.root(), req, response, null);
+        tracer.setAttributes(request, otelAttrs.build());
+
+        // Legacy backward-compat attributes
+        tracer.setAttribute(request, "http.status_code", (long) response.status().getStatus());
+        response.getHeaders()
+            .forEach((key, values) -> tracer.setAttribute(request, "http.response.headers." + key, String.join("; ", values)));
+
+        tracer.stopTrace(request);
+    }
+
+    /** Builds the legacy attribute map that preserves backward compatibility with APM dashboards. */
+    private static Map<String, Object> legacyRequestAttributes(RestRequest req) {
+        String method = null;
+        try {
+            method = req.method().name();
+        } catch (IllegalArgumentException e) {
+            // invalid method — will be recorded as <unknown>
+        }
+        final Map<String, Object> attrs = Maps.newMapWithExpectedSize(req.getHeaders().size() + 3);
+        req.getHeaders().forEach((key, values) -> {
+            final String lowerKey = key.toLowerCase(Locale.ROOT).replace('-', '_');
+            attrs.put("http.request.headers." + lowerKey, values == null ? "" : String.join("; ", values));
+        });
+        attrs.put("http.method", Objects.requireNonNullElse(method, "<unknown>"));
+        attrs.put("http.url", Objects.requireNonNullElse(req.uri(), "<unknown>"));
+        switch (req.getHttpRequest().protocolVersion()) {
+            case HTTP_1_0 -> attrs.put("http.flavour", "1.0");
+            case HTTP_1_1 -> attrs.put("http.flavour", "1.1");
+        }
+        return attrs;
+    }
+}

--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/instrumentation/OtelAttributesGetter.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/instrumentation/OtelAttributesGetter.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.telemetry.apm.internal.instrumentation;
+
+import io.opentelemetry.instrumentation.api.semconv.http.HttpServerAttributesGetter;
+
+import org.elasticsearch.rest.RestResponse;
+import org.elasticsearch.telemetry.instrumentation.HttpServerSemConvAttributes;
+
+import java.util.List;
+
+/**
+ * Maps ES {@link RequestAndRoute} and {@link RestResponse} to the OTel HTTP server semconv attributes
+ * expected by {@link io.opentelemetry.instrumentation.api.semconv.http.HttpServerAttributesExtractor}.
+ * <p>
+ * Proxy-header resolution (RFC 7239 {@code Forwarded}, {@code X-Forwarded-*}) is delegated to
+ * {@link HttpServerSemConvAttributes} rather than duplicated here.
+ */
+final class OtelAttributesGetter implements HttpServerAttributesGetter<RequestAndRoute, RestResponse> {
+
+    @Override
+    public String getUrlScheme(RequestAndRoute requestAndRoute) {
+        final String forwarded = HttpServerSemConvAttributes.firstHeaderValue(requestAndRoute.request(), "Forwarded");
+        return HttpServerSemConvAttributes.extractScheme(requestAndRoute.request(), forwarded);
+    }
+
+    @Override
+    public String getUrlPath(RequestAndRoute requestAndRoute) {
+        final String uri = requestAndRoute.uri();
+        final int queryIdx = uri.indexOf('?');
+        return queryIdx >= 0 ? uri.substring(0, queryIdx) : uri;
+    }
+
+    @Override
+    public String getUrlQuery(RequestAndRoute requestAndRoute) {
+        final String uri = requestAndRoute.uri();
+        final int queryIdx = uri.indexOf('?');
+        return queryIdx >= 0 ? uri.substring(queryIdx + 1) : null;
+    }
+
+    @Override
+    public String getHttpRoute(RequestAndRoute requestAndRoute) {
+        return requestAndRoute.matchedRoute();
+    }
+
+    @Override
+    public String getHttpRequestMethod(RequestAndRoute requestAndRoute) {
+        try {
+            return requestAndRoute.request().method().name();
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    @Override
+    public List<String> getHttpRequestHeader(RequestAndRoute requestAndRoute, String name) {
+        return requestAndRoute.request().getHeaders().getOrDefault(name, List.of());
+    }
+
+    @Override
+    public Integer getHttpResponseStatusCode(RequestAndRoute requestAndRoute, RestResponse response, Throwable error) {
+        return response.status().getStatus();
+    }
+
+    @Override
+    public List<String> getHttpResponseHeader(RequestAndRoute requestAndRoute, RestResponse response, String name) {
+        return response.getHeaders().getOrDefault(name, List.of());
+    }
+
+    @Override
+    public String getNetworkProtocolName(RequestAndRoute requestAndRoute, RestResponse response) {
+        return "http";
+    }
+
+    @Override
+    public String getNetworkProtocolVersion(RequestAndRoute requestAndRoute, RestResponse response) {
+        return switch (requestAndRoute.request().getHttpRequest().protocolVersion()) {
+            case HTTP_1_0 -> "1.0";
+            case HTTP_1_1 -> "1.1";
+        };
+    }
+
+}

--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/instrumentation/RequestAndRoute.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/instrumentation/RequestAndRoute.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.telemetry.apm.internal.instrumentation;
+
+import org.elasticsearch.rest.RestRequest;
+
+import java.util.Objects;
+
+/**
+ * Carrier pairing a {@link RestRequest} with the matched route pattern for use as the
+ * {@code REQUEST} type parameter in OTel {@code HttpServerAttributesGetter}.
+ */
+record RequestAndRoute(RestRequest request, String matchedRoute) {
+
+    String uri() {
+        return Objects.requireNonNullElse(request.uri(), "<unknown>");
+    }
+}

--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/tracing/APMTracer.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/tracing/APMTracer.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.telemetry.apm.internal.tracing;
 
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.SpanKind;
@@ -478,6 +479,18 @@ public class APMTracer extends AbstractLifecycleComponent implements org.elastic
         if (span != null) {
             logger.trace("Finishing trace [{}]", spanId);
             span.end();
+        }
+    }
+
+    /**
+     * Sets all attributes from an OTel {@link Attributes} bag on the active span for the given traceable.
+     * Used by {@code APMHttpServerInstrumentation} to apply OTel semconv attributes computed by
+     * {@code HttpServerAttributesExtractor} without going through the legacy {@link Map} path.
+     */
+    public void setAttributes(Traceable traceable, Attributes attributes) {
+        final var span = Span.fromContextOrNull(spans.get(traceable.getSpanId()));
+        if (span != null) {
+            span.setAllAttributes(attributes);
         }
     }
 

--- a/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/internal/instrumentation/APMHttpServerInstrumentationTests.java
+++ b/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/internal/instrumentation/APMHttpServerInstrumentationTests.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.telemetry.apm.internal.instrumentation;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.RestResponse;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.telemetry.apm.internal.tracing.APMTracer;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.rest.FakeRestRequest;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Unit tests for {@link APMHttpServerInstrumentation}.
+ * Uses a Mockito mock of {@link APMTracer} to capture tracer calls without requiring a full OTel agent.
+ */
+public class APMHttpServerInstrumentationTests extends ESTestCase {
+
+    @SuppressWarnings("unchecked")
+    public void testStartWritesLegacyAndOtelAttributes() {
+        APMTracer tracer = mock(APMTracer.class);
+        APMHttpServerInstrumentation inst = new APMHttpServerInstrumentation(tracer);
+
+        FakeRestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.GET)
+            .withPath("/search?q=test")
+            .withHeaders(Map.of("Host", List.of("myhost:9200")))
+            .build();
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+
+        inst.start(threadContext, request, "/search");
+
+        // Verify span name was derived from the OTel name extractor (GET /search)
+        ArgumentCaptor<String> spanNameCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Map<String, Object>> legacyAttrsCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(tracer).startTrace(eq(threadContext), eq(request), spanNameCaptor.capture(), legacyAttrsCaptor.capture());
+
+        assertThat(spanNameCaptor.getValue(), equalTo("GET /search"));
+
+        Map<String, Object> legacy = legacyAttrsCaptor.getValue();
+        assertThat(legacy.get("http.method"), equalTo("GET"));
+        assertThat(legacy.get("http.url"), equalTo("/search?q=test"));
+        assertThat(legacy.get("http.flavour"), equalTo("1.1"));
+
+        // Verify OTel attributes were applied
+        ArgumentCaptor<Attributes> otelAttrsCaptor = ArgumentCaptor.forClass(Attributes.class);
+        verify(tracer).setAttributes(eq(request), otelAttrsCaptor.capture());
+
+        Attributes otel = otelAttrsCaptor.getValue();
+        assertThat(otel.get(AttributeKey.stringKey("http.request.method")), equalTo("GET"));
+        assertThat(otel.get(AttributeKey.stringKey("url.path")), equalTo("/search"));
+        assertThat(otel.get(AttributeKey.stringKey("url.query")), equalTo("q=test"));
+        assertThat(otel.get(AttributeKey.stringKey("url.scheme")), equalTo("http"));
+        assertThat(otel.get(AttributeKey.stringKey("server.address")), equalTo("myhost"));
+        assertThat(otel.get(AttributeKey.longKey("server.port")), equalTo(9200L));
+        // network.protocol.name/version are response-phase attributes set in end(), not start()
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testStartWritesLegacyRequestHeaders() {
+        APMTracer tracer = mock(APMTracer.class);
+        APMHttpServerInstrumentation inst = new APMHttpServerInstrumentation(tracer);
+
+        FakeRestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.POST)
+            .withPath("/index/_doc")
+            .withHeaders(Map.of("Content-Type", List.of("application/json"), "Host", List.of("localhost")))
+            .build();
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+
+        inst.start(threadContext, request, "/index/_doc");
+
+        ArgumentCaptor<Map<String, Object>> legacyAttrsCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(tracer).startTrace(any(), any(RestRequest.class), anyString(), legacyAttrsCaptor.capture());
+
+        Map<String, Object> legacy = legacyAttrsCaptor.getValue();
+        assertThat(legacy, hasKey("http.request.headers.content_type"));
+    }
+
+    public void testEndWritesLegacyAndOtelResponseAttributes() {
+        APMTracer tracer = mock(APMTracer.class);
+        APMHttpServerInstrumentation inst = new APMHttpServerInstrumentation(tracer);
+
+        FakeRestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.GET).withPath("/").build();
+        RestResponse response = new RestResponse(RestStatus.OK, "test");
+
+        inst.end(request, response);
+
+        // OTel http.response.status_code via setAttributes
+        ArgumentCaptor<Attributes> attrsCaptor = ArgumentCaptor.forClass(Attributes.class);
+        verify(tracer).setAttributes(eq(request), attrsCaptor.capture());
+        Attributes otelAttrs = attrsCaptor.getValue();
+        assertThat(otelAttrs.get(AttributeKey.longKey("http.response.status_code")), equalTo(200L));
+        // The OTel library omits network.protocol.name when it equals "http" (the implied default for HTTP spans).
+        // network.protocol.version is a response-phase attribute set here.
+        assertThat(otelAttrs.get(AttributeKey.stringKey("network.protocol.version")), equalTo("1.1"));
+
+        // Legacy http.status_code as long
+        verify(tracer).setAttribute(eq(request), eq("http.status_code"), eq(200L));
+
+        // Span stopped
+        verify(tracer).stopTrace(eq(request));
+    }
+
+    public void testRecordExceptionDelegatesToTracer() {
+        APMTracer tracer = mock(APMTracer.class);
+        APMHttpServerInstrumentation inst = new APMHttpServerInstrumentation(tracer);
+
+        FakeRestRequest request = new FakeRestRequest.Builder(xContentRegistry()).build();
+        RuntimeException error = new RuntimeException("boom");
+
+        inst.recordException(request, error);
+
+        verify(tracer).addError(eq(request), eq(error));
+    }
+
+    public void testStartSetsHttpRouteFromMatchedRoute() {
+        APMTracer tracer = mock(APMTracer.class);
+        APMHttpServerInstrumentation inst = new APMHttpServerInstrumentation(tracer);
+
+        FakeRestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.GET)
+            .withPath("/index/_search")
+            .withHeaders(Map.of("Host", List.of("localhost")))
+            .build();
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+
+        inst.start(threadContext, request, "/{index}/_search");
+
+        ArgumentCaptor<Attributes> attrsCaptor = ArgumentCaptor.forClass(Attributes.class);
+        verify(tracer).setAttributes(eq(request), attrsCaptor.capture());
+
+        Attributes otelAttrs = attrsCaptor.getValue();
+        assertThat(otelAttrs.get(AttributeKey.stringKey("http.route")), equalTo("/{index}/_search"));
+    }
+
+    public void testStartDerivesSpanNameFromRoute() {
+        APMTracer tracer = mock(APMTracer.class);
+        APMHttpServerInstrumentation inst = new APMHttpServerInstrumentation(tracer);
+
+        FakeRestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.DELETE)
+            .withPath("/my-index")
+            .withHeaders(Map.of("Host", List.of("localhost")))
+            .build();
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+
+        inst.start(threadContext, request, "/{index}");
+
+        ArgumentCaptor<String> spanNameCaptor = ArgumentCaptor.forClass(String.class);
+        verify(tracer).startTrace(any(), any(RestRequest.class), spanNameCaptor.capture(), any());
+
+        // OTel HttpSpanNameExtractor uses the matched route when available
+        assertThat(spanNameCaptor.getValue(), notNullValue());
+    }
+}

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpPipeliningHandler.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpPipeliningHandler.java
@@ -96,22 +96,26 @@ public class Netty4HttpPipeliningHandler extends ChannelDuplexHandler {
     private final Queue<WriteOperation> queuedWrites = new ArrayDeque<>();
 
     private final Netty4HttpServerTransport serverTransport;
+    private final String scheme;
 
     /**
      * Construct a new pipelining handler; this handler should be used downstream of HTTP decoding/aggregation.
      *
      * @param maxEventsHeld the maximum number of channel events that will be retained prior to aborting the channel connection; this is
      *                      required as events cannot queue up indefinitely
+     * @param scheme        either {@code "http"} or {@code "https"} depending on whether TLS is enabled for this channel
      */
     public Netty4HttpPipeliningHandler(
         final int maxEventsHeld,
         final Netty4HttpServerTransport serverTransport,
-        final ThreadWatchdog.ActivityTracker activityTracker
+        final ThreadWatchdog.ActivityTracker activityTracker,
+        final String scheme
     ) {
         this.maxEventsHeld = maxEventsHeld;
         this.activityTracker = activityTracker;
         this.outboundHoldingQueue = new PriorityQueue<>(1, Comparator.comparingInt(t -> t.v1().getSequence()));
         this.serverTransport = serverTransport;
+        this.scheme = scheme;
     }
 
     @Override
@@ -130,12 +134,12 @@ public class Netty4HttpPipeliningHandler extends ChannelDuplexHandler {
                     } else {
                         nonError = (Exception) cause;
                     }
-                    netty4HttpRequest = new Netty4HttpRequest(readSequence++, request, nonError);
+                    netty4HttpRequest = new Netty4HttpRequest(readSequence++, request, nonError, scheme);
                 } else {
                     assert currentRequestStream == null : "current stream must be null for new request";
                     var contentStream = new Netty4HttpRequestBodyStream(ctx, serverTransport.getThreadPool().getThreadContext());
                     currentRequestStream = contentStream;
-                    netty4HttpRequest = new Netty4HttpRequest(readSequence++, request, contentStream);
+                    netty4HttpRequest = new Netty4HttpRequest(readSequence++, request, contentStream, scheme);
                     shouldRead = false;
                 }
                 handlePipelinedRequest(ctx, netty4HttpRequest);

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequest.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequest.java
@@ -46,13 +46,14 @@ public class Netty4HttpRequest implements HttpRequest {
     private final AtomicBoolean released;
     private final Exception inboundException;
     private final QueryStringDecoder queryStringDecoder;
+    private final String scheme;
 
-    public Netty4HttpRequest(int sequence, io.netty.handler.codec.http.HttpRequest nettyRequest, Exception exception) {
-        this(sequence, nettyRequest, HttpBody.empty(), new AtomicBoolean(false), exception);
+    public Netty4HttpRequest(int sequence, io.netty.handler.codec.http.HttpRequest nettyRequest, Exception exception, String scheme) {
+        this(sequence, nettyRequest, HttpBody.empty(), new AtomicBoolean(false), exception, scheme);
     }
 
-    public Netty4HttpRequest(int sequence, io.netty.handler.codec.http.HttpRequest nettyRequest, HttpBody content) {
-        this(sequence, nettyRequest, content, new AtomicBoolean(false), null);
+    public Netty4HttpRequest(int sequence, io.netty.handler.codec.http.HttpRequest nettyRequest, HttpBody content, String scheme) {
+        this(sequence, nettyRequest, content, new AtomicBoolean(false), null, scheme);
     }
 
     private Netty4HttpRequest(
@@ -60,7 +61,8 @@ public class Netty4HttpRequest implements HttpRequest {
         io.netty.handler.codec.http.HttpRequest nettyRequest,
         HttpBody content,
         AtomicBoolean released,
-        Exception inboundException
+        Exception inboundException,
+        String scheme
     ) {
         this.sequence = sequence;
         this.nettyRequest = nettyRequest;
@@ -70,6 +72,7 @@ public class Netty4HttpRequest implements HttpRequest {
         this.released = released;
         this.inboundException = inboundException;
         this.queryStringDecoder = new QueryStringDecoder(nettyRequest.uri());
+        this.scheme = scheme;
     }
 
     private static boolean hasContentHeader(io.netty.handler.codec.http.HttpRequest nettyRequest) {
@@ -155,7 +158,12 @@ public class Netty4HttpRequest implements HttpRequest {
             nettyRequest.uri(),
             copiedHeadersWithout
         );
-        return new Netty4HttpRequest(sequence, requestWithoutHeader, content, released, null);
+        return new Netty4HttpRequest(sequence, requestWithoutHeader, content, released, null, scheme);
+    }
+
+    @Override
+    public String getScheme() {
+        return scheme;
     }
 
     @Override

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
@@ -477,7 +477,12 @@ public class Netty4HttpServerTransport extends AbstractHttpServerTransport {
             ch.pipeline()
                 .addLast(
                     "pipelining",
-                    new Netty4HttpPipeliningHandler(transport.pipeliningMaxEvents, transport, threadWatchdogActivityTracker)
+                    new Netty4HttpPipeliningHandler(
+                        transport.pipeliningMaxEvents,
+                        transport,
+                        threadWatchdogActivityTracker,
+                        tlsConfig.isTLSEnabled() ? "https" : "http"
+                    )
                 );
             transport.serverAcceptedChannel(nettyHttpChannel);
 

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpPipeliningHandlerTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpPipeliningHandlerTests.java
@@ -140,7 +140,7 @@ public class Netty4HttpPipeliningHandlerTests extends ESTestCase {
 
     private EmbeddedChannel makeEmbeddedChannelWithSimulatedWork(int numberOfRequests) {
         return new EmbeddedChannel(
-            new Netty4HttpPipeliningHandler(numberOfRequests, httpServerTransport(), new ThreadWatchdog.ActivityTracker()) {
+            new Netty4HttpPipeliningHandler(numberOfRequests, httpServerTransport(), new ThreadWatchdog.ActivityTracker(), "http") {
                 @Override
                 protected void handlePipelinedRequest(ChannelHandlerContext ctx, Netty4HttpRequest pipelinedRequest) {
                     ctx.fireChannelRead(pipelinedRequest);
@@ -225,7 +225,7 @@ public class Netty4HttpPipeliningHandlerTests extends ESTestCase {
     public void testPipeliningRequestsAreReleased() {
         final int numberOfRequests = 10;
         final EmbeddedChannel embeddedChannel = new EmbeddedChannel(
-            new Netty4HttpPipeliningHandler(numberOfRequests + 1, httpServerTransport(), new ThreadWatchdog.ActivityTracker())
+            new Netty4HttpPipeliningHandler(numberOfRequests + 1, httpServerTransport(), new ThreadWatchdog.ActivityTracker(), "http")
         );
 
         for (int i = 0; i < numberOfRequests; i++) {
@@ -517,7 +517,7 @@ public class Netty4HttpPipeliningHandlerTests extends ESTestCase {
         final var watchdog = new ThreadWatchdog();
         final var activityTracker = watchdog.getActivityTrackerForCurrentThread();
         final var requestHandled = new AtomicBoolean();
-        final var handler = new Netty4HttpPipeliningHandler(Integer.MAX_VALUE, httpServerTransport(), activityTracker) {
+        final var handler = new Netty4HttpPipeliningHandler(Integer.MAX_VALUE, httpServerTransport(), activityTracker, "http") {
             @Override
             protected void handlePipelinedRequest(ChannelHandlerContext ctx, Netty4HttpRequest pipelinedRequest) {
                 // thread is not idle while handling the request
@@ -558,7 +558,7 @@ public class Netty4HttpPipeliningHandlerTests extends ESTestCase {
     }
 
     private Netty4HttpPipeliningHandler getTestHttpHandler() {
-        return new Netty4HttpPipeliningHandler(Integer.MAX_VALUE, httpServerTransport(), new ThreadWatchdog.ActivityTracker()) {
+        return new Netty4HttpPipeliningHandler(Integer.MAX_VALUE, httpServerTransport(), new ThreadWatchdog.ActivityTracker(), "http") {
             @Override
             protected void handlePipelinedRequest(ChannelHandlerContext ctx, Netty4HttpRequest pipelinedRequest) {
                 ctx.fireChannelRead(pipelinedRequest);

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpRequestTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpRequestTests.java
@@ -24,7 +24,12 @@ import org.elasticsearch.test.rest.FakeHttpBodyStream;
 public class Netty4HttpRequestTests extends ESTestCase {
 
     public void testEmptyFullContent() {
-        final var request = new Netty4HttpRequest(0, new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/"), HttpBody.empty());
+        final var request = new Netty4HttpRequest(
+            0,
+            new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/"),
+            HttpBody.empty(),
+            "http"
+        );
         assertFalse(request.hasContent());
     }
 
@@ -32,7 +37,8 @@ public class Netty4HttpRequestTests extends ESTestCase {
         final var request = new Netty4HttpRequest(
             0,
             new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/"),
-            new FakeHttpBodyStream()
+            new FakeHttpBodyStream(),
+            "http"
         );
         assertFalse(request.hasContent());
     }
@@ -47,7 +53,8 @@ public class Netty4HttpRequestTests extends ESTestCase {
                 "/",
                 new DefaultHttpHeaders().add(HttpHeaderNames.CONTENT_LENGTH, len)
             ),
-            HttpBody.fromBytesReference(new BytesArray(new byte[len]))
+            HttpBody.fromBytesReference(new BytesArray(new byte[len])),
+            "http"
         );
         assertTrue(request.hasContent());
     }
@@ -56,12 +63,12 @@ public class Netty4HttpRequestTests extends ESTestCase {
         final var len = between(1, 1024);
         final var nettyRequestWithLen = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/");
         HttpUtil.setContentLength(nettyRequestWithLen, len);
-        final var requestWithLen = new Netty4HttpRequest(0, nettyRequestWithLen, new FakeHttpBodyStream());
+        final var requestWithLen = new Netty4HttpRequest(0, nettyRequestWithLen, new FakeHttpBodyStream(), "http");
         assertTrue(requestWithLen.hasContent());
 
         final var nettyChunkedRequest = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/", new DefaultHttpHeaders());
         HttpUtil.setTransferEncodingChunked(nettyChunkedRequest, true);
-        final var chunkedRequest = new Netty4HttpRequest(0, nettyChunkedRequest, new FakeHttpBodyStream());
+        final var chunkedRequest = new Netty4HttpRequest(0, nettyChunkedRequest, new FakeHttpBodyStream(), "http");
         assertTrue(chunkedRequest.hasContent());
     }
 
@@ -69,9 +76,29 @@ public class Netty4HttpRequestTests extends ESTestCase {
         final var len = between(1, 1024);
         final var nettyRequestWithLen = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/");
         HttpUtil.setContentLength(nettyRequestWithLen, len);
-        final var streamRequest = new Netty4HttpRequest(0, nettyRequestWithLen, new FakeHttpBodyStream());
+        final var streamRequest = new Netty4HttpRequest(0, nettyRequestWithLen, new FakeHttpBodyStream(), "http");
 
         streamRequest.setBody(HttpBody.fromBytesReference(randomBytesReference(len)));
         assertTrue(streamRequest.hasContent());
+    }
+
+    public void testGetSchemeHttp() {
+        final var request = new Netty4HttpRequest(
+            0,
+            new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/"),
+            HttpBody.empty(),
+            "http"
+        );
+        assertEquals("http", request.getScheme());
+    }
+
+    public void testGetSchemeHttps() {
+        final var request = new Netty4HttpRequest(
+            0,
+            new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/"),
+            HttpBody.empty(),
+            "https"
+        );
+        assertEquals("https", request.getScheme());
     }
 }

--- a/server/src/main/java/module-info.java
+++ b/server/src/main/java/module-info.java
@@ -412,6 +412,7 @@ module org.elasticsearch.server {
             org.elasticsearch.xpack.diskbbq,
             org.elasticsearch.xpack.stateless;
 
+    exports org.elasticsearch.telemetry.instrumentation;
     exports org.elasticsearch.telemetry.tracing;
     exports org.elasticsearch.telemetry;
     exports org.elasticsearch.telemetry.metric;

--- a/server/src/main/java/org/elasticsearch/http/AbstractHttpServerTransport.java
+++ b/server/src/main/java/org/elasticsearch/http/AbstractHttpServerTransport.java
@@ -41,6 +41,7 @@ import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.telemetry.TelemetryProvider;
+import org.elasticsearch.telemetry.instrumentation.HttpServerInstrumentation;
 import org.elasticsearch.telemetry.metric.LongWithAttributes;
 import org.elasticsearch.telemetry.metric.MeterRegistry;
 import org.elasticsearch.telemetry.tracing.Tracer;
@@ -105,6 +106,7 @@ public abstract class AbstractHttpServerTransport extends AbstractLifecycleCompo
 
     private final HttpTracer httpLogger;
     private final Tracer tracer;
+    private final HttpServerInstrumentation instrumentation;
     private final MeterRegistry meterRegistry;
     private final List<AutoCloseable> metricsToClose = new ArrayList<>(2);
     private volatile boolean shuttingDown;
@@ -146,6 +148,7 @@ public abstract class AbstractHttpServerTransport extends AbstractLifecycleCompo
 
         this.maxContentLength = SETTING_HTTP_MAX_CONTENT_LENGTH.get(settings);
         this.tracer = telemetryProvider.getTracer();
+        this.instrumentation = telemetryProvider.getHttpServerInstrumentation();
         this.meterRegistry = telemetryProvider.getMeterRegistry();
         this.httpLogger = new HttpTracer(settings, clusterSettings);
         clusterSettings.addSettingsUpdateConsumer(
@@ -597,7 +600,7 @@ public abstract class AbstractHttpServerTransport extends AbstractLifecycleCompo
                     threadContext,
                     corsHandler,
                     maybeHttpLogger,
-                    tracer
+                    instrumentation
                 );
             } catch (final IllegalArgumentException e) {
                 badRequestCause = ExceptionsHelper.useOrSuppress(badRequestCause, e);
@@ -611,7 +614,7 @@ public abstract class AbstractHttpServerTransport extends AbstractLifecycleCompo
                     threadContext,
                     corsHandler,
                     httpLogger,
-                    tracer
+                    instrumentation
                 );
             }
             channel = innerChannel;

--- a/server/src/main/java/org/elasticsearch/http/DefaultRestChannel.java
+++ b/server/src/main/java/org/elasticsearch/http/DefaultRestChannel.java
@@ -27,7 +27,7 @@ import org.elasticsearch.rest.LoggingChunkedRestResponseBodyPart;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestResponse;
 import org.elasticsearch.rest.RestStatus;
-import org.elasticsearch.telemetry.tracing.Tracer;
+import org.elasticsearch.telemetry.instrumentation.HttpServerInstrumentation;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -54,7 +54,7 @@ public class DefaultRestChannel extends AbstractRestChannel {
     private final ThreadContext threadContext;
     private final HttpChannel httpChannel;
     private final CorsHandler corsHandler;
-    private final Tracer tracer;
+    private final HttpServerInstrumentation instrumentation;
 
     @Nullable
     private final HttpTracer httpLogger;
@@ -68,7 +68,7 @@ public class DefaultRestChannel extends AbstractRestChannel {
         ThreadContext threadContext,
         CorsHandler corsHandler,
         @Nullable HttpTracer httpLogger,
-        Tracer tracer
+        HttpServerInstrumentation instrumentation
     ) {
         super(request, settings.detailedErrorsEnabled());
         this.httpChannel = httpChannel;
@@ -78,7 +78,7 @@ public class DefaultRestChannel extends AbstractRestChannel {
         this.threadContext = threadContext;
         this.corsHandler = corsHandler;
         this.httpLogger = httpLogger;
-        this.tracer = tracer;
+        this.instrumentation = instrumentation;
     }
 
     @Override
@@ -95,7 +95,7 @@ public class DefaultRestChannel extends AbstractRestChannel {
         if (HttpUtils.shouldCloseConnection(httpRequest)) {
             toClose.add(() -> CloseableChannel.closeChannel(httpChannel));
         }
-        toClose.add(() -> tracer.stopTrace(request));
+        toClose.add(() -> instrumentation.end(request, restResponse));
         toClose.add(restResponse);
 
         boolean success = false;
@@ -169,11 +169,6 @@ public class DefaultRestChannel extends AbstractRestChannel {
             }
 
             addCookies(httpResponse);
-
-            tracer.setAttribute(request, "http.status_code", restResponse.status().getStatus());
-            tracer.setAttribute(request, "http.response.status_code", restResponse.status().getStatus());
-            restResponse.getHeaders()
-                .forEach((key, values) -> tracer.setAttribute(request, "http.response.headers." + key, String.join("; ", values)));
 
             ActionListener<Void> listener = ActionListener.releasing(Releasables.wrap(toClose));
             if (httpLogger != null) {

--- a/server/src/main/java/org/elasticsearch/http/HttpRequest.java
+++ b/server/src/main/java/org/elasticsearch/http/HttpRequest.java
@@ -28,6 +28,11 @@ public interface HttpRequest extends HttpPreRequest {
         HTTP_1_1
     }
 
+    /** Returns the URI scheme for this request: either {@code "http"} or {@code "https"}. */
+    default String getScheme() {
+        return "http";
+    }
+
     HttpBody body();
 
     void setBody(HttpBody body);

--- a/server/src/main/java/org/elasticsearch/rest/RestController.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestController.java
@@ -26,7 +26,6 @@ import org.elasticsearch.common.io.stream.BytesStream;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.path.PathTrie;
 import org.elasticsearch.common.recycler.Recycler;
-import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasable;
@@ -43,8 +42,8 @@ import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.rest.RestHandler.Route;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.telemetry.TelemetryProvider;
+import org.elasticsearch.telemetry.instrumentation.HttpServerInstrumentation;
 import org.elasticsearch.telemetry.metric.LongCounter;
-import org.elasticsearch.telemetry.tracing.Tracer;
 import org.elasticsearch.transport.Transports;
 import org.elasticsearch.usage.SearchUsageHolder;
 import org.elasticsearch.usage.UsageService;
@@ -59,9 +58,7 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -116,7 +113,7 @@ public class RestController implements HttpServerTransport.Dispatcher {
     private final CircuitBreakerService circuitBreakerService;
 
     private final UsageService usageService;
-    private final Tracer tracer;
+    private final HttpServerInstrumentation instrumentation;
     private final LongCounter requestsCounter;
     // If true, the ServerlessScope annotations will be enforced
     private final ServerlessApiProtections apiProtections;
@@ -131,7 +128,7 @@ public class RestController implements HttpServerTransport.Dispatcher {
         TelemetryProvider telemetryProvider
     ) {
         this.usageService = usageService;
-        this.tracer = telemetryProvider.getTracer();
+        this.instrumentation = telemetryProvider.getHttpServerInstrumentation();
         this.requestsCounter = telemetryProvider.getMeterRegistry()
             .registerLongCounter(METRIC_REQUESTS_TOTAL, "The total number of rest requests/responses processed", "unit");
         if (restInterceptor == null) {
@@ -545,59 +542,14 @@ public class RestController implements HttpServerTransport.Dispatcher {
     }
 
     private void startTrace(ThreadContext threadContext, RestChannel channel, String restPath) {
-        final RestRequest req = channel.request();
         if (restPath == null) {
-            restPath = req.path();
+            restPath = channel.request().path();
         }
-        String method = null;
-        try {
-            method = req.method().name();
-        } catch (IllegalArgumentException e) {
-            // Invalid methods throw an exception
-        }
-        String name;
-        if (method != null) {
-            name = method + " " + restPath;
-        } else {
-            name = restPath;
-        }
-
-        final Map<String, Object> attributes = Maps.newMapWithExpectedSize(req.getHeaders().size() + 3);
-        req.getHeaders().forEach((key, values) -> {
-            final String lowerKey = key.toLowerCase(Locale.ROOT).replace('-', '_');
-            attributes.put("http.request.headers." + lowerKey, values == null ? "" : String.join("; ", values));
-        });
-        String resolvedMethod = Objects.requireNonNullElse(method, "<unknown>");
-        String resolvedUri = Objects.requireNonNullElse(req.uri(), "<unknown>");
-        attributes.put("http.method", resolvedMethod);
-        // OTel HTTP server SemConv (https://opentelemetry.io/docs/specs/semconv/http/http-spans/):
-        // http.request.method MUST be "_OTHER" for methods unknown to the instrumentation.
-        attributes.put("http.request.method", method != null ? method : "_OTHER");
-        attributes.put("http.url", resolvedUri);
-        attributes.put("url.full", resolvedUri);
-        int queryIdx = resolvedUri.indexOf('?');
-        if (queryIdx >= 0) {
-            attributes.put("url.path", resolvedUri.substring(0, queryIdx));
-            attributes.put("url.query", resolvedUri.substring(queryIdx + 1));
-        } else {
-            attributes.put("url.path", resolvedUri);
-        }
-        switch (req.getHttpRequest().protocolVersion()) {
-            case HTTP_1_0 -> {
-                attributes.put("http.flavour", "1.0");
-                attributes.put("network.protocol.version", "1.0");
-            }
-            case HTTP_1_1 -> {
-                attributes.put("http.flavour", "1.1");
-                attributes.put("network.protocol.version", "1.1");
-            }
-        }
-
-        tracer.startTrace(threadContext, channel.request(), name, attributes);
+        instrumentation.start(threadContext, channel.request(), restPath);
     }
 
     private void traceException(RestChannel channel, Throwable e) {
-        this.tracer.addError(channel.request(), e);
+        instrumentation.recordException(channel.request(), e);
     }
 
     private static void sendContentTypeErrorMessage(@Nullable List<String> contentTypeHeader, RestChannel channel) throws IOException {

--- a/server/src/main/java/org/elasticsearch/telemetry/TelemetryProvider.java
+++ b/server/src/main/java/org/elasticsearch/telemetry/TelemetryProvider.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.telemetry;
 
+import org.elasticsearch.telemetry.instrumentation.HttpServerInstrumentation;
 import org.elasticsearch.telemetry.metric.MeterRegistry;
 import org.elasticsearch.telemetry.tracing.Tracer;
 
@@ -26,6 +27,16 @@ public interface TelemetryProvider {
     Tracer getTracer();
 
     MeterRegistry getMeterRegistry();
+
+    /**
+     * Returns the {@link HttpServerInstrumentation} for tracing REST request spans.
+     * The default implementation returns {@link HttpServerInstrumentation#NOOP}, which is a safe
+     * no-op suitable for environments without tracing. Implementations that enable tracing
+     * should override this to return a live implementation.
+     */
+    default HttpServerInstrumentation getHttpServerInstrumentation() {
+        return HttpServerInstrumentation.NOOP;
+    }
 
     /**
      * Ensures buffered metrics are exported. Implementations should flush the meter provider they own

--- a/server/src/main/java/org/elasticsearch/telemetry/instrumentation/HttpServerInstrumentation.java
+++ b/server/src/main/java/org/elasticsearch/telemetry/instrumentation/HttpServerInstrumentation.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.telemetry.instrumentation;
+
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.RestResponse;
+
+/**
+ * Instrumentation hook for HTTP server spans. Implementations are responsible for starting,
+ * annotating, and ending a tracing span over the lifetime of a single REST request.
+ * <p>
+ * The interface is defined entirely in ES types so that the {@code server} module remains
+ * free of any direct OpenTelemetry library dependency; attribute extraction details live
+ * in the APM module implementation.
+ * <p>
+ * {@link #NOOP} is available for environments where tracing is disabled.
+ */
+public interface HttpServerInstrumentation {
+
+    /**
+     * Called when a REST request is received and a trace span should be started.
+     *
+     * @param threadContext the current thread context (used to propagate span context)
+     * @param request       the incoming REST request
+     * @param matchedRoute  the matched route pattern (e.g. {@code "_index/_search"}), or {@code null}
+     *                      when the route is not yet known (e.g. bad-request path)
+     */
+    void start(ThreadContext threadContext, RestRequest request, String matchedRoute);
+
+    /**
+     * Called when an exception occurs during request handling. Implementations should
+     * record the error on the active span.
+     */
+    void recordException(RestRequest request, Throwable t);
+
+    /**
+     * Called when the response is sent and the span should be ended. Implementations
+     * should record response attributes (status code, response headers) and close the span.
+     */
+    void end(RestRequest request, RestResponse response);
+
+    HttpServerInstrumentation NOOP = new HttpServerInstrumentation() {
+        @Override
+        public void start(ThreadContext threadContext, RestRequest request, String matchedRoute) {}
+
+        @Override
+        public void recordException(RestRequest request, Throwable t) {}
+
+        @Override
+        public void end(RestRequest request, RestResponse response) {}
+    };
+}

--- a/server/src/main/java/org/elasticsearch/telemetry/instrumentation/HttpServerSemConvAttributes.java
+++ b/server/src/main/java/org/elasticsearch/telemetry/instrumentation/HttpServerSemConvAttributes.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.telemetry.instrumentation;
+
+import org.elasticsearch.common.network.NetworkAddress;
+import org.elasticsearch.http.HttpChannel;
+import org.elasticsearch.rest.RestRequest;
+
+import java.net.InetSocketAddress;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Stateless utilities for resolving OTel HTTP server SemConv attributes that require
+ * proxy-header awareness. The priority order follows RFC 7239 and de-facto standards:
+ * <ol>
+ *   <li>{@code Forwarded} (RFC 7239)</li>
+ *   <li>{@code X-Forwarded-Proto} / {@code X-Forwarded-Host} / {@code X-Forwarded-Port}</li>
+ *   <li>{@code Host} header</li>
+ *   <li>local socket address (fallback)</li>
+ * </ol>
+ * These helpers are package-visible so that {@code HttpServerInstrumentation} implementations
+ * in other modules (e.g. APM) can import and call them without duplicating the logic.
+ */
+public final class HttpServerSemConvAttributes {
+
+    private HttpServerSemConvAttributes() {}
+
+    /**
+     * Resolves {@code url.scheme} (OTel HTTP server SemConv).
+     * Checks {@code Forwarded proto=} (RFC 7239), then {@code X-Forwarded-Proto},
+     * then falls back to the transport-layer scheme from {@link org.elasticsearch.http.HttpRequest#getScheme()}.
+     *
+     * @param req       the REST request
+     * @param forwarded the first value of the {@code Forwarded} request header, or {@code null}
+     */
+    public static String extractScheme(RestRequest req, String forwarded) {
+        if (forwarded != null) {
+            final String proto = extractForwardedParam(forwarded, "proto");
+            if (proto != null) {
+                return proto.toLowerCase(Locale.ROOT);
+            }
+        }
+        final String xProto = firstHeaderValue(req, "X-Forwarded-Proto");
+        if (xProto != null && xProto.isBlank() == false) {
+            return xProto.strip().toLowerCase(Locale.ROOT);
+        }
+        return req.getHttpRequest().getScheme();
+    }
+
+    /**
+     * Resolves {@code server.address} (OTel HTTP server SemConv).
+     * Checks {@code Forwarded host=} (RFC 7239), then {@code X-Forwarded-Host},
+     * then {@code Host} header, then the local socket address.
+     *
+     * @param req         the REST request
+     * @param httpChannel the HTTP channel (used for local socket fallback); may be {@code null}
+     * @param forwarded   the first value of the {@code Forwarded} request header, or {@code null}
+     */
+    public static String extractServerAddress(RestRequest req, HttpChannel httpChannel, String forwarded) {
+        if (forwarded != null) {
+            final String host = extractForwardedParam(forwarded, "host");
+            if (host != null) {
+                final String address = splitHostPort(host)[0];
+                if (address != null) return address;
+            }
+        }
+        final String xHost = firstHeaderValue(req, "X-Forwarded-Host");
+        if (xHost != null && xHost.isBlank() == false) {
+            final String address = splitHostPort(xHost.strip())[0];
+            if (address != null) return address;
+        }
+        final String hostHeader = firstHeaderValue(req, "Host");
+        if (hostHeader != null && hostHeader.isBlank() == false) {
+            final String address = splitHostPort(hostHeader.strip())[0];
+            if (address != null) return address;
+        }
+        if (httpChannel != null) {
+            final InetSocketAddress local = httpChannel.getLocalAddress();
+            if (local != null) return NetworkAddress.format(local.getAddress());
+        }
+        return null;
+    }
+
+    /**
+     * Resolves {@code server.port} (OTel HTTP server SemConv).
+     * Checks {@code Forwarded host=} (RFC 7239), then {@code X-Forwarded-Host}/{@code X-Forwarded-Port},
+     * then the {@code Host} header, then the local socket port.
+     * <p>
+     * When an address comes from a forwarding header without a port component, no fallback to the
+     * socket port is attempted. {@code X-Forwarded-Port} is only consulted when {@code X-Forwarded-Host}
+     * is also present; a standalone {@code X-Forwarded-Port} is ignored.
+     *
+     * @param req         the REST request
+     * @param httpChannel the HTTP channel (used for local socket fallback); may be {@code null}
+     * @param forwarded   the first value of the {@code Forwarded} request header, or {@code null}
+     */
+    public static Integer extractServerPort(RestRequest req, HttpChannel httpChannel, String forwarded) {
+        if (forwarded != null) {
+            final String host = extractForwardedParam(forwarded, "host");
+            if (host != null) {
+                final String[] addrPort = splitHostPort(host);
+                if (addrPort[0] != null) return parsePortSafe(addrPort[1]);
+            }
+        }
+        final String xHost = firstHeaderValue(req, "X-Forwarded-Host");
+        if (xHost != null && xHost.isBlank() == false) {
+            final String[] addrPort = splitHostPort(xHost.strip());
+            if (addrPort[0] != null) {
+                final String xPort = firstHeaderValue(req, "X-Forwarded-Port");
+                return parsePortSafe(xPort != null ? xPort.strip() : addrPort[1]);
+            }
+        }
+        final String hostHeader = firstHeaderValue(req, "Host");
+        if (hostHeader != null && hostHeader.isBlank() == false) {
+            final String[] addrPort = splitHostPort(hostHeader.strip());
+            if (addrPort[0] != null) return parsePortSafe(addrPort[1]);
+        }
+        if (httpChannel != null) {
+            final InetSocketAddress local = httpChannel.getLocalAddress();
+            if (local != null) return local.getPort();
+        }
+        return null;
+    }
+
+    /** Returns the first value of the named request header, or {@code null} if absent. */
+    public static String firstHeaderValue(RestRequest req, String name) {
+        final List<String> values = req.getHeaders().get(name);
+        return values != null && values.isEmpty() == false ? values.get(0) : null;
+    }
+
+    /**
+     * Extracts the value of the named directive from an RFC 7239 {@code Forwarded} header value.
+     * Handles quoted values. Note: quoted values containing {@code ';'} or {@code ','} are not
+     * fully supported (the split will produce incorrect tokens).
+     */
+    public static String extractForwardedParam(String forwarded, String param) {
+        final String prefix = param + "=";
+        for (String entry : forwarded.split(",")) {
+            for (String directive : entry.split(";")) {
+                final String token = directive.strip();
+                if (token.regionMatches(true, 0, prefix, 0, prefix.length())) {
+                    String value = token.substring(prefix.length()).strip();
+                    if (value.length() > 1 && value.startsWith("\"") && value.endsWith("\"")) {
+                        value = value.substring(1, value.length() - 1);
+                    }
+                    if (value.isBlank() == false) {
+                        return value;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Splits a {@code host[:port]} token into a two-element {@code {address, port}} array.
+     * The port element may be {@code null}. Handles IPv6 bracketed addresses ({@code [::1]:8080}).
+     */
+    public static String[] splitHostPort(String hostToken) {
+        if (hostToken.startsWith("[")) {
+            final int close = hostToken.indexOf(']');
+            if (close < 0) {
+                return new String[] { hostToken, null };
+            }
+            final String address = hostToken.substring(1, close);
+            final String rest = hostToken.substring(close + 1);
+            return new String[] { address.isBlank() ? null : address, rest.startsWith(":") ? rest.substring(1) : null };
+        }
+        final int colon = hostToken.lastIndexOf(':');
+        if (colon < 0) {
+            return new String[] { hostToken.isBlank() ? null : hostToken, null };
+        }
+        final String address = hostToken.substring(0, colon);
+        return new String[] { address.isBlank() ? null : address, hostToken.substring(colon + 1) };
+    }
+
+    /**
+     * Parses a port string. Returns {@code null} if {@code portStr} is {@code null}, not a valid
+     * integer, or outside the valid port range {@code [1, 65535]}.
+     */
+    public static Integer parsePortSafe(String portStr) {
+        if (portStr == null) return null;
+        try {
+            final int port = Integer.parseInt(portStr.strip());
+            return port > 0 && port <= 65535 ? port : null;
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/http/DefaultRestChannelTests.java
+++ b/server/src/test/java/org/elasticsearch/http/DefaultRestChannelTests.java
@@ -37,7 +37,7 @@ import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestResponse;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.tasks.Task;
-import org.elasticsearch.telemetry.tracing.Tracer;
+import org.elasticsearch.telemetry.instrumentation.HttpServerInstrumentation;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.junit.annotations.TestLogging;
@@ -73,8 +73,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -87,7 +85,7 @@ public class DefaultRestChannelTests extends ESTestCase {
     private Recycler<BytesRef> bigArrays;
     private HttpChannel httpChannel;
     private HttpTracer httpTracer;
-    private Tracer tracer;
+    private HttpServerInstrumentation instrumentation;
 
     @Before
     public void setup() {
@@ -95,7 +93,7 @@ public class DefaultRestChannelTests extends ESTestCase {
         threadPool = new TestThreadPool("test");
         bigArrays = new BytesRefRecycler(new MockPageCacheRecycler(Settings.EMPTY));
         httpTracer = mock(HttpTracer.class);
-        tracer = mock(Tracer.class);
+        instrumentation = mock(HttpServerInstrumentation.class);
     }
 
     @After
@@ -177,7 +175,7 @@ public class DefaultRestChannelTests extends ESTestCase {
             threadPool.getThreadContext(),
             CorsHandler.fromSettings(settings),
             httpTracer,
-            tracer
+            instrumentation
         );
         RestResponse resp = testRestResponse();
         final String customHeader = "custom-header";
@@ -212,7 +210,7 @@ public class DefaultRestChannelTests extends ESTestCase {
             threadPool.getThreadContext(),
             CorsHandler.fromSettings(settings),
             httpTracer,
-            tracer
+            instrumentation
         );
 
         RestResponse resp = testRestResponse();
@@ -243,7 +241,7 @@ public class DefaultRestChannelTests extends ESTestCase {
             threadPool.getThreadContext(),
             CorsHandler.fromSettings(settings),
             httpTracer,
-            tracer
+            instrumentation
         );
         channel.sendResponse(testRestResponse());
 
@@ -272,7 +270,7 @@ public class DefaultRestChannelTests extends ESTestCase {
             threadPool.getThreadContext(),
             CorsHandler.fromSettings(settings),
             httpTracer,
-            tracer
+            instrumentation
         );
         final RestResponse response = new RestResponse(
             RestStatus.INTERNAL_SERVER_ERROR,
@@ -340,7 +338,7 @@ public class DefaultRestChannelTests extends ESTestCase {
             threadPool.getThreadContext(),
             CorsHandler.fromSettings(settings),
             httpTracer,
-            tracer
+            instrumentation
         );
         channel.sendResponse(testRestResponse());
         Class<ActionListener<Void>> listenerClass = (Class<ActionListener<Void>>) (Class) ActionListener.class;
@@ -372,7 +370,7 @@ public class DefaultRestChannelTests extends ESTestCase {
             threadPool.getThreadContext(),
             CorsHandler.fromSettings(Settings.EMPTY),
             httpTracer,
-            tracer
+            instrumentation
         );
         doAnswer(invocationOnMock -> {
             ActionListener<?> listener = invocationOnMock.getArgument(1);
@@ -419,7 +417,7 @@ public class DefaultRestChannelTests extends ESTestCase {
             threadPool.getThreadContext(),
             CorsHandler.fromSettings(Settings.EMPTY),
             httpTracer,
-            tracer
+            instrumentation
         );
 
         // ESTestCase#after will invoke ensureAllArraysAreReleased which will fail if the response content was not released
@@ -466,7 +464,7 @@ public class DefaultRestChannelTests extends ESTestCase {
             threadPool.getThreadContext(),
             CorsHandler.fromSettings(Settings.EMPTY),
             httpTracer,
-            tracer
+            instrumentation
         );
 
         // ESTestCase#after will invoke ensureAllArraysAreReleased which will fail if the response content was not released
@@ -499,8 +497,7 @@ public class DefaultRestChannelTests extends ESTestCase {
 
         executeRequest(Settings.EMPTY, "request-host");
 
-        verify(tracer).setAttribute(argThat(id -> id.getSpanId().startsWith("rest-")), eq("http.status_code"), eq(200L));
-        verify(tracer).stopTrace(any(RestRequest.class));
+        verify(instrumentation).end(any(RestRequest.class), any(RestResponse.class));
     }
 
     public void testHandleHeadRequest() {
@@ -515,7 +512,7 @@ public class DefaultRestChannelTests extends ESTestCase {
             threadPool.getThreadContext(),
             CorsHandler.fromSettings(Settings.EMPTY),
             httpTracer,
-            tracer
+            instrumentation
         );
         ArgumentCaptor<HttpResponse> requestCaptor = ArgumentCaptor.forClass(HttpResponse.class);
         {
@@ -598,7 +595,7 @@ public class DefaultRestChannelTests extends ESTestCase {
             threadPool.getThreadContext(),
             new CorsHandler(CorsHandler.buildConfig(Settings.EMPTY)),
             new HttpTracer(),
-            tracer
+            instrumentation
         );
 
         try (var sendingResponseMockLog = MockLog.capture(HttpTracer.class)) {
@@ -658,7 +655,7 @@ public class DefaultRestChannelTests extends ESTestCase {
             threadPool.getThreadContext(),
             new CorsHandler(CorsHandler.buildConfig(Settings.EMPTY)),
             new HttpTracer(),
-            tracer
+            instrumentation
         );
 
         try (var mockLog = MockLog.capture(HttpTracer.class)) {
@@ -721,7 +718,7 @@ public class DefaultRestChannelTests extends ESTestCase {
             threadPool.getThreadContext(),
             CorsHandler.fromSettings(Settings.EMPTY),
             new HttpTracer(),
-            tracer
+            instrumentation
         );
 
         var responseBody = new BytesArray(randomUnicodeOfLengthBetween(1, 100).getBytes(StandardCharsets.UTF_8));
@@ -830,7 +827,7 @@ public class DefaultRestChannelTests extends ESTestCase {
             threadPool.getThreadContext(),
             new CorsHandler(CorsHandler.buildConfig(settings)),
             httpTracer,
-            tracer
+            instrumentation
         );
         channel.sendResponse(testRestResponse());
 

--- a/server/src/test/java/org/elasticsearch/rest/RestControllerTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/RestControllerTests.java
@@ -41,6 +41,7 @@ import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
 import org.elasticsearch.rest.RestHandler.Route;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.telemetry.TelemetryProvider;
+import org.elasticsearch.telemetry.instrumentation.HttpServerInstrumentation;
 import org.elasticsearch.telemetry.metric.LongCounter;
 import org.elasticsearch.telemetry.metric.MeterRegistry;
 import org.elasticsearch.telemetry.tracing.Tracer;
@@ -84,7 +85,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.clearInvocations;
@@ -104,6 +104,7 @@ public class RestControllerTests extends ESTestCase {
     private TestThreadPool threadPool;
     private NodeClient client;
     private Tracer tracer;
+    private HttpServerInstrumentation instrumentation;
     private LongCounter requestsCounter;
     private TelemetryProvider telemetryProvider;
     private List<RestRequest.Method> methodList;
@@ -128,10 +129,12 @@ public class RestControllerTests extends ESTestCase {
         threadPool = createThreadPool();
         client = new NoOpNodeClient(threadPool);
         tracer = mock(Tracer.class);
+        instrumentation = mock(HttpServerInstrumentation.class);
         requestsCounter = mock(LongCounter.class);
         telemetryProvider = mock(TelemetryProvider.class);
         var mockMeterRegister = mock(MeterRegistry.class);
         when(telemetryProvider.getTracer()).thenReturn(tracer);
+        when(telemetryProvider.getHttpServerInstrumentation()).thenReturn(instrumentation);
         when(telemetryProvider.getMeterRegistry()).thenReturn(mockMeterRegister);
         when(mockMeterRegister.registerLongCounter(eq(RestController.METRIC_REQUESTS_TOTAL), anyString(), anyString())).thenReturn(
             requestsCounter
@@ -316,29 +319,7 @@ public class RestControllerTests extends ESTestCase {
         });
         AssertingChannel channel = new AssertingChannel(fakeRequest, randomBoolean(), RestStatus.BAD_REQUEST);
         restController.dispatchRequest(fakeRequest, channel, threadContext);
-        verify(tracer).startTrace(
-            eq(threadContext),
-            eq(channel.request()),
-            eq("GET /"),
-            eq(
-                Map.of(
-                    "http.method",
-                    "GET",
-                    "http.request.method",
-                    "GET",
-                    "http.flavour",
-                    "1.1",
-                    "network.protocol.version",
-                    "1.1",
-                    "http.url",
-                    "/",
-                    "url.full",
-                    "/",
-                    "url.path",
-                    "/"
-                )
-            )
-        );
+        verify(instrumentation).start(eq(threadContext), eq(channel.request()), eq("/"));
     }
 
     public void testRequestWithDisallowedMultiValuedHeaderButSameValues() {
@@ -971,8 +952,8 @@ public class RestControllerTests extends ESTestCase {
 
         final AssertingChannel channel = new AssertingChannel(request, randomBoolean(), RestStatus.METHOD_NOT_ALLOWED);
         restController.dispatchRequest(request, channel, client.threadPool().getThreadContext());
-        verify(tracer).startTrace(any(), any(RestRequest.class), anyString(), anyMap());
-        verify(tracer).addError(any(RestRequest.class), any(IllegalArgumentException.class));
+        verify(instrumentation).start(any(), any(RestRequest.class), anyString());
+        verify(instrumentation).recordException(any(RestRequest.class), any(IllegalArgumentException.class));
     }
 
     public void testDispatchCompatibleHandler() {

--- a/server/src/test/java/org/elasticsearch/telemetry/instrumentation/HttpServerSemConvAttributesTests.java
+++ b/server/src/test/java/org/elasticsearch/telemetry/instrumentation/HttpServerSemConvAttributesTests.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.telemetry.instrumentation;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.http.HttpChannel;
+import org.elasticsearch.http.HttpResponse;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.rest.FakeRestRequest;
+
+import java.net.InetSocketAddress;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+public class HttpServerSemConvAttributesTests extends ESTestCase {
+
+    // ---- parsePortSafe ----
+
+    public void testParsePortSafe_validPorts() {
+        assertThat(HttpServerSemConvAttributes.parsePortSafe("1"), equalTo(1));
+        assertThat(HttpServerSemConvAttributes.parsePortSafe("80"), equalTo(80));
+        assertThat(HttpServerSemConvAttributes.parsePortSafe("65535"), equalTo(65535));
+    }
+
+    public void testParsePortSafe_invalidPorts() {
+        assertThat(HttpServerSemConvAttributes.parsePortSafe(null), nullValue());
+        assertThat(HttpServerSemConvAttributes.parsePortSafe("0"), nullValue());
+        assertThat(HttpServerSemConvAttributes.parsePortSafe("65536"), nullValue());
+        assertThat(HttpServerSemConvAttributes.parsePortSafe("-1"), nullValue());
+        assertThat(HttpServerSemConvAttributes.parsePortSafe("abc"), nullValue());
+        assertThat(HttpServerSemConvAttributes.parsePortSafe(""), nullValue());
+    }
+
+    public void testParsePortSafe_stripsWhitespace() {
+        assertThat(HttpServerSemConvAttributes.parsePortSafe("  8080  "), equalTo(8080));
+    }
+
+    // ---- splitHostPort ----
+
+    public void testSplitHostPort_plainHost() {
+        String[] result = HttpServerSemConvAttributes.splitHostPort("example.com");
+        assertThat(result[0], equalTo("example.com"));
+        assertThat(result[1], nullValue());
+    }
+
+    public void testSplitHostPort_hostWithPort() {
+        String[] result = HttpServerSemConvAttributes.splitHostPort("example.com:8080");
+        assertThat(result[0], equalTo("example.com"));
+        assertThat(result[1], equalTo("8080"));
+    }
+
+    public void testSplitHostPort_ipv4WithPort() {
+        String[] result = HttpServerSemConvAttributes.splitHostPort("192.168.1.1:443");
+        assertThat(result[0], equalTo("192.168.1.1"));
+        assertThat(result[1], equalTo("443"));
+    }
+
+    public void testSplitHostPort_ipv6Bracketed() {
+        String[] result = HttpServerSemConvAttributes.splitHostPort("[::1]");
+        assertThat(result[0], equalTo("::1"));
+        assertThat(result[1], nullValue());
+    }
+
+    public void testSplitHostPort_ipv6BracketedWithPort() {
+        String[] result = HttpServerSemConvAttributes.splitHostPort("[::1]:8080");
+        assertThat(result[0], equalTo("::1"));
+        assertThat(result[1], equalTo("8080"));
+    }
+
+    // ---- extractForwardedParam ----
+
+    public void testExtractForwardedParam_simpleProto() {
+        assertThat(HttpServerSemConvAttributes.extractForwardedParam("proto=https", "proto"), equalTo("https"));
+    }
+
+    public void testExtractForwardedParam_quotedValue() {
+        assertThat(HttpServerSemConvAttributes.extractForwardedParam("proto=\"https\"", "proto"), equalTo("https"));
+    }
+
+    public void testExtractForwardedParam_multipleParams() {
+        assertThat(HttpServerSemConvAttributes.extractForwardedParam("host=proxy.example.com;proto=https", "proto"), equalTo("https"));
+        assertThat(
+            HttpServerSemConvAttributes.extractForwardedParam("host=proxy.example.com;proto=https", "host"),
+            equalTo("proxy.example.com")
+        );
+    }
+
+    public void testExtractForwardedParam_missingParam() {
+        assertThat(HttpServerSemConvAttributes.extractForwardedParam("host=proxy.example.com", "proto"), nullValue());
+    }
+
+    public void testExtractForwardedParam_caseInsensitive() {
+        assertThat(HttpServerSemConvAttributes.extractForwardedParam("Proto=https", "proto"), equalTo("https"));
+    }
+
+    // ---- extractScheme ----
+
+    public void testExtractScheme_fromForwardedProto() {
+        FakeRestRequest req = requestWithHeaders(Map.of("Forwarded", List.of("proto=https"), "X-Forwarded-Proto", List.of("http")));
+        assertThat(HttpServerSemConvAttributes.extractScheme(req, "proto=https"), equalTo("https"));
+    }
+
+    public void testExtractScheme_fromXForwardedProto() {
+        FakeRestRequest req = requestWithHeaders(Map.of("X-Forwarded-Proto", List.of("https")));
+        assertThat(HttpServerSemConvAttributes.extractScheme(req, null), equalTo("https"));
+    }
+
+    public void testExtractScheme_fallbackToTransportScheme() {
+        FakeRestRequest req = requestWithHeaders(Map.of());
+        // TestHttpRequest.getScheme() returns "http" by default
+        assertThat(HttpServerSemConvAttributes.extractScheme(req, null), equalTo("http"));
+    }
+
+    // ---- extractServerAddress ----
+
+    public void testExtractServerAddress_fromForwardedHost() {
+        FakeRestRequest req = requestWithHeaders(Map.of("Forwarded", List.of("host=proxy.example.com"), "Host", List.of("origin.com")));
+        String addr = HttpServerSemConvAttributes.extractServerAddress(req, null, "host=proxy.example.com");
+        assertThat(addr, equalTo("proxy.example.com"));
+    }
+
+    public void testExtractServerAddress_fromXForwardedHost() {
+        FakeRestRequest req = requestWithHeaders(Map.of("X-Forwarded-Host", List.of("proxy.example.com"), "Host", List.of("origin.com")));
+        String addr = HttpServerSemConvAttributes.extractServerAddress(req, null, null);
+        assertThat(addr, equalTo("proxy.example.com"));
+    }
+
+    public void testExtractServerAddress_fromHostHeader() {
+        FakeRestRequest req = requestWithHeaders(Map.of("Host", List.of("origin.com:9200")));
+        String addr = HttpServerSemConvAttributes.extractServerAddress(req, null, null);
+        assertThat(addr, equalTo("origin.com"));
+    }
+
+    public void testExtractServerAddress_fromLocalSocket() {
+        FakeRestRequest req = requestWithHeaders(Map.of());
+        HttpChannel channel = localAddressChannel(new InetSocketAddress("192.168.0.1", 9200));
+        String addr = HttpServerSemConvAttributes.extractServerAddress(req, channel, null);
+        assertThat(addr, equalTo("192.168.0.1"));
+    }
+
+    public void testExtractServerAddress_nullWhenNoSource() {
+        FakeRestRequest req = requestWithHeaders(Map.of());
+        String addr = HttpServerSemConvAttributes.extractServerAddress(req, null, null);
+        assertThat(addr, nullValue());
+    }
+
+    // ---- extractServerPort ----
+
+    public void testExtractServerPort_fromForwardedHostWithPort() {
+        FakeRestRequest req = requestWithHeaders(Map.of("Forwarded", List.of("host=proxy.example.com:8443")));
+        Integer port = HttpServerSemConvAttributes.extractServerPort(req, null, "host=proxy.example.com:8443");
+        assertThat(port, equalTo(8443));
+    }
+
+    public void testExtractServerPort_fromXForwardedPort() {
+        FakeRestRequest req = requestWithHeaders(
+            Map.of("X-Forwarded-Host", List.of("proxy.example.com"), "X-Forwarded-Port", List.of("8443"))
+        );
+        Integer port = HttpServerSemConvAttributes.extractServerPort(req, null, null);
+        assertThat(port, equalTo(8443));
+    }
+
+    public void testExtractServerPort_fromHostHeader() {
+        FakeRestRequest req = requestWithHeaders(Map.of("Host", List.of("origin.com:9200")));
+        Integer port = HttpServerSemConvAttributes.extractServerPort(req, null, null);
+        assertThat(port, equalTo(9200));
+    }
+
+    public void testExtractServerPort_fromLocalSocket() {
+        FakeRestRequest req = requestWithHeaders(Map.of());
+        HttpChannel channel = localAddressChannel(new InetSocketAddress("192.168.0.1", 9200));
+        Integer port = HttpServerSemConvAttributes.extractServerPort(req, channel, null);
+        assertThat(port, equalTo(9200));
+    }
+
+    public void testExtractServerPort_nullWhenNoSource() {
+        FakeRestRequest req = requestWithHeaders(Map.of());
+        Integer port = HttpServerSemConvAttributes.extractServerPort(req, null, null);
+        assertThat(port, nullValue());
+    }
+
+    // ---- helpers ----
+
+    private FakeRestRequest requestWithHeaders(Map<String, List<String>> headers) {
+        return new FakeRestRequest.Builder(xContentRegistry()).withHeaders(headers).build();
+    }
+
+    private static HttpChannel localAddressChannel(InetSocketAddress local) {
+        return new HttpChannel() {
+            @Override
+            public void sendResponse(HttpResponse response, ActionListener<Void> listener) {}
+
+            @Override
+            public InetSocketAddress getLocalAddress() {
+                return local;
+            }
+
+            @Override
+            public InetSocketAddress getRemoteAddress() {
+                return null;
+            }
+
+            @Override
+            public void addCloseListener(ActionListener<Void> listener) {}
+
+            @Override
+            public boolean isOpen() {
+                return true;
+            }
+
+            @Override
+            public void close() {}
+        };
+    }
+}

--- a/server/src/test/java/org/elasticsearch/telemetry/instrumentation/HttpServerSemConvAttributesTests.java
+++ b/server/src/test/java/org/elasticsearch/telemetry/instrumentation/HttpServerSemConvAttributesTests.java
@@ -15,7 +15,9 @@ import org.elasticsearch.http.HttpResponse;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.rest.FakeRestRequest;
 
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
 import java.util.List;
 import java.util.Map;
 
@@ -143,7 +145,7 @@ public class HttpServerSemConvAttributesTests extends ESTestCase {
 
     public void testExtractServerAddress_fromLocalSocket() {
         FakeRestRequest req = requestWithHeaders(Map.of());
-        HttpChannel channel = localAddressChannel(new InetSocketAddress("192.168.0.1", 9200));
+        HttpChannel channel = localAddressChannel(new InetSocketAddress(addr192_168_0_1(), 9200));
         String addr = HttpServerSemConvAttributes.extractServerAddress(req, channel, null);
         assertThat(addr, equalTo("192.168.0.1"));
     }
@@ -178,7 +180,7 @@ public class HttpServerSemConvAttributesTests extends ESTestCase {
 
     public void testExtractServerPort_fromLocalSocket() {
         FakeRestRequest req = requestWithHeaders(Map.of());
-        HttpChannel channel = localAddressChannel(new InetSocketAddress("192.168.0.1", 9200));
+        HttpChannel channel = localAddressChannel(new InetSocketAddress(addr192_168_0_1(), 9200));
         Integer port = HttpServerSemConvAttributes.extractServerPort(req, channel, null);
         assertThat(port, equalTo(9200));
     }
@@ -193,6 +195,14 @@ public class HttpServerSemConvAttributesTests extends ESTestCase {
 
     private FakeRestRequest requestWithHeaders(Map<String, List<String>> headers) {
         return new FakeRestRequest.Builder(xContentRegistry()).withHeaders(headers).build();
+    }
+
+    private static InetAddress addr192_168_0_1() {
+        try {
+            return InetAddress.getByAddress(new byte[] { (byte) 192, (byte) 168, (byte) 0, (byte) 1 });
+        } catch (UnknownHostException e) {
+            throw new AssertionError(e);
+        }
     }
 
     private static HttpChannel localAddressChannel(InetSocketAddress local) {


### PR DESCRIPTION
Closes #149020.

Adds the remaining OTel HTTP server SemConv attributes (`url.scheme`, `server.address`, `server.port`) to REST traces. Introduces a `HttpServerInstrumentation` interface in `server/` so `RestController` and `DefaultRestChannel` no longer have any knowledge of OTel types or attribute names, all SemConv logic lives in `modules/apm` via `APMHttpServerInstrumentation`, which uses `opentelemetry-instrumentation-api:2.26.1` for attribute computation. Proxy-header resolution (RFC 7239 `Forwarded` → `X-Forwarded-*` → `Host` → socket) is handled by a new `HttpServerSemConvAttributes` utility in `server/`. Legacy `http.*` attributes are dual-written for backward compatibility with existing APM dashboards.