### PR TITLE
ESQL: fix non-deterministic sort in statsByFlattenedAllRows test

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/flattened.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/flattened.csv-spec
@@ -270,9 +270,9 @@ required_capability: fn_field_extract
 
 FROM flattened_otel_logs
 | STATS count = COUNT(*) BY resource.attributes
-| EVAL hn = field_extract(resource.attributes, "host.name")
-| SORT count DESC, hn
-| DROP hn
+| EVAL host_name = FIELD_EXTRACT(resource.attributes, "host.name")
+| SORT count DESC, host_name
+| KEEP count, resource.attributes
 ;
 
 count:long | resource.attributes:flattened


### PR DESCRIPTION
The test sorted by count DESC only, leaving 10 rows with count=1 in non-deterministic order. Use FIELD_EXTRACT to get host.name as a secondary sort key; host.name is the one scalar key present in every resource.attributes value including the equal-host row.
