### PR TITLE
wait for both indices to convert in concurrent rollovers IT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -480,9 +480,6 @@ tests:
 - class: org.elasticsearch.xpack.stateless.snapshots.StatelessSnapshotIT
   method: testSnapshotFailsCleanlyWhenShardClosesDuringDisconnect
   issue: https://github.com/elastic/elasticsearch/issues/149032
-- class: org.elasticsearch.xpack.dlm.frozen.DLMFrozenTransitionDisruptionIT
-  method: testConcurrentRolloverDuringTransition
-  issue: https://github.com/elastic/elasticsearch/issues/149039
 - class: org.elasticsearch.packaging.test.BootstrapCheckTests
   method: test20RunWithBootstrapChecks
   issue: https://github.com/elastic/elasticsearch/issues/149040

--- a/x-pack/plugin/dlm-frozen-transition/src/internalClusterTest/java/org/elasticsearch/xpack/dlm/frozen/DLMFrozenTransitionDisruptionIT.java
+++ b/x-pack/plugin/dlm-frozen-transition/src/internalClusterTest/java/org/elasticsearch/xpack/dlm/frozen/DLMFrozenTransitionDisruptionIT.java
@@ -423,9 +423,14 @@ public class DLMFrozenTransitionDisruptionIT extends ESIntegTestCase {
         );
         triggerRollover();
 
+        // The second backing index (created by triggerRollover) will also become a candidate
+        // after the concurrent rollover creates a third backing index.
+        String secondBackingIndex = backingIndexNames().get(1);
+
         assertTrue("ForceMerge request was never seen by the interceptor", latch.await(30, TimeUnit.SECONDS));
 
         String expectedFrozenIndexName = DLMConvertToFrozen.SNAPSHOT_NAME_PREFIX + candidateIndex;
+        String expectedFrozenIndexName2 = DLMConvertToFrozen.SNAPSHOT_NAME_PREFIX + secondBackingIndex;
         assertBusy(() -> {
             var projectMetadata = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
                 .get()
@@ -433,13 +438,18 @@ public class DLMFrozenTransitionDisruptionIT extends ESIntegTestCase {
                 .metadata()
                 .getProject(Metadata.DEFAULT_PROJECT_ID);
             assertThat(
-                "Frozen index should exist despite concurrent rollover",
+                "Frozen index should exist for first candidate despite concurrent rollover",
                 projectMetadata.index(expectedFrozenIndexName),
+                notNullValue()
+            );
+            assertThat(
+                "Frozen index should exist for second candidate after concurrent rollover",
+                projectMetadata.index(expectedFrozenIndexName2),
                 notNullValue()
             );
         }, 120, TimeUnit.SECONDS);
 
-        logger.info("--> concurrent rollover during transition handled gracefully");
+        logger.info("--> concurrent rollover during transition handled gracefully, both indices converted to frozen");
     }
 
     /**


### PR DESCRIPTION
testConcurrentRolloverDuringTransition() was failing sometimes due to a race condition. The test triggered 2 rollovers but only waited for 1 frozen transition to complete, causing an exception if the test cleanup was triggered during the snapshot of the other backing index. 

This PR fixes that bug by waiting for both transitions to complete. Ran for 100 iterations.

```
➜  elasticsearch git:(main) ✗ ./gradlew ":x-pack:plugin:dlm-frozen-transition:internalClusterTest" --tests "org.elasticsearch.xpack.dlm.frozen.DLMFrozenTransitionDisruptionIT.testConcurrentRolloverDuringTransition" -Dtests.iters=100
=======================================
Elasticsearch Build Hamster says Hello!
  Gradle Version        : 9.5.0
  OS Info               : Mac OS X 15.7.5 (aarch64)
  JDK Version           : 21.0.7+6-LTS (Eclipse Temurin)
  JAVA_HOME             : /Users/seanzatz/.gradle/jdks/eclipse_adoptium-21-aarch64-os_x.2/jdk-21.0.7+6/Contents/Home
  Random Testing Seed   : 31FE80352BF38246
  In FIPS 140 mode      : false
=======================================

> Task :x-pack:plugin:dlm-frozen-transition:internalClusterTest
WARNING: module-info.class ignored in patch: /Users/seanzatz/workspace/elasticsearch/libs/entitlement/bridge/build/distributions/elasticsearch-entitlement-bridge-9.5.0-SNAPSHOT.jar
WARNING: Using incubator modules: jdk.incubator.vector

BUILD SUCCESSFUL in 17m 30s
```


/closes https://github.com/elastic/elasticsearch/issues/149039