### PR TITLE
ESQL:DS: ORC: fix missing class (#147807) (9.4 backport)

### DIFF
--- a/x-pack/plugin/esql-datasource-orc/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/x-pack/plugin/esql-datasource-orc/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.apache.commons.lang3;
+
+/**
+ * Minimal stub replacing the {@code commons-lang3} jar.
+ * <p>
+ * The original class lives in Apache Commons Lang
+ * ({@code org.apache.commons.lang3.StringUtils}, Apache License 2.0). The
+ * bytecode of {@code org.apache.hadoop.fs.Path#normalizePath} (in
+ * {@code hadoop-common}) calls {@code StringUtils.replace(path, "\\", "/")}
+ * to convert backslashes to forward slashes — but only inside an
+ * {@code if (Path.WINDOWS)} branch (further gated on a Windows drive prefix
+ * or {@code file:}/empty scheme). On Linux/macOS the JVM never resolves this
+ * reference, so the missing class stays latent; on Windows, the first
+ * {@code file:///C:/…} path passed to {@link org.apache.hadoop.fs.Path#Path}
+ * triggers class-loading and crashes the node with
+ * {@code NoClassDefFoundError}.
+ * <p>
+ * Hadoop also references {@code StringUtils} from its
+ * {@code IOStatisticsContext → Shell.<clinit>} chain (documented in
+ * {@code OrcFormatReaderTests.NoPermissionLocalFileSystem}), but that chain
+ * is only reachable through {@code LocalFSFileOutputStream} on the write
+ * path, which the production reader never exercises. Providing the single
+ * {@link #replace} method is therefore sufficient.
+ * <p>
+ * This is an independent reimplementation of the documented contract; no
+ * code was copied from Apache Commons Lang.
+ */
+public final class StringUtils {
+
+    private StringUtils() {}
+
+    /**
+     * Replaces all occurrences of {@code searchString} in {@code text} with
+     * {@code replacement}. Matches the contract of
+     * {@code org.apache.commons.lang3.StringUtils#replace(String, String, String)}:
+     * a {@code null} {@code text}/{@code searchString}/{@code replacement} or
+     * an empty {@code searchString} returns {@code text} unchanged; otherwise
+     * delegates to {@link String#replace(CharSequence, CharSequence)} for
+     * literal (non-regex) replacement.
+     */
+    public static String replace(String text, String searchString, String replacement) {
+        if (text == null || searchString == null || replacement == null || searchString.isEmpty()) {
+            return text;
+        }
+        return text.replace(searchString, replacement);
+    }
+}


### PR DESCRIPTION
Backport of #147807 to the `9.4` branch.

## Summary

On Windows, `org.apache.hadoop.fs.Path#normalizePath` calls `StringUtils.replace(path, "\\", "/")` inside its `if (Path.WINDOWS)` branch, which triggers loading of `org.apache.commons.lang3.StringUtils`. The `esql-datasource-orc` plugin intentionally does not bundle `commons-lang3` (the rest of the class is dead code at runtime), so on Linux/macOS the reference stays latent, but on Windows every `Path` constructor crashes with:

```
java.lang.NoClassDefFoundError: org/apache/commons/lang3/StringUtils
    at org.apache.hadoop.fs.Path.normalizePath(Path.java:308)
    at org.apache.hadoop.fs.Path.initialize(Path.java:261)
    at org.apache.hadoop.fs.Path.<init>(Path.java:222)
    at org.apache.hadoop.fs.RawLocalFileSystem.getInitialWorkingDirectory(...)
```

PR #147807 (merged to `main` on April 29) added a 1-method shim (`StringUtils.replace`) under `x-pack/plugin/esql-datasource-orc/src/main/java/org/apache/commons/lang3/` to satisfy the linkage. The shim was never backported to `9.4`, which is why the same `OrcFormatReaderTests` failures keep recurring in the `elasticsearch-periodic-platform-support` Windows jobs for the `9.4` branch — most recently in [build 12269](https://buildkite.com/elastic/elasticsearch-periodic-platform-support/builds/12269) (May 22).

This is a pure cherry-pick of `f8c98be3151b` (1 file, +54 lines, no test changes). The shim is an independent reimplementation of the documented `StringUtils.replace(String, String, String)` contract; no code is copied from Apache Commons Lang.

Relates to #147514