### PR TITLE
[ESQL] ESQL: Parquet/ORC nested STRUCT pushdown

### DIFF
--- a/docs/changelog/149664.yaml
+++ b/docs/changelog/149664.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 149664
+summary: Parquet/ORC nested STRUCT pushdown
+type: enhancement

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFixtureParser.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFixtureParser.java
@@ -14,8 +14,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 
 /**
  * Standalone CSV parser for fixture generation. Parses CSV files with bracket-aware
@@ -412,6 +414,37 @@ public final class CsvFixtureParser {
         }
         char c = value.charAt(0);
         return c == '-' || c == '+' || (c >= '0' && c <= '9');
+    }
+
+    /**
+     * Marks columns whose dotted names must be kept literal (flat) rather than flattened into a
+     * nested STRUCT by a downstream fixture generator. A column is kept flat when any prefix of
+     * its dotted name is itself a literal top-level column name in the same CSV. This preserves
+     * files like {@code employees.csv} whose schema mixes a flat {@code languages} column with
+     * sibling flat columns named {@code languages.long}, {@code languages.short}, etc.
+     *
+     * <p>Shared by {@code ParquetFixtureGenerator} and {@code OrcFixtureGenerator} so the rule
+     * stays in lock-step between the two formats. Returns an array of the same length as
+     * {@code columns}, indexed by column position.
+     */
+    public static boolean[] computeFlatten(List<ColumnSpec> columns) {
+        Set<String> names = new HashSet<>();
+        for (ColumnSpec c : columns) {
+            names.add(c.name());
+        }
+        boolean[] flatten = new boolean[columns.size()];
+        for (int i = 0; i < columns.size(); i++) {
+            String name = columns.get(i).name();
+            int dot = name.indexOf('.');
+            while (dot > 0) {
+                if (names.contains(name.substring(0, dot))) {
+                    flatten[i] = true;
+                    break;
+                }
+                dot = name.indexOf('.', dot + 1);
+            }
+        }
+        return flatten;
     }
 
     public record ColumnSpec(String name, String type) {}

--- a/x-pack/plugin/esql-datasource-orc/qa/src/javaRestTest/resources/external-nested-struct.csv-spec
+++ b/x-pack/plugin/esql-datasource-orc/qa/src/javaRestTest/resources/external-nested-struct.csv-spec
@@ -85,3 +85,69 @@ id:integer | event.action:keyword
 3          | null
 6          | null
 ;
+
+// Filter pushdown on a nested KEYWORD leaf. The Parquet / ORC readers translate this to
+// a FilterPredicate / SearchArgument against the dotted column path and prune row groups /
+// stripes whose statistics rule out the value (see ParquetPushedExpressions /
+// OrcPushedExpressions). FilterExec re-applies the conjunct to catch any leakage.
+nestedWhereEquals
+required_capability: external_command
+required_capability: external_source_nested_struct_projection
+EXTERNAL "{{nested_events}}"
+| WHERE event.action == "login"
+| KEEP id, event.action
+| SORT id;
+
+id:integer | event.action:keyword
+1          | "login"
+4          | "login"
+;
+
+// IS NULL pushdown on a nested leaf. The reader stats expose the per-leaf null count, so
+// a fully-non-null row group / stripe can be pruned; rows that survive are re-checked.
+nestedWhereIsNull
+required_capability: external_command
+required_capability: external_source_nested_struct_projection
+EXTERNAL "{{nested_events}}"
+| WHERE event.outcome IS NULL
+| KEEP id, event.outcome
+| SORT id;
+
+id:integer | event.outcome:keyword
+4          | null
+6          | null
+;
+
+// Mixed aggregate pushdown: MIN(id)/MAX(id) over a nested grouping key. The aggregate
+// itself is pushed (column-level stats publish min/max for the dotted leaf "id"), the
+// grouping by event.action is evaluated post-read. Exercises both the nested-stats
+// publication path (T2 / T3) and grouping over a nested key.
+nestedStatsMinMax
+required_capability: external_command
+required_capability: external_source_nested_struct_projection
+EXTERNAL "{{nested_events}}"
+| STATS min_id = MIN(id), max_id = MAX(id) BY event.action
+| SORT event.action;
+
+min_id:integer | max_id:integer | event.action:keyword
+1              | 4              | "login"
+2              | 2              | "logout"
+5              | 5              | "read"
+3              | 6              | null
+;
+
+// Combined filter on a nested leaf and a top-level column, plus projection of another
+// nested leaf the predicate doesn't reference. Exercises the dotted-path resolver
+// alongside top-level pushdown, and verifies that nested columns referenced only by the
+// projection still appear (no over-pruning when a sibling leaf is filtered).
+nestedFilterAndProjectMixed
+required_capability: external_command
+required_capability: external_source_nested_struct_projection
+EXTERNAL "{{nested_events}}"
+| WHERE event.action == "login" AND id > 2
+| KEEP id, event.outcome
+| SORT id;
+
+id:integer | event.outcome:keyword
+4          | null
+;

--- a/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReader.java
+++ b/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReader.java
@@ -38,6 +38,8 @@ import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.CloseableIterator;
 import org.elasticsearch.core.Releasables;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
 import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Nullability;
