### PR TITLE
[Docs] Add H3s per ES|QL function category in overview page

### DIFF
--- a/docs/reference/query-languages/esql/esql-functions-operators.md
+++ b/docs/reference/query-languages/esql/esql-functions-operators.md
@@ -14,79 +14,105 @@ mapped_pages:
 
 ## Functions overview [esql-functions]
 
-::::{dropdown} Aggregate functions
+### Aggregate functions
+
+::::{dropdown} Aggregate function list
 :open:
 :::{include} _snippets/lists/aggregation-functions.md
 :::
 ::::
 
-::::{dropdown} Time-series aggregate functions
+### Time-series aggregate functions
+
+::::{dropdown} Time-series aggregate function list
 :open:
 :::{include} _snippets/lists/time-series-aggregation-functions.md
 :::
 ::::
 
-::::{dropdown} Grouping functions
+### Grouping functions
+
+::::{dropdown} Grouping function list
 :open:
 :::{include} _snippets/lists/grouping-functions.md
 :::
 ::::
 
-::::{dropdown} Conditional functions and expressions
+### Conditional functions and expressions
+
+::::{dropdown} Conditional function and expression list
 :open:
 :::{include} _snippets/lists/conditional-functions-and-expressions.md
 :::
 ::::
 
-::::{dropdown} Date and time functions
+### Date and time functions
+
+::::{dropdown} Date and time function list
 :open:
 :::{include} _snippets/lists/date-time-functions.md
 :::
 ::::
 
-::::{dropdown} IP functions
+### IP functions
+
+::::{dropdown} IP function list
 :open:
 :::{include} _snippets/lists/ip-functions.md
 :::
 ::::
 
-::::{dropdown} Math functions
+### Math functions
+
+::::{dropdown} Math function list
 :open:
 :::{include} _snippets/lists/math-functions.md
 :::
 ::::
 
-::::{dropdown} Search functions
+### Search functions
+
+::::{dropdown} Search function list
 :open:
 :::{include} _snippets/lists/search-functions.md
 :::
 ::::
 
-::::{dropdown} Spatial functions
+### Spatial functions
+
+::::{dropdown} Spatial function list
 :open:
 :::{include} _snippets/lists/spatial-functions.md
 :::
 ::::
 
-::::{dropdown} String functions
+### String functions
+
+::::{dropdown} String function list
 :open:
 :::{include} _snippets/lists/string-functions.md
 :::
 ::::
 
-::::{dropdown} Type conversion functions
+### Type conversion functions
+
+::::{dropdown} Type conversion function list
 :open:
 :::{include} _snippets/lists/type-conversion-functions.md
 :::
 ::::
 
-::::{dropdown} Dense vector functions
+### Dense vector functions
+
+::::{dropdown} Dense vector function list
 :open:
 :::{include} _snippets/lists/dense-vector-functions.md
 :::
 ::::
 
-::::{dropdown} Multi value functions
+### Multi value functions
+
+::::{dropdown} Multi value function list
 :open:
 :::{include} _snippets/lists/mv-functions.md
 :::
@@ -95,7 +121,7 @@ mapped_pages:
 
 ## Operators overview [esql-operators-overview]
 
-::::{dropdown} Operators
+::::{dropdown} Operator list
 :open:
 :::{include} _snippets/lists/operators.md
 :::


### PR DESCRIPTION
## Summary

- Adds an H3 heading per function category in the ES|QL functions and operators overview so each category surfaces in the right-rail **On this page** navigation.

## Before
<img width="177" height="119" alt="before" src="https://github.com/user-attachments/assets/7a412b43-7564-4521-bc53-c0952cc5ad65" />



## After

<img width="227" height="469" alt="after" src="https://github.com/user-attachments/assets/644bcb3d-51ea-4c4c-8d75-864feb2f960f" />
