### PR TITLE
Verify S3 `PutObject` requests never unsigned

### DIFF
--- a/test/fixtures/s3-fixture/src/main/java/fixture/s3/S3HttpHandler.java
+++ b/test/fixtures/s3-fixture/src/main/java/fixture/s3/S3HttpHandler.java
@@ -50,7 +50,6 @@ import javax.xml.parsers.DocumentBuilderFactory;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.elasticsearch.test.ESTestCase.assertThat;
-import static org.elasticsearch.test.fixture.HttpHeaderParser.parseRangeHeader;
 import static org.hamcrest.Matchers.oneOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -213,7 +212,8 @@ public class S3HttpHandler implements HttpHandler {
                         "STREAMING-AWS4-HMAC-SHA256-PAYLOAD",
                         MessageDigests.toHexString(MessageDigests.digest(blob.v2(), MessageDigests.sha256()))
                     )
-                );    blobs.put(request.path(), blob.v2());
+                );
+                blobs.put(request.path(), blob.v2());
                 exchange.getResponseHeaders().add("ETag", blob.v1());
                 exchange.sendResponseHeaders(RestStatus.OK.getStatus(), -1);
 

--- a/test/fixtures/s3-fixture/src/main/java/fixture/s3/S3HttpHandler.java
+++ b/test/fixtures/s3-fixture/src/main/java/fixture/s3/S3HttpHandler.java
@@ -49,6 +49,9 @@ import java.util.regex.Pattern;
 import javax.xml.parsers.DocumentBuilderFactory;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.elasticsearch.test.ESTestCase.assertThat;
+import static org.elasticsearch.test.fixture.HttpHeaderParser.parseRangeHeader;
+import static org.hamcrest.Matchers.oneOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.w3c.dom.Node.ELEMENT_NODE;
@@ -60,6 +63,8 @@ import static org.w3c.dom.Node.ELEMENT_NODE;
 public class S3HttpHandler implements HttpHandler {
 
     private static final Logger logger = LogManager.getLogger(S3HttpHandler.class);
+    public static final String STORAGE_CLASS_HEADER = "X-amz-storage-class";
+    public static final String CONTENT_SHA256_HEADER = "X-amz-content-sha256";
 
     private final String bucket;
     private final String basePath;
@@ -202,7 +207,13 @@ public class S3HttpHandler implements HttpHandler {
 
             } else if (request.isPutObjectRequest()) {
                 final Tuple<String, BytesReference> blob = parseRequestBody(exchange);
-                blobs.put(request.path(), blob.v2());
+                assertThat(
+                    exchange.getRequestHeaders().getFirst(CONTENT_SHA256_HEADER),
+                    oneOf(
+                        "STREAMING-AWS4-HMAC-SHA256-PAYLOAD",
+                        MessageDigests.toHexString(MessageDigests.digest(blob.v2(), MessageDigests.sha256()))
+                    )
+                );    blobs.put(request.path(), blob.v2());
                 exchange.getResponseHeaders().add("ETag", blob.v1());
                 exchange.sendResponseHeaders(RestStatus.OK.getStatus(), -1);
 

--- a/test/fixtures/s3-fixture/src/test/java/fixture/s3/S3HttpHandlerTests.java
+++ b/test/fixtures/s3-fixture/src/test/java/fixture/s3/S3HttpHandlerTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.hash.MessageDigests;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.rest.RestStatus;
@@ -420,7 +421,18 @@ public class S3HttpHandlerTests extends ESTestCase {
         BytesReference requestBody,
         Headers requestHeaders
     ) {
-        final var httpExchange = new TestHttpExchange(method, uri, requestBody, requestHeaders);
+        final Headers finalRequestHeaders;
+        if (method.equals("PUT")) {
+            finalRequestHeaders = new Headers();
+            requestHeaders.forEach((k, v) -> finalRequestHeaders.put(k, requestHeaders.get(k)));
+            finalRequestHeaders.add(
+                S3HttpHandler.CONTENT_SHA256_HEADER,
+                MessageDigests.toHexString(MessageDigests.digest(requestBody, MessageDigests.sha256()))
+            );
+        } else {
+            finalRequestHeaders = requestHeaders;
+        }
+        final var httpExchange = new TestHttpExchange(method, uri, requestBody, finalRequestHeaders);
         try {
             handler.handle(httpExchange);
         } catch (IOException e) {


### PR DESCRIPTION
Adds an assertion into `S3HttpHandler` to fail tests if the payload of a
`PutObject` request is not properly checksummed.

Backport of #149460 to `8.19`