### PR TITLE
[DOCS] Improve ES|QL TS command conceptual guidance

### DIFF
--- a/docs/reference/query-languages/esql/_snippets/commands/layout/ts.md
+++ b/docs/reference/query-languages/esql/_snippets/commands/layout/ts.md
@@ -41,6 +41,12 @@ querying. For supported inner (time series) functions per
 [](/reference/query-languages/esql/functions-operators/time-series-aggregation-functions.md). These functions also
 apply to downsampled data, with the same semantics as for raw data.
 
+::::{tip}
+To discover which metrics, metric types, and dimensions are available before writing a
+`TS` query, use [`METRICS_INFO`](/reference/query-languages/esql/commands/metrics-info.md)
+or [`TS_INFO`](/reference/query-languages/esql/commands/ts-info.md).
+::::
+
 ::::{note}
 If a query is missing an inner (time series) aggregation function,
 [`LAST_OVER_TIME()`](/reference/query-languages/esql/functions-operators/time-series-aggregation-functions/last_over_time.md)
@@ -55,6 +61,53 @@ You can also combine time series aggregation functions with regular [aggregation
 However, using a time series aggregation function in combination with an inner time series function causes an error. For an example, refer to [Invalid query: nested time series functions](#invalid-query-nested-time-series-functions).
 
 If there is no `STATS` command in the query, the output of the `TS` command gets sorted by `@timestamp` in descending order by default. This helps listing recent values across many time series, as opposed to listing the results based on index sort configuration that may just return data points for a single time series.
+
+## When to use TS vs FROM
+
+[`FROM`](/reference/query-languages/esql/commands/from.md) can read time series indices,
+but applying `STATS` directly to raw metric values produces silently wrong results in
+three common cases. `TS` is designed to handle each of them correctly.
+
+### Counters need deltas, not raw sums
+
+Counter metrics (such as a `request_count` that monotonically increases) record a
+running total, not per-interval events. Summing or averaging the raw counter column
+has no meaningful interpretation: the result reflects how many samples each series
+happened to publish, not the underlying rate. Counter resets on process restart make
+the problem worse by mixing pre-reset and post-reset values:
+
+```esql
+FROM metrics | STATS SUM(request_count) BY host
+```
+
+`TS` with [`RATE()`](/reference/query-languages/esql/functions-operators/time-series-aggregation-functions/rate.md)
+or [`INCREASE()`](/reference/query-languages/esql/functions-operators/time-series-aggregation-functions/increase.md)
+first computes the per-bucket delta for each time series (handling resets correctly
+along the way), then lets you aggregate those deltas across series:
+
+```esql
+TS metrics | STATS SUM(RATE(request_count)) BY host
+```
+
+### Unequal publish rates
+
+Different hosts and agents publish at different cadences. A host emitting CPU samples
+every second contributes 120x more rows than one emitting every two minutes, so `AVG()`
+over the raw column weights the chatty host accordingly:
+
+```esql
+FROM metrics | STATS AVG(cpu_usage) BY cluster
+```
+
+`TS` first reduces each time series to a single value per time bucket (using
+[`AVG_OVER_TIME`](/reference/query-languages/esql/functions-operators/time-series-aggregation-functions/avg_over_time.md)
+or another inner function), then aggregates across series. Each series contributes
+equally to the outer average:
+
+```esql
+TS metrics
+| STATS AVG(AVG_OVER_TIME(cpu_usage)) BY cluster, TBUCKET(1 minute)
+```
 
 ## Grouping time series [grouping-time-series]
 
@@ -91,22 +144,40 @@ query leads to an error.
 
 ## Best practices
 
+- [Prefer `TS` over `FROM`](#when-to-use-ts-vs-from) for time series aggregations.
+  `FROM` is still appropriate for non-aggregation uses such as listing document contents.
 - Avoid aggregating multiple metrics in the same query when those metrics have different dimensional cardinalities.
   For example, in `STATS max(rate(foo)) + rate(bar))`, if `foo` and `bar` don't share the same dimension values, the rate
   for one metric will be null for some dimension combinations. Because the + operator returns null when either input
   is null, the entire result becomes null for those dimensions. Additionally, queries that aggregate a single metric
   can filter out null values more efficiently.
-- Use the `TS` command for aggregations on time series data, rather than `FROM`. The `FROM` command is still available
-  (for example, for listing document contents), but it's not optimized for processing time series data and may produce
-  unexpected results.
-- The `TS` command can't be combined with certain operations (such as
-  [`FORK`](/reference/query-languages/esql/commands/fork.md)) before the `STATS` command is applied. Once `STATS` is
-  applied, you can process the tabular output with any applicable ES|QL operations.
 - Add a time range filter on `@timestamp` to limit the data volume scanned and improve query performance.
 - Time series aggregations produce large result sets, especially if they involve many dimensions and small time buckets.
   The limits are updated accordingly, with the default result truncation size increased to 10,000 rows. For more
   information on the limits and how to adjust them, refer to
   [Result set size limitation](/reference/query-languages/esql/_snippets/common/result-set-size-limitation.md).
+
+## Limitations
+
+- **`COUNT(*)` under `TS`**: After the first `STATS` under `TS`, rows are grouped per
+  time series rather than counted as raw metric documents, so `COUNT(*)` does not have
+  the same meaning it does under `FROM`. To count samples for a specific metric, use
+  `COUNT(<field>)` or
+  [`COUNT_OVER_TIME()`](/reference/query-languages/esql/functions-operators/time-series-aggregation-functions/count_over_time.md)
+  against a named field.
+- **Commands that reorder rows**: Commands that change row order, such as
+  [`SORT`](/reference/query-languages/esql/commands/sort.md) or
+  [`FORK`](/reference/query-languages/esql/commands/fork.md), cannot appear between
+  `TS` and the first `STATS`. Time series aggregations rely on the natural `@timestamp`
+  ordering produced by `TS`. After the first `STATS`, results are tabular and these
+  commands are available again — see
+  [Process tabular results after the first STATS](#process-tabular-results-after-the-first-stats).
+- **Metric type compatibility**: Time series aggregation functions enforce the field's
+  `metric_type` mapping. For example,
+  [`RATE()`](/reference/query-languages/esql/functions-operators/time-series-aggregation-functions/rate.md)
+  requires a counter and rejects gauge fields. See
+  [](/reference/query-languages/esql/functions-operators/time-series-aggregation-functions.md#metric-type-compatibility)
+  for the per-function mapping.
 
 ## Examples
 
@@ -168,6 +239,22 @@ Use `AVG_OVER_TIME` to compute per-time-series averages, then group the results 
 TS metrics
 | WHERE @timestamp >= now() - 1 day
 | STATS SUM(AVG_OVER_TIME(memory_usage)) BY host, TBUCKET(1 hour)
+```
+
+### Process tabular results after the first STATS
+
+Once the first `STATS` under `TS` completes, the pipeline becomes a regular ES|QL table.
+Chain additional `STATS`, `EVAL`, `SORT`, and similar commands to derive secondary
+aggregations or computed columns. For example, take per-minute rates per cluster, then
+compute the 95th-percentile and maximum rate per cluster and rank clusters by headroom:
+
+```esql
+TS k8s
+| WHERE @timestamp >= now() - 1 hour
+| STATS rate = MAX(RATE(network.total_bytes_in)) BY cluster, TBUCKET(1 minute)
+| STATS p95 = PERCENTILE(rate, 95), peak = MAX(rate) BY cluster
+| EVAL headroom = peak - p95
+| SORT headroom DESC
 ```
 
 ### Group by all dimensions implicitly

--- a/docs/reference/query-languages/esql/_snippets/commands/layout/ts.md
+++ b/docs/reference/query-languages/esql/_snippets/commands/layout/ts.md
@@ -64,9 +64,11 @@ If there is no `STATS` command in the query, the output of the `TS` command gets
 
 ## When to use TS vs FROM
 
-[`FROM`](/reference/query-languages/esql/commands/from.md) can read time series indices,
-but applying `STATS` directly to raw metric values produces silently wrong results in
-three common cases. `TS` is designed to handle each of them correctly.
+`TS` is the right choice for aggregating metrics. It's aware of time series
+semantics, commonly provides better performance, and avoids correctness issues
+that [`FROM`](/reference/query-languages/esql/commands/from.md) `| STATS` runs into
+on raw metric data. Two common examples where `FROM` silently produces wrong
+results that `TS` handles correctly:
 
 ### Counters need deltas, not raw sums
 
@@ -89,7 +91,7 @@ along the way), then lets you aggregate those deltas across series:
 TS metrics | STATS SUM(RATE(request_count)) BY host
 ```
 
-### Unequal publish rates
+### Uneven publish intervals for metrics
 
 Different hosts and agents publish at different cadences. A host emitting CPU samples
 every second contributes 120x more rows than one emitting every two minutes, so `AVG()`

--- a/docs/reference/query-languages/esql/_snippets/commands/layout/ts.md
+++ b/docs/reference/query-languages/esql/_snippets/commands/layout/ts.md
@@ -64,11 +64,12 @@ If there is no `STATS` command in the query, the output of the `TS` command gets
 
 ## When to use TS vs FROM
 
-`TS` is the right choice for aggregating metrics. It's aware of time series
-semantics, commonly provides better performance, and avoids correctness issues
-that [`FROM`](/reference/query-languages/esql/commands/from.md) `| STATS` runs into
-on raw metric data. Two common examples where `FROM` silently produces wrong
-results that `TS` handles correctly:
+`TS` is the right choice for aggregating metrics. It's optimized for time series
+data and avoids correctness issues that
+[`FROM`](/reference/query-languages/esql/commands/from.md) `| STATS` runs into on
+raw metric data. The two most common examples where `FROM` silently produces
+wrong results that `TS` handles correctly are counter handling and uneven
+publish intervals for metrics.
 
 ### Counters need deltas, not raw sums
 

--- a/docs/reference/query-languages/esql/esql-time-spans.md
+++ b/docs/reference/query-languages/esql/esql-time-spans.md
@@ -24,9 +24,10 @@ Convert strings to time spans using [TO_DATEPERIOD](/reference/query-languages/e
 [TO_TIMEDURATION](/reference/query-languages/esql/functions-operators/type-conversion-functions/to_timeduration.md),
 or the [cast operators](/reference/query-languages/esql/functions-operators/operators.md#esql-cast-operator) `::DATE_PERIOD`, `::TIME_DURATION`.
 
-For time series queries with the [`TS`](/reference/query-languages/esql/commands/ts.md)
-source command, the [`TRANGE`](/reference/query-languages/esql/functions-operators/date-time-functions/trange.md)
-function takes a time span and filters on a sliding range relative to query time.
+The [`TRANGE`](/reference/query-languages/esql/functions-operators/date-time-functions/trange.md)
+function takes a time span and filters on a sliding range relative to query time. It
+works in any ES|QL query, and is commonly paired with
+[`TS`](/reference/query-languages/esql/commands/ts.md) for time series.
 
 
 ## Examples of using time spans in {{esql}} [esql-time-spans-examples]

--- a/docs/reference/query-languages/esql/esql-time-spans.md
+++ b/docs/reference/query-languages/esql/esql-time-spans.md
@@ -24,10 +24,14 @@ Convert strings to time spans using [TO_DATEPERIOD](/reference/query-languages/e
 [TO_TIMEDURATION](/reference/query-languages/esql/functions-operators/type-conversion-functions/to_timeduration.md),
 or the [cast operators](/reference/query-languages/esql/functions-operators/operators.md#esql-cast-operator) `::DATE_PERIOD`, `::TIME_DURATION`.
 
+For time series queries with the [`TS`](/reference/query-languages/esql/commands/ts.md)
+source command, the [`TRANGE`](/reference/query-languages/esql/functions-operators/date-time-functions/trange.md)
+function takes a time span and filters on a sliding range relative to query time.
+
 
 ## Examples of using time spans in {{esql}} [esql-time-spans-examples]
 
-With `BUCKET`:
+### With BUCKET
 
 ```esql
 FROM employees
@@ -45,7 +49,7 @@ FROM employees
 | 2 | 1985-10-14T00:00:00.000Z |
 | 4 | 1985-11-18T00:00:00.000Z |
 
-With `DATE_TRUNC`:
+### With DATE_TRUNC
 
 ```esql
 FROM employees
@@ -59,7 +63,7 @@ FROM employees
 | Amabile | Gomatam | 1992-11-18T00:00:00.000Z | 1992-01-01T00:00:00.000Z |
 | Anneke | Preusig | 1989-06-02T00:00:00.000Z | 1989-01-01T00:00:00.000Z |
 
-With `+` and/or `-`:
+### With arithmetic operators
 
 ```esql
 FROM sample_data
@@ -68,6 +72,20 @@ FROM sample_data
 
 | @timestamp:date | client_ip:ip | event_duration:long | message:keyword |
 | --- | --- | --- | --- |
+
+### With TRANGE
+
+```{applies_to}
+stack: ga 9.3
+```
+
+```esql
+TS k8s
+| WHERE TRANGE(1 hour)
+| STATS SUM(RATE(network.total_bytes_in)) BY cluster, TBUCKET(1 minute)
+```
+
+### Named parameters with arithmetic operators
 
 When a time span is provided as a named parameter in string format, `TO_DATEPERIOD`, `::DATE_PERIOD`, `TO_TIMEDURATION` or `::TIME_DURATION` can be used to convert to its corresponding time span value for arithmetic operations like `+` and/or `-`.
 
@@ -82,7 +100,9 @@ POST /_query
 }
 ```
 
-When a time span is provided as a named parameter in string format, it can be automatically converted to its corresponding time span value in grouping functions and scalar functions, like `BUCKET` and `DATE_TRUNC`.
+### Named parameters with BUCKET
+
+When a time span is provided as a named parameter in string format, it can be automatically converted to its corresponding time span value in grouping functions such as `BUCKET`.
 
 ```esql
 POST /_query
@@ -96,6 +116,10 @@ POST /_query
    "params": [{"timespan" : "1 week"}]
 }
 ```
+
+### Named parameters with DATE_TRUNC
+
+Named string parameters are also automatically converted in scalar functions such as `DATE_TRUNC`.
 
 ```esql
 POST /_query

--- a/docs/reference/query-languages/esql/esql-time-spans.md
+++ b/docs/reference/query-languages/esql/esql-time-spans.md
@@ -75,10 +75,6 @@ FROM sample_data
 
 ### With TRANGE
 
-```{applies_to}
-stack: ga 9.3
-```
-
 ```esql
 TS k8s
 | WHERE TRANGE(1 hour)

--- a/docs/reference/query-languages/esql/functions-operators/time-series-aggregation-functions.md
+++ b/docs/reference/query-languages/esql/functions-operators/time-series-aggregation-functions.md
@@ -52,7 +52,9 @@ for details and examples.
 
 ## Metric type compatibility
 
-The inner function you pick depends on the field's `metric_type` mapping:
+The inner function you pick depends on the field's
+[`metric_type`](docs-content://manage-data/data-store/data-streams/time-series-data-stream-tsds.md#time-series-metric)
+mapping:
 
 - **Counters**: monotonically increasing values that reset on process restart. Use
   [`RATE`](/reference/query-languages/esql/functions-operators/time-series-aggregation-functions/rate.md),
@@ -67,10 +69,8 @@ The inner function you pick depends on the field's `metric_type` mapping:
   [`MAX_OVER_TIME`](/reference/query-languages/esql/functions-operators/time-series-aggregation-functions/max_over_time.md),
   and the other `*_OVER_TIME` variants. Counter functions like `RATE` reject gauge fields.
 
-For the conceptual context behind this split (counter resets, weighting by publish rate,
-and choosing an inner function), see
-[When to use TS vs FROM](/reference/query-languages/esql/commands/ts.md#when-to-use-ts-vs-from)
-on the `TS` command page.
+For the conceptual context behind the counter/gauge split, refer to
+[When to use TS vs FROM](/reference/query-languages/esql/commands/ts.md#when-to-use-ts-vs-from).
 
 The following time series aggregation functions are supported:
 

--- a/docs/reference/query-languages/esql/functions-operators/time-series-aggregation-functions.md
+++ b/docs/reference/query-languages/esql/functions-operators/time-series-aggregation-functions.md
@@ -50,6 +50,28 @@ grouping function ({applies_to}`stack: ga 9.4`). Refer to
 [Grouping time series](/reference/query-languages/esql/commands/ts.md#grouping-time-series)
 for details and examples.
 
+## Metric type compatibility
+
+The inner function you pick depends on the field's `metric_type` mapping:
+
+- **Counters**: monotonically increasing values that reset on process restart. Use
+  [`RATE`](/reference/query-languages/esql/functions-operators/time-series-aggregation-functions/rate.md),
+  [`INCREASE`](/reference/query-languages/esql/functions-operators/time-series-aggregation-functions/increase.md),
+  and the other counter-aware functions. These detect resets per time series and compute
+  correct deltas; applying a gauge-only function such as `AVG_OVER_TIME` to a counter is
+  rarely what you want.
+- **Gauges**: point-in-time values that can move up or down. Use
+  [`LAST_OVER_TIME`](/reference/query-languages/esql/functions-operators/time-series-aggregation-functions/last_over_time.md)
+  (the implicit default when no inner function is given),
+  [`AVG_OVER_TIME`](/reference/query-languages/esql/functions-operators/time-series-aggregation-functions/avg_over_time.md),
+  [`MAX_OVER_TIME`](/reference/query-languages/esql/functions-operators/time-series-aggregation-functions/max_over_time.md),
+  and the other `*_OVER_TIME` variants. Counter functions like `RATE` reject gauge fields.
+
+For the conceptual context behind this split (counter resets, weighting by publish rate,
+and choosing an inner function), see
+[When to use TS vs FROM](/reference/query-languages/esql/commands/ts.md#when-to-use-ts-vs-from)
+on the `TS` command page.
+
 The following time series aggregation functions are supported:
 
 :::{include} ../_snippets/lists/time-series-aggregation-functions.md


### PR DESCRIPTION
The ES|QL `TS` reference docs covered syntax and examples well but assumed readers already understood why `TS` exists — leaving users likely to keep using `FROM` on time series indices and get silently wrong results. This PR fills that gap by adding conceptual guidance on when to reach for `TS` over `FROM`, surfacing the limitations that aren't obvious from syntax alone, and giving readers a clearer path between the `TS` command, the time series aggregation functions, and the time spans pages.

Each page is in its own commit for easier review.

Closes #149304

### Flagging for reviewer

- The `COUNT(*)` limitation is hedged as *"does not have the same meaning"* rather than asserting hard rejection, since I couldn't find an explicit Verifier check.