### PR TITLE
WIP: move full precision vector prefetch to segment search thread

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/vectors/AbstractIVFKnnVectorQuery.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/AbstractIVFKnnVectorQuery.java
@@ -9,10 +9,12 @@
 
 package org.elasticsearch.search.vectors;
 
+import org.apache.lucene.codecs.lucene95.HasIndexSlice;
+import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.KnnVectorValues;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.internal.hppc.IntObjectHashMap;
 import org.apache.lucene.search.AcceptDocs;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
@@ -31,6 +33,7 @@ import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.search.knn.KnnCollectorManager;
 import org.apache.lucene.search.knn.KnnSearchStrategy;
+import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.util.Bits;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.index.codec.vectors.cluster.BulkNeighborQueue;
@@ -38,6 +41,8 @@ import org.elasticsearch.search.profile.query.QueryProfiler;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.Callable;
@@ -186,20 +191,33 @@ abstract class AbstractIVFKnnVectorQuery extends Query implements QueryProfilerP
     private TopDocs searchLeaf(LeafReaderContext ctx, Weight filterWeight, IVFCollectorManager knnCollectorManager, float visitRatio)
         throws IOException {
         TopDocs results = getLeafResults(ctx, filterWeight, knnCollectorManager, visitRatio);
-        IntObjectHashMap<ScoreDoc> dedupByDoc = new IntObjectHashMap<>(results.scoreDocs.length * 4 / 3);
+        FloatVectorValues floatVectorValues = ctx.reader().getFloatVectorValues(field);
+        IndexInput input = null;
+        int vectorByteSize = 0;
+        if (floatVectorValues != null) {
+            vectorByteSize = floatVectorValues.getVectorByteLength();
+            final HasIndexSlice sliceable = (floatVectorValues instanceof HasIndexSlice h) ? h : null;
+            input = sliceable != null ? sliceable.getSlice() : null;
+        }
+        // Sort by local doc ID to enable both simple adjacent-dedup and forward-only ordinal lookup for prefetch.
+        Arrays.sort(results.scoreDocs, Comparator.comparingInt(sd -> sd.doc));
+        KnnVectorValues.DocIndexIterator vectorIter = input != null ? floatVectorValues.iterator() : null;
+        int uniqueCount = 0;
+        int prevLocalDoc = -1;
         for (ScoreDoc scoreDoc : results.scoreDocs) {
-            int globalDoc = scoreDoc.doc + ctx.docBase;
-            if (dedupByDoc.containsKey(globalDoc) == false) {
-                scoreDoc.doc = globalDoc;
-                dedupByDoc.put(globalDoc, scoreDoc);
+            int localDoc = scoreDoc.doc;
+            if (localDoc == prevLocalDoc) {
+                continue;
+            }
+            prevLocalDoc = localDoc;
+            scoreDoc.doc = localDoc + ctx.docBase;
+            results.scoreDocs[uniqueCount++] = scoreDoc;
+            if (vectorIter != null) {
+                vectorIter.advance(localDoc);
+                input.prefetch((long) vectorIter.index() * vectorByteSize, vectorByteSize);
             }
         }
-        ScoreDoc[] deduplicatedScoreDocs = new ScoreDoc[dedupByDoc.size()];
-        int index = 0;
-        for (IntObjectHashMap.IntObjectCursor<ScoreDoc> deduplicated : dedupByDoc) {
-            deduplicatedScoreDocs[index++] = deduplicated.value;
-        }
-        return new TopDocs(results.totalHits, deduplicatedScoreDocs);
+        return new TopDocs(results.totalHits, Arrays.copyOf(results.scoreDocs, uniqueCount));
     }
 
     TopDocs getLeafResults(LeafReaderContext ctx, Weight filterWeight, IVFCollectorManager knnCollectorManager, float visitRatio)

--- a/server/src/main/java/org/elasticsearch/search/vectors/RescoreKnnVectorQuery.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/RescoreKnnVectorQuery.java
@@ -33,7 +33,6 @@ import org.elasticsearch.search.profile.query.QueryProfiler;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 

--- a/server/src/main/java/org/elasticsearch/search/vectors/RescoreKnnVectorQuery.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/RescoreKnnVectorQuery.java
@@ -9,7 +9,6 @@
 
 package org.elasticsearch.search.vectors;
 
-import org.apache.lucene.codecs.lucene95.HasIndexSlice;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.KnnVectorValues;
 import org.apache.lucene.queries.function.FunctionScoreQuery;
@@ -229,7 +228,6 @@ public abstract class RescoreKnnVectorQuery extends Query implements QueryProfil
             assert innerRewritten.getClass() != MatchAllDocsQuery.class;
 
             List<ScoreDoc> results = new ArrayList<>(10);
-            List<CheckedRunnable<IOException>> buffer = new LinkedList<>();
             for (var leaf : indexSearcher.getIndexReader().leaves()) {
                 var knnVectorValues = leaf.reader().getFloatVectorValues(fieldName);
                 if (knnVectorValues == null) {
@@ -246,13 +244,9 @@ public abstract class RescoreKnnVectorQuery extends Query implements QueryProfil
                     continue;
                 }
                 var filterIterator = scorer.iterator();
-                rescoreIndividually(leaf.docBase, knnVectorValues, buffer, results, filterIterator);
+                rescoreIndividually(leaf.docBase, knnVectorValues, results, filterIterator);
             }
 
-            for (var runnable : buffer) {
-                runnable.run();
-            }
-            buffer.clear();
             // Remove any remaining sentinel values
             ScoreDoc[] arrayResults = results.toArray(new ScoreDoc[0]);
             return new KnnScoreDocQuery(arrayResults, indexSearcher.getIndexReader());
@@ -285,42 +279,22 @@ public abstract class RescoreKnnVectorQuery extends Query implements QueryProfil
         private void rescoreIndividually(
             int docBase,
             FloatVectorValues knnVectorValues,
-            List<CheckedRunnable<IOException>> buffer,
             List<ScoreDoc> queue,
             DocIdSetIterator filterIterator
         ) throws IOException {
-            final int vectorByteSize = knnVectorValues.getVectorByteLength();
-            final HasIndexSlice sliceable = (knnVectorValues instanceof HasIndexSlice h) ? h : null;
-            final var input = sliceable != null ? sliceable.getSlice() : null;
-
             KnnVectorValues.DocIndexIterator vectorIter = knnVectorValues.iterator();
             DocIdSetIterator conjunction = ConjunctionUtils.intersectIterators(List.of(vectorIter, filterIterator));
             // using bulk doesn't get us anywhere; this is expected to be extremely sparse
             VectorScorer scorer = knnVectorValues.rescorer(floatTarget);
-            int doc;
-            while ((doc = conjunction.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
-                assert doc == vectorIter.docID();
-                final int docID = doc;
-                final int ord = vectorIter.index();
-
-                if (buffer.size() == PREFETCH_BUFFER_SIZE) {
-                    for (var runnable : buffer) {
-                        runnable.run();
-                    }
-                    buffer.clear();
+            int docID;
+            while ((docID = conjunction.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
+                assert docID == vectorIter.docID();
+                int target = scorer.iterator().advance(docID);
+                assert target == docID;
+                float score = scorer.score();
+                if (Float.isNaN(score) == false) {
+                    queue.add(new ScoreDoc(docID + docBase, score));
                 }
-
-                if (input != null) {
-                    input.prefetch((long) ord * vectorByteSize, vectorByteSize);
-                }
-                buffer.add(() -> {
-                    int target = scorer.iterator().advance(docID);
-                    assert target == docID;
-                    float score = scorer.score();
-                    if (Float.isNaN(score) == false) {
-                        queue.add(new ScoreDoc(docID + docBase, score));
-                    }
-                });
             }
         }
     }


### PR DESCRIPTION
Work in progress to demonstrate one possible option for moving prefetch to earlier in query execution. Since this is just a POC, I implemented it with the assumption that we always overquery.