### PR TITLE
ESQL: fast-path CSV datetime parsing

### DIFF
--- a/docs/changelog/149577.yaml
+++ b/docs/changelog/149577.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 149577
+summary: Fast-path CSV datetime parsing
+type: enhancement

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
@@ -16,6 +16,8 @@ import org.apache.lucene.document.InetAddressPoint;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.network.InetAddresses;
+import org.elasticsearch.common.time.DateFormatter;
+import org.elasticsearch.common.time.DateFormatters;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BlockUtils;
@@ -54,11 +56,13 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.Charset;
+import java.time.DateTimeException;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.time.temporal.TemporalAccessor;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -160,6 +164,103 @@ public class CsvFormatReader implements SegmentableFormatReader {
 
     /** Sentinel passed to {@link CsvBatchIterator#onRowError} when the offending row could not be tokenised. */
     private static final String[] EMPTY_ROW = new String[0];
+
+    /**
+     * Reused {@link DateFormatter} that delegates to ES's hand-rolled
+     * {@code Iso8601DateTimeParser}: covers the {@code YYYY-MM-DDTHH:MM:SS[.fff][Z|+HH:MM]} family
+     * (plus date-only inputs like {@code YYYY-MM-DD}) without the {@link DateTimeFormatter}
+     * {@code Parsed} HashMap allocation and copy that dominates {@code tryParseDatetime} on
+     * datetime-heavy queries. Space-separated {@code YYYY-MM-DD HH:MM:SS} inputs are NOT
+     * accepted by this parser and are handled separately by
+     * {@link #tryParseSpaceSeparatedDatetimeMillis(String)}.
+     */
+    private static final DateFormatter ISO_DATETIME_FAST_FORMATTER = DateFormatter.forPattern("strict_date_optional_time");
+
+    /**
+     * Sentinel returned by {@link #tryParseSpaceSeparatedDatetimeMillis(String)} when the input
+     * does not match the supported space-separated template. {@link Long#MIN_VALUE} is chosen
+     * because it cannot be produced by a legal {@code YYYY-MM-DD HH:MM:SS} value (the
+     * {@link LocalDateTime} range tops out billions of years before that millisecond).
+     */
+    static final long FAST_PATH_MISS = Long.MIN_VALUE;
+
+    /**
+     * Hand-rolled fast parser for {@code YYYY-MM-DD HH:MM:SS} (length 19) and
+     * {@code YYYY-MM-DD HH:MM:SS.fff} (length 23). Returns the epoch millisecond value, or
+     * {@link #FAST_PATH_MISS} if {@code value} does not match the supported template (caller
+     * then falls through to the general-purpose parser).
+     * <p>
+     * This is the documented hot path on datetime-heavy queries that filter, sort or group by
+     * a space-separated DATETIME column: the JDK {@link DateTimeFormatter} builds a {@code Parsed}
+     * intermediate (HashMap keyed by {@code TemporalField}) and copies it during resolve,
+     * accounting for ~16% of CPU on profiled CSV scans even though the input is fixed-width and
+     * can be parsed in a constant number of digit comparisons.
+     * <p>
+     * Only inputs that yield the same epoch milliseconds as
+     * {@link DateUtils#asDateTime(String)} are accepted; any rejected input still goes through
+     * the original parser, preserving the existing surface contract.
+     */
+    static long tryParseSpaceSeparatedDatetimeMillis(String value) {
+        int len = value.length();
+        if (len != 19 && len != 23) {
+            return FAST_PATH_MISS;
+        }
+        if (value.charAt(4) != '-'
+            || value.charAt(7) != '-'
+            || value.charAt(10) != ' '
+            || value.charAt(13) != ':'
+            || value.charAt(16) != ':') {
+            return FAST_PATH_MISS;
+        }
+        int year = parseFixedDigits(value, 0, 4);
+        int month = parseFixedDigits(value, 5, 2);
+        int day = parseFixedDigits(value, 8, 2);
+        int hour = parseFixedDigits(value, 11, 2);
+        int minute = parseFixedDigits(value, 14, 2);
+        int second = parseFixedDigits(value, 17, 2);
+        if ((year | month | day | hour | minute | second) < 0) {
+            return FAST_PATH_MISS;
+        }
+        int millis = 0;
+        if (len == 23) {
+            if (value.charAt(19) != '.') {
+                return FAST_PATH_MISS;
+            }
+            millis = parseFixedDigits(value, 20, 3);
+            if (millis < 0) {
+                return FAST_PATH_MISS;
+            }
+        }
+        // LocalDateTime.of validates calendar bounds (month 1..12, day-of-month per month, leap
+        // years etc.). Trapping the DateTimeException here keeps the fast path side-effect-free on
+        // invalid dates: the caller falls through to the general-purpose Stage 3 parser, which
+        // preserves the existing DateUtils.asDateTime semantics (including the user-facing
+        // "Failed to parse" error message it produces for genuinely invalid inputs).
+        try {
+            LocalDateTime ldt = LocalDateTime.of(year, month, day, hour, minute, second);
+            return ldt.toInstant(ZoneOffset.UTC).toEpochMilli() + millis;
+        } catch (DateTimeException e) {
+            return FAST_PATH_MISS;
+        }
+    }
+
+    /**
+     * Parses {@code count} consecutive ASCII decimal digits starting at {@code offset} and
+     * returns the integer value, or {@code -1} if any character is outside {@code '0'..'9'}.
+     * Used by the datetime fast path so a non-digit triggers a fall-through instead of an
+     * exception.
+     */
+    private static int parseFixedDigits(String value, int offset, int count) {
+        int result = 0;
+        for (int i = 0; i < count; i++) {
+            char c = value.charAt(offset + i);
+            if (c < '0' || c > '9') {
+                return -1;
+            }
+            result = result * 10 + (c - '0');
+        }
+        return result;
+    }
 
     static final String CONFIG_DELIMITER = "delimiter";
     static final String CONFIG_QUOTE = "quote";
@@ -1971,7 +2072,31 @@ public class CsvFormatReader implements SegmentableFormatReader {
                     return null;
                 }
             }
