### PR TITLE
Add multi-project support to PEK services

### DIFF
--- a/x-pack/plugin/encryption/src/main/java/org/elasticsearch/xpack/encryption/KeyRotationCoordinator.java
+++ b/x-pack/plugin/encryption/src/main/java/org/elasticsearch/xpack/encryption/KeyRotationCoordinator.java
@@ -18,6 +18,8 @@ import org.elasticsearch.cluster.LocalNodeMasterListener;
 import org.elasticsearch.cluster.ProjectState;
 import org.elasticsearch.cluster.SimpleBatchedExecutor;
 import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.metadata.ProjectId;
+import org.elasticsearch.cluster.metadata.ProjectMetadata;
 import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.cluster.service.MasterService;
@@ -44,23 +46,27 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 /**
- * Owns the project encryption key (PEK) lifecycle on the elected master: installs the initial key, rotates the active key on a timer,
- * drives registered {@link EncryptedDataHandler}s to re-encrypt their owned data, and retires non-active keys once their grace window
- * expires.
+ * Owns the project encryption key (PEK) lifecycle on the elected master, fanned out across every project in cluster state. Per project,
+ * the coordinator installs the initial key, rotates the active key on a timer, drives registered {@link EncryptedDataHandler}s to
+ * re-encrypt their owned data, and retires non-active keys once their grace window expires.
  *
- * <p>Re-encryption follows a two-phase compute-then-CAS pattern:
+ * <p>Every task that flows through the coordinator's task queue carries a {@link ProjectId} so the executor mutates exactly the named
+ * project's slice — never relying on a {@link ProjectResolver} fallback to pick which project to operate on.
+ *
+ * <p>Re-encryption follows a two-phase compute-then-CAS pattern (per project, per handler):
  * <ol>
- *     <li>For each handler whose {@code handlerKeyIds} entry is not yet on the current {@code activeKeyId}, the coordinator forks to
+ *     <li>For each project whose {@code handlerKeyIds} entry is not yet on the project's {@code activeKeyId}, the coordinator forks to
  *     the generic thread pool, snapshots cluster state, and asks the handler to produce a re-encrypted copy of its
- *     {@link Metadata.ProjectCustom} slice.</li>
- *     <li>The result is submitted as a {@link ReEncryptApplyTask} which, on the master thread, atomically swaps the handler's custom
- *     and updates {@code handlerKeyIds} — but only if the snapshot the compute phase ran against is still current
+ *     {@link Metadata.ProjectCustom} slice. The handler is invoked inside {@link ProjectResolver#executeOnProject} so any calls it
+ *     makes back into {@link EncryptionService} resolve to the correct project.</li>
+ *     <li>The result is submitted as a {@link ReEncryptApplyTask} which, on the master thread, atomically swaps the project's
+ *     handler custom and updates {@code handlerKeyIds} — but only if the snapshot the compute phase ran against is still current
  *     (slice unchanged and {@code activeKeyId} unchanged). On conflict the task is a no-op and the next tick re-attempts.</li>
  * </ol>
  */
@@ -135,9 +141,10 @@ public class KeyRotationCoordinator implements LocalNodeMasterListener, Closeabl
 
     private Scheduler.Cancellable scheduledTask;
     private volatile boolean closed = false;
-    private final AtomicBoolean rotating = new AtomicBoolean(false);
-    // Used for logging when a rotation is in progress for an unexpectedly long time. Same access pattern as `rotating`.
-    private final AtomicLong rotatingSince = new AtomicLong(0L);
+    // Tracks which projects currently have an in-flight re-encrypt fan-out and when that fan-out started (millis since epoch). Per-project
+    // gating means a slow project does not block other projects' ticks. The value is purely diagnostic (used in the "rotation in progress
+    // for X ms" warn log).
+    private final ConcurrentHashMap<ProjectId, Long> rotatingSinceByProject = new ConcurrentHashMap<>();
 
     public static KeyRotationCoordinator create(
         ClusterService clusterService,
@@ -181,11 +188,7 @@ public class KeyRotationCoordinator implements LocalNodeMasterListener, Closeabl
         this.featureService = featureService;
         this.encryptionService = encryptionService;
         this.handlers = new CopyOnWriteArrayList<>(handlers);
-        this.taskQueue = clusterService.createTaskQueue(
-            "project-encryption-key",
-            Priority.NORMAL,
-            new KeyRotationExecutor(projectResolver, threadPool)
-        );
+        this.taskQueue = clusterService.createTaskQueue("project-encryption-key", Priority.NORMAL, new KeyRotationExecutor(threadPool));
         this.rotationInterval = rotationInterval;
         this.checkInterval = checkInterval;
     }
@@ -197,8 +200,7 @@ public class KeyRotationCoordinator implements LocalNodeMasterListener, Closeabl
 
     @Override
     public void offMaster() {
-        rotating.set(false);
-        rotatingSince.set(0L);
+        rotatingSinceByProject.clear();
         stopSchedule();
     }
 
@@ -211,9 +213,14 @@ public class KeyRotationCoordinator implements LocalNodeMasterListener, Closeabl
         if (event.localNodeMaster() == false) {
             return;
         }
-        // Install runs regardless of whether rotation is enabled — we always want a key once the cluster is ready.
-        if (getCurrentMetadata(state) == null && checkPekFeatureAvailable(state)) {
-            submitInstallKey();
+        if (checkPekFeatureAvailable(state) == false) {
+            return;
+        }
+        // Install runs regardless of whether rotation is enabled — we always want a key once the cluster is ready, for every project.
+        for (ProjectMetadata project : state.metadata().projects().values()) {
+            if (project.custom(ProjectEncryptionKeyMetadata.TYPE) == null) {
+                submitInstallKey(project.id());
+            }
         }
     }
 
@@ -246,70 +253,89 @@ public class KeyRotationCoordinator implements LocalNodeMasterListener, Closeabl
             return;
         }
 
-        ProjectEncryptionKeyMetadata metadata = getCurrentMetadata(state);
+        long now = threadPool.absoluteTimeInMillis();
+        for (ProjectMetadata project : state.metadata().projects().values()) {
+            tickProject(project, now);
+        }
+    }
+
+    private void tickProject(ProjectMetadata project, long now) {
+        ProjectId projectId = project.id();
+        ProjectEncryptionKeyMetadata metadata = project.custom(ProjectEncryptionKeyMetadata.TYPE);
         if (metadata == null) {
             return;
         }
 
-        long now = threadPool.absoluteTimeInMillis();
         long activeKeyAge = now - metadata.getGeneratedAt(metadata.getActiveKeyId());
 
-        rotate(metadata, now);
+        rotate(projectId, metadata, now);
 
         if (activeKeyAge >= rotationInterval.millis()) {
-            logger.info("project encryption key due for rotation (active key generated {} ago)", TimeValue.timeValueMillis(activeKeyAge));
-            submitBeginRotation();
+            logger.info(
+                "project [{}] encryption key due for rotation (active key generated {} ago)",
+                projectId,
+                TimeValue.timeValueMillis(activeKeyAge)
+            );
+            submitBeginRotation(projectId);
         }
 
         long retireCutoff = now - GRACE_TICKS * checkInterval.millis();
         if (metadata.findRetireableKeyIds(retireCutoff).isEmpty() == false) {
-            submitRetireKeys(retireCutoff);
+            submitRetireKeys(projectId, retireCutoff);
         }
     }
 
