### PR TITLE
ESQL: nullable defaults for ORC and Parquet attributes

### DIFF
--- a/docs/changelog/149541.yaml
+++ b/docs/changelog/149541.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 149541
+summary: Nullable defaults for ORC and Parquet attributes
+type: bug

--- a/x-pack/plugin/esql-datasource-grpc/src/main/java/org/elasticsearch/xpack/esql/datasource/grpc/FlightTypeMapping.java
+++ b/x-pack/plugin/esql-datasource-grpc/src/main/java/org/elasticsearch/xpack/esql/datasource/grpc/FlightTypeMapping.java
@@ -14,6 +14,7 @@ import org.apache.arrow.vector.types.pojo.Schema;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.datasources.arrow.ArrowToEsql;
@@ -30,6 +31,12 @@ final class FlightTypeMapping {
 
     private FlightTypeMapping() {}
 
+    /**
+     * Convert an Arrow schema into ES|QL attributes, honoring Arrow's field-level nullability flag. Defaulting to
+     * non-nullable (as the 3-arg {@link ReferenceAttribute} constructor does) would mislead planner rules
+     * (e.g. {@code COALESCE} simplification, {@code IS NULL}/{@code IS NOT NULL} rewriting) into dropping legitimate
+     * null rows for nullable Arrow fields.
+     */
     static List<Attribute> toAttributes(Schema schema) {
         List<Attribute> attributes = new ArrayList<>(schema.getFields().size());
         for (Field field : schema.getFields()) {
@@ -37,7 +44,8 @@ final class FlightTypeMapping {
             if (mapping == null) {
                 throw new IllegalArgumentException("Unsupported Arrow vector type: " + field.getType());
             }
-            attributes.add(new ReferenceAttribute(Source.EMPTY, field.getName(), mapping.dataType()));
+            Nullability nullability = field.isNullable() ? Nullability.TRUE : Nullability.FALSE;
+            attributes.add(new ReferenceAttribute(Source.EMPTY, null, field.getName(), mapping.dataType(), nullability, null, false));
         }
         return attributes;
     }

--- a/x-pack/plugin/esql-datasource-grpc/src/test/java/org/elasticsearch/xpack/esql/datasource/grpc/FlightTypeMappingTests.java
+++ b/x-pack/plugin/esql-datasource-grpc/src/test/java/org/elasticsearch/xpack/esql/datasource/grpc/FlightTypeMappingTests.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.grpc;
+
+import org.apache.arrow.vector.types.FloatingPointPrecision;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Nullability;
+
+import java.util.List;
+
+public class FlightTypeMappingTests extends ESTestCase {
+
+    /**
+     * Regression: attribute nullability must reflect Arrow's per-field {@code isNullable()} flag. Defaulting to
+     * non-nullable would mislead planner rules (e.g. {@code COALESCE} simplification, {@code IS NULL}/{@code IS NOT NULL}
+     * rewriting, {@code FoldNull}) into dropping legitimate null rows for nullable Arrow fields.
+     */
+    public void testToAttributesPropagatesArrowFieldNullability() {
+        Schema schema = new Schema(
+            List.of(
+                new Field("req_id", FieldType.notNullable(new ArrowType.Int(64, true)), null),
+                new Field("opt_name", FieldType.nullable(new ArrowType.Utf8()), null),
+                new Field("req_score", FieldType.notNullable(new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)), null),
+                new Field("opt_active", FieldType.nullable(new ArrowType.Bool()), null)
+            )
+        );
+
+        List<Attribute> attributes = FlightTypeMapping.toAttributes(schema);
+        assertEquals(4, attributes.size());
+
+        assertEquals("req_id", attributes.get(0).name());
+        assertEquals(Nullability.FALSE, attributes.get(0).nullable());
+
+        assertEquals("opt_name", attributes.get(1).name());
+        assertEquals(Nullability.TRUE, attributes.get(1).nullable());
+
+        assertEquals("req_score", attributes.get(2).name());
+        assertEquals(Nullability.FALSE, attributes.get(2).nullable());
+
+        assertEquals("opt_active", attributes.get(3).name());
+        assertEquals(Nullability.TRUE, attributes.get(3).nullable());
+    }
+}

--- a/x-pack/plugin/esql-datasource-iceberg/src/main/java/org/elasticsearch/xpack/esql/datasource/iceberg/IcebergTableMetadata.java
+++ b/x-pack/plugin/esql-datasource-iceberg/src/main/java/org/elasticsearch/xpack/esql/datasource/iceberg/IcebergTableMetadata.java
@@ -10,6 +10,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -49,13 +50,23 @@ public class IcebergTableMetadata implements ExternalSourceMetadata {
         this.attributes = buildAttributes();
     }
 
+    /**
+     * Build ES|QL attributes from the Iceberg schema, honoring Iceberg's field-level optional/required marker
+     * ({@link Types.NestedField#isOptional()}). Defaulting to non-nullable (as the 3-arg {@link ReferenceAttribute}
+     * constructor does) would mislead planner rules (e.g. {@code COALESCE} simplification, {@code IS NULL}/
+     * {@code IS NOT NULL} rewriting) into dropping legitimate null rows for optional Iceberg columns.
+     * <p>
+     * Nullability is taken from the top-level column; element-level nullability inside a {@code LIST} (i.e.
+     * {@code ListType.elementIsOptional()}) is independent and not modelled at the attribute level.
+     */
     private List<Attribute> buildAttributes() {
         List<Attribute> attrs = new ArrayList<>();
         for (Types.NestedField field : schema.columns()) {
             DataType esqlType = mapIcebergTypeToEsql(field.type());
             // Skip unsupported types (MAP, STRUCT, etc.)
             if (esqlType != null && esqlType != DataType.UNSUPPORTED) {
-                attrs.add(new ReferenceAttribute(Source.EMPTY, field.name(), esqlType));
+                Nullability nullability = field.isOptional() ? Nullability.TRUE : Nullability.FALSE;
+                attrs.add(new ReferenceAttribute(Source.EMPTY, null, field.name(), esqlType, nullability, null, false));
             }
         }
         return attrs;

--- a/x-pack/plugin/esql-datasource-iceberg/src/test/java/org/elasticsearch/xpack/esql/datasource/iceberg/IcebergTableMetadataTests.java
+++ b/x-pack/plugin/esql-datasource-iceberg/src/test/java/org/elasticsearch/xpack/esql/datasource/iceberg/IcebergTableMetadataTests.java
@@ -11,6 +11,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.types.Types;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 
 import java.util.List;
@@ -279,6 +280,47 @@ public class IcebergTableMetadataTests extends ESTestCase {
         IcebergTableMetadata metadata2 = new IcebergTableMetadata("s3://bucket/table", schema, null, "parquet");
 
         assertNotEquals(metadata1, metadata2);
+    }
+
+    /**
+     * Regression: attribute nullability must reflect Iceberg's {@link Types.NestedField#isOptional()} marker.
+     * {@code required} columns are non-nullable, {@code optional} columns are nullable. A wrong default would let
+     * downstream planner rules (e.g. {@code COALESCE} simplification, {@code IS NULL}/{@code IS NOT NULL} rewriting,
+     * {@code FoldNull}) drop legitimate null rows for optional Iceberg columns. Top-level nullability also applies
+     * to {@code LIST} columns; element-level nullability is independent and not asserted here.
+     */
+    public void testAttributeNullabilityReflectsIcebergRequiredOptional() {
+        Schema schema = new Schema(
+            Types.NestedField.required(1, "req_id", Types.LongType.get()),
+            Types.NestedField.optional(2, "opt_name", Types.StringType.get()),
+            Types.NestedField.required(3, "req_score", Types.DoubleType.get()),
+            Types.NestedField.optional(4, "opt_active", Types.BooleanType.get()),
+            // List columns: top-level required/optional drives attribute nullability regardless of element nullability.
+            Types.NestedField.required(5, "req_tags", Types.ListType.ofOptional(6, Types.IntegerType.get())),
+            Types.NestedField.optional(7, "opt_tags", Types.ListType.ofRequired(8, Types.IntegerType.get()))
+        );
+        IcebergTableMetadata metadata = new IcebergTableMetadata("s3://bucket/table", schema, null, "iceberg");
+
+        List<Attribute> attributes = metadata.attributes();
+        assertEquals(6, attributes.size());
+
+        assertEquals("req_id", attributes.get(0).name());
+        assertEquals(Nullability.FALSE, attributes.get(0).nullable());
+
+        assertEquals("opt_name", attributes.get(1).name());
+        assertEquals(Nullability.TRUE, attributes.get(1).nullable());
+
+        assertEquals("req_score", attributes.get(2).name());
+        assertEquals(Nullability.FALSE, attributes.get(2).nullable());
+
+        assertEquals("opt_active", attributes.get(3).name());
+        assertEquals(Nullability.TRUE, attributes.get(3).nullable());
+
+        assertEquals("req_tags", attributes.get(4).name());
+        assertEquals(Nullability.FALSE, attributes.get(4).nullable());
+
+        assertEquals("opt_tags", attributes.get(5).name());
+        assertEquals(Nullability.TRUE, attributes.get(5).nullable());
     }
 
     public void testToString() {

--- a/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReader.java
+++ b/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReader.java
@@ -39,6 +39,7 @@ import org.elasticsearch.compute.operator.CloseableIterator;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -452,7 +453,9 @@ public class OrcFormatReader implements RangeAwareFormatReader, NoConfigFormatRe
         }
         for (String columnName : projectedColumns) {
             Attribute attr = attributeMap.get(columnName);
-            projected.add(attr != null ? attr : new ReferenceAttribute(Source.EMPTY, columnName, DataType.NULL));
+            projected.add(
+                attr != null ? attr : new ReferenceAttribute(Source.EMPTY, null, columnName, DataType.NULL, Nullability.TRUE, null, false)
+            );
         }
         return projected;
     }
@@ -554,6 +557,13 @@ public class OrcFormatReader implements RangeAwareFormatReader, NoConfigFormatRe
         // No resources to close at the reader level
     }
 
