### PR TITLE
Add the name of the circuit breaker when a leak is detected.

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -2612,7 +2612,11 @@ public final class InternalTestCluster extends TestCluster {
                 try {
                     assertBusy(() -> {
                         CircuitBreaker reqBreaker = breakerService.getBreaker(CircuitBreaker.REQUEST);
-                        assertThat("Request breaker not reset to 0 on node: " + name, reqBreaker.getUsed(), equalTo(0L));
+                        assertThat(
+                            "Request breaker [" + reqBreaker.getName() + "] not reset to 0 on node: " + name,
+                            reqBreaker.getUsed(),
+                            equalTo(0L)
+                        );
                     });
                 } catch (Exception e) {
                     throw new AssertionError("Exception during check for request breaker reset to 0", e);


### PR DESCRIPTION
Since we cannot reproduce the leak in https://github.com/elastic/elasticsearch/issues/149450, we add the name of the circuit breaker to help us narrow it down, if it occurs again.