-            // Handles ISO-8601 with zone, zone-less timestamps, date-only, and whitespace-separated date-times
+            // Stage 1: ES's hand-rolled ISO-8601 parser (T-separator, date-only, zones, fractions)
+            // avoids the DateTimeFormatter Parsed-HashMap allocation that dominates DateUtils.asDateTime.
+            // tryParse returns null on mismatch so we don't pay an exception per missed input.
+            // Iso8601Parser only checks loose bounds (month <= 12, day <= 31) and defers month-length
+            // validation to LocalDate.of(...) inside DateFormatters.from(...), which throws a generic
+            // DateTimeException (not DateTimeParseException). Catch that here and fall through so a
+            // calendar-invalid input like 2021-02-30T10:00:00 takes the slow Stage 3 path instead of
+            // propagating an uncaught exception and aborting the batch.
+            TemporalAccessor parsed = ISO_DATETIME_FAST_FORMATTER.tryParse(value);
+            if (parsed != null) {
+                try {
+                    return DateFormatters.from(parsed).toInstant().toEpochMilli();
+                } catch (DateTimeException e) {
+                    // fall through to Stage 2 / 3
+                }
+            }
+            // Stage 2: hot path for `YYYY-MM-DD HH:MM:SS[.fff]` (space-separated, no zone), which the
+            // ISO parser does not accept. Returns FAST_PATH_MISS on any mismatch.
+            long spaceMillis = tryParseSpaceSeparatedDatetimeMillis(value);
+            if (spaceMillis != FAST_PATH_MISS) {
+                return spaceMillis;
+            }
+            // Stage 3: full DateUtils.asDateTime fallback for the long tail (space-separated with zone,
+            // lowercase `t`, non-millisecond fractional precision, etc.). Same exception-based path as
+            // before — only reached when neither fast path matched.
             try {
                 return DateUtils.asDateTime(value).toInstant().toEpochMilli();
             } catch (DateTimeParseException e) {

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
@@ -3360,6 +3360,105 @@ public class CsvFormatReaderTests extends ESTestCase {
         }
     }
 
