### PR TITLE
[9.4] Honor task settings for Amazon Bedrock and Google Vertex chat completion (#149268)

### DIFF
--- a/docs/changelog/149268.yaml
+++ b/docs/changelog/149268.yaml
@@ -1,0 +1,6 @@
+area: Inference
+issues:
+ - 148792
+pr: 149268
+summary: Honor task settings for Amazon Bedrock and Google Vertex chat completion
+type: bug

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/request/completion/AmazonBedrockChatCompletionEntityFactory.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/request/completion/AmazonBedrockChatCompletionEntityFactory.java
@@ -53,6 +53,7 @@ public final class AmazonBedrockChatCompletionEntityFactory {
         Objects.requireNonNull(model);
         Objects.requireNonNull(request);
         var serviceSettings = model.getServiceSettings();
+        var taskSettings = model.getTaskSettings();
 
         var messages = request.messages()
             .stream()
@@ -61,15 +62,23 @@ public final class AmazonBedrockChatCompletionEntityFactory {
 
         switch (serviceSettings.provider()) {
             case ANTHROPIC, AI21LABS, AMAZONTITAN, COHERE, META, MISTRAL -> {
+                // Task settings configured at endpoint creation must be used when the per-request value
+                // is null, otherwise endpoint-level configuration is silently ignored. top_k cannot be
+                // set on the request at all, so it always comes from task settings.
                 return new AmazonBedrockChatCompletionRequestEntity(
                     messages,
                     request.model(),
-                    request.maxCompletionTokens(),
+                    request.maxCompletionTokens() != null
+                        ? request.maxCompletionTokens()
+                        : (taskSettings.maxNewTokens() != null ? taskSettings.maxNewTokens().longValue() : null),
                     request.stop(),
-                    request.temperature(),
+                    request.temperature() != null
+                        ? request.temperature()
+                        : (taskSettings.temperature() != null ? taskSettings.temperature().floatValue() : null),
                     request.toolChoice(),
                     request.tools(),
-                    request.topP()
+                    request.topP() != null ? request.topP() : (taskSettings.topP() != null ? taskSettings.topP().floatValue() : null),
+                    taskSettings.topK()
                 );
             }
             default -> {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/request/completion/AmazonBedrockChatCompletionRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/request/completion/AmazonBedrockChatCompletionRequest.java
@@ -37,6 +37,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.Flow;
 
+import static org.elasticsearch.xpack.inference.services.amazonbedrock.request.completion.AmazonBedrockConverseUtils.additionalTopK;
 import static org.elasticsearch.xpack.inference.services.amazonbedrock.request.completion.AmazonBedrockConverseUtils.convertChatCompletionMessagesToConverse;
 import static org.elasticsearch.xpack.inference.services.amazonbedrock.request.completion.AmazonBedrockConverseUtils.inferenceConfig;
 import static org.elasticsearch.xpack.inference.services.amazonbedrock.request.completion.AmazonBedrockConverseUtils.toDocument;
@@ -92,6 +93,15 @@ public class AmazonBedrockChatCompletionRequest extends AmazonBedrockRequest {
         }
 
         inferenceConfig(requestEntity).ifPresent(converseStreamRequest::inferenceConfig);
+
+        // top_k has no field on the Bedrock InferenceConfiguration, so providers that support it
+        // (Anthropic, Cohere, Mistral) get it via additional model fields. Mirrors the wiring used
+        // in AmazonBedrockCompletionRequest for the non-unified completion path.
+        var topKFields = additionalTopK(requestEntity.topK());
+        if (topKFields != null) {
+            converseStreamRequest.additionalModelResponseFieldPaths(topKFields);
+        }
+
         return awsBedrockClient.converseUnifiedStream(converseStreamRequest.build(), amazonBedrockModel);
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/request/completion/AmazonBedrockChatCompletionRequestEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/request/completion/AmazonBedrockChatCompletionRequestEntity.java
@@ -22,5 +22,19 @@ public record AmazonBedrockChatCompletionRequestEntity(
     @Nullable Float temperature,
     @Nullable ToolChoice toolChoice,
     @Nullable List<Tool> tools,
-    @Nullable Float topP
-) {}
+    @Nullable Float topP,
+    @Nullable Double topK
+) {
+    public AmazonBedrockChatCompletionRequestEntity(
+        List<Message> messages,
+        @Nullable String model,
+        @Nullable Long maxCompletionTokens,
+        @Nullable List<String> stop,
+        @Nullable Float temperature,
+        @Nullable ToolChoice toolChoice,
+        @Nullable List<Tool> tools,
+        @Nullable Float topP
+    ) {
+        this(messages, model, maxCompletionTokens, stop, temperature, toolChoice, tools, topP, null);
+    }
+}

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/GoogleModelGardenProvider.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/GoogleModelGardenProvider.java
@@ -40,9 +40,12 @@ public enum GoogleModelGardenProvider {
     GOOGLE(
         CompletionResponseHandlerHolder.GOOGLE_VERTEX_AI_COMPLETION_HANDLER,
         ChatCompletionResponseHandlerHolder.GOOGLE_VERTEX_AI_CHAT_COMPLETION_HANDLER,
+        // Pass the full task settings so the entity can fall back to the configured maxTokens when
+        // the per-request value is null.
         (unifiedChatInput, modelId, taskSettings) -> new GoogleVertexAiUnifiedChatCompletionRequestEntity(
             unifiedChatInput,
-            taskSettings.thinkingConfig()
+            taskSettings.thinkingConfig(),
+            taskSettings.maxTokens()
         )
     ),
     ANTHROPIC(

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/request/completion/GoogleVertexAiUnifiedChatCompletionRequestEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/request/completion/GoogleVertexAiUnifiedChatCompletionRequestEntity.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.inference.services.googlevertexai.request.comple
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.completion.ContentObject.ContentObjectText;
 import org.elasticsearch.inference.completion.ContentObjects;
 import org.elasticsearch.inference.completion.ContentString;
@@ -65,6 +66,8 @@ public class GoogleVertexAiUnifiedChatCompletionRequestEntity implements ToXCont
 
     private final UnifiedChatInput unifiedChatInput;
     private final ThinkingConfig thinkingConfig;
+    @Nullable
+    private final Integer taskMaxTokens;
 
     private static final String USER_ROLE = "user";
     private static final String MODEL_ROLE = "model";
@@ -76,8 +79,17 @@ public class GoogleVertexAiUnifiedChatCompletionRequestEntity implements ToXCont
     private static final String SYSTEM_INSTRUCTION = "systemInstruction";
 
     public GoogleVertexAiUnifiedChatCompletionRequestEntity(UnifiedChatInput unifiedChatInput, ThinkingConfig thinkingConfig) {
+        this(unifiedChatInput, thinkingConfig, null);
+    }
+
+    public GoogleVertexAiUnifiedChatCompletionRequestEntity(
+        UnifiedChatInput unifiedChatInput,
+        ThinkingConfig thinkingConfig,
+        @Nullable Integer taskMaxTokens
+    ) {
         this.unifiedChatInput = Objects.requireNonNull(unifiedChatInput);
         this.thinkingConfig = Objects.requireNonNull(thinkingConfig);
+        this.taskMaxTokens = taskMaxTokens;
     }
 
     private String messageRoleToGoogleVertexAiSupportedRole(String messageRole) {
@@ -331,9 +343,20 @@ public class GoogleVertexAiUnifiedChatCompletionRequestEntity implements ToXCont
     private void buildGenerationConfig(XContentBuilder builder) throws IOException {
         var request = unifiedChatInput.getRequest();
 
+        // Fall back to the configured task-settings maxTokens when the per-request value is null,
+        // so endpoint-level configuration isn't silently ignored. Use an explicit if/else (not a
+        // ternary) to avoid Java unboxing both Long and Integer to a primitive, which would NPE on
+        // the unused branch when one side is null.
+        final Number maxOutputTokens;
+        if (request.maxCompletionTokens() != null) {
+            maxOutputTokens = request.maxCompletionTokens();
+        } else {
+            maxOutputTokens = taskMaxTokens;
+        }
+
         boolean hasAnyConfig = request.stop() != null
             || request.temperature() != null
-            || request.maxCompletionTokens() != null
+            || maxOutputTokens != null
             || request.topP() != null
             || thinkingConfig.isEmpty() == false;
 
@@ -349,8 +372,8 @@ public class GoogleVertexAiUnifiedChatCompletionRequestEntity implements ToXCont
         if (request.temperature() != null) {
             builder.field(TEMPERATURE, request.temperature());
         }
-        if (request.maxCompletionTokens() != null) {
-            builder.field(MAX_OUTPUT_TOKENS, request.maxCompletionTokens());
+        if (maxOutputTokens != null) {
+            builder.field(MAX_OUTPUT_TOKENS, maxOutputTokens);
         }
         if (request.topP() != null) {
             builder.field(TOP_P, request.topP());

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/completion/AmazonBedrockChatCompletionEntityFactoryTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/completion/AmazonBedrockChatCompletionEntityFactoryTests.java
@@ -91,6 +91,7 @@ public class AmazonBedrockChatCompletionEntityFactoryTests extends ESTestCase {
             var expectedStop = List.of("stop");
             var expectedTemp = randomDoubleBetween(1, 10, true);
             var expectedTopP = randomDoubleBetween(1, 10, true);
+            var expectedTopK = randomDoubleBetween(1, 10, true);
 
             var content = new ContentString("content");
             var toolCall = new ToolCall("id", new ToolCall.FunctionField("function", expectedModel), "");
@@ -110,7 +111,7 @@ public class AmazonBedrockChatCompletionEntityFactoryTests extends ESTestCase {
                 tools,
                 (float) expectedTopP
             );
-            var model = model(provider, expectedTemp, expectedTopP, (int) expectedMaxToken);
+            var model = model(provider, expectedTemp, expectedTopP, (int) expectedMaxToken, expectedTopK);
 
             var entity = AmazonBedrockChatCompletionEntityFactory.createEntity(model, request);
 
@@ -122,6 +123,89 @@ public class AmazonBedrockChatCompletionEntityFactoryTests extends ESTestCase {
             assertThat(entity.temperature(), equalTo((float) expectedTemp));
             assertThat(entity.toolChoice(), equalTo(expectedToolChoice));
             assertThat(entity.topP(), equalTo((float) expectedTopP));
+            // top_k can never be set on the request, so it must always come from task settings.
+            assertThat(entity.topK(), equalTo(expectedTopK));
+        });
+    }
+
+    public void testEntitiesForChatCompletionFallBackToTaskSettingsWhenRequestValuesAreNull() {
+        // task_settings on the endpoint must be honoured when the per-request values are null
+        // instead of being silently ignored.
+        List.of(ANTHROPIC, AI21LABS, AMAZONTITAN, COHERE, META, MISTRAL).forEach(provider -> {
+            var taskTemp = randomDoubleBetween(1, 10, true);
+            var taskTopP = randomDoubleBetween(1, 10, true);
+            var taskMaxToken = randomIntBetween(1, 10);
+            var taskTopK = randomDoubleBetween(1, 10, true);
+            var model = model(provider, taskTemp, taskTopP, taskMaxToken, taskTopK);
+
+            var content = new ContentString("content");
+            var message = new Message(content, "user", null, null);
+            var request = new UnifiedCompletionRequest(List.of(message), "modelId", null, null, null, null, null, null);
+
+            var entity = AmazonBedrockChatCompletionEntityFactory.createEntity(model, request);
+
+            assertThat(entity, notNullValue());
+            assertThat(entity.maxCompletionTokens(), equalTo((long) taskMaxToken));
+            assertThat(entity.temperature(), equalTo((float) taskTemp));
+            assertThat(entity.topP(), equalTo((float) taskTopP));
+            assertThat(entity.topK(), equalTo(taskTopK));
+        });
+    }
+
+    public void testEntitiesForChatCompletionRequestValuesTakePrecedenceOverTaskSettings() {
+        // The request body should always win when the user explicitly sets a value, so the task
+        // settings only act as a fallback for null fields.
+        List.of(ANTHROPIC, AI21LABS, AMAZONTITAN, COHERE, META, MISTRAL).forEach(provider -> {
+            long requestMaxToken = 11L;
+            float requestTemp = 0.4f;
+            float requestTopP = 0.6f;
+
+            // Distinct from request so we can assert it isn't used.
+            double taskTemp = 5.5;
+            double taskTopP = 6.6;
+            int taskMaxToken = 99;
+            double taskTopK = 7.7;
+            var model = model(provider, taskTemp, taskTopP, taskMaxToken, taskTopK);
+
+            var content = new ContentString("content");
+            var message = new Message(content, "user", null, null);
+            var request = new UnifiedCompletionRequest(
+                List.of(message),
+                "modelId",
+                requestMaxToken,
+                null,
+                requestTemp,
+                null,
+                null,
+                requestTopP
+            );
+
+            var entity = AmazonBedrockChatCompletionEntityFactory.createEntity(model, request);
+
+            assertThat(entity, notNullValue());
+            assertThat(entity.maxCompletionTokens(), equalTo(requestMaxToken));
+            assertThat(entity.temperature(), equalTo(requestTemp));
+            assertThat(entity.topP(), equalTo(requestTopP));
+            // top_k still comes from task settings since the request has no field for it.
+            assertThat(entity.topK(), equalTo(taskTopK));
+        });
+    }
+
+    public void testEntitiesForChatCompletionLeaveFieldsNullWhenNeitherRequestNorTaskSettingsProvideThem() {
+        List.of(ANTHROPIC, AI21LABS, AMAZONTITAN, COHERE, META, MISTRAL).forEach(provider -> {
+            var model = model(provider, null, null, null, null);
+
+            var content = new ContentString("content");
+            var message = new Message(content, "user", null, null);
+            var request = new UnifiedCompletionRequest(List.of(message), "modelId", null, null, null, null, null, null);
+
+            var entity = AmazonBedrockChatCompletionEntityFactory.createEntity(model, request);
+
+            assertThat(entity, notNullValue());
+            assertThat(entity.maxCompletionTokens(), nullValue());
+            assertThat(entity.temperature(), nullValue());
+            assertThat(entity.topP(), nullValue());
+            assertThat(entity.topK(), nullValue());
         });
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/request/completion/GoogleVertexAiUnifiedChatCompletionRequestEntityTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/request/completion/GoogleVertexAiUnifiedChatCompletionRequestEntityTests.java
@@ -362,6 +362,76 @@ public class GoogleVertexAiUnifiedChatCompletionRequestEntityTests extends ESTes
         assertJsonEquals(jsonString, expectedJson);
     }
 
+    public void testSerialization_FallsBackToTaskSettingsMaxTokensWhenRequestValueIsNull() throws IOException {
+        // The max_tokens task setting must be honoured when the per-request maxCompletionTokens is null.
+        Message message = new Message(new ContentString("Use my task setting."), USER_ROLE, null, null);
+        var unifiedRequest = UnifiedCompletionRequest.of(List.of(message));
+        UnifiedChatInput unifiedChatInput = new UnifiedChatInput(unifiedRequest, true);
+
+        GoogleVertexAiUnifiedChatCompletionRequestEntity entity = new GoogleVertexAiUnifiedChatCompletionRequestEntity(
+            unifiedChatInput,
+            emptyThinkingConfig,
+            42
+        );
+
+        XContentBuilder builder = JsonXContent.contentBuilder();
+        entity.toXContent(builder, ToXContent.EMPTY_PARAMS);
+
+        String expectedJson = """
+            {
+                "contents": [
+                    {
+                        "role": "user",
+                        "parts": [ { "text": "Use my task setting." } ]
+                    }
+                ],
+                "generationConfig": {
+                    "maxOutputTokens": 42
+                }
+            }
+            """;
+        assertJsonEquals(Strings.toString(builder), expectedJson);
+    }
+
+    public void testSerialization_RequestMaxCompletionTokensTakesPrecedenceOverTaskSettings() throws IOException {
+        Message message = new Message(new ContentString("Use the request value."), USER_ROLE, null, null);
+        var unifiedRequest = new UnifiedCompletionRequest(
+            List.of(message),
+            "modelId",
+            123L, // explicit per-request value
+            null,
+            null,
+            null,
+            null,
+            null
+        );
+        UnifiedChatInput unifiedChatInput = new UnifiedChatInput(unifiedRequest, true);
+
+        GoogleVertexAiUnifiedChatCompletionRequestEntity entity = new GoogleVertexAiUnifiedChatCompletionRequestEntity(
+            unifiedChatInput,
+            emptyThinkingConfig,
+            42 // would be used if request value were null
+        );
+
+        XContentBuilder builder = JsonXContent.contentBuilder();
+        entity.toXContent(builder, ToXContent.EMPTY_PARAMS);
+
+        String expectedJson = """
+            {
+                "contents": [
+                    {
+                        "role": "user",
+                        "parts": [ { "text": "Use the request value." } ]
+                    }
+                ],
+                "generationConfig": {
+                    "maxOutputTokens": 123
+                }
+            }
+            """;
+        assertJsonEquals(Strings.toString(builder), expectedJson);
+    }
+
     public void testSerialization_NoGenerationConfig() throws IOException {
         Message message = new Message(new ContentString("No extra config."), USER_ROLE, null, null);
         // No generation config fields set on unifiedRequest


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Honor task settings for Amazon Bedrock and Google Vertex chat completion (#149268)](https://github.com/elastic/elasticsearch/pull/149268)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)