### PR TITLE
[ESQL] Per-query partition column nullability

### DIFF
--- a/docs/changelog/149592.yaml
+++ b/docs/changelog/149592.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 149592
+summary: Per-query nullability for partition columns on external sources
+type: enhancement

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
@@ -859,13 +859,21 @@ public class ExternalSourceResolver {
             }
         }
 
+        // Per-query nullability: a partition column is non-nullable when no file in the matched
+        // fileset has a null value for it. The Hive sentinel __HIVE_DEFAULT_PARTITION__ is decoded
+        // to null in PartitionMetadata#filePartitionValues, so this is precise rather than
+        // pessimistic. The same dataset may yield different nullability across globs depending on
+        // which files match.
+        Set<String> nullableColumns = partitionMetadata.nullablePartitionColumns();
+
         for (Map.Entry<String, DataType> entry : partitionColumns.entrySet()) {
             String name = entry.getKey();
             DataType type = entry.getValue();
+            Nullability nullability = nullableColumns.contains(name) ? Nullability.TRUE : Nullability.FALSE;
             // synthetic=false: partition columns are user-addressable (referenceable in WHERE, STATS BY, EVAL, ...).
             // Marking them synthetic causes AnalyzerRules.maybeResolveAgainstList to skip them during name resolution
             // and produces "Unknown column [X], did you mean [X]?" errors.
-            enrichedSchema.add(new ReferenceAttribute(Source.EMPTY, null, name, type, Nullability.TRUE, null, false));
+            enrichedSchema.add(new ReferenceAttribute(Source.EMPTY, null, name, type, nullability, null, false));
         }
 
         return withSchema(metadata, List.copyOf(enrichedSchema));

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/PartitionMetadata.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/PartitionMetadata.java
@@ -13,7 +13,9 @@ import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Holds partition information detected from file paths.
@@ -57,5 +59,46 @@ public record PartitionMetadata(Map<String, DataType> partitionColumns, Map<Stor
 
     public boolean isEmpty() {
         return partitionColumns.isEmpty();
+    }
+
+    /**
+     * Returns the names of partition columns that cannot be proven non-null across the matched
+     * fileset. A column is in this set when at least one file in {@link #filePartitionValues}
+     * has {@code null} (or no entry) for it — typically because the file lives under a
+     * {@code __HIVE_DEFAULT_PARTITION__} directory decoded by {@link HivePartitionDetector}.
+     * When per-file values are absent altogether (e.g. metadata constructed without scanning
+     * files), every declared column is returned: no evidence means no non-null guarantee.
+     * <p>
+     * This is a per-query property: different globs over the same dataset can match
+     * different subsets of files and therefore yield different null-bearing column sets.
+     * Callers use it to decide per-column {@code Nullability.TRUE}/{@code FALSE} when
+     * building attributes; columns absent from this set are provably non-null in the
+     * matched fileset.
+     */
+    public Set<String> nullablePartitionColumns() {
+        if (partitionColumns.isEmpty()) {
+            return Set.of();
+        }
+        if (filePartitionValues.isEmpty()) {
+            // No per-file evidence — stay conservative: every column may be null.
+            return Set.copyOf(partitionColumns.keySet());
+        }
+        Set<String> nullable = new LinkedHashSet<>();
+        for (Map<String, Object> values : filePartitionValues.values()) {
+            for (String column : partitionColumns.keySet()) {
+                if (nullable.contains(column)) {
+                    continue;
+                }
+                // Map.get returns null for both explicit nulls and absent keys; either case means
+                // we have no non-null guarantee for this column.
+                if (values.get(column) == null) {
+                    nullable.add(column);
+                }
+            }
+            if (nullable.size() == partitionColumns.size()) {
+                break;
+            }
+        }
+        return Collections.unmodifiableSet(nullable);
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolverTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolverTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.compute.operator.CloseableIterator;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -820,6 +821,10 @@ public class ExternalSourceResolverTests extends ESTestCase {
         assertEquals("month", resolvedSchema.get(2).name());
         assertThat(resolvedSchema.get(1), instanceOf(ReferenceAttribute.class));
         assertThat(resolvedSchema.get(2), instanceOf(ReferenceAttribute.class));
+        // End-to-end check: HivePartitionDetector produced non-null values for every file, so the
+        // resolver emits Nullability.FALSE for both partition columns.
+        assertEquals(Nullability.FALSE, resolvedSchema.get(1).nullable());
+        assertEquals(Nullability.FALSE, resolvedSchema.get(2).nullable());
     }
 
     public void testEnrichSchemaWithPartitionColumnsDirectly() {
@@ -846,6 +851,65 @@ public class ExternalSourceResolverTests extends ESTestCase {
         // AnalyzerRules.maybeResolveAgainstList skips them during name resolution.
         assertFalse(schema.get(2).synthetic());
         assertFalse(schema.get(3).synthetic());
+        // No per-file evidence is supplied here: every partition column must stay Nullability.TRUE.
+        assertEquals(Nullability.TRUE, schema.get(2).nullable());
+        assertEquals(Nullability.TRUE, schema.get(3).nullable());
+    }
+
+    public void testEnrichSchemaWithPartitionColumnsEmitsNullabilityFalseWhenNoNulls() {
+        // Per-query optimization: when every matched file has a non-null value for the partition
+        // column, the resolver emits Nullability.FALSE so downstream rules that consult nullability
+        // (Coalesce simplification, PropagateNullable) have correct metadata.
+        List<Attribute> originalSchema = List.of(attr("value", DataType.DOUBLE));
+        ExternalSourceMetadata metadata = createStubMetadata("s3://bucket/data/*.parquet", originalSchema);
+
+        LinkedHashMap<String, DataType> partCols = new LinkedHashMap<>();
+        partCols.put("year", DataType.INTEGER);
+        partCols.put("month", DataType.INTEGER);
+
+        Map<StoragePath, Map<String, Object>> filePartitions = new LinkedHashMap<>();
+        filePartitions.put(StoragePath.of("s3://bucket/data/year=2024/month=01/f1.parquet"), Map.of("year", 2024, "month", 1));
+        filePartitions.put(StoragePath.of("s3://bucket/data/year=2024/month=02/f2.parquet"), Map.of("year", 2024, "month", 2));
+        PartitionMetadata partitions = new PartitionMetadata(partCols, filePartitions);
+
+        ExternalSourceMetadata enriched = ExternalSourceResolver.enrichSchemaWithPartitionColumns(metadata, partitions);
+        List<Attribute> schema = enriched.schema();
+        assertEquals(3, schema.size());
+        assertEquals("year", schema.get(1).name());
+        assertEquals("month", schema.get(2).name());
+        assertEquals(Nullability.FALSE, schema.get(1).nullable());
+        assertEquals(Nullability.FALSE, schema.get(2).nullable());
+    }
+
+    public void testEnrichSchemaWithPartitionColumnsEmitsNullabilityTrueForHiveDefaultSentinel() {
+        // When at least one file lives under __HIVE_DEFAULT_PARTITION__ (decoded to null in
+        // PartitionMetadata#filePartitionValues by HivePartitionDetector), the resolver must keep
+        // Nullability.TRUE for that column. Sibling partition columns that are still all-non-null
+        // remain Nullability.FALSE.
+        List<Attribute> originalSchema = List.of(attr("value", DataType.DOUBLE));
+        ExternalSourceMetadata metadata = createStubMetadata("s3://bucket/data/*.parquet", originalSchema);
+
+        LinkedHashMap<String, DataType> partCols = new LinkedHashMap<>();
+        partCols.put("year", DataType.INTEGER);
+        partCols.put("month", DataType.INTEGER);
+
+        Map<StoragePath, Map<String, Object>> filePartitions = new LinkedHashMap<>();
+        filePartitions.put(StoragePath.of("s3://bucket/data/year=2024/month=01/f1.parquet"), Map.of("year", 2024, "month", 1));
+        Map<String, Object> nullMonth = new HashMap<>();
+        nullMonth.put("year", 2024);
+        nullMonth.put("month", null);
+        filePartitions.put(StoragePath.of("s3://bucket/data/year=2024/month=__HIVE_DEFAULT_PARTITION__/f2.parquet"), nullMonth);
+        PartitionMetadata partitions = new PartitionMetadata(partCols, filePartitions);
+
+        ExternalSourceMetadata enriched = ExternalSourceResolver.enrichSchemaWithPartitionColumns(metadata, partitions);
+        List<Attribute> schema = enriched.schema();
+        assertEquals(3, schema.size());
+        assertEquals("year", schema.get(1).name());
+        assertEquals("month", schema.get(2).name());
+        // year has no nulls in the matched fileset → provably non-null.
+        assertEquals(Nullability.FALSE, schema.get(1).nullable());
+        // month contains a sentinel-decoded null → must stay nullable.
+        assertEquals(Nullability.TRUE, schema.get(2).nullable());
     }
 
     public void testSchemaWithFieldAttributeFailsValidation() throws Exception {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/PartitionMetadataTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/PartitionMetadataTests.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class PartitionMetadataTests extends ESTestCase {
+
+    public void testEmptyMetadataHasNoNullableColumns() {
+        assertEquals(Set.of(), PartitionMetadata.EMPTY.nullablePartitionColumns());
+    }
+
+    public void testNoNullValuesYieldsEmptyNullableSet() {
+        LinkedHashMap<String, DataType> cols = new LinkedHashMap<>();
+        cols.put("year", DataType.INTEGER);
+        cols.put("region", DataType.KEYWORD);
+
+        Map<StoragePath, Map<String, Object>> files = new LinkedHashMap<>();
+        files.put(StoragePath.of("s3://b/year=2024/region=us/f1.parquet"), Map.of("year", 2024, "region", "us"));
+        files.put(StoragePath.of("s3://b/year=2023/region=eu/f2.parquet"), Map.of("year", 2023, "region", "eu"));
+
+        PartitionMetadata pm = new PartitionMetadata(cols, files);
+        assertEquals(Set.of(), pm.nullablePartitionColumns());
+    }
+
+    public void testSingleNullValueMarksColumnNullable() {
+        LinkedHashMap<String, DataType> cols = new LinkedHashMap<>();
+        cols.put("year", DataType.INTEGER);
+        cols.put("month", DataType.INTEGER);
+
+        Map<StoragePath, Map<String, Object>> files = new LinkedHashMap<>();
+        files.put(StoragePath.of("s3://b/year=2024/month=01/f1.parquet"), Map.of("year", 2024, "month", 1));
+        // Map.of() rejects nulls — use HashMap for the sentinel-decoded entry.
+        Map<String, Object> withNullMonth = new HashMap<>();
+        withNullMonth.put("year", 2024);
+        withNullMonth.put("month", null);
+        files.put(StoragePath.of("s3://b/year=2024/month=__HIVE_DEFAULT_PARTITION__/f2.parquet"), withNullMonth);
+
+        PartitionMetadata pm = new PartitionMetadata(cols, files);
+        assertEquals(Set.of("month"), pm.nullablePartitionColumns());
+    }
+
+    public void testMultipleNullableColumns() {
+        LinkedHashMap<String, DataType> cols = new LinkedHashMap<>();
+        cols.put("a", DataType.KEYWORD);
+        cols.put("b", DataType.KEYWORD);
+        cols.put("c", DataType.KEYWORD);
+
+        Map<StoragePath, Map<String, Object>> files = new LinkedHashMap<>();
+        Map<String, Object> row1 = new HashMap<>();
+        row1.put("a", "x");
+        row1.put("b", null);
+        row1.put("c", "z");
+        Map<String, Object> row2 = new HashMap<>();
+        row2.put("a", null);
+        row2.put("b", "y");
+        row2.put("c", "z");
+        files.put(StoragePath.of("s3://b/a=x/b=__HIVE_DEFAULT_PARTITION__/c=z/f1.parquet"), row1);
+        files.put(StoragePath.of("s3://b/a=__HIVE_DEFAULT_PARTITION__/b=y/c=z/f2.parquet"), row2);
+
+        PartitionMetadata pm = new PartitionMetadata(cols, files);
+        assertEquals(Set.of("a", "b"), pm.nullablePartitionColumns());
+    }
+
+    public void testMissingEntryTreatedAsNullable() {
+        // A defensive case: if a file's value map is missing a declared column, treat that
+        // column as nullable rather than asserting non-null based on incomplete data.
+        LinkedHashMap<String, DataType> cols = new LinkedHashMap<>();
+        cols.put("year", DataType.INTEGER);
+        cols.put("region", DataType.KEYWORD);
+
+        Map<StoragePath, Map<String, Object>> files = new LinkedHashMap<>();
+        files.put(StoragePath.of("s3://b/year=2024/region=us/f1.parquet"), Map.of("year", 2024, "region", "us"));
+        files.put(StoragePath.of("s3://b/year=2023/f2.parquet"), Map.of("year", 2023));
+
+        PartitionMetadata pm = new PartitionMetadata(cols, files);
+        assertEquals(Set.of("region"), pm.nullablePartitionColumns());
+    }
+
+    public void testEmptyFileValuesReturnsAllColumns() {
+        // Defensive: when partition columns are declared but no per-file values are tracked,
+        // we have no basis to prove non-null — every column must remain nullable.
+        LinkedHashMap<String, DataType> cols = new LinkedHashMap<>();
+        cols.put("year", DataType.INTEGER);
+        cols.put("region", DataType.KEYWORD);
+
+        PartitionMetadata pm = new PartitionMetadata(cols, Map.of());
+        assertEquals(Set.of("year", "region"), pm.nullablePartitionColumns());
+    }
+
+    public void testNullInLastFileStillDetected() {
+        // Regression guard against any future short-circuit-after-first-file mistake:
+        // the helper must inspect every file, not stop once it has seen one non-null value.
+        LinkedHashMap<String, DataType> cols = new LinkedHashMap<>();
+        cols.put("year", DataType.INTEGER);
+        cols.put("region", DataType.KEYWORD);
+
+        Map<StoragePath, Map<String, Object>> files = new LinkedHashMap<>();
+        files.put(StoragePath.of("s3://b/year=2024/region=us/f1.parquet"), Map.of("year", 2024, "region", "us"));
+        files.put(StoragePath.of("s3://b/year=2024/region=eu/f2.parquet"), Map.of("year", 2024, "region", "eu"));
+        Map<String, Object> lateNull = new HashMap<>();
+        lateNull.put("year", 2024);
+        lateNull.put("region", null);
+        files.put(StoragePath.of("s3://b/year=2024/region=__HIVE_DEFAULT_PARTITION__/f3.parquet"), lateNull);
+
+        PartitionMetadata pm = new PartitionMetadata(cols, files);
+        assertEquals(Set.of("region"), pm.nullablePartitionColumns());
+    }
+
+    public void testFromHivePartitionDetectorWithSentinel() {
+        // End-to-end bridge with HivePartitionDetector: confirms the sentinel decoding from
+        // #149353 surfaces here as a null entry that nullablePartitionColumns() picks up.
+        List<StorageEntry> files = List.of(
+            new StorageEntry(StoragePath.of("s3://b/year=2024/month=01/f1.parquet"), 100, Instant.EPOCH),
+            new StorageEntry(StoragePath.of("s3://b/year=2024/month=__HIVE_DEFAULT_PARTITION__/f2.parquet"), 100, Instant.EPOCH)
+        );
+
+        PartitionMetadata pm = HivePartitionDetector.detect(files);
+        assertFalse(pm.isEmpty());
+        assertEquals(Set.of("month"), pm.nullablePartitionColumns());
+    }
+
+    public void testFromHivePartitionDetectorWithoutSentinel() {
+        List<StorageEntry> files = List.of(
+            new StorageEntry(StoragePath.of("s3://b/year=2024/month=01/f1.parquet"), 100, Instant.EPOCH),
+            new StorageEntry(StoragePath.of("s3://b/year=2024/month=02/f2.parquet"), 100, Instant.EPOCH)
+        );
+
+        PartitionMetadata pm = HivePartitionDetector.detect(files);
+        assertFalse(pm.isEmpty());
+        assertEquals(Set.of(), pm.nullablePartitionColumns());
+    }
+}


### PR DESCRIPTION
## Why

`enrichSchemaWithPartitionColumns` hard-coded `Nullability.TRUE` on every partition column attribute. After sentinel decoding landed (#149353), `PartitionMetadata#filePartitionValues` carries `null` for files under a `__HIVE_DEFAULT_PARTITION__` directory, so the resolver can now decide per query: columns with no null value across the matched fileset are emitted as `Nullability.FALSE`; columns with at least one null stay `TRUE`.

## What

- New derived helper `PartitionMetadata#nullablePartitionColumns()` returns the set of columns that cannot be proven non-null. Conservative when per-file values are absent: every declared column stays nullable, preserving prior behavior.
- `enrichSchemaWithPartitionColumns` consults the helper and emits `Nullability.TRUE` / `FALSE` per column.
- Unit coverage in `PartitionMetadataTests` (empty, all-non-null, single null, multi-column, missing entry, late-null regression guard, end-to-end via `HivePartitionDetector`) and `ExternalSourceResolverTests` (direct enrichment + multi-file resolution).

Nullability is a per-query property: different globs over the same dataset can match different filesets and yield different results. The new metadata flows into `Coalesce` simplification and `PropagateNullable`; predicate folding around `IsNull` is intentionally untouched here.

Developed with AI-assisted tooling