### PR TITLE
Fixed TimeSlottedCounter for boost window cache quotas

### DIFF
--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/BlobCachePlugin.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/BlobCachePlugin.java
@@ -26,6 +26,9 @@ public class BlobCachePlugin extends Plugin implements ExtensiblePlugin {
             SharedBlobCacheService.SHARED_CACHE_MAX_FREQ_SETTING,
             SharedBlobCacheService.SHARED_CACHE_DECAY_INTERVAL_SETTING,
             SharedBlobCacheService.SHARED_CACHE_MIN_TIME_DELTA_SETTING,
+            SharedBlobCacheService.SHARED_CACHE_TIME_SLOTS_GRANULARITY_SETTING,
+            SharedBlobCacheService.SHARED_CACHE_TIME_SLOTS_PAST_COUNT_SETTING,
+            SharedBlobCacheService.SHARED_CACHE_TIME_SLOTS_FUTURE_COUNT_SETTING,
             SharedBlobCacheService.SHARED_CACHE_MMAP,
             SharedBlobCacheService.SHARED_CACHE_COUNT_READS,
             SharedBlobCacheService.SHARED_CACHE_CONCURRENT_EVICTIONS_SETTING

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
@@ -290,6 +290,27 @@ public class SharedBlobCacheService<KeyType extends SharedBlobCacheService.KeyBa
         Setting.Property.NodeScope
     );
 