-    private void rotate(ProjectEncryptionKeyMetadata metadata, long now) {
+    private void rotate(ProjectId projectId, ProjectEncryptionKeyMetadata metadata, long now) {
         String activeKeyId = metadata.getActiveKeyId();
         List<EncryptedDataHandler<?>> pending = handlers.stream().filter(h -> metadata.isHandlerOnActive(h.customName()) == false).toList();
         if (pending.isEmpty()) {
             return;
         }
-        if (rotating.compareAndSet(false, true) == false) {
+        Long existingStart = rotatingSinceByProject.putIfAbsent(projectId, now);
+        if (existingStart != null) {
             logger.warn(
-                "rotation already in progress, skipping this tick (in progress for {})",
-                TimeValue.timeValueMillis(now - rotatingSince.get())
+                "rotation already in progress for project [{}], skipping this tick (in progress for {})",
+                projectId,
+                TimeValue.timeValueMillis(now - existingStart)
             );
             return;
         }
-        rotatingSince.set(now);
         try (
             var listeners = new RefCountingListener(
                 ActionListener.runAfter(
-                    ActionListener.wrap(unused -> {}, e -> logger.warn("re-encryption failed; will retry on next tick", e)),
-                    () -> {
-                        rotatingSince.set(0L);
-                        rotating.set(false);
-                    }
+                    ActionListener.wrap(
+                        unused -> {},
+                        e -> logger.warn(() -> "re-encryption failed for project [" + projectId + "]; will retry on next tick", e)
+                    ),
+                    () -> rotatingSinceByProject.remove(projectId)
                 )
             )
         ) {
             for (EncryptedDataHandler<?> handler : pending) {
                 ActionListener<Void> l = listeners.acquire();
-                threadPool.generic().execute(() -> dispatchOne(handler, activeKeyId, l));
+                threadPool.generic().execute(() -> dispatchOne(projectId, handler, activeKeyId, l));
             }
         }
     }
 
     private <T extends Metadata.ProjectCustom> void dispatchOne(
+        ProjectId projectId,
         EncryptedDataHandler<T> handler,
         String expectedActiveKeyId,
         ActionListener<Void> listener
     ) {
         try {
             ClusterState snapshot = clusterService.state();
-            ProjectState projectState = projectResolver.getProjectState(snapshot);
-
-            T oldCustom = projectState.metadata().custom(handler.customName());
-            T newCustom = handler.reEncrypt(oldCustom, encryptionService, expectedActiveKeyId);
+            ProjectMetadata project = snapshot.metadata().projects().get(projectId);
+            if (project == null) {
+                // Project vanished between schedule and dispatch. Drop and let the next tick reconcile.
+                listener.onResponse(null);
+                return;
+            }
+            T oldCustom = project.custom(handler.customName());
+            // Wrap the handler invocation so any encrypt/decrypt the handler issues resolves keys for `projectId`. The generic-thread we
+            // forked to has no project header in its ThreadContext, so the resolver would otherwise fall back to the default project.
+            T newCustom = invokeHandler(projectId, handler, oldCustom, expectedActiveKeyId);
             if (newCustom == null || newCustom == oldCustom) {
                 // Nothing to do — handler signaled no change.
                 listener.onResponse(null);
@@ -323,13 +349,25 @@ public class KeyRotationCoordinator implements LocalNodeMasterListener, Closeabl
                     + " does not match returned custom getWriteableName="
                     + newCustom.getWriteableName();
             taskQueue.submitTask(
-                "re-encrypt-" + handler.customName(),
-                new ReEncryptApplyTask(handler.customName(), oldCustom, newCustom, expectedActiveKeyId, listener),
+                "re-encrypt-" + handler.customName() + "[" + projectId + "]",
+                new ReEncryptApplyTask(projectId, handler.customName(), oldCustom, newCustom, expectedActiveKeyId, listener),
                 null
             );
         } catch (Exception e) {
             listener.onFailure(e);
         }
+    }
+
+    private <T extends Metadata.ProjectCustom> T invokeHandler(
+        ProjectId projectId,
+        EncryptedDataHandler<T> handler,
+        T oldCustom,
+        String expectedActiveKeyId
+    ) {
+        // Single-slot holder lets us return the handler's result out of the executeOnProject lambda without losing the generic type.
+        AtomicReference<T> result = new AtomicReference<>();
+        projectResolver.executeOnProject(projectId, () -> result.set(handler.reEncrypt(oldCustom, encryptionService, expectedActiveKeyId)));
+        return result.get();
     }
 
     @Override
@@ -346,8 +384,9 @@ public class KeyRotationCoordinator implements LocalNodeMasterListener, Closeabl
     }
 
     @Nullable
-    public ProjectEncryptionKeyMetadata getCurrentMetadata(ClusterState state) {
-        return projectResolver.getProjectState(state).metadata().custom(ProjectEncryptionKeyMetadata.TYPE);
+    public ProjectEncryptionKeyMetadata getCurrentMetadata(ClusterState state, ProjectId projectId) {
+        ProjectMetadata project = state.metadata().projects().get(projectId);
+        return project != null ? project.custom(ProjectEncryptionKeyMetadata.TYPE) : null;
     }
 
     private boolean checkPekFeatureAvailable(ClusterState state) {
@@ -358,23 +397,30 @@ public class KeyRotationCoordinator implements LocalNodeMasterListener, Closeabl
         return true;
     }
 
-    void submitInstallKey() {
-        taskQueue.submitTask("install-project-encryption-key", new InstallKeyTask(), null);
+    void submitInstallKey(ProjectId projectId) {
+        taskQueue.submitTask("install-project-encryption-key[" + projectId + "]", new InstallKeyTask(projectId), null);
     }
 
-    void submitBeginRotation() {
-        taskQueue.submitTask("begin-project-encryption-key-rotation", new BeginRotationTask(), null);
+    void submitBeginRotation(ProjectId projectId) {
+        taskQueue.submitTask("begin-project-encryption-key-rotation[" + projectId + "]", new BeginRotationTask(projectId), null);
     }
 
-    void submitRetireKeys(long cutoffDeactivationMillis) {
-        taskQueue.submitTask("retire-project-encryption-keys", new RetireKeysTask(cutoffDeactivationMillis), null);
+    void submitRetireKeys(ProjectId projectId, long cutoffDeactivationMillis) {
+        taskQueue.submitTask(
+            "retire-project-encryption-keys[" + projectId + "]",
+            new RetireKeysTask(projectId, cutoffDeactivationMillis),
+            null
+        );
     }
 
     /**
-     * Hierarchy of cluster-state tasks that flow through the PEK task queue. {@link KeyRotationExecutor} dispatches on the concrete type.
+     * Hierarchy of cluster-state tasks that flow through the PEK task queue. Each task carries the {@link ProjectId} it targets;
+     * {@link KeyRotationExecutor} dispatches on the concrete type.
      */
     sealed interface KeyRotationTask extends ClusterStateTaskListener permits InstallKeyTask, BeginRotationTask, RetireKeysTask,
         ReEncryptApplyTask {
+
+        ProjectId projectId();
 
         String description();
 
@@ -384,33 +430,34 @@ public class KeyRotationCoordinator implements LocalNodeMasterListener, Closeabl
         }
     }
 
-    static final class InstallKeyTask implements KeyRotationTask {
+    record InstallKeyTask(ProjectId projectId) implements KeyRotationTask {
         @Override
         public String description() {
-            return "project encryption key initial install";
+            return "project encryption key initial install [" + projectId + "]";
         }
     }
 
-    static final class BeginRotationTask implements KeyRotationTask {
+    record BeginRotationTask(ProjectId projectId) implements KeyRotationTask {
         @Override
         public String description() {
-            return "project encryption key rotation begin";
+            return "project encryption key rotation begin [" + projectId + "]";
         }
     }
 
-    record RetireKeysTask(long cutoffDeactivationMillis) implements KeyRotationTask {
+    record RetireKeysTask(ProjectId projectId, long cutoffDeactivationMillis) implements KeyRotationTask {
         @Override
         public String description() {
-            return "project encryption key retire (cutoff=" + cutoffDeactivationMillis + ")";
+            return "project encryption key retire [" + projectId + "] (cutoff=" + cutoffDeactivationMillis + ")";
         }
     }
 
     /**
-     * Atomically swap a handler's {@link Metadata.ProjectCustom} for a re-encrypted copy and record progress in
-     * {@code handlerKeyIds}. Conflict cases (slice changed, or a new rotation began since compute) are turned into no-ops; the next
-     * tick will re-dispatch.
+     * Atomically swap a project's handler {@link Metadata.ProjectCustom} for a re-encrypted copy and record progress in
+     * {@code handlerKeyIds}. Conflict cases (project gone, slice changed, or a new rotation began since compute) are turned into no-ops;
+     * the next tick will re-dispatch.
      */
     record ReEncryptApplyTask(
+        ProjectId projectId,
         String customName,
         Metadata.ProjectCustom expectedOld,
         Metadata.ProjectCustom newCustom,
@@ -419,7 +466,7 @@ public class KeyRotationCoordinator implements LocalNodeMasterListener, Closeabl
     ) implements KeyRotationTask {
         @Override
         public String description() {
-            return "project encryption key re-encrypt [" + customName + "]";
+            return "project encryption key re-encrypt [" + projectId + "][" + customName + "]";
         }
 
         @Override
@@ -432,22 +479,25 @@ public class KeyRotationCoordinator implements LocalNodeMasterListener, Closeabl
     static class KeyRotationExecutor extends SimpleBatchedExecutor<KeyRotationTask, Void> {
         private static final SecureRandom RANDOM = new SecureRandom();
 
-        private final ProjectResolver projectResolver;
         private final ThreadPool threadPool;
 
-        KeyRotationExecutor(ProjectResolver projectResolver, ThreadPool threadPool) {
-            this.projectResolver = projectResolver;
+        KeyRotationExecutor(ThreadPool threadPool) {
             this.threadPool = threadPool;
         }
 
         @Override
         public Tuple<ClusterState, Void> executeTask(KeyRotationTask task, ClusterState clusterState) {
-            ProjectState projectState = projectResolver.getProjectState(clusterState);
+            if (clusterState.metadata().hasProject(task.projectId()) == false) {
+                // Project was deleted between submission and execution. Drop the task as a no-op.
+                logger.debug("dropping [{}]: project no longer present in cluster state", task.description());
+                return Tuple.tuple(clusterState, null);
+            }
+            ProjectState projectState = clusterState.projectState(task.projectId());
             ProjectEncryptionKeyMetadata existing = projectState.metadata().custom(ProjectEncryptionKeyMetadata.TYPE);
 
             return switch (task) {
-                case InstallKeyTask ignored -> executeInstallInitial(clusterState, projectState, existing);
-                case BeginRotationTask ignored -> executeBeginRotation(clusterState, projectState, existing);
+                case InstallKeyTask install -> executeInstallInitial(clusterState, projectState, existing);
+                case BeginRotationTask begin -> executeBeginRotation(clusterState, projectState, existing);
                 case RetireKeysTask retireKeysTask -> executeRetireKeys(
                     clusterState,
                     projectState,
@@ -474,7 +524,7 @@ public class KeyRotationCoordinator implements LocalNodeMasterListener, Closeabl
                 Map.of(keyId, new ProjectEncryptionKeyMetadata.KeyEntry(keyBytes, threadPool.absoluteTimeInMillis())),
                 keyId
             );
-            logger.info("installing project encryption key [{}]", keyId);
+            logger.info("installing project encryption key [{}] for project [{}]", keyId, projectState.projectId());
             return Tuple.tuple(putMetadata(clusterState, projectState, metadata), null);
         }
 
@@ -484,7 +534,10 @@ public class KeyRotationCoordinator implements LocalNodeMasterListener, Closeabl
             ProjectEncryptionKeyMetadata existing
         ) {
             if (existing == null) {
-                logger.warn("ignoring begin-rotation task because no project encryption key is installed");
+                logger.warn(
+                    "ignoring begin-rotation task because no project encryption key is installed for project [{}]",
+                    projectState.projectId()
+                );
                 return Tuple.tuple(clusterState, null);
             }
             byte[] keyBytes = randomKey();
@@ -492,7 +545,11 @@ public class KeyRotationCoordinator implements LocalNodeMasterListener, Closeabl
             Map<String, ProjectEncryptionKeyMetadata.KeyEntry> newEntries = new HashMap<>(existing.getKeys());
             newEntries.put(newKeyId, new ProjectEncryptionKeyMetadata.KeyEntry(keyBytes, threadPool.absoluteTimeInMillis()));
             ProjectEncryptionKeyMetadata metadata = new ProjectEncryptionKeyMetadata(newEntries, newKeyId, existing.getHandlerKeyIds());
-            logger.info("beginning project encryption key rotation: new active key [{}]", newKeyId);
+            logger.info(
+                "beginning project encryption key rotation for project [{}]: new active key [{}]",
+                projectState.projectId(),
+                newKeyId
+            );
             return Tuple.tuple(putMetadata(clusterState, projectState, metadata), null);
         }
 
@@ -513,7 +570,12 @@ public class KeyRotationCoordinator implements LocalNodeMasterListener, Closeabl
             Map<String, ProjectEncryptionKeyMetadata.KeyEntry> retained = new HashMap<>(existing.getKeys());
             retained.keySet().removeAll(retiredIds);
             ProjectEncryptionKeyMetadata metadata = new ProjectEncryptionKeyMetadata(retained, activeKeyId, existing.getHandlerKeyIds());
-            logger.info("project encryption key retire: retained active key [{}], retired keys {}", activeKeyId, new TreeSet<>(retiredIds));
+            logger.info(
+                "project encryption key retire for project [{}]: retained active key [{}], retired keys {}",
+                projectState.projectId(),
+                activeKeyId,
+                new TreeSet<>(retiredIds)
+            );
             return Tuple.tuple(putMetadata(clusterState, projectState, metadata), null);
         }
 
@@ -525,14 +587,14 @@ public class KeyRotationCoordinator implements LocalNodeMasterListener, Closeabl
         ) {
             if (existing == null) {
                 // PEK metadata vanished. Drop and let next tick re-attempt.
-                logger.debug("dropping re-encrypt task for [{}]: no PEK metadata installed", task.customName());
+                logger.debug("dropping re-encrypt task for [{}]: no PEK metadata installed", task.description());
                 return Tuple.tuple(clusterState, null);
             }
             if (existing.getActiveKeyId().equals(task.expectedActiveKeyId()) == false) {
                 // A new rotation began since the compute phase. The re-encrypted custom is stale; drop and re-tick.
                 logger.debug(
                     "dropping re-encrypt task for [{}]: activeKeyId drifted from [{}] to [{}]",
-                    task.customName(),
+                    task.description(),
                     task.expectedActiveKeyId(),
                     existing.getActiveKeyId()
                 );
@@ -541,7 +603,7 @@ public class KeyRotationCoordinator implements LocalNodeMasterListener, Closeabl
             Metadata.ProjectCustom current = projectState.metadata().custom(task.customName());
             if (current != task.expectedOld()) {
                 // Slice was modified between snapshot and apply. Drop and re-tick.
-                logger.debug("dropping re-encrypt task for [{}]: slice mutated between compute and apply", task.customName());
+                logger.debug("dropping re-encrypt task for [{}]: slice mutated between compute and apply", task.description());
                 return Tuple.tuple(clusterState, null);
             }
             ProjectEncryptionKeyMetadata updatedPek = existing.withHandlerKeyId(task.customName(), task.expectedActiveKeyId());

--- a/x-pack/plugin/encryption/src/main/java/org/elasticsearch/xpack/encryption/ProjectEncryptionKeyService.java
+++ b/x-pack/plugin/encryption/src/main/java/org/elasticsearch/xpack/encryption/ProjectEncryptionKeyService.java
@@ -10,7 +10,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ProjectState;
+import org.elasticsearch.cluster.metadata.ProjectId;
+import org.elasticsearch.cluster.metadata.ProjectMetadata;
 import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.util.FeatureFlag;
@@ -19,15 +20,27 @@ import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.gateway.GatewayService;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import javax.crypto.SecretKey;
 
 /**
  * Owns the in-memory cache of the project encryption key (PEK) material and serves it to {@link AesGcmEncryptionService}.
  *
- * <p>This service listens to cluster-state changes and rebuilds its local cache whenever {@link ProjectEncryptionKeyMetadata} changes.
- * Installation, rotation, and retirement of PEK material are owned by {@link KeyRotationCoordinator}; this class is read-only with
+ * <p>The cache is keyed by {@link ProjectId} — one slot per project. On every cluster-state change the service iterates all projects
+ * whose {@link ProjectEncryptionKeyMetadata} actually changed (using {@link ClusterChangedEvent#customMetadataChanged(ProjectId, String)})
+ * and rebuilds only the affected slots. Cache slots for deleted projects are removed.
+ *
+ * <p>Read access through the {@link AesGcmEncryptionService.KeyProvider} accessors resolves the caller's project via the injected
+ * {@link ProjectResolver}: callers (e.g. ES|QL) must already operate inside a project context (set explicitly via
+ * {@link ProjectResolver#executeOnProject(ProjectId, org.elasticsearch.core.CheckedRunnable)} or implicitly via the request thread
+ * context). If no slot exists for the resolved project id the accessors return {@code null}, which the encryption service surfaces as
+ * an {@link org.elasticsearch.xpack.encryption.spi.EncryptionKeyNotYetAvailableException}. We never fall back to another project's slot.
+ *
+ * <p>Installation, rotation, and retirement of PEK material are owned by {@link KeyRotationCoordinator}; this class is read-only with
  * respect to cluster state.
  */
 public class ProjectEncryptionKeyService implements AesGcmEncryptionService.KeyProvider {
@@ -43,7 +56,7 @@ public class ProjectEncryptionKeyService implements AesGcmEncryptionService.KeyP
     public static final NodeFeature PROJECT_ENCRYPTION_KEY_FEATURE = new NodeFeature("security.primary_encryption_key");
 
     private final ProjectResolver projectResolver;
-    private volatile KeyCache cache = KeyCache.EMPTY;
+    private final ConcurrentHashMap<ProjectId, KeyCache> cacheByProject = new ConcurrentHashMap<>();
 
     private ProjectEncryptionKeyService(ProjectResolver projectResolver) {
         this.projectResolver = projectResolver;
@@ -63,49 +76,63 @@ public class ProjectEncryptionKeyService implements AesGcmEncryptionService.KeyP
             return;
         }
 
-        if (event.changedCustomProjectMetadataSet().contains(ProjectEncryptionKeyMetadata.TYPE) == false) {
-            return;
-        }
+        // Refresh each project whose PEK metadata actually changed in this event. We do not rely on a single "current" project
+        // resolved from the cluster-applier thread's (empty) ThreadContext — that's the bug class fixed by this listener.
+        Set<ProjectId> projectsToCheck = new HashSet<>(state.metadata().projects().keySet());
+        projectsToCheck.addAll(event.previousState().metadata().projects().keySet());
 
-        ProjectState projectState = projectResolver.getProjectState(state);
-        ProjectEncryptionKeyMetadata metadata = projectState.metadata().custom(ProjectEncryptionKeyMetadata.TYPE);
-
-        if (metadata == null) {
-            if (this.cache != KeyCache.EMPTY) {
-                logger.debug("project encryption key cache cleared after snapshot restore");
-                this.cache = KeyCache.EMPTY;
+        for (ProjectId projectId : projectsToCheck) {
+            if (event.customMetadataChanged(projectId, ProjectEncryptionKeyMetadata.TYPE) == false) {
+                continue;
             }
-            return;
-        }
+            ProjectMetadata project = state.metadata().projects().get(projectId);
+            ProjectEncryptionKeyMetadata metadata = project != null ? project.custom(ProjectEncryptionKeyMetadata.TYPE) : null;
 
-        Map<String, SecretKey> keysByKeyId = HashMap.newHashMap(metadata.getKeys().size());
-        for (String keyId : metadata.getKeys().keySet()) {
-            SecretKey secretKey = metadata.toSecretKey(keyId);
-            assert secretKey != null : "key [" + keyId + "] present in metadata but toSecretKey returned null";
-            keysByKeyId.put(keyId, secretKey);
+            if (metadata == null) {
+                if (cacheByProject.remove(projectId) != null) {
+                    logger.debug("project encryption key cache cleared for project [{}]", projectId);
+                }
+                continue;
+            }
+
+            Map<String, SecretKey> keysByKeyId = HashMap.newHashMap(metadata.getKeys().size());
+            for (String keyId : metadata.getKeys().keySet()) {
+                SecretKey secretKey = metadata.toSecretKey(keyId);
+                assert secretKey != null : "key [" + keyId + "] present in metadata but toSecretKey returned null";
+                keysByKeyId.put(keyId, secretKey);
+            }
+            cacheByProject.put(projectId, new KeyCache(metadata.getActiveKeyId(), keysByKeyId));
+            logger.debug("project encryption key cache updated for project [{}]: activeKeyId={}", projectId, metadata.getActiveKeyId());
         }
-        this.cache = new KeyCache(metadata.getActiveKeyId(), keysByKeyId);
-        logger.debug("project encryption key cache updated: activeKeyId={}", metadata.getActiveKeyId());
     }
 
     @Override
     @Nullable
     public AesGcmEncryptionService.ActiveKey getActiveKey() {
-        KeyCache snapshot = cache;
-        if (snapshot.activeKeyId() == null) {
+        ProjectId projectId = projectResolver.getProjectId();
+        assert projectId != null : "ProjectResolver returned null project id";
+        KeyCache slot = cacheByProject.get(projectId);
+        if (slot == null || slot.activeKeyId() == null) {
+            logger.debug("no encryption key available for project [{}]", projectId);
             return null;
         }
-        return new AesGcmEncryptionService.ActiveKey(snapshot.activeKeyId(), snapshot.activeKey());
+        return new AesGcmEncryptionService.ActiveKey(slot.activeKeyId(), slot.activeKey());
     }
 
     @Override
     @Nullable
     public SecretKey getKey(String keyId) {
-        return cache.keysByKeyId().get(keyId);
+        ProjectId projectId = projectResolver.getProjectId();
+        assert projectId != null : "ProjectResolver returned null project id";
+        KeyCache slot = cacheByProject.get(projectId);
+        if (slot == null) {
+            logger.debug("no encryption key cache slot for project [{}]", projectId);
+            return null;
+        }
+        return slot.keysByKeyId().get(keyId);
     }
 
     private record KeyCache(String activeKeyId, Map<String, SecretKey> keysByKeyId) {
-        static final KeyCache EMPTY = new KeyCache(null, Map.of());
 
         KeyCache {
             assert activeKeyId == null || keysByKeyId.containsKey(activeKeyId);

--- a/x-pack/plugin/encryption/src/test/java/org/elasticsearch/xpack/encryption/KeyRotationCoordinatorTests.java
+++ b/x-pack/plugin/encryption/src/test/java/org/elasticsearch/xpack/encryption/KeyRotationCoordinatorTests.java
@@ -16,16 +16,19 @@ import org.elasticsearch.cluster.NamedDiff;
 import org.elasticsearch.cluster.ProjectState;
 import org.elasticsearch.cluster.SimpleBatchedExecutor;
 import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.metadata.ProjectId;
 import org.elasticsearch.cluster.metadata.ProjectMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
-import org.elasticsearch.cluster.project.DefaultProjectResolver;
+import org.elasticsearch.cluster.project.ProjectResolver;
+import org.elasticsearch.cluster.project.TestProjectResolvers;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.cluster.service.MasterServiceTaskQueue;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.ChunkedToXContentHelper;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
@@ -38,7 +41,9 @@ import org.elasticsearch.xpack.encryption.spi.EncryptedDataHandler;
 import org.elasticsearch.xpack.encryption.spi.EncryptionService;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -48,8 +53,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.ArgumentMatchers.startsWith;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -96,6 +104,19 @@ public class KeyRotationCoordinatorTests extends ESTestCase {
             .build();
     }
 
+    /** Builds cluster state populated with a PEK per project listed in {@code pekByProject}. */
+    private static ClusterState clusterStateWithProjects(Map<ProjectId, ProjectEncryptionKeyMetadata> pekByProject, boolean isLocalMaster) {
+        Metadata.Builder metadata = Metadata.builder();
+        for (var entry : pekByProject.entrySet()) {
+            ProjectMetadata.Builder project = ProjectMetadata.builder(entry.getKey());
+            if (entry.getValue() != null) {
+                project.putCustom(ProjectEncryptionKeyMetadata.TYPE, entry.getValue());
+            }
+            metadata.put(project.build());
+        }
+        return ClusterState.builder(CLUSTER_NAME).metadata(metadata.build()).nodes(nodes(isLocalMaster)).build();
+    }
+
     private KeyRotationCoordinator coordinator;
     private MasterServiceTaskQueue taskQueue;
     private EncryptionService encryptionService;
@@ -106,7 +127,8 @@ public class KeyRotationCoordinatorTests extends ESTestCase {
         TimeValue rotationInterval,
         TimeValue checkInterval,
         FeatureService featureService,
-        List<EncryptedDataHandler<?>> handlers
+        List<EncryptedDataHandler<?>> handlers,
+        ProjectResolver projectResolver
     ) {
         taskQueue = mock(MasterServiceTaskQueue.class);
         ClusterService clusterService = mock(ClusterService.class);
@@ -120,7 +142,7 @@ public class KeyRotationCoordinatorTests extends ESTestCase {
         coordinator = KeyRotationCoordinator.create(
             clusterService,
             threadPool,
-            DefaultProjectResolver.INSTANCE,
+            projectResolver,
             featureService,
             encryptionService,
             handlers,
@@ -129,6 +151,17 @@ public class KeyRotationCoordinatorTests extends ESTestCase {
                 .put(KeyRotationCoordinator.CHECK_INTERVAL_SETTING.getKey(), checkInterval)
                 .build()
         );
+    }
+
+    private void setup(
+        ClusterState state,
+        long now,
+        TimeValue rotationInterval,
+        TimeValue checkInterval,
+        FeatureService featureService,
+        List<EncryptedDataHandler<?>> handlers
+    ) {
+        setup(state, now, rotationInterval, checkInterval, featureService, handlers, TestProjectResolvers.DEFAULT_PROJECT_ONLY);
     }
 
     private void setup(ClusterState state, long now, TimeValue rotationInterval, TimeValue checkInterval, FeatureService featureService) {
@@ -156,7 +189,13 @@ public class KeyRotationCoordinatorTests extends ESTestCase {
         ClusterState next = clusterStateWith(null, true);
         coordinator.onClusterStateChanged(new ClusterChangedEvent("test", next, prev));
 
-        verify(taskQueue).submitTask(eq("install-project-encryption-key"), isA(KeyRotationCoordinator.InstallKeyTask.class), any());
+        verify(taskQueue).submitTask(
+            startsWith("install-project-encryption-key"),
+            argThat(
+                t -> t instanceof KeyRotationCoordinator.InstallKeyTask install && install.projectId().equals(Metadata.DEFAULT_PROJECT_ID)
+            ),
+            any()
+        );
     }
 
     public void testInstallNotSubmittedWhenNotMaster() {
@@ -190,6 +229,56 @@ public class KeyRotationCoordinatorTests extends ESTestCase {
         verify(taskQueue, never()).submitTask(anyString(), any(), any());
     }
 
+    public void testInstallSubmittedForEachProjectMissingKey() {
+        FeatureService featureService = mock(FeatureService.class);
+        when(featureService.clusterHasFeature(any(), any())).thenReturn(true);
+        ProjectId p1 = ProjectId.fromId("p1");
+        ProjectId p2 = ProjectId.fromId("p2");
+        Map<ProjectId, ProjectEncryptionKeyMetadata> none = new HashMap<>();
+        none.put(p1, null);
+        none.put(p2, null);
+        ClusterState state = clusterStateWithProjects(none, true);
+        setup(state, 0L, TimeValue.timeValueDays(30), TimeValue.timeValueMinutes(1), featureService);
+
+        coordinator.onClusterStateChanged(new ClusterChangedEvent("test", state, state));
+
+        verify(taskQueue).submitTask(
+            startsWith("install-project-encryption-key"),
+            argThat(t -> t instanceof KeyRotationCoordinator.InstallKeyTask install && install.projectId().equals(p1)),
+            any()
+        );
+        verify(taskQueue).submitTask(
+            startsWith("install-project-encryption-key"),
+            argThat(t -> t instanceof KeyRotationCoordinator.InstallKeyTask install && install.projectId().equals(p2)),
+            any()
+        );
+    }
+
+    public void testInstallOnlySubmittedForProjectsWithoutKey() {
+        FeatureService featureService = mock(FeatureService.class);
+        when(featureService.clusterHasFeature(any(), any())).thenReturn(true);
+        ProjectId p1 = ProjectId.fromId("p1");
+        ProjectId p2 = ProjectId.fromId("p2");
+        Map<ProjectId, ProjectEncryptionKeyMetadata> projects = new HashMap<>();
+        projects.put(p1, new ProjectEncryptionKeyMetadata(Map.of("k1", entry(0L)), "k1"));
+        projects.put(p2, null);
+        ClusterState state = clusterStateWithProjects(projects, true);
+        setup(state, 0L, TimeValue.timeValueDays(30), TimeValue.timeValueMinutes(1), featureService);
+
+        coordinator.onClusterStateChanged(new ClusterChangedEvent("test", state, state));
+
+        verify(taskQueue).submitTask(
+            startsWith("install-project-encryption-key"),
+            argThat(t -> t instanceof KeyRotationCoordinator.InstallKeyTask install && install.projectId().equals(p2)),
+            any()
+        );
+        verify(taskQueue, never()).submitTask(
+            anyString(),
+            argThat(t -> t instanceof KeyRotationCoordinator.InstallKeyTask install && install.projectId().equals(p1)),
+            any()
+        );
+    }
+
     public void testTickIsNoopWhenRotationDisabled() {
         setup(clusterStateWith(null, true), 0L, TimeValue.ZERO);
         coordinator.tick();
@@ -217,8 +306,10 @@ public class KeyRotationCoordinatorTests extends ESTestCase {
         coordinator.tick();
 
         verify(taskQueue).submitTask(
-            eq("begin-project-encryption-key-rotation"),
-            isA(KeyRotationCoordinator.BeginRotationTask.class),
+            startsWith("begin-project-encryption-key-rotation"),
+            argThat(
+                t -> t instanceof KeyRotationCoordinator.BeginRotationTask begin && begin.projectId().equals(Metadata.DEFAULT_PROJECT_ID)
+            ),
             any()
         );
     }
@@ -232,6 +323,32 @@ public class KeyRotationCoordinatorTests extends ESTestCase {
         coordinator.tick();
 
         verify(taskQueue, never()).submitTask(anyString(), any(), any());
+    }
+
+    public void testRotationOnlyBeginsForProjectsWithStaleActiveKey() {
+        long now = 10_000_000L;
+        long fresh = now - 1;
+        long stale = now - TimeValue.timeValueDays(30).millis() - 1;
+        ProjectId p1 = ProjectId.fromId("p1");
+        ProjectId p2 = ProjectId.fromId("p2");
+        Map<ProjectId, ProjectEncryptionKeyMetadata> projects = new HashMap<>();
+        projects.put(p1, new ProjectEncryptionKeyMetadata(Map.of("k1", entry(fresh)), "k1"));
+        projects.put(p2, new ProjectEncryptionKeyMetadata(Map.of("k2", entry(stale)), "k2"));
+        ClusterState state = clusterStateWithProjects(projects, true);
+        setup(state, now, TimeValue.timeValueDays(30));
+
+        coordinator.tick();
+
+        verify(taskQueue).submitTask(
+            startsWith("begin-project-encryption-key-rotation"),
+            argThat(t -> t instanceof KeyRotationCoordinator.BeginRotationTask begin && begin.projectId().equals(p2)),
+            any()
+        );
+        verify(taskQueue, never()).submitTask(
+            anyString(),
+            argThat(t -> t instanceof KeyRotationCoordinator.BeginRotationTask begin && begin.projectId().equals(p1)),
+            any()
+        );
     }
 
     public void testTickShortCircuitsHandlerAlreadyOnActiveKey() {
@@ -261,7 +378,11 @@ public class KeyRotationCoordinatorTests extends ESTestCase {
         coordinator.tick();
 
         assertEquals(1, calls.get());
-        verify(taskQueue).submitTask(eq("re-encrypt-" + TestCustom.TYPE), isA(KeyRotationCoordinator.ReEncryptApplyTask.class), any());
+        verify(taskQueue).submitTask(
+            contains("re-encrypt-" + TestCustom.TYPE),
+            isA(KeyRotationCoordinator.ReEncryptApplyTask.class),
+            any()
+        );
     }
 
     public void testHandlerReturningInputSkipsTaskSubmission() {
@@ -286,7 +407,51 @@ public class KeyRotationCoordinatorTests extends ESTestCase {
         coordinator.tick();
 
         assertEquals(1, calls.get());
-        verify(taskQueue, never()).submitTask(eq("re-encrypt-" + TestCustom.TYPE), any(), any());
+        verify(taskQueue, never()).submitTask(contains("re-encrypt-" + TestCustom.TYPE), any(), any());
+    }
+
+    public void testDispatchSetsProjectContextForHandler() {
+        long now = 100L;
+        ProjectId projectId = ProjectId.fromId("p-dispatch");
+        ProjectEncryptionKeyMetadata metadata = new ProjectEncryptionKeyMetadata(Map.of("k1", entry(50L)), "k1");
+        TestCustom seeded = TestCustom.encryptedUnder("old-key");
+        Map<ProjectId, ProjectEncryptionKeyMetadata> projects = Map.of(projectId, metadata);
+        Metadata.Builder metaBuilder = Metadata.builder();
+        ProjectMetadata.Builder project = ProjectMetadata.builder(projectId);
+        project.putCustom(ProjectEncryptionKeyMetadata.TYPE, metadata);
+        project.putCustom(seeded.getWriteableName(), seeded);
+        metaBuilder.put(project.build());
+        ClusterState state = ClusterState.builder(CLUSTER_NAME).metadata(metaBuilder.build()).nodes(nodes(true)).build();
+
+        // Resolver that exposes the project header in the thread context; the handler observes it during reEncrypt.
+        ThreadContext threadContext = new ThreadContext(org.elasticsearch.common.settings.Settings.EMPTY);
+        ProjectResolver projectResolver = TestProjectResolvers.usingRequestHeader(threadContext);
+        List<String> observed = new ArrayList<>();
+        EncryptedDataHandler<TestCustom> handler = new EncryptedDataHandler<>() {
+            @Override
+            public String customName() {
+                return TestCustom.TYPE;
+            }
+
+            @Override
+            public TestCustom reEncrypt(TestCustom current, EncryptionService svc, String activeKeyId) {
+                observed.add(threadContext.getHeader(org.elasticsearch.tasks.Task.X_ELASTIC_PROJECT_ID_HTTP_HEADER));
+                return TestCustom.encryptedUnder(activeKeyId);
+            }
+        };
+        setup(
+            state,
+            now,
+            TimeValue.timeValueDays(30),
+            TimeValue.timeValueMinutes(1),
+            mock(FeatureService.class),
+            List.of(handler),
+            projectResolver
+        );
+
+        coordinator.tick();
+
+        assertEquals("handler observed exactly one project context", List.of(projectId.id()), observed);
     }
 
     public void testTickSubmitsRetireForKeysOlderThanGrace() {
@@ -304,8 +469,8 @@ public class KeyRotationCoordinatorTests extends ESTestCase {
         coordinator.tick();
 
         verify(taskQueue).submitTask(
-            eq("retire-project-encryption-keys"),
-            eq(new KeyRotationCoordinator.RetireKeysTask(now - graceMillis)),
+            startsWith("retire-project-encryption-keys"),
+            eq(new KeyRotationCoordinator.RetireKeysTask(Metadata.DEFAULT_PROJECT_ID, now - graceMillis)),
             any()
         );
     }
@@ -324,11 +489,7 @@ public class KeyRotationCoordinatorTests extends ESTestCase {
 
         coordinator.tick();
 
-        verify(taskQueue, never()).submitTask(
-            eq("retire-project-encryption-keys"),
-            isA(KeyRotationCoordinator.RetireKeysTask.class),
-            any()
-        );
+        verify(taskQueue, never()).submitTask(anyString(), isA(KeyRotationCoordinator.RetireKeysTask.class), any());
     }
 
     public void testRetireGateHonorsHandlerKeyIds() {
@@ -345,11 +506,7 @@ public class KeyRotationCoordinatorTests extends ESTestCase {
 
         coordinator.tick();
 
-        verify(taskQueue, never()).submitTask(
-            eq("retire-project-encryption-keys"),
-            isA(KeyRotationCoordinator.RetireKeysTask.class),
-            any()
-        );
+        verify(taskQueue, never()).submitTask(anyString(), isA(KeyRotationCoordinator.RetireKeysTask.class), any());
     }
 
     public void testReEncryptApplyTaskUpdatesCustomAndHandlerKeyIds() throws Exception {
@@ -362,6 +519,7 @@ public class KeyRotationCoordinatorTests extends ESTestCase {
         SimpleBatchedExecutor<KeyRotationCoordinator.KeyRotationTask, Void> executor = newExecutor(now);
         ActionListener<Void> listener = listenerCapturingResponses(new AtomicInteger());
         KeyRotationCoordinator.ReEncryptApplyTask task = new KeyRotationCoordinator.ReEncryptApplyTask(
+            Metadata.DEFAULT_PROJECT_ID,
             TestCustom.TYPE,
             oldCustom,
             newCustom,
@@ -371,7 +529,7 @@ public class KeyRotationCoordinatorTests extends ESTestCase {
 
         Tuple<ClusterState, Void> result = executor.executeTask(task, state);
 
-        ProjectState projectState = DefaultProjectResolver.INSTANCE.getProjectState(result.v1());
+        ProjectState projectState = result.v1().projectState(Metadata.DEFAULT_PROJECT_ID);
         assertSame("new custom installed", newCustom, projectState.metadata().custom(TestCustom.TYPE));
         ProjectEncryptionKeyMetadata updated = projectState.metadata().custom(ProjectEncryptionKeyMetadata.TYPE);
         assertEquals("handlerKeyIds entry recorded", "k1", updated.getHandlerKeyIds().get(TestCustom.TYPE));
@@ -387,6 +545,7 @@ public class KeyRotationCoordinatorTests extends ESTestCase {
 
         SimpleBatchedExecutor<KeyRotationCoordinator.KeyRotationTask, Void> executor = newExecutor(now);
         KeyRotationCoordinator.ReEncryptApplyTask task = new KeyRotationCoordinator.ReEncryptApplyTask(
+            Metadata.DEFAULT_PROJECT_ID,
             TestCustom.TYPE,
             expectedOld,
             newCustom,
@@ -408,6 +567,7 @@ public class KeyRotationCoordinatorTests extends ESTestCase {
 
         SimpleBatchedExecutor<KeyRotationCoordinator.KeyRotationTask, Void> executor = newExecutor(now);
         KeyRotationCoordinator.ReEncryptApplyTask task = new KeyRotationCoordinator.ReEncryptApplyTask(
+            Metadata.DEFAULT_PROJECT_ID,
             TestCustom.TYPE,
             oldCustom,
             newCustomForK1,
@@ -420,10 +580,28 @@ public class KeyRotationCoordinatorTests extends ESTestCase {
         assertSame("cluster state unchanged when activeKeyId drifted", state, result.v1());
     }
 
+    public void testTaskForVanishedProjectIsDroppedAsNoop() throws Exception {
+        long now = 100L;
+        ProjectId vanished = ProjectId.fromId("vanished");
+        ProjectEncryptionKeyMetadata metadata = new ProjectEncryptionKeyMetadata(Map.of("k1", entry(50L)), "k1");
+        // Cluster state contains only DEFAULT_PROJECT_ID, not `vanished`.
+        ClusterState state = clusterStateWith(metadata, true);
+        SimpleBatchedExecutor<KeyRotationCoordinator.KeyRotationTask, Void> executor = newExecutor(now);
+
+        Tuple<ClusterState, Void> result = executor.executeTask(new KeyRotationCoordinator.InstallKeyTask(vanished), state);
+        assertSame("install task for missing project is a no-op", state, result.v1());
+
+        result = executor.executeTask(new KeyRotationCoordinator.BeginRotationTask(vanished), state);
+        assertSame("begin-rotation task for missing project is a no-op", state, result.v1());
+
+        result = executor.executeTask(new KeyRotationCoordinator.RetireKeysTask(vanished, 0L), state);
+        assertSame("retire task for missing project is a no-op", state, result.v1());
+    }
+
     private static SimpleBatchedExecutor<KeyRotationCoordinator.KeyRotationTask, Void> newExecutor(long now) {
         ThreadPool threadPool = mock(ThreadPool.class);
         when(threadPool.absoluteTimeInMillis()).thenReturn(now);
-        return new KeyRotationCoordinator.KeyRotationExecutor(DefaultProjectResolver.INSTANCE, threadPool);
+        return new KeyRotationCoordinator.KeyRotationExecutor(threadPool);
     }
 
     private static ActionListener<Void> listenerCapturingResponses(AtomicInteger counter) {

--- a/x-pack/plugin/encryption/src/test/java/org/elasticsearch/xpack/encryption/KeyRotationExecutorTests.java
+++ b/x-pack/plugin/encryption/src/test/java/org/elasticsearch/xpack/encryption/KeyRotationExecutorTests.java
@@ -9,8 +9,8 @@ package org.elasticsearch.xpack.encryption;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.metadata.ProjectId;
 import org.elasticsearch.cluster.metadata.ProjectMetadata;
-import org.elasticsearch.cluster.project.DefaultProjectResolver;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -27,10 +27,7 @@ public class KeyRotationExecutorTests extends ESTestCase {
 
     private static final ClusterName CLUSTER_NAME = new ClusterName("test");
     private final ThreadPool threadPool = mockThreadPool();
-    private final KeyRotationCoordinator.KeyRotationExecutor executor = new KeyRotationCoordinator.KeyRotationExecutor(
-        DefaultProjectResolver.INSTANCE,
-        threadPool
-    );
+    private final KeyRotationCoordinator.KeyRotationExecutor executor = new KeyRotationCoordinator.KeyRotationExecutor(threadPool);
 
     private static ThreadPool mockThreadPool() {
         ThreadPool tp = mock(ThreadPool.class);
@@ -49,22 +46,41 @@ public class KeyRotationExecutorTests extends ESTestCase {
     }
 
     private static ClusterState stateWith(ProjectEncryptionKeyMetadata metadata) {
-        ProjectMetadata.Builder project = ProjectMetadata.builder(Metadata.DEFAULT_PROJECT_ID);
+        return stateWith(Metadata.DEFAULT_PROJECT_ID, metadata);
+    }
+
+    private static ClusterState stateWith(ProjectId projectId, ProjectEncryptionKeyMetadata metadata) {
+        ProjectMetadata.Builder project = ProjectMetadata.builder(projectId);
         if (metadata != null) {
             project.putCustom(ProjectEncryptionKeyMetadata.TYPE, metadata);
         }
         return ClusterState.builder(CLUSTER_NAME).metadata(Metadata.builder().put(project.build()).build()).build();
     }
 
-    private static ProjectEncryptionKeyMetadata metadataOf(ClusterState state) {
-        return state.metadata().getProject(Metadata.DEFAULT_PROJECT_ID).custom(ProjectEncryptionKeyMetadata.TYPE);
+    private static ClusterState stateWithProjects(Map<ProjectId, ProjectEncryptionKeyMetadata> projects) {
+        Metadata.Builder metadata = Metadata.builder();
+        for (var entry : projects.entrySet()) {
+            ProjectMetadata.Builder project = ProjectMetadata.builder(entry.getKey());
+            if (entry.getValue() != null) {
+                project.putCustom(ProjectEncryptionKeyMetadata.TYPE, entry.getValue());
+            }
+            metadata.put(project.build());
+        }
+        return ClusterState.builder(CLUSTER_NAME).metadata(metadata.build()).build();
+    }
+
+    private static ProjectEncryptionKeyMetadata metadataOf(ClusterState state, ProjectId projectId) {
+        return state.metadata().getProject(projectId).custom(ProjectEncryptionKeyMetadata.TYPE);
     }
 
     public void testInstallInitialKeyOnEmptyState() {
         ClusterState state = stateWith(null);
-        Tuple<ClusterState, Void> result = executor.executeTask(new KeyRotationCoordinator.InstallKeyTask(), state);
+        Tuple<ClusterState, Void> result = executor.executeTask(
+            new KeyRotationCoordinator.InstallKeyTask(Metadata.DEFAULT_PROJECT_ID),
+            state
+        );
 
-        ProjectEncryptionKeyMetadata metadata = metadataOf(result.v1());
+        ProjectEncryptionKeyMetadata metadata = metadataOf(result.v1(), Metadata.DEFAULT_PROJECT_ID);
         assertNotNull(metadata);
         assertEquals(1, metadata.getKeys().size());
         String activeKeyId = metadata.getActiveKeyId();
@@ -75,17 +91,40 @@ public class KeyRotationExecutorTests extends ESTestCase {
     public void testInstallInitialKeyIsNoopWhenKeyExists() {
         ProjectEncryptionKeyMetadata existing = new ProjectEncryptionKeyMetadata(Map.of("k1", entry(42L)), "k1");
         ClusterState state = stateWith(existing);
-        Tuple<ClusterState, Void> result = executor.executeTask(new KeyRotationCoordinator.InstallKeyTask(), state);
+        Tuple<ClusterState, Void> result = executor.executeTask(
+            new KeyRotationCoordinator.InstallKeyTask(Metadata.DEFAULT_PROJECT_ID),
+            state
+        );
         assertSame(state, result.v1());
+    }
+
+    public void testInstallOnlyMutatesNamedProject() {
+        ProjectId p1 = ProjectId.fromId("p1");
+        ProjectId p2 = ProjectId.fromId("p2");
+        ProjectEncryptionKeyMetadata existing = new ProjectEncryptionKeyMetadata(Map.of("k1", entry(42L)), "k1");
+        Map<ProjectId, ProjectEncryptionKeyMetadata> projects = new HashMap<>();
+        projects.put(p1, null);
+        projects.put(p2, existing);
+        ClusterState state = stateWithProjects(projects);
+
+        Tuple<ClusterState, Void> result = executor.executeTask(new KeyRotationCoordinator.InstallKeyTask(p1), state);
+
+        ProjectEncryptionKeyMetadata p1Metadata = metadataOf(result.v1(), p1);
+        ProjectEncryptionKeyMetadata p2Metadata = metadataOf(result.v1(), p2);
+        assertNotNull("p1 should have been installed", p1Metadata);
+        assertEquals("p2 must not be mutated", existing, p2Metadata);
     }
 
     public void testBeginRotationAddsKeyAndAdvancesActive() {
         long activeBornAt = System.currentTimeMillis() - 60_000L;
         ProjectEncryptionKeyMetadata existing = new ProjectEncryptionKeyMetadata(Map.of("k1", entry(activeBornAt)), "k1");
         ClusterState state = stateWith(existing);
-        Tuple<ClusterState, Void> result = executor.executeTask(new KeyRotationCoordinator.BeginRotationTask(), state);
+        Tuple<ClusterState, Void> result = executor.executeTask(
+            new KeyRotationCoordinator.BeginRotationTask(Metadata.DEFAULT_PROJECT_ID),
+            state
+        );
 
-        ProjectEncryptionKeyMetadata metadata = metadataOf(result.v1());
+        ProjectEncryptionKeyMetadata metadata = metadataOf(result.v1(), Metadata.DEFAULT_PROJECT_ID);
         assertEquals(2, metadata.getKeys().size());
         assertNotEquals("k1", metadata.getActiveKeyId());
         assertTrue("k1 should remain in the map", metadata.getKeys().containsKey("k1"));
@@ -95,8 +134,29 @@ public class KeyRotationExecutorTests extends ESTestCase {
 
     public void testBeginRotationIsNoopWhenNoMetadata() {
         ClusterState state = stateWith(null);
-        Tuple<ClusterState, Void> result = executor.executeTask(new KeyRotationCoordinator.BeginRotationTask(), state);
+        Tuple<ClusterState, Void> result = executor.executeTask(
+            new KeyRotationCoordinator.BeginRotationTask(Metadata.DEFAULT_PROJECT_ID),
+            state
+        );
         assertSame(state, result.v1());
+    }
+
+    public void testBeginRotationOnlyMutatesNamedProject() {
+        ProjectId p1 = ProjectId.fromId("p1");
+        ProjectId p2 = ProjectId.fromId("p2");
+        ProjectEncryptionKeyMetadata p1Metadata = new ProjectEncryptionKeyMetadata(Map.of("a", entry(10L)), "a");
+        ProjectEncryptionKeyMetadata p2Metadata = new ProjectEncryptionKeyMetadata(Map.of("b", entry(20L)), "b");
+        Map<ProjectId, ProjectEncryptionKeyMetadata> projects = new HashMap<>();
+        projects.put(p1, p1Metadata);
+        projects.put(p2, p2Metadata);
+        ClusterState state = stateWithProjects(projects);
+
+        Tuple<ClusterState, Void> result = executor.executeTask(new KeyRotationCoordinator.BeginRotationTask(p1), state);
+
+        ProjectEncryptionKeyMetadata p1After = metadataOf(result.v1(), p1);
+        ProjectEncryptionKeyMetadata p2After = metadataOf(result.v1(), p2);
+        assertNotEquals("p1 should have a new active key", "a", p1After.getActiveKeyId());
+        assertEquals("p2 must not be mutated", p2Metadata, p2After);
     }
 
     public void testRetireKeysDropsOnlyKeysBelowCutoff() {
@@ -108,9 +168,12 @@ public class KeyRotationExecutorTests extends ESTestCase {
         ProjectEncryptionKeyMetadata existing = new ProjectEncryptionKeyMetadata(entries, "active");
         ClusterState state = stateWith(existing);
 
-        Tuple<ClusterState, Void> result = executor.executeTask(new KeyRotationCoordinator.RetireKeysTask(450L), state);
+        Tuple<ClusterState, Void> result = executor.executeTask(
+            new KeyRotationCoordinator.RetireKeysTask(Metadata.DEFAULT_PROJECT_ID, 450L),
+            state
+        );
 
-        ProjectEncryptionKeyMetadata metadata = metadataOf(result.v1());
+        ProjectEncryptionKeyMetadata metadata = metadataOf(result.v1(), Metadata.DEFAULT_PROJECT_ID);
         assertEquals("only 'old' should have been retired", Set.of("active", "recent"), metadata.getKeys().keySet());
         assertEquals("active", metadata.getActiveKeyId());
     }
@@ -124,9 +187,12 @@ public class KeyRotationExecutorTests extends ESTestCase {
         ClusterState state = stateWith(existing);
 
         long cutoff = 200L;
-        Tuple<ClusterState, Void> result = executor.executeTask(new KeyRotationCoordinator.RetireKeysTask(cutoff), state);
+        Tuple<ClusterState, Void> result = executor.executeTask(
+            new KeyRotationCoordinator.RetireKeysTask(Metadata.DEFAULT_PROJECT_ID, cutoff),
+            state
+        );
 
-        ProjectEncryptionKeyMetadata metadata = metadataOf(result.v1());
+        ProjectEncryptionKeyMetadata metadata = metadataOf(result.v1(), Metadata.DEFAULT_PROJECT_ID);
         assertEquals(Set.of("active"), metadata.getKeys().keySet());
         assertEquals("active", metadata.getActiveKeyId());
     }
@@ -135,13 +201,29 @@ public class KeyRotationExecutorTests extends ESTestCase {
         ProjectEncryptionKeyMetadata existing = new ProjectEncryptionKeyMetadata(Map.of("active", entry(1000L)), "active");
         ClusterState state = stateWith(existing);
 
-        Tuple<ClusterState, Void> result = executor.executeTask(new KeyRotationCoordinator.RetireKeysTask(500L), state);
+        Tuple<ClusterState, Void> result = executor.executeTask(
+            new KeyRotationCoordinator.RetireKeysTask(Metadata.DEFAULT_PROJECT_ID, 500L),
+            state
+        );
         assertSame(state, result.v1());
     }
 
     public void testRetireKeysIsNoopWhenNoMetadata() {
         ClusterState state = stateWith(null);
-        Tuple<ClusterState, Void> result = executor.executeTask(new KeyRotationCoordinator.RetireKeysTask(100L), state);
+        Tuple<ClusterState, Void> result = executor.executeTask(
+            new KeyRotationCoordinator.RetireKeysTask(Metadata.DEFAULT_PROJECT_ID, 100L),
+            state
+        );
         assertSame(state, result.v1());
+    }
+
+    public void testTaskForVanishedProjectIsNoop() throws Exception {
+        ProjectId vanished = ProjectId.fromId("vanished");
+        ProjectEncryptionKeyMetadata existing = new ProjectEncryptionKeyMetadata(Map.of("k1", entry(50L)), "k1");
+        ClusterState state = stateWith(Metadata.DEFAULT_PROJECT_ID, existing);
+
+        assertSame(state, executor.executeTask(new KeyRotationCoordinator.InstallKeyTask(vanished), state).v1());
+        assertSame(state, executor.executeTask(new KeyRotationCoordinator.BeginRotationTask(vanished), state).v1());
+        assertSame(state, executor.executeTask(new KeyRotationCoordinator.RetireKeysTask(vanished, 100L), state).v1());
     }
 }

--- a/x-pack/plugin/encryption/src/test/java/org/elasticsearch/xpack/encryption/ProjectEncryptionKeyServiceTests.java
+++ b/x-pack/plugin/encryption/src/test/java/org/elasticsearch/xpack/encryption/ProjectEncryptionKeyServiceTests.java
@@ -12,16 +12,22 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateListener;
 import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.metadata.ProjectId;
 import org.elasticsearch.cluster.metadata.ProjectMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.project.DefaultProjectResolver;
+import org.elasticsearch.cluster.project.ProjectResolver;
+import org.elasticsearch.cluster.project.TestProjectResolvers;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.gateway.GatewayService;
 import org.elasticsearch.test.ESTestCase;
 import org.mockito.ArgumentCaptor;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.mockito.Mockito.mock;
@@ -51,14 +57,29 @@ public class ProjectEncryptionKeyServiceTests extends ESTestCase {
     }
 
     private static ClusterState stateWithKey(ProjectEncryptionKeyMetadata pek) {
-        ProjectMetadata project = ProjectMetadata.builder(Metadata.DEFAULT_PROJECT_ID)
-            .putCustom(ProjectEncryptionKeyMetadata.TYPE, pek)
-            .build();
+        return stateWithKeyOnProject(Metadata.DEFAULT_PROJECT_ID, pek);
+    }
+
+    private static ClusterState stateWithKeyOnProject(ProjectId projectId, ProjectEncryptionKeyMetadata pek) {
+        ProjectMetadata project = ProjectMetadata.builder(projectId).putCustom(ProjectEncryptionKeyMetadata.TYPE, pek).build();
         return ClusterState.builder(CLUSTER_NAME).metadata(Metadata.builder().put(project).build()).nodes(nodes()).build();
     }
 
     private static ClusterState stateWithoutKey() {
         return ClusterState.builder(CLUSTER_NAME).nodes(nodes()).build();
+    }
+
+    /** Builds cluster state with each project from {@code pekByProject} keyed by its (possibly null) metadata. */
+    private static ClusterState stateWithProjects(Map<ProjectId, ProjectEncryptionKeyMetadata> pekByProject) {
+        Metadata.Builder metadata = Metadata.builder();
+        for (var entry : pekByProject.entrySet()) {
+            ProjectMetadata.Builder project = ProjectMetadata.builder(entry.getKey());
+            if (entry.getValue() != null) {
+                project.putCustom(ProjectEncryptionKeyMetadata.TYPE, entry.getValue());
+            }
+            metadata.put(project.build());
+        }
+        return ClusterState.builder(CLUSTER_NAME).metadata(metadata.build()).nodes(nodes()).build();
     }
 
     public void testGetActiveKeyReturnsNullInitially() {
@@ -113,7 +134,135 @@ public class ProjectEncryptionKeyServiceTests extends ESTestCase {
         listener.clusterChanged(new ClusterChangedEvent("test", withKey, stateWithoutKey()));
         assertNotNull(service.getActiveKey());
 
-        listener.clusterChanged(new ClusterChangedEvent("test", stateWithoutKey(), withKey));
+        // Replace the project's PEK metadata with absence — same project, but no PEK custom anymore.
+        ProjectMetadata emptyProject = ProjectMetadata.builder(Metadata.DEFAULT_PROJECT_ID).build();
+        ClusterState withoutKeyOnDefaultProject = ClusterState.builder(CLUSTER_NAME)
+            .metadata(Metadata.builder().put(emptyProject).build())
+            .nodes(nodes())
+            .build();
+        listener.clusterChanged(new ClusterChangedEvent("test", withoutKeyOnDefaultProject, withKey));
         assertNull(service.getActiveKey());
+    }
+
+    public void testTwoProjectsKeepDistinctKeys() {
+        // Regression for elastic/elasticsearch#149194: a single-slot cache silently dropped one project's keys when another project's
+        // metadata changed. With a project-keyed cache, each project's PEK must be reachable independently when the caller's
+        // ThreadContext names that project.
+        ClusterService clusterService = mock(ClusterService.class);
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        ProjectResolver projectResolver = TestProjectResolvers.usingRequestHeader(threadContext);
+        ProjectEncryptionKeyService service = ProjectEncryptionKeyService.create(clusterService, projectResolver);
+        ClusterStateListener listener = captureListener(clusterService);
+
+        ProjectId p1 = ProjectId.fromId("p1");
+        ProjectId p2 = ProjectId.fromId("p2");
+        ProjectEncryptionKeyMetadata pek1 = randomPekMetadata();
+        ProjectEncryptionKeyMetadata pek2 = randomPekMetadata();
+        Map<ProjectId, ProjectEncryptionKeyMetadata> projects = new HashMap<>();
+        projects.put(p1, pek1);
+        projects.put(p2, pek2);
+        listener.clusterChanged(new ClusterChangedEvent("test", stateWithProjects(projects), stateWithoutKey()));
+
+        projectResolver.executeOnProject(p1, () -> {
+            AesGcmEncryptionService.ActiveKey activeKey = service.getActiveKey();
+            assertNotNull("p1 must see its own key", activeKey);
+            assertEquals(pek1.getActiveKeyId(), activeKey.keyId());
+        });
+
+        projectResolver.executeOnProject(p2, () -> {
+            AesGcmEncryptionService.ActiveKey activeKey = service.getActiveKey();
+            assertNotNull("p2 must see its own key", activeKey);
+            assertEquals(pek2.getActiveKeyId(), activeKey.keyId());
+        });
+    }
+
+    public void testProjectAdditionAndRemoval() {
+        ClusterService clusterService = mock(ClusterService.class);
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        ProjectResolver projectResolver = TestProjectResolvers.usingRequestHeader(threadContext);
+        ProjectEncryptionKeyService service = ProjectEncryptionKeyService.create(clusterService, projectResolver);
+        ClusterStateListener listener = captureListener(clusterService);
+
+        ProjectId p1 = ProjectId.fromId("p1");
+        ProjectId p2 = ProjectId.fromId("p2");
+        ProjectEncryptionKeyMetadata pek1 = randomPekMetadata();
+        ProjectEncryptionKeyMetadata pek2 = randomPekMetadata();
+
+        ClusterState withP1 = stateWithProjects(Map.of(p1, pek1));
+        listener.clusterChanged(new ClusterChangedEvent("test", withP1, stateWithoutKey()));
+        projectResolver.executeOnProject(p1, () -> assertNotNull(service.getActiveKey()));
+
+        // Add p2 — p1 must remain reachable.
+        Map<ProjectId, ProjectEncryptionKeyMetadata> withBoth = new HashMap<>();
+        withBoth.put(p1, pek1);
+        withBoth.put(p2, pek2);
+        listener.clusterChanged(new ClusterChangedEvent("test", stateWithProjects(withBoth), withP1));
+        projectResolver.executeOnProject(p1, () -> assertEquals(pek1.getActiveKeyId(), service.getActiveKey().keyId()));
+        projectResolver.executeOnProject(p2, () -> assertEquals(pek2.getActiveKeyId(), service.getActiveKey().keyId()));
+
+        // Remove p1 — only p2 remains.
+        ClusterState onlyP2 = stateWithProjects(Map.of(p2, pek2));
+        listener.clusterChanged(new ClusterChangedEvent("test", onlyP2, stateWithProjects(withBoth)));
+        projectResolver.executeOnProject(p1, () -> assertNull("p1's slot must be cleared after removal", service.getActiveKey()));
+        projectResolver.executeOnProject(p2, () -> assertNotNull("p2 still reachable after p1 removal", service.getActiveKey()));
+    }
+
+    public void testMetadataChangeForOneProjectDoesNotDisturbOthers() {
+        ClusterService clusterService = mock(ClusterService.class);
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        ProjectResolver projectResolver = TestProjectResolvers.usingRequestHeader(threadContext);
+        ProjectEncryptionKeyService service = ProjectEncryptionKeyService.create(clusterService, projectResolver);
+        ClusterStateListener listener = captureListener(clusterService);
+
+        ProjectId p1 = ProjectId.fromId("p1");
+        ProjectId p2 = ProjectId.fromId("p2");
+        ProjectEncryptionKeyMetadata pek1Initial = randomPekMetadata();
+        ProjectEncryptionKeyMetadata pek2Initial = randomPekMetadata();
+        Map<ProjectId, ProjectEncryptionKeyMetadata> initial = new HashMap<>();
+        initial.put(p1, pek1Initial);
+        initial.put(p2, pek2Initial);
+        listener.clusterChanged(new ClusterChangedEvent("test", stateWithProjects(initial), stateWithoutKey()));
+
+        // Rotate p1's key only.
+        ProjectEncryptionKeyMetadata pek1Rotated = randomPekMetadata();
+        Map<ProjectId, ProjectEncryptionKeyMetadata> rotated = new HashMap<>();
+        rotated.put(p1, pek1Rotated);
+        rotated.put(p2, pek2Initial);
+        listener.clusterChanged(new ClusterChangedEvent("test", stateWithProjects(rotated), stateWithProjects(initial)));
+
+        projectResolver.executeOnProject(
+            p1,
+            () -> assertEquals("p1's slot reflects the rotation", pek1Rotated.getActiveKeyId(), service.getActiveKey().keyId())
+        );
+        projectResolver.executeOnProject(
+            p2,
+            () -> assertEquals(
+                "p2's slot must be untouched by p1's metadata change",
+                pek2Initial.getActiveKeyId(),
+                service.getActiveKey().keyId()
+            )
+        );
+    }
+
+    public void testGetActiveKeyWithoutProjectContextReturnsNullOnUnknownProject() {
+        // In a multi-project cluster, a caller that forgets to set its project header lands on whatever the resolver's fallback returns
+        // (typically DEFAULT_PROJECT_ID). If no PEK is installed on that fallback project, we must return null — never silently route
+        // to another project's keys.
+        ClusterService clusterService = mock(ClusterService.class);
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        ProjectResolver projectResolver = TestProjectResolvers.usingRequestHeader(threadContext);
+        ProjectEncryptionKeyService service = ProjectEncryptionKeyService.create(clusterService, projectResolver);
+        ClusterStateListener listener = captureListener(clusterService);
+
+        ProjectId installedProject = ProjectId.fromId("only-p1");
+        ProjectEncryptionKeyMetadata pek = randomPekMetadata();
+        listener.clusterChanged(new ClusterChangedEvent("test", stateWithProjects(Map.of(installedProject, pek)), stateWithoutKey()));
+
+        // No project header set — the test resolver falls back to DEFAULT_PROJECT_ID, which has no cache slot.
+        assertNull("no slot for fallback project must surface as null", service.getActiveKey());
+        assertNull(service.getKey(pek.getActiveKeyId()));
+
+        // With the correct project header, the keys become reachable.
+        projectResolver.executeOnProject(installedProject, () -> assertNotNull(service.getActiveKey()));
     }
 }


### PR DESCRIPTION
Closes elastic/elasticsearch-team#2893 (https://github.com/elastic/elasticsearch-team/issues/2893). Fixes the structural defect tracked in elastic/elasticsearch#149194 (https://github.com/elastic/elasticsearch/issues/149194).

The bug. ProjectEncryptionKeyService held a single in-memory key cache slot and only ever loaded one project's ProjectEncryptionKeyMetadata into it (whichever the cluster-applier-thread's empty ThreadContext resolved to). Every project's encrypt/decrypt silently landed on that one slot. KeyRotationCoordinator had the
 same single-project assumption across install / begin-rotation / retire / re-encrypt.

The fix.
• ProjectEncryptionKeyService now keeps a ConcurrentHashMap<ProjectId, KeyCache> and rebuilds only the affected slot per cluster-state change (using customMetadataChanged(ProjectId, TYPE)); slots for deleted projects are dropped.
• Read accessors resolve the caller's project via the injected ProjectResolver and return null (no fallback) when there is no slot — surfaces as EncryptionKeyNotYetAvailableException instead of silently routing to another project's keys.
• KeyRotationCoordinator fans out over state.metadata().projects(); every KeyRotationTask (InstallKeyTask, BeginRotationTask, RetireKeysTask, ReEncryptApplyTask) carries a ProjectId; KeyRotationExecutor reads clusterState.projectState(task.projectId()) and no longer depends on ProjectResolver.
• The in-flight rotation flag is now a per-project ConcurrentHashMap<ProjectId, Long> so a slow project can't block others.
• dispatchOne wraps handler.reEncrypt(...) in projectResolver.executeOnProject(projectId, ...) so any encrypt/decrypt the handler issues lands on the correct project's keys.
• EncryptionService / EncryptedDataHandler SPI signatures are unchanged — consumers (e.g. ES|QL) keep using the standard project-in-ThreadContext contract.

Tests. Added multi-project unit coverage including the direct regression for the one-slot cache (testTwoProjectsKeepDistinctKeys), project add/remove, isolation under per-project metadata changes, loud-failure on missing project context, per-project install / begin-rotation / retire dispatch, vanished-project no-ops,
 and verification that the handler observes the right project id in ThreadContext during dispatch. ./gradlew :x-pack:plugin:encryption:check is green.
