### PR TITLE
Unmute AccountableQueryCircuitBreakerIT regexp test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -570,9 +570,6 @@ tests:
 - class: org.elasticsearch.index.reindex.ResumeBulkByScrollRequestWireSerializingTests
   method: testEqualsAndHashcode
   issue: https://github.com/elastic/elasticsearch/issues/149721
-- class: org.elasticsearch.indices.memory.breaker.AccountableQueryCircuitBreakerIT
-  method: testRegexpQueryMemoryReleased
-  issue: https://github.com/elastic/elasticsearch/issues/149727
 - class: org.elasticsearch.xpack.stateless.StatelessCommitServiceIT
   method: testRetainCommitForReadersAfterShardReplicasSetToZero
   issue: https://github.com/elastic/elasticsearch/issues/149740

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/memory/breaker/AccountableQueryCircuitBreakerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/memory/breaker/AccountableQueryCircuitBreakerIT.java
@@ -253,11 +253,10 @@ public class AccountableQueryCircuitBreakerIT extends ESIntegTestCase {
     }
 
     private void assertQueryMemoryReleased(QueryBuilder query) throws Exception {
-        long baseline = getRequestBreakerEstimated();
+        assertBusy(() -> assertEquals("Request breaker should be empty before search", 0L, getRequestBreakerEstimated()));
         client().prepareSearch(INDEX_NAME).setQuery(query).get().decRef();
-        assertBusy(() -> {
-            long estimated = getRequestBreakerEstimated();
-            assertEquals("Request breaker memory should be released after search completes", baseline, estimated);
-        });
+        assertBusy(
+            () -> assertEquals("Request breaker memory should be released after search completes", 0L, getRequestBreakerEstimated())
+        );
     }
 }


### PR DESCRIPTION
The helper `assertQueryMemoryReleased` captured a `baseline` from the REQUEST circuit breaker right after
`createAndPopulateIndex()`, then waited for the post-search value to match it. That baseline can be non-zero from
in-flight indexing or nodes-stats accounting, which then drains to `0`, making the equality check fail.

 This PR drops the baseline and instead asserts that the REQUEST breaker is empty (`0`) both before and after the search..

Closes #149727
