### PR TITLE
Add postings to the per shard memory estimate for Stateless

### DIFF
--- a/docs/changelog/149741.yaml
+++ b/docs/changelog/149741.yaml
@@ -1,0 +1,5 @@
+area: Search
+issues: []
+pr: 149741
+summary: Add postings to the per shard memory estimate for Stateless
+type: enhancement

--- a/server/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -370,8 +370,6 @@ public abstract class Engine implements Closeable {
         );
     }
 
-
-
     private static boolean validateLiveDocsClass(Bits liveDocs) {
         if (liveDocs instanceof LiveDocs) {
             return true;

--- a/server/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -40,6 +40,8 @@ import org.apache.lucene.util.LiveDocs;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.apache.lucene.util.SetOnce;
 import org.apache.lucene.util.SparseLiveDocs;
+import org.apache.lucene.util.bkd.BKDConfig;
+import org.apache.lucene.util.bkd.BKDReader;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.flush.FlushRequest;
@@ -148,6 +150,8 @@ public abstract class Engine implements Closeable {
     protected static final String FIELD_HAS_VALUE_SOURCE = "field_has_value";
     public static final long UNKNOWN_PRIMARY_TERM = -1L;
     public static final String ROOT_DOC_FIELD_NAME = "__root_doc_for_nested";
+    private static final long BKD_READER_BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(BKDReader.class);
+    private static final long BKD_CONFIG_BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(BKDConfig.class);
 
     protected final ShardId shardId;
     protected final Logger logger;
@@ -297,6 +301,8 @@ public abstract class Engine implements Closeable {
         long usages = 0;
         long totalPostingBytes = 0;
         long totalLiveDocsBytes = 0;
+        long totalPointsBytes = 0;
+
         for (LeafReaderContext leaf : leaves) {
             numSegments++;
             var fieldInfos = leaf.reader().getFieldInfos();
@@ -323,10 +329,30 @@ public abstract class Engine implements Closeable {
                         long liveDocsBytes = getLiveDocsBytes(liveDocs);
                         totalLiveDocsBytes += liveDocsBytes;
                     }
+                    totalPointsBytes += getPointsBytes(fieldInfos);
                 }
             }
         }
-        return new ShardFieldStats(numSegments, totalFields, usages, totalPostingBytes, totalLiveDocsBytes);
+        return new ShardFieldStats(numSegments, totalFields, usages, totalPostingBytes, totalLiveDocsBytes, totalPointsBytes);
+    }
+
+    private static long getPointsBytes(FieldInfos fieldInfos) {
+        long totalPointsBytes = 0;
+        for (FieldInfo fieldInfo : fieldInfos) {
+            if (fieldInfo.getPointDimensionCount() > 0) {
+                totalPointsBytes += getBKDReaderBytes(fieldInfo);
+            }
+        }
+        return totalPointsBytes;
+    }
+
+    private static long getBKDReaderBytes(FieldInfo fieldInfo) {
+        int packedIndexBytesLength = fieldInfo.getPointIndexDimensionCount() * fieldInfo.getPointNumBytes();
+        return BKD_READER_BASE_RAM_BYTES_USED + BKD_CONFIG_BASE_RAM_BYTES_USED + 2 * byteArrayRamBytesUsed(packedIndexBytesLength);
+    }
+
+    private static long byteArrayRamBytesUsed(int length) {
+        return RamUsageEstimator.alignObjectSize(RamUsageEstimator.NUM_BYTES_ARRAY_HEADER + (long) Byte.BYTES * length);
     }
 
     // Would prefer to use FixedBitSet#ramBytesUsed() however FixedBits / Bits interface don't expose that.
@@ -343,6 +369,8 @@ public abstract class Engine implements Closeable {
             RamUsageEstimator.NUM_BYTES_ARRAY_HEADER + (long) Long.BYTES * words
         );
     }
