### PR TITLE
ESQL: CSV datetime fast path follow-ups

### DIFF
--- a/docs/changelog/149600.yaml
+++ b/docs/changelog/149600.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 149600
+summary: CSV datetime fast path follow-ups
+type: enhancement

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
@@ -175,6 +175,12 @@ public class CsvFormatReader implements SegmentableFormatReader {
      * datetime-heavy queries. Space-separated {@code YYYY-MM-DD HH:MM:SS} inputs are NOT
      * accepted by this parser and are handled separately by
      * {@link #tryParseSpaceSeparatedDatetimeMillis(String)}.
+     * <p>
+     * Note: deliberately not chained with {@code .withZone(UTC)} (unlike
+     * {@code DateUtils.UTC_DATE_TIME_FORMATTER}). The downstream {@code DateFormatters.from} call
+     * already defaults to {@link ZoneOffset#UTC} when the parsed accessor carries no zone, so the
+     * extra {@code withZone} call would only allocate a second {@link DateFormatter} for no
+     * behavioural difference on this hot path.
      */
     private static final DateFormatter ISO_DATETIME_FAST_FORMATTER = DateFormatter.forPattern("strict_date_optional_time");
 
@@ -2471,15 +2477,17 @@ public class CsvFormatReader implements SegmentableFormatReader {
             // avoids the DateTimeFormatter Parsed-HashMap allocation that dominates DateUtils.asDateTime.
             // tryParse returns null on mismatch so we don't pay an exception per missed input.
             // Iso8601Parser only checks loose bounds (month <= 12, day <= 31) and defers month-length
-            // validation to LocalDate.of(...) inside DateFormatters.from(...), which throws a generic
-            // DateTimeException (not DateTimeParseException). Catch that here and fall through so a
-            // calendar-invalid input like 2021-02-30T10:00:00 takes the slow Stage 3 path instead of
+            // validation to LocalDate.of(...) inside DateFormatters.from(...). That call can throw two
+            // distinct unchecked exceptions: a DateTimeException for calendar-invalid inputs like
+            // 2021-02-30T10:00:00, and an IllegalArgumentException for the fallthrough branch in
+            // DateFormatters.from when the parsed accessor cannot be converted to a zoned date-time.
+            // Catch both and fall through so the slow Stage 3 path handles the input instead of
             // propagating an uncaught exception and aborting the batch.
             TemporalAccessor parsed = ISO_DATETIME_FAST_FORMATTER.tryParse(value);
             if (parsed != null) {
                 try {
                     return DateFormatters.from(parsed).toInstant().toEpochMilli();
-                } catch (DateTimeException e) {
+                } catch (DateTimeException | IllegalArgumentException e) {
                     // fall through to Stage 2 / 3
                 }
             }

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
@@ -3524,7 +3524,7 @@ public class CsvFormatReaderTests extends ESTestCase {
         }
     }
 
-    // --- Datetime fast-path equivalence tests (#769) ---
+    // --- Datetime fast-path equivalence tests ---
     // tryParseSpaceSeparatedDatetimeMillis avoids the JDK DateTimeFormatter Parsed-HashMap
     // allocation that dominated ~16% of CPU on Q24 of the CSV ClickBench profile. These tests lock
     // in the equivalence contract: any input the fast path accepts must produce the same epoch
@@ -3577,6 +3577,11 @@ public class CsvFormatReaderTests extends ESTestCase {
         assertEquals(CsvFormatReader.FAST_PATH_MISS, CsvFormatReader.tryParseSpaceSeparatedDatetimeMillis("2024/05/12 14:30:45"));
         // Non-ASCII digit (full-width '1') in the year — must be rejected without throwing
         assertEquals(CsvFormatReader.FAST_PATH_MISS, CsvFormatReader.tryParseSpaceSeparatedDatetimeMillis("\uFF12024-05-12 14:30:45"));
+        // Negative year — `-2024-05-12 14:30:45` is 20 chars and fails the length guard
+        // (19 or 23 only); `-999-05-12 14:30:45` is 19 chars but the leading '-' fails
+        // parseFixedDigits at offset 0. Either way, BCE-style dates route to Stage 3.
+        assertEquals(CsvFormatReader.FAST_PATH_MISS, CsvFormatReader.tryParseSpaceSeparatedDatetimeMillis("-2024-05-12 14:30:45"));
+        assertEquals(CsvFormatReader.FAST_PATH_MISS, CsvFormatReader.tryParseSpaceSeparatedDatetimeMillis("-999-05-12 14:30:45"));
     }
 
     public void testDatetimeFastPathInvalidIsoFallsThroughCleanly() throws IOException {


### PR DESCRIPTION
Address review nits on #149577:

- Also catch `IllegalArgumentException` in Stage 1 alongside the existing `DateTimeException`, covering the `DateFormatters.from` fallthrough that throws when an accessor cannot be converted to a zoned date-time.
- Document why `ISO_DATETIME_FAST_FORMATTER` is intentionally not chained with `.withZone(UTC)` (`DateFormatters.from` defaults to UTC for zone-less accessors; the extra call would only allocate a duplicate `DateFormatter`).
- Drop the private-issue reference from the test section header.
- Add an explicit negative-year rejection assertion plus a 19-char counterpart that exercises `parseFixedDigits` at offset 0.

Developed with AI-assisted tooling