### PR TITLE
Unmute ArrayObjectsLimitIT tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -420,15 +420,6 @@ tests:
 - class: org.elasticsearch.xpack.stateless.commits.StatelessBatchedBehavioursIT
   method: testGenerationalFileBlobReferenceIsRetainedCorrectly
   issue: https://github.com/elastic/elasticsearch/issues/148723
-- class: org.elasticsearch.index.mapper.ArrayObjectsLimitIT
-  method: testDynamicSettingUpdateAffectsSubsequentDocuments
-  issue: https://github.com/elastic/elasticsearch/issues/148745
-- class: org.elasticsearch.index.mapper.ArrayObjectsLimitIT
-  method: testBulkPartialFailureOnArrayObjectsLimit
-  issue: https://github.com/elastic/elasticsearch/issues/148746
-- class: org.elasticsearch.index.mapper.ArrayObjectsLimitIT
-  method: testNestedArrayExceeded
-  issue: https://github.com/elastic/elasticsearch/issues/148747
 - class: org.elasticsearch.xpack.stateless.commits.StatelessFileDeletionIT
   method: testDeleteIndexWhileNodeStopping
   issue: https://github.com/elastic/elasticsearch/issues/148807


### PR DESCRIPTION
These three tests were fixed by #149163. The mutes were removed in that PR but accidentally re-added the same day by #148028, which merged a stale `muted-tests.yml`.
