### PR TITLE
[Gradle] Support resolving BWC snapshots from DRA

### DIFF
--- a/.buildkite/packer_cache.sh
+++ b/.buildkite/packer_cache.sh
@@ -29,7 +29,7 @@ for branch in "${branches[@]}"; do
   fi
 
   export JAVA_HOME="$HOME/.java/$ES_BUILD_JAVA"
-  "checkout/${branch}/gradlew" --project-dir "$CHECKOUT_DIR" --parallel -s resolveAllDependencies -Dbwc.throttle.maxParallelUsages=1 -Dorg.gradle.warning.mode=none -DisCI --max-workers=4
+  "checkout/${branch}/gradlew" --project-dir "$CHECKOUT_DIR" --parallel -s resolveAllDependencies -Dbwc.throttle.maxParallelUsages=1 -Dorg.gradle.warning.mode=none -DisCI --max-workers=4 "$@"
   "checkout/${branch}/gradlew" --stop
   pkill -f '.*GradleDaemon.*'
   rm -rf "checkout/${branch}"

--- a/.buildkite/pipelines/intake.template.yml
+++ b/.buildkite/pipelines/intake.template.yml
@@ -60,7 +60,7 @@ steps:
   - group: bwc-snapshots
     steps:
       - label: "{{matrix.BWC_VERSION}} / bwc-snapshots"
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-file-fingerprints -Dtests.bwc.dra.enabled=true v$$BWC_VERSION#bwcTest
+        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-file-fingerprints -Dtests.bwc.mode=auto v$$BWC_VERSION#bwcTest
         timeout_in_minutes: 300
         matrix:
           setup:

--- a/.buildkite/pipelines/intake.template.yml
+++ b/.buildkite/pipelines/intake.template.yml
@@ -60,7 +60,7 @@ steps:
   - group: bwc-snapshots
     steps:
       - label: "{{matrix.BWC_VERSION}} / bwc-snapshots"
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-file-fingerprints v$$BWC_VERSION#bwcTest
+        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-file-fingerprints -Dtests.bwc.dra.enabled=true v$$BWC_VERSION#bwcTest
         timeout_in_minutes: 300
         matrix:
           setup:

--- a/.buildkite/pipelines/intake.yml
+++ b/.buildkite/pipelines/intake.yml
@@ -61,7 +61,7 @@ steps:
   - group: bwc-snapshots
     steps:
       - label: "{{matrix.BWC_VERSION}} / bwc-snapshots"
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-file-fingerprints v$$BWC_VERSION#bwcTest
+        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-file-fingerprints -Dtests.bwc.dra.enabled=true v$$BWC_VERSION#bwcTest
         timeout_in_minutes: 300
         matrix:
           setup:

--- a/.buildkite/pipelines/intake.yml
+++ b/.buildkite/pipelines/intake.yml
@@ -61,7 +61,7 @@ steps:
   - group: bwc-snapshots
     steps:
       - label: "{{matrix.BWC_VERSION}} / bwc-snapshots"
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-file-fingerprints -Dtests.bwc.dra.enabled=true v$$BWC_VERSION#bwcTest
+        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-file-fingerprints -Dtests.bwc.mode=auto v$$BWC_VERSION#bwcTest
         timeout_in_minutes: 300
         matrix:
           setup:

--- a/.buildkite/pipelines/pull-request/bwc-snapshots.yml
+++ b/.buildkite/pipelines/pull-request/bwc-snapshots.yml
@@ -8,7 +8,7 @@ steps:
     steps:
       - label: "{{matrix.BWC_VERSION}} / Part 1 / bwc-snapshots"
         key: "bwc-snapshots-part1"
-        command: .ci/scripts/run-gradle.sh -Dignore.tests.seed -Dtests.bwc.dra.enabled=true v{{matrix.BWC_VERSION}}#bwcTestPart1
+        command: .ci/scripts/run-gradle.sh -Dignore.tests.seed -Dtests.bwc.mode=auto v{{matrix.BWC_VERSION}}#bwcTestPart1
         timeout_in_minutes: 300
         matrix:
           setup:
@@ -23,7 +23,7 @@ steps:
           buildDirectory: /dev/shm/bk
       - label: "{{matrix.BWC_VERSION}} / Part 2 / bwc-snapshots"
         key: "bwc-snapshots-part2"
-        command: .ci/scripts/run-gradle.sh -Dignore.tests.seed -Dtests.bwc.dra.enabled=true v{{matrix.BWC_VERSION}}#bwcTestPart2
+        command: .ci/scripts/run-gradle.sh -Dignore.tests.seed -Dtests.bwc.mode=auto v{{matrix.BWC_VERSION}}#bwcTestPart2
         timeout_in_minutes: 300
         matrix:
           setup:
@@ -38,7 +38,7 @@ steps:
           buildDirectory: /dev/shm/bk
       - label: "{{matrix.BWC_VERSION}} / Part 3 / bwc-snapshots"
         key: "bwc-snapshots-part3"
-        command: .ci/scripts/run-gradle.sh -Dignore.tests.seed -Dtests.bwc.dra.enabled=true v{{matrix.BWC_VERSION}}#bwcTestPart3
+        command: .ci/scripts/run-gradle.sh -Dignore.tests.seed -Dtests.bwc.mode=auto v{{matrix.BWC_VERSION}}#bwcTestPart3
         timeout_in_minutes: 300
         matrix:
           setup:
@@ -53,7 +53,7 @@ steps:
           buildDirectory: /dev/shm/bk
       - label: "{{matrix.BWC_VERSION}} / Part 4 / bwc-snapshots"
         key: "bwc-snapshots-part4"
-        command: .ci/scripts/run-gradle.sh -Dignore.tests.seed -Dtests.bwc.dra.enabled=true v{{matrix.BWC_VERSION}}#bwcTestPart5
+        command: .ci/scripts/run-gradle.sh -Dignore.tests.seed -Dtests.bwc.mode=auto v{{matrix.BWC_VERSION}}#bwcTestPart5
         timeout_in_minutes: 300
         matrix:
           setup:
@@ -68,7 +68,7 @@ steps:
           buildDirectory: /dev/shm/bk
       - label: "{{matrix.BWC_VERSION}} / Part 5 / bwc-snapshots"
         key: "bwc-snapshots-part5"
-        command: .ci/scripts/run-gradle.sh -Dignore.tests.seed -Dtests.bwc.dra.enabled=true v{{matrix.BWC_VERSION}}#bwcTestPart5
+        command: .ci/scripts/run-gradle.sh -Dignore.tests.seed -Dtests.bwc.mode=auto v{{matrix.BWC_VERSION}}#bwcTestPart5
         timeout_in_minutes: 300
         matrix:
           setup:
@@ -83,7 +83,7 @@ steps:
           buildDirectory: /dev/shm/bk
       - label: "{{matrix.BWC_VERSION}} / Part 6 / bwc-snapshots"
         key: "bwc-snapshots-part6"
-        command: .ci/scripts/run-gradle.sh -Dignore.tests.seed -Dtests.bwc.dra.enabled=true v{{matrix.BWC_VERSION}}#bwcTestPart6
+        command: .ci/scripts/run-gradle.sh -Dignore.tests.seed -Dtests.bwc.mode=auto v{{matrix.BWC_VERSION}}#bwcTestPart6
         timeout_in_minutes: 300
         matrix:
           setup:

--- a/.buildkite/pipelines/pull-request/bwc-snapshots.yml
+++ b/.buildkite/pipelines/pull-request/bwc-snapshots.yml
@@ -8,7 +8,7 @@ steps:
     steps:
       - label: "{{matrix.BWC_VERSION}} / Part 1 / bwc-snapshots"
         key: "bwc-snapshots-part1"
-        command: .ci/scripts/run-gradle.sh -Dignore.tests.seed v{{matrix.BWC_VERSION}}#bwcTestPart1
+        command: .ci/scripts/run-gradle.sh -Dignore.tests.seed -Dtests.bwc.dra.enabled=true v{{matrix.BWC_VERSION}}#bwcTestPart1
         timeout_in_minutes: 300
         matrix:
           setup:
@@ -23,7 +23,7 @@ steps:
           buildDirectory: /dev/shm/bk
       - label: "{{matrix.BWC_VERSION}} / Part 2 / bwc-snapshots"
         key: "bwc-snapshots-part2"
-        command: .ci/scripts/run-gradle.sh -Dignore.tests.seed v{{matrix.BWC_VERSION}}#bwcTestPart2
+        command: .ci/scripts/run-gradle.sh -Dignore.tests.seed -Dtests.bwc.dra.enabled=true v{{matrix.BWC_VERSION}}#bwcTestPart2
         timeout_in_minutes: 300
         matrix:
           setup:
@@ -38,7 +38,7 @@ steps:
           buildDirectory: /dev/shm/bk
       - label: "{{matrix.BWC_VERSION}} / Part 3 / bwc-snapshots"
         key: "bwc-snapshots-part3"
-        command: .ci/scripts/run-gradle.sh -Dignore.tests.seed v{{matrix.BWC_VERSION}}#bwcTestPart3
+        command: .ci/scripts/run-gradle.sh -Dignore.tests.seed -Dtests.bwc.dra.enabled=true v{{matrix.BWC_VERSION}}#bwcTestPart3
         timeout_in_minutes: 300
         matrix:
           setup:
@@ -53,7 +53,7 @@ steps:
           buildDirectory: /dev/shm/bk
       - label: "{{matrix.BWC_VERSION}} / Part 4 / bwc-snapshots"
         key: "bwc-snapshots-part4"
-        command: .ci/scripts/run-gradle.sh -Dignore.tests.seed v{{matrix.BWC_VERSION}}#bwcTestPart5
+        command: .ci/scripts/run-gradle.sh -Dignore.tests.seed -Dtests.bwc.dra.enabled=true v{{matrix.BWC_VERSION}}#bwcTestPart5
         timeout_in_minutes: 300
         matrix:
           setup:
@@ -68,7 +68,7 @@ steps:
           buildDirectory: /dev/shm/bk
       - label: "{{matrix.BWC_VERSION}} / Part 5 / bwc-snapshots"
         key: "bwc-snapshots-part5"
-        command: .ci/scripts/run-gradle.sh -Dignore.tests.seed v{{matrix.BWC_VERSION}}#bwcTestPart5
+        command: .ci/scripts/run-gradle.sh -Dignore.tests.seed -Dtests.bwc.dra.enabled=true v{{matrix.BWC_VERSION}}#bwcTestPart5
         timeout_in_minutes: 300
         matrix:
           setup:
@@ -83,7 +83,7 @@ steps:
           buildDirectory: /dev/shm/bk
       - label: "{{matrix.BWC_VERSION}} / Part 6 / bwc-snapshots"
         key: "bwc-snapshots-part6"
-        command: .ci/scripts/run-gradle.sh -Dignore.tests.seed v{{matrix.BWC_VERSION}}#bwcTestPart6
+        command: .ci/scripts/run-gradle.sh -Dignore.tests.seed -Dtests.bwc.dra.enabled=true v{{matrix.BWC_VERSION}}#bwcTestPart6
         timeout_in_minutes: 300
         matrix:
           setup:

--- a/.buildkite/pipelines/pull-request/bwc-snapshots.yml
+++ b/.buildkite/pipelines/pull-request/bwc-snapshots.yml
@@ -8,7 +8,7 @@ steps:
     steps:
       - label: "{{matrix.BWC_VERSION}} / Part 1 / bwc-snapshots"
         key: "bwc-snapshots-part1"
-        command: .ci/scripts/run-gradle.sh -Dignore.tests.seed -Dtests.bwc.mode=auto v{{matrix.BWC_VERSION}}#bwcTestPart1
+        command: .ci/scripts/run-gradle.sh -Dignore.tests.seed -Dtests.bwc.mode=dra v{{matrix.BWC_VERSION}}#bwcTestPart1
         timeout_in_minutes: 300
         matrix:
           setup:
@@ -23,7 +23,7 @@ steps:
           buildDirectory: /dev/shm/bk
       - label: "{{matrix.BWC_VERSION}} / Part 2 / bwc-snapshots"
         key: "bwc-snapshots-part2"
-        command: .ci/scripts/run-gradle.sh -Dignore.tests.seed -Dtests.bwc.mode=auto v{{matrix.BWC_VERSION}}#bwcTestPart2
+        command: .ci/scripts/run-gradle.sh -Dignore.tests.seed -Dtests.bwc.mode=dra v{{matrix.BWC_VERSION}}#bwcTestPart2
         timeout_in_minutes: 300
         matrix:
           setup:
@@ -38,7 +38,7 @@ steps:
           buildDirectory: /dev/shm/bk
       - label: "{{matrix.BWC_VERSION}} / Part 3 / bwc-snapshots"
         key: "bwc-snapshots-part3"
-        command: .ci/scripts/run-gradle.sh -Dignore.tests.seed -Dtests.bwc.mode=auto v{{matrix.BWC_VERSION}}#bwcTestPart3
+        command: .ci/scripts/run-gradle.sh -Dignore.tests.seed -Dtests.bwc.mode=dra v{{matrix.BWC_VERSION}}#bwcTestPart3
         timeout_in_minutes: 300
         matrix:
           setup:
@@ -53,7 +53,7 @@ steps:
           buildDirectory: /dev/shm/bk
       - label: "{{matrix.BWC_VERSION}} / Part 4 / bwc-snapshots"
         key: "bwc-snapshots-part4"
-        command: .ci/scripts/run-gradle.sh -Dignore.tests.seed -Dtests.bwc.mode=auto v{{matrix.BWC_VERSION}}#bwcTestPart5
+        command: .ci/scripts/run-gradle.sh -Dignore.tests.seed -Dtests.bwc.mode=dra v{{matrix.BWC_VERSION}}#bwcTestPart5
         timeout_in_minutes: 300
         matrix:
           setup:
@@ -68,7 +68,7 @@ steps:
           buildDirectory: /dev/shm/bk
       - label: "{{matrix.BWC_VERSION}} / Part 5 / bwc-snapshots"
         key: "bwc-snapshots-part5"
-        command: .ci/scripts/run-gradle.sh -Dignore.tests.seed -Dtests.bwc.mode=auto v{{matrix.BWC_VERSION}}#bwcTestPart5
+        command: .ci/scripts/run-gradle.sh -Dignore.tests.seed -Dtests.bwc.mode=dra v{{matrix.BWC_VERSION}}#bwcTestPart5
         timeout_in_minutes: 300
         matrix:
           setup:
@@ -83,7 +83,7 @@ steps:
           buildDirectory: /dev/shm/bk
       - label: "{{matrix.BWC_VERSION}} / Part 6 / bwc-snapshots"
         key: "bwc-snapshots-part6"
-        command: .ci/scripts/run-gradle.sh -Dignore.tests.seed -Dtests.bwc.mode=auto v{{matrix.BWC_VERSION}}#bwcTestPart6
+        command: .ci/scripts/run-gradle.sh -Dignore.tests.seed -Dtests.bwc.mode=dra v{{matrix.BWC_VERSION}}#bwcTestPart6
         timeout_in_minutes: 300
         matrix:
           setup:

--- a/.buildkite/pipelines/pull-request/bwc-snapshots.yml
+++ b/.buildkite/pipelines/pull-request/bwc-snapshots.yml
@@ -8,7 +8,7 @@ steps:
     steps:
       - label: "{{matrix.BWC_VERSION}} / Part 1 / bwc-snapshots"
         key: "bwc-snapshots-part1"
-        command: .ci/scripts/run-gradle.sh -Dignore.tests.seed -Dtests.bwc.mode=dra v{{matrix.BWC_VERSION}}#bwcTestPart1
+        command: .ci/scripts/run-gradle.sh -Dignore.tests.seed -Dtests.bwc.mode=auto v{{matrix.BWC_VERSION}}#bwcTestPart1
         timeout_in_minutes: 300
         matrix:
           setup:
@@ -23,7 +23,7 @@ steps:
           buildDirectory: /dev/shm/bk
       - label: "{{matrix.BWC_VERSION}} / Part 2 / bwc-snapshots"
         key: "bwc-snapshots-part2"
-        command: .ci/scripts/run-gradle.sh -Dignore.tests.seed -Dtests.bwc.mode=dra v{{matrix.BWC_VERSION}}#bwcTestPart2
+        command: .ci/scripts/run-gradle.sh -Dignore.tests.seed -Dtests.bwc.mode=auto v{{matrix.BWC_VERSION}}#bwcTestPart2
         timeout_in_minutes: 300
         matrix:
           setup:
@@ -38,7 +38,7 @@ steps:
           buildDirectory: /dev/shm/bk
       - label: "{{matrix.BWC_VERSION}} / Part 3 / bwc-snapshots"
         key: "bwc-snapshots-part3"
-        command: .ci/scripts/run-gradle.sh -Dignore.tests.seed -Dtests.bwc.mode=dra v{{matrix.BWC_VERSION}}#bwcTestPart3
+        command: .ci/scripts/run-gradle.sh -Dignore.tests.seed -Dtests.bwc.mode=auto v{{matrix.BWC_VERSION}}#bwcTestPart3
         timeout_in_minutes: 300
         matrix:
           setup:
@@ -53,7 +53,7 @@ steps:
           buildDirectory: /dev/shm/bk
       - label: "{{matrix.BWC_VERSION}} / Part 4 / bwc-snapshots"
         key: "bwc-snapshots-part4"
-        command: .ci/scripts/run-gradle.sh -Dignore.tests.seed -Dtests.bwc.mode=dra v{{matrix.BWC_VERSION}}#bwcTestPart5
+        command: .ci/scripts/run-gradle.sh -Dignore.tests.seed -Dtests.bwc.mode=auto v{{matrix.BWC_VERSION}}#bwcTestPart5
         timeout_in_minutes: 300
         matrix:
           setup:
@@ -68,7 +68,7 @@ steps:
           buildDirectory: /dev/shm/bk
       - label: "{{matrix.BWC_VERSION}} / Part 5 / bwc-snapshots"
         key: "bwc-snapshots-part5"
-        command: .ci/scripts/run-gradle.sh -Dignore.tests.seed -Dtests.bwc.mode=dra v{{matrix.BWC_VERSION}}#bwcTestPart5
+        command: .ci/scripts/run-gradle.sh -Dignore.tests.seed -Dtests.bwc.mode=auto v{{matrix.BWC_VERSION}}#bwcTestPart5
         timeout_in_minutes: 300
         matrix:
           setup:
@@ -83,7 +83,7 @@ steps:
           buildDirectory: /dev/shm/bk
       - label: "{{matrix.BWC_VERSION}} / Part 6 / bwc-snapshots"
         key: "bwc-snapshots-part6"
-        command: .ci/scripts/run-gradle.sh -Dignore.tests.seed -Dtests.bwc.mode=dra v{{matrix.BWC_VERSION}}#bwcTestPart6
+        command: .ci/scripts/run-gradle.sh -Dignore.tests.seed -Dtests.bwc.mode=auto v{{matrix.BWC_VERSION}}#bwcTestPart6
         timeout_in_minutes: 300
         matrix:
           setup:

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -389,16 +389,24 @@ This source build is correct but slow, and every parallel BWC test job repeats i
 
 ### DRA fast path
 
