### PR TITLE
ESQL: Fix data type of partial folded CASE

### DIFF
--- a/x-pack/plugin/esql/qa/server/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/multi_node/AggOnCaseFoldIT.java
+++ b/x-pack/plugin/esql/qa/server/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/multi_node/AggOnCaseFoldIT.java
@@ -60,6 +60,7 @@ public class AggOnCaseFoldIT extends ESRestTestCase {
 
     @Before
     public void loadAndPinIndices() throws Exception {
+        assumeFalse("Cannot pin shards to specific nodes in serverless mode", isServerless());
         CsvTestsDataLoader.loadDatasetsIntoEs(client(), List.of("event_alerts", "event_logs"));
 
         // Pin each index to a different node so they are optimized independently of one another.
@@ -219,6 +220,23 @@ public class AggOnCaseFoldIT extends ESRestTestCase {
             | SORT ts_month
             """);
         assertThat(values, equalTo(List.of(List.of(0, 0, "2024-01-01T00:00:00.000Z"), List.of(0, 3, "2024-02-01T00:00:00.000Z"))));
+    }
+
+    /**
+     * Returns true when the cluster is running in serverless mode, where index settings like
+     * {@code index.number_of_replicas} and shard allocation filters are not available.
+     */
+    private boolean isServerless() throws IOException {
+        for (Map<?, ?> nodeInfo : getNodesInfo(client()).values()) {
+            @SuppressWarnings("unchecked")
+            List<Map<?, ?>> modules = (List<Map<?, ?>>) nodeInfo.get("modules");
+            for (Map<?, ?> module : modules) {
+                if (module.get("name").toString().startsWith("serverless-")) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     /**

--- a/x-pack/plugin/esql/qa/server/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/multi_node/AggOnCaseFoldIT.java
+++ b/x-pack/plugin/esql/qa/server/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/multi_node/AggOnCaseFoldIT.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.qa.multi_node;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.WarningsHandler;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.test.TestClustersThreadFilter;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.rest.ESRestTestCase;
+import org.elasticsearch.xpack.esql.CsvTestsDataLoader;
+import org.junit.Before;
+import org.junit.ClassRule;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.elasticsearch.test.MapMatcher.assertMap;
+import static org.elasticsearch.test.MapMatcher.matchesMap;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+
+/**
+ * Tests for {@snippet lang="esql" :
+ * | STATS COUNT_DISTINCT(CASE(foldable, ...))
+ * }
+ * when foldable at different places.
+ */
+@ThreadLeakFilters(filters = TestClustersThreadFilter.class)
+public class AggOnCaseFoldIT extends ESRestTestCase {
+
+    @ClassRule
+    public static ElasticsearchCluster cluster = Clusters.testCluster(ignored -> {});
+
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
+    }
+
+    @Before
+    public void enableChangeLogging() throws IOException {
+        Request request = new Request("PUT", "/_cluster/settings");
+        request.setJsonEntity(
+            "{\"transient\": {\"logger.org.elasticsearch.xpack.esql.optimizer.LocalLogicalPlanOptimizer.changes\": \"TRACE\"}}"
+        );
+        assertOK(client().performRequest(request));
+    }
+
+    @Before
+    public void loadAndPinIndices() throws Exception {
+        CsvTestsDataLoader.loadDatasetsIntoEs(client(), List.of("event_alerts", "event_logs"));
+
+        // Pin each index to a different node so they are optimized independently of one another.
+        Request nodesRequest = new Request("GET", "/_nodes");
+        nodesRequest.addParameter("filter_path", "nodes.*.name");
+        Map<String, Object> nodesResponse = entityAsMap(client().performRequest(nodesRequest));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> nodes = (Map<String, Object>) nodesResponse.get("nodes");
+        List<String> nodeNames = new ArrayList<>();
+        for (Object nodeInfo : nodes.values()) {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> info = (Map<String, Object>) nodeInfo;
+            nodeNames.add((String) info.get("name"));
+        }
+        assertThat("Need at least 2 nodes", nodeNames.size(), greaterThanOrEqualTo(2));
+
+        Request pinAlerts = new Request("PUT", "/event_alerts/_settings");
+        pinAlerts.setJsonEntity(Strings.format("""
+            {
+              "index.routing.allocation.require._name": "%s",
+              "index.number_of_replicas": 0
+            }
+            """, nodeNames.get(0)));
+        assertOK(client().performRequest(pinAlerts));
+
+        Request pinLogs = new Request("PUT", "/event_logs/_settings");
+        pinLogs.setJsonEntity(Strings.format("""
+            {
+              "index.routing.allocation.require._name": "%s",
+              "index.number_of_replicas": 0
+            }
+            """, nodeNames.get(1)));
+        assertOK(client().performRequest(pinLogs));
+
+        ensureGreen("event_alerts");
+        ensureGreen("event_logs");
+
+        // Paranoidly wait until the shards have landed on the nodes we expect
+        Request shardsRequest = new Request("GET", "/_cat/shards/event_alerts,event_logs");
+        shardsRequest.addParameter("format", "json");
+        assertBusy(() -> {
+            List<Object> shards = entityAsList(client().performRequest(shardsRequest));
+            Map<String, List<Map<String, Object>>> shardByIndex = new HashMap<>();
+            for (Object entry : shards) {
+                @SuppressWarnings("unchecked")
+                Map<String, Object> shard = (Map<String, Object>) entry;
+                shardByIndex.computeIfAbsent((String) shard.get("index"), k -> new ArrayList<>()).add(shard);
+            }
+            String ctx = "nodeNames=" + nodeNames + " shards=" + shards;
+            List<Map<String, Object>> alertsShards = shardByIndex.get("event_alerts");
+            assertNotNull("event_alerts shards not found in: " + ctx, alertsShards);
+            for (Map<String, Object> shard : alertsShards) {
+                assertThat(ctx + " event_alerts shard must be STARTED", shard.get("state"), equalTo("STARTED"));
+                assertThat(ctx + " event_alerts shard on wrong node", shard.get("node"), equalTo(nodeNames.get(0)));
+            }
+            List<Map<String, Object>> logsShards = shardByIndex.get("event_logs");
+            assertNotNull("event_logs shards not found in: " + ctx, logsShards);
+            for (Map<String, Object> shard : logsShards) {
+                assertThat(ctx + " event_logs shard must be STARTED", shard.get("state"), equalTo("STARTED"));
+                assertThat(ctx + " event_logs shard on wrong node", shard.get("node"), equalTo(nodeNames.get(1)));
+            }
+        }, 30, TimeUnit.SECONDS);
+    }
+
+    public void testCoordinatingNodeFoldInline() throws IOException {
+        List<List<Object>> values = esql("""
+            FROM event_alerts, event_logs
+            | STATS COUNT_DISTINCT(CASE(false, username, null))
+            """);
+        assertThat(values, equalTo(List.of(List.of(0))));
+    }
+
+    public void testDataNodeFoldInline() throws IOException {
+        List<List<Object>> values = esql("""
+            FROM event_alerts, event_logs
+            | STATS COUNT_DISTINCT(CASE(event_type == "alert", username, null))
+            """);
+        assertThat(values, equalTo(List.of(List.of(0))));
+    }
+
+    public void testDataNodeFoldEval() throws IOException {
+        List<List<Object>> values = esql("""
+            FROM event_alerts, event_logs
+            | EVAL username = CASE(event_type == "alert", username, null)
+            | STATS COUNT_DISTINCT(username)
+            """);
+        assertThat(values, equalTo(List.of(List.of(0))));
+    }
+
+    public void testDataNodeFoldEvalAnd() throws IOException {
+        List<List<Object>> values = esql("""
+            FROM event_alerts, event_logs
+            | EVAL foo = CASE(event_type == "alert" AND severity > 0, username, null)
+            | STATS COUNT_DISTINCT(foo)
+            """);
+        assertThat(values, equalTo(List.of(List.of(0))));
+    }
+
+    public void testDataNodeFoldEvalAndTwoBranches() throws IOException {
+        List<List<Object>> values = esql("""
+            FROM event_alerts, event_logs
+            | EVAL foo = CASE(event_type == "alert" AND severity > 0, username,
+                              event_type == "alert" AND severity > 1, label,
+                              null)
+            | STATS COUNT_DISTINCT(foo)
+            """);
+        assertThat(values, equalTo(List.of(List.of(0))));
+    }
+
+    public void testDataNodeFoldInlineTwoBranches() throws IOException {
+        List<List<Object>> values = esql("""
+            FROM event_alerts, event_logs
+            | STATS COUNT_DISTINCT(CASE(event_type == "alert" AND severity > 0, username,
+                                        event_type == "alert" AND severity > 1, label,
+                                        null))
+            """);
+        assertThat(values, equalTo(List.of(List.of(0))));
+    }
+
+    public void testDataNodeFoldEvalOr() throws IOException {
+        List<List<Object>> values = esql("""
+            FROM event_alerts, event_logs
+            | EVAL foo = CASE(event_type == "alert" OR severity > 0, username, null)
+            | STATS COUNT_DISTINCT(foo)
+            """);
+        assertThat(values, equalTo(List.of(List.of(0))));
+    }
+
+    public void testDataNodeNotIn() throws IOException {
+        List<List<Object>> values = esql("""
+            FROM event_alerts, event_logs
+            | EVAL foo = CASE(NOT event_type IN ("login", "other"), username, null)
+            | STATS COUNT_DISTINCT(foo)
+            """);
+        assertThat(values, equalTo(List.of(List.of(0))));
+    }
+
+    public void testDataNodeMultipleCases() throws IOException {
+        List<List<Object>> values = esql("""
+            FROM event_alerts, event_logs
+            | EVAL severity_case = CASE(event_type == "alert", severity, null),
+                   username_case = CASE(event_type == "login", username, null)
+            | STATS COUNT_DISTINCT(severity_case), COUNT_DISTINCT(username_case)
+              BY ts_month = DATE_TRUNC(1 month, @timestamp)
+            | SORT ts_month
+            """);
+        assertThat(values, equalTo(List.of(List.of(3, 0, "2024-01-01T00:00:00.000Z"), List.of(0, 3, "2024-02-01T00:00:00.000Z"))));
+    }
+
+    public void testDataNodeMultipleCasesAnd() throws IOException {
+        List<List<Object>> values = esql("""
+            FROM event_alerts, event_logs
+            | EVAL case1 = CASE(event_type == "alert" AND severity > 0, username, null),
+                   case2 = CASE(NOT event_type IN ("alert", "other"), username, null)
+            | STATS COUNT_DISTINCT(case1), COUNT_DISTINCT(case2)
+              BY ts_month = DATE_TRUNC(1 month, @timestamp)
+            | SORT ts_month
+            """);
+        assertThat(values, equalTo(List.of(List.of(0, 0, "2024-01-01T00:00:00.000Z"), List.of(0, 3, "2024-02-01T00:00:00.000Z"))));
+    }
+
+    /**
+     * Runs an ES|QL query, asserts the result is not partial, and returns the values rows.
+     * The query may be a text block with newlines between pipe stages.
+     */
+    private List<List<Object>> esql(String query) throws IOException {
+        Request request = new Request("POST", "/_query");
+        request.setOptions(RequestOptions.DEFAULT.toBuilder().setWarningsHandler(WarningsHandler.PERMISSIVE).build());
+        String escaped = query.replace("\"", "\\\"").replace("\n", "\\n");
+        request.setJsonEntity("{\"query\": \"" + escaped + "\"}");
+        Map<String, Object> result = entityAsMap(client().performRequest(request));
+        assertMap("no partial failures", result, matchesMap().extraOk().entry("is_partial", false));
+        @SuppressWarnings("unchecked")
+        List<List<Object>> values = (List<List<Object>>) result.get("values");
+        return values;
+    }
+}

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
@@ -133,6 +133,9 @@ public class CsvTestsDataLoader {
             "partial_mapping_sample_data.csv"
         ),
         new TestDataset("mv_sample_data"),
+        new TestDataset("event_alerts"),
+        new TestDataset("event_logs"),
+        new TestDataset("event_empty").noData(),
         new TestDataset("alerts"),
         new TestDataset("sample_data").withIndex("sample_data_str").withTypeMapping(Map.of("client_ip", "keyword")),
         new TestDataset("sample_data").withIndex("sample_data_ts_long")

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/data/event_alerts.csv
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/data/event_alerts.csv
@@ -1,0 +1,4 @@
+@timestamp:date,severity:integer,label:keyword
+2024-01-01T00:00:00.000Z,1,low
+2024-01-02T00:00:00.000Z,2,medium
+2024-01-03T00:00:00.000Z,3,high

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/data/event_logs.csv
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/data/event_logs.csv
@@ -1,0 +1,4 @@
+@timestamp:date,username:keyword
+2024-02-01T00:00:00.000Z,alice
+2024-02-02T00:00:00.000Z,bob
+2024-02-03T00:00:00.000Z,carol

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/index/mappings/mapping-event_alerts.json
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/index/mappings/mapping-event_alerts.json
@@ -1,0 +1,17 @@
+{
+    "properties": {
+        "@timestamp": {
+            "type": "date"
+        },
+        "event_type": {
+            "type": "constant_keyword",
+            "value": "alert"
+        },
+        "severity": {
+            "type": "integer"
+        },
+        "label": {
+            "type": "keyword"
+        }
+    }
+}

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/index/mappings/mapping-event_empty.json
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/index/mappings/mapping-event_empty.json
@@ -1,0 +1,13 @@
+{
+    "properties": {
+        "@timestamp": {
+            "type": "date"
+        },
+        "event_type": {
+            "type": "constant_keyword"
+        },
+        "severity": {
+            "type": "integer"
+        }
+    }
+}

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/index/mappings/mapping-event_logs.json
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/index/mappings/mapping-event_logs.json
@@ -1,0 +1,14 @@
+{
+    "properties": {
+        "@timestamp": {
+            "type": "date"
+        },
+        "event_type": {
+            "type": "constant_keyword",
+            "value": "login"
+        },
+        "username": {
+            "type": "keyword"
+        }
+    }
+}

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats_count_distinct.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats_count_distinct.csv-spec
@@ -178,3 +178,136 @@ m:long  | languages:i
 20   | 5
 10   | null
 ;
+
+countDistinctOfCaseResult
+FROM employees
+| EVAL foo = CASE(languages > 1, languages)
+| STATS COUNT_DISTINCT(foo);
+
+COUNT_DISTINCT(foo):long
+4
+;
+
+countDistinctOfCaseWithLiteralFalse
+FROM employees
+| EVAL foo = CASE(false, languages)
+| STATS COUNT_DISTINCT(foo);
+
+COUNT_DISTINCT(foo):long
+0
+;
+
+countDistinctOfCaseWithDataNodeFold
+FROM employees, sample_data
+| EVAL foo = CASE(event_duration > 0, languages)
+| STATS COUNT_DISTINCT(foo);
+
+COUNT_DISTINCT(foo):long
+0
+;
+
+countDistinctOfCaseWithConstantKeywordFold
+FROM event_alerts, event_logs
+| EVAL alert_severity = CASE(event_type == "alert", severity)
+| STATS COUNT_DISTINCT(alert_severity);
+
+COUNT_DISTINCT(alert_severity):long
+3
+;
+
+countDistinctOfCaseResultExplicitNull
+FROM employees
+| EVAL foo = CASE(languages > 1, languages, null)
+| STATS COUNT_DISTINCT(foo);
+
+COUNT_DISTINCT(foo):long
+4
+;
+
+countDistinctOfCaseWithLiteralFalseExplicitNull
+FROM employees
+| EVAL foo = CASE(false, languages, null)
+| STATS COUNT_DISTINCT(foo);
+
+COUNT_DISTINCT(foo):long
+0
+;
+
+countDistinctOfCaseWithDataNodeFoldExplicitNull
+FROM employees, sample_data
+| EVAL foo = CASE(event_duration > 0, languages, null)
+| STATS COUNT_DISTINCT(foo);
+
+COUNT_DISTINCT(foo):long
+0
+;
+
+countDistinctOfCaseWithConstantKeywordFoldExplicitNull
+FROM event_alerts, event_logs
+| EVAL alert_severity = CASE(event_type == "alert", severity, null)
+| STATS COUNT_DISTINCT(alert_severity);
+
+COUNT_DISTINCT(alert_severity):long
+3
+;
+
+countDistinctOfEmptyConstantKeyword
+FROM event_empty
+| STATS COUNT_DISTINCT(severity);
+
+COUNT_DISTINCT(severity):long
+0
+;
+
+countDistinctOfCaseFoldableAnd
+FROM event_alerts, event_logs
+| EVAL foo = CASE(event_type == "alert" AND severity > 0, username)
+| STATS COUNT_DISTINCT(foo);
+
+COUNT_DISTINCT(foo):long
+0
+;
+
+countDistinctOfCaseFoldableAndExplicitNull
+FROM event_alerts, event_logs
+| EVAL foo = CASE(event_type == "alert" AND severity > 0, username, null)
+| STATS COUNT_DISTINCT(foo);
+
+COUNT_DISTINCT(foo):long
+0
+;
+
+countDistinctOfCaseNotInCondition
+FROM event_alerts, event_logs
+| EVAL foo = CASE(NOT event_type IN ("login", "other"), username, null)
+| STATS COUNT_DISTINCT(foo);
+
+COUNT_DISTINCT(foo):long
+0
+;
+
+countDistinctOfMultipleCasesWithByExpression
+FROM event_alerts, event_logs
+| EVAL severity_case = CASE(event_type == "alert", severity, null),
+       username_case = CASE(event_type == "login", username, null)
+| STATS COUNT_DISTINCT(severity_case), COUNT_DISTINCT(username_case)
+  BY ts_month = DATE_TRUNC(1 month, @timestamp)
+| SORT ts_month;
+
+COUNT_DISTINCT(severity_case):long | COUNT_DISTINCT(username_case):long | ts_month:datetime
+3                                   | 0                                   | 2024-01-01T00:00:00.000Z
+0                                   | 3                                   | 2024-02-01T00:00:00.000Z
+;
+
+countDistinctOfProductionLikePatternAndNotIn
+FROM event_alerts, event_logs
+| EVAL case1 = CASE(event_type == "alert" AND severity > 0, username, null),
+       case2 = CASE(NOT event_type IN ("alert", "other"), username, null)
+| STATS COUNT_DISTINCT(case1), COUNT_DISTINCT(case2)
+  BY ts_month = DATE_TRUNC(1 month, @timestamp)
+| SORT ts_month;
+
+COUNT_DISTINCT(case1):long | COUNT_DISTINCT(case2):long | ts_month:datetime
+0                           | 0                           | 2024-01-01T00:00:00.000Z
+0                           | 3                           | 2024-02-01T00:00:00.000Z
+;

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvIT.java
@@ -248,7 +248,7 @@ public class CsvIT extends ESTestCase {
         if (randomBoolean()) {
             Settings.Builder pragmaSettings = Settings.builder();
             pragmaSettings.put("max_concurrent_shards_per_node", randomBoolean() ? 1 : between(2, 10));
-            request.pragmasOk().pragmas(new QueryPragmas(pragmaSettings.build()));
+            request.acceptedPragmaRisks(true).pragmas(new QueryPragmas(pragmaSettings.build()));
         }
         var listener = new ResponseListener(cluster.getInstance(TransportService.class).getThreadPool());
         cluster.client().execute(EsqlQueryAction.INSTANCE, request, listener);

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvIT.java
@@ -66,6 +66,7 @@ import org.elasticsearch.xpack.esql.action.EsqlQueryResponse;
 import org.elasticsearch.xpack.esql.action.EsqlResolveFieldsAction;
 import org.elasticsearch.xpack.esql.enrich.EnrichPolicyResolver;
 import org.elasticsearch.xpack.esql.plugin.EsqlPlugin;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 import org.elasticsearch.xpack.esql.view.DeleteViewAction;
 import org.elasticsearch.xpack.esql.view.PutViewAction;
 import org.elasticsearch.xpack.inference.LocalStateInferencePlugin;
@@ -244,10 +245,16 @@ public class CsvIT extends ESTestCase {
         if (testCase.requestTimeRangeGte != null && testCase.requestTimeRangeGte.isEmpty() == false) {
             request.filter(new RangeQueryBuilder("@timestamp").gte(testCase.requestTimeRangeGte).lte(testCase.requestTimeRangeLte));
         }
+        if (randomBoolean()) {
+            Settings.Builder pragmaSettings = Settings.builder();
+            pragmaSettings.put("max_concurrent_shards_per_node", randomBoolean() ? 1 : between(2, 10));
+            request.pragmasOk().pragmas(new QueryPragmas(pragmaSettings.build()));
+        }
         var listener = new ResponseListener(cluster.getInstance(TransportService.class).getThreadPool());
         cluster.client().execute(EsqlQueryAction.INSTANCE, request, listener);
         // Using a longer timeout here as test infrastructure might populate data lazily while request is in progress.
         try (var response = listener.actionGet(5, TimeUnit.MINUTES)) {
+            assertFalse("response must not be partial: " + response.getExecutionInfo(), response.isPartial());
             ExpectedResults expected = loadCsvSpecValues(testCase.expectedResults);
             ActualResults actual = new ActualResults(
                 response.zoneId(),

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlQueryRequest.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlQueryRequest.java
@@ -373,6 +373,11 @@ public class EsqlQueryRequest extends org.elasticsearch.xpack.core.esql.action.E
         this.acceptedPragmaRisks = accepted;
     }
 
+    public EsqlQueryRequest pragmasOk() {
+        this.acceptedPragmaRisks = true;
+        return this;
+    }
+
     public EsqlQueryRequest projectRouting(String projectRouting) {
         this.projectRouting = projectRouting;
         return this;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlQueryRequest.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlQueryRequest.java
@@ -369,12 +369,8 @@ public class EsqlQueryRequest extends org.elasticsearch.xpack.core.esql.action.E
         this.onSnapshotBuild = onSnapshotBuild;
     }
 
-    void acceptedPragmaRisks(boolean accepted) {
+    public EsqlQueryRequest acceptedPragmaRisks(boolean accepted) {
         this.acceptedPragmaRisks = accepted;
-    }
-
-    public EsqlQueryRequest pragmasOk() {
-        this.acceptedPragmaRisks = true;
         return this;
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/conditional/Case.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/conditional/Case.java
@@ -358,9 +358,35 @@ public final class Case extends EsqlScalarFunction {
     }
 
     private Expression finishPartialFold(List<Expression> newChildren) {
+        Expression result = innerFinishPartialFold(newChildren);
+        if (result.dataType().noText().equals(dataType()) == false) {
+            throw new IllegalStateException("partiallyFold produced type [" + result.dataType() + "] but expected [" + dataType() + "]");
+        }
+        return result;
+    }
+
+    private Expression innerFinishPartialFold(List<Expression> newChildren) {
         return switch (newChildren.size()) {
+            // CASE(false, a) -> NULL
             case 0 -> new Literal(source(), null, dataType());
-            case 1 -> newChildren.get(0);
+            /*
+             * CASE(false, a, b) -> b
+             *
+             * We *must* return something of dataType or downstream stuff will
+             * blow up. `b` can be:
+             *   - dataType - return as-is
+             *   - TEXT when dataType is keyword - convert to KEYWORD
+             *   - any NULL-typed expression — cast it to dataType so callers
+             *     see the right type (e.g. KEYWORD, not NULL)
+             */
+            case 1 -> {
+                Expression child = newChildren.getFirst();
+                if (child.dataType() == NULL) {
+                    yield new Literal(child.source(), null, dataType());
+                }
+                yield child;
+            }
+            // CASE(false, a, b, c, d) -> CASE(b, c, d)
             default -> replaceChildren(newChildren);
         };
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/conditional/Case.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/conditional/Case.java
@@ -375,7 +375,8 @@ public final class Case extends EsqlScalarFunction {
              * We *must* return something of dataType or downstream stuff will
              * blow up. `b` can be:
              *   - dataType - return as-is
-             *   - TEXT when dataType is keyword - convert to KEYWORD
+             *   - TEXT when dataType is keyword - return as-is - which is safe because
+             *     TEXT is the same as KEYWORD everywhere that matters downstream from here
              *   - any NULL-typed expression — cast it to dataType so callers
              *     see the right type (e.g. KEYWORD, not NULL)
              */

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/conditional/Case.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/conditional/Case.java
@@ -381,7 +381,7 @@ public final class Case extends EsqlScalarFunction {
              */
             case 1 -> {
                 Expression child = newChildren.getFirst();
-                if (child.dataType() == NULL) {
+                if (child.dataType() == NULL && dataType() != NULL) {
                     yield new Literal(child.source(), null, dataType());
                 }
                 yield child;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/conditional/CaseExtraTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/conditional/CaseExtraTests.java
@@ -184,6 +184,73 @@ public class CaseExtraTests extends ESTestCase {
         assertThat(c.partiallyFold(FoldContext.small()), equalToIgnoringIds(field("last", DataType.LONG)));
     }
 
+    public void testPartialFoldTrailingTextLeadingKeyword() {
+        Case c = new Case(
+            Source.synthetic("case"),
+            new Literal(Source.EMPTY, false, DataType.BOOLEAN),
+            List.of(field("keyword_field", DataType.KEYWORD), field("text_field", DataType.TEXT))
+        );
+        assertThat(c.dataType(), equalTo(DataType.KEYWORD));
+        Expression result = c.partiallyFold(FoldContext.small());
+        assertThat(result, equalToIgnoringIds(field("text_field", DataType.TEXT)));
+        // This should be KEYWORD so it lines up with the original value, but it's not
+        // likely to break anything as is.
+    }
+
+    public void testPartialFoldTrailingKeywordLeadingText() {
+        Case c = new Case(
+            Source.synthetic("case"),
+            new Literal(Source.EMPTY, false, DataType.BOOLEAN),
+            List.of(field("text_field", DataType.TEXT), field("keyword_field", DataType.KEYWORD))
+        );
+        assertThat(c.dataType(), equalTo(DataType.KEYWORD));
+        Expression result = c.partiallyFold(FoldContext.small());
+        assertThat(result, equalToIgnoringIds(field("keyword_field", DataType.KEYWORD)));
+    }
+
+    public void testPartialFoldExplicitNull() {
+        Case c = new Case(
+            Source.synthetic("case"),
+            new Literal(Source.EMPTY, false, DataType.BOOLEAN),
+            List.of(field("username", DataType.KEYWORD), new Literal(Source.EMPTY, null, DataType.NULL))
+        );
+        assertThat(c.dataType(), equalTo(DataType.KEYWORD));
+        Expression result = c.partiallyFold(FoldContext.small());
+        assertThat("partiallyFold must preserve the Case's declared type, not null[NULL]", result.dataType(), equalTo(DataType.KEYWORD));
+    }
+
+    public void testPartialFoldAllFalseExplicitNull() {
+        Case c = new Case(
+            Source.synthetic("case"),
+            new Literal(Source.EMPTY, false, DataType.BOOLEAN),
+            List.of(
+                new Literal(Source.EMPTY, BytesRefs.toBytesRef("a"), DataType.KEYWORD),
+                new Literal(Source.EMPTY, false, DataType.BOOLEAN),
+                new Literal(Source.EMPTY, BytesRefs.toBytesRef("b"), DataType.KEYWORD),
+                new Literal(Source.EMPTY, null, DataType.NULL)
+            )
+        );
+        assertThat(c.dataType(), equalTo(DataType.KEYWORD));
+        Expression result = c.partiallyFold(FoldContext.small());
+        assertThat("partiallyFold must preserve the Case's declared type, not null[NULL]", result.dataType(), equalTo(DataType.KEYWORD));
+    }
+
+    public void testPartialFoldTrueBranchWithNullValue() {
+        Case c = new Case(
+            Source.synthetic("case"),
+            new Literal(Source.EMPTY, false, DataType.BOOLEAN),
+            List.of(
+                new Literal(Source.EMPTY, BytesRefs.toBytesRef("a"), DataType.KEYWORD),
+                new Literal(Source.EMPTY, true, DataType.BOOLEAN),
+                new Literal(Source.EMPTY, null, DataType.NULL),
+                new Literal(Source.EMPTY, BytesRefs.toBytesRef("b"), DataType.KEYWORD)
+            )
+        );
+        assertThat(c.dataType(), equalTo(DataType.KEYWORD));
+        Expression result = c.partiallyFold(FoldContext.small());
+        assertThat("partiallyFold must preserve the Case's declared type, not null[NULL]", result.dataType(), equalTo(DataType.KEYWORD));
+    }
+
     public void testPartialFoldLastAfterKeepingUnknown() {
         Case c = new Case(
             Source.synthetic("case"),

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/conditional/CaseExtraTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/conditional/CaseExtraTests.java
@@ -193,8 +193,9 @@ public class CaseExtraTests extends ESTestCase {
         assertThat(c.dataType(), equalTo(DataType.KEYWORD));
         Expression result = c.partiallyFold(FoldContext.small());
         assertThat(result, equalToIgnoringIds(field("text_field", DataType.TEXT)));
-        // This should be KEYWORD so it lines up with the original value, but it's not
-        // likely to break anything as is.
+        // This should be KEYWORD so it lines up with the original value.
+        // It isn't because the conversion is difficult.
+        // But it's not likely to break anything as is.
     }
 
     public void testPartialFoldTrailingKeywordLeadingText() {


### PR DESCRIPTION
When partially fold something like:
```
CASE(false, "a", null)
```

We'd emit it as `null` with the `NULL` data type. But that'll break aggs! They expect to never receive a `NULL` data type. They are *fine* getting `null` of any other data type.

We've had that bug for a long time, but it never surfaced until #145968 landed. And, boy, is it exciting how it comes out! Specifically, you need:
```
CASE(constant_keyword == "mismatch" AND severity > 0, field, null)
```

The rules would mostly just fold the whole thing to NULL and work, except if:
1. It folds on the data node - like constant_keyword
2. It contains an AND in the condition
3. `field` is mapped locally
4. The CASE ends in an explicit trailing `null`.

If all of these are true, then the replacement wouldn't happen on the coordinating node at all. On the data node you'll get:

* `ReplaceFieldWithConstantOrNull` substitutes the constant_keyword field with its per-shard literal value and any absent fields (`severity` above) with `null[INTEGER]`.
```
CASE("login" == "mismatch" AND null > 0, field, null)
```

* `ConstantFolding` folds the inner parts to:
```
CASE(false AND null, field, null)
```
  It cannot fold the whole CASE, though: `Case.foldable()` returns `false` because the condition is a foldable-but-non-Literal `And(...)` expression while the then-value is a non-foldable `FieldAttribute`.

* `PartiallyFoldCase` fires in the same pass and folds the condition. So it sees:
```
CASE(false, field{f}, null)
```
  It strips the dead `(false, field)` pair, leaving only `null` with the data_type `NULL`.

That `null[NULL]` then flows into `CountDistinct.supplier` which throws `EsqlIllegalArgumentException: illegal data type [null]`, crashing the shard. The query returns partial results from the surviving shards.

Before #145968 the `ConstantFolding` would fold the whole thing in one go, all the way to a literal `null` with the data type of whatever the whole CASE expression produced.

With this fix we'll catch the literal `null` and convert it to the correct data type, just as we would do if we could fold entirely in one go.
