### PR TITLE
ESQL: Handle null aggs paired with SPARKLINE

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-count-distinct-over-time.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-count-distinct-over-time.csv-spec
@@ -265,3 +265,55 @@ distincts:long | cluster:keyword | time_bucket:datetime
 2              | qa              | 2024-05-10T00:18:00.000Z
 2              | staging         | 2024-05-10T00:18:00.000Z
 ;
+
+// Make sure that the non-time series aggs don't choke on null.
+countDistinctNull
+required_capability: ts_command_v0
+
+TS k8s
+| EVAL y = null
+| STATS m = min(count_over_time(client.ip)), cd = COUNT_DISTINCT(y)
+  BY cluster, time_bucket = bucket(@timestamp, 10minute)
+| SORT time_bucket, cluster
+| LIMIT 3
+;
+
+m:long | cd:long | cluster:keyword | time_bucket:datetime
+4      | 0       | prod            | 2024-05-10T00:00:00.000Z
+11     | 0       | qa              | 2024-05-10T00:00:00.000Z
+6      | 0       | staging         | 2024-05-10T00:00:00.000Z
+;
+
+valuesNull
+required_capability: ts_command_v0
+
+TS k8s
+| EVAL y = null
+| STATS m = min(count_over_time(client.ip)), v = VALUES(y)
+  BY cluster, time_bucket = bucket(@timestamp, 10minute)
+| SORT time_bucket, cluster
+| LIMIT 3
+;
+
+m:long | v:null | cluster:keyword | time_bucket:datetime
+4      | null   | prod            | 2024-05-10T00:00:00.000Z
+11     | null   | qa              | 2024-05-10T00:00:00.000Z
+6      | null   | staging         | 2024-05-10T00:00:00.000Z
+;
+
+sumNull
+required_capability: ts_command_v0
+
+TS k8s
+| EVAL y = null
+| STATS m = min(count_over_time(client.ip)), sm = SUM(y)
+  BY cluster, time_bucket = bucket(@timestamp, 10minute)
+| SORT time_bucket, cluster
+| LIMIT 3
+;
+
+m:long | sm:null | cluster:keyword | time_bucket:datetime
+4      | null    | prod            | 2024-05-10T00:00:00.000Z
+11     | null    | qa              | 2024-05-10T00:00:00.000Z
+6      | null    | staging         | 2024-05-10T00:00:00.000Z
+;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-count-distinct-over-time.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-count-distinct-over-time.csv-spec
@@ -303,6 +303,7 @@ m:long | v:null | cluster:keyword | time_bucket:datetime
 
 sumNull
 required_capability: ts_command_v0
+required_capability: fix_sum_of_null_optimization
 
 TS k8s
 | EVAL y = null

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats_sparkline.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats_sparkline.csv-spec
@@ -160,6 +160,67 @@ name_length:double                                                              
 [9.0, 0.0, 7.0, 0.0, 9.0, 4.0, 0.0, 8.0, 9.0, 0.0, 8.0, 0.0, 0.0, 0.0, 7.0]                                                           | [-0.177, 0.0, 0.894, 0.0, 0.314, 0.969, 0.0, 0.733, 0.86, 0.0, 0.036, 0.0, 0.0, 0.0, 0.105] | null
 ;
 
