### PR TITLE
fix(tsdb): wire `DocValuesSkipper.maxValueCount()` in TSDB codec

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/AbstractTSDBDocValuesConsumer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/AbstractTSDBDocValuesConsumer.java
@@ -1112,12 +1112,15 @@ public abstract class AbstractTSDBDocValuesConsumer extends XDocValuesConsumer {
         long globalMinValue = Long.MAX_VALUE;
         int globalDocCount = 0;
         int maxDocId = -1;
+        int globalMaxValueCount = 0;
         final List<SkipAccumulator> accumulators = new ArrayList<>();
         SkipAccumulator accumulator = null;
         final int maxAccumulators = 1 << (formatConfig.skipIndexLevelShift() * (formatConfig.skipIndexMaxLevel() - 1));
         for (int doc = values.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = values.nextDoc()) {
             final long firstValue = values.nextValue();
-            if (accumulator != null && accumulator.isDone(formatConfig.skipIndexIntervalSize(), values.docValueCount(), firstValue, doc)) {
+            final int valueCount = values.docValueCount();
+            globalMaxValueCount = Math.max(globalMaxValueCount, valueCount);
+            if (accumulator != null && accumulator.isDone(formatConfig.skipIndexIntervalSize(), valueCount, firstValue, doc)) {
                 globalMaxValue = Math.max(globalMaxValue, accumulator.maxValue);
                 globalMinValue = Math.min(globalMinValue, accumulator.minValue);
                 globalDocCount += accumulator.docCount;
@@ -1134,7 +1137,7 @@ public abstract class AbstractTSDBDocValuesConsumer extends XDocValuesConsumer {
             }
             accumulator.nextDoc(doc);
             accumulator.accumulate(firstValue);
-            for (int i = 1, end = values.docValueCount(); i < end; ++i) {
+            for (int i = 1; i < valueCount; ++i) {
                 accumulator.accumulate(values.nextValue());
             }
         }
@@ -1154,6 +1157,7 @@ public abstract class AbstractTSDBDocValuesConsumer extends XDocValuesConsumer {
         assert globalDocCount <= maxDocId + 1;
         meta.writeInt(globalDocCount);
         meta.writeInt(maxDocId);
+        meta.writeInt(globalMaxValueCount);
     }
 
     private void writeLevels(final List<SkipAccumulator> accumulators) throws IOException {

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/AbstractTSDBDocValuesProducer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/AbstractTSDBDocValuesProducer.java
@@ -144,6 +144,9 @@ public abstract class AbstractTSDBDocValuesProducer extends DocValuesProducer {
                 }
                 this.readContext = new NumericReadContext(1 << blockShift, formatConfig);
                 readFields(in, state.fieldInfos, version, blockShift);
+                if (version < TSDBDocValuesFormatConfig.VERSION_SKIPPER_MAX_VALUE_COUNT) {
+                    inferMaxValueCounts(state.fieldInfos);
+                }
             } catch (Throwable exception) {
                 priorE = exception;
             } finally {
@@ -2025,6 +2028,53 @@ public abstract class AbstractTSDBDocValuesProducer extends DocValuesProducer {
         }
 
         return new DocValuesSkipperEntry(offset, length, minValue, maxValue, docCount, maxDocID, maxValueCount);
+    }
+
+    private void inferMaxValueCounts(FieldInfos fieldInfos) {
+        for (IntObjectHashMap.IntObjectCursor<DocValuesSkipperEntry> cursor : skippers) {
+            DocValuesSkipperEntry entry = cursor.value;
+            if (entry.maxValueCount == -1 && entry.docCount != 0) {
+                FieldInfo info = fieldInfos.fieldInfo(cursor.key);
+                if (info != null) {
+                    int inferred = -1;
+                    switch (info.getDocValuesType()) {
+                        case NUMERIC, SORTED -> inferred = 1;
+                        case SORTED_NUMERIC -> {
+                            SortedNumericEntry sne = sortedNumerics.get(cursor.key);
+                            if (sne != null && sne.numValues == sne.numDocsWithField) {
+                                inferred = 1;
+                            }
+                        }
+                        case SORTED_SET -> {
+                            SortedSetEntry sse = sortedSets.get(cursor.key);
+                            if (sse != null) {
+                                if (sse.singleValueEntry != null) {
+                                    inferred = 1;
+                                } else if (sse.ordsEntry != null && sse.ordsEntry.numValues == sse.ordsEntry.numDocsWithField) {
+                                    inferred = 1;
+                                }
+                            }
+                        }
+                        case BINARY, NONE -> {
+                        }
+                    }
+                    if (inferred != -1) {
+                        skippers.put(
+                            cursor.key,
+                            new DocValuesSkipperEntry(
+                                entry.offset,
+                                entry.length,
+                                entry.minValue,
+                                entry.maxValue,
+                                entry.docCount,
+                                entry.maxDocId,
+                                inferred
+                            )
+                        );
+                    }
+                }
+            }
+        }
     }
 
     private void readNumericField(IndexInput meta, NumericEntry entry, int numericBlockShift) throws IOException {

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/AbstractTSDBDocValuesProducer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/AbstractTSDBDocValuesProducer.java
@@ -194,7 +194,7 @@ public abstract class AbstractTSDBDocValuesProducer extends DocValuesProducer {
                     tempIn,
                     skipCodec,
                     TSDBDocValuesFormatConfig.VERSION_START,
-                    TSDBDocValuesFormatConfig.VERSION_SEPARATE_SKIPLIST,
+                    TSDBDocValuesFormatConfig.VERSION_CURRENT,
                     state.segmentInfo.getId(),
                     state.segmentSuffix
                 );
@@ -1929,6 +1929,11 @@ public abstract class AbstractTSDBDocValuesProducer extends DocValuesProducer {
             public int docCount() {
                 return entry.docCount;
             }
+
+            @Override
+            public int maxValueCount() {
+                return entry.maxValueCount;
+            }
         };
     }
 
@@ -1971,7 +1976,7 @@ public abstract class AbstractTSDBDocValuesProducer extends DocValuesProducer {
             }
             byte type = meta.readByte();
             if (info.docValuesSkipIndexType() != DocValuesSkipIndexType.NONE) {
-                skippers.put(info.number, readDocValueSkipperMeta(meta));
+                skippers.put(info.number, readDocValueSkipperMeta(meta, version));
             }
             if (type == AbstractTSDBDocValuesConsumer.NUMERIC) {
                 numerics.put(info.number, readNumeric(meta, numericBlockShift));
@@ -2007,15 +2012,19 @@ public abstract class AbstractTSDBDocValuesProducer extends DocValuesProducer {
         return entry;
     }
 
-    private static DocValuesSkipperEntry readDocValueSkipperMeta(IndexInput meta) throws IOException {
+    private static DocValuesSkipperEntry readDocValueSkipperMeta(IndexInput meta, int version) throws IOException {
         long offset = meta.readLong();
         long length = meta.readLong();
         long maxValue = meta.readLong();
         long minValue = meta.readLong();
         int docCount = meta.readInt();
         int maxDocID = meta.readInt();
+        int maxValueCount = docCount == 0 ? 0 : -1;
+        if (version >= TSDBDocValuesFormatConfig.VERSION_SKIPPER_MAX_VALUE_COUNT) {
+            maxValueCount = meta.readInt();
+        }
 
-        return new DocValuesSkipperEntry(offset, length, minValue, maxValue, docCount, maxDocID);
+        return new DocValuesSkipperEntry(offset, length, minValue, maxValue, docCount, maxDocID, maxValueCount);
     }
 
     private void readNumericField(IndexInput meta, NumericEntry entry, int numericBlockShift) throws IOException {
@@ -2959,7 +2968,15 @@ public abstract class AbstractTSDBDocValuesProducer extends DocValuesProducer {
         }
     }
 
-    private record DocValuesSkipperEntry(long offset, long length, long minValue, long maxValue, int docCount, int maxDocId) {}
+    private record DocValuesSkipperEntry(
+        long offset,
+        long length,
+        long minValue,
+        long maxValue,
+        int docCount,
+        int maxDocId,
+        int maxValueCount
+    ) {}
 
     public static class NumericEntry {
         public long docsWithFieldOffset;

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/ES87TSDBDocValuesFormat.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/ES87TSDBDocValuesFormat.java
@@ -28,7 +28,8 @@ public class ES87TSDBDocValuesFormat extends org.apache.lucene.codecs.DocValuesF
     static final String META_CODEC = "ES87TSDBDocValuesMetadata";
     static final String META_EXTENSION = "dvm";
     static final int VERSION_START = 0;
-    static final int VERSION_CURRENT = VERSION_START;
+    static final int VERSION_SKIPPER_MAX_VALUE_COUNT = 1;
+    static final int VERSION_CURRENT = VERSION_SKIPPER_MAX_VALUE_COUNT;
     static final byte NUMERIC = 0;
     static final byte BINARY = 1;
     static final byte SORTED = 2;

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/ES87TSDBDocValuesProducer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/ES87TSDBDocValuesProducer.java
@@ -88,7 +88,7 @@ final class ES87TSDBDocValuesProducer extends DocValuesProducer {
                     state.segmentSuffix
                 );
 
-                readFields(in, state.fieldInfos);
+                readFields(in, state.fieldInfos, version);
 
             } catch (Throwable exception) {
                 priorE = exception;
@@ -846,6 +846,11 @@ final class ES87TSDBDocValuesProducer extends DocValuesProducer {
             public int docCount() {
                 return entry.docCount;
             }
+
+            @Override
+            public int maxValueCount() {
+                return entry.maxValueCount;
+            }
         };
     }
 
@@ -859,7 +864,7 @@ final class ES87TSDBDocValuesProducer extends DocValuesProducer {
         data.close();
     }
 
-    private void readFields(IndexInput meta, FieldInfos infos) throws IOException {
+    private void readFields(IndexInput meta, FieldInfos infos, int version) throws IOException {
         for (int fieldNumber = meta.readInt(); fieldNumber != -1; fieldNumber = meta.readInt()) {
             FieldInfo info = infos.fieldInfo(fieldNumber);
             if (info == null) {
@@ -867,7 +872,7 @@ final class ES87TSDBDocValuesProducer extends DocValuesProducer {
             }
             byte type = meta.readByte();
             if (info.docValuesSkipIndexType() != DocValuesSkipIndexType.NONE) {
-                skippers.put(info.number, readDocValueSkipperMeta(meta));
+                skippers.put(info.number, readDocValueSkipperMeta(meta, version));
             }
             if (type == ES87TSDBDocValuesFormat.NUMERIC) {
                 numerics.put(info.number, readNumeric(meta));
@@ -891,15 +896,19 @@ final class ES87TSDBDocValuesProducer extends DocValuesProducer {
         return entry;
     }
 
-    private static DocValuesSkipperEntry readDocValueSkipperMeta(IndexInput meta) throws IOException {
+    private static DocValuesSkipperEntry readDocValueSkipperMeta(IndexInput meta, int version) throws IOException {
         long offset = meta.readLong();
         long length = meta.readLong();
         long maxValue = meta.readLong();
         long minValue = meta.readLong();
         int docCount = meta.readInt();
         int maxDocID = meta.readInt();
+        int maxValueCount = docCount == 0 ? 0 : -1;
+        if (version >= ES87TSDBDocValuesFormat.VERSION_CURRENT) {
+            maxValueCount = meta.readInt();
+        }
 
-        return new DocValuesSkipperEntry(offset, length, minValue, maxValue, docCount, maxDocID);
+        return new DocValuesSkipperEntry(offset, length, minValue, maxValue, docCount, maxDocID, maxValueCount);
     }
 
     private static void readNumeric(IndexInput meta, NumericEntry entry) throws IOException {
@@ -1412,7 +1421,15 @@ final class ES87TSDBDocValuesProducer extends DocValuesProducer {
         }
     }
 
-    private record DocValuesSkipperEntry(long offset, long length, long minValue, long maxValue, int docCount, int maxDocId) {}
+    private record DocValuesSkipperEntry(
+        long offset,
+        long length,
+        long minValue,
+        long maxValue,
+        int docCount,
+        int maxDocId,
+        int maxValueCount
+    ) {}
 
     private static class NumericEntry {
         long docsWithFieldOffset;

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/ES87TSDBDocValuesProducer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/ES87TSDBDocValuesProducer.java
@@ -89,7 +89,9 @@ final class ES87TSDBDocValuesProducer extends DocValuesProducer {
                 );
 
                 readFields(in, state.fieldInfos, version);
-
+                if (version < ES87TSDBDocValuesFormat.VERSION_SKIPPER_MAX_VALUE_COUNT) {
+                    inferMaxValueCounts(state.fieldInfos);
+                }
             } catch (Throwable exception) {
                 priorE = exception;
             } finally {
@@ -909,6 +911,53 @@ final class ES87TSDBDocValuesProducer extends DocValuesProducer {
         }
 
         return new DocValuesSkipperEntry(offset, length, minValue, maxValue, docCount, maxDocID, maxValueCount);
+    }
+
+    private void inferMaxValueCounts(FieldInfos fieldInfos) {
+        for (IntObjectHashMap.IntObjectCursor<DocValuesSkipperEntry> cursor : skippers) {
+            DocValuesSkipperEntry entry = cursor.value;
+            if (entry.maxValueCount == -1 && entry.docCount != 0) {
+                FieldInfo info = fieldInfos.fieldInfo(cursor.key);
+                if (info != null) {
+                    int inferred = -1;
+                    switch (info.getDocValuesType()) {
+                        case NUMERIC, SORTED -> inferred = 1;
+                        case SORTED_NUMERIC -> {
+                            SortedNumericEntry sne = sortedNumerics.get(cursor.key);
+                            if (sne != null && sne.numValues == sne.numDocsWithField) {
+                                inferred = 1;
+                            }
+                        }
+                        case SORTED_SET -> {
+                            SortedSetEntry sse = sortedSets.get(cursor.key);
+                            if (sse != null) {
+                                if (sse.singleValueEntry != null) {
+                                    inferred = 1;
+                                } else if (sse.ordsEntry != null && sse.ordsEntry.numValues == sse.ordsEntry.numDocsWithField) {
+                                    inferred = 1;
+                                }
+                            }
+                        }
+                        case BINARY, NONE -> {
+                        }
+                    }
+                    if (inferred != -1) {
+                        skippers.put(
+                            cursor.key,
+                            new DocValuesSkipperEntry(
+                                entry.offset,
+                                entry.length,
+                                entry.minValue,
+                                entry.maxValue,
+                                entry.docCount,
+                                entry.maxDocId,
+                                inferred
+                            )
+                        );
+                    }
+                }
+            }
+        }
     }
 
     private static void readNumeric(IndexInput meta, NumericEntry entry) throws IOException {

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/TSDBDocValuesFormatConfig.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/TSDBDocValuesFormatConfig.java
@@ -140,5 +140,6 @@ public record TSDBDocValuesFormatConfig(
     public static final int VERSION_NUMERIC_LARGE_BLOCKS = 2;
     public static final int VERSION_PREFIX_PARTITIONS = 4;
     public static final int VERSION_SEPARATE_SKIPLIST = 5;
-    public static final int VERSION_CURRENT = VERSION_SEPARATE_SKIPLIST;
+    public static final int VERSION_SKIPPER_MAX_VALUE_COUNT = 6;
+    public static final int VERSION_CURRENT = VERSION_SKIPPER_MAX_VALUE_COUNT;
 }

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/ES87TSDBDocValuesConsumer.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/ES87TSDBDocValuesConsumer.java
@@ -693,12 +693,15 @@ final class ES87TSDBDocValuesConsumer extends DocValuesConsumer {
         long globalMinValue = Long.MAX_VALUE;
         int globalDocCount = 0;
         int maxDocId = -1;
+        int globalMaxValueCount = 0;
         final List<SkipAccumulator> accumulators = new ArrayList<>();
         SkipAccumulator accumulator = null;
         final int maxAccumulators = 1 << (SKIP_INDEX_LEVEL_SHIFT * (SKIP_INDEX_MAX_LEVEL - 1));
         for (int doc = values.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = values.nextDoc()) {
+            int valueCount = values.docValueCount();
             final long firstValue = values.nextValue();
-            if (accumulator != null && accumulator.isDone(skipIndexIntervalSize, values.docValueCount(), firstValue, doc)) {
+            globalMaxValueCount = Math.max(globalMaxValueCount, valueCount);
+            if (accumulator != null && accumulator.isDone(skipIndexIntervalSize, valueCount, firstValue, doc)) {
                 globalMaxValue = Math.max(globalMaxValue, accumulator.maxValue);
                 globalMinValue = Math.min(globalMinValue, accumulator.minValue);
                 globalDocCount += accumulator.docCount;
@@ -715,7 +718,7 @@ final class ES87TSDBDocValuesConsumer extends DocValuesConsumer {
             }
             accumulator.nextDoc(doc);
             accumulator.accumulate(firstValue);
-            for (int i = 1, end = values.docValueCount(); i < end; ++i) {
+            for (int i = 1; i < valueCount; ++i) {
                 accumulator.accumulate(values.nextValue());
             }
         }
@@ -735,6 +738,7 @@ final class ES87TSDBDocValuesConsumer extends DocValuesConsumer {
         assert globalDocCount <= maxDocId + 1;
         meta.writeInt(globalDocCount);
         meta.writeInt(maxDocId);
+        meta.writeInt(globalMaxValueCount);
     }
 
     private void writeLevels(List<SkipAccumulator> accumulators) throws IOException {


### PR DESCRIPTION
## TL;DR

Implements `DocValuesSkipper.maxValueCount()` in the TSDB doc values codec by porting `apache/lucene#15993`, fixing the `lucene_snapshot` CI failures on the `WithSkipper` test family across ES87, ES819, and ES95.

## Summary

Lucene 10.5 added `DocValuesSkipper.maxValueCount()` but the TSDB codec did not override it, so the new `BaseDocValuesFormatTestCase` assertion fired `expected:<N> but was:<-1>` across the `WithSkipper` test family. This change ports the consumer and producer logic from `apache/lucene#15993` to both the shared TSDB abstract base (used by ES95 and ES819) and to the self contained legacy ES87 codec.

The change also ports `inferMaxValueCounts` from the same Lucene PR, so segments written before the format bump still report `maxValueCount = 1` when the field type (`NUMERIC`, `SORTED`) or existing per field metadata (`numValues == numDocsWithField` for sorted numeric and sorted set) proves the field is single valued, instead of falling back to the unknown sentinel.

## Changes

* `TSDBDocValuesFormatConfig`: adds `VERSION_SKIPPER_MAX_VALUE_COUNT` and moves `VERSION_CURRENT` to it.
* `AbstractTSDBDocValuesConsumer`: tracks `globalMaxValueCount` during skip index construction and persists it after `maxDocId`.
* `AbstractTSDBDocValuesProducer`: extends `DocValuesSkipperEntry`, reads `maxValueCount` conditionally on segment version, overrides `maxValueCount()` on the anonymous skipper, and threads `version` through `readFields` so the conditional read uses the local rather than the uninitialized instance field. Also runs `inferMaxValueCounts` when the segment version is below `VERSION_SKIPPER_MAX_VALUE_COUNT`, rewriting skipper entries with `maxValueCount = 1` for provably single valued fields.
* `ES87TSDBDocValuesFormat`: adds its own `VERSION_SKIPPER_MAX_VALUE_COUNT` and bumps `VERSION_CURRENT`.
* `ES87TSDBDocValuesProducer`: mirrors the abstract producer changes scoped to the ES87 codepath, including the `version` threading fix and the `inferMaxValueCounts` pass for pre `VERSION_SKIPPER_MAX_VALUE_COUNT` segments.
* `ES87TSDBDocValuesConsumer` (test only): mirrors the abstract consumer changes scoped to the ES87 codepath.

## Testing

The failing test families on `lucene_snapshot` reproduce and resolve with:

```
./gradlew :server:test --tests \
  "org.elasticsearch.index.codec.tsdb.es819.ES819TSDBDocValuesFormatVariableSkipIntervalTests"

./gradlew :server:test --tests \
  "org.elasticsearch.index.codec.tsdb.ES87TSDBDocValuesFormatVariableSkipIntervalTests"
```

The full TSDB codec test pass also runs green with:

```
./gradlew :server:test --tests "org.elasticsearch.index.codec.tsdb.*"
```

Close #149715
