### PR TITLE
ESQL: close raw stream when codec rejects header

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DecompressingStorageObject.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DecompressingStorageObject.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.datasources;
 
+import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.xpack.esql.core.util.Check;
 import org.elasticsearch.xpack.esql.datasources.spi.DecompressionCodec;
 import org.elasticsearch.xpack.esql.datasources.spi.IndexedDecompressionCodec;
@@ -46,7 +47,20 @@ final class DecompressingStorageObject implements StorageObject {
         if (codec instanceof SplittableDecompressionCodec splittable && delegate instanceof RangeStorageObject range) {
             return splittable.decompressRange(range.rawDelegate(), range.offset(), range.offset() + range.length());
         }
-        return codec.decompress(delegate.newStream());
+        // raw is bound to a local before being handed to the codec so that, when the codec's
+        // wrapping-stream constructor throws on header inspection (e.g. SnappyFramedInputStream
+        // rejects a non-snappy file with "invalid stream header"), we still own a reference to
+        // the underlying stream and can close it. Closing matters because, when the delegate is
+        // a ConcurrencyLimitedStorageObject, the underlying stream is a PermitReleasingInputStream
+        // whose close() releases the cloud-API concurrency permit. Leaking it pins the permit
+        // until JVM shutdown — and the limiter pool only holds 50.
+        InputStream raw = delegate.newStream();
+        try {
+            return codec.decompress(raw);
+        } catch (Throwable t) {
+            IOUtils.closeWhileHandlingException(raw);
+            throw t;
+        }
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/DecompressingStorageObjectTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/DecompressingStorageObjectTests.java
@@ -201,4 +201,75 @@ public class DecompressingStorageObjectTests extends ESTestCase {
             return path;
         }
     }
+
+    /**
+     * Regression test for the cloud-API permit leak fixed in this PR. When the codec throws on
+     * header inspection (here: a fabricated codec that rejects everything as a stand-in for
+     * SnappyFramedInputStream rejecting a non-snappy file), the underlying stream must be
+     * closed so a wrapping {@code PermitReleasingInputStream} releases its permit. Before the
+     * fix, the unclosed stream pinned the permit until JVM shutdown and 50 such failures
+     * exhausted the limiter pool.
+     */
+    public void testNewStreamClosesRawWhenCodecThrows() throws IOException {
+        java.util.concurrent.atomic.AtomicBoolean rawClosed = new java.util.concurrent.atomic.AtomicBoolean(false);
+        StorageObject tracking = new StorageObject() {
+            @Override
+            public InputStream newStream() {
+                return new ByteArrayInputStream("garbage".getBytes(StandardCharsets.UTF_8)) {
+                    @Override
+                    public void close() throws IOException {
+                        rawClosed.set(true);
+                        super.close();
+                    }
+                };
+            }
+
+            @Override
+            public InputStream newStream(long position, long length) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public long length() {
+                return 7L;
+            }
+
+            @Override
+            public Instant lastModified() {
+                return Instant.EPOCH;
+            }
+
+            @Override
+            public boolean exists() {
+                return true;
+            }
+
+            @Override
+            public StoragePath path() {
+                return StoragePath.of("file:///garbage.csv.bad");
+            }
+        };
+
+        DecompressionCodec throwingCodec = new DecompressionCodec() {
+            @Override
+            public String name() {
+                return "throwing-codec";
+            }
+
+            @Override
+            public java.util.List<String> extensions() {
+                return java.util.List.of(".bad");
+            }
+
+            @Override
+            public InputStream decompress(InputStream in) throws IOException {
+                throw new IOException("invalid stream header");
+            }
+        };
+
+        DecompressingStorageObject decompressing = new DecompressingStorageObject(tracking, throwingCodec);
+        IOException thrown = expectThrows(IOException.class, decompressing::newStream);
+        assertEquals("invalid stream header", thrown.getMessage());
+        assertTrue("underlying stream must be closed when the codec rejects the header", rawClosed.get());
+    }
 }


### PR DESCRIPTION
## What this is about

`DecompressingStorageObject.newStream()` inlines `delegate.newStream()` into `codec.decompress(...)`. When the codec throws on header inspection — `SnappyFramedInputStream.<init>` rejecting a non-snappy file with `IOException: invalid stream header`, equivalents in gzip/zstd/bzip2/lz4 wrappers — the raw stream is orphaned with no `close()` call.

When the delegate is a `ConcurrencyLimitedStorageObject`, the raw stream is a `PermitReleasingInputStream` that holds a cloud-API permit until closed. Orphaning it pins the permit for the life of the JVM. 50 such failures exhaust the limiter pool and every subsequent EXTERNAL query times out after 60s on permit-acquire with:

```
Failed to acquire concurrency permit for cloud API call: Timed out waiting for cloud API permit after [60000]ms (max permits [50])
```

Recovery requires a node restart. A single bad blob (malformed magic header for the URI's codec), queried 50 times by a dashboard or alert, takes EXTERNAL down across the node for the cluster lifetime.

## What this PR does

In `DecompressingStorageObject.newStream()`:
- Bind `delegate.newStream()` to a local `raw` before handing it to the codec.
- Wrap `codec.decompress(raw)` in try/catch.
- On throw, `IOUtils.closeWhileHandlingException(raw)` and rethrow.

This matches the shape already used inside `ConcurrencyLimitedStorageObject.newStream()` (acquire → try → return wrapped stream → catch + release on throw).

The decorator was the missing link. The codec implementations (gzip / zstd / snappy / bzip2 / lz4 / brotli) all follow the convention that a constructor that throws does not take ownership — they correctly do not close `raw`. The fix puts ownership where it belongs: on the decorator that obtained `raw` from the delegate.

## Does it work?

`DecompressingStorageObjectTests.testNewStreamClosesRawWhenCodecThrows` (new) — uses a tracking `StorageObject` whose stream sets a flag on `close()`, and a fabricated `DecompressionCodec` that throws `IOException("invalid stream header")`. Asserts the flag is set after the throw.

Local run: `./gradlew :x-pack:plugin:esql:test --tests 'org.elasticsearch.xpack.esql.datasources.DecompressingStorageObjectTests'` — 10/10 green, 2.4s.

End-to-end reproducer (without the fix): fire ~50 LIMIT-1 EXTERNAL queries against a CSV-with-bad-snappy-magic file → all fail with `IllegalArgumentException("Failed to resolve metadata for ...")` → 51st query against a *valid* sibling file times out with permit-exhaust. With the fix applied, the 51st query resolves normally.

## What's in the diff

- `x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DecompressingStorageObject.java` — narrow change to `newStream()`, +1 import (`IOUtils`).
- `x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/DecompressingStorageObjectTests.java` — `testNewStreamClosesRawWhenCodecThrows`.

## What's out of scope

The same orphan-on-throw shape exists at `CsvFormatReader.read(...)` between `newStream()` and the `new CsvBatchIterator(...)` line — any throw in `skipHeaderLine` / `readCsvRecord` between the two leaks the same permit by the same mechanism. The audit fix belongs in the format-reader layer, separately. Same goes for `NdJsonFormatReader`, `TsvFormatReader`, and any other reader that consumes `StorageObject.newStream()` without immediate try-with-resources binding.

The `DecompressionCodec` SPI javadoc should also be tightened to state explicitly that on throw, `raw` is not consumed; the caller retains ownership. Follow-up.


Closes elastic/esql-planning#812
