### PR TITLE
[ESQL] snappy codec accepts Hadoop and xerial framings

### DIFF
--- a/docs/changelog/149572.yaml
+++ b/docs/changelog/149572.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 149572
+summary: Snappy codec accepts Hadoop and xerial framings
+type: enhancement

--- a/x-pack/plugin/esql-datasource-snappy/build.gradle
+++ b/x-pack/plugin/esql-datasource-snappy/build.gradle
@@ -26,10 +26,12 @@ dependencies {
   compileOnly project(path: xpackModule('core'))
   compileOnly project(':server')
   compileOnly project(xpackModule('esql:compute'))
-  // snappy-java provided by compression-libs parent plugin via extendedPlugins
+  // snappy-java and aircompressor provided by compression-libs parent plugin via extendedPlugins
   compileOnly "org.xerial.snappy:snappy-java:${versions.snappyJava}"
+  compileOnly "io.airlift:aircompressor:${versions.aircompressor}"
 
   testImplementation project(':test:framework')
   testImplementation(testArtifact(project(xpackModule('core'))))
   testImplementation "org.xerial.snappy:snappy-java:${versions.snappyJava}"
+  testImplementation "io.airlift:aircompressor:${versions.aircompressor}"
 }

--- a/x-pack/plugin/esql-datasource-snappy/src/main/java/org/elasticsearch/xpack/esql/datasource/snappy/SnappyDecompressionCodec.java
+++ b/x-pack/plugin/esql-datasource-snappy/src/main/java/org/elasticsearch/xpack/esql/datasource/snappy/SnappyDecompressionCodec.java
@@ -7,24 +7,61 @@
 
 package org.elasticsearch.xpack.esql.datasource.snappy;
 
+import io.airlift.compress.MalformedInputException;
+import io.airlift.compress.snappy.SnappyHadoopStreams;
+
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.xpack.esql.datasources.spi.DecompressionCodec;
 import org.xerial.snappy.SnappyFramedInputStream;
 
