### PR TITLE
ESQL: anchor CSV row errors in fused fast path too

### DIFF
--- a/docs/changelog/149660.yaml
+++ b/docs/changelog/149660.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 149567
+pr: 149660
+summary: Anchor CSV row errors in fused fast path too
+type: bug

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -558,9 +558,6 @@ tests:
 - class: org.elasticsearch.gateway.PersistedClusterStateServiceTests
   method: testLimitsFileCount
   issue: https://github.com/elastic/elasticsearch/issues/149557
-- class: org.elasticsearch.xpack.esql.datasource.csv.CsvFormatReaderTests
-  method: testMalformedRowErrorAnchorsOnQuoteOffset
-  issue: https://github.com/elastic/elasticsearch/issues/149567
 - class: org.elasticsearch.xpack.esql.CsvIT
   method: test {csv-spec:stats.sumWithOverflowRow}
   issue: https://github.com/elastic/elasticsearch/issues/149574

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
@@ -2081,6 +2081,11 @@ public class CsvFormatReader implements SegmentableFormatReader {
             StringBuilder current = new StringBuilder();
             boolean inQuotes = false;
             int bracketDepth = 0;
+            // Remember where the parser entered the unclosed state so error messages can anchor on
+            // the actual fault site instead of head/tail-truncating a long line and hiding it.
+            // Mirrors the offset tracking in splitCommaDelimiterBracketAwareFields.
+            int quoteOpenAt = -1;
+            int bracketOpenAt = -1;
             int fieldIndex = 0;
             boolean fieldHasNonWhitespace = false;
             boolean trailingFieldHasContent = false;
@@ -2132,12 +2137,14 @@ public class CsvFormatReader implements SegmentableFormatReader {
                 } else if (c == quote && fieldHasNonWhitespace == false) {
                     trailingFieldHasContent = true;
                     inQuotes = true;
+                    quoteOpenAt = i;
                     numericValid = false;
                     i++;
                 } else if (c == '[' && fieldHasNonWhitespace == false) {
                     trailingFieldHasContent = true;
                     if (hasMvcBracketClose(line, i)) {
                         bracketDepth = 1;
+                        bracketOpenAt = i;
                     }
                     if (isProjected) current.append(c);
                     numericValid = false;
@@ -2203,10 +2210,14 @@ public class CsvFormatReader implements SegmentableFormatReader {
             }
 
             if (inQuotes) {
-                throw new MalformedRowException("Unclosed quoted field in line [" + CsvErrorMessages.summarize(line) + "]");
+                throw new MalformedRowException(
+                    "Unclosed quoted field in line [" + CsvErrorMessages.summarizeAround(line, quoteOpenAt) + "]"
+                );
             }
             if (bracketDepth > 0) {
-                throw new MalformedRowException("Unclosed bracket cell in line [" + CsvErrorMessages.summarize(line) + "]");
+                throw new MalformedRowException(
+                    "Unclosed bracket cell in line [" + CsvErrorMessages.summarizeAround(line, bracketOpenAt) + "]"
+                );
             }
 
             int totalFields = trailingFieldHasContent ? fieldIndex + 1 : fieldIndex;

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
@@ -1566,12 +1566,10 @@ public class CsvFormatReader implements SegmentableFormatReader {
             }
         }
         if (inQuotes) {
-            throw new MalformedRowException("Unclosed quoted field in line [" + CsvErrorMessages.summarizeAround(line, quoteOpenAt) + "]");
+            throw MalformedRowException.unclosedQuotedField(line, quoteOpenAt);
         }
         if (bracketDepth > 0) {
-            throw new MalformedRowException(
-                "Unclosed bracket cell in line [" + CsvErrorMessages.summarizeAround(line, bracketOpenAt) + "]"
-            );
+            throw MalformedRowException.unclosedBracketCell(line, bracketOpenAt);
         }
         if (current.length() > 0) {
             entries.add(emitField(current));
@@ -2210,14 +2208,10 @@ public class CsvFormatReader implements SegmentableFormatReader {
             }
 
             if (inQuotes) {
-                throw new MalformedRowException(
-                    "Unclosed quoted field in line [" + CsvErrorMessages.summarizeAround(line, quoteOpenAt) + "]"
-                );
+                throw MalformedRowException.unclosedQuotedField(line, quoteOpenAt);
             }
             if (bracketDepth > 0) {
-                throw new MalformedRowException(
-                    "Unclosed bracket cell in line [" + CsvErrorMessages.summarizeAround(line, bracketOpenAt) + "]"
-                );
+                throw MalformedRowException.unclosedBracketCell(line, bracketOpenAt);
             }
 
             int totalFields = trailingFieldHasContent ? fieldIndex + 1 : fieldIndex;

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/MalformedRowException.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/MalformedRowException.java
@@ -27,4 +27,17 @@ final class MalformedRowException extends RuntimeException {
     MalformedRowException(String message, Throwable cause) {
         super(message, cause);
     }
+
+    /**
+     * Shared message template for the structural fault factories below: keeps the two splitter
+     * copies aligned and routes every long-row excerpt through {@link CsvErrorMessages#summarizeAround}
+     * so the printed window is anchored on {@code offset} (the parser's known fault index).
+     */
+    static MalformedRowException unclosedQuotedField(String line, int offset) {
+        return new MalformedRowException("Unclosed quoted field in line [" + CsvErrorMessages.summarizeAround(line, offset) + "]");
+    }
+
+    static MalformedRowException unclosedBracketCell(String line, int offset) {
+        return new MalformedRowException("Unclosed bracket cell in line [" + CsvErrorMessages.summarizeAround(line, offset) + "]");
+    }
 }


### PR DESCRIPTION
## Summary

PR #149533 anchored the `Unclosed quoted field` / `Unclosed bracket cell` error excerpts on the parser fault offset but only updated `splitCommaDelimiterBracketAwareFields`. The bound-schema fast path `splitAndConvertProjected` (added in #149326) has its own duplicate state machine and throw sites; those kept calling the legacy `summarize(line)`, so with explicit-schema CSVs the new offset annotation never appeared and `testMalformedRowErrorAnchorsOnQuoteOffset` failed in CI.

This change mirrors the offset-tracking pattern in `splitAndConvertProjected` (`quoteOpenAt` set when `inQuotes` flips, `bracketOpenAt` set when `bracketDepth` goes 0→1) and routes both throw sites through `summarizeAround`. The test is unmuted.

- `CsvFormatReader#splitAndConvertProjected`: track open offsets, throw via `summarizeAround`
- `muted-tests.yml`: unmute `testMalformedRowErrorAnchorsOnQuoteOffset`

Closes #149567