### PR TITLE
Fix StatelessRealTimeGetIT#testStress

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -309,9 +309,6 @@ tests:
 - class: org.elasticsearch.xpack.stateless.engine.RefreshNodeCreditManagerTests
   method: testPeriodicWarning
   issue: https://github.com/elastic/elasticsearch-serverless/issues/6518
-- class: org.elasticsearch.xpack.stateless.StatelessRealTimeGetIT
-  method: testStress
-  issue: https://github.com/elastic/elasticsearch/issues/147850
 - class: org.elasticsearch.backwards.RareTermsIT
   method: testSingleValuedString
   issue: https://github.com/elastic/elasticsearch/issues/147853

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/ConcurrentMultiPartUploadsMockFsRepository.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/ConcurrentMultiPartUploadsMockFsRepository.java
@@ -224,7 +224,6 @@ class ConcurrentMultiPartUploadsMockFsRepository extends FsRepository {
                                             format("[%d] bytes copied for writing part, expecting [%d] bytes", bytesCopied, partSize)
                                         );
                                     }
-
                                 }));
                                 remaining -= partSize;
                                 assert 0 <= remaining : remaining;
@@ -244,7 +243,9 @@ class ConcurrentMultiPartUploadsMockFsRepository extends FsRepository {
                             if (assertion.getCause() instanceof ExecutionException ee && ee.getCause() instanceof IOException ioe) {
                                 throw ioe;
                             }
-                            throw assertion;
+                            // For all other cases, consumers of writeBlobAtomic expect IOExceptions,
+                            // not AssertionErrors, so convert here to meet that contract.
+                            throw new IOException("multipart upload failed", assertion);
                         }
 
                         if (bytesWritten.get() != blobSize) {


### PR DESCRIPTION
Convert AssertionError from safeGet into IOException
so consumers of writeBlobAtomic see the expected type
and release store references on failure.

Closes https://github.com/elastic/elasticsearch/issues/147850