### PR TITLE
[9.4] Improve inference field gathering performance during rewrite (#149539)

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/query/QueryRewriteContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryRewriteContext.java
@@ -88,6 +88,8 @@ public class QueryRewriteContext {
     private final boolean isProfile;
     private Long timeRangeFilterFromMillis;
     private boolean trackTimeRangeFilterFrom = true;
+    @Nullable
+    private Boolean hasAnyLocalInferenceFields;
     private final boolean allowPartialSearchResults;
 
     public QueryRewriteContext(
@@ -607,6 +609,23 @@ public class QueryRewriteContext {
 
     public ResolvedIndices getResolvedIndices() {
         return resolvedIndices;
+    }
+
+    /**
+     * Returns whether concrete local indices include any inference fields. Returns {@code null} if unknown.
+     */
+    @Nullable
+    public Boolean getHasAnyLocalInferenceFields() {
+        return hasAnyLocalInferenceFields;
+    }
+
+    /**
+     * Sets whether concrete local indices include any inference fields.
+     */
+    public void setHasAnyLocalInferenceFields(boolean hasAnyLocalInferenceFields) {
+        // we don't expect this to ever change during the lifetime of the context
+        assert this.hasAnyLocalInferenceFields == null || this.hasAnyLocalInferenceFields == hasAnyLocalInferenceFields;
+        this.hasAnyLocalInferenceFields = hasAnyLocalInferenceFields;
     }
 
     /**

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/queries/InferenceQueryUtils.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/queries/InferenceQueryUtils.java
@@ -228,20 +228,31 @@ public final class InferenceQueryUtils {
         ActionListener<InferenceInfo> localInferenceInfoListener
     ) {
         String query = inferenceInfoRequest.query();
+        ResolvedIndices resolvedIndices = queryRewriteContext.getResolvedIndices();
         var inferenceResultsMap = inferenceInfoRequest.inferenceResultsMap();
+        int indexCount = resolvedIndices.getConcreteLocalIndicesMetadata().size();
 
-        Map<String, Set<InferenceFieldMetadata>> localInferenceFields = getLocalInferenceFields(
-            queryRewriteContext.getResolvedIndices(),
+        if (Boolean.FALSE.equals(queryRewriteContext.getHasAnyLocalInferenceFields())) {
+            localInferenceInfoListener.onResponse(
+                new InferenceInfo(
+                    0,
+                    indexCount,
+                    inferenceResultsMap != null ? inferenceResultsMap : Map.of(),
+                    queryRewriteContext.getMinTransportVersion()
+                )
+            );
+            return;
+        }
+
+        LocalInferenceFieldsInfo localInferenceFieldsInfo = getLocalInferenceFields(
+            queryRewriteContext,
+            resolvedIndices,
             inferenceInfoRequest.fields(),
             inferenceInfoRequest.resolveWildcards(),
             inferenceInfoRequest.useDefaultFields()
         );
-
-        int indexCount = localInferenceFields.size();
-        int inferenceFieldCount = 0;
-        for (var inferenceFieldMetadataSet : localInferenceFields.values()) {
-            inferenceFieldCount += inferenceFieldMetadataSet.size();
-        }
+        assert indexCount == localInferenceFieldsInfo.indexCount();
+        int inferenceFieldCount = localInferenceFieldsInfo.inferenceFieldCount();
 
         if (inferenceFieldCount == 0 || query == null) {
             // Skip local inference result generation if:
@@ -259,7 +270,7 @@ public final class InferenceQueryUtils {
         }
 
         final Set<FullyQualifiedInferenceId> localInferenceIds = getLocalInferenceIds(
-            localInferenceFields,
+            localInferenceFieldsInfo.inferenceFieldMap(),
             queryRewriteContext.getLocalClusterAlias()
         );
         final int finalInferenceFieldCount = inferenceFieldCount;
@@ -355,27 +366,44 @@ public final class InferenceQueryUtils {
         return new InferenceInfo(totalInferenceFieldCount, totalIndexCount, completeInferenceResultsMap, minTransportVersion);
     }
 
-    private static Map<String, Set<InferenceFieldMetadata>> getLocalInferenceFields(
+    private record LocalInferenceFieldsInfo(
+        Map<String, Set<InferenceFieldMetadata>> inferenceFieldMap,
+        int inferenceFieldCount,
+        int indexCount
+    ) {}
+
+    private static LocalInferenceFieldsInfo getLocalInferenceFields(
+        QueryRewriteContext queryRewriteContext,
         ResolvedIndices resolvedIndices,
         Map<String, Float> fields,
         boolean resolveWildcards,
         boolean useDefaultFields
     ) {
         Map<String, Set<InferenceFieldMetadata>> inferenceFieldMap = new HashMap<>();
+        int inferenceFieldCount = 0;
+        boolean hasAnyLocalInferenceFields = false;
 
         Collection<IndexMetadata> indexMetadataCollection = resolvedIndices.getConcreteLocalIndicesMetadata().values();
         for (IndexMetadata indexMetadata : indexMetadataCollection) {
-            final String indexName = indexMetadata.getIndex().getName();
+            if (indexMetadata.getInferenceFields().isEmpty()) {
+                continue;
+            }
+            hasAnyLocalInferenceFields = true;
             final Map<InferenceFieldMetadata, Float> matchingInferenceFieldMap = indexMetadata.getMatchingInferenceFields(
                 fields,
                 resolveWildcards,
                 useDefaultFields
             );
 
-            inferenceFieldMap.put(indexName, matchingInferenceFieldMap.keySet());
+            Set<InferenceFieldMetadata> inferenceFieldMetadataSet = matchingInferenceFieldMap.keySet();
+            if (inferenceFieldMetadataSet.isEmpty() == false) {
+                inferenceFieldMap.put(indexMetadata.getIndex().getName(), inferenceFieldMetadataSet);
+                inferenceFieldCount += inferenceFieldMetadataSet.size();
+            }
         }
+        queryRewriteContext.setHasAnyLocalInferenceFields(hasAnyLocalInferenceFields);
 
-        return inferenceFieldMap;
+        return new LocalInferenceFieldsInfo(inferenceFieldMap, inferenceFieldCount, indexMetadataCollection.size());
     }
 
     private static Set<FullyQualifiedInferenceId> getLocalInferenceIds(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Improve inference field gathering performance during rewrite (#149539)](https://github.com/elastic/elasticsearch/pull/149539)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)