### PR TITLE
[Test] Fix testCacheIsWarmedBeforeSearchShardRecovery

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -378,9 +378,6 @@ tests:
 - class: org.elasticsearch.xpack.stateless.allocation.EstimatedHeapUsageAllocationDeciderIT
   method: testEstimatedHeapHighWatermarkMonitorTriggersReroute
   issue: https://github.com/elastic/elasticsearch/issues/148246
-- class: org.elasticsearch.xpack.stateless.cache.SharedBlobCacheWarmingServiceIT
-  method: testCacheIsWarmedBeforeSearchShardRecovery
-  issue: https://github.com/elastic/elasticsearch/issues/148275
 - class: org.elasticsearch.xpack.stateless.StatelessHollowIndexShardsIT
   method: testStressWithoutFailures
   issue: https://github.com/elastic/elasticsearch/issues/148310

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/cache/SharedBlobCacheWarmingServiceIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/cache/SharedBlobCacheWarmingServiceIT.java
@@ -518,8 +518,12 @@ public class SharedBlobCacheWarmingServiceIT extends AbstractStatelessPluginInte
         startIndexNode(nodeSettings);
 
         var searchNodeA = startSearchNode(nodeSettings);
-        ensureStableCluster(3);
+        var searchNodeB = startSearchNode(nodeSettings);
+        ensureStableCluster(4);
 
+        // Pin the search shard to searchNodeA so nothing relocates it to searchNodeB
+        // before we install the warming-completed listener on B in phase B. The exclusion is flipped from B to A
+        // at the start of phase B to drive the relocation under test.
         final String indexName = randomIdentifier();
         assertAcked(
             prepareCreate(
@@ -529,6 +533,7 @@ public class SharedBlobCacheWarmingServiceIT extends AbstractStatelessPluginInte
                     .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
                     .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
                     .put(EngineConfig.USE_COMPOUND_FILE, randomBoolean())
+                    .put("index.routing.allocation.exclude._name", searchNodeB)
             )
         );
 
@@ -553,6 +558,11 @@ public class SharedBlobCacheWarmingServiceIT extends AbstractStatelessPluginInte
 
         ensureGreen(indexName);
 
+        // Force the search-recovery warming on searchNodeA to await completion. Without this,
+        // warmCacheForSearchShardRecovery is fire-and-forget on the new-shard-copy path (searchRecoveryTimeout
+        // returns skip()), letting concurrent reads claim cache gaps that warming then skips and the post-warming
+        // ban then trips. See ObservableSharedBlobCacheWarmingService Javadoc for the wrapper semantics.
+        getSharedBlobCacheWarmingService(searchNodeA).setAwaitWarmingForSearchRecovery(true);
         // Verify that we performed pre-warming and don't need to hit the object store on searches
         failObjectStoreAndFetchFromIndexingNodeAfterPrewarming(indexName, searchNodeA, Type.SEARCH);
 
@@ -564,12 +574,14 @@ public class SharedBlobCacheWarmingServiceIT extends AbstractStatelessPluginInte
         disableTransportBlocking(searchNodeA);
         ensureSearchHits(indexName, totalDocs);
 
-        var searchNodeB = startSearchNode(nodeSettings);
-        ensureStableCluster(4);
-
+        // Same await-warming rationale as above: ensure the warming-complete listener (which installs the object-store ban) fires
+        // before the engine opens, so no reader can race the warming task for cache gaps.
+        getSharedBlobCacheWarmingService(searchNodeB).setAwaitWarmingForSearchRecovery(true);
         // The cache also gets pre-warmed when a shard gets relocated to a new node
         failObjectStoreAndFetchFromIndexingNodeAfterPrewarming(indexName, searchNodeB, Type.SEARCH);
-        shutdownNode(searchNodeA);
+        // Flip the exclusion from searchNodeB to searchNodeA so the search shard relocates to searchNodeB.
+        // Simpler than SIGTERM-driven shutdown and equivalent for the recovery path under test.
+        updateIndexSettings(Settings.builder().put("index.routing.allocation.exclude._name", searchNodeA), indexName);
         ensureGreen(indexName);
         assertThat(findSearchShard(resolveIndex(indexName), 0).routingEntry().currentNodeId(), equalTo(getNodeId(searchNodeB)));
         assertHitCount(prepareSearch(indexName).setSize(0), totalDocs);
@@ -1217,32 +1229,6 @@ public class SharedBlobCacheWarmingServiceIT extends AbstractStatelessPluginInte
         };
     }
 
