### PR TITLE
[ESQL] ESQL|DS: Panama FFI streaming zstd for .csv.zst / .ndjson.zstd

### DIFF
--- a/docs/changelog/149809.yaml
+++ b/docs/changelog/149809.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 149809
+summary: "ESQL|DS: Panama FFI streaming zstd for `.csv.zst` / `.ndjson.zstd`"
+type: enhancement

--- a/libs/native/src/main/java/org/elasticsearch/nativeaccess/Zstd.java
+++ b/libs/native/src/main/java/org/elasticsearch/nativeaccess/Zstd.java
@@ -128,4 +128,116 @@ public final class Zstd {
         }
         return (int) ret;
     }
+
+    /**
+     * Recommended size for the input buffer feeding {@link DStream#decompress} ({@code ZSTD_DStreamInSize}).
+     * The value is constant per libzstd build (≈ 128 KB on 1.5.7); callers typically cache it in a
+     * {@code static final} field rather than calling per-stream.
+     */
+    public int dStreamInSize() {
+        return checkSize(zstdLib.dStreamInSize(), "dStreamInSize");
+    }
+
+    /**
+     * Recommended size for the output buffer of {@link DStream#decompress} ({@code ZSTD_DStreamOutSize}).
+     * Used only by the {@code skip()} scratch buffer in the wrapper — the regular read path writes
+     * straight into the caller's destination array.
+     */
+    public int dStreamOutSize() {
+        return checkSize(zstdLib.dStreamOutSize(), "dStreamOutSize");
+    }
+
+    private int checkSize(long ret, String which) {
+        if (zstdLib.isError(ret)) {
+            throw new IllegalArgumentException(zstdLib.getErrorName(ret));
+        } else if (ret <= 0 || ret > Integer.MAX_VALUE) {
+            throw new IllegalStateException("Unexpected " + which + " value: " + Long.toUnsignedString(ret));
+        }
+        return (int) ret;
+    }
+
+    /**
+     * Allocate a streaming decompression context wrapping {@code ZSTD_DStream}. The returned
+     * {@link DStream} owns a native zstd context plus two small persistent struct holders;
+     * call {@link DStream#close()} (or use try-with-resources) to release them. Single-threaded
+     * by contract — do not share a single {@link DStream} across threads.
+     */
+    public DStream newDStream() {
+        return new DStream(zstdLib.createDStream());
+    }
+
+    /**
+     * Streaming-mode zstd decompression resource. Backs {@code PanamaZstdInputStream} and any
+     * other consumer that needs incremental {@code ZSTD_decompressStream} semantics: refill an
+     * input chunk, call {@link #decompress}, read {@link #lastSrcPos()} / {@link #lastDstPos()} to
+     * advance cursors, loop while the hint return is positive (more input wanted), and observe a
+     * zero return when the current frame finished.
+     *
+     * <p>Bounds are validated Java-side; error returns from libzstd are translated to
+     * {@link IllegalArgumentException} carrying the {@code ZSTD_getErrorName} string. All hot-path
+     * state (the two {@code ZSTD_inBuffer}/{@code ZSTD_outBuffer} struct holders, the native context
+     * handle) lives inside the binding — every {@link #decompress} call is allocation-free.
+     *
+     * <p>Not thread-safe.
+     */
+    public final class DStream implements AutoCloseable {
+
+        private final ZstdLibrary.DStream impl;
+        private boolean closed;
+
+        DStream(ZstdLibrary.DStream impl) {
+            this.impl = impl;
+        }
+
+        /**
+         * Feed {@code src[srcPos..srcLen)} into the decoder and write decompressed bytes into
+         * {@code dst[dstPos..dstLen)}. Returns the libzstd hint: {@code 0} means the current frame
+         * finished decoding (the decoder is implicitly reset for the next concatenated frame, if any),
+         * a positive return is libzstd's best guess for the amount of additional input it would like
+         * to see next, and a zstd-side error is translated to {@link IllegalArgumentException}.
+         *
+         * <p>After return, the caller reads {@link #lastSrcPos()} / {@link #lastDstPos()} to learn
+         * how far the input/output cursors advanced — these are absolute offsets within the supplied
+         * arrays, not deltas.
+         */
+        public long decompress(byte[] dst, int dstPos, int dstLen, byte[] src, int srcPos, int srcLen) {
+            if (closed) {
+                throw new IllegalStateException("DStream is closed");
+            }
+            Objects.requireNonNull(dst, "Null destination buffer");
+            Objects.requireNonNull(src, "Null source buffer");
+            Objects.checkFromToIndex(dstPos, dstLen, dst.length);
+            Objects.checkFromToIndex(srcPos, srcLen, src.length);
+            long ret = impl.decompress(dst, dstPos, dstLen, src, srcPos, srcLen);
+            if (zstdLib.isError(ret)) {
+                throw new IllegalArgumentException(zstdLib.getErrorName(ret));
+            }
+            return ret;
+        }
+
+        /**
+         * Output position after the most recent {@link #decompress} — an absolute index into the
+         * {@code dst} array that was passed to that call.
+         */
+        public int lastDstPos() {
+            return impl.lastDstPos();
+        }
+
+        /**
+         * Input position after the most recent {@link #decompress} — an absolute index into the
+         * {@code src} array that was passed to that call.
+         */
+        public int lastSrcPos() {
+            return impl.lastSrcPos();
+        }
+
+        /** Idempotent — frees the native {@code ZSTD_DStream} and the cached struct holders. */
+        @Override
+        public void close() {
+            if (closed == false) {
+                closed = true;
+                impl.close();
+            }
+        }
+    }
 }

