### PR TITLE
[ESQL] snappy codec follow-up: override read(byte[])

### DIFF
--- a/docs/changelog/149598.yaml
+++ b/docs/changelog/149598.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 149598
+summary: "Snappy codec follow-up: override read(byte[])"
+type: enhancement

--- a/x-pack/plugin/esql-datasource-snappy/src/main/java/org/elasticsearch/xpack/esql/datasource/snappy/SnappyDecompressionCodec.java
+++ b/x-pack/plugin/esql-datasource-snappy/src/main/java/org/elasticsearch/xpack/esql/datasource/snappy/SnappyDecompressionCodec.java
@@ -127,6 +127,13 @@ public class SnappyDecompressionCodec implements DecompressionCodec {
         }
 
         @Override
+        public int read(byte[] b) throws IOException {
+            // FilterInputStream.read(byte[]) delegates straight to in.read(b, 0, b.length), bypassing
+            // our overridden read(byte[], int, int). Route it through this.read so the catch applies.
+            return read(b, 0, b.length);
+        }
+
+        @Override
         public int read(byte[] b, int off, int len) throws IOException {
             try {
                 return in.read(b, off, len);

--- a/x-pack/plugin/esql-datasource-snappy/src/test/java/org/elasticsearch/xpack/esql/datasource/snappy/SnappyDecompressionCodecTests.java
+++ b/x-pack/plugin/esql-datasource-snappy/src/test/java/org/elasticsearch/xpack/esql/datasource/snappy/SnappyDecompressionCodecTests.java
@@ -108,7 +108,8 @@ public class SnappyDecompressionCodecTests extends ESTestCase {
     }
 
     public void testEmptyStreamThrows() {
-        // A zero-byte input matches no framing; the xerial reader correctly reports EOF.
+        // A zero-byte input routes to the xerial reader (the empty-stream branch); its constructor
+        // rejects the input because the 10-byte stream identifier chunk is missing.
         SnappyDecompressionCodec codec = new SnappyDecompressionCodec();
         expectThrows(IOException.class, () -> codec.decompress(new ByteArrayInputStream(new byte[0])));
     }
@@ -170,6 +171,37 @@ public class SnappyDecompressionCodecTests extends ESTestCase {
         });
         assertThat(e.getMessage(), containsString("malformed Hadoop-snappy stream at offset"));
         assertNotNull(e.getCause());
+        assertEquals("io.airlift.compress.MalformedInputException", e.getCause().getClass().getName());
+    }
+
+    /**
+     * Reads via the single-argument {@code read(byte[])} path. {@link java.io.FilterInputStream}'s
+     * default implementation of that method delegates straight to {@code in.read(b, 0, b.length)},
+     * which would bypass the overridden three-argument read and let aircompressor's unchecked
+     * {@code MalformedInputException} escape. Our wrapper overrides the single-argument form to
+     * route through the overridden three-argument form, so the translation applies here too.
+     */
+    public void testMalformedHadoopPayloadTranslatedOnReadByteArrayPath() throws IOException {
+        byte[] block = new byte[] { 0x10, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff };
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (DataOutputStream dos = new DataOutputStream(out)) {
+            dos.writeInt(16);
+            dos.writeInt(block.length);
+            dos.write(block);
+        }
+
+        SnappyDecompressionCodec codec = new SnappyDecompressionCodec();
+        IOException e = expectThrows(IOException.class, () -> {
+            try (InputStream decompressed = codec.decompress(new ByteArrayInputStream(out.toByteArray()))) {
+                byte[] buf = new byte[64];
+                // Use the single-arg read(byte[]) form explicitly, not readAllBytes() (which goes
+                // through read(byte[], int, int)).
+                while (decompressed.read(buf) != -1) {
+                    // drain
+                }
+            }
+        });
+        assertThat(e.getMessage(), containsString("malformed Hadoop-snappy stream at offset"));
         assertEquals("io.airlift.compress.MalformedInputException", e.getCause().getClass().getName());
     }
 


### PR DESCRIPTION
Follow-up to #149572 addressing review feedback.

`FilterInputStream.read(byte[])` delegates straight to `in.read(b, 0, b.length)`, bypassing the overridden three-argument form in `HadoopErrorTranslatingStream`. Callers using the single-argument `read(byte[])` (including `transferTo` on some JDK paths) would leak aircompressor's unchecked `MalformedInputException` past the translator. Route it through `this.read` so the translation applies on that path too, and add a test that drives reads exclusively through `read(byte[])`. Also tightens the empty-stream test comment to describe the actual failure (xerial constructor rejects the missing 10-byte stream identifier).

Developed with AI-assisted tooling