### PR TITLE
ES|QL|DS Fix wrong nullability for ParquetFormatReader attributes

### DIFF
--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -44,6 +44,7 @@ import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -1203,7 +1204,14 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
         for (Type field : schema.getFields()) {
             String name = field.getName();
             DataType esqlType = convertParquetTypeToEsql(field);
-            attributes.add(new ReferenceAttribute(Source.EMPTY, name, esqlType));
+            // Map the Parquet footer's repetition level onto planner-level nullability so the
+            // optimizer sees an accurate view of which columns can contain nulls. REQUIRED is the
+            // only repetition that guarantees no nulls; OPTIONAL fields, and the outer group of a
+            // LIST (which is itself OPTIONAL or REQUIRED), follow the same rule. Without this,
+            // every column was marked Nullability.FALSE and downstream rules trusting that
+            // (e.g. Coalesce.nullable()) could produce wrong results for OPTIONAL columns.
+            Nullability nullability = field.getRepetition() == Type.Repetition.REQUIRED ? Nullability.FALSE : Nullability.TRUE;
+            attributes.add(new ReferenceAttribute(Source.EMPTY, null, name, esqlType, nullability, null, false));
         }
         return attributes;
     }

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
@@ -43,6 +43,7 @@ import org.elasticsearch.compute.data.UninitializedArrays;
 import org.elasticsearch.compute.operator.CloseableIterator;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -892,6 +893,108 @@ public class ParquetFormatReaderTests extends ESTestCase {
 
             assertFalse(iterator.hasNext());
         }
