### PR TITLE
Maintain array order for numeric fields in columnar mode

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/_nightly/esql/ValuesSourceReaderBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/_nightly/esql/ValuesSourceReaderBenchmark.java
@@ -281,6 +281,7 @@ public class ValuesSourceReaderBenchmark {
             false,
             null,
             null,
+            false,
             false
         ).blockLoader(new BenchContext());
     }

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/script/ScriptScoreBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/script/ScriptScoreBenchmark.java
@@ -103,6 +103,7 @@ public class ScriptScoreBenchmark {
                 false,
                 null,
                 null,
+                false,
                 false
             )
         )

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapper.java
@@ -32,6 +32,7 @@ import org.elasticsearch.index.mapper.CompositeSyntheticFieldLoader;
 import org.elasticsearch.index.mapper.DocValuesFieldFactory;
 import org.elasticsearch.index.mapper.DocumentParserContext;
 import org.elasticsearch.index.mapper.FallbackSyntheticSourceBlockLoader;
+import org.elasticsearch.index.mapper.FieldArrayContext;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.IgnoreMalformedStoredValues;
 import org.elasticsearch.index.mapper.IgnoredSourceFieldMapper;
@@ -233,6 +234,20 @@ public class ScaledFloatFieldMapper extends FieldMapper {
 
         @Override
         public ScaledFloatFieldMapper build(MapperBuilderContext context) {
+            String offsetsFieldName = getOffsetsFieldName(
+                context,
+                indexSettings.sourceKeepMode(),
+                docValuesParameters.getValue().enabled(),
+                stored.getValue(),
+                this,
+                indexSettings.getIndexVersionCreated(),
+                IndexVersions.SYNTHETIC_SOURCE_STORE_ARRAYS_NATIVELY_SCALED_FLOAT,
+                indexSettings.getMode().isStrictColumnar(),
+                docValuesParameters.getValue().multiValue()
+            );
+            boolean readInArrayOrder = offsetsFieldName != null
+                && docValuesParameters.getValue().multiValue()
+                && indexSettings.getMode().isStrictColumnar();
             ScaledFloatFieldType type = new ScaledFloatFieldType(
                 context.buildFullName(leafName()),
                 indexType(),
@@ -243,16 +258,8 @@ public class ScaledFloatFieldMapper extends FieldMapper {
                 metric.getValue(),
                 indexSettings.getMode(),
                 coerce.getValue().value(),
-                context.isSourceSynthetic()
-            );
-            String offsetsFieldName = getOffsetsFieldName(
-                context,
-                indexSettings.sourceKeepMode(),
-                docValuesParameters.getValue().enabled(),
-                stored.getValue(),
-                this,
-                indexSettings.getIndexVersionCreated(),
-                IndexVersions.SYNTHETIC_SOURCE_STORE_ARRAYS_NATIVELY_SCALED_FLOAT
+                context.isSourceSynthetic(),
+                readInArrayOrder
             );
             return new ScaledFloatFieldMapper(
                 leafName(),
@@ -275,6 +282,7 @@ public class ScaledFloatFieldMapper extends FieldMapper {
         private final IndexMode indexMode;
         private final boolean coerce;
         private final boolean isSyntheticSource;
+        private final boolean readInArrayOrder;
 
         public ScaledFloatFieldType(
             String name,
@@ -288,6 +296,22 @@ public class ScaledFloatFieldMapper extends FieldMapper {
             boolean coerce,
             boolean isSyntheticSource
         ) {
+            this(name, indexType, stored, meta, scalingFactor, nullValue, metricType, indexMode, coerce, isSyntheticSource, false);
+        }
+
+        public ScaledFloatFieldType(
+            String name,
+            IndexType indexType,
+            boolean stored,
+            Map<String, String> meta,
+            double scalingFactor,
+            Double nullValue,
+            TimeSeriesParams.MetricType metricType,
+            IndexMode indexMode,
+            boolean coerce,
+            boolean isSyntheticSource,
+            boolean readInArrayOrder
+        ) {
             super(name, indexType, stored, meta);
             this.scalingFactor = scalingFactor;
             this.nullValue = nullValue;
@@ -295,6 +319,7 @@ public class ScaledFloatFieldMapper extends FieldMapper {
             this.indexMode = indexMode;
             this.coerce = coerce;
             this.isSyntheticSource = isSyntheticSource;
+            this.readInArrayOrder = readInArrayOrder;
         }
 
         public ScaledFloatFieldType(String name, double scalingFactor) {
@@ -386,7 +411,7 @@ public class ScaledFloatFieldMapper extends FieldMapper {
                 return ConstantNull.INSTANCE;
             }
             if (hasDocValues() && (blContext.fieldExtractPreference() != FieldExtractPreference.STORED || isSyntheticSource)) {
-                return new DoublesBlockLoader(name(), l -> l / scalingFactor);
+                return new DoublesBlockLoader(name(), l -> l / scalingFactor, readInArrayOrder);
             }
             // Multi fields don't have fallback synthetic source.
             if (isSyntheticSource && blContext.parentField(name()) == null) {
@@ -695,7 +720,7 @@ public class ScaledFloatFieldMapper extends FieldMapper {
             value = numericValue;
         }
 
-        boolean shouldStoreOffsets = offsetsFieldName != null && context.isImmediateParentAnArray() && context.canAddIgnoredField();
+        boolean shouldStoreOffsets = FieldArrayContext.shouldRecordOffsets(context, offsetsFieldName, docValuesParameters.multiValue());
 
         if (value == null) {
             value = nullValue;

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/TokenCountFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/TokenCountFieldMapper.java
@@ -133,7 +133,8 @@ public class TokenCountFieldMapper extends FieldMapper {
                 false,
                 null,
                 null,
-                isSyntheticSource
+                isSyntheticSource,
+                false
             );
         }
 

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapperTests.java
@@ -15,6 +15,7 @@ import org.apache.lucene.index.IndexableField;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.mapper.DocumentMapper;
@@ -672,5 +673,23 @@ public class ScaledFloatFieldMapperTests extends NumberFieldMapperTests {
             // TODO doubles currently disable pruning, can we re-enable?
             new SortShortcutSupport(this::minimalMapping, this::writeField, false)
         );
+    }
+
+    public void testColumnarArrayOrderRoundTrip() throws IOException {
+        assumeTrue("columnar index mode requires snapshot build", IndexMode.COLUMNAR_FEATURE_FLAG.isEnabled());
+        Settings settings = Settings.builder().put(IndexSettings.MODE.getKey(), IndexMode.COLUMNAR.name()).build();
+        double scalingFactor = 100.0;
+        DocumentMapper mapper = createMapperService(
+            settings,
+            mapping(b -> b.startObject("field").field("type", "scaled_float").field("scaling_factor", scalingFactor).endObject())
+        ).documentMapper();
+
+        // Pick raw ints then divide by the scaling factor so values already lie on the scaled grid — no quantization loss.
+        double v1 = randomIntBetween(0, 100_000) / scalingFactor;
+        double v2 = randomIntBetween(0, 100_000) / scalingFactor;
+        double v3 = randomIntBetween(0, 100_000) / scalingFactor;
+
+        String src = syntheticSource(mapper, b -> b.array("field", v2, v1, v3, v2));
+        assertThat(src, containsString("\"field\":[" + v2 + "," + v1 + "," + v3 + "," + v2 + "]"));
     }
 }

--- a/plugins/mapper-size/src/main/java/org/elasticsearch/index/mapper/size/SizeFieldMapper.java
+++ b/plugins/mapper-size/src/main/java/org/elasticsearch/index/mapper/size/SizeFieldMapper.java
@@ -68,6 +68,7 @@ public class SizeFieldMapper extends MetadataFieldMapper {
                 false,
                 null,
                 null,
+                false,
                 false
             );
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
@@ -179,6 +179,20 @@ public class BooleanFieldMapper extends FieldMapper {
             if (inheritDimensionParameterFromParentObject(context)) {
                 dimension(true);
             }
+            String offsetsFieldName = getOffsetsFieldName(
+                context,
+                indexSettings.sourceKeepMode(),
+                docValuesParameters.getValue().enabled(),
+                stored.getValue(),
+                this,
+                indexSettings.getIndexVersionCreated(),
+                IndexVersions.SYNTHETIC_SOURCE_STORE_ARRAYS_NATIVELY_BOOLEAN,
+                indexSettings.getMode().isStrictColumnar(),
+                docValuesParameters.getValue().multiValue()
+            );
+            boolean readInArrayOrder = offsetsFieldName != null
+                && docValuesParameters.getValue().multiValue()
+                && indexSettings.getMode().isStrictColumnar();
             MappedFieldType ft = new BooleanFieldType(
                 context.buildFullName(leafName()),
                 indexType(),
@@ -187,19 +201,11 @@ public class BooleanFieldMapper extends FieldMapper {
                 scriptValues(),
                 meta.getValue(),
                 dimension.getValue(),
-                context.isSourceSynthetic()
+                context.isSourceSynthetic(),
+                readInArrayOrder
             );
             hasScript = script.get() != null;
             onScriptError = onScriptErrorParam.getValue();
-            String offsetsFieldName = getOffsetsFieldName(
-                context,
-                indexSettings.sourceKeepMode(),
-                docValuesParameters.getValue().enabled(),
-                stored.getValue(),
-                this,
-                indexSettings.getIndexVersionCreated(),
-                IndexVersions.SYNTHETIC_SOURCE_STORE_ARRAYS_NATIVELY_BOOLEAN
-            );
             return new BooleanFieldMapper(
                 leafName(),
                 ft,
@@ -233,6 +239,7 @@ public class BooleanFieldMapper extends FieldMapper {
         private final FieldValues<Boolean> scriptValues;
         private final boolean isDimension;
         private final boolean isSyntheticSource;
+        private final boolean readInArrayOrder;
 
         public BooleanFieldType(
             String name,
@@ -244,11 +251,26 @@ public class BooleanFieldMapper extends FieldMapper {
             boolean isDimension,
             boolean isSyntheticSource
         ) {
+            this(name, indexType, isStored, nullValue, scriptValues, meta, isDimension, isSyntheticSource, false);
+        }
+
+        public BooleanFieldType(
+            String name,
+            IndexType indexType,
+            boolean isStored,
+            Boolean nullValue,
+            FieldValues<Boolean> scriptValues,
+            Map<String, String> meta,
+            boolean isDimension,
+            boolean isSyntheticSource,
+            boolean readInArrayOrder
+        ) {
             super(name, indexType, isStored, TextSearchInfo.SIMPLE_MATCH_ONLY, meta);
             this.nullValue = nullValue;
             this.scriptValues = scriptValues;
             this.isDimension = isDimension;
             this.isSyntheticSource = isSyntheticSource;
+            this.readInArrayOrder = readInArrayOrder;
         }
 
         public BooleanFieldType(String name) {
@@ -351,7 +373,7 @@ public class BooleanFieldMapper extends FieldMapper {
         @Override
         public BlockLoader blockLoader(BlockLoaderContext blContext) {
             if (hasDocValues()) {
-                return new BooleansBlockLoader(name());
+                return new BooleansBlockLoader(name(), readInArrayOrder);
             }
 
             // Multi fields don't have fallback synthetic source.
@@ -624,7 +646,7 @@ public class BooleanFieldMapper extends FieldMapper {
             }
         }
         indexValue(context, value);
-        if (offsetsFieldName != null && context.isImmediateParentAnArray() && context.canAddIgnoredField()) {
+        if (FieldArrayContext.shouldRecordOffsets(context, offsetsFieldName, docValuesParameters.multiValue())) {
             if (value != null) {
                 context.getOffSetContext().recordOffset(offsetsFieldName, value);
             } else {

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -444,6 +444,23 @@ public final class DateFieldMapper extends FieldMapper {
         public DateFieldMapper build(MapperBuilderContext context) {
             final String fullFieldName = context.buildFullName(leafName());
             IndexType indexType = indexType(fullFieldName);
+
+            String offsetsFieldName = FieldArrayContext.getOffsetsFieldName(
+                context,
+                indexSettings.sourceKeepMode(),
+                docValuesParameters.getValue().enabled(),
+                store.getValue(),
+                this,
+                indexSettings.getIndexVersionCreated(),
+                IndexVersions.SYNTHETIC_SOURCE_STORE_ARRAYS_NATIVELY_NUMBER,
+                indexSettings.getMode().isStrictColumnar(),
+                docValuesParameters.getValue().multiValue()
+            );
+
+            boolean readInArrayOrder = offsetsFieldName != null
+                && docValuesParameters.getValue().multiValue()
+                && indexSettings.getMode().isStrictColumnar();
+
             DateFieldType ft = new DateFieldType(
                 fullFieldName,
                 indexType,
@@ -453,7 +470,8 @@ public final class DateFieldMapper extends FieldMapper {
                 resolution,
                 nullValue.getValue(),
                 scriptValues(),
-                meta.getValue()
+                meta.getValue(),
+                readInArrayOrder
             );
 
             Long nullTimestamp = parseNullValue(ft);
@@ -471,7 +489,8 @@ public final class DateFieldMapper extends FieldMapper {
                 nullTimestamp,
                 resolution,
                 context.isSourceSynthetic(),
-                this
+                this,
+                offsetsFieldName
             );
         }
     }
@@ -491,6 +510,7 @@ public final class DateFieldMapper extends FieldMapper {
         private final String nullValue;
         private final FieldValues<Long> scriptValues;
         private final boolean isSyntheticSource;
+        private final boolean readInArrayOrder;
 
         public DateFieldType(
             String name,
@@ -503,6 +523,21 @@ public final class DateFieldMapper extends FieldMapper {
             FieldValues<Long> scriptValues,
             Map<String, String> meta
         ) {
+            this(name, indexType, isStored, isSyntheticSource, dateTimeFormatter, resolution, nullValue, scriptValues, meta, false);
+        }
+
+        public DateFieldType(
+            String name,
+            IndexType indexType,
+            boolean isStored,
+            boolean isSyntheticSource,
+            DateFormatter dateTimeFormatter,
+            Resolution resolution,
+            String nullValue,
+            FieldValues<Long> scriptValues,
+            Map<String, String> meta,
+            boolean readInArrayOrder
+        ) {
             super(name, indexType, isStored, meta);
             this.dateTimeFormatter = dateTimeFormatter;
             this.dateMathParser = dateTimeFormatter.toDateMathParser();
@@ -510,6 +545,7 @@ public final class DateFieldMapper extends FieldMapper {
             this.nullValue = nullValue;
             this.scriptValues = scriptValues;
             this.isSyntheticSource = isSyntheticSource;
+            this.readInArrayOrder = readInArrayOrder;
         }
 
         public DateFieldType(
@@ -961,7 +997,7 @@ public final class DateFieldMapper extends FieldMapper {
             if (hasDocValues()) {
                 BlockLoaderFunctionConfig cfg = blContext.blockLoaderFunctionConfig();
                 if (cfg == null) {
-                    return new LongsBlockLoader(name());
+                    return new LongsBlockLoader(name(), readInArrayOrder);
                 }
                 return switch (cfg.function()) {
                     case ROUND_TO -> new RoundToLongsFromDocValuesBlockLoader(
@@ -1126,6 +1162,7 @@ public final class DateFieldMapper extends FieldMapper {
 
     private final boolean isDataStreamTimestampField;
     private final IndexSettings indexSettings;
+    private final String offsetsFieldName;
 
     private DateFieldMapper(
         String leafName,
@@ -1134,7 +1171,8 @@ public final class DateFieldMapper extends FieldMapper {
         Long nullValue,
         Resolution resolution,
         boolean isSourceSynthetic,
-        Builder builder
+        Builder builder,
+        String offsetsFieldName
     ) {
         super(leafName, mappedFieldType, builderParams);
         this.store = builder.store.getValue();
@@ -1157,6 +1195,7 @@ public final class DateFieldMapper extends FieldMapper {
         this.scriptValues = builder.scriptValues();
         this.isDataStreamTimestampField = mappedFieldType.name().equals(DataStreamTimestampFieldMapper.DEFAULT_PATH);
         this.indexSettings = builder.indexSettings;
+        this.offsetsFieldName = offsetsFieldName;
     }
 
     /**
@@ -1223,6 +1262,9 @@ public final class DateFieldMapper extends FieldMapper {
         long timestamp;
         if (context.parser().currentToken() == XContentParser.Token.VALUE_NULL) {
             if (nullValue == null) {
+                if (FieldArrayContext.shouldRecordOffsets(context, offsetsFieldName, docValuesParameters.multiValue())) {
+                    context.getOffSetContext().recordNull(offsetsFieldName);
+                }
                 return;
             }
             timestamp = nullValue;
@@ -1263,6 +1305,9 @@ public final class DateFieldMapper extends FieldMapper {
             }
 
         indexValue(context, timestamp);
+        if (FieldArrayContext.shouldRecordOffsets(context, offsetsFieldName, docValuesParameters.multiValue())) {
+            context.getOffSetContext().recordOffset(offsetsFieldName, timestamp);
+        }
     }
 
     /*
@@ -1338,12 +1383,22 @@ public final class DateFieldMapper extends FieldMapper {
         if (docValuesParameters.enabled()) {
             return new SyntheticSourceSupport.Native(() -> {
                 var layers = new ArrayList<CompositeSyntheticFieldLoader.Layer>(2);
-                layers.add(
-                    new SortedNumericDocValuesSyntheticFieldLoaderLayer(
-                        fullPath(),
-                        (b, value) -> b.value(fieldType().format(value, fieldType().dateTimeFormatter()))
-                    )
-                );
+                if (offsetsFieldName != null) {
+                    layers.add(
+                        new SortedNumericWithOffsetsDocValuesSyntheticFieldLoaderLayer(
+                            fullPath(),
+                            offsetsFieldName,
+                            (b, value) -> b.value(fieldType().format(value, fieldType().dateTimeFormatter()))
+                        )
+                    );
+                } else {
+                    layers.add(
+                        new SortedNumericDocValuesSyntheticFieldLoaderLayer(
+                            fullPath(),
+                            (b, value) -> b.value(fieldType().format(value, fieldType().dateTimeFormatter()))
+                        )
+                    );
+                }
                 if (ignoreMalformed) {
                     layers.add(CompositeSyntheticFieldLoader.malformedValuesLayer(fullPath(), indexSettings.getIndexVersionCreated()));
                 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldArrayContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldArrayContext.java
@@ -35,6 +35,22 @@ public class FieldArrayContext {
         return fieldName + OFFSETS_FIELD_NAME_SUFFIX;
     }
 
+    public static boolean shouldRecordOffsets(DocumentParserContext context, String offsetsFieldName, boolean multiValue) {
+        if (offsetsFieldName == null) {
+            return false;
+        }
+
+        // Columnar mode relies solely on offsets for array order reconstruction. Record an offset for every indexed value so the offset
+        // slots remain aligned with the sorted-set ords during decode, regardless of whether the value's immediate parent was an array.
+        if (multiValue && context.indexSettings().getMode().isStrictColumnar()) {
+            return true;
+        }
+
+        // synthetic_source_keep=arrays path: only record when the value's immediate parent is an array, since out-of-array values are
+        // captured by _ignored_source.
+        return context.isImmediateParentAnArray() && context.canAddIgnoredField();
+    }
+
     protected final Map<String, Offsets> offsetsPerField = new HashMap<>();
 
     public void recordOffset(String field, Comparable<?> value) {
@@ -135,7 +151,7 @@ public class FieldArrayContext {
         FieldMapper.Builder fieldMapperBuilder,
         IndexVersion indexCreatedVersion,
         IndexVersion minSupportedVersionMain,
-        boolean isColumnar,
+        boolean isStrictColumnar,
         boolean multiValue
     ) {
         var sourceKeepMode = fieldMapperBuilder.sourceKeepMode.orElse(indexSourceKeepMode);
@@ -159,7 +175,7 @@ public class FieldArrayContext {
         // Note, doc values cannot be disabled in columnar mode
         // TODO: copy_to is disabled since copy_to forces _ignored_source to be used for synthetic source, recording offsets in addition
         // to that is a big storage overhead. This will be addressed in a follow up
-        if (multiValue && isColumnar && context.isSourceSynthetic() && fieldMapperBuilder.copyTo.copyToFields().isEmpty()) {
+        if (multiValue && isStrictColumnar && context.isSourceSynthetic() && fieldMapperBuilder.copyTo.copyToFields().isEmpty()) {
             return context.buildFullName(offsetsFieldName(fieldMapperBuilder.leafName()));
         }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -490,7 +490,7 @@ public final class KeywordFieldMapper extends FieldMapper {
                 this,
                 indexCreatedVersion,
                 IndexVersions.SYNTHETIC_SOURCE_STORE_ARRAYS_NATIVELY_KEYWORD,
-                indexSettings.getMode().isColumnar(),
+                indexSettings.getMode().isStrictColumnar(),
                 docValuesParameters().multiValue()
             );
             return new KeywordFieldMapper(
@@ -619,7 +619,7 @@ public final class KeywordFieldMapper extends FieldMapper {
             this.indexVersion = builder.indexSettings.getIndexVersionCreated();
             this.readInArrayOrder = builder.offsetsFieldName != null
                 && builder.docValuesParameters().multiValue()
-                && builder.indexSettings.getMode().isColumnar();
+                && builder.indexSettings.getMode().isStrictColumnar();
         }
 
         public KeywordFieldType(String name) {
@@ -1422,29 +1422,13 @@ public final class KeywordFieldMapper extends FieldMapper {
         }
 
         boolean indexed = indexValue(context, value);
-        if (shouldRecordOffset(context)) {
+        if (FieldArrayContext.shouldRecordOffsets(context, offsetsFieldName, docValuesParameters.multiValue())) {
             if (indexed) {
                 context.getOffSetContext().recordOffset(offsetsFieldName, value.bytes());
             } else if (value == null) {
                 context.getOffSetContext().recordNull(offsetsFieldName);
             }
         }
-    }
-
-    private boolean shouldRecordOffset(DocumentParserContext context) {
-        if (offsetsFieldName == null) {
-            return false;
-        }
-
-        // Columnar mode relies solely on offsets for array order reconstruction. Record an offset for every indexed value so the offset
-        // slots remain aligned with the sorted-set ords during decode, regardless of whether the value's immediate parent was an array.
-        if (docValuesParameters.multiValue() && indexSettings.getMode().isStrictColumnar()) {
-            return true;
-        }
-
-        // synthetic_source_keep=arrays path: only record when the value's immediate parent is an array, since out-of-array values are
-        // captured by _ignored_source.
-        return context.isImmediateParentAnArray() && context.canAddIgnoredField();
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
@@ -106,6 +106,7 @@ public class MapperFeatures implements FeatureSpecification {
         "mapper.analyzer-wrapper.reloadable_search_analyzer"
     );
     static final NodeFeature STORE_NOT_ALLOWED_IN_COLUMNAR_INDEX_MODE = new NodeFeature("mapper.columnar.store_not_allowed");
+    static final NodeFeature COLUMNAR_MAINTAIN_ARRAY_ORDER = new NodeFeature("mapper.columnar.maintain_array_order");
 
     @Override
     public Set<NodeFeature> getTestFeatures() {
@@ -179,7 +180,8 @@ public class MapperFeatures implements FeatureSpecification {
             ANALYZER_WRAPPER_RELOADABLE_SEARCH_ANALYZER,
             ROUTING_AS_DOC_VALUES,
             ROUTING_AS_DOC_VALUES_BY_DEFAULT,
-            STORE_NOT_ALLOWED_IN_COLUMNAR_INDEX_MODE
+            STORE_NOT_ALLOWED_IN_COLUMNAR_INDEX_MODE,
+            COLUMNAR_MAINTAIN_ARRAY_ORDER
         );
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -308,24 +308,29 @@ public class NumberFieldMapper extends FieldMapper {
             return type.typeName();
         }
 
+        private String offsetsFieldName;
+
         @Override
         public NumberFieldMapper build(MapperBuilderContext context) {
             if (inheritDimensionParameterFromParentObject(context)) {
                 dimension.setValue(true);
             }
 
-            MappedFieldType ft = new NumberFieldType(context.buildFullName(leafName()), this, context.isSourceSynthetic());
             hasScript = script.get() != null;
             onScriptError = onScriptErrorParam.getValue();
-            String offsetsFieldName = getOffsetsFieldName(
+            this.offsetsFieldName = getOffsetsFieldName(
                 context,
                 indexSettings.sourceKeepMode(),
                 docValuesParameters.getValue().enabled(),
                 stored.getValue(),
                 this,
                 indexSettings.getIndexVersionCreated(),
-                IndexVersions.SYNTHETIC_SOURCE_STORE_ARRAYS_NATIVELY_NUMBER
+                IndexVersions.SYNTHETIC_SOURCE_STORE_ARRAYS_NATIVELY_NUMBER,
+                indexSettings.getMode().isStrictColumnar(),
+                docValuesParameters.getValue().multiValue()
             );
+            MappedFieldType ft = new NumberFieldType(context.buildFullName(leafName()), this, context.isSourceSynthetic());
+
             return new NumberFieldMapper(leafName(), ft, builderParams(this, context), context.isSourceSynthetic(), this, offsetsFieldName);
         }
     }
@@ -524,8 +529,8 @@ public class NumberFieldMapper extends FieldMapper {
             }
 
             @Override
-            BlockLoader blockLoaderFromDocValues(String fieldName) {
-                return new DoublesBlockLoader(fieldName, l -> HalfFloatPoint.sortableShortToHalfFloat((short) l));
+            BlockLoader blockLoaderFromDocValues(String fieldName, boolean readInArrayOrder) {
+                return new DoublesBlockLoader(fieldName, l -> HalfFloatPoint.sortableShortToHalfFloat((short) l), readInArrayOrder);
             }
 
             @Override
@@ -744,8 +749,8 @@ public class NumberFieldMapper extends FieldMapper {
             }
 
             @Override
-            BlockLoader blockLoaderFromDocValues(String fieldName) {
-                return new DoublesBlockLoader(fieldName, l -> NumericUtils.sortableIntToFloat((int) l));
+            BlockLoader blockLoaderFromDocValues(String fieldName, boolean readInArrayOrder) {
+                return new DoublesBlockLoader(fieldName, l -> NumericUtils.sortableIntToFloat((int) l), readInArrayOrder);
             }
 
             @Override
@@ -930,8 +935,8 @@ public class NumberFieldMapper extends FieldMapper {
             }
 
             @Override
-            BlockLoader blockLoaderFromDocValues(String fieldName) {
-                return new DoublesBlockLoader(fieldName, NumericUtils::sortableLongToDouble);
+            BlockLoader blockLoaderFromDocValues(String fieldName, boolean readInArrayOrder) {
+                return new DoublesBlockLoader(fieldName, NumericUtils::sortableLongToDouble, readInArrayOrder);
             }
 
             @Override
@@ -1080,8 +1085,8 @@ public class NumberFieldMapper extends FieldMapper {
             }
 
             @Override
-            BlockLoader blockLoaderFromDocValues(String fieldName) {
-                return new IntsBlockLoader(fieldName);
+            BlockLoader blockLoaderFromDocValues(String fieldName, boolean readInArrayOrder) {
+                return new IntsBlockLoader(fieldName, readInArrayOrder);
             }
 
             @Override
@@ -1230,8 +1235,8 @@ public class NumberFieldMapper extends FieldMapper {
             }
 
             @Override
-            BlockLoader blockLoaderFromDocValues(String fieldName) {
-                return new IntsBlockLoader(fieldName);
+            BlockLoader blockLoaderFromDocValues(String fieldName, boolean readInArrayOrder) {
+                return new IntsBlockLoader(fieldName, readInArrayOrder);
             }
 
             @Override
@@ -1455,8 +1460,8 @@ public class NumberFieldMapper extends FieldMapper {
             }
 
             @Override
-            BlockLoader blockLoaderFromDocValues(String fieldName) {
-                return new IntsBlockLoader(fieldName);
+            BlockLoader blockLoaderFromDocValues(String fieldName, boolean readInArrayOrder) {
+                return new IntsBlockLoader(fieldName, readInArrayOrder);
             }
 
             @Override
@@ -1641,8 +1646,8 @@ public class NumberFieldMapper extends FieldMapper {
             }
 
             @Override
-            BlockLoader blockLoaderFromDocValues(String fieldName) {
-                return new LongsBlockLoader(fieldName);
+            BlockLoader blockLoaderFromDocValues(String fieldName, boolean readInArrayOrder) {
+                return new LongsBlockLoader(fieldName, readInArrayOrder);
             }
 
             @Override
@@ -1979,7 +1984,7 @@ public class NumberFieldMapper extends FieldMapper {
             return new CompositeSyntheticFieldLoader(fieldSimpleName, fieldName, layers);
         }
 
-        abstract BlockLoader blockLoaderFromDocValues(String fieldName);
+        abstract BlockLoader blockLoaderFromDocValues(String fieldName, boolean readInArrayOrder);
 
         abstract BlockLoader blockLoaderFromSource(SourceValueFetcher sourceValueFetcher, BlockSourceReader.LeafIteratorLookup lookup);
 
@@ -2114,6 +2119,7 @@ public class NumberFieldMapper extends FieldMapper {
         private final MetricType metricType;
         private final IndexMode indexMode;
         private final boolean isSyntheticSource;
+        private final boolean readInArrayOrder;
 
         public NumberFieldType(
             String name,
@@ -2127,7 +2133,8 @@ public class NumberFieldMapper extends FieldMapper {
             boolean isDimension,
             MetricType metricType,
             IndexMode indexMode,
-            boolean isSyntheticSource
+            boolean isSyntheticSource,
+            boolean readInArrayOrder
         ) {
             super(name, indexType, isStored, meta);
             this.type = Objects.requireNonNull(type);
@@ -2138,6 +2145,7 @@ public class NumberFieldMapper extends FieldMapper {
             this.metricType = metricType;
             this.indexMode = indexMode;
             this.isSyntheticSource = isSyntheticSource;
+            this.readInArrayOrder = readInArrayOrder;
         }
 
         NumberFieldType(String name, Builder builder, boolean isSyntheticSource) {
@@ -2153,7 +2161,10 @@ public class NumberFieldMapper extends FieldMapper {
                 builder.dimension.getValue(),
                 builder.metric.getValue(),
                 builder.indexSettings.getMode(),
-                isSyntheticSource
+                isSyntheticSource,
+                builder.offsetsFieldName != null
+                    && builder.docValuesParameters.getValue().multiValue()
+                    && builder.indexSettings.getMode().isStrictColumnar()
             );
         }
 
@@ -2162,7 +2173,21 @@ public class NumberFieldMapper extends FieldMapper {
         }
 
         public NumberFieldType(String name, NumberType type, boolean isIndexed) {
-            this(name, type, IndexType.points(isIndexed, true), false, true, null, Collections.emptyMap(), null, false, null, null, false);
+            this(
+                name,
+                type,
+                IndexType.points(isIndexed, true),
+                false,
+                true,
+                null,
+                Collections.emptyMap(),
+                null,
+                false,
+                null,
+                null,
+                false,
+                false
+            );
         }
 
         public NumberFieldType(String name, NumberType type, boolean isIndexed, boolean hasDocValues) {
@@ -2178,6 +2203,7 @@ public class NumberFieldMapper extends FieldMapper {
                 false,
                 null,
                 null,
+                false,
                 false
             );
         }
@@ -2270,12 +2296,12 @@ public class NumberFieldMapper extends FieldMapper {
             if (hasDocValues() && (blContext.fieldExtractPreference() != FieldExtractPreference.STORED || isSyntheticSource)) {
                 BlockLoaderFunctionConfig cfg = blContext.blockLoaderFunctionConfig();
                 if (cfg == null) {
-                    return type.blockLoaderFromDocValues(name());
+                    return type.blockLoaderFromDocValues(name(), readInArrayOrder);
                 }
                 return switch (cfg.function()) {
                     case MV_MAX -> type.blockLoaderFromDocValuesMvMax(name());
                     case MV_MIN -> type.blockLoaderFromDocValuesMvMin(name());
-                    case AMD_COUNT, AMD_DEFAULT, AMD_MAX, AMD_MIN, AMD_SUM -> type.blockLoaderFromDocValues(name());
+                    case AMD_COUNT, AMD_DEFAULT, AMD_MAX, AMD_MIN, AMD_SUM -> type.blockLoaderFromDocValues(name(), false);
                     case ROUND_TO -> type.blockLoaderFromDocValuesRoundTo(name(), ((BlockLoaderFunctionConfig.RoundToLongs) cfg).points());
                     default -> throw new UnsupportedOperationException("unknown fusion config [" + cfg.function() + "]");
                 };
@@ -2541,7 +2567,7 @@ public class NumberFieldMapper extends FieldMapper {
         } else {
             value = fieldType.nullValue;
         }
-        if (offsetsFieldName != null && context.isImmediateParentAnArray() && context.canAddIgnoredField()) {
+        if (FieldArrayContext.shouldRecordOffsets(context, offsetsFieldName, docValuesParameters.multiValue())) {
             if (value != null) {
                 // We cannot simply cast value to Comparable<> because we need to also capture the potential loss of precision that occurs
                 // when the value is stored into the doc values.

--- a/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/AbstractNumericBlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/AbstractNumericBlockLoader.java
@@ -224,7 +224,7 @@ public abstract class AbstractNumericBlockLoader<B extends BlockLoader.Builder> 
         }
     }
 
-    static final class ArrayOrder<B extends BlockLoader.Builder> extends BlockDocValuesReader {
+    public static final class ArrayOrder<B extends BlockLoader.Builder> extends BlockDocValuesReader {
 
         private final AbstractNumericBlockLoader<B> loader;
         private final String name;
@@ -275,11 +275,19 @@ public abstract class AbstractNumericBlockLoader<B extends BlockLoader.Builder> 
                 return;
             }
 
-            // materialize the per-doc values once so we can index into them by ord
+            // Offsets are encoded against a unique collection of entries, but for numerics, the underlying doc values
+            // (SortedNumericDocValuesField) does not dedupe, it just sorts. Hence, we must dedupe ourselves.
             int count = values.docValues().docValueCount();
             long[] materialized = new long[count];
+            int duplicates = 0;
             for (int i = 0; i < count; i++) {
-                materialized[i] = values.docValues().nextValue();
+                long value = values.docValues().nextValue();
+                // since the values are in sorted order, to detect a duplicate compare the current value against the previous one
+                if (i > 0 && value == materialized[i - duplicates - 1]) {
+                    duplicates++;
+                    continue;
+                }
+                materialized[i - duplicates] = value;
             }
 
             OffsetsAwareBlockLoaderHelper.emit(offsetToOrd, builder, ord -> loader.appendValue(builder, materialized[ord]));
@@ -298,7 +306,8 @@ public abstract class AbstractNumericBlockLoader<B extends BlockLoader.Builder> 
 
         @Override
         public void close() {
-            Releasables.close(values, offsets, sortedFallback);
+            // sortedFallback wraps `values` and owns no other resources, so closing it would double-release `values`.
+            Releasables.close(values, offsets);
         }
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/fielddata/IndexFieldDataServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/IndexFieldDataServiceTests.java
@@ -313,6 +313,7 @@ public class IndexFieldDataServiceTests extends ESSingleNodeTestCase {
                 false,
                 null,
                 null,
+                false,
                 false
             )
         );
@@ -333,6 +334,7 @@ public class IndexFieldDataServiceTests extends ESSingleNodeTestCase {
                 false,
                 null,
                 null,
+                false,
                 false
             )
         );

--- a/server/src/test/java/org/elasticsearch/index/mapper/BooleanFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/BooleanFieldMapperTests.java
@@ -415,4 +415,18 @@ public class BooleanFieldMapperTests extends MapperTestCase {
             new SortShortcutSupport(this::minimalMapping, this::writeField, false)
         );
     }
+
+    public void testColumnarBooleanArrayOrderRoundTrip() throws IOException {
+        assumeTrue("columnar index mode requires snapshot build", IndexMode.COLUMNAR_FEATURE_FLAG.isEnabled());
+        Settings settings = Settings.builder().put(IndexSettings.MODE.getKey(), IndexMode.COLUMNAR.name()).build();
+        DocumentMapper mapper = createMapperService(settings, mapping(b -> b.startObject("field").field("type", "boolean").endObject()))
+            .documentMapper();
+        // Mixed order — sorted doc-values order would group all false before all true regardless of input order.
+        boolean v1 = randomBoolean();
+        boolean v2 = randomBoolean();
+        boolean v3 = randomBoolean();
+        boolean v4 = randomBoolean();
+        String src = syntheticSource(mapper, b -> b.array("field", v1, v2, v3, v4));
+        assertThat(src, containsString("\"field\":[" + v1 + "," + v2 + "," + v3 + "," + v4 + "]"));
+    }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperTests.java
@@ -30,6 +30,7 @@ import org.elasticsearch.common.time.DateUtils;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.core.Strings;
+import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.IndexVersions;
@@ -965,5 +966,23 @@ public class DateFieldMapperTests extends MapperTestCase {
                 false
             )
         );
+    }
+
+    public void testColumnarDateArrayOrderRoundTrip() throws IOException {
+        assumeTrue("columnar index mode requires snapshot build", IndexMode.COLUMNAR_FEATURE_FLAG.isEnabled());
+        Settings settings = Settings.builder().put(IndexSettings.MODE.getKey(), IndexMode.COLUMNAR.name()).build();
+        // Use epoch_millis format so input numbers and synthetic-source output both serialize as raw millis strings without ambiguity.
+        DocumentMapper mapper = createMapperService(
+            settings,
+            mapping(b -> b.startObject("field").field("type", "date").field("format", "epoch_millis").endObject())
+        ).documentMapper();
+        // Cap at year ~2096 to stay well within Java's date range.
+        long v1 = randomLongBetween(0L, 4_000_000_000_000L);
+        long v2 = randomLongBetween(0L, 4_000_000_000_000L);
+        long v3 = randomLongBetween(0L, 4_000_000_000_000L);
+        // Out-of-order with v2 duplicated — sorted-deduped output would collapse the run.
+        String src = syntheticSource(mapper, b -> b.array("field", v2, v1, v3, v2));
+        // epoch_millis values are emitted as quoted strings under strict columnar synthetic source.
+        assertThat(src, containsString("\"field\":[\"" + v2 + "\",\"" + v1 + "\",\"" + v3 + "\",\"" + v2 + "\"]"));
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/DoubleFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DoubleFieldMapperTests.java
@@ -9,6 +9,9 @@
 
 package org.elasticsearch.index.mapper;
 
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexMode;
+import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.script.DoubleFieldScript;
 import org.elasticsearch.script.Script;
@@ -18,6 +21,7 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import java.io.IOException;
 import java.util.List;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
 public class DoubleFieldMapperTests extends NumberFieldMapperTests {
@@ -172,5 +176,19 @@ public class DoubleFieldMapperTests extends NumberFieldMapperTests {
             new SortShortcutSupport(this::minimalMapping, this::writeField, true),
             new SortShortcutSupport(IndexVersion.fromId(5000099), this::minimalMapping, this::writeField, false)
         );
+    }
+
+    public void testColumnarArrayOrderRoundTrip() throws IOException {
+        assumeTrue("columnar index mode requires snapshot build", IndexMode.COLUMNAR_FEATURE_FLAG.isEnabled());
+        Settings settings = Settings.builder().put(IndexSettings.MODE.getKey(), IndexMode.COLUMNAR.name()).build();
+        DocumentMapper mapper = createMapperService(settings, mapping(b -> b.startObject("field").field("type", "double").endObject()))
+            .documentMapper();
+        // randomDouble() returns [0,1) — survives double roundtrip cleanly and serializes without scientific notation.
+        double v1 = randomDouble();
+        double v2 = randomDouble();
+        double v3 = randomDouble();
+        // Out-of-order with v2 duplicated — sorted-deduped output would collapse the run.
+        String src = syntheticSource(mapper, b -> b.array("field", v2, v1, v3, v2));
+        assertThat(src, containsString("\"field\":[" + v2 + "," + v1 + "," + v3 + "," + v2 + "]"));
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/FieldArrayContextTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FieldArrayContextTests.java
@@ -17,12 +17,15 @@ import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.script.ScriptCompiler;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 import static org.elasticsearch.index.mapper.FieldArrayContext.getOffsetsFieldName;
 import static org.elasticsearch.index.mapper.FieldArrayContext.parseOffsetArray;
+import static org.elasticsearch.index.mapper.FieldArrayContext.shouldRecordOffsets;
 
 public class FieldArrayContextTests extends ESTestCase {
 
@@ -289,5 +292,46 @@ public class FieldArrayContextTests extends ESTestCase {
 
     private static FieldMapper.Builder newTestBuilder(String name) {
         return new BooleanFieldMapper.Builder(name, ScriptCompiler.NONE, defaultIndexSettings());
+    }
+
+    public void testShouldRecordOffsetsReturnsFalseWhenOffsetsFieldNameNull() {
+        var context = new TestDocumentParserContext();
+        assertFalse(shouldRecordOffsets(context, null, true));
+        assertFalse(shouldRecordOffsets(context, null, false));
+    }
+
+    public void testShouldRecordOffsetsStrictColumnarFiresWhenMultiValue() {
+        assumeTrue("columnar index mode requires snapshot build", IndexMode.COLUMNAR_FEATURE_FLAG.isEnabled());
+        for (IndexMode indexMode : List.of(IndexMode.COLUMNAR, IndexMode.LOGSDB_COLUMNAR)) {
+            Settings settings = Settings.builder().put(IndexSettings.MODE.getKey(), indexMode.getName()).build();
+            var context = new TestDocumentParserContext(settings);
+            assertTrue(shouldRecordOffsets(context, "field.offsets", true));
+            // single-valued fields don't need offsets
+            assertFalse(shouldRecordOffsets(context, "field.offsets", false));
+        }
+    }
+
+    public void testShouldRecordOffsetsSyntheticSourceKeepRequiresImmediateArrayAndSyntheticSource() {
+        // Synthetic-source MappingLookup so canAddIgnoredField() returns true; index mode left as STANDARD so the strict-columnar branch
+        // does not short-circuit.
+        SourceFieldMapper syntheticSource = new SourceFieldMapper.Builder(null, Settings.EMPTY, false, false, false).setSynthetic().build();
+        RootObjectMapper root = new RootObjectMapper.Builder("_doc").build(MapperBuilderContext.root(true, false));
+        Mapping mapping = new Mapping(root, new MetadataFieldMapper[] { syntheticSource }, Map.of());
+        MappingLookup syntheticLookup = MappingLookup.fromMapping(mapping, IndexMode.STANDARD);
+
+        // Immediate parent is an array + synthetic source -> record.
+        var arrayCtx = new TestDocumentParserContext(syntheticLookup, null);
+        arrayCtx.setImmediateXContentParent(XContentParser.Token.START_ARRAY);
+        assertTrue(shouldRecordOffsets(arrayCtx, "field.offsets", true));
+
+        // Immediate parent is not an array -> skip even when synthetic source is on.
+        var nonArrayCtx = new TestDocumentParserContext(syntheticLookup, null);
+        nonArrayCtx.setImmediateXContentParent(XContentParser.Token.START_OBJECT);
+        assertFalse(shouldRecordOffsets(nonArrayCtx, "field.offsets", true));
+
+        // Non-synthetic source -> canAddIgnoredField is false, branch skips even with immediate-array parent.
+        var storedCtx = new TestDocumentParserContext();
+        storedCtx.setImmediateXContentParent(XContentParser.Token.START_ARRAY);
+        assertFalse(shouldRecordOffsets(storedCtx, "field.offsets", true));
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
@@ -1817,25 +1817,6 @@ public class KeywordFieldMapperTests extends MapperTestCase {
         assertThat(result, containsString("\"field\":[null]"));
     }
 
-    /**
-     * A {@code multi_fields} parent must record its own array-order offsets and round-trip its array order in synthetic source.
-     */
-    public void testColumnarKeywordMultiFieldsParentArrayOrderRoundTrip() throws IOException {
-        assumeTrue("columnar index mode requires snapshot build", IndexMode.COLUMNAR_FEATURE_FLAG.isEnabled());
-        Settings settings = Settings.builder().put(IndexSettings.MODE.getKey(), IndexMode.COLUMNAR.getName()).build();
-        DocumentMapper mapper = createMapperService(settings, mapping(b -> {
-            b.startObject("parent").field("type", "keyword");
-            b.startObject("fields").startObject("raw").field("type", "keyword").endObject().endObject();
-            b.endObject();
-        })).documentMapper();
-
-        String v1 = randomAlphanumericOfLength(4);
-        String v2 = randomAlphanumericOfLength(4);
-        String v3 = randomAlphanumericOfLength(4);
-        String result = syntheticSource(mapper, b -> b.array("parent", v2, v1, v3, v2));
-        assertThat(result, containsString("\"parent\":[\"" + v2 + "\",\"" + v1 + "\",\"" + v3 + "\",\"" + v2 + "\"]"));
-    }
-
     private DocumentMapper columnarKeywordMapper(String fieldName) throws IOException {
         Settings settings = Settings.builder().put(IndexSettings.MODE.getKey(), IndexMode.COLUMNAR.getName()).build();
         return createMapperService(settings, mapping(b -> b.startObject(fieldName).field("type", "keyword").endObject())).documentMapper();

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
@@ -1716,7 +1716,8 @@ public class KeywordFieldMapperTests extends MapperTestCase {
     }
 
     public void testColumnarKeywordArrayOrderRoundTrip() throws IOException {
-        Settings settings = Settings.builder().put(IndexSettings.MODE.getKey(), IndexMode.LOGSDB.name()).build();
+        assumeTrue("columnar index mode requires snapshot build", IndexMode.COLUMNAR_FEATURE_FLAG.isEnabled());
+        Settings settings = Settings.builder().put(IndexSettings.MODE.getKey(), IndexMode.COLUMNAR.name()).build();
         DocumentMapper mapper = createMapperService(settings, mapping(b -> b.startObject("field").field("type", "keyword").endObject()))
             .documentMapper();
 
@@ -1724,10 +1725,10 @@ public class KeywordFieldMapperTests extends MapperTestCase {
         String v2 = randomAlphanumericOfLength(4);
         String v3 = randomAlphanumericOfLength(4);
         // Duplicate v2 — sorted-deduped doc-values order would collapse it; arrival order must be preserved.
-        assertThat(syntheticSource(mapper, b -> {
-            b.array("field", v2, v1, v3, v2);
-            b.field("@timestamp", Instant.now().toEpochMilli());
-        }), containsString("\"field\":[\"" + v2 + "\",\"" + v1 + "\",\"" + v3 + "\",\"" + v2 + "\"]"));
+        assertThat(
+            syntheticSource(mapper, b -> b.array("field", v2, v1, v3, v2)),
+            containsString("\"field\":[\"" + v2 + "\",\"" + v1 + "\",\"" + v3 + "\",\"" + v2 + "\"]")
+        );
     }
 
     public void testStoreNotAllowedInColumnarMode() throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/mapper/LongFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/LongFieldMapperTests.java
@@ -10,6 +10,9 @@
 package org.elasticsearch.index.mapper;
 
 import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexMode;
+import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.script.LongFieldScript;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptContext;
@@ -20,6 +23,7 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.util.List;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -163,6 +167,19 @@ public class LongFieldMapperTests extends WholeNumberFieldMapperTests {
 
     protected boolean supportsBulkLongBlockReading() {
         return true;
+    }
+
+    public void testColumnarArrayOrderRoundTrip() throws IOException {
+        assumeTrue("columnar index mode requires snapshot build", IndexMode.COLUMNAR_FEATURE_FLAG.isEnabled());
+        Settings settings = Settings.builder().put(IndexSettings.MODE.getKey(), IndexMode.COLUMNAR.name()).build();
+        DocumentMapper mapper = createMapperService(settings, mapping(b -> b.startObject("field").field("type", "long").endObject()))
+            .documentMapper();
+        long v1 = randomLong();
+        long v2 = randomLong();
+        long v3 = randomLong();
+        // Out-of-order with v2 duplicated — sorted-deduped output would collapse the run.
+        String src = syntheticSource(mapper, b -> b.array("field", v2, v1, v3, v2));
+        assertThat(src, containsString("\"field\":[" + v2 + "," + v1 + "," + v3 + "," + v2 + "]"));
     }
 
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/MapperServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/MapperServiceTests.java
@@ -2043,6 +2043,7 @@ public class MapperServiceTests extends MapperServiceTestCase {
     }
 
     public void testColumnarModesRejectSyntheticSourceKeepIndexSetting() {
+        // The "all"" value is already rejected globally by the setting's value validator, so we only need to cover "arrays" here
         assumeTrue("columnar index mode requires snapshot build", IndexMode.COLUMNAR_FEATURE_FLAG.isEnabled());
         for (IndexMode indexMode : List.of(IndexMode.COLUMNAR, IndexMode.LOGSDB_COLUMNAR)) {
             Settings settings = Settings.builder()

--- a/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldTypeTests.java
@@ -170,6 +170,7 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
             false,
             null,
             null,
+            false,
             false
         );
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/blockloader/BooleanFieldBlockLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/blockloader/BooleanFieldBlockLoaderTests.java
@@ -37,8 +37,10 @@ public class BooleanFieldBlockLoaderTests extends BlockLoaderTestCase {
         }
 
         if ((boolean) fieldMapping.getOrDefault("doc_values", false)) {
-            // Sorted
-            var resultList = ((List<Object>) value).stream().map(v -> convert(v, nullValue)).filter(Objects::nonNull).sorted().toList();
+            var stream = ((List<Object>) value).stream().map(v -> convert(v, nullValue)).filter(Objects::nonNull);
+            // Columnar index modes preserve arrival order via offsets
+            boolean preserveOrder = params.indexMode().isColumnar();
+            var resultList = preserveOrder ? stream.toList() : stream.sorted().toList();
             return maybeFoldList(resultList);
         }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/blockloader/DateFieldBlockLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/blockloader/DateFieldBlockLoaderTests.java
@@ -38,12 +38,10 @@ public class DateFieldBlockLoaderTests extends BlockLoaderTestCase {
         }
 
         if ((boolean) fieldMapping.getOrDefault("doc_values", false)) {
-            // Sorted
-            var resultList = ((List<Object>) value).stream()
-                .map(v -> convert(v, nullValue, format))
-                .filter(Objects::nonNull)
-                .sorted()
-                .toList();
+            var stream = ((List<Object>) value).stream().map(v -> convert(v, nullValue, format)).filter(Objects::nonNull);
+            // Columnar index modes preserve arrival order via offsets
+            boolean preserveOrder = params.indexMode().isColumnar();
+            var resultList = preserveOrder ? stream.toList() : stream.sorted().toList();
             return maybeFoldList(resultList);
         }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/blockloader/KeywordFieldBlockLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/blockloader/KeywordFieldBlockLoaderTests.java
@@ -54,11 +54,14 @@ public class KeywordFieldBlockLoaderTests extends BlockLoaderTestCase {
             || params.preference() == MappedFieldType.FieldExtractPreference.DOC_VALUES
             || params.syntheticSource();
         if (hasDocValues && useDocValues) {
-            // Sorted and no duplicates
-            var resultList = convertValues.andThen(Stream::distinct)
-                .andThen(Stream::sorted)
-                .andThen(Stream::toList)
-                .apply(((List<String>) value).stream());
+            // Columnar index modes preserve arrival order via offsets
+            boolean preserveOrder = params.indexMode().isColumnar();
+            var resultList = preserveOrder
+                ? convertValues.andThen(Stream::toList).apply(((List<String>) value).stream())
+                : convertValues.andThen(Stream::distinct)
+                    .andThen(Stream::sorted)
+                    .andThen(Stream::toList)
+                    .apply(((List<String>) value).stream());
             return maybeFoldList(resultList);
         }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/blockloader/TextFieldWithParentBlockLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/blockloader/TextFieldWithParentBlockLoaderTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.datageneration.Template;
 import org.elasticsearch.datageneration.datasource.MultifieldAddonHandler;
 import org.elasticsearch.index.mapper.BlockLoaderTestCase;
 import org.elasticsearch.index.mapper.BlockLoaderTestRunner;
+import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.MapperServiceTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentType;
@@ -51,7 +52,10 @@ public class TextFieldWithParentBlockLoaderTests extends MapperServiceTestCase {
     // of text multi field in a keyword field.
     public void testBlockLoaderOfParentField() throws IOException {
         var template = new Template(Map.of("parent", new Template.Leaf("parent", FieldType.KEYWORD.toString())));
-        var specification = buildSpecification(List.of(new MultifieldAddonHandler(Map.of(FieldType.KEYWORD, List.of(FieldType.TEXT)), 1f)));
+        var specification = buildSpecification(
+            List.of(new MultifieldAddonHandler(Map.of(FieldType.KEYWORD, List.of(FieldType.TEXT)), 1f)),
+            params.indexMode()
+        );
 
         var mapping = new MappingGenerator(specification).generate(template);
         var fieldMapping = mapping.lookup().get("parent");
@@ -61,11 +65,19 @@ public class TextFieldWithParentBlockLoaderTests extends MapperServiceTestCase {
 
         Object expected = expected(fieldMapping, fieldValue, new BlockLoaderTestCase.TestContext(false, true));
         var mappingXContent = XContentBuilder.builder(XContentType.JSON.xContent()).map(mapping.raw());
-        runner.mapperService(
-            params.syntheticSource() ? createSytheticSourceMapperService(mappingXContent) : createMapperService(mappingXContent)
-        );
+        runner.mapperService(mapperServiceForParams(mappingXContent));
         runner.fieldName("parent.subfield_text");
         runner.run(expected);
+    }
+
+    private MapperService mapperServiceForParams(XContentBuilder mappingXContent) throws IOException {
+        // Columnar index modes preserve array order via offsets recorded on the keyword parent. The text subfield delegates its block
+        // loader to that parent, so the index must actually be built in columnar mode for the offsets to exist - otherwise the delegate
+        // falls back to sorted ordinal order and no longer matches the arrival-order expectation.
+        if (params.indexMode().isColumnar()) {
+            return createMapperService(BlockLoaderTestCase.getSettingsForParams(params).build(), mappingXContent);
+        }
+        return params.syntheticSource() ? createSytheticSourceMapperService(mappingXContent) : createMapperService(mappingXContent);
     }
 
     @SuppressWarnings("unchecked")

--- a/server/src/test/java/org/elasticsearch/search/aggregations/AggregatorBaseTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/AggregatorBaseTests.java
@@ -93,6 +93,7 @@ public class AggregatorBaseTests extends MapperServiceTestCase {
             false,
             null,
             null,
+            false,
             false
         );
         return ValuesSourceConfig.resolveFieldOnly(ft, context);

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregatorTests.java
@@ -312,6 +312,7 @@ public class RangeAggregatorTests extends AggregatorTestCase {
                     false,
                     null,
                     null,
+                    false,
                     false
                 )
             )
@@ -693,6 +694,7 @@ public class RangeAggregatorTests extends AggregatorTestCase {
             false,
             null,
             null,
+            false,
             false
         );
         RangeAggregationBuilder aggregationBuilder = new RangeAggregationBuilder("test_range_agg");

--- a/server/src/test/java/org/elasticsearch/search/collapse/CollapseBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/collapse/CollapseBuilderTests.java
@@ -155,6 +155,7 @@ public class CollapseBuilderTests extends AbstractXContentSerializingTestCase<Co
                 false,
                 null,
                 null,
+                false,
                 false
             );
             when(searchExecutionContext.getFieldType("field")).thenReturn(numberFieldType);
@@ -173,6 +174,7 @@ public class CollapseBuilderTests extends AbstractXContentSerializingTestCase<Co
                 false,
                 null,
                 null,
+                false,
                 false
             );
             when(searchExecutionContext.getFieldType("field")).thenReturn(numberFieldType);

--- a/server/src/test/java/org/elasticsearch/search/sort/FieldSortBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/sort/FieldSortBuilderTests.java
@@ -427,6 +427,7 @@ public class FieldSortBuilderTests extends AbstractSortTestCase<FieldSortBuilder
                         false,
                         null,
                         null,
+                        false,
                         false
                     );
                 } else {

--- a/test/framework/src/main/java/org/elasticsearch/datageneration/datasource/MultifieldAddonHandler.java
+++ b/test/framework/src/main/java/org/elasticsearch/datageneration/datasource/MultifieldAddonHandler.java
@@ -46,8 +46,10 @@ public class MultifieldAddonHandler implements DataSourceHandler {
     public DataSourceResponse.LeafMappingParametersGenerator handle(DataSourceRequest.LeafMappingParametersGenerator request) {
 
         // Need to delegate creation of the same type of field to other handlers. So skip request
-        // if it's for the placeholder name used when creating the child and parent fields.
-        if (request.fieldName().equals(PLACEHOLDER)) {
+        // if it's for the placeholder name used when creating the child and parent fields. We match on contains rather than equals
+        // because columnar-mode specifications rename the placeholder with a prefix before re-dispatching, and re-handling it here would
+        // recurse indefinitely between this handler and the renaming handler.
+        if (request.fieldName().contains(PLACEHOLDER)) {
             return null;
         }
 

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/BlockLoaderTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/BlockLoaderTestCase.java
@@ -23,6 +23,8 @@ import org.elasticsearch.datageneration.Template;
 import org.elasticsearch.datageneration.datasource.DataSourceHandler;
 import org.elasticsearch.datageneration.datasource.DataSourceRequest;
 import org.elasticsearch.datageneration.datasource.DataSourceResponse;
+import org.elasticsearch.index.IndexMode;
+import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.indices.CrankyCircuitBreakerService;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentType;
@@ -58,15 +60,30 @@ public abstract class BlockLoaderTestCase extends MapperServiceTestCase {
     @ParametersFactory(argumentFormatting = "preference=%s")
     public static List<Object[]> args() {
         List<Object[]> args = new ArrayList<>();
-        for (boolean syntheticSource : new boolean[] { false, true }) {
-            for (MappedFieldType.FieldExtractPreference preference : PREFERENCES) {
-                args.add(new Object[] { new Params(syntheticSource, preference) });
+
+        List<IndexMode> modes = IndexMode.COLUMNAR_FEATURE_FLAG.isEnabled()
+            ? List.of(IndexMode.STANDARD, IndexMode.COLUMNAR)
+            : List.of(IndexMode.STANDARD);
+
+        for (IndexMode indexMode : modes) {
+            for (boolean syntheticSource : new boolean[] { false, true }) {
+                // COLUMNAR already implies synthetic source mode; skip the non-synthetic combo to avoid invalid configurations.
+                if (indexMode == IndexMode.COLUMNAR && syntheticSource == false) {
+                    continue;
+                }
+                for (MappedFieldType.FieldExtractPreference preference : PREFERENCES) {
+                    args.add(new Object[] { new Params(syntheticSource, preference, indexMode) });
+                }
             }
         }
         return args;
     }
 
-    public record Params(boolean syntheticSource, MappedFieldType.FieldExtractPreference preference) {}
+    public record Params(boolean syntheticSource, MappedFieldType.FieldExtractPreference preference, IndexMode indexMode) {
+        public Params(boolean syntheticSource, MappedFieldType.FieldExtractPreference preference) {
+            this(syntheticSource, preference, IndexMode.STANDARD);
+        }
+    }
 
     public record TestContext(boolean forceFallbackSyntheticSource, boolean isMultifield) {}
 
@@ -125,7 +142,7 @@ public abstract class BlockLoaderTestCase extends MapperServiceTestCase {
     private void testBlockLoader(CircuitBreaker breaker) throws IOException {
         runner.breaker(breaker);
         var template = new Template(Map.of(fieldName, new Template.Leaf(fieldName, fieldType)));
-        var specification = buildSpecification(customDataSourceHandlers);
+        var specification = buildSpecification(customDataSourceHandlers, params.indexMode);
 
         var mapping = new MappingGenerator(specification).generate(template);
         runner.document(new DocumentGenerator(specification).generate(template, mapping));
@@ -185,13 +202,15 @@ public abstract class BlockLoaderTestCase extends MapperServiceTestCase {
         currentLevel.put(fieldName, new Template.Leaf(fieldName, fieldType));
         var template = new Template(top);
 
-        var specification = buildSpecification(customDataSourceHandlers);
+        var specification = buildSpecification(customDataSourceHandlers, params.indexMode);
         var mapping = new MappingGenerator(specification).generate(template);
         runner.document(new DocumentGenerator(specification).generate(template, mapping));
 
         TestContext testContext = new TestContext(false, false);
 
-        if (params.syntheticSource && randomBoolean()) {
+        // synthetic_source_keep is rejected on strict-columnar indices, so the fallback-through-ignored-source path can only be exercised
+        // on non-strict-columnar synthetic-source indices.
+        if (params.syntheticSource && params.indexMode.isStrictColumnar() == false && randomBoolean()) {
             // force fallback synthetic source in the hierarchy
             var docMapping = (Map<String, Object>) mapping.raw().get("_doc");
             var topLevelMapping = (Map<String, Object>) ((Map<String, Object>) docMapping.get("properties")).get("top");
@@ -251,9 +270,10 @@ public abstract class BlockLoaderTestCase extends MapperServiceTestCase {
             @Override
             public DataSourceResponse.LeafMappingParametersGenerator handle(DataSourceRequest.LeafMappingParametersGenerator request) {
                 // This is a bit tricky meta-logic.
-                // We want to customize mapping but to do this we need the mapping for the same field type
-                // so we use name to untangle this.
-                if (request.fieldName().equals("parent") == false) {
+                // We want to customize mapping but to do this we need the mapping for the same field type so we use name to untangle this.
+                // In strict-columnar mode, the buildSpecification wrapper renames "parent" to "_columnar_inner_parent" when it recurses
+                // through the handler chain; match that too so the {fields: {mf: …}} subtree still lands on the parent mapping.
+                if (request.fieldName().equals("parent") == false && request.fieldName().equals("_columnar_inner_parent") == false) {
                     return null;
                 }
 
@@ -286,7 +306,7 @@ public abstract class BlockLoaderTestCase extends MapperServiceTestCase {
             }
         });
         customHandlers.addAll(customDataSourceHandlers);
-        var specification = buildSpecification(customHandlers);
+        var specification = buildSpecification(customHandlers, params.indexMode);
         var mapping = new MappingGenerator(specification).generate(template);
         @SuppressWarnings("unchecked")
         var fieldMapping = (Map<String, Object>) ((Map<String, Object>) mapping.lookup().get("parent").get("fields")).get("mf");
@@ -306,26 +326,62 @@ public abstract class BlockLoaderTestCase extends MapperServiceTestCase {
         if (params.syntheticSource) {
             builder.put("index.mapping.source.mode", "synthetic");
         }
+        if (params.indexMode != IndexMode.STANDARD) {
+            builder.put(IndexSettings.MODE.getKey(), params.indexMode.name());
+        }
         return builder;
     }
 
     public static DataGeneratorSpecification buildSpecification(Collection<DataSourceHandler> customHandlers) {
+        return buildSpecification(customHandlers, IndexMode.STANDARD);
+    }
+
+    private static DataGeneratorSpecification buildSpecification(Collection<DataSourceHandler> customHandlers, IndexMode indexMode) {
+        var coreHandlers = new ArrayList<DataSourceHandler>();
+        coreHandlers.add(new DataSourceHandler() {
+            @Override
+            public DataSourceResponse.DynamicMappingGenerator handle(DataSourceRequest.DynamicMappingGenerator request) {
+                return new DataSourceResponse.DynamicMappingGenerator(isObject -> false);
+            }
+
+            @Override
+            public DataSourceResponse.ObjectMappingParametersGenerator handle(DataSourceRequest.ObjectMappingParametersGenerator request) {
+                return new DataSourceResponse.ObjectMappingParametersGenerator(HashMap::new); // just defaults
+            }
+        });
+        if (indexMode.isStrictColumnar()) {
+            // synthetic_source_keep is forbidden on strict-columnar indices, so strip any value the randomized field-mapping generator
+            // emits before the mapping reaches MapperService. Delegate to the downstream handler under a new name to avoid self-recursion.
+            String columnarUnwrapMarker = "_columnar_inner_";
+            coreHandlers.add(new DataSourceHandler() {
+                @Override
+                public DataSourceResponse.LeafMappingParametersGenerator handle(DataSourceRequest.LeafMappingParametersGenerator request) {
+                    if (request.fieldName().startsWith(columnarUnwrapMarker)) {
+                        return null;
+                    }
+                    var dataSource = request.dataSource();
+                    return new DataSourceResponse.LeafMappingParametersGenerator(() -> {
+                        var mapping = new HashMap<>(
+                            dataSource.get(
+                                new DataSourceRequest.LeafMappingParametersGenerator(
+                                    dataSource,
+                                    columnarUnwrapMarker + request.fieldName(),  // new name
+                                    request.fieldType(),
+                                    request.eligibleCopyToFields(),
+                                    request.dynamicMapping()
+                                )
+                            ).mappingGenerator().get()
+                        );
+                        mapping.remove(Mapper.SYNTHETIC_SOURCE_KEEP_PARAM);
+                        return mapping;
+                    });
+                }
+            });
+        }
         return DataGeneratorSpecification.builder()
             .withFullyDynamicMapping(false)
             // Disable dynamic mapping and disabled objects
-            .withDataSourceHandlers(List.of(new DataSourceHandler() {
-                @Override
-                public DataSourceResponse.DynamicMappingGenerator handle(DataSourceRequest.DynamicMappingGenerator request) {
-                    return new DataSourceResponse.DynamicMappingGenerator(isObject -> false);
-                }
-
-                @Override
-                public DataSourceResponse.ObjectMappingParametersGenerator handle(
-                    DataSourceRequest.ObjectMappingParametersGenerator request
-                ) {
-                    return new DataSourceResponse.ObjectMappingParametersGenerator(HashMap::new); // just defaults
-                }
-            }))
+            .withDataSourceHandlers(coreHandlers)
             .withDataSourceHandlers(customHandlers)
             .build();
     }

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/BlockLoaderTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/BlockLoaderTestCase.java
@@ -322,12 +322,16 @@ public abstract class BlockLoaderTestCase extends MapperServiceTestCase {
     }
 
     protected Settings.Builder getSettingsForParams() {
+        return getSettingsForParams(params);
+    }
+
+    public static Settings.Builder getSettingsForParams(Params params) {
         var builder = Settings.builder();
-        if (params.syntheticSource) {
+        if (params.syntheticSource()) {
             builder.put("index.mapping.source.mode", "synthetic");
         }
-        if (params.indexMode != IndexMode.STANDARD) {
-            builder.put(IndexSettings.MODE.getKey(), params.indexMode.name());
+        if (params.indexMode() != IndexMode.STANDARD) {
+            builder.put(IndexSettings.MODE.getKey(), params.indexMode().name());
         }
         return builder;
     }
@@ -336,7 +340,7 @@ public abstract class BlockLoaderTestCase extends MapperServiceTestCase {
         return buildSpecification(customHandlers, IndexMode.STANDARD);
     }
 
-    private static DataGeneratorSpecification buildSpecification(Collection<DataSourceHandler> customHandlers, IndexMode indexMode) {
+    public static DataGeneratorSpecification buildSpecification(Collection<DataSourceHandler> customHandlers, IndexMode indexMode) {
         var coreHandlers = new ArrayList<DataSourceHandler>();
         coreHandlers.add(new DataSourceHandler() {
             @Override
@@ -350,8 +354,6 @@ public abstract class BlockLoaderTestCase extends MapperServiceTestCase {
             }
         });
         if (indexMode.isStrictColumnar()) {
-            // synthetic_source_keep is forbidden on strict-columnar indices, so strip any value the randomized field-mapping generator
-            // emits before the mapping reaches MapperService. Delegate to the downstream handler under a new name to avoid self-recursion.
             String columnarUnwrapMarker = "_columnar_inner_";
             coreHandlers.add(new DataSourceHandler() {
                 @Override
@@ -365,14 +367,17 @@ public abstract class BlockLoaderTestCase extends MapperServiceTestCase {
                             dataSource.get(
                                 new DataSourceRequest.LeafMappingParametersGenerator(
                                     dataSource,
-                                    columnarUnwrapMarker + request.fieldName(),  // new name
+                                    // Delegate to the downstream handler under a new name to avoid self-recursion.
+                                    columnarUnwrapMarker + request.fieldName(),
                                     request.fieldType(),
                                     request.eligibleCopyToFields(),
                                     request.dynamicMapping()
                                 )
                             ).mappingGenerator().get()
                         );
+                        // synthetic_source_keep and store are forbidden on strict-columnar indices
                         mapping.remove(Mapper.SYNTHETIC_SOURCE_KEEP_PARAM);
+                        mapping.remove("store");
                         return mapping;
                     });
                 }

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
@@ -1932,10 +1932,6 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
                 var blockLoader = mapperService.fieldType("field").blockLoader(mockBlockContext);
                 CircuitBreaker breaker = newLimitedBreaker(ByteSizeValue.ofMb(1));
                 try (BlockLoader.ColumnAtATimeReader columnReader = blockLoader.columnAtATimeReader(context).apply(breaker)) {
-                    assertThat(
-                        columnReader,
-                        anyOf(instanceOf(AbstractNumericBlockLoader.Sorted.class), instanceOf(AbstractNumericBlockLoader.Singleton.class))
-                    );
                     var docBlock = TestBlock.docs(IntStream.range(0, 3).toArray());
                     var block = (TestBlock) columnReader.read(TestBlock.factory(), docBlock, 0, false);
                     assertThat(block.get(0), equalTo(expectedSampleValues[0]));

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/NumberFieldBlockLoaderTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/NumberFieldBlockLoaderTestCase.java
@@ -48,12 +48,10 @@ public abstract class NumberFieldBlockLoaderTestCase<T extends Number> extends B
         }
 
         if (source == ValueSource.DOC_VALUES) {
-            // Sorted
-            var resultList = ((List<Object>) value).stream()
-                .map(v -> convert(v, nullValue, fieldMapping, source))
-                .filter(Objects::nonNull)
-                .sorted()
-                .toList();
+            // Columnar index modes preserve arrival order via offsets; standard mode returns doc values sorted.
+            boolean preserveOrder = params.indexMode().isColumnar();
+            var stream = ((List<Object>) value).stream().map(v -> convert(v, nullValue, fieldMapping, source)).filter(Objects::nonNull);
+            var resultList = preserveOrder ? stream.toList() : stream.sorted().toList();
             return maybeFoldList(resultList);
         }
 

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/rate/TimeSeriesRateAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/rate/TimeSeriesRateAggregatorTests.java
@@ -210,6 +210,7 @@ public class TimeSeriesRateAggregatorTests extends AggregatorTestCase {
             false,
             TimeSeriesParams.MetricType.COUNTER,
             IndexMode.TIME_SERIES,
+            false,
             false
         );
     }

--- a/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
@@ -31,6 +31,7 @@ import org.elasticsearch.index.mapper.CompositeSyntheticFieldLoader;
 import org.elasticsearch.index.mapper.DocValuesFieldFactory;
 import org.elasticsearch.index.mapper.DocumentParserContext;
 import org.elasticsearch.index.mapper.FallbackSyntheticSourceBlockLoader;
+import org.elasticsearch.index.mapper.FieldArrayContext;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.IgnoreMalformedStoredValues;
 import org.elasticsearch.index.mapper.IgnoredSourceFieldMapper;
@@ -229,6 +230,22 @@ public class UnsignedLongFieldMapper extends FieldMapper {
             if (inheritDimensionParameterFromParentObject(context)) {
                 dimension.setValue(true);
             }
+            String offsetsFieldName = getOffsetsFieldName(
+                context,
+                indexSettings.sourceKeepMode(),
+                docValuesParameters.getValue().enabled(),
+                stored.getValue(),
+                this,
+                indexSettings.getIndexVersionCreated(),
+                IndexVersions.SYNTHETIC_SOURCE_STORE_ARRAYS_NATIVELY_UNSIGNED_LONG,
+                indexSettings.getMode().isStrictColumnar(),
+                docValuesParameters.getValue().multiValue()
+            );
+
+            boolean readInArrayOrder = offsetsFieldName != null
+                && docValuesParameters.getValue().multiValue()
+                && indexSettings.getMode().isStrictColumnar();
+
             UnsignedLongFieldType fieldType = new UnsignedLongFieldType(
                 context.buildFullName(leafName()),
                 indexType(),
@@ -238,16 +255,8 @@ public class UnsignedLongFieldMapper extends FieldMapper {
                 dimension.getValue(),
                 metric.getValue(),
                 indexSettings.getMode(),
-                context.isSourceSynthetic()
-            );
-            String offsetsFieldName = getOffsetsFieldName(
-                context,
-                indexSettings.sourceKeepMode(),
-                docValuesParameters.getValue().enabled(),
-                stored.getValue(),
-                this,
-                indexSettings.getIndexVersionCreated(),
-                IndexVersions.SYNTHETIC_SOURCE_STORE_ARRAYS_NATIVELY_UNSIGNED_LONG
+                context.isSourceSynthetic(),
+                readInArrayOrder
             );
             return new UnsignedLongFieldMapper(
                 leafName(),
@@ -269,6 +278,7 @@ public class UnsignedLongFieldMapper extends FieldMapper {
         private final MetricType metricType;
         private final IndexMode indexMode;
         private final boolean isSyntheticSource;
+        private final boolean readInArrayOrder;
 
         public UnsignedLongFieldType(
             String name,
@@ -281,12 +291,28 @@ public class UnsignedLongFieldMapper extends FieldMapper {
             IndexMode indexMode,
             boolean isSyntheticSource
         ) {
+            this(name, indexType, isStored, nullValueFormatted, meta, isDimension, metricType, indexMode, isSyntheticSource, false);
+        }
+
+        public UnsignedLongFieldType(
+            String name,
+            IndexType indexType,
+            boolean isStored,
+            Number nullValueFormatted,
+            Map<String, String> meta,
+            boolean isDimension,
+            MetricType metricType,
+            IndexMode indexMode,
+            boolean isSyntheticSource,
+            boolean readInArrayOrder
+        ) {
             super(name, indexType, isStored, meta);
             this.nullValueFormatted = nullValueFormatted;
             this.isDimension = isDimension;
             this.metricType = metricType;
             this.indexMode = indexMode;
             this.isSyntheticSource = isSyntheticSource;
+            this.readInArrayOrder = readInArrayOrder;
         }
 
         public UnsignedLongFieldType(String name) {
@@ -379,7 +405,7 @@ public class UnsignedLongFieldMapper extends FieldMapper {
                 return ConstantNull.INSTANCE;
             }
             if (hasDocValues() && (blContext.fieldExtractPreference() != FieldExtractPreference.STORED || isSyntheticSource)) {
-                return new LongsBlockLoader(name());
+                return new LongsBlockLoader(name(), readInArrayOrder);
             }
             // Multi fields don't have fallback synthetic source.
             if (isSyntheticSource && blContext.parentField(name()) == null) {
@@ -840,7 +866,7 @@ public class UnsignedLongFieldMapper extends FieldMapper {
             }
         }
 
-        if (offsetsFieldName != null && context.isImmediateParentAnArray() && context.canAddIgnoredField()) {
+        if (FieldArrayContext.shouldRecordOffsets(context, offsetsFieldName, docValuesParameters.multiValue())) {
             if (numericValue != null) {
                 context.getOffSetContext().recordOffset(offsetsFieldName, numericValue);
             } else {

--- a/x-pack/plugin/mapper-unsigned-long/src/test/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapperTests.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/test/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapperTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.action.bulk.BulkItemRequest;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.eirf.EirfBatch;
 import org.elasticsearch.eirf.EirfRowBuilder;
 import org.elasticsearch.index.IndexMode;
@@ -429,6 +430,21 @@ public class UnsignedLongFieldMapperTests extends WholeNumberFieldMapperTests {
             return randomDouble();
         }
         return randomDoubleBetween(0L, Long.MAX_VALUE, true);
+    }
+
+    public void testColumnarArrayOrderRoundTrip() throws IOException {
+        assumeTrue("columnar index mode requires snapshot build", IndexMode.COLUMNAR_FEATURE_FLAG.isEnabled());
+        Settings settings = Settings.builder().put(IndexSettings.MODE.getKey(), IndexMode.COLUMNAR.name()).build();
+        DocumentMapper mapper = createMapperService(
+            settings,
+            mapping(b -> b.startObject("field").field("type", "unsigned_long").endObject())
+        ).documentMapper();
+        // Stay in the signed-long range so JSON emits a plain number and Java's Long.toString matches the synthetic-source format.
+        long v1 = randomNonNegativeLong();
+        long v2 = randomNonNegativeLong();
+        long v3 = randomNonNegativeLong();
+        String src = syntheticSource(mapper, b -> b.array("field", v2, v1, v3, v2));
+        assertThat(src, containsString("\"field\":[" + v2 + "," + v1 + "," + v3 + "," + v2 + "]"));
     }
 
     class NumberSyntheticSourceSupport implements SyntheticSourceSupport {

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeFieldBlockLoaderTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeFieldBlockLoaderTests.java
@@ -7,6 +7,8 @@
 
 package org.elasticsearch.xpack.spatial.index.mapper;
 
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.geo.GeoJson;
 import org.elasticsearch.common.geo.GeometryNormalizer;
@@ -16,6 +18,7 @@ import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.geometry.utils.GeographyValidator;
 import org.elasticsearch.geometry.utils.WellKnownBinary;
 import org.elasticsearch.geometry.utils.WellKnownText;
+import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.mapper.BlockLoaderTestCase;
 import org.elasticsearch.plugins.ExtensiblePlugin;
 import org.elasticsearch.plugins.Plugin;
@@ -34,6 +37,13 @@ import java.util.Objects;
 public class GeoShapeFieldBlockLoaderTests extends BlockLoaderTestCase {
     public GeoShapeFieldBlockLoaderTests(Params params) {
         super("geo_shape", List.of(new GeoShapeDataSourceHandler()), params);
+    }
+
+    // TODO: there is a potential bug in AbstractShapeGeometryFieldMapper.supportsParsingObject() that breaks synthetic source for shapes
+    // in columnar mode. So for now, exclude columnar from these tests.
+    @ParametersFactory(argumentFormatting = "preference=%s")
+    public static List<Object[]> args() {
+        return BlockLoaderTestCase.args().stream().filter(a -> ((Params) a[0]).indexMode() != IndexMode.COLUMNAR).toList();
     }
 
     @Override

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeFieldBlockLoaderTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeFieldBlockLoaderTests.java
@@ -7,6 +7,8 @@
 
 package org.elasticsearch.xpack.spatial.index.mapper;
 
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.geo.GeoJson;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
@@ -14,6 +16,7 @@ import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.geometry.utils.StandardValidator;
 import org.elasticsearch.geometry.utils.WellKnownBinary;
 import org.elasticsearch.geometry.utils.WellKnownText;
+import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.mapper.BlockLoaderTestCase;
 import org.elasticsearch.plugins.ExtensiblePlugin;
 import org.elasticsearch.plugins.Plugin;
@@ -32,6 +35,13 @@ import java.util.Objects;
 public class ShapeFieldBlockLoaderTests extends BlockLoaderTestCase {
     public ShapeFieldBlockLoaderTests(Params params) {
         super("shape", List.of(new ShapeDataSourceHandler()), params);
+    }
+
+    // TODO: there is a potential bug in AbstractShapeGeometryFieldMapper.supportsParsingObject() that breaks synthetic source for shapes
+    // in columnar mode. So for now, exclude columnar from these tests.
+    @ParametersFactory(argumentFormatting = "preference=%s")
+    public static List<Object[]> args() {
+        return BlockLoaderTestCase.args().stream().filter(a -> ((Params) a[0]).indexMode() != IndexMode.COLUMNAR).toList();
     }
 
     @Override

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/300_columnar_array_ordering.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/300_columnar_array_ordering.yml
@@ -6,7 +6,9 @@ setup:
         - method: PUT
           path: /{index}
           capabilities: [ columnar_index_modes ]
-      reason: "Strict columnar index modes are only available on builds where the columnar feature flag is enabled"
+      cluster_features: [ "mapper.columnar.maintain_array_order" ]
+      reason: "Strict columnar index modes are only available on builds where the columnar feature flag is enabled, and array
+        ordering in columnar mode requires the mapper.columnar.maintain_array_order feature"
 
 # Each scenario writes the same multi-value document to two indices and reads it back:
 #   - test_columnar (index.mode: logsdb_columnar) - must return insertion order, since strict columnar emits a .offsets

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/300_columnar_array_ordering.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/300_columnar_array_ordering.yml
@@ -1,0 +1,393 @@
+---
+setup:
+  - requires:
+      test_runner_features: [ capabilities, allowed_warnings ]
+      capabilities:
+        - method: PUT
+          path: /{index}
+          capabilities: [ columnar_index_modes ]
+      reason: "Strict columnar index modes are only available on builds where the columnar feature flag is enabled"
+
+# Each scenario writes the same multi-value document to two indices and reads it back:
+#   - test_columnar (index.mode: logsdb_columnar) - must return insertion order, since strict columnar emits a .offsets
+#     sub-field and the block loader reads doc values in array order.
+#   - test_logsdb (index.mode: logsdb) - is columnar() but not isStrictColumnar(); must return sorted doc-values order.
+#     This is the direct regression guard for the isColumnar -> isStrictColumnar narrowing in the field mappers.
+
+---
+"integer multi-value array order":
+  - do:
+      indices.create:
+        index: test_columnar
+        body:
+          settings:
+            index.mode: logsdb_columnar
+          mappings:
+            properties:
+              "@timestamp": { type: date }
+              val: { type: integer }
+  - do:
+      indices.create:
+        index: test_logsdb
+        body:
+          settings:
+            index.mode: logsdb
+          mappings:
+            properties:
+              "@timestamp": { type: date }
+              val: { type: integer }
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - { "index": { "_index": "test_columnar" } }
+          - { "@timestamp": "2024-05-10T00:00:00.000Z", "val": [5, 1, 3] }
+          - { "index": { "_index": "test_logsdb" } }
+          - { "@timestamp": "2024-05-10T00:00:00.000Z", "val": [5, 1, 3] }
+
+  - do:
+      allowed_warnings:
+        - "No limit defined, adding default limit of [1000]"
+      esql.query:
+        body:
+          query: 'FROM test_columnar | KEEP val'
+  - match: { values.0.0: [5, 1, 3] }
+
+  - do:
+      allowed_warnings:
+        - "No limit defined, adding default limit of [1000]"
+      esql.query:
+        body:
+          query: 'FROM test_logsdb | KEEP val'
+  - match: { values.0.0: [1, 3, 5] }
+
+---
+"long multi-value array order":
+  - do:
+      indices.create:
+        index: test_columnar
+        body:
+          settings:
+            index.mode: logsdb_columnar
+          mappings:
+            properties:
+              "@timestamp": { type: date }
+              val: { type: long }
+  - do:
+      indices.create:
+        index: test_logsdb
+        body:
+          settings:
+            index.mode: logsdb
+          mappings:
+            properties:
+              "@timestamp": { type: date }
+              val: { type: long }
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - { "index": { "_index": "test_columnar" } }
+          - { "@timestamp": "2024-05-10T00:00:00.000Z", "val": [5, 1, 3] }
+          - { "index": { "_index": "test_logsdb" } }
+          - { "@timestamp": "2024-05-10T00:00:00.000Z", "val": [5, 1, 3] }
+
+  - do:
+      allowed_warnings:
+        - "No limit defined, adding default limit of [1000]"
+      esql.query:
+        body:
+          query: 'FROM test_columnar | KEEP val'
+  - match: { values.0.0: [5, 1, 3] }
+
+  - do:
+      allowed_warnings:
+        - "No limit defined, adding default limit of [1000]"
+      esql.query:
+        body:
+          query: 'FROM test_logsdb | KEEP val'
+  - match: { values.0.0: [1, 3, 5] }
+
+---
+"double multi-value array order":
+  - do:
+      indices.create:
+        index: test_columnar
+        body:
+          settings:
+            index.mode: logsdb_columnar
+          mappings:
+            properties:
+              "@timestamp": { type: date }
+              val: { type: double }
+  - do:
+      indices.create:
+        index: test_logsdb
+        body:
+          settings:
+            index.mode: logsdb
+          mappings:
+            properties:
+              "@timestamp": { type: date }
+              val: { type: double }
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - { "index": { "_index": "test_columnar" } }
+          - { "@timestamp": "2024-05-10T00:00:00.000Z", "val": [5.5, 1.5, 3.5] }
+          - { "index": { "_index": "test_logsdb" } }
+          - { "@timestamp": "2024-05-10T00:00:00.000Z", "val": [5.5, 1.5, 3.5] }
+
+  - do:
+      allowed_warnings:
+        - "No limit defined, adding default limit of [1000]"
+      esql.query:
+        body:
+          query: 'FROM test_columnar | KEEP val'
+  - match: { values.0.0: [5.5, 1.5, 3.5] }
+
+  - do:
+      allowed_warnings:
+        - "No limit defined, adding default limit of [1000]"
+      esql.query:
+        body:
+          query: 'FROM test_logsdb | KEEP val'
+  - match: { values.0.0: [1.5, 3.5, 5.5] }
+
+---
+"keyword multi-value array order":
+  - do:
+      indices.create:
+        index: test_columnar
+        body:
+          settings:
+            index.mode: logsdb_columnar
+          mappings:
+            properties:
+              "@timestamp": { type: date }
+              val: { type: keyword }
+  - do:
+      indices.create:
+        index: test_logsdb
+        body:
+          settings:
+            index.mode: logsdb
+          mappings:
+            properties:
+              "@timestamp": { type: date }
+              val: { type: keyword }
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - { "index": { "_index": "test_columnar" } }
+          - { "@timestamp": "2024-05-10T00:00:00.000Z", "val": ["banana", "apple", "cherry"] }
+          - { "index": { "_index": "test_logsdb" } }
+          - { "@timestamp": "2024-05-10T00:00:00.000Z", "val": ["banana", "apple", "cherry"] }
+
+  - do:
+      allowed_warnings:
+        - "No limit defined, adding default limit of [1000]"
+      esql.query:
+        body:
+          query: 'FROM test_columnar | KEEP val'
+  - match: { values.0.0: [banana, apple, cherry] }
+
+  - do:
+      allowed_warnings:
+        - "No limit defined, adding default limit of [1000]"
+      esql.query:
+        body:
+          query: 'FROM test_logsdb | KEEP val'
+  - match: { values.0.0: [apple, banana, cherry] }
+
+---
+"boolean multi-value array order":
+  # SortedNumericDocValues retains duplicates, so [true, false, true] stays three-wide; sorted form is [false, true, true].
+  - do:
+      indices.create:
+        index: test_columnar
+        body:
+          settings:
+            index.mode: logsdb_columnar
+          mappings:
+            properties:
+              "@timestamp": { type: date }
+              val: { type: boolean }
+  - do:
+      indices.create:
+        index: test_logsdb
+        body:
+          settings:
+            index.mode: logsdb
+          mappings:
+            properties:
+              "@timestamp": { type: date }
+              val: { type: boolean }
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - { "index": { "_index": "test_columnar" } }
+          - { "@timestamp": "2024-05-10T00:00:00.000Z", "val": [true, false, true] }
+          - { "index": { "_index": "test_logsdb" } }
+          - { "@timestamp": "2024-05-10T00:00:00.000Z", "val": [true, false, true] }
+
+  - do:
+      allowed_warnings:
+        - "No limit defined, adding default limit of [1000]"
+      esql.query:
+        body:
+          query: 'FROM test_columnar | KEEP val'
+  - match: { values.0.0: [true, false, true] }
+
+  - do:
+      allowed_warnings:
+        - "No limit defined, adding default limit of [1000]"
+      esql.query:
+        body:
+          query: 'FROM test_logsdb | KEEP val'
+  - match: { values.0.0: [false, true, true] }
+
+---
+"date multi-value array order":
+  - do:
+      indices.create:
+        index: test_columnar
+        body:
+          settings:
+            index.mode: logsdb_columnar
+          mappings:
+            properties:
+              "@timestamp": { type: date }
+              val: { type: date }
+  - do:
+      indices.create:
+        index: test_logsdb
+        body:
+          settings:
+            index.mode: logsdb
+          mappings:
+            properties:
+              "@timestamp": { type: date }
+              val: { type: date }
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - { "index": { "_index": "test_columnar" } }
+          - { "@timestamp": "2024-05-10T00:00:00.000Z", "val": ["2024-05-10T00:02:00.000Z", "2024-05-10T00:00:00.000Z", "2024-05-10T00:01:00.000Z"] }
+          - { "index": { "_index": "test_logsdb" } }
+          - { "@timestamp": "2024-05-10T00:00:00.000Z", "val": ["2024-05-10T00:02:00.000Z", "2024-05-10T00:00:00.000Z", "2024-05-10T00:01:00.000Z"] }
+
+  - do:
+      allowed_warnings:
+        - "No limit defined, adding default limit of [1000]"
+      esql.query:
+        body:
+          query: 'FROM test_columnar | KEEP val'
+  - match: { values.0.0: [ "2024-05-10T00:02:00.000Z", "2024-05-10T00:00:00.000Z", "2024-05-10T00:01:00.000Z" ] }
+
+  - do:
+      allowed_warnings:
+        - "No limit defined, adding default limit of [1000]"
+      esql.query:
+        body:
+          query: 'FROM test_logsdb | KEEP val'
+  - match: { values.0.0: [ "2024-05-10T00:00:00.000Z", "2024-05-10T00:01:00.000Z", "2024-05-10T00:02:00.000Z" ] }
+
+---
+"scaled_float multi-value array order":
+  # scaled_float surfaces as DOUBLE in ESQL; use values that round-trip exactly through scaling_factor=10.
+  - do:
+      indices.create:
+        index: test_columnar
+        body:
+          settings:
+            index.mode: logsdb_columnar
+          mappings:
+            properties:
+              "@timestamp": { type: date }
+              val: { type: scaled_float, scaling_factor: 10 }
+  - do:
+      indices.create:
+        index: test_logsdb
+        body:
+          settings:
+            index.mode: logsdb
+          mappings:
+            properties:
+              "@timestamp": { type: date }
+              val: { type: scaled_float, scaling_factor: 10 }
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - { "index": { "_index": "test_columnar" } }
+          - { "@timestamp": "2024-05-10T00:00:00.000Z", "val": [5.5, 1.5, 3.5] }
+          - { "index": { "_index": "test_logsdb" } }
+          - { "@timestamp": "2024-05-10T00:00:00.000Z", "val": [5.5, 1.5, 3.5] }
+
+  - do:
+      allowed_warnings:
+        - "No limit defined, adding default limit of [1000]"
+      esql.query:
+        body:
+          query: 'FROM test_columnar | KEEP val'
+  - match: { values.0.0: [5.5, 1.5, 3.5] }
+
+  - do:
+      allowed_warnings:
+        - "No limit defined, adding default limit of [1000]"
+      esql.query:
+        body:
+          query: 'FROM test_logsdb | KEEP val'
+  - match: { values.0.0: [1.5, 3.5, 5.5] }
+
+---
+"unsigned_long multi-value array order":
+  - do:
+      indices.create:
+        index: test_columnar
+        body:
+          settings:
+            index.mode: logsdb_columnar
+          mappings:
+            properties:
+              "@timestamp": { type: date }
+              val: { type: unsigned_long }
+  - do:
+      indices.create:
+        index: test_logsdb
+        body:
+          settings:
+            index.mode: logsdb
+          mappings:
+            properties:
+              "@timestamp": { type: date }
+              val: { type: unsigned_long }
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - { "index": { "_index": "test_columnar" } }
+          - { "@timestamp": "2024-05-10T00:00:00.000Z", "val": [5, 1, 3] }
+          - { "index": { "_index": "test_logsdb" } }
+          - { "@timestamp": "2024-05-10T00:00:00.000Z", "val": [5, 1, 3] }
+
+  - do:
+      allowed_warnings:
+        - "No limit defined, adding default limit of [1000]"
+      esql.query:
+        body:
+          query: 'FROM test_columnar | KEEP val'
+  - match: { values.0.0: [5, 1, 3] }
+
+  - do:
+      allowed_warnings:
+        - "No limit defined, adding default limit of [1000]"
+      esql.query:
+        body:
+          query: 'FROM test_logsdb | KEEP val'
+  - match: { values.0.0: [1, 3, 5] }


### PR DESCRIPTION
In columnar mode, multi-valued numeric fields will maintain array order for both synthetic source and ESQL.

Note, this PR is also a follow up for https://github.com/elastic/elasticsearch/pull/149445#discussion_r3272553384.

Note also, this PR includes https://github.com/elastic/elasticsearch/pull/149655 since it has not been merged yet.