+
+
 
     private static boolean validateLiveDocsClass(Bits liveDocs) {
         if (liveDocs instanceof LiveDocs) {

--- a/server/src/main/java/org/elasticsearch/index/shard/ShardFieldStats.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/ShardFieldStats.java
@@ -34,9 +34,14 @@ import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg
  * @param liveDocsBytes         the total bytes in memory used for live docs
  * @param pointsInMemoryBytes   the total bytes in memory used for points across all fields
  */
-public record ShardFieldStats(int numSegments, int totalFields, long fieldUsages, long postingsInMemoryBytes, long liveDocsBytes, long pointsInMemoryBytes)
-    implements
-        ToXContentFragment {
+public record ShardFieldStats(
+    int numSegments,
+    int totalFields,
+    long fieldUsages,
+    long postingsInMemoryBytes,
+    long liveDocsBytes,
+    long pointsInMemoryBytes
+) implements ToXContentFragment {
 
     public static final long FIXED_BITSET_BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(FixedBitSet.class);
 

--- a/server/src/main/java/org/elasticsearch/index/shard/ShardFieldStats.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/ShardFieldStats.java
@@ -32,8 +32,9 @@ import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg
  *                              -1 if unavailable
  * @param postingsInMemoryBytes the total bytes in memory used for postings across all fields
  * @param liveDocsBytes         the total bytes in memory used for live docs
+ * @param pointsInMemoryBytes   the total bytes in memory used for points across all fields
  */
-public record ShardFieldStats(int numSegments, int totalFields, long fieldUsages, long postingsInMemoryBytes, long liveDocsBytes)
+public record ShardFieldStats(int numSegments, int totalFields, long fieldUsages, long postingsInMemoryBytes, long liveDocsBytes, long pointsInMemoryBytes)
     implements
         ToXContentFragment {
 
@@ -48,6 +49,8 @@ public record ShardFieldStats(int numSegments, int totalFields, long fieldUsages
         static final String POSTINGS_IN_MEMORY = "postings_in_memory";
         static final String LIVE_DOCS_BYTES = "live_docs_bytes";
         static final String LIVE_DOCS = "live_docs";
+        static final String POINTS_IN_MEMORY = "points_in_memory";
+        static final String POINTS_IN_MEMORY_BYTES = "points_in_memory_bytes";
     }
 
     public static final ConstructingObjectParser<ShardFieldStats, Void> PARSER = new ConstructingObjectParser<>(
@@ -59,7 +62,7 @@ public record ShardFieldStats(int numSegments, int totalFields, long fieldUsages
     protected static final ConstructingObjectParser<ShardFieldStats, Void> SHARD_FIELD_STATS_PARSER = new ConstructingObjectParser<>(
         "shard_field_stats_fields",
         true,
-        args -> new ShardFieldStats((int) args[0], (int) args[1], (long) args[2], (long) args[3], (long) args[4])
+        args -> new ShardFieldStats((int) args[0], (int) args[1], (long) args[2], (long) args[3], (long) args[4], (long) args[5])
     );
 
     static {
@@ -72,6 +75,7 @@ public record ShardFieldStats(int numSegments, int totalFields, long fieldUsages
         SHARD_FIELD_STATS_PARSER.declareLong(constructorArg(), new ParseField(Fields.FIELD_USAGES));
         SHARD_FIELD_STATS_PARSER.declareLong(constructorArg(), new ParseField(Fields.POSTINGS_IN_MEMORY_BYTES));
         SHARD_FIELD_STATS_PARSER.declareLong(constructorArg(), new ParseField(Fields.LIVE_DOCS_BYTES));
+        SHARD_FIELD_STATS_PARSER.declareLong(constructorArg(), new ParseField(Fields.POINTS_IN_MEMORY_BYTES));
     }
 
     @Override
@@ -86,6 +90,7 @@ public record ShardFieldStats(int numSegments, int totalFields, long fieldUsages
             ByteSizeValue.ofBytes(postingsInMemoryBytes)
         );
         builder.humanReadableField(Fields.LIVE_DOCS_BYTES, Fields.LIVE_DOCS, ByteSizeValue.ofBytes(liveDocsBytes));
+        builder.humanReadableField(Fields.POINTS_IN_MEMORY_BYTES, Fields.POINTS_IN_MEMORY, ByteSizeValue.ofBytes(pointsInMemoryBytes));
         builder.endObject();
         return builder;
     }

--- a/server/src/test/java/org/elasticsearch/index/shard/ShardFieldStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/ShardFieldStatsTests.java
@@ -23,6 +23,7 @@ public class ShardFieldStatsTests extends AbstractXContentTestCase<ShardFieldSta
             randomNonNegativeInt(),
             randomNonNegativeLong(),
             randomNonNegativeLong(),
+            randomNonNegativeLong(),
             randomNonNegativeLong()
         );
     }

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/StatelessMemoryMetricsService.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/StatelessMemoryMetricsService.java
@@ -337,7 +337,7 @@ public class StatelessMemoryMetricsService implements ClusterStateListener {
             return fixedShardOverhead.getBytes();
         }
         long estimateBytes = ADAPTIVE_SHARD_MEMORY_OVERHEAD.getBytes() + metrics.numSegments * ADAPTIVE_SEGMENT_MEMORY_OVERHEAD.getBytes()
-            + metrics.totalFields * ADAPTIVE_FIELD_MEMORY_OVERHEAD.getBytes() + metrics.liveDocsBytes;
+            + metrics.totalFields * ADAPTIVE_FIELD_MEMORY_OVERHEAD.getBytes() + metrics.liveDocsBytes + metrics.postingsInMemoryBytes;
         long extraBytes = (long) (estimateBytes * adaptiveExtraOverheadRatio);
 
         if (this.adaptiveShardMemoryEstimationMinThresholdEnabled) {

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/StatelessMemoryMetricsService.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/memory/StatelessMemoryMetricsService.java
@@ -329,7 +329,7 @@ public class StatelessMemoryMetricsService implements ClusterStateListener {
     private record NodeHeapEstimateSnapshot(String nodeId, String nodeName, long heapBytes) {}
 
     /**
-     * Estimates the heap usage for a single shard, based on: segment, number of fields and live doc byte counts.
+     * Estimates the heap usage for a single shard, based on: segment, number of fields, live doc byte counts and postings bytes.
      */
     public long estimateShardMemoryUsageInBytes(ShardMemoryMetrics metrics) {
         final var fixedShardOverhead = this.fixedShardMemoryOverhead;

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/memory/ShardsMappingSizeCollectorTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/memory/ShardsMappingSizeCollectorTests.java
@@ -121,6 +121,7 @@ public class ShardsMappingSizeCollectorTests extends ESTestCase {
                 randomNonNegativeInt(),
                 randomNonNegativeLong(),
                 randomNonNegativeLong(),
+                randomNonNegativeLong(),
                 randomNonNegativeLong()
             )
         );
@@ -258,7 +259,7 @@ public class ShardsMappingSizeCollectorTests extends ESTestCase {
         IndexShard indexShard = mock(IndexShard.class);
         when(indexShard.shardId()).thenReturn(shardId);
         when(indexShard.routingEntry()).thenReturn(shardRoutingStub);
-        when(indexShard.getShardFieldStats()).thenReturn(new ShardFieldStats(1, 1, -1, 0, 0));
+        when(indexShard.getShardFieldStats()).thenReturn(new ShardFieldStats(1, 1, -1, 0, 0, 0));
 
         when(indexService.getShardOrNull(shardId.id())).thenReturn(indexShard);
         final long testIndexMappingSizeInBytes = 1024;
@@ -300,7 +301,7 @@ public class ShardsMappingSizeCollectorTests extends ESTestCase {
         when(indexShard.shardId()).thenReturn(shardId);
         when(indexShard.routingEntry()).thenReturn(TestShardRouting.newShardRouting(shardId, "node-0", true, ShardRoutingState.STARTED));
         final int numSegments = randomIntBetween(1, 10);
-        when(indexShard.getShardFieldStats()).thenReturn(new ShardFieldStats(numSegments, 1, -1, 10, 20));
+        when(indexShard.getShardFieldStats()).thenReturn(new ShardFieldStats(numSegments, 1, -1, 10, 20, 0));
 
         when(indexService.getShardOrNull(shardId.id())).thenReturn(indexShard);
         final long testIndexMappingSizeInBytes = 1024;


### PR DESCRIPTION
We want to include the postings memory requirements in the shard memory usage metrics so that we can improve the overall memory footprint of all shards across all indices for serverless autoscaling. 