+    public static final Setting<TimeValue> SHARED_CACHE_TIME_SLOTS_GRANULARITY_SETTING = Setting.timeSetting(
+        SHARED_CACHE_SETTINGS_PREFIX + "time_slots.granularity",
+        TimeValue.timeValueHours(1),
+        TimeValue.timeValueMinutes(1),
+        Setting.Property.NodeScope
+    );
+
+    public static final Setting<Integer> SHARED_CACHE_TIME_SLOTS_PAST_COUNT_SETTING = Setting.intSetting(
+        SHARED_CACHE_SETTINGS_PREFIX + "time_slots.past.count",
+        87600, // default 10y past retention (for 1h slots)
+        1,
+        Setting.Property.NodeScope
+    );
+
+    public static final Setting<Integer> SHARED_CACHE_TIME_SLOTS_FUTURE_COUNT_SETTING = Setting.intSetting(
+        SHARED_CACHE_SETTINGS_PREFIX + "time_slots.future.count",
+        8760, // default 1y future retention (for 1h slots); uptime beyond this without restart clamps new counts to the head slot
+        0,
+        Setting.Property.NodeScope
+    );
+
     public static final Setting<Boolean> SHARED_CACHE_MMAP = Setting.boolSetting(
         SHARED_CACHE_SETTINGS_PREFIX + "mmap",
         false,

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/TimeSlottedCounter.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/TimeSlottedCounter.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.blobcache.shared;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
+
+import java.util.concurrent.atomic.AtomicLongArray;
+import java.util.function.LongSupplier;
+
+/**
+ * Tracks counts in fixed-duration time slots using a fixed array of buckets indexed by slot time. Slots are
+ * defined by a time granularity, a past retention count, and a future retention count. E.g., 10:37 would be in
+ * slot 10:00 for 1h slots.
+ * <p>
+ * Used at node level for cache boost quota tracking (expected totals from shard data, and actual
+ * totals from cache residency). Callers pass arbitrary counts via {@link #add} and {@link #remove};
+ * this type is agnostic to what is being counted (the expectation is that it is cache regions).
+ * <p>
+ * The array is anchored at construction time and never rolled. It spans {@code [now - past, now + future]}
+ * at startup. Bucket sums are updated atomically.
+ * <p>
+ * Timestamps older than the tail slot are clamped to the tail bucket. Timestamps beyond the construction head
+ * slot are clamped to the head bucket. If the node runs longer than the configured future retention without
+ * restart, timestamps beyond the head slot are still clamped to the head bucket and {@link #sum} range queries
+ * lose time resolution for post-retention data until restart (quota accuracy degrades). Nodes are expected to
+ * restart at least once within {@code time_slots.future.count * time_slots.granularity} (defaults: one year
+ * at hourly slots).
+ */
+public class TimeSlottedCounter {
+
+    private static final Logger logger = LogManager.getLogger(TimeSlottedCounter.class);
+
+    private final long granularityMillis;
+    private final int pastBuckets;
+    private final int futureBuckets;
+    private final LongSupplier timeProvider;
+
+    private final AtomicLongArray counts;
+
+    /** {@code slotStart} of the oldest retained (tail) bucket; fixed at construction. */
+    private final long tailSlotStart;
+
+    /** {@code slotStart} of the newest retained (head) bucket; fixed at construction. */
+    private final long headSlotStart;
+
+    /**
+     * Creates a fixed array of {@code pastBuckets + futureBuckets} atomic count buckets, one per time slot of
+     * {@code granularity}, anchored at the current wall-clock time.
+     * <p>
+     * Example ({@code pastBuckets=4}, {@code futureBuckets=2}, 1h granularity, clock at 12:00):
+     * <pre>
+     *   tail slot 09:00, anchor 12:00, head slot 14:00
+     *   +--------------+--------------+--------------+--------------+--------------+--------------+
+     *   | index 0      | index 1      | index 2      | index 3      | index 4      | index 5      |
+     *   | tail         |              |              | anchor       |              | head         |
+     *   +--------------+--------------+--------------+--------------+--------------+--------------+
+     *   | 09:00-09:59  | 10:00-10:59  | 11:00-11:59  | 12:00-12:59  | 13:00-13:59  | 14:00-14:59  |
+     *   +--------------+--------------+--------------+--------------+--------------+--------------+
+     * </pre>
+     *
+     * @param granularity duration of each time slot
+     * @param pastBuckets number of past slots retained, including the anchor slot
+     * @param futureBuckets number of future slots retained beyond the anchor slot
+     * @param timeProvider source of wall-clock time in milliseconds
+     */
+    public TimeSlottedCounter(TimeValue granularity, int pastBuckets, int futureBuckets, LongSupplier timeProvider) {
+        if (granularity.millis() <= 0) {
+            throw new IllegalArgumentException("granularity must be positive");
+        }
+        if (pastBuckets < 1) {
+            throw new IllegalArgumentException("pastBuckets must be >= 1");
+        }
+        if (futureBuckets < 0) {
+            throw new IllegalArgumentException("futureBuckets must be >= 0");
+        }
+        this.granularityMillis = granularity.millis();
+        this.pastBuckets = pastBuckets;
+        this.futureBuckets = futureBuckets;
+        this.timeProvider = timeProvider;
+        this.counts = new AtomicLongArray(pastBuckets + futureBuckets);
+        long anchorSlot = slotStartForTimestamp(currentTimeMillis());
+        this.tailSlotStart = anchorSlot - (long) (pastBuckets - 1) * granularityMillis;
+        this.headSlotStart = anchorSlot + (long) futureBuckets * granularityMillis;
+    }
+
+    public static TimeSlottedCounter createFromSettings(Settings settings, LongSupplier timeProvider) {
+        return new TimeSlottedCounter(
+            SharedBlobCacheService.SHARED_CACHE_TIME_SLOTS_GRANULARITY_SETTING.get(settings),
+            SharedBlobCacheService.SHARED_CACHE_TIME_SLOTS_PAST_COUNT_SETTING.get(settings),
+            SharedBlobCacheService.SHARED_CACHE_TIME_SLOTS_FUTURE_COUNT_SETTING.get(settings),
+            timeProvider
+        );
+    }
+
+    public TimeValue granularity() {
+        return TimeValue.timeValueMillis(granularityMillis);
+    }
+
+    public int pastBuckets() {
+        return pastBuckets;
+    }
+
+    public int futureBuckets() {
+        return futureBuckets;
+    }
+
+    public int maxBuckets() {
+        return counts.length();
+    }
+
+    /**
+     * Adds {@code count} to the slot containing {@code timestampMillis}.
+     */
+    public void add(long timestampMillis, long count) {
+        if (count <= 0) {
+            return;
+        }
+        mutateSlot(timestampMillis, count);
+    }
+
+    /**
+     * Removes {@code count} from the slot containing {@code timestampMillis}.
+     * <p>
+     * The bucket is never driven below zero (excess remove is clamped).
+     */
+    public void remove(long timestampMillis, long count) {
+        if (count <= 0) {
+            return;
+        }
+        mutateSlot(timestampMillis, -count);
+    }
+
+    /**
+     * Returns the sum of counts in slots overlapping {@code [windowStartMillis, windowEndMillis)}.
+     * The query range is clamped to {@code [tailSlotStart, headSlotStart + granularity)} before summing.
+     * <p>
+     * Example (1h slots, range {@code [10:00, 13:00)}):
+     * <pre>
+     *   includes slots 10:00, 11:00, 12:00 (each [slotStart, slotStart+granularity) intersects the range)
+     *   excludes slot 13:00 (starts at range end)
+     * </pre>
+     */
+    public long sum(long windowStartMillis, long windowEndMillis) {
+        if (windowEndMillis <= windowStartMillis) {
+            return 0;
+        }
+        windowStartMillis = Math.max(Math.max(0, windowStartMillis), tailSlotStart);
+        long retainedEndExclusive = headSlotStart + granularityMillis;
+        windowEndMillis = Math.min(windowEndMillis, retainedEndExclusive);
+        if (windowEndMillis <= windowStartMillis) {
+            return 0;
+        }
+        int firstOverlapping = offsetFromTailForSlotStart(slotStartForTimestamp(windowStartMillis));
+        int firstNonOverlapping = offsetFromTailForSlotStart(slotStartForTimestamp(windowEndMillis - 1)) + 1;
+        return sumBucketsInOffsetRange(firstOverlapping, firstNonOverlapping);
+    }
+
+    long currentTimeMillis() {
+        return Math.max(0, timeProvider.getAsLong());
+    }
+
+    private long sumBucketsInOffsetRange(int startOffsetFromTail, int endOffsetFromTail) {
+        int start = Math.max(0, startOffsetFromTail);
+        int end = Math.min(counts.length(), endOffsetFromTail);
+        if (end <= start) {
+            return 0;
+        }
+        long total = 0;
+        for (int offsetFromTail = start; offsetFromTail < end; offsetFromTail++) {
+            total += counts.get(offsetFromTail);
+        }
+        return total;
+    }
+
+    private int offsetFromTailForSlotStart(long slotStart) {
+        return (int) Math.floorDiv(slotStart - tailSlotStart, granularityMillis);
+    }
+
+    private void mutateSlot(long timestampMillis, long delta) {
+        long slotStart = resolveSlotStart(timestampMillis);
+        int index = offsetFromTailForSlotStart(slotStart);
+        applyDelta(index, slotStart, delta);
+    }
+
+    private void applyDelta(int index, long slotStart, long delta) {
+        assert index >= 0 && index < counts.length() : "index [" + index + "] out of range [0," + counts.length() + "]";
+        if (delta > 0) {
+            counts.addAndGet(index, delta);
+            return;
+        }
+        long removal = -delta;
+        long previous = counts.getAndAccumulate(index, removal, (current, amount) -> current < amount ? 0 : current - amount);
+        if (previous < removal) {
+            assert false
+                : "remove clamped: slot start [" + slotStart + "] count [" + previous + "] less than remove count [" + removal + "]";
+            logger.warn("remove clamped: slot start [{}] count [{}] less than remove count [{}]", slotStart, previous, removal);
+        }
+    }
+
+    /**
+     * Maps a timestamp to the {@code slotStart} used for bucket lookup, clamped to the fixed array range.
+     */
+    private long resolveSlotStart(long timestampMillis) {
+        return Math.clamp(slotStartForTimestamp(Math.max(0, timestampMillis)), tailSlotStart, headSlotStart);
+    }
+
+    /**
+     * Truncates {@code timestampMillis} down to the start of its granularity-aligned slot.
+     * <p>
+     * Example: granularity 1h, {@code timestamp=10:37} -> {@code 10:00}.
+     */
+    private long slotStartForTimestamp(long timestampMillis) {
+        return Math.floorDiv(timestampMillis, granularityMillis) * granularityMillis;
+    }
+}

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/TimeSlottedCounter.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/TimeSlottedCounter.java
@@ -12,7 +12,11 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicLongArray;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.LongSupplier;
 
 /**
@@ -24,15 +28,21 @@ import java.util.function.LongSupplier;
  * totals from cache residency). Callers pass arbitrary counts via {@link #add} and {@link #remove};
  * this type is agnostic to what is being counted (the expectation is that it is cache regions).
  * <p>
+ * Fixed relative window sums can be registered via {@link #registerRelativeWindow} and read
+ * through {@link TimeSlottedCounterWindow#sum()}. The class automatically updates registered
+ * window sums as counts change. We expect a limited number of such windows, corresponding to the
+ * configured boost levels.
+ * <p>
  * The array is anchored at construction time and never rolled. It spans {@code [now - past, now + future]}
- * at startup. Bucket sums are updated atomically.
+ * at startup. Bucket sums are updated atomically; {@link #windowLock} coordinates registered window
+ * slides with concurrent {@link #add} and {@link #remove} calls.
  * <p>
  * Timestamps older than the tail slot are clamped to the tail bucket. Timestamps beyond the construction head
  * slot are clamped to the head bucket. If the node runs longer than the configured future retention without
- * restart, timestamps beyond the head slot are still clamped to the head bucket and {@link #sum} range queries
- * lose time resolution for post-retention data until restart (quota accuracy degrades). Nodes are expected to
- * restart at least once within {@code time_slots.future.count * time_slots.granularity} (defaults: one year
- * at hourly slots).
+ * restart, the sliding-window anchor stays at the head slot and all new counts beyond that slot accumulate
+ * in the head bucket; registered relative-window sums and {@link #sum} range queries then lose time resolution
+ * for post-retention data until restart (quota accuracy degrades). Nodes are expected to restart at least once
+ * within {@code time_slots.future.count * time_slots.granularity} (defaults: one year at hourly slots).
  */
 public class TimeSlottedCounter {
 
@@ -42,6 +52,8 @@ public class TimeSlottedCounter {
     private final int pastBuckets;
     private final int futureBuckets;
     private final LongSupplier timeProvider;
+    private final ReadWriteLock windowLock = new ReentrantReadWriteLock();
+    private final List<TimeSlottedCounterWindow> registeredWindows = new ArrayList<>();
 
     private final AtomicLongArray counts;
 
@@ -104,6 +116,10 @@ public class TimeSlottedCounter {
         return TimeValue.timeValueMillis(granularityMillis);
     }
 
+    long granularityMillis() {
+        return granularityMillis;
+    }
+
     public int pastBuckets() {
         return pastBuckets;
     }
@@ -114,6 +130,62 @@ public class TimeSlottedCounter {
 
     public int maxBuckets() {
         return counts.length();
+    }
+
+    /**
+     * Registers a fixed relative window whose sum is maintained incrementally by this counter.
+     * <p>
+     * {@code startOffsetMillis} and {@code endOffsetMillis} are clamped to whole slots at registration time.
+     * The resulting window spans {@code [now - endOffset, now - startOffset)} in slot-aligned boundaries.
+     * <p>
+     * Example at {@code now=10d} with 1h slots, {@code registerRelativeWindow(1d, 3d)}:
+     * <pre>
+     *   exclusiveEndSlotsBackFromAnchor=24, inclusiveStartSlotsBackFromAnchor=72 — slots overlapping [7d, 9d)
+     *
+     *   |---- retained buckets ----|.... now ....|
+     *                    ^windowStart    ^windowEnd
+     * </pre>
+     * The returned {@link TimeSlottedCounterWindow} is updated on every {@link #add}/{@link #remove} and window slide.
+     */
+    public TimeSlottedCounterWindow registerRelativeWindow(long startOffsetMillis, long endOffsetMillis) {
+        if (startOffsetMillis < 0 || endOffsetMillis < 0) {
+            throw new IllegalArgumentException("offsets must be non-negative");
+        }
+        if (endOffsetMillis <= startOffsetMillis) {
+            throw new IllegalArgumentException("endOffsetMillis must be greater than startOffsetMillis");
+        }
+        long now = currentTimeMillis();
+        int anchorOffset = anchorOffsetForNow(now);
+        int nearSlotsBackFromAnchor = anchorOffset - offsetFromTailForSlotStart(slotStartForTimestamp(now - startOffsetMillis));
+        int farSlotsBackFromAnchor = anchorOffset - offsetFromTailForSlotStart(slotStartForTimestamp(Math.max(0, now - endOffsetMillis)));
+        int exclusiveEndSlotsBackFromAnchor = Math.min(nearSlotsBackFromAnchor, anchorOffset);
+        int inclusiveStartSlotsBackFromAnchor = Math.min(farSlotsBackFromAnchor, anchorOffset);
+        if (inclusiveStartSlotsBackFromAnchor <= exclusiveEndSlotsBackFromAnchor) {
+            throw new IllegalArgumentException(
+                "inclusiveStartSlotsBackFromAnchor must be greater than exclusiveEndSlotsBackFromAnchor after slot clamping"
+            );
+        }
+        return registerRelativeWindow(exclusiveEndSlotsBackFromAnchor, inclusiveStartSlotsBackFromAnchor);
+    }
+
+    private TimeSlottedCounterWindow registerRelativeWindow(int exclusiveEndSlotsBackFromAnchor, int inclusiveStartSlotsBackFromAnchor) {
+        windowLock.writeLock().lock();
+        try {
+            long now = currentTimeMillis();
+            for (TimeSlottedCounterWindow registeredWindow : registeredWindows) {
+                registeredWindow.advanceUnderWriteLock(now);
+            }
+            TimeSlottedCounterWindow window = new TimeSlottedCounterWindow(
+                this,
+                exclusiveEndSlotsBackFromAnchor,
+                inclusiveStartSlotsBackFromAnchor
+            );
+            window.advanceUnderWriteLock(now);
+            registeredWindows.add(window);
+            return window;
+        } finally {
+            windowLock.writeLock().unlock();
+        }
     }
 
     /**
@@ -139,6 +211,59 @@ public class TimeSlottedCounter {
     }
 
     /**
+     * Returns the incrementally maintained sum for {@code window} after advancing time if needed.
+     * The sum is read under the same read lock used for slot mutations.
+     */
+    long readRegisteredWindowSum(TimeSlottedCounterWindow window) {
+        windowLock.readLock().lock();
+        try {
+            ensureRegisteredWindowsAdvancedWhileHoldingReadLock();
+            return window.cachedSum();
+        } finally {
+            windowLock.readLock().unlock();
+        }
+    }
+
+    /**
+     * Slides registered windows when the anchor slot has moved. Caller must hold {@link #windowLock} read lock;
+     * may temporarily release it to acquire the write lock.
+     */
+    private void ensureRegisteredWindowsAdvancedWhileHoldingReadLock() {
+        if (registeredWindows.isEmpty()) {
+            return;
+        }
+        long now = currentTimeMillis();
+        if (anyRegisteredWindowNeedsUpdate(now) == false) {
+            return;
+        }
+        windowLock.readLock().unlock();
+        windowLock.writeLock().lock();
+        try {
+            long advancedNow = currentTimeMillis();
+            if (anyRegisteredWindowNeedsUpdate(advancedNow)) {
+                for (TimeSlottedCounterWindow registeredWindow : registeredWindows) {
+                    registeredWindow.advanceUnderWriteLock(advancedNow);
+                }
+            }
+        } finally {
+            windowLock.writeLock().unlock();
+        }
+        windowLock.readLock().lock();
+        if (registeredWindows.isEmpty() == false && anyRegisteredWindowNeedsUpdate(currentTimeMillis())) {
+            ensureRegisteredWindowsAdvancedWhileHoldingReadLock();
+        }
+    }
+
+    private boolean anyRegisteredWindowNeedsUpdate(long now) {
+        for (TimeSlottedCounterWindow registeredWindow : registeredWindows) {
+            if (registeredWindow.needsUpdate(now)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Returns the sum of counts in slots overlapping {@code [windowStartMillis, windowEndMillis)}.
      * The query range is clamped to {@code [tailSlotStart, headSlotStart + granularity)} before summing.
      * <p>
@@ -158,16 +283,24 @@ public class TimeSlottedCounter {
         if (windowEndMillis <= windowStartMillis) {
             return 0;
         }
-        int firstOverlapping = offsetFromTailForSlotStart(slotStartForTimestamp(windowStartMillis));
-        int firstNonOverlapping = offsetFromTailForSlotStart(slotStartForTimestamp(windowEndMillis - 1)) + 1;
-        return sumBucketsInOffsetRange(firstOverlapping, firstNonOverlapping);
+        windowLock.readLock().lock();
+        try {
+            int firstOverlapping = offsetFromTailForSlotStart(slotStartForTimestamp(windowStartMillis));
+            int firstNonOverlapping = offsetFromTailForSlotStart(slotStartForTimestamp(windowEndMillis - 1)) + 1;
+            return sumBucketsInOffsetRange(firstOverlapping, firstNonOverlapping);
+        } finally {
+            windowLock.readLock().unlock();
+        }
     }
 
     long currentTimeMillis() {
         return Math.max(0, timeProvider.getAsLong());
     }
 
-    private long sumBucketsInOffsetRange(int startOffsetFromTail, int endOffsetFromTail) {
+    /**
+     * Sum over {@code [startOffsetFromTail, endOffsetFromTail)}. Caller must hold {@link #windowLock} read or write lock.
+     */
+    long sumBucketsInOffsetRange(int startOffsetFromTail, int endOffsetFromTail) {
         int start = Math.max(0, startOffsetFromTail);
         int end = Math.min(counts.length(), endOffsetFromTail);
         if (end <= start) {
@@ -180,21 +313,48 @@ public class TimeSlottedCounter {
         return total;
     }
 
-    private int offsetFromTailForSlotStart(long slotStart) {
+    int offsetFromTailForSlotStart(long slotStart) {
         return (int) Math.floorDiv(slotStart - tailSlotStart, granularityMillis);
     }
 
-    private void mutateSlot(long timestampMillis, long delta) {
-        long slotStart = resolveSlotStart(timestampMillis);
-        int index = offsetFromTailForSlotStart(slotStart);
-        applyDelta(index, slotStart, delta);
+    /**
+     * Slot start used as the sliding-window anchor for {@code now}. When wall clock has moved beyond
+     * the construction head slot, the anchor stays at the head so relative windows remain within the
+     * fixed bucket array.
+     */
+    long effectiveAnchorSlotStart(long now) {
+        long wallSlot = slotStartForTimestamp(now);
+        return wallSlot > headSlotStart ? headSlotStart : wallSlot;
     }
 
-    private void applyDelta(int index, long slotStart, long delta) {
+    int anchorOffsetForNow(long now) {
+        return offsetFromTailForSlotStart(effectiveAnchorSlotStart(now));
+    }
+
+    private void mutateSlot(long timestampMillis, long delta) {
+        windowLock.readLock().lock();
+        try {
+            ensureRegisteredWindowsAdvancedWhileHoldingReadLock();
+            long slotStart = resolveSlotStart(timestampMillis);
+            int index = offsetFromTailForSlotStart(slotStart);
+            long appliedDelta = applyDelta(index, slotStart, delta);
+            if (appliedDelta != 0) {
+                for (TimeSlottedCounterWindow window : registeredWindows) {
+                    if (window.containsSlot(slotStart)) {
+                        window.onSlotDelta(appliedDelta);
+                    }
+                }
+            }
+        } finally {
+            windowLock.readLock().unlock();
+        }
+    }
+
+    private long applyDelta(int index, long slotStart, long delta) {
         assert index >= 0 && index < counts.length() : "index [" + index + "] out of range [0," + counts.length() + "]";
         if (delta > 0) {
             counts.addAndGet(index, delta);
-            return;
+            return delta;
         }
         long removal = -delta;
         long previous = counts.getAndAccumulate(index, removal, (current, amount) -> current < amount ? 0 : current - amount);
@@ -203,6 +363,7 @@ public class TimeSlottedCounter {
                 : "remove clamped: slot start [" + slotStart + "] count [" + previous + "] less than remove count [" + removal + "]";
             logger.warn("remove clamped: slot start [{}] count [{}] less than remove count [{}]", slotStart, previous, removal);
         }
+        return -Math.min(removal, previous);
     }
 
     /**
@@ -217,7 +378,7 @@ public class TimeSlottedCounter {
      * <p>
      * Example: granularity 1h, {@code timestamp=10:37} -> {@code 10:00}.
      */
-    private long slotStartForTimestamp(long timestampMillis) {
+    long slotStartForTimestamp(long timestampMillis) {
         return Math.floorDiv(timestampMillis, granularityMillis) * granularityMillis;
     }
 }

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/TimeSlottedCounterWindow.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/TimeSlottedCounterWindow.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.blobcache.shared;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * A fixed relative-to-now window registered with a {@link TimeSlottedCounter}. The counter
+ * incrementally maintains the sum on slot mutations and window time slides; {@link #sum()}
+ * advances time if needed and returns the cached total under the counter read lock.
+ */
+public class TimeSlottedCounterWindow {
+
+    private final TimeSlottedCounter counter;
+    /**
+     * Exclusive window end: slots back from the sliding anchor at registration time. Smaller values are closer to
+     * {@code now}.
+     */
+    private final int exclusiveEndSlotsBackFromAnchor;
+    /**
+     * Inclusive window start: slots back from the sliding anchor at registration time. Larger values reach farther
+     * into the past.
+     */
+    private final int inclusiveStartSlotsBackFromAnchor;
+    private final AtomicLong sum = new AtomicLong();
+
+    private long lastNow = -1;
+    /** Inclusive window start as an offset from the tail slot. */
+    private int lastWindowStartOffsetFromTail = -1;
+    /** Exclusive window end as an offset from the tail slot. */
+    private int lastWindowEndOffsetFromTail = -1;
+
+    /**
+     * Package-private constructor; use {@link TimeSlottedCounter#registerRelativeWindow}.
+     * <p>
+     * Defines a sliding interval over {@code inclusiveStartSlotsBackFromAnchor - exclusiveEndSlotsBackFromAnchor}
+     * whole slots ending {@code exclusiveEndSlotsBackFromAnchor} slots before the current anchor. For example,
+     * {@code exclusiveEndSlotsBackFromAnchor=24, inclusiveStartSlotsBackFromAnchor=72} with 1h slots at
+     * {@code now=10d} tracks {@code [7d, 9d)}.
+     */
+    TimeSlottedCounterWindow(TimeSlottedCounter counter, int exclusiveEndSlotsBackFromAnchor, int inclusiveStartSlotsBackFromAnchor) {
+        this.counter = counter;
+        this.exclusiveEndSlotsBackFromAnchor = exclusiveEndSlotsBackFromAnchor;
+        this.inclusiveStartSlotsBackFromAnchor = inclusiveStartSlotsBackFromAnchor;
+    }
+
+    /**
+     * Returns the incrementally maintained sum after advancing the counter to the current time.
+     */
+    public long sum() {
+        return counter.readRegisteredWindowSum(this);
+    }
+
+    long cachedSum() {
+        return sum.get();
+    }
+
+    /**
+     * Whether this window needs a metadata touch or time slide for {@code now}. Caller must hold
+     * {@link TimeSlottedCounter}'s read lock.
+     */
+    boolean needsUpdate(long now) {
+        if (lastNow < 0) {
+            return true;
+        }
+        return counter.effectiveAnchorSlotStart(now) != counter.effectiveAnchorSlotStart(lastNow);
+    }
+
+    /**
+     * Full scan for tests and validation. Recomputes the bucket sum for the current window;
+     * does not read the cached {@link #sum}.
+     */
+    long sumUncached() {
+        long now = counter.currentTimeMillis();
+        long anchorSlot = counter.effectiveAnchorSlotStart(now);
+        return counter.sum(
+            anchorSlot - (long) inclusiveStartSlotsBackFromAnchor * counter.granularityMillis(),
+            anchorSlot - (long) exclusiveEndSlotsBackFromAnchor * counter.granularityMillis()
+        );
+    }
+
+    /**
+     * Fast reject before applying a slot delta.
+     */
+    boolean containsSlot(long slotStart) {
+        int slotOffset = counter.offsetFromTailForSlotStart(slotStart);
+        return slotOffset >= lastWindowStartOffsetFromTail && slotOffset < lastWindowEndOffsetFromTail;
+    }
+
+    /**
+     * Adjusts the cached sum when a bucket overlapping the current window changes.
+     */
+    void onSlotDelta(long delta) {
+        sum.addAndGet(delta);
+    }
+
+    /**
+     * Initializes or slides the cached sum when time advances. Caller must hold the counter write lock.
+     */
+    void advanceUnderWriteLock(long now) {
+        if (now <= lastNow) {
+            return;
+        }
+        int anchorOffset = counter.anchorOffsetForNow(now);
+        int windowStart = anchorOffset - inclusiveStartSlotsBackFromAnchor;
+        int windowEnd = anchorOffset - exclusiveEndSlotsBackFromAnchor;
+        if (lastWindowStartOffsetFromTail < 0) {
+            sum.set(counter.sumBucketsInOffsetRange(windowStart, windowEnd));
+        } else {
+            if (windowStart > lastWindowStartOffsetFromTail) {
+                sum.addAndGet(-counter.sumBucketsInOffsetRange(lastWindowStartOffsetFromTail, windowStart));
+            }
+            if (windowEnd > lastWindowEndOffsetFromTail) {
+                sum.addAndGet(counter.sumBucketsInOffsetRange(lastWindowEndOffsetFromTail, windowEnd));
+            }
+        }
+        updateMetadata(now, windowStart, windowEnd);
+    }
+
+    private void updateMetadata(long now, int windowStart, int windowEnd) {
+        lastNow = now;
+        lastWindowStartOffsetFromTail = windowStart;
+        lastWindowEndOffsetFromTail = windowEnd;
+    }
+}

--- a/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/TimeSlottedCounterTests.java
+++ b/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/TimeSlottedCounterTests.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.blobcache.shared;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class TimeSlottedCounterTests extends ESTestCase {
+
+    private static final long HOUR = TimeValue.timeValueHours(1).millis();
+    private static final long DAY = TimeValue.timeValueDays(1).millis();
+
+    public void testAddInRetainedPastSlot() {
+        AtomicLong clock = new AtomicLong(10 * DAY);
+        TimeSlottedCounter counter = new TimeSlottedCounter(TimeValue.timeValueHours(1), 500, 0, clock::get);
+        counter.add(8 * DAY, 7);
+        assertThat(counter.sum(7 * DAY, 9 * DAY), equalTo(7L));
+    }
+
+    public void testCreateFromSettings() {
+        Settings settings = Settings.builder()
+            .put(SharedBlobCacheService.SHARED_CACHE_TIME_SLOTS_GRANULARITY_SETTING.getKey(), "30m")
+            .put(SharedBlobCacheService.SHARED_CACHE_TIME_SLOTS_PAST_COUNT_SETTING.getKey(), 48)
+            .put(SharedBlobCacheService.SHARED_CACHE_TIME_SLOTS_FUTURE_COUNT_SETTING.getKey(), 24)
+            .build();
+        AtomicLong clock = new AtomicLong(0);
+        TimeSlottedCounter counter = TimeSlottedCounter.createFromSettings(settings, clock::get);
+        assertThat(counter.granularity(), equalTo(TimeValue.timeValueMinutes(30)));
+        assertThat(counter.pastBuckets(), equalTo(48));
+        assertThat(counter.futureBuckets(), equalTo(24));
+        assertThat(counter.maxBuckets(), equalTo(72));
+    }
+
+    public void testSlotTruncationAndClamping() {
+        AtomicLong clock = new AtomicLong(5 * HOUR + 30 * 60 * 1000);
+        TimeSlottedCounter counter = new TimeSlottedCounter(TimeValue.timeValueHours(1), 3, 0, clock::get);
+
+        long headSlot = 5 * HOUR;
+        counter.add(clock.get(), 10);
+        assertThat(counter.sum(headSlot, headSlot + HOUR), equalTo(10L));
+
+        counter.add(headSlot + 15 * 60 * 1000, 5);
+        assertThat(counter.sum(headSlot, headSlot + HOUR), equalTo(15L));
+
+        counter.add(headSlot + HOUR, 100);
+        assertThat(counter.sum(headSlot, headSlot + HOUR), equalTo(115L));
+
+        long tailSlot = headSlot - 2 * HOUR;
+        counter.add(tailSlot, 7);
+        assertThat(counter.sum(tailSlot, tailSlot + HOUR), equalTo(7L));
+    }
+
+    public void testAddRemoveSymmetry() {
+        AtomicLong clock = new AtomicLong(HOUR);
+        TimeSlottedCounter counter = new TimeSlottedCounter(TimeValue.timeValueHours(1), 5, 0, clock::get);
+
+        counter.add(HOUR + 100, 20);
+        counter.add(HOUR + 100, 10);
+        assertThat(counter.sum(HOUR, 2 * HOUR), equalTo(30L));
+
+        counter.remove(HOUR + 100, 25);
+        assertThat(counter.sum(HOUR, 2 * HOUR), equalTo(5L));
+    }
+
+    public void testConcurrentAdds() throws Exception {
+        AtomicLong clock = new AtomicLong(10 * HOUR);
+        TimeSlottedCounter counter = new TimeSlottedCounter(TimeValue.timeValueHours(1), 24, 0, clock::get);
+        long ts = clock.get();
+        int threads = 4;
+        int iterations = 500;
+        ExecutorService executor = Executors.newFixedThreadPool(threads);
+        try {
+            CountDownLatch start = new CountDownLatch(1);
+            CountDownLatch done = new CountDownLatch(threads);
+
+            for (int t = 0; t < threads; t++) {
+                executor.execute(() -> {
+                    try {
+                        start.await();
+                        for (int i = 0; i < iterations; i++) {
+                            counter.add(ts, 1);
+                        }
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    } finally {
+                        done.countDown();
+                    }
+                });
+            }
+            start.countDown();
+            assertTrue(done.await(30, TimeUnit.SECONDS));
+            assertThat(counter.sum(ts, ts + HOUR), equalTo((long) threads * iterations));
+        } finally {
+            terminate(executor);
+        }
+    }
+
+    public void testConcurrentAddAndSum() throws Exception {
+        AtomicLong clock = new AtomicLong(10 * HOUR);
+        TimeSlottedCounter counter = new TimeSlottedCounter(TimeValue.timeValueHours(1), 24, 0, clock::get);
+        long windowStart = 10 * HOUR;
+        long windowEnd = 15 * HOUR;
+        int addThreads = 2;
+        int sumThreads = 2;
+        int iterations = 300;
+        ExecutorService executor = Executors.newFixedThreadPool(addThreads + sumThreads);
+        try {
+            CountDownLatch start = new CountDownLatch(1);
+            CountDownLatch done = new CountDownLatch(addThreads + sumThreads);
+
+            for (int t = 0; t < addThreads; t++) {
+                executor.execute(() -> {
+                    try {
+                        start.await();
+                        for (int i = 0; i < iterations; i++) {
+                            long ts = windowStart + (i % 5) * HOUR;
+                            counter.add(ts, 1);
+                        }
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    } finally {
+                        done.countDown();
+                    }
+                });
+            }
+            for (int t = 0; t < sumThreads; t++) {
+                executor.execute(() -> {
+                    try {
+                        start.await();
+                        for (int i = 0; i < iterations; i++) {
+                            long sum = counter.sum(windowStart, windowEnd);
+                            assertThat(sum, org.hamcrest.Matchers.greaterThanOrEqualTo(0L));
+                        }
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    } finally {
+                        done.countDown();
+                    }
+                });
+            }
+            start.countDown();
+            assertTrue(done.await(30, TimeUnit.SECONDS));
+            assertThat(counter.sum(windowStart, windowEnd), equalTo((long) addThreads * iterations));
+        } finally {
+            terminate(executor);
+        }
+    }
+
+    public void testConcurrentAddRemove() throws Exception {
+        AtomicLong clock = new AtomicLong(10 * HOUR);
+        TimeSlottedCounter counter = new TimeSlottedCounter(TimeValue.timeValueHours(1), 24, 0, clock::get);
+        int threads = 4;
+        int iterations = 500;
+        ExecutorService executor = Executors.newFixedThreadPool(threads);
+        try {
+            CountDownLatch start = new CountDownLatch(1);
+            CountDownLatch done = new CountDownLatch(threads);
+
+            for (int t = 0; t < threads; t++) {
+                executor.execute(() -> {
+                    try {
+                        start.await();
+                        for (int i = 0; i < iterations; i++) {
+                            long ts = 10 * HOUR + (i % 5) * HOUR;
+                            counter.add(ts, 1);
+                            counter.remove(ts, 1);
+                        }
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    } finally {
+                        done.countDown();
+                    }
+                });
+            }
+            start.countDown();
+            assertTrue(done.await(30, TimeUnit.SECONDS));
+            assertThat(counter.sum(10 * HOUR, 15 * HOUR), equalTo(0L));
+        } finally {
+            terminate(executor);
+        }
+    }
+
+    public void testInvalidConstructorArgs() {
+        AtomicLong clock = new AtomicLong(0);
+        expectThrows(IllegalArgumentException.class, () -> new TimeSlottedCounter(TimeValue.ZERO, 1, 0, clock::get));
+        expectThrows(IllegalArgumentException.class, () -> new TimeSlottedCounter(TimeValue.timeValueHours(1), 0, 0, clock::get));
+        expectThrows(IllegalArgumentException.class, () -> new TimeSlottedCounter(TimeValue.timeValueHours(1), 1, -1, clock::get));
+    }
+
+    public void testFutureTimestampMapsToFutureSlot() {
+        AtomicLong clock = new AtomicLong(10 * HOUR);
+        TimeSlottedCounter counter = new TimeSlottedCounter(TimeValue.timeValueHours(1), 3, 2, clock::get);
+
+        long futureSlot = 12 * HOUR;
+        counter.add(futureSlot, 4);
+        assertThat(counter.sum(futureSlot, futureSlot + HOUR), equalTo(4L));
+        assertThat(counter.sum(10 * HOUR, 11 * HOUR), equalTo(0L));
+    }
+
+    public void testFutureTimestampBeyondHeadClampsToHead() {
+        AtomicLong clock = new AtomicLong(10 * HOUR);
+        TimeSlottedCounter counter = new TimeSlottedCounter(TimeValue.timeValueHours(1), 3, 1, clock::get);
+
+        long headSlot = 11 * HOUR;
+        counter.add(20 * HOUR, 6);
+        assertThat(counter.sum(headSlot, headSlot + HOUR), equalTo(6L));
+    }
+
+    public void testPastTimestampBeyondTailClampsToTail() {
+        AtomicLong clock = new AtomicLong(10 * DAY);
+        TimeSlottedCounter counter = new TimeSlottedCounter(TimeValue.timeValueHours(1), 48, 0, clock::get);
+
+        long tailSlot = 10 * DAY - (48 - 1) * HOUR;
+        counter.add(0, 9);
+        assertThat(counter.sum(tailSlot, tailSlot + HOUR), equalTo(9L));
+    }
+
+    public void testSumBeforeTailReturnsZero() {
+        AtomicLong clock = new AtomicLong(10 * DAY);
+        TimeSlottedCounter counter = new TimeSlottedCounter(TimeValue.timeValueHours(1), 48, 0, clock::get);
+
+        long tailSlot = 10 * DAY - (48 - 1) * HOUR;
+        counter.add(tailSlot + HOUR, 42);
+        assertThat(counter.sum(0, tailSlot), equalTo(0L));
+    }
+
+    public void testSumAfterHeadReturnsZero() {
+        AtomicLong clock = new AtomicLong(10 * HOUR);
+        TimeSlottedCounter counter = new TimeSlottedCounter(TimeValue.timeValueHours(1), 3, 1, clock::get);
+
+        long headSlot = 11 * HOUR;
+        counter.add(headSlot, 6);
+        assertThat(counter.sum(20 * HOUR, 30 * HOUR), equalTo(0L));
+    }
+}

--- a/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/TimeSlottedCounterWindowTests.java
+++ b/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/TimeSlottedCounterWindowTests.java
@@ -1,0 +1,314 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.blobcache.shared;
+
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class TimeSlottedCounterWindowTests extends ESTestCase {
+
+    private static final long HOUR = TimeValue.timeValueHours(1).millis();
+    private static final long DAY = TimeValue.timeValueDays(1).millis();
+
+    public void testMatchesUncachedLast24Hours() {
+        AtomicLong clock = new AtomicLong(10 * DAY);
+        TimeSlottedCounter counter = new TimeSlottedCounter(TimeValue.timeValueHours(1), 500, 0, clock::get);
+        TimeSlottedCounterWindow sliding = counter.registerRelativeWindow(0, 24 * HOUR);
+
+        for (int i = 0; i < 48; i++) {
+            counter.add(10 * DAY - i * HOUR, i + 1);
+        }
+
+        assertThat(sliding.sum(), equalTo(sliding.sumUncached()));
+    }
+
+    public void testMatchesUncachedRelativeWindow() {
+        AtomicLong clock = new AtomicLong(30 * DAY);
+        TimeSlottedCounter counter = new TimeSlottedCounter(TimeValue.timeValueHours(1), 1000, 0, clock::get);
+        TimeSlottedCounterWindow sliding = counter.registerRelativeWindow(DAY, 3 * DAY);
+
+        counter.add(clock.get() - DAY, 50);
+        counter.add(clock.get() - 2 * DAY, 25);
+
+        assertThat(sliding.sum(), equalTo(sliding.sumUncached()));
+    }
+
+    public void testFastPathWithinGranularity() {
+        AtomicLong clock = new AtomicLong(5 * DAY);
+        TimeSlottedCounter counter = new TimeSlottedCounter(TimeValue.timeValueHours(1), 200, 0, clock::get);
+        TimeSlottedCounterWindow sliding = counter.registerRelativeWindow(0, DAY);
+
+        counter.add(4 * DAY + HOUR, 10);
+        sliding.sum();
+
+        clock.addAndGet(TimeValue.timeValueMinutes(30).millis());
+        long second = sliding.sum();
+        assertThat(second, equalTo(sliding.sumUncached()));
+        assertThat(second, equalTo(10L));
+    }
+
+    public void testIncrementalRelativeWindow() {
+        AtomicLong clock = new AtomicLong(10 * DAY);
+        TimeSlottedCounter counter = new TimeSlottedCounter(TimeValue.timeValueHours(1), 500, 48, clock::get);
+        TimeSlottedCounterWindow sliding = counter.registerRelativeWindow(DAY, 3 * DAY);
+
+        counter.add(10 * DAY - 2 * DAY, 7);
+        long first = sliding.sum();
+
+        clock.addAndGet(2 * HOUR);
+        long newEntryTime = clock.get() - DAY - HOUR;
+        counter.add(newEntryTime, 3);
+
+        long second = sliding.sum();
+        assertThat(second, equalTo(sliding.sumUncached()));
+        assertThat(second, equalTo(first + 3L));
+    }
+
+    public void testIncrementalUpdateOnAdd() {
+        AtomicLong clock = new AtomicLong(5 * DAY);
+        TimeSlottedCounter counter = new TimeSlottedCounter(TimeValue.timeValueHours(1), 200, 0, clock::get);
+        TimeSlottedCounterWindow sliding = counter.registerRelativeWindow(0, DAY);
+
+        counter.add(4 * DAY + HOUR, 10);
+        long first = sliding.sum();
+        assertThat(first, equalTo(10L));
+
+        counter.add(4 * DAY + 2 * HOUR, 5);
+        long second = sliding.sum();
+        assertThat(second, equalTo(sliding.sumUncached()));
+        assertThat(second, equalTo(15L));
+    }
+
+    public void testManyMutationsWithoutRescan() {
+        AtomicLong clock = new AtomicLong(10 * DAY);
+        TimeSlottedCounter counter = new TimeSlottedCounter(TimeValue.timeValueHours(1), 500, 0, clock::get);
+        TimeSlottedCounterWindow sliding = counter.registerRelativeWindow(0, 7 * DAY);
+
+        sliding.sum();
+        for (int i = 0; i < 1000; i++) {
+            counter.add(clock.get() - DAY - (i % 120) * HOUR, 1);
+        }
+        assertThat(sliding.sum(), equalTo(sliding.sumUncached()));
+    }
+
+    public void testTwoWindowsOnOneCounter() {
+        AtomicLong clock = new AtomicLong(400 * DAY);
+        TimeSlottedCounter counter = new TimeSlottedCounter(TimeValue.timeValueHours(1), 10000, 0, clock::get);
+        TimeSlottedCounterWindow recent = counter.registerRelativeWindow(0, 7 * DAY);
+        TimeSlottedCounterWindow prior = counter.registerRelativeWindow(7 * DAY, 365 * DAY);
+
+        counter.add(clock.get() - 2 * DAY, 10);
+        counter.add(clock.get() - 30 * DAY, 20);
+        counter.add(clock.get() - 400 * DAY, 100);
+
+        assertThat(recent.sum(), equalTo(10L));
+        assertThat(recent.sum(), equalTo(recent.sumUncached()));
+        assertThat(prior.sum(), equalTo(20L));
+        assertThat(prior.sum(), equalTo(prior.sumUncached()));
+    }
+
+    public void testTimeOnlySlide() {
+        AtomicLong clock = new AtomicLong(10 * DAY);
+        TimeSlottedCounter counter = new TimeSlottedCounter(TimeValue.timeValueHours(1), 500, 0, clock::get);
+        TimeSlottedCounterWindow sliding = counter.registerRelativeWindow(0, 3 * DAY);
+
+        counter.add(10 * DAY - DAY, 42);
+        sliding.sum();
+
+        clock.addAndGet(2 * DAY);
+        assertThat(sliding.sum(), equalTo(sliding.sumUncached()));
+    }
+
+    public void testWindowConsistentAfterHeadExceeded() {
+        AtomicLong clock = new AtomicLong(10 * HOUR);
+        TimeSlottedCounter counter = new TimeSlottedCounter(TimeValue.timeValueHours(1), 3, 1, clock::get);
+        TimeSlottedCounterWindow sliding = counter.registerRelativeWindow(0, 2 * HOUR);
+
+        counter.add(9 * HOUR, 5);
+        clock.set(15 * HOUR);
+        counter.add(clock.get(), 3);
+
+        assertThat(sliding.sum(), equalTo(sliding.sumUncached()));
+    }
+
+    public void testConcurrentAddAndSlidingSum() throws Exception {
+        AtomicLong clock = new AtomicLong(20 * DAY);
+        TimeSlottedCounter counter = new TimeSlottedCounter(TimeValue.timeValueHours(1), 500, 0, clock::get);
+        TimeSlottedCounterWindow sliding = counter.registerRelativeWindow(DAY, 7 * DAY);
+
+        int addThreads = 2;
+        int sumThreads = 2;
+        int iterations = 200;
+        ExecutorService executor = Executors.newFixedThreadPool(addThreads + sumThreads);
+        try {
+            CountDownLatch start = new CountDownLatch(1);
+            CountDownLatch done = new CountDownLatch(addThreads + sumThreads);
+
+            for (int t = 0; t < addThreads; t++) {
+                executor.execute(() -> {
+                    try {
+                        start.await();
+                        for (int i = 0; i < iterations; i++) {
+                            counter.add(clock.get() - DAY + i, 1);
+                        }
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    } finally {
+                        done.countDown();
+                    }
+                });
+            }
+            for (int t = 0; t < sumThreads; t++) {
+                executor.execute(() -> {
+                    try {
+                        start.await();
+                        for (int i = 0; i < iterations; i++) {
+                            sliding.sum();
+                        }
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    } finally {
+                        done.countDown();
+                    }
+                });
+            }
+            start.countDown();
+            assertTrue(done.await(30, TimeUnit.SECONDS));
+
+            assertThat(sliding.sum(), equalTo(sliding.sumUncached()));
+        } finally {
+            terminate(executor);
+        }
+    }
+
+    public void testConcurrentSumCalls() throws Exception {
+        AtomicLong clock = new AtomicLong(20 * DAY);
+        TimeSlottedCounter counter = new TimeSlottedCounter(TimeValue.timeValueHours(1), 500, 0, clock::get);
+        TimeSlottedCounterWindow sliding = counter.registerRelativeWindow(DAY, 7 * DAY);
+        counter.add(clock.get() - DAY, 100);
+
+        int threads = 4;
+        ExecutorService executor = Executors.newFixedThreadPool(threads);
+        try {
+            CountDownLatch start = new CountDownLatch(1);
+            CountDownLatch done = new CountDownLatch(threads);
+            List<Long> results = Collections.synchronizedList(new ArrayList<>());
+
+            for (int t = 0; t < threads; t++) {
+                executor.execute(() -> {
+                    try {
+                        start.await();
+                        for (int i = 0; i < 200; i++) {
+                            results.add(sliding.sum());
+                        }
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    } finally {
+                        done.countDown();
+                    }
+                });
+            }
+            start.countDown();
+            assertTrue(done.await(30, TimeUnit.SECONDS));
+
+            long expected = sliding.sumUncached();
+            for (Long result : results) {
+                assertThat(result, equalTo(expected));
+            }
+        } finally {
+            terminate(executor);
+        }
+    }
+
+    public void testWindowConsistentWhenWallClockExceedsHead() {
+        AtomicLong clock = new AtomicLong(10 * HOUR);
+        TimeSlottedCounter counter = new TimeSlottedCounter(TimeValue.timeValueHours(1), 3, 1, clock::get);
+        TimeSlottedCounterWindow sliding = counter.registerRelativeWindow(0, 2 * HOUR);
+
+        counter.add(9 * HOUR, 5);
+        counter.add(11 * HOUR, 2);
+        sliding.sum();
+
+        clock.set(100 * HOUR);
+        counter.add(clock.get(), 7);
+        counter.add(9 * HOUR, 1);
+
+        assertThat(sliding.sum(), equalTo(sliding.sumUncached()));
+        assertThat(sliding.sum(), equalTo(6L));
+    }
+
+    public void testMutateAfterTimeAdvanceWithoutPriorSum() {
+        AtomicLong clock = new AtomicLong(10 * DAY);
+        TimeSlottedCounter counter = new TimeSlottedCounter(TimeValue.timeValueHours(1), 500, 0, clock::get);
+        TimeSlottedCounterWindow sliding = counter.registerRelativeWindow(0, DAY);
+
+        long slotLeavingWindow = 10 * DAY - 12 * HOUR;
+        counter.add(slotLeavingWindow, 10);
+        sliding.sum();
+
+        clock.addAndGet(DAY);
+        counter.add(slotLeavingWindow, 5);
+        assertThat(sliding.sum(), equalTo(sliding.sumUncached()));
+
+        long slotEnteringWindow = clock.get() - 12 * HOUR;
+        counter.add(slotEnteringWindow, 7);
+        assertThat(sliding.sum(), equalTo(sliding.sumUncached()));
+    }
+
+    public void testInvalidRegistrationOffsets() {
+        AtomicLong clock = new AtomicLong(0);
+        TimeSlottedCounter counter = new TimeSlottedCounter(TimeValue.timeValueHours(1), 10, 0, clock::get);
+        expectThrows(IllegalArgumentException.class, () -> counter.registerRelativeWindow(DAY, DAY));
+        expectThrows(IllegalArgumentException.class, () -> counter.registerRelativeWindow(2 * DAY, DAY));
+        expectThrows(IllegalArgumentException.class, () -> counter.registerRelativeWindow(-HOUR, DAY));
+        expectThrows(IllegalArgumentException.class, () -> counter.registerRelativeWindow(0, -DAY));
+    }
+
+    public void testDegradationAfterHeadExceeded() {
+        AtomicLong clock = new AtomicLong(10 * HOUR);
+        TimeSlottedCounter counter = new TimeSlottedCounter(TimeValue.timeValueHours(1), 3, 1, clock::get);
+        TimeSlottedCounterWindow window = counter.registerRelativeWindow(0, 2 * HOUR);
+
+        long headSlot = 11 * HOUR;
+        counter.add(9 * HOUR, 5);
+        counter.add(headSlot, 2);
+
+        clock.set(15 * HOUR);
+        counter.add(clock.get(), 7);
+
+        assertThat(counter.sum(headSlot, headSlot + HOUR), equalTo(9L));
+        assertThat(window.sum(), equalTo(window.sumUncached()));
+    }
+
+    public void testRegisteredWindowsStayConsistent() {
+        AtomicLong clock = new AtomicLong(30 * DAY);
+        TimeSlottedCounter counter = new TimeSlottedCounter(TimeValue.timeValueHours(1), 1000, 0, clock::get);
+        TimeSlottedCounterWindow recent = counter.registerRelativeWindow(0, 7 * DAY);
+        TimeSlottedCounterWindow prior = counter.registerRelativeWindow(7 * DAY, 30 * DAY);
+
+        counter.add(clock.get() - 2 * DAY, 11);
+        counter.add(clock.get() - 10 * DAY, 22);
+        counter.remove(clock.get() - 2 * DAY, 3);
+
+        assertThat(recent.sum(), equalTo(recent.sumUncached()));
+        assertThat(prior.sum(), equalTo(prior.sumUncached()));
+        assertThat(recent.sum(), equalTo(8L));
+        assertThat(prior.sum(), equalTo(22L));
+    }
+}


### PR DESCRIPTION
This PR is split into two incremental commits (but can do separate PRs if wished), and reviewers are urged to review each commit separately and comment on each separately. Seeking early feedback on direction and main code primarily for now; I'll work more on tests (which at the moment are auto-generated and not that randomized).

## 1) TimeSlottedCounter for boost window cache quotas

Introduce TimeSlottedCounter with a fixed array of hourly buckets, settings for granularity and bucket count, and add/remove/sum APIs. The slots correspond to a time frame in the past and in the future, anchored to server startup time, and are never rolled, to decrease complexity that would otherwise be needed to roll it.

With default settings, we expect servers to be restarted at least once in a year.

## 2) Add incrementally maintained relative time windows

We also introduce incrementally maintained relative time windows. These are registered on the TimeSlottedCounter so boost quota sums stay current without scanning buckets on every read.

## Comparison to other PR

Compared to https://github.com/elastic/elasticsearch/pull/149722 , this is more self-contained and simplified since we do not need to roll the overall time window, as we have fixed future time slots. The disadvantage is more memory for future time slots, and if by any chance the server outlives 1y (if, e.g., we assume a long-running self-managed stateless node keeps running over a year without a restart), we clamp everything to one slot.