### PR TITLE
Fix a flake in `CancelTasksRelocationIT`

### DIFF
--- a/modules/reindex-management/src/internalClusterTest/java/org/elasticsearch/reindex/management/CancelTasksRelocationIT.java
+++ b/modules/reindex-management/src/internalClusterTest/java/org/elasticsearch/reindex/management/CancelTasksRelocationIT.java
@@ -380,19 +380,18 @@ public class CancelTasksRelocationIT extends ESIntegTestCase {
         assertThat("relocated task has a distinct numeric id", relocatedTaskId, not(equalTo(originalTaskId)));
 
         if (slices > 1) {
-            BulkByPaginatedSearchTask.Status status = asInstanceOf(
-                BulkByPaginatedSearchTask.Status.class,
-                clusterAdmin().getTask(new GetTaskRequest().setTaskId(originalTaskId)).actionGet().getTask().getTask().status()
-            );
-            int slicesCompletedOnOriginalTask = toIntExact(status.getSliceStatuses().stream().filter(Objects::nonNull).count());
-
-            assertBusy(
-                () -> assertThat(
+            assertBusy(() -> {
+                BulkByPaginatedSearchTask.Status status = asInstanceOf(
+                    BulkByPaginatedSearchTask.Status.class,
+                    clusterAdmin().getTask(new GetTaskRequest().setTaskId(originalTaskId)).actionGet().getTask().getTask().status()
+                );
+                int slicesCompletedOnOriginalTask = toIntExact(status.getSliceStatuses().stream().filter(Objects::nonNull).count());
+                assertThat(
                     "slice workers should be registered under the relocated parent",
                     listChildrenOf(relocatedTaskId),
                     hasSize(slices - slicesCompletedOnOriginalTask)
-                )
-            );
+                );
+            });
         }
 
         return new RelocatedReindex(survivorNodeName, originalTaskId, relocatedTaskId);

--- a/modules/reindex-management/src/internalClusterTest/java/org/elasticsearch/reindex/management/CancelTasksRelocationIT.java
+++ b/modules/reindex-management/src/internalClusterTest/java/org/elasticsearch/reindex/management/CancelTasksRelocationIT.java
@@ -14,6 +14,7 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.admin.cluster.node.tasks.cancel.CancelTasksRequest;
+import org.elasticsearch.action.admin.cluster.node.tasks.get.GetTaskRequest;
 import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksResponse;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.client.Request;
@@ -24,6 +25,7 @@ import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Strings;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.reindex.BulkByPaginatedSearchTask;
 import org.elasticsearch.index.reindex.ReindexAction;
 import org.elasticsearch.index.reindex.ResumeReindexAction;
 import org.elasticsearch.node.ShutdownPrepareService;
@@ -47,11 +49,13 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static java.lang.Math.toIntExact;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
@@ -376,11 +380,17 @@ public class CancelTasksRelocationIT extends ESIntegTestCase {
         assertThat("relocated task has a distinct numeric id", relocatedTaskId, not(equalTo(originalTaskId)));
 
         if (slices > 1) {
+            BulkByPaginatedSearchTask.Status status = asInstanceOf(
+                BulkByPaginatedSearchTask.Status.class,
+                clusterAdmin().getTask(new GetTaskRequest().setTaskId(originalTaskId)).actionGet().getTask().getTask().status()
+            );
+            int slicesCompletedOnOriginalTask = toIntExact(status.getSliceStatuses().stream().filter(Objects::nonNull).count());
+
             assertBusy(
                 () -> assertThat(
                     "slice workers should be registered under the relocated parent",
                     listChildrenOf(relocatedTaskId),
-                    hasSize(slices)
+                    hasSize(slices - slicesCompletedOnOriginalTask)
                 )
             );
         }

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -570,6 +570,3 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.multi_node.GenerativeIT
   method: test {feature:SUBQUERIES}
   issue: https://github.com/elastic/elasticsearch/issues/149681
-- class: org.elasticsearch.reindex.management.CancelTasksRelocationIT
-  method: testCancelByOriginalTaskIdAfterRelocation
-  issue: https://github.com/elastic/elasticsearch/issues/149688


### PR DESCRIPTION
This test was asserting that the number of children of the relocated task would match the number of slices. This does not hold if some of the slices completed on the original task.

This could be reproduced as follows:
```
./gradlew ":modules:reindex-management:internalClusterTest" --tests "org.elasticsearch.reindex.management.CancelTasksRelocationIT.testCancelRelocatedTaskByNewTaskId" -Dtests.seed=22D026EC026AD857 -Dtests.locale=qu-Latn-PE -Dtests.timezone=Asia/Tomsk -Druntime.java=26
```
Logging shows that, with this repro, 1 of the 4 slices completed before relocation, and so the relocated task only had 3 children.

This change fixes that, by finding the number of completed slices on the original task and subtracting it from the expected number of children.

Closes #149688.