+// Make sure that the non-time series aggs don't choke on null.
+withCountDistinctNull
+required_capability: fn_sparkline
+
+FROM employees
+| EVAL y = null
+| STATS s = SPARKLINE(SUM(salary), hire_date, 20, "1985-01-01T00:00:00Z", "1985-12-31T00:00:00Z"),
+       cd = COUNT_DISTINCT(y)
+;
+
+s:long                                                           | cd:long
+[0, 92610, 0, 0, 44817, 0, 62405, 0, 49095, 103064, 218159, 0]  | 0
+;
+
+withCountDistinctNullFromRow
+required_capability: fn_sparkline
+
+ROW hire_date = to_datetime("1985-06-01T00:00:00Z"), y = null
+| STATS s = SPARKLINE(COUNT(*), hire_date, 5, "1985-01-01T00:00:00Z", "1985-12-31T00:00:00Z"), cd = COUNT_DISTINCT(y)
+;
+
+s:long | cd:long
+1      | 0
+;
+
+withValuesNull
+required_capability: fn_sparkline
+
+ROW hire_date = to_datetime("1985-06-01T00:00:00Z"), y = null
+| STATS s = SPARKLINE(COUNT(*), hire_date, 5, "1985-01-01T00:00:00Z", "1985-12-31T00:00:00Z"),
+        v = VALUES(y)
+;
+
+s:long | v:null
+1      | null
+;
+
+withSumNull
+required_capability: fn_sparkline
+
+ROW hire_date = to_datetime("1985-06-01T00:00:00Z"), y = null
+| STATS s = SPARKLINE(COUNT(*), hire_date, 5, "1985-01-01T00:00:00Z", "1985-12-31T00:00:00Z"),
+       sm = SUM(y)
+;
+
+s:long | sm:null
+1      | null
+;
+
+withTopNull
+required_capability: fn_sparkline
+
+ROW hire_date = to_datetime("1985-06-01T00:00:00Z"), y = null
+| STATS s = SPARKLINE(COUNT(*), hire_date, 5, "1985-01-01T00:00:00Z", "1985-12-31T00:00:00Z"),
+        t = TOP(y, 3, "asc")
+;
+
+s:long | t:null
+1      | null
+;
+
 sparklineComplexWithGroupingMapped-Ignore
 required_capability: fn_sparkline_complex
 FROM employees

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats_sparkline.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats_sparkline.csv-spec
@@ -162,7 +162,7 @@ name_length:double                                                              
 
 // Make sure that the non-time series aggs don't choke on null.
 withCountDistinctNull
-required_capability: fn_sparkline
+required_capability: fn_sparkline_null_alongside
 
 FROM employees
 | EVAL y = null
@@ -175,7 +175,7 @@ s:long                                                           | cd:long
 ;
 
 withCountDistinctNullFromRow
-required_capability: fn_sparkline
+required_capability: fn_sparkline_null_alongside
 
 ROW hire_date = to_datetime("1985-06-01T00:00:00Z"), y = null
 | STATS s = SPARKLINE(COUNT(*), hire_date, 5, "1985-01-01T00:00:00Z", "1985-12-31T00:00:00Z"), cd = COUNT_DISTINCT(y)
@@ -186,7 +186,7 @@ s:long | cd:long
 ;
 
 withValuesNull
-required_capability: fn_sparkline
+required_capability: fn_sparkline_null_alongside
 
 ROW hire_date = to_datetime("1985-06-01T00:00:00Z"), y = null
 | STATS s = SPARKLINE(COUNT(*), hire_date, 5, "1985-01-01T00:00:00Z", "1985-12-31T00:00:00Z"),
@@ -198,7 +198,7 @@ s:long | v:null
 ;
 
 withSumNull
-required_capability: fn_sparkline
+required_capability: fn_sparkline_null_alongside
 
 ROW hire_date = to_datetime("1985-06-01T00:00:00Z"), y = null
 | STATS s = SPARKLINE(COUNT(*), hire_date, 5, "1985-01-01T00:00:00Z", "1985-12-31T00:00:00Z"),
@@ -210,7 +210,7 @@ s:long | sm:null
 ;
 
 withTopNull
-required_capability: fn_sparkline
+required_capability: fn_sparkline_null_alongside
 
 ROW hire_date = to_datetime("1985-06-01T00:00:00Z"), y = null
 | STATS s = SPARKLINE(COUNT(*), hire_date, 5, "1985-01-01T00:00:00Z", "1985-12-31T00:00:00Z"),

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/unmapped-nullify.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/unmapped-nullify.csv-spec
@@ -1258,7 +1258,7 @@ cd:long | c:long | language_code:integer
 
 sparklineOnCountDistinct
 required_capability: optional_fields_nullify_tech_preview
-required_capability: fn_sparkline
+required_capability: fn_sparkline_null_alongside
 
 SET unmapped_fields="nullify"\;
 FROM employees
@@ -1271,7 +1271,7 @@ s:long
 
 sparklineOnCountDistinctOnValues
 required_capability: optional_fields_nullify_tech_preview
-required_capability: fn_sparkline
+required_capability: fn_sparkline_null_alongside
 
 SET unmapped_fields="nullify"\;
 FROM employees
@@ -1285,7 +1285,7 @@ s:long
 
 sparklineOnSum
 required_capability: optional_fields_nullify_tech_preview