-When the latest [DRA](https://github.com/elastic/apm-pipeline-library/blob/main/vars/README.md#publishToBuildkiteDRA) snapshot for a BWC branch was built from the **same commit** as the local remote-tracking reference, the build can skip the source compilation entirely and download the pre-built artifact from `artifacts-snapshot.elastic.co` instead.
-Gradle downloads the archive through an Ivy repository and unpacks it with the existing `SymbolicLinkPreservingUntarTransform` / `UnzipTransform` — no custom HTTP or extraction code.
+Instead of cloning the BWC branch and compiling it from source, Gradle can download pre-built artifacts directly from the [DRA](https://github.com/elastic/apm-pipeline-library/blob/main/vars/README.md#publishToBuildkiteDRA) (Distribution Release Artifacts) snapshot server at `artifacts-snapshot.elastic.co`.
+Gradle downloads archives through an Ivy repository and unpacks them with the existing `SymbolicLinkPreservingUntarTransform` / `UnzipTransform` — no custom HTTP or extraction code.
 
 The fast path covers:
 - **Distribution archives** (Linux/Darwin/Windows tar.gz, zip, deb, rpm) — downloaded from the DRA `/downloads/elasticsearch/` path.
 - **JDBC jar** (`x-pack-sql-jdbc`) and **stable API jars** (`elasticsearch-logging`, `elasticsearch-plugin-api`, `elasticsearch-plugin-analysis-api`) — downloaded from the DRA `/maven/` tree using their Maven group-path layout.
 
-The fast path is **opt-in** and does not affect local development builds by default.
-Enable it by passing `-Dtests.bwc.dra.enabled=true`.
-When disabled (the default), `DraSnapshotBuildIdValueSource` returns an empty string immediately with no network activity.
+#### BWC mode (`-Dtests.bwc.mode`)
+
+The `tests.bwc.mode` system property selects how BWC artifacts are resolved:
+
+| Value | Behaviour |
+|---|---|
+| `gradle` *(default)* | Always build from source via a nested Gradle invocation. No network activity. |
+| `auto` | Fetch the latest DRA snapshot and compare its commit hash against the local remote-tracking ref. Use DRA if they match, otherwise fall back to a source build silently. |
+| `dra` | Always download from the latest DRA snapshot without checking the commit hash. If DRA is unreachable or returns no build for the branch, log a warning and fall back to a source build. |
+
+When `tests.bwc.mode=gradle` (the default), `DraSnapshotBuildIdValueSource` returns an empty string immediately with no network activity, keeping local development builds unaffected.
 
 ### Testing locally
 
@@ -410,7 +418,7 @@ When disabled (the default), `DraSnapshotBuildIdValueSource` returns an empty st
   --tests "org.elasticsearch.gradle.internal.InternalDistributionBwcSetupPluginFuncTest"
 ```
 
-#### 2 — Inspect the task graph with DRA disabled (no network)
+#### 2 — Inspect the task graph with the default gradle mode (no network)
 
 ```bash
 ./gradlew :distribution:bwc:minor3:buildBwcLinuxTar --dry-run
@@ -418,13 +426,13 @@ When disabled (the default), `DraSnapshotBuildIdValueSource` returns an empty st
 
 Expected chain: `createClone` → `findRemote` → `addRemote` → `fetchLatest` → `checkoutBwcBranch` → `buildBwcLinuxTar` (nested Gradle build).
 
-#### 3 — Inspect the task graph with DRA enabled
+#### 3 — Inspect the task graph with auto mode
 
 ```bash
 git fetch --all   # keep remote-tracking refs fresh
 
 ./gradlew :distribution:bwc:minor3:buildBwcLinuxTar --dry-run \
-  -Dtests.bwc.dra.enabled=true --info 2>&1 | grep -E "onlyIf|DRA"
+  -Dtests.bwc.mode=auto --info 2>&1 | grep -E "onlyIf|DRA"
 ```
 
 When the DRA snapshot matches the branch tip the git tasks are skipped and `buildBwcLinuxTar` (a `Copy` task backed by the Ivy download) appears instead.
@@ -456,18 +464,21 @@ echo "Local ref:    $LOCAL_COMMIT"
 
 #### 5 — Run a real DRA-backed BWC build end-to-end
 
-Once the hashes match, run a real test to confirm the full pipeline works:
+With `auto` (once the hashes match) or `dra` (always download latest):
 
 ```bash
 # Build just the distribution artifact (much faster than a full source build)
-./gradlew :distribution:bwc:minor3:buildBwcLinuxTar -Dtests.bwc.dra.enabled=true
+./gradlew :distribution:bwc:minor3:buildBwcLinuxTar -Dtests.bwc.mode=auto
 
-# Build the JDBC or stable API jars from DRA (no git checkout required)
-./gradlew :distribution:bwc:minor3:buildBwcJdbc -Dtests.bwc.dra.enabled=true
-./gradlew :distribution:bwc:minor3:buildBwcLogging -Dtests.bwc.dra.enabled=true
+# Always use the latest DRA snapshot regardless of commit hash
+./gradlew :distribution:bwc:minor3:buildBwcLinuxTar -Dtests.bwc.mode=dra
+
+# Build the JDBC or stable API jars from DRA
+./gradlew :distribution:bwc:minor3:buildBwcJdbc -Dtests.bwc.mode=auto
+./gradlew :distribution:bwc:minor3:buildBwcLogging -Dtests.bwc.mode=auto
 
 # Or run a BWC test suite part
-./gradlew v9.4.2#bwcTestPart1 -Dtests.bwc.dra.enabled=true -Dignore.tests.seed
+./gradlew v9.4.2#bwcTestPart1 -Dtests.bwc.mode=auto -Dignore.tests.seed
 ```
 
 #### Tip — pinning to an explicit commit hash
@@ -479,7 +490,7 @@ This is particularly useful when the DRA latest has moved on to a newer commit b
 ```bash
 # Use the short hash from a specific DRA build (e.g. 9.4.2-1a738181)
 ./gradlew :distribution:bwc:minor1:buildBwcLinuxTar \
-  -Dtests.bwc.dra.enabled=true \
+  -Dtests.bwc.mode=dra \
   -Dtests.bwc.dra.hash.9.4=1a738181
 ```
 
@@ -487,7 +498,7 @@ The value must be the abbreviated commit hash as it appears in the DRA build ID 
 
 ### How CI uses the DRA fast path
 
-On Buildkite, BWC snapshot jobs pass `-Dtests.bwc.dra.enabled=true`.
+On Buildkite, BWC snapshot jobs pass `-Dtests.bwc.mode=auto`.
 `DraSnapshotBuildIdValueSource` is evaluated once per BWC version at Gradle configuration time.
 If the DRA snapshot commit matches the remote-tracking ref, the entire git clone / compile / nested Gradle invocation is replaced by an Ivy download + artifact transform, cutting typical BWC snapshot job time significantly.
 Periodic BWC tests use `bwc.checkout.align=true` (time-based commit alignment) and therefore almost always build from source — the DRA path is primarily a speedup for PR-level BWC snapshot tests.

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -392,6 +392,10 @@ This source build is correct but slow, and every parallel BWC test job repeats i
 When the latest [DRA](https://github.com/elastic/apm-pipeline-library/blob/main/vars/README.md#publishToBuildkiteDRA) snapshot for a BWC branch was built from the **same commit** as the local remote-tracking reference, the build can skip the source compilation entirely and download the pre-built artifact from `artifacts-snapshot.elastic.co` instead.
 Gradle downloads the archive through an Ivy repository and unpacks it with the existing `SymbolicLinkPreservingUntarTransform` / `UnzipTransform` — no custom HTTP or extraction code.
 
+The fast path covers:
+- **Distribution archives** (Linux/Darwin/Windows tar.gz, zip, deb, rpm) — downloaded from the DRA `/downloads/elasticsearch/` path.
+- **JDBC jar** (`x-pack-sql-jdbc`) and **stable API jars** (`elasticsearch-logging`, `elasticsearch-plugin-api`, `elasticsearch-plugin-analysis-api`) — downloaded from the DRA `/maven/` tree using their Maven group-path layout.
+
 The fast path is **opt-in** and does not affect local development builds by default.
 Enable it by passing `-Dtests.bwc.dra.enabled=true`.
 When disabled (the default), `DraSnapshotBuildIdValueSource` returns an empty string immediately with no network activity.
@@ -440,7 +444,7 @@ echo "DRA build ID: $BUILD_ID"
 
 # 2. Get the commit the DRA snapshot was built from
 DRA_COMMIT=$(curl -s "https://artifacts-snapshot.elastic.co/elasticsearch/$BUILD_ID/manifest-9.4.2-SNAPSHOT.json" \
-  | python3 -c "import sys,json; print(json.load(sys.stdin)['projects']['elasticsearch']['commit'])")
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['projects']['elasticsearch']['commit_hash'])")
 echo "DRA commit:   $DRA_COMMIT"
 
 # 3. Compare with the local remote-tracking ref
@@ -457,6 +461,10 @@ Once the hashes match, run a real test to confirm the full pipeline works:
 ```bash
 # Build just the distribution artifact (much faster than a full source build)
 ./gradlew :distribution:bwc:minor3:buildBwcLinuxTar -Dtests.bwc.dra.enabled=true
+
+# Build the JDBC or stable API jars from DRA (no git checkout required)
+./gradlew :distribution:bwc:minor3:buildBwcJdbc -Dtests.bwc.dra.enabled=true
+./gradlew :distribution:bwc:minor3:buildBwcLogging -Dtests.bwc.dra.enabled=true
 
 # Or run a BWC test suite part
 ./gradlew v9.4.2#bwcTestPart1 -Dtests.bwc.dra.enabled=true -Dignore.tests.seed

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -424,10 +424,10 @@ Expected chain: `createClone` → `findRemote` → `addRemote` → `fetchLatest`
 git fetch --all   # keep remote-tracking refs fresh
 
 ./gradlew :distribution:bwc:minor3:buildBwcLinuxTar --dry-run \
-  -Dtests.bwc.dra.enabled=true --info 2>&1 | grep -E "onlyIf|DRA|writeDra"
+  -Dtests.bwc.dra.enabled=true --info 2>&1 | grep -E "onlyIf|DRA"
 ```
 
-When the DRA snapshot matches the branch tip the git tasks are skipped and `writeDraRefspec` + `buildBwcLinuxTar` (a `Copy` task backed by the Ivy download) appear instead.
+When the DRA snapshot matches the branch tip the git tasks are skipped and `buildBwcLinuxTar` (a `Copy` task backed by the Ivy download) appears instead.
 `--info` surfaces lines like:
 
 ```

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -381,6 +381,109 @@ restResources {
 }
 ```
 
+## BWC Snapshot Testing
+
+Backward-compatibility (BWC) tests verify that the current build can communicate with earlier Elasticsearch versions.
+By default the BWC version is built from source: Gradle clones the target branch, checks out its tip, and runs a nested `./gradlew` invocation to compile and assemble the distribution artifacts.
+This source build is correct but slow, and every parallel BWC test job repeats it independently.
+
+### DRA fast path
+
+When the latest [DRA](https://github.com/elastic/apm-pipeline-library/blob/main/vars/README.md#publishToBuildkiteDRA) snapshot for a BWC branch was built from the **same commit** as the local remote-tracking reference, the build can skip the source compilation entirely and download the pre-built artifact from `artifacts-snapshot.elastic.co` instead.
+Gradle downloads the archive through an Ivy repository and unpacks it with the existing `SymbolicLinkPreservingUntarTransform` / `UnzipTransform` — no custom HTTP or extraction code.
+
+The fast path is **opt-in** and does not affect local development builds by default.
+Enable it by passing `-Dtests.bwc.dra.enabled=true`.
+When disabled (the default), `DraSnapshotBuildIdValueSource` returns an empty string immediately with no network activity.
+
+### Testing locally
+
+#### 1 — Verify the local-build path is unaffected (regression check)
+
+```bash
+./gradlew :build-tools-internal:integTest \
+  --tests "org.elasticsearch.gradle.internal.InternalBwcGitPluginFuncTest" \
+  --tests "org.elasticsearch.gradle.internal.InternalDistributionBwcSetupPluginFuncTest"
+```
+
+#### 2 — Inspect the task graph with DRA disabled (no network)
+
+```bash
+./gradlew :distribution:bwc:minor3:buildBwcLinuxTar --dry-run
+```
+
+Expected chain: `createClone` → `findRemote` → `addRemote` → `fetchLatest` → `checkoutBwcBranch` → `buildBwcLinuxTar` (nested Gradle build).
+
+#### 3 — Inspect the task graph with DRA enabled
+
+```bash
+git fetch --all   # keep remote-tracking refs fresh
+
+./gradlew :distribution:bwc:minor3:buildBwcLinuxTar --dry-run \
+  -Dtests.bwc.dra.enabled=true --info 2>&1 | grep -E "onlyIf|DRA|writeDra"
+```
+
+When the DRA snapshot matches the branch tip the git tasks are skipped and `writeDraRefspec` + `buildBwcLinuxTar` (a `Copy` task backed by the Ivy download) appear instead.
+`--info` surfaces lines like:
+
+```
+Skipping task ':distribution:bwc:minor3:createClone' as task onlyIf 'DRA snapshot not available' is false.
+```
+
+#### 4 — Verify whether a DRA snapshot is currently available for a version
+
+```bash
+# 1. Get the latest DRA build ID for the branch
+BUILD_ID=$(curl -s https://artifacts-snapshot.elastic.co/elasticsearch/latest/9.4.json \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['build_id'])")
+echo "DRA build ID: $BUILD_ID"
+
+# 2. Get the commit the DRA snapshot was built from
+DRA_COMMIT=$(curl -s "https://artifacts-snapshot.elastic.co/elasticsearch/$BUILD_ID/manifest-9.4.2-SNAPSHOT.json" \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['projects']['elasticsearch']['commit'])")
+echo "DRA commit:   $DRA_COMMIT"
+
+# 3. Compare with the local remote-tracking ref
+LOCAL_COMMIT=$(git rev-parse elastic/9.4)
+echo "Local ref:    $LOCAL_COMMIT"
+
+[ "$DRA_COMMIT" = "$LOCAL_COMMIT" ] && echo "Match — DRA path will be used" || echo "No match — local build will be used"
+```
+
+#### 5 — Run a real DRA-backed BWC build end-to-end
+
+Once the hashes match, run a real test to confirm the full pipeline works:
+
+```bash
+# Build just the distribution artifact (much faster than a full source build)
+./gradlew :distribution:bwc:minor3:buildBwcLinuxTar -Dtests.bwc.dra.enabled=true
+
+# Or run a BWC test suite part
+./gradlew v9.4.2#bwcTestPart1 -Dtests.bwc.dra.enabled=true -Dignore.tests.seed
+```
+
+#### Tip — pinning to an explicit commit hash
+
+Pass `-Dtests.bwc.dra.hash.{branch}` to use the DRA build for a specific commit hash.
+When set the "latest" DRA lookup is skipped entirely: the build ID is constructed directly as `{version}-{hash}` and its existence is verified against the manifest endpoint.
+This is particularly useful when the DRA latest has moved on to a newer commit but you still want to use an older snapshot, or when you want a reproducible build pinned to a known-good artifact.
+
+```bash
+# Use the short hash from a specific DRA build (e.g. 9.4.2-1a738181)
+./gradlew :distribution:bwc:minor1:buildBwcLinuxTar \
+  -Dtests.bwc.dra.enabled=true \
+  -Dtests.bwc.dra.hash.9.4=1a738181
+```
+
+The value must be the abbreviated commit hash as it appears in the DRA build ID (the part after the last `-`).
+
+### How CI uses the DRA fast path
+
+On Buildkite, BWC snapshot jobs pass `-Dtests.bwc.dra.enabled=true`.
+`DraSnapshotBuildIdValueSource` is evaluated once per BWC version at Gradle configuration time.
+If the DRA snapshot commit matches the remote-tracking ref, the entire git clone / compile / nested Gradle invocation is replaced by an Ivy download + artifact transform, cutting typical BWC snapshot job time significantly.
+Periodic BWC tests use `bwc.checkout.align=true` (time-based commit alignment) and therefore almost always build from source — the DRA path is primarily a speedup for PR-level BWC snapshot tests.
+
 ## FAQ
 
 ### How do I test a development version of a third party dependency?

--- a/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/info/GitInfo.java
+++ b/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/info/GitInfo.java
@@ -175,6 +175,50 @@ public class GitInfo {
         return firstLine;
     }
 
+    /**
+     * Returns the full commit hash for a remote tracking reference (e.g. {@code refs/remotes/elastic/9.4})
+     * by reading directly from the local git object store without forking a process.
+     * Returns {@code null} if the reference cannot be resolved.
+     */
+    public static String remoteRefRevision(File rootDir, String remote, String branch) throws IOException {
+        Path dotGit = rootDir.toPath().resolve(".git");
+        if (Files.exists(dotGit) == false) {
+            return null;
+        }
+        final Path gitDir;
+        if (Files.isDirectory(dotGit)) {
+            gitDir = dotGit;
+        } else {
+            final Path reference = Paths.get(readFirstLine(dotGit).substring("gitdir:".length()).trim());
+            if (reference.getParent() != null && reference.getParent().endsWith("modules")) {
+                gitDir = rootDir.toPath().resolve(reference);
+            } else {
+                if (Files.exists(reference) == false) {
+                    return null;
+                }
+                final Path commonDir = Paths.get(readFirstLine(reference.resolve("commondir")));
+                gitDir = commonDir.isAbsolute() ? commonDir : reference.resolve(commonDir);
+            }
+        }
+        String refName = "refs/remotes/" + remote + "/" + branch;
+        Path refFile = gitDir.resolve(refName);
+        if (Files.exists(refFile)) {
+            return readFirstLine(refFile);
+        }
+        Path packedRefs = gitDir.resolve("packed-refs");
+        if (Files.exists(packedRefs)) {
+            Pattern p = Pattern.compile("^([a-f0-9]{40}) " + Pattern.quote(refName) + "$");
+            try (Stream<String> lines = Files.lines(packedRefs, StandardCharsets.UTF_8)) {
+                return lines.map(p::matcher)
+                    .filter(Matcher::matches)
+                    .map(m -> m.group(1))
+                    .findFirst()
+                    .orElse(null);
+            }
+        }
+        return null;
+    }
+
     /** Find the reponame. */
     public String urlFromOrigin() {
         if (origin == null) {

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalBwcGitPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalBwcGitPluginFuncTest.groovy
@@ -39,17 +39,19 @@ class InternalBwcGitPluginFuncTest extends AbstractGitAwareGradleFuncTest {
         file("cloned/build/checkout/settings.gradle").exists()
     }
 
-    def "git tasks are skipped and writeDraRefspec writes the short hash when DRA build ID is configured"() {
+    def "git checkout is skipped when DRA build ID is configured and no checkout is needed"() {
         given:
         buildFile << """
             plugins.getPlugin(org.elasticsearch.gradle.internal.InternalBwcGitPlugin)
                 .configureDraBuildId(project.providers.provider { "7.9.1-abc12345" })
         """
         when:
-        def result = gradleRunner("writeDraRefspec", '--stacktrace').build()
+        // Run a task that depends on git tasks so we can verify they are skipped
+        def result = gradleRunner("checkoutBwcBranch", '--stacktrace', "-DtestRemoteRepo=" + remoteGitRepo, "-Dbwc.remote=origin").build()
         then:
-        result.task(":writeDraRefspec").outcome == TaskOutcome.SUCCESS
-        file("cloned/build/refspec").text == "abc12345"
+        result.task(":createClone").outcome == TaskOutcome.SKIPPED
+        result.task(":fetchLatest").outcome == TaskOutcome.SKIPPED
+        result.task(":checkoutBwcBranch").outcome == TaskOutcome.SKIPPED
     }
 
     def "git checkout is skipped when DRA build ID is configured"() {
@@ -71,15 +73,10 @@ class InternalBwcGitPluginFuncTest extends AbstractGitAwareGradleFuncTest {
         result.task(":checkoutBwcBranch").outcome == TaskOutcome.SKIPPED
     }
 
-    def "writeDraRefspec is skipped and git tasks run when no DRA build ID is configured"() {
+    def "git tasks run when no DRA build ID is configured"() {
         when:
-        def result = gradleRunner(
-            "writeDraRefspec",
-            "createClone",
-            '--stacktrace'
-        ).build()
+        def result = gradleRunner("createClone", '--stacktrace').build()
         then:
-        result.task(":writeDraRefspec").outcome == TaskOutcome.SKIPPED
         result.task(":createClone").outcome == TaskOutcome.SUCCESS
     }
 

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalBwcGitPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalBwcGitPluginFuncTest.groovy
@@ -39,6 +39,50 @@ class InternalBwcGitPluginFuncTest extends AbstractGitAwareGradleFuncTest {
         file("cloned/build/checkout/settings.gradle").exists()
     }
 
+    def "git tasks are skipped and writeDraRefspec writes the short hash when DRA build ID is configured"() {
+        given:
+        buildFile << """
+            plugins.getPlugin(org.elasticsearch.gradle.internal.InternalBwcGitPlugin)
+                .configureDraBuildId(project.providers.provider { "7.9.1-abc12345" })
+        """
+        when:
+        def result = gradleRunner("writeDraRefspec", '--stacktrace').build()
+        then:
+        result.task(":writeDraRefspec").outcome == TaskOutcome.SUCCESS
+        file("cloned/build/refspec").text == "abc12345"
+    }
+
+    def "git checkout is skipped when DRA build ID is configured"() {
+        given:
+        buildFile << """
+            plugins.getPlugin(org.elasticsearch.gradle.internal.InternalBwcGitPlugin)
+                .configureDraBuildId(project.providers.provider { "7.9.1-abc12345" })
+        """
+        when:
+        def result = gradleRunner(
+            "checkoutBwcBranch",
+            '--stacktrace',
+            "-DtestRemoteRepo=" + remoteGitRepo,
+            "-Dbwc.remote=origin"
+        ).build()
+        then: "all git tasks are skipped because the DRA build ID is non-empty"
+        result.task(":createClone").outcome == TaskOutcome.SKIPPED
+        result.task(":fetchLatest").outcome == TaskOutcome.SKIPPED
+        result.task(":checkoutBwcBranch").outcome == TaskOutcome.SKIPPED
+    }
+
+    def "writeDraRefspec is skipped and git tasks run when no DRA build ID is configured"() {
+        when:
+        def result = gradleRunner(
+            "writeDraRefspec",
+            "createClone",
+            '--stacktrace'
+        ).build()
+        then:
+        result.task(":writeDraRefspec").outcome == TaskOutcome.SKIPPED
+        result.task(":createClone").outcome == TaskOutcome.SUCCESS
+    }
+
     def "can resolve checkout folder as project artifact"() {
         given:
         settingsFile << "include ':consumer'"

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalBwcGitPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalBwcGitPluginFuncTest.groovy
@@ -39,21 +39,6 @@ class InternalBwcGitPluginFuncTest extends AbstractGitAwareGradleFuncTest {
         file("cloned/build/checkout/settings.gradle").exists()
     }
 
-    def "git checkout is skipped when DRA build ID is configured and no checkout is needed"() {
-        given:
-        buildFile << """
-            plugins.getPlugin(org.elasticsearch.gradle.internal.InternalBwcGitPlugin)
-                .configureDraBuildId(project.providers.provider { "7.9.1-abc12345" })
-        """
-        when:
-        // Run a task that depends on git tasks so we can verify they are skipped
-        def result = gradleRunner("checkoutBwcBranch", '--stacktrace', "-DtestRemoteRepo=" + remoteGitRepo, "-Dbwc.remote=origin").build()
-        then:
-        result.task(":createClone").outcome == TaskOutcome.SKIPPED
-        result.task(":fetchLatest").outcome == TaskOutcome.SKIPPED
-        result.task(":checkoutBwcBranch").outcome == TaskOutcome.SKIPPED
-    }
-
     def "git checkout is skipped when DRA build ID is configured"() {
         given:
         buildFile << """

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPluginFuncTest.groovy
@@ -95,7 +95,7 @@ class InternalDistributionBwcSetupPluginFuncTest extends AbstractGitAwareGradleF
         "8.4.0"       | "linux"
     }
 
-    def "downloads distribution from DRA snapshot when hash matches"() {
+    def "downloads distribution from DRA snapshot when mode=dra and hash override is set"() {
         given:
         def bwcVersion = "8.4.0"
         def bwcBranch = "8.x"
@@ -110,7 +110,7 @@ class InternalDistributionBwcSetupPluginFuncTest extends AbstractGitAwareGradleF
             ":distribution:bwc:major1:buildBwcDarwinTar",
             "-DtestRemoteRepo=" + remoteGitRepo,
             "-Dbwc.remote=origin",
-            "-Dtests.bwc.dra.enabled=true",
+            "-Dtests.bwc.mode=dra",
             "-Dtests.bwc.dra.hash.${bwcBranch}=${shortHash}",
             "-Dtests.bwc.dra.base.url=${wireMock.baseUrl()}"
         ).build()
@@ -157,7 +157,7 @@ class InternalDistributionBwcSetupPluginFuncTest extends AbstractGitAwareGradleF
             ":distribution:bwc:major1:buildBwcDarwinTar",
             "-DtestRemoteRepo=" + remoteGitRepo,
             "-Dbwc.remote=elastic",
-            "-Dtests.bwc.dra.enabled=true",
+            "-Dtests.bwc.mode=auto",
             "-Dtests.bwc.dra.base.url=${wireMock.baseUrl()}"
         ).build()
 
@@ -171,7 +171,7 @@ class InternalDistributionBwcSetupPluginFuncTest extends AbstractGitAwareGradleF
         result.output.contains("DRA snapshot ${buildId}")
     }
 
-    def "downloads JDBC jar from DRA snapshot when hash matches"() {
+    def "downloads JDBC jar from DRA snapshot when mode=dra and hash override is set"() {
         given:
         def bwcVersion = "8.4.0"
         def bwcBranch = "8.x"
@@ -186,7 +186,7 @@ class InternalDistributionBwcSetupPluginFuncTest extends AbstractGitAwareGradleF
             ":distribution:bwc:major1:buildBwcJdbc",
             "-DtestRemoteRepo=" + remoteGitRepo,
             "-Dbwc.remote=origin",
-            "-Dtests.bwc.dra.enabled=true",
+            "-Dtests.bwc.mode=dra",
             "-Dtests.bwc.dra.hash.${bwcBranch}=${shortHash}",
             "-Dtests.bwc.dra.base.url=${wireMock.baseUrl()}"
         ).build()
@@ -206,7 +206,7 @@ class InternalDistributionBwcSetupPluginFuncTest extends AbstractGitAwareGradleF
             "x-pack-sql-jdbc-${bwcVersion}-SNAPSHOT.jar").exists()
     }
 
-    def "falls back to local gradle build when DRA is disabled"() {
+    def "builds from source when mode is gradle (default)"() {
         when:
         def result = gradleRunner(":distribution:bwc:major1:buildBwcDarwinTar",
             "-DtestRemoteRepo=" + remoteGitRepo,
@@ -233,7 +233,7 @@ class InternalDistributionBwcSetupPluginFuncTest extends AbstractGitAwareGradleF
             "-DtestRemoteRepo=" + remoteGitRepo,
             "-Dbwc.remote=origin",
             "-Dbwc.dist.version=8.4.0-SNAPSHOT",
-            "-Dtests.bwc.dra.enabled=true",
+            "-Dtests.bwc.mode=auto",
             "-Dtests.bwc.dra.hash.8.x=${shortHash}",
             "-Dtests.bwc.dra.base.url=${wireMock.baseUrl()}"
         ).build()
@@ -245,7 +245,7 @@ class InternalDistributionBwcSetupPluginFuncTest extends AbstractGitAwareGradleF
         assertOutputContains(result.output, "[8.4.0] > Task :distribution:archives:darwin-tar:extractedAssemble")
     }
 
-    def "downloads distribution via resolveByLatest when remote tracking ref matches DRA manifest commit"() {
+    def "downloads distribution via resolveByLatest when mode=auto and remote tracking ref matches DRA manifest commit"() {
         given:
         def bwcVersion = "8.4.0"
         def bwcBranch = "8.x"
@@ -267,7 +267,7 @@ class InternalDistributionBwcSetupPluginFuncTest extends AbstractGitAwareGradleF
             ":distribution:bwc:major1:buildBwcDarwinTar",
             "-DtestRemoteRepo=" + remoteGitRepo,
             "-Dbwc.remote=origin",
-            "-Dtests.bwc.dra.enabled=true",
+            "-Dtests.bwc.mode=auto",
             "-Dtests.bwc.dra.base.url=${wireMock.baseUrl()}"
         ).build()
 
@@ -281,7 +281,7 @@ class InternalDistributionBwcSetupPluginFuncTest extends AbstractGitAwareGradleF
         result.output.contains("DRA snapshot ${buildId}")
     }
 
-    def "falls back to local build when DRA manifest commit does not match remote tracking ref"() {
+    def "falls back to local build when mode=auto and DRA manifest commit does not match remote tracking ref"() {
         given:
         def bwcBranch = "8.x"
         def fullHash = execute("git rev-parse HEAD", file("cloned")).trim()
@@ -305,7 +305,7 @@ class InternalDistributionBwcSetupPluginFuncTest extends AbstractGitAwareGradleF
             "-DtestRemoteRepo=" + remoteGitRepo,
             "-Dbwc.remote=origin",
             "-Dbwc.dist.version=8.4.0-SNAPSHOT",
-            "-Dtests.bwc.dra.enabled=true",
+            "-Dtests.bwc.mode=auto",
             "-Dtests.bwc.dra.base.url=${wireMock.baseUrl()}"
         ).build()
 
@@ -317,6 +317,66 @@ class InternalDistributionBwcSetupPluginFuncTest extends AbstractGitAwareGradleF
 
         and: "log explains why DRA was not used"
         result.output.contains("DRA snapshot commit did not match")
+    }
+
+    def "downloads distribution from DRA when mode=dra and no hash override uses latest snapshot without commit check"() {
+        given:
+        def bwcVersion = "8.4.0"
+        def bwcBranch = "8.x"
+        def shortHash = "abc12345"
+        def buildId = "${bwcVersion}-${shortHash}"
+        // resolveLatestBuildId does not read local git refs — no remote tracking ref needed.
+        stubLatest(wireMock, draLatestPath(bwcBranch), buildId)
+        stubTarArtifact(wireMock, draTarArtifactPath(buildId, bwcVersion, "darwin-x86_64"), bwcVersion)
+        redirectDraRepositories(wireMock.baseUrl())
+
+        when:
+        def result = gradleRunner(
+            ":distribution:bwc:major1:buildBwcDarwinTar",
+            "-DtestRemoteRepo=" + remoteGitRepo,
+            "-Dbwc.remote=origin",
+            "-Dtests.bwc.mode=dra",
+            "-Dtests.bwc.dra.base.url=${wireMock.baseUrl()}"
+        ).build()
+
+        then: "DRA Copy task succeeds without any commit-hash comparison"
+        result.task(":distribution:bwc:major1:buildBwcDarwinTar").outcome == TaskOutcome.SUCCESS
+
+        and: "no nested Gradle build was triggered"
+        result.output.contains("extractedAssemble") == false
+
+        and: "the DRA log message names the snapshot build ID"
+        result.output.contains("DRA snapshot ${buildId}")
+
+        and: "the distribution directory was created at the expected path"
+        file("cloned/distribution/bwc/major1/build/bwc/checkout-${bwcBranch}/" +
+            "distribution/archives/darwin-tar/build/install/" +
+            "elasticsearch-${bwcVersion}-SNAPSHOT").exists()
+    }
+
+    def "falls back to source build with warning when mode=dra but DRA snapshot is unavailable (distribution archive)"() {
+        given:
+        // Stub the latest endpoint with 404 so resolveLatestBuildId returns an empty build ID.
+        wireMock.stubFor(get(urlEqualTo(draLatestPath("8.x"))).willReturn(aResponse().withStatus(404)))
+
+        when:
+        def result = gradleRunner(
+            ":distribution:bwc:major1:buildBwcDarwinTar",
+            "-DtestRemoteRepo=" + remoteGitRepo,
+            "-Dbwc.remote=origin",
+            "-Dbwc.dist.version=8.4.0-SNAPSHOT",
+            "-Dtests.bwc.mode=dra",
+            "-Dtests.bwc.dra.base.url=${wireMock.baseUrl()}"
+        ).build()
+
+        then: "task still succeeds via source-build fallback"
+        result.task(":distribution:bwc:major1:buildBwcDarwinTar").outcome == TaskOutcome.SUCCESS
+
+        and: "local nested build was triggered"
+        assertOutputContains(result.output, "[8.4.0] > Task :distribution:archives:darwin-tar:extractedAssemble")
+
+        and: "a warning explains that DRA was unavailable"
+        result.output.contains("tests.bwc.mode=dra but no DRA snapshot was available")
     }
 
     def "bwc expanded distribution folder can be resolved as bwc project artifact"() {

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPluginFuncTest.groovy
@@ -217,6 +217,65 @@ class InternalDistributionBwcSetupPluginFuncTest extends AbstractGitAwareGradleF
         }
     }
 
+    def "downloads JDBC jar from DRA snapshot when hash matches"() {
+        given:
+        def bwcVersion = "8.4.0"
+        def bwcBranch = "8.x"
+        def shortHash = "abc12345"
+        def buildId = "${bwcVersion}-${shortHash}"
+        def manifestPath = "/elasticsearch/${buildId}/manifest-${bwcVersion}-SNAPSHOT.json"
+        def jdbcArtifactPath = "/elasticsearch/${buildId}/downloads/elasticsearch/" +
+            "x-pack-sql-jdbc-${bwcVersion}-SNAPSHOT.jar"
+
+        def wireMock = new WireMockServer(0)
+        wireMock.start()
+        try {
+            wireMock.stubFor(head(urlEqualTo(manifestPath)).willReturn(aResponse().withStatus(200)))
+            wireMock.stubFor(get(urlEqualTo(manifestPath))
+                .willReturn(aResponse().withStatus(200).withBody("{}")))
+            wireMock.stubFor(head(urlEqualTo(jdbcArtifactPath)).willReturn(aResponse().withStatus(200)))
+            wireMock.stubFor(get(urlEqualTo(jdbcArtifactPath))
+                .willReturn(aResponse().withStatus(200).withBody("fake-jdbc-content".bytes)))
+
+            buildFile << """
+                allprojects { p ->
+                    p.repositories.all { repo ->
+                        if (repo.name.startsWith("dra-bwc-elasticsearch-")) {
+                            repo.setUrl('${wireMock.baseUrl()}')
+                            allowInsecureProtocol = true
+                        }
+                    }
+                }
+            """
+
+            when:
+            def result = gradleRunner(
+                ":distribution:bwc:major1:buildBwcJdbc",
+                "-DtestRemoteRepo=" + remoteGitRepo,
+                "-Dbwc.remote=origin",
+                "-Dtests.bwc.dra.enabled=true",
+                "-Dtests.bwc.dra.hash.${bwcBranch}=${shortHash}",
+                "-Dtests.bwc.dra.base.url=${wireMock.baseUrl()}"
+            ).build()
+
+            then: "DRA Copy task succeeds"
+            result.task(":distribution:bwc:major1:buildBwcJdbc").outcome == TaskOutcome.SUCCESS
+
+            and: "no nested Gradle build was triggered"
+            result.output.contains("> Task :x-pack:plugin:sql:jdbc:assemble") == false
+
+            and: "the DRA log message names the snapshot build ID"
+            result.output.contains("DRA snapshot ${buildId}")
+
+            and: "the JDBC jar was created at the expected path"
+            file("cloned/distribution/bwc/major1/build/bwc/checkout-${bwcBranch}/" +
+                "x-pack/plugin/sql/jdbc/build/distributions/" +
+                "x-pack-sql-jdbc-${bwcVersion}-SNAPSHOT.jar").exists()
+        } finally {
+            wireMock.stop()
+        }
+    }
+
     def "falls back to local gradle build when DRA is disabled"() {
         when:
         def result = gradleRunner(":distribution:bwc:major1:buildBwcDarwinTar",

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPluginFuncTest.groovy
@@ -177,7 +177,7 @@ class InternalDistributionBwcSetupPluginFuncTest extends AbstractGitAwareGradleF
             wireMock.stubFor(head(urlEqualTo(manifestPath)).willReturn(aResponse().withStatus(200)))
             wireMock.stubFor(get(urlEqualTo(manifestPath))
                 .willReturn(aResponse().withStatus(200)
-                    .withBody("""{"projects": {"elasticsearch": {"commit": "${fullHash}"}}}""")))
+                    .withBody("""{"projects": {"elasticsearch": {"commit_hash": "${fullHash}"}}}""")))
             wireMock.stubFor(head(urlEqualTo(artifactPath)).willReturn(aResponse().withStatus(200)))
             wireMock.stubFor(get(urlEqualTo(artifactPath))
                 .willReturn(aResponse().withStatus(200)
@@ -291,7 +291,7 @@ class InternalDistributionBwcSetupPluginFuncTest extends AbstractGitAwareGradleF
             wireMock.stubFor(head(urlEqualTo(manifestPath)).willReturn(aResponse().withStatus(200)))
             wireMock.stubFor(get(urlEqualTo(manifestPath))
                 .willReturn(aResponse().withStatus(200)
-                    .withBody("""{"projects": {"elasticsearch": {"commit": "${fullHash}"}}}""")))
+                    .withBody("""{"projects": {"elasticsearch": {"commit_hash": "${fullHash}"}}}""")))
             wireMock.stubFor(head(urlEqualTo(artifactPath)).willReturn(aResponse().withStatus(200)))
             wireMock.stubFor(get(urlEqualTo(artifactPath))
                 .willReturn(aResponse().withStatus(200)
@@ -357,7 +357,7 @@ class InternalDistributionBwcSetupPluginFuncTest extends AbstractGitAwareGradleF
             wireMock.stubFor(head(urlEqualTo(manifestPath)).willReturn(aResponse().withStatus(200)))
             wireMock.stubFor(get(urlEqualTo(manifestPath))
                 .willReturn(aResponse().withStatus(200)
-                    .withBody("""{"projects": {"elasticsearch": {"commit": "${differentCommit}"}}}""")))
+                    .withBody("""{"projects": {"elasticsearch": {"commit_hash": "${differentCommit}"}}}""")))
 
             when:
             def result = gradleRunner(

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPluginFuncTest.groovy
@@ -224,8 +224,8 @@ class InternalDistributionBwcSetupPluginFuncTest extends AbstractGitAwareGradleF
         def shortHash = "abc12345"
         def buildId = "${bwcVersion}-${shortHash}"
         def manifestPath = "/elasticsearch/${buildId}/manifest-${bwcVersion}-SNAPSHOT.json"
-        def jdbcArtifactPath = "/elasticsearch/${buildId}/downloads/elasticsearch/" +
-            "x-pack-sql-jdbc-${bwcVersion}-SNAPSHOT.jar"
+        def jdbcArtifactPath = "/elasticsearch/${buildId}/maven/org/elasticsearch/plugin/" +
+            "x-pack-sql-jdbc/${bwcVersion}-SNAPSHOT/x-pack-sql-jdbc-${bwcVersion}-SNAPSHOT.jar"
 
         def wireMock = new WireMockServer(0)
         wireMock.start()

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPluginFuncTest.groovy
@@ -11,8 +11,17 @@ package org.elasticsearch.gradle.internal
 
 import spock.lang.Unroll
 
+import com.github.tomakehurst.wiremock.WireMockServer
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream
+import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream
 import org.elasticsearch.gradle.fixtures.AbstractGitAwareGradleFuncTest
 import org.gradle.testkit.runner.TaskOutcome
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import static com.github.tomakehurst.wiremock.client.WireMock.get
+import static com.github.tomakehurst.wiremock.client.WireMock.head
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 
 class InternalDistributionBwcSetupPluginFuncTest extends AbstractGitAwareGradleFuncTest {
 
@@ -78,6 +87,114 @@ class InternalDistributionBwcSetupPluginFuncTest extends AbstractGitAwareGradleF
         "8.4.0"       | "linux"
     }
 
+    def "downloads distribution from DRA snapshot when hash matches"() {
+        given:
+        def bwcVersion = "8.4.0"
+        def bwcBranch = "8.x"
+        def shortHash = "abc12345"
+        def buildId = "${bwcVersion}-${shortHash}"
+        def manifestPath = "/elasticsearch/${buildId}/manifest-${bwcVersion}-SNAPSHOT.json"
+        def artifactPath = "/elasticsearch/${buildId}/downloads/elasticsearch/" +
+            "elasticsearch-${bwcVersion}-SNAPSHOT-darwin-x86_64.tar.gz"
+
+        def wireMock = new WireMockServer(0)
+        wireMock.start()
+        try {
+            wireMock.stubFor(head(urlEqualTo(manifestPath)).willReturn(aResponse().withStatus(200)))
+            wireMock.stubFor(get(urlEqualTo(manifestPath))
+                .willReturn(aResponse().withStatus(200).withBody("{}")))
+            wireMock.stubFor(head(urlEqualTo(artifactPath)).willReturn(aResponse().withStatus(200)))
+            wireMock.stubFor(get(urlEqualTo(artifactPath))
+                .willReturn(aResponse().withStatus(200)
+                    .withBody(minimalElasticsearchTarGz("${bwcVersion}-SNAPSHOT"))))
+
+            buildFile << """
+                allprojects { p ->
+                    p.repositories.all { repo ->
+                        if (repo.name.startsWith("dra-bwc-elasticsearch-")) {
+                            repo.setUrl('${wireMock.baseUrl()}')
+                            allowInsecureProtocol = true
+                        }
+                    }
+                }
+            """
+
+            when:
+            def result = gradleRunner(
+                ":distribution:bwc:major1:buildBwcDarwinTar",
+                "-DtestRemoteRepo=" + remoteGitRepo,
+                "-Dbwc.remote=origin",
+                "-Dtests.bwc.dra.enabled=true",
+                "-Dtests.bwc.dra.hash.${bwcBranch}=${shortHash}",
+                "-Dtests.bwc.dra.base.url=${wireMock.baseUrl()}"
+            ).build()
+
+            then: "DRA Copy task succeeds"
+            result.task(":distribution:bwc:major1:buildBwcDarwinTar").outcome == TaskOutcome.SUCCESS
+
+            and: "no nested Gradle build was triggered"
+            result.output.contains("extractedAssemble") == false
+
+            and: "the DRA log message names the snapshot build ID"
+            result.output.contains("DRA snapshot ${buildId}")
+
+            and: "the distribution directory was created at the expected path"
+            file("cloned/distribution/bwc/major1/build/bwc/checkout-${bwcBranch}/" +
+                "distribution/archives/darwin-tar/build/install/" +
+                "elasticsearch-${bwcVersion}-SNAPSHOT").exists()
+        } finally {
+            wireMock.stop()
+        }
+    }
+
+    def "falls back to local gradle build when DRA is disabled"() {
+        when:
+        def result = gradleRunner(":distribution:bwc:major1:buildBwcDarwinTar",
+            "-DtestRemoteRepo=" + remoteGitRepo,
+            "-Dbwc.remote=origin",
+            "-Dbwc.dist.version=8.4.0-SNAPSHOT")
+            .build()
+        then:
+        result.task(":distribution:bwc:major1:buildBwcDarwinTar").outcome == TaskOutcome.SUCCESS
+
+        and: "local nested build was triggered"
+        assertOutputContains(result.output, "[8.4.0] > Task :distribution:archives:darwin-tar:extractedAssemble")
+    }
+
+    def "falls back to local gradle build when DRA manifest returns 404"() {
+        given:
+        def bwcVersion = "8.4.0"
+        def shortHash = "notexist"
+        def buildId = "${bwcVersion}-${shortHash}"
+        def manifestPath = "/elasticsearch/${buildId}/manifest-${bwcVersion}-SNAPSHOT.json"
+
+        def wireMock = new WireMockServer(0)
+        wireMock.start()
+        try {
+            wireMock.stubFor(head(urlEqualTo(manifestPath)).willReturn(aResponse().withStatus(404)))
+            wireMock.stubFor(get(urlEqualTo(manifestPath)).willReturn(aResponse().withStatus(404)))
+
+            when:
+            def result = gradleRunner(
+                ":distribution:bwc:major1:buildBwcDarwinTar",
+                "-DtestRemoteRepo=" + remoteGitRepo,
+                "-Dbwc.remote=origin",
+                "-Dbwc.dist.version=8.4.0-SNAPSHOT",
+                "-Dtests.bwc.dra.enabled=true",
+                "-Dtests.bwc.dra.hash.8.x=${shortHash}",
+                "-Dtests.bwc.dra.base.url=${wireMock.baseUrl()}"
+            ).build()
+
+            then: "task succeeds via local build fallback"
+            result.task(":distribution:bwc:major1:buildBwcDarwinTar").outcome == TaskOutcome.SUCCESS
+
+            and: "local nested build was used, not DRA"
+            assertOutputContains(result.output, "[8.4.0] > Task :distribution:archives:darwin-tar:extractedAssemble")
+        } finally {
+            wireMock.stop()
+        }
+    }
+
     def "bwc expanded distribution folder can be resolved as bwc project artifact"() {
         setup:
         buildFile << """
@@ -116,5 +233,41 @@ class InternalDistributionBwcSetupPluginFuncTest extends AbstractGitAwareGradleF
                         "distribution/archives/darwin-tar/build/install")
         result.output.contains("nested folder /distribution/bwc/major1/build/bwc/checkout-8.x/" +
                         "distribution/archives/darwin-tar/build/install/elasticsearch-8.4.0-SNAPSHOT")
+    }
+
+    /**
+     * Creates a minimal tar.gz that {@link org.elasticsearch.gradle.transform.SymbolicLinkPreservingUntarTransform}
+     * can extract.  The archive contains a single top-level directory {@code elasticsearch-{version}/} with one
+     * executable file inside, matching the real distribution layout well enough to satisfy the
+     * {@code expectedOutputFile.exists()} check in the DRA Copy task.
+     */
+    private static byte[] minimalElasticsearchTarGz(String version) {
+        def baos = new ByteArrayOutputStream()
+        def gzos = new GzipCompressorOutputStream(baos)
+        def taos = new TarArchiveOutputStream(gzos)
+        taos.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX)
+
+        def addDir = { String name ->
+            def entry = new TarArchiveEntry(name)
+            entry.setMode(0755)
+            taos.putArchiveEntry(entry)
+            taos.closeArchiveEntry()
+        }
+        def addFile = { String name, byte[] content ->
+            def entry = new TarArchiveEntry(name)
+            entry.setSize(content.length)
+            entry.setMode(0755)
+            taos.putArchiveEntry(entry)
+            taos.write(content)
+            taos.closeArchiveEntry()
+        }
+
+        addDir("elasticsearch-${version}/")
+        addDir("elasticsearch-${version}/bin/")
+        addFile("elasticsearch-${version}/bin/elasticsearch", "#!/bin/sh\n".bytes)
+
+        taos.finish()
+        gzos.close()
+        return baos.toByteArray()
     }
 }

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPluginFuncTest.groovy
@@ -25,6 +25,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 
 class InternalDistributionBwcSetupPluginFuncTest extends AbstractGitAwareGradleFuncTest {
 
+    WireMockServer wireMock
+
     def setup() {
         // Cannot serialize BwcSetupExtension containing project object
         configurationCacheCompatible = false
@@ -37,6 +39,12 @@ class InternalDistributionBwcSetupPluginFuncTest extends AbstractGitAwareGradleF
         execute("git branch origin/8.2", file("cloned"))
         execute("git branch origin/8.1", file("cloned"))
         execute("git branch origin/7.16", file("cloned"))
+        wireMock = new WireMockServer(0)
+        wireMock.start()
+    }
+
+    def cleanup() {
+        wireMock?.stop()
     }
 
     def "builds distribution from branches via archives extractedAssemble"() {
@@ -93,58 +101,33 @@ class InternalDistributionBwcSetupPluginFuncTest extends AbstractGitAwareGradleF
         def bwcBranch = "8.x"
         def shortHash = "abc12345"
         def buildId = "${bwcVersion}-${shortHash}"
-        def manifestPath = "/elasticsearch/${buildId}/manifest-${bwcVersion}-SNAPSHOT.json"
-        def artifactPath = "/elasticsearch/${buildId}/downloads/elasticsearch/" +
-            "elasticsearch-${bwcVersion}-SNAPSHOT-darwin-x86_64.tar.gz"
+        stubManifestOk(wireMock, draManifestPath(buildId, bwcVersion))
+        stubTarArtifact(wireMock, draTarArtifactPath(buildId, bwcVersion, "darwin-x86_64"), bwcVersion)
+        redirectDraRepositories(wireMock.baseUrl())
 
-        def wireMock = new WireMockServer(0)
-        wireMock.start()
-        try {
-            wireMock.stubFor(head(urlEqualTo(manifestPath)).willReturn(aResponse().withStatus(200)))
-            wireMock.stubFor(get(urlEqualTo(manifestPath))
-                .willReturn(aResponse().withStatus(200).withBody("{}")))
-            wireMock.stubFor(head(urlEqualTo(artifactPath)).willReturn(aResponse().withStatus(200)))
-            wireMock.stubFor(get(urlEqualTo(artifactPath))
-                .willReturn(aResponse().withStatus(200)
-                    .withBody(minimalElasticsearchTarGz("${bwcVersion}-SNAPSHOT"))))
+        when:
+        def result = gradleRunner(
+            ":distribution:bwc:major1:buildBwcDarwinTar",
+            "-DtestRemoteRepo=" + remoteGitRepo,
+            "-Dbwc.remote=origin",
+            "-Dtests.bwc.dra.enabled=true",
+            "-Dtests.bwc.dra.hash.${bwcBranch}=${shortHash}",
+            "-Dtests.bwc.dra.base.url=${wireMock.baseUrl()}"
+        ).build()
 
-            buildFile << """
-                allprojects { p ->
-                    p.repositories.all { repo ->
-                        if (repo.name.startsWith("dra-bwc-elasticsearch-")) {
-                            repo.setUrl('${wireMock.baseUrl()}')
-                            allowInsecureProtocol = true
-                        }
-                    }
-                }
-            """
+        then: "DRA Copy task succeeds"
+        result.task(":distribution:bwc:major1:buildBwcDarwinTar").outcome == TaskOutcome.SUCCESS
 
-            when:
-            def result = gradleRunner(
-                ":distribution:bwc:major1:buildBwcDarwinTar",
-                "-DtestRemoteRepo=" + remoteGitRepo,
-                "-Dbwc.remote=origin",
-                "-Dtests.bwc.dra.enabled=true",
-                "-Dtests.bwc.dra.hash.${bwcBranch}=${shortHash}",
-                "-Dtests.bwc.dra.base.url=${wireMock.baseUrl()}"
-            ).build()
+        and: "no nested Gradle build was triggered"
+        result.output.contains("extractedAssemble") == false
 
-            then: "DRA Copy task succeeds"
-            result.task(":distribution:bwc:major1:buildBwcDarwinTar").outcome == TaskOutcome.SUCCESS
+        and: "the DRA log message names the snapshot build ID"
+        result.output.contains("DRA snapshot ${buildId}")
 
-            and: "no nested Gradle build was triggered"
-            result.output.contains("extractedAssemble") == false
-
-            and: "the DRA log message names the snapshot build ID"
-            result.output.contains("DRA snapshot ${buildId}")
-
-            and: "the distribution directory was created at the expected path"
-            file("cloned/distribution/bwc/major1/build/bwc/checkout-${bwcBranch}/" +
-                "distribution/archives/darwin-tar/build/install/" +
-                "elasticsearch-${bwcVersion}-SNAPSHOT").exists()
-        } finally {
-            wireMock.stop()
-        }
+        and: "the distribution directory was created at the expected path"
+        file("cloned/distribution/bwc/major1/build/bwc/checkout-${bwcBranch}/" +
+            "distribution/archives/darwin-tar/build/install/" +
+            "elasticsearch-${bwcVersion}-SNAPSHOT").exists()
     }
 
     def "resolveByLatest falls back to origin remote when configured remote ref is absent (CI scenario)"() {
@@ -163,58 +146,29 @@ class InternalDistributionBwcSetupPluginFuncTest extends AbstractGitAwareGradleF
         def elasticRefFile = new File(file("cloned/.git/refs/remotes").parentFile, "remotes/elastic/${bwcBranch}")
         elasticRefFile.delete()
 
-        def latestPath = "/elasticsearch/latest/${bwcBranch}.json"
-        def manifestPath = "/elasticsearch/${buildId}/manifest-${bwcVersion}-SNAPSHOT.json"
-        def artifactPath = "/elasticsearch/${buildId}/downloads/elasticsearch/" +
-            "elasticsearch-${bwcVersion}-SNAPSHOT-darwin-x86_64.tar.gz"
+        stubLatest(wireMock, draLatestPath(bwcBranch), buildId)
+        stubManifestWithCommit(wireMock, draManifestPath(buildId, bwcVersion), fullHash)
+        stubTarArtifact(wireMock, draTarArtifactPath(buildId, bwcVersion, "darwin-x86_64"), bwcVersion)
+        redirectDraRepositories(wireMock.baseUrl())
 
-        def wireMock = new WireMockServer(0)
-        wireMock.start()
-        try {
-            wireMock.stubFor(get(urlEqualTo(latestPath))
-                .willReturn(aResponse().withStatus(200)
-                    .withBody("""{"build_id": "${buildId}"}""")))
-            wireMock.stubFor(head(urlEqualTo(manifestPath)).willReturn(aResponse().withStatus(200)))
-            wireMock.stubFor(get(urlEqualTo(manifestPath))
-                .willReturn(aResponse().withStatus(200)
-                    .withBody("""{"projects": {"elasticsearch": {"commit_hash": "${fullHash}"}}}""")))
-            wireMock.stubFor(head(urlEqualTo(artifactPath)).willReturn(aResponse().withStatus(200)))
-            wireMock.stubFor(get(urlEqualTo(artifactPath))
-                .willReturn(aResponse().withStatus(200)
-                    .withBody(minimalElasticsearchTarGz("${bwcVersion}-SNAPSHOT"))))
+        when:
+        // bwc.remote=elastic (the default) — no elastic remote ref exists, only origin
+        def result = gradleRunner(
+            ":distribution:bwc:major1:buildBwcDarwinTar",
+            "-DtestRemoteRepo=" + remoteGitRepo,
+            "-Dbwc.remote=elastic",
+            "-Dtests.bwc.dra.enabled=true",
+            "-Dtests.bwc.dra.base.url=${wireMock.baseUrl()}"
+        ).build()
 
-            buildFile << """
-                allprojects { p ->
-                    p.repositories.all { repo ->
-                        if (repo.name.startsWith("dra-bwc-elasticsearch-")) {
-                            repo.setUrl('${wireMock.baseUrl()}')
-                            allowInsecureProtocol = true
-                        }
-                    }
-                }
-            """
+        then: "DRA Copy task succeeds via origin fallback"
+        result.task(":distribution:bwc:major1:buildBwcDarwinTar").outcome == TaskOutcome.SUCCESS
 
-            when:
-            // bwc.remote=elastic (the default) — no elastic remote ref exists, only origin
-            def result = gradleRunner(
-                ":distribution:bwc:major1:buildBwcDarwinTar",
-                "-DtestRemoteRepo=" + remoteGitRepo,
-                "-Dbwc.remote=elastic",
-                "-Dtests.bwc.dra.enabled=true",
-                "-Dtests.bwc.dra.base.url=${wireMock.baseUrl()}"
-            ).build()
+        and: "no nested Gradle build was triggered"
+        result.output.contains("extractedAssemble") == false
 
-            then: "DRA Copy task succeeds via origin fallback"
-            result.task(":distribution:bwc:major1:buildBwcDarwinTar").outcome == TaskOutcome.SUCCESS
-
-            and: "no nested Gradle build was triggered"
-            result.output.contains("extractedAssemble") == false
-
-            and: "the DRA log message names the snapshot build ID"
-            result.output.contains("DRA snapshot ${buildId}")
-        } finally {
-            wireMock.stop()
-        }
+        and: "the DRA log message names the snapshot build ID"
+        result.output.contains("DRA snapshot ${buildId}")
     }
 
     def "downloads JDBC jar from DRA snapshot when hash matches"() {
@@ -223,57 +177,33 @@ class InternalDistributionBwcSetupPluginFuncTest extends AbstractGitAwareGradleF
         def bwcBranch = "8.x"
         def shortHash = "abc12345"
         def buildId = "${bwcVersion}-${shortHash}"
-        def manifestPath = "/elasticsearch/${buildId}/manifest-${bwcVersion}-SNAPSHOT.json"
-        def jdbcArtifactPath = "/elasticsearch/${buildId}/maven/org/elasticsearch/plugin/" +
-            "x-pack-sql-jdbc/${bwcVersion}-SNAPSHOT/x-pack-sql-jdbc-${bwcVersion}-SNAPSHOT.jar"
+        stubManifestOk(wireMock, draManifestPath(buildId, bwcVersion))
+        stubJarArtifact(wireMock, draMavenArtifactPath(buildId, bwcVersion, "org.elasticsearch.plugin", "x-pack-sql-jdbc"))
+        redirectDraRepositories(wireMock.baseUrl())
 
-        def wireMock = new WireMockServer(0)
-        wireMock.start()
-        try {
-            wireMock.stubFor(head(urlEqualTo(manifestPath)).willReturn(aResponse().withStatus(200)))
-            wireMock.stubFor(get(urlEqualTo(manifestPath))
-                .willReturn(aResponse().withStatus(200).withBody("{}")))
-            wireMock.stubFor(head(urlEqualTo(jdbcArtifactPath)).willReturn(aResponse().withStatus(200)))
-            wireMock.stubFor(get(urlEqualTo(jdbcArtifactPath))
-                .willReturn(aResponse().withStatus(200).withBody("fake-jdbc-content".bytes)))
+        when:
+        def result = gradleRunner(
+            ":distribution:bwc:major1:buildBwcJdbc",
+            "-DtestRemoteRepo=" + remoteGitRepo,
+            "-Dbwc.remote=origin",
+            "-Dtests.bwc.dra.enabled=true",
+            "-Dtests.bwc.dra.hash.${bwcBranch}=${shortHash}",
+            "-Dtests.bwc.dra.base.url=${wireMock.baseUrl()}"
+        ).build()
 
-            buildFile << """
-                allprojects { p ->
-                    p.repositories.all { repo ->
-                        if (repo.name.startsWith("dra-bwc-elasticsearch-")) {
-                            repo.setUrl('${wireMock.baseUrl()}')
-                            allowInsecureProtocol = true
-                        }
-                    }
-                }
-            """
+        then: "DRA Copy task succeeds"
+        result.task(":distribution:bwc:major1:buildBwcJdbc").outcome == TaskOutcome.SUCCESS
 
-            when:
-            def result = gradleRunner(
-                ":distribution:bwc:major1:buildBwcJdbc",
-                "-DtestRemoteRepo=" + remoteGitRepo,
-                "-Dbwc.remote=origin",
-                "-Dtests.bwc.dra.enabled=true",
-                "-Dtests.bwc.dra.hash.${bwcBranch}=${shortHash}",
-                "-Dtests.bwc.dra.base.url=${wireMock.baseUrl()}"
-            ).build()
+        and: "no nested Gradle build was triggered"
+        result.output.contains("> Task :x-pack:plugin:sql:jdbc:assemble") == false
 
-            then: "DRA Copy task succeeds"
-            result.task(":distribution:bwc:major1:buildBwcJdbc").outcome == TaskOutcome.SUCCESS
+        and: "the DRA log message names the snapshot build ID"
+        result.output.contains("DRA snapshot ${buildId}")
 
-            and: "no nested Gradle build was triggered"
-            result.output.contains("> Task :x-pack:plugin:sql:jdbc:assemble") == false
-
-            and: "the DRA log message names the snapshot build ID"
-            result.output.contains("DRA snapshot ${buildId}")
-
-            and: "the JDBC jar was created at the expected path"
-            file("cloned/distribution/bwc/major1/build/bwc/checkout-${bwcBranch}/" +
-                "x-pack/plugin/sql/jdbc/build/distributions/" +
-                "x-pack-sql-jdbc-${bwcVersion}-SNAPSHOT.jar").exists()
-        } finally {
-            wireMock.stop()
-        }
+        and: "the JDBC jar was created at the expected path"
+        file("cloned/distribution/bwc/major1/build/bwc/checkout-${bwcBranch}/" +
+            "x-pack/plugin/sql/jdbc/build/distributions/" +
+            "x-pack-sql-jdbc-${bwcVersion}-SNAPSHOT.jar").exists()
     }
 
     def "falls back to local gradle build when DRA is disabled"() {
@@ -295,33 +225,24 @@ class InternalDistributionBwcSetupPluginFuncTest extends AbstractGitAwareGradleF
         def bwcVersion = "8.4.0"
         def shortHash = "notexist"
         def buildId = "${bwcVersion}-${shortHash}"
-        def manifestPath = "/elasticsearch/${buildId}/manifest-${bwcVersion}-SNAPSHOT.json"
+        stubManifestNotFound(wireMock, draManifestPath(buildId, bwcVersion))
 
-        def wireMock = new WireMockServer(0)
-        wireMock.start()
-        try {
-            wireMock.stubFor(head(urlEqualTo(manifestPath)).willReturn(aResponse().withStatus(404)))
-            wireMock.stubFor(get(urlEqualTo(manifestPath)).willReturn(aResponse().withStatus(404)))
+        when:
+        def result = gradleRunner(
+            ":distribution:bwc:major1:buildBwcDarwinTar",
+            "-DtestRemoteRepo=" + remoteGitRepo,
+            "-Dbwc.remote=origin",
+            "-Dbwc.dist.version=8.4.0-SNAPSHOT",
+            "-Dtests.bwc.dra.enabled=true",
+            "-Dtests.bwc.dra.hash.8.x=${shortHash}",
+            "-Dtests.bwc.dra.base.url=${wireMock.baseUrl()}"
+        ).build()
 
-            when:
-            def result = gradleRunner(
-                ":distribution:bwc:major1:buildBwcDarwinTar",
-                "-DtestRemoteRepo=" + remoteGitRepo,
-                "-Dbwc.remote=origin",
-                "-Dbwc.dist.version=8.4.0-SNAPSHOT",
-                "-Dtests.bwc.dra.enabled=true",
-                "-Dtests.bwc.dra.hash.8.x=${shortHash}",
-                "-Dtests.bwc.dra.base.url=${wireMock.baseUrl()}"
-            ).build()
+        then: "task succeeds via local build fallback"
+        result.task(":distribution:bwc:major1:buildBwcDarwinTar").outcome == TaskOutcome.SUCCESS
 
-            then: "task succeeds via local build fallback"
-            result.task(":distribution:bwc:major1:buildBwcDarwinTar").outcome == TaskOutcome.SUCCESS
-
-            and: "local nested build was used, not DRA"
-            assertOutputContains(result.output, "[8.4.0] > Task :distribution:archives:darwin-tar:extractedAssemble")
-        } finally {
-            wireMock.stop()
-        }
+        and: "local nested build was used, not DRA"
+        assertOutputContains(result.output, "[8.4.0] > Task :distribution:archives:darwin-tar:extractedAssemble")
     }
 
     def "downloads distribution via resolveByLatest when remote tracking ref matches DRA manifest commit"() {
@@ -336,57 +257,28 @@ class InternalDistributionBwcSetupPluginFuncTest extends AbstractGitAwareGradleF
         def remoteRefFile = file("cloned/.git/refs/remotes/origin/${bwcBranch}")
         remoteRefFile.text = fullHash + "\n"
 
-        def latestPath = "/elasticsearch/latest/${bwcBranch}.json"
-        def manifestPath = "/elasticsearch/${buildId}/manifest-${bwcVersion}-SNAPSHOT.json"
-        def artifactPath = "/elasticsearch/${buildId}/downloads/elasticsearch/" +
-            "elasticsearch-${bwcVersion}-SNAPSHOT-darwin-x86_64.tar.gz"
+        stubLatest(wireMock, draLatestPath(bwcBranch), buildId)
+        stubManifestWithCommit(wireMock, draManifestPath(buildId, bwcVersion), fullHash)
+        stubTarArtifact(wireMock, draTarArtifactPath(buildId, bwcVersion, "darwin-x86_64"), bwcVersion)
+        redirectDraRepositories(wireMock.baseUrl())
 
-        def wireMock = new WireMockServer(0)
-        wireMock.start()
-        try {
-            wireMock.stubFor(get(urlEqualTo(latestPath))
-                .willReturn(aResponse().withStatus(200)
-                    .withBody("""{"build_id": "${buildId}"}""")))
-            wireMock.stubFor(head(urlEqualTo(manifestPath)).willReturn(aResponse().withStatus(200)))
-            wireMock.stubFor(get(urlEqualTo(manifestPath))
-                .willReturn(aResponse().withStatus(200)
-                    .withBody("""{"projects": {"elasticsearch": {"commit_hash": "${fullHash}"}}}""")))
-            wireMock.stubFor(head(urlEqualTo(artifactPath)).willReturn(aResponse().withStatus(200)))
-            wireMock.stubFor(get(urlEqualTo(artifactPath))
-                .willReturn(aResponse().withStatus(200)
-                    .withBody(minimalElasticsearchTarGz("${bwcVersion}-SNAPSHOT"))))
+        when:
+        def result = gradleRunner(
+            ":distribution:bwc:major1:buildBwcDarwinTar",
+            "-DtestRemoteRepo=" + remoteGitRepo,
+            "-Dbwc.remote=origin",
+            "-Dtests.bwc.dra.enabled=true",
+            "-Dtests.bwc.dra.base.url=${wireMock.baseUrl()}"
+        ).build()
 
-            buildFile << """
-                allprojects { p ->
-                    p.repositories.all { repo ->
-                        if (repo.name.startsWith("dra-bwc-elasticsearch-")) {
-                            repo.setUrl('${wireMock.baseUrl()}')
-                            allowInsecureProtocol = true
-                        }
-                    }
-                }
-            """
+        then: "DRA Copy task succeeds"
+        result.task(":distribution:bwc:major1:buildBwcDarwinTar").outcome == TaskOutcome.SUCCESS
 
-            when:
-            def result = gradleRunner(
-                ":distribution:bwc:major1:buildBwcDarwinTar",
-                "-DtestRemoteRepo=" + remoteGitRepo,
-                "-Dbwc.remote=origin",
-                "-Dtests.bwc.dra.enabled=true",
-                "-Dtests.bwc.dra.base.url=${wireMock.baseUrl()}"
-            ).build()
+        and: "no nested Gradle build was triggered"
+        result.output.contains("extractedAssemble") == false
 
-            then: "DRA Copy task succeeds"
-            result.task(":distribution:bwc:major1:buildBwcDarwinTar").outcome == TaskOutcome.SUCCESS
-
-            and: "no nested Gradle build was triggered"
-            result.output.contains("extractedAssemble") == false
-
-            and: "the DRA log message names the snapshot build ID"
-            result.output.contains("DRA snapshot ${buildId}")
-        } finally {
-            wireMock.stop()
-        }
+        and: "the DRA log message names the snapshot build ID"
+        result.output.contains("DRA snapshot ${buildId}")
     }
 
     def "falls back to local build when DRA manifest commit does not match remote tracking ref"() {
@@ -404,41 +296,27 @@ class InternalDistributionBwcSetupPluginFuncTest extends AbstractGitAwareGradleF
         // DRA manifest reports a different commit — mismatch triggers local build fallback.
         def differentCommit = "0" * 40
 
-        def latestPath = "/elasticsearch/latest/${bwcBranch}.json"
-        def manifestPath = "/elasticsearch/${buildId}/manifest-${bwcVersion}-SNAPSHOT.json"
+        stubLatest(wireMock, draLatestPath(bwcBranch), buildId)
+        stubManifestWithCommit(wireMock, draManifestPath(buildId, bwcVersion), differentCommit)
 
-        def wireMock = new WireMockServer(0)
-        wireMock.start()
-        try {
-            wireMock.stubFor(get(urlEqualTo(latestPath))
-                .willReturn(aResponse().withStatus(200)
-                    .withBody("""{"build_id": "${buildId}"}""")))
-            wireMock.stubFor(head(urlEqualTo(manifestPath)).willReturn(aResponse().withStatus(200)))
-            wireMock.stubFor(get(urlEqualTo(manifestPath))
-                .willReturn(aResponse().withStatus(200)
-                    .withBody("""{"projects": {"elasticsearch": {"commit_hash": "${differentCommit}"}}}""")))
+        when:
+        def result = gradleRunner(
+            ":distribution:bwc:major1:buildBwcDarwinTar",
+            "-DtestRemoteRepo=" + remoteGitRepo,
+            "-Dbwc.remote=origin",
+            "-Dbwc.dist.version=8.4.0-SNAPSHOT",
+            "-Dtests.bwc.dra.enabled=true",
+            "-Dtests.bwc.dra.base.url=${wireMock.baseUrl()}"
+        ).build()
 
-            when:
-            def result = gradleRunner(
-                ":distribution:bwc:major1:buildBwcDarwinTar",
-                "-DtestRemoteRepo=" + remoteGitRepo,
-                "-Dbwc.remote=origin",
-                "-Dbwc.dist.version=8.4.0-SNAPSHOT",
-                "-Dtests.bwc.dra.enabled=true",
-                "-Dtests.bwc.dra.base.url=${wireMock.baseUrl()}"
-            ).build()
+        then: "task succeeds via local build fallback"
+        result.task(":distribution:bwc:major1:buildBwcDarwinTar").outcome == TaskOutcome.SUCCESS
 
-            then: "task succeeds via local build fallback"
-            result.task(":distribution:bwc:major1:buildBwcDarwinTar").outcome == TaskOutcome.SUCCESS
+        and: "local nested build was used, not DRA"
+        assertOutputContains(result.output, "[8.4.0] > Task :distribution:archives:darwin-tar:extractedAssemble")
 
-            and: "local nested build was used, not DRA"
-            assertOutputContains(result.output, "[8.4.0] > Task :distribution:archives:darwin-tar:extractedAssemble")
-
-            and: "log explains why DRA was not used"
-            result.output.contains("DRA snapshot commit did not match")
-        } finally {
-            wireMock.stop()
-        }
+        and: "log explains why DRA was not used"
+        result.output.contains("DRA snapshot commit did not match")
     }
 
     def "bwc expanded distribution folder can be resolved as bwc project artifact"() {
@@ -480,6 +358,92 @@ class InternalDistributionBwcSetupPluginFuncTest extends AbstractGitAwareGradleF
         result.output.contains("nested folder /distribution/bwc/major1/build/bwc/checkout-8.x/" +
                         "distribution/archives/darwin-tar/build/install/elasticsearch-8.4.0-SNAPSHOT")
     }
+
+    // -------------------------------------------------------------------------
+    // Build-file helper
+    // -------------------------------------------------------------------------
+
+    /** Appends a Gradle snippet that redirects all DRA Ivy repositories to {@code baseUrl}. */
+    private void redirectDraRepositories(String baseUrl) {
+        buildFile << """
+            allprojects { p ->
+                p.repositories.all { repo ->
+                    if (repo.name.startsWith("dra-bwc-elasticsearch-")) {
+                        repo.setUrl('${baseUrl}')
+                        allowInsecureProtocol = true
+                    }
+                }
+            }
+        """
+    }
+
+    // -------------------------------------------------------------------------
+    // DRA URL path helpers
+    // -------------------------------------------------------------------------
+
+    private static String draManifestPath(String buildId, String version) {
+        "/elasticsearch/${buildId}/manifest-${version}-SNAPSHOT.json"
+    }
+
+    private static String draLatestPath(String branch) {
+        "/elasticsearch/latest/${branch}.json"
+    }
+
+    private static String draTarArtifactPath(String buildId, String version, String classifier) {
+        "/elasticsearch/${buildId}/downloads/elasticsearch/elasticsearch-${version}-SNAPSHOT-${classifier}.tar.gz"
+    }
+
+    private static String draMavenArtifactPath(String buildId, String version, String mavenGroup, String module) {
+        "/elasticsearch/${buildId}/maven/${mavenGroup.replace('.', '/')}/${module}/${version}-SNAPSHOT/${module}-${version}-SNAPSHOT.jar"
+    }
+
+    // -------------------------------------------------------------------------
+    // WireMock stub helpers
+    // -------------------------------------------------------------------------
+
+    /** Stubs HEAD+GET for a manifest path, returning HTTP 200 with an empty JSON body. */
+    private static void stubManifestOk(WireMockServer wireMock, String path) {
+        wireMock.stubFor(head(urlEqualTo(path)).willReturn(aResponse().withStatus(200)))
+        wireMock.stubFor(get(urlEqualTo(path)).willReturn(aResponse().withStatus(200).withBody("{}")))
+    }
+
+    /** Stubs HEAD+GET for a manifest path, returning HTTP 200 with the given commit hash in the body. */
+    private static void stubManifestWithCommit(WireMockServer wireMock, String path, String commitHash) {
+        wireMock.stubFor(head(urlEqualTo(path)).willReturn(aResponse().withStatus(200)))
+        wireMock.stubFor(get(urlEqualTo(path))
+            .willReturn(aResponse().withStatus(200)
+                .withBody("""{"projects": {"elasticsearch": {"commit_hash": "${commitHash}"}}}""")))
+    }
+
+    /** Stubs HEAD+GET for a manifest path to return HTTP 404, triggering source-build fallback. */
+    private static void stubManifestNotFound(WireMockServer wireMock, String path) {
+        wireMock.stubFor(head(urlEqualTo(path)).willReturn(aResponse().withStatus(404)))
+        wireMock.stubFor(get(urlEqualTo(path)).willReturn(aResponse().withStatus(404)))
+    }
+
+    /** Stubs GET for the DRA "latest" endpoint, returning a JSON body with the given build ID. */
+    private static void stubLatest(WireMockServer wireMock, String path, String buildId) {
+        wireMock.stubFor(get(urlEqualTo(path))
+            .willReturn(aResponse().withStatus(200).withBody("""{"build_id": "${buildId}"}""")))
+    }
+
+    /** Stubs HEAD+GET for a distribution tar.gz artifact path, serving a minimal extractable archive. */
+    private static void stubTarArtifact(WireMockServer wireMock, String path, String bwcVersion) {
+        wireMock.stubFor(head(urlEqualTo(path)).willReturn(aResponse().withStatus(200)))
+        wireMock.stubFor(get(urlEqualTo(path))
+            .willReturn(aResponse().withStatus(200).withBody(minimalElasticsearchTarGz("${bwcVersion}-SNAPSHOT"))))
+    }
+
+    /** Stubs HEAD+GET for a Maven JAR artifact path, serving a minimal fake JAR body. */
+    private static void stubJarArtifact(WireMockServer wireMock, String path, byte[] content = "fake-jar-content".bytes) {
+        wireMock.stubFor(head(urlEqualTo(path)).willReturn(aResponse().withStatus(200)))
+        wireMock.stubFor(get(urlEqualTo(path))
+            .willReturn(aResponse().withStatus(200).withBody(content)))
+    }
+
+    // -------------------------------------------------------------------------
+    // Artifact factory
+    // -------------------------------------------------------------------------
 
     /**
      * Creates a minimal tar.gz that {@link org.elasticsearch.gradle.transform.SymbolicLinkPreservingUntarTransform}

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPluginFuncTest.groovy
@@ -147,6 +147,76 @@ class InternalDistributionBwcSetupPluginFuncTest extends AbstractGitAwareGradleF
         }
     }
 
+    def "resolveByLatest falls back to origin remote when configured remote ref is absent (CI scenario)"() {
+        given:
+        def bwcVersion = "8.4.0"
+        def bwcBranch = "8.x"
+        def fullHash = execute("git rev-parse HEAD", file("cloned")).trim()
+        def shortHash = fullHash.substring(0, 8)
+        def buildId = "${bwcVersion}-${shortHash}"
+
+        // Write the ref under 'origin' only — simulates a CI checkout where the
+        // configured BWC remote ('elastic') is absent but 'origin' IS elastic/elasticsearch.
+        def originRefFile = file("cloned/.git/refs/remotes/origin/${bwcBranch}")
+        originRefFile.text = fullHash + "\n"
+        // Ensure there is no 'elastic' remote ref so the fallback path is exercised.
+        def elasticRefFile = new File(file("cloned/.git/refs/remotes").parentFile, "remotes/elastic/${bwcBranch}")
+        elasticRefFile.delete()
+
+        def latestPath = "/elasticsearch/latest/${bwcBranch}.json"
+        def manifestPath = "/elasticsearch/${buildId}/manifest-${bwcVersion}-SNAPSHOT.json"
+        def artifactPath = "/elasticsearch/${buildId}/downloads/elasticsearch/" +
+            "elasticsearch-${bwcVersion}-SNAPSHOT-darwin-x86_64.tar.gz"
+
+        def wireMock = new WireMockServer(0)
+        wireMock.start()
+        try {
+            wireMock.stubFor(get(urlEqualTo(latestPath))
+                .willReturn(aResponse().withStatus(200)
+                    .withBody("""{"build_id": "${buildId}"}""")))
+            wireMock.stubFor(head(urlEqualTo(manifestPath)).willReturn(aResponse().withStatus(200)))
+            wireMock.stubFor(get(urlEqualTo(manifestPath))
+                .willReturn(aResponse().withStatus(200)
+                    .withBody("""{"projects": {"elasticsearch": {"commit": "${fullHash}"}}}""")))
+            wireMock.stubFor(head(urlEqualTo(artifactPath)).willReturn(aResponse().withStatus(200)))
+            wireMock.stubFor(get(urlEqualTo(artifactPath))
+                .willReturn(aResponse().withStatus(200)
+                    .withBody(minimalElasticsearchTarGz("${bwcVersion}-SNAPSHOT"))))
+
+            buildFile << """
+                allprojects { p ->
+                    p.repositories.all { repo ->
+                        if (repo.name.startsWith("dra-bwc-elasticsearch-")) {
+                            repo.setUrl('${wireMock.baseUrl()}')
+                            allowInsecureProtocol = true
+                        }
+                    }
+                }
+            """
+
+            when:
+            // bwc.remote=elastic (the default) — no elastic remote ref exists, only origin
+            def result = gradleRunner(
+                ":distribution:bwc:major1:buildBwcDarwinTar",
+                "-DtestRemoteRepo=" + remoteGitRepo,
+                "-Dbwc.remote=elastic",
+                "-Dtests.bwc.dra.enabled=true",
+                "-Dtests.bwc.dra.base.url=${wireMock.baseUrl()}"
+            ).build()
+
+            then: "DRA Copy task succeeds via origin fallback"
+            result.task(":distribution:bwc:major1:buildBwcDarwinTar").outcome == TaskOutcome.SUCCESS
+
+            and: "no nested Gradle build was triggered"
+            result.output.contains("extractedAssemble") == false
+
+            and: "the DRA log message names the snapshot build ID"
+            result.output.contains("DRA snapshot ${buildId}")
+        } finally {
+            wireMock.stop()
+        }
+    }
+
     def "falls back to local gradle build when DRA is disabled"() {
         when:
         def result = gradleRunner(":distribution:bwc:major1:buildBwcDarwinTar",
@@ -190,6 +260,123 @@ class InternalDistributionBwcSetupPluginFuncTest extends AbstractGitAwareGradleF
 
             and: "local nested build was used, not DRA"
             assertOutputContains(result.output, "[8.4.0] > Task :distribution:archives:darwin-tar:extractedAssemble")
+        } finally {
+            wireMock.stop()
+        }
+    }
+
+    def "downloads distribution via resolveByLatest when remote tracking ref matches DRA manifest commit"() {
+        given:
+        def bwcVersion = "8.4.0"
+        def bwcBranch = "8.x"
+        def fullHash = execute("git rev-parse HEAD", file("cloned")).trim()
+        def shortHash = fullHash.substring(0, 8)
+        def buildId = "${bwcVersion}-${shortHash}"
+
+        // Write a remote tracking ref so remoteRefRevision() can resolve it without network access.
+        def remoteRefFile = file("cloned/.git/refs/remotes/origin/${bwcBranch}")
+        remoteRefFile.text = fullHash + "\n"
+
+        def latestPath = "/elasticsearch/latest/${bwcBranch}.json"
+        def manifestPath = "/elasticsearch/${buildId}/manifest-${bwcVersion}-SNAPSHOT.json"
+        def artifactPath = "/elasticsearch/${buildId}/downloads/elasticsearch/" +
+            "elasticsearch-${bwcVersion}-SNAPSHOT-darwin-x86_64.tar.gz"
+
+        def wireMock = new WireMockServer(0)
+        wireMock.start()
+        try {
+            wireMock.stubFor(get(urlEqualTo(latestPath))
+                .willReturn(aResponse().withStatus(200)
+                    .withBody("""{"build_id": "${buildId}"}""")))
+            wireMock.stubFor(head(urlEqualTo(manifestPath)).willReturn(aResponse().withStatus(200)))
+            wireMock.stubFor(get(urlEqualTo(manifestPath))
+                .willReturn(aResponse().withStatus(200)
+                    .withBody("""{"projects": {"elasticsearch": {"commit": "${fullHash}"}}}""")))
+            wireMock.stubFor(head(urlEqualTo(artifactPath)).willReturn(aResponse().withStatus(200)))
+            wireMock.stubFor(get(urlEqualTo(artifactPath))
+                .willReturn(aResponse().withStatus(200)
+                    .withBody(minimalElasticsearchTarGz("${bwcVersion}-SNAPSHOT"))))
+
+            buildFile << """
+                allprojects { p ->
+                    p.repositories.all { repo ->
+                        if (repo.name.startsWith("dra-bwc-elasticsearch-")) {
+                            repo.setUrl('${wireMock.baseUrl()}')
+                            allowInsecureProtocol = true
+                        }
+                    }
+                }
+            """
+
+            when:
+            def result = gradleRunner(
+                ":distribution:bwc:major1:buildBwcDarwinTar",
+                "-DtestRemoteRepo=" + remoteGitRepo,
+                "-Dbwc.remote=origin",
+                "-Dtests.bwc.dra.enabled=true",
+                "-Dtests.bwc.dra.base.url=${wireMock.baseUrl()}"
+            ).build()
+
+            then: "DRA Copy task succeeds"
+            result.task(":distribution:bwc:major1:buildBwcDarwinTar").outcome == TaskOutcome.SUCCESS
+
+            and: "no nested Gradle build was triggered"
+            result.output.contains("extractedAssemble") == false
+
+            and: "the DRA log message names the snapshot build ID"
+            result.output.contains("DRA snapshot ${buildId}")
+        } finally {
+            wireMock.stop()
+        }
+    }
+
+    def "falls back to local build when DRA manifest commit does not match remote tracking ref"() {
+        given:
+        def bwcBranch = "8.x"
+        def fullHash = execute("git rev-parse HEAD", file("cloned")).trim()
+
+        // Write a remote tracking ref pointing to the real local commit.
+        def remoteRefFile = file("cloned/.git/refs/remotes/origin/${bwcBranch}")
+        remoteRefFile.text = fullHash + "\n"
+
+        def bwcVersion = "8.4.0"
+        def shortHash = "deadbeef"
+        def buildId = "${bwcVersion}-${shortHash}"
+        // DRA manifest reports a different commit — mismatch triggers local build fallback.
+        def differentCommit = "0" * 40
+
+        def latestPath = "/elasticsearch/latest/${bwcBranch}.json"
+        def manifestPath = "/elasticsearch/${buildId}/manifest-${bwcVersion}-SNAPSHOT.json"
+
+        def wireMock = new WireMockServer(0)
+        wireMock.start()
+        try {
+            wireMock.stubFor(get(urlEqualTo(latestPath))
+                .willReturn(aResponse().withStatus(200)
+                    .withBody("""{"build_id": "${buildId}"}""")))
+            wireMock.stubFor(head(urlEqualTo(manifestPath)).willReturn(aResponse().withStatus(200)))
+            wireMock.stubFor(get(urlEqualTo(manifestPath))
+                .willReturn(aResponse().withStatus(200)
+                    .withBody("""{"projects": {"elasticsearch": {"commit": "${differentCommit}"}}}""")))
+
+            when:
+            def result = gradleRunner(
+                ":distribution:bwc:major1:buildBwcDarwinTar",
+                "-DtestRemoteRepo=" + remoteGitRepo,
+                "-Dbwc.remote=origin",
+                "-Dbwc.dist.version=8.4.0-SNAPSHOT",
+                "-Dtests.bwc.dra.enabled=true",
+                "-Dtests.bwc.dra.base.url=${wireMock.baseUrl()}"
+            ).build()
+
+            then: "task succeeds via local build fallback"
+            result.task(":distribution:bwc:major1:buildBwcDarwinTar").outcome == TaskOutcome.SUCCESS
+
+            and: "local nested build was used, not DRA"
+            assertOutputContains(result.output, "[8.4.0] > Task :distribution:archives:darwin-tar:extractedAssemble")
+
+            and: "log explains why DRA was not used"
+            result.output.contains("DRA snapshot commit did not match")
         } finally {
             wireMock.stop()
         }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/DraSnapshotBuildIdValueSource.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/DraSnapshotBuildIdValueSource.java
@@ -27,15 +27,29 @@ import java.net.http.HttpResponse;
 import java.time.Duration;
 
 /**
- * Resolves the DRA (Distribution Release Artifacts) snapshot build ID for a BWC branch and validates
- * that the snapshot was built from the same commit as the local remote tracking reference.
+ * Resolves the DRA (Distribution Release Artifacts) snapshot build ID for a BWC branch.
  *
- * <p>Returns the DRA build ID (e.g. {@code "9.4.2-abc12345"}) when a matching snapshot is found,
- * or an empty string when no match exists or when DRA resolution is disabled.
+ * <p>The behaviour is controlled by the {@link Params#getMode()} parameter, which mirrors the
+ * {@code tests.bwc.mode} system property:
  *
- * <p>DRA resolution is opt-in: set system property {@code tests.bwc.dra.enabled=true} to enable.
- * Without that property all calls return an empty string immediately with no network activity,
- * keeping local development builds unaffected.
+ * <ul>
+ *   <li>{@code gradle} (the default) — returns {@code ""} immediately with no network activity,
+ *       so the caller falls back to a nested Gradle source build.</li>
+ *   <li>{@code dra} — resolves the <em>latest</em> DRA snapshot build ID for the branch without
+ *       comparing commit hashes.  Returns the build ID when the latest endpoint responds
+ *       successfully, or {@code ""} on any error (the caller should treat {@code ""} as a fatal
+ *       condition for this mode).</li>
+ *   <li>{@code auto} — resolves the latest DRA snapshot build ID <em>and</em> verifies
+ *       that the snapshot was built from the same commit as the local remote-tracking ref.
+ *       Returns the build ID on a match, or {@code ""} when the hashes differ or when the
+ *       endpoint is unreachable (the caller will then fall back to a source build).</li>
+ * </ul>
+ *
+ * <p>In both DRA modes an optional commit-hash override can be supplied via
+ * {@code -Dtests.bwc.dra.hash.{branch}}.  When set, the build ID is constructed directly as
+ * {@code {version}-{hash}} and its existence is verified against the manifest endpoint — the
+ * "latest" lookup and remote-tracking ref comparison are both skipped.  This lets you pin to a
+ * specific DRA snapshot even after the branch tip has moved.
  */
 public abstract class DraSnapshotBuildIdValueSource implements ValueSource<String, DraSnapshotBuildIdValueSource.Params> {
 
@@ -54,8 +68,15 @@ public abstract class DraSnapshotBuildIdValueSource implements ValueSource<Strin
         /** Git remote name, e.g. {@code "elastic"}. */
         Property<String> getRemote();
 
-        /** Gate flag: when {@code false} (the default) return {@code ""} immediately with no network I/O. */
-        Property<Boolean> getDraEnabled();
+        /**
+         * BWC mode that controls how DRA snapshots are resolved.  Accepted values:
+         * {@code "gradle"} (default — always build from source),
+         * {@code "dra"} (always download latest DRA snapshot, no hash check), or
+         * {@code "auto"} (download from DRA if commit hash matches, otherwise build from source).
+         *
+         * <p>Set via the {@code tests.bwc.mode} system property.
+         */
+        Property<String> getMode();
 
         /**
          * Optional abbreviated commit hash supplied via {@code -Dtests.bwc.dra.hash.{branch}}.
@@ -76,7 +97,8 @@ public abstract class DraSnapshotBuildIdValueSource implements ValueSource<Strin
 
     @Override
     public String obtain() {
-        if (getParameters().getDraEnabled().get() == false) {
+        String mode = getParameters().getMode().getOrElse("gradle");
+        if (mode.equals("gradle")) {
             return "";
         }
         try {
@@ -84,6 +106,7 @@ public abstract class DraSnapshotBuildIdValueSource implements ValueSource<Strin
             String branch = getParameters().getBranch().get();
             String baseUrl = getParameters().getBaseUrl().get();
             HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
+            ObjectMapper mapper = new ObjectMapper();
 
             String hashOverride = getParameters().getHashOverride().getOrElse("");
             if (hashOverride.isEmpty() == false) {
@@ -92,9 +115,16 @@ public abstract class DraSnapshotBuildIdValueSource implements ValueSource<Strin
                 return resolveByHash(client, baseUrl, version, hashOverride);
             }
 
+            if (mode.equals("dra")) {
+                // Always use DRA: return the latest build ID without checking the commit hash.
+                return resolveLatestBuildId(client, mapper, baseUrl, version, branch);
+            }
+
+            // mode is "auto": only use DRA when the latest snapshot commit matches the
+            // local remote-tracking ref.
             return resolveByLatest(
                 client,
-                new ObjectMapper(),
+                mapper,
                 baseUrl,
                 version,
                 branch,
@@ -117,6 +147,38 @@ public abstract class DraSnapshotBuildIdValueSource implements ValueSource<Strin
         return response.statusCode() == 200 ? buildId : "";
     }
 
+    /**
+     * Fetches the latest DRA snapshot build ID for {@code branch} without comparing commit hashes.
+     * Used for {@code dra} mode where the caller always wants the newest pre-built snapshot.
+     */
+    private static String resolveLatestBuildId(HttpClient client, ObjectMapper mapper, String baseUrl, String version, String branch)
+        throws Exception {
+        String latestUrl = baseUrl + "/elasticsearch/latest/" + branch + ".json";
+        HttpResponse<String> latestResponse = client.send(
+            HttpRequest.newBuilder().uri(URI.create(latestUrl)).timeout(Duration.ofSeconds(10)).GET().build(),
+            HttpResponse.BodyHandlers.ofString()
+        );
+        if (latestResponse.statusCode() != 200) {
+            return "";
+        }
+        JsonNode latestJson = mapper.readTree(latestResponse.body());
+        String buildId = latestJson.path("build_id").asText("");
+        if (buildId.isEmpty()) {
+            return "";
+        }
+        int lastDash = buildId.lastIndexOf('-');
+        if (lastDash < 0 || buildId.substring(0, lastDash).equals(version) == false) {
+            return "";
+        }
+        return buildId;
+    }
+
+    /**
+     * Fetches the latest DRA snapshot build ID for {@code branch} and returns it only when the
+     * snapshot commit hash matches the local remote-tracking ref for that branch.  Used for
+     * {@code auto} mode so that a stale snapshot does not silently replace a newer
+     * local build.
+     */
     private static String resolveByLatest(
         HttpClient client,
         ObjectMapper mapper,
@@ -137,23 +199,8 @@ public abstract class DraSnapshotBuildIdValueSource implements ValueSource<Strin
             return "";
         }
 
-        String latestUrl = baseUrl + "/elasticsearch/latest/" + branch + ".json";
-        HttpResponse<String> latestResponse = client.send(
-            HttpRequest.newBuilder().uri(URI.create(latestUrl)).timeout(Duration.ofSeconds(10)).GET().build(),
-            HttpResponse.BodyHandlers.ofString()
-        );
-        if (latestResponse.statusCode() != 200) {
-            return "";
-        }
-
-        JsonNode latestJson = mapper.readTree(latestResponse.body());
-        String buildId = latestJson.path("build_id").asText("");
+        String buildId = resolveLatestBuildId(client, mapper, baseUrl, version, branch);
         if (buildId.isEmpty()) {
-            return "";
-        }
-
-        int lastDash = buildId.lastIndexOf('-');
-        if (lastDash < 0 || buildId.substring(0, lastDash).equals(version) == false) {
             return "";
         }
 
@@ -172,6 +219,18 @@ public abstract class DraSnapshotBuildIdValueSource implements ValueSource<Strin
             return "";
         }
 
-        return branchTipHash.equals(draCommit) ? buildId : "";
+        if (branchTipHash.equals(draCommit) == false) {
+            logger.info(
+                "BWC DRA [{}]: commit mismatch for branch [{}] — local ref is [{}] but DRA build [{}] was built from [{}];"
+                    + " falling back to source build",
+                version,
+                branch,
+                branchTipHash,
+                buildId,
+                draCommit
+            );
+            return "";
+        }
+        return buildId;
     }
 }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/DraSnapshotBuildIdValueSource.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/DraSnapshotBuildIdValueSource.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.gradle.internal;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.elasticsearch.gradle.internal.conventions.info.GitInfo;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.ValueSource;
+import org.gradle.api.provider.ValueSourceParameters;
+
+import java.io.File;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+
+/**
+ * Resolves the DRA (Distribution Release Artifacts) snapshot build ID for a BWC branch and validates
+ * that the snapshot was built from the same commit as the local remote tracking reference.
+ *
+ * <p>Returns the DRA build ID (e.g. {@code "9.4.2-abc12345"}) when a matching snapshot is found,
+ * or an empty string when no match exists or when DRA resolution is disabled.
+ *
+ * <p>DRA resolution is opt-in: set system property {@code tests.bwc.dra.enabled=true} to enable.
+ * Without that property all calls return an empty string immediately with no network activity,
+ * keeping local development builds unaffected.
+ */
+public abstract class DraSnapshotBuildIdValueSource implements ValueSource<String, DraSnapshotBuildIdValueSource.Params> {
+
+    public interface Params extends ValueSourceParameters {
+        /** BWC version string, e.g. {@code "9.4.2"}. */
+        Property<String> getVersion();
+
+        /** BWC branch name, e.g. {@code "9.4"}. */
+        Property<String> getBranch();
+
+        /** Root directory of the main git checkout, used to read remote tracking refs without forking a process. */
+        Property<File> getRootProjectDir();
+
+        /** Git remote name, e.g. {@code "elastic"}. */
+        Property<String> getRemote();
+
+        /** Gate flag: when {@code false} (the default) return {@code ""} immediately with no network I/O. */
+        Property<Boolean> getDraEnabled();
+
+        /**
+         * Optional abbreviated commit hash supplied via {@code -Dtests.bwc.dra.hash.{branch}}.
+         * When set the DRA build ID is constructed directly as {@code {version}-{hash}}
+         * (e.g. {@code 9.4.2-1a738181}) and its existence is verified against the manifest
+         * endpoint — the "latest" lookup and remote-tracking ref comparison are both skipped.
+         * This lets you pin to a specific DRA snapshot even after the branch tip has moved.
+         */
+        Property<String> getHashOverride();
+
+        /**
+         * Base URL for all DRA API and artifact requests.  Defaults to the real DRA server
+         * ({@code https://artifacts-snapshot.elastic.co}).  Override via
+         * {@code -Dtests.bwc.dra.base.url} in tests to redirect calls to a local mock server.
+         */
+        Property<String> getBaseUrl();
+    }
+
+    @Override
+    public String obtain() {
+        if (getParameters().getDraEnabled().get() == false) {
+            return "";
+        }
+        try {
+            String version = getParameters().getVersion().get();
+            String branch = getParameters().getBranch().get();
+            String baseUrl = getParameters().getBaseUrl().get();
+            HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
+
+            String hashOverride = getParameters().getHashOverride().getOrElse("");
+            if (hashOverride.isEmpty() == false) {
+                // Build ID is deterministic: {version}-{hash}. Skip the "latest" lookup and
+                // commit comparison — just verify the specific build exists in DRA.
+                return resolveByHash(client, baseUrl, version, hashOverride);
+            }
+
+            return resolveByLatest(
+                client,
+                new ObjectMapper(),
+                baseUrl,
+                version,
+                branch,
+                getParameters().getRootProjectDir().get(),
+                getParameters().getRemote().get()
+            );
+        } catch (Exception e) {
+            return "";
+        }
+    }
+
+    private static String resolveByHash(HttpClient client, String baseUrl, String version, String hash) throws Exception {
+        String buildId = version + "-" + hash;
+        String manifestUrl = baseUrl + "/elasticsearch/" + buildId + "/manifest-" + version + "-SNAPSHOT.json";
+        HttpResponse<String> response = client.send(
+            HttpRequest.newBuilder().uri(URI.create(manifestUrl)).timeout(Duration.ofSeconds(30)).GET().build(),
+            HttpResponse.BodyHandlers.ofString()
+        );
+        return response.statusCode() == 200 ? buildId : "";
+    }
+
+    private static String resolveByLatest(
+        HttpClient client,
+        ObjectMapper mapper,
+        String baseUrl,
+        String version,
+        String branch,
+        File rootProjectDir,
+        String remote
+    ) throws Exception {
+        String branchTipHash = GitInfo.remoteRefRevision(rootProjectDir, remote, branch);
+        if (branchTipHash == null) {
+            return "";
+        }
+
+        String latestUrl = baseUrl + "/elasticsearch/latest/" + branch + ".json";
+        HttpResponse<String> latestResponse = client.send(
+            HttpRequest.newBuilder().uri(URI.create(latestUrl)).timeout(Duration.ofSeconds(30)).GET().build(),
+            HttpResponse.BodyHandlers.ofString()
+        );
+        if (latestResponse.statusCode() != 200) {
+            return "";
+        }
+
+        JsonNode latestJson = mapper.readTree(latestResponse.body());
+        String buildId = latestJson.path("build_id").asText("");
+        if (buildId.isEmpty()) {
+            return "";
+        }
+
+        int lastDash = buildId.lastIndexOf('-');
+        if (lastDash < 0 || buildId.substring(0, lastDash).equals(version) == false) {
+            return "";
+        }
+
+        String manifestUrl = baseUrl + "/elasticsearch/" + buildId + "/manifest-" + version + "-SNAPSHOT.json";
+        HttpResponse<String> manifestResponse = client.send(
+            HttpRequest.newBuilder().uri(URI.create(manifestUrl)).timeout(Duration.ofSeconds(30)).GET().build(),
+            HttpResponse.BodyHandlers.ofString()
+        );
+        if (manifestResponse.statusCode() != 200) {
+            return "";
+        }
+
+        JsonNode manifestJson = mapper.readTree(manifestResponse.body());
+        String draCommit = manifestJson.path("projects").path("elasticsearch").path("commit").asText("");
+        if (draCommit.isEmpty()) {
+            return "";
+        }
+
+        return branchTipHash.equals(draCommit) ? buildId : "";
+    }
+}

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/DraSnapshotBuildIdValueSource.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/DraSnapshotBuildIdValueSource.java
@@ -167,7 +167,7 @@ public abstract class DraSnapshotBuildIdValueSource implements ValueSource<Strin
         }
 
         JsonNode manifestJson = mapper.readTree(manifestResponse.body());
-        String draCommit = manifestJson.path("projects").path("elasticsearch").path("commit").asText("");
+        String draCommit = manifestJson.path("projects").path("elasticsearch").path("commit_hash").asText("");
         if (draCommit.isEmpty()) {
             return "";
         }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/DraSnapshotBuildIdValueSource.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/DraSnapshotBuildIdValueSource.java
@@ -13,6 +13,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.elasticsearch.gradle.internal.conventions.info.GitInfo;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.ValueSource;
 import org.gradle.api.provider.ValueSourceParameters;
@@ -36,6 +38,8 @@ import java.time.Duration;
  * keeping local development builds unaffected.
  */
 public abstract class DraSnapshotBuildIdValueSource implements ValueSource<String, DraSnapshotBuildIdValueSource.Params> {
+
+    private static final Logger logger = Logging.getLogger(DraSnapshotBuildIdValueSource.class);
 
     public interface Params extends ValueSourceParameters {
         /** BWC version string, e.g. {@code "9.4.2"}. */
@@ -98,6 +102,7 @@ public abstract class DraSnapshotBuildIdValueSource implements ValueSource<Strin
                 getParameters().getRemote().get()
             );
         } catch (Exception e) {
+            logger.debug("DRA snapshot resolution failed for version [{}]: {}", getParameters().getVersion().get(), e.getMessage());
             return "";
         }
     }
@@ -106,7 +111,7 @@ public abstract class DraSnapshotBuildIdValueSource implements ValueSource<Strin
         String buildId = version + "-" + hash;
         String manifestUrl = baseUrl + "/elasticsearch/" + buildId + "/manifest-" + version + "-SNAPSHOT.json";
         HttpResponse<String> response = client.send(
-            HttpRequest.newBuilder().uri(URI.create(manifestUrl)).timeout(Duration.ofSeconds(30)).GET().build(),
+            HttpRequest.newBuilder().uri(URI.create(manifestUrl)).timeout(Duration.ofSeconds(10)).GET().build(),
             HttpResponse.BodyHandlers.ofString()
         );
         return response.statusCode() == 200 ? buildId : "";
@@ -121,14 +126,20 @@ public abstract class DraSnapshotBuildIdValueSource implements ValueSource<Strin
         File rootProjectDir,
         String remote
     ) throws Exception {
-        String branchTipHash = GitInfo.remoteRefRevision(rootProjectDir, remote, branch);
+        // CI checkouts always clone from elastic/elasticsearch as 'origin'; developer
+        // setups may have the branch under a different remote name. Check 'origin' first
+        // since it is authoritative in both environments.
+        String branchTipHash = GitInfo.remoteRefRevision(rootProjectDir, "origin", branch);
+        if (branchTipHash == null) {
+            branchTipHash = GitInfo.remoteRefRevision(rootProjectDir, remote, branch);
+        }
         if (branchTipHash == null) {
             return "";
         }
 
         String latestUrl = baseUrl + "/elasticsearch/latest/" + branch + ".json";
         HttpResponse<String> latestResponse = client.send(
-            HttpRequest.newBuilder().uri(URI.create(latestUrl)).timeout(Duration.ofSeconds(30)).GET().build(),
+            HttpRequest.newBuilder().uri(URI.create(latestUrl)).timeout(Duration.ofSeconds(10)).GET().build(),
             HttpResponse.BodyHandlers.ofString()
         );
         if (latestResponse.statusCode() != 200) {
@@ -148,7 +159,7 @@ public abstract class DraSnapshotBuildIdValueSource implements ValueSource<Strin
 
         String manifestUrl = baseUrl + "/elasticsearch/" + buildId + "/manifest-" + version + "-SNAPSHOT.json";
         HttpResponse<String> manifestResponse = client.send(
-            HttpRequest.newBuilder().uri(URI.create(manifestUrl)).timeout(Duration.ofSeconds(30)).GET().build(),
+            HttpRequest.newBuilder().uri(URI.create(manifestUrl)).timeout(Duration.ofSeconds(10)).GET().build(),
             HttpResponse.BodyHandlers.ofString()
         );
         if (manifestResponse.statusCode() != 200) {

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalBwcGitPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalBwcGitPlugin.java
@@ -159,17 +159,6 @@ public class InternalBwcGitPlugin implements Plugin<Project> {
             });
         });
 
-        // When a DRA snapshot is available, write the short commit hash from the build ID to build/refspec
-        // so downstream tasks that declare it as an input track changes correctly.
-        tasks.register("writeDraRefspec", writeDraRefspec -> {
-            writeDraRefspec.onlyIf("DRA snapshot available", t -> draBuildId.get().isEmpty() == false);
-            writeDraRefspec.doLast(t -> {
-                String buildId = draBuildId.get();
-                String shortHash = buildId.substring(buildId.lastIndexOf('-') + 1);
-                writeFile(projectLayout.getBuildDirectory().file("refspec").get().getAsFile(), shortHash);
-            });
-        });
-
         String checkoutConfiguration = "checkout";
         project.getConfigurations().create(checkoutConfiguration);
 

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalBwcGitPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalBwcGitPlugin.java
@@ -48,6 +48,7 @@ public class InternalBwcGitPlugin implements Plugin<Project> {
     private final ProviderFactory providerFactory;
 
     private BwcGitExtension gitExtension;
+    private Provider<String> draBuildId;
 
     @Inject
     public InternalBwcGitPlugin(
@@ -65,16 +66,20 @@ public class InternalBwcGitPlugin implements Plugin<Project> {
     @Override
     public void apply(Project project) {
         this.gitExtension = project.getExtensions().create("bwcGitConfig", BwcGitExtension.class);
+        // Default to no DRA — replaced by configureDraBuildId() after the git extension is fully set up.
+        this.draBuildId = providerFactory.provider(() -> "");
         Provider<String> remote = providerFactory.systemProperty("bwc.remote").orElse("elastic");
 
         TaskContainer tasks = project.getTasks();
         TaskProvider<LoggedExec> createCloneTaskProvider = tasks.register("createClone", LoggedExec.class, createClone -> {
             createClone.onlyIf("git checkout dir missing", task -> this.gitExtension.getCheckoutDir().get().exists() == false);
+            createClone.onlyIf("DRA snapshot not available", task -> draBuildId.get().isEmpty());
             createClone.commandLine("git", "clone", buildLayout.getRootDirectory(), gitExtension.getCheckoutDir().get());
         });
 
         TaskProvider<LoggedExec> findRemoteTaskProvider = tasks.register("findRemote", LoggedExec.class, findRemote -> {
             findRemote.dependsOn(createCloneTaskProvider);
+            findRemote.onlyIf("DRA snapshot not available", task -> draBuildId.get().isEmpty());
             findRemote.getWorkingDir().set(gitExtension.getCheckoutDir());
             findRemote.commandLine("git", "remote", "-v");
             findRemote.getCaptureOutput().set(true);
@@ -85,6 +90,7 @@ public class InternalBwcGitPlugin implements Plugin<Project> {
             String rootProjectName = project.getRootProject().getName();
 
             addRemote.dependsOn(findRemoteTaskProvider);
+            addRemote.onlyIf("DRA snapshot not available", task -> draBuildId.get().isEmpty());
             addRemote.onlyIf("remote exists", task -> (Boolean.valueOf(providerFactory.systemProperty("remoteExists").get()) == false));
             addRemote.doLast(new Action<Task>() {
                 @Override
@@ -112,6 +118,7 @@ public class InternalBwcGitPlugin implements Plugin<Project> {
                 }
                 throw new GradleException("tests.bwc.git_fetch_latest must be [true] or [false] but was [" + fetchProp + "]");
             });
+            fetchLatest.onlyIf("DRA snapshot not available", task -> draBuildId.get().isEmpty());
             fetchLatest.onlyIf("online and gitFetchLatest == true", t -> isOffline == false && gitFetchLatest.get());
             fetchLatest.dependsOn(addRemoteTaskProvider);
             fetchLatest.getWorkingDir().set(gitExtension.getCheckoutDir());
@@ -122,6 +129,7 @@ public class InternalBwcGitPlugin implements Plugin<Project> {
         String projectPath = project.getPath();
         TaskProvider<Task> checkoutBwcBranchTaskProvider = tasks.register("checkoutBwcBranch", checkoutBwcBranch -> {
             checkoutBwcBranch.dependsOn(fetchLatestTaskProvider);
+            checkoutBwcBranch.onlyIf("DRA snapshot not available", task -> draBuildId.get().isEmpty());
             ExtraPropertiesExtension taskExtensionsProperties = checkoutBwcBranch.getExtensions().getExtraProperties();
             checkoutBwcBranch.doLast(new Action<Task>() {
                 @Override
@@ -151,6 +159,17 @@ public class InternalBwcGitPlugin implements Plugin<Project> {
             });
         });
 
+        // When a DRA snapshot is available, write the short commit hash from the build ID to build/refspec
+        // so downstream tasks that declare it as an input track changes correctly.
+        tasks.register("writeDraRefspec", writeDraRefspec -> {
+            writeDraRefspec.onlyIf("DRA snapshot available", t -> draBuildId.get().isEmpty() == false);
+            writeDraRefspec.doLast(t -> {
+                String buildId = draBuildId.get();
+                String shortHash = buildId.substring(buildId.lastIndexOf('-') + 1);
+                writeFile(projectLayout.getBuildDirectory().file("refspec").get().getAsFile(), shortHash);
+            });
+        });
+
         String checkoutConfiguration = "checkout";
         project.getConfigurations().create(checkoutConfiguration);
 
@@ -159,6 +178,22 @@ public class InternalBwcGitPlugin implements Plugin<Project> {
             configurablePublishArtifact.setType("directory");
             configurablePublishArtifact.setName("checkoutDir");
         });
+    }
+
+    /**
+     * Replaces the default no-op DRA provider with a real one.  Must be called after the BWC git
+     * extension properties ({@code bwcVersion}, {@code bwcBranch}) have been set by the caller,
+     * so the provider is constructed with the correct version and branch values.
+     *
+     * <p>The {@code onlyIf} lambdas registered in {@link #apply} access the field through {@code this},
+     * so replacing the field here is reflected in all subsequent task executions.
+     */
+    public void configureDraBuildId(Provider<String> draBuildIdProvider) {
+        this.draBuildId = draBuildIdProvider;
+    }
+
+    public Provider<String> getDraBuildId() {
+        return draBuildId;
     }
 
     public BwcGitExtension getGitExtension() {

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalBwcGitPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalBwcGitPlugin.java
@@ -90,6 +90,10 @@ public class InternalBwcGitPlugin implements Plugin<Project> {
             String rootProjectName = project.getRootProject().getName();
 
             addRemote.dependsOn(findRemoteTaskProvider);
+            // Must be registered before "remote exists": when DRA is active findRemote is skipped
+            // and never sets the remoteExists system property, so the "remote exists" onlyIf would
+            // throw MissingValueException. Gradle short-circuits onlyIf in registration order, so
+            // placing this guard first prevents the unsafe check from being evaluated.
             addRemote.onlyIf("DRA snapshot not available", task -> draBuildId.get().isEmpty());
             addRemote.onlyIf("remote exists", task -> (Boolean.valueOf(providerFactory.systemProperty("remoteExists").get()) == false));
             addRemote.doLast(new Action<Task>() {

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
@@ -165,25 +165,8 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
         BwcGitExtension gitExtension = bwcGitPlugin.getGitExtension();
         Provider<Version> bwcVersion = versionInfoProvider.map(info -> info.version());
 
-        // Register artifact types and transforms for DRA archive unpacking (idempotent).
-        project.getDependencies().getArtifactTypes().maybeCreate("tar.gz");
-        project.getDependencies().registerTransform(SymbolicLinkPreservingUntarTransform.class, spec -> {
-            spec.getFrom().attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, "tar.gz").attribute(BWC_DISTRIBUTION_ATTRIBUTE, true);
-            spec.getTo()
-                .attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, ArtifactTypeDefinition.DIRECTORY_TYPE)
-                .attribute(BWC_DISTRIBUTION_ATTRIBUTE, true);
-            spec.parameters(p -> {});
-        });
-        project.getDependencies().getArtifactTypes().maybeCreate(ArtifactTypeDefinition.ZIP_TYPE);
-        project.getDependencies().registerTransform(UnzipTransform.class, spec -> {
-            spec.getFrom()
-                .attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, ArtifactTypeDefinition.ZIP_TYPE)
-                .attribute(BWC_DISTRIBUTION_ATTRIBUTE, true);
-            spec.getTo()
-                .attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, ArtifactTypeDefinition.DIRECTORY_TYPE)
-                .attribute(BWC_DISTRIBUTION_ATTRIBUTE, true);
-            spec.parameters(p -> {});
-        });
+        // Register DRA artifact types and transforms for this BWC sub-project.
+        registerDraArtifactTransforms(project);
 
         // Set the git extension properties before creating the DRA provider, so the provider's
         // ValueSource parameters receive proper lazy Provider<String> values.
@@ -318,6 +301,27 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
                 draBaseUrl
             );
         }
+    }
+
+    private static void registerDraArtifactTransforms(Project project) {
+        project.getDependencies().getArtifactTypes().maybeCreate("tar.gz");
+        project.getDependencies().registerTransform(SymbolicLinkPreservingUntarTransform.class, spec -> {
+            spec.getFrom().attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, "tar.gz").attribute(BWC_DISTRIBUTION_ATTRIBUTE, true);
+            spec.getTo()
+                .attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, ArtifactTypeDefinition.DIRECTORY_TYPE)
+                .attribute(BWC_DISTRIBUTION_ATTRIBUTE, true);
+            spec.parameters(p -> {});
+        });
+        project.getDependencies().getArtifactTypes().maybeCreate(ArtifactTypeDefinition.ZIP_TYPE);
+        project.getDependencies().registerTransform(UnzipTransform.class, spec -> {
+            spec.getFrom()
+                .attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, ArtifactTypeDefinition.ZIP_TYPE)
+                .attribute(BWC_DISTRIBUTION_ATTRIBUTE, true);
+            spec.getTo()
+                .attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, ArtifactTypeDefinition.DIRECTORY_TYPE)
+                .attribute(BWC_DISTRIBUTION_ATTRIBUTE, true);
+            spec.parameters(p -> {});
+        });
     }
 
     private static void registerBwcDistributionArtifacts(Project bwcProject, DistributionProject distributionProject) {

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
@@ -12,17 +12,23 @@ package org.elasticsearch.gradle.internal;
 import org.elasticsearch.gradle.Version;
 import org.elasticsearch.gradle.internal.info.BuildParameterExtension;
 import org.elasticsearch.gradle.internal.info.GlobalBuildInfoPlugin;
+import org.elasticsearch.gradle.transform.SymbolicLinkPreservingUntarTransform;
+import org.elasticsearch.gradle.transform.UnzipTransform;
 import org.gradle.api.Action;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.type.ArtifactTypeDefinition;
+import org.gradle.api.attributes.Attribute;
 import org.gradle.api.file.FileSystemOperations;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.JvmToolchainsPlugin;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
+import org.gradle.api.tasks.Copy;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.jvm.toolchain.JavaToolchainService;
@@ -51,6 +57,8 @@ import static org.elasticsearch.gradle.internal.util.ParamsUtils.loadBuildParams
  * and configure them to build various versions here.
  */
 public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
+
+    static final Attribute<Boolean> BWC_DISTRIBUTION_ATTRIBUTE = Attribute.of("bwc-distribution", Boolean.class);
 
     private final ObjectFactory objectFactory;
     private ProviderFactory providerFactory;
@@ -153,11 +161,56 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
                 checkoutDir,
                 isCi
             );
-        BwcGitExtension gitExtension = project.getPlugins().apply(InternalBwcGitPlugin.class).getGitExtension();
+        InternalBwcGitPlugin bwcGitPlugin = project.getPlugins().apply(InternalBwcGitPlugin.class);
+        BwcGitExtension gitExtension = bwcGitPlugin.getGitExtension();
         Provider<Version> bwcVersion = versionInfoProvider.map(info -> info.version());
+
+        // Register artifact types and transforms for DRA archive unpacking (idempotent).
+        project.getDependencies().getArtifactTypes().maybeCreate("tar.gz");
+        project.getDependencies().registerTransform(SymbolicLinkPreservingUntarTransform.class, spec -> {
+            spec.getFrom().attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, "tar.gz").attribute(BWC_DISTRIBUTION_ATTRIBUTE, true);
+            spec.getTo()
+                .attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, ArtifactTypeDefinition.DIRECTORY_TYPE)
+                .attribute(BWC_DISTRIBUTION_ATTRIBUTE, true);
+            spec.parameters(p -> {});
+        });
+        project.getDependencies().getArtifactTypes().maybeCreate(ArtifactTypeDefinition.ZIP_TYPE);
+        project.getDependencies().registerTransform(UnzipTransform.class, spec -> {
+            spec.getFrom()
+                .attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, ArtifactTypeDefinition.ZIP_TYPE)
+                .attribute(BWC_DISTRIBUTION_ATTRIBUTE, true);
+            spec.getTo()
+                .attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, ArtifactTypeDefinition.DIRECTORY_TYPE)
+                .attribute(BWC_DISTRIBUTION_ATTRIBUTE, true);
+            spec.parameters(p -> {});
+        });
+
+        // Set the git extension properties before creating the DRA provider, so the provider's
+        // ValueSource parameters receive proper lazy Provider<String> values.
         gitExtension.setBwcVersion(versionInfoProvider.map(info -> info.version()));
         gitExtension.setBwcBranch(versionInfoProvider.map(info -> info.branch()));
         gitExtension.getCheckoutDir().set(checkoutDir);