@@ -94,6 +96,8 @@ import java.util.concurrent.ExecutionException;
  * </ul>
  */
 public class OrcFormatReader implements RangeAwareFormatReader, NoConfigFormatReader {
+
+    private static final Logger LOGGER = LogManager.getLogger(OrcFormatReader.class);
 
     private static final long MILLIS_PER_DAY = Duration.ofDays(1).toMillis();
 
@@ -225,50 +229,21 @@ public class OrcFormatReader implements RangeAwareFormatReader, NoConfigFormatRe
         long rowCount = reader.getNumberOfRows();
         long sizeInBytes = reader.getContentLength();
         ColumnStatistics[] orcStats = reader.getStatistics();
-        List<String> fieldNames = schema.getFieldNames();
-        List<TypeDescription> children = schema.getChildren();
 
+        // Walk every dotted leaf the flattener emits, publishing stats at the same names the
+        // planner sees as ESQL attributes. Without this, only top-level entries land in the
+        // map and nested-leaf aggregate pushdown (e.g. MIN(event.id)) silently degrades.
+        // STRUCT intermediates are skipped by walkDottedLeaves — their ColumnStatistics carry
+        // no useful min/max (they aggregate child statistics into the parent's id) and they
+        // bind to no ESQL attribute. Truncated over-cap groups are also skipped: the flattener
+        // emits them as a single UNSUPPORTED attribute that the planner never reads stats for.
         Map<String, SourceStatistics.ColumnStatistics> columnStats = new HashMap<>();
-        for (int i = 0; i < fieldNames.size(); i++) {
-            String name = fieldNames.get(i);
-            int colId = children.get(i).getId();
-            if (colId >= orcStats.length) {
-                continue;
+        walkDottedLeaves(schema, (dottedPath, type, truncated) -> {
+            if (truncated) {
+                return;
             }
-            ColumnStatistics cs = orcStats[colId];
-            long totalValues = cs.getNumberOfValues();
-            long nullCount = rowCount - totalValues;
-            Object minVal = extractOrcMin(cs);
-            Object maxVal = extractOrcMax(cs);
-            long bytesOnDisk = cs.getBytesOnDisk();
-
-            columnStats.put(name, new SourceStatistics.ColumnStatistics() {
-                @Override
-                public OptionalLong nullCount() {
-                    return OptionalLong.of(nullCount);
-                }
-
-                @Override
-                public OptionalLong distinctCount() {
-                    return OptionalLong.empty();
-                }
-
-                @Override
-                public Optional<Object> minValue() {
-                    return Optional.ofNullable(minVal);
-                }
-
-                @Override
-                public Optional<Object> maxValue() {
-                    return Optional.ofNullable(maxVal);
-                }
-
-                @Override
-                public OptionalLong sizeInBytes() {
-                    return bytesOnDisk > 0 ? OptionalLong.of(bytesOnDisk) : OptionalLong.empty();
-                }
-            });
-        }
+            collectLeafStatistics(type, dottedPath, rowCount, orcStats, columnStats);
+        });
 
         return new SourceStatistics() {
             @Override
@@ -286,6 +261,61 @@ public class OrcFormatReader implements RangeAwareFormatReader, NoConfigFormatRe
                 return columnStats.isEmpty() ? Optional.empty() : Optional.of(columnStats);
             }
         };
+    }
+
+    /**
+     * Publishes ORC column statistics for a single non-STRUCT leaf at its dotted attribute name.
+     * Called from {@link #extractStatistics} via {@link #walkDottedLeaves}, so the keys match
+     * exactly what {@link #convertOrcSchemaToAttributes} produces and the planner looks up.
+     *
+     * <p>MAP/LIST&lt;STRUCT&gt;/UNION leaves are still emitted with whatever ColumnStatistics ORC
+     * computed for them — the planner sees those as UNSUPPORTED attributes and never reads the
+     * stats, but emitting them does no harm and keeps this helper unconditional.
+     */
+    private static void collectLeafStatistics(
+        TypeDescription type,
+        String dottedPath,
+        long rowCount,
+        ColumnStatistics[] orcStats,
+        Map<String, SourceStatistics.ColumnStatistics> out
+    ) {
+        int colId = type.getId();
+        if (colId >= orcStats.length) {
+            return;
+        }
+        ColumnStatistics cs = orcStats[colId];
+        long totalValues = cs.getNumberOfValues();
+        long nullCount = rowCount - totalValues;
+        Object minVal = extractOrcMin(cs);
+        Object maxVal = extractOrcMax(cs);
+        long bytesOnDisk = cs.getBytesOnDisk();
+
+        out.put(dottedPath, new SourceStatistics.ColumnStatistics() {
+            @Override
+            public OptionalLong nullCount() {
+                return OptionalLong.of(nullCount);
+            }
+
+            @Override
+            public OptionalLong distinctCount() {
+                return OptionalLong.empty();
+            }
+
+            @Override
+            public Optional<Object> minValue() {
+                return Optional.ofNullable(minVal);
+            }
+
+            @Override
+            public Optional<Object> maxValue() {
+                return Optional.ofNullable(maxVal);
+            }
+
+            @Override
+            public OptionalLong sizeInBytes() {
+                return bytesOnDisk > 0 ? OptionalLong.of(bytesOnDisk) : OptionalLong.empty();
+            }
+        });
     }
 
     private static Object extractOrcMin(ColumnStatistics cs) {
@@ -603,10 +633,12 @@ public class OrcFormatReader implements RangeAwareFormatReader, NoConfigFormatRe
      * Maximum recursion depth for nested STRUCT flattening; mirrors
      * {@code ParquetFormatReader.MAX_STRUCT_FLATTENING_DEPTH}. Groups deeper than the cap
      * surface as a single UNSUPPORTED attribute and a DEBUG log line.
+     *
+     * <p>Depth counts from 1 at the schema's top-level children, so the deepest reachable
+     * group is at depth {@code MAX_STRUCT_FLATTENING_DEPTH}. The Parquet flattener uses the
+     * same convention so the two formats accept the same set of valid paths.
      */
     static final int MAX_STRUCT_FLATTENING_DEPTH = 64;
-
-    private static final org.elasticsearch.logging.Logger LOGGER = org.elasticsearch.logging.LogManager.getLogger(OrcFormatReader.class);
 
     /**
      * Recursively converts an ORC {@link TypeDescription} into ESQL {@link Attribute}s, flattening
@@ -850,13 +882,15 @@ public class OrcFormatReader implements RangeAwareFormatReader, NoConfigFormatRe
                                     break;
                                 }
                             } else {
+                                // Reuse the shared boolean[]->BitSet helper plus BitSet.or so each
+                                // ancestor contributes via a single bulk operation rather than a
+                                // hand-rolled per-row loop; matches the pattern used elsewhere in
+                                // the reader for converting ORC's raw null arrays.
+                                BitSet svNulls = ColumnBlockConversions.toBitSet(sv.isNull, rowCount);
                                 if (ancestorNulls == null) {
-                                    ancestorNulls = new BitSet(rowCount);
-                                }
-                                for (int r = 0; r < rowCount; r++) {
-                                    if (sv.isNull[r]) {
-                                        ancestorNulls.set(r);
-                                    }
+                                    ancestorNulls = svNulls;
+                                } else if (svNulls != null) {
+                                    ancestorNulls.or(svNulls);
                                 }
                             }
                         }

--- a/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcPushedExpressions.java
+++ b/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcPushedExpressions.java
@@ -94,14 +94,65 @@ record OrcPushedExpressions(List<Expression> expressions) {
         return builder.build();
     }
 
-    private static Map<String, TypeDescription.Category> buildColumnTypeMap(TypeDescription schema) {
+    /**
+     * Maximum recursion depth for nested STRUCT flattening; mirrors
+     * {@code OrcFormatReader.MAX_STRUCT_FLATTENING_DEPTH}. The two must stay in lock-step:
+     * a path the reader-side flattener emits as UNSUPPORTED has no corresponding ESQL
+     * attribute, so publishing a column-type entry for it here would yield a stat that no
+     * predicate could ever bind to. We re-declare the value rather than depend on the reader
+     * class so the pushdown package stays free of reader-internal coupling; the
+     * {@code OrcFormatReader} class has a regression test that asserts the two values agree.
+     */
+    static final int MAX_STRUCT_FLATTENING_DEPTH = 64;
+
+    /**
+     * Builds a map from dotted attribute name to the leaf {@link TypeDescription.Category}.
+     * Recurses into STRUCT children so {@code event.action} resolves to the leaf's category,
+     * not the parent STRUCT. Per the prior PR's D2 precedence (same as Parquet T1), a literal
+     * top-level field literally named {@code "event.action"} wins over a nested STRUCT walk
+     * to {@code event -> action} — produce a single entry keyed by the literal name and skip
+     * the conflicting nested traversal at that path. Stops descending at non-STRUCT types
+     * (LIST, MAP, primitives), matching {@code OrcFormatReader.walkDottedLeaves}.
+     *
+     * <p>The map carries both top-level entries (e.g. {@code "id" -> LONG}) and dotted leaves
+     * (e.g. {@code "event.action" -> STRING}); top-level non-STRUCT names retain their old
+     * shape for backward compatibility with the existing tests.
+     */
+    static Map<String, TypeDescription.Category> buildColumnTypeMap(TypeDescription schema) {
         Map<String, TypeDescription.Category> map = new HashMap<>();
         List<String> fieldNames = schema.getFieldNames();
         List<TypeDescription> children = schema.getChildren();
         for (int i = 0; i < fieldNames.size(); i++) {
-            map.put(fieldNames.get(i), children.get(i).getCategory());
+            collectColumnTypes(children.get(i), fieldNames.get(i), 1, map);
         }
         return map;
+    }
+
+    private static void collectColumnTypes(TypeDescription type, String dottedPath, int depth, Map<String, TypeDescription.Category> out) {
+        // D2 precedence: a literal field name already registered at this path wins over a
+        // deeper recursion that would otherwise compose the same dotted string.
+        if (out.containsKey(dottedPath)) {
+            return;
+        }
+        if (depth > MAX_STRUCT_FLATTENING_DEPTH) {
+            // The flattener emits the over-cap group as a single UNSUPPORTED attribute. There
+            // is no corresponding ESQL attribute for any leaf below it, so no predicate can
+            // bind to one — leave the entry off the map entirely.
+            return;
+        }
+        if (type.getCategory() == TypeDescription.Category.STRUCT) {
+            // STRUCT itself is not addressable as a leaf — record its category at the dotted
+            // path so the resolver returns null for any predicate landing on it (mirrors the
+            // Parquet T1 "lands on group" rule), then recurse into children.
+            out.put(dottedPath, TypeDescription.Category.STRUCT);
+            List<String> childNames = type.getFieldNames();
+            List<TypeDescription> children = type.getChildren();
+            for (int i = 0; i < childNames.size(); i++) {
+                collectColumnTypes(children.get(i), dottedPath + "." + childNames.get(i), depth + 1, out);
+            }
+            return;
+        }
+        out.put(dottedPath, type.getCategory());
     }
 
     /**

--- a/x-pack/plugin/esql-datasource-orc/src/test/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-orc/src/test/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReaderTests.java
@@ -660,6 +660,16 @@ public class OrcFormatReaderTests extends ESTestCase {
 
     // --- Pushdown tests ---
 
+    /**
+     * {@link OrcPushedExpressions#MAX_STRUCT_FLATTENING_DEPTH} re-declares the reader-side constant
+     * to keep the pushdown package free of reader-internal coupling. This regression test asserts
+     * the two values agree so a path the flattener emits as UNSUPPORTED cannot end up with a
+     * pushdown column-type entry that no ESQL attribute can ever bind to.
+     */
+    public void testStructFlatteningDepthCapAgreesAcrossReaderAndPushdown() {
+        assertEquals(OrcFormatReader.MAX_STRUCT_FLATTENING_DEPTH, OrcPushedExpressions.MAX_STRUCT_FLATTENING_DEPTH);
+    }
+
     public void testWithPushedFilterReturnsNewInstance() {
         OrcFormatReader reader = new OrcFormatReader(blockFactory);
         SearchArgument sarg = SearchArgumentFactory.newBuilder().startAnd().equals("id", PredicateLeaf.Type.LONG, 1L).end().build();
@@ -1578,6 +1588,117 @@ public class OrcFormatReaderTests extends ESTestCase {
             }
             assertEquals(rows, seen);
         }
+    }
+
+    public void testNestedStructFilterPushdownPrunesStripes() throws Exception {
+        // Two stripes with disjoint event.id ranges. Pushing event.id > 999 must prune the
+        // first stripe via SearchArgument-based stripe statistics; the surviving row count
+        // must be strictly less than the total.
+        TypeDescription schema = TypeDescription.createStruct()
+            .addField("event", TypeDescription.createStruct().addField("id", TypeDescription.createLong()));
+
+        byte[] orcData = createMultiStripeOrcFile(schema, 2, stripe -> {
+            VectorizedRowBatch batch = schema.createRowBatch(100);
+            batch.size = 100;
+            long base = stripe == 0 ? 0L : 1000L;
+            org.apache.hadoop.hive.ql.exec.vector.StructColumnVector ev =
+                (org.apache.hadoop.hive.ql.exec.vector.StructColumnVector) batch.cols[0];
+            LongColumnVector evId = (LongColumnVector) ev.fields[0];
+            for (int i = 0; i < 100; i++) {
+                evId.vector[i] = base + i;
+            }
+            return batch;
+        });
+
+        // Sanity: without pushdown, all 200 rows survive.
+        OrcFormatReader baseline = new OrcFormatReader(blockFactory);
+        StorageObject storageObject = createStorageObject(orcData);
+        int totalRows = countRows(baseline, storageObject, List.of("event.id"), 1024);
+        assertEquals(200, totalRows);
+
+        // Push event.id > 999 — first stripe (max=99) is fully prunable.
+        org.elasticsearch.xpack.esql.core.expression.Expression filter =
+            new org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThan(
+                org.elasticsearch.xpack.esql.core.tree.Source.EMPTY,
+                new org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute(
+                    org.elasticsearch.xpack.esql.core.tree.Source.EMPTY,
+                    "event.id",
+                    DataType.LONG
+                ),
+                new org.elasticsearch.xpack.esql.core.expression.Literal(
+                    org.elasticsearch.xpack.esql.core.tree.Source.EMPTY,
+                    999L,
+                    DataType.LONG
+                )
+            );
+        OrcPushedExpressions pushed = new OrcPushedExpressions(List.of(filter));
+        OrcFormatReader filtered = (OrcFormatReader) new OrcFormatReader(blockFactory).withPushedFilter(pushed);
+        int survived = countRows(filtered, storageObject, List.of("event.id"), 1024);
+        assertTrue("expected pruning to drop the first stripe (100 rows). survived=" + survived, survived <= 100 && survived < totalRows);
+    }
+
+    public void testNestedColumnStatistics() throws Exception {
+        // Two stripes with disjoint event.id ranges; assert per-leaf stats are published with
+        // the dotted name, matching the ESQL attribute names the planner sees. Mirrors the
+        // Parquet-side testNestedColumnStatistics.
+        TypeDescription schema = TypeDescription.createStruct()
+            .addField("id", TypeDescription.createLong())
+            .addField(
+                "event",
+                TypeDescription.createStruct()
+                    .addField("id", TypeDescription.createLong())
+                    .addField("action", TypeDescription.createString())
+            );
+        byte[] orcData = createMultiStripeOrcFile(schema, 2, stripe -> {
+            VectorizedRowBatch batch = schema.createRowBatch(50);
+            batch.size = 50;
+            long base = stripe == 0 ? 0L : 1000L;
+            String action = stripe == 0 ? "login" : "logout";
+            byte[] actionBytes = action.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+            LongColumnVector topId = (LongColumnVector) batch.cols[0];
+            org.apache.hadoop.hive.ql.exec.vector.StructColumnVector ev =
+                (org.apache.hadoop.hive.ql.exec.vector.StructColumnVector) batch.cols[1];
+            LongColumnVector evId = (LongColumnVector) ev.fields[0];
+            BytesColumnVector evAction = (BytesColumnVector) ev.fields[1];
+            for (int i = 0; i < 50; i++) {
+                topId.vector[i] = base + i;
+                evId.vector[i] = base + i;
+                evAction.setVal(i, actionBytes);
+            }
+            return batch;
+        });
+
+        OrcFormatReader reader = new OrcFormatReader(blockFactory);
+        SourceMetadata metadata = reader.metadata(createStorageObject(orcData));
+        assertTrue("expected source statistics", metadata.statistics().isPresent());
+        var optColStats = metadata.statistics().get().columnStatistics();
+        assertTrue("expected per-column statistics", optColStats.isPresent());
+        var colStats = optColStats.get();
+
+        // Nested leaves present at dotted names.
+        assertTrue("event.id stats must be published", colStats.containsKey("event.id"));
+        assertTrue("event.action stats must be published", colStats.containsKey("event.action"));
+        // Top-level still present (no regression).
+        assertTrue("top-level id stats still present", colStats.containsKey("id"));
+        // STRUCT parent should NOT publish stats — collectStatistics descends into STRUCT
+        // children without adding the parent path itself.
+        assertFalse("STRUCT parent must not appear as a stats column", colStats.containsKey("event"));
+
+        // event.id ranges across the two stripes are aggregated by ORC into [0, 1049].
+        var evIdStats = colStats.get("event.id");
+        assertEquals(java.util.Optional.of(0L), evIdStats.minValue());
+        assertEquals(java.util.Optional.of(1049L), evIdStats.maxValue());
+        assertEquals(java.util.OptionalLong.of(0L), evIdStats.nullCount());
+
+        // event.action min/max are STRING; just assert presence rather than exact value.
+        var evActionStats = colStats.get("event.action");
+        assertTrue("event.action min must be present", evActionStats.minValue().isPresent());
+        assertTrue("event.action max must be present", evActionStats.maxValue().isPresent());
+
+        // Top-level id covers the same range.
+        var topIdStats = colStats.get("id");
+        assertEquals(java.util.Optional.of(0L), topIdStats.minValue());
+        assertEquals(java.util.Optional.of(1049L), topIdStats.maxValue());
     }
 
     public void testReadNestedStructAncestorNullPropagation() throws Exception {

--- a/x-pack/plugin/esql-datasource-orc/src/test/java/org/elasticsearch/xpack/esql/datasource/orc/OrcPushedExpressionsTests.java
+++ b/x-pack/plugin/esql-datasource-orc/src/test/java/org/elasticsearch/xpack/esql/datasource/orc/OrcPushedExpressionsTests.java
@@ -1,0 +1,348 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.orc;
+
+import org.apache.hadoop.hive.ql.io.sarg.PredicateLeaf;
+import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
+import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
+import org.apache.lucene.util.BytesRef;
+import org.apache.orc.TypeDescription;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.type.EsField;
+import org.elasticsearch.xpack.esql.expression.predicate.Range;
+import org.elasticsearch.xpack.esql.expression.predicate.logical.And;
+import org.elasticsearch.xpack.esql.expression.predicate.logical.Not;
+import org.elasticsearch.xpack.esql.expression.predicate.logical.Or;
+import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNotNull;
+import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNull;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Equals;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThan;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.In;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThan;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.NotEquals;
+
+import java.sql.Date;
+import java.time.ZoneOffset;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.xpack.esql.core.type.EsField.TimeSeriesFieldType;
+import static org.hamcrest.Matchers.instanceOf;
+
+/**
+ * Symmetric matrix tests for {@link OrcPushedExpressions#toSearchArgument(TypeDescription)}
+ * over nested STRUCT subfields (e.g. {@code event.action}). Mirrors the Parquet-side
+ * {@code ParquetPushedExpressionsTests} nested coverage. The plan's T3 calls these out
+ * explicitly: comparison + IN / IsNull / Range / And / Or / Not over dotted paths, plus
+ * DATETIME-vs-DATE and DOUBLE-vs-DECIMAL type-override resolution under a STRUCT parent.
+ *
+ * <p>ORC's {@code SearchArgument.Builder} accepts dotted names natively (see ORC-323).
+ * The work here verifies that {@link OrcPushedExpressions#buildColumnTypeMap} resolves
+ * the nested leaf so the DATE / DECIMAL overrides keep firing for nested columns.
+ */
+public class OrcPushedExpressionsTests extends ESTestCase {
+
+    private static final Source SOURCE = Source.EMPTY;
+
+    // -------------------- Comparison matrix --------------------
+
+    public void testNestedEqualsString() {
+        TypeDescription schema = nestedKeywordSchema();
+        SearchArgument sarg = toSearchArgument(schema, eq("event.action", DataType.KEYWORD, new BytesRef("login")));
+        assertNotNull(sarg);
+        PredicateLeaf leaf = sarg.getLeaves().get(0);
+        assertEquals("event.action", leaf.getColumnName());
+        assertEquals(PredicateLeaf.Type.STRING, leaf.getType());
+        assertEquals(PredicateLeaf.Operator.EQUALS, leaf.getOperator());
+        assertEquals("login", leaf.getLiteral());
+    }
+
+    public void testNestedNotEqualsString() {
+        TypeDescription schema = nestedKeywordSchema();
+        SearchArgument sarg = toSearchArgument(schema, neq("event.action", DataType.KEYWORD, new BytesRef("admin")));
+        assertNotNull(sarg);
+        // NotEquals is rendered as NOT(EQUALS) in SearchArgument; the leaf is still EQUALS,
+        // but the expression tree negates it. Verify the leaf shape regardless.
+        PredicateLeaf leaf = sarg.getLeaves().get(0);
+        assertEquals("event.action", leaf.getColumnName());
+        assertEquals(PredicateLeaf.Operator.EQUALS, leaf.getOperator());
+    }
+
+    public void testNestedLessThanLong() {
+        TypeDescription schema = nestedLongSchema();
+        SearchArgument sarg = toSearchArgument(schema, lt("event.id", DataType.LONG, 100L));
+        assertNotNull(sarg);
+        PredicateLeaf leaf = sarg.getLeaves().get(0);
+        assertEquals("event.id", leaf.getColumnName());
+        assertEquals(PredicateLeaf.Type.LONG, leaf.getType());
+        assertEquals(PredicateLeaf.Operator.LESS_THAN, leaf.getOperator());
+        assertEquals(100L, leaf.getLiteral());
+    }
+
+    public void testNestedGreaterThanLong() {
+        TypeDescription schema = nestedLongSchema();
+        SearchArgument sarg = toSearchArgument(
+            schema,
+            new GreaterThan(SOURCE, field("event.id", DataType.LONG), literal(7L, DataType.LONG))
+        );
+        assertNotNull(sarg);
+        PredicateLeaf leaf = sarg.getLeaves().get(0);
+        assertEquals("event.id", leaf.getColumnName());
+        assertEquals(PredicateLeaf.Type.LONG, leaf.getType());
+        // GreaterThan is encoded as NOT(LESS_THAN_EQUALS); leaf is LESS_THAN_EQUALS.
+        assertEquals(PredicateLeaf.Operator.LESS_THAN_EQUALS, leaf.getOperator());
+    }
+
+    public void testNestedIsNull() {
+        TypeDescription schema = nestedKeywordSchema();
+        SearchArgument sarg = toSearchArgument(schema, new IsNull(SOURCE, field("event.action", DataType.KEYWORD)));
+        assertNotNull(sarg);
+        PredicateLeaf leaf = sarg.getLeaves().get(0);
+        assertEquals("event.action", leaf.getColumnName());
+        assertEquals(PredicateLeaf.Operator.IS_NULL, leaf.getOperator());
+    }
+
+    public void testNestedIsNotNull() {
+        TypeDescription schema = nestedKeywordSchema();
+        SearchArgument sarg = toSearchArgument(schema, new IsNotNull(SOURCE, field("event.action", DataType.KEYWORD)));
+        assertNotNull(sarg);
+        PredicateLeaf leaf = sarg.getLeaves().get(0);
+        assertEquals("event.action", leaf.getColumnName());
+        assertEquals(PredicateLeaf.Operator.IS_NULL, leaf.getOperator());
+    }
+
+    public void testNestedInList() {
+        TypeDescription schema = nestedKeywordSchema();
+        Expression inExpr = new In(
+            SOURCE,
+            field("event.action", DataType.KEYWORD),
+            List.of(literal(new BytesRef("login"), DataType.KEYWORD), literal(new BytesRef("logout"), DataType.KEYWORD))
+        );
+        SearchArgument sarg = toSearchArgument(schema, inExpr);
+        assertNotNull(sarg);
+        PredicateLeaf leaf = sarg.getLeaves().get(0);
+        assertEquals("event.action", leaf.getColumnName());
+        assertEquals(PredicateLeaf.Operator.IN, leaf.getOperator());
+        assertEquals(2, leaf.getLiteralList().size());
+    }
+
+    public void testNestedRangeLong() {
+        TypeDescription schema = nestedLongSchema();
+        Expression range = new Range(
+            SOURCE,
+            field("event.id", DataType.LONG),
+            literal(10L, DataType.LONG),
+            true,
+            literal(99L, DataType.LONG),
+            true,
+            ZoneOffset.UTC
+        );
+        SearchArgument sarg = toSearchArgument(schema, range);
+        assertNotNull(sarg);
+        // BETWEEN renders as a single leaf with two literals.
+        PredicateLeaf leaf = sarg.getLeaves().get(0);
+        assertEquals("event.id", leaf.getColumnName());
+        assertEquals(PredicateLeaf.Type.LONG, leaf.getType());
+        assertEquals(PredicateLeaf.Operator.BETWEEN, leaf.getOperator());
+    }
+
+    // -------------------- Logical operators over nested predicates --------------------
+
+    public void testNestedAndCombinesTwoNestedLeaves() {
+        TypeDescription schema = nestedActionAndIdSchema();
+        Expression action = eq("event.action", DataType.KEYWORD, new BytesRef("login"));
+        Expression idGt = new GreaterThan(SOURCE, field("event.id", DataType.LONG), literal(0L, DataType.LONG));
+        SearchArgument sarg = toSearchArgument(schema, new And(SOURCE, action, idGt));
+        assertNotNull(sarg);
+        assertEquals(2, sarg.getLeaves().size());
+        // Order is deterministic (left, right); verify dotted names appear on each leaf.
+        assertEquals("event.action", sarg.getLeaves().get(0).getColumnName());
+        assertEquals("event.id", sarg.getLeaves().get(1).getColumnName());
+    }
+
+    public void testNestedOrTwoNestedKeywords() {
+        TypeDescription schema = nestedKeywordSchema();
+        Expression a = eq("event.action", DataType.KEYWORD, new BytesRef("login"));
+        Expression b = eq("event.action", DataType.KEYWORD, new BytesRef("logout"));
+        SearchArgument sarg = toSearchArgument(schema, new Or(SOURCE, a, b));
+        assertNotNull(sarg);
+        assertEquals(2, sarg.getLeaves().size());
+        for (PredicateLeaf leaf : sarg.getLeaves()) {
+            assertEquals("event.action", leaf.getColumnName());
+        }
+    }
+
+    public void testNestedNot() {
+        TypeDescription schema = nestedKeywordSchema();
+        Expression inner = new NotEquals(SOURCE, field("event.action", DataType.KEYWORD), literal(new BytesRef("x"), DataType.KEYWORD));
+        SearchArgument sarg = toSearchArgument(schema, new Not(SOURCE, inner));
+        assertNotNull(sarg);
+        PredicateLeaf leaf = sarg.getLeaves().get(0);
+        assertEquals("event.action", leaf.getColumnName());
+    }
+
+    // -------------------- Type-override resolution (the bug T3 fixes) --------------------
+
+    public void testNestedDatetimeOnDateColumn() {
+        // event.d is DATE under a STRUCT. Without the dotted-path column-type map, the
+        // resolver would not see the DATE override and would emit a TIMESTAMP literal,
+        // mis-pruning stripes. With T3's recursive map, the DATE override fires.
+        TypeDescription schema = TypeDescription.createStruct()
+            .addField("event", TypeDescription.createStruct().addField("d", TypeDescription.createDate()));
+        long millis = 86400000L * 19723;
+        SearchArgument sarg = toSearchArgument(schema, eq("event.d", DataType.DATETIME, millis));
+        assertNotNull(sarg);
+        PredicateLeaf leaf = sarg.getLeaves().get(0);
+        assertEquals("event.d", leaf.getColumnName());
+        assertEquals(PredicateLeaf.Type.DATE, leaf.getType());
+        assertThat(leaf.getLiteral(), instanceOf(Date.class));
+    }
+
+    public void testNestedDatetimeOnTimestampColumnStaysTimestamp() {
+        // No-regression: under the STRUCT parent, a TIMESTAMP leaf must still resolve to
+        // TIMESTAMP (not be incorrectly overridden to DATE).
+        TypeDescription schema = TypeDescription.createStruct()
+            .addField("event", TypeDescription.createStruct().addField("ts", TypeDescription.createTimestamp()));
+        SearchArgument sarg = toSearchArgument(schema, eq("event.ts", DataType.DATETIME, 1700000000000L));
+        assertNotNull(sarg);
+        PredicateLeaf leaf = sarg.getLeaves().get(0);
+        assertEquals("event.ts", leaf.getColumnName());
+        assertEquals(PredicateLeaf.Type.TIMESTAMP, leaf.getType());
+    }
+
+    public void testNestedDoubleOnDecimalColumn() {
+        TypeDescription schema = TypeDescription.createStruct()
+            .addField("event", TypeDescription.createStruct().addField("price", TypeDescription.createDecimal().withScale(2)));
+        SearchArgument sarg = toSearchArgument(schema, eq("event.price", DataType.DOUBLE, 99.99));
+        assertNotNull(sarg);
+        PredicateLeaf leaf = sarg.getLeaves().get(0);
+        assertEquals("event.price", leaf.getColumnName());
+        assertEquals(PredicateLeaf.Type.DECIMAL, leaf.getType());
+        assertThat(leaf.getLiteral(), instanceOf(HiveDecimalWritable.class));
+    }
+
+    public void testNestedDoubleOnDoubleColumnStaysFloat() {
+        TypeDescription schema = TypeDescription.createStruct()
+            .addField("event", TypeDescription.createStruct().addField("score", TypeDescription.createDouble()));
+        SearchArgument sarg = toSearchArgument(schema, eq("event.score", DataType.DOUBLE, 0.5));
+        assertNotNull(sarg);
+        PredicateLeaf leaf = sarg.getLeaves().get(0);
+        assertEquals("event.score", leaf.getColumnName());
+        assertEquals(PredicateLeaf.Type.FLOAT, leaf.getType());
+    }
+
+    // -------------------- Deep path & D2 precedence --------------------
+
+    public void testNestedDeepPathFourLevels() {
+        TypeDescription schema = TypeDescription.createStruct()
+            .addField(
+                "a",
+                TypeDescription.createStruct()
+                    .addField(
+                        "b",
+                        TypeDescription.createStruct()
+                            .addField("c", TypeDescription.createStruct().addField("d", TypeDescription.createLong()))
+                    )
+            );
+        SearchArgument sarg = toSearchArgument(schema, eq("a.b.c.d", DataType.LONG, 42L));
+        assertNotNull(sarg);
+        PredicateLeaf leaf = sarg.getLeaves().get(0);
+        assertEquals("a.b.c.d", leaf.getColumnName());
+        assertEquals(PredicateLeaf.Type.LONG, leaf.getType());
+    }
+
+    public void testBuildColumnTypeMapRecursesAndAppliesD2Precedence() {
+        // The literal top-level "event.action" (STRING) wins over the nested struct walk
+        // which would also produce an entry at "event.action" (INT). Mirrors the Parquet
+        // testLiteralDottedNameWinsOverPath rule.
+        TypeDescription literalThenNested = TypeDescription.createStruct()
+            .addField("event.action", TypeDescription.createString())
+            .addField("event", TypeDescription.createStruct().addField("action", TypeDescription.createInt()));
+
+        Map<String, TypeDescription.Category> map = OrcPushedExpressions.buildColumnTypeMap(literalThenNested);
+        // Literal wins:
+        assertEquals(TypeDescription.Category.STRING, map.get("event.action"));
+        // The intermediate STRUCT entry is still published for the nested side:
+        assertEquals(TypeDescription.Category.STRUCT, map.get("event"));
+    }
+
+    public void testBuildColumnTypeMapEnumeratesNestedLeaves() {
+        TypeDescription schema = TypeDescription.createStruct()
+            .addField("id", TypeDescription.createLong())
+            .addField(
+                "event",
+                TypeDescription.createStruct()
+                    .addField("action", TypeDescription.createString())
+                    .addField("id", TypeDescription.createLong())
+            );
+        Map<String, TypeDescription.Category> map = OrcPushedExpressions.buildColumnTypeMap(schema);
+        // Top-level entries preserved (no regression).
+        assertEquals(TypeDescription.Category.LONG, map.get("id"));
+        // STRUCT marker present at the parent path.
+        assertEquals(TypeDescription.Category.STRUCT, map.get("event"));
+        // Nested leaves present with the dotted path.
+        assertEquals(TypeDescription.Category.STRING, map.get("event.action"));
+        assertEquals(TypeDescription.Category.LONG, map.get("event.id"));
+    }
+
+    // -------------------- Helpers --------------------
+
+    private static TypeDescription nestedKeywordSchema() {
+        return TypeDescription.createStruct()
+            .addField("event", TypeDescription.createStruct().addField("action", TypeDescription.createString()));
+    }
+
+    private static TypeDescription nestedLongSchema() {
+        return TypeDescription.createStruct()
+            .addField("event", TypeDescription.createStruct().addField("id", TypeDescription.createLong()));
+    }
+
+    private static TypeDescription nestedActionAndIdSchema() {
+        return TypeDescription.createStruct()
+            .addField(
+                "event",
+                TypeDescription.createStruct()
+                    .addField("action", TypeDescription.createString())
+                    .addField("id", TypeDescription.createLong())
+            );
+    }
+
+    private static SearchArgument toSearchArgument(TypeDescription schema, Expression... exprs) {
+        return new OrcPushedExpressions(List.of(exprs)).toSearchArgument(schema);
+    }
+
+    private static FieldAttribute field(String name, DataType dataType) {
+        return new FieldAttribute(SOURCE, name, new EsField(name, dataType, Collections.emptyMap(), true, TimeSeriesFieldType.NONE));
+    }
+
+    private static Literal literal(Object value, DataType dataType) {
+        Object literalValue = value;
+        if (value instanceof String s) {
+            literalValue = new BytesRef(s);
+        }
+        return new Literal(SOURCE, literalValue, dataType);
+    }
+
+    private static Expression eq(String fieldName, DataType type, Object value) {
+        return new Equals(SOURCE, field(fieldName, type), literal(value, type));
+    }
+
+    private static Expression neq(String fieldName, DataType type, Object value) {
+        return new NotEquals(SOURCE, field(fieldName, type), literal(value, type));
+    }
+
+    private static Expression lt(String fieldName, DataType type, Object value) {
+        return new LessThan(SOURCE, field(fieldName, type), literal(value, type));
+    }
+}

--- a/x-pack/plugin/esql-datasource-parquet-rs/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/parquet/ParquetRsFormatSpecIT.java
+++ b/x-pack/plugin/esql-datasource-parquet-rs/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/parquet/ParquetRsFormatSpecIT.java
@@ -92,7 +92,11 @@ public class ParquetRsFormatSpecIT extends AbstractExternalSourceSpecTestCase {
         "nestedKeepTwoSubfieldsSameParent",
         "nestedKeepMixedTopLevelAndNested",
         "nestedStatsByNested",
-        "nestedNullPropagation"
+        "nestedNullPropagation",
+        "nestedWhereEquals",
+        "nestedWhereIsNull",
+        "nestedStatsMinMax",
+        "nestedFilterAndProjectMixed"
     );
 
     @Override

--- a/x-pack/plugin/esql-datasource-parquet/qa/src/javaRestTest/resources/external-nested-struct.csv-spec
+++ b/x-pack/plugin/esql-datasource-parquet/qa/src/javaRestTest/resources/external-nested-struct.csv-spec
@@ -85,3 +85,69 @@ id:integer | event.action:keyword
 3          | null
 6          | null
 ;
+
+// Filter pushdown on a nested KEYWORD leaf. The Parquet / ORC readers translate this to
+// a FilterPredicate / SearchArgument against the dotted column path and prune row groups /
+// stripes whose statistics rule out the value (see ParquetPushedExpressions /
+// OrcPushedExpressions). FilterExec re-applies the conjunct to catch any leakage.
+nestedWhereEquals
+required_capability: external_command
+required_capability: external_source_nested_struct_projection
+EXTERNAL "{{nested_events}}"
+| WHERE event.action == "login"
+| KEEP id, event.action
+| SORT id;
+
+id:integer | event.action:keyword
+1          | "login"
+4          | "login"
+;
+
+// IS NULL pushdown on a nested leaf. The reader stats expose the per-leaf null count, so
+// a fully-non-null row group / stripe can be pruned; rows that survive are re-checked.
+nestedWhereIsNull
+required_capability: external_command
+required_capability: external_source_nested_struct_projection
+EXTERNAL "{{nested_events}}"
+| WHERE event.outcome IS NULL
+| KEEP id, event.outcome
+| SORT id;
+
+id:integer | event.outcome:keyword
+4          | null
+6          | null
+;
+
+// Mixed aggregate pushdown: MIN(id)/MAX(id) over a nested grouping key. The aggregate
+// itself is pushed (column-level stats publish min/max for the dotted leaf "id"), the
+// grouping by event.action is evaluated post-read. Exercises both the nested-stats
+// publication path (T2 / T3) and grouping over a nested key.
+nestedStatsMinMax
+required_capability: external_command
+required_capability: external_source_nested_struct_projection
+EXTERNAL "{{nested_events}}"
+| STATS min_id = MIN(id), max_id = MAX(id) BY event.action
+| SORT event.action;
+
+min_id:integer | max_id:integer | event.action:keyword
+1              | 4              | "login"
+2              | 2              | "logout"
+5              | 5              | "read"
+3              | 6              | null
+;
+
+// Combined filter on a nested leaf and a top-level column, plus projection of another
+// nested leaf the predicate doesn't reference. Exercises the dotted-path resolver
+// alongside top-level pushdown, and verifies that nested columns referenced only by the
+// projection still appear (no over-pruning when a sibling leaf is filtered).
+nestedFilterAndProjectMixed
+required_capability: external_command
+required_capability: external_source_nested_struct_projection
+EXTERNAL "{{nested_events}}"
+| WHERE event.action == "login" AND id > 2
+| KEEP id, event.outcome
+| SORT id;
+
+id:integer | event.outcome:keyword
+4          | null
+;

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
@@ -1949,8 +1949,13 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
         if (pageColumnReaders != null && pageColumnReaders[colIndex] != null) {
             // PageColumnReader handles maxDefLevel > 1 for nested-flat STRUCT leaves (e.g.
             // `event.action`). maxRepLevel must stay 0 because LIST<STRUCT> is intentionally
-            // unsupported in this PR — see issue elastic/esql-planning#435.
-            assert info.maxRepLevel() == 0 : "PageColumnReader path expects maxRepLevel == 0 for [" + info + "]";
+            // unsupported in this PR — see issue elastic/esql-planning#435. Enforce the invariant
+            // with a hard throw rather than an assertion so it survives production builds where
+            // assertions are disabled — a LIST<STRUCT> leaf reaching this branch would otherwise
+            // silently emit wrong data.
+            if (info.maxRepLevel() != 0) {
+                throw new IllegalStateException("PageColumnReader path expects maxRepLevel == 0 for [" + info + "]");
+            }
             return pageColumnReaders[colIndex].readBatch(rowsToRead, blockFactory);
         }
         ColumnReader cr = columnReaders != null ? columnReaders[colIndex] : null;

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -434,13 +434,13 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
             FileMetaData fileMetaData = reader.getFileMetaData();
             MessageType parquetSchema = fileMetaData.getSchema();
             List<Attribute> schema = convertParquetSchemaToAttributes(parquetSchema);
-            SourceStatistics statistics = extractStatistics(reader, parquetSchema);
+            SourceStatistics statistics = extractStatistics(reader, schema);
             return new SimpleSourceMetadata(schema, formatName(), object.path().toString(), statistics, null);
         }
     }
 
     @SuppressWarnings("rawtypes")
