### PR TITLE
Rolling TimeSlottedCounter for boost window cache quotas

### DIFF
--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/BlobCachePlugin.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/BlobCachePlugin.java
@@ -26,6 +26,8 @@ public class BlobCachePlugin extends Plugin implements ExtensiblePlugin {
             SharedBlobCacheService.SHARED_CACHE_MAX_FREQ_SETTING,
             SharedBlobCacheService.SHARED_CACHE_DECAY_INTERVAL_SETTING,
             SharedBlobCacheService.SHARED_CACHE_MIN_TIME_DELTA_SETTING,
+            SharedBlobCacheService.SHARED_CACHE_TIME_SLOTS_GRANULARITY_SETTING,
+            SharedBlobCacheService.SHARED_CACHE_TIME_SLOTS_COUNT_SETTING,
             SharedBlobCacheService.SHARED_CACHE_MMAP,
             SharedBlobCacheService.SHARED_CACHE_COUNT_READS,
             SharedBlobCacheService.SHARED_CACHE_CONCURRENT_EVICTIONS_SETTING

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
@@ -290,6 +290,20 @@ public class SharedBlobCacheService<KeyType extends SharedBlobCacheService.KeyBa
         Setting.Property.NodeScope
     );
 
+    public static final Setting<TimeValue> SHARED_CACHE_TIME_SLOTS_GRANULARITY_SETTING = Setting.timeSetting(
+        SHARED_CACHE_SETTINGS_PREFIX + "time_slots.granularity",
+        TimeValue.timeValueHours(1),
+        TimeValue.timeValueMinutes(1),
+        Setting.Property.NodeScope
+    );
+
+    public static final Setting<Integer> SHARED_CACHE_TIME_SLOTS_COUNT_SETTING = Setting.intSetting(
+        SHARED_CACHE_SETTINGS_PREFIX + "time_slots.count",
+        87600, // default 10y (for 1h slots)
+        1,
+        Setting.Property.NodeScope
+    );
+
     public static final Setting<Boolean> SHARED_CACHE_MMAP = Setting.boolSetting(
         SHARED_CACHE_SETTINGS_PREFIX + "mmap",
         false,

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
@@ -300,7 +300,7 @@ public class SharedBlobCacheService<KeyType extends SharedBlobCacheService.KeyBa
     public static final Setting<Integer> SHARED_CACHE_TIME_SLOTS_COUNT_SETTING = Setting.intSetting(
         SHARED_CACHE_SETTINGS_PREFIX + "time_slots.count",
         87600, // default 10y (for 1h slots)
-        1,
+        2, // min 2 slots to support a rolling ring
         Setting.Property.NodeScope
     );
 

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/TimeSlottedCounter.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/TimeSlottedCounter.java
@@ -13,6 +13,8 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 
 import java.util.concurrent.atomic.AtomicLongArray;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.LongSupplier;
 
 /**
@@ -23,28 +25,37 @@ import java.util.function.LongSupplier;
  * totals from cache residency). Callers pass arbitrary counts via {@link #add} and {@link #remove};
  * this type is agnostic to what is being counted (the expectation is that it is cache regions).
  * <p>
- * The ring is fixed at construction: {@code tailSlotStart} does not move. Timestamps after the head slot are
- * clamped to the head bucket; timestamps before the tail slot are clamped to the tail bucket.
+ * Bucket sums are updated atomically; ring structure ({@code tailSlotStart}, {@code tailBucketIndex},
+ * rollover/eviction) is guarded by {@link #structureLock}. Concurrent {@link #add} and
+ * {@link #remove} on existing slots use the structure read lock plus atomic bucket updates.
  * <p>
- * Bucket sums are updated atomically via {@link AtomicLongArray}.
+ * Buckets roll forward lazily on {@link #add}, {@link #remove}, and {@link #sum}. When time advances,
+ * the oldest bucket is merged into its neighbor, then {@code tailBucketIndex} rotates and {@code tailSlotStart}
+ * advances so the new head slot is empty without copying the array. Overflow mass older than retention
+ * remains in the tail slot.
  */
 public class TimeSlottedCounter {
 
     private static final Logger logger = LogManager.getLogger(TimeSlottedCounter.class);
 
     private final long granularityMillis;
-
-    /** {@code slotStart} of the oldest retained (tail) bucket. */
-    private final long tailSlotStart;
+    private final LongSupplier timeProvider;
+    private final ReadWriteLock structureLock = new ReentrantReadWriteLock();
 
     private final AtomicLongArray counts;
+
+    /** {@code slotStart} of the oldest retained (tail) bucket. */
+    private long tailSlotStart;
+
+    /** Physical index of the tail bucket in {@link #counts}. */
+    private int tailBucketIndex;
 
     /**
      * Creates a ring of {@code maxBuckets} atomic count buckets, one per time slot of {@code granularity}.
      * <p>
      * Example ({@code maxBuckets=4}, 1h granularity, clock at 12:00):
      * <pre>
-     *   tail slot 09:00-09:59 at offset 0; head slot 12:00-12:59 at offset 3
+     *   tail slot 09:00-09:59, tailBucketIndex=0; head slot 12:00-12:59 at offset 3
      *   +--------------+--------------+--------------+--------------+
      *   | physical 0   | physical 1   | physical 2   | physical 3   |
      *   | tail         |              |              | head         |
@@ -58,7 +69,7 @@ public class TimeSlottedCounter {
      * </pre>
      *
      * @param granularity duration of each time slot
-     * @param maxBuckets maximum number of slots retained
+     * @param maxBuckets maximum number of slots retained; oldest slot absorbs overflow when evicted
      * @param timeProvider source of wall-clock time in milliseconds
      */
     public TimeSlottedCounter(TimeValue granularity, int maxBuckets, LongSupplier timeProvider) {
@@ -69,10 +80,12 @@ public class TimeSlottedCounter {
             throw new IllegalArgumentException("maxBuckets must be positive");
         }
         this.granularityMillis = granularity.millis();
+        this.timeProvider = timeProvider;
         this.counts = new AtomicLongArray(maxBuckets);
-        long now = timeProvider.getAsLong();
-        long headSlot = slotStartForTimestamp(now < 0 ? 0 : now);
+        long headSlot = slotStartForTimestamp(currentTimeMillis());
         this.tailSlotStart = headSlot - (long) (maxBuckets - 1) * granularityMillis;
+        this.tailBucketIndex = 0;
+        assert maxBuckets() >= 2 : "max buckets must be at least 2 but was " + maxBuckets();
     }
 
     public static TimeSlottedCounter createFromSettings(Settings settings, LongSupplier timeProvider) {
@@ -87,6 +100,10 @@ public class TimeSlottedCounter {
         return TimeValue.timeValueMillis(granularityMillis);
     }
 
+    long granularityMillis() {
+        return granularityMillis;
+    }
+
     public int maxBuckets() {
         return counts.length();
     }
@@ -94,14 +111,17 @@ public class TimeSlottedCounter {
     /**
      * Adds {@code count} to the slot containing {@code timestampMillis}.
      * <p>
-     * Timestamps older than the retained tail are clamped to the tail slot; timestamps after the head
-     * slot are clamped to the head slot.
+     * Delegates to {@link #mutateSlot}; may roll the ring forward first if wall clock has moved past the head slot.
+     * Timestamps older than the retained tail are clamped to the tail slot (see {@link #resolveSlotStart}).
      */
     public void add(long timestampMillis, long count) {
         if (count <= 0) {
             return;
         }
-        counts.addAndGet(bucketIndex(timestampMillis), count);
+        mutateSlot(timestampMillis, (index, slotStart) -> {
+            counts.addAndGet(index, count);
+            return count;
+        });
     }
 
     /**
@@ -113,15 +133,37 @@ public class TimeSlottedCounter {
         if (count <= 0) {
             return;
         }
-        int index = bucketIndex(timestampMillis);
-        long slotStart = tailSlotStart + (long) index * granularityMillis;
-        counts.accumulateAndGet(index, count, (current, removal) -> {
-            if (current < removal) {
-                logger.debug("remove clamped: slot start [{}] count [{}] less than remove count [{}]", slotStart, current, removal);
-                return 0;
+        mutateSlot(timestampMillis, (index, slotStart) -> {
+            long previous = counts.getAndAccumulate(index, count, (current, removal) -> current < removal ? 0 : current - removal);
+            long next = previous < count ? 0 : previous - count;
+            if (previous < count) {
+                logger.debug("remove clamped: slot start [{}] count [{}] less than remove count [{}]", slotStart, previous, count);
             }
-            return current - removal;
+            return next - previous;
         });
+    }
+
+    /**
+     * Rolls buckets forward to the current time. Exposed for tests.
+     * <p>
+     * Repeatedly calls {@link #rollForwardOneSlot} until the head slot matches the current time slot.
+     */
+    public void advanceToNow() {
+        structureLock.readLock().lock();
+        try {
+            long now = currentTimeMillis();
+            if (needsAdvanceToNow(now) == false) {
+                return;
+            }
+        } finally {
+            structureLock.readLock().unlock();
+        }
+        structureLock.writeLock().lock();
+        try {
+            advanceToNowUnderWriteLock(currentTimeMillis());
+        } finally {
+            structureLock.writeLock().unlock();
+        }
     }
 
     /**
@@ -132,13 +174,49 @@ public class TimeSlottedCounter {
      *   includes slots 10:00, 11:00, 12:00 (each [slotStart, slotStart+granularity) intersects the range)
      *   excludes slot 13:00 (starts at range end)
      * </pre>
+     * Advances the ring to now before summing.
      */
     public long sum(long windowStartMillis, long windowEndMillis) {
         if (windowEndMillis <= windowStartMillis) {
             return 0;
         }
-        long retentionEnd = tailSlotStart + (long) counts.length() * granularityMillis;
-        if (windowEndMillis <= tailSlotStart || windowStartMillis >= retentionEnd) {
+        return sumInRange(windowStartMillis, windowEndMillis);
+    }
+
+    long currentTimeMillis() {
+        long now = timeProvider.getAsLong();
+        return now < 0 ? 0 : now;
+    }
+
+    /**
+     * Sum over {@code [windowStartMillis, windowEndMillis)} after advancing to the current time.
+     * <p>
+     * Takes the write lock to roll forward, then sums under the read lock via {@link #sumBucketsInRange}.
+     */
+    long sumInRange(long windowStartMillis, long windowEndMillis) {
+        structureLock.writeLock().lock();
+        try {
+            advanceToNowUnderWriteLock(currentTimeMillis());
+        } finally {
+            structureLock.writeLock().unlock();
+        }
+        structureLock.readLock().lock();
+        try {
+            return sumBucketsInRange(windowStartMillis, windowEndMillis);
+        } finally {
+            structureLock.readLock().unlock();
+        }
+    }
+
+    /**
+     * Sum over {@code [windowStartMillis, windowEndMillis)}. Caller must hold {@link #structureLock} read or write lock.
+     * <p>
+     * Iterates only bucket offsets whose slot interval overlaps the range.
+     */
+    long sumBucketsInRange(long windowStartMillis, long windowEndMillis) {
+        if (windowEndMillis <= windowStartMillis
+            || windowEndMillis <= tailSlotStart
+            || windowStartMillis >= tailSlotStart + (long) counts.length() * granularityMillis) {
             return 0;
         }
         long firstOffset = Math.max(0L, Math.floorDiv(windowStartMillis - tailSlotStart - granularityMillis, granularityMillis) + 1);
@@ -147,53 +225,123 @@ public class TimeSlottedCounter {
             return 0;
         }
         long total = 0;
-        for (int offset = (int) firstOffset; offset <= lastOffset; offset++) {
-            total += counts.get(offset);
+        for (int offsetFromTail = (int) firstOffset; offsetFromTail <= lastOffset; offsetFromTail++) {
+            total += counts.get(bucketIndexForOffset(offsetFromTail));
         }
         return total;
     }
 
+    @FunctionalInterface
+    private interface SlotMutation {
+        /**
+         * @return the count delta applied to the bucket (positive for add, negative for remove)
+         */
+        long apply(int index, long slotStart);
+    }
+
     /**
-     * Resolves {@code timestampMillis} to a physical bucket index.
+     * Resolves {@code timestampMillis} to a bucket and applies {@code mutation}.
      * <p>
-     * Example ({@code maxBuckets=4}, 1h granularity, tail 09:00-09:59):
+     * Example ({@code maxBuckets=4}, 1h granularity, tail 09:00-09:59, {@code tailBucketIndex=3}):
      * <pre>
      *   +--------------+--------------+--------------+--------------+
      *   | physical 0   | physical 1   | physical 2   | physical 3   |
-     *   | tail         |              |              | head         |
+     *   |              |              | head         | tail         |
      *   +--------------+--------------+--------------+--------------+
-     *   | offset 0     | offset 1     | offset 2     | offset 3     |
+     *   | offset 1     | offset 2     | offset 3     | offset 0     |
      *   +--------------+--------------+--------------+--------------+
-     *   | 09:00-09:59  | 10:00-10:59  | 11:00-11:59  | 12:00-12:59  |
+     *   | 10:00-10:59  | 11:00-11:59  | 12:00-12:59  | 09:00-09:59  |
+     *   +--------------+--------------+--------------+--------------+
+     *   | count [0]    | count [7]    | count [3]    | count [5]    |
      *   +--------------+--------------+--------------+--------------+
      *
      *   add(timestamp=10:30, count=4):
-     *     1. resolve slot start -> 10:00 (floor to hour)
+     *     1. resolveSlotStart(10:30) -> 10:00 (floor to hour)
      *     2. offsetFromTail = (10:00 - 09:00) / 1h = 1
-     *     3. counts.addAndGet(1, 4)
+     *     3. index = bucketIndexForOffset(1) = floorMod(3+1, 4) = 0
+     *     4. counts.addAndGet(0, 4) -> counts[0] becomes 4
      * </pre>
-     * Slot start clamping:
+     * If the ring is stale ({@link #needsAdvanceToNow(long)}), loops: release read lock, take write lock and
+     * {@link #advanceToNowUnderWriteLock}, then retry. {@link #resolveSlotStart} clamps timestamps to the retained
+     * range, so the resolved slot always maps to a bucket.
+     * <p>
+     * Wall clock is read once per attempt under the read lock and passed to {@link #needsAdvanceToNow(long)} and
+     * {@link #resolveSlotStart(long, long)} so a slot-boundary crossing cannot leave a stale head while attributing
+     * counts to an older bucket.
+     */
+    private void mutateSlot(long timestampMillis, SlotMutation mutation) {
+        while (true) {
+            structureLock.readLock().lock();
+            try {
+                long now = currentTimeMillis();
+                if (needsAdvanceToNow(now) == false) {
+                    long slotStart = resolveSlotStart(timestampMillis, now);
+                    int index = findSlotIndex(slotStart);
+                    mutation.apply(index, slotStart);
+                    return;
+                }
+            } finally {
+                structureLock.readLock().unlock();
+            }
+            structureLock.writeLock().lock();
+            try {
+                advanceToNowUnderWriteLock(currentTimeMillis());
+            } finally {
+                structureLock.writeLock().unlock();
+            }
+        }
+    }
+
+    /**
+     * Whether {@link #advanceToNowUnderWriteLock(long)} must roll the ring forward. Caller must hold structure lock
+     * and pass a {@code now} read while holding it.
+     * <p>
+     * True when the current time slot is newer than the head slot (wall clock moved into a future bucket).
+     */
+    private boolean needsAdvanceToNow(long now) {
+        return headSlotStart() < slotStartForTimestamp(now);
+    }
+
+    /**
+     * Rolls the ring until the head slot equals the current time slot.
+     * Caller must hold {@link #structureLock} write lock and pass a {@code now} read while holding it.
+     * <p>
+     * The expectation is that this will be (indirectly) called frequently enough that the ring is rolled
+     * by one slot (or a small amount of slots). We do not expect a situation that a lot of time has passed
+     * where this function will need to block for a long time to roll the ring by a high number of slots.
+     */
+    private void advanceToNowUnderWriteLock(long now) {
+        long targetHeadSlot = slotStartForTimestamp(now);
+        while (headSlotStart() < targetHeadSlot) {
+            rollForwardOneSlot();
+        }
+    }
+
+    /**
+     * Maps a timestamp to the {@code slotStart} used for bucket lookup, clamped to retained range.
+     * <p>
      * <pre>
      *   +---------------------------+----------------------------------------+
      *   | condition                 | resolved slotStart                     |
      *   +---------------------------+----------------------------------------+
-     *   | timestamp too old         | tail slot                              |
-     *   | timestamp in future       | head slot (newest retained)            |
+     *   | timestamp too old         | tail slot (overflow mass lives here)   |
+     *   | timestamp in future       | current wall-clock slot ({@code now})  |
      *   | otherwise                 | floor(timestamp) to granularity        |
      *   +---------------------------+----------------------------------------+
      * </pre>
+     * Caller must hold structure lock and pass a {@code now} read while holding it (same value as
+     * {@link #needsAdvanceToNow(long)} for that attempt).
      */
-    private int bucketIndex(long timestampMillis) {
-        long slotStart = slotStartForTimestamp(Math.max(0, timestampMillis));
-        if (slotStart < tailSlotStart) {
-            slotStart = tailSlotStart;
-        } else {
-            long headSlot = tailSlotStart + (long) (counts.length() - 1) * granularityMillis;
-            if (slotStart > headSlot) {
-                slotStart = headSlot;
-            }
+    private long resolveSlotStart(long timestampMillis, long now) {
+        long slot = slotStartForTimestamp(Math.max(0, timestampMillis));
+        if (slot < tailSlotStart) {
+            return tailSlotStart;
         }
-        return Math.toIntExact((slotStart - tailSlotStart) / granularityMillis);
+        long currentSlot = slotStartForTimestamp(now);
+        if (slot > currentSlot) {
+            return currentSlot;
+        }
+        return slot;
     }
 
     /**
@@ -201,7 +349,124 @@ public class TimeSlottedCounter {
      * <p>
      * Example: granularity 1h, {@code timestamp=10:37} -> {@code 10:00}.
      */
-    private long slotStartForTimestamp(long timestampMillis) {
+    long slotStartForTimestamp(long timestampMillis) {
         return Math.floorDiv(timestampMillis, granularityMillis) * granularityMillis;
+    }
+
+    /**
+     * Whether the half-open slot {@code [slotStart, slotStart + granularity)} intersects
+     * {@code [rangeStart, rangeEnd)}.
+     * <p>
+     * Example: slot {@code [10:00, 11:00)}, range {@code [10:30, 12:00)} -> true (shared 10:30–11:00).
+     */
+    boolean slotOverlaps(long slotStart, long rangeStart, long rangeEnd) {
+        if (rangeEnd <= rangeStart) {
+            return false;
+        }
+        return slotStart < rangeEnd && slotStart + granularityMillis > rangeStart;
+    }
+
+    /**
+     * Advances the ring by one time slot: evict tail into its neighbor, rotate {@code tailBucketIndex},
+     * advance {@code tailSlotStart}, clear new head.
+     * <p>
+     * Example ({@code maxBuckets=3}, before roll; new head slot will be 13:00-13:59):
+     * <pre>
+     *   Before:
+     *   +--------------+--------------+--------------+
+     *   | physical 0   | physical 1   | physical 2   |
+     *   |              | head         | tail         |
+     *   +--------------+--------------+--------------+
+     *   | offset 1     | offset 2     | offset 0     |
+     *   +--------------+--------------+--------------+
+     *   | 11:00-11:59  | 12:00-12:59  | 10:00-10:59  |
+     *   +--------------+--------------+--------------+
+     *   | count [5]    | count [10]   | count [99]   |
+     *   +--------------+--------------+--------------+
+     *   tail [99] at offset 0 (physical 2) holds overflow from evicted slots
+     *
+     *   Step 1 mergeTailIntoNeighbor: counts[0] += 99, counts[2] = 0
+     *   Step 2 tailBucketIndex = (2+1)%3 = 0, tailSlotStart += 1h (10:00 -> 11:00)
+     *   Step 3 zero physical cell for new head (offset 2), head slot 13:00-13:59
+     *
+     *   After:
+     *   +--------------+--------------+--------------+
+     *   | physical 0   | physical 1   | physical 2   |
+     *   |              |              | head         |
+     *   +--------------+--------------+--------------+
+     *   | offset 0     | offset 1     | offset 2     |
+     *   +--------------+--------------+--------------+
+     *   | 11:00-11:59  | 12:00-12:59  | 13:00-13:59  |
+     *   +--------------+--------------+--------------+
+     *   | count [104]  | count [10]   | count [0]    |
+     *   +--------------+--------------+--------------+
+     *   former tail mass [99] merged into physical 0 (neighbor of tail)
+     * </pre>
+     */
+    private void rollForwardOneSlot() {
+        if (counts.length() >= 2) {
+            mergeTailIntoNeighbor(bucketIndexForOffset(0), bucketIndexForOffset(1));
+        }
+        tailBucketIndex = (tailBucketIndex + 1) % counts.length();
+        tailSlotStart += granularityMillis;
+        counts.set(bucketIndexForOffset(counts.length() - 1), 0);
+    }
+
+    /**
+     * Moves all count from the tail bucket into the next-older neighbor before the tail slot is reused.
+     * <p>
+     * Overflow from slots evicted off the left of the ring accumulates in the tail; merging preserves that mass
+     * in the oldest retained bucket.
+     */
+    private void mergeTailIntoNeighbor(int tailIndex, int neighborIndex) {
+        counts.addAndGet(neighborIndex, counts.getAndSet(tailIndex, 0));
+    }
+
+    /**
+     * Returns the physical {@link #counts} index for {@code slotStart}, or {@code -1} if the slot is not retained.
+     * <p>
+     * Uses {@code offsetFromTail = floorDiv(slotStart - tailSlotStart, granularityMillis)} then
+     * {@link #bucketIndexForOffset(int)}. See {@link #mutateSlot}.
+     */
+    private int findSlotIndex(long slotStart) {
+        long offsetFromTail = Math.floorDiv(slotStart - tailSlotStart, granularityMillis);
+        if (offsetFromTail < 0 || offsetFromTail >= counts.length()) {
+            return -1;
+        }
+        return bucketIndexForOffset((int) offsetFromTail);
+    }
+
+    /**
+     * {@code slotStart} of the newest retained bucket ({@code offsetFromTail=maxBuckets-1}).
+     */
+    private long headSlotStart() {
+        return tailSlotStart + (long) (counts.length() - 1) * granularityMillis;
+    }
+
+    /**
+     * Wall-clock start of the bucket at {@code offsetFromTail} (0 = tail, {@code maxBuckets-1} = head).
+     */
+    private long slotStartForOffset(int offsetFromTail) {
+        return tailSlotStart + (long) offsetFromTail * granularityMillis;
+    }
+
+    /**
+     * Maps a logical offset from tail to a physical index in {@link #counts}.
+     * <p>
+     * Example ({@code maxBuckets=4}, {@code tailBucketIndex=3}, head slot 12:00-12:59):
+     * <pre>
+     *   +--------------+--------------+--------------+--------------+
+     *   | physical 0   | physical 1   | physical 2   | physical 3   |
+     *   |              |              | head         | tail         |
+     *   +--------------+--------------+--------------+--------------+
+     *   | offset 1     | offset 2     | offset 3     | offset 0     |
+     *   +--------------+--------------+--------------+--------------+
+     *   | 10:00-10:59  | 11:00-11:59  | 12:00-12:59  | 09:00-09:59  |
+     *   +--------------+--------------+--------------+--------------+
+     *   floorMod(tailBucketIndex + offsetFromTail, 4)
+     * </pre>
+     */
+    private int bucketIndexForOffset(int offsetFromTail) {
+        return Math.floorMod(tailBucketIndex + offsetFromTail, counts.length());
     }
 }

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/TimeSlottedCounter.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/TimeSlottedCounter.java
@@ -12,6 +12,8 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicLongArray;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -24,6 +26,11 @@ import java.util.function.LongSupplier;
  * Used at node level for cache boost quota tracking (expected totals from shard data, and actual
  * totals from cache residency). Callers pass arbitrary counts via {@link #add} and {@link #remove};
  * this type is agnostic to what is being counted (the expectation is that it is cache regions).
+ * <p>
+ * Fixed relative window sums can be registered via {@link #registerRelativeWindow} and read
+ * through {@link TimeSlottedCounterWindow#sum()}. The class automatically updates registered
+ * window sums as counts change. We expect a limited number of such windows, corresponding to the
+ * configured boost levels.
  * <p>
  * Bucket sums are updated atomically; ring structure ({@code tailSlotStart}, {@code tailBucketIndex},
  * rollover/eviction) is guarded by {@link #structureLock}. Concurrent {@link #add} and
@@ -41,6 +48,7 @@ public class TimeSlottedCounter {
     private final long granularityMillis;
     private final LongSupplier timeProvider;
     private final ReadWriteLock structureLock = new ReentrantReadWriteLock();
+    private final List<TimeSlottedCounterWindow> registeredWindows = new ArrayList<>();
 
     private final AtomicLongArray counts;
 
@@ -109,6 +117,33 @@ public class TimeSlottedCounter {
     }
 
     /**
+     * Registers a fixed relative window {@code [now - endOffsetMillis, now - startOffsetMillis)} whose sum
+     * is maintained incrementally by this counter.
+     * <p>
+     * Example at {@code now=10d}, {@code registerRelativeWindow(1d, 3d)}:
+     * <pre>
+     *   window = [now-3d, now-1d)  — counts in slots overlapping that interval
+     *
+     *   |---- retained buckets ----|.... now ....|
+     *                    ^windowStart    ^windowEnd
+     * </pre>
+     * The returned {@link TimeSlottedCounterWindow} is updated on every {@link #add}/{@link #remove} and ring roll.
+     */
+    public TimeSlottedCounterWindow registerRelativeWindow(long startOffsetMillis, long endOffsetMillis) {
+        TimeSlottedCounterWindow window = new TimeSlottedCounterWindow(this, startOffsetMillis, endOffsetMillis);
+        structureLock.writeLock().lock();
+        try {
+            long now = currentTimeMillis();
+            advanceToNowUnderWriteLock(now);
+            window.initializeUnderWriteLock(now);
+            registeredWindows.add(window);
+        } finally {
+            structureLock.writeLock().unlock();
+        }
+        return window;
+    }
+
+    /**
      * Adds {@code count} to the slot containing {@code timestampMillis}.
      * <p>
      * Delegates to {@link #mutateSlot}; may roll the ring forward first if wall clock has moved past the head slot.
@@ -146,13 +181,33 @@ public class TimeSlottedCounter {
     /**
      * Rolls buckets forward to the current time. Exposed for tests.
      * <p>
-     * Repeatedly calls {@link #rollForwardOneSlot} until the head slot matches the current time slot.
+     * Equivalent to {@link #advanceIfNeededForWindow} with no window: repeatedly calls
+     * {@link #rollForwardOneSlot} until the head slot matches the current time slot.
      */
     public void advanceToNow() {
+        advanceIfNeededForWindow(null);
+    }
+
+    /**
+     * Advances ring structure and the given window when required.
+     * <p>
+     * Fast path (structure read lock only): return immediately when the head slot is already current
+     * <em>and</em> the window's {@code [start, end)} boundaries have not crossed a slot boundary since the last slide.
+     * <p>
+     * Slow path: take the write lock, re-read {@code now}, re-check, then {@link #advanceToNowUnderWriteLock(long)}
+     * (ring roll + window slide) using that fresh timestamp.
+     * <pre>
+     *   read lock: needsAdvance? / window.needsTimeSlide?
+     *        | no                          | yes
+     *        v                             v
+     *     return                    write lock + roll/slide
+     * </pre>
+     */
+    void advanceIfNeededForWindow(TimeSlottedCounterWindow window) {
+        long now = currentTimeMillis();
         structureLock.readLock().lock();
         try {
-            long now = currentTimeMillis();
-            if (needsAdvanceToNow(now) == false) {
+            if (needsAdvanceToNow(now) == false && (window == null || window.needsTimeSlide(now) == false)) {
                 return;
             }
         } finally {
@@ -160,7 +215,14 @@ public class TimeSlottedCounter {
         }
         structureLock.writeLock().lock();
         try {
-            advanceToNowUnderWriteLock(currentTimeMillis());
+            now = currentTimeMillis();
+            if (needsAdvanceToNow(now) == false && (window == null || window.needsTimeSlide(now) == false)) {
+                if (window != null) {
+                    window.touchMetadataIfNewer(now);
+                }
+                return;
+            }
+            advanceToNowUnderWriteLock(now);
         } finally {
             structureLock.writeLock().unlock();
         }
@@ -260,6 +322,7 @@ public class TimeSlottedCounter {
      *     2. offsetFromTail = (10:00 - 09:00) / 1h = 1
      *     3. index = bucketIndexForOffset(1) = floorMod(3+1, 4) = 0
      *     4. counts.addAndGet(0, 4) -> counts[0] becomes 4
+     *     5. notify windows overlapping slot 10:00-10:59
      * </pre>
      * If the ring is stale ({@link #needsAdvanceToNow(long)}), loops: release read lock, take write lock and
      * {@link #advanceToNowUnderWriteLock}, then retry. {@link #resolveSlotStart} clamps timestamps to the retained
@@ -277,7 +340,10 @@ public class TimeSlottedCounter {
                 if (needsAdvanceToNow(now) == false) {
                     long slotStart = resolveSlotStart(timestampMillis, now);
                     int index = findSlotIndex(slotStart);
-                    mutation.apply(index, slotStart);
+                    long delta = mutation.apply(index, slotStart);
+                    if (delta != 0) {
+                        notifyRegisteredWindowsSlotDelta(slotStart, delta, now);
+                    }
                     return;
                 }
             } finally {
@@ -293,8 +359,22 @@ public class TimeSlottedCounter {
     }
 
     /**
-     * Whether {@link #advanceToNowUnderWriteLock(long)} must roll the ring forward. Caller must hold structure lock
-     * and pass a {@code now} read while holding it.
+     * Propagates a bucket change to registered windows whose interval overlaps {@code slotStart}.
+     */
+    private void notifyRegisteredWindowsSlotDelta(long slotStart, long delta, long now) {
+        if (registeredWindows.isEmpty()) {
+            return;
+        }
+        long slotEnd = slotStart + granularityMillis;
+        for (TimeSlottedCounterWindow window : registeredWindows) {
+            if (window.mayOverlapSlot(slotStart, slotEnd, now)) {
+                window.onSlotDelta(slotStart, delta, now);
+            }
+        }
+    }
+
+    /**
+     * Whether {@link #advanceToNowUnderWriteLock(long)} must roll the ring forward. Caller must hold structure lock.
      * <p>
      * True when the current time slot is newer than the head slot (wall clock moved into a future bucket).
      */
@@ -303,7 +383,7 @@ public class TimeSlottedCounter {
     }
 
     /**
-     * Rolls the ring until the head slot equals the current time slot.
+     * Rolls the ring until the head slot equals the current time slot, then updates registered windows.
      * Caller must hold {@link #structureLock} write lock and pass a {@code now} read while holding it.
      * <p>
      * The expectation is that this will be (indirectly) called frequently enough that the ring is rolled
@@ -313,7 +393,14 @@ public class TimeSlottedCounter {
     private void advanceToNowUnderWriteLock(long now) {
         long targetHeadSlot = slotStartForTimestamp(now);
         while (headSlotStart() < targetHeadSlot) {
-            rollForwardOneSlot();
+            rollForwardOneSlot(now);
+        }
+        for (TimeSlottedCounterWindow window : registeredWindows) {
+            if (window.needsTimeSlide(now)) {
+                window.advanceTimeSlideUnderWriteLock(now);
+            } else {
+                window.touchMetadataIfNewer(now);
+            }
         }
     }
 
@@ -403,9 +490,9 @@ public class TimeSlottedCounter {
      *   former tail mass [99] merged into physical 0 (neighbor of tail)
      * </pre>
      */
-    private void rollForwardOneSlot() {
+    private void rollForwardOneSlot(long now) {
         if (counts.length() >= 2) {
-            mergeTailIntoNeighbor(bucketIndexForOffset(0), bucketIndexForOffset(1));
+            mergeTailIntoNeighbor(bucketIndexForOffset(0), bucketIndexForOffset(1), now);
         }
         tailBucketIndex = (tailBucketIndex + 1) % counts.length();
         tailSlotStart += granularityMillis;
@@ -416,9 +503,22 @@ public class TimeSlottedCounter {
      * Moves all count from the tail bucket into the next-older neighbor before the tail slot is reused.
      * <p>
      * Overflow from slots evicted off the left of the ring accumulates in the tail; merging preserves that mass
-     * in the oldest retained bucket.
+     * in the oldest retained bucket. Notifies registered windows via
+     * {@link TimeSlottedCounterWindow#onTailMergeUnderWriteLock} when tail/neighbor overlap with the window differs.
      */
-    private void mergeTailIntoNeighbor(int tailIndex, int neighborIndex) {
+    private void mergeTailIntoNeighbor(int tailIndex, int neighborIndex, long now) {
+        long tailCount = counts.get(tailIndex);
+        if (tailCount != 0 && registeredWindows.isEmpty() == false) {
+            long neighborSlotStart = slotStartForOffset(1);
+            long tailSlotEnd = tailSlotStart + granularityMillis;
+            long neighborSlotEnd = neighborSlotStart + granularityMillis;
+            for (TimeSlottedCounterWindow window : registeredWindows) {
+                if (window.mayOverlapSlot(tailSlotStart, tailSlotEnd, now)
+                    || window.mayOverlapSlot(neighborSlotStart, neighborSlotEnd, now)) {
+                    window.onTailMergeUnderWriteLock(tailSlotStart, neighborSlotStart, tailCount, now);
+                }
+            }
+        }
         counts.addAndGet(neighborIndex, counts.getAndSet(tailIndex, 0));
     }
 

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/TimeSlottedCounter.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/TimeSlottedCounter.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.blobcache.shared;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
+
+import java.util.concurrent.atomic.AtomicLongArray;
+import java.util.function.LongSupplier;
+
+/**
+ * Tracks counts in fixed-duration time slots using a ring buffer of buckets indexed by slot time. Slots are
+ * defined by a time granularity and a max number of slots. E.g., 10:37 would be in slot 10:00 for 1h slots.
+ * <p>
+ * Used at node level for cache boost quota tracking (expected totals from shard data, and actual
+ * totals from cache residency). Callers pass arbitrary counts via {@link #add} and {@link #remove};
+ * this type is agnostic to what is being counted (the expectation is that it is cache regions).
+ * <p>
+ * The ring is fixed at construction: {@code tailSlotStart} does not move. Timestamps after the head slot are
+ * clamped to the head bucket; timestamps before the tail slot are clamped to the tail bucket.
+ * <p>
+ * Bucket sums are updated atomically via {@link AtomicLongArray}.
+ */
+public class TimeSlottedCounter {
+
+    private static final Logger logger = LogManager.getLogger(TimeSlottedCounter.class);
+
+    private final long granularityMillis;
+
+    /** {@code slotStart} of the oldest retained (tail) bucket. */
+    private final long tailSlotStart;
+
+    private final AtomicLongArray counts;
+
+    /**
+     * Creates a ring of {@code maxBuckets} atomic count buckets, one per time slot of {@code granularity}.
+     * <p>
+     * Example ({@code maxBuckets=4}, 1h granularity, clock at 12:00):
+     * <pre>
+     *   tail slot 09:00-09:59 at offset 0; head slot 12:00-12:59 at offset 3
+     *   +--------------+--------------+--------------+--------------+
+     *   | physical 0   | physical 1   | physical 2   | physical 3   |
+     *   | tail         |              |              | head         |
+     *   +--------------+--------------+--------------+--------------+
+     *   | offset 0     | offset 1     | offset 2     | offset 3     |
+     *   +--------------+--------------+--------------+--------------+
+     *   | 09:00-09:59  | 10:00-10:59  | 11:00-11:59  | 12:00-12:59  |
+     *   +--------------+--------------+--------------+--------------+
+     *   | count [0]    | count [0]    | count [0]    | count [0]    |
+     *   +--------------+--------------+--------------+--------------+
+     * </pre>
+     *
+     * @param granularity duration of each time slot
+     * @param maxBuckets maximum number of slots retained
+     * @param timeProvider source of wall-clock time in milliseconds
+     */
+    public TimeSlottedCounter(TimeValue granularity, int maxBuckets, LongSupplier timeProvider) {
+        if (granularity.millis() <= 0) {
+            throw new IllegalArgumentException("granularity must be positive");
+        }
+        if (maxBuckets <= 0) {
+            throw new IllegalArgumentException("maxBuckets must be positive");
+        }
+        this.granularityMillis = granularity.millis();
+        this.counts = new AtomicLongArray(maxBuckets);
+        long now = timeProvider.getAsLong();
+        long headSlot = slotStartForTimestamp(now < 0 ? 0 : now);
+        this.tailSlotStart = headSlot - (long) (maxBuckets - 1) * granularityMillis;
+    }
+
+    public static TimeSlottedCounter createFromSettings(Settings settings, LongSupplier timeProvider) {
+        return new TimeSlottedCounter(
+            SharedBlobCacheService.SHARED_CACHE_TIME_SLOTS_GRANULARITY_SETTING.get(settings),
+            SharedBlobCacheService.SHARED_CACHE_TIME_SLOTS_COUNT_SETTING.get(settings),
+            timeProvider
+        );
+    }
+
+    public TimeValue granularity() {
+        return TimeValue.timeValueMillis(granularityMillis);
+    }
+
+    public int maxBuckets() {
+        return counts.length();
+    }
+
+    /**
+     * Adds {@code count} to the slot containing {@code timestampMillis}.
+     * <p>
+     * Timestamps older than the retained tail are clamped to the tail slot; timestamps after the head
+     * slot are clamped to the head slot.
+     */
+    public void add(long timestampMillis, long count) {
+        if (count <= 0) {
+            return;
+        }
+        counts.addAndGet(bucketIndex(timestampMillis), count);
+    }
+
+    /**
+     * Removes {@code count} from the slot containing {@code timestampMillis}.
+     * <p>
+     * Same slot resolution as {@link #add}; the bucket is never driven below zero (excess remove is clamped).
+     */
+    public void remove(long timestampMillis, long count) {
+        if (count <= 0) {
+            return;
+        }
+        int index = bucketIndex(timestampMillis);
+        long slotStart = tailSlotStart + (long) index * granularityMillis;
+        counts.accumulateAndGet(index, count, (current, removal) -> {
+            if (current < removal) {
+                logger.debug("remove clamped: slot start [{}] count [{}] less than remove count [{}]", slotStart, current, removal);
+                return 0;
+            }
+            return current - removal;
+        });
+    }
+
+    /**
+     * Returns the sum of counts in slots overlapping {@code [windowStartMillis, windowEndMillis)}.
+     * <p>
+     * Example (1h slots, range {@code [10:00, 13:00)}):
+     * <pre>
+     *   includes slots 10:00, 11:00, 12:00 (each [slotStart, slotStart+granularity) intersects the range)
+     *   excludes slot 13:00 (starts at range end)
+     * </pre>
+     */
+    public long sum(long windowStartMillis, long windowEndMillis) {
+        if (windowEndMillis <= windowStartMillis) {
+            return 0;
+        }
+        long retentionEnd = tailSlotStart + (long) counts.length() * granularityMillis;
+        if (windowEndMillis <= tailSlotStart || windowStartMillis >= retentionEnd) {
+            return 0;
+        }
+        long firstOffset = Math.max(0L, Math.floorDiv(windowStartMillis - tailSlotStart - granularityMillis, granularityMillis) + 1);
+        long lastOffset = Math.min(counts.length() - 1L, Math.floorDiv(windowEndMillis - 1 - tailSlotStart, granularityMillis));
+        if (firstOffset > lastOffset) {
+            return 0;
+        }
+        long total = 0;
+        for (int offset = (int) firstOffset; offset <= lastOffset; offset++) {
+            total += counts.get(offset);
+        }
+        return total;
+    }
+
+    /**
+     * Resolves {@code timestampMillis} to a physical bucket index.
+     * <p>
+     * Example ({@code maxBuckets=4}, 1h granularity, tail 09:00-09:59):
+     * <pre>
+     *   +--------------+--------------+--------------+--------------+
+     *   | physical 0   | physical 1   | physical 2   | physical 3   |
+     *   | tail         |              |              | head         |
+     *   +--------------+--------------+--------------+--------------+
+     *   | offset 0     | offset 1     | offset 2     | offset 3     |
+     *   +--------------+--------------+--------------+--------------+
+     *   | 09:00-09:59  | 10:00-10:59  | 11:00-11:59  | 12:00-12:59  |
+     *   +--------------+--------------+--------------+--------------+
+     *
+     *   add(timestamp=10:30, count=4):
+     *     1. resolve slot start -> 10:00 (floor to hour)
+     *     2. offsetFromTail = (10:00 - 09:00) / 1h = 1
+     *     3. counts.addAndGet(1, 4)
+     * </pre>
+     * Slot start clamping:
+     * <pre>
+     *   +---------------------------+----------------------------------------+
+     *   | condition                 | resolved slotStart                     |
+     *   +---------------------------+----------------------------------------+
+     *   | timestamp too old         | tail slot                              |
+     *   | timestamp in future       | head slot (newest retained)            |
+     *   | otherwise                 | floor(timestamp) to granularity        |
+     *   +---------------------------+----------------------------------------+
+     * </pre>
+     */
+    private int bucketIndex(long timestampMillis) {
+        long slotStart = slotStartForTimestamp(Math.max(0, timestampMillis));
+        if (slotStart < tailSlotStart) {
+            slotStart = tailSlotStart;
+        } else {
+            long headSlot = tailSlotStart + (long) (counts.length() - 1) * granularityMillis;
+            if (slotStart > headSlot) {
+                slotStart = headSlot;
+            }
+        }
+        return Math.toIntExact((slotStart - tailSlotStart) / granularityMillis);
+    }
+
+    /**
+     * Truncates {@code timestampMillis} down to the start of its granularity-aligned slot.
+     * <p>
+     * Example: granularity 1h, {@code timestamp=10:37} -> {@code 10:00}.
+     */
+    private long slotStartForTimestamp(long timestampMillis) {
+        return Math.floorDiv(timestampMillis, granularityMillis) * granularityMillis;
+    }
+}

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/TimeSlottedCounterWindow.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/TimeSlottedCounterWindow.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.blobcache.shared;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * A fixed relative-to-now window registered with a {@link TimeSlottedCounter}. The counter
+ * incrementally maintains the sum on slot mutations and structural updates; {@link #sum()}
+ * only advances time and returns the cached total.
+ */
+public class TimeSlottedCounterWindow {
+
+    private final TimeSlottedCounter counter;
+    private final long startOffsetMillis;
+    private final long endOffsetMillis;
+    private final AtomicLong sum = new AtomicLong();
+
+    private long lastNow = -1;
+    private long lastWindowStartMillis;
+    private long lastWindowEndMillis;
+
+    /**
+     * Package-private constructor; use {@link TimeSlottedCounter#registerRelativeWindow}.
+     * <p>
+     * Defines a sliding interval {@code [now - endOffsetMillis, now - startOffsetMillis)}. For example,
+     * {@code startOffset=1d, endOffset=3d} at {@code now=10d} tracks {@code [7d, 9d)}.
+     */
+    TimeSlottedCounterWindow(TimeSlottedCounter counter, long startOffsetMillis, long endOffsetMillis) {
+        if (startOffsetMillis < 0 || endOffsetMillis < 0) {
+            throw new IllegalArgumentException("offsets must be non-negative");
+        }
+        if (endOffsetMillis <= startOffsetMillis) {
+            throw new IllegalArgumentException("endOffsetMillis must be greater than startOffsetMillis");
+        }
+        this.counter = counter;
+        this.startOffsetMillis = startOffsetMillis;
+        this.endOffsetMillis = endOffsetMillis;
+    }
+
+    /**
+     * Initializes the cached sum from a full bucket scan. Caller must hold {@link TimeSlottedCounter}'s write lock.
+     * <p>
+     * Example at registration time {@code now=10d}, window {@code [now-3d, now-1d)}:
+     * <pre>
+     *   sum = counter.sumBucketsInRange(7d, 9d)   // one-time full scan
+     *   lastWindowStart/End stored for later incremental slides
+     * </pre>
+     */
+    void initializeUnderWriteLock(long now) {
+        long windowStart = windowStart(now);
+        long windowEnd = windowEnd(now);
+        sum.set(counter.sumBucketsInRange(windowStart, windowEnd));
+        updateMetadata(now, windowStart, windowEnd);
+    }
+
+    /**
+     * Returns the incrementally maintained sum after advancing the counter to the current time.
+     * <p>
+     * May trigger a ring roll and/or {@link #advanceTimeSlideUnderWriteLock} when time or slot boundaries moved;
+     * otherwise returns the cached {@link #sum} with no bucket scan.
+     */
+    public long sum() {
+        counter.advanceIfNeededForWindow(this);
+        return sum.get();
+    }
+
+    /**
+     * Whether {@link #advanceTimeSlideUnderWriteLock(long)} must run for {@code now}. Caller must hold
+     * {@link TimeSlottedCounter}'s structure read lock.
+     * <p>
+     * True when {@code now} advanced and either window boundary crossed into a new time slot:
+     * <pre>
+     *   last window [7d, 9d) at now=10d
+     *   clock -> 10d + 2h still same slot boundaries -> false (fast path in advanceIfNeededForWindow)
+     *   clock -> 10d + 2h such that windowEnd enters next hour slot -> true
+     * </pre>
+     */
+    boolean needsTimeSlide(long now) {
+        return lastNow < 0 || (now > lastNow && windowBoundariesSlotChanged(now));
+    }
+
+    /**
+     * Full scan for tests and validation. Recomputes {@code sumBucketsInRange} for the current window;
+     * does not read the cached {@link #sum}.
+     */
+    long sumUncached() {
+        long now = counter.currentTimeMillis();
+        return counter.sumInRange(windowStart(now), windowEnd(now));
+    }
+
+    /**
+     * Fast reject before applying a slot delta. Caller must pass the same {@code now} used for the mutation.
+     */
+    boolean mayOverlapSlot(long slotStart, long slotEnd, long now) {
+        long windowStart = windowStart(now);
+        long windowEnd = windowEnd(now);
+        return slotEnd > windowStart && slotStart < windowEnd;
+    }
+
+    /**
+     * Adjusts the cached sum when a bucket overlapping the current window changes.
+     * Called only after {@link #mayOverlapSlot(long, long, long)} returns true.
+     */
+    void onSlotDelta(long slotStart, long delta, long now) {
+        if (delta != 0) {
+            sum.addAndGet(delta);
+        }
+    }
+
+    /**
+     * Adjusts the cached sum when tail mass is merged into the neighbor slot. Caller must hold the counter write lock.
+     * <p>
+     * During ring roll, overflow in the tail bucket moves to the neighbor. If exactly one of the two slots overlaps
+     * the window, the cached sum must change by {@code ±tailCount}:
+     * <pre>
+     *   tail in window, neighbor not  -> sum -= tailCount  (mass left the window's slot representation)
+     *   neighbor in window, tail not -> sum += tailCount
+     *   both in or both out          -> no change (mass stayed inside or outside the window)
+     * </pre>
+     */
+    void onTailMergeUnderWriteLock(long tailSlotStart, long neighborSlotStart, long tailCount, long now) {
+        if (tailCount == 0) {
+            return;
+        }
+        long windowStart = windowStart(now);
+        long windowEnd = windowEnd(now);
+        boolean tailInWindow = counter.slotOverlaps(tailSlotStart, windowStart, windowEnd);
+        boolean neighborInWindow = counter.slotOverlaps(neighborSlotStart, windowStart, windowEnd);
+        if (tailInWindow != neighborInWindow) {
+            sum.addAndGet(tailInWindow ? -tailCount : tailCount);
+        }
+    }
+
+    /**
+     * Slides the cached sum when time advances across slot boundaries. Caller must hold the counter write lock.
+     * <p>
+     * The relative window moves with {@code now}; when a boundary enters a new bucket, drop or add whole slots:
+     * <pre>
+     *   was [7d, 9d), now [7d+2h, 9d+2h) — start boundary crossed a slot:
+     *     sum -= sumBucketsInRange(oldStart, newStart)   // slots that fell out of the left edge
+     *   end boundary crossed a slot:
+     *     sum += sumBucketsInRange(oldEnd, newEnd)       // slots that entered on the right
+     * </pre>
+     * If neither boundary changed slot alignment, only metadata is updated.
+     */
+    void advanceTimeSlideUnderWriteLock(long now) {
+        if (now <= lastNow) {
+            return;
+        }
+        long windowStart = windowStart(now);
+        long windowEnd = windowEnd(now);
+        if (lastNow >= 0 && windowBoundariesSlotChanged(now)) {
+            if (windowStart > lastWindowStartMillis) {
+                sum.addAndGet(-counter.sumBucketsInRange(lastWindowStartMillis, windowStart));
+            }
+            if (windowEnd > lastWindowEndMillis) {
+                sum.addAndGet(counter.sumBucketsInRange(lastWindowEndMillis, windowEnd));
+            }
+        }
+        updateMetadata(now, windowStart, windowEnd);
+    }
+
+    /**
+     * Updates cached window boundaries when time moved but slot-aligned boundaries did not. Caller must hold write lock.
+     */
+    void touchMetadataIfNewer(long now) {
+        if (now > lastNow) {
+            updateMetadata(now, windowStart(now), windowEnd(now));
+        }
+    }
+
+    private boolean windowBoundariesSlotChanged(long now) {
+        return counter.slotStartForTimestamp(windowStart(now)) != counter.slotStartForTimestamp(lastWindowStartMillis)
+            || counter.slotStartForTimestamp(windowEnd(now)) != counter.slotStartForTimestamp(lastWindowEndMillis);
+    }
+
+    private long windowStart(long now) {
+        return Math.max(0, now - endOffsetMillis);
+    }
+
+    /**
+     * Exclusive end of the half-open window at {@code now}.
+     */
+    private long windowEnd(long now) {
+        return now - startOffsetMillis;
+    }
+
+    /**
+     * Records {@code now} and the last window boundaries used for {@link #needsTimeSlide} and incremental slides.
+     */
+    private void updateMetadata(long now, long windowStart, long windowEnd) {
+        lastNow = now;
+        lastWindowStartMillis = windowStart;
+        lastWindowEndMillis = windowEnd;
+    }
+}

--- a/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/TimeSlottedCounterTests.java
+++ b/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/TimeSlottedCounterTests.java
@@ -272,4 +272,19 @@ public class TimeSlottedCounterTests extends ESTestCase {
         assertThat(counter.sum(106 * HOUR, 110 * HOUR), equalTo(21L));
     }
 
+    public void testRegisteredWindowsStayConsistent() {
+        AtomicLong clock = new AtomicLong(30 * DAY);
+        TimeSlottedCounter counter = new TimeSlottedCounter(TimeValue.timeValueHours(1), 1000, clock::get);
+        TimeSlottedCounterWindow recent = counter.registerRelativeWindow(0, 7 * DAY);
+        TimeSlottedCounterWindow prior = counter.registerRelativeWindow(7 * DAY, 30 * DAY);
+
+        counter.add(clock.get() - 2 * DAY, 11);
+        counter.add(clock.get() - 10 * DAY, 22);
+        counter.remove(clock.get() - 2 * DAY, 3);
+
+        assertThat(recent.sum(), equalTo(recent.sumUncached()));
+        assertThat(prior.sum(), equalTo(prior.sumUncached()));
+        assertThat(recent.sum(), equalTo(8L));
+        assertThat(prior.sum(), equalTo(22L));
+    }
 }

--- a/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/TimeSlottedCounterTests.java
+++ b/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/TimeSlottedCounterTests.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.blobcache.shared;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class TimeSlottedCounterTests extends ESTestCase {
+
+    private static final long HOUR = TimeValue.timeValueHours(1).millis();
+    private static final long DAY = TimeValue.timeValueDays(1).millis();
+
+    public void testAddInRetainedPastSlot() {
+        AtomicLong clock = new AtomicLong(10 * DAY);
+        TimeSlottedCounter counter = new TimeSlottedCounter(TimeValue.timeValueHours(1), 500, clock::get);
+        counter.add(8 * DAY, 7);
+        assertThat(counter.sum(7 * DAY, 9 * DAY), equalTo(7L));
+    }
+
+    public void testCreateFromSettings() {
+        Settings settings = Settings.builder()
+            .put(SharedBlobCacheService.SHARED_CACHE_TIME_SLOTS_GRANULARITY_SETTING.getKey(), "30m")
+            .put(SharedBlobCacheService.SHARED_CACHE_TIME_SLOTS_COUNT_SETTING.getKey(), 48)
+            .build();
+        AtomicLong clock = new AtomicLong(0);
+        TimeSlottedCounter counter = TimeSlottedCounter.createFromSettings(settings, clock::get);
+        assertThat(counter.granularity(), equalTo(TimeValue.timeValueMinutes(30)));
+        assertThat(counter.maxBuckets(), equalTo(48));
+    }
+
+    public void testSlotTruncationAndClamping() {
+        AtomicLong clock = new AtomicLong(5 * HOUR + 30 * 60 * 1000);
+        TimeSlottedCounter counter = new TimeSlottedCounter(TimeValue.timeValueHours(1), 3, clock::get);
+
+        long headSlot = 5 * HOUR;
+        counter.add(clock.get(), 10);
+        assertThat(counter.sum(headSlot, headSlot + HOUR), equalTo(10L));
+
+        counter.add(headSlot + 15 * 60 * 1000, 5);
+        assertThat(counter.sum(headSlot, headSlot + HOUR), equalTo(15L));
+
+        counter.add(headSlot + HOUR, 100);
+        assertThat(counter.sum(headSlot, headSlot + HOUR), equalTo(115L));
+
+        long tailSlot = headSlot - 2 * HOUR;
+        counter.add(tailSlot, 7);
+        assertThat(counter.sum(tailSlot, tailSlot + HOUR), equalTo(7L));
+    }
+
+    public void testFutureTimestampsClampToHeadWithoutRoll() {
+        AtomicLong clock = new AtomicLong(0);
+        TimeSlottedCounter counter = new TimeSlottedCounter(TimeValue.timeValueHours(1), 3, clock::get);
+
+        counter.add(0, 4);
+        clock.set(5 * HOUR);
+        counter.add(clock.get(), 6);
+        // Head slot is still hour 0; future adds accumulate in that bucket
+        assertThat(counter.sum(0, HOUR), equalTo(10L));
+        assertThat(counter.sum(5 * HOUR, 6 * HOUR), equalTo(0L));
+    }
+
+    public void testAddRemoveSymmetry() {
+        AtomicLong clock = new AtomicLong(HOUR);
+        TimeSlottedCounter counter = new TimeSlottedCounter(TimeValue.timeValueHours(1), 5, clock::get);
+
+        counter.add(HOUR + 100, 20);
+        counter.add(HOUR + 100, 10);
+        assertThat(counter.sum(HOUR, 2 * HOUR), equalTo(30L));
+
+        counter.remove(HOUR + 100, 25);
+        assertThat(counter.sum(HOUR, 2 * HOUR), equalTo(5L));
+
+        counter.remove(HOUR + 100, 100);
+        assertThat(counter.sum(HOUR, 2 * HOUR), equalTo(0L));
+    }
+
+    public void testConcurrentAdds() throws Exception {
+        AtomicLong clock = new AtomicLong(10 * HOUR);
+        TimeSlottedCounter counter = new TimeSlottedCounter(TimeValue.timeValueHours(1), 24, clock::get);
+        long ts = clock.get();
+        int threads = 4;
+        int iterations = 500;
+        ExecutorService executor = Executors.newFixedThreadPool(threads);
+        try {
+            CountDownLatch start = new CountDownLatch(1);
+            CountDownLatch done = new CountDownLatch(threads);
+
+            for (int t = 0; t < threads; t++) {
+                executor.execute(() -> {
+                    try {
+                        start.await();
+                        for (int i = 0; i < iterations; i++) {
+                            counter.add(ts, 1);
+                        }
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    } finally {
+                        done.countDown();
+                    }
+                });
+            }
+            start.countDown();
+            assertTrue(done.await(30, TimeUnit.SECONDS));
+            assertThat(counter.sum(ts, ts + HOUR), equalTo((long) threads * iterations));
+        } finally {
+            terminate(executor);
+        }
+    }
+
+    public void testConcurrentAddRemove() throws Exception {
+        AtomicLong clock = new AtomicLong(10 * HOUR);
+        TimeSlottedCounter counter = new TimeSlottedCounter(TimeValue.timeValueHours(1), 24, clock::get);
+        int threads = 4;
+        int iterations = 500;
+        ExecutorService executor = Executors.newFixedThreadPool(threads);
+        try {
+            CountDownLatch start = new CountDownLatch(1);
+            CountDownLatch done = new CountDownLatch(threads);
+
+            for (int t = 0; t < threads; t++) {
+                executor.execute(() -> {
+                    try {
+                        start.await();
+                        for (int i = 0; i < iterations; i++) {
+                            long ts = 10 * HOUR + (i % 5) * HOUR;
+                            counter.add(ts, 1);
+                            counter.remove(ts, 1);
+                        }
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    } finally {
+                        done.countDown();
+                    }
+                });
+            }
+            start.countDown();
+            assertTrue(done.await(30, TimeUnit.SECONDS));
+            assertThat(counter.sum(10 * HOUR, 15 * HOUR), equalTo(0L));
+        } finally {
+            terminate(executor);
+        }
+    }
+
+    public void testInvalidConstructorArgs() {
+        AtomicLong clock = new AtomicLong(0);
+        expectThrows(IllegalArgumentException.class, () -> new TimeSlottedCounter(TimeValue.ZERO, 1, clock::get));
+        expectThrows(IllegalArgumentException.class, () -> new TimeSlottedCounter(TimeValue.timeValueHours(1), 0, clock::get));
+    }
+}

--- a/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/TimeSlottedCounterTests.java
+++ b/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/TimeSlottedCounterTests.java
@@ -61,16 +61,29 @@ public class TimeSlottedCounterTests extends ESTestCase {
         assertThat(counter.sum(tailSlot, tailSlot + HOUR), equalTo(7L));
     }
 
-    public void testFutureTimestampsClampToHeadWithoutRoll() {
+    public void testRolloverAdvancesHead() {
         AtomicLong clock = new AtomicLong(0);
-        TimeSlottedCounter counter = new TimeSlottedCounter(TimeValue.timeValueHours(1), 3, clock::get);
+        TimeSlottedCounter counter = new TimeSlottedCounter(TimeValue.timeValueHours(1), 2, clock::get);
 
-        counter.add(0, 4);
-        clock.set(5 * HOUR);
-        counter.add(clock.get(), 6);
-        // Head slot is still hour 0; future adds accumulate in that bucket
-        assertThat(counter.sum(0, HOUR), equalTo(10L));
-        assertThat(counter.sum(5 * HOUR, 6 * HOUR), equalTo(0L));
+        counter.add(0, 1);
+        assertThat(counter.sum(0, HOUR), equalTo(1L));
+
+        clock.set(2 * HOUR);
+        counter.advanceToNow();
+        counter.add(2 * HOUR, 2);
+        assertThat(counter.sum(2 * HOUR, 3 * HOUR), equalTo(2L));
+        assertThat(counter.sum(0, HOUR), equalTo(0L));
+    }
+
+    public void testTailMergeRetainsOverflowMass() {
+        AtomicLong clock = new AtomicLong(0);
+        TimeSlottedCounter counter = new TimeSlottedCounter(TimeValue.timeValueHours(1), 2, clock::get);
+
+        counter.add(0, 5);
+        clock.set(3 * HOUR);
+        counter.advanceToNow();
+        counter.add(0, 3);
+        assertThat(counter.sum(2 * HOUR, 3 * HOUR), equalTo(8L));
     }
 
     public void testAddRemoveSymmetry() {
@@ -86,6 +99,17 @@ public class TimeSlottedCounterTests extends ESTestCase {
 
         counter.remove(HOUR + 100, 100);
         assertThat(counter.sum(HOUR, 2 * HOUR), equalTo(0L));
+    }
+
+    public void testSumTriggeredRolloverWhenIdle() {
+        AtomicLong clock = new AtomicLong(0);
+        TimeSlottedCounter counter = new TimeSlottedCounter(TimeValue.timeValueHours(1), 3, clock::get);
+        counter.add(0, 4);
+
+        clock.set(2 * HOUR);
+        assertThat(counter.sum(2 * HOUR, 3 * HOUR), equalTo(0L));
+        counter.add(2 * HOUR, 1);
+        assertThat(counter.sum(2 * HOUR, 3 * HOUR), equalTo(1L));
     }
 
     public void testConcurrentAdds() throws Exception {
@@ -116,6 +140,57 @@ public class TimeSlottedCounterTests extends ESTestCase {
             start.countDown();
             assertTrue(done.await(30, TimeUnit.SECONDS));
             assertThat(counter.sum(ts, ts + HOUR), equalTo((long) threads * iterations));
+        } finally {
+            terminate(executor);
+        }
+    }
+
+    public void testConcurrentAddAndSum() throws Exception {
+        AtomicLong clock = new AtomicLong(10 * HOUR);
+        TimeSlottedCounter counter = new TimeSlottedCounter(TimeValue.timeValueHours(1), 24, clock::get);
+        long windowStart = 10 * HOUR;
+        long windowEnd = 15 * HOUR;
+        int addThreads = 2;
+        int sumThreads = 2;
+        int iterations = 300;
+        ExecutorService executor = Executors.newFixedThreadPool(addThreads + sumThreads);
+        try {
+            CountDownLatch start = new CountDownLatch(1);
+            CountDownLatch done = new CountDownLatch(addThreads + sumThreads);
+
+            for (int t = 0; t < addThreads; t++) {
+                executor.execute(() -> {
+                    try {
+                        start.await();
+                        for (int i = 0; i < iterations; i++) {
+                            long ts = windowStart + (i % 5) * HOUR;
+                            counter.add(ts, 1);
+                        }
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    } finally {
+                        done.countDown();
+                    }
+                });
+            }
+            for (int t = 0; t < sumThreads; t++) {
+                executor.execute(() -> {
+                    try {
+                        start.await();
+                        for (int i = 0; i < iterations; i++) {
+                            long sum = counter.sum(windowStart, windowEnd);
+                            assertThat(sum, org.hamcrest.Matchers.greaterThanOrEqualTo(0L));
+                        }
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    } finally {
+                        done.countDown();
+                    }
+                });
+            }
+            start.countDown();
+            assertTrue(done.await(30, TimeUnit.SECONDS));
+            assertThat(counter.sum(windowStart, windowEnd), equalTo((long) addThreads * iterations));
         } finally {
             terminate(executor);
         }
@@ -160,4 +235,41 @@ public class TimeSlottedCounterTests extends ESTestCase {
         expectThrows(IllegalArgumentException.class, () -> new TimeSlottedCounter(TimeValue.ZERO, 1, clock::get));
         expectThrows(IllegalArgumentException.class, () -> new TimeSlottedCounter(TimeValue.timeValueHours(1), 0, clock::get));
     }
+
+    /**
+     * When wall clock crosses a slot boundary, add must roll the ring (not clamp to the previous head).
+     */
+    public void testAddAtSlotBoundaryAdvancesRing() {
+        long headSlot = 11 * HOUR;
+        AtomicLong clock = new AtomicLong(headSlot + 59 * 60 * 1000);
+        TimeSlottedCounter counter = new TimeSlottedCounter(TimeValue.timeValueHours(1), 3, clock::get);
+        counter.add(headSlot, 1);
+
+        clock.set(headSlot + HOUR + 5 * 60 * 1000);
+        counter.add(clock.get(), 2);
+
+        assertThat(counter.sum(headSlot + HOUR, headSlot + 2 * HOUR), equalTo(2L));
+        assertThat(counter.sum(headSlot, headSlot + HOUR), equalTo(1L));
+    }
+
+    public void testManySequentialRolls() {
+        AtomicLong clock = new AtomicLong(10 * HOUR);
+        TimeSlottedCounter counter = new TimeSlottedCounter(TimeValue.timeValueHours(1), 5, clock::get);
+
+        long tailSlot = 6 * HOUR;
+        long headSlot = 10 * HOUR;
+        counter.add(tailSlot, 7);
+        counter.add(headSlot, 11);
+
+        clock.set(110 * HOUR);
+        counter.advanceToNow();
+
+        assertThat(counter.sum(headSlot, headSlot + HOUR), equalTo(0L));
+        assertThat(counter.sum(109 * HOUR, 110 * HOUR), equalTo(0L));
+        assertThat(counter.sum(106 * HOUR, 110 * HOUR), equalTo(18L));
+
+        counter.add(0, 3);
+        assertThat(counter.sum(106 * HOUR, 110 * HOUR), equalTo(21L));
+    }
+
 }

--- a/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/TimeSlottedCounterWindowTests.java
+++ b/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/TimeSlottedCounterWindowTests.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.blobcache.shared;
+
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class TimeSlottedCounterWindowTests extends ESTestCase {
+
+    private static final long HOUR = TimeValue.timeValueHours(1).millis();
+    private static final long DAY = TimeValue.timeValueDays(1).millis();
+
+    public void testMatchesUncachedLast24Hours() {
+        AtomicLong clock = new AtomicLong(10 * DAY);
+        TimeSlottedCounter counter = new TimeSlottedCounter(TimeValue.timeValueHours(1), 500, clock::get);
+        TimeSlottedCounterWindow sliding = counter.registerRelativeWindow(0, 24 * HOUR);
+
+        for (int i = 0; i < 48; i++) {
+            counter.add(10 * DAY - i * HOUR, i + 1);
+        }
+
+        assertThat(sliding.sum(), equalTo(sliding.sumUncached()));
+    }
+
+    public void testMatchesUncachedRelativeWindow() {
+        AtomicLong clock = new AtomicLong(30 * DAY);
+        TimeSlottedCounter counter = new TimeSlottedCounter(TimeValue.timeValueHours(1), 1000, clock::get);
+        TimeSlottedCounterWindow sliding = counter.registerRelativeWindow(DAY, 3 * DAY);
+
+        counter.add(clock.get() - DAY, 50);
+        counter.add(clock.get() - 2 * DAY, 25);
+
+        assertThat(sliding.sum(), equalTo(sliding.sumUncached()));
+    }
+
+    public void testFastPathWithinGranularity() {
+        AtomicLong clock = new AtomicLong(5 * DAY);
+        TimeSlottedCounter counter = new TimeSlottedCounter(TimeValue.timeValueHours(1), 200, clock::get);
+        TimeSlottedCounterWindow sliding = counter.registerRelativeWindow(0, DAY);
+
+        counter.add(4 * DAY + HOUR, 10);
+        sliding.sum();
+
+        clock.addAndGet(TimeValue.timeValueMinutes(30).millis());
+        long second = sliding.sum();
+        assertThat(second, equalTo(sliding.sumUncached()));
+        assertThat(second, equalTo(10L));
+    }
+
+    public void testIncrementalRelativeWindow() {
+        AtomicLong clock = new AtomicLong(10 * DAY);
+        TimeSlottedCounter counter = new TimeSlottedCounter(TimeValue.timeValueHours(1), 500, clock::get);
+        TimeSlottedCounterWindow sliding = counter.registerRelativeWindow(DAY, 3 * DAY);
+
+        counter.add(10 * DAY - 2 * DAY, 7);
+        long first = sliding.sum();
+
+        clock.addAndGet(2 * HOUR);
+        long newEntryTime = clock.get() - DAY - HOUR;
+        counter.add(newEntryTime, 3);
+
+        long second = sliding.sum();
+        assertThat(second, equalTo(sliding.sumUncached()));
+        assertThat(second, equalTo(first + 3L));
+    }
+
+    public void testIncrementalUpdateOnAdd() {
+        AtomicLong clock = new AtomicLong(5 * DAY);
+        TimeSlottedCounter counter = new TimeSlottedCounter(TimeValue.timeValueHours(1), 200, clock::get);
+        TimeSlottedCounterWindow sliding = counter.registerRelativeWindow(0, DAY);
+
+        counter.add(4 * DAY + HOUR, 10);
+        long first = sliding.sum();
+        assertThat(first, equalTo(10L));
+
+        counter.add(4 * DAY + 2 * HOUR, 5);
+        long second = sliding.sum();
+        assertThat(second, equalTo(sliding.sumUncached()));
+        assertThat(second, equalTo(15L));
+    }
+
+    public void testManyMutationsWithoutRescan() {
+        AtomicLong clock = new AtomicLong(10 * DAY);
+        TimeSlottedCounter counter = new TimeSlottedCounter(TimeValue.timeValueHours(1), 500, clock::get);
+        TimeSlottedCounterWindow sliding = counter.registerRelativeWindow(0, 7 * DAY);
+
+        sliding.sum();
+        for (int i = 0; i < 1000; i++) {
+            counter.add(clock.get() - DAY - (i % 120) * HOUR, 1);
+        }
+        assertThat(sliding.sum(), equalTo(sliding.sumUncached()));
+    }
+
+    public void testTwoWindowsOnOneCounter() {
+        AtomicLong clock = new AtomicLong(400 * DAY);
+        TimeSlottedCounter counter = new TimeSlottedCounter(TimeValue.timeValueHours(1), 10000, clock::get);
+        TimeSlottedCounterWindow recent = counter.registerRelativeWindow(0, 7 * DAY);
+        TimeSlottedCounterWindow prior = counter.registerRelativeWindow(7 * DAY, 365 * DAY);
+
+        counter.add(clock.get() - 2 * DAY, 10);
+        counter.add(clock.get() - 30 * DAY, 20);
+        counter.add(clock.get() - 400 * DAY, 100);
+
+        assertThat(recent.sum(), equalTo(10L));
+        assertThat(recent.sum(), equalTo(recent.sumUncached()));
+        assertThat(prior.sum(), equalTo(20L));
+        assertThat(prior.sum(), equalTo(prior.sumUncached()));
+    }
+
+    public void testTimeOnlySlide() {
+        AtomicLong clock = new AtomicLong(10 * DAY);
+        TimeSlottedCounter counter = new TimeSlottedCounter(TimeValue.timeValueHours(1), 500, clock::get);
+        TimeSlottedCounterWindow sliding = counter.registerRelativeWindow(0, 3 * DAY);
+
+        counter.add(10 * DAY - DAY, 42);
+        sliding.sum();
+
+        clock.addAndGet(2 * DAY);
+        assertThat(sliding.sum(), equalTo(sliding.sumUncached()));
+    }
+
+    public void testTailMergeWithRegisteredWindow() {
+        AtomicLong clock = new AtomicLong(0);
+        TimeSlottedCounter counter = new TimeSlottedCounter(TimeValue.timeValueHours(1), 2, clock::get);
+        TimeSlottedCounterWindow sliding = counter.registerRelativeWindow(0, 5 * HOUR);
+
+        counter.add(0, 5);
+        clock.set(3 * HOUR);
+        counter.advanceToNow();
+        counter.add(0, 3);
+
+        assertThat(sliding.sum(), equalTo(sliding.sumUncached()));
+        assertThat(sliding.sum(), equalTo(8L));
+    }
+
+    public void testConcurrentAddAndSlidingSum() throws Exception {
+        AtomicLong clock = new AtomicLong(20 * DAY);
+        TimeSlottedCounter counter = new TimeSlottedCounter(TimeValue.timeValueHours(1), 500, clock::get);
+        TimeSlottedCounterWindow sliding = counter.registerRelativeWindow(DAY, 7 * DAY);
+
+        int addThreads = 2;
+        int sumThreads = 2;
+        int iterations = 200;
+        ExecutorService executor = Executors.newFixedThreadPool(addThreads + sumThreads);
+        try {
+            CountDownLatch start = new CountDownLatch(1);
+            CountDownLatch done = new CountDownLatch(addThreads + sumThreads);
+
+            for (int t = 0; t < addThreads; t++) {
+                executor.execute(() -> {
+                    try {
+                        start.await();
+                        for (int i = 0; i < iterations; i++) {
+                            counter.add(clock.get() - DAY + i, 1);
+                        }
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    } finally {
+                        done.countDown();
+                    }
+                });
+            }
+            for (int t = 0; t < sumThreads; t++) {
+                executor.execute(() -> {
+                    try {
+                        start.await();
+                        for (int i = 0; i < iterations; i++) {
+                            sliding.sum();
+                        }
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    } finally {
+                        done.countDown();
+                    }
+                });
+            }
+            start.countDown();
+            assertTrue(done.await(30, TimeUnit.SECONDS));
+
+            assertThat(sliding.sum(), equalTo(sliding.sumUncached()));
+        } finally {
+            terminate(executor);
+        }
+    }
+
+    public void testConcurrentSumCalls() throws Exception {
+        AtomicLong clock = new AtomicLong(20 * DAY);
+        TimeSlottedCounter counter = new TimeSlottedCounter(TimeValue.timeValueHours(1), 500, clock::get);
+        TimeSlottedCounterWindow sliding = counter.registerRelativeWindow(DAY, 7 * DAY);
+        counter.add(clock.get() - DAY, 100);
+
+        int threads = 4;
+        ExecutorService executor = Executors.newFixedThreadPool(threads);
+        try {
+            CountDownLatch start = new CountDownLatch(1);
+            CountDownLatch done = new CountDownLatch(threads);
+            List<Long> results = Collections.synchronizedList(new ArrayList<>());
+
+            for (int t = 0; t < threads; t++) {
+                executor.execute(() -> {
+                    try {
+                        start.await();
+                        for (int i = 0; i < 200; i++) {
+                            results.add(sliding.sum());
+                        }
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    } finally {
+                        done.countDown();
+                    }
+                });
+            }
+            start.countDown();
+            assertTrue(done.await(30, TimeUnit.SECONDS));
+
+            long expected = sliding.sumUncached();
+            for (Long result : results) {
+                assertThat(result, equalTo(expected));
+            }
+        } finally {
+            terminate(executor);
+        }
+    }
+
+    public void testInvalidRegistrationOffsets() {
+        AtomicLong clock = new AtomicLong(0);
+        TimeSlottedCounter counter = new TimeSlottedCounter(TimeValue.timeValueHours(1), 10, clock::get);
+        expectThrows(IllegalArgumentException.class, () -> counter.registerRelativeWindow(DAY, DAY));
+        expectThrows(IllegalArgumentException.class, () -> counter.registerRelativeWindow(2 * DAY, DAY));
+        expectThrows(IllegalArgumentException.class, () -> counter.registerRelativeWindow(-HOUR, DAY));
+        expectThrows(IllegalArgumentException.class, () -> counter.registerRelativeWindow(0, -DAY));
+    }
+}


### PR DESCRIPTION
This PR is split into three incremental commits (but can do separate PRs if wished), and reviewers are urged to review each commit separately and comment on each separately. Seeking early feedback on direction and main code primarily for now; I'll work more on tests (which at the moment are auto-generated and not that randomized).

## 1) TimeSlottedCounter for boost window cache quotas

Introduce TimeSlottedCounter with a fixed ring of hourly buckets, settings for granularity and bucket count, and add/remove/sum APIs. The ring does not roll forward with wall clock yet; timestamps after the head slot clamp to the head bucket. Can sum up the counts in a given time window (e.g., boost window).

## 2) Roll TimeSlottedCounter ring with wall clock

Advance the ring on add, remove, and sum when time moves into a new slot (e.g., hourly). Merge evicted tail mass into the neighbor bucket and add tests for rollover, tail overflow, and concurrent access.

## 3) Add incrementally maintained relative time windows

Register (a low number of) fixed relative windows on TimeSlottedCounter so boost quota sums stay current without scanning buckets on every read.

## Comparison to other PR

Compared to https://github.com/elastic/elasticsearch/pull/149825 , this is more complex as we roll the overall time frame as time goes by into the future and we need a structure lock to do that at every check. The advantage is that we do not need more memory for future slots, and the server can run for as long as needed (if, e.g., we assume a long-running self-managed stateless node keeps running over a year without a restart). Although there is a disadvantage that future timestamps are clamped to head slot, and cannot be correctly nor efficiently decremented if time has passed so that the timestamp now has a corresponding slot in the ring.