+import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.PushbackInputStream;
 import java.util.List;
 
 /**
  * Snappy decompression codec for compound extensions like {@code .csv.snappy} or {@code .ndjson.snappy}.
  *
- * <p>Uses the standard Snappy framing format (64KB chunks with CRC-32C checksums).
- * CRC-32C verification is enabled by default to detect silent data corruption
- * from remote blob stores. The underlying {@link SnappyFramedInputStream} is
- * provided by snappy-java via the {@code esql-datasource-compression-libs} parent plugin.
+ * <p>Snappy ships with several incompatible stream framings; this codec sniffs the first byte of the
+ * stream and dispatches to the matching reader:
+ * <ul>
+ *   <li><b>Xerial / Google framed snappy</b> (snappy-java's {@code SnappyFramedOutputStream}, the
+ *   {@code snzip -t framing2} format) — recognized by the {@code \xff\x06\x00\x00sNaPpY} stream
+ *   identifier. Read with snappy-java's {@link SnappyFramedInputStream} with CRC-32C verification
+ *   enabled to catch silent corruption from remote blob stores.</li>
+ *   <li><b>Hadoop snappy</b> (Hadoop/Hive/Spark exports, ClickHouse text exports, {@code snzip -t
+ *   hadoop-snappy}) — recognized by a leading {@code 0x00} byte from the big-endian uncompressed
+ *   block length. Read with aircompressor's Hadoop snappy reader via {@link SnappyHadoopStreams}.
+ *   Hadoop framing carries no per-block checksum, so corruption can only be detected by snappy's
+ *   own block-level validation.</li>
+ * </ul>
+ *
+ * <p>Raw, unframed block snappy (varint length + LZ77 opcodes, as embedded inside Parquet/ORC
+ * pages) is not a whole-file format and is intentionally not supported here — callers should use
+ * the format reader's own page-level decompression.
+ *
+ * <p>The Hadoop-snappy sniff assumes the first block's uncompressed length fits in 24 bits (high
+ * byte {@code 0x00}). This holds for all standard producers: Hadoop's default 256 KB block size,
+ * aircompressor's {@code SnappyHadoopOutputStream} (also 256 KB), and {@code snzip}. A
+ * hand-crafted single-block file with an uncompressed payload of 16 MiB or more would not be
+ * detected and would fall through to the unrecognized-framing error.
+ *
+ * <p>Both decoders are provided by the {@code esql-datasource-compression-libs} parent plugin.
  */
 public class SnappyDecompressionCodec implements DecompressionCodec {
 
     private static final List<String> EXTENSIONS = List.of(".snappy");
+
+    /** First byte of the xerial/Google framed-snappy stream identifier chunk ({@code 0xff}). */
+    private static final int XERIAL_MAGIC_FIRST_BYTE = 0xFF;
+
+    /** First byte of a Hadoop-snappy stream — the high byte of a big-endian uncompressed block length. */
+    private static final int HADOOP_FIRST_BYTE = 0x00;
+
+    /** Stateless factory; reused across calls to avoid per-decompress allocation. */
+    private static final SnappyHadoopStreams HADOOP_STREAMS = new SnappyHadoopStreams();
 
     @Override
     public String name() {
@@ -38,6 +75,76 @@ public class SnappyDecompressionCodec implements DecompressionCodec {
 
     @Override
     public InputStream decompress(InputStream raw) throws IOException {
-        return new SnappyFramedInputStream(raw, /* verifyCrc32c= */ true);
+        // This method takes ownership of {@code raw}: the returned stream's close() closes the
+        // pushback wrapper which closes raw. If we throw before returning that stream, we must
+        // close raw ourselves or the caller (which has already lost the reference) leaks it.
+        PushbackInputStream pushback = new PushbackInputStream(raw, 1);
+        try {
+            int first = pushback.read();
+            if (first == -1) {
+                // Empty stream — let the xerial reader produce its standard end-of-stream behavior.
+                return new SnappyFramedInputStream(pushback, /* verifyCrc32c= */ true);
+            }
+            pushback.unread(first);
+            return switch (first) {
+                case XERIAL_MAGIC_FIRST_BYTE -> new SnappyFramedInputStream(pushback, /* verifyCrc32c= */ true);
+                case HADOOP_FIRST_BYTE -> new HadoopErrorTranslatingStream(HADOOP_STREAMS.createInputStream(pushback));
+                default -> throw new IOException(
+                    Strings.format(
+                        "unrecognized snappy stream framing (first byte 0x%02x); expected xerial framed snappy "
+                            + "(magic '\\xff\\x06\\x00\\x00sNaPpY') or Hadoop snappy (big-endian int32-prefixed "
+                            + "blocks). Raw block snappy is not supported as a whole-file format",
+                        first
+                    )
+                );
+            };
+        } catch (Throwable t) {
+            IOUtils.closeWhileHandlingException(pushback);
+            throw t;
+        }
+    }
+
+    /**
+     * Translates aircompressor's {@link MalformedInputException} (an unchecked
+     * {@link RuntimeException}) thrown during reads into {@link IOException}, matching the
+     * checked contract that the codec advertises and that the xerial reader satisfies.
+     * Aircompressor uses {@code RuntimeException} for compressed-stream corruption, but
+     * callers in the data-source pipeline (e.g. format readers) only catch {@code IOException}
+     * and would otherwise see the corruption as an unrecoverable crash.
+     */
+    private static final class HadoopErrorTranslatingStream extends FilterInputStream {
+        HadoopErrorTranslatingStream(InputStream in) {
+            super(in);
+        }
+
+        @Override
+        public int read() throws IOException {
+            try {
+                return in.read();
+            } catch (MalformedInputException e) {
+                throw translate(e);
+            }
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException {
+            try {
+                return in.read(b, off, len);
+            } catch (MalformedInputException e) {
+                throw translate(e);
+            }
+        }
+
+        private static IOException translate(MalformedInputException e) {
+            String detail = e.getMessage();
+            return new IOException(
+                Strings.format(
+                    "malformed Hadoop-snappy stream at offset [%d]%s",
+                    e.getOffset(),
+                    detail == null || detail.isEmpty() ? "" : ": " + detail
+                ),
+                e
+            );
+        }
     }
 }

--- a/x-pack/plugin/esql-datasource-snappy/src/test/java/org/elasticsearch/xpack/esql/datasource/snappy/SnappyDecompressionCodecTests.java
+++ b/x-pack/plugin/esql-datasource-snappy/src/test/java/org/elasticsearch/xpack/esql/datasource/snappy/SnappyDecompressionCodecTests.java
@@ -7,15 +7,23 @@
 
 package org.elasticsearch.xpack.esql.datasource.snappy;
 
+import io.airlift.compress.hadoop.HadoopOutputStream;
+import io.airlift.compress.snappy.SnappyHadoopStreams;
+
 import org.elasticsearch.test.ESTestCase;
+import org.xerial.snappy.Snappy;
 import org.xerial.snappy.SnappyFramedOutputStream;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 
 /**
  * Unit tests for {@link SnappyDecompressionCodec}.
@@ -29,9 +37,9 @@ public class SnappyDecompressionCodecTests extends ESTestCase {
         assertTrue(codec.extensions().contains(".snappy"));
     }
 
-    public void testRoundTripDecompression() throws IOException {
+    public void testRoundTripXerialFraming() throws IOException {
         String original = "hello,world\n1,2\nbar,baz";
-        byte[] compressed = snappyFrame(original.getBytes(StandardCharsets.UTF_8));
+        byte[] compressed = xerialFrame(original.getBytes(StandardCharsets.UTF_8));
 
         SnappyDecompressionCodec codec = new SnappyDecompressionCodec();
         try (InputStream decompressed = codec.decompress(new ByteArrayInputStream(compressed))) {
@@ -40,20 +48,57 @@ public class SnappyDecompressionCodecTests extends ESTestCase {
         }
     }
 
-    public void testInvalidSnappyThrows() {
-        byte[] invalidSnappy = new byte[] { 0x00, 0x01, 0x02 };
+    public void testRoundTripHadoopFraming() throws IOException {
+        String original = "hello,world\n1,2\nbar,baz\nthe,quick,brown,fox";
+        byte[] compressed = hadoopFrame(original.getBytes(StandardCharsets.UTF_8));
+
+        SnappyDecompressionCodec codec = new SnappyDecompressionCodec();
+        try (InputStream decompressed = codec.decompress(new ByteArrayInputStream(compressed))) {
+            byte[] result = decompressed.readAllBytes();
+            assertEquals(original, new String(result, StandardCharsets.UTF_8));
+        }
+    }
+
+    /**
+     * Reproduces the framing the original bug report constructed by hand (BE int32 lengths +
+     * a single raw {@code Snappy.compress} block). This is the on-disk shape that {@code snzip
+     * -t hadoop-snappy} and ClickHouse text snappy exports produce.
+     */
+    public void testRoundTripHandCraftedHadoopBlock() throws IOException {
+        byte[] payload = "hello,world\n1,2\n".getBytes(StandardCharsets.UTF_8);
+        byte[] compressedBlock = Snappy.compress(payload);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (DataOutputStream dos = new DataOutputStream(out)) {
+            dos.writeInt(payload.length);
+            dos.writeInt(compressedBlock.length);
+            dos.write(compressedBlock);
+        }
+
+        SnappyDecompressionCodec codec = new SnappyDecompressionCodec();
+        try (InputStream decompressed = codec.decompress(new ByteArrayInputStream(out.toByteArray()))) {
+            byte[] result = decompressed.readAllBytes();
+            assertArrayEquals(payload, result);
+        }
+    }
+
+    public void testUnknownFramingThrowsActionableError() {
+        // First byte 0x42 matches neither xerial (0xff) nor Hadoop (0x00).
+        byte[] garbage = new byte[] { 0x42, 0x01, 0x02, 0x03 };
         SnappyDecompressionCodec codec = new SnappyDecompressionCodec();
 
         IOException e = expectThrows(IOException.class, () -> {
-            try (InputStream ignored = codec.decompress(new ByteArrayInputStream(invalidSnappy))) {
+            try (InputStream ignored = codec.decompress(new ByteArrayInputStream(garbage))) {
                 ignored.readAllBytes();
             }
         });
-        assertNotNull(e.getMessage());
+        assertThat(e.getMessage(), containsString("unrecognized snappy stream framing"));
+        assertThat(e.getMessage(), containsString("0x42"));
+        assertThat(e.getMessage(), containsString("xerial"));
+        assertThat(e.getMessage(), containsString("Hadoop"));
     }
 
-    public void testEmptyInput() throws IOException {
-        byte[] compressed = snappyFrame(new byte[0]);
+    public void testEmptyInputXerial() throws IOException {
+        byte[] compressed = xerialFrame(new byte[0]);
         SnappyDecompressionCodec codec = new SnappyDecompressionCodec();
 
         try (InputStream decompressed = codec.decompress(new ByteArrayInputStream(compressed))) {
@@ -62,10 +107,15 @@ public class SnappyDecompressionCodecTests extends ESTestCase {
         }
     }
 
-    public void testTruncatedStreamThrows() throws IOException {
+    public void testEmptyStreamThrows() {
+        // A zero-byte input matches no framing; the xerial reader correctly reports EOF.
+        SnappyDecompressionCodec codec = new SnappyDecompressionCodec();
+        expectThrows(IOException.class, () -> codec.decompress(new ByteArrayInputStream(new byte[0])));
+    }
+
+    public void testTruncatedXerialStreamThrows() throws IOException {
         String original = "hello,world\n1,2\nbar,baz\nsome,more,data,here";
-        byte[] compressed = snappyFrame(original.getBytes(StandardCharsets.UTF_8));
-        // Truncate to half the compressed data
+        byte[] compressed = xerialFrame(original.getBytes(StandardCharsets.UTF_8));
         byte[] truncated = Arrays.copyOf(compressed, compressed.length / 2);
 
         SnappyDecompressionCodec codec = new SnappyDecompressionCodec();
@@ -76,10 +126,87 @@ public class SnappyDecompressionCodecTests extends ESTestCase {
         });
     }
 
-    private static byte[] snappyFrame(byte[] input) throws IOException {
+    public void testTruncatedHadoopStreamThrows() throws IOException {
+        String original = "hello,world\n1,2\nbar,baz\nsome,more,data,here";
+        byte[] compressed = hadoopFrame(original.getBytes(StandardCharsets.UTF_8));
+        // Truncate mid-block: keep the 8-byte header but drop most of the payload.
+        byte[] truncated = Arrays.copyOf(compressed, Math.max(9, compressed.length / 2));
+
+        SnappyDecompressionCodec codec = new SnappyDecompressionCodec();
+        expectThrows(IOException.class, () -> {
+            try (InputStream decompressed = codec.decompress(new ByteArrayInputStream(truncated))) {
+                decompressed.readAllBytes();
+            }
+        });
+    }
+
+    /**
+     * Hadoop snappy framing with a valid header but a corrupted compressed payload: aircompressor
+     * raises {@code MalformedInputException} (unchecked) from inside the snappy decoder. The codec
+     * must translate that into a checked {@link IOException} so callers that only catch
+     * {@code IOException} don't crash, and the error message must name the Hadoop layer.
+     */
+    public void testMalformedHadoopPayloadTranslatedToIOException() throws IOException {
+        // Hadoop framing with a header that passes aircompressor's sanity checks but a block whose
+        // snappy payload is invalid. The block format is varint(uncompressedLen) followed by snappy
+        // tag bytes. We use uncompressedLen=16 (0x10 fits in one varint byte) so the chunk-vs-block
+        // length check passes; the remaining bytes are 0xff, which is an invalid snappy literal/copy
+        // tag, so SnappyDecompressor throws aircompressor's unchecked MalformedInputException. The
+        // codec must translate that into a checked IOException for callers that only catch IOException.
+        byte[] block = new byte[] { 0x10, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff };
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (DataOutputStream dos = new DataOutputStream(out)) {
+            dos.writeInt(16);
+            dos.writeInt(block.length);
+            dos.write(block);
+        }
+
+        SnappyDecompressionCodec codec = new SnappyDecompressionCodec();
+        IOException e = expectThrows(IOException.class, () -> {
+            try (InputStream decompressed = codec.decompress(new ByteArrayInputStream(out.toByteArray()))) {
+                decompressed.readAllBytes();
+            }
+        });
+        assertThat(e.getMessage(), containsString("malformed Hadoop-snappy stream at offset"));
+        assertNotNull(e.getCause());
+        assertEquals("io.airlift.compress.MalformedInputException", e.getCause().getClass().getName());
+    }
+
+    /**
+     * Input whose first byte is {@code 0x00} routes to the Hadoop reader. If the rest of the
+     * header is malformed the failure comes from the Hadoop reader, not from the
+     * unrecognized-framing path; the two error surfaces are distinct on purpose.
+     */
+    public void testMalformedHadoopHeaderThrowsFromHadoopReader() {
+        // Valid-looking BE int32 uncompressed length, then garbage where the BE int32 compressed
+        // length and the snappy block should be.
+        byte[] malformed = new byte[] { 0x00, 0x00, 0x00, 0x10, (byte) 0xde, (byte) 0xad, (byte) 0xbe, (byte) 0xef };
+
+        SnappyDecompressionCodec codec = new SnappyDecompressionCodec();
+        IOException e = expectThrows(IOException.class, () -> {
+            try (InputStream decompressed = codec.decompress(new ByteArrayInputStream(malformed))) {
+                decompressed.readAllBytes();
+            }
+        });
+        // The message must NOT be the unrecognized-framing one — that path is reserved for
+        // truly unknown first bytes. Hadoop-layer failures bubble up with their own wording.
+        assertThat(e.getMessage() == null ? "" : e.getMessage(), not(containsString("unrecognized snappy stream framing")));
+    }
+
+    private static byte[] xerialFrame(byte[] input) throws IOException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         try (SnappyFramedOutputStream snappyOut = new SnappyFramedOutputStream(baos)) {
             snappyOut.write(input);
+        }
+        return baos.toByteArray();
+    }
+
+    private static byte[] hadoopFrame(byte[] input) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (HadoopOutputStream snappyOut = new SnappyHadoopStreams().createOutputStream(baos)) {
+            snappyOut.write(input, 0, input.length);
+            snappyOut.finish();
         }
         return baos.toByteArray();
     }


### PR DESCRIPTION
The `.snappy` text codec only accepted xerial/Google framed snappy and
failed with a confusing `IOException: invalid stream header` on Hadoop-
framed inputs (Hadoop/Hive/Spark exports, `snzip -t hadoop-snappy`,
ClickHouse text exports). The Hadoop reader is already on the classpath
via the parent compression-libs plugin, so dispatch by sniffing the
first byte: xerial (0xff) -> snappy-java; Hadoop (0x00) -> aircompressor.
Unknown framings now throw an actionable error naming both supported
shapes. Aircompressor's unchecked `MalformedInputException` is wrapped
as `IOException` to match the codec contract callers rely on.

Developed with AI-assisted tooling

Closes elastic/esql-planning#681