+
+        Provider<String> remote = providerFactory.systemProperty("bwc.remote").orElse("elastic");
+        Provider<String> draBaseUrl = providerFactory.systemProperty("tests.bwc.dra.base.url")
+            .orElse("https://artifacts-snapshot.elastic.co");
+        Provider<String> draBuildId = providerFactory.of(DraSnapshotBuildIdValueSource.class, spec -> {
+            spec.getParameters().getVersion().set(versionInfoProvider.map(info -> info.version().toString()));
+            Provider<String> branch = versionInfoProvider.map(info -> info.branch());
+            spec.getParameters().getBranch().set(branch);
+            spec.getParameters().getRootProjectDir().set(project.getRootProject().getLayout().getProjectDirectory().getAsFile());
+            spec.getParameters().getRemote().set(remote);
+            spec.getParameters()
+                .getDraEnabled()
+                .set(providerFactory.systemProperty("tests.bwc.dra.enabled").map(Boolean::parseBoolean).orElse(false));
+            // -Dtests.bwc.dra.hash.{branch} overrides the local remote-tracking ref lookup,
+            // allowing the DRA fast path on stale or absent refs.
+            spec.getParameters()
+                .getHashOverride()
+                .set(branch.flatMap(b -> providerFactory.systemProperty("tests.bwc.dra.hash." + b)).orElse(""));
+            spec.getParameters().getBaseUrl().set(draBaseUrl);
+        });
+        bwcGitPlugin.configureDraBuildId(draBuildId);
 
         // we want basic lifecycle tasks like `clean` here.
         project.getPlugins().apply(LifecycleBasePlugin.class);
