### PR TITLE
[9.4] No built-in role sync in internal cluster tests  (#149494)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchTestBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchTestBasePlugin.java
@@ -209,6 +209,12 @@ public abstract class ElasticsearchTestBasePlugin implements Plugin<Project> {
             // TODO: remove this once cname is prepended to transport.publish_address by default in 8.0
             test.systemProperty("es.transport.cname_in_publish_address", "true");
 
+            // Disable queryable built-in roles by default in test JVMs. In-process integ tests
+            // (ESIntegTestCase / ESSingleNodeTestCase and subclasses) inherit this; tests that
+            // exercise the feature opt back in explicitly. REST/upgrade clusters run in separate
+            // JVMs and are unaffected.
+            test.systemProperty("es.queryable_built_in_roles_enabled", "false");
+
             // Set netty system properties to the properties we configure in jvm.options
             test.systemProperty("io.netty.noUnsafe", "true");
             test.systemProperty("io.netty.noKeySetOptimization", "true");


### PR DESCRIPTION
Backports the following commits to 9.4:
 - No built-in role sync in internal cluster tests  (#149494)