### PR TITLE
ESQL: parquet reader support for legacy LZ4 codec

### DIFF
--- a/docs/changelog/149532.yaml
+++ b/docs/changelog/149532.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 149532
+summary: Parquet reader support for legacy LZ4 codec
+type: enhancement

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PlainCompressionCodecFactory.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PlainCompressionCodecFactory.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.datasource.parquet;
 
+import io.airlift.compress.MalformedInputException;
 import io.airlift.compress.lz4.Lz4Compressor;
 import io.airlift.compress.lz4.Lz4Decompressor;
 
@@ -74,6 +75,11 @@ final class PlainCompressionCodecFactory implements CompressionCodecFactory {
         dec.put(CompressionCodecName.GZIP, lazy(GzipBytesDecompressor::new));
         dec.put(CompressionCodecName.ZSTD, lazy(ZstdBytesDecompressor::new));
         dec.put(CompressionCodecName.LZ4_RAW, lazy(Lz4RawBytesDecompressor::new));
+        // Legacy Hadoop-framed LZ4 (CompressionCodecName.LZ4) is read-only — see
+        // Lz4HadoopFramedBytesDecompressor for the rationale and frame format. No matching entry
+        // is added to the compressors map: the codec is deprecated by the parquet-format spec
+        // and ES|QL must not emit it. getCompressor(LZ4) continues to throw.
+        dec.put(CompressionCodecName.LZ4, lazy(Lz4HadoopFramedBytesDecompressor::new));
         this.decompressors = dec;
 
         Map<CompressionCodecName, LazyInitializable<BytesInputCompressor, RuntimeException>> com = new EnumMap<>(
@@ -297,6 +303,219 @@ final class PlainCompressionCodecFactory implements CompressionCodecFactory {
 
         @Override
         public void release() {}
+    }
+
+    /**
+     * Legacy Hadoop-framed LZ4 decompressor — reads files written with
+     * {@link CompressionCodecName#LZ4} (the deprecated codec, distinct from {@code LZ4_RAW}).
+     *
+     * <p>This codec wraps raw LZ4 block-format payloads in Hadoop's {@code BlockCompressorStream}
+     * framing — the same framing parquet-mr embeds when it writes the legacy codec. The framing
+     * is:
+     *
+     * <pre>
+     * [outer uncompressed length: int32 big-endian]
+     *   one or more sub-blocks:
+     *     [sub-block compressed length: int32 big-endian]
+     *     [sub-block compressed bytes: raw LZ4 block format]
+     * </pre>
+     *
+     * <p>Sub-blocks accumulate until the decompressed bytes written equal the outer uncompressed
+     * length. In practice parquet-mr produces a single sub-block per column chunk page, but the
+     * Hadoop frame format permits multiple sub-blocks and this decompressor honors it.
+     *
+     * <p>The implementation strips the Hadoop frame in plain Java and delegates each sub-block to
+     * the existing aircompressor {@link Lz4Decompressor} — the same library used for
+     * {@link CompressionCodecName#LZ4_RAW}. No Hadoop dependency is required, which is the entire
+     * reason {@link PlainCompressionCodecFactory} exists: keep the ~50 MB Hadoop jar off the
+     * runtime classpath.
+     *
+     * <p>This codec is deliberately read-only. The parquet-format spec deprecated it in November
+     * 2021 in favor of {@code LZ4_RAW} (see PARQUET-2032); ES|QL accepts files written during the
+     * deprecation window (notably ClickHouse {@code FORMAT Parquet} exports from v23.3 through
+     * mid-2024, and Spark 3.0–3.4 with explicit {@code lz4} compression) but never emits the
+     * deprecated codec itself. No entry is registered in the compressors map.
+     */
+    private static class Lz4HadoopFramedBytesDecompressor implements BytesInputDecompressor {
+        private final Lz4Decompressor lz4 = new Lz4Decompressor();
+
+        @Override
+        public BytesInput decompress(BytesInput bytes, int decompressedSize) throws IOException {
+            byte[] in = bytes.toByteArray();
+            byte[] out = UninitializedArrays.newByteArray(decompressedSize);
+            decompressHadoopFramed(in, 0, in.length, out, 0, decompressedSize);
+            return BytesInput.from(out);
+        }
+
+        @Override
+        public void decompress(ByteBuffer input, int compressedSize, ByteBuffer output, int decompressedSize) throws IOException {
+            // The frame envelope and sub-block headers are parsed via ByteBuffer slicing, then each
+            // sub-block is handed to aircompressor's ByteBuffer decompress overload — preserving the
+            // direct-buffer fast path when both buffers are off-heap and avoiding any extra copy of
+            // the compressed payload regardless of buffer kind. The byte-array fallback is reserved
+            // for inputs that are neither direct nor heap-backed (rare).
+            if (input.hasArray() == false && input.isDirect() == false) {
+                decompressViaHeapCopy(this, input, compressedSize, output, decompressedSize);
+                return;
+            }
+            int origLimit = input.limit();
+            int origPos = input.position();
+            int compressedEnd = origPos + compressedSize;
+            input.limit(compressedEnd);
+            try {
+                int outWritten = 0;
+                while (outWritten < decompressedSize) {
+                    if (input.remaining() < 4) {
+                        throw new IOException("Hadoop-framed LZ4: truncated outer length header");
+                    }
+                    // Read BE int32 independently of the buffer's current byte order — the parquet
+                    // read path doesn't set order explicitly today, but defending against a caller
+                    // that does prevents silent corruption.
+                    int outerUncompressedLen = readIntBE(input);
+                    if (outerUncompressedLen <= 0) {
+                        throw new IOException("Hadoop-framed LZ4: invalid outer uncompressed length " + outerUncompressedLen);
+                    }
+                    if (outWritten + outerUncompressedLen > decompressedSize) {
+                        throw new IOException(
+                            "Hadoop-framed LZ4: outer length "
+                                + outerUncompressedLen
+                                + " at offset "
+                                + outWritten
+                                + " exceeds declared decompressed size "
+                                + decompressedSize
+                        );
+                    }
+                    int outerEnd = outWritten + outerUncompressedLen;
+                    while (outWritten < outerEnd) {
+                        if (input.remaining() < 4) {
+                            throw new IOException("Hadoop-framed LZ4: truncated sub-block length header");
+                        }
+                        int subCompressedLen = readIntBE(input);
+                        if (subCompressedLen <= 0 || subCompressedLen > input.remaining()) {
+                            throw new IOException(
+                                "Hadoop-framed LZ4: invalid sub-block compressed length "
+                                    + subCompressedLen
+                                    + " (remaining "
+                                    + input.remaining()
+                                    + ")"
+                            );
+                        }
+                        // Slice the sub-block into its own ByteBuffer view and a same-kind sliced
+                        // output view. Aircompressor consumes the entire source buffer up to its
+                        // limit and advances the output buffer position by the number of bytes
+                        // written; we then advance our cursors accordingly.
+                        int subInPos = input.position();
+                        ByteBuffer subIn = input.duplicate();
+                        subIn.position(subInPos).limit(subInPos + subCompressedLen);
+                        ByteBuffer subOut = output.duplicate();
+                        int subOutPos = output.position() + outWritten;
+                        subOut.position(subOutPos).limit(output.position() + outerEnd);
+                        try {
+                            lz4.decompress(subIn, subOut);
+                        } catch (MalformedInputException e) {
+                            throw new IOException("Hadoop-framed LZ4: malformed sub-block at output offset " + outWritten, e);
+                        }
+                        int written = subOut.position() - subOutPos;
+                        if (written <= 0) {
+                            throw new IOException("Hadoop-framed LZ4: sub-block decoded to 0 bytes");
+                        }
+                        outWritten += written;
+                        input.position(subInPos + subCompressedLen);
+                    }
+                    if (outWritten != outerEnd) {
+                        throw new IOException(
+                            "Hadoop-framed LZ4: outer block underflow, expected " + outerEnd + " uncompressed bytes, got " + outWritten
+                        );
+                    }
+                }
+                if (input.position() != compressedEnd) {
+                    throw new IOException(
+                        "Hadoop-framed LZ4: trailing bytes after frame, " + (compressedEnd - input.position()) + " bytes unconsumed"
+                    );
+                }
+                output.position(output.position() + outWritten);
+            } finally {
+                input.limit(origLimit);
+                input.position(compressedEnd);
+            }
+        }
+
+        @Override
+        public void release() {}
+
+        private void decompressHadoopFramed(byte[] in, int inOff, int inLen, byte[] out, int outOff, int outCapacity) throws IOException {
+            int inEnd = inOff + inLen;
+            int inPos = inOff;
+            int outWritten = 0;
+            while (outWritten < outCapacity) {
+                if (inEnd - inPos < 4) {
+                    throw new IOException("Hadoop-framed LZ4: truncated outer length header");
+                }
+                int outerUncompressedLen = readIntBE(in, inPos);
+                inPos += 4;
+                if (outerUncompressedLen <= 0) {
+                    throw new IOException("Hadoop-framed LZ4: invalid outer uncompressed length " + outerUncompressedLen);
+                }
+                if (outWritten + outerUncompressedLen > outCapacity) {
+                    throw new IOException(
+                        "Hadoop-framed LZ4: outer length "
+                            + outerUncompressedLen
+                            + " at offset "
+                            + outWritten
+                            + " exceeds declared decompressed size "
+                            + outCapacity
+                    );
+                }
+                int outerEnd = outWritten + outerUncompressedLen;
+                while (outWritten < outerEnd) {
+                    if (inEnd - inPos < 4) {
+                        throw new IOException("Hadoop-framed LZ4: truncated sub-block length header");
+                    }
+                    int subCompressedLen = readIntBE(in, inPos);
+                    inPos += 4;
+                    if (subCompressedLen <= 0 || subCompressedLen > inEnd - inPos) {
+                        throw new IOException(
+                            "Hadoop-framed LZ4: invalid sub-block compressed length "
+                                + subCompressedLen
+                                + " (remaining "
+                                + (inEnd - inPos)
+                                + ")"
+                        );
+                    }
+                    int written;
+                    try {
+                        written = lz4.decompress(in, inPos, subCompressedLen, out, outOff + outWritten, outerEnd - outWritten);
+                    } catch (MalformedInputException e) {
+                        throw new IOException("Hadoop-framed LZ4: malformed sub-block at output offset " + outWritten, e);
+                    }
+                    if (written <= 0) {
+                        throw new IOException("Hadoop-framed LZ4: sub-block decoded to 0 bytes");
+                    }
+                    outWritten += written;
+                    inPos += subCompressedLen;
+                }
+                if (outWritten != outerEnd) {
+                    throw new IOException(
+                        "Hadoop-framed LZ4: outer block underflow, expected " + outerEnd + " uncompressed bytes, got " + outWritten
+                    );
+                }
+            }
+            if (inPos != inEnd) {
+                throw new IOException("Hadoop-framed LZ4: trailing bytes after frame, " + (inEnd - inPos) + " bytes unconsumed");
+            }
+        }
+
+        private static int readIntBE(byte[] buf, int off) {
+            return ((buf[off] & 0xFF) << 24) | ((buf[off + 1] & 0xFF) << 16) | ((buf[off + 2] & 0xFF) << 8) | (buf[off + 3] & 0xFF);
+        }
+
+        private static int readIntBE(ByteBuffer in) {
+            int b1 = in.get() & 0xFF;
+            int b2 = in.get() & 0xFF;
+            int b3 = in.get() & 0xFF;
+            int b4 = in.get() & 0xFF;
+            return (b1 << 24) | (b2 << 16) | (b3 << 8) | b4;
+        }
     }
 
     // --------------------------------- compressors ---------------------------------

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PlainCompressionCodecFactory.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PlainCompressionCodecFactory.java
@@ -375,7 +375,12 @@ final class PlainCompressionCodecFactory implements CompressionCodecFactory {
                     if (outerUncompressedLen <= 0) {
                         throw new IOException("Hadoop-framed LZ4: invalid outer uncompressed length " + outerUncompressedLen);
                     }
-                    if (outWritten + outerUncompressedLen > decompressedSize) {
+                    // Compare against remaining space rather than adding to outWritten, so a crafted
+                    // outerUncompressedLen near Integer.MAX_VALUE cannot wrap the sum to a negative
+                    // value and bypass the bounds check. The loop guard guarantees
+                    // outWritten < decompressedSize, so (decompressedSize - outWritten) is a
+                    // non-negative int.
+                    if (outerUncompressedLen > decompressedSize - outWritten) {
                         throw new IOException(
                             "Hadoop-framed LZ4: outer length "
                                 + outerUncompressedLen
@@ -456,7 +461,8 @@ final class PlainCompressionCodecFactory implements CompressionCodecFactory {
                 if (outerUncompressedLen <= 0) {
                     throw new IOException("Hadoop-framed LZ4: invalid outer uncompressed length " + outerUncompressedLen);
                 }
-                if (outWritten + outerUncompressedLen > outCapacity) {
+                // See the ByteBuffer overload — same overflow-safe rearrangement.
+                if (outerUncompressedLen > outCapacity - outWritten) {
                     throw new IOException(
                         "Hadoop-framed LZ4: outer length "
                             + outerUncompressedLen

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/LegacyLz4HadoopFramedCodecFactory.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/LegacyLz4HadoopFramedCodecFactory.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import io.airlift.compress.lz4.Lz4Compressor;
+
+import org.apache.parquet.bytes.BytesInput;
+import org.apache.parquet.compression.CompressionCodecFactory;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+
+import java.io.IOException;
+
+/**
+ * Test-only codec factory that adds a writer for the deprecated Hadoop-framed
+ * {@link CompressionCodecName#LZ4} codec on top of {@link PlainCompressionCodecFactory}.
+ *
+ * <p>The production factory deliberately exposes the legacy LZ4 codec as read-only — see
+ * {@code PlainCompressionCodecFactory.Lz4HadoopFramedBytesDecompressor} — because the
+ * parquet-format spec deprecated the codec in November 2021 (PARQUET-2032) and ES|QL should not
+ * emit it. To exercise the reader against real legacy-LZ4 parquet files this test helper provides
+ * a compressor that produces the exact same Hadoop {@code BlockCompressorStream} framing that
+ * parquet-mr embedded when it wrote the deprecated codec, so the existing in-memory codec-sweep
+ * tests can drive the new decompressor without checking in binary fixtures.
+ *
+ * <p>The frame format produced here is the inverse of the one parsed by the reader:
+ *
+ * <pre>
+ * [outer uncompressed length: int32 big-endian]
+ *   [sub-block compressed length: int32 big-endian]
+ *   [sub-block compressed bytes: raw LZ4 block format]
+ * </pre>
+ *
+ * <p>This compressor emits a single sub-block per outer block — sufficient for parquet round-trip
+ * tests since column chunks are bounded per page and parquet-mr itself produced one sub-block in
+ * the overwhelming majority of legacy-LZ4 files in the wild. The decompressor still supports
+ * multi-sub-block inputs; that path is exercised directly in
+ * {@link PlainCompressionCodecFactoryTests} by hand-crafted frame bytes rather than through this
+ * helper.
+ */
+final class LegacyLz4HadoopFramedCodecFactory implements CompressionCodecFactory {
+
+    private final PlainCompressionCodecFactory delegate;
+    private final BytesInputCompressor legacyLz4Compressor;
+
+    LegacyLz4HadoopFramedCodecFactory() {
+        this.delegate = new PlainCompressionCodecFactory();
+        this.legacyLz4Compressor = new HadoopFramedLz4Compressor();
+    }
+
+    @Override
+    public BytesInputDecompressor getDecompressor(CompressionCodecName codecName) {
+        return delegate.getDecompressor(codecName);
+    }
+
+    @Override
+    public BytesInputCompressor getCompressor(CompressionCodecName codecName) {
+        if (codecName == CompressionCodecName.LZ4) {
+            return legacyLz4Compressor;
+        }
+        return delegate.getCompressor(codecName);
+    }
+
+    @Override
+    public void release() {
+        delegate.release();
+    }
+
+    /**
+     * Test-only writer that mirrors Hadoop's {@code BlockCompressorStream} single-sub-block frame.
+     * Production code intentionally never emits this format.
+     */
+    private static final class HadoopFramedLz4Compressor implements BytesInputCompressor {
+        private final Lz4Compressor lz4 = new Lz4Compressor();
+
+        @Override
+        public BytesInput compress(BytesInput bytes) throws IOException {
+            byte[] in = bytes.toByteArray();
+            int uncompressedLen = in.length;
+            byte[] rawCompressed = new byte[lz4.maxCompressedLength(uncompressedLen)];
+            int compressedLen = lz4.compress(in, 0, uncompressedLen, rawCompressed, 0, rawCompressed.length);
+
+            byte[] framed = new byte[4 + 4 + compressedLen];
+            writeIntBE(framed, 0, uncompressedLen);
+            writeIntBE(framed, 4, compressedLen);
+            System.arraycopy(rawCompressed, 0, framed, 8, compressedLen);
+            return BytesInput.from(framed);
+        }
+
+        @Override
+        public CompressionCodecName getCodecName() {
+            return CompressionCodecName.LZ4;
+        }
+
+        @Override
+        public void release() {}
+
+        private static void writeIntBE(byte[] buf, int off, int v) {
+            buf[off] = (byte) (v >>> 24);
+            buf[off + 1] = (byte) (v >>> 16);
+            buf[off + 2] = (byte) (v >>> 8);
+            buf[off + 3] = (byte) v;
+        }
+    }
+}

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/LegacyLz4HadoopFramedCodecFactory.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/LegacyLz4HadoopFramedCodecFactory.java
@@ -41,6 +41,14 @@ import java.io.IOException;
  * multi-sub-block inputs; that path is exercised directly in
  * {@link PlainCompressionCodecFactoryTests} by hand-crafted frame bytes rather than through this
  * helper.
+ *
+ * <p>The tests deliberately avoid checking in a binary {@code .parquet} fixture. A static fixture
+ * would be opaque on failure, awkward to extend across the V1/V2 × nullable × layout matrix, and
+ * brittle to maintain. The framing here is a direct line-for-line transcription of Hadoop's
+ * {@code BlockCompressorStream.compress} (BE int32 outer length + BE int32 sub-block length + raw
+ * LZ4 block), and the BE encoding is independently re-verified in
+ * {@link PlainCompressionCodecFactoryTests} via two other writers — {@code ByteBuffer.putInt} and
+ * hand-typed byte literals — that all decode correctly through the same production decompressor.
  */
 final class LegacyLz4HadoopFramedCodecFactory implements CompressionCodecFactory {
 
@@ -50,6 +58,15 @@ final class LegacyLz4HadoopFramedCodecFactory implements CompressionCodecFactory
     LegacyLz4HadoopFramedCodecFactory() {
         this.delegate = new PlainCompressionCodecFactory();
         this.legacyLz4Compressor = new HadoopFramedLz4Compressor();
+    }
+
+    /**
+     * Returns the codec factory that parquet writers should use to produce a fixture for the
+     * given {@code codec}. Centralizes the “LZ4 needs the test compressor, everything else uses
+     * production” decision so the parameterized test classes do not each carry their own copy.
+     */
+    static CompressionCodecFactory forCodec(CompressionCodecName codec) {
+        return codec == CompressionCodecName.LZ4 ? new LegacyLz4HadoopFramedCodecFactory() : new PlainCompressionCodecFactory();
     }
 
     @Override

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedReaderFileVariantTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedReaderFileVariantTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.datasource.parquet;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.apache.parquet.column.ParquetProperties.WriterVersion;
+import org.apache.parquet.compression.CompressionCodecFactory;
 import org.apache.parquet.conf.PlainParquetConfiguration;
 import org.apache.parquet.example.data.Group;
 import org.apache.parquet.example.data.simple.SimpleGroupFactory;
@@ -83,12 +84,17 @@ public class OptimizedReaderFileVariantTests extends ESTestCase {
     public static Iterable<Object[]> parameters() {
         List<Object[]> params = new ArrayList<>();
 
+        // CompressionCodecName.LZ4 is the deprecated Hadoop-framed codec, supported on the read
+        // path only — see Lz4HadoopFramedBytesDecompressor. The writer side is provided by
+        // LegacyLz4HadoopFramedCodecFactory in tests so the existing in-memory codec sweep covers
+        // legacy-LZ4 fixtures without checking in binary files.
         CompressionCodecName[] codecs = {
             CompressionCodecName.UNCOMPRESSED,
             CompressionCodecName.SNAPPY,
             CompressionCodecName.GZIP,
             CompressionCodecName.ZSTD,
-            CompressionCodecName.LZ4_RAW };
+            CompressionCodecName.LZ4_RAW,
+            CompressionCodecName.LZ4 };
 
         // V1 retains the original RG/page-size matrix so all prior coverage stays intact.
         for (CompressionCodecName codec : codecs) {
@@ -180,7 +186,7 @@ public class OptimizedReaderFileVariantTests extends ESTestCase {
         try (
             ParquetWriter<Group> writer = ExampleParquetWriter.builder(outputFile)
                 .withConf(new PlainParquetConfiguration())
-                .withCodecFactory(new PlainCompressionCodecFactory())
+                .withCodecFactory(codecFactoryFor(codec))
                 .withType(schema)
                 .withCompressionCodec(codec)
                 .withWriterVersion(writerVersion)
@@ -277,6 +283,19 @@ public class OptimizedReaderFileVariantTests extends ESTestCase {
                 }
             }
         }
+    }
+
+    /**
+     * Returns the codec factory used to write parquet files for this variant. Production code
+     * supplies a compressor for every codec except legacy Hadoop-framed {@code LZ4}, which is
+     * intentionally read-only; the test-only {@link LegacyLz4HadoopFramedCodecFactory} provides
+     * the writer side for that codec.
+     */
+    private static CompressionCodecFactory codecFactoryFor(CompressionCodecName codec) {
+        if (codec == CompressionCodecName.LZ4) {
+            return new LegacyLz4HadoopFramedCodecFactory();
+        }
+        return new PlainCompressionCodecFactory();
     }
 
     private StorageObject createStorageObject(byte[] data) {

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedReaderFileVariantTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedReaderFileVariantTests.java
@@ -10,7 +10,6 @@ package org.elasticsearch.xpack.esql.datasource.parquet;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.apache.parquet.column.ParquetProperties.WriterVersion;
-import org.apache.parquet.compression.CompressionCodecFactory;
 import org.apache.parquet.conf.PlainParquetConfiguration;
 import org.apache.parquet.example.data.Group;
 import org.apache.parquet.example.data.simple.SimpleGroupFactory;
@@ -186,7 +185,7 @@ public class OptimizedReaderFileVariantTests extends ESTestCase {
         try (
             ParquetWriter<Group> writer = ExampleParquetWriter.builder(outputFile)
                 .withConf(new PlainParquetConfiguration())
-                .withCodecFactory(codecFactoryFor(codec))
+                .withCodecFactory(LegacyLz4HadoopFramedCodecFactory.forCodec(codec))
                 .withType(schema)
                 .withCompressionCodec(codec)
                 .withWriterVersion(writerVersion)
@@ -283,19 +282,6 @@ public class OptimizedReaderFileVariantTests extends ESTestCase {
                 }
             }
         }
-    }
-
-    /**
-     * Returns the codec factory used to write parquet files for this variant. Production code
-     * supplies a compressor for every codec except legacy Hadoop-framed {@code LZ4}, which is
-     * intentionally read-only; the test-only {@link LegacyLz4HadoopFramedCodecFactory} provides
-     * the writer side for that codec.
-     */
-    private static CompressionCodecFactory codecFactoryFor(CompressionCodecName codec) {
-        if (codec == CompressionCodecName.LZ4) {
-            return new LegacyLz4HadoopFramedCodecFactory();
-        }
-        return new PlainCompressionCodecFactory();
     }
 
     private StorageObject createStorageObject(byte[] data) {

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReaderCorrectnessTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReaderCorrectnessTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.datasource.parquet;
 
 import org.apache.lucene.util.BytesRef;
 import org.apache.parquet.column.ParquetProperties;
+import org.apache.parquet.compression.CompressionCodecFactory;
 import org.apache.parquet.conf.PlainParquetConfiguration;
 import org.apache.parquet.example.data.Group;
 import org.apache.parquet.example.data.simple.SimpleGroupFactory;
@@ -130,6 +131,10 @@ public class PageColumnReaderCorrectnessTests extends ESTestCase {
         assertReadersMatch(ParquetProperties.WriterVersion.PARQUET_1_0, CompressionCodecName.LZ4_RAW);
     }
 
+    public void testV1Lz4HadoopFramed() throws IOException {
+        assertReadersMatch(ParquetProperties.WriterVersion.PARQUET_1_0, CompressionCodecName.LZ4);
+    }
+
     public void testV2Uncompressed() throws IOException {
         assertReadersMatch(ParquetProperties.WriterVersion.PARQUET_2_0, CompressionCodecName.UNCOMPRESSED);
     }
@@ -148,6 +153,10 @@ public class PageColumnReaderCorrectnessTests extends ESTestCase {
 
     public void testV2Lz4Raw() throws IOException {
         assertReadersMatch(ParquetProperties.WriterVersion.PARQUET_2_0, CompressionCodecName.LZ4_RAW);
+    }
+
+    public void testV2Lz4HadoopFramed() throws IOException {
+        assertReadersMatch(ParquetProperties.WriterVersion.PARQUET_2_0, CompressionCodecName.LZ4);
     }
 
     // --- filterBlock tests ---
@@ -319,7 +328,8 @@ public class PageColumnReaderCorrectnessTests extends ESTestCase {
             CompressionCodecName.SNAPPY,
             CompressionCodecName.ZSTD,
             CompressionCodecName.GZIP,
-            CompressionCodecName.LZ4_RAW
+            CompressionCodecName.LZ4_RAW,
+            CompressionCodecName.LZ4
         );
 
         byte[] data = writeTestFile(version, codec, schema, numRows, (group, row) -> {
@@ -479,7 +489,7 @@ public class PageColumnReaderCorrectnessTests extends ESTestCase {
         try (
             ParquetWriter<Group> writer = ExampleParquetWriter.builder(outputFile(out))
                 .withConf(new PlainParquetConfiguration())
-                .withCodecFactory(new PlainCompressionCodecFactory())
+                .withCodecFactory(codecFactoryFor(codec))
                 .withType(schema)
                 .withWriterVersion(version)
                 .withCompressionCodec(codec)
@@ -494,6 +504,19 @@ public class PageColumnReaderCorrectnessTests extends ESTestCase {
             }
         }
         return out.toByteArray();
+    }
+
+    /**
+     * Returns the codec factory used to write parquet files for this case. Production code
+     * supplies a compressor for every codec except legacy Hadoop-framed {@code LZ4}, which is
+     * intentionally read-only; the test-only {@link LegacyLz4HadoopFramedCodecFactory} provides
+     * the writer side for that codec.
+     */
+    private static CompressionCodecFactory codecFactoryFor(CompressionCodecName codec) {
+        if (codec == CompressionCodecName.LZ4) {
+            return new LegacyLz4HadoopFramedCodecFactory();
+        }
+        return new PlainCompressionCodecFactory();
     }
 
     // --- In-memory Parquet infrastructure ---

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReaderCorrectnessTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReaderCorrectnessTests.java
@@ -106,6 +106,13 @@ public class PageColumnReaderCorrectnessTests extends ESTestCase {
     public void setUp() throws Exception {
         super.setUp();
         blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(new NoopCircuitBreaker("none")).build();
+        // Every test in this class writes to the same in-memory path ("memory://correctness_test.parquet")
+        // with a different file body. The JVM-wide FooterByteCache is keyed by (path, length) and would
+        // otherwise serve the previous test's footer when the new file happens to land on the same byte
+        // length (which testRandomSchema's seeded combinations occasionally do). Clear it before each
+        // test so every iteration reads its own footer. Other tests in this package that reuse a single
+        // path follow the same pattern (see OptimizedReaderFileVariantTests).
+        ParquetStorageObjectAdapter.clearFooterCacheForTests();
     }
 
     // --- Explicit V1/V2 x compression matrix ---
@@ -322,18 +329,13 @@ public class PageColumnReaderCorrectnessTests extends ESTestCase {
             ParquetProperties.WriterVersion.PARQUET_1_0,
             ParquetProperties.WriterVersion.PARQUET_2_0
         );
-        // Legacy Hadoop-framed LZ4 is intentionally excluded from this randomized sweep: it would
-        // shift the random sequence enough to occasionally trip a pre-existing fragility in the
-        // optimized reader's prefetched page-header path on V2 files with small page/row-group
-        // sizes (manifests as truncated PageHeader bytes that have nothing to do with LZ4). The
-        // codec is still exhaustively exercised by the explicit testV1/V2Lz4HadoopFramed methods
-        // above and by the parameterized OptimizedReaderFileVariantTests sweep.
         CompressionCodecName codec = randomFrom(
             CompressionCodecName.UNCOMPRESSED,
             CompressionCodecName.SNAPPY,
             CompressionCodecName.ZSTD,
             CompressionCodecName.GZIP,
-            CompressionCodecName.LZ4_RAW
+            CompressionCodecName.LZ4_RAW,
+            CompressionCodecName.LZ4
         );
 
         byte[] data = writeTestFile(version, codec, schema, numRows, (group, row) -> {

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReaderCorrectnessTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReaderCorrectnessTests.java
@@ -322,13 +322,18 @@ public class PageColumnReaderCorrectnessTests extends ESTestCase {
             ParquetProperties.WriterVersion.PARQUET_1_0,
             ParquetProperties.WriterVersion.PARQUET_2_0
         );
+        // Legacy Hadoop-framed LZ4 is intentionally excluded from this randomized sweep: it would
+        // shift the random sequence enough to occasionally trip a pre-existing fragility in the
+        // optimized reader's prefetched page-header path on V2 files with small page/row-group
+        // sizes (manifests as truncated PageHeader bytes that have nothing to do with LZ4). The
+        // codec is still exhaustively exercised by the explicit testV1/V2Lz4HadoopFramed methods
+        // above and by the parameterized OptimizedReaderFileVariantTests sweep.
         CompressionCodecName codec = randomFrom(
             CompressionCodecName.UNCOMPRESSED,
             CompressionCodecName.SNAPPY,
             CompressionCodecName.ZSTD,
             CompressionCodecName.GZIP,
-            CompressionCodecName.LZ4_RAW,
-            CompressionCodecName.LZ4
+            CompressionCodecName.LZ4_RAW
         );
 
         byte[] data = writeTestFile(version, codec, schema, numRows, (group, row) -> {

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReaderCorrectnessTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReaderCorrectnessTests.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.esql.datasource.parquet;
 
 import org.apache.lucene.util.BytesRef;
 import org.apache.parquet.column.ParquetProperties;
-import org.apache.parquet.compression.CompressionCodecFactory;
 import org.apache.parquet.conf.PlainParquetConfiguration;
 import org.apache.parquet.example.data.Group;
 import org.apache.parquet.example.data.simple.SimpleGroupFactory;
@@ -489,7 +488,7 @@ public class PageColumnReaderCorrectnessTests extends ESTestCase {
         try (
             ParquetWriter<Group> writer = ExampleParquetWriter.builder(outputFile(out))
                 .withConf(new PlainParquetConfiguration())
-                .withCodecFactory(codecFactoryFor(codec))
+                .withCodecFactory(LegacyLz4HadoopFramedCodecFactory.forCodec(codec))
                 .withType(schema)
                 .withWriterVersion(version)
                 .withCompressionCodec(codec)
@@ -504,19 +503,6 @@ public class PageColumnReaderCorrectnessTests extends ESTestCase {
             }
         }
         return out.toByteArray();
-    }
-
-    /**
-     * Returns the codec factory used to write parquet files for this case. Production code
-     * supplies a compressor for every codec except legacy Hadoop-framed {@code LZ4}, which is
-     * intentionally read-only; the test-only {@link LegacyLz4HadoopFramedCodecFactory} provides
-     * the writer side for that codec.
-     */
-    private static CompressionCodecFactory codecFactoryFor(CompressionCodecName codec) {
-        if (codec == CompressionCodecName.LZ4) {
-            return new LegacyLz4HadoopFramedCodecFactory();
-        }
-        return new PlainCompressionCodecFactory();
     }
 
     // --- In-memory Parquet infrastructure ---

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PlainCompressionCodecFactoryTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PlainCompressionCodecFactoryTests.java
@@ -7,6 +7,8 @@
 
 package org.elasticsearch.xpack.esql.datasource.parquet;
 
+import io.airlift.compress.lz4.Lz4Compressor;
+
 import org.apache.parquet.bytes.BytesInput;
 import org.apache.parquet.compression.CompressionCodecFactory.BytesInputCompressor;
 import org.apache.parquet.compression.CompressionCodecFactory.BytesInputDecompressor;
@@ -15,6 +17,7 @@ import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
 public class PlainCompressionCodecFactoryTests extends ESTestCase {
 
@@ -52,9 +55,222 @@ public class PlainCompressionCodecFactoryTests extends ESTestCase {
         assertRoundTrip(CompressionCodecName.LZ4_RAW);
     }
 
-    public void testLz4HadoopFramedUnsupported() {
-        expectThrows(UnsupportedOperationException.class, () -> factory.getDecompressor(CompressionCodecName.LZ4));
+    /**
+     * Round-trips a payload via a test-only Hadoop-framed LZ4 compressor and the production
+     * decompressor wired into the factory. The compressor is intentionally not part of
+     * {@link PlainCompressionCodecFactory} — legacy {@code LZ4} is read-only — but exercising the
+     * decompressor against real Hadoop-framed bytes is the only way to lock in reader correctness
+     * for customer files written during the deprecation window.
+     */
+    public void testLz4HadoopFramedRoundTrip() throws IOException {
+        LegacyLz4HadoopFramedCodecFactory writeFactory = new LegacyLz4HadoopFramedCodecFactory();
+        BytesInputCompressor compressor = writeFactory.getCompressor(CompressionCodecName.LZ4);
+        BytesInputDecompressor decompressor = factory.getDecompressor(CompressionCodecName.LZ4);
+
+        byte[] original = randomByteArrayOfLength(between(100, 4096));
+        BytesInput compressed = compressor.compress(BytesInput.from(original));
+        BytesInput decompressed = decompressor.decompress(compressed, original.length);
+        assertArrayEquals(original, decompressed.toByteArray());
+    }
+
+    /**
+     * Reader must still reject {@code getCompressor(LZ4)}: the parquet-format spec deprecated the
+     * Hadoop-framed codec and ES|QL must not emit it. Acceptance criterion of the feature.
+     */
+    public void testLz4HadoopFramedCompressorStillUnsupported() {
         expectThrows(UnsupportedOperationException.class, () -> factory.getCompressor(CompressionCodecName.LZ4));
+    }
+
+    /**
+     * Verifies the decompressor honors Hadoop's frame format when an outer block carries
+     * multiple sub-blocks. Parquet-mr in practice emits one sub-block per page, but the Hadoop
+     * frame format permits more; a writer that splits an outer block across sub-blocks must
+     * still produce a readable file. The frame bytes here are hand-crafted to force the
+     * sub-block loop in the decompressor.
+     */
+    public void testLz4HadoopFramedMultipleSubBlocks() throws IOException {
+        byte[] partA = randomByteArrayOfLength(between(64, 256));
+        byte[] partB = randomByteArrayOfLength(between(64, 256));
+        byte[] partC = randomByteArrayOfLength(between(64, 256));
+        byte[] framed = buildMultiSubBlockFrame(new byte[][] { partA, partB, partC });
+
+        BytesInputDecompressor decompressor = factory.getDecompressor(CompressionCodecName.LZ4);
+        int total = partA.length + partB.length + partC.length;
+        BytesInput decompressed = decompressor.decompress(BytesInput.from(framed), total);
+        byte[] out = decompressed.toByteArray();
+
+        byte[] expected = new byte[total];
+        System.arraycopy(partA, 0, expected, 0, partA.length);
+        System.arraycopy(partB, 0, expected, partA.length, partB.length);
+        System.arraycopy(partC, 0, expected, partA.length + partB.length, partC.length);
+        assertArrayEquals(expected, out);
+    }
+
+    public void testLz4HadoopFramedMultipleSubBlocksDirectByteBuffer() throws IOException {
+        byte[] partA = randomByteArrayOfLength(between(64, 256));
+        byte[] partB = randomByteArrayOfLength(between(64, 256));
+        byte[] framed = buildMultiSubBlockFrame(new byte[][] { partA, partB });
+
+        ByteBuffer input = ByteBuffer.allocateDirect(framed.length);
+        input.put(framed).flip();
+        int total = partA.length + partB.length;
+        ByteBuffer output = ByteBuffer.allocateDirect(total);
+
+        BytesInputDecompressor decompressor = factory.getDecompressor(CompressionCodecName.LZ4);
+        decompressor.decompress(input, framed.length, output, total);
+        output.flip();
+        byte[] result = new byte[total];
+        output.get(result);
+
+        byte[] expected = new byte[total];
+        System.arraycopy(partA, 0, expected, 0, partA.length);
+        System.arraycopy(partB, 0, expected, partA.length, partB.length);
+        assertArrayEquals(expected, result);
+    }
+
+    /**
+     * Decompressor must defend against a caller that flips the input {@link ByteBuffer} to
+     * little-endian byte order: Hadoop's frame uses BE int32 headers unconditionally, so the
+     * decompressor must read them in BE regardless of the buffer's configured order.
+     */
+    public void testLz4HadoopFramedLittleEndianBufferOrderIgnored() throws IOException {
+        LegacyLz4HadoopFramedCodecFactory writeFactory = new LegacyLz4HadoopFramedCodecFactory();
+        BytesInputCompressor compressor = writeFactory.getCompressor(CompressionCodecName.LZ4);
+        byte[] original = randomByteArrayOfLength(between(100, 4096));
+        byte[] framed = compressor.compress(BytesInput.from(original)).toByteArray();
+
+        ByteBuffer input = ByteBuffer.allocate(framed.length).order(ByteOrder.LITTLE_ENDIAN);
+        input.put(framed).flip();
+        ByteBuffer output = ByteBuffer.allocate(original.length);
+
+        BytesInputDecompressor decompressor = factory.getDecompressor(CompressionCodecName.LZ4);
+        decompressor.decompress(input, framed.length, output, original.length);
+        output.flip();
+        byte[] result = new byte[original.length];
+        output.get(result);
+        assertArrayEquals(original, result);
+    }
+
+    public void testLz4HadoopFramedTruncatedOuterHeader() {
+        BytesInputDecompressor decompressor = factory.getDecompressor(CompressionCodecName.LZ4);
+        // Two bytes is short of the four-byte outer length header.
+        byte[] truncated = new byte[] { 0x00, 0x00 };
+        IOException e = expectThrows(IOException.class, () -> decompressor.decompress(BytesInput.from(truncated), 16));
+        assertTrue(e.getMessage(), e.getMessage().contains("truncated outer length header"));
+    }
+
+    public void testLz4HadoopFramedTruncatedSubBlockHeader() {
+        BytesInputDecompressor decompressor = factory.getDecompressor(CompressionCodecName.LZ4);
+        // Outer length declares 32 bytes, but the sub-block header is truncated to two bytes.
+        byte[] framed = new byte[] { 0x00, 0x00, 0x00, 0x20, 0x00, 0x00 };
+        IOException e = expectThrows(IOException.class, () -> decompressor.decompress(BytesInput.from(framed), 32));
+        assertTrue(e.getMessage(), e.getMessage().contains("truncated sub-block length header"));
+    }
+
+    public void testLz4HadoopFramedInvalidOuterLength() {
+        BytesInputDecompressor decompressor = factory.getDecompressor(CompressionCodecName.LZ4);
+        // Outer length of 0 is rejected — Hadoop streams treat it as EOF, but parquet pages
+        // never legitimately carry an empty outer block in the middle of a frame.
+        byte[] framed = new byte[] { 0x00, 0x00, 0x00, 0x00 };
+        IOException e = expectThrows(IOException.class, () -> decompressor.decompress(BytesInput.from(framed), 16));
+        assertTrue(e.getMessage(), e.getMessage().contains("invalid outer uncompressed length"));
+    }
+
+    public void testLz4HadoopFramedInvalidSubBlockLength() {
+        BytesInputDecompressor decompressor = factory.getDecompressor(CompressionCodecName.LZ4);
+        // Outer length declares 32 bytes; sub-block declares 200 bytes of compressed data but only
+        // 4 trailing bytes follow. The decompressor must reject the over-long sub-block before
+        // handing it to aircompressor.
+        byte[] framed = new byte[] { 0x00, 0x00, 0x00, 0x20, 0x00, 0x00, 0x00, (byte) 0xC8, 0x01, 0x02, 0x03, 0x04 };
+        IOException e = expectThrows(IOException.class, () -> decompressor.decompress(BytesInput.from(framed), 32));
+        assertTrue(e.getMessage(), e.getMessage().contains("invalid sub-block compressed length"));
+    }
+
+    /**
+     * Negative-path coverage for the {@code ByteBuffer} decompress overload, which has its own
+     * frame parsing loop distinct from the {@code BytesInput} path. Truncating the outer header
+     * here ensures the buffer-cursor restoration in the finally block doesn't leak invalid state
+     * to callers on the error path.
+     */
+    public void testLz4HadoopFramedTruncatedOuterHeaderDirectByteBuffer() {
+        BytesInputDecompressor decompressor = factory.getDecompressor(CompressionCodecName.LZ4);
+        byte[] truncated = new byte[] { 0x00, 0x00 };
+        ByteBuffer input = ByteBuffer.allocateDirect(truncated.length);
+        input.put(truncated).flip();
+        ByteBuffer output = ByteBuffer.allocateDirect(16);
+        IOException e = expectThrows(IOException.class, () -> decompressor.decompress(input, truncated.length, output, 16));
+        assertTrue(e.getMessage(), e.getMessage().contains("truncated outer length header"));
+    }
+
+    public void testLz4HadoopFramedTrailingBytesRejected() throws IOException {
+        LegacyLz4HadoopFramedCodecFactory writeFactory = new LegacyLz4HadoopFramedCodecFactory();
+        BytesInputCompressor compressor = writeFactory.getCompressor(CompressionCodecName.LZ4);
+        byte[] original = randomByteArrayOfLength(between(100, 256));
+        byte[] framed = compressor.compress(BytesInput.from(original)).toByteArray();
+
+        // Append a stray byte after the legitimate frame. The reader must reject it: parquet pages
+        // are sized exactly to the compressed payload and unconsumed trailing bytes signal corruption.
+        byte[] withTrailing = new byte[framed.length + 1];
+        System.arraycopy(framed, 0, withTrailing, 0, framed.length);
+        withTrailing[framed.length] = (byte) 0xAB;
+
+        BytesInputDecompressor decompressor = factory.getDecompressor(CompressionCodecName.LZ4);
+        IOException e = expectThrows(IOException.class, () -> decompressor.decompress(BytesInput.from(withTrailing), original.length));
+        assertTrue(e.getMessage(), e.getMessage().contains("trailing bytes after frame"));
+    }
+
+    public void testDirectByteBufferDecompressionLz4HadoopFramed() throws IOException {
+        assertDirectByteBufferRoundTripWithLegacyLz4Writer();
+    }
+
+    private void assertDirectByteBufferRoundTripWithLegacyLz4Writer() throws IOException {
+        LegacyLz4HadoopFramedCodecFactory writeFactory = new LegacyLz4HadoopFramedCodecFactory();
+        BytesInputCompressor compressor = writeFactory.getCompressor(CompressionCodecName.LZ4);
+        byte[] original = randomByteArrayOfLength(between(100, 4096));
+        byte[] compressedBytes = compressor.compress(BytesInput.from(original)).toByteArray();
+
+        ByteBuffer input = ByteBuffer.allocateDirect(compressedBytes.length);
+        input.put(compressedBytes).flip();
+        ByteBuffer output = ByteBuffer.allocateDirect(original.length);
+
+        BytesInputDecompressor decompressor = factory.getDecompressor(CompressionCodecName.LZ4);
+        decompressor.decompress(input, compressedBytes.length, output, original.length);
+        output.flip();
+        byte[] result = new byte[original.length];
+        output.get(result);
+        assertArrayEquals(original, result);
+    }
+
+    /**
+     * Builds a Hadoop {@code BlockCompressorStream} frame from raw uncompressed payload parts,
+     * emitting one outer block whose declared uncompressed length covers all parts and
+     * {@code parts.length} sub-blocks back to back. Used to exercise the decompressor's
+     * sub-block loop on hand-crafted inputs that the simpler test compressor would never emit.
+     */
+    private static byte[] buildMultiSubBlockFrame(byte[][] parts) throws IOException {
+        Lz4Compressor lz4 = new Lz4Compressor();
+        int totalUncompressed = 0;
+        byte[][] compressed = new byte[parts.length][];
+        for (int i = 0; i < parts.length; i++) {
+            byte[] part = parts[i];
+            totalUncompressed += part.length;
+            byte[] buf = new byte[lz4.maxCompressedLength(part.length)];
+            int len = lz4.compress(part, 0, part.length, buf, 0, buf.length);
+            compressed[i] = new byte[len];
+            System.arraycopy(buf, 0, compressed[i], 0, len);
+        }
+        int frameLen = 4;
+        for (byte[] c : compressed) {
+            frameLen += 4 + c.length;
+        }
+        byte[] framed = new byte[frameLen];
+        ByteBuffer buf = ByteBuffer.wrap(framed); // BE by default
+        buf.putInt(totalUncompressed);
+        for (byte[] c : compressed) {
+            buf.putInt(c.length);
+            buf.put(c);
+        }
+        return framed;
     }
 
     public void testDirectByteBufferDecompressionSnappy() throws IOException {
@@ -248,6 +464,10 @@ public class PlainCompressionCodecFactoryTests extends ESTestCase {
             assertSame(factory.getDecompressor(codec), factory.getDecompressor(codec));
             assertSame(factory.getCompressor(codec), factory.getCompressor(codec));
         }
+        // Legacy LZ4 has a decompressor only, but the LazyInitializable holder must still hand
+        // out a single shared instance under contention.
+        BytesInputDecompressor legacyLz4 = factory.getDecompressor(CompressionCodecName.LZ4);
+        assertSame(legacyLz4, factory.getDecompressor(CompressionCodecName.LZ4));
     }
 
     private void assertRoundTrip(CompressionCodecName codec) throws IOException {


### PR DESCRIPTION
Add reader-side support for the deprecated Hadoop-framed LZ4 parquet
codec (`CompressionCodecName.LZ4`, distinct from `LZ4_RAW`) so files
written during the deprecation window remain queryable without
re-encoding.

Customer data written between November 2021 and mid-2024 by ClickHouse
exports and Spark 3.0-3.4 may still be on disk under the legacy codec;
ES|QL previously failed mid-query with `UnsupportedOperationException`.

The frame is parsed in plain Java (outer int32-BE length plus one or
more sub-blocks of int32-BE compressed-length plus raw LZ4 bytes) and
each sub-block is handed to the aircompressor `Lz4Decompressor` already
used for `LZ4_RAW`. No Hadoop dependency is introduced and no new
runtime artifact is added — the LZ4 library is reused from the existing
shared compression-libs plugin and remains lazily initialized.

The codec is read-only: `getCompressor(LZ4)` still throws so ES|QL never
emits the deprecated codec.

Developed with AI-assisted tooling

Closes elastic/esql-planning#677
