### PR TITLE
ESQL:DS: unmute tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -569,9 +569,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.csv.CsvFormatSpecIT
   method: test {csv-spec:csv-union-by-name.* [LOCAL]}
   issue: https://github.com/elastic/elasticsearch/issues/149482
-- class: org.elasticsearch.xpack.esql.qa.parquet.ParquetFormatSpecIT
-  method: test {csv-spec:external-hive-partitioned.* [LOCAL]}
-  issue: https://github.com/elastic/elasticsearch/issues/149495
 - class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
   method: test {csv-spec:flattened.statsByFlattenedAllRows}
   issue: https://github.com/elastic/elasticsearch/issues/149549


### PR DESCRIPTION
Unmute one suite, ParquetFormatSpecIT, external-hive-partitioned.

Fixed in https://github.com/elastic/elasticsearch/pull/149469

Closes #149446