@@ -193,7 +246,11 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
                 distributionProject.projectPath,
                 distributionProject.expectedBuildArtifact,
                 buildBwcTaskProvider,
-                distributionProject.getAssembleTaskName()
+                distributionProject.getAssembleTaskName(),
+                draBuildId,
+                distributionProject.gradleClassifier,
+                distributionProject.extension,
+                draBaseUrl
             );
 
             registerBwcDistributionArtifacts(project, distributionProject);
@@ -216,7 +273,11 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
             jdbcProjectDir,
             jdbcProjectArtifact,
             buildBwcTaskProvider,
-            "assemble"
+            "assemble",
+            draBuildId,
+            "",
+            "jar",
+            draBaseUrl
         );
 
         // for versions before 8.7.0, we do not need to set up stable API bwc
@@ -250,7 +311,11 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
                 "libs/" + stableApiProject.getName(),
                 stableAnalysisPluginProjectArtifact,
                 buildBwcTaskProvider,
-                "assemble"
+                "assemble",
+                draBuildId,
+                "",
+                "jar",
+                draBaseUrl
             );
         }
     }
@@ -370,38 +435,180 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
         String projectPath,
         DistributionProjectArtifact projectArtifact,
         TaskProvider<Task> bwcTaskProvider,
-        String assembleTaskName
+        String assembleTaskName,
+        Provider<String> draBuildId,
+        String gradleClassifier,
+        String extension,
+        Provider<String> draBaseUrl
     ) {
         String bwcTaskName = buildBwcTaskName(projectName);
-        bwcSetupExtension.bwcTask(bwcTaskName, c -> {
-            boolean useNativeExpanded = projectArtifact.expandedDistDir != null;
-            boolean isReleaseBuild = System.getProperty("tests.bwc.snapshot", "true").equals("false");
-            File expectedOutputFile = useNativeExpanded
-                ? new File(projectArtifact.expandedDistDir, "elasticsearch-" + bwcVersion.get() + (isReleaseBuild ? "" : "-SNAPSHOT"))
-                : projectArtifact.distFile;
-            c.getInputs().file(new File(project.getBuildDir(), "refspec")).withPathSensitivity(PathSensitivity.RELATIVE);
-            if (useNativeExpanded) {
-                c.getOutputs().dir(expectedOutputFile);
-            } else {
-                c.getOutputs().files(expectedOutputFile);
-            }
-            c.getOutputs().doNotCacheIf("BWC distribution caching is disabled for local builds", task -> buildParams.getCi() == false);
-            c.getArgs().add("-p");
-            c.getArgs().add(projectPath);
-            c.getArgs().add(assembleTaskName);
-            if (project.getGradle().getStartParameter().isBuildCacheEnabled()) {
-                c.getArgs().add("--build-cache");
-            }
-            File rootDir = project.getRootDir();
-            c.doLast(new Action<Task>() {
-                @Override
-                public void execute(Task task) {
-                    if (expectedOutputFile.exists() == false) {
-                        Path relativeOutputPath = rootDir.toPath().relativize(expectedOutputFile.toPath());
-                        final String message = "Building %s didn't generate expected artifact [%s]. The working branch may be "
-                            + "out-of-date - try merging in the latest upstream changes to the branch.";
-                        throw new InvalidUserDataException(message.formatted(bwcVersion.get(), relativeOutputPath));
+        boolean useNativeExpanded = projectArtifact.expandedDistDir != null;
+        boolean isReleaseBuild = System.getProperty("tests.bwc.snapshot", "true").equals("false");
+        File expectedOutputFile = useNativeExpanded
+            ? new File(projectArtifact.expandedDistDir, "elasticsearch-" + bwcVersion.get() + (isReleaseBuild ? "" : "-SNAPSHOT"))
+            : projectArtifact.distFile;
+
+        boolean isDistributionArchive = projectPath.startsWith("distribution/");
+        // Evaluate the DRA build ID at configuration time. When tests.bwc.dra.enabled is not set
+        // (the default), the ValueSource returns "" immediately with no network activity.
+        String buildId = draBuildId.get();
+        boolean useDra = buildId.isEmpty() == false && isDistributionArchive;
+
+        if (useDra) {
+            createDraBwcTask(
+                project,
+                bwcTaskName,
+                buildId,
+                draBaseUrl.get(),
+                bwcVersion,
+                projectName,
+                projectArtifact,
+                gradleClassifier,
+                extension,
+                useNativeExpanded,
+                expectedOutputFile,
+                buildParams,
+                bwcTaskProvider
+            );
+        } else {
+            // Evaluate tests.bwc.dra.enabled at configuration time so the boolean is captured
+            // in the doFirst action rather than the Project instance (which is not CC-serializable).
+            boolean draEnabled = project.getProviders().systemProperty("tests.bwc.dra.enabled").map(Boolean::parseBoolean).getOrElse(false);
+            bwcSetupExtension.bwcTask(bwcTaskName, c -> {
+                c.doFirst(task -> {
+                    if (isDistributionArchive) {
+                        if (draEnabled) {
+                            task.getLogger()
+                                .lifecycle(
+                                    "BWC [{}]: building distribution [{}] from source"
+                                        + " — DRA snapshot commit did not match local remote-tracking ref (or was unreachable)",
+                                    bwcVersion.get(),
+                                    projectName
+                                );
+                        } else {
+                            task.getLogger()
+                                .lifecycle(
+                                    "BWC [{}]: building distribution [{}] from source"
+                                        + " — set -Dtests.bwc.dra.enabled=true to use a pre-built DRA snapshot when the commit matches",
+                                    bwcVersion.get(),
+                                    projectName
+                                );
+                        }
+                    } else {
+                        task.getLogger().lifecycle("BWC [{}]: building [{}] from source", bwcVersion.get(), projectName);
                     }
+                });
+                c.getInputs().file(new File(project.getBuildDir(), "refspec")).withPathSensitivity(PathSensitivity.RELATIVE);
+                if (useNativeExpanded) {
+                    c.getOutputs().dir(expectedOutputFile);
+                } else {
+                    c.getOutputs().files(expectedOutputFile);
+                }
+                c.getOutputs().doNotCacheIf("BWC distribution caching is disabled for local builds", task -> buildParams.getCi() == false);
+                c.getArgs().add("-p");
+                c.getArgs().add(projectPath);
+                c.getArgs().add(assembleTaskName);
+                if (project.getGradle().getStartParameter().isBuildCacheEnabled()) {
+                    c.getArgs().add("--build-cache");
+                }
+                File rootDir = project.getRootDir();
+                c.doLast(new Action<Task>() {
+                    @Override
+                    public void execute(Task task) {
+                        if (expectedOutputFile.exists() == false) {
+                            Path relativeOutputPath = rootDir.toPath().relativize(expectedOutputFile.toPath());
+                            final String message = "Building %s didn't generate expected artifact [%s]. The working branch may be "
+                                + "out-of-date - try merging in the latest upstream changes to the branch.";
+                            throw new InvalidUserDataException(message.formatted(bwcVersion.get(), relativeOutputPath));
+                        }
+                    }
+                });
+            });
+            bwcTaskProvider.configure(t -> t.dependsOn(bwcTaskName));
+        }
+    }
+
+    private static void createDraBwcTask(
+        Project project,
+        String bwcTaskName,
+        String buildId,
+        String draBaseUrl,
+        Provider<Version> bwcVersion,
+        String projectName,
+        DistributionProjectArtifact projectArtifact,
+        String gradleClassifier,
+        String extension,
+        boolean useNativeExpanded,
+        File expectedOutputFile,
+        BuildParameterExtension buildParams,
+        TaskProvider<Task> bwcTaskProvider
+    ) {
+        // Configure the DRA Ivy repository for this specific BWC version and build.
+        String repoName = "dra-bwc-elasticsearch-" + bwcVersion.get() + "-" + projectName;
+        if (project.getRepositories().findByName(repoName) == null) {
+            project.getRepositories().ivy(repo -> {
+                repo.setName(repoName);
+                repo.setUrl(draBaseUrl);
+                repo.patternLayout(p -> {
+                    if (gradleClassifier.isEmpty()) {
+                        p.artifact("/elasticsearch/" + buildId + "/downloads/elasticsearch/[module]-[revision].[ext]");
+                    } else {
+                        p.artifact("/elasticsearch/" + buildId + "/downloads/elasticsearch/[module]-[revision]-[classifier].[ext]");
+                    }
+                });
+                repo.metadataSources(s -> s.artifact());
+                repo.content(c -> c.includeVersionByRegex("org.elasticsearch", "elasticsearch", ".*-SNAPSHOT"));
+            });
+        }
+
+        // Resolvable configuration: requests directory type for archives that support expansion,
+        // or the raw artifact type for packages (deb, rpm) and older archives.
+        String draConfigName = "draResolvable-" + bwcVersion.get() + "-" + projectName;
+        Configuration draConfig = project.getConfigurations().create(draConfigName);
+        draConfig.setCanBeResolved(true);
+        draConfig.setCanBeConsumed(false);
+        draConfig.getAttributes().attribute(BWC_DISTRIBUTION_ATTRIBUTE, true);
+        if (useNativeExpanded) {
+            draConfig.getAttributes().attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, ArtifactTypeDefinition.DIRECTORY_TYPE);
+        } else {
+            draConfig.getAttributes().attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, extension);
+        }
+
+        String versionString = bwcVersion.get() + "-SNAPSHOT";
+        String dependencyNotation = gradleClassifier.isEmpty()
+            ? "org.elasticsearch:elasticsearch:" + versionString + "@" + extension
+            : "org.elasticsearch:elasticsearch:" + versionString + ":" + gradleClassifier + "@" + extension;
+        project.getDependencies().add(draConfigName, dependencyNotation);
+
+        // Copy task that places the resolved (and optionally unpacked) artifact at the expected path.
+        File rootDir = project.getRootDir();
+        project.getTasks().register(bwcTaskName, Copy.class, t -> {
+            t.doFirst(
+                task -> task.getLogger()
+                    .lifecycle(
+                        "BWC [{}]: downloading pre-built distribution [{}] from DRA snapshot {} — skipping source build",
+                        bwcVersion.get(),
+                        projectName,
+                        buildId
+                    )
+            );
+            t.dependsOn("writeDraRefspec");
+            t.getInputs().file(new File(project.getBuildDir(), "refspec")).withPathSensitivity(PathSensitivity.RELATIVE);
+            t.from(draConfig);
+            if (useNativeExpanded) {
+                t.into(projectArtifact.expandedDistDir);
+                t.getOutputs().dir(expectedOutputFile);
+            } else {
+                t.into(projectArtifact.distFile.getParentFile());
+                t.getOutputs().files(projectArtifact.distFile);
+            }
+            t.getOutputs().doNotCacheIf("BWC distribution caching is disabled for local builds", task -> buildParams.getCi() == false);
+            t.doLast(task -> {
+                if (expectedOutputFile.exists() == false) {
+                    Path relativeOutputPath = rootDir.toPath().relativize(expectedOutputFile.toPath());
+                    throw new InvalidUserDataException(
+                        "Downloading %s from DRA didn't produce expected artifact [%s].".formatted(bwcVersion.get(), relativeOutputPath)
+                    );
                 }
             });
         });
@@ -416,6 +623,9 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
         final String name;
         final File checkoutDir;
         final String projectPath;
+        /** Classifier without the leading {@code -}, suitable for use in a Gradle dependency notation. */
+        final String gradleClassifier;
+        final String extension;
 
         /**
          * can be removed once we don't build 7.10 anymore
@@ -431,6 +641,8 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
             this.name = name;
             this.checkoutDir = checkoutDir;
             this.projectPath = baseDir + "/" + name;
+            this.gradleClassifier = classifier.isEmpty() ? "" : classifier.substring(1);
+            this.extension = extension;
             this.expandedDistDirSupport = version.onOrAfter("7.10.0") && (name.endsWith("zip") || name.endsWith("tar"));
             this.extractedAssembleSupported = version.onOrAfter("7.11.0") && (name.endsWith("zip") || name.endsWith("tar"));
             this.expectedBuildArtifact = new DistributionProjectArtifact(

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
@@ -15,6 +15,7 @@ import org.elasticsearch.gradle.internal.info.GlobalBuildInfoPlugin;
 import org.elasticsearch.gradle.transform.SymbolicLinkPreservingUntarTransform;
 import org.elasticsearch.gradle.transform.UnzipTransform;
 import org.gradle.api.Action;
+import org.gradle.api.DefaultTask;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -22,14 +23,20 @@ import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition;
 import org.gradle.api.attributes.Attribute;
+import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileSystemOperations;
 import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.JvmToolchainsPlugin;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.tasks.Copy;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.jvm.toolchain.JavaToolchainService;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
@@ -612,12 +619,14 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
 
         File rootDir = project.getRootDir();
         if (mavenModule.isEmpty() == false) {
-            // Maven JAR artifacts (JDBC, stable API): use a plain DefaultTask so that
+            // Maven JAR artifacts (JDBC, stable API): use a dedicated task type so that
             // getOutputs().getFiles() contains exactly the downloaded JAR. A Copy task's
             // implicit @OutputDirectory would also appear in the output file set, causing
             // JarApiComparisonTask's single-jar assertion to fail with both the JAR name
             // and the parent directory name ("distributions") in the set.
-            project.getTasks().register(bwcTaskName, task -> {
+            // A typed task class also avoids Configuration Cache issues: a plain
+            // DefaultTask doLast lambda cannot capture a Configuration object.
+            project.getTasks().register(bwcTaskName, DownloadMavenJarTask.class, task -> {
                 task.doFirst(
                     t -> t.getLogger()
                         .lifecycle(
@@ -628,25 +637,10 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
                         )
                 );
                 task.dependsOn("writeDraRefspec");
-                task.getInputs().files(draConfig).withPropertyName("draJar");
+                task.getDraJar().from(draConfig);
                 task.getInputs().file(new File(project.getBuildDir(), "refspec")).withPathSensitivity(PathSensitivity.RELATIVE);
-                task.getOutputs().file(projectArtifact.distFile);
+                task.getOutputJar().set(projectArtifact.distFile);
                 task.getOutputs().doNotCacheIf("BWC distribution caching is disabled for local builds", t -> buildParams.getCi() == false);
-                task.doLast(t -> {
-                    projectArtifact.distFile.getParentFile().mkdirs();
-                    File src = draConfig.getSingleFile();
-                    try {
-                        Files.copy(src.toPath(), projectArtifact.distFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
-                    } catch (IOException e) {
-                        throw new RuntimeException(e);
-                    }
-                    if (projectArtifact.distFile.exists() == false) {
-                        Path relativeOutputPath = rootDir.toPath().relativize(projectArtifact.distFile.toPath());
-                        throw new InvalidUserDataException(
-                            "Downloading %s from DRA didn't produce expected artifact [%s].".formatted(bwcVersion.get(), relativeOutputPath)
-                        );
-                    }
-                });
             });
         } else {
             // Distribution archives: use a Copy task which handles tar.gz/zip extraction
@@ -749,6 +743,37 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
         DistributionProjectArtifact(File distFile, File expandedDistDir) {
             this.distFile = distFile;
             this.expandedDistDir = expandedDistDir;
+        }
+    }
+
+    /**
+     * Downloads a single Maven JAR artifact from the DRA snapshot repository into the declared
+     * output file location.
+     *
+     * <p>Using a dedicated task type (rather than {@link Copy}) ensures that
+     * {@code getOutputs().getFiles()} contains exactly the one downloaded JAR, without the
+     * implicit {@code @OutputDirectory} that a {@code Copy} task registers, which would break
+     * {@link JarApiComparisonTask}'s single-jar assertion.
+     *
+     * <p>Declaring {@code draJar} as an abstract {@link ConfigurableFileCollection} property
+     * (rather than capturing the {@link org.gradle.api.artifacts.Configuration} in a lambda)
+     * also keeps this task compatible with Gradle's Configuration Cache.
+     */
+    public abstract static class DownloadMavenJarTask extends DefaultTask {
+
+        @InputFiles
+        @PathSensitive(PathSensitivity.NONE)
+        public abstract ConfigurableFileCollection getDraJar();
+
+        @OutputFile
+        public abstract RegularFileProperty getOutputJar();
+
+        @TaskAction
+        public void download() throws IOException {
+            File src = getDraJar().getSingleFile();
+            File dest = getOutputJar().getAsFile().get();
+            dest.getParentFile().mkdirs();
+            Files.copy(src.toPath(), dest.toPath(), StandardCopyOption.REPLACE_EXISTING);
         }
     }
 }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
@@ -29,9 +29,11 @@ import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.JvmToolchainsPlugin;
+import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.tasks.Copy;
+import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.PathSensitive;
@@ -636,9 +638,8 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
                             buildId
                         )
                 );
-                task.dependsOn("writeDraRefspec");
                 task.getDraJar().from(draConfig);
-                task.getInputs().file(new File(project.getBuildDir(), "refspec")).withPathSensitivity(PathSensitivity.RELATIVE);
+                task.getDraBuildId().set(buildId);
                 task.getOutputJar().set(projectArtifact.distFile);
                 task.getOutputs().doNotCacheIf("BWC distribution caching is disabled for local builds", t -> buildParams.getCi() == false);
             });
