### PR TITLE
Mute queued recovery tests in IndexRecoveryIT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -585,3 +585,9 @@ tests:
 - class: org.elasticsearch.indices.recovery.IndexRecoveryIT
   method: testSourceNodeQueuesRecoveriesPastConcurrencyLimit
   issue: https://github.com/elastic/elasticsearch/issues/149753
+- class: org.elasticsearch.indices.recovery.IndexRecoveryIT
+  method: testQueuedRecoveryCancelledWhenTargetNodeLeaves
+  issue: https://github.com/elastic/elasticsearch/issues/149753
+- class: org.elasticsearch.indices.recovery.IndexRecoveryIT
+  method: testQueuedRecoveryCancelledWhenSourceShardClosed
+  issue: https://github.com/elastic/elasticsearch/issues/149753


### PR DESCRIPTION
See: https://github.com/elastic/elasticsearch/issues/149753 and [failures](https://gradle-enterprise.elastic.co/scans/tests?search.startTimeMax=1779512399999&search.startTimeMin=1779339600000&search.timeZoneId=America%2FChicago&tests.container=org.elasticsearch.indices.recovery.IndexRecoveryIT)