+    // --- Datetime fast-path equivalence tests (#769) ---
+    // tryParseSpaceSeparatedDatetimeMillis avoids the JDK DateTimeFormatter Parsed-HashMap
+    // allocation that dominated ~16% of CPU on Q24 of the CSV ClickBench profile. These tests lock
+    // in the equivalence contract: any input the fast path accepts must produce the same epoch
+    // millis as the existing slow path (DateUtils.asDateTime), and any input it rejects must hit
+    // the slow path unchanged (returning FAST_PATH_MISS).
+
+    public void testFastPathSpaceSeparatedNoFraction() {
+        long actual = CsvFormatReader.tryParseSpaceSeparatedDatetimeMillis("2024-05-12 14:30:45");
+        assertEquals(Instant.parse("2024-05-12T14:30:45Z").toEpochMilli(), actual);
+    }
+
+    public void testFastPathSpaceSeparatedWithMillis() {
+        long actual = CsvFormatReader.tryParseSpaceSeparatedDatetimeMillis("2024-05-12 14:30:45.123");
+        assertEquals(Instant.parse("2024-05-12T14:30:45.123Z").toEpochMilli(), actual);
+    }
+
+    public void testFastPathSpaceSeparatedLeapDay() {
+        long actual = CsvFormatReader.tryParseSpaceSeparatedDatetimeMillis("2020-02-29 00:00:00");
+        assertEquals(Instant.parse("2020-02-29T00:00:00Z").toEpochMilli(), actual);
+    }
+
+    public void testFastPathSpaceSeparatedEpoch() {
+        long actual = CsvFormatReader.tryParseSpaceSeparatedDatetimeMillis("1970-01-01 00:00:00");
+        assertEquals(0L, actual);
+    }
+
+    public void testFastPathRejectsCalendarInvalidDates() {
+        // 30 February — valid digits, invalid calendar date. Must fall through (FAST_PATH_MISS)
+        // so the slow path can produce the usual "Failed to parse" error.
+        assertEquals(CsvFormatReader.FAST_PATH_MISS, CsvFormatReader.tryParseSpaceSeparatedDatetimeMillis("2021-02-30 10:00:00"));
+        // 13th month
+        assertEquals(CsvFormatReader.FAST_PATH_MISS, CsvFormatReader.tryParseSpaceSeparatedDatetimeMillis("2021-13-01 10:00:00"));
+        // Hour 24 — Iso8601Parser also rejects this and LocalDateTime.of throws.
+        assertEquals(CsvFormatReader.FAST_PATH_MISS, CsvFormatReader.tryParseSpaceSeparatedDatetimeMillis("2021-01-01 24:00:00"));
+    }
+
+    public void testFastPathRejectsWrongShape() {
+        // T-separated → not the space-separated fast path's job; ISO fast path handles it instead.
+        assertEquals(CsvFormatReader.FAST_PATH_MISS, CsvFormatReader.tryParseSpaceSeparatedDatetimeMillis("2024-05-12T14:30:45"));
+        // Date-only
+        assertEquals(CsvFormatReader.FAST_PATH_MISS, CsvFormatReader.tryParseSpaceSeparatedDatetimeMillis("2024-05-12"));
+        // Trailing Z — falls back to the general-purpose parser (preserves the existing semantics
+        // that DateUtils.asDateTime's whitespace formatter would apply).
+        assertEquals(CsvFormatReader.FAST_PATH_MISS, CsvFormatReader.tryParseSpaceSeparatedDatetimeMillis("2024-05-12 14:30:45Z"));
+        // Microsecond precision (6-digit fraction) — only 3-digit ms is fast-pathed.
+        assertEquals(CsvFormatReader.FAST_PATH_MISS, CsvFormatReader.tryParseSpaceSeparatedDatetimeMillis("2024-05-12 14:30:45.123456"));
+        // Garbage
+        assertEquals(CsvFormatReader.FAST_PATH_MISS, CsvFormatReader.tryParseSpaceSeparatedDatetimeMillis("not-a-date"));
+        // Wrong separators
+        assertEquals(CsvFormatReader.FAST_PATH_MISS, CsvFormatReader.tryParseSpaceSeparatedDatetimeMillis("2024/05/12 14:30:45"));
+        // Non-ASCII digit (full-width '1') in the year — must be rejected without throwing
+        assertEquals(CsvFormatReader.FAST_PATH_MISS, CsvFormatReader.tryParseSpaceSeparatedDatetimeMillis("\uFF12024-05-12 14:30:45"));
+    }
+
+    public void testDatetimeFastPathInvalidIsoFallsThroughCleanly() throws IOException {
+        // Regression for the Stage 1 catch path: an ISO-shaped but calendar-invalid input like
+        // 2021-02-30T10:00:00 succeeds in Iso8601Parser's lexical parse but fails inside
+        // DateFormatters.from(...) with a generic DateTimeException (not DateTimeParseException).
+        // Without the catch, the batch would abort with an uncaught exception. The catch routes
+        // the row through Stage 3, whose JDK SMART resolver leniently maps Feb 30 to Feb 28 (same
+        // behaviour as before this change). The second row is a sanity-check that the batch
+        // continues normally.
+        String csv = "ts:datetime\n2021-02-30T10:00:00\n2021-01-01T00:00:00Z\n";
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(2, page.getPositionCount());
+            LongBlock block = (LongBlock) page.getBlock(0);
+            assertEquals(Instant.parse("2021-02-28T10:00:00Z").toEpochMilli(), block.getLong(0));
+            assertEquals(Instant.parse("2021-01-01T00:00:00Z").toEpochMilli(), block.getLong(1));
+        }
+    }
+
+    public void testDatetimeFastPathRouting() throws IOException {
+        // End-to-end smoke test exercising all three stages of tryParseDatetime in one batch:
+        // * 2024-05-12 14:30:45 → Stage 2 (space-separated fast path)
+        // * 2024-05-12T14:30:45Z → Stage 1 (ISO fast path)
+        // * 2024-05-12T14:30:45+02:00 → Stage 1 (ISO fast path, with zone offset)
+        // * 1715520645000 → looksNumeric → Long.parseLong
+        String csv = "ts:datetime\n2024-05-12 14:30:45\n2024-05-12T14:30:45Z\n2024-05-12T14:30:45+02:00\n1715520645000\n";
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(4, page.getPositionCount());
+            LongBlock block = (LongBlock) page.getBlock(0);
+            assertEquals(Instant.parse("2024-05-12T14:30:45Z").toEpochMilli(), block.getLong(0));
+            assertEquals(Instant.parse("2024-05-12T14:30:45Z").toEpochMilli(), block.getLong(1));
+            assertEquals(Instant.parse("2024-05-12T12:30:45Z").toEpochMilli(), block.getLong(2));
+            assertEquals(1715520645000L, block.getLong(3));
+        }
+    }
+
     // --- Numeric alias tests (#324) ---
 
     public void testFloatAlias() throws IOException {


### PR DESCRIPTION
Bypass the JDK `DateTimeFormatter` HashMap allocation for the common ISO and `YYYY-MM-DD HH:MM:SS[.fff]` shapes that dominate CPU on datetime-heavy CSV scans. Falls through to the existing `DateUtils.asDateTime` path for any input the fast parsers reject.

Stage 1 reuses ES's `strict_date_optional_time` Iso8601 parser via `DateFormatter.tryParse`; Stage 2 is a tiny hand-rolled parser for the space-separated variant the ISO parser does not accept.

Developed with AI-assisted tooling

Closes elastic/esql-planning#769