-required_capability: fn_sparkline
+required_capability: fn_sparkline_null_alongside
 
 SET unmapped_fields="nullify"\;
 FROM employees

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/unmapped-nullify.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/unmapped-nullify.csv-spec
@@ -1210,3 +1210,88 @@ emp_no:integer | foo:null | x:null
 10099          | null     | null
 10100          | null     | null
 ;
+
+// countDistinct
+statsCountDistinctNullifiedField
+required_capability: optional_fields_nullify_tech_preview
+
+SET unmapped_fields="nullify"\;
+FROM employees
+| STATS c = COUNT_DISTINCT(foo)
+;
+
+c:long
+0
+;
+
+groupedCountDistinct
+required_capability: optional_fields_nullify_tech_preview
+
+SET unmapped_fields="nullify"\;
+FROM languages
+| STATS c = COUNT_DISTINCT(does_not_exist) BY language_code
+| SORT language_code
+;
+
+c:long | language_code:integer
+0      | 1
+0      | 2
+0      | 3
+0      | 4
+;
+
+countDistinctMixed
+required_capability: optional_fields_nullify_tech_preview
+
+SET unmapped_fields="nullify"\;
+FROM languages
+| STATS cd = COUNT_DISTINCT(does_not_exist), c = COUNT(*) BY language_code
+| SORT language_code
+;
+
+cd:long | c:long | language_code:integer
+0       | 1      | 1
+0       | 1      | 2
+0       | 1      | 3
+0       | 1      | 4
+;
+
+sparklineOnCountDistinct
+required_capability: optional_fields_nullify_tech_preview
+required_capability: fn_sparkline
+
+SET unmapped_fields="nullify"\;
+FROM employees
+| STATS s = SPARKLINE(COUNT_DISTINCT(foo), hire_date, 20, "1985-01-01T00:00:00Z", "1985-12-31T00:00:00Z")
+;
+
+s:long
+[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+;
+
+sparklineOnCountDistinctOnValues
+required_capability: optional_fields_nullify_tech_preview
+required_capability: fn_sparkline
+
+SET unmapped_fields="nullify"\;
+FROM employees
+| STATS v = VALUES(foo) BY hire_date
+| STATS s = SPARKLINE(COUNT_DISTINCT(v), hire_date, 20, "1985-01-01T00:00:00Z", "1985-12-31T00:00:00Z")
+;
+
+s:long
+[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+;
+
+sparklineOnSum
+required_capability: optional_fields_nullify_tech_preview
+required_capability: fn_sparkline
+
+SET unmapped_fields="nullify"\;
+FROM employees
+| STATS s = SPARKLINE(SUM(salary), hire_date, 20, "1985-01-01T00:00:00Z", "1985-12-31T00:00:00Z"), cd = COUNT_DISTINCT(foo)
+;
+
+s:long                                                           | cd:long
+[0, 92610, 0, 0, 44817, 0, 62405, 0, 49095, 103064, 218159, 0]  | 0
+;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Sparkline.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Sparkline.java
@@ -88,7 +88,8 @@ public class Sparkline extends AggregateFunction implements AggregateMetricDoubl
     public static final FunctionDefinition DEFINITION = FunctionDefinition.def(Sparkline.class)
         .quinary(Sparkline::new, 0)
         .capabilities(
-            "complex" // Fix for complex queries inside the agg inside the SPARKLINE
+            "complex", // Fix for complex queries inside the agg inside the SPARKLINE
+            "null_alongside" // Fix for null aggs (e.g. COUNT_DISTINCT(null)) paired with SPARKLINE
         )
         .name("sparkline");
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceStatsFilteredOrNullAggWithEval.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceStatsFilteredOrNullAggWithEval.java
@@ -25,8 +25,10 @@ import org.elasticsearch.xpack.esql.expression.function.aggregate.CountApproxima
 import org.elasticsearch.xpack.esql.expression.function.aggregate.CountDistinct;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.CountDistinctOverTime;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.CountOverTime;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.FromPartial;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Present;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.PresentOverTime;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.ToPartial;
 import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
 import org.elasticsearch.xpack.esql.plan.logical.Eval;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
@@ -133,15 +135,45 @@ public class ReplaceStatsFilteredOrNullAggWithEval extends OptimizerRules.Optimi
     }
 
     public static boolean shouldReplace(AggregateFunction aggFunction) {
-        return hasFalseFilter(aggFunction) || DataType.isNull(aggFunction.field().dataType());
+        if (hasFalseFilter(aggFunction)) {
+            return true;
+        }
+        /*
+         * Look for aggregations operating on `null`. If they are wrapped in FROM_PARTIAL
+         * or TO_PARTIAL, then unwrap them and operate on the internal agg.
+         */
+        if (aggFunction instanceof ToPartial toPartial && toPartial.function() instanceof AggregateFunction inner) {
+            return DataType.isNull(inner.field().dataType());
+        }
+        return DataType.isNull(unwrapFromPartial(aggFunction).field().dataType());
     }
 
     private static boolean hasFalseFilter(AggregateFunction aggFunction) {
         return aggFunction.hasFilter() && aggFunction.filter() instanceof Literal literal && Boolean.FALSE.equals(literal.value());
     }
 
+    /**
+     * If {@code aggFunction} is a {@link FromPartial} whose inner function is an {@link AggregateFunction},
+     * returns that inner function; otherwise returns {@code aggFunction} itself.
+     */
+    private static AggregateFunction unwrapFromPartial(AggregateFunction aggFunction) {
+        if (aggFunction instanceof FromPartial fromPartial && fromPartial.function() instanceof AggregateFunction inner) {
+            return inner;
+        }
+        return aggFunction;
+    }
+
     public static Object mapNullToValue(AggregateFunction aggFunction) {
-        return switch (aggFunction) {
+        if (aggFunction instanceof ToPartial) {
+            /*
+             * The intermediate partial-state value is irrelevant; Phase 2's FromPartial will be replaced
+             * by the correct constant via its own shouldReplace/mapNullToValue call.
+             */
+            return null;
+        }
+        // For FromPartial, the correct return value depends on the inner (wrapped) aggregate type.
+        AggregateFunction effective = unwrapFromPartial(aggFunction);
+        return switch (effective) {
             case Count ignored -> 0L;
             case CountApproximate ignored -> 0.0;
             case CountOverTime ignored -> 0L;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceStatsFilteredOrNullAggWithEvalTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceStatsFilteredOrNullAggWithEvalTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.xpack.esql.core.expression.Alias;
 import org.elasticsearch.xpack.esql.core.expression.Expressions;
 import org.elasticsearch.xpack.esql.core.expression.FoldContext;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.util.Holder;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Count;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Add;
 import org.elasticsearch.xpack.esql.optimizer.AbstractLogicalPlanOptimizerTests;
@@ -22,7 +23,9 @@ import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
 import org.elasticsearch.xpack.esql.plan.logical.EsRelation;
 import org.elasticsearch.xpack.esql.plan.logical.Eval;
 import org.elasticsearch.xpack.esql.plan.logical.Limit;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.Project;
+import org.elasticsearch.xpack.esql.plan.logical.SparklineGenerateEmptyBuckets;
 import org.elasticsearch.xpack.esql.plan.logical.TopN;
 import org.elasticsearch.xpack.esql.plan.logical.join.InlineJoin;
 import org.elasticsearch.xpack.esql.plan.logical.join.StubRelation;
@@ -952,5 +955,74 @@ public class ReplaceStatsFilteredOrNullAggWithEvalTests extends AbstractLogicalP
         assertThat(((LongBlock) page.getBlock(1)).getLong(0), is(0L));
         assertThat(page.getBlock(2), instanceOf(BooleanBlock.class));
         assertThat(((BooleanBlock) page.getBlock(2)).getBoolean(0), is(false));
+    }
+
+    /**
+     * Makes sure we run the {@code null} replacement on the results of SPARKLINE's substitution.
+     * Specifically, this one looks from {@code SPARKLINE, COUNT_DISTINCT(null)}. That's different
+     * from {@code VALUES} because {@code COUNT_DISTINCT} always emits a {@code long}.
+     */
+    public void testSparklineWithCountDistinctNull() {
+        LogicalPlan plan = plan("""
+            ROW hire_date = to_datetime("1985-06-01T00:00:00Z"), y = null
+            | STATS s = SPARKLINE(COUNT(*), hire_date, 5, "1985-01-01T00:00:00Z", "1985-12-31T00:00:00Z"),
+                   cd = COUNT_DISTINCT(y)
+            """);
+
+        // The plan must contain a SparklineGenerateEmptyBuckets node for the sparkline
+        boolean[] hasSparkline = { false };
+        plan.forEachDown(SparklineGenerateEmptyBuckets.class, n -> hasSparkline[0] = true);
+        assertTrue("plan must contain SparklineGenerateEmptyBuckets", hasSparkline[0]);
+
+        // COUNT_DISTINCT(y) where y is null-typed must be replaced with 0L
+        // Find the Eval node that holds the replacement for cd
+        Holder<Alias> cdAlias = findFoldableAlias(plan, "cd");
+        assertNotNull("plan must contain a foldable alias for 'cd'", cdAlias.get());
+        assertThat(cdAlias.get().child().fold(FoldContext.small()), is(0L));
+        assertThat(cdAlias.get().child().dataType(), is(LONG));
+    }
+
+    /**
+     * Makes sure we run the {@code null} replacement on the results of SPARKLINE's substitution.
+     * Specifically, this one looks from {@code SPARKLINE, VALUES(null)}. That's different from
+     * {@code COUNT_DISTINCT} because {@code VALUES} inherits the {@code null} input type.
+     */
+    public void testSparklineWithValuesNull() {
+        LogicalPlan plan = plan("""
+            ROW hire_date = to_datetime("1985-06-01T00:00:00Z"), y = null
+            | STATS s = SPARKLINE(COUNT(*), hire_date, 5, "1985-01-01T00:00:00Z", "1985-12-31T00:00:00Z"),
+                    v = VALUES(y)
+            """);
+
+        // The plan must contain a SparklineGenerateEmptyBuckets node for the sparkline
+        boolean[] hasSparkline = { false };
+        plan.forEachDown(SparklineGenerateEmptyBuckets.class, n -> hasSparkline[0] = true);
+        assertTrue("plan must contain SparklineGenerateEmptyBuckets", hasSparkline[0]);
+
+        // VALUES(y) where y is null-typed must be replaced with null
+        Holder<Alias> vAlias = findFoldableAlias(plan, "v");
+        assertNotNull("plan must contain a foldable alias for 'v'", vAlias.get());
+        assertThat(vAlias.get().child().fold(FoldContext.small()), nullValue());
+    }
+
+    /**
+     * Searches the plan tree depth-first for an {@link Eval} node containing a foldable
+     * {@link Alias} whose name equals {@code name}. Returns a {@link Holder} containing the
+     * first such alias found, or a {@link Holder} containing {@code null} if none exists.
+     */
+    private static Holder<Alias> findFoldableAlias(LogicalPlan plan, String name) {
+        Holder<Alias> result = new Holder<>();
+        plan.forEachDown(Eval.class, eval -> {
+            if (result.get() != null) {
+                return;
+            }
+            for (Alias alias : eval.fields()) {
+                if (alias.name().equals(name) && alias.child().foldable()) {
+                    result.set(alias);
+                    return;
+                }
+            }
+        });
+        return result;
     }
 }


### PR DESCRIPTION
`SPARKLINE` is a special, magical aggregation that runs in two phases:
```
| STATS SPARKLINE(MAX(a)), MIN(a)
```
becomes:
```
| STATS a1=MAX(a), a2=TO_PARTIAL(MIN(a)) BY b=BUCKET(@timestamp)
| STATS FINISH_SPARKLINE(a1, b), FROM_PARTIAL(MIN(a2))
```

TO_PARTIAL is an internal aggregations that forces the aggregation it
wraps to emit partial results. FROM_PARTIAL forces the aggregation to
consume partial results.

This works great, except when SPARKLINE is paired with an aggregation
that we fold to `null`. Think:
```
| STATS SPARKLINE(MIN(a)), COUNT_DISTINCT(null)
```

In that world we don't properly apply our "aggs-are-null" rule which
ends up trying to make a `COUNT_DISTINCT(null)` which is actually
invalid - we can't run the agg on `null`.

```
| STATS SPARKLINE(MIN(a)), VALUES(null)
```
also crashes, but because the "aggs-are-null" only applies to the
`TO_PARTIAL(VALUES(null))` half of the plan - and not the `FROM_PARTIAL`
half - there we'd try to make a `VALUES(null)` which is also invalid.