### PR TITLE
[9.4] Unmute AccountableQueryCircuitBreakerIT regexp test (#149802)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/memory/breaker/AccountableQueryCircuitBreakerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/memory/breaker/AccountableQueryCircuitBreakerIT.java
@@ -214,11 +214,10 @@ public class AccountableQueryCircuitBreakerIT extends ESIntegTestCase {
     }
 
     private void assertQueryMemoryReleased(QueryBuilder query) throws Exception {
-        long baseline = getRequestBreakerEstimated();
+        assertBusy(() -> assertEquals("Request breaker should be empty before search", 0L, getRequestBreakerEstimated()));
         client().prepareSearch(INDEX_NAME).setQuery(query).get().decRef();
-        assertBusy(() -> {
-            long estimated = getRequestBreakerEstimated();
-            assertEquals("Request breaker memory should be released after search completes", baseline, estimated);
-        });
+        assertBusy(
+            () -> assertEquals("Request breaker memory should be released after search completes", 0L, getRequestBreakerEstimated())
+        );
     }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Unmute AccountableQueryCircuitBreakerIT regexp test (#149802)](https://github.com/elastic/elasticsearch/pull/149802)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)