### PR TITLE
[8.19] Generalize `S3HttpHandler#parseAmzChunkedRequestBody` (#149686)

### DIFF
--- a/test/fixtures/s3-fixture/src/main/java/fixture/s3/S3HttpHandler.java
+++ b/test/fixtures/s3-fixture/src/main/java/fixture/s3/S3HttpHandler.java
@@ -348,7 +348,7 @@ public class S3HttpHandler implements HttpHandler {
         return blobs;
     }
 
-    private static final Pattern chunkSignaturePattern = Pattern.compile("^([0-9a-z]+);chunk-signature=([^\\r\\n]*)$");
+    private static final Pattern chunkSignaturePattern = Pattern.compile("^([0-9a-fA-F]+)(;chunk-signature=[^\\r\\n]*)?$");
 
     private static Tuple<String, BytesReference> parseRequestBody(final HttpExchange exchange) throws IOException {
         try {
@@ -403,6 +403,11 @@ public class S3HttpHandler implements HttpHandler {
             }
             final int chunkSize = Integer.parseUnsignedInt(matcher.group(1), 16);
 
+            if (chunkSize == 0) {
+                // ignore any trailers (e.g. checksum)
+                break;
+            }
+
             final int chunkTerminatorIndex = headerLength + chunkSize;
             if (chunkTerminatorIndex + 2 > encodedRequestBody.length()
                 || encodedRequestBody.get(chunkTerminatorIndex) != '\r'
@@ -410,16 +415,10 @@ public class S3HttpHandler implements HttpHandler {
                 throw new IllegalStateException("chunk [" + chunkIndex + "] not terminated with [\\r\\n]");
             }
 
-            if (chunkSize != 0) {
-                chunks.add(encodedRequestBody.slice(headerLength, chunkSize));
-            }
+            chunks.add(encodedRequestBody.slice(headerLength, chunkSize));
 
             final int toSkip = headerLength + chunkSize + 2;
             encodedRequestBody = encodedRequestBody.slice(toSkip, encodedRequestBody.length() - toSkip);
-
-            if (chunkSize == 0) {
-                break;
-            }
         }
 
         final BytesReference decodedRequestBody = CompositeBytesReference.of(chunks.toArray(new BytesReference[0]));

--- a/test/fixtures/s3-fixture/src/test/java/fixture/s3/S3HttpHandlerTests.java
+++ b/test/fixtures/s3-fixture/src/test/java/fixture/s3/S3HttpHandlerTests.java
@@ -358,7 +358,7 @@ public class S3HttpHandlerTests extends ESTestCase {
         expectParseAmzChunkedFailure("header of chunk [1] was too long", 0, new BytesArray(randomAlphaOfLength(149) + "\r\n"));
         expectParseAmzChunkedFailure("header of chunk [1] was too short", 0, new BytesArray("\n"));
         expectParseAmzChunkedFailure("header of chunk [1] not terminated with [\\r\\n]", 0, new BytesArray("abc\n"));
-        expectParseAmzChunkedFailure("header of chunk [1] did not match expected pattern", 0, new BytesArray("5\r\n"));
+        expectParseAmzChunkedFailure("header of chunk [1] did not match expected pattern", 0, new BytesArray("z\r\n"));
 
         try (var out = new BytesStreamOutput()) {
             writeAmzChunkedBodyChunk(out, singleChunkData);
@@ -393,11 +393,24 @@ public class S3HttpHandlerTests extends ESTestCase {
     private static void writeAmzChunkedBodyChunk(OutputStream out, BytesReference dataChunk) throws IOException {
         try (var writer = new OutputStreamWriter(Streams.noCloseStream(out), StandardCharsets.UTF_8)) {
             writer.write(Integer.toHexString(dataChunk.length()));
-            writer.write(";chunk-signature=");
-            writer.write(randomAlphaOfLengthBetween(0, 64));
+            if (randomBoolean()) {
+                // a chunk-signature chunk header is permitted but not required:
+                writer.write(";chunk-signature=");
+                writer.write(randomAlphaOfLengthBetween(0, 64));
+            }
             writer.write("\r\n");
-            writer.flush();
-            dataChunk.writeTo(out);
+            if (dataChunk.length() == 0) {
+                if (randomBoolean()) {
+                    // the last chunk may include trailers such as a checksum
+                    writer.write(randomIdentifier("x-amz-checksum-"));
+                    writer.write(":");
+                    writer.write(randomAlphaOfLengthBetween(0, 64));
+                    writer.write("\r\n");
+                }
+            } else {
+                writer.flush();
+                dataChunk.writeTo(out);
+            }
             writer.write("\r\n");
         }
     }


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Generalize `S3HttpHandler#parseAmzChunkedRequestBody` (#149686)