### PR TITLE
[9.4] [otel-data] Explicitly map http.response.status_code as long (#149631)

### DIFF
--- a/docs/changelog/149631.yaml
+++ b/docs/changelog/149631.yaml
@@ -1,0 +1,5 @@
+area: Data streams
+issues: []
+pr: 149631
+summary: "[otel-data] Explicitly map `http.response.status_code` as long"
+type: enhancement

--- a/x-pack/plugin/otel-data/src/main/resources/component-templates/metrics-otel@mappings.yaml
+++ b/x-pack/plugin/otel-data/src/main/resources/component-templates/metrics-otel@mappings.yaml
@@ -22,6 +22,15 @@ template:
         type: keyword
         time_series_dimension: true
         ignore_above: 1024
+      attributes:
+        type: passthrough
+        dynamic: true
+        priority: 20
+        time_series_dimension: true
+        properties:
+          # Explicitly map http.response.status_code to work around mapping conflict caused by non-semconv-compliant clients
+          http.response.status_code:
+            type: long
     dynamic_templates:
       - histogram:
           mapping:

--- a/x-pack/plugin/otel-data/src/main/resources/component-templates/traces-otel@mappings.yaml
+++ b/x-pack/plugin/otel-data/src/main/resources/component-templates/traces-otel@mappings.yaml
@@ -48,6 +48,9 @@ template:
         properties:
           elastic.profiler_stack_trace_ids:
             type: counted_keyword
+          # Explicitly map http.response.status_code to work around mapping conflict caused by non-semconv-compliant clients
+          http.response.status_code:
+            type: long
       links:
         synthetic_source_keep: arrays
         properties:

--- a/x-pack/plugin/otel-data/src/main/resources/resources.yaml
+++ b/x-pack/plugin/otel-data/src/main/resources/resources.yaml
@@ -1,7 +1,7 @@
 # "version" holds the version of the templates and ingest pipelines installed
 # by xpack-plugin otel-data. This must be increased whenever an existing template is
 # changed, in order for it to be updated on Elasticsearch upgrade.
-version: 14
+version: 15
 
 component-templates:
   - otel@mappings

--- a/x-pack/plugin/otel-data/src/yamlRestTest/resources/rest-api-spec/test/20_metrics_tests.yml
+++ b/x-pack/plugin/otel-data/src/yamlRestTest/resources/rest-api-spec/test/20_metrics_tests.yml
@@ -193,6 +193,32 @@ IP dimensions:
       search:
         index: metrics-generic.otel-default
   - length: { hits.hits: 1 }
+
+---
+"http.response.status_code should be mapped as long":
+  - do:
+      bulk:
+        index: metrics-generic.otel-default
+        refresh: true
+        body:
+          - create: {}
+          - "@timestamp": 2024-10-05T00:00:00Z
+            attributes:
+              http.response.status_code: "200"
+          - create: {}
+          - "@timestamp": 2024-10-05T01:00:00Z
+            attributes:
+              http.response.status_code: 201
+  - is_false: errors
+  - do:
+      search:
+        index: metrics-generic.otel-default
+        body:
+          fields: ["attributes.http.response.status_code"]
+          sort: ["@timestamp"]
+  - length: { hits.hits: 2 }
+  - match: { hits.hits.0.fields.attributes\.http\.response\.status_code: [200] }
+  - match: { hits.hits.1.fields.attributes\.http\.response\.status_code: [201] }
 ---
 "Dynamic templates":
   - do:

--- a/x-pack/plugin/otel-data/src/yamlRestTest/resources/rest-api-spec/test/20_traces_tests.yml
+++ b/x-pack/plugin/otel-data/src/yamlRestTest/resources/rest-api-spec/test/20_traces_tests.yml
@@ -100,6 +100,32 @@ Conflicting attribute types:
   - length: { hits.hits: 2 }
   - match: { hits.hits.0.fields.attributes\.http\.status_code: [200] }
   - match: { hits.hits.1._ignored: ["attributes.http.status_code"] }
+
+---
+"http.response.status_code should be mapped as long":
+  - do:
+      bulk:
+        index: traces-generic.otel-default
+        refresh: true
+        body:
+          - create: {}
+          - "@timestamp": 2024-10-05T00:00:00
+            attributes:
+              http.response.status_code: "200"
+          - create: {}
+          - "@timestamp": 2024-10-05T01:00:00
+            attributes:
+              http.response.status_code: 201
+  - is_false: errors
+  - do:
+      search:
+        index: traces-generic.otel-default
+        body:
+          fields: ["*"]
+          "sort" : [ "@timestamp" ]
+  - length: { hits.hits: 2 }
+  - match: { hits.hits.0.fields.attributes\.http\.response\.status_code: [200] }
+  - match: { hits.hits.1.fields.attributes\.http\.response\.status_code: [201] }
 ---
 "resource.attributes.host.name @timestamp should be used as sort fields":
   - do:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[otel-data] Explicitly map http.response.status_code as long (#149631)](https://github.com/elastic/elasticsearch/pull/149631)

<!--- Backport version: 12.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)