-    private static void shutdownNode(String indexNode) {
-        var shutdownNodeId = client().admin()
-            .cluster()
-            .prepareState(TEST_REQUEST_TIMEOUT)
-            .get()
-            .getState()
-            .nodes()
-            .resolveNode(indexNode)
-            .getId();
-        assertAcked(
-            client().execute(
-                PutShutdownNodeAction.INSTANCE,
-                new PutShutdownNodeAction.Request(
-                    TEST_REQUEST_TIMEOUT,
-                    TEST_REQUEST_TIMEOUT,
-                    shutdownNodeId,
-                    SingleNodeShutdownMetadata.Type.SIGTERM,
-                    "Shutdown for cache warming test",
-                    null,
-                    null,
-                    TimeValue.timeValueMinutes(randomIntBetween(1, 5))
-                )
-            )
-        );
-    }
-
     private void blockAccessToGenerationBeforePostHandoffPreWarmingStarts(String node, long generationToBlock) {
         getSharedBlobCacheWarmingService(node).addBeforeWarmingStartsListener(warmingType -> {
             logger.info("Disabling object store access to generation {}", generationToBlock);
@@ -1384,10 +1370,16 @@ public class SharedBlobCacheWarmingServiceIT extends AbstractStatelessPluginInte
      * {@code warmCacheForSearchShardRecovery}) are not converted into blocking calls. Tests that need "warming done" as a
      * precondition must explicitly await via {@link #addWarmingCompletedListener} or {@link #addMergeWarmingCompletedListener}.
      *
-     * <p>Specific recovery paths can be opted into blocking semantics via {@link #setAwaitWarmingForSearchRecovery(boolean)}
-     * and {@link #setAwaitWarmingForIndexingRecovery(boolean)}. When enabled, the corresponding {@code warmCacheFor*Recovery*}
-     * override blocks the caller thread until the wrapped warming chain (including any registered warming-completed listeners)
-     * completes; this is used by tests that need to install an object-store ban before recovery proceeds.
+     * <p>Specific recovery paths can be opted into await-warming semantics via {@link #setAwaitWarmingForSearchRecovery(boolean)}
+     * and {@link #setAwaitWarmingForIndexingRecovery(boolean)}. Both ensure that any registered {@code warmingCompletedListeners}
+     * fire before recovery resumes, which lets tests install an object-store ban before the engine opens. They differ in how:
+     * <ul>
+     *   <li>{@link #warmCacheForShardRecoveryOrUnhollowing} (indexing) blocks the calling thread until warming completes, because
+     *   in production the recovery thread immediately reads {@code segments_N} after kicking off fire-and-forget warming.</li>
+     *   <li>{@link #warmCacheForSearchShardRecovery} (search) does not block the caller. It routes warming through
+     *   {@link #warmCache} so {@code resumeRecoveryListener} is invoked only after warming (and any
+     *   {@code warmingCompletedListeners}) have completed, deferring the resume step rather than blocking the caller.</li>
+     * </ul>
      */
     private static class ObservableSharedBlobCacheWarmingService extends SharedBlobCacheWarmingService {
 


### PR DESCRIPTION
### Summary

Fix the flaky `SharedBlobCacheWarmingServiceIT.testCacheIsWarmedBeforeSearchShardRecovery` (#148275) using the same await-warming pattern as #149177's fix for `..._AfterHandoff`.

The search-recovery path is fire-and-forget on the new-shard-copy branch (`searchRecoveryTimeout` returns `skip()` for a new copy with no other active search shard, and unconditionally on the non-internal-files path), so concurrent reads can claim cache gaps that the warming task then skips. When the test installs its post-warming object-store ban via `failObjectStoreAndFetchFromIndexingNodeAfterPrewarming`, those in-flight reads fail and the test trips (or, in the CI flake's case, the search thread dies on an `AssertionError` and the test hangs to suite timeout).

### Changes

- Enable `setAwaitWarmingForSearchRecovery(true)` on both `searchNodeA` (round 1, initial search-shard recovery via `setReplicaCount(1)`) and `searchNodeB` (round 2, relocation) before installing the object-store ban. The wrapper override fires `warmingCompletedListeners` before `resumeRecoveryListener`, so the engine only opens once the ban is in place and warming has actually filled the regions it targeted.
- Unmute the test.

### Testing

- Soaked with iters in VM for an hour: main without fix fails in 20 minutes, with fix no failure

---

Assisted with Cursor

Closes #148275