### PR TITLE
ESQL:DS: Unmute CsvCompressedFormatSpecIT, enforce fix

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -558,14 +558,6 @@ tests:
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=index/100_field_name_length_limit/Test field name length limit array synthetic source}
   issue: https://github.com/elastic/elasticsearch/issues/149350
-- class: org.elasticsearch.xpack.esql.qa.csv.CsvCompressedFormatSpecIT
-  methods:
-  - test {csv-spec:csv-headerless.multiFileHeaderlessReadSchemaPreventsTypeDrift [csv.bz2/LOCAL]}
-  - test {csv-spec:csv-headerless.multiFileHeaderlessReadSchemaPreventsTypeDrift [csv.zst/LOCAL]}
-  - test {csv-spec:csv-headerless.multiFileHeaderlessReadSchemaPreventsTypeDrift [csv.zstd/LOCAL]}
-  - test {csv-spec:csv-headerless.multiFileHeaderlessReadSchemaPreventsTypeDrift [csv.bz/LOCAL]}
-  - test {csv-spec:csv-headerless.multiFileHeaderlessReadSchemaPreventsTypeDrift [csv.gz/LOCAL]}
-  issue: https://github.com/elastic/elasticsearch/issues/149481
 - class: org.elasticsearch.xpack.esql.qa.csv.CsvFormatSpecIT
   method: test {csv-spec:csv-union-by-name.* [LOCAL]}
   issue: https://github.com/elastic/elasticsearch/issues/149482

--- a/x-pack/plugin/esql-datasource-http/src/main/java/org/elasticsearch/xpack/esql/datasource/http/local/LocalStorageProvider.java
+++ b/x-pack/plugin/esql-datasource-http/src/main/java/org/elasticsearch/xpack/esql/datasource/http/local/LocalStorageProvider.java
@@ -124,6 +124,14 @@ public final class LocalStorageProvider implements StorageProvider {
             throw new IllegalArgumentException("Path cannot be empty for file:// scheme");
         }
 
+        if (storagePath.isPattern()) {
+            throw new IllegalArgumentException(
+                "LocalStorageProvider received a glob pattern: ["
+                    + pathStr
+                    + "]; glob expansion must be performed via listObjects() before resolving a single object"
+            );
+        }
+
         return PathUtils.get(pathStr);
     }
 

--- a/x-pack/plugin/esql-datasource-http/src/test/java/org/elasticsearch/xpack/esql/datasource/http/local/LocalStorageProviderTests.java
+++ b/x-pack/plugin/esql-datasource-http/src/test/java/org/elasticsearch/xpack/esql/datasource/http/local/LocalStorageProviderTests.java
@@ -363,6 +363,22 @@ public class LocalStorageProviderTests extends ESTestCase {
         assertEquals(0, flatEntries.size());
     }
 
+    // -- glob guard --
+
+    public void testNewObjectRejectsGlobPattern() {
+        LocalStorageProvider provider = new LocalStorageProvider();
+        StoragePath globPath = StoragePath.of("file:///tmp/multifile/*.csv.zst");
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> provider.newObject(globPath));
+        assertThat(e.getMessage(), containsString("glob pattern"));
+        assertThat(e.getMessage(), containsString("*.csv.zst"));
+    }
+
+    public void testExistsRejectsGlobPattern() throws IOException {
+        LocalStorageProvider provider = new LocalStorageProvider();
+        StoragePath globPath = StoragePath.of("file:///tmp/multifile/*.csv");
+        expectThrows(IllegalArgumentException.class, () -> provider.exists(globPath));
+    }
+
     // -- helpers --
 
     private static List<String> collectObjectNames(StorageIterator iterator) throws IOException {


### PR DESCRIPTION
This unmutes CsvCompressedFormatSpecIT, fixed by #149469.
Also, add supplemental guard to prevent the cause from happening.

Closes #149481
Closes #149125