### PR TITLE
Add tests for parsing `amz-chunked` request bodies

### DIFF
--- a/test/fixtures/s3-fixture/src/main/java/fixture/s3/S3HttpHandler.java
+++ b/test/fixtures/s3-fixture/src/main/java/fixture/s3/S3HttpHandler.java
@@ -352,76 +352,18 @@ public class S3HttpHandler implements HttpHandler {
 
     private static Tuple<String, BytesReference> parseRequestBody(final HttpExchange exchange) throws IOException {
         try {
-            final BytesReference bytesReference;
-
             final String headerDecodedContentLength = exchange.getRequestHeaders().getFirst("x-amz-decoded-content-length");
+            final var encodedRequestBody = Streams.readFully(exchange.getRequestBody());
+            final BytesReference decodedRequestBody;
             if (headerDecodedContentLength == null) {
-                bytesReference = Streams.readFully(exchange.getRequestBody());
+                decodedRequestBody = encodedRequestBody;
             } else {
-                BytesReference requestBody = Streams.readFully(exchange.getRequestBody());
-                int chunkIndex = 0;
-                final List<BytesReference> chunks = new ArrayList<>();
-
-                while (true) {
-                    chunkIndex += 1;
-
-                    final int headerLength = requestBody.indexOf((byte) '\n', 0) + 1; // includes terminating \r\n
-                    if (headerLength == 0) {
-                        throw new IllegalStateException("header of chunk [" + chunkIndex + "] was not terminated");
-                    }
-                    if (headerLength > 150) {
-                        throw new IllegalStateException(
-                            "header of chunk [" + chunkIndex + "] was too long at [" + headerLength + "] bytes"
-                        );
-                    }
-                    if (headerLength < 3) {
-                        throw new IllegalStateException(
-                            "header of chunk [" + chunkIndex + "] was too short at [" + headerLength + "] bytes"
-                        );
-                    }
-                    if (requestBody.get(headerLength - 1) != '\n' || requestBody.get(headerLength - 2) != '\r') {
-                        throw new IllegalStateException("header of chunk [" + chunkIndex + "] not terminated with [\\r\\n]");
-                    }
-
-                    final String header = requestBody.slice(0, headerLength - 2).utf8ToString();
-                    final Matcher matcher = chunkSignaturePattern.matcher(header);
-                    if (matcher.find() == false) {
-                        throw new IllegalStateException(
-                            "header of chunk [" + chunkIndex + "] did not match expected pattern: [" + header + "]"
-                        );
-                    }
-                    final int chunkSize = Integer.parseUnsignedInt(matcher.group(1), 16);
-
-                    if (requestBody.get(headerLength + chunkSize) != '\r' || requestBody.get(headerLength + chunkSize + 1) != '\n') {
-                        throw new IllegalStateException("chunk [" + chunkIndex + "] not terminated with [\\r\\n]");
-                    }
-
-                    if (chunkSize != 0) {
-                        chunks.add(requestBody.slice(headerLength, chunkSize));
-                    }
-
-                    final int toSkip = headerLength + chunkSize + 2;
-                    requestBody = requestBody.slice(toSkip, requestBody.length() - toSkip);
-
-                    if (chunkSize == 0) {
-                        break;
-                    }
-                }
-
-                bytesReference = CompositeBytesReference.of(chunks.toArray(new BytesReference[0]));
-
-                if (bytesReference.length() != Integer.parseInt(headerDecodedContentLength)) {
-                    throw new IllegalStateException(
-                        "Something went wrong when parsing the chunked request "
-                            + "[bytes read="
-                            + bytesReference.length()
-                            + ", expected="
-                            + headerDecodedContentLength
-                            + "]"
-                    );
-                }
+                decodedRequestBody = parseAmzChunkedRequestBody(Integer.parseInt(headerDecodedContentLength), encodedRequestBody);
             }
-            return Tuple.tuple(MessageDigests.toHexString(MessageDigests.digest(bytesReference, MessageDigests.md5())), bytesReference);
+            return Tuple.tuple(
+                MessageDigests.toHexString(MessageDigests.digest(decodedRequestBody, MessageDigests.md5())),
+                decodedRequestBody
+            );
         } catch (Exception e) {
             logger.error("exception in parseRequestBody", e);
             exchange.sendResponseHeaders(500, 0);
@@ -431,6 +373,68 @@ public class S3HttpHandler implements HttpHandler {
             }
             throw e;
         }
+    }
+
+    static BytesReference parseAmzChunkedRequestBody(int headerDecodedContentLength, BytesReference encodedRequestBody) {
+        int chunkIndex = 0;
+        final List<BytesReference> chunks = new ArrayList<>();
+
+        while (true) {
+            chunkIndex += 1;
+
+            final int headerLength = encodedRequestBody.indexOf((byte) '\n', 0) + 1; // includes terminating \r\n
+            if (headerLength == 0) {
+                throw new IllegalStateException("header of chunk [" + chunkIndex + "] was not terminated");
+            }
+            if (headerLength > 150) {
+                throw new IllegalStateException("header of chunk [" + chunkIndex + "] was too long at [" + headerLength + "] bytes");
+            }
+            if (headerLength < 3) {
+                throw new IllegalStateException("header of chunk [" + chunkIndex + "] was too short at [" + headerLength + "] bytes");
+            }
+            if (encodedRequestBody.get(headerLength - 1) != '\n' || encodedRequestBody.get(headerLength - 2) != '\r') {
+                throw new IllegalStateException("header of chunk [" + chunkIndex + "] not terminated with [\\r\\n]");
+            }
+
+            final String header = encodedRequestBody.slice(0, headerLength - 2).utf8ToString();
+            final Matcher matcher = chunkSignaturePattern.matcher(header);
+            if (matcher.find() == false) {
+                throw new IllegalStateException("header of chunk [" + chunkIndex + "] did not match expected pattern: [" + header + "]");
+            }
+            final int chunkSize = Integer.parseUnsignedInt(matcher.group(1), 16);
+
+            final int chunkTerminatorIndex = headerLength + chunkSize;
+            if (chunkTerminatorIndex + 2 > encodedRequestBody.length()
+                || encodedRequestBody.get(chunkTerminatorIndex) != '\r'
+                || encodedRequestBody.get(chunkTerminatorIndex + 1) != '\n') {
+                throw new IllegalStateException("chunk [" + chunkIndex + "] not terminated with [\\r\\n]");
+            }
+
+            if (chunkSize != 0) {
+                chunks.add(encodedRequestBody.slice(headerLength, chunkSize));
+            }
+
+            final int toSkip = headerLength + chunkSize + 2;
+            encodedRequestBody = encodedRequestBody.slice(toSkip, encodedRequestBody.length() - toSkip);
+
+            if (chunkSize == 0) {
+                break;
+            }
+        }
+
+        final BytesReference decodedRequestBody = CompositeBytesReference.of(chunks.toArray(new BytesReference[0]));
+
+        if (decodedRequestBody.length() != headerDecodedContentLength) {
+            throw new IllegalStateException(
+                "Something went wrong when parsing the chunked request "
+                    + "[bytes read="
+                    + decodedRequestBody.length()
+                    + ", expected="
+                    + headerDecodedContentLength
+                    + "]"
+            );
+        }
+        return decodedRequestBody;
     }
 
     static List<String> extractPartEtags(BytesReference completeMultipartUploadBody) {

--- a/test/fixtures/s3-fixture/src/test/java/fixture/s3/S3HttpHandlerTests.java
+++ b/test/fixtures/s3-fixture/src/test/java/fixture/s3/S3HttpHandlerTests.java
@@ -18,15 +18,18 @@ import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.bytes.CompositeBytesReference;
 import org.elasticsearch.common.hash.MessageDigests;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.Streams;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.OutputStreamWriter;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
@@ -34,6 +37,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.greaterThan;
@@ -332,6 +336,80 @@ public class S3HttpHandlerTests extends ESTestCase {
         assertThat(startTagPosition, greaterThan(0));
         final var startIdPosition = startTagPosition + startTag.length();
         return createUploadResponseBody.substring(startIdPosition, startIdPosition + 22);
+    }
+
+    public void testParseAmzChunkedRequestBody() throws IOException {
+        assertThat(S3HttpHandler.parseAmzChunkedRequestBody(0, buildAmzChunkedBody()), equalBytes(BytesArray.EMPTY));
+
+        final var singleChunkData = randomBytesReference(between(1, 256));
+        assertThat(
+            S3HttpHandler.parseAmzChunkedRequestBody(singleChunkData.length(), buildAmzChunkedBody(singleChunkData)),
+            equalBytes(singleChunkData)
+        );
+
+        final var chunk1 = randomBytesReference(between(1, 128));
+        final var chunk2 = randomBytesReference(between(1, 128));
+        assertThat(
+            S3HttpHandler.parseAmzChunkedRequestBody(chunk1.length() + chunk2.length(), buildAmzChunkedBody(chunk1, chunk2)),
+            equalBytes(CompositeBytesReference.of(chunk1, chunk2))
+        );
+
+        expectParseAmzChunkedFailure("header of chunk [1] was not terminated", 0, new BytesArray("no-newline-here"));
+        expectParseAmzChunkedFailure("header of chunk [1] was too long", 0, new BytesArray(randomAlphaOfLength(149) + "\r\n"));
+        expectParseAmzChunkedFailure("header of chunk [1] was too short", 0, new BytesArray("\n"));
+        expectParseAmzChunkedFailure("header of chunk [1] not terminated with [\\r\\n]", 0, new BytesArray("abc\n"));
+        expectParseAmzChunkedFailure("header of chunk [1] did not match expected pattern", 0, new BytesArray("5\r\n"));
+
+        try (var out = new BytesStreamOutput()) {
+            writeAmzChunkedBodyChunk(out, singleChunkData);
+            // remove or corrupt terminator
+            out.seek(out.size() - 2);
+            if (randomBoolean()) {
+                out.writeByte((byte) (int) randomValueOtherThan(0x0d, () -> between(0x00, 0xff)));
+            }
+            if (randomBoolean()) {
+                out.writeByte((byte) (int) randomValueOtherThan(0x0a, () -> between(0x00, 0xff)));
+            }
+            expectParseAmzChunkedFailure("chunk [1] not terminated with [\\r\\n]", singleChunkData.length(), out.bytes());
+        }
+
+        expectParseAmzChunkedFailure(
+            "Something went wrong when parsing the chunked request",
+            singleChunkData.length() + randomFrom(-2, -1, 1, 2),
+            buildAmzChunkedBody(singleChunkData)
+        );
+    }
+
+    private static BytesReference buildAmzChunkedBody(BytesReference... dataChunks) throws IOException {
+        try (var out = new BytesStreamOutput()) {
+            for (BytesReference dataChunk : dataChunks) {
+                writeAmzChunkedBodyChunk(out, dataChunk);
+            }
+            writeAmzChunkedBodyChunk(out, BytesArray.EMPTY);
+            return out.bytes();
+        }
+    }
+
+    private static void writeAmzChunkedBodyChunk(OutputStream out, BytesReference dataChunk) throws IOException {
+        try (var writer = new OutputStreamWriter(Streams.noCloseStream(out), StandardCharsets.UTF_8)) {
+            writer.write(Integer.toHexString(dataChunk.length()));
+            writer.write(";chunk-signature=");
+            writer.write(randomAlphaOfLengthBetween(0, 64));
+            writer.write("\r\n");
+            writer.flush();
+            dataChunk.writeTo(out);
+            writer.write("\r\n");
+        }
+    }
+
+    private void expectParseAmzChunkedFailure(String expectedMessageFragment, int headerDecodedContentLength, BytesReference encodedBody) {
+        assertThat(
+            expectThrows(
+                IllegalStateException.class,
+                () -> S3HttpHandler.parseAmzChunkedRequestBody(headerDecodedContentLength, encodedBody)
+            ).getMessage(),
+            containsString(expectedMessageFragment)
+        );
     }
 
     public void testExtractPartEtags() {

--- a/test/framework/src/main/java/org/elasticsearch/common/bytes/BytesReferenceTestUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/common/bytes/BytesReferenceTestUtils.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.common.bytes;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.Strings;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+
+import java.io.IOException;
+import java.util.Objects;
+
+public enum BytesReferenceTestUtils {
+    ;
+
+    /**
+     * Like {@link Matchers#equalTo} except it reports the contents of the respective {@link BytesReference} instances on mismatch.
+     */
+    public static Matcher<BytesReference> equalBytes(BytesReference expected) {
+        return new BaseMatcher<>() {
+            @Override
+            public boolean matches(Object actual) {
+                return Objects.equals(expected, actual);
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                if (expected == null) {
+                    description.appendValue(null);
+                } else {
+                    appendBytesReferenceDescription(expected, description);
+                }
+            }
+
+            private void appendBytesReferenceDescription(BytesReference bytesReference, Description description) {
+                final var stringBuilder = new StringBuilder("BytesReference[");
+                final var iterator = bytesReference.iterator();
+                BytesRef bytesRef;
+                boolean first = true;
+                try {
+                    while ((bytesRef = iterator.next()) != null) {
+                        for (int i = 0; i < bytesRef.length; i++) {
+                            if (first) {
+                                first = false;
+                            } else {
+                                stringBuilder.append(' ');
+                            }
+                            stringBuilder.append(Strings.format("%02x", bytesRef.bytes[bytesRef.offset + i]));
+                        }
+                    }
+                    description.appendText(stringBuilder.append(']').toString());
+                } catch (IOException e) {
+                    throw new AssertionError("no IO happens here", e);
+                }
+            }
+
+            @Override
+            public void describeMismatch(Object item, Description description) {
+                description.appendText("was ");
+                if (item instanceof BytesReference bytesReference) {
+                    appendBytesReferenceDescription(bytesReference, description);
+                } else {
+                    description.appendValue(item);
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
This parsing process is somewhat complicated, and today it's incomplete
(it doesn't handle trailers). This commit extracts it into a testable
method and adds test coverage of the current functionality.

Relates https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-streaming.html

Backport of #149672 to `8.19`