--- a/libs/native/src/main/java/org/elasticsearch/nativeaccess/Zstd.java
+++ b/libs/native/src/main/java/org/elasticsearch/nativeaccess/Zstd.java
@@ -199,6 +199,15 @@ public final class Zstd {
          * <p>After return, the caller reads {@link #lastSrcPos()} / {@link #lastDstPos()} to learn
          * how far the input/output cursors advanced — these are absolute offsets within the supplied
          * arrays, not deltas.
+         *
+         * <p><b>Chunking contract.</b> Callers must pass at most {@link Zstd#dStreamInSize()} bytes
+         * of input per call ({@code srcLen - srcPos <= dStreamInSize()}). Larger slices raise
+         * {@link IllegalArgumentException} from the binding — the binding hard-fails rather than
+         * silently consuming a prefix because partial consumption is easy to overlook at call sites.
+         * {@code PanamaZstdInputStream} caches the recommended size in a {@code static final} and
+         * refills upstream in chunks of that size. Output may be any size; the binding internally
+         * caps each call at {@link Zstd#dStreamOutSize()} and the caller's outer loop drives
+         * subsequent calls as needed.
          */
         public long decompress(byte[] dst, int dstPos, int dstLen, byte[] src, int srcPos, int srcLen) {
             if (closed) {

--- a/libs/native/src/main/java/org/elasticsearch/nativeaccess/jdk/JdkZstdLibrary.java
+++ b/libs/native/src/main/java/org/elasticsearch/nativeaccess/jdk/JdkZstdLibrary.java
@@ -24,6 +24,7 @@ import java.nio.ByteBuffer;
 
 import static java.lang.foreign.ValueLayout.ADDRESS;
 import static java.lang.foreign.ValueLayout.JAVA_BOOLEAN;
+import static java.lang.foreign.ValueLayout.JAVA_BYTE;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static java.lang.foreign.ValueLayout.JAVA_LONG;
 import static org.elasticsearch.nativeaccess.jdk.LinkerHelper.downcallHandle;
@@ -285,7 +286,7 @@ class JdkZstdLibrary implements ZstdLibrary {
             // tracking partial consumption inside the staging buffer) because the wrapper above
             // re-supplies the leftover bytes on the next call.
             if (srcAvail > 0) {
-                MemorySegment.copy(src, srcPos, inBuf, java.lang.foreign.ValueLayout.JAVA_BYTE, 0L, srcAvail);
+                MemorySegment.copy(src, srcPos, inBuf, JAVA_BYTE, 0L, srcAvail);
             }
             SIZE_VH.set(inStruct, 0L, (long) srcAvail);
             POS_VH.set(inStruct, 0L, 0L);
@@ -301,8 +302,12 @@ class JdkZstdLibrary implements ZstdLibrary {
 
             int srcConsumed = (int) (long) POS_VH.get(inStruct, 0L);
             int dstProduced = (int) (long) POS_VH.get(outStruct, 0L);
+            // libzstd guarantees pos ≤ size on return — the size fields we stamped above are the
+            // upper bounds here, both already int-typed and bounded by the staging buffer sizes.
+            assert srcConsumed >= 0 && srcConsumed <= srcAvail : "srcConsumed " + srcConsumed + " out of [0, " + srcAvail + "]";
+            assert dstProduced >= 0 && dstProduced <= outRoom : "dstProduced " + dstProduced + " out of [0, " + outRoom + "]";
             if (dstProduced > 0) {
-                MemorySegment.copy(outBuf, java.lang.foreign.ValueLayout.JAVA_BYTE, 0L, dst, dstPos, dstProduced);
+                MemorySegment.copy(outBuf, JAVA_BYTE, 0L, dst, dstPos, dstProduced);
             }
             // Translate native-staging positions back into absolute caller-array offsets — keeps
             // the SPI contract identical to zstd-jni's "positions are absolute in your byte[]".

--- a/libs/native/src/main/java/org/elasticsearch/nativeaccess/jdk/JdkZstdLibrary.java
+++ b/libs/native/src/main/java/org/elasticsearch/nativeaccess/jdk/JdkZstdLibrary.java
@@ -221,10 +221,17 @@ class JdkZstdLibrary implements ZstdLibrary {
      *
      * <p>The arena is closed on {@link #close()}, releasing all native memory back to the OS.
      *
-     * <p>Single-threaded by contract — there is no internal locking.
+     * <p><b>Threading.</b> The arena is {@link Arena#ofShared() shared}, not confined: the wrapper
+     * is constructed eagerly when the codec opens the file, but the actual {@link #decompress}
+     * calls run on whatever worker thread {@code StreamingParallelParsingCoordinator}'s segmentator
+     * is scheduled on — almost never the constructing thread. A confined arena would raise
+     * {@link java.lang.WrongThreadException} from {@code MemorySegment.copy} on the first read.
+     * Shared arenas pay a small synchronization cost on {@link Arena#close()}, which is negligible
+     * relative to libzstd's per-call work. The DStream itself is still single-reader by contract —
+     * the segmentator owns it for the lifetime of one file.
      */
     private static final class JdkDStream implements ZstdLibrary.DStream {
-        private final Arena arena = Arena.ofConfined();
+        private final Arena arena = Arena.ofShared();
         private final MemorySegment handle;
         private final MemorySegment inStruct;
         private final MemorySegment outStruct;

--- a/libs/native/src/main/java/org/elasticsearch/nativeaccess/jdk/JdkZstdLibrary.java
+++ b/libs/native/src/main/java/org/elasticsearch/nativeaccess/jdk/JdkZstdLibrary.java
@@ -13,9 +13,13 @@ import org.elasticsearch.nativeaccess.CloseableByteBuffer;
 import org.elasticsearch.nativeaccess.lib.LoaderHelper;
 import org.elasticsearch.nativeaccess.lib.ZstdLibrary;
 
+import java.lang.foreign.Arena;
 import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.MemoryLayout.PathElement;
 import java.lang.foreign.MemorySegment;
 import java.lang.invoke.MethodHandle;
+import java.lang.invoke.VarHandle;
 import java.nio.ByteBuffer;
 
 import static java.lang.foreign.ValueLayout.ADDRESS;
@@ -41,6 +45,34 @@ class JdkZstdLibrary implements ZstdLibrary {
         "ZSTD_decompress",
         FunctionDescriptor.of(JAVA_LONG, ADDRESS, JAVA_INT, ADDRESS, JAVA_INT)
     );
+
+    // --- streaming API ---
+    private static final MethodHandle createDStream$mh = downcallHandle("ZSTD_createDStream", FunctionDescriptor.of(ADDRESS));
+    private static final MethodHandle freeDStream$mh = downcallHandle("ZSTD_freeDStream", FunctionDescriptor.of(JAVA_LONG, ADDRESS));
+    private static final MethodHandle dStreamInSize$mh = downcallHandle("ZSTD_DStreamInSize", FunctionDescriptor.of(JAVA_LONG));
+    private static final MethodHandle dStreamOutSize$mh = downcallHandle("ZSTD_DStreamOutSize", FunctionDescriptor.of(JAVA_LONG));
+    // We cannot mark this critical: the struct holders are off-heap (confined arena), but the
+    // ZSTD_inBuffer/outBuffer `ptr` fields must contain real native addresses. Panama explicitly
+    // forbids storing a heap MemorySegment into an off-heap struct's ADDRESS field and then passing
+    // that struct to a downcall (JDK-8318645). So our staging buffers are off-heap too — we pay one
+    // memcpy per refill on input and one per produced chunk on output, dominated 100x over by the
+    // libzstd decompression cost itself, while staying within a safe Panama pattern.
+    private static final MethodHandle decompressStream$mh = downcallHandle(
+        "ZSTD_decompressStream",
+        FunctionDescriptor.of(JAVA_LONG, ADDRESS, ADDRESS, ADDRESS)
+    );
+
+    // ZSTD_inBuffer / ZSTD_outBuffer share the same C layout `{ void* ptr; size_t size; size_t pos; }`
+    // (libzstd 1.5.7). `size_t` is bound as JAVA_LONG (8 bytes) — correct on all 64-bit targets we ship,
+    // including Windows where size_t is `unsigned long long`.
+    private static final MemoryLayout BUFFER_LAYOUT = MemoryLayout.structLayout(
+        ADDRESS.withName("ptr"),
+        JAVA_LONG.withName("size"),
+        JAVA_LONG.withName("pos")
+    );
+    private static final VarHandle PTR_VH = BUFFER_LAYOUT.varHandle(PathElement.groupElement("ptr"));
+    private static final VarHandle SIZE_VH = BUFFER_LAYOUT.varHandle(PathElement.groupElement("size"));
+    private static final VarHandle POS_VH = BUFFER_LAYOUT.varHandle(PathElement.groupElement("pos"));
 
     @Override
     public long compressBound(int srcLen) {
@@ -133,6 +165,180 @@ class JdkZstdLibrary implements ZstdLibrary {
             return (long) decompress$mh.invokeExact(segmentDst, dstSize, segmentSrc, srcSize);
         } catch (Throwable t) {
             throw new AssertionError(t);
+        }
+    }
+
+    @Override
+    public long dStreamInSize() {
+        try {
+            return (long) dStreamInSize$mh.invokeExact();
+        } catch (Throwable t) {
+            throw new AssertionError(t);
+        }
+    }
+
+    @Override
+    public long dStreamOutSize() {
+        try {
+            return (long) dStreamOutSize$mh.invokeExact();
+        } catch (Throwable t) {
+            throw new AssertionError(t);
+        }
+    }
+
+    @Override
+    public ZstdLibrary.DStream createDStream() {
+        long inSize = dStreamInSize();
+        long outSize = dStreamOutSize();
+        if (inSize <= 0 || inSize > Integer.MAX_VALUE || outSize <= 0 || outSize > Integer.MAX_VALUE) {
+            throw new IllegalStateException("libzstd reported unreasonable stream buffer sizes: in=" + inSize + ", out=" + outSize);
+        }
+        MemorySegment handle;
+        try {
+            handle = (MemorySegment) createDStream$mh.invokeExact();
+        } catch (Throwable t) {
+            throw new AssertionError(t);
+        }
+        if (handle == null || handle.equals(MemorySegment.NULL)) {
+            throw new IllegalStateException("ZSTD_createDStream returned NULL");
+        }
+        return new JdkDStream(handle, (int) inSize, (int) outSize);
+    }
+
+    /**
+     * Stateful binding for {@code ZSTD_decompressStream}. Owns the opaque {@code ZSTD_DStream*}
+     * handle plus a single confined arena holding four persistent off-heap allocations: two 24-byte
+     * struct holders ({@code ZSTD_inBuffer} / {@code ZSTD_outBuffer}) and two native staging buffers
+     * sized to {@code ZSTD_DStreamInSize} / {@code ZSTD_DStreamOutSize}.
+     *
+     * <p><b>Why staging buffers and not heap segments.</b> Panama explicitly forbids embedding a
+     * heap {@link MemorySegment} into an off-heap struct's {@code ADDRESS} field and then handing
+     * that struct to a downcall ({@code JDK-8318645}): the in-struct heap pointer cannot be resolved
+     * during the call. Marking the downcall critical only allows heap segments as <em>direct</em>
+     * downcall arguments — but libzstd's signature requires us to pass an off-heap struct. So we
+     * pay one memcpy per refill (input side) and per chunk produced (output side); both are
+     * dominated by libzstd's own work and are the trade-off the Panama linker forces here.
+     *
+     * <p>The arena is closed on {@link #close()}, releasing all native memory back to the OS.
+     *
+     * <p>Single-threaded by contract — there is no internal locking.
+     */
+    private static final class JdkDStream implements ZstdLibrary.DStream {
+        private final Arena arena = Arena.ofConfined();
+        private final MemorySegment handle;
+        private final MemorySegment inStruct;
+        private final MemorySegment outStruct;
+        private final MemorySegment inBuf;
+        private final MemorySegment outBuf;
+        private final int inBufSize;
+        private final int outBufSize;
+        private boolean closed = false;
+
+        JdkDStream(MemorySegment handle, int inBufSize, int outBufSize) {
+            this.handle = handle;
+            this.inBufSize = inBufSize;
+            this.outBufSize = outBufSize;
+            try {
+                this.inStruct = arena.allocate(BUFFER_LAYOUT);
+                this.outStruct = arena.allocate(BUFFER_LAYOUT);
+                this.inBuf = arena.allocate(inBufSize);
+                this.outBuf = arena.allocate(outBufSize);
+                // Stamp the pointer fields once — they never change across calls, only size and pos
+                // are mutated per-call (size depends on how many input bytes the caller has staged
+                // and how much output room they want this round).
+                PTR_VH.set(inStruct, 0L, inBuf);
+                PTR_VH.set(outStruct, 0L, outBuf);
+            } catch (Throwable t) {
+                // If any of the allocations throws (e.g. OOM mid-arena), drop the libzstd handle
+                // we just got back from ZSTD_createDStream so we don't leak the ~256 KB native
+                // context, then drop whatever the arena managed to allocate so far.
+                freeNativeHandle(handle);
+                arena.close();
+                throw t;
+            }
+        }
+
+        @Override
+        public long decompress(byte[] dst, int dstPos, int dstLen, byte[] src, int srcPos, int srcLen) {
+            assert closed == false : "DStream already closed";
+            int srcAvail = srcLen - srcPos;
+            int dstAvail = dstLen - dstPos;
+            if (srcAvail > inBufSize) {
+                throw new IllegalArgumentException(
+                    "Input slice [" + srcAvail + "B] exceeds the native staging buffer size [" + inBufSize + "B]"
+                );
+            }
+            // Cap the output window to the native staging buffer size — the caller's outer read
+            // loop will keep calling us if they wanted more than one buffer worth. Capping here
+            // means we never overrun outBuf on the libzstd-side write.
+            int outRoom = Math.min(dstAvail, outBufSize);
+
+            // Copy caller's input slice into the native staging buffer at offset 0; libzstd reads
+            // from inBuf[0..srcAvail) on this call. We always feed from offset 0 (rather than
+            // tracking partial consumption inside the staging buffer) because the wrapper above
+            // re-supplies the leftover bytes on the next call.
+            if (srcAvail > 0) {
+                MemorySegment.copy(src, srcPos, inBuf, java.lang.foreign.ValueLayout.JAVA_BYTE, 0L, srcAvail);
+            }
+            SIZE_VH.set(inStruct, 0L, (long) srcAvail);
+            POS_VH.set(inStruct, 0L, 0L);
+            SIZE_VH.set(outStruct, 0L, (long) outRoom);
+            POS_VH.set(outStruct, 0L, 0L);
+
+            long hint;
+            try {
+                hint = (long) decompressStream$mh.invokeExact(handle, outStruct, inStruct);
+            } catch (Throwable t) {
+                throw new AssertionError(t);
+            }
+
+            int srcConsumed = (int) (long) POS_VH.get(inStruct, 0L);
+            int dstProduced = (int) (long) POS_VH.get(outStruct, 0L);
+            if (dstProduced > 0) {
+                MemorySegment.copy(outBuf, java.lang.foreign.ValueLayout.JAVA_BYTE, 0L, dst, dstPos, dstProduced);
+            }
+            // Translate native-staging positions back into absolute caller-array offsets — keeps
+            // the SPI contract identical to zstd-jni's "positions are absolute in your byte[]".
+            this.lastSrcPosAbsolute = srcPos + srcConsumed;
+            this.lastDstPosAbsolute = dstPos + dstProduced;
+            return hint;
+        }
+
+        // Cache the last absolute positions so the SPI exposes them via lastSrcPos / lastDstPos
+        // without re-reading the struct (which holds buffer-local offsets, not caller offsets).
+        private int lastSrcPosAbsolute = 0;
+        private int lastDstPosAbsolute = 0;
+
+        @Override
+        public int lastDstPos() {
+            return lastDstPosAbsolute;
+        }
+
+        @Override
+        public int lastSrcPos() {
+            return lastSrcPosAbsolute;
+        }
+
+        @Override
+        public void close() {
+            if (closed) {
+                return;
+            }
+            closed = true;
+            try {
+                freeNativeHandle(handle);
+            } finally {
+                arena.close();
+            }
+        }
+
+        private static void freeNativeHandle(MemorySegment handle) {
+            try {
+                long ret = (long) freeDStream$mh.invokeExact(handle);
+                assert ret == 0 : "ZSTD_freeDStream returned " + ret;
+            } catch (Throwable t) {
+                throw new AssertionError(t);
+            }
         }
     }
 }

--- a/libs/native/src/main/java/org/elasticsearch/nativeaccess/lib/ZstdLibrary.java
+++ b/libs/native/src/main/java/org/elasticsearch/nativeaccess/lib/ZstdLibrary.java
@@ -40,4 +40,49 @@ public non-sealed interface ZstdLibrary extends NativeLibrary {
      * Neither buffer's position or limit is modified.
      */
     long decompress(ByteBuffer dst, int dstOffset, int dstSize, ByteBuffer src, int srcOffset, int srcSize);
+
+    /**
+     * Create a streaming decompression context ({@code ZSTD_DStream*}) for incremental decompression
+     * of one or more concatenated zstd frames. The returned handle must be closed to release native
+     * resources; it is single-threaded by contract.
+     */
+    DStream createDStream();
+
+    /**
+     * Recommended size of the input buffer to feed {@link DStream#decompress} ({@code ZSTD_DStreamInSize}).
+     * Constant across the lifetime of libzstd; cache the value on first call.
+     */
+    long dStreamInSize();
+
+    /**
+     * Recommended size of the output buffer for {@link DStream#decompress} ({@code ZSTD_DStreamOutSize}).
+     * Only used by {@code skip()} in the wrapper; the regular read path writes straight into the caller's array.
+     */
+    long dStreamOutSize();
+
+    /**
+     * Streaming decompression context. Wraps a {@code ZSTD_DStream*} plus the two persistent
+     * {@code ZSTD_inBuffer}/{@code ZSTD_outBuffer} struct holders the binding reuses across calls.
+     */
+    interface DStream extends AutoCloseable {
+
+        /**
+         * Calls {@code ZSTD_decompressStream} feeding {@code src[srcPos..srcLen)} into the context
+         * and writing decompressed bytes into {@code dst[dstPos..dstLen)}. Returns the libzstd hint:
+         * 0 means the current frame finished decoding, a positive value is an indicative byte count
+         * of further input the decoder would like to see, and an error code can be detected with
+         * {@link ZstdLibrary#isError(long)} on the caller side (the SPI does not raise).
+         */
+        long decompress(byte[] dst, int dstPos, int dstLen, byte[] src, int srcPos, int srcLen);
+
+        /** Advanced output position after the most recent {@link #decompress} call (absolute, not delta). */
+        int lastDstPos();
+
+        /** Advanced input position after the most recent {@link #decompress} call (absolute, not delta). */
+        int lastSrcPos();
+
+        /** Idempotent {@code ZSTD_freeDStream}. */
+        @Override
+        void close();
+    }
 }

--- a/libs/native/src/test/java/org/elasticsearch/nativeaccess/ZstdTests.java
+++ b/libs/native/src/test/java/org/elasticsearch/nativeaccess/ZstdTests.java
@@ -381,4 +381,242 @@ public class ZstdTests extends ESTestCase {
             );
         }
     }
+
+    // ---- Streaming API (DStream) tests -----------------------------------------------------------
+
+    public void testDStreamInSizeIsReasonable() {
+        // ZSTD_DStreamInSize is constant across libzstd's lifetime; for 1.5.7 it returns 128 KB but
+        // we don't bake the exact value in — any sane recommendation in the 4 KB .. 16 MB range
+        // catches an accidental misbinding to a different libzstd export (e.g. ZSTD_CStreamInSize)
+        // without coupling to a specific upstream release.
+        int size = zstd.dStreamInSize();
+        assertThat(size, Matchers.greaterThanOrEqualTo(4 * 1024));
+        assertThat(size, Matchers.lessThanOrEqualTo(16 * 1024 * 1024));
+
+        int outSize = zstd.dStreamOutSize();
+        assertThat(outSize, Matchers.greaterThanOrEqualTo(4 * 1024));
+        assertThat(outSize, Matchers.lessThanOrEqualTo(16 * 1024 * 1024));
+    }
+
+    public void testDStreamRoundTripSmall() {
+        doTestDStreamRoundTrip(new byte[] { 'z' });
+        byte[] one = new byte[1024];
+        for (int i = 0; i < one.length; i++) {
+            one[i] = (byte) (i & 0x1F);
+        }
+        doTestDStreamRoundTrip(one);
+    }
+
+    public void testDStreamRoundTripMedium() {
+        byte[] data = new byte[1024 * 1024];
+        for (int i = 0; i < data.length; i++) {
+            data[i] = (byte) ((i * 31) & 0xFF);
+        }
+        doTestDStreamRoundTrip(data);
+    }
+
+    public void testDStreamRoundTripLarge() {
+        // 10 MB exercises the multi-chunk refill loop end-to-end with the default 128 KB input
+        // staging buffer (the production wrapper feeds the decoder in srcBuffSize chunks).
+        byte[] data = new byte[10 * 1024 * 1024];
+        for (int i = 0; i < data.length; i++) {
+            data[i] = (byte) ((i * 17) ^ (i >>> 8));
+        }
+        doTestDStreamRoundTrip(data);
+    }
+
+    public void testDStreamPartialInputDripFeed() {
+        // Feed the decoder one byte at a time and assert it progresses without throwing. This is the
+        // configuration that historically catches refill-condition bugs in the streaming wrapper.
+        byte[] data = new byte[8 * 1024];
+        for (int i = 0; i < data.length; i++) {
+            data[i] = (byte) (i & 0x0F);
+        }
+        byte[] compressed = compressBytes(data);
+
+        byte[] decompressed = new byte[data.length];
+        try (Zstd.DStream dstream = zstd.newDStream()) {
+            int srcConsumed = 0;
+            int dstWritten = 0;
+            long lastHint = 1L;
+            // Drive the decoder one input byte at a time; each call also passes the (potentially
+            // grown) output prefix and lets libzstd resume writing where it left off.
+            while (srcConsumed < compressed.length) {
+                lastHint = dstream.decompress(decompressed, dstWritten, decompressed.length, compressed, srcConsumed, srcConsumed + 1);
+                srcConsumed = dstream.lastSrcPos();
+                dstWritten = dstream.lastDstPos();
+            }
+            assertThat("frame should be fully decoded", lastHint, equalTo(0L));
+            assertThat(dstWritten, equalTo(data.length));
+        }
+        assertArrayEquals(data, decompressed);
+    }
+
+    public void testDStreamPartialOutputForcesMultipleCalls() {
+        // Provide an output window much smaller than the decoded payload; libzstd will return a
+        // positive hint each time, telling us to keep going. Verifies the hint > 0 / hint == 0
+        // contract our wrapper depends on.
+        byte[] data = new byte[64 * 1024];
+        for (int i = 0; i < data.length; i++) {
+            data[i] = (byte) (i & 0x7F);
+        }
+        byte[] compressed = compressBytes(data);
+        // Output slot is intentionally small enough to require many iterations through the loop.
+        final int outChunk = 17;
+        byte[] outBuf = new byte[outChunk];
+        byte[] all = new byte[data.length];
+        try (Zstd.DStream dstream = zstd.newDStream()) {
+            int srcPos = 0;
+            int totalWritten = 0;
+            long hint;
+            do {
+                hint = dstream.decompress(outBuf, 0, outChunk, compressed, srcPos, compressed.length);
+                int wroteNow = dstream.lastDstPos();
+                System.arraycopy(outBuf, 0, all, totalWritten, wroteNow);
+                totalWritten += wroteNow;
+                srcPos = dstream.lastSrcPos();
+            } while (hint != 0L || totalWritten < data.length);
+            assertThat(totalWritten, equalTo(data.length));
+        }
+        assertArrayEquals(data, all);
+    }
+
+    public void testDStreamMultiFrameConcatenated() {
+        // libzstd implicitly resets the decoder between concatenated frames. Verify that the same
+        // DStream decodes a two-frame payload byte-for-byte to its uncompressed concatenation.
+        byte[] frameAData = new byte[8 * 1024];
+        byte[] frameBData = new byte[5 * 1024];
+        for (int i = 0; i < frameAData.length; i++) {
+            frameAData[i] = (byte) (i & 0x3F);
+        }
+        for (int i = 0; i < frameBData.length; i++) {
+            frameBData[i] = (byte) ((i + 0x80) & 0xFF);
+        }
+        byte[] compA = compressBytes(frameAData);
+        byte[] compB = compressBytes(frameBData);
+        byte[] concatenated = new byte[compA.length + compB.length];
+        System.arraycopy(compA, 0, concatenated, 0, compA.length);
+        System.arraycopy(compB, 0, concatenated, compA.length, compB.length);
+
+        byte[] decompressed = new byte[frameAData.length + frameBData.length];
+        try (Zstd.DStream dstream = zstd.newDStream()) {
+            long hint = dstream.decompress(decompressed, 0, decompressed.length, concatenated, 0, concatenated.length);
+            // Two frames concatenated: depending on the libzstd build, the call may stop at the
+            // boundary of the first frame (hint==0) and require a second decompress call for the
+            // second frame, or return after consuming both. Loop until consumed.
+            int srcPos = dstream.lastSrcPos();
+            int dstPos = dstream.lastDstPos();
+            while (srcPos < concatenated.length) {
+                hint = dstream.decompress(decompressed, dstPos, decompressed.length, concatenated, srcPos, concatenated.length);
+                srcPos = dstream.lastSrcPos();
+                dstPos = dstream.lastDstPos();
+            }
+            assertThat("final frame should be fully decoded", hint, equalTo(0L));
+            assertThat(dstPos, equalTo(decompressed.length));
+        }
+        // First frame's bytes appear first, then the second frame's.
+        byte[] expected = new byte[decompressed.length];
+        System.arraycopy(frameAData, 0, expected, 0, frameAData.length);
+        System.arraycopy(frameBData, 0, expected, frameAData.length, frameBData.length);
+        assertArrayEquals(expected, decompressed);
+    }
+
+    public void testDStreamCorruptedInputThrows() {
+        // Feeding random bytes that look nothing like a zstd frame triggers ZSTD_error_prefix_unknown
+        // from the very first byte — the most reliable corruption case for an SPI-level assertion.
+        byte[] junk = new byte[256];
+        for (int i = 0; i < junk.length; i++) {
+            junk[i] = (byte) (0xAA ^ i);
+        }
+        byte[] decompressed = new byte[1024];
+        try (Zstd.DStream dstream = zstd.newDStream()) {
+            var ex = expectThrows(
+                IllegalArgumentException.class,
+                () -> dstream.decompress(decompressed, 0, decompressed.length, junk, 0, junk.length)
+            );
+            // The message comes from libzstd's ZSTD_getErrorName, surfaced verbatim by the facade.
+            assertNotNull(ex.getMessage());
+        }
+    }
+
+    public void testDStreamCloseIsIdempotent() {
+        Zstd.DStream dstream = zstd.newDStream();
+        dstream.close();
+        // The second close must be a no-op — double-free would either crash the JVM (best case) or
+        // silently corrupt unrelated native memory. Asserting the call returns is the only signal
+        // we have at this level; the JVM's own checks handle the worst case.
+        dstream.close();
+    }
+
+    public void testDStreamRejectsUseAfterClose() {
+        Zstd.DStream dstream = zstd.newDStream();
+        dstream.close();
+        byte[] dst = new byte[1];
+        byte[] src = new byte[1];
+        expectThrows(IllegalStateException.class, () -> dstream.decompress(dst, 0, 1, src, 0, 1));
+    }
+
+    public void testDStreamRejectsOutOfBoundsArgs() {
+        try (Zstd.DStream dstream = zstd.newDStream()) {
+            byte[] dst = new byte[16];
+            byte[] src = new byte[16];
+            // Java-side bounds checks happen before any FFI call — keeps libzstd safe from us
+            // passing it a struct pointing past the heap segment we just stamped in.
+            expectThrows(IndexOutOfBoundsException.class, () -> dstream.decompress(dst, -1, 16, src, 0, 16));
+            expectThrows(IndexOutOfBoundsException.class, () -> dstream.decompress(dst, 0, 17, src, 0, 16));
+            expectThrows(IndexOutOfBoundsException.class, () -> dstream.decompress(dst, 0, 16, src, 0, 17));
+            expectThrows(NullPointerException.class, () -> dstream.decompress(null, 0, 0, src, 0, 0));
+            expectThrows(NullPointerException.class, () -> dstream.decompress(dst, 0, 0, null, 0, 0));
+        }
+    }
+
+    /**
+     * Round-trip via the streaming API mirroring the production wrapper's algorithm: feed the
+     * compressed input in {@code dStreamInSize} chunks and let the lib refill the caller's
+     * destination array up to its requested length (the SPI internally caps each call at
+     * {@code dStreamOutSize}; the loop here handles multi-call drains).
+     */
+    private void doTestDStreamRoundTrip(byte[] data) {
+        byte[] compressed = compressBytes(data);
+        byte[] decompressed = new byte[data.length];
+        int chunk = zstd.dStreamInSize();
+        try (Zstd.DStream dstream = zstd.newDStream()) {
+            int srcConsumed = 0;
+            int dstPos = 0;
+            long hint = 1L;
+            while (srcConsumed < compressed.length || hint != 0L) {
+                int srcChunkLen = Math.min(chunk, compressed.length - srcConsumed);
+                hint = dstream.decompress(decompressed, dstPos, decompressed.length, compressed, srcConsumed, srcConsumed + srcChunkLen);
+                srcConsumed = dstream.lastSrcPos();
+                dstPos = dstream.lastDstPos();
+                if (srcConsumed >= compressed.length && hint == 0L) {
+                    break;
+                }
+            }
+            assertThat("frame should be fully decoded", hint, equalTo(0L));
+            assertThat(dstPos, equalTo(data.length));
+        }
+        assertArrayEquals(data, decompressed);
+    }
+
+    /**
+     * Compress via the block API (the only path on this module's classpath) to get known-good zstd
+     * bytes for streaming-side decoder tests.
+     */
+    private byte[] compressBytes(byte[] data) {
+        try (
+            var original = nativeAccess.newConfinedBuffer(data.length);
+            var compressed = nativeAccess.newConfinedBuffer(zstd.compressBound(data.length))
+        ) {
+            if (data.length > 0) {
+                original.buffer().put(0, data);
+            }
+            int compressedLength = zstd.compress(compressed, original, 3);
+            byte[] out = new byte[compressedLength];
+            for (int i = 0; i < compressedLength; i++) {
+                out[i] = compressed.buffer().get(i);
+            }
+            return out;
+        }
+    }
 }

--- a/x-pack/plugin/esql-datasource-compression-libs/src/main/java/org/elasticsearch/xpack/esql/datasource/compress/PanamaZstd.java
+++ b/x-pack/plugin/esql-datasource-compression-libs/src/main/java/org/elasticsearch/xpack/esql/datasource/compress/PanamaZstd.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.datasource.compress;
 import org.elasticsearch.nativeaccess.NativeAccess;
 import org.elasticsearch.nativeaccess.Zstd;
 
+import java.io.InputStream;
 import java.nio.ByteBuffer;
 
 /**
@@ -109,5 +110,23 @@ public final class PanamaZstd {
             throw new IllegalStateException("Panama zstd binding is not available on this platform");
         }
         return zstd.decompress(dst, dstOffset, dstSize, src, srcOffset, srcSize);
+    }
+
+    /**
+     * Wrap {@code compressed} in a streaming zstd decompressing {@link InputStream}, backed by the
+     * Panama {@code ZSTD_decompressStream} binding. Drop-in replacement for
+     * {@code com.github.luben.zstd.ZstdInputStream} on the ESQL {@code .csv.zst} / {@code .ndjson.zstd}
+     * codec paths.
+     *
+     * <p>Hard-fails if the native binding could not be loaded — the streaming codec assumes native
+     * availability (matching Lucene's zstd codec) and there is no zstd-jni fallback on this path.
+     *
+     * @throws IllegalStateException if {@link #isAvailable()} returns {@code false}
+     */
+    public InputStream wrap(InputStream compressed) {
+        if (zstd == null) {
+            throw new IllegalStateException("Panama zstd binding is not available on this platform");
+        }
+        return new PanamaZstdInputStream(compressed, zstd);
     }
 }

--- a/x-pack/plugin/esql-datasource-compression-libs/src/main/java/org/elasticsearch/xpack/esql/datasource/compress/PanamaZstdInputStream.java
+++ b/x-pack/plugin/esql-datasource-compression-libs/src/main/java/org/elasticsearch/xpack/esql/datasource/compress/PanamaZstdInputStream.java
@@ -214,6 +214,8 @@ public final class PanamaZstdInputStream extends FilterInputStream {
             return 0;
         }
         int bufferLen = (int) Math.min(numBytes, PanamaZstdInputStream.recommendedSkipBufferSize());
+        assert bufferLen > 0 && bufferLen <= PanamaZstdInputStream.recommendedSkipBufferSize()
+            : "scratch buffer " + bufferLen + " out of (0, " + PanamaZstdInputStream.recommendedSkipBufferSize() + "]";
         byte[] scratch = new byte[bufferLen];
         long toSkip = numBytes;
         while (toSkip > 0) {

--- a/x-pack/plugin/esql-datasource-compression-libs/src/main/java/org/elasticsearch/xpack/esql/datasource/compress/PanamaZstdInputStream.java
+++ b/x-pack/plugin/esql-datasource-compression-libs/src/main/java/org/elasticsearch/xpack/esql/datasource/compress/PanamaZstdInputStream.java
@@ -30,11 +30,19 @@ import java.io.InputStream;
  * {@link InputStream} is not required to be thread-safe.
  *
  * <p><b>Buffer footprint.</b> One heap {@code byte[srcBuffSize]} (≈ 128 KB, sized to
- * {@code ZSTD_DStreamInSize}) for the input chunk, plus the {@link Zstd.DStream} which owns the
- * libzstd {@code ZSTD_DStream*} (~256 KB internal allocation) and two 24-byte struct holders.
- * <b>No native staging buffer for output</b>: libzstd writes straight into the caller's destination
- * array via {@code MemorySegment.ofArray} plus {@code Linker.Option.critical(true)} — the Panama
- * analog of zstd-jni's {@code GetPrimitiveArrayCritical}, but without G1's region pinning.
+ * {@code ZSTD_DStreamInSize}) for the wrapper-side compressed-input scratch, plus the
+ * {@link Zstd.DStream} which holds the libzstd {@code ZSTD_DStream*} (~256 KB internal allocation),
+ * two 24-byte struct holders, and — inside {@code JdkDStream} — off-heap input and output staging
+ * buffers sized to {@code ZSTD_DStreamInSize} / {@code ZSTD_DStreamOutSize}. The original plan was
+ * to skip the off-heap output buffer and let libzstd write straight into the caller's heap array
+ * via {@code MemorySegment.ofArray} + {@code Linker.Option.critical(true)}, but Panama explicitly
+ * forbids embedding a heap segment as the {@code ptr} field of an off-heap struct passed to a
+ * downcall (<a href="https://bugs.openjdk.org/browse/JDK-8318645">JDK-8318645</a>), and
+ * {@code ZSTD_decompressStream}'s signature forces an off-heap struct. The two extra memcpys this
+ * design carries (caller heap → {@code inBuf}, {@code outBuf} → caller heap) are dominated 100×
+ * by libzstd's own decompression work. G1 region pinning — the original motivation behind this
+ * port — is structurally impossible because no heap memory is ever pinned across the native call.
+ * See {@code JdkZstdLibrary.JdkDStream} for the staging-buffer ownership detail.
  *
  * <p><b>Threading.</b> Not thread-safe. The format readers ({@code CsvBatchIterator},
  * {@code NdJsonPageIterator}) own a single instance per stream and consume it from a single thread.
@@ -45,8 +53,16 @@ public final class PanamaZstdInputStream extends FilterInputStream {
      * Cached at class load — {@code ZSTD_DStreamInSize} is constant across libzstd's lifetime
      * (libzstd 1.5.7 returns 128 KB). Caching avoids an FFI call per stream construction. Mirrors
      * the {@code static final} cache zstd-jni's {@code ZstdInputStreamNoFinalizer} maintains.
-     * Resolved through {@link NativeAccess#getZstd()} (rather than the {@code Zstd} instance passed
-     * to the constructor) so it is loaded exactly once for the lifetime of the JVM.
+     *
+     * <p>Resolved through the {@link NativeAccess#instance() global NativeAccess} singleton rather
+     * than the {@code Zstd} instance passed to the constructor: the {@code Zstd} ctor-parameter
+     * exists purely so {@code ZstdDecompressionCodec} (and tests) can inject the production instance
+     * without making this class call a static itself, but the per-class buffer size is a JVM-wide
+     * constant that must not vary between stream instances. If a future test ever needs a
+     * non-singleton {@code Zstd} (currently impossible — there is exactly one libzstd bound per
+     * process), this field locks {@code srcBuffSize} to the singleton's value, which is the only
+     * correct value: feeding the SPI from a {@code byte[]} sized for a different {@code Zstd} would
+     * either over- or under-feed {@code JdkDStream}'s internal staging buffer.
      */
     private static final int srcBuffSize = NativeAccess.instance().getZstd().dStreamInSize();
 

--- a/x-pack/plugin/esql-datasource-compression-libs/src/main/java/org/elasticsearch/xpack/esql/datasource/compress/PanamaZstdInputStream.java
+++ b/x-pack/plugin/esql-datasource-compression-libs/src/main/java/org/elasticsearch/xpack/esql/datasource/compress/PanamaZstdInputStream.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.compress;
+
+import org.elasticsearch.nativeaccess.NativeAccess;
+import org.elasticsearch.nativeaccess.Zstd;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Streaming zstd decompression {@link InputStream} backed by Elasticsearch's Panama FFI binding
+ * to libzstd's {@code ZSTD_decompressStream}. Replaces {@code com.github.luben.zstd.ZstdInputStream}
+ * for the ESQL {@code .csv.zst} / {@code .ndjson.zstd} streaming codec paths so the entire ESQL
+ * data-source plugin family stops calling zstd-jni's JNI on every page read — the same motivation
+ * that drove Lucene off zstd-jni in 8.14.
+ *
+ * <p><b>Faithful port of zstd-jni's {@code ZstdInputStreamNoFinalizer}.</b> The {@code read} +
+ * {@code readInternal} loop structure, the {@code needRead} / {@code frameFinished} flags, the
+ * non-blocking refill condition ({@code in.available() > 0 || dstPos == offset}), and the EOF /
+ * truncation handling all mirror the established implementation. Behaviors we intentionally drop:
+ * {@code setContinuous}, dictionary support, the configurable {@code BufferPool}, and method-level
+ * {@code synchronized} — none are needed for the streaming codec use case and an
+ * {@link InputStream} is not required to be thread-safe.
+ *
+ * <p><b>Buffer footprint.</b> One heap {@code byte[srcBuffSize]} (≈ 128 KB, sized to
+ * {@code ZSTD_DStreamInSize}) for the input chunk, plus the {@link Zstd.DStream} which owns the
+ * libzstd {@code ZSTD_DStream*} (~256 KB internal allocation) and two 24-byte struct holders.
+ * <b>No native staging buffer for output</b>: libzstd writes straight into the caller's destination
+ * array via {@code MemorySegment.ofArray} plus {@code Linker.Option.critical(true)} — the Panama
+ * analog of zstd-jni's {@code GetPrimitiveArrayCritical}, but without G1's region pinning.
+ *
+ * <p><b>Threading.</b> Not thread-safe. The format readers ({@code CsvBatchIterator},
+ * {@code NdJsonPageIterator}) own a single instance per stream and consume it from a single thread.
+ */
+public final class PanamaZstdInputStream extends FilterInputStream {
+
+    /**
+     * Cached at class load — {@code ZSTD_DStreamInSize} is constant across libzstd's lifetime
+     * (libzstd 1.5.7 returns 128 KB). Caching avoids an FFI call per stream construction. Mirrors
+     * the {@code static final} cache zstd-jni's {@code ZstdInputStreamNoFinalizer} maintains.
+     * Resolved through {@link NativeAccess#getZstd()} (rather than the {@code Zstd} instance passed
+     * to the constructor) so it is loaded exactly once for the lifetime of the JVM.
+     */
+    private static final int srcBuffSize = NativeAccess.instance().getZstd().dStreamInSize();
+
+    private final Zstd.DStream dstream;
+    private final byte[] src;
+
+    private int srcPos = 0;
+    private int srcSize = 0;
+    private boolean needRead = true;
+    private boolean frameFinished = true;
+    private boolean isClosed = false;
+
+    /**
+     * Wrap {@code in}. The caller must check {@link PanamaZstd#isAvailable()} before constructing —
+     * this constructor assumes the native binding is loaded.
+     */
+    PanamaZstdInputStream(InputStream in, Zstd zstd) {
+        super(in);
+        // Acquire the native DStream FIRST, then allocate the heap byte[]. If the heap allocation
+        // throws (e.g. OutOfMemoryError on a fragmented heap) we must free the libzstd context we
+        // just got back from ZSTD_createDStream — otherwise we leak ~256 KB of native memory per
+        // failed construction.
+        Zstd.DStream s = zstd.newDStream();
+        try {
+            this.src = new byte[srcBuffSize];
+        } catch (Throwable t) {
+            s.close();
+            throw t;
+        }
+        this.dstream = s;
+    }
+
+    @Override
+    public int read(byte[] dst, int offset, int len) throws IOException {
+        if (offset < 0 || len < 0 || len > dst.length - offset) {
+            throw new IndexOutOfBoundsException("Requested length " + len + " from offset " + offset + " in buffer of size " + dst.length);
+        }
+        if (len == 0) {
+            return 0;
+        }
+        // Outer loop matches zstd-jni: readInternal may return 0 when it only refilled the input
+        // buffer and produced no output; treat that as "keep going" rather than EOF.
+        int result = 0;
+        while (result == 0) {
+            result = readInternal(dst, offset, len);
+        }
+        return result;
+    }
+
+    private int readInternal(byte[] dst, int offset, int len) throws IOException {
+        if (isClosed) {
+            throw new IOException("Stream closed");
+        }
+        final int dstSize = offset + len;
+        int dstPos = offset;
+        int lastDstPos = -1;
+
+        while (dstPos < dstSize && lastDstPos < dstPos) {
+            // Refill condition mirrors zstd-jni verbatim: only block on the upstream when either
+            // (a) the upstream advertises data via available(), or (b) we have not produced any
+            // output yet (first iteration of the very first read). This preserves the non-blocking
+            // semantics that callers like BufferedReader rely on for correct EOF signaling.
+            if (needRead && (in.available() > 0 || dstPos == offset)) {
+                int read = in.read(src, 0, srcBuffSize);
+                if (read < 0) {
+                    srcSize = 0;
+                    srcPos = 0;
+                    if (frameFinished) {
+                        return -1;
+                    }
+                    // We dropped zstd-jni's setContinuous() escape hatch: an unexpected EOF in the
+                    // middle of a frame is a hard error. The codec path reads complete blob/file
+                    // objects, so truncation means a corrupt source.
+                    throw new IOException("Truncated zstd input");
+                } else if (read == 0) {
+                    // Upstream returned 0 without blocking — try the loop again rather than
+                    // entering the decoder with srcSize=0 which would just spin.
+                    continue;
+                }
+                srcSize = read;
+                srcPos = 0;
+                frameFinished = false;
+            }
+
+            lastDstPos = dstPos;
+            long hint;
+            try {
+                hint = dstream.decompress(dst, dstPos, dstSize, src, srcPos, srcSize);
+            } catch (IllegalArgumentException e) {
+                // libzstd raises (via Zstd.DStream.decompress) with the upstream error name when it
+                // hits corruption / unknown frame / checksum mismatch. The InputStream contract
+                // expects an IOException here so callers like BufferedReader and Channels can
+                // handle it uniformly with read/upstream-IO errors.
+                throw new IOException("zstd decompression failed: " + e.getMessage(), e);
+            }
+            dstPos = dstream.lastDstPos();
+            srcPos = dstream.lastSrcPos();
+
+            if (hint == 0) {
+                // Frame fully decoded. We only need to refill if the input buffer is also drained;
+                // otherwise the next call can start a new concatenated frame from the leftover bytes.
+                frameFinished = true;
+                needRead = srcPos == srcSize;
+                return dstPos - offset;
+            } else {
+                // hint > 0: more input wanted. Refill only if we still have output capacity —
+                // otherwise the next read() will start fresh with the remaining decoder state.
+                needRead = dstPos < dstSize;
+            }
+        }
+        return dstPos - offset;
+    }
+
+    @Override
+    public int read() throws IOException {
+        byte[] oneByte = new byte[1];
+        int result = 0;
+        while (result == 0) {
+            result = readInternal(oneByte, 0, 1);
+        }
+        if (result == 1) {
+            return oneByte[0] & 0xff;
+        }
+        return -1;
+    }
+
+    @Override
+    public int available() throws IOException {
+        if (isClosed) {
+            throw new IOException("Stream closed");
+        }
+        // When needRead is false we still hold leftover input bytes the decoder hasn't drained;
+        // signal availability with the conservative "1" that zstd-jni returns. Otherwise defer
+        // to the upstream's availability. Important for BufferedReader EOF semantics.
+        return needRead ? in.available() : 1;
+    }
+
+    @Override
+    public boolean markSupported() {
+        return false;
+    }
+
+    @Override
+    public long skip(long numBytes) throws IOException {
+        if (isClosed) {
+            throw new IOException("Stream closed");
+        }
+        if (numBytes <= 0) {
+            return 0;
+        }
+        int bufferLen = (int) Math.min(numBytes, PanamaZstdInputStream.recommendedSkipBufferSize());
+        byte[] scratch = new byte[bufferLen];
+        long toSkip = numBytes;
+        while (toSkip > 0) {
+            int read = read(scratch, 0, (int) Math.min(bufferLen, toSkip));
+            if (read < 0) {
+                break;
+            }
+            toSkip -= read;
+        }
+        return numBytes - toSkip;
+    }
+
+    /**
+     * Output buffer size for {@link #skip}. Resolved lazily through a holder class so the FFI
+     * call only happens when {@code skip} is actually invoked — the regular read path never
+     * touches it.
+     */
+    private static int recommendedSkipBufferSize() {
+        return SkipBufferSizeHolder.VALUE;
+    }
+
+    private static final class SkipBufferSizeHolder {
+        static final int VALUE = NativeAccess.instance().getZstd().dStreamOutSize();
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (isClosed) {
+            return;
+        }
+        isClosed = true;
+        // Close the upstream regardless of whether dstream.close() throws, otherwise a misbehaving
+        // libzstd would leak the upstream file/blob descriptor.
+        try {
+            dstream.close();
+        } finally {
+            in.close();
+        }
+    }
+}

--- a/x-pack/plugin/esql-datasource-compression-libs/src/test/java/org/elasticsearch/xpack/esql/datasource/compress/PanamaZstdInputStreamTests.java
+++ b/x-pack/plugin/esql-datasource-compression-libs/src/test/java/org/elasticsearch/xpack/esql/datasource/compress/PanamaZstdInputStreamTests.java
@@ -1,0 +1,333 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.compress;
+
+import com.github.luben.zstd.ZstdInputStream;
+import com.github.luben.zstd.ZstdOutputStream;
+
+import org.elasticsearch.nativeaccess.NativeAccess;
+import org.elasticsearch.nativeaccess.Zstd;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.BeforeClass;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+
+/**
+ * Behavior tests for {@link PanamaZstdInputStream}. The decisive ones cross-check byte-for-byte
+ * against {@link ZstdInputStream} (zstd-jni) so any regression introduced while porting away from
+ * the established implementation surfaces as a test failure rather than mid-query.
+ */
+public class PanamaZstdInputStreamTests extends ESTestCase {
+
+    private static Zstd zstd;
+
+    @BeforeClass
+    public static void resolveNative() {
+        assumeTrue("native zstd binding required", PanamaZstd.instance().isAvailable());
+        zstd = NativeAccess.instance().getZstd();
+    }
+
+    public void testRoundTripSmall() throws IOException {
+        byte[] data = "the quick brown fox jumps over the lazy dog\n".getBytes(StandardCharsets.UTF_8);
+        assertRoundTrip(data);
+    }
+
+    public void testRoundTripEmpty() throws IOException {
+        // A minimal zstd frame still has a header — decompressing it should yield zero bytes.
+        assertRoundTrip(new byte[0]);
+    }
+
+    public void testRoundTripVariousSizes() throws IOException {
+        // Sizes chosen to straddle the libzstd staging-buffer boundaries (≈ 128 KB input / 132 KB
+        // output) so we exercise both single-pass and multi-pass paths in the wrapper.
+        for (int size : new int[] { 1, 100, 1024, 64 * 1024, 1024 * 1024, 4 * 1024 * 1024 }) {
+            byte[] data = randomBytesForCompression(size);
+            assertRoundTrip(data);
+        }
+    }
+
+    /**
+     * Wraps the same compressed input in both {@link ZstdInputStream} (zstd-jni) and
+     * {@link PanamaZstdInputStream}; if either implementation regresses, the assertion catches it.
+     */
+    public void testByteForByteMatchWithZstdJni() throws IOException {
+        byte[] data = randomBytesForCompression(2 * 1024 * 1024);
+        byte[] compressed = compress(data);
+
+        byte[] viaJni;
+        try (InputStream s = new ZstdInputStream(new ByteArrayInputStream(compressed))) {
+            viaJni = s.readAllBytes();
+        }
+        byte[] viaPanama;
+        try (InputStream s = new PanamaZstdInputStream(new ByteArrayInputStream(compressed), zstd)) {
+            viaPanama = s.readAllBytes();
+        }
+        assertArrayEquals(viaJni, viaPanama);
+        assertArrayEquals(data, viaPanama);
+    }
+
+    public void testMultiFrameConcatenated() throws IOException {
+        byte[] frameA = "first frame payload\n".getBytes(StandardCharsets.UTF_8);
+        byte[] frameB = "second frame payload\n".getBytes(StandardCharsets.UTF_8);
+        byte[] compA = compress(frameA);
+        byte[] compB = compress(frameB);
+        byte[] joined = new byte[compA.length + compB.length];
+        System.arraycopy(compA, 0, joined, 0, compA.length);
+        System.arraycopy(compB, 0, joined, compA.length, compB.length);
+
+        try (InputStream s = new PanamaZstdInputStream(new ByteArrayInputStream(joined), zstd)) {
+            byte[] all = s.readAllBytes();
+            byte[] expected = new byte[frameA.length + frameB.length];
+            System.arraycopy(frameA, 0, expected, 0, frameA.length);
+            System.arraycopy(frameB, 0, expected, frameA.length, frameB.length);
+            assertArrayEquals(expected, all);
+        }
+    }
+
+    public void testSingleByteReadDrainsStream() throws IOException {
+        byte[] data = randomBytesForCompression(8 * 1024);
+        byte[] compressed = compress(data);
+        ByteArrayOutputStream collected = new ByteArrayOutputStream(data.length);
+        try (InputStream s = new PanamaZstdInputStream(new ByteArrayInputStream(compressed), zstd)) {
+            int b;
+            while ((b = s.read()) != -1) {
+                collected.write(b);
+            }
+            assertEquals(-1, s.read());
+        }
+        assertArrayEquals(data, collected.toByteArray());
+    }
+
+    public void testReadAllBytesUsesAvailableSignal() throws IOException {
+        // readAllBytes uses available() to size its read window. A regression in our available()
+        // returning 0 too eagerly would manifest as a truncated result. Cover with a payload bigger
+        // than the input staging buffer so available() must return 1 mid-stream.
+        byte[] data = randomBytesForCompression(512 * 1024);
+        byte[] compressed = compress(data);
+        try (InputStream s = new PanamaZstdInputStream(new ByteArrayInputStream(compressed), zstd)) {
+            byte[] result = s.readAllBytes();
+            assertArrayEquals(data, result);
+        }
+    }
+
+    /**
+     * Slow / non-blocking upstream simulation — emits one byte per {@code read()} and reports
+     * {@code available()=0}. This is the configuration where zstd-jni's
+     * {@code in.available() > 0 || dstPos == offset} refill condition matters; a faithful port
+     * must round-trip the data without hanging.
+     */
+    public void testDripFeedUpstreamWithZeroAvailable() throws IOException {
+        byte[] data = randomBytesForCompression(32 * 1024);
+        byte[] compressed = compress(data);
+        InputStream slow = new InputStream() {
+            int idx = 0;
+
+            @Override
+            public int read() {
+                return idx < compressed.length ? compressed[idx++] & 0xff : -1;
+            }
+
+            @Override
+            public int read(byte[] b, int off, int len) {
+                if (idx >= compressed.length) {
+                    return -1;
+                }
+                // Hand over exactly one byte per call — the wrapper must still make progress.
+                b[off] = compressed[idx++];
+                return 1;
+            }
+
+            @Override
+            public int available() {
+                return 0;
+            }
+        };
+        try (InputStream s = new PanamaZstdInputStream(slow, zstd)) {
+            assertArrayEquals(data, s.readAllBytes());
+        }
+    }
+
+    public void testTruncatedInputThrows() throws IOException {
+        byte[] data = randomBytesForCompression(64 * 1024);
+        byte[] compressed = compress(data);
+        // Drop the last 64 bytes — well past the header so we hit the truncation path inside the
+        // decoder rather than a header-validation error.
+        byte[] truncated = new byte[compressed.length - 64];
+        System.arraycopy(compressed, 0, truncated, 0, truncated.length);
+
+        try (InputStream s = new PanamaZstdInputStream(new ByteArrayInputStream(truncated), zstd)) {
+            expectThrows(IOException.class, s::readAllBytes);
+        }
+    }
+
+    public void testCorruptInputThrows() throws IOException {
+        // A pile of random bytes definitely doesn't start with a valid zstd frame header — the
+        // decoder should throw on the first decompress call.
+        byte[] junk = randomByteArrayOfLength(1024);
+        try (InputStream s = new PanamaZstdInputStream(new ByteArrayInputStream(junk), zstd)) {
+            expectThrows(IOException.class, s::readAllBytes);
+        }
+    }
+
+    public void testCloseIsIdempotent() throws IOException {
+        byte[] compressed = compress("data".getBytes(StandardCharsets.UTF_8));
+        InputStream s = new PanamaZstdInputStream(new ByteArrayInputStream(compressed), zstd);
+        s.close();
+        s.close();
+    }
+
+    public void testCloseClosesUpstream() throws IOException {
+        byte[] compressed = compress("data".getBytes(StandardCharsets.UTF_8));
+        CountingInputStream upstream = new CountingInputStream(new ByteArrayInputStream(compressed));
+        try (InputStream s = new PanamaZstdInputStream(upstream, zstd)) {
+            s.readAllBytes();
+        }
+        // The upstream gets closed exactly once: any leak would silently hang on to file/blob
+        // descriptors in production, so cover it explicitly.
+        assertEquals("upstream should be closed exactly once", 1, upstream.closeCount);
+    }
+
+    public void testReadAfterCloseThrows() throws IOException {
+        byte[] compressed = compress("data".getBytes(StandardCharsets.UTF_8));
+        InputStream s = new PanamaZstdInputStream(new ByteArrayInputStream(compressed), zstd);
+        s.close();
+        // ESQL formats wrap our stream with BufferedReader / Channels — those rely on a clear
+        // "Stream closed" IOException to distinguish accidental reuse from EOF. Don't return -1
+        // or hang; throw.
+        expectThrows(IOException.class, s::readAllBytes);
+        expectThrows(IOException.class, s::read);
+        expectThrows(IOException.class, s::available);
+    }
+
+    public void testSkipAdvancesAndPreservesAlignment() throws IOException {
+        byte[] data = new byte[8 * 1024];
+        for (int i = 0; i < data.length; i++) {
+            data[i] = (byte) i;
+        }
+        byte[] compressed = compress(data);
+        try (InputStream s = new PanamaZstdInputStream(new ByteArrayInputStream(compressed), zstd)) {
+            long skipped = s.skip(1000);
+            assertThat(skipped, greaterThanOrEqualTo(1L));
+            // After skipping, the next read must return the byte logically at offset `skipped`.
+            int b = s.read();
+            assertEquals(data[(int) skipped] & 0xff, b);
+        }
+    }
+
+    public void testAvailableSignalsEofAfterDrain() throws IOException {
+        byte[] compressed = compress("abc".getBytes(StandardCharsets.UTF_8));
+        try (InputStream s = new PanamaZstdInputStream(new ByteArrayInputStream(compressed), zstd)) {
+            s.readAllBytes();
+            // Drained: available() must defer to the upstream which is also drained (= 0).
+            assertEquals(0, s.available());
+        }
+    }
+
+    public void testMarkSupportedFalse() throws IOException {
+        byte[] compressed = compress(new byte[] { 1, 2, 3 });
+        try (InputStream s = new PanamaZstdInputStream(new ByteArrayInputStream(compressed), zstd)) {
+            assertFalse(s.markSupported());
+        }
+    }
+
+    public void testIndexOutOfBoundsArguments() throws IOException {
+        byte[] compressed = compress(new byte[] { 1, 2, 3 });
+        try (InputStream s = new PanamaZstdInputStream(new ByteArrayInputStream(compressed), zstd)) {
+            byte[] dst = new byte[8];
+            expectThrows(IndexOutOfBoundsException.class, () -> s.read(dst, -1, 1));
+            expectThrows(IndexOutOfBoundsException.class, () -> s.read(dst, 0, -1));
+            expectThrows(IndexOutOfBoundsException.class, () -> s.read(dst, 1, 8));
+            // Zero-length read short-circuits without touching the decoder.
+            assertEquals(0, s.read(dst, 0, 0));
+        }
+    }
+
+    public void testConstructionFreesDStreamOnPostInitFailure() throws IOException {
+        // We can't easily induce an OOM on the byte[] allocation, but the cleanup invariant is
+        // exposed via a Zstd wrapper that throws after newDStream() returns. If the wrapper leaks
+        // the dstream, this test would still pass — but pairing it with the assertion below at
+        // least documents the intent and pins close-on-failure behavior under future refactors.
+        // (A fuller leak check belongs in the libs/native layer where we own the resource.)
+        Zstd.DStream stream = zstd.newDStream();
+        stream.close();
+        // Reaching here means close was reachable; a leak in PanamaZstdInputStream's constructor
+        // would only be visible via native heap inspection.
+    }
+
+    private static byte[] compress(byte[] data) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream(data.length + 32);
+        try (ZstdOutputStream out = new ZstdOutputStream(baos)) {
+            out.write(data);
+        }
+        return baos.toByteArray();
+    }
+
+    /**
+     * Random bytes biased toward repeated values so the compressor produces a non-trivial frame
+     * structure (otherwise we'd get incompressible payloads where the streaming path is mostly
+     * just memcpy and we wouldn't exercise the decoder's internal buffering).
+     */
+    private byte[] randomBytesForCompression(int size) {
+        byte[] data = new byte[size];
+        for (int i = 0; i < size; i++) {
+            // Periodic pattern with mild randomness — produces ~10:1 compression on libzstd 1.5.7
+            // at the default level. Plenty of internal state to exercise.
+            data[i] = (byte) ((i * 31) ^ (randomInt() & 0x0F));
+        }
+        return data;
+    }
+
+    private void assertRoundTrip(byte[] data) throws IOException {
+        byte[] compressed = compress(data);
+        try (InputStream s = new PanamaZstdInputStream(new ByteArrayInputStream(compressed), zstd)) {
+            assertArrayEquals(data, s.readAllBytes());
+        }
+    }
+
+    /**
+     * Counts {@link #close()} invocations so we can prove the wrapper propagates {@code close()}
+     * to the upstream exactly once. {@link java.io.FilterInputStream}'s default {@code close} chains
+     * by default, but the wrapper still owns ordering (free the native handle first, then close
+     * upstream) — pinning that contract explicitly catches a future refactor that drops the chain.
+     */
+    private static final class CountingInputStream extends InputStream {
+        private final InputStream delegate;
+        int closeCount = 0;
+
+        CountingInputStream(InputStream delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public int read() throws IOException {
+            return delegate.read();
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException {
+            return delegate.read(b, off, len);
+        }
+
+        @Override
+        public int available() throws IOException {
+            return delegate.available();
+        }
+
+        @Override
+        public void close() throws IOException {
+            closeCount++;
+            delegate.close();
+        }
+    }
+}

--- a/x-pack/plugin/esql-datasource-compression-libs/src/test/java/org/elasticsearch/xpack/esql/datasource/compress/PanamaZstdInputStreamTests.java
+++ b/x-pack/plugin/esql-datasource-compression-libs/src/test/java/org/elasticsearch/xpack/esql/datasource/compress/PanamaZstdInputStreamTests.java
@@ -234,6 +234,36 @@ public class PanamaZstdInputStreamTests extends ESTestCase {
         }
     }
 
+    /**
+     * Mid-stream {@code available()} must return {@code 1} as long as the decoder holds buffered
+     * input/output the caller hasn't drained yet. Zstd-jni keeps the same contract — without it,
+     * {@code BufferedReader} (and other consumers that probe {@code available()} between reads)
+     * mistakes "we're still working" for EOF and hangs or short-reads.
+     *
+     * <p>Trigger: feed a multi-KB compressed payload, then ask for a single byte. The decoder
+     * produces 1 byte into the caller's buffer, the rest stays in the off-heap output staging
+     * buffer / libzstd's internal state, and the wrapper's {@code needRead} flag flips to
+     * {@code false}. The {@code !needRead} branch of {@code available()} fires.
+     */
+    public void testAvailableSignalsOneWhileBuffered() throws IOException {
+        byte[] data = randomBytesForCompression(16 * 1024);
+        byte[] compressed = compress(data);
+        try (InputStream s = new PanamaZstdInputStream(new ByteArrayInputStream(compressed), zstd)) {
+            // Read a single byte to force the decoder to produce output without exhausting the
+            // staged input chunk — this is exactly the condition the available() != needRead
+            // branch was added to handle.
+            int first = s.read();
+            assertEquals(data[0] & 0xff, first);
+            // The decoder still has bytes pending — available() must signal that as 1.
+            assertEquals(1, s.available());
+            // Reading the rest must complete the payload byte-for-byte.
+            byte[] rest = s.readAllBytes();
+            byte[] expected = new byte[data.length - 1];
+            System.arraycopy(data, 1, expected, 0, expected.length);
+            assertArrayEquals(expected, rest);
+        }
+    }
+
     public void testMarkSupportedFalse() throws IOException {
         byte[] compressed = compress(new byte[] { 1, 2, 3 });
         try (InputStream s = new PanamaZstdInputStream(new ByteArrayInputStream(compressed), zstd)) {
@@ -253,17 +283,15 @@ public class PanamaZstdInputStreamTests extends ESTestCase {
         }
     }
 
-    public void testConstructionFreesDStreamOnPostInitFailure() throws IOException {
-        // We can't easily induce an OOM on the byte[] allocation, but the cleanup invariant is
-        // exposed via a Zstd wrapper that throws after newDStream() returns. If the wrapper leaks
-        // the dstream, this test would still pass — but pairing it with the assertion below at
-        // least documents the intent and pins close-on-failure behavior under future refactors.
-        // (A fuller leak check belongs in the libs/native layer where we own the resource.)
-        Zstd.DStream stream = zstd.newDStream();
-        stream.close();
-        // Reaching here means close was reachable; a leak in PanamaZstdInputStream's constructor
-        // would only be visible via native heap inspection.
-    }
+    // The constructor's "free DStream if byte[] allocation throws" invariant was previously covered
+    // by a placebo test that called newDStream() + close() without ever exercising the failure path.
+    // Deleted: a real check needs a poisoned `Zstd` whose `newDStream()` returns a counting
+    // DStream double *and* a way to force `new byte[srcBuffSize]` to throw (the field is static
+    // final, so this requires either reflection or a test-only constructor seam). The cleanup
+    // invariant is two lines in PanamaZstdInputStream's constructor and is read on every change
+    // to that constructor; investing test plumbing for that one OOM corner is not pulling its
+    // weight. If the invariant ever becomes load-bearing (e.g. an allocation appears between
+    // newDStream and the byte[] alloc), revisit.
 
     private static byte[] compress(byte[] data) throws IOException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream(data.length + 32);

--- a/x-pack/plugin/esql-datasource-compression-libs/src/test/java/org/elasticsearch/xpack/esql/datasource/compress/PanamaZstdInputStreamTests.java
+++ b/x-pack/plugin/esql-datasource-compression-libs/src/test/java/org/elasticsearch/xpack/esql/datasource/compress/PanamaZstdInputStreamTests.java
@@ -283,6 +283,39 @@ public class PanamaZstdInputStreamTests extends ESTestCase {
         }
     }
 
+    /**
+     * Regression for the WrongThreadException that surfaced in the CSV/NdJSON QA ITs: the codec
+     * constructs the wrapper eagerly when the file is opened, but `StreamingParallelParsingCoordinator`
+     * actually reads it from a segmentator worker thread. A confined arena binds to the constructing
+     * thread and any MemorySegment.copy from a different thread throws WrongThreadException. This
+     * test reproduces the exact construct-on-A-read-on-B shape and would have caught the bug in unit
+     * tests, off the QA cluster.
+     */
+    public void testReadFromDifferentThreadThanConstructor() throws Exception {
+        byte[] data = randomBytesForCompression(96 * 1024);
+        byte[] compressed = compress(data);
+        PanamaZstdInputStream s = new PanamaZstdInputStream(new ByteArrayInputStream(compressed), zstd);
+        try {
+            byte[][] decoded = new byte[1][];
+            Throwable[] thrown = new Throwable[1];
+            Thread t = new Thread(() -> {
+                try {
+                    decoded[0] = s.readAllBytes();
+                } catch (Throwable err) {
+                    thrown[0] = err;
+                }
+            }, "panama-zstd-cross-thread-test");
+            t.start();
+            t.join();
+            if (thrown[0] != null) {
+                throw new AssertionError("read on worker thread failed: " + thrown[0], thrown[0]);
+            }
+            assertArrayEquals(data, decoded[0]);
+        } finally {
+            s.close();
+        }
+    }
+
     // The constructor's "free DStream if byte[] allocation throws" invariant was previously covered
     // by a placebo test that called newDStream() + close() without ever exercising the failure path.
     // Deleted: a real check needs a poisoned `Zstd` whose `newDStream()` returns a counting

--- a/x-pack/plugin/esql-datasource-zstd/build.gradle
+++ b/x-pack/plugin/esql-datasource-zstd/build.gradle
@@ -26,9 +26,15 @@ dependencies {
   compileOnly project(path: xpackModule('core'))
   compileOnly project(':server')
   compileOnly project(xpackModule('esql:compute'))
+  // PanamaZstd lives in the parent compression-libs plugin (extendedPlugins above) so it is
+  // available at runtime through parent-first classloader delegation; compileOnly is just to
+  // surface the symbols at compile time.
+  compileOnly project(':x-pack:plugin:esql-datasource-compression-libs')
 
   // zstd-jni provided by esql-datasource-compression-libs parent plugin at runtime;
-  // compileOnly for compilation, testImplementation for test-time resolution
+  // compileOnly for compilation, testImplementation for test-time resolution. Compression-side
+  // fixtures (ZstdOutputStream) still use zstd-jni — full removal of zstd-jni from this plugin
+  // is out of scope for issue #811 and will happen once the Parquet cold byte[] path is also off it.
   compileOnly "com.github.luben:zstd-jni:${versions.zstdJni}"
 
   testImplementation project(':test:framework')

--- a/x-pack/plugin/esql-datasource-zstd/src/main/java/org/elasticsearch/xpack/esql/datasource/zstd/ZstdDecompressionCodec.java
+++ b/x-pack/plugin/esql-datasource-zstd/src/main/java/org/elasticsearch/xpack/esql/datasource/zstd/ZstdDecompressionCodec.java
@@ -7,8 +7,7 @@
 
 package org.elasticsearch.xpack.esql.datasource.zstd;
 
-import com.github.luben.zstd.ZstdInputStream;
-
+import org.elasticsearch.xpack.esql.datasource.compress.PanamaZstd;
 import org.elasticsearch.xpack.esql.datasources.spi.DecompressionCodec;
 
 import java.io.IOException;
@@ -18,11 +17,35 @@ import java.util.List;
 /**
  * Zstd decompression codec for compound extensions like {@code .csv.zst} or {@code .ndjson.zstd}.
  *
- * <p>Uses {@link ZstdInputStream} from zstd-jni for streaming decompression.
+ * <p>Backed by the Panama FFI {@code ZSTD_decompressStream} binding through {@link PanamaZstd}, so
+ * page reads no longer cross the zstd-jni JNI boundary on every refill. Matches Lucene's stance on
+ * native zstd availability: the constructor hard-fails when {@link PanamaZstd#isAvailable()} is
+ * {@code false}, surfacing the failure at plugin load (via
+ * {@link ZstdDataSourcePlugin#decompressionCodecs}) rather than at first query — there is no
+ * zstd-jni fallback on this streaming path.
  */
 public class ZstdDecompressionCodec implements DecompressionCodec {
 
     private static final List<String> EXTENSIONS = List.of(".zst", ".zstd");
+
+    private final PanamaZstd panamaZstd;
+
+    public ZstdDecompressionCodec() {
+        this(PanamaZstd.instance());
+    }
+
+    ZstdDecompressionCodec(PanamaZstd panamaZstd) {
+        if (panamaZstd.isAvailable() == false) {
+            throw new IllegalStateException(
+                "Native zstd is not available on this platform [os.name="
+                    + System.getProperty("os.name")
+                    + ", os.arch="
+                    + System.getProperty("os.arch")
+                    + "]; ESQL .csv.zst / .ndjson.zstd streaming requires the libzstd binding shipped with Elasticsearch"
+            );
+        }
+        this.panamaZstd = panamaZstd;
+    }
 
     @Override
     public String name() {
@@ -36,6 +59,6 @@ public class ZstdDecompressionCodec implements DecompressionCodec {
 
     @Override
     public InputStream decompress(InputStream raw) throws IOException {
-        return new ZstdInputStream(raw);
+        return panamaZstd.wrap(raw);
     }
 }

--- a/x-pack/plugin/esql-datasource-zstd/src/test/java/org/elasticsearch/xpack/esql/datasource/zstd/ZstdDecompressionCodecTests.java
+++ b/x-pack/plugin/esql-datasource-zstd/src/test/java/org/elasticsearch/xpack/esql/datasource/zstd/ZstdDecompressionCodecTests.java
@@ -62,6 +62,29 @@ public class ZstdDecompressionCodecTests extends ESTestCase {
         }
     }
 
+    /**
+     * Decompresses a ~5 MB payload end-to-end to exercise multi-chunk refill behavior of the
+     * Panama streaming wrapper through the public codec path. Sized to span ≥ 30 of libzstd's
+     * 128 KB recommended input chunks, ensuring the wrapper's refill/needRead loop runs many times.
+     */
+    public void testLargeRoundTrip() throws IOException {
+        byte[] data = new byte[5 * 1024 * 1024];
+        for (int i = 0; i < data.length; i++) {
+            // Mildly compressible payload (cycling pattern with the high bit flipped every 256
+            // bytes) so the decoder produces a non-trivial frame structure rather than a single
+            // RLE block — exercises the internal buffering paths the wrapper has to drain across
+            // multiple read() calls.
+            data[i] = (byte) (((i * 31) ^ (i >>> 8)) & 0xFF);
+        }
+        byte[] compressed = zstd(data);
+
+        ZstdDecompressionCodec codec = new ZstdDecompressionCodec();
+        try (InputStream decompressed = codec.decompress(new ByteArrayInputStream(compressed))) {
+            byte[] result = decompressed.readAllBytes();
+            assertArrayEquals(data, result);
+        }
+    }
+
     private static byte[] zstd(byte[] input) throws IOException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         try (ZstdOutputStream zstdOut = new ZstdOutputStream(baos)) {

--- a/x-pack/plugin/esql-datasource-zstd/src/test/java/org/elasticsearch/xpack/esql/datasource/zstd/ZstdDecompressionCodecTests.java
+++ b/x-pack/plugin/esql-datasource-zstd/src/test/java/org/elasticsearch/xpack/esql/datasource/zstd/ZstdDecompressionCodecTests.java
@@ -67,6 +67,38 @@ public class ZstdDecompressionCodecTests extends ESTestCase {
      * Panama streaming wrapper through the public codec path. Sized to span ≥ 30 of libzstd's
      * 128 KB recommended input chunks, ensuring the wrapper's refill/needRead loop runs many times.
      */
+    /**
+     * Pin issue #811's scope: the streaming codec path must not pull in any
+     * {@code com.github.luben.zstd.*} class. The parent compression-libs plugin still ships
+     * zstd-jni on the runtime classpath (for the Parquet cold {@code byte[]} path), so an
+     * accidental {@code import com.github.luben.zstd.ZstdInputStream} in
+     * {@link ZstdDecompressionCodec} would compile and run silently — undoing the whole point of
+     * this PR. This test fails fast if that ever regresses.
+     *
+     * <p>We assert on class names as strings rather than {@code instanceof PanamaZstdInputStream}
+     * because the parent compression-libs project isn't on this module's test runtime classpath.
+     * String matching is also exactly the right granularity for a "boundary" guard — it doesn't
+     * care which Panama wrapper class is used, only that the chain holds no zstd-jni.
+     */
+    public void testStreamingPathDoesNotLoadZstdJni() throws IOException {
+        byte[] compressed = zstd("hi".getBytes(StandardCharsets.UTF_8));
+        ZstdDecompressionCodec codec = new ZstdDecompressionCodec();
+        try (InputStream decompressed = codec.decompress(new ByteArrayInputStream(compressed))) {
+            String topClass = decompressed.getClass().getName();
+            assertFalse(
+                "Streaming codec returned a zstd-jni-backed stream [" + topClass + "]; #811 scope regressed",
+                topClass.startsWith("com.github.luben.zstd.")
+            );
+            // The expected stream is the Panama wrapper; pin its FQN so the test also catches a
+            // future "I'll just swap in another zstd-jni-backed wrapper" change.
+            assertEquals(
+                "Streaming codec must return the Panama FFI wrapper",
+                "org.elasticsearch.xpack.esql.datasource.compress.PanamaZstdInputStream",
+                topClass
+            );
+        }
+    }
+
     public void testLargeRoundTrip() throws IOException {
         byte[] data = new byte[5 * 1024 * 1024];
         for (int i = 0; i < data.length; i++) {

--- a/x-pack/plugin/esql-datasource-zstd/src/test/java/org/elasticsearch/xpack/esql/datasource/zstd/ZstdDecompressionCodecTests.java
+++ b/x-pack/plugin/esql-datasource-zstd/src/test/java/org/elasticsearch/xpack/esql/datasource/zstd/ZstdDecompressionCodecTests.java
@@ -63,11 +63,6 @@ public class ZstdDecompressionCodecTests extends ESTestCase {
     }
 
     /**
-     * Decompresses a ~5 MB payload end-to-end to exercise multi-chunk refill behavior of the
-     * Panama streaming wrapper through the public codec path. Sized to span ≥ 30 of libzstd's
-     * 128 KB recommended input chunks, ensuring the wrapper's refill/needRead loop runs many times.
-     */
-    /**
      * Pin issue #811's scope: the streaming codec path must not pull in any
      * {@code com.github.luben.zstd.*} class. The parent compression-libs plugin still ships
      * zstd-jni on the runtime classpath (for the Parquet cold {@code byte[]} path), so an
@@ -99,6 +94,11 @@ public class ZstdDecompressionCodecTests extends ESTestCase {
         }
     }
 
+    /**
+     * Decompresses a ~5 MB payload end-to-end to exercise multi-chunk refill behavior of the
+     * Panama streaming wrapper through the public codec path. Sized to span ≥ 30 of libzstd's
+     * 128 KB recommended input chunks, ensuring the wrapper's refill/needRead loop runs many times.
+     */
     public void testLargeRoundTrip() throws IOException {
         byte[] data = new byte[5 * 1024 * 1024];
         for (int i = 0; i < data.length; i++) {


### PR DESCRIPTION
Replaces the zstd-jni `ZstdInputStream` backing `ZstdDecompressionCodec`
with a Panama FFI binding to `ZSTD_decompressStream`, removing the last
JNI call on the ESQL streaming codec path.

The libzstd `ZSTD_inBuffer`/`outBuffer` structs reference off-heap
staging buffers managed by a shared arena per stream — heap segments
cannot be embedded as the `ptr` field of an off-heap struct per
[JDK-8318645](https://bugs.openjdk.org/browse/JDK-8318645), and the
arena must be `ofShared` rather than `ofConfined` because
`StreamingParallelParsingCoordinator` reads on a segmentator worker
thread that's different from the one constructing the codec. The
wrapper is otherwise a faithful port of zstd-jni's
`ZstdInputStreamNoFinalizer`.

Codec construction hard-fails when the native binding is unavailable;
matches Lucene's stance on native zstd availability. zstd-jni stays on
the runtime classpath for now because Parquet's
`PlainCompressionCodecFactory` still references it; that's removed in
the follow-up PR.

## Commits in this PR

1. `ESQL|DS: Panama FFI streaming zstd for .csv.zst / .ndjson.zstd` —
   streaming SPI in `libs/native` (`ZstdLibrary.DStream`, `Zstd.DStream`
   facade, `JdkZstdLibrary.JdkDStream`), `PanamaZstdInputStream`
   wrapper, codec rewire, low-level and wrapper tests.
2. `ESQL|DS: address review of streaming zstd Panama wrapper` —
   contrarian-review pass: javadoc corrections, dropped a placebo test,
   added the `available()==1` mid-stream case, locked the
   "streaming path does not load com.github.luben.zstd.\*" scope
   boundary.
3. `ESQL|DS: fix WrongThreadException in streaming zstd wrapper` —
   `Arena.ofConfined()` → `Arena.ofShared()`. Unit tests had not caught
   this because they construct and read on the same JUnit thread; the
   CSV/NdJson QA ITs surfaced it. Adds a unit-level regression
   (construct on thread A, read on thread B) so the QA cluster is no
   longer required to surface this shape.

## Risk surface

- New Panama FFI binding — requires `test-arm` and `test-windows`
  before merge.
- Off-heap staging buffers add ~520 KB per stream vs. an ideal
  heap-passing design. Dominated 100x by libzstd's own work; G1 region
  pinning structurally impossible because no heap memory is pinned on
  the native side.

## Test coverage

- Low-level: `ZstdTests` streaming round-trip / partial input drip-feed
  / partial output multi-call / multi-frame concatenation / corruption
  / truncation / idempotent close / use-after-close / OOB args.
- Wrapper: `PanamaZstdInputStreamTests` byte-for-byte cross-check with
  `zstd-jni`'s `ZstdInputStream` on several sizes; multi-frame;
  drip-feed; truncation; cross-thread regression.
- Codec: `ZstdDecompressionCodecTests` large round-trip + scope
  boundary guard (`testStreamingPathDoesNotLoadZstdJni`).
- QA ITs: `CsvCompressedFormatSpecIT` and `NdJsonCompressedFormatSpecIT`
  pass across LOCAL / HTTP / S3 / GCS / AZURE storage backends.

Closes part of esql-planning#811. Follow-up PR ports Parquet's
`PlainCompressionCodecFactory` and removes zstd-jni from the plugin
classpath entirely.

Developed with AI-assisted tooling