### PR TITLE
ES|QL: document JSON_EXTRACT(_source) behavior on synthetic source

### DIFF
--- a/docs/reference/query-languages/esql/_snippets/generated/x-pack-esql/functions/description/json_extract.md
+++ b/docs/reference/query-languages/esql/_snippets/generated/x-pack-esql/functions/description/json_extract.md
@@ -37,14 +37,17 @@ This function does not support wildcards (`*`), recursive descent
 (`..`), array slicing (`[0:3]`), filter expressions
 (`?(@.price<10)`), or negative array indices (`[-1]`).
 
-When called with `_source`, this function reads `_source` as
-Elasticsearch returns it. On indices using
-[synthetic `_source`](/reference/elasticsearch/mapping-reference/mapping-source-field.md#synthetic-source),
-Elasticsearch reconstructs `_source` from stored data when
-documents are retrieved, so the JSON the function sees can
-differ from the original document. See
-[synthetic `_source` modifications](/reference/elasticsearch/mapping-reference/mapping-source-field.md#synthetic-source-modifications)
-for the changes that apply — for example, arrays are moved to
-leaves, fields are named as in the mapping, and object keys are
-sorted alphabetically.
+When called with [`_source`][source], this function reads
+`_source` as Elasticsearch returns it. On indices using
+[synthetic `_source`][synthetic], Elasticsearch reconstructs
+`_source` from stored data when documents are retrieved, so the
+JSON the function sees can differ from the original document.
+See [synthetic `_source` modifications][modifications] for the
+changes that apply — for example, arrays are moved to leaves,
+fields are named as in the mapping, and object keys are sorted
+alphabetically.
+
+[source]: /reference/elasticsearch/mapping-reference/mapping-source-field.md
+[synthetic]: /reference/elasticsearch/mapping-reference/mapping-source-field.md#synthetic-source
+[modifications]: /reference/elasticsearch/mapping-reference/mapping-source-field.md#synthetic-source-modifications
 

--- a/docs/reference/query-languages/esql/_snippets/generated/x-pack-esql/functions/description/json_extract.md
+++ b/docs/reference/query-languages/esql/_snippets/generated/x-pack-esql/functions/description/json_extract.md
@@ -37,3 +37,13 @@ This function does not support wildcards (`*`), recursive descent
 (`..`), array slicing (`[0:3]`), filter expressions
 (`?(@.price<10)`), or negative array indices (`[-1]`).
 
+When called with `_source`, the function operates on `_source` as
+the index currently materializes it. On indices using
+[synthetic `_source`](/reference/elasticsearch/mapping-reference/mapping-source-field.md#synthetic-source),
+`_source` is reconstructed from doc values and may differ from the
+originally indexed JSON — see
+[synthetic `_source` modifications](/reference/elasticsearch/mapping-reference/mapping-source-field.md#synthetic-source-modifications)
+for the specific ways the reconstruction can change (notably, leaf
+arrays are moved, fields use their mapped names, and object keys
+are sorted alphabetically).
+

--- a/docs/reference/query-languages/esql/_snippets/generated/x-pack-esql/functions/description/json_extract.md
+++ b/docs/reference/query-languages/esql/_snippets/generated/x-pack-esql/functions/description/json_extract.md
@@ -37,13 +37,14 @@ This function does not support wildcards (`*`), recursive descent
 (`..`), array slicing (`[0:3]`), filter expressions
 (`?(@.price<10)`), or negative array indices (`[-1]`).
 
-When called with `_source`, the function operates on `_source` as
-the index currently materializes it. On indices using
+When called with `_source`, this function reads `_source` as
+Elasticsearch returns it. On indices using
 [synthetic `_source`](/reference/elasticsearch/mapping-reference/mapping-source-field.md#synthetic-source),
-`_source` is reconstructed from doc values and may differ from the
-originally indexed JSON — see
+Elasticsearch reconstructs `_source` from stored data when
+documents are retrieved, so the JSON the function sees can
+differ from the original document. See
 [synthetic `_source` modifications](/reference/elasticsearch/mapping-reference/mapping-source-field.md#synthetic-source-modifications)
-for the specific ways the reconstruction can change (notably, leaf
-arrays are moved, fields use their mapped names, and object keys
-are sorted alphabetically).
+for the changes that apply — for example, arrays are moved to
+leaves, fields are named as in the mapping, and object keys are
+sorted alphabetically.
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/JsonExtract.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/JsonExtract.java
@@ -107,7 +107,17 @@ public class JsonExtract extends EsqlScalarFunction {
 
             This function does not support wildcards (`*`), recursive descent
             (`..`), array slicing (`[0:3]`), filter expressions
-            (`?(@.price<10)`), or negative array indices (`[-1]`).""",
+            (`?(@.price<10)`), or negative array indices (`[-1]`).
+
+            When called with `_source`, the function operates on `_source` as
+            the index currently materializes it. On indices using
+            [synthetic `_source`](/reference/elasticsearch/mapping-reference/mapping-source-field.md#synthetic-source),
+            `_source` is reconstructed from doc values and may differ from the
+            originally indexed JSON — see
+            [synthetic `_source` modifications](/reference/elasticsearch/mapping-reference/mapping-source-field.md#synthetic-source-modifications)
+            for the specific ways the reconstruction can change (notably, leaf
+            arrays are moved, fields use their mapped names, and object keys
+            are sorted alphabetically).""",
         examples = {
             @Example(file = "json_extract", tag = "json_extract"),
             @Example(file = "json_extract", tag = "json_extract_dollar", description = """

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/JsonExtract.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/JsonExtract.java
@@ -109,15 +109,16 @@ public class JsonExtract extends EsqlScalarFunction {
             (`..`), array slicing (`[0:3]`), filter expressions
             (`?(@.price<10)`), or negative array indices (`[-1]`).
 
-            When called with `_source`, the function operates on `_source` as
-            the index currently materializes it. On indices using
+            When called with `_source`, this function reads `_source` as
+            Elasticsearch returns it. On indices using
             [synthetic `_source`](/reference/elasticsearch/mapping-reference/mapping-source-field.md#synthetic-source),
-            `_source` is reconstructed from doc values and may differ from the
-            originally indexed JSON — see
+            Elasticsearch reconstructs `_source` from stored data when
+            documents are retrieved, so the JSON the function sees can
+            differ from the original document. See
             [synthetic `_source` modifications](/reference/elasticsearch/mapping-reference/mapping-source-field.md#synthetic-source-modifications)
-            for the specific ways the reconstruction can change (notably, leaf
-            arrays are moved, fields use their mapped names, and object keys
-            are sorted alphabetically).""",
+            for the changes that apply — for example, arrays are moved to
+            leaves, fields are named as in the mapping, and object keys are
+            sorted alphabetically.""",
         examples = {
             @Example(file = "json_extract", tag = "json_extract"),
             @Example(file = "json_extract", tag = "json_extract_dollar", description = """

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/JsonExtract.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/JsonExtract.java
@@ -109,16 +109,19 @@ public class JsonExtract extends EsqlScalarFunction {
             (`..`), array slicing (`[0:3]`), filter expressions
             (`?(@.price<10)`), or negative array indices (`[-1]`).
 
-            When called with `_source`, this function reads `_source` as
-            Elasticsearch returns it. On indices using
-            [synthetic `_source`](/reference/elasticsearch/mapping-reference/mapping-source-field.md#synthetic-source),
-            Elasticsearch reconstructs `_source` from stored data when
-            documents are retrieved, so the JSON the function sees can
-            differ from the original document. See
-            [synthetic `_source` modifications](/reference/elasticsearch/mapping-reference/mapping-source-field.md#synthetic-source-modifications)
-            for the changes that apply — for example, arrays are moved to
-            leaves, fields are named as in the mapping, and object keys are
-            sorted alphabetically.""",
+            When called with [`_source`][source], this function reads
+            `_source` as Elasticsearch returns it. On indices using
+            [synthetic `_source`][synthetic], Elasticsearch reconstructs
+            `_source` from stored data when documents are retrieved, so the
+            JSON the function sees can differ from the original document.
+            See [synthetic `_source` modifications][modifications] for the
+            changes that apply — for example, arrays are moved to leaves,
+            fields are named as in the mapping, and object keys are sorted
+            alphabetically.
+
+            [source]: /reference/elasticsearch/mapping-reference/mapping-source-field.md
+            [synthetic]: /reference/elasticsearch/mapping-reference/mapping-source-field.md#synthetic-source
+            [modifications]: /reference/elasticsearch/mapping-reference/mapping-source-field.md#synthetic-source-modifications""",
         examples = {
             @Example(file = "json_extract", tag = "json_extract"),
             @Example(file = "json_extract", tag = "json_extract_dollar", description = """


### PR DESCRIPTION
## What this is about

`JSON_EXTRACT(_source, …)` on synthetic-source indices returns values that can differ from the originally indexed JSON — array order, object key order, mapped field names, etc. Followers of #149514 expected this to be a function-level hardening problem; on review the contract is simpler than that.

## What this PR does

States the contract explicitly in `JSON_EXTRACT`'s detailed description: the function operates on `_source` as the index currently materializes it. Synthetic-source reconstruction is upstream of the function, not a `JSON_EXTRACT` concern. Links to the canonical [synthetic `_source` modifications](/reference/elasticsearch/mapping-reference/mapping-source-field.md#synthetic-source-modifications) page rather than enumerating modifications here — that page is the source of truth and will track future changes.

## What's in the diff

- `JsonExtract.java` — new paragraph in `detailedDescription` stating the contract + two links to the canonical mapping-source-field doc.
- Regenerated `docs/reference/query-languages/esql/_snippets/generated/x-pack-esql/functions/description/json_extract.md`.

## What's out of scope

`JSON_EXTRACT`'s function-level behavior is correct under this contract; no code changes required. The synthetic-source modifications themselves (leaf arrays moved, alphabetical sorting, etc.) are upstream features documented at the mapping-source-field page.

Closes #149514