### PR TITLE
ESQL: anchor CSV row errors on the parser fault offset

### DIFF
--- a/docs/changelog/149533.yaml
+++ b/docs/changelog/149533.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 149533
+summary: Anchor CSV row errors on the parser fault offset
+type: enhancement

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvErrorMessages.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvErrorMessages.java
@@ -53,6 +53,64 @@ final class CsvErrorMessages {
         return value.substring(0, head) + marker + value.substring(value.length() - tail);
     }
 
+    /** Characters of context to keep before the fault offset in {@link #summarizeAround}. Small enough
+     *  that most of the {@link #MAX_EXCERPT_CHARS} budget is spent on the characters <em>at and after</em>
+     *  the fault, where the unmatched delimiter actually lives. */
+    static final int OFFSET_LOOKBACK_CHARS = 32;
+
+    /**
+     * Like {@link #summarize}, but anchored on the character index where the parser detected the
+     * fault. Short values are returned unchanged regardless of {@code offset}. Long values are
+     * reduced to a window anchored slightly before {@code offset} (see {@link #OFFSET_LOOKBACK_CHARS})
+     * and labelled with the offset and total length so the operator can locate the fault in the
+     * source file.
+     *
+     * <p>This is the right shape for parse-fault excerpts: the parser knows where it failed (the
+     * index where {@code inQuotes} or {@code bracketDepth} flipped to a state that was never
+     * closed), so we keep the characters <em>at and after</em> that index rather than a symmetric
+     * head/tail snapshot that hides the middle of long rows.
+     *
+     * <p>If {@code offset} is negative (caller does not know where the fault is) the head of the
+     * value is returned with a {@code "(truncated, N chars total)"} suffix \u2014 same shape as
+     * {@link #summarize} but without the tail, since for parse errors a head-only excerpt is the
+     * least-misleading fallback. Offsets that fall outside the multi-line gluing seam (e.g.
+     * computed against a {@code logicalLine} that joined continuations with {@code \n}) are
+     * relative to the glued logical line, not absolute file positions.
+     *
+     * @param value  the full row (or other parsed input); {@code null} maps to {@code "null"}.
+     * @param offset zero-based char index into {@code value} where the parser flagged the fault;
+     *               clamped to {@code [0, value.length()]}; negative means "unknown".
+     */
+    static String summarizeAround(String value, int offset) {
+        if (value == null) {
+            return "null";
+        }
+        if (value.length() <= MAX_EXCERPT_CHARS) {
+            return value;
+        }
+        if (offset < 0) {
+            String marker = "… (truncated, " + value.length() + " chars total)";
+            int head = Math.max(0, MAX_EXCERPT_CHARS - marker.length());
+            return value.substring(0, head) + marker;
+        }
+        int clampedOffset = Math.min(offset, value.length());
+        int start = Math.max(0, clampedOffset - OFFSET_LOOKBACK_CHARS);
+        // Always emit the offset/total annotation so operators can locate the fault in the source file,
+        // even when the window happens to start at index 0. Bracket-style ellipses match the existing
+        // marker idiom in summarize().
+        String prefix = "(offset " + clampedOffset + " of " + value.length() + " chars) ";
+        if (start > 0) {
+            prefix = "… " + prefix + "… ";
+        }
+        String suffix = "…";
+        int budget = Math.max(0, MAX_EXCERPT_CHARS - prefix.length() - suffix.length());
+        int end = Math.min(value.length(), start + budget);
+        if (end >= value.length()) {
+            suffix = "";
+        }
+        return prefix + value.substring(start, end) + suffix;
+    }
+
     /**
      * Builds a short row excerpt of the form {@code col0=[…], col1=[…], …}. Empty rows
      * (sentinel for rows that could not be tokenised) return the literal {@code "<unparsed>"}.

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
@@ -1248,6 +1248,10 @@ public class CsvFormatReader implements SegmentableFormatReader {
         StringBuilder current = new StringBuilder();
         boolean inQuotes = false;
         int bracketDepth = 0;
+        // Remember where the parser entered the unclosed state so error messages can anchor on
+        // the actual fault site instead of head/tail-truncating a long line and hiding it.
+        int quoteOpenAt = -1;
+        int bracketOpenAt = -1;
         int i = 0;
         while (i < line.length()) {
             char c = line.charAt(i);
@@ -1282,10 +1286,12 @@ public class CsvFormatReader implements SegmentableFormatReader {
                 i++;
             } else if (c == quote && (current.length() == 0 || isWhitespaceOnlyFieldPrefix(current))) {
                 inQuotes = true;
+                quoteOpenAt = i;
                 i++;
             } else if (c == '[' && (current.length() == 0 || isWhitespaceOnlyFieldPrefix(current))) {
                 if (hasMvcBracketClose(line, i)) {
                     bracketDepth = 1;
+                    bracketOpenAt = i;
                 }
                 current.append(c);
                 i++;
@@ -1303,10 +1309,12 @@ public class CsvFormatReader implements SegmentableFormatReader {
             }
         }
         if (inQuotes) {
-            throw new MalformedRowException("Unclosed quoted field in line [" + CsvErrorMessages.summarize(line) + "]");
+            throw new MalformedRowException("Unclosed quoted field in line [" + CsvErrorMessages.summarizeAround(line, quoteOpenAt) + "]");
         }
         if (bracketDepth > 0) {
-            throw new MalformedRowException("Unclosed bracket cell in line [" + CsvErrorMessages.summarize(line) + "]");
+            throw new MalformedRowException(
+                "Unclosed bracket cell in line [" + CsvErrorMessages.summarizeAround(line, bracketOpenAt) + "]"
+            );
         }
         if (current.length() > 0) {
             entries.add(current.toString().trim());

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
@@ -4661,6 +4661,166 @@ public class CsvFormatReaderTests extends ESTestCase {
         assertTrue("expected col2, got: " + summary, summary.contains("col2=[null]"));
     }
 
+    public void testCsvErrorMessagesSummarizeAroundShortValuePassesThrough() {
+        assertEquals("hello", CsvErrorMessages.summarizeAround("hello", 0));
+        assertEquals("hello", CsvErrorMessages.summarizeAround("hello", 4));
+        // Short values must pass through regardless of offset value (including negative and out-of-range).
+        assertEquals("hello", CsvErrorMessages.summarizeAround("hello", -1));
+        assertEquals("hello", CsvErrorMessages.summarizeAround("hello", 100));
+        assertEquals("null", CsvErrorMessages.summarizeAround(null, 0));
+        assertEquals("null", CsvErrorMessages.summarizeAround(null, -1));
+    }
+
+    public void testCsvErrorMessagesSummarizeAroundLongValueAnchorsOnOffset() {
+        // Build a >MAX_EXCERPT_CHARS value with a unique marker at a known offset; the window
+        // must include the marker (the actual fault) plus the offset annotation, and must start
+        // with the elided-prefix indicator because the window does not begin at index 0.
+        StringBuilder huge = new StringBuilder();
+        for (int i = 0; i < 1000; i++) {
+            huge.append('x');
+        }
+        int faultOffset = 500;
+        String marker = "FAULTHERE";
+        huge.replace(faultOffset, faultOffset + marker.length(), marker);
+        String summarized = CsvErrorMessages.summarizeAround(huge.toString(), faultOffset);
+        assertTrue(
+            "expected length <= MAX_EXCERPT_CHARS, got " + summarized.length() + ": " + summarized,
+            summarized.length() <= CsvErrorMessages.MAX_EXCERPT_CHARS
+        );
+        assertTrue(
+            "expected offset annotation, got: " + summarized,
+            summarized.contains("(offset " + faultOffset + " of " + huge.length() + " chars)")
+        );
+        assertTrue("expected fault bytes in window, got: " + summarized, summarized.contains(marker));
+        // With start > 0 the excerpt must announce the elided prefix.
+        assertTrue("expected leading ellipsis marker, got: " + summarized, summarized.startsWith("… "));
+        // The window does not reach EOL (faultOffset + budget < length) so a trailing ellipsis is required.
+        assertTrue("expected trailing ellipsis marker, got: " + summarized, summarized.endsWith("…"));
+    }
+
+    public void testCsvErrorMessagesSummarizeAroundOffsetNearStartHasNoLeadingEllipsis() {
+        // When the fault is within OFFSET_LOOKBACK_CHARS of the start, the window begins at index 0
+        // so the "… " leading marker is omitted (no characters elided before the window).
+        StringBuilder huge = new StringBuilder();
+        for (int i = 0; i < 1000; i++) {
+            huge.append('a');
+        }
+        String summarized = CsvErrorMessages.summarizeAround(huge.toString(), 5);
+        assertFalse("did not expect leading ellipsis, got: " + summarized, summarized.startsWith("… "));
+        assertTrue("expected offset annotation, got: " + summarized, summarized.contains("(offset 5 of 1000 chars)"));
+    }
+
+    public void testCsvErrorMessagesSummarizeAroundLookbackBoundary() {
+        // OFFSET_LOOKBACK_CHARS is 32: at offset 32 the window starts at index 0 (no leading marker);
+        // at offset 33 the window starts at index 1 (leading marker emitted). Pin both sides of the
+        // transition so an off-by-one in the lookback boundary is caught.
+        StringBuilder huge = new StringBuilder();
+        for (int i = 0; i < 1000; i++) {
+            huge.append('b');
+        }
+        String atBoundary = CsvErrorMessages.summarizeAround(huge.toString(), CsvErrorMessages.OFFSET_LOOKBACK_CHARS);
+        assertFalse("expected no leading ellipsis at offset == OFFSET_LOOKBACK_CHARS, got: " + atBoundary, atBoundary.startsWith("… "));
+        String pastBoundary = CsvErrorMessages.summarizeAround(huge.toString(), CsvErrorMessages.OFFSET_LOOKBACK_CHARS + 1);
+        assertTrue("expected leading ellipsis at offset == OFFSET_LOOKBACK_CHARS + 1, got: " + pastBoundary, pastBoundary.startsWith("… "));
+    }
+
+    public void testCsvErrorMessagesSummarizeAroundOffsetNearEndOmitsTrailingEllipsis() {
+        // When the window reaches end-of-string, the trailing "…" marker is dropped because
+        // nothing follows.
+        StringBuilder huge = new StringBuilder();
+        for (int i = 0; i < 1000; i++) {
+            huge.append('z');
+        }
+        String summarized = CsvErrorMessages.summarizeAround(huge.toString(), 990);
+        assertFalse("did not expect trailing ellipsis, got: " + summarized, summarized.endsWith("…"));
+        // The final char of the underlying value must therefore be the final char of the excerpt.
+        assertTrue("expected excerpt to end with the last char of value, got: " + summarized, summarized.endsWith("z"));
+    }
+
+    public void testCsvErrorMessagesSummarizeAroundUnknownOffsetFallsBackToHead() {
+        StringBuilder huge = new StringBuilder();
+        for (int i = 0; i < 5000; i++) {
+            huge.append('x');
+        }
+        String summarized = CsvErrorMessages.summarizeAround(huge.toString(), -1);
+        assertTrue(
+            "expected length <= MAX_EXCERPT_CHARS, got " + summarized.length(),
+            summarized.length() <= CsvErrorMessages.MAX_EXCERPT_CHARS
+        );
+        assertTrue("expected truncated marker, got: " + summarized, summarized.contains("truncated"));
+        assertTrue("expected total-length marker, got: " + summarized, summarized.contains("5000"));
+        // The unknown-offset branch must not synthesize a fake offset annotation; assert the
+        // anchored path was not taken.
+        assertFalse("did not expect '(offset' in fallback, got: " + summarized, summarized.contains("(offset"));
+        // Excerpt must come from the head of the value.
+        assertTrue("expected excerpt to start at index 0, got: " + summarized, summarized.startsWith("x"));
+    }
+
+    public void testCsvErrorMessagesSummarizeAroundPathologicalInputStaysBounded() {
+        // 100 KB input must not bloat the error message AND the offset annotation must survive,
+        // since that is the operator's only handle into the source file.
+        StringBuilder huge = new StringBuilder();
+        for (int i = 0; i < 100_000; i++) {
+            huge.append('q');
+        }
+        String marker = "FAULTHERE";
+        int faultOffset = 50_000;
+        huge.replace(faultOffset, faultOffset + marker.length(), marker);
+        String summarized = CsvErrorMessages.summarizeAround(huge.toString(), faultOffset);
+        assertTrue(
+            "expected length <= MAX_EXCERPT_CHARS, got " + summarized.length(),
+            summarized.length() <= CsvErrorMessages.MAX_EXCERPT_CHARS
+        );
+        assertTrue("expected offset annotation, got: " + summarized, summarized.contains("(offset " + faultOffset + " of 100000 chars)"));
+        assertTrue("expected fault bytes in window, got: " + summarized, summarized.contains(marker));
+    }
+
+    /**
+     * End-to-end: an unclosed quoted field at end-of-file produces an error excerpt anchored on the
+     * opening quote, not a head/tail-truncated view of the entire row. The row is sized so the
+     * opening quote sits well inside the elided middle of the legacy head/tail summary, so a
+     * regression that re-routes to {@link CsvErrorMessages#summarize} would hide the fault bytes.
+     */
+    public void testMalformedRowErrorAnchorsOnQuoteOffset() {
+        // Pad both sides of the unmatched quote so the line is much longer than MAX_EXCERPT_CHARS
+        // AND the fault sits in the middle of the line — where head/tail truncation hides it.
+        StringBuilder padHead = new StringBuilder();
+        for (int i = 0; i < 400; i++) {
+            padHead.append('h');
+        }
+        // Trailing padding (still inside the unclosed quoted field) so the line is ~1000 chars and the
+        // legacy head/tail summary would NOT include the opening quote in either window.
+        StringBuilder padTail = new StringBuilder();
+        for (int i = 0; i < 400; i++) {
+            padTail.append('t');
+        }
+        String row = "1," + padHead + ",\"unterminated_field_here_" + padTail;
+        int expectedOffset = "1,".length() + padHead.length() + ",".length();
+
+        String csv = "id:long,name:keyword\n" + row;
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+
+        ParsingException e = expectThrows(ParsingException.class, () -> {
+            try (
+                CloseableIterator<Page> iterator = reader.read(
+                    object,
+                    FormatReadContext.builder().batchSize(10).errorPolicy(ErrorPolicy.STRICT).build()
+                )
+            ) {
+                while (iterator.hasNext()) {
+                    iterator.next().releaseBlocks();
+                }
+            }
+        });
+        String msg = e.getMessage();
+        assertTrue("expected Unclosed quoted field, got: " + msg, msg.contains("Unclosed quoted field"));
+        assertTrue("expected offset annotation, got: " + msg, msg.contains("(offset " + expectedOffset + " of "));
+        // The unique fault marker sits at the elided middle for legacy head/tail; with offset
+        // anchoring it must survive in the excerpt.
+        assertTrue("expected fault bytes in excerpt, got: " + msg, msg.contains("\"unterminated_field_here_"));
+    }
+
     // --- FormatReadContext.readSchema() honor tests ---
     // These tests prove the runtime CSV reader uses the planner-resolved read schema (passed via
     // FormatReadContext.readSchema()) as the authoritative positional column layout, overriding


### PR DESCRIPTION
## Why

Operators investigating CSV parse failures on long rows (1KB+, common in
ClickBench-style data) currently see error messages whose row excerpt is
head/tail-truncated at 256 characters. The middle of the row — which is
exactly where the offending unmatched quote/bracket sits — is hidden, so
the message tells them a row failed but not where in the row.

## What changed

The CSV parser already knows where the fault is: the index where
`inQuotes` flipped, or where `bracketDepth` went 0→1, never came back to
balance. This change records that index and a new
`CsvErrorMessages.summarizeAround(value, offset)` helper builds the
excerpt as a window anchored slightly before the fault, annotated with
`(offset N of M chars)`. Same 256-character budget as before — no
response/log bloat — but the offending character and the bytes that
follow it stay visible, and operators get an offset they can jump to in
the source file.

Closes elastic/esql-planning#682.

Developed with AI-assisted tooling