@@ -655,9 +656,8 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
                             buildId
                         )
                 );
-                t.dependsOn("writeDraRefspec");
-                t.getInputs().file(new File(project.getBuildDir(), "refspec")).withPathSensitivity(PathSensitivity.RELATIVE);
                 t.from(draConfig);
+                t.getInputs().property("draBuildId", buildId);
                 if (useNativeExpanded) {
                     t.into(projectArtifact.expandedDistDir);
                     t.getOutputs().dir(expectedOutputFile);
@@ -755,11 +755,14 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
      * implicit {@code @OutputDirectory} that a {@code Copy} task registers, which would break
      * {@link JarApiComparisonTask}'s single-jar assertion.
      *
-     * <p>Declaring {@code draJar} as an abstract {@link ConfigurableFileCollection} property
-     * (rather than capturing the {@link org.gradle.api.artifacts.Configuration} in a lambda)
-     * also keeps this task compatible with Gradle's Configuration Cache.
+     * <p>Declaring inputs as abstract properties (rather than capturing a
+     * {@link org.gradle.api.artifacts.Configuration} in a lambda) keeps this task compatible
+     * with Gradle's Configuration Cache and enables up-to-date checking via {@code draBuildId}.
      */
     public abstract static class DownloadMavenJarTask extends DefaultTask {
+
+        @Input
+        public abstract Property<String> getDraBuildId();
 
         @InputFiles
         @PathSensitive(PathSensitivity.NONE)

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
@@ -569,7 +569,19 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
                 repo.setName(repoName);
                 repo.setUrl(draBaseUrl);
                 repo.patternLayout(p -> {
-                    if (gradleClassifier.isEmpty()) {
+                    if (mavenGroup.isEmpty() == false) {
+                        // Maven-coordinated artifacts (e.g. JDBC jar) live under the /maven/ tree
+                        // using the standard Maven group-path layout rather than the flat
+                        // /downloads/elasticsearch/ path used for distribution archives.
+                        String groupPath = effectiveMavenGroup.replace(".", "/");
+                        p.artifact(
+                            "/elasticsearch/"
+                                + buildId
+                                + "/maven/"
+                                + groupPath
+                                + "/[module]/[revision]/[module]-[revision].[ext]"
+                        );
+                    } else if (gradleClassifier.isEmpty()) {
                         p.artifact("/elasticsearch/" + buildId + "/downloads/elasticsearch/[module]-[revision].[ext]");
                     } else {
                         p.artifact("/elasticsearch/" + buildId + "/downloads/elasticsearch/[module]-[revision]-[classifier].[ext]");

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
@@ -289,6 +289,8 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
                 null
             );
 
+            String stableMavenModule = "elasticsearch-" + stableApiProject.getName();
+            String stableMavenGroup = stableApiProject.getName().startsWith("plugin-") ? "org.elasticsearch.plugin" : "org.elasticsearch";
             createBuildBwcTask(
                 bwcSetupExtension,
                 buildParams,
@@ -303,8 +305,8 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
                 "",
                 "jar",
                 draBaseUrl,
-                "",
-                ""
+                stableMavenGroup,
+                stableMavenModule
             );
         }
     }
@@ -574,13 +576,7 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
                         // using the standard Maven group-path layout rather than the flat
                         // /downloads/elasticsearch/ path used for distribution archives.
                         String groupPath = effectiveMavenGroup.replace(".", "/");
-                        p.artifact(
-                            "/elasticsearch/"
-                                + buildId
-                                + "/maven/"
-                                + groupPath
-                                + "/[module]/[revision]/[module]-[revision].[ext]"
-                        );
+                        p.artifact("/elasticsearch/" + buildId + "/maven/" + groupPath + "/[module]/[revision]/[module]-[revision].[ext]");
                     } else if (gradleClassifier.isEmpty()) {
                         p.artifact("/elasticsearch/" + buildId + "/downloads/elasticsearch/[module]-[revision].[ext]");
                     } else {

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
@@ -197,9 +197,7 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
             spec.getParameters().getBranch().set(branch);
             spec.getParameters().getRootProjectDir().set(project.getRootProject().getLayout().getProjectDirectory().getAsFile());
             spec.getParameters().getRemote().set(remote);
-            spec.getParameters()
-                .getMode()
-                .set(providerFactory.systemProperty("tests.bwc.mode").orElse("gradle"));
+            spec.getParameters().getMode().set(providerFactory.systemProperty("tests.bwc.mode").orElse("gradle"));
             // -Dtests.bwc.dra.hash.{branch} overrides the local remote-tracking ref lookup,
             // allowing the DRA fast path on stale or absent refs.
             spec.getParameters()
@@ -672,9 +670,7 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
      */
     static void validateBwcMode(String mode) {
         if (Set.of("gradle", "dra", "auto").contains(mode) == false) {
-            throw new InvalidUserDataException(
-                "Invalid tests.bwc.mode value [" + mode + "]. Must be one of: gradle, dra, auto"
-            );
+            throw new InvalidUserDataException("Invalid tests.bwc.mode value [" + mode + "]. Must be one of: gradle, dra, auto");
         }
     }
 
@@ -692,9 +688,17 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
         if (isDistributionArchive) {
             return switch (bwcMode) {
                 case "dra" -> "BWC [" + bwcVersion + "]: building distribution [" + projectName + "] from source" + draUnavailable;
-                case "auto" -> "BWC [" + bwcVersion + "]: building distribution [" + projectName + "] from source"
+                case "auto" -> "BWC ["
+                    + bwcVersion
+                    + "]: building distribution ["
+                    + projectName
+                    + "] from source"
                     + " — DRA snapshot commit did not match local remote-tracking ref (or was unreachable)";
-                default -> "BWC [" + bwcVersion + "]: building distribution [" + projectName + "] from source"
+                default -> "BWC ["
+                    + bwcVersion
+                    + "]: building distribution ["
+                    + projectName
+                    + "] from source"
                     + " — set -Dtests.bwc.mode=auto to use a pre-built DRA snapshot when the commit matches";
             };
         } else {

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
@@ -35,7 +35,10 @@ import org.gradle.jvm.toolchain.JavaToolchainService;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -607,38 +610,78 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
             : effectiveMavenGroup + ":" + effectiveMavenModule + ":" + versionString + ":" + gradleClassifier + "@" + extension;
         project.getDependencies().add(draConfigName, dependencyNotation);
 
-        // Copy task that places the resolved (and optionally unpacked) artifact at the expected path.
         File rootDir = project.getRootDir();
-        project.getTasks().register(bwcTaskName, Copy.class, t -> {
-            t.doFirst(
-                task -> task.getLogger()
-                    .lifecycle(
-                        "BWC [{}]: downloading pre-built distribution [{}] from DRA snapshot {} — skipping source build",
-                        bwcVersion.get(),
-                        projectName,
-                        buildId
-                    )
-            );
-            t.dependsOn("writeDraRefspec");
-            t.getInputs().file(new File(project.getBuildDir(), "refspec")).withPathSensitivity(PathSensitivity.RELATIVE);
-            t.from(draConfig);
-            if (useNativeExpanded) {
-                t.into(projectArtifact.expandedDistDir);
-                t.getOutputs().dir(expectedOutputFile);
-            } else {
-                t.into(projectArtifact.distFile.getParentFile());
-                t.getOutputs().files(projectArtifact.distFile);
-            }
-            t.getOutputs().doNotCacheIf("BWC distribution caching is disabled for local builds", task -> buildParams.getCi() == false);
-            t.doLast(task -> {
-                if (expectedOutputFile.exists() == false) {
-                    Path relativeOutputPath = rootDir.toPath().relativize(expectedOutputFile.toPath());
-                    throw new InvalidUserDataException(
-                        "Downloading %s from DRA didn't produce expected artifact [%s].".formatted(bwcVersion.get(), relativeOutputPath)
-                    );
-                }
+        if (mavenModule.isEmpty() == false) {
+            // Maven JAR artifacts (JDBC, stable API): use a plain DefaultTask so that
+            // getOutputs().getFiles() contains exactly the downloaded JAR. A Copy task's
+            // implicit @OutputDirectory would also appear in the output file set, causing
+            // JarApiComparisonTask's single-jar assertion to fail with both the JAR name
+            // and the parent directory name ("distributions") in the set.
+            project.getTasks().register(bwcTaskName, task -> {
+                task.doFirst(
+                    t -> t.getLogger()
+                        .lifecycle(
+                            "BWC [{}]: downloading pre-built [{}] from DRA snapshot {} — skipping source build",
+                            bwcVersion.get(),
+                            projectName,
+                            buildId
+                        )
+                );
+                task.dependsOn("writeDraRefspec");
+                task.getInputs().files(draConfig).withPropertyName("draJar");
+                task.getInputs().file(new File(project.getBuildDir(), "refspec")).withPathSensitivity(PathSensitivity.RELATIVE);
+                task.getOutputs().file(projectArtifact.distFile);
+                task.getOutputs().doNotCacheIf("BWC distribution caching is disabled for local builds", t -> buildParams.getCi() == false);
+                task.doLast(t -> {
+                    projectArtifact.distFile.getParentFile().mkdirs();
+                    File src = draConfig.getSingleFile();
+                    try {
+                        Files.copy(src.toPath(), projectArtifact.distFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                    if (projectArtifact.distFile.exists() == false) {
+                        Path relativeOutputPath = rootDir.toPath().relativize(projectArtifact.distFile.toPath());
+                        throw new InvalidUserDataException(
+                            "Downloading %s from DRA didn't produce expected artifact [%s].".formatted(bwcVersion.get(), relativeOutputPath)
+                        );
+                    }
+                });
             });
-        });
+        } else {
+            // Distribution archives: use a Copy task which handles tar.gz/zip extraction
+            // via registered artifact transforms.
+            project.getTasks().register(bwcTaskName, Copy.class, t -> {
+                t.doFirst(
+                    task -> task.getLogger()
+                        .lifecycle(
+                            "BWC [{}]: downloading pre-built distribution [{}] from DRA snapshot {} — skipping source build",
+                            bwcVersion.get(),
+                            projectName,
+                            buildId
+                        )
+                );
+                t.dependsOn("writeDraRefspec");
+                t.getInputs().file(new File(project.getBuildDir(), "refspec")).withPathSensitivity(PathSensitivity.RELATIVE);
+                t.from(draConfig);
+                if (useNativeExpanded) {
+                    t.into(projectArtifact.expandedDistDir);
+                    t.getOutputs().dir(expectedOutputFile);
+                } else {
+                    t.into(projectArtifact.distFile.getParentFile());
+                    t.getOutputs().files(projectArtifact.distFile);
+                }
+                t.getOutputs().doNotCacheIf("BWC distribution caching is disabled for local builds", task -> buildParams.getCi() == false);
+                t.doLast(task -> {
+                    if (expectedOutputFile.exists() == false) {
+                        Path relativeOutputPath = rootDir.toPath().relativize(expectedOutputFile.toPath());
+                        throw new InvalidUserDataException(
+                            "Downloading %s from DRA didn't produce expected artifact [%s].".formatted(bwcVersion.get(), relativeOutputPath)
+                        );
+                    }
+                });
+            });
+        }
         bwcTaskProvider.configure(t -> t.dependsOn(bwcTaskName));
     }
 

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
@@ -233,7 +233,9 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
                 draBuildId,
                 distributionProject.gradleClassifier,
                 distributionProject.extension,
-                draBaseUrl
+                draBaseUrl,
+                "",
+                ""
             );
 
             registerBwcDistributionArtifacts(project, distributionProject);
@@ -260,7 +262,9 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
             draBuildId,
             "",
             "jar",
-            draBaseUrl
+            draBaseUrl,
+            "org.elasticsearch.plugin",
+            "x-pack-sql-jdbc"
         );
 
         // for versions before 8.7.0, we do not need to set up stable API bwc
@@ -298,7 +302,9 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
                 draBuildId,
                 "",
                 "jar",
-                draBaseUrl
+                draBaseUrl,
+                "",
+                ""
             );
         }
     }
@@ -443,7 +449,9 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
         Provider<String> draBuildId,
         String gradleClassifier,
         String extension,
-        Provider<String> draBaseUrl
+        Provider<String> draBaseUrl,
+        String mavenGroup,
+        String mavenModule
     ) {
         String bwcTaskName = buildBwcTaskName(projectName);
         boolean useNativeExpanded = projectArtifact.expandedDistDir != null;
@@ -456,7 +464,7 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
         // Evaluate the DRA build ID at configuration time. When tests.bwc.dra.enabled is not set
         // (the default), the ValueSource returns "" immediately with no network activity.
         String buildId = draBuildId.get();
-        boolean useDra = buildId.isEmpty() == false && isDistributionArchive;
+        boolean useDra = buildId.isEmpty() == false && (isDistributionArchive || mavenModule.isEmpty() == false);
 
         if (useDra) {
             createDraBwcTask(
@@ -472,7 +480,9 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
                 useNativeExpanded,
                 expectedOutputFile,
                 buildParams,
-                bwcTaskProvider
+                bwcTaskProvider,
+                mavenGroup,
+                mavenModule
             );
         } else {
             // Evaluate tests.bwc.dra.enabled at configuration time so the boolean is captured
@@ -545,8 +555,13 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
         boolean useNativeExpanded,
         File expectedOutputFile,
         BuildParameterExtension buildParams,
-        TaskProvider<Task> bwcTaskProvider
+        TaskProvider<Task> bwcTaskProvider,
+        String mavenGroup,
+        String mavenModule
     ) {
+        String effectiveMavenGroup = mavenGroup.isEmpty() ? "org.elasticsearch" : mavenGroup;
+        String effectiveMavenModule = mavenModule.isEmpty() ? "elasticsearch" : mavenModule;
+
         // Configure the DRA Ivy repository for this specific BWC version and build.
         String repoName = "dra-bwc-elasticsearch-" + bwcVersion.get() + "-" + projectName;
         if (project.getRepositories().findByName(repoName) == null) {
@@ -561,7 +576,7 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
                     }
                 });
                 repo.metadataSources(s -> s.artifact());
-                repo.content(c -> c.includeVersionByRegex("org.elasticsearch", "elasticsearch", ".*-SNAPSHOT"));
+                repo.content(c -> c.includeVersionByRegex(effectiveMavenGroup, effectiveMavenModule, ".*-SNAPSHOT"));
             });
         }
 