+    /**
+     * ORC's {@link TypeDescription} carries no schema-level non-null guarantee — every column is
+     * nullable at the schema level (per-file non-null observations live in footer column statistics,
+     * not in the type itself). Build attributes as {@link Nullability#TRUE} so downstream planner
+     * rules (e.g. {@code Coalesce} simplification, {@code IS NULL}/{@code IS NOT NULL} rewriting)
+     * don't drop legitimate null rows based on a wrong type-level assumption.
+     */
     private static List<Attribute> convertOrcSchemaToAttributes(TypeDescription schema) {
         List<Attribute> attributes = new ArrayList<>();
         List<String> fieldNames = schema.getFieldNames();
@@ -561,7 +571,7 @@ public class OrcFormatReader implements RangeAwareFormatReader, NoConfigFormatRe
         for (int i = 0; i < fieldNames.size(); i++) {
             String name = fieldNames.get(i);
             DataType esqlType = convertOrcTypeToEsql(children.get(i));
-            attributes.add(new ReferenceAttribute(Source.EMPTY, name, esqlType));
+            attributes.add(new ReferenceAttribute(Source.EMPTY, null, name, esqlType, Nullability.TRUE, null, false));
         }
         return attributes;
     }

--- a/x-pack/plugin/esql-datasource-orc/src/test/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-orc/src/test/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReaderTests.java
@@ -41,6 +41,7 @@ import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.RangeAwareFormatReader.SplitRange;
@@ -127,6 +128,39 @@ public class OrcFormatReaderTests extends ESTestCase {
 
         assertEquals("active", attributes.get(3).name());
         assertEquals(DataType.BOOLEAN, attributes.get(3).dataType());
+    }
+
+    /**
+     * Regression: every attribute produced from an ORC schema must be {@link Nullability#TRUE} regardless of the column shape.
+     * ORC's {@code TypeDescription} encodes no non-null guarantee at the schema level — per-file non-null observations live
+     * only in footer statistics — so defaulting attributes to non-nullable would cause planner rules (e.g. {@code COALESCE}
+     * simplification, {@code IS NULL}/{@code IS NOT NULL} rewriting) to drop legitimate null rows. The schema below covers
+     * every branch of {@code convertOrcTypeToEsql}, including the {@code UNSUPPORTED} fallback (binary).
+     */
+    public void testSchemaAttributesAreAlwaysNullable() throws Exception {
+        TypeDescription schema = TypeDescription.createStruct()
+            .addField("id", TypeDescription.createLong())
+            .addField("age", TypeDescription.createInt())
+            .addField("name", TypeDescription.createString())
+            .addField("score", TypeDescription.createDouble())
+            .addField("ratio", TypeDescription.createFloat())
+            .addField("active", TypeDescription.createBoolean())
+            .addField("created", TypeDescription.createTimestamp())
+            .addField("created_utc", TypeDescription.createTimestampInstant())
+            .addField("birth", TypeDescription.createDate())
+            .addField("price", TypeDescription.createDecimal().withPrecision(10).withScale(2))
+            .addField("payload", TypeDescription.createBinary())
+            .addField("tags", TypeDescription.createList(TypeDescription.createString()));
+
+        byte[] orcData = createOrcFile(schema, batch -> { batch.size = 0; });
+        StorageObject storageObject = createStorageObject(orcData);
+        OrcFormatReader reader = new OrcFormatReader(blockFactory);
+
+        List<Attribute> attributes = reader.metadata(storageObject).schema();
+        assertEquals(schema.getFieldNames().size(), attributes.size());
+        for (Attribute attr : attributes) {
+            assertEquals("attribute [" + attr.name() + "] should be nullable", Nullability.TRUE, attr.nullable());
+        }
     }
 
     public void testReadDataFromSimpleOrc() throws Exception {

--- a/x-pack/plugin/esql-datasource-parquet-rs/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/parquetrs/ParquetRsFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet-rs/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/parquetrs/ParquetRsFormatReader.java
@@ -44,6 +44,7 @@ import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xpack.esql.arrow.ArrowToBlockConverter;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -569,12 +570,25 @@ public class ParquetRsFormatReader implements RangeAwareFormatReader {
         try (ArrowSchema ffiSchema = ArrowSchema.allocateNew(allocator)) {
             ParquetRsBridge.getSchemaFFI(path, configJson, ffiSchema.memoryAddress());
             Schema arrowSchema = Data.importSchema(allocator, ffiSchema, null);
-            List<Attribute> attributes = new ArrayList<>(arrowSchema.getFields().size());
-            for (Field field : arrowSchema.getFields()) {
-                attributes.add(new ReferenceAttribute(Source.EMPTY, field.getName(), ArrowToEsql.dataTypeForField(field)));
-            }
-            return attributes;
+            return arrowSchemaToAttributes(arrowSchema);
         }
+    }
+
+    /**
+     * Convert an Arrow schema into ES|QL attributes, honoring Arrow's field-level nullability flag. Defaulting to
+     * non-nullable (as the 3-arg {@link ReferenceAttribute} constructor does) would mislead planner rules
+     * (e.g. {@code COALESCE} simplification, {@code IS NULL}/{@code IS NOT NULL} rewriting) into dropping legitimate
+     * null rows for nullable Arrow fields.
+     */
+    static List<Attribute> arrowSchemaToAttributes(Schema arrowSchema) {
+        List<Attribute> attributes = new ArrayList<>(arrowSchema.getFields().size());
+        for (Field field : arrowSchema.getFields()) {
+            Nullability nullability = field.isNullable() ? Nullability.TRUE : Nullability.FALSE;
+            attributes.add(
+                new ReferenceAttribute(Source.EMPTY, null, field.getName(), ArrowToEsql.dataTypeForField(field), nullability, null, false)
+            );
+        }
+        return attributes;
     }
 
     @Override

--- a/x-pack/plugin/esql-datasource-parquet-rs/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/parquetrs/ParquetRsFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet-rs/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/parquetrs/ParquetRsFormatReaderTests.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet.parquetrs;
+
+import org.apache.arrow.vector.types.FloatingPointPrecision;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Nullability;
+
+import java.util.List;
+
+public class ParquetRsFormatReaderTests extends ESTestCase {
+
+    /**
+     * Regression: when an Arrow schema is imported from native code via FFI, attribute nullability must reflect Arrow's
+     * per-field {@code isNullable()} flag. Defaulting to non-nullable would mislead planner rules (e.g. {@code COALESCE}
+     * simplification, {@code IS NULL}/{@code IS NOT NULL} rewriting, {@code FoldNull}) into dropping legitimate null
+     * rows for nullable columns.
+     */
+    public void testArrowSchemaToAttributesPropagatesNullability() {
+        Schema schema = new Schema(
+            List.of(
+                new Field("req_id", FieldType.notNullable(new ArrowType.Int(64, true)), null),
+                new Field("opt_name", FieldType.nullable(new ArrowType.Utf8()), null),
+                new Field("req_score", FieldType.notNullable(new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)), null),
+                new Field("opt_active", FieldType.nullable(new ArrowType.Bool()), null)
+            )
+        );
+
+        List<Attribute> attributes = ParquetRsFormatReader.arrowSchemaToAttributes(schema);
+        assertEquals(4, attributes.size());
+
+        assertEquals("req_id", attributes.get(0).name());
+        assertEquals(Nullability.FALSE, attributes.get(0).nullable());
+
+        assertEquals("opt_name", attributes.get(1).name());
+        assertEquals(Nullability.TRUE, attributes.get(1).nullable());
+
+        assertEquals("req_score", attributes.get(2).name());
+        assertEquals(Nullability.FALSE, attributes.get(2).nullable());
+
+        assertEquals("opt_active", attributes.get(3).name());
+        assertEquals(Nullability.TRUE, attributes.get(3).nullable());
+    }
+}

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -44,6 +44,7 @@ import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -1167,9 +1168,12 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
                 // The deferred-extraction synthetic column has no presence in the file's schema;
                 // the iterator materialises it. We must give it a real {@link DataType#LONG} so
                 // {@link #buildColumnInfos} routes it to {@link ColumnInfo#rowPosition()} instead
