### PR TITLE
[9.4] Add deprecation message for ESQL log (#149013)

### DIFF
--- a/docs/changelog/149013.yaml
+++ b/docs/changelog/149013.yaml
@@ -1,0 +1,10 @@
+area: ES|QL
+deprecation:
+  area: ES|QL
+  details: ES|QL query logging is deprecated - please use core query logging. 
+  impact: This will produce a deprecation message if ES|QL query logging setting is enabled. 
+  title: Add deprecation message for ES|QL query log
+issues: []
+pr: 149013
+summary: Add deprecation message for ES|QL query log
+type: deprecation

--- a/server/src/test/java/org/elasticsearch/script/ScriptServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/script/ScriptServiceTests.java
@@ -571,7 +571,7 @@ public class ScriptServiceTests extends ESTestCase {
 
         assertEquals(cacheExpireFooTimeValue, ScriptService.SCRIPT_CACHE_EXPIRE_SETTING.getConcreteSettingForNamespace("foo").get(s));
         assertEquals(cacheExpireBackupTimeValue, ScriptService.SCRIPT_CACHE_EXPIRE_SETTING.getConcreteSettingForNamespace("bar").get(s));
-        assertSettingDeprecationsAndWarnings(new Setting<?>[] { cacheExpireSetting, cacheExpireSetting });
+        assertSettingDeprecationsAndWarnings(new Setting<?>[] { cacheSizeSetting, cacheExpireSetting });
     }
 
     public void testUseContextSettingValue() {

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -797,25 +797,21 @@ public abstract class ESTestCase extends LuceneTestCase {
                     }
                     return new DeprecationWarning(level, warningText);
                 }).collect(Collectors.toSet());
+                final Set<String> unexpectedWarnings = actualDeprecationWarnings.stream()
+                    .map(warning -> warning.message)
+                    .collect(Collectors.toCollection(HashSet::new));
+
                 for (DeprecationWarning expectedWarning : expectedWarnings) {
                     DeprecationWarning escapedExpectedWarning = new DeprecationWarning(
                         expectedWarning.level,
                         HeaderWarning.escapeAndEncode(expectedWarning.message)
                     );
                     assertThat(actualDeprecationWarnings, hasItem(escapedExpectedWarning));
+                    unexpectedWarnings.remove(escapedExpectedWarning.message);
                 }
