### PR TITLE
Fix failing tests in EsqlSecurityIT/EsqlAsyncSecurityIT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -354,24 +354,24 @@ tests:
 - class: org.elasticsearch.xpack.stateless.reshard.StatelessReshardIT
   method: testTermVectorsApiRealtimeGet
   issue: https://github.com/elastic/elasticsearch/issues/148175
-- class: org.elasticsearch.xpack.esql.EsqlAsyncSecurityIT
-  method: testDatasetCrudForbiddenWithoutIndexManage
-  issue: https://github.com/elastic/elasticsearch/issues/148182
-- class: org.elasticsearch.xpack.esql.EsqlAsyncSecurityIT
-  method: testDataSourceAdminListEmpty
-  issue: https://github.com/elastic/elasticsearch/issues/148183
-- class: org.elasticsearch.xpack.esql.EsqlAsyncSecurityIT
-  method: testDataSourceCrudForbiddenWithoutClusterManage
-  issue: https://github.com/elastic/elasticsearch/issues/148184
-- class: org.elasticsearch.xpack.esql.EsqlSecurityIT
-  method: testDatasetCrudForbiddenWithoutIndexManage
-  issue: https://github.com/elastic/elasticsearch/issues/148185
-- class: org.elasticsearch.xpack.esql.EsqlSecurityIT
-  method: testDataSourceAdminListEmpty
-  issue: https://github.com/elastic/elasticsearch/issues/148186
-- class: org.elasticsearch.xpack.esql.EsqlSecurityIT
-  method: testDataSourceCrudForbiddenWithoutClusterManage
-  issue: https://github.com/elastic/elasticsearch/issues/148187
+#- class: org.elasticsearch.xpack.esql.EsqlAsyncSecurityIT
+#  method: testDatasetCrudForbiddenWithoutIndexManage
+#  issue: https://github.com/elastic/elasticsearch/issues/148182
+#- class: org.elasticsearch.xpack.esql.EsqlAsyncSecurityIT
+#  method: testDataSourceAdminListEmpty
+#  issue: https://github.com/elastic/elasticsearch/issues/148183
+#- class: org.elasticsearch.xpack.esql.EsqlAsyncSecurityIT
+#  method: testDataSourceCrudForbiddenWithoutClusterManage
+#  issue: https://github.com/elastic/elasticsearch/issues/148184
+#- class: org.elasticsearch.xpack.esql.EsqlSecurityIT
+#  method: testDatasetCrudForbiddenWithoutIndexManage
+#  issue: https://github.com/elastic/elasticsearch/issues/148185
+#- class: org.elasticsearch.xpack.esql.EsqlSecurityIT
+#  method: testDataSourceAdminListEmpty
+#  issue: https://github.com/elastic/elasticsearch/issues/148186
+#- class: org.elasticsearch.xpack.esql.EsqlSecurityIT
+#  method: testDataSourceCrudForbiddenWithoutClusterManage
+#  issue: https://github.com/elastic/elasticsearch/issues/148187
 - class: org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsIntegTests
   method: testCreateAndRestoreSearchableSnapshot
   issue: https://github.com/elastic/elasticsearch/issues/148217

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -354,24 +354,6 @@ tests:
 - class: org.elasticsearch.xpack.stateless.reshard.StatelessReshardIT
   method: testTermVectorsApiRealtimeGet
   issue: https://github.com/elastic/elasticsearch/issues/148175
-#- class: org.elasticsearch.xpack.esql.EsqlAsyncSecurityIT
-#  method: testDatasetCrudForbiddenWithoutIndexManage
-#  issue: https://github.com/elastic/elasticsearch/issues/148182
-#- class: org.elasticsearch.xpack.esql.EsqlAsyncSecurityIT
-#  method: testDataSourceAdminListEmpty
-#  issue: https://github.com/elastic/elasticsearch/issues/148183
-#- class: org.elasticsearch.xpack.esql.EsqlAsyncSecurityIT
-#  method: testDataSourceCrudForbiddenWithoutClusterManage
-#  issue: https://github.com/elastic/elasticsearch/issues/148184
-#- class: org.elasticsearch.xpack.esql.EsqlSecurityIT
-#  method: testDatasetCrudForbiddenWithoutIndexManage
-#  issue: https://github.com/elastic/elasticsearch/issues/148185
-#- class: org.elasticsearch.xpack.esql.EsqlSecurityIT
-#  method: testDataSourceAdminListEmpty
-#  issue: https://github.com/elastic/elasticsearch/issues/148186
-#- class: org.elasticsearch.xpack.esql.EsqlSecurityIT
-#  method: testDataSourceCrudForbiddenWithoutClusterManage
-#  issue: https://github.com/elastic/elasticsearch/issues/148187
 - class: org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsIntegTests
   method: testCreateAndRestoreSearchableSnapshot
   issue: https://github.com/elastic/elasticsearch/issues/148217

--- a/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlSecurityIT.java
+++ b/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlSecurityIT.java
@@ -2012,7 +2012,8 @@ public class EsqlSecurityIT extends ESRestTestCase {
     }
 
     // TODO: use named privileges when available — https://github.com/elastic/elasticsearch/issues/147017
-    public void testDataSourceCrudForbiddenWithoutClusterManage() {
+    public void testDataSourceCrudForbiddenWithoutClusterManage() throws IOException {
+        assumeTrue("data_sources REST API not supported by cluster", dataSourcesApiSupported());
         // user2 has cluster: []. All three data source actions are cluster-level → 403.
         for (String path : List.of("/_query/data_source/ds_x", "/_query/data_source")) {
             Request get = new Request("GET", path);
@@ -2033,7 +2034,8 @@ public class EsqlSecurityIT extends ESRestTestCase {
         assertThat(ex.getResponse().getStatusLine().getStatusCode(), equalTo(403));
     }
 
-    public void testDatasetCrudForbiddenWithoutIndexManage() {
+    public void testDatasetCrudForbiddenWithoutIndexManage() throws IOException {
+        assumeTrue("data_sources REST API not supported by cluster", dataSourcesApiSupported());
         // user3 has only `read` on `index`. Dataset actions need index `manage`.
         Request put = new Request("PUT", "/_query/dataset/index");
         put.setJsonEntity("{\"data_source\":\"parent\",\"resource\":\"s3://b/\"}");


### PR DESCRIPTION
Only run data source security tests when data sources API is available, to avoid `Expect 403, got 400/BadRequest` failures.

Closes #148182
Closes #148184
Closes #148185
Closes #148186
Closes #148187
Closes #148160