-                // of skipping it as an absent column.
-                DataType type = ColumnExtractor.ROW_POSITION_COLUMN.equals(columnName) ? DataType.LONG : DataType.NULL;
-                attr = new ReferenceAttribute(Source.EMPTY, columnName, type);
+                // of skipping it as an absent column. The row-position column is always materialised
+                // (non-nullable); an absent file column is always null at runtime (nullable).
+                boolean isRowPosition = ColumnExtractor.ROW_POSITION_COLUMN.equals(columnName);
+                DataType type = isRowPosition ? DataType.LONG : DataType.NULL;
+                Nullability nullability = isRowPosition ? Nullability.FALSE : Nullability.TRUE;
+                attr = new ReferenceAttribute(Source.EMPTY, null, columnName, type, nullability, null, false);
             }
             result.add(attr);
         }
@@ -1198,12 +1202,23 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
         return new MessageType(fullSchema.getName(), projectedFields);
     }
 
+    /**
+     * Derive attribute nullability from Parquet repetition: only top-level {@link Type.Repetition#REQUIRED} fields carry a
+     * schema-level non-null guarantee. Everything else ({@link Type.Repetition#OPTIONAL} and the legacy top-level
+     * {@link Type.Repetition#REPEATED}) is nullable from the planner's perspective. Note this is the cell-level guarantee
+     * for the column attribute; element-level nullability inside a {@code LIST} group is independent and not modelled here.
+     * <p>
+     * Defaulting everything to non-nullable — as the 3-arg {@link ReferenceAttribute} constructor does — would cause
+     * planner rules (e.g. {@code COALESCE} simplification, {@code IS NULL}/{@code IS NOT NULL} rewriting) to drop legitimate
+     * null rows for {@code OPTIONAL} columns.
+     */
     private List<Attribute> convertParquetSchemaToAttributes(MessageType schema) {
         List<Attribute> attributes = new ArrayList<>();
         for (Type field : schema.getFields()) {
             String name = field.getName();
             DataType esqlType = convertParquetTypeToEsql(field);
-            attributes.add(new ReferenceAttribute(Source.EMPTY, name, esqlType));
+            Nullability nullability = field.isRepetition(Type.Repetition.REQUIRED) ? Nullability.FALSE : Nullability.TRUE;
+            attributes.add(new ReferenceAttribute(Source.EMPTY, null, name, esqlType, nullability, null, false));
         }
         return attributes;
     }

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
@@ -43,6 +43,7 @@ import org.elasticsearch.compute.data.UninitializedArrays;
 import org.elasticsearch.compute.operator.CloseableIterator;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -892,6 +893,55 @@ public class ParquetFormatReaderTests extends ESTestCase {
 
             assertFalse(iterator.hasNext());
         }