-    private SourceStatistics extractStatistics(ParquetFileReader reader, MessageType schema) {
+    private SourceStatistics extractStatistics(ParquetFileReader reader, List<Attribute> attributes) {
         List<BlockMetaData> rowGroups = reader.getRowGroups();
         if (rowGroups.isEmpty()) {
             return null;
@@ -490,8 +490,17 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
         final long rowCount = totalRows;
         final long sizeBytes = totalSize;
         Map<String, SourceStatistics.ColumnStatistics> columnStats = new HashMap<>();
-        for (Type field : schema.getFields()) {
-            String name = field.getName();
+        // Publish stats keyed by every dotted leaf the flattener produced an addressable
+        // attribute for. Skip UNSUPPORTED — they will not bind to a planner attribute the
+        // aggregate-pushdown layer can read stats off of, and over-depth / MAP / LIST<STRUCT>
+        // groups surface as UNSUPPORTED here exactly so this filter removes them. Names match
+        // the collection-loop's col.getPath().toDotString() exactly because
+        // {@link #collectAttributes} concatenates the same Parquet child names with '.'.
+        for (Attribute attribute : attributes) {
+            if (attribute.dataType() == DataType.UNSUPPORTED) {
+                continue;
+            }
+            String name = attribute.name();
             long[] nc = nullCounts.get(name);
             Comparable[] mn = mins.get(name);
             Comparable[] mx = maxs.get(name);
@@ -1230,21 +1239,26 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
             // Try dotted-path traversal: walk prefixes from shortest to longest and stop at the
             // first one that resolves to a STRUCT group whose remainder also matches. The literal
             // top-level name already won above; here we only deal with synthetic dotted names.
+            // Walk dot positions directly with substring rather than splitting + re-joining each
+            // probe; the segments array is still computed once for the remainder.
             String[] segments = name.split("\\.");
-            for (int prefixLen = 1; prefixLen < segments.length; prefixLen++) {
-                String topLevel = String.join(".", Arrays.copyOfRange(segments, 0, prefixLen));
-                if (fullSchema.containsField(topLevel) == false) {
-                    continue;
+            int dotIdx = name.indexOf('.');
+            int prefixLen = 1;
+            while (dotIdx >= 0) {
+                String topLevel = name.substring(0, dotIdx);
+                if (fullSchema.containsField(topLevel)) {
+                    Type field = fullSchema.getType(topLevel);
+                    if (field.isPrimitive()) {
+                        break;
+                    }
+                    List<String> remainder = List.of(Arrays.copyOfRange(segments, prefixLen, segments.length));
+                    if (groupContainsPath(field.asGroupType(), remainder, 0)) {
+                        topLevelToChildPaths.computeIfAbsent(topLevel, k -> new LinkedHashMap<>()).put(remainder, Boolean.TRUE);
+                        break;
+                    }
                 }
-                Type field = fullSchema.getType(topLevel);
-                if (field.isPrimitive()) {
-                    break;
-                }
-                List<String> remainder = List.of(Arrays.copyOfRange(segments, prefixLen, segments.length));
-                if (groupContainsPath(field.asGroupType(), remainder, 0)) {
-                    topLevelToChildPaths.computeIfAbsent(topLevel, k -> new LinkedHashMap<>()).put(remainder, Boolean.TRUE);
-                    break;
-                }
+                dotIdx = name.indexOf('.', dotIdx + 1);
+                prefixLen++;
             }
         }
         List<Type> projectedFields = new ArrayList<>();
@@ -1279,23 +1293,26 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
             return fullSchema.getType(name);
         }
         String[] segments = name.split("\\.");
-        for (int prefixLen = 1; prefixLen < segments.length; prefixLen++) {
-            String topLevel = String.join(".", Arrays.copyOfRange(segments, 0, prefixLen));
-            if (fullSchema.containsField(topLevel) == false) {
-                continue;
-            }
-            Type field = fullSchema.getType(topLevel);
-            for (int i = prefixLen; i < segments.length; i++) {
-                if (field.isPrimitive()) {
-                    return null;
+        int dotIdx = name.indexOf('.');
+        int prefixLen = 1;
+        while (dotIdx >= 0) {
+            String topLevel = name.substring(0, dotIdx);
+            if (fullSchema.containsField(topLevel)) {
+                Type field = fullSchema.getType(topLevel);
+                for (int i = prefixLen; i < segments.length; i++) {
+                    if (field.isPrimitive()) {
+                        return null;
+                    }
+                    GroupType group = field.asGroupType();
+                    if (group.containsField(segments[i]) == false) {
+                        return null;
+                    }
+                    field = group.getType(segments[i]);
                 }
-                GroupType group = field.asGroupType();
-                if (group.containsField(segments[i]) == false) {
-                    return null;
-                }
-                field = group.getType(segments[i]);
+                return field;
             }
-            return field;
+            dotIdx = name.indexOf('.', dotIdx + 1);
+            prefixLen++;
         }
         return null;
     }
@@ -1365,6 +1382,10 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
      * Maximum recursion depth for nested STRUCT flattening. Beyond this, the offending group
      * surfaces as a single {@link DataType#UNSUPPORTED} attribute at its dotted path and a
      * DEBUG log entry is emitted; no infinite recursion or partial flattening occurs.
+     *
+     * <p>Depth counts from 1 at the schema's top-level children, so the deepest reachable
+     * group sits at depth {@code MAX_STRUCT_FLATTENING_DEPTH}. The ORC flattener uses the
+     * same convention so the two formats accept the same set of valid paths.
      */
     static final int MAX_STRUCT_FLATTENING_DEPTH = 64;
 

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressions.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressions.java
@@ -16,9 +16,11 @@ import org.apache.parquet.filter2.predicate.FilterApi;
 import org.apache.parquet.filter2.predicate.FilterPredicate;
 import org.apache.parquet.filter2.predicate.Operators;
 import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Type;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BytesRefBlock;
@@ -418,21 +420,76 @@ final class ParquetPushedExpressions {
     }
 
     /**
-     * Returns {@code true} when the file's physical primitive for {@code columnName} is
-     * {@link PrimitiveType.PrimitiveTypeName#DOUBLE}.
+     * Returns {@code true} when the file's physical primitive at {@code columnName} (which may be
+     * a dotted path into a nested STRUCT) is {@link PrimitiveType.PrimitiveTypeName#DOUBLE}.
      */
     private static boolean isPhysicalDouble(MessageType schema, String columnName) {
-        if (schema.containsField(columnName) == false) {
+        PrimitiveType primitive = resolveNestedPrimitive(schema, columnName);
+        if (primitive == null) {
             return false;
         }
-        return schema.getType(columnName).asPrimitiveType().getPrimitiveTypeName() == PrimitiveType.PrimitiveTypeName.DOUBLE;
+        return primitive.getPrimitiveTypeName() == PrimitiveType.PrimitiveTypeName.DOUBLE;
+    }
+
+    /**
+     * Resolves a (possibly dotted) {@code name} to the leaf {@link PrimitiveType} in {@code schema}.
+     * Applies the same D2 precedence as the prior PR's projection-time flattener: a literal
+     * top-level field named exactly {@code "a.b.c"} wins over the dotted-path traversal
+     * {@code a -> b -> c}. Returns {@code null} when the path is missing or lands on a group
+     * (e.g. an intermediate STRUCT, MAP, or LIST) rather than a primitive — predicate pushdown
+     * is only meaningful at primitive leaves.
+     *
+     * <p>This is the single dotted-path resolver used by {@link #isPhysicalDouble} and
+     * {@link #buildDatetimePredicate} (and {@link #translateDatetimeIn}). Translation of the
+     * raw column name into a parquet-mr {@link Operators.Column} happens via
+     * {@link FilterApi#binaryColumn(String)} etc. which internally build a multi-segment
+     * {@link org.apache.parquet.hadoop.metadata.ColumnPath} via
+     * {@code ColumnPath.fromDotString} — so the dotted name flows end-to-end through the row
+     * group filter without any additional wrapping here.
+     */
+    @Nullable
+    static PrimitiveType resolveNestedPrimitive(MessageType schema, String dottedName) {
+        if (schema.containsField(dottedName)) {
+            Type leaf = schema.getType(dottedName);
+            return leaf.isPrimitive() ? leaf.asPrimitiveType() : null;
+        }
+        // Walk left-to-right, allowing literal-dot top-level prefixes to compose with nested
+        // children — the exact-name fast path above already handled the no-dot case. Probe each
+        // prefix via substring rather than re-joining segments on every iteration; when
+        // {@code dottedName} has no dot at all the loop is skipped and we return null below.
+        String[] segments = dottedName.split("\\.");
+        int probeDot = dottedName.indexOf('.');
+        int prefixLen = 1;
+        while (probeDot >= 0) {
+            String topLevel = dottedName.substring(0, probeDot);
+            if (schema.containsField(topLevel)) {
+                Type field = schema.getType(topLevel);
+                for (int i = prefixLen; i < segments.length; i++) {
+                    if (field.isPrimitive()) {
+                        return null;
+                    }
+                    GroupType group = field.asGroupType();
+                    if (group.containsField(segments[i]) == false) {
+                        field = null;
+                        break;
+                    }
+                    field = group.getType(segments[i]);
+                }
+                if (field != null && field.isPrimitive()) {
+                    return field.asPrimitiveType();
+                }
+            }
+            probeDot = dottedName.indexOf('.', probeDot + 1);
+            prefixLen++;
+        }
+        return null;
     }
 
     private static FilterPredicate buildDatetimePredicate(String columnName, Object value, PredicateOp op, MessageType schema) {
-        if (schema.containsField(columnName) == false) {
+        PrimitiveType ptype = resolveNestedPrimitive(schema, columnName);
+        if (ptype == null) {
             return null;
         }
-        PrimitiveType ptype = schema.getType(columnName).asPrimitiveType();
         LogicalTypeAnnotation logical = ptype.getLogicalTypeAnnotation();
 
         if (value == null) {
@@ -523,10 +580,10 @@ final class ParquetPushedExpressions {
     }
 
     private static FilterPredicate translateDatetimeIn(String columnName, List<Object> rawValues, MessageType schema) {
-        if (schema.containsField(columnName) == false) {
+        PrimitiveType ptype = resolveNestedPrimitive(schema, columnName);
+        if (ptype == null) {
             return null;
         }
-        PrimitiveType ptype = schema.getType(columnName).asPrimitiveType();
         LogicalTypeAnnotation logical = ptype.getLogicalTypeAnnotation();
         try {
             return switch (ptype.getPrimitiveTypeName()) {

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
@@ -72,6 +72,7 @@ import java.util.Deque;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -2837,6 +2838,164 @@ public class ParquetFormatReaderTests extends ESTestCase {
             ParquetFormatReader.MAX_STRUCT_FLATTENING_DEPTH + 1,
             attr.name().split("\\.").length
         );
+    }
+
+    public void testNestedStructFilterPushdownPrunesRowGroups() throws Exception {
+        // Two row groups with disjoint event.id ranges. Pushing event.id > 999 must prune the
+        // first row group entirely; the surviving row count must reflect only the second.
+        MessageType schema = new MessageType(
+            "test_schema",
+            Types.required(PrimitiveType.PrimitiveTypeName.INT64).named("id"),
+            Types.optionalGroup().required(PrimitiveType.PrimitiveTypeName.INT64).named("id").named("event")
+        );
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        OutputFile outputFile = createOutputFile(outputStream);
+        SimpleGroupFactory groupFactory = new SimpleGroupFactory(schema);
+        // Small row-group size so each batch of writes lands in its own row group, large
+        // enough to fit ~50 rows. Disable column index (small files default off) — row group
+        // statistics are sufficient for this assertion.
+        try (
+            ParquetWriter<Group> writer = ExampleParquetWriter.builder(outputFile)
+                .withConf(new PlainParquetConfiguration())
+                .withCodecFactory(new PlainCompressionCodecFactory())
+                .withType(schema)
+                .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
+                .withRowGroupSize(1024L)
+                .withPageSize(256)
+                .build()
+        ) {
+            for (long i = 1; i <= 50; i++) {
+                Group g = groupFactory.newGroup();
+                g.add("id", i);
+                g.addGroup("event").append("id", i);
+                writer.write(g);
+            }
+            for (long i = 1000; i <= 1050; i++) {
+                Group g = groupFactory.newGroup();
+                g.add("id", i);
+                g.addGroup("event").append("id", i);
+                writer.write(g);
+            }
+        }
+        byte[] parquetData = outputStream.toByteArray();
+
+        // Sanity: without pushdown, all rows are read.
+        ParquetFormatReader baseline = new ParquetFormatReader(blockFactory);
+        int totalRows = countRows(baseline, parquetData, List.of("event.id"));
+        assertEquals(101, totalRows);
+
+        // Push event.id > 999. The first row group's max is 50 → stats prune it entirely;
+        // only the second row group (51 rows) survives.
+        org.elasticsearch.xpack.esql.core.expression.Expression filter =
+            new org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThan(
+                org.elasticsearch.xpack.esql.core.tree.Source.EMPTY,
+                new ReferenceAttribute(org.elasticsearch.xpack.esql.core.tree.Source.EMPTY, "event.id", DataType.LONG),
+                new org.elasticsearch.xpack.esql.core.expression.Literal(
+                    org.elasticsearch.xpack.esql.core.tree.Source.EMPTY,
+                    999L,
+                    DataType.LONG
+                ),
+                null
+            );
+        ParquetPushedExpressions pushed = new ParquetPushedExpressions(List.of(filter));
+        ParquetFormatReader filtered = new ParquetFormatReader(blockFactory).withPushedFilter(pushed);
+        int survived = countRows(filtered, parquetData, List.of("event.id"));
+        // Strict less-than is the contract: the first row group's 50 rows must be pruned. The
+        // exact count is at most 51 (the second row group), since parquet-mr may not perform
+        // per-row strict cleanup at the reader level without a record filter.
+        assertTrue("expected pruning to drop the first row group (50 rows). survived=" + survived, survived <= 51 && survived < totalRows);
+    }
+
+    private int countRows(ParquetFormatReader reader, byte[] parquetData, List<String> projection) throws IOException {
+        int total = 0;
+        try (CloseableIterator<Page> iter = reader.read(createStorageObject(parquetData), projection, 1024)) {
+            while (iter.hasNext()) {
+                Page page = iter.next();
+                total += page.getPositionCount();
+                page.releaseBlocks();
+            }
+        }
+        return total;
+    }
+
+    public void testNestedColumnStatistics() throws Exception {
+        // Two row groups with distinct min/max for event.id, plus a flat top-level "id" to assert
+        // the publication walk does not drop top-level stats when adding nested ones.
+        MessageType schema = new MessageType(
+            "test_schema",
+            Types.required(PrimitiveType.PrimitiveTypeName.INT64).named("id"),
+            Types.optionalGroup()
+                .optional(PrimitiveType.PrimitiveTypeName.INT64)
+                .named("id")
+                .optional(PrimitiveType.PrimitiveTypeName.BINARY)
+                .as(LogicalTypeAnnotation.stringType())
+                .named("action")
+                .named("event")
+        );
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        OutputFile outputFile = createOutputFile(outputStream);
+        SimpleGroupFactory groupFactory = new SimpleGroupFactory(schema);
+        // Small row-group size so each batch of writes lands in its own row group.
+        try (
+            ParquetWriter<Group> writer = ExampleParquetWriter.builder(outputFile)
+                .withConf(new PlainParquetConfiguration())
+                .withCodecFactory(new PlainCompressionCodecFactory())
+                .withType(schema)
+                .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
+                .withRowGroupSize(1024L)
+                .withPageSize(256)
+                .build()
+        ) {
+            // Group 1: event.id in [1, 50], event.action = "login"
+            for (long i = 1; i <= 50; i++) {
+                Group g = groupFactory.newGroup();
+                g.add("id", i);
+                g.addGroup("event").append("id", i).append("action", "login");
+                writer.write(g);
+            }
+            // Flush by writing more rows that exceed the small row-group budget; group 2
+            // has a disjoint event.id range [1000, 1050] and event.action = "logout".
+            for (long i = 1000; i <= 1050; i++) {
+                Group g = groupFactory.newGroup();
+                g.add("id", i);
+                g.addGroup("event").append("id", i).append("action", "logout");
+                writer.write(g);
+            }
+        }
+        byte[] parquetData = outputStream.toByteArray();
+
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+        SourceMetadata metadata = reader.metadata(createStorageObject(parquetData));
+
+        assertTrue("expected source statistics", metadata.statistics().isPresent());
+        var optColStats = metadata.statistics().get().columnStatistics();
+        assertTrue("expected per-column statistics", optColStats.isPresent());
+        Map<String, ? extends org.elasticsearch.xpack.esql.datasources.spi.SourceStatistics.ColumnStatistics> colStats = optColStats.get();
+
+        // Nested leaves are present with the dotted name.
+        assertTrue("event.id stats must be published", colStats.containsKey("event.id"));
+        assertTrue("event.action stats must be published", colStats.containsKey("event.action"));
+        // Top-level stats remain (no regression).
+        assertTrue("top-level id stats still present", colStats.containsKey("id"));
+
+        // event.id: 1 .. 1050 across the two row groups.
+        var eventIdStats = colStats.get("event.id");
+        assertEquals(Optional.of(1L), eventIdStats.minValue());
+        assertEquals(Optional.of(1050L), eventIdStats.maxValue());
+        assertEquals(java.util.OptionalLong.of(0L), eventIdStats.nullCount());
+
+        // event.action: KEYWORD → min/max are BytesRef-backed; we only assert presence to avoid
+        // coupling to parquet-mr's internal Binary representation.
+        var eventActionStats = colStats.get("event.action");
+        assertTrue("event.action min must be present", eventActionStats.minValue().isPresent());
+        assertTrue("event.action max must be present", eventActionStats.maxValue().isPresent());
+
+        // Top-level id stats: 1 .. 1050.
+        var topIdStats = colStats.get("id");
+        assertEquals(Optional.of(1L), topIdStats.minValue());
+        assertEquals(Optional.of(1050L), topIdStats.maxValue());
     }
 
     public void testNestedStructEndToEndWithThreeWayNullPropagation() throws Exception {

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressionsTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressionsTests.java
@@ -7,9 +7,11 @@
 
 package org.elasticsearch.xpack.esql.datasource.parquet;
 
+import org.apache.lucene.util.BytesRef;
 import org.apache.parquet.filter2.predicate.FilterPredicate;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Types;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
@@ -27,11 +29,14 @@ import org.elasticsearch.xpack.esql.expression.predicate.Range;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.And;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.Not;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.Or;
+import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNotNull;
+import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNull;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Equals;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThan;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.In;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThan;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThanOrEqual;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.NotEquals;
 
 import java.time.ZoneOffset;
 import java.util.List;
@@ -520,6 +525,324 @@ public class ParquetPushedExpressionsTests extends ESTestCase {
         FilterPredicate fp = pushed.toFilterPredicate(schema);
         assertNotNull(fp);
         assertThat(fp.toString(), containsString("score"));
+    }
+
+    // -----------------------------------------------------------------------------------
+    // Nested STRUCT pushdown — dotted column names (e.g. event.action) flow through the
+    // same FilterPredicate translation as top-level names. The resolveNestedPrimitive
+    // helper walks the dotted path; FilterApi.binaryColumn / intColumn / longColumn etc.
+    // internally store the name as a multi-segment ColumnPath via ColumnPath.fromDotString,
+    // which is then compared against the multi-segment ColumnDescriptor.getPath() at row
+    // group filter time — so the dotted name must reappear verbatim in the predicate's
+    // toString. Per the prior PR's D2 rule, a literal top-level field literally named
+    // "event.action" wins over a nested resolution of the same dotted path.
+    // -----------------------------------------------------------------------------------
+    // Nested STRUCT type-shape helpers: each builds a single event-group schema with the
+    // requested leaf primitive and logical-type annotation.
+
+    private static MessageType nestedTimestamp(LogicalTypeAnnotation.TimeUnit unit) {
+        return Types.buildMessage().requiredGroup().required(INT64).as(timestampType(true, unit)).named("ts").named("event").named("test");
+    }
+
+    private static MessageType nestedDate() {
+        return Types.buildMessage().requiredGroup().required(INT32).as(dateType()).named("d").named("event").named("test");
+    }
+
+    private static MessageType nestedKeyword() {
+        return Types.buildMessage()
+            .requiredGroup()
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("action")
+            .named("event")
+            .named("test");
+    }
+
+    public void testToFilterPredicateNestedTimestampMillis() {
+        MessageType schema = nestedTimestamp(LogicalTypeAnnotation.TimeUnit.MILLIS);
+        long millis = 1700000000000L;
+        Expression expr = eq("event.ts", DataType.DATETIME, millis);
+        ParquetPushedExpressions pushed = new ParquetPushedExpressions(List.of(expr));
+
+        FilterPredicate fp = pushed.toFilterPredicate(schema);
+        assertNotNull(fp);
+        String repr = fp.toString();
+        assertThat(repr, containsString("event.ts"));
+        assertThat(repr, containsString(String.valueOf(millis)));
+    }
+
+    public void testToFilterPredicateNestedTimestampMicros() {
+        MessageType schema = nestedTimestamp(LogicalTypeAnnotation.TimeUnit.MICROS);
+        long millis = 1700000000000L;
+        Expression expr = eq("event.ts", DataType.DATETIME, millis);
+
+        FilterPredicate fp = new ParquetPushedExpressions(List.of(expr)).toFilterPredicate(schema);
+        assertNotNull(fp);
+        assertThat(fp.toString(), containsString("event.ts"));
+        assertThat(fp.toString(), containsString(String.valueOf(millis * 1000)));
+    }
+
+    public void testToFilterPredicateNestedTimestampNanos() {
+        MessageType schema = nestedTimestamp(LogicalTypeAnnotation.TimeUnit.NANOS);
+        long millis = 1700000000000L;
+        Expression expr = eq("event.ts", DataType.DATETIME, millis);
+
+        FilterPredicate fp = new ParquetPushedExpressions(List.of(expr)).toFilterPredicate(schema);
+        assertNotNull(fp);
+        assertThat(fp.toString(), containsString("event.ts"));
+        assertThat(fp.toString(), containsString(String.valueOf(millis * 1_000_000L)));
+    }
+
+    public void testToFilterPredicateNestedDate() {
+        MessageType schema = nestedDate();
+        long millis = 86400000L * 19723;
+        int expectedDays = (int) (millis / ParquetPushedExpressions.MILLIS_PER_DAY);
+        Expression expr = eq("event.d", DataType.DATETIME, millis);
+
+        FilterPredicate fp = new ParquetPushedExpressions(List.of(expr)).toFilterPredicate(schema);
+        assertNotNull(fp);
+        assertThat(fp.toString(), containsString("event.d"));
+        assertThat(fp.toString(), containsString(String.valueOf(expectedDays)));
+    }
+
+    public void testToFilterPredicateNestedKeyword() {
+        MessageType schema = nestedKeyword();
+        Expression expr = eq("event.action", DataType.KEYWORD, new BytesRef("login"));
+
+        FilterPredicate fp = new ParquetPushedExpressions(List.of(expr)).toFilterPredicate(schema);
+        assertNotNull(fp);
+        // parquet-mr renders the column path with dots in toString — verify the dotted name
+        // round-trips end-to-end through FilterApi.binaryColumn -> ColumnPath.fromDotString.
+        // Note: the BytesRef literal is rendered as raw byte values (Binary{N constant bytes,
+        // [108, ...]}) rather than the ASCII text, so we cannot assert on "login" here.
+        assertThat(fp.toString(), containsString("event.action"));
+    }
+
+    public void testToFilterPredicateNestedLongRange() {
+        MessageType schema = Types.buildMessage().requiredGroup().required(INT64).named("id").named("event").named("test");
+        Expression range = new Range(
+            Source.EMPTY,
+            attr("event.id", DataType.LONG),
+            lit(10L, DataType.LONG),
+            true,
+            lit(99L, DataType.LONG),
+            true,
+            ZoneOffset.UTC
+        );
+
+        FilterPredicate fp = new ParquetPushedExpressions(List.of(range)).toFilterPredicate(schema);
+        assertNotNull(fp);
+        assertThat(fp.toString(), containsString("event.id"));
+    }
+
+    public void testToFilterPredicateNestedDoubleSkippedForNonDouble() {
+        // Nested physical INT64+DECIMAL is read as ESQL DOUBLE but parquet-mr rejects a
+        // doubleColumn predicate against an INT64 — must skip pushdown, mirror of top-level
+        // testDoubleEqAgainstDecimalInt64IsNotPushed.
+        MessageType schema = Types.buildMessage()
+            .requiredGroup()
+            .required(INT64)
+            .as(decimalType(2, 18))
+            .named("price")
+            .named("event")
+            .named("test");
+        Expression expr = eq("event.price", DataType.DOUBLE, 100.0);
+        assertNull(new ParquetPushedExpressions(List.of(expr)).toFilterPredicate(schema));
+    }
+
+    public void testToFilterPredicateNestedDoublePushed() {
+        // Native DOUBLE under a struct must keep going through pushdown unchanged.
+        MessageType schema = Types.buildMessage().requiredGroup().required(DOUBLE).named("score").named("event").named("test");
+        Expression expr = eq("event.score", DataType.DOUBLE, 0.5);
+
+        FilterPredicate fp = new ParquetPushedExpressions(List.of(expr)).toFilterPredicate(schema);
+        assertNotNull(fp);
+        assertThat(fp.toString(), containsString("event.score"));
+    }
+
+    public void testToFilterPredicateNestedIsNull() {
+        MessageType schema = nestedKeyword();
+        Expression expr = new IsNull(Source.EMPTY, attr("event.action", DataType.KEYWORD));
+
+        FilterPredicate fp = new ParquetPushedExpressions(List.of(expr)).toFilterPredicate(schema);
+        assertNotNull(fp);
+        // IsNull lowers to eq(col, null). The dotted name must still appear.
+        assertThat(fp.toString(), containsString("event.action"));
+        assertThat(fp.toString(), containsString("null"));
+    }
+
+    public void testToFilterPredicateNestedIsNotNull() {
+        MessageType schema = nestedKeyword();
+        Expression expr = new IsNotNull(Source.EMPTY, attr("event.action", DataType.KEYWORD));
+
+        FilterPredicate fp = new ParquetPushedExpressions(List.of(expr)).toFilterPredicate(schema);
+        assertNotNull(fp);
+        assertThat(fp.toString(), containsString("event.action"));
+    }
+
+    public void testToFilterPredicateNestedInList() {
+        MessageType schema = nestedKeyword();
+        Expression inExpr = new In(
+            Source.EMPTY,
+            attr("event.action", DataType.KEYWORD),
+            List.of(lit(new BytesRef("login"), DataType.KEYWORD), lit(new BytesRef("logout"), DataType.KEYWORD))
+        );
+
+        FilterPredicate fp = new ParquetPushedExpressions(List.of(inExpr)).toFilterPredicate(schema);
+        assertNotNull(fp);
+        String repr = fp.toString();
+        assertThat(repr, containsString("in("));
+        assertThat(repr, containsString("event.action"));
+    }
+
+    public void testToFilterPredicateNestedAnd() {
+        // Two conjuncts sharing the same parent path AND one top-level conjunct — verifies
+        // the dotted path resolves correctly per-leaf, alongside an exact top-level name.
+        MessageType schema = Types.buildMessage()
+            .required(INT64)
+            .named("id")
+            .requiredGroup()
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("action")
+            .required(INT64)
+            .named("ts")
+            .named("event")
+            .named("test");
+
+        Expression action = eq("event.action", DataType.KEYWORD, new BytesRef("login"));
+        Expression ts = new GreaterThan(Source.EMPTY, attr("event.ts", DataType.LONG), lit(0L, DataType.LONG), null);
+        Expression id = eq("id", DataType.LONG, 1L);
+        ParquetPushedExpressions pushed = new ParquetPushedExpressions(List.of(action, ts, id));
+
+        FilterPredicate fp = pushed.toFilterPredicate(schema);
+        assertNotNull(fp);
+        String repr = fp.toString();
+        assertThat(repr, containsString("event.action"));
+        assertThat(repr, containsString("event.ts"));
+        assertThat(repr, containsString("id"));
+    }
+
+    public void testToFilterPredicateNestedOrAndNot() {
+        MessageType schema = nestedKeyword();
+        Expression eq1 = eq("event.action", DataType.KEYWORD, new BytesRef("login"));
+        Expression eq2 = eq("event.action", DataType.KEYWORD, new BytesRef("logout"));
+        Expression or = new Or(Source.EMPTY, eq1, eq2);
+        Expression notEq = new Not(
+            Source.EMPTY,
+            new NotEquals(Source.EMPTY, attr("event.action", DataType.KEYWORD), lit(new BytesRef("admin"), DataType.KEYWORD), null)
+        );
+        Expression and = new And(Source.EMPTY, or, notEq);
+
+        FilterPredicate fp = new ParquetPushedExpressions(List.of(and)).toFilterPredicate(schema);
+        assertNotNull(fp);
+        String repr = fp.toString();
+        // The dotted name appears on every leaf; verify And/Or/Not nesting all preserve it.
+        assertThat(repr, containsString("event.action"));
+        assertThat(repr, containsString("and("));
+        assertThat(repr, containsString("or("));
+        assertThat(repr, containsString("not("));
+    }
+
+    public void testToFilterPredicateNestedDeepPath() {
+        // Four-level path a.b.c.d — verifies the walker does not stop after the first dot.
+        MessageType schema = Types.buildMessage()
+            .requiredGroup()
+            .requiredGroup()
+            .requiredGroup()
+            .required(INT64)
+            .named("d")
+            .named("c")
+            .named("b")
+            .named("a")
+            .named("test");
+        Expression expr = eq("a.b.c.d", DataType.LONG, 42L);
+
+        FilterPredicate fp = new ParquetPushedExpressions(List.of(expr)).toFilterPredicate(schema);
+        assertNotNull(fp);
+        assertThat(fp.toString(), containsString("a.b.c.d"));
+        assertThat(fp.toString(), containsString("42"));
+    }
+
+    public void testToFilterPredicateNestedPathMissingReturnsNull() {
+        // Schema has event.ts (DATETIME), but predicate references event.does_not_exist; the
+        // DATETIME path resolves the leaf via resolveNestedPrimitive and returns null when
+        // missing. KEYWORD/INT/LONG predicates bypass schema resolution and forward the
+        // dotted name straight to FilterApi.binaryColumn — parquet-mr's RowGroupFilter
+        // tolerates unknown columns at filter time, so they are not the right shape for
+        // testing the resolver. DATETIME exercises the resolver because it has to map epoch
+        // millis to the correct physical encoding.
+        MessageType schema = nestedTimestamp(LogicalTypeAnnotation.TimeUnit.MILLIS);
+        Expression expr = eq("event.does_not_exist", DataType.DATETIME, 1700000000000L);
+        assertNull(new ParquetPushedExpressions(List.of(expr)).toFilterPredicate(schema));
+    }
+
+    public void testToFilterPredicateNestedPathLandsOnGroupReturnsNull() {
+        // The name resolves to an intermediate group ("event") rather than a primitive leaf
+        // — for DATETIME (which routes through resolveNestedPrimitive), the translator must
+        // return null since pushdown is meaningless against a group.
+        MessageType schema = nestedTimestamp(LogicalTypeAnnotation.TimeUnit.MILLIS);
+        Expression expr = eq("event", DataType.DATETIME, 1700000000000L);
+        assertNull(new ParquetPushedExpressions(List.of(expr)).toFilterPredicate(schema));
+    }
+
+    public void testToFilterPredicateLiteralDottedNameWinsOverPath() {
+        // Schema has BOTH a literal top-level "event.action" and a nested struct event.action.
+        // Per the prior PR's D2 rule (preserved by resolveNestedPrimitive), the literal wins —
+        // the predicate type-shape is decided from the literal's primitive (BINARY here), not
+        // from the nested INT64 "event.action" leaf.
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("event.action")
+            .requiredGroup()
+            .required(INT64)
+            .named("action")
+            .named("event")
+            .named("test");
+
+        // KEYWORD predicate succeeds because the literal field's primitive is BINARY.
+        Expression keywordEq = eq("event.action", DataType.KEYWORD, new BytesRef("login"));
+        FilterPredicate keywordPred = new ParquetPushedExpressions(List.of(keywordEq)).toFilterPredicate(schema);
+        assertNotNull("literal BINARY 'event.action' wins → KEYWORD pushdown valid", keywordPred);
+        assertThat(keywordPred.toString(), containsString("event.action"));
+    }
+
+    public void testResolveNestedPrimitiveLiteralWinsOverPath() {
+        // Directly assert the helper's D2 contract.
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("event.action")
+            .requiredGroup()
+            .required(INT64)
+            .named("action")
+            .named("event")
+            .named("test");
+
+        PrimitiveType resolved = ParquetPushedExpressions.resolveNestedPrimitive(schema, "event.action");
+        assertNotNull(resolved);
+        assertEquals(PrimitiveType.PrimitiveTypeName.BINARY, resolved.getPrimitiveTypeName());
+    }
+
+    public void testResolveNestedPrimitiveDottedPathFallback() {
+        MessageType schema = nestedKeyword();
+        PrimitiveType resolved = ParquetPushedExpressions.resolveNestedPrimitive(schema, "event.action");
+        assertNotNull(resolved);
+        assertEquals(PrimitiveType.PrimitiveTypeName.BINARY, resolved.getPrimitiveTypeName());
+    }
+
+    public void testResolveNestedPrimitiveMissingPathReturnsNull() {
+        MessageType schema = nestedKeyword();
+        assertNull(ParquetPushedExpressions.resolveNestedPrimitive(schema, "event.nope"));
+        assertNull(ParquetPushedExpressions.resolveNestedPrimitive(schema, "nope"));
+        assertNull(ParquetPushedExpressions.resolveNestedPrimitive(schema, "nope.also.missing"));
+    }
+
+    public void testResolveNestedPrimitiveLandsOnGroupReturnsNull() {
+        // "event" alone resolves to a GroupType, not a primitive — helper returns null.
+        MessageType schema = nestedKeyword();
+        assertNull(ParquetPushedExpressions.resolveNestedPrimitive(schema, "event"));
     }
 
     // --- helpers ---

--- a/x-pack/plugin/esql/qa/server/src/orcFixtureGenerator/java/org/elasticsearch/xpack/esql/datasources/OrcFixtureGenerator.java
+++ b/x-pack/plugin/esql/qa/server/src/orcFixtureGenerator/java/org/elasticsearch/xpack/esql/datasources/OrcFixtureGenerator.java
@@ -30,12 +30,10 @@ import org.elasticsearch.xpack.esql.datasource.csv.SplitPartitioner;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * Build-time generator for ORC fixture files. Converts CSV to ORC.
@@ -134,7 +132,7 @@ public final class OrcFixtureGenerator {
         // Precompute per-column child-index paths (top-level fields have a 1-element path);
         // used at write-time to navigate StructColumnVector.fields[]. Flat (literal-dot)
         // columns resolve to a single top-level index even if their name contains dots.
-        boolean[] flatten = computeFlatten(columns);
+        boolean[] flatten = CsvFixtureParser.computeFlatten(columns);
         int[][] columnVectorPaths = new int[columns.size()][];
         for (int i = 0; i < columns.size(); i++) {
             if (flatten[i]) {
@@ -215,7 +213,7 @@ public final class OrcFixtureGenerator {
      * flat to preserve backward compatibility with existing fixtures.
      */
     private static TypeDescription buildSchema(List<CsvFixtureParser.ColumnSpec> columns, boolean[] isListColumn) {
-        boolean[] flatten = computeFlatten(columns);
+        boolean[] flatten = CsvFixtureParser.computeFlatten(columns);
         SchemaNode root = new SchemaNode();
         for (int i = 0; i < columns.size(); i++) {
             if (flatten[i]) {
@@ -238,27 +236,6 @@ public final class OrcFixtureGenerator {
             struct.addField(e.getKey(), buildType(e.getValue(), columns, isListColumn));
         }
         return struct;
-    }
-
-    /** See {@code ParquetFixtureGenerator.computeFlatten}; same rule applied for ORC. */
-    static boolean[] computeFlatten(List<CsvFixtureParser.ColumnSpec> columns) {
-        Set<String> names = new HashSet<>();
-        for (CsvFixtureParser.ColumnSpec c : columns) {
-            names.add(c.name());
-        }
-        boolean[] flatten = new boolean[columns.size()];
-        for (int i = 0; i < columns.size(); i++) {
-            String name = columns.get(i).name();
-            int dot = name.indexOf('.');
-            while (dot > 0) {
-                if (names.contains(name.substring(0, dot))) {
-                    flatten[i] = true;
-                    break;
-                }
-                dot = name.indexOf('.', dot + 1);
-            }
-        }
-        return flatten;
     }
 
     private static TypeDescription buildType(SchemaNode node, List<CsvFixtureParser.ColumnSpec> columns, boolean[] isListColumn) {

--- a/x-pack/plugin/esql/qa/server/src/parquetFixtureGenerator/java/org/elasticsearch/xpack/esql/datasources/ParquetFixtureGenerator.java
+++ b/x-pack/plugin/esql/qa/server/src/parquetFixtureGenerator/java/org/elasticsearch/xpack/esql/datasources/ParquetFixtureGenerator.java
@@ -27,12 +27,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * Build-time generator for Parquet fixture files. Converts CSV to Parquet.
@@ -208,7 +206,7 @@ public final class ParquetFixtureGenerator {
         OutputFile outputFile = createOutputFile(baos);
         SimpleGroupFactory factory = new SimpleGroupFactory(schema);
 
-        boolean[] flatten = computeFlatten(columns);
+        boolean[] flatten = CsvFixtureParser.computeFlatten(columns);
         // Pre-compute per-column dotted-path segments; flat (literal-dot) columns get a 1-element
         // path containing the original full name, so resolveParent treats them as top-level.
         String[][] columnPaths = new String[columns.size()][];
@@ -268,7 +266,7 @@ public final class ParquetFixtureGenerator {
      * top-level column names.
      */
     private static MessageType buildSchema(List<CsvFixtureParser.ColumnSpec> columns, boolean[] isListColumn) {
-        boolean[] flatten = computeFlatten(columns);
+        boolean[] flatten = CsvFixtureParser.computeFlatten(columns);
         Node root = new Node();
         for (int i = 0; i < columns.size(); i++) {
             if (flatten[i]) {
@@ -291,32 +289,6 @@ public final class ParquetFixtureGenerator {
             fields.add(buildType(e.getKey(), e.getValue(), columns, isListColumn));
         }
         return new MessageType("schema", fields);
-    }
-
-    /**
-     * Marks columns whose dotted names must be kept literal (flat). A column is kept flat when
-     * any prefix of its dotted name is itself a literal top-level column name in the same CSV.
-     * This preserves files like {@code employees.csv} whose schema mixes a flat {@code languages}
-     * column with sibling flat columns named {@code languages.long}, {@code languages.short}, etc.
-     */
-    static boolean[] computeFlatten(List<CsvFixtureParser.ColumnSpec> columns) {
-        Set<String> names = new HashSet<>();
-        for (CsvFixtureParser.ColumnSpec c : columns) {
-            names.add(c.name());
-        }
-        boolean[] flatten = new boolean[columns.size()];
-        for (int i = 0; i < columns.size(); i++) {
-            String name = columns.get(i).name();
-            int dot = name.indexOf('.');
-            while (dot > 0) {
-                if (names.contains(name.substring(0, dot))) {
-                    flatten[i] = true;
-                    break;
-                }
-                dot = name.indexOf('.', dot + 1);
-            }
-        }
-        return flatten;
     }
 
     private static Type buildType(String name, Node node, List<CsvFixtureParser.ColumnSpec> columns, boolean[] isListColumn) {


### PR DESCRIPTION
## Summary

Extends the nested STRUCT projection work (#149662) to push filter
predicates and MIN/MAX/COUNT aggregates down to Parquet row groups
and ORC stripes for dotted subfields (e.g. event.action).

Parquet:
 - Add a dotted-path schema introspection helper that respects the
   literal-dot-wins precedence rule, and route isPhysicalDouble and
   the DATETIME/TIMESTAMP encoding selection through it so nested
   leaves pick the right physical encoding.
 - Publish per-column statistics for every dotted leaf the schema
   flattener produces, so aggregate pushdown can resolve nested
   MIN/MAX from row-group metadata instead of decoding rows.

ORC:
 - Make buildColumnTypeMap recurse into STRUCT children and emit
   dotted-name entries (capped at the existing flattening depth).
   This restores DATE-vs-TIMESTAMP and DECIMAL-vs-DOUBLE override
   resolution for nested leaves so SearchArgument literals match
   the physical column type.
 - Publish per-leaf statistics through the same dotted names used
   by the projection layer, skipping intermediate STRUCT markers.

Tests:
 - Mirror the existing positive Parquet pushdown matrix for nested
   columns: comparisons, IN, IS NULL, And/Or/Not, deep paths, the
   literal-dot precedence rule, missing path, and path-lands-on-
   group fallbacks.
 - Add the symmetric ORC matrix in a new OrcPushedExpressionsTests
   including DATE-vs-TIMESTAMP and DECIMAL-vs-DOUBLE.
 - Add metadata tests asserting nested-column statistics appear in
   SourceStatistics.columnStatistics() under dotted names.
 - Add multi-row-group Parquet and multi-stripe ORC fixtures that
   verify selective predicates on event.id actually skip data at
   the file-format level, not just post-decode.
 - Append nestedWhereEquals, nestedWhereIsNull, nestedStatsMinMax,
   and nestedFilterAndProjectMixed cases to the shared csv-spec;
   skip them in the parquet-rs and CSV readers (no pushdown yet).

This is the follow-up to elastic/elasticsearch#149662: it adds filter
and aggregate pushdown for nested STRUCT subfields in the Parquet and
ORC external-source readers. With projection in place, this PR closes
the remaining correctness/performance gap so queries like
`WHERE event.action == "login"` or `STATS MIN(event.id)` use row-group
/ stripe statistics to skip data instead of decoding every row.

## Stacked PR

Base is `esql/parquet-orc-nested-struct-projection` (elastic/elasticsearch#149662).
Please review/merge #149662 first; this PR will retarget to `main`
once that lands.

Closes elastic/esql-planning#436

Developed with AI-assisted tooling