### PR TITLE
Add PartitionConfig.CONFIG_KEYS and thread into FileSourceFactory.COORDINATOR_KEYS

### DIFF
--- a/docs/changelog/149816.yaml
+++ b/docs/changelog/149816.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 149816
+summary: Add `PartitionConfig.CONFIG_KEYS` and thread into `FileSourceFactory.COORDINATOR_KEYS`
+type: bug

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalCsvHivePartitionedIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalCsvHivePartitionedIT.java
@@ -61,7 +61,8 @@ public class ExternalCsvHivePartitionedIT extends AbstractEsqlIntegTestCase {
         Path root = createTempDir().resolve("hive_csv");
         writePartitionedCsvFiles(root);
 
-        // ** triggers recursive listing so LocalStorageProvider descends into year=/month= dirs.
+        // The '**' pattern triggers recursive listing so LocalStorageProvider descends into year=/month= dirs.
+        @SuppressWarnings("checkstyle:EmptyJavadoc") // checkstyle thinks this is Javadoc
         String glob = StoragePath.fileUri(root) + "/**/*.csv";
         String query = "EXTERNAL \"" + glob + "\" WITH {\"hive_partitioning\": true} | LIMIT 1";
 
@@ -85,6 +86,7 @@ public class ExternalCsvHivePartitionedIT extends AbstractEsqlIntegTestCase {
         Path root = createTempDir().resolve("template_csv");
         writePartitionedCsvFiles(root);
 
+        @SuppressWarnings("checkstyle:EmptyJavadoc") // checkstyle thinks this is Javadoc
         String glob = StoragePath.fileUri(root) + "/**/*.csv";
         String query = "EXTERNAL \"" + glob + "\" WITH {\"partition_path\": \"year={year}/month={month}/*.csv\"}" + " | LIMIT 1";
 

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalCsvHivePartitionedIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalCsvHivePartitionedIT.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.action;
+
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.xpack.esql.datasource.csv.CsvDataSourcePlugin;
+import org.elasticsearch.xpack.esql.datasource.http.HttpDataSourcePlugin;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.elasticsearch.xpack.esql.action.EsqlCapabilities.Cap.EXTERNAL_COMMAND;
+import static org.elasticsearch.xpack.esql.action.EsqlQueryRequest.syncEsqlQueryRequest;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasItem;
+
+/**
+ * Regression test: {@code hive_partitioning} and {@code partition_path} * were not included in
+ * {@code FileSourceFactory.COORDINATOR_KEYS}, causing the strict query-time validator
+ * (added by elastic/elasticsearch#148327) to reject every EXTERNAL query that specified
+ * either key with an "unknown option" error.
+ *
+ * <p>Each test here exercises a key that was previously blocked so that any regression in
+ * the coordinator-key wiring fails with a clear "unknown option" exception rather than silently.
+ */
+public class ExternalCsvHivePartitionedIT extends AbstractEsqlIntegTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        List<Class<? extends Plugin>> plugins = new ArrayList<>(super.nodePlugins());
+        plugins.add(HttpDataSourcePlugin.class);
+        plugins.add(CsvDataSourcePlugin.class);
+        return plugins;
+    }
+
+    /**
+     * Writes a two-level Hive-style partition tree ({@code year=YYYY/month=MM/data.csv}),
+     * queries it with {@code hive_partitioning: true}, and asserts that the query succeeds
+     * (i.e., {@code hive_partitioning} is a known coordinator key) and that the partition
+     * columns {@code year} and {@code month} are present in the result schema.
+     *
+     * <p>The glob uses {@code **} (double-star) rather than {@code year=*} because the local
+     * filesystem storage provider only performs a shallow {@code DirectoryStream} listing for
+     * non-recursive globs (single {@code *} has no {@code /} in its match); multi-level Hive
+     * directories require recursive walking, which {@code **} triggers.
+     */
+    public void testHivePartitioningValidatesAndParses() throws Exception {
+        assumeTrue("requires EXTERNAL command capability", EXTERNAL_COMMAND.isEnabled());
+
+        Path root = createTempDir().resolve("hive_csv");
+        writePartitionedCsvFiles(root);
+
+        // ** triggers recursive listing so LocalStorageProvider descends into year=/month= dirs.
+        String glob = StoragePath.fileUri(root) + "/**/*.csv";
+        String query = "EXTERNAL \"" + glob + "\" WITH {\"hive_partitioning\": true} | LIMIT 1";
+
+        try (var response = run(syncEsqlQueryRequest(query))) {
+            List<String> columnNames = response.columns().stream().map(c -> c.name()).collect(Collectors.toList());
+            assertThat("partition column 'year' must appear in result schema", columnNames, hasItem("year"));
+            assertThat("partition column 'month' must appear in result schema", columnNames, hasItem("month"));
+            assertThat("expect at least 1 row", response.columns().size(), greaterThanOrEqualTo(1));
+        }
+    }
+
+    /**
+     * Same fixture, queries with explicit {@code partition_path} key, asserting that
+     * {@code partition_path} is accepted by the coordinator-key validator (was also missing
+     * from COORDINATOR_KEYS before this fix). The primary assertion is that the query does
+     * not fail with "unknown option [partition_path]".
+     */
+    public void testPartitionPathValidatesAndParses() throws Exception {
+        assumeTrue("requires EXTERNAL command capability", EXTERNAL_COMMAND.isEnabled());
+
+        Path root = createTempDir().resolve("template_csv");
+        writePartitionedCsvFiles(root);
+
+        String glob = StoragePath.fileUri(root) + "/**/*.csv";
+        String query = "EXTERNAL \"" + glob + "\" WITH {\"partition_path\": \"year={year}/month={month}/*.csv\"}" + " | LIMIT 1";
+
+        // Primary assertion: query does not throw "unknown option [partition_path]".
+        try (var response = run(syncEsqlQueryRequest(query))) {
+            assertThat("expect at least 1 column", response.columns().size(), greaterThanOrEqualTo(1));
+        }
+    }
+
+    private static void writePartitionedCsvFiles(Path root) throws Exception {
+        Path month01 = root.resolve("year=2024").resolve("month=01");
+        Path month02 = root.resolve("year=2024").resolve("month=02");
+        Files.createDirectories(month01);
+        Files.createDirectories(month02);
+
+        String content01 = "id,value\n1,alpha\n2,beta\n";
+        String content02 = "id,value\n3,gamma\n4,delta\n";
+        Files.writeString(month01.resolve("data.csv"), content01, StandardCharsets.UTF_8);
+        Files.writeString(month02.resolve("data.csv"), content02, StandardCharsets.UTF_8);
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSourceFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSourceFactory.java
@@ -55,8 +55,9 @@ final class FileSourceFactory implements ExternalSourceFactory {
      * Built from each component's own {@code CONFIG_KEYS} set so adding a new coordinator-level
      * configuration consumer requires updating only the consumer's own constant — the union here
      * picks it up automatically. Components contributing today: {@link ErrorPolicy},
-     * {@link FileSplitProvider}, the {@link #CONFIG_FORMAT} override read by this class, and the
-     * {@link FormatNameResolver#CONFIG_READER} override read by the format-name resolver.
+     * {@link FileSplitProvider}, {@link PartitionConfig}, the {@link #CONFIG_FORMAT} override read
+     * by this class, and the {@link FormatNameResolver#CONFIG_READER} override read by the
+     * format-name resolver.
      */
     static final Set<String> COORDINATOR_KEYS;
 
@@ -67,6 +68,7 @@ final class FileSourceFactory implements ExternalSourceFactory {
         keys.addAll(ErrorPolicy.CONFIG_KEYS);
         keys.addAll(FileSplitProvider.CONFIG_KEYS);
         keys.addAll(ExternalSourceResolver.CONFIG_KEYS);
+        keys.addAll(PartitionConfig.CONFIG_KEYS);
         COORDINATOR_KEYS = Set.copyOf(keys);
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/PartitionConfig.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/PartitionConfig.java
@@ -11,6 +11,7 @@ import org.elasticsearch.core.Nullable;
 
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Configuration for partition detection strategy, parsed from WITH clause parameters.
@@ -39,6 +40,9 @@ public record PartitionConfig(Strategy strategy, @Nullable String pathTemplate) 
     public static final String CONFIG_PARTITIONING_DETECTION = "partition_detection";
     public static final String CONFIG_PARTITIONING_PATH = "partition_path";
     public static final String CONFIG_PARTITIONING_HIVE = "hive_partitioning";
+
+    /** Keys recognised by {@link #fromConfig}. */
+    public static final Set<String> CONFIG_KEYS = Set.of(CONFIG_PARTITIONING_DETECTION, CONFIG_PARTITIONING_PATH, CONFIG_PARTITIONING_HIVE);
 
     public static final PartitionConfig DEFAULT = new PartitionConfig(Strategy.AUTO, null);
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/FileSourceFactoryValidationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/FileSourceFactoryValidationTests.java
@@ -84,6 +84,16 @@ public class FileSourceFactoryValidationTests extends ESTestCase {
         assertConfigKeysMatchConstants(FileSplitProvider.class, FileSplitProvider.CONFIG_KEYS);
     }
 
+    public void testCoordinatorKeysIncludesAllPartitionConfigKeys() {
+        for (String key : PartitionConfig.CONFIG_KEYS) {
+            assertTrue("PartitionConfig key " + key + " must be a coordinator key", FileSourceFactory.COORDINATOR_KEYS.contains(key));
+        }
+    }
+
+    public void testPartitionConfigKeysMatchConstants() {
+        assertConfigKeysMatchConstants(PartitionConfig.class, PartitionConfig.CONFIG_KEYS);
+    }
+
     /**
      * Asserts {@code declared} equals the set of values of every {@code static final String CONFIG_*}
      * constant declared on {@code clazz}. Reflection-based so new constants are picked up without


### PR DESCRIPTION
Adds `PartitionConfig.CONFIG_KEYS = Set.of(...)` and wires it into the `COORDINATOR_KEYS` static initializer.

`PartitionConfig` declared three `CONFIG_*` constants but never collected them into a `CONFIG_KEYS` set, and `FileSourceFactory` never unioned them into `COORDINATOR_KEYS`.

Since #148327 added strict validation at planning time, any `EXTERNAL` query using these keys threw `"unknown option [hive_partitioning]"`.

Fixes elastic/esql-planning#764