+    }
+
+    /**
+     * REQUIRED parquet columns must produce attributes with {@link Nullability#FALSE} so the optimizer
+     * can correctly fold {@code IS NULL}/{@code IS NOT NULL}/{@code COALESCE} on columns the file
+     * footer guarantees contain no nulls.
+     */
+    public void testSchemaNullabilityForRequiredColumns() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("name")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            Group g = factory.newGroup();
+            g.add("id", 1L);
+            g.add("name", "Alice");
+            return List.of(g);
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+
+        SourceMetadata metadata = reader.metadata(storageObject);
+        List<Attribute> attributes = metadata.schema();
+        assertEquals(2, attributes.size());
+        assertEquals("id", attributes.get(0).name());
+        assertEquals(Nullability.FALSE, attributes.get(0).nullable());
+        assertEquals("name", attributes.get(1).name());
+        assertEquals(Nullability.FALSE, attributes.get(1).nullable());
+    }
+
+    /**
+     * OPTIONAL parquet columns must produce attributes with {@link Nullability#TRUE}, otherwise
+     * the optimizer folds {@code WHERE col IS NULL} to {@code FALSE} (and {@code IS NOT NULL} to
+     * {@code TRUE}) for columns whose footer-declared repetition allows null rows.
+     */
+    public void testSchemaNullabilityForOptionalColumns() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .optional(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("name")
+            .optional(PrimitiveType.PrimitiveTypeName.INT32)
+            .named("age")
+            .optional(PrimitiveType.PrimitiveTypeName.DOUBLE)
+            .named("score")
+            .optional(PrimitiveType.PrimitiveTypeName.BOOLEAN)
+            .named("active")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            Group g = factory.newGroup();
+            g.add("id", 1L);
+            g.add("name", "Alice");
+            g.add("age", 30);
+            g.add("score", 95.5);
+            g.add("active", true);
+            return List.of(g);
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+
+        SourceMetadata metadata = reader.metadata(storageObject);
+        List<Attribute> attributes = metadata.schema();
+        assertEquals(5, attributes.size());
+        assertEquals("id", attributes.get(0).name());
+        assertEquals(Nullability.FALSE, attributes.get(0).nullable());
+        for (int i = 1; i < attributes.size(); i++) {
+            Attribute attr = attributes.get(i);
+            assertEquals("OPTIONAL column [" + attr.name() + "] must be nullable", Nullability.TRUE, attr.nullable());
+        }
+    }
+
+    /**
+     * LIST columns are exposed as a single attribute whose nullability is driven by the outer
+     * group's repetition (the inner {@code repeated group list} is a Parquet structural artifact).
+     */
+    public void testSchemaNullabilityForOptionalListColumn() throws Exception {
+        Type listType = Types.optionalList().optionalElement(PrimitiveType.PrimitiveTypeName.INT32).named("numbers");
+        MessageType schema = new MessageType("test_schema", listType);
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            Group g = factory.newGroup();
+            Group list = g.addGroup("numbers");
+            list.addGroup("list").append("element", 1);
+            return List.of(g);
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+
+        SourceMetadata metadata = reader.metadata(storageObject);
+        List<Attribute> attributes = metadata.schema();
+        assertEquals(1, attributes.size());
+        assertEquals("numbers", attributes.get(0).name());
+        assertEquals(Nullability.TRUE, attributes.get(0).nullable());
     }
 
     public void testReadOptionalLongWithNulls() throws Exception {

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/external-basic.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/external-basic.csv-spec
@@ -89,6 +89,56 @@ emp_no:integer | first_name:keyword | last_name:keyword | gender:keyword
 10007          | "Tzvetan"          | "Zielinski"       | "F"
 ;
 
+// Locks in the planner-level contract that OPTIONAL parquet columns (and empty
+// CSV cells) are exposed as nullable attributes. Without this, future optimizer
+// rules trusting Nullability.FALSE could fold these predicates away and silently
+// return wrong results. See https://github.com/elastic/esql-planning/issues/756.
+whereGenderIsNull
+required_capability: external_command
+
+EXTERNAL "{{employees}}"
+| WHERE gender IS NULL
+| STATS null_genders = COUNT()
+;
+
+null_genders:long
+10
+;
+
+whereGenderIsNotNull
+required_capability: external_command
+
+EXTERNAL "{{employees}}"
+| WHERE gender IS NOT NULL
+| STATS non_null_genders = COUNT()
+;
+
+non_null_genders:long
+90
+;
+
+whereLanguagesIsNull
+required_capability: external_command
+
+EXTERNAL "{{employees}}"
+| WHERE languages IS NULL
+| KEEP emp_no
+| SORT emp_no
+;
+
+emp_no:integer
+10020
+10021
+10022
+10023
+10024
+10025
+10026
+10027
+10028
+10029
+;
+
 filterByEmploymentStatus
 required_capability: external_command
 


### PR DESCRIPTION
# Fix wrong nullability for ParquetFormatReader attributes

Resolves https://github.com/elastic/esql-planning/issues/756.

## Problem

`ParquetFormatReader.convertParquetSchemaToAttributes` built every attribute via the 3-arg
`ReferenceAttribute` constructor, which defaults to `Nullability.FALSE`. The Parquet footer's
repetition level was ignored, so OPTIONAL columns (and OPTIONAL LIST outer groups) were exposed
to the planner as non-nullable. This is a contract violation: any rule keying off the attribute's
nullability (e.g. `Coalesce.nullable()`) sees a misleading view of the schema and could produce
wrong results for nullable columns.

## Fix

Map the field's `Type.Repetition` onto `Nullability`:

- `REQUIRED` -> `Nullability.FALSE`
- `OPTIONAL` / `REPEATED` -> `Nullability.TRUE`

The runtime `Block` already carries the row-level null mask, so this is a planner-side correctness
fix only — no changes to decoding or pushdown.

## Tests

- `ParquetFormatReaderTests` adds three failing-without-the-fix unit tests covering REQUIRED,
  OPTIONAL primitives, and OPTIONAL LIST outer groups.
- `external-basic.csv-spec` adds three forward-looking csv-spec cases (`whereGenderIsNull`,
  `whereGenderIsNotNull`, `whereLanguagesIsNull`) that lock in correct end-to-end behavior across
  parquet, CSV, and TSV readers.

Assisted by Cursor