### PR TITLE
Fix binary expressions with unresolved PromQL functions

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/PromqlPlan.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/PromqlPlan.java
@@ -11,6 +11,8 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.promql.function.PromqlFunctionDefinition;
+import org.elasticsearch.xpack.esql.expression.promql.function.PromqlFunctionRegistry;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 
 import java.util.List;
@@ -67,8 +69,16 @@ public interface PromqlPlan {
         return getType(plan) == PromqlDataType.SCALAR;
     }
 
+    /**
+     * Returns the PromQL data type for the given plan, or {@code null} if it's not a PromQL plan.
+     * Handles {@link UnresolvedPromqlFunction} by looking up the function's output type from the registry.
+     */
     @Nullable
     static PromqlDataType getType(@Nullable LogicalPlan plan) {
+        if (plan instanceof UnresolvedPromqlFunction unresolved) {
+            PromqlFunctionDefinition def = PromqlFunctionRegistry.INSTANCE.functionMetadata(unresolved.functionName());
+            return def != null ? def.functionType().outputType() : null;
+        }
         if (plan instanceof PromqlPlan promqlPlan) {
             return promqlPlan.returnType();
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/operator/VectorBinaryOperator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/operator/VectorBinaryOperator.java
@@ -196,6 +196,12 @@ public abstract sealed class VectorBinaryOperator extends BinaryPlan implements 
 
     @Override
     public PromqlDataType returnType() {
+        PromqlDataType leftType = PromqlPlan.getType(left());
+        PromqlDataType rightType = PromqlPlan.getType(right());
+        // scalar op scalar → scalar; otherwise → vector
+        if (leftType == PromqlDataType.SCALAR && rightType == PromqlDataType.SCALAR) {
+            return PromqlDataType.SCALAR;
+        }
         return PromqlDataType.INSTANT_VECTOR;
     }
 }

--- a/x-pack/plugin/prometheus/src/javaRestTest/java/org/elasticsearch/xpack/prometheus/PrometheusInstantQueryRestIT.java
+++ b/x-pack/plugin/prometheus/src/javaRestTest/java/org/elasticsearch/xpack/prometheus/PrometheusInstantQueryRestIT.java
@@ -92,6 +92,34 @@ public class PrometheusInstantQueryRestIT extends AbstractPrometheusRestIT {
         assertThat(responsePath.evaluate("data.result"), empty());
     }
 
+    /**
+     * Verifies that time() function works in binary expressions.
+     * This is a regression test for a bug where binary operators failed when
+     * an operand was an unresolved function like time().
+     */
+    public void testInstantQueryWithTimeFunctionInBinaryExpression() throws Exception {
+        ingestTestData("test_gauge_iq");
+
+        // time() + 1 returns scalar (scalar + scalar = scalar per Prometheus semantics)
+        ObjectPath responsePath = executeInstantQueryRaw("time() + 1", "2026-01-01T00:05:00Z", null);
+        assertThat(responsePath.evaluate("status"), equalTo("success"));
+        assertThat(responsePath.evaluate("data.resultType"), equalTo("scalar"));
+    }
+
+    /**
+     * Verifies that aggregations work in binary expressions.
+     * This is a regression test for a bug where binary operators failed when
+     * an operand was an aggregation like sum().
+     */
+    public void testInstantQueryWithAggregationInBinaryExpression() throws Exception {
+        ingestTestData("test_gauge_iq");
+
+        // sum(metric) + 1 returns vector (vector + scalar = vector per Prometheus semantics)
+        ObjectPath responsePath = executeInstantQueryRaw("sum(test_gauge_iq) + 1", "2026-01-01T00:05:00Z", null);
+        assertThat(responsePath.evaluate("status"), equalTo("success"));
+        assertThat(responsePath.evaluate("data.resultType"), equalTo("vector"));
+    }
+
     private static void assertMetricResult(ObjectPath responsePath) throws IOException {
         assertThat(responsePath.evaluate("data.result"), hasSize(1));
         assertThat(responsePath.evaluate("data.result.0.metric.job"), equalTo("test_job"));
@@ -109,6 +137,12 @@ public class PrometheusInstantQueryRestIT extends AbstractPrometheusRestIT {
     }
 
     private ObjectPath executeInstantQuery(String query, String time, String index) throws Exception {
+        ObjectPath responsePath = executeInstantQueryRaw(query, time, index);
+        assertThat(responsePath.evaluate("data.resultType"), equalTo("vector"));
+        return responsePath;
+    }
+
+    private ObjectPath executeInstantQueryRaw(String query, String time, String index) throws Exception {
         String path = index == null ? "/_prometheus/api/v1/query" : "/_prometheus/" + index + "/api/v1/query";
         Request request = new Request("GET", path);
         request.addParameter("query", query);
@@ -120,7 +154,6 @@ public class PrometheusInstantQueryRestIT extends AbstractPrometheusRestIT {
 
         ObjectPath responsePath = ObjectPath.createFromResponse(response);
         assertThat(responsePath.evaluate("status"), equalTo("success"));
-        assertThat(responsePath.evaluate("data.resultType"), equalTo("vector"));
         return responsePath;
     }
 


### PR DESCRIPTION
## Summary

Handle `UnresolvedPromqlFunction` in `PromqlPlan.getType()` by looking up the function's output type from the registry. This fixes crashes when `time()` or aggregations like `sum()` appear as operands in binary expressions.

**Root cause:** When either `time()` or an aggregation like `sum()` appears as an operand of a binary expression, the type resolution fails. The `returnType()` method is called during binary expression planning, hits an unresolved function node, and throws instead of returning a type.

**Fix:** Check for `UnresolvedPromqlFunction` in `PromqlPlan.getType()` and look up the output type from the `PromqlFunctionRegistry`.

## Test plan

- [x] Added integration tests for `time() + 1` and `sum(metric) + 1`
- [x] All existing tests pass