-                assertEquals(
-                    "Expected "
-                        + expectedWarnings.length
-                        + " warnings but found "
-                        + actualWarningStrings.size()
-                        + "\nExpected: "
-                        + Arrays.asList(expectedWarnings)
-                        + "\nActual: "
-                        + actualWarningStrings,
-                    expectedWarnings.length,
-                    actualWarningStrings.size()
-                );
+                // Do not alert on filtered warnings in addition to expected ones.
+                filteredWarnings().forEach(filtered -> unexpectedWarnings.removeIf(warning -> warning.contains(filtered)));
+                assertThat("Unexpected warnings found: " + unexpectedWarnings, unexpectedWarnings, empty());
             }
         } finally {
             resetDeprecationLogger();

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterQueryLogUnavailableRemotesIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterQueryLogUnavailableRemotesIT.java
@@ -17,6 +17,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.xpack.esql.plugin.EsqlPlugin;
 import org.elasticsearch.xpack.esql.querylog.EsqlQueryLog;
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
@@ -68,6 +69,11 @@ public class CrossClusterQueryLogUnavailableRemotesIT extends AbstractCrossClust
     @Override
     protected Settings nodeSettings() {
         return Settings.builder().put(super.nodeSettings()).put(EsqlPlugin.ESQL_QUERYLOG_THRESHOLD_TRACE_SETTING.getKey(), "0ms").build();
+    }
+
+    @After
+    public void expectDeprecationWarning() {
+        assertWarnings(EsqlQueryLog.DEPRECATION_MESSAGE);
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/querylog/EsqlQueryLog.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/querylog/EsqlQueryLog.java
@@ -9,6 +9,8 @@ package org.elasticsearch.xpack.esql.querylog;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.common.logging.DeprecationCategory;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.logging.ESLogMessage;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.core.TimeValue;
@@ -24,6 +26,7 @@ import org.elasticsearch.xpack.esql.session.Versioned;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 
 import static org.elasticsearch.xpack.esql.plugin.EsqlPlugin.ESQL_QUERYLOG_INCLUDE_USER_SETTING;
@@ -49,6 +52,11 @@ public final class EsqlQueryLog {
 
     public static final String LOGGER_NAME = "esql.querylog";
     private static final Logger queryLogger = LogManager.getLogger(LOGGER_NAME);
+    private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(EsqlQueryLog.class);
+    public static final String DEPRECATION_MESSAGE = "ES|QL query logging configured via the [esql.querylog.*] settings is deprecated. "
+        + "ES|QL queries can still be logged using the core query logging feature by enabling the [elasticsearch.querylog.enabled] "
+        + "cluster setting.";
+    private final AtomicBoolean deprecatedLogged = new AtomicBoolean(false);
     private final ActionLoggingFields additionalFields;
 
     private volatile long queryWarnThreshold;
@@ -92,20 +100,30 @@ public final class EsqlQueryLog {
         }
     }
 
+    private void deprecatedIfEnabled(long threshold) {
+        if (threshold >= 0 && deprecatedLogged.compareAndSet(false, true)) {
+            deprecationLogger.warn(DeprecationCategory.SETTINGS, LOGGER_NAME, DEPRECATION_MESSAGE);
+        }
+    }
+
     public void setQueryWarnThreshold(TimeValue queryWarnThreshold) {
         this.queryWarnThreshold = queryWarnThreshold.nanos();
+        deprecatedIfEnabled(this.queryWarnThreshold);
     }
 
     public void setQueryInfoThreshold(TimeValue queryInfoThreshold) {
         this.queryInfoThreshold = queryInfoThreshold.nanos();
+        deprecatedIfEnabled(this.queryInfoThreshold);
     }
 
     public void setQueryDebugThreshold(TimeValue queryDebugThreshold) {
         this.queryDebugThreshold = queryDebugThreshold.nanos();
+        deprecatedIfEnabled(this.queryDebugThreshold);
     }
 
     public void setQueryTraceThreshold(TimeValue queryTraceThreshold) {
         this.queryTraceThreshold = queryTraceThreshold.nanos();
+        deprecatedIfEnabled(this.queryTraceThreshold);
     }
 
     static final class Message {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/querylog/EsqlQueryLogTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/querylog/EsqlQueryLogTests.java
@@ -97,6 +97,7 @@ public class EsqlQueryLogTests extends ESTestCase {
 
     public void testPrioritiesOnSuccess() {
         EsqlQueryLog queryLog = new EsqlQueryLog(settings, mockLogFieldProvider());
+        assertWarnings(EsqlQueryLog.DEPRECATION_MESSAGE);
         String query = "from " + randomAlphaOfLength(10);
 
         long[] actualTook = {
@@ -148,6 +149,7 @@ public class EsqlQueryLogTests extends ESTestCase {
 
     public void testPrioritiesOnFailure() {
         EsqlQueryLog queryLog = new EsqlQueryLog(settings, mockLogFieldProvider());
+        assertWarnings(EsqlQueryLog.DEPRECATION_MESSAGE);
         String query = "from " + randomAlphaOfLength(10);
 
         long[] actualTook = {

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/logging/10_usage.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/logging/10_usage.yml
@@ -22,7 +22,7 @@
 "Logging usage reflects persisted querylog and ES|QL querylog settings":
   - requires:
       reason: "Logging usage tracking requires 'logging_usage' capability"
-      test_runner_features: [ capabilities ]
+      test_runner_features: [ capabilities, allowed_warnings_regex ]
       capabilities:
         - method: GET
           path: /_xpack/usage
@@ -38,6 +38,8 @@
             elasticsearch.querylog.include.system_indices: true
             esql.querylog.threshold.info: 0ms
             esql.querylog.include.user: true
+      allowed_warnings_regex:
+        - "ES[|]QL query logging configured via .*"
 
   - do:
       xpack.usage: {}


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Add deprecation message for ESQL log (#149013)