+    }
+
+    /**
+     * Regression: attribute nullability must reflect Parquet repetition.
+     * <ul>
+     *   <li>{@code REQUIRED} top-level fields → {@link Nullability#FALSE} (schema-level non-null guarantee).</li>
+     *   <li>{@code OPTIONAL} fields and {@code optionalList()} → {@link Nullability#TRUE} (the cell itself can be absent).</li>
+     *   <li>Top-level {@code REPEATED} primitives (the legacy un-annotated list form) → {@link Nullability#TRUE}.</li>
+     *   <li>{@code requiredList()} → {@link Nullability#FALSE} (the list group must be present, even though its
+     *       elements can be null — element-level nullability is not modelled at the attribute level).</li>
+     * </ul>
+     * A wrong default would let downstream planner rules (e.g. {@code COALESCE} simplification, {@code IS NULL}
+     * rewriting, {@code FoldNull}) drop legitimate null rows for {@code OPTIONAL} columns.
+     */
+    public void testSchemaAttributeNullabilityReflectsRepetition() throws Exception {
+        Type requiredList = Types.requiredList().optionalElement(PrimitiveType.PrimitiveTypeName.INT32).named("required_tags");
+        Type optionalList = Types.optionalList().optionalElement(PrimitiveType.PrimitiveTypeName.INT32).named("optional_tags");
+
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("req_id")
+            .optional(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("opt_id")
+            .repeated(PrimitiveType.PrimitiveTypeName.INT32)
+            .named("rep_value")
+            .addField(requiredList)
+            .addField(optionalList)
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> List.of());
+        StorageObject storageObject = createStorageObject(parquetData);
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+
+        List<Attribute> attributes = reader.metadata(storageObject).schema();
+        assertEquals(5, attributes.size());
+
+        assertNullability(attributes, "req_id", Nullability.FALSE);
+        assertNullability(attributes, "opt_id", Nullability.TRUE);
+        assertNullability(attributes, "rep_value", Nullability.TRUE);
+        assertNullability(attributes, "required_tags", Nullability.FALSE);
+        assertNullability(attributes, "optional_tags", Nullability.TRUE);
+    }
+
+    private static void assertNullability(List<Attribute> attributes, String name, Nullability expected) {
+        Attribute attr = attributes.stream()
+            .filter(a -> a.name().equals(name))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("attribute [" + name + "] not found"));
+        assertEquals("attribute [" + name + "]", expected, attr.nullable());
     }
 
     public void testReadOptionalLongWithNulls() throws Exception {


### PR DESCRIPTION
## Why

The ORC and Parquet readers were building attributes with a `ReferenceAttribute` constructor that defaults to `Nullability.FALSE`, telling the planner every external column was schema-guaranteed non-null. This is always wrong for ORC (the schema carries no non-null guarantee) and wrong for Parquet `OPTIONAL`/`REPEATED` fields. The bad default lets downstream planner rules (`COALESCE` simplification, `IS NULL`/`IS NOT NULL` rewriting, `FoldNull`) drop or simplify away legitimate null rows for external sources, producing silently wrong results.

## What

- ORC attributes are built with `Nullability.TRUE` uniformly, including the missing-column projection fallback.
- Parquet attributes derive nullability from `field.isRepetition(REQUIRED)`: `REQUIRED` → `FALSE`, `OPTIONAL`/`REPEATED` → `TRUE`. The synthetic row-position column stays non-nullable.
- Regression tests cover every type branch in ORC and every repetition shape in Parquet (including `requiredList()`/`optionalList()`).

Developed with AI-assisted tooling

Closes elastic/esql-planning#757
