### PR TITLE
[9.3] Honor task settings for Google Vertex chat completion (#149268)

### DIFF
--- a/docs/changelog/149268.yaml
+++ b/docs/changelog/149268.yaml
@@ -1,0 +1,6 @@
+area: Inference
+issues:
+ - 148792
+pr: 149268
+summary: Honor task settings for Amazon Bedrock and Google Vertex chat completion
+type: bug

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/GoogleModelGardenProvider.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/GoogleModelGardenProvider.java
@@ -40,9 +40,12 @@ public enum GoogleModelGardenProvider {
     GOOGLE(
         CompletionResponseHandlerHolder.GOOGLE_VERTEX_AI_COMPLETION_HANDLER,
         ChatCompletionResponseHandlerHolder.GOOGLE_VERTEX_AI_CHAT_COMPLETION_HANDLER,
+        // Pass the full task settings so the entity can fall back to the configured maxTokens when
+        // the per-request value is null.
         (unifiedChatInput, modelId, taskSettings) -> new GoogleVertexAiUnifiedChatCompletionRequestEntity(
             unifiedChatInput,
-            taskSettings.thinkingConfig()
+            taskSettings.thinkingConfig(),
+            taskSettings.maxTokens()
         )
     ),
     ANTHROPIC(

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/request/completion/GoogleVertexAiUnifiedChatCompletionRequestEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/request/completion/GoogleVertexAiUnifiedChatCompletionRequestEntity.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.inference.services.googlevertexai.request.comple
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.UnifiedCompletionRequest;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xcontent.ToXContentObject;
@@ -60,6 +61,8 @@ public class GoogleVertexAiUnifiedChatCompletionRequestEntity implements ToXCont
 
     private final UnifiedChatInput unifiedChatInput;
     private final ThinkingConfig thinkingConfig;
+    @Nullable
+    private final Integer taskMaxTokens;
 
     private static final String USER_ROLE = "user";
     private static final String MODEL_ROLE = "model";
@@ -71,8 +74,17 @@ public class GoogleVertexAiUnifiedChatCompletionRequestEntity implements ToXCont
     private static final String SYSTEM_INSTRUCTION = "systemInstruction";
 
     public GoogleVertexAiUnifiedChatCompletionRequestEntity(UnifiedChatInput unifiedChatInput, ThinkingConfig thinkingConfig) {
+        this(unifiedChatInput, thinkingConfig, null);
+    }
+
+    public GoogleVertexAiUnifiedChatCompletionRequestEntity(
+        UnifiedChatInput unifiedChatInput,
+        ThinkingConfig thinkingConfig,
+        @Nullable Integer taskMaxTokens
+    ) {
         this.unifiedChatInput = Objects.requireNonNull(unifiedChatInput);
         this.thinkingConfig = Objects.requireNonNull(thinkingConfig);
+        this.taskMaxTokens = taskMaxTokens;
     }
 
     private String messageRoleToGoogleVertexAiSupportedRole(String messageRole) {
@@ -318,9 +330,20 @@ public class GoogleVertexAiUnifiedChatCompletionRequestEntity implements ToXCont
     private void buildGenerationConfig(XContentBuilder builder) throws IOException {
         var request = unifiedChatInput.getRequest();
 
+        // Fall back to the configured task-settings maxTokens when the per-request value is null,
+        // so endpoint-level configuration isn't silently ignored. Use an explicit if/else (not a
+        // ternary) to avoid Java unboxing both Long and Integer to a primitive, which would NPE on
+        // the unused branch when one side is null.
+        final Number maxOutputTokens;
+        if (request.maxCompletionTokens() != null) {
+            maxOutputTokens = request.maxCompletionTokens();
+        } else {
+            maxOutputTokens = taskMaxTokens;
+        }
+
         boolean hasAnyConfig = request.stop() != null
             || request.temperature() != null
-            || request.maxCompletionTokens() != null
+            || maxOutputTokens != null
             || request.topP() != null
             || thinkingConfig.isEmpty() == false;
 
@@ -336,8 +359,8 @@ public class GoogleVertexAiUnifiedChatCompletionRequestEntity implements ToXCont
         if (request.temperature() != null) {
             builder.field(TEMPERATURE, request.temperature());
         }
-        if (request.maxCompletionTokens() != null) {
-            builder.field(MAX_OUTPUT_TOKENS, request.maxCompletionTokens());
+        if (maxOutputTokens != null) {
+            builder.field(MAX_OUTPUT_TOKENS, maxOutputTokens);
         }
         if (request.topP() != null) {
             builder.field(TOP_P, request.topP());

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/request/completion/GoogleVertexAiUnifiedChatCompletionRequestEntityTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/request/completion/GoogleVertexAiUnifiedChatCompletionRequestEntityTests.java
@@ -397,6 +397,86 @@ public class GoogleVertexAiUnifiedChatCompletionRequestEntityTests extends ESTes
         assertJsonEquals(jsonString, expectedJson);
     }
 
+    public void testSerialization_FallsBackToTaskSettingsMaxTokensWhenRequestValueIsNull() throws IOException {
+        // The max_tokens task setting must be honoured when the per-request maxCompletionTokens is null.
+        UnifiedCompletionRequest.Message message = new UnifiedCompletionRequest.Message(
+            new UnifiedCompletionRequest.ContentString("Use my task setting."),
+            USER_ROLE,
+            null,
+            null
+        );
+        var unifiedRequest = UnifiedCompletionRequest.of(List.of(message));
+        UnifiedChatInput unifiedChatInput = new UnifiedChatInput(unifiedRequest, true);
+
+        GoogleVertexAiUnifiedChatCompletionRequestEntity entity = new GoogleVertexAiUnifiedChatCompletionRequestEntity(
+            unifiedChatInput,
+            emptyThinkingConfig,
+            42
+        );
+
+        XContentBuilder builder = JsonXContent.contentBuilder();
+        entity.toXContent(builder, ToXContent.EMPTY_PARAMS);
+
+        String expectedJson = """
+            {
+                "contents": [
+                    {
+                        "role": "user",
+                        "parts": [ { "text": "Use my task setting." } ]
+                    }
+                ],
+                "generationConfig": {
+                    "maxOutputTokens": 42
+                }
+            }
+            """;
+        assertJsonEquals(Strings.toString(builder), expectedJson);
+    }
+
+    public void testSerialization_RequestMaxCompletionTokensTakesPrecedenceOverTaskSettings() throws IOException {
+        UnifiedCompletionRequest.Message message = new UnifiedCompletionRequest.Message(
+            new UnifiedCompletionRequest.ContentString("Use the request value."),
+            USER_ROLE,
+            null,
+            null
+        );
+        var unifiedRequest = new UnifiedCompletionRequest(
+            List.of(message),
+            "modelId",
+            123L, // explicit per-request value
+            null,
+            null,
+            null,
+            null,
+            null
+        );
+        UnifiedChatInput unifiedChatInput = new UnifiedChatInput(unifiedRequest, true);
+
+        GoogleVertexAiUnifiedChatCompletionRequestEntity entity = new GoogleVertexAiUnifiedChatCompletionRequestEntity(
+            unifiedChatInput,
+            emptyThinkingConfig,
+            42 // would be used if request value were null
+        );
+
+        XContentBuilder builder = JsonXContent.contentBuilder();
+        entity.toXContent(builder, ToXContent.EMPTY_PARAMS);
+
+        String expectedJson = """
+            {
+                "contents": [
+                    {
+                        "role": "user",
+                        "parts": [ { "text": "Use the request value." } ]
+                    }
+                ],
+                "generationConfig": {
+                    "maxOutputTokens": 123
+                }
+            }
+            """;
+        assertJsonEquals(Strings.toString(builder), expectedJson);
+    }
+
     public void testSerialization_NoGenerationConfig() throws IOException {
         UnifiedCompletionRequest.Message message = new UnifiedCompletionRequest.Message(
             new UnifiedCompletionRequest.ContentString("No extra config."),


### PR DESCRIPTION
When a Google Vertex chat_completion endpoint was created with task_settings, the values were silently ignored on requests. The Google Vertex unified entity (used when provider is omitted or set to google) never read max_tokens from its task settings.

Fall back to the configured task settings whenever the corresponding request field is null.

Closes #148792

(cherry picked from commit 7d225d41ec8d583c629e2d74eb31c5ea2d22f9fe)
