### PR TITLE
Refactor, renaming SymmetricInt4Encoding to BitEncoding w/ params

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerOSQBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerOSQBenchmark.java
@@ -107,8 +107,8 @@ public class VectorScorerOSQBenchmark {
     @Param({ "1", "2", "4", "7" })
     public byte bits;
 
-    @Param({ "STRIPED", "PACKED_NIBBLE" })
-    public ES940OSQVectorsScorer.SymmetricInt4Encoding int4Encoding;
+    @Param({ "STRIPED", "PACKED" })
+    public ES940OSQVectorsScorer.BitEncoding bitEncoding;
 
     @Param
     public VectorImplementation implementation;
@@ -151,24 +151,21 @@ public class VectorScorerOSQBenchmark {
         int sparseOffsetsCount
     ) {}
 
-    private static ES940OSQVectorsScorer.SymmetricInt4Encoding resolveInt4Encoding(
-        byte bits,
-        ES940OSQVectorsScorer.SymmetricInt4Encoding int4Encoding
-    ) {
-        return bits == 4 ? int4Encoding : ES940OSQVectorsScorer.SymmetricInt4Encoding.STRIPED;
+    private static ES940OSQVectorsScorer.BitEncoding resolvebitEncoding(byte bits, ES940OSQVectorsScorer.BitEncoding bitEncoding) {
+        return bits == 4 ? bitEncoding : ES940OSQVectorsScorer.BitEncoding.STRIPED;
     }
 
-    private static int docPackedLength(int dims, byte bits, ES940OSQVectorsScorer.SymmetricInt4Encoding int4Encoding) {
-        if (bits == 4 && int4Encoding == ES940OSQVectorsScorer.SymmetricInt4Encoding.STRIPED) {
+    private static int docPackedLength(int dims, byte bits, ES940OSQVectorsScorer.BitEncoding bitEncoding) {
+        if (bits == 4 && bitEncoding == ES940OSQVectorsScorer.BitEncoding.STRIPED) {
             int discretized = ES940DiskBBQVectorsFormat.QuantEncoding.fromBits(bits).discretizedDimensions(dims);
             return 4 * ((discretized + 7) / 8);
         }
         return ES940DiskBBQVectorsFormat.QuantEncoding.fromBits(bits).getDocPackedLength(dims);
     }
 
-    private static int queryPackedLength(int dims, byte bits, ES940OSQVectorsScorer.SymmetricInt4Encoding int4Encoding) {
-        if (bits == 4 && int4Encoding == ES940OSQVectorsScorer.SymmetricInt4Encoding.STRIPED) {
-            return docPackedLength(dims, bits, int4Encoding);
+    private static int queryPackedLength(int dims, byte bits, ES940OSQVectorsScorer.BitEncoding bitEncoding) {
+        if (bits == 4 && bitEncoding == ES940OSQVectorsScorer.BitEncoding.STRIPED) {
+            return docPackedLength(dims, bits, bitEncoding);
         }
         return ES940DiskBBQVectorsFormat.QuantEncoding.fromBits(bits).getQueryPackedLength(dims);
     }
@@ -177,10 +174,10 @@ public class VectorScorerOSQBenchmark {
         Random random,
         int dims,
         byte bits,
-        ES940OSQVectorsScorer.SymmetricInt4Encoding int4Encoding,
+        ES940OSQVectorsScorer.BitEncoding bitEncoding,
         VectorSimilarityFunction similarityFunction
     ) {
-        ES940OSQVectorsScorer.SymmetricInt4Encoding resolvedEncoding = resolveInt4Encoding(bits, int4Encoding);
+        ES940OSQVectorsScorer.BitEncoding resolvedEncoding = resolvebitEncoding(bits, bitEncoding);
         int binaryIndexLength = docPackedLength(dims, bits, resolvedEncoding);
 
         final float[] centroid = new float[dims];
@@ -277,7 +274,7 @@ public class VectorScorerOSQBenchmark {
 
     @Setup
     public void setup() throws IOException {
-        setup(generateRandomVectorData(new Random(123), dims, bits, int4Encoding, similarityFunction));
+        setup(generateRandomVectorData(new Random(123), dims, bits, bitEncoding, similarityFunction));
     }
 
     void setup(VectorData data) throws IOException {
@@ -319,7 +316,7 @@ public class VectorScorerOSQBenchmark {
             }
             default -> throw new IllegalArgumentException("Unsupported bits: " + bits);
         };
-        ES940OSQVectorsScorer.SymmetricInt4Encoding resolvedEncoding = resolveInt4Encoding(bits, int4Encoding);
+        ES940OSQVectorsScorer.BitEncoding resolvedEncoding = resolvebitEncoding(bits, bitEncoding);
         this.scorer = switch (implementation) {
             case SCALAR -> ESVectorizationProvider.lookup(false, false)
                 .getVectorScorerFactory()

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerOSQBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerOSQBenchmark.java
@@ -151,7 +151,7 @@ public class VectorScorerOSQBenchmark {
         int sparseOffsetsCount
     ) {}
 
-    private static ES940OSQVectorsScorer.BitEncoding resolvebitEncoding(byte bits, ES940OSQVectorsScorer.BitEncoding bitEncoding) {
+    private static ES940OSQVectorsScorer.BitEncoding resolvedBitEncoding(byte bits, ES940OSQVectorsScorer.BitEncoding bitEncoding) {
         return bits == 4 ? bitEncoding : ES940OSQVectorsScorer.BitEncoding.STRIPED;
     }
 
@@ -177,7 +177,7 @@ public class VectorScorerOSQBenchmark {
         ES940OSQVectorsScorer.BitEncoding bitEncoding,
         VectorSimilarityFunction similarityFunction
     ) {
-        ES940OSQVectorsScorer.BitEncoding resolvedEncoding = resolvebitEncoding(bits, bitEncoding);
+        ES940OSQVectorsScorer.BitEncoding resolvedEncoding = resolvedBitEncoding(bits, bitEncoding);
         int binaryIndexLength = docPackedLength(dims, bits, resolvedEncoding);
 
         final float[] centroid = new float[dims];
@@ -316,7 +316,7 @@ public class VectorScorerOSQBenchmark {
             }
             default -> throw new IllegalArgumentException("Unsupported bits: " + bits);
         };
-        ES940OSQVectorsScorer.BitEncoding resolvedEncoding = resolvebitEncoding(bits, bitEncoding);
+        ES940OSQVectorsScorer.BitEncoding resolvedEncoding = resolvedBitEncoding(bits, bitEncoding);
         this.scorer = switch (implementation) {
             case SCALAR -> ESVectorizationProvider.lookup(false, false)
                 .getVectorScorerFactory()

--- a/benchmarks/src/test/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerOSQBenchmarkTests.java
+++ b/benchmarks/src/test/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerOSQBenchmarkTests.java
@@ -29,25 +29,25 @@ public class VectorScorerOSQBenchmarkTests extends BenchmarkTest {
     private final int dims;
     private final byte bits;
     private final VectorScorerOSQBenchmark.DirectoryType directoryType;
-    private final ES940OSQVectorsScorer.SymmetricInt4Encoding int4Encoding;
+    private final ES940OSQVectorsScorer.BitEncoding bitEncoding;
     private final VectorSimilarityFunction similarityFunction;
 
     public VectorScorerOSQBenchmarkTests(
         int dims,
         byte bits,
         VectorScorerOSQBenchmark.DirectoryType directoryType,
-        ES940OSQVectorsScorer.SymmetricInt4Encoding int4Encoding,
+        ES940OSQVectorsScorer.BitEncoding bitEncoding,
         VectorSimilarityFunction similarityFunction
     ) {
         this.dims = dims;
         this.bits = bits;
         this.directoryType = directoryType;
-        this.int4Encoding = int4Encoding;
+        this.bitEncoding = bitEncoding;
         this.similarityFunction = similarityFunction;
     }
 
     public void testSingle() throws Exception {
-        var data = VectorScorerOSQBenchmark.generateRandomVectorData(random(), dims, bits, int4Encoding, similarityFunction);
+        var data = VectorScorerOSQBenchmark.generateRandomVectorData(random(), dims, bits, bitEncoding, similarityFunction);
 
         float[] expected = null;
         for (var impl : VectorScorerOSQBenchmark.VectorImplementation.values()) {
@@ -56,7 +56,7 @@ public class VectorScorerOSQBenchmarkTests extends BenchmarkTest {
             bench.dims = dims;
             bench.bits = bits;
             bench.directoryType = directoryType;
-            bench.int4Encoding = int4Encoding;
+            bench.bitEncoding = bitEncoding;
             bench.similarityFunction = similarityFunction;
             bench.setup(data);
 
@@ -76,7 +76,7 @@ public class VectorScorerOSQBenchmarkTests extends BenchmarkTest {
     }
 
     public void testBulk() throws Exception {
-        var data = VectorScorerOSQBenchmark.generateRandomVectorData(random(), dims, bits, int4Encoding, similarityFunction);
+        var data = VectorScorerOSQBenchmark.generateRandomVectorData(random(), dims, bits, bitEncoding, similarityFunction);
 
         float[] expected = null;
         for (var impl : VectorScorerOSQBenchmark.VectorImplementation.values()) {
@@ -85,7 +85,7 @@ public class VectorScorerOSQBenchmarkTests extends BenchmarkTest {
             bench.dims = dims;
             bench.bits = bits;
             bench.directoryType = directoryType;
-            bench.int4Encoding = int4Encoding;
+            bench.bitEncoding = bitEncoding;
             bench.similarityFunction = similarityFunction;
             bench.setup(data);
 
@@ -105,7 +105,7 @@ public class VectorScorerOSQBenchmarkTests extends BenchmarkTest {
     }
 
     public void testFilteredOne() throws Exception {
-        var data = VectorScorerOSQBenchmark.generateRandomVectorData(random(), dims, bits, int4Encoding, similarityFunction);
+        var data = VectorScorerOSQBenchmark.generateRandomVectorData(random(), dims, bits, bitEncoding, similarityFunction);
         runFilteredBenchmarks(
             data,
             VectorScorerOSQBenchmark::controlScoreBulkFilteredOne,
@@ -116,7 +116,7 @@ public class VectorScorerOSQBenchmarkTests extends BenchmarkTest {
     }
 
     public void testFilteredDense() throws Exception {
-        var data = VectorScorerOSQBenchmark.generateRandomVectorData(random(), dims, bits, int4Encoding, similarityFunction);
+        var data = VectorScorerOSQBenchmark.generateRandomVectorData(random(), dims, bits, bitEncoding, similarityFunction);
         runFilteredBenchmarks(
             data,
             VectorScorerOSQBenchmark::scoreBulkFilteredDense,
@@ -127,7 +127,7 @@ public class VectorScorerOSQBenchmarkTests extends BenchmarkTest {
     }
 
     public void testFilteredSparse() throws Exception {
-        var data = VectorScorerOSQBenchmark.generateRandomVectorData(random(), dims, bits, int4Encoding, similarityFunction);
+        var data = VectorScorerOSQBenchmark.generateRandomVectorData(random(), dims, bits, bitEncoding, similarityFunction);
         runFilteredBenchmarks(
             data,
             VectorScorerOSQBenchmark::scoreBulkFilteredSparse,
@@ -184,7 +184,7 @@ public class VectorScorerOSQBenchmarkTests extends BenchmarkTest {
         bench.dims = dims;
         bench.bits = bits;
         bench.directoryType = directoryType;
-        bench.int4Encoding = int4Encoding;
+        bench.bitEncoding = bitEncoding;
         bench.similarityFunction = similarityFunction;
         bench.setup(data);
 
@@ -216,7 +216,7 @@ public class VectorScorerOSQBenchmarkTests extends BenchmarkTest {
             VectorScorerOSQBenchmark.class.getField("dims"),
             VectorScorerOSQBenchmark.class.getField("bits"),
             VectorScorerOSQBenchmark.class.getField("directoryType"),
-            VectorScorerOSQBenchmark.class.getField("int4Encoding"),
+            VectorScorerOSQBenchmark.class.getField("bitEncoding"),
             VectorScorerOSQBenchmark.class.getField("similarityFunction")
         );
     }

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/DefaultVectorScorerFactory.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/DefaultVectorScorerFactory.java
@@ -40,9 +40,9 @@ final class DefaultVectorScorerFactory implements VectorScorerFactory {
         int dimension,
         int dataLength,
         int bulkSize,
-        ES940OSQVectorsScorer.SymmetricInt4Encoding int4Encoding
+        ES940OSQVectorsScorer.BitEncoding bitEncoding
     ) {
-        return new ES940OSQVectorsScorer(input, queryBits, indexBits, dimension, dataLength, bulkSize, int4Encoding);
+        return new ES940OSQVectorsScorer(input, queryBits, indexBits, dimension, dataLength, bulkSize, bitEncoding);
     }
 
     @Override

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/ES940OSQVectorsScorer.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/ES940OSQVectorsScorer.java
@@ -24,9 +24,9 @@ public class ES940OSQVectorsScorer {
 
     public static final int BULK_SIZE = 32;
 
-    public enum SymmetricInt4Encoding {
+    public enum BitEncoding {
         STRIPED,
-        PACKED_NIBBLE
+        PACKED
     }
 
     protected static final float[] BIT_SCALES = new float[] {
@@ -47,7 +47,7 @@ public class ES940OSQVectorsScorer {
     protected final int length;
     protected final int dimensions;
     protected final int bulkSize;
-    protected final SymmetricInt4Encoding int4Encoding;
+    protected final BitEncoding bitEncoding;
 
     protected final float[] lowerIntervals;
     protected final float[] upperIntervals;
@@ -63,7 +63,7 @@ public class ES940OSQVectorsScorer {
         int dimensions,
         int dataLength,
         int bulkSize,
-        SymmetricInt4Encoding int4Encoding
+        BitEncoding bitEncoding
     ) {
         if (indexBits == 1 && (queryBits == 4 || queryBits == 1) == false) {
             throw new IllegalArgumentException("Only asymmetric 4-bit or symmetric 1-bit query supported for 1-bit index");
@@ -87,13 +87,13 @@ public class ES940OSQVectorsScorer {
         this.targetComponentSums = new int[bulkSize];
         this.additionalCorrections = new float[bulkSize];
         this.bulkSize = bulkSize;
-        this.int4Encoding = int4Encoding == null ? SymmetricInt4Encoding.STRIPED : int4Encoding;
+        this.bitEncoding = bitEncoding == null ? BitEncoding.STRIPED : bitEncoding;
         this.scratch = indexBits == 7 ? new byte[dimensions] : null;
-        this.packedScratch = indexBits == 4 && this.int4Encoding == SymmetricInt4Encoding.PACKED_NIBBLE ? new byte[dataLength] : null;
+        this.packedScratch = indexBits == 4 && this.bitEncoding == BitEncoding.PACKED ? new byte[dataLength] : null;
     }
 
     public ES940OSQVectorsScorer(IndexInput in, byte queryBits, byte indexBits, int dimensions, int dataLength, int bulkSize) {
-        this(in, queryBits, indexBits, dimensions, dataLength, bulkSize, SymmetricInt4Encoding.STRIPED);
+        this(in, queryBits, indexBits, dimensions, dataLength, bulkSize, BitEncoding.STRIPED);
     }
 
     public ES940OSQVectorsScorer(IndexInput in, byte queryBits, byte indexBits, int dimensions, int dataLength) {
@@ -116,7 +116,7 @@ public class ES940OSQVectorsScorer {
             return quantized4BitScore2BitIndex(q);
         }
         if (indexBits == 4) {
-            if (int4Encoding == SymmetricInt4Encoding.PACKED_NIBBLE) {
+            if (bitEncoding == BitEncoding.PACKED) {
                 return quantized4BitScorePacked(q);
             }
             return quantized4BitScoreSymmetric(q);

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/ESVectorUtil.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/ESVectorUtil.java
@@ -58,9 +58,9 @@ public class ESVectorUtil {
         int dimension,
         int dataLength,
         int bulkSize,
-        ES940OSQVectorsScorer.SymmetricInt4Encoding int4Encoding
+        ES940OSQVectorsScorer.BitEncoding bitEncoding
     ) throws IOException {
-        return SCORERS.newES940OSQVectorsScorer(input, queryBits, indexBits, dimension, dataLength, bulkSize, int4Encoding);
+        return SCORERS.newES940OSQVectorsScorer(input, queryBits, indexBits, dimension, dataLength, bulkSize, bitEncoding);
     }
 
     public static ES92Int7VectorsScorer getES92Int7VectorsScorer(IndexInput input, int dimension, int bulkSize) throws IOException {

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/Native22VectorScorerFactory.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/Native22VectorScorerFactory.java
@@ -60,7 +60,7 @@ final class Native22VectorScorerFactory implements VectorScorerFactory {
         int dimension,
         int dataLength,
         int bulkSize,
-        ES940OSQVectorsScorer.SymmetricInt4Encoding int4Encoding
+        ES940OSQVectorsScorer.BitEncoding bitEncoding
     ) throws IOException {
         if (PanamaVectorConstants.ENABLE_INTEGER_VECTORS
             && ((queryBits == 1 && indexBits == 1)
@@ -76,12 +76,12 @@ final class Native22VectorScorerFactory implements VectorScorerFactory {
                     dimension,
                     dataLength,
                     bulkSize,
-                    int4Encoding,
+                    bitEncoding,
                     true
                 );
             }
         }
-        return FALLBACK.newES940OSQVectorsScorer(input, queryBits, indexBits, dimension, dataLength, bulkSize, int4Encoding);
+        return FALLBACK.newES940OSQVectorsScorer(input, queryBits, indexBits, dimension, dataLength, bulkSize, bitEncoding);
     }
 
     @Override

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/Panama21VectorScorerFactory.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/Panama21VectorScorerFactory.java
@@ -56,7 +56,7 @@ final class Panama21VectorScorerFactory implements VectorScorerFactory {
         int dimension,
         int dataLength,
         int bulkSize,
-        ES940OSQVectorsScorer.SymmetricInt4Encoding int4Encoding
+        ES940OSQVectorsScorer.BitEncoding bitEncoding
     ) throws IOException {
         if (PanamaVectorConstants.ENABLE_INTEGER_VECTORS
             && ((queryBits == 1 && indexBits == 1)
@@ -72,12 +72,12 @@ final class Panama21VectorScorerFactory implements VectorScorerFactory {
                     dimension,
                     dataLength,
                     bulkSize,
-                    int4Encoding,
+                    bitEncoding,
                     false   // native support requires heap segments
                 );
             }
         }
-        return FALLBACK.newES940OSQVectorsScorer(input, queryBits, indexBits, dimension, dataLength, bulkSize, int4Encoding);
+        return FALLBACK.newES940OSQVectorsScorer(input, queryBits, indexBits, dimension, dataLength, bulkSize, bitEncoding);
     }
 
     @Override

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/Panama22VectorScorerFactory.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/Panama22VectorScorerFactory.java
@@ -56,7 +56,7 @@ final class Panama22VectorScorerFactory implements VectorScorerFactory {
         int dimension,
         int dataLength,
         int bulkSize,
-        ES940OSQVectorsScorer.SymmetricInt4Encoding int4Encoding
+        ES940OSQVectorsScorer.BitEncoding bitEncoding
     ) throws IOException {
         if (PanamaVectorConstants.ENABLE_INTEGER_VECTORS
             && ((queryBits == 1 && indexBits == 1)
@@ -72,12 +72,12 @@ final class Panama22VectorScorerFactory implements VectorScorerFactory {
                     dimension,
                     dataLength,
                     bulkSize,
-                    int4Encoding,
+                    bitEncoding,
                     false   // native not enabled
                 );
             }
         }
-        return FALLBACK.newES940OSQVectorsScorer(input, queryBits, indexBits, dimension, dataLength, bulkSize, int4Encoding);
+        return FALLBACK.newES940OSQVectorsScorer(input, queryBits, indexBits, dimension, dataLength, bulkSize, bitEncoding);
     }
 
     @Override

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/VectorScorerFactory.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/VectorScorerFactory.java
@@ -31,7 +31,7 @@ public interface VectorScorerFactory {
     ES91OSQVectorsScorer newES91OSQVectorsScorer(IndexInput input, int dimension, int bulkSize) throws IOException;
 
     /**
-     * Create a new {@link ES940OSQVectorsScorer} for the given {@link IndexInput} and explicit int4 disk format.
+     * Create a new {@link ES940OSQVectorsScorer} for the given {@link IndexInput} and explicit packed-vs-striped disk layout.
      * The input should be unwrapped before calling this method. If the input is
      * still a {@code FilterIndexInput} that does not implement
      * {@code MemorySegmentAccessInput} or {@code DirectAccessInput}, an
@@ -45,7 +45,7 @@ public interface VectorScorerFactory {
         int dimension,
         int dataLength,
         int bulkSize,
-        ES940OSQVectorsScorer.SymmetricInt4Encoding int4Encoding
+        ES940OSQVectorsScorer.BitEncoding bitEncoding
     ) throws IOException;
 
     /**

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/MemorySegmentES940OSQVectorsScorer.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/MemorySegmentES940OSQVectorsScorer.java
@@ -45,12 +45,12 @@ public final class MemorySegmentES940OSQVectorsScorer extends ES940OSQVectorsSco
         D4Q4_PACKED,
         D7Q7;
 
-        static QuantEncoding of(byte queryBits, byte indexBits, SymmetricInt4Encoding int4Encoding) {
+        static QuantEncoding of(byte queryBits, byte indexBits, BitEncoding bitEncoding) {
             return switch ((queryBits << 8) | indexBits) {
                 case (1 << 8) | 1 -> D1Q1;
                 case (4 << 8) | 1 -> D1Q4;
                 case (4 << 8) | 2 -> D2Q4;
-                case (4 << 8) | 4 -> int4Encoding == SymmetricInt4Encoding.PACKED_NIBBLE ? D4Q4_PACKED : D4Q4_STRIPED;
+                case (4 << 8) | 4 -> bitEncoding == BitEncoding.PACKED ? D4Q4_PACKED : D4Q4_STRIPED;
                 case (7 << 8) | 7 -> D7Q7;
                 default -> throw new IllegalArgumentException("Unsupported query/index bits combination: " + queryBits + "/" + indexBits);
             };
@@ -66,20 +66,12 @@ public final class MemorySegmentES940OSQVectorsScorer extends ES940OSQVectorsSco
         int dimensions,
         int dataLength,
         int bulkSize,
-        SymmetricInt4Encoding int4Encoding,
+        BitEncoding bitEncoding,
         boolean nativeEnabled
     ) {
-        super(
-            in,
-            queryBits,
-            indexBits,
-            dimensions,
-            dataLength,
-            bulkSize,
-            int4Encoding == null ? SymmetricInt4Encoding.STRIPED : int4Encoding
-        );
-        SymmetricInt4Encoding resolvedInt4 = int4Encoding == null ? SymmetricInt4Encoding.STRIPED : int4Encoding;
-        QuantEncoding enc = QuantEncoding.of(queryBits, indexBits, resolvedInt4);
+        super(in, queryBits, indexBits, dimensions, dataLength, bulkSize, bitEncoding == null ? BitEncoding.STRIPED : bitEncoding);
+        BitEncoding resolvedBitEncoding = bitEncoding == null ? BitEncoding.STRIPED : bitEncoding;
+        QuantEncoding enc = QuantEncoding.of(queryBits, indexBits, resolvedBitEncoding);
         if (enc == QuantEncoding.D1Q1) {
             this.scorer = createPanamaScorer(enc, in, dimensions, dataLength, bulkSize);
         } else {

--- a/libs/simdvec/src/test/java/org/elasticsearch/simdvec/internal/vectorization/ES940OSQVectorsScorerTests.java
+++ b/libs/simdvec/src/test/java/org/elasticsearch/simdvec/internal/vectorization/ES940OSQVectorsScorerTests.java
@@ -43,7 +43,7 @@ public class ES940OSQVectorsScorerTests extends BaseVectorizationTests {
     private final byte indexBits;
     private final byte queryBits;
     private final VectorSimilarityFunction similarityFunction;
-    private final ES940OSQVectorsScorer.SymmetricInt4Encoding int4Encoding;
+    private final ES940OSQVectorsScorer.BitEncoding bitEncoding;
 
     public enum DirectoryType {
         NIOFS,
@@ -55,22 +55,22 @@ public class ES940OSQVectorsScorerTests extends BaseVectorizationTests {
         DirectoryType directoryType,
         byte indexBits,
         byte queryBits,
-        ES940OSQVectorsScorer.SymmetricInt4Encoding int4Encoding,
+        ES940OSQVectorsScorer.BitEncoding bitEncoding,
         VectorSimilarityFunction similarityFunction
     ) {
         this.directoryType = directoryType;
         this.indexBits = indexBits;
         this.queryBits = queryBits;
-        this.int4Encoding = int4Encoding;
+        this.bitEncoding = bitEncoding;
         this.similarityFunction = similarityFunction;
     }
 
-    private ES940OSQVectorsScorer.SymmetricInt4Encoding int4Encoding() {
-        return int4Encoding;
+    private ES940OSQVectorsScorer.BitEncoding bitEncoding() {
+        return bitEncoding;
     }
 
     private int docPackedLength(int dimensions) {
-        if (indexBits == 4 && int4Encoding == ES940OSQVectorsScorer.SymmetricInt4Encoding.STRIPED) {
+        if (indexBits == 4 && bitEncoding == ES940OSQVectorsScorer.BitEncoding.STRIPED) {
             int discretized = ES940DiskBBQVectorsFormat.QuantEncoding.fromBits(indexBits).discretizedDimensions(dimensions);
             return 4 * ((discretized + 7) / 8);
         }
@@ -78,7 +78,7 @@ public class ES940OSQVectorsScorerTests extends BaseVectorizationTests {
     }
 
     private int queryPackedLength(int dimensions) {
-        if (indexBits == 4 && int4Encoding == ES940OSQVectorsScorer.SymmetricInt4Encoding.STRIPED) {
+        if (indexBits == 4 && bitEncoding == ES940OSQVectorsScorer.BitEncoding.STRIPED) {
             return docPackedLength(dimensions);
         }
         return ES940DiskBBQVectorsFormat.QuantEncoding.fromBits(indexBits).getQueryPackedLength(dimensions);
@@ -105,7 +105,7 @@ public class ES940OSQVectorsScorerTests extends BaseVectorizationTests {
             }
             final byte[] query = new byte[queryBytes];
             random().nextBytes(query);
-            if (indexBits == 4 && int4Encoding == ES940OSQVectorsScorer.SymmetricInt4Encoding.PACKED_NIBBLE) {
+            if (indexBits == 4 && bitEncoding == ES940OSQVectorsScorer.BitEncoding.PACKED) {
                 clampTo4Bit(query);
             }
             if (indexBits == 7) clampTo7Bit(query, dimensions);
@@ -122,7 +122,7 @@ public class ES940OSQVectorsScorerTests extends BaseVectorizationTests {
                         dimensions,
                         length,
                         ES940OSQVectorsScorer.BULK_SIZE,
-                        int4Encoding()
+                        bitEncoding()
                     );
                 ES940OSQVectorsScorer panamaScorer = panamaProvider().getVectorScorerFactory()
                     .newES940OSQVectorsScorer(
@@ -132,18 +132,10 @@ public class ES940OSQVectorsScorerTests extends BaseVectorizationTests {
                         dimensions,
                         length,
                         ES940OSQVectorsScorer.BULK_SIZE,
-                        int4Encoding()
+                        bitEncoding()
                     );
                 ES940OSQVectorsScorer nativeScorer = nativeProvider().getVectorScorerFactory()
-                    .newES940OSQVectorsScorer(
-                        in,
-                        queryBits,
-                        indexBits,
-                        dimensions,
-                        length,
-                        ES940OSQVectorsScorer.BULK_SIZE,
-                        int4Encoding()
-                    );
+                    .newES940OSQVectorsScorer(in, queryBits, indexBits, dimensions, length, ES940OSQVectorsScorer.BULK_SIZE, bitEncoding());
                 for (int i = 0; i < numVectors; i++) {
                     long expectedScore = defaultScorer.quantizeScore(query);
                     assertEquals(expectedScore, panamaScorer.quantizeScore(query));
@@ -183,7 +175,7 @@ public class ES940OSQVectorsScorerTests extends BaseVectorizationTests {
                         dimensions,
                         indexBits,
                         indexVectorPackedLengthInBytes,
-                        int4Encoding
+                        bitEncoding
                     );
                     writeSingleOSQVectorData(out, vectorData);
                 }
@@ -201,7 +193,7 @@ public class ES940OSQVectorsScorerTests extends BaseVectorizationTests {
                 queryBits,
                 queryVectorPackedLengthInBytes,
                 indexBits,
-                int4Encoding
+                bitEncoding
             );
 
             final float centroidDp = VectorUtil.dotProduct(centroid, centroid);
@@ -225,7 +217,7 @@ public class ES940OSQVectorsScorerTests extends BaseVectorizationTests {
                             dimensions,
                             indexVectorPackedLengthInBytes,
                             ES940OSQVectorsScorer.BULK_SIZE,
-                            int4Encoding()
+                            bitEncoding()
                         );
                     final var panamaScorer = panamaProvider().getVectorScorerFactory()
                         .newES940OSQVectorsScorer(
@@ -235,7 +227,7 @@ public class ES940OSQVectorsScorerTests extends BaseVectorizationTests {
                             dimensions,
                             indexVectorPackedLengthInBytes,
                             ES940OSQVectorsScorer.BULK_SIZE,
-                            int4Encoding()
+                            bitEncoding()
                         );
                     final var nativeScorer = nativeProvider().getVectorScorerFactory()
                         .newES940OSQVectorsScorer(
@@ -245,7 +237,7 @@ public class ES940OSQVectorsScorerTests extends BaseVectorizationTests {
                             dimensions,
                             indexVectorPackedLengthInBytes,
                             ES940OSQVectorsScorer.BULK_SIZE,
-                            int4Encoding()
+                            bitEncoding()
                         );
                     long qDist = defaultScorer.quantizeScore(queryData.quantizedVector());
                     slice.readFloats(floatScratch, 0, 3);
@@ -349,7 +341,7 @@ public class ES940OSQVectorsScorerTests extends BaseVectorizationTests {
                             dimensions,
                             indexBits,
                             indexVectorPackedLengthInBytes,
-                            int4Encoding
+                            bitEncoding
                         );
                     }
                     writeBulkOSQVectorData(bulkSize, out, vectors);
@@ -367,7 +359,7 @@ public class ES940OSQVectorsScorerTests extends BaseVectorizationTests {
                 queryBits,
                 queryVectorPackedLengthInBytes,
                 indexBits,
-                int4Encoding
+                bitEncoding
             );
 
             final float centroidDp = VectorUtil.dotProduct(centroid, centroid);
@@ -391,7 +383,7 @@ public class ES940OSQVectorsScorerTests extends BaseVectorizationTests {
                             dimensions,
                             indexVectorPackedLengthInBytes,
                             ES940OSQVectorsScorer.BULK_SIZE,
-                            int4Encoding()
+                            bitEncoding()
                         );
                     final var panamaScorer = panamaProvider().getVectorScorerFactory()
                         .newES940OSQVectorsScorer(
@@ -401,7 +393,7 @@ public class ES940OSQVectorsScorerTests extends BaseVectorizationTests {
                             dimensions,
                             indexVectorPackedLengthInBytes,
                             ES940OSQVectorsScorer.BULK_SIZE,
-                            int4Encoding()
+                            bitEncoding()
                         );
                     final var nativeScorer = nativeProvider().getVectorScorerFactory()
                         .newES940OSQVectorsScorer(
@@ -411,7 +403,7 @@ public class ES940OSQVectorsScorerTests extends BaseVectorizationTests {
                             dimensions,
                             indexVectorPackedLengthInBytes,
                             ES940OSQVectorsScorer.BULK_SIZE,
-                            int4Encoding()
+                            bitEncoding()
                         );
                     float defaultMaxScore = defaultScorer.scoreBulk(
                         queryData.quantizedVector(),
@@ -531,7 +523,7 @@ public class ES940OSQVectorsScorerTests extends BaseVectorizationTests {
                             dimensions,
                             indexBits,
                             indexVectorPackedLengthInBytes,
-                            int4Encoding
+                            bitEncoding
                         );
                     }
                     writeBulkOSQVectorData(count, out, vectors);
@@ -549,7 +541,7 @@ public class ES940OSQVectorsScorerTests extends BaseVectorizationTests {
                 queryBits,
                 queryVectorPackedLengthInBytes,
                 indexBits,
-                int4Encoding
+                bitEncoding
             );
 
             final float centroidDp = VectorUtil.dotProduct(centroid, centroid);
@@ -574,7 +566,7 @@ public class ES940OSQVectorsScorerTests extends BaseVectorizationTests {
                             dimensions,
                             indexVectorPackedLengthInBytes,
                             bulkSize,
-                            int4Encoding()
+                            bitEncoding()
                         );
                     final var panamaScorer = panamaProvider().getVectorScorerFactory()
                         .newES940OSQVectorsScorer(
@@ -584,7 +576,7 @@ public class ES940OSQVectorsScorerTests extends BaseVectorizationTests {
                             dimensions,
                             indexVectorPackedLengthInBytes,
                             bulkSize,
-                            int4Encoding()
+                            bitEncoding()
                         );
                     final var nativeScorer = nativeProvider().getVectorScorerFactory()
                         .newES940OSQVectorsScorer(
@@ -594,7 +586,7 @@ public class ES940OSQVectorsScorerTests extends BaseVectorizationTests {
                             dimensions,
                             indexVectorPackedLengthInBytes,
                             bulkSize,
-                            int4Encoding()
+                            bitEncoding()
                         );
                     float defaultMaxScore = defaultScorer.scoreBulkOffsets(
                         queryData.quantizedVector(),
@@ -690,7 +682,7 @@ public class ES940OSQVectorsScorerTests extends BaseVectorizationTests {
 
             byte[] query = new byte[queryBytes];
             random().nextBytes(query);
-            if (indexBits == 4 && int4Encoding == ES940OSQVectorsScorer.SymmetricInt4Encoding.PACKED_NIBBLE) {
+            if (indexBits == 4 && bitEncoding == ES940OSQVectorsScorer.BitEncoding.PACKED) {
                 clampTo4Bit(query);
             }
             if (indexBits == 7) clampTo7Bit(query, dimensions);
@@ -703,11 +695,11 @@ public class ES940OSQVectorsScorerTests extends BaseVectorizationTests {
                 final long dataLength = (long) bulkSize * length + 16L * bulkSize;
                 final IndexInput slice = in.slice("test", 0, dataLength);
                 final var defaultScorer = defaultProvider().getVectorScorerFactory()
-                    .newES940OSQVectorsScorer(slice, queryBits, indexBits, dimensions, length, bulkSize, int4Encoding());
+                    .newES940OSQVectorsScorer(slice, queryBits, indexBits, dimensions, length, bulkSize, bitEncoding());
                 final var panamaScorer = panamaProvider().getVectorScorerFactory()
-                    .newES940OSQVectorsScorer(in.clone(), queryBits, indexBits, dimensions, length, bulkSize, int4Encoding());
+                    .newES940OSQVectorsScorer(in.clone(), queryBits, indexBits, dimensions, length, bulkSize, bitEncoding());
                 final var nativeScorer = panamaProvider().getVectorScorerFactory()
-                    .newES940OSQVectorsScorer(in, queryBits, indexBits, dimensions, length, bulkSize, int4Encoding());
+                    .newES940OSQVectorsScorer(in, queryBits, indexBits, dimensions, length, bulkSize, bitEncoding());
 
                 // Pass Float.NEGATIVE_INFINITY as queryAdditionalCorrection.
                 // With all-zero corrections and zero query intervals, the base score is zero,
@@ -781,11 +773,11 @@ public class ES940OSQVectorsScorerTests extends BaseVectorizationTests {
     @ParametersFactory
     public static Iterable<Object[]> parametersFactory() {
         var bitCombinations = List.of(
-            List.of((byte) 1, (byte) 4, ES940OSQVectorsScorer.SymmetricInt4Encoding.STRIPED),
-            List.of((byte) 2, (byte) 4, ES940OSQVectorsScorer.SymmetricInt4Encoding.STRIPED),
-            List.of((byte) 4, (byte) 4, ES940OSQVectorsScorer.SymmetricInt4Encoding.STRIPED),
-            List.of((byte) 4, (byte) 4, ES940OSQVectorsScorer.SymmetricInt4Encoding.PACKED_NIBBLE),
-            List.of((byte) 7, (byte) 7, ES940OSQVectorsScorer.SymmetricInt4Encoding.STRIPED)
+            List.of((byte) 1, (byte) 4, ES940OSQVectorsScorer.BitEncoding.STRIPED),
+            List.of((byte) 2, (byte) 4, ES940OSQVectorsScorer.BitEncoding.STRIPED),
+            List.of((byte) 4, (byte) 4, ES940OSQVectorsScorer.BitEncoding.STRIPED),
+            List.of((byte) 4, (byte) 4, ES940OSQVectorsScorer.BitEncoding.PACKED),
+            List.of((byte) 7, (byte) 7, ES940OSQVectorsScorer.BitEncoding.STRIPED)
         );
         return () -> bitCombinations.stream()
             .flatMap(bits -> Arrays.stream(DirectoryType.values()).map(d -> List.of(d, bits.get(0), bits.get(1), bits.get(2))))

--- a/libs/simdvec/src/testFixtures/java/org/elasticsearch/simdvec/internal/vectorization/VectorScorerTestUtils.java
+++ b/libs/simdvec/src/testFixtures/java/org/elasticsearch/simdvec/internal/vectorization/VectorScorerTestUtils.java
@@ -160,7 +160,7 @@ public class VectorScorerTestUtils {
         int dimensions,
         byte indexBits,
         int vectorPackedLengthInBytes,
-        ES940OSQVectorsScorer.SymmetricInt4Encoding int4Encoding
+        ES940OSQVectorsScorer.BitEncoding bitEncoding
     ) {
         final float[] residualScratch = new float[dimensions];
         final int[] scratch = new int[ES940DiskBBQVectorsFormat.QuantEncoding.fromBits(indexBits).discretizedDimensions(dimensions)];
@@ -173,7 +173,7 @@ public class VectorScorerTestUtils {
             indexBits,
             centroid
         );
-        if (indexBits == 4 && int4Encoding == ES940OSQVectorsScorer.SymmetricInt4Encoding.STRIPED) {
+        if (indexBits == 4 && bitEncoding == ES940OSQVectorsScorer.BitEncoding.STRIPED) {
             ESVectorUtil.transposeHalfByte(scratch, qVector);
         } else {
             ES940DiskBBQVectorsFormat.QuantEncoding.fromBits(indexBits).pack(scratch, qVector);
@@ -227,7 +227,7 @@ public class VectorScorerTestUtils {
         byte queryBits,
         int queryVectorPackedLengthInBytes,
         byte indexBits,
-        ES940OSQVectorsScorer.SymmetricInt4Encoding int4Encoding
+        ES940OSQVectorsScorer.BitEncoding bitEncoding
     ) {
         final float[] residualScratch = new float[dimensions];
         final int[] scratch = new int[ES940DiskBBQVectorsFormat.QuantEncoding.fromBits(indexBits).discretizedDimensions(dimensions)];
@@ -240,7 +240,7 @@ public class VectorScorerTestUtils {
             centroid
         );
         final byte[] quantizeQuery = new byte[queryVectorPackedLengthInBytes];
-        if (indexBits == 4 && int4Encoding == ES940OSQVectorsScorer.SymmetricInt4Encoding.STRIPED) {
+        if (indexBits == 4 && bitEncoding == ES940OSQVectorsScorer.BitEncoding.STRIPED) {
             ESVectorUtil.transposeHalfByte(scratch, quantizeQuery);
         } else {
             ES940DiskBBQVectorsFormat.QuantEncoding.fromBits(indexBits).packQuery(scratch, quantizeQuery);

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/es94/ES940DiskBBQVectorsReader.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/es94/ES940DiskBBQVectorsReader.java
@@ -772,10 +772,10 @@ public class ES940DiskBBQVectorsReader extends IVFVectorsReader<ES940DiskBBQVect
             this.acceptDocs = acceptDocs;
             quantizedVectorByteSize = quantEncoding.getDocPackedLength(fieldInfo.getVectorDimension());
             quantizedByteLength = quantizedVectorByteSize + (Float.BYTES * 3) + Integer.BYTES;
-            ES940OSQVectorsScorer.SymmetricInt4Encoding int4Encoding =
+            ES940OSQVectorsScorer.BitEncoding bitEncoding =
                 quantEncoding == ES940DiskBBQVectorsFormat.QuantEncoding.FOUR_BIT_SYMMETRIC_PACKED
-                    ? ES940OSQVectorsScorer.SymmetricInt4Encoding.PACKED_NIBBLE
-                    : ES940OSQVectorsScorer.SymmetricInt4Encoding.STRIPED;
+                    ? ES940OSQVectorsScorer.BitEncoding.PACKED
+                    : ES940OSQVectorsScorer.BitEncoding.STRIPED;
             osqVectorsScorer = ESVectorUtil.getES940OSQVectorsScorer(
                 indexInput,
                 quantEncoding.queryBits(),
@@ -783,7 +783,7 @@ public class ES940DiskBBQVectorsReader extends IVFVectorsReader<ES940DiskBBQVect
                 fieldInfo.getVectorDimension(),
                 (int) quantizedVectorByteSize,
                 BULK_SIZE,
-                int4Encoding
+                bitEncoding
             );
         }
 

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/next/ESNextDiskBBQVectorsReader.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/next/ESNextDiskBBQVectorsReader.java
@@ -992,9 +992,7 @@ public class ESNextDiskBBQVectorsReader extends IVFVectorsReader<ESNextDiskBBQVe
                 fieldInfo.getVectorDimension(),
                 (int) quantizedVectorByteSize,
                 BULK_SIZE,
-                quantEncoding.bits() == 4
-                    ? ES940OSQVectorsScorer.SymmetricInt4Encoding.PACKED_NIBBLE
-                    : ES940OSQVectorsScorer.SymmetricInt4Encoding.STRIPED
+                quantEncoding.bits() == 4 ? ES940OSQVectorsScorer.BitEncoding.PACKED : ES940OSQVectorsScorer.BitEncoding.STRIPED
             );
         }
 

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/diskbbq/es94/ES940DiskBBQVectorsFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/diskbbq/es94/ES940DiskBBQVectorsFormatTests.java
@@ -215,7 +215,7 @@ public class ES940DiskBBQVectorsFormatTests extends BaseKnnVectorsFormatTestCase
         expectThrows(IllegalArgumentException.class, () -> new ES940DiskBBQVectorsFormat(128, MAX_CENTROIDS_PER_PARENT_CLUSTER + 1));
     }
 
-    public void testInt4EncodingVersionEnforcement() {
+    public void testbitEncodingVersionEnforcement() {
         expectThrows(
             IllegalArgumentException.class,
             () -> new ES940DiskBBQVectorsFormat(


### PR DESCRIPTION
This is the minor refactoring for PR: https://github.com/elastic/elasticsearch/pull/149344/changes

Does a rename and param rename, pretty simple. We will support more than just 4bit striped vs. packed.