@@ -580,8 +595,8 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
 
         String versionString = bwcVersion.get() + "-SNAPSHOT";
         String dependencyNotation = gradleClassifier.isEmpty()
-            ? "org.elasticsearch:elasticsearch:" + versionString + "@" + extension
-            : "org.elasticsearch:elasticsearch:" + versionString + ":" + gradleClassifier + "@" + extension;
+            ? effectiveMavenGroup + ":" + effectiveMavenModule + ":" + versionString + "@" + extension
+            : effectiveMavenGroup + ":" + effectiveMavenModule + ":" + versionString + ":" + gradleClassifier + "@" + extension;
         project.getDependencies().add(draConfigName, dependencyNotation);
 
         // Copy task that places the resolved (and optionally unpacked) artifact at the expected path.

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
@@ -189,6 +189,8 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
         Provider<String> remote = providerFactory.systemProperty("bwc.remote").orElse("elastic");
         Provider<String> draBaseUrl = providerFactory.systemProperty("tests.bwc.dra.base.url")
             .orElse("https://artifacts-snapshot.elastic.co");
+        String bwcMode = providerFactory.systemProperty("tests.bwc.mode").getOrElse("gradle");
+        validateBwcMode(bwcMode);
         Provider<String> draBuildId = providerFactory.of(DraSnapshotBuildIdValueSource.class, spec -> {
             spec.getParameters().getVersion().set(versionInfoProvider.map(info -> info.version().toString()));
             Provider<String> branch = versionInfoProvider.map(info -> info.branch());
@@ -196,8 +198,8 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
             spec.getParameters().getRootProjectDir().set(project.getRootProject().getLayout().getProjectDirectory().getAsFile());
             spec.getParameters().getRemote().set(remote);
             spec.getParameters()
-                .getDraEnabled()
-                .set(providerFactory.systemProperty("tests.bwc.dra.enabled").map(Boolean::parseBoolean).orElse(false));
+                .getMode()
+                .set(providerFactory.systemProperty("tests.bwc.mode").orElse("gradle"));
             // -Dtests.bwc.dra.hash.{branch} overrides the local remote-tracking ref lookup,
             // allowing the DRA fast path on stale or absent refs.
             spec.getParameters()
@@ -475,8 +477,9 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
             : projectArtifact.distFile;
 
         boolean isDistributionArchive = projectPath.startsWith("distribution/");
-        // Evaluate the DRA build ID at configuration time. When tests.bwc.dra.enabled is not set
-        // (the default), the ValueSource returns "" immediately with no network activity.
+        // Evaluate mode and DRA build ID at configuration time. For "gradle" mode the ValueSource
+        // returns "" immediately with no network activity.
+        String bwcMode = project.getProviders().systemProperty("tests.bwc.mode").getOrElse("gradle");
         String buildId = draBuildId.get();
         boolean useDra = buildId.isEmpty() == false && (isDistributionArchive || mavenModule.isEmpty() == false);
 
@@ -499,31 +502,15 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
                 mavenModule
             );
         } else {
-            // Evaluate tests.bwc.dra.enabled at configuration time so the boolean is captured
-            // in the doFirst action rather than the Project instance (which is not CC-serializable).
-            boolean draEnabled = project.getProviders().systemProperty("tests.bwc.dra.enabled").map(Boolean::parseBoolean).getOrElse(false);
+            // Evaluate bwcMode at configuration time so the value is captured in the doFirst
+            // action rather than the Project instance (which is not CC-serializable).
             bwcSetupExtension.bwcTask(bwcTaskName, c -> {
                 c.doFirst(task -> {
-                    if (isDistributionArchive) {
-                        if (draEnabled) {
-                            task.getLogger()
-                                .lifecycle(
-                                    "BWC [{}]: building distribution [{}] from source"
-                                        + " — DRA snapshot commit did not match local remote-tracking ref (or was unreachable)",
-                                    bwcVersion.get(),
-                                    projectName
-                                );
-                        } else {
-                            task.getLogger()
-                                .lifecycle(
-                                    "BWC [{}]: building distribution [{}] from source"
-                                        + " — set -Dtests.bwc.dra.enabled=true to use a pre-built DRA snapshot when the commit matches",
-                                    bwcVersion.get(),
-                                    projectName
-                                );
-                        }
+                    String msg = buildFallbackMessage(bwcMode, isDistributionArchive, bwcVersion.get().toString(), projectName);
+                    if (bwcMode.equals("dra")) {
+                        task.getLogger().warn(msg);
                     } else {
-                        task.getLogger().lifecycle("BWC [{}]: building [{}] from source", bwcVersion.get(), projectName);
+                        task.getLogger().lifecycle(msg);
                     }
                 });
                 c.getInputs().file(new File(project.getBuildDir(), "refspec")).withPathSensitivity(PathSensitivity.RELATIVE);
@@ -677,6 +664,45 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
             });
         }
         bwcTaskProvider.configure(t -> t.dependsOn(bwcTaskName));
+    }
+
+    /**
+     * Validates the {@code tests.bwc.mode} value, throwing {@link InvalidUserDataException} for
+     * unrecognised values so users get a clear error message rather than a silent no-op.
+     */
+    static void validateBwcMode(String mode) {
+        if (Set.of("gradle", "dra", "auto").contains(mode) == false) {
+            throw new InvalidUserDataException(
+                "Invalid tests.bwc.mode value [" + mode + "]. Must be one of: gradle, dra, auto"
+            );
+        }
+    }
+
+    /**
+     * Returns the human-readable log message to emit when the gradle source-build fallback is
+     * taken.  The message varies by mode (to explain <em>why</em> the fallback occurred) and by
+     * artifact type (distribution archive vs. Maven JAR).
+     *
+     * <p>Extracted as a package-private static method so it can be exercised by unit tests without
+     * standing up a full Gradle project.
+     */
+    static String buildFallbackMessage(String bwcMode, boolean isDistributionArchive, String bwcVersion, String projectName) {
+        String draUnavailable = " — tests.bwc.mode=dra but no DRA snapshot was available"
+            + " (endpoint unreachable or no build for this branch yet); falling back to source build";
+        if (isDistributionArchive) {
+            return switch (bwcMode) {
+                case "dra" -> "BWC [" + bwcVersion + "]: building distribution [" + projectName + "] from source" + draUnavailable;
+                case "auto" -> "BWC [" + bwcVersion + "]: building distribution [" + projectName + "] from source"
+                    + " — DRA snapshot commit did not match local remote-tracking ref (or was unreachable)";
+                default -> "BWC [" + bwcVersion + "]: building distribution [" + projectName + "] from source"
+                    + " — set -Dtests.bwc.mode=auto to use a pre-built DRA snapshot when the commit matches";
+            };
+        } else {
+            return switch (bwcMode) {
+                case "dra" -> "BWC [" + bwcVersion + "]: building [" + projectName + "] from source" + draUnavailable;
+                default -> "BWC [" + bwcVersion + "]: building [" + projectName + "] from source";
+            };
+        }
     }
 
     /**

--- a/build-tools-internal/src/test/groovy/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPluginSpec.groovy
+++ b/build-tools-internal/src/test/groovy/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPluginSpec.groovy
@@ -1,0 +1,118 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.gradle.internal
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import org.gradle.api.InvalidUserDataException
+
+/**
+ * Unit tests for the pure-logic helpers in {@link InternalDistributionBwcSetupPlugin}.
+ * These tests require no Gradle project, no TestKit, and no network access.
+ */
+class InternalDistributionBwcSetupPluginSpec extends Specification {
+
+    // -------------------------------------------------------------------------
+    // validateBwcMode
+    // -------------------------------------------------------------------------
+
+    @Unroll
+    def "validateBwcMode accepts valid mode '#mode'"() {
+        when:
+        InternalDistributionBwcSetupPlugin.validateBwcMode(mode)
+
+        then:
+        noExceptionThrown()
+
+        where:
+        mode << ["gradle", "dra", "auto"]
+    }
+
+    @Unroll
+    def "validateBwcMode rejects invalid mode '#mode'"() {
+        when:
+        InternalDistributionBwcSetupPlugin.validateBwcMode(mode)
+
+        then:
+        def ex = thrown(InvalidUserDataException)
+        ex.message.contains("Invalid tests.bwc.mode value [${mode}]")
+        ex.message.contains("Must be one of: gradle, dra, auto")
+
+        where:
+        mode << ["invalid-mode", "DRA", "AUTO", "", "dra-or-gradle"]
+    }
+
+    // -------------------------------------------------------------------------
+    // buildFallbackMessage — distribution archives
+    // -------------------------------------------------------------------------
+
+    def "buildFallbackMessage for dra mode and distribution archive mentions DRA unavailable"() {
+        when:
+        def msg = InternalDistributionBwcSetupPlugin.buildFallbackMessage("dra", true, "9.4.2", "darwin-tar")
+
+        then:
+        msg.contains("tests.bwc.mode=dra but no DRA snapshot was available")
+        msg.contains("9.4.2")
+        msg.contains("darwin-tar")
+        msg.contains("building distribution")
+    }
+
+    def "buildFallbackMessage for auto mode and distribution archive mentions commit mismatch"() {
+        when:
+        def msg = InternalDistributionBwcSetupPlugin.buildFallbackMessage("auto", true, "9.4.2", "linux-tar")
+
+        then:
+        msg.contains("DRA snapshot commit did not match")
+        msg.contains("9.4.2")
+        msg.contains("linux-tar")
+    }
+
+    def "buildFallbackMessage for gradle mode and distribution archive hints at auto mode"() {
+        when:
+        def msg = InternalDistributionBwcSetupPlugin.buildFallbackMessage("gradle", true, "9.4.2", "windows-zip")
+
+        then:
+        msg.contains("-Dtests.bwc.mode=auto")
+        msg.contains("9.4.2")
+    }
+
+    // -------------------------------------------------------------------------
+    // buildFallbackMessage — Maven JAR artifacts (non-archive)
+    // -------------------------------------------------------------------------
+
+    def "buildFallbackMessage for dra mode and Maven JAR mentions DRA unavailable"() {
+        when:
+        def msg = InternalDistributionBwcSetupPlugin.buildFallbackMessage("dra", false, "9.4.2", "jdbc")
+
+        then:
+        msg.contains("tests.bwc.mode=dra but no DRA snapshot was available")
+        msg.contains("9.4.2")
+        msg.contains("jdbc")
+        // Maven JAR path does NOT say "distribution" — keep the messages distinct
+        !msg.contains("building distribution")
+    }
+
+    def "buildFallbackMessage for gradle mode and Maven JAR emits a plain source-build message"() {
+        when:
+        def msg = InternalDistributionBwcSetupPlugin.buildFallbackMessage("gradle", false, "9.4.2", "logging")
+
+        then:
+        msg == "BWC [9.4.2]: building [logging] from source"
+    }
+
+    def "buildFallbackMessage for auto mode and Maven JAR emits a plain source-build message"() {
+        when:
+        def msg = InternalDistributionBwcSetupPlugin.buildFallbackMessage("auto", false, "9.3.5", "plugin-api")
+
+        then:
+        msg == "BWC [9.3.5]: building [plugin-api] from source"
+    }
+}


### PR DESCRIPTION
This basically introduces three modes for running tests against BWC snapshots: 
- dra (always use latest DRA artifacts for bwc snapshots)
- gradle (always build bwc snapshot locally in a nested gradle -build)
- auto (pick latest and prefer DRA)

The PR above currently uses auto which compares DRA hash and git hash from branch) and resolves the DRA artifact if available. I tend to default to just pick the latest DRA artifact as this reflects reality most in a sense that this is what is currently our release and snapshot candidate we have for those branches. 
Picking the DRA saves us several minutes over building the bwc snapshot for every PR on every time we request a snapshot (which is across build jobs)