### PR TITLE
[ESQL] Specialize TopN for numeric keys on external sources

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/_nightly/esql/NumericTopNBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/_nightly/esql/NumericTopNBenchmark.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.benchmark._nightly.esql;
+
+import org.elasticsearch.benchmark.Utils;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.LongVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Operator;
+import org.elasticsearch.compute.operator.topn.NumericTopNOperator;
+import org.elasticsearch.compute.operator.topn.SharedMinCompetitive;
+import org.elasticsearch.compute.operator.topn.TopNEncoder;
+import org.elasticsearch.compute.operator.topn.TopNOperator;
+import org.elasticsearch.core.Releasables;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Go/no-go benchmark for {@link NumericTopNOperator}: at K ∈ {100, 1000, 10000} on a single
+ * LONG sort key with a 2-channel {@code [sortKey, _rowPosition]} page, the new operator must
+ * be measurably faster than the generic {@link TopNOperator}. If it isn't, Stage 1 stops and
+ * the plan reconsiders the buffer-based variant.
+ *
+ * <p>A separate benchmark class (rather than a new flag on {@code TopNBenchmark}) keeps the
+ * self-test domain pure: this class's parameter combinations are all valid for both operators,
+ * so the mandatory self-test exercises every cell without skips.
+ */
+@Warmup(iterations = 5)
+@Measurement(iterations = 7)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+@Fork(1)
+public class NumericTopNBenchmark {
+
+    static {
+        Utils.configureBenchmarkLogging();
+    }
+
+    private static final BlockFactory BLOCK_FACTORY = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE)
+        .breaker(new NoopCircuitBreaker("none"))
+        .build();
+
+    private static final int BLOCK_LENGTH = 4 * 1024;
+    private static final int RUNS_PER_INVOCATION = 1024;
+
+    static {
+        if (false == "true".equals(System.getProperty("skipSelfTest"))) {
+            selfTest();
+        }
+    }
+
+    static void selfTest() {
+        for (String impl : Utils.possibleValues(NumericTopNBenchmark.class, "impl")) {
+            for (String topCount : Utils.possibleValues(NumericTopNBenchmark.class, "topCount")) {
+                for (String direction : Utils.possibleValues(NumericTopNBenchmark.class, "direction")) {
+                    NumericTopNBenchmark bench = new NumericTopNBenchmark();
+                    bench.impl = impl;
+                    bench.topCount = Integer.parseInt(topCount);
+                    bench.direction = direction;
+                    bench.setup();
+                    bench.run();
+                }
+            }
+        }
+    }
+
+    @Param({ "generic", "numericTernaryHeap" })
+    public String impl;
+
+    @Param({ "100", "1000", "10000" })
+    public int topCount;
+
+    @Param({ "asc", "desc" })
+    public String direction;
+
+    private Page page;
+
+    @Setup
+    public void setup() {
+        page = buildPage();
+    }
+
+    private static Page buildPage() {
+        // Random distinct longs over a wide range so the threshold tightens monotonically and
+        // we exercise the {@code updateTop} path heavily once the heap fills.
+        Random rng = new Random(42);
+        LongBlock sortBlock;
+        LongVector rowPositionVector;
+        try (
+            LongBlock.Builder sortBuilder = BLOCK_FACTORY.newLongBlockBuilder(BLOCK_LENGTH);
+            LongVector.FixedBuilder rpBuilder = BLOCK_FACTORY.newLongVectorFixedBuilder(BLOCK_LENGTH)
+        ) {
+            for (int i = 0; i < BLOCK_LENGTH; i++) {
+                sortBuilder.appendLong(rng.nextLong());
+                rpBuilder.appendLong(i);
+            }
+            sortBlock = sortBuilder.build();
+            rowPositionVector = rpBuilder.build();
+        }
+        return new Page(sortBlock, rowPositionVector.asBlock());
+    }
+
+    private boolean asc() {
+        return "asc".equals(direction);
+    }
+
+    private Operator operator() {
+        if ("generic".equals(impl)) {
+            return new TopNOperator(
+                BLOCK_FACTORY,
+                BLOCK_FACTORY.breaker(),
+                topCount,
+                List.of(ElementType.LONG, ElementType.LONG),
+                List.of(TopNEncoder.DEFAULT_SORTABLE, TopNEncoder.DEFAULT_SORTABLE),
+                List.of(new TopNOperator.SortOrder(NumericTopNOperator.SORT_KEY_CHANNEL, asc(), false)),
+                8 * 1024,
+                Long.MAX_VALUE,
+                TopNOperator.InputOrdering.NOT_SORTED,
+                (SharedMinCompetitive.Supplier) null
+            );
+        }
+        if ("numericTernaryHeap".equals(impl)) {
+            return new NumericTopNOperator.NumericTopNOperatorFactory(topCount, ElementType.LONG, asc(), false).get(
+                new DriverContext(BigArrays.NON_RECYCLING_INSTANCE, BLOCK_FACTORY, null)
+            );
+        }
+        throw new IllegalArgumentException("unknown impl [" + impl + "]");
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(RUNS_PER_INVOCATION * BLOCK_LENGTH)
+    public void run() {
+        try (Operator op = operator()) {
+            for (int i = 0; i < RUNS_PER_INVOCATION; i++) {
+                op.addInput(page.shallowCopy());
+            }
+            op.finish();
+            List<Page> out = new ArrayList<>();
+            try {
+                Page p;
+                while ((p = op.getOutput()) != null) {
+                    out.add(p);
+                }
+                long emitted = out.stream().mapToLong(Page::getPositionCount).sum();
+                if (emitted != topCount) {
+                    throw new AssertionError("expected [" + topCount + "] but got [" + emitted + "]");
+                }
+            } finally {
+                Releasables.close(out);
+            }
+        }
+    }
+}

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/_nightly/esql/NumericTopNBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/_nightly/esql/NumericTopNBenchmark.java
@@ -134,6 +134,7 @@ public class NumericTopNBenchmark {
 
     private Operator operator() {
         if ("generic".equals(impl)) {
+            SharedMinCompetitive.Supplier noThreshold = null;
             return new TopNOperator(
                 BLOCK_FACTORY,
                 BLOCK_FACTORY.breaker(),
@@ -144,7 +145,7 @@ public class NumericTopNBenchmark {
                 8 * 1024,
                 Long.MAX_VALUE,
                 TopNOperator.InputOrdering.NOT_SORTED,
-                (SharedMinCompetitive.Supplier) null
+                noThreshold
             );
         }
         if ("numericTernaryHeap".equals(impl)) {

--- a/docs/changelog/149841.yaml
+++ b/docs/changelog/149841.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 149841
+summary: Specialize TopN for numeric keys on external sources
+type: enhancement

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/BooleanSortKeyExtractor.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/BooleanSortKeyExtractor.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.operator.topn;
+
+import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.BooleanVector;
+
+/**
+ * Per-page {@link NumericSortKeyExtractor} for {@code BooleanBlock} sort keys.
+ *
+ * <p>Encoding is the trivial map {@code false → 0L, true → 1L}, which matches ESQL's documented
+ * boolean sort order ({@code false} sorts before {@code true} under ASC). The heap then ranks
+ * the widened long with the same flip used for other types.
+ *
+ * <p>MV-min ASC short-circuits as soon as it sees {@code false} (there's no value to find that
+ * sorts earlier); MV-max DESC short-circuits on {@code true}. This is purely a hot-loop speedup
+ * for wide MV lists and produces the same answer as the full scan.
+ */
+abstract class BooleanSortKeyExtractor implements NumericSortKeyExtractor {
+
+    static BooleanSortKeyExtractor extractorFor(BooleanBlock block, boolean ascending) {
+        BooleanVector v = block.asVector();
+        if (v != null) {
+            return new FromVector(v, ascending);
+        }
+        if (ascending) {
+            return block.mvSortedAscending() ? new MinFromAscendingBlock(block) : new MinFromUnorderedBlock(block);
+        }
+        return block.mvSortedAscending() ? new MaxFromAscendingBlock(block) : new MaxFromUnorderedBlock(block);
+    }
+
+    private static long encode(boolean raw, boolean ascending) {
+        return NumericSortKeyExtractor.encode(raw ? 1L : 0L, ascending);
+    }
+
+    private static final class FromVector extends BooleanSortKeyExtractor {
+        private final BooleanVector vector;
+        private final boolean ascending;
+
+        FromVector(BooleanVector vector, boolean ascending) {
+            this.vector = vector;
+            this.ascending = ascending;
+        }
+
+        @Override
+        public long encodedAt(int position) {
+            return encode(vector.getBoolean(position), ascending);
+        }
+
+        @Override
+        public boolean isNullAt(int position) {
+            return false;
+        }
+    }
+
+    private static final class MinFromAscendingBlock extends BooleanSortKeyExtractor {
+        private final BooleanBlock block;
+
+        MinFromAscendingBlock(BooleanBlock block) {
+            this.block = block;
+        }
+
+        @Override
+        public long encodedAt(int position) {
+            return encode(block.getBoolean(block.getFirstValueIndex(position)), true);
+        }
+
+        @Override
+        public boolean isNullAt(int position) {
+            return block.isNull(position) || block.getValueCount(position) == 0;
+        }
+    }
+
+    private static final class MaxFromAscendingBlock extends BooleanSortKeyExtractor {
+        private final BooleanBlock block;
+
+        MaxFromAscendingBlock(BooleanBlock block) {
+            this.block = block;
+        }
+
+        @Override
+        public long encodedAt(int position) {
+            int end = block.getFirstValueIndex(position) + block.getValueCount(position) - 1;
+            return encode(block.getBoolean(end), false);
+        }
+
+        @Override
+        public boolean isNullAt(int position) {
+            return block.isNull(position) || block.getValueCount(position) == 0;
+        }
+    }
+
+    private static final class MinFromUnorderedBlock extends BooleanSortKeyExtractor {
+        private final BooleanBlock block;
+
+        MinFromUnorderedBlock(BooleanBlock block) {
+            this.block = block;
+        }
+
+        @Override
+        public long encodedAt(int position) {
+            int start = block.getFirstValueIndex(position);
+            int end = start + block.getValueCount(position);
+            for (int i = start; i < end; i++) {
+                if (block.getBoolean(i) == false) {
+                    return encode(false, true);
+                }
+            }
+            return encode(true, true);
+        }
+
+        @Override
+        public boolean isNullAt(int position) {
+            return block.isNull(position) || block.getValueCount(position) == 0;
+        }
+    }
+
+    private static final class MaxFromUnorderedBlock extends BooleanSortKeyExtractor {
+        private final BooleanBlock block;
+
+        MaxFromUnorderedBlock(BooleanBlock block) {
+            this.block = block;
+        }
+
+        @Override
+        public long encodedAt(int position) {
+            int start = block.getFirstValueIndex(position);
+            int end = start + block.getValueCount(position);
+            for (int i = start; i < end; i++) {
+                if (block.getBoolean(i)) {
+                    return encode(true, false);
+                }
+            }
+            return encode(false, false);
+        }
+
+        @Override
+        public boolean isNullAt(int position) {
+            return block.isNull(position) || block.getValueCount(position) == 0;
+        }
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/DoubleSortKeyExtractor.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/DoubleSortKeyExtractor.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.operator.topn;
+
+import org.apache.lucene.util.NumericUtils;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.DoubleVector;
+
+/**
+ * Per-page {@link NumericSortKeyExtractor} for {@code DoubleBlock} sort keys.
+ *
+ * <p>Lucene's {@link NumericUtils#doubleToSortableLong(double)} maps doubles to longs preserving
+ * IEEE-754 total order: it flips the sign bit for positives, and inverts the bit pattern for
+ * negatives so that the long ordering matches the floating-point ordering across signed zeros
+ * and the NaN payload. The encoded long can then be ranked by the heap like any other LONG.
+ *
+ * <p>For MV-min/MV-max we scan in the {@code double} domain — comparing {@code double}s gives the
+ * correct numeric minimum without an extra encode-and-compare round trip, matching how
+ * {@code KeyExtractorForDouble.MinFromUnorderedBlock} behaves.
+ */
+abstract class DoubleSortKeyExtractor implements NumericSortKeyExtractor {
+
+    static DoubleSortKeyExtractor extractorFor(DoubleBlock block, boolean ascending) {
+        DoubleVector v = block.asVector();
+        if (v != null) {
+            return new FromVector(v, ascending);
+        }
+        if (ascending) {
+            return block.mvSortedAscending() ? new MinFromAscendingBlock(block) : new MinFromUnorderedBlock(block);
+        }
+        return block.mvSortedAscending() ? new MaxFromAscendingBlock(block) : new MaxFromUnorderedBlock(block);
+    }
+
+    private static final class FromVector extends DoubleSortKeyExtractor {
+        private final DoubleVector vector;
+        private final boolean ascending;
+
+        FromVector(DoubleVector vector, boolean ascending) {
+            this.vector = vector;
+            this.ascending = ascending;
+        }
+
+        @Override
+        public long encodedAt(int position) {
+            return NumericSortKeyExtractor.encode(NumericUtils.doubleToSortableLong(vector.getDouble(position)), ascending);
+        }
+
+        @Override
+        public boolean isNullAt(int position) {
+            return false;
+        }
+    }
+
+    private static final class MinFromAscendingBlock extends DoubleSortKeyExtractor {
+        private final DoubleBlock block;
+
+        MinFromAscendingBlock(DoubleBlock block) {
+            this.block = block;
+        }
+
+        @Override
+        public long encodedAt(int position) {
+            return NumericSortKeyExtractor.encode(
+                NumericUtils.doubleToSortableLong(block.getDouble(block.getFirstValueIndex(position))),
+                true
+            );
+        }
+
+        @Override
+        public boolean isNullAt(int position) {
+            return block.isNull(position) || block.getValueCount(position) == 0;
+        }
+    }
+
+    private static final class MaxFromAscendingBlock extends DoubleSortKeyExtractor {
+        private final DoubleBlock block;
+
+        MaxFromAscendingBlock(DoubleBlock block) {
+            this.block = block;
+        }
+
+        @Override
+        public long encodedAt(int position) {
+            int end = block.getFirstValueIndex(position) + block.getValueCount(position) - 1;
+            return NumericSortKeyExtractor.encode(NumericUtils.doubleToSortableLong(block.getDouble(end)), false);
+        }
+
+        @Override
+        public boolean isNullAt(int position) {
+            return block.isNull(position) || block.getValueCount(position) == 0;
+        }
+    }
+
+    private static final class MinFromUnorderedBlock extends DoubleSortKeyExtractor {
+        private final DoubleBlock block;
+
+        MinFromUnorderedBlock(DoubleBlock block) {
+            this.block = block;
+        }
+
+        @Override
+        public long encodedAt(int position) {
+            int start = block.getFirstValueIndex(position);
+            int end = start + block.getValueCount(position);
+            double min = block.getDouble(start);
+            for (int i = start + 1; i < end; i++) {
+                min = Math.min(min, block.getDouble(i));
+            }
+            return NumericSortKeyExtractor.encode(NumericUtils.doubleToSortableLong(min), true);
+        }
+
+        @Override
+        public boolean isNullAt(int position) {
+            return block.isNull(position) || block.getValueCount(position) == 0;
+        }
+    }
+
+    private static final class MaxFromUnorderedBlock extends DoubleSortKeyExtractor {
+        private final DoubleBlock block;
+
+        MaxFromUnorderedBlock(DoubleBlock block) {
+            this.block = block;
+        }
+
+        @Override
+        public long encodedAt(int position) {
+            int start = block.getFirstValueIndex(position);
+            int end = start + block.getValueCount(position);
+            double max = block.getDouble(start);
+            for (int i = start + 1; i < end; i++) {
+                max = Math.max(max, block.getDouble(i));
+            }
+            return NumericSortKeyExtractor.encode(NumericUtils.doubleToSortableLong(max), false);
+        }
+
+        @Override
+        public boolean isNullAt(int position) {
+            return block.isNull(position) || block.getValueCount(position) == 0;
+        }
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/IntSortKeyExtractor.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/IntSortKeyExtractor.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.operator.topn;
+
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+
+/**
+ * Per-page {@link NumericSortKeyExtractor} for {@code IntBlock} sort keys.
+ *
+ * <p>Widening to {@code long} is a plain signed extension: the low 32 bits are unchanged and the
+ * high bits replicate the sign, which preserves total order. The heap can therefore rank the
+ * widened value with the shared {@link NumericSortKeyExtractor#encode(long, boolean)} routine.
+ */
+abstract class IntSortKeyExtractor implements NumericSortKeyExtractor {
+
+    static IntSortKeyExtractor extractorFor(IntBlock block, boolean ascending) {
+        IntVector v = block.asVector();
+        if (v != null) {
+            return new FromVector(v, ascending);
+        }
+        if (ascending) {
+            return block.mvSortedAscending() ? new MinFromAscendingBlock(block) : new MinFromUnorderedBlock(block);
+        }
+        return block.mvSortedAscending() ? new MaxFromAscendingBlock(block) : new MaxFromUnorderedBlock(block);
+    }
+
+    private static final class FromVector extends IntSortKeyExtractor {
+        private final IntVector vector;
+        private final boolean ascending;
+
+        FromVector(IntVector vector, boolean ascending) {
+            this.vector = vector;
+            this.ascending = ascending;
+        }
+
+        @Override
+        public long encodedAt(int position) {
+            return NumericSortKeyExtractor.encode(vector.getInt(position), ascending);
+        }
+
+        @Override
+        public boolean isNullAt(int position) {
+            return false;
+        }
+    }
+
+    private static final class MinFromAscendingBlock extends IntSortKeyExtractor {
+        private final IntBlock block;
+
+        MinFromAscendingBlock(IntBlock block) {
+            this.block = block;
+        }
+
+        @Override
+        public long encodedAt(int position) {
+            return NumericSortKeyExtractor.encode(block.getInt(block.getFirstValueIndex(position)), true);
+        }
+
+        @Override
+        public boolean isNullAt(int position) {
+            return block.isNull(position) || block.getValueCount(position) == 0;
+        }
+    }
+
+    private static final class MaxFromAscendingBlock extends IntSortKeyExtractor {
+        private final IntBlock block;
+
+        MaxFromAscendingBlock(IntBlock block) {
+            this.block = block;
+        }
+
+        @Override
+        public long encodedAt(int position) {
+            int end = block.getFirstValueIndex(position) + block.getValueCount(position) - 1;
+            return NumericSortKeyExtractor.encode(block.getInt(end), false);
+        }
+
+        @Override
+        public boolean isNullAt(int position) {
+            return block.isNull(position) || block.getValueCount(position) == 0;
+        }
+    }
+
+    private static final class MinFromUnorderedBlock extends IntSortKeyExtractor {
+        private final IntBlock block;
+
+        MinFromUnorderedBlock(IntBlock block) {
+            this.block = block;
+        }
+
+        @Override
+        public long encodedAt(int position) {
+            int start = block.getFirstValueIndex(position);
+            int end = start + block.getValueCount(position);
+            int min = block.getInt(start);
+            for (int i = start + 1; i < end; i++) {
+                min = Math.min(min, block.getInt(i));
+            }
+            return NumericSortKeyExtractor.encode(min, true);
+        }
+
+        @Override
+        public boolean isNullAt(int position) {
+            return block.isNull(position) || block.getValueCount(position) == 0;
+        }
+    }
+
+    private static final class MaxFromUnorderedBlock extends IntSortKeyExtractor {
+        private final IntBlock block;
+
+        MaxFromUnorderedBlock(IntBlock block) {
+            this.block = block;
+        }
+
+        @Override
+        public long encodedAt(int position) {
+            int start = block.getFirstValueIndex(position);
+            int end = start + block.getValueCount(position);
+            int max = block.getInt(start);
+            for (int i = start + 1; i < end; i++) {
+                max = Math.max(max, block.getInt(i));
+            }
+            return NumericSortKeyExtractor.encode(max, false);
+        }
+
+        @Override
+        public boolean isNullAt(int position) {
+            return block.isNull(position) || block.getValueCount(position) == 0;
+        }
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/LongSortKeyExtractor.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/LongSortKeyExtractor.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.operator.topn;
+
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.LongVector;
+
+/**
+ * Per-page {@link NumericSortKeyExtractor} for {@code LongBlock} sort keys. Also serves
+ * {@code DATETIME} and {@code DATE_NANOS}, which both lower to {@code LongBlock} at the compute
+ * layer with identity ordering against the raw long.
+ *
+ * <p>The five inner implementations mirror {@code KeyExtractorForLong} (lines 21–34): pick a
+ * dense-vector path when the block has no nulls and no MV, otherwise pick an MV-min/max scan
+ * sized to the sort direction. {@link #encodedAt(int)} returns the already-flipped long so the
+ * operator's hot loop is branch-free on ASC/DESC; the bit-flip is the shared
+ * {@link NumericSortKeyExtractor#encode(long, boolean)} contract.
+ */
+abstract class LongSortKeyExtractor implements NumericSortKeyExtractor {
+
+    /**
+     * Build the right extractor for {@code block} and the configured sort direction. The
+     * dispatch matches {@code KeyExtractorForLong.extractorFor} so that {@link NumericTopNOperator}
+     * sees the same MV semantics the generic {@code TopNOperator} would have applied to the same
+     * page.
+     */
+    static LongSortKeyExtractor extractorFor(LongBlock block, boolean ascending) {
+        LongVector v = block.asVector();
+        if (v != null) {
+            return new FromVector(v, ascending);
+        }
+        if (ascending) {
+            return block.mvSortedAscending() ? new MinFromAscendingBlock(block) : new MinFromUnorderedBlock(block);
+        }
+        return block.mvSortedAscending() ? new MaxFromAscendingBlock(block) : new MaxFromUnorderedBlock(block);
+    }
+
+    private static final class FromVector extends LongSortKeyExtractor {
+        private final LongVector vector;
+        private final boolean ascending;
+
+        FromVector(LongVector vector, boolean ascending) {
+            this.vector = vector;
+            this.ascending = ascending;
+        }
+
+        @Override
+        public long encodedAt(int position) {
+            return NumericSortKeyExtractor.encode(vector.getLong(position), ascending);
+        }
+
+        @Override
+        public boolean isNullAt(int position) {
+            return false;
+        }
+    }
+
+    private static final class MinFromAscendingBlock extends LongSortKeyExtractor {
+        private final LongBlock block;
+
+        MinFromAscendingBlock(LongBlock block) {
+            this.block = block;
+        }
+
+        @Override
+        public long encodedAt(int position) {
+            return NumericSortKeyExtractor.encode(block.getLong(block.getFirstValueIndex(position)), true);
+        }
+
+        @Override
+        public boolean isNullAt(int position) {
+            return block.isNull(position) || block.getValueCount(position) == 0;
+        }
+    }
+
+    private static final class MaxFromAscendingBlock extends LongSortKeyExtractor {
+        private final LongBlock block;
+
+        MaxFromAscendingBlock(LongBlock block) {
+            this.block = block;
+        }
+
+        @Override
+        public long encodedAt(int position) {
+            int start = block.getFirstValueIndex(position);
+            int end = start + block.getValueCount(position) - 1;
+            return NumericSortKeyExtractor.encode(block.getLong(end), false);
+        }
+
+        @Override
+        public boolean isNullAt(int position) {
+            return block.isNull(position) || block.getValueCount(position) == 0;
+        }
+    }
+
+    private static final class MinFromUnorderedBlock extends LongSortKeyExtractor {
+        private final LongBlock block;
+
+        MinFromUnorderedBlock(LongBlock block) {
+            this.block = block;
+        }
+
+        @Override
+        public long encodedAt(int position) {
+            int start = block.getFirstValueIndex(position);
+            int end = start + block.getValueCount(position);
+            long min = block.getLong(start);
+            for (int i = start + 1; i < end; i++) {
+                min = Math.min(min, block.getLong(i));
+            }
+            return NumericSortKeyExtractor.encode(min, true);
+        }
+
+        @Override
+        public boolean isNullAt(int position) {
+            return block.isNull(position) || block.getValueCount(position) == 0;
+        }
+    }
+
+    private static final class MaxFromUnorderedBlock extends LongSortKeyExtractor {
+        private final LongBlock block;
+
+        MaxFromUnorderedBlock(LongBlock block) {
+            this.block = block;
+        }
+
+        @Override
+        public long encodedAt(int position) {
+            int start = block.getFirstValueIndex(position);
+            int end = start + block.getValueCount(position);
+            long max = block.getLong(start);
+            for (int i = start + 1; i < end; i++) {
+                max = Math.max(max, block.getLong(i));
+            }
+            return NumericSortKeyExtractor.encode(max, false);
+        }
+
+        @Override
+        public boolean isNullAt(int position) {
+            return block.isNull(position) || block.getValueCount(position) == 0;
+        }
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/NumericSortKeyExtractor.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/NumericSortKeyExtractor.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.operator.topn;
+
+/**
+ * Per-page reader of the sort-key channel feeding {@link NumericTopNOperator}'s heap. The
+ * operator builds one extractor at the top of each {@code addInput} call and then drives the
+ * tight per-row loop through {@link #encodedAt(int)} + {@link #isNullAt(int)} — both monomorphic
+ * once the JIT specialises on the concrete class produced by the per-type
+ * {@code extractorFor(...)} factory.
+ *
+ * <p>This is the {@code NumericTopNOperator} analogue of {@link KeyExtractor} (which the generic
+ * {@code TopNOperator} uses): instead of writing a sortable byte run into a
+ * {@code BreakingBytesRefBuilder}, it returns an already-encoded {@code long} that the heap can
+ * rank directly. The encoding is type-specific (e.g. {@code NumericUtils.doubleToSortableLong}
+ * for {@code DOUBLE}, then bitwise NOT for ASC); see each per-type implementation.
+ *
+ * <p>Multi-valued sort keys are handled here, not in the operator. Mirroring the generic
+ * {@link KeyExtractor} family ({@code KeyExtractorForLong.MinFromAscendingBlock} etc.) the per-page
+ * factory picks an MV-MIN extractor for ASC and an MV-MAX extractor for DESC: a row that holds
+ * multiple values in its sort-key slot competes as the most-favourable one under the sort
+ * direction. An empty MV slot is treated as a null. This is exactly the semantic the generic
+ * operator implements; the same query keeps producing the same answer when it switches to
+ * {@link NumericTopNOperator}.
+ */
+interface NumericSortKeyExtractor {
+
+    /**
+     * The encoded long for {@code position} — ready to push into {@link PrimitiveTernaryHeap}.
+     * Caller is responsible for first checking {@link #isNullAt(int)}: when the slot is null the
+     * return value is undefined (an arbitrary placeholder), and the heap's composite ordering
+     * routes the null via the null bit, not via this value.
+     */
+    long encodedAt(int position);
+
+    /**
+     * Whether the row at {@code position} is null on the sort key. A row whose multi-valued slot
+     * holds zero values is treated as null, matching the generic
+     * {@code KeyExtractorForLong.MinFromUnorderedBlock} behaviour ({@code size == 0 → nul(key)}).
+     */
+    boolean isNullAt(int position);
+
+    /**
+     * Shared encoding contract for every per-type extractor: under the configured direction, map
+     * a raw signed-long sort key to the form {@link PrimitiveTernaryHeap}'s min-heap ranks
+     * directly.
+     *
+     * <ul>
+     *     <li>DESC: identity ({@code encoded = raw}). The heap root is the smallest raw
+     *         survivor, i.e. the rejection threshold for the next incoming row.</li>
+     *     <li>ASC: bitwise complement ({@code encoded = ~raw}). NOT is the monotonically
+     *         decreasing involution that flips the order without the {@link Long#MIN_VALUE}
+     *         overflow trap of unary negation ({@code -Long.MIN_VALUE == Long.MIN_VALUE}). The
+     *         heap root is the largest raw survivor in encoded space.</li>
+     * </ul>
+     *
+     * <p>Per-type extractors widen their primitive (INT signed extension, DOUBLE via
+     * {@link org.apache.lucene.util.NumericUtils#doubleToSortableLong}, BOOLEAN to 0/1) into a
+     * long before calling this. Decoding back to the raw type is the operator's job — see
+     * {@code NumericTopNOperator#decodeLong}.
+     */
+    static long encode(long raw, boolean ascending) {
+        return ascending ? ~raw : raw;
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/NumericTopNOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/NumericTopNOperator.java
@@ -1,0 +1,545 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.operator.topn;
+
+import org.apache.lucene.util.NumericUtils;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.BooleanVector;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.DoubleVector;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.LongVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Operator;
+import org.elasticsearch.core.Releasables;
+
+import java.util.Locale;
+
+/**
+ * Specialised, allocation-free Top-K operator for a single fixed-width numeric sort key sitting
+ * directly above an {@code ExternalSourceExec} that has been narrowed to
+ * {@code [sortKey, _rowPosition]} by the {@code InsertExternalFieldExtraction} rule.
+ *
+ * <p>The operator replaces {@link TopNOperator} for this specific plan shape: instead of
+ * encoding each sort key into a {@code BytesRef} and ranking {@code TopNRow} objects in a
+ * Lucene {@link org.apache.lucene.util.PriorityQueue}, it ranks primitive {@code long} encodings
+ * directly using {@link PrimitiveTernaryHeap}. The encoding maps the raw sort value to a long
+ * such that "more competitive" corresponds to "larger encoded" — a min-heap of size K then
+ * exactly holds the top-K most competitive rows, with the root being the rejection threshold
+ * for the next incoming row.
+ *
+ * <p>Scope (PR 1, Tier 1):
+ * <ul>
+ *     <li>Exactly one sort key.</li>
+ *     <li>Sort key {@link ElementType} is {@link ElementType#LONG}, {@link ElementType#INT},
+ *         {@link ElementType#DOUBLE}, or {@link ElementType#BOOLEAN}. ESQL DATETIME and
+ *         DATE_NANOS map to LONG at planning time, so they go through the LONG path.</li>
+ *     <li>Input page has exactly 2 channels in this fixed order:
+ *         {@code [sortKey, _rowPosition]}. Enforced by the
+ *         {@code ReplaceTopNWithNumericTopN} optimizer rule, asserted at runtime.</li>
+ *     <li>Sort key may contain nulls but must be single-valued: multi-valued blocks trigger
+ *         {@link IllegalStateException} at runtime with a rewrite hint.</li>
+ * </ul>
+ *
+ * <p>Out of scope (deferred PRs): cross-driver shared threshold, row-group skipping in the
+ * external source, multi-key sorts, byte-keyed sorts, FLOAT / UNSIGNED_LONG / HALF_FLOAT /
+ * SCALED_FLOAT sort keys.
+ */
+public final class NumericTopNOperator implements Operator {
+
+    /**
+     * Channel of the primary sort key in every input page.
+     */
+    public static final int SORT_KEY_CHANNEL = 0;
+    /**
+     * Channel of the synthetic {@code _rowPosition} column in every input page.
+     */
+    public static final int ROW_POSITION_CHANNEL = 1;
+
+    /**
+     * Factory wired in by {@code LocalExecutionPlanner.planNumericTopN()}. Carries the topN
+     * limit, the sort element type, and the sort order (asc/desc, nulls position) — everything
+     * else (channel layout) is fixed by the rule's precondition.
+     */
+    public record NumericTopNOperatorFactory(int topCount, ElementType elementType, boolean asc, boolean nullsFirst)
+        implements
+            OperatorFactory {
+
+        public NumericTopNOperatorFactory {
+            if (topCount <= 0) {
+                throw new IllegalArgumentException("topCount must be > 0, got [" + topCount + "]");
+            }
+            if (elementType == null) {
+                throw new IllegalArgumentException("elementType must not be null");
+            }
+            assertSupportedType(elementType);
+        }
+
+        @Override
+        public Operator get(DriverContext driverContext) {
+            return new NumericTopNOperator(driverContext.blockFactory(), driverContext.breaker(), topCount, elementType, asc, nullsFirst);
+        }
+
+        @Override
+        public String describe() {
+            return String.format(
+                Locale.ROOT,
+                "NumericTopNOperator[count=%d, elementType=%s, asc=%s, nullsFirst=%s]",
+                topCount,
+                elementType,
+                asc,
+                nullsFirst
+            );
+        }
+    }
+
+    private final BlockFactory blockFactory;
+    private final CircuitBreaker breaker;
+    private final int topCount;
+    private final ElementType elementType;
+    private final boolean asc;
+    private final boolean nullsFirst;
+
+    private PrimitiveTernaryHeap heap;
+    private boolean heapFull;
+
+    private Page output;
+
+    private long receiveNanos;
+    private long emitNanos;
+    private int pagesReceived;
+    private int pagesEmitted;
+    private long rowsReceived;
+    private long rowsEmitted;
+
+    NumericTopNOperator(
+        BlockFactory blockFactory,
+        CircuitBreaker breaker,
+        int topCount,
+        ElementType elementType,
+        boolean asc,
+        boolean nullsFirst
+    ) {
+        this.blockFactory = blockFactory;
+        this.breaker = breaker;
+        this.topCount = topCount;
+        this.elementType = elementType;
+        this.asc = asc;
+        this.nullsFirst = nullsFirst;
+        assertSupportedType(elementType);
+        // Pass nullsFirst through to the heap so its composite {@code lessThan} ordering
+        // handles the null bit directly. This avoids the sentinel-collision trap (encoding a
+        // null as {@link Long#MAX_VALUE} collides with the encoded form of {@link Long#MIN_VALUE}
+        // raw under ASC, where {@code ~Long.MIN_VALUE == Long.MAX_VALUE}); see the heap's
+        // {@link PrimitiveTernaryHeap#lessThan(int, int)} javadoc for the full argument.
+        this.heap = new PrimitiveTernaryHeap(breaker, topCount, nullsFirst);
+    }
+
+    private static void assertSupportedType(ElementType elementType) {
+        // The optimizer rule is the real gate; this is a defence-in-depth check so an
+        // accidental cross-type wiring fails loudly with a clear message.
+        switch (elementType) {
+            case LONG, INT, DOUBLE, BOOLEAN -> {
+                // supported in PR 1
+            }
+            default -> throw new IllegalArgumentException(
+                "NumericTopNOperator does not support ElementType [" + elementType + "]; supported types are LONG, INT, DOUBLE, BOOLEAN"
+            );
+        }
+    }
+
+    @Override
+    public boolean needsInput() {
+        return output == null;
+    }
+
+    @Override
+    public void addInput(Page page) {
+        long start = System.nanoTime();
+        try {
+            assert page.getBlockCount() == 2
+                : "NumericTopNOperator expects a 2-channel page [sortKey, _rowPosition]; got blockCount=" + page.getBlockCount();
+            Block sortBlock = page.getBlock(SORT_KEY_CHANNEL);
+            LongBlock rowPositionBlock = page.getBlock(ROW_POSITION_CHANNEL);
+
+            if (sortBlock.mayHaveMultivaluedFields()) {
+                throw new IllegalStateException(
+                    "NumericTopNOperator requires single-valued sort keys; "
+                        + "got a multi-valued page in the sort key channel. "
+                        + "Wrap the sort key with MV_MIN(...) or MV_MAX(...)."
+                );
+            }
+
+            // The _rowPosition column is emitted by AsyncExternalSourceOperatorFactory in
+            // deferredExtraction mode and is, by contract, always a dense non-null LongVector.
+            // We read through the Block API to stay decoupled from the producer's exact layout;
+            // any null in this channel signals a serious wiring bug, so we fail loudly.
+            LongVector rowPositionVector = rowPositionBlock.asVector();
+            assert rowPositionVector != null : "_rowPosition channel must be a non-nullable LongVector";
+
+            int positions = page.getPositionCount();
+            switch (elementType) {
+                case LONG -> ingestLong((LongBlock) sortBlock, rowPositionVector, positions);
+                case INT -> ingestInt((IntBlock) sortBlock, rowPositionVector, positions);
+                case DOUBLE -> ingestDouble((DoubleBlock) sortBlock, rowPositionVector, positions);
+                case BOOLEAN -> ingestBoolean((BooleanBlock) sortBlock, rowPositionVector, positions);
+                default -> throw new IllegalStateException(
+                    "Unreachable: assertSupportedType already validated elementType [" + elementType + "]"
+                );
+            }
+        } finally {
+            page.releaseBlocks();
+            pagesReceived++;
+            rowsReceived += page.getPositionCount();
+            receiveNanos += System.nanoTime() - start;
+        }
+    }
+
+    private void ingestLong(LongBlock sortBlock, LongVector rowPositionVector, int positions) {
+        LongVector v = sortBlock.asVector();
+        if (v != null) {
+            for (int p = 0; p < positions; p++) {
+                ingest(encodeLong(v.getLong(p)), rowPositionVector.getLong(p), false);
+            }
+        } else {
+            for (int p = 0; p < positions; p++) {
+                long rp = rowPositionVector.getLong(p);
+                if (sortBlock.isNull(p)) {
+                    ingest(0L, rp, true);
+                } else {
+                    long raw = sortBlock.getLong(sortBlock.getFirstValueIndex(p));
+                    ingest(encodeLong(raw), rp, false);
+                }
+            }
+        }
+    }
+
+    private void ingestInt(IntBlock sortBlock, LongVector rowPositionVector, int positions) {
+        IntVector v = sortBlock.asVector();
+        if (v != null) {
+            for (int p = 0; p < positions; p++) {
+                // Widen to long: signed extension preserves ordering, so the encoded value is
+                // identical to LONG's identity encoding under both ASC and DESC.
+                ingest(encodeLong(v.getInt(p)), rowPositionVector.getLong(p), false);
+            }
+        } else {
+            for (int p = 0; p < positions; p++) {
+                long rp = rowPositionVector.getLong(p);
+                if (sortBlock.isNull(p)) {
+                    ingest(0L, rp, true);
+                } else {
+                    int raw = sortBlock.getInt(sortBlock.getFirstValueIndex(p));
+                    ingest(encodeLong(raw), rp, false);
+                }
+            }
+        }
+    }
+
+    private void ingestDouble(DoubleBlock sortBlock, LongVector rowPositionVector, int positions) {
+        DoubleVector v = sortBlock.asVector();
+        if (v != null) {
+            for (int p = 0; p < positions; p++) {
+                // {@link NumericUtils#doubleToSortableLong} maps doubles to longs preserving
+                // numeric order (handles signed zeros, NaNs, and the sign bit correctly). The
+                // resulting long can then be encoded the same way as a LONG sort key.
+                ingest(encodeLong(NumericUtils.doubleToSortableLong(v.getDouble(p))), rowPositionVector.getLong(p), false);
+            }
+        } else {
+            for (int p = 0; p < positions; p++) {
+                long rp = rowPositionVector.getLong(p);
+                if (sortBlock.isNull(p)) {
+                    ingest(0L, rp, true);
+                } else {
+                    double raw = sortBlock.getDouble(sortBlock.getFirstValueIndex(p));
+                    ingest(encodeLong(NumericUtils.doubleToSortableLong(raw)), rp, false);
+                }
+            }
+        }
+    }
+
+    private void ingestBoolean(BooleanBlock sortBlock, LongVector rowPositionVector, int positions) {
+        BooleanVector v = sortBlock.asVector();
+        if (v != null) {
+            for (int p = 0; p < positions; p++) {
+                ingest(encodeLong(v.getBoolean(p) ? 1L : 0L), rowPositionVector.getLong(p), false);
+            }
+        } else {
+            for (int p = 0; p < positions; p++) {
+                long rp = rowPositionVector.getLong(p);
+                if (sortBlock.isNull(p)) {
+                    ingest(0L, rp, true);
+                } else {
+                    boolean raw = sortBlock.getBoolean(sortBlock.getFirstValueIndex(p));
+                    ingest(encodeLong(raw ? 1L : 0L), rp, false);
+                }
+            }
+        }
+    }
+
+    /**
+     * Decision point for every incoming row. Three outcomes:
+     * <ul>
+     *     <li>Heap not yet full: push unconditionally. Flip {@link #heapFull} on the push that
+     *         fills it.</li>
+     *     <li>Heap full and the row would evict the root under the composite ordering:
+     *         replace the root.</li>
+     *     <li>Otherwise: O(1) reject.</li>
+     * </ul>
+     */
+    private void ingest(long encoded, long rowPosition, boolean isNull) {
+        if (heapFull == false) {
+            heap.push(encoded, rowPosition, isNull);
+            if (heap.isFull()) {
+                heapFull = true;
+            }
+            return;
+        }
+        if (heap.wouldEvictTop(encoded, rowPosition, isNull)) {
+            heap.updateTop(encoded, rowPosition, isNull);
+        }
+    }
+
+    /**
+     * Encode the raw sort value so that, under the configured order, a "more competitive" raw
+     * value maps to a larger encoded long. {@link PrimitiveTernaryHeap} is a min-heap, so the
+     * root after K inserts is the smallest encoded = the least competitive survivor = the
+     * rejection threshold for the next row.
+     *
+     * <ul>
+     *     <li>DESC (largest raw wins): {@code encoded = raw}. Root = smallest raw survivor.</li>
+     *     <li>ASC (smallest raw wins): {@code encoded = ~raw}. Bitwise complement is the
+     *         monotonically-decreasing involution on signed longs that flips the order without
+     *         the overflow trap of unary negation (which is undefined for {@link Long#MIN_VALUE}).
+     *         Root = largest raw survivor (its complement is smallest in encoded space).</li>
+     * </ul>
+     */
+    private long encodeLong(long raw) {
+        return asc ? ~raw : raw;
+    }
+
+    /**
+     * Inverse of {@link #encodeLong(long)}: bitwise NOT is its own inverse, so this is a
+     * one-liner. Kept named so the call sites in {@link #buildOutput()} document intent.
+     */
+    private long decodeLong(long encoded) {
+        return asc ? ~encoded : encoded;
+    }
+
+    @Override
+    public void finish() {
+        if (output == null) {
+            long start = System.nanoTime();
+            output = buildOutput();
+            emitNanos += System.nanoTime() - start;
+        }
+    }
+
+    @Override
+    public boolean isFinished() {
+        return output != null && output == EMPTY_OUTPUT;
+    }
+
+    @Override
+    public boolean canProduceMoreDataWithoutExtraInput() {
+        return output != null && output != EMPTY_OUTPUT;
+    }
+
+    /**
+     * Sentinel returned from {@link #getOutput()} to signal "already produced my single page".
+     * Using an object identity rather than {@code null} lets {@link #needsInput()} and
+     * {@link #isFinished()} distinguish "haven't finished yet" from "produced and drained".
+     */
+    private static final Page EMPTY_OUTPUT = new Page(0);
+
+    @Override
+    public Page getOutput() {
+        if (output == null || output == EMPTY_OUTPUT) {
+            return null;
+        }
+        Page ret = output;
+        output = EMPTY_OUTPUT;
+        pagesEmitted++;
+        rowsEmitted += ret.getPositionCount();
+        return ret;
+    }
+
+    /**
+     * Drain the heap into a single output page of shape {@code [sortKey, _rowPosition]} in the
+     * configured sort order. Implementation: {@link PrimitiveTernaryHeap#popTop()} repeatedly
+     * yields the slot index of each popped entry in increasing-encoded order; we record into
+     * a reversed buffer so the emitted page is in descending-encoded order = ascending-raw
+     * order for ASC sorts, descending-raw for DESC sorts.
+     *
+     * <p>Allocation: the operator only owns the long buffer for raw values, the int buffer for
+     * row positions, and a boolean array for null flags. The block builders for the output page
+     * are sized exactly to the surviving heap size (≤ K) and built directly from those buffers.
+     */
+    private Page buildOutput() {
+        int size = heap.size();
+        if (size == 0) {
+            // Empty result: emit no page. Driver treats this as "operator finished with no
+            // output", which is exactly the desired semantics for a TopN over zero input.
+            return EMPTY_OUTPUT;
+        }
+        long[] encodedValues = new long[size];
+        long[] outRowPositions = new long[size];
+        boolean[] isNull = new boolean[size];
+        // Pop yields entries in min-first (least-competitive-first) order. We want the output
+        // page in most-competitive-first order, so we fill the buffers from the end.
+        for (int i = size - 1; i >= 0; i--) {
+            int slot = heap.popTop();
+            isNull[i] = heap.isNullAt(slot);
+            outRowPositions[i] = heap.rowPositionAt(slot);
+            encodedValues[i] = isNull[i] ? 0L : heap.valueAt(slot);
+        }
+        // Build the two output blocks. The sort key column may contain nulls (carried over
+        // from the input); the _rowPosition column is dense non-nullable by construction.
+        Block sortBlock = null;
+        LongVector rowPositionVector = null;
+        boolean success = false;
+        try {
+            sortBlock = buildSortBlock(size, encodedValues, isNull);
+            try (LongVector.FixedBuilder rowPositionBuilder = blockFactory.newLongVectorFixedBuilder(size)) {
+                for (int i = 0; i < size; i++) {
+                    rowPositionBuilder.appendLong(outRowPositions[i]);
+                }
+                rowPositionVector = rowPositionBuilder.build();
+            }
+            Page page = new Page(size, sortBlock, rowPositionVector.asBlock());
+            success = true;
+            return page;
+        } finally {
+            if (success == false) {
+                if (sortBlock != null) {
+                    sortBlock.close();
+                }
+                Releasables.close(rowPositionVector);
+            }
+        }
+    }
+
+    /**
+     * Build the sort-key output block as the type the operator was configured for. Each
+     * encoded value is undone by {@link #decodeLong} (bitwise NOT for ASC, identity for DESC)
+     * and then narrowed / round-tripped back into the type's raw form before being appended.
+     */
+    private Block buildSortBlock(int size, long[] encodedValues, boolean[] isNull) {
+        return switch (elementType) {
+            case LONG -> {
+                try (LongBlock.Builder b = blockFactory.newLongBlockBuilder(size)) {
+                    for (int i = 0; i < size; i++) {
+                        if (isNull[i]) {
+                            b.appendNull();
+                        } else {
+                            b.appendLong(decodeLong(encodedValues[i]));
+                        }
+                    }
+                    yield b.build();
+                }
+            }
+            case INT -> {
+                try (IntBlock.Builder b = blockFactory.newIntBlockBuilder(size)) {
+                    for (int i = 0; i < size; i++) {
+                        if (isNull[i]) {
+                            b.appendNull();
+                        } else {
+                            // The encoded long was widened from int; narrowing back is safe
+                            // because we never modified the low 32 bits (signed extension only
+                            // touched the upper bits).
+                            b.appendInt((int) decodeLong(encodedValues[i]));
+                        }
+                    }
+                    yield b.build();
+                }
+            }
+            case DOUBLE -> {
+                try (DoubleBlock.Builder b = blockFactory.newDoubleBlockBuilder(size)) {
+                    for (int i = 0; i < size; i++) {
+                        if (isNull[i]) {
+                            b.appendNull();
+                        } else {
+                            b.appendDouble(NumericUtils.sortableLongToDouble(decodeLong(encodedValues[i])));
+                        }
+                    }
+                    yield b.build();
+                }
+            }
+            case BOOLEAN -> {
+                try (BooleanBlock.Builder b = blockFactory.newBooleanBlockBuilder(size)) {
+                    for (int i = 0; i < size; i++) {
+                        if (isNull[i]) {
+                            b.appendNull();
+                        } else {
+                            b.appendBoolean(decodeLong(encodedValues[i]) != 0L);
+                        }
+                    }
+                    yield b.build();
+                }
+            }
+            default -> throw new IllegalStateException("Unreachable: " + elementType);
+        };
+    }
+
+    @Override
+    public void close() {
+        // The heap owns its breaker accounting and is always safe to close. The output page is
+        // released only if finish() built one and getOutput() never drained it (e.g. driver
+        // aborted between finish and the first getOutput). EMPTY_OUTPUT is a shared sentinel
+        // and must not be closed.
+        Page pageToRelease = (output != null && output != EMPTY_OUTPUT) ? output : null;
+        try {
+            Releasables.closeExpectNoException(heap);
+        } finally {
+            if (pageToRelease != null) {
+                pageToRelease.releaseBlocks();
+            }
+            heap = null;
+            output = EMPTY_OUTPUT;
+        }
+    }
+
+    @Override
+    public Status status() {
+        // {@code minCompetitiveUpdates} is null here — the numeric operator doesn't yet publish a
+        // cross-driver shared threshold (PR 2 / PR 3 work), so there is no "tracked" counter to
+        // report. Passing 0 would lie by suggesting the threshold is being tracked but never
+        // updated; null is the explicit "not tracked" sentinel that the status field's nullable
+        // {@link Integer} type was designed for.
+        return new TopNOperatorStatus(
+            receiveNanos,
+            emitNanos,
+            heap != null ? heap.size() : 0,
+            0L,
+            pagesReceived,
+            pagesEmitted,
+            rowsReceived,
+            rowsEmitted,
+            null
+        );
+    }
+
+    @Override
+    public String toString() {
+        return String.format(
+            Locale.ROOT,
+            "NumericTopNOperator[count=%d/%d, elementType=%s, asc=%s, nullsFirst=%s]",
+            heap == null ? 0 : heap.size(),
+            topCount,
+            elementType,
+            asc,
+            nullsFirst
+        );
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/NumericTopNOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/NumericTopNOperator.java
@@ -12,12 +12,9 @@ import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BooleanBlock;
-import org.elasticsearch.compute.data.BooleanVector;
 import org.elasticsearch.compute.data.DoubleBlock;
-import org.elasticsearch.compute.data.DoubleVector;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.IntBlock;
-import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Page;
@@ -45,17 +42,21 @@ import java.util.Locale;
  *     <li>Exactly one sort key.</li>
  *     <li>Sort key {@link ElementType} is {@link ElementType#LONG}, {@link ElementType#INT},
  *         {@link ElementType#DOUBLE}, or {@link ElementType#BOOLEAN}. ESQL DATETIME and
- *         DATE_NANOS map to LONG at planning time, so they go through the LONG path.</li>
+ *         DATE_NANOS map to LONG at planning time, so they go through the LONG path. ESQL FLOAT,
+ *         HALF_FLOAT and SCALED_FLOAT widen to DOUBLE on load so they reach this operator as
+ *         {@link org.elasticsearch.compute.data.DoubleBlock}.</li>
  *     <li>Input page has exactly 2 channels in this fixed order:
- *         {@code [sortKey, _rowPosition]}. Enforced by the
- *         {@code ReplaceTopNWithNumericTopN} optimizer rule, asserted at runtime.</li>
- *     <li>Sort key may contain nulls but must be single-valued: multi-valued blocks trigger
- *         {@link IllegalStateException} at runtime with a rewrite hint.</li>
+ *         {@code [sortKey, _rowPosition]}. Enforced by
+ *         {@code LocalExecutionPlanner.tryBuildNumericTopN()}, asserted at runtime.</li>
+ *     <li>Sort key may contain nulls and may be multi-valued. Multi-values are reduced to the
+ *         most-favourable single value for the configured direction (MV-min for ASC, MV-max for
+ *         DESC) — exactly the semantics the generic {@code TopNOperator} applies via its
+ *         {@code KeyExtractorForX} family. An empty MV slot is treated as a null. See
+ *         {@link NumericSortKeyExtractor} for the per-type breakdown.</li>
  * </ul>
  *
  * <p>Out of scope (deferred PRs): cross-driver shared threshold, row-group skipping in the
- * external source, multi-key sorts, byte-keyed sorts, FLOAT / UNSIGNED_LONG / HALF_FLOAT /
- * SCALED_FLOAT sort keys.
+ * external source, multi-key sorts, byte-keyed sorts, UNSIGNED_LONG sort keys.
  */
 public final class NumericTopNOperator implements Operator {
 
@@ -69,9 +70,9 @@ public final class NumericTopNOperator implements Operator {
     public static final int ROW_POSITION_CHANNEL = 1;
 
     /**
-     * Factory wired in by {@code LocalExecutionPlanner.planNumericTopN()}. Carries the topN
+     * Factory wired in by {@code LocalExecutionPlanner.tryBuildNumericTopN()}. Carries the topN
      * limit, the sort element type, and the sort order (asc/desc, nulls position) — everything
-     * else (channel layout) is fixed by the rule's precondition.
+     * else (channel layout) is fixed by the planner's precondition check.
      */
     public record NumericTopNOperatorFactory(int topCount, ElementType elementType, boolean asc, boolean nullsFirst)
         implements
@@ -168,19 +169,15 @@ public final class NumericTopNOperator implements Operator {
     @Override
     public void addInput(Page page) {
         long start = System.nanoTime();
+        // Capture the position count up front: the finally block updates the {@code rowsReceived}
+        // counter after {@code page.releaseBlocks()} has been called, and we don't want to depend
+        // on {@code Page#getPositionCount()} continuing to return the right value after release.
+        int positions = page.getPositionCount();
         try {
             assert page.getBlockCount() == 2
                 : "NumericTopNOperator expects a 2-channel page [sortKey, _rowPosition]; got blockCount=" + page.getBlockCount();
             Block sortBlock = page.getBlock(SORT_KEY_CHANNEL);
             LongBlock rowPositionBlock = page.getBlock(ROW_POSITION_CHANNEL);
-
-            if (sortBlock.mayHaveMultivaluedFields()) {
-                throw new IllegalStateException(
-                    "NumericTopNOperator requires single-valued sort keys; "
-                        + "got a multi-valued page in the sort key channel. "
-                        + "Wrap the sort key with MV_MIN(...) or MV_MAX(...)."
-                );
-            }
 
             // The _rowPosition column is emitted by AsyncExternalSourceOperatorFactory in
             // deferredExtraction mode and is, by contract, always a dense non-null LongVector.
@@ -189,103 +186,39 @@ public final class NumericTopNOperator implements Operator {
             LongVector rowPositionVector = rowPositionBlock.asVector();
             assert rowPositionVector != null : "_rowPosition channel must be a non-nullable LongVector";
 
-            int positions = page.getPositionCount();
-            switch (elementType) {
-                case LONG -> ingestLong((LongBlock) sortBlock, rowPositionVector, positions);
-                case INT -> ingestInt((IntBlock) sortBlock, rowPositionVector, positions);
-                case DOUBLE -> ingestDouble((DoubleBlock) sortBlock, rowPositionVector, positions);
-                case BOOLEAN -> ingestBoolean((BooleanBlock) sortBlock, rowPositionVector, positions);
-                default -> throw new IllegalStateException(
-                    "Unreachable: assertSupportedType already validated elementType [" + elementType + "]"
-                );
+            // Build the per-type, per-direction, per-page extractor once and let the inner loop
+            // see a single monomorphic instance. The dispatch matches KeyExtractorForX.extractorFor
+            // so MV semantics (MV-min for ASC, MV-max for DESC, empty MV = null) are exactly the
+            // ones the generic TopNOperator would have applied to the same page.
+            NumericSortKeyExtractor extractor = extractorFor(sortBlock);
+            for (int p = 0; p < positions; p++) {
+                boolean isNull = extractor.isNullAt(p);
+                long encoded = isNull ? 0L : extractor.encodedAt(p);
+                ingest(encoded, rowPositionVector.getLong(p), isNull);
             }
         } finally {
             page.releaseBlocks();
             pagesReceived++;
-            rowsReceived += page.getPositionCount();
+            rowsReceived += positions;
             receiveNanos += System.nanoTime() - start;
         }
     }
 
-    private void ingestLong(LongBlock sortBlock, LongVector rowPositionVector, int positions) {
-        LongVector v = sortBlock.asVector();
-        if (v != null) {
-            for (int p = 0; p < positions; p++) {
-                ingest(encodeLong(v.getLong(p)), rowPositionVector.getLong(p), false);
-            }
-        } else {
-            for (int p = 0; p < positions; p++) {
-                long rp = rowPositionVector.getLong(p);
-                if (sortBlock.isNull(p)) {
-                    ingest(0L, rp, true);
-                } else {
-                    long raw = sortBlock.getLong(sortBlock.getFirstValueIndex(p));
-                    ingest(encodeLong(raw), rp, false);
-                }
-            }
-        }
-    }
-
-    private void ingestInt(IntBlock sortBlock, LongVector rowPositionVector, int positions) {
-        IntVector v = sortBlock.asVector();
-        if (v != null) {
-            for (int p = 0; p < positions; p++) {
-                // Widen to long: signed extension preserves ordering, so the encoded value is
-                // identical to LONG's identity encoding under both ASC and DESC.
-                ingest(encodeLong(v.getInt(p)), rowPositionVector.getLong(p), false);
-            }
-        } else {
-            for (int p = 0; p < positions; p++) {
-                long rp = rowPositionVector.getLong(p);
-                if (sortBlock.isNull(p)) {
-                    ingest(0L, rp, true);
-                } else {
-                    int raw = sortBlock.getInt(sortBlock.getFirstValueIndex(p));
-                    ingest(encodeLong(raw), rp, false);
-                }
-            }
-        }
-    }
-
-    private void ingestDouble(DoubleBlock sortBlock, LongVector rowPositionVector, int positions) {
-        DoubleVector v = sortBlock.asVector();
-        if (v != null) {
-            for (int p = 0; p < positions; p++) {
-                // {@link NumericUtils#doubleToSortableLong} maps doubles to longs preserving
-                // numeric order (handles signed zeros, NaNs, and the sign bit correctly). The
-                // resulting long can then be encoded the same way as a LONG sort key.
-                ingest(encodeLong(NumericUtils.doubleToSortableLong(v.getDouble(p))), rowPositionVector.getLong(p), false);
-            }
-        } else {
-            for (int p = 0; p < positions; p++) {
-                long rp = rowPositionVector.getLong(p);
-                if (sortBlock.isNull(p)) {
-                    ingest(0L, rp, true);
-                } else {
-                    double raw = sortBlock.getDouble(sortBlock.getFirstValueIndex(p));
-                    ingest(encodeLong(NumericUtils.doubleToSortableLong(raw)), rp, false);
-                }
-            }
-        }
-    }
-
-    private void ingestBoolean(BooleanBlock sortBlock, LongVector rowPositionVector, int positions) {
-        BooleanVector v = sortBlock.asVector();
-        if (v != null) {
-            for (int p = 0; p < positions; p++) {
-                ingest(encodeLong(v.getBoolean(p) ? 1L : 0L), rowPositionVector.getLong(p), false);
-            }
-        } else {
-            for (int p = 0; p < positions; p++) {
-                long rp = rowPositionVector.getLong(p);
-                if (sortBlock.isNull(p)) {
-                    ingest(0L, rp, true);
-                } else {
-                    boolean raw = sortBlock.getBoolean(sortBlock.getFirstValueIndex(p));
-                    ingest(encodeLong(raw ? 1L : 0L), rp, false);
-                }
-            }
-        }
+    /**
+     * Build the per-type extractor for {@code sortBlock} under the configured direction. Picking
+     * the extractor concrete class is the operator's only per-page type-dispatch — the rest of
+     * {@link #addInput(Page)} stays type-free.
+     */
+    private NumericSortKeyExtractor extractorFor(Block sortBlock) {
+        return switch (elementType) {
+            case LONG -> LongSortKeyExtractor.extractorFor((LongBlock) sortBlock, asc);
+            case INT -> IntSortKeyExtractor.extractorFor((IntBlock) sortBlock, asc);
+            case DOUBLE -> DoubleSortKeyExtractor.extractorFor((DoubleBlock) sortBlock, asc);
+            case BOOLEAN -> BooleanSortKeyExtractor.extractorFor((BooleanBlock) sortBlock, asc);
+            default -> throw new IllegalStateException(
+                "Unreachable: assertSupportedType already validated elementType [" + elementType + "]"
+            );
+        };
     }
 
     /**
@@ -312,26 +245,11 @@ public final class NumericTopNOperator implements Operator {
     }
 
     /**
-     * Encode the raw sort value so that, under the configured order, a "more competitive" raw
-     * value maps to a larger encoded long. {@link PrimitiveTernaryHeap} is a min-heap, so the
-     * root after K inserts is the smallest encoded = the least competitive survivor = the
-     * rejection threshold for the next row.
-     *
-     * <ul>
-     *     <li>DESC (largest raw wins): {@code encoded = raw}. Root = smallest raw survivor.</li>
-     *     <li>ASC (smallest raw wins): {@code encoded = ~raw}. Bitwise complement is the
-     *         monotonically-decreasing involution on signed longs that flips the order without
-     *         the overflow trap of unary negation (which is undefined for {@link Long#MIN_VALUE}).
-     *         Root = largest raw survivor (its complement is smallest in encoded space).</li>
-     * </ul>
-     */
-    private long encodeLong(long raw) {
-        return asc ? ~raw : raw;
-    }
-
-    /**
-     * Inverse of {@link #encodeLong(long)}: bitwise NOT is its own inverse, so this is a
-     * one-liner. Kept named so the call sites in {@link #buildOutput()} document intent.
+     * Undo the per-direction bit flip applied by
+     * {@link NumericSortKeyExtractor#encode(long, boolean)}. Bitwise NOT is its own inverse, so
+     * this is a one-liner. Kept named so the call sites in {@link #buildOutput()} document
+     * intent. Decoding stays here because the operator owns the round-trip back to the per-type
+     * raw form in {@link #buildSortBlock}.
      */
     private long decodeLong(long encoded) {
         return asc ? ~encoded : encoded;
@@ -512,11 +430,8 @@ public final class NumericTopNOperator implements Operator {
 
     @Override
     public Status status() {
-        // {@code minCompetitiveUpdates} is null here — the numeric operator doesn't yet publish a
-        // cross-driver shared threshold (PR 2 / PR 3 work), so there is no "tracked" counter to
-        // report. Passing 0 would lie by suggesting the threshold is being tracked but never
-        // updated; null is the explicit "not tracked" sentinel that the status field's nullable
-        // {@link Integer} type was designed for.
+        // TODO: publish minCompetitiveUpdates once SharedNumericThreshold lands; null is the
+        // "not tracked" sentinel for now.
         return new TopNOperatorStatus(
             receiveNanos,
             emitNanos,

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/PrimitiveTernaryHeap.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/PrimitiveTernaryHeap.java
@@ -1,0 +1,447 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.operator.topn;
+
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.core.Releasable;
+
+import java.util.BitSet;
+
+/**
+ * A fixed-capacity ternary min-heap over three parallel structures that always move together:
+ * a primary {@code long} sort value, an associated {@code int} row position, and a per-slot
+ * {@link BitSet} null flag.
+ *
+ * <p>This class is the storage core of {@link NumericTopNOperator}. It is intentionally
+ * {@code final} and uses raw arrays so the hot path (compare, swap, sift) compiles to direct
+ * memory accesses and monomorphic call sites — no interface dispatch, no paged-array shims.
+ * The triple ({@link #values}, {@link #rowPositions}, {@link #nulls}) is treated as a single
+ * logical record indexed by heap slot; the {@code private} {@link #swap(int, int)} method is
+ * the only place that touches all three structures so the three remain aligned by construction.
+ *
+ * <p>The heap is min-ordered on the encoded sort value. To run a top-K, encode each input value
+ * so the "winners" compare as greater (e.g. negate for ASC numeric sorts), then push until the
+ * heap fills and {@link #updateTop} thereafter when the incoming encoded value is greater than
+ * {@link #peekTop()}. The threshold for skipping non-competitive rows is always {@code peekTop()}.
+ *
+ * <p>Nulls participate in the ordering via the convention encoded by the operator: the operator
+ * picks the sentinel encoded value that places nulls correctly for the configured nulls-first /
+ * nulls-last semantics and sets the slot's bit in {@link #nulls}. Heap operations themselves
+ * only compare the encoded {@code long}; the {@link #nulls} bit is just carried alongside so
+ * the operator can reconstruct a null block when draining results.
+ *
+ * <p>Ternary arity (each parent has up to three children) is chosen over binary so the heap is
+ * shallower at the same capacity ({@code log3 K} vs {@code log2 K}), which translates to fewer
+ * comparisons in {@code downHeap} on competitive inserts — the operator's dominant cost when
+ * the threshold is tight. Indexing is 1-based to avoid an extra subtraction in
+ * parent / first-child arithmetic; slot 0 is unused so we allocate {@code K + 1} entries.
+ *
+ * <p>Memory accounting follows the {@code TopNRow} pattern: one
+ * {@link CircuitBreaker#addEstimateBytesAndMaybeBreak} call up front for the arrays and the
+ * {@link BitSet} backing storage, paired with a single {@link CircuitBreaker#addWithoutBreaking}
+ * release in {@link #close()} and a defensive release if the constructor fails partway through.
+ */
+final class PrimitiveTernaryHeap implements Releasable {
+
+    private static final long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(PrimitiveTernaryHeap.class);
+    /**
+     * Shallow size of the {@link BitSet} object itself. {@link BitSet#size} is reported by the
+     * BitSet (it rounds capacity up to a 64-bit boundary), so the backing-array bytes are
+     * computed from {@code BitSet#size() / 8}.
+     */
+    private static final long BITSET_SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(BitSet.class);
+
+    private final CircuitBreaker breaker;
+
+    /**
+     * Whether nulls are "more competitive" than any non-null. Captures the operator's
+     * nulls-first policy in a form the heap can evaluate inside {@link #lessThan(int, int)}
+     * without an extra parameter on every call. The hot-path comparison reads this once per
+     * field access (constant after construction, so the JIT can hoist it out of the loop).
+     */
+    private final boolean nullsAreMoreCompetitive;
+
+    /**
+     * Encoded sort values. Slot 0 is unused; live slots are {@code 1..size}.
+     */
+    private final long[] values;
+    /**
+     * Row positions parallel to {@link #values}. Slot 0 is unused; live slots are
+     * {@code 1..size}.
+     *
+     * <p>Stored as {@code long} (not {@code int}) because the external source's synthetic
+     * {@code _rowPosition} column carries a packed value (extractor id high bits + file-local
+     * position low bits) that does not fit in 32 bits. The downstream {@code SourceExtractors}
+     * registry expects the long round-tripped through TopN unchanged.
+     */
+    private final long[] rowPositions;
+    /**
+     * Null flags parallel to {@link #values}: bit {@code i} set means the slot's row was null
+     * in the input. Slot 0 is unused. The hot path checks {@link BitSet#isEmpty()} once at the
+     * top of {@link #downHeap(int)} so the common (no-nulls-in-heap) case skips per-step
+     * {@link BitSet} accesses entirely.
+     */
+    private final BitSet nulls;
+
+    private final int capacity;
+    private int size;
+    /**
+     * Bytes registered with {@link #breaker}; recorded so {@link #close()} can release exactly
+     * what was reserved even if the constructor's last bookkeeping step is updated later.
+     */
+    private final long registeredBytes;
+    private boolean closed;
+
+    PrimitiveTernaryHeap(CircuitBreaker breaker, int capacity, boolean nullsAreMoreCompetitive) {
+        if (capacity <= 0) {
+            throw new IllegalArgumentException("capacity must be > 0, got [" + capacity + "]");
+        }
+        this.breaker = breaker;
+        this.capacity = capacity;
+        this.nullsAreMoreCompetitive = nullsAreMoreCompetitive;
+        // BitSet sizes its backing long[] to ceil((K+1)/64) longs; precompute the exact byte
+        // footprint so the breaker reservation matches the eventual allocation.
+        int bitSetLongs = ((capacity + 1) + 63) >>> 6;
+        long bytes = SHALLOW_SIZE + RamUsageEstimator.alignObjectSize(
+            RamUsageEstimator.NUM_BYTES_ARRAY_HEADER + (long) (capacity + 1) * Long.BYTES
+        ) + RamUsageEstimator.alignObjectSize(RamUsageEstimator.NUM_BYTES_ARRAY_HEADER + (long) (capacity + 1) * Long.BYTES)
+            + BITSET_SHALLOW_SIZE + RamUsageEstimator.alignObjectSize(
+                RamUsageEstimator.NUM_BYTES_ARRAY_HEADER + (long) bitSetLongs * Long.BYTES
+            );
+        breaker.addEstimateBytesAndMaybeBreak(bytes, "numeric_topn_heap");
+        boolean success = false;
+        try {
+            this.values = new long[capacity + 1];
+            this.rowPositions = new long[capacity + 1];
+            this.nulls = new BitSet(capacity + 1);
+            this.registeredBytes = bytes;
+            this.size = 0;
+            success = true;
+        } finally {
+            if (success == false) {
+                breaker.addWithoutBreaking(-bytes);
+            }
+        }
+    }
+
+    int size() {
+        return size;
+    }
+
+    int capacity() {
+        return capacity;
+    }
+
+    boolean isFull() {
+        return size == capacity;
+    }
+
+    /**
+     * Encoded value of the current root. Callers use this only for diagnostic reads and for
+     * the rejection threshold in the dominant "no nulls in heap" fast path; the precise
+     * competitiveness check is {@link #wouldEvictTop(long, long, boolean)} which also accounts
+     * for the null bit and the row-position tiebreaker.
+     */
+    long peekTop() {
+        assert size > 0 : "peekTop on empty heap";
+        return values[1];
+    }
+
+    /**
+     * Whether inserting {@code (newValue, newRowPosition, newIsNull)} would replace the
+     * current root under the heap's composite ordering. Equivalent to "the proposed entry is
+     * strictly greater than the current root", which is the operator's hot-path predicate for
+     * choosing between {@link #updateTop} and an O(1) reject.
+     *
+     * <p>The full triple check is the right thing to do — value-only comparison would either
+     * (a) miss inserts that beat the root via the null bit (when null status differs) or (b)
+     * silently break stability on equal values. The per-call cost is one BitSet read in the
+     * worst case ({@link BitSet#isEmpty()} short-circuit elides it for the dominant
+     * no-null-in-heap path).
+     */
+    boolean wouldEvictTop(long newValue, long newRowPosition, boolean newIsNull) {
+        // Null bit check (skipped when nothing in the heap is null AND the proposed entry is
+        // not null — i.e. the dominant fast path stays branch-free on values).
+        boolean rootIsNull = nulls.isEmpty() == false && nulls.get(1);
+        if (rootIsNull != newIsNull) {
+            // Root and proposal differ on null status. Proposal evicts iff it is the MORE
+            // competitive of the two:
+            // nulls-first: nulls are more competitive -> proposal evicts iff it is null.
+            // nulls-last: nulls are less competitive -> proposal evicts iff it is non-null.
+            return nullsAreMoreCompetitive == newIsNull;
+        }
+        // Same null status: compare value, then row position.
+        long rootValue = values[1];
+        if (newValue != rootValue) {
+            return newValue > rootValue;
+        }
+        return Long.compareUnsigned(newRowPosition, rowPositions[1]) < 0;
+    }
+
+    /**
+     * Whether the current heap root represents a null input row. Used at drain time to
+     * reconstruct null blocks; the operator does not need to gate hot-loop comparisons on this.
+     */
+    boolean topIsNull() {
+        assert size > 0 : "topIsNull on empty heap";
+        return nulls.get(1);
+    }
+
+    long topRowPosition() {
+        assert size > 0 : "topRowPosition on empty heap";
+        return rowPositions[1];
+    }
+
+    /**
+     * Insert a new entry. Caller guarantees {@code size < capacity}: the operator's hot loop
+     * routes overflowing inserts through {@link #updateTop} instead so the heap never has to
+     * resize.
+     */
+    void push(long value, long rowPosition, boolean isNull) {
+        assert size < capacity : "push on full heap";
+        size++;
+        values[size] = value;
+        rowPositions[size] = rowPosition;
+        // Only touch the BitSet when the new row is null — for the common all-non-null run we
+        // leave the backing bit cleared by construction and nulls.isEmpty() stays true, which
+        // the downHeap fast path keys off.
+        if (isNull) {
+            nulls.set(size);
+        }
+        upHeap(size);
+    }
+
+    /**
+     * Replace the current root with a new entry and restore the heap invariant. Used by the
+     * operator when an incoming row is greater than the current threshold (= peekTop) and the
+     * heap is already full.
+     */
+    void updateTop(long value, long rowPosition, boolean isNull) {
+        assert size > 0 : "updateTop on empty heap";
+        values[1] = value;
+        rowPositions[1] = rowPosition;
+        if (isNull) {
+            nulls.set(1);
+        } else {
+            // Explicit clear: a slot can transition null -> non-null when overwriting a null
+            // root; without this the stale bit would survive into draining.
+            nulls.clear(1);
+        }
+        downHeap(1);
+    }
+
+    /**
+     * Pop the current root and return its slot index after the swap so the caller can read
+     * {@code values[i]}, {@code rowPositions[i]}, and {@code nulls.get(i)} before the next pop.
+     * Used at drain time; not part of the hot insert path.
+     *
+     * <p>After this returns, {@link #size} has been decremented and the popped slot lives at
+     * {@code size + 1}, where the caller can read it. The next call to {@code popTop} (or any
+     * mutator) invalidates that index, so callers must copy out before continuing.
+     */
+    int popTop() {
+        assert size > 0 : "popTop on empty heap";
+        int popped = size;
+        // Swap root with last live slot, then sift down. The popped slot at index `popped`
+        // (formerly index 1) holds the popped values until the next mutation.
+        swap(1, popped);
+        size--;
+        if (size > 0) {
+            downHeap(1);
+        }
+        return popped;
+    }
+
+    long valueAt(int slot) {
+        return values[slot];
+    }
+
+    long rowPositionAt(int slot) {
+        return rowPositions[slot];
+    }
+
+    boolean isNullAt(int slot) {
+        return nulls.get(slot);
+    }
+
+    /**
+     * Single private mutator that moves all three parallel structures atomically. Centralising
+     * the swap is what keeps the {@code (value, rowPosition, isNull)} triple aligned through
+     * every heap operation; reviewers (and the runtime invariant assertion) only need to verify
+     * this one method.
+     */
+    private void swap(int i, int j) {
+        if (i == j) {
+            return;
+        }
+        long v = values[i];
+        values[i] = values[j];
+        values[j] = v;
+        long rp = rowPositions[i];
+        rowPositions[i] = rowPositions[j];
+        rowPositions[j] = rp;
+        // Hot-path skip: an empty nulls BitSet stays empty under a swap (no bits to move).
+        // This branch elides every BitSet access for the all-non-null common case.
+        if (nulls.isEmpty() == false) {
+            boolean ni = nulls.get(i);
+            boolean nj = nulls.get(j);
+            if (ni != nj) {
+                nulls.set(i, nj);
+                nulls.set(j, ni);
+            }
+        }
+    }
+
+    /**
+     * Heap ordering, primary then secondary then tertiary:
+     * <ol>
+     *     <li>Null bit: under {@link #nullsAreMoreCompetitive} = {@code true} (nulls-first) a
+     *         null slot is <em>less</em> than a non-null slot, so nulls bubble toward the root
+     *         and are the candidates for eviction once K nulls are in the heap. Under
+     *         {@code false} (nulls-last) a non-null slot is <em>less</em> than a null slot.
+     *         This avoids the sentinel-collision trap of "encode null as {@code Long.MAX_VALUE}":
+     *         {@code ~Long.MIN_VALUE} also equals {@code Long.MAX_VALUE}, so a sentinel cannot
+     *         be distinguished from a real value at the long range's extreme.</li>
+     *     <li>Encoded {@link #values} ascending: smaller encoded sorts to the root.</li>
+     *     <li>{@link #rowPositions} <em>descending</em> (unsigned): when both null status and
+     *         encoded value tie, the slot with the larger row position is "less" and sinks to
+     *         the root, so it is the next eviction candidate. This matches the operator's
+     *         "first-seen wins" stability.</li>
+     * </ol>
+     * The {@code nulls.isEmpty()} fast path keeps the per-comparison BitSet access cost at zero
+     * for the dominant case (no nulls ever entered the heap).
+     */
+    private boolean lessThan(int i, int j) {
+        // BitSet skip: when nothing in the heap is null, all slots agree on the null bit, so
+        // we can collapse to value-then-rowPosition.
+        if (nulls.isEmpty() == false) {
+            boolean ni = nulls.get(i);
+            boolean nj = nulls.get(j);
+            if (ni != nj) {
+                // i is "less" (sinks toward the root = next eviction candidate) when it is the
+                // LESS competitive of the two. Nulls-first means nulls are the most
+                // competitive; under that policy a null sinks to the root only when paired
+                // with another null — never against a non-null. Nulls-last is the inverse.
+                // The pair (ni, nj) is asymmetric here (we already know they differ), so:
+                // nulls-first: i is less iff i is non-null -> return ni == false
+                // nulls-last: i is less iff i is null -> return ni == true
+                return nullsAreMoreCompetitive != ni;
+            }
+        }
+        long vi = values[i];
+        long vj = values[j];
+        if (vi != vj) {
+            return vi < vj;
+        }
+        // Equal encoded values: the slot with a strictly greater rowPosition is "less" — it
+        // sinks toward the root, so it is the one evicted on the next competitive insert.
+        // {@code rowPositions} carries the producer's packed (extractor id, file-local
+        // position) long; the comparison uses unsigned ordering so the packing is reproducible
+        // regardless of the high-bit sign of the packed long.
+        return Long.compareUnsigned(rowPositions[i], rowPositions[j]) > 0;
+    }
+
+    private void upHeap(int i) {
+        while (i > 1) {
+            int parent = ((i - 2) / 3) + 1;
+            if (lessThan(i, parent)) {
+                swap(i, parent);
+                i = parent;
+            } else {
+                break;
+            }
+        }
+    }
+
+    private void downHeap(int i) {
+        while (true) {
+            int firstChild = 3 * (i - 1) + 2;
+            if (firstChild > size) {
+                return;
+            }
+            int smallest = i;
+            int c = firstChild;
+            if (lessThan(c, smallest)) {
+                smallest = c;
+            }
+            c++;
+            if (c <= size && lessThan(c, smallest)) {
+                smallest = c;
+            }
+            c++;
+            if (c <= size && lessThan(c, smallest)) {
+                smallest = c;
+            }
+            if (smallest == i) {
+                return;
+            }
+            swap(i, smallest);
+            i = smallest;
+        }
+    }
+
+    /**
+     * Test-only walk over every occupied slot {@code [1..size]}, invoking the visitor with the
+     * slot index and its {@code (value, rowPosition, isNull)} triple. The visitor must not
+     * mutate the heap. Used by the Stage 3 triple-alignment stress test to verify
+     * {@link #swap(int, int)} keeps all three structures in lockstep through every up- and
+     * down-heap.
+     */
+    void forEachSlot(SlotVisitor visitor) {
+        for (int slot = 1; slot <= size; slot++) {
+            visitor.visit(slot, values[slot], rowPositions[slot], nulls.get(slot));
+        }
+    }
+
+    /**
+     * Visitor over an occupied heap slot. See {@link #forEachSlot}.
+     */
+    @FunctionalInterface
+    interface SlotVisitor {
+        void visit(int slot, long value, long rowPosition, boolean isNull);
+    }
+
+    /**
+     * Walks the heap and asserts the heap invariant under the composite ordering used by
+     * {@link #lessThan(int, int)}: every parent compares as less-than-or-equal to each of its
+     * (up to three) children. Test-only — called from operator unit tests after every mutation
+     * in randomised sequences (Stage 3 alignment test).
+     */
+    boolean assertInvariant() {
+        for (int parent = 1; parent <= size; parent++) {
+            int firstChild = 3 * (parent - 1) + 2;
+            for (int c = firstChild; c < firstChild + 3 && c <= size; c++) {
+                assert lessThan(c, parent) == false
+                    : "heap invariant broken at parent="
+                        + parent
+                        + " child="
+                        + c
+                        + " values=["
+                        + values[parent]
+                        + ","
+                        + values[c]
+                        + "] rowPositions=["
+                        + rowPositions[parent]
+                        + ","
+                        + rowPositions[c]
+                        + "]";
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public void close() {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        breaker.addWithoutBreaking(-registeredBytes);
+    }
+}

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/NumericTopNOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/NumericTopNOperatorTests.java
@@ -129,7 +129,16 @@ public class NumericTopNOperatorTests extends ComputeTestCase {
     }
 
     private List<Page> runTopN(Operator op, BlockFactory blockFactory, List<Long> values, boolean[] nullMask) {
-        List<Page> input = pagesFor(blockFactory, values, nullMask);
+        return runTopN(op, () -> pagesFor(blockFactory, values, nullMask));
+    }
+
+    /**
+     * Drive {@code op} with the pages produced by {@code inputSupplier}. The supplier indirection
+     * exists so callers can run two operators on freshly-built copies of the same logical input
+     * — pages are released after consumption, so a single {@code List<Page>} can't be reused.
+     */
+    private List<Page> runTopN(Operator op, java.util.function.Supplier<List<Page>> inputSupplier) {
+        List<Page> input = inputSupplier.get();
         List<Page> output = new ArrayList<>();
         try {
             for (Page p : input) {
@@ -203,13 +212,15 @@ public class NumericTopNOperatorTests extends ComputeTestCase {
         assertThat("both operators must emit the same total row count", numRows, equalTo(refRows));
         assertThat("at most K rows", refRows, lessThanOrEqualTo((long) k));
         // The generic TopNOperator is non-stable across equal sort keys: its underlying Lucene
-        // {@link org.apache.lucene.util.PriorityQueue} drains equal-key rows in heap-internal
-        // order. The numeric operator is stable on {@code _rowPosition} ascending by design.
-        // To compare under a single canonical ordering, materialise both results into
-        // {@code [(sortKey, rowPosition)]} lists and sort each by {@code (sortKey, rowPosition
-        // ASC)} before comparing — this collapses the drain-order ambiguity while still
-        // catching any mismatch in heap content (which rows survived) or in the surviving
-        // payload ({@code _rowPosition} values).
+        // PriorityQueue drains equal-key rows in heap-internal order, and at the K-th boundary
+        // any of several tied rows may survive. The numeric operator's stable
+        // {@code _rowPosition} ASC tiebreak picks a single specific row. So a row-position-level
+        // comparison is too strict — both operators may return valid Top-K answers that disagree
+        // on which boundary-tied row position survived. The right invariant is "same surviving
+        // sort-key multiset" (catches wrong threshold, wrong direction, missing/duplicate rows,
+        // missing nulls). The {@code _rowPosition} payload is exercised by the typed-correctness
+        // tests below, which compare against an independent ranking helper using the same
+        // {@code _rowPosition}-ASC tiebreak as the operator.
         List<long[]> refRowsList = canonicalize(reference);
         List<long[]> numRowsList = canonicalize(numeric);
         assertThat("canonicalized row count", numRowsList.size(), equalTo(refRowsList.size()));
@@ -217,10 +228,9 @@ public class NumericTopNOperatorTests extends ComputeTestCase {
             long[] r = refRowsList.get(i);
             long[] m = numRowsList.get(i);
             assertThat("sort key null flag at row " + i, m[2], equalTo(r[2]));
-            if (r[2] == 0) { // not null
+            if (r[2] == 0) {
                 assertThat("sort key value at row " + i, m[0], equalTo(r[0]));
             }
-            assertThat("row position at row " + i, m[1], equalTo(r[1]));
         }
     }
 
@@ -259,39 +269,433 @@ public class NumericTopNOperatorTests extends ComputeTestCase {
         return out;
     }
 
-    public void testRejectMultiValuedSortKey() {
+    /**
+     * MV correctness: feed multi-valued LONG sort keys through {@link NumericTopNOperator} and
+     * assert the surviving set equals the K most-competitive rows under the same composite
+     * ordering the operator uses internally (MV-min for ASC, MV-max for DESC, empty slot = null,
+     * then {@code _rowPosition} ASC tiebreak).
+     *
+     * <p>This is structurally the same check as
+     * {@code runTypeCorrectness(ElementType.LONG, ...)} but with MV inputs instead of
+     * single-valued. The comparison is against an independently-computed reference (not the
+     * generic operator) so we avoid the generic operator's heap-internal-order ambiguity at the
+     * K boundary.
+     */
+    public void testMultiValuedUnorderedLongCorrectness() {
+        runMvLongCorrectness(/*mvSortedAscending*/ false);
+    }
+
+    /**
+     * MV correctness on the {@code SORTED_ASCENDING} path: the builder marks the block as having
+     * sorted MV ordering, so {@link LongSortKeyExtractor#extractorFor(LongBlock, boolean)} picks
+     * the O(1) {@code MinFromAscendingBlock} / {@code MaxFromAscendingBlock} variant. The check
+     * verifies the optimised path produces the same surviving set as the unordered scan would.
+     */
+    public void testMultiValuedAscendingLongCorrectness() {
+        runMvLongCorrectness(/*mvSortedAscending*/ true);
+    }
+
+    /**
+     * MV correctness for INT, DOUBLE, and BOOLEAN — covers the per-type extractors'
+     * {@code MinFromUnorderedBlock} / {@code MaxFromUnorderedBlock} branches. The LONG MV tests
+     * above already cover the {@code MinFromAscendingBlock} / {@code MaxFromAscendingBlock}
+     * branches, and those branches are structurally identical across types (single read at
+     * {@code firstValueIndex} or {@code firstValueIndex + valueCount - 1}), so we don't
+     * duplicate the ascending-MV variant for every type.
+     */
+    public void testMultiValuedIntCorrectness() {
+        runMvTypedCorrectness(ElementType.INT);
+    }
+
+    public void testMultiValuedDoubleCorrectness() {
+        runMvTypedCorrectness(ElementType.DOUBLE);
+    }
+
+    public void testMultiValuedBooleanCorrectness() {
+        runMvTypedCorrectness(ElementType.BOOLEAN);
+    }
+
+    private void runMvTypedCorrectness(ElementType elementType) {
+        boolean asc = randomBoolean();
+        boolean nullsFirst = randomBoolean();
+        int n = randomIntBetween(50, 400);
+        int k = randomIntBetween(1, Math.min(40, n));
+        // For each input row, randomly pick 0/1/2-or-more values of the type, then reduce them
+        // to a single "competing" value the way the operator's extractor will. Track:
+        // - the raw MV slot (to build the input block),
+        // - the reduced typed value (to feed the independent ranking helper).
+        boolean[] nullMask = new boolean[n];
+        Object reduced = switch (elementType) {
+            case INT -> new int[n];
+            case DOUBLE -> new double[n];
+            case BOOLEAN -> new boolean[n];
+            default -> throw new AssertionError(elementType);
+        };
+        List<Object> rowValues = new ArrayList<>(n);
+        for (int i = 0; i < n; i++) {
+            int kind = randomInt(2);
+            if (kind == 1) {
+                nullMask[i] = true;
+                rowValues.add(null);
+                continue;
+            }
+            int sz = kind == 0 ? 1 : randomIntBetween(2, 5);
+            switch (elementType) {
+                case INT -> {
+                    int[] vs = new int[sz];
+                    int best = 0;
+                    for (int j = 0; j < sz; j++) {
+                        vs[j] = randomIntBetween(-1000, 1000);
+                        if (j == 0) {
+                            best = vs[j];
+                        } else {
+                            best = asc ? Math.min(best, vs[j]) : Math.max(best, vs[j]);
+                        }
+                    }
+                    ((int[]) reduced)[i] = best;
+                    rowValues.add(vs);
+                }
+                case DOUBLE -> {
+                    double[] vs = new double[sz];
+                    double best = 0;
+                    for (int j = 0; j < sz; j++) {
+                        vs[j] = randomDoubleBetween(-1000.0, 1000.0, true);
+                        if (j == 0) {
+                            best = vs[j];
+                        } else {
+                            best = asc ? Math.min(best, vs[j]) : Math.max(best, vs[j]);
+                        }
+                    }
+                    ((double[]) reduced)[i] = best;
+                    rowValues.add(vs);
+                }
+                case BOOLEAN -> {
+                    boolean[] vs = new boolean[sz];
+                    boolean best = false;
+                    for (int j = 0; j < sz; j++) {
+                        vs[j] = randomBoolean();
+                        if (j == 0) {
+                            best = vs[j];
+                        } else if (asc) {
+                            best = best && vs[j]; // min: any false → false
+                        } else {
+                            best = best || vs[j]; // max: any true → true
+                        }
+                    }
+                    ((boolean[]) reduced)[i] = best;
+                    rowValues.add(vs);
+                }
+                default -> throw new AssertionError(elementType);
+            }
+        }
+
         BlockFactory blockFactory = blockFactory();
-        try (Operator op = numeric(blockFactory, 5, true, false)) {
-            Page page;
-            try (
-                LongBlock.Builder sortBuilder = blockFactory.newLongBlockBuilder(2);
-                LongBlock.Builder rpBuilder = blockFactory.newLongBlockBuilder(2)
-            ) {
-                sortBuilder.beginPositionEntry();
-                sortBuilder.appendLong(1L);
-                sortBuilder.appendLong(2L);
-                sortBuilder.endPositionEntry();
-                sortBuilder.appendLong(3L);
-                rpBuilder.appendLong(0);
-                rpBuilder.appendLong(1);
-                LongBlock sortBlock = sortBuilder.build();
-                LongBlock rpBlock;
-                boolean built = false;
+        List<Integer> survivors = new ArrayList<>();
+        try (
+            Operator op = new NumericTopNOperator.NumericTopNOperatorFactory(k, elementType, asc, nullsFirst).get(
+                new DriverContext(blockFactory.bigArrays(), blockFactory, null)
+            )
+        ) {
+            for (Page p : typedMvPagesFor(blockFactory, elementType, rowValues, nullMask)) {
+                op.addInput(p);
+            }
+            op.finish();
+            while (op.isFinished() == false) {
+                Page out = op.getOutput();
+                if (out != null) {
+                    try {
+                        LongBlock rp = out.getBlock(NumericTopNOperator.ROW_POSITION_CHANNEL);
+                        for (int pos = 0; pos < out.getPositionCount(); pos++) {
+                            survivors.add((int) rp.getLong(rp.getFirstValueIndex(pos)));
+                        }
+                    } finally {
+                        out.releaseBlocks();
+                    }
+                }
+            }
+        }
+        List<Integer> ranked = independentRanking(elementType, reduced, nullMask, asc, nullsFirst);
+        assertSubsetWithBoundaryTies(elementType, reduced, nullMask, asc, nullsFirst, ranked, survivors, k);
+    }
+
+    /**
+     * Build typed 2-channel pages where the sort-key slot at each position is the MV list from
+     * {@code rowValues} (or null when {@code nullMask[i]} is set). Mirrors {@link #typedPagesFor}
+     * but uses MV builders.
+     */
+    private List<Page> typedMvPagesFor(BlockFactory blockFactory, ElementType elementType, List<Object> rowValues, boolean[] nullMask) {
+        int n = nullMask.length;
+        if (n == 0) {
+            return List.of();
+        }
+        int pageSize = randomIntBetween(1, Math.max(1, n));
+        List<Page> out = new ArrayList<>();
+        int p = 0;
+        while (p < n) {
+            int end = Math.min(p + pageSize, n);
+            int sz = end - p;
+            Block sortBlock = buildTypedMvSortBlock(blockFactory, elementType, rowValues, nullMask, p, sz);
+            LongBlock rpBlock;
+            boolean success = false;
+            try (LongBlock.Builder rpBuilder = blockFactory.newLongBlockBuilder(sz)) {
+                for (int i = 0; i < sz; i++) {
+                    rpBuilder.appendLong(p + i);
+                }
                 try {
                     rpBlock = rpBuilder.build();
-                    built = true;
+                    success = true;
                 } finally {
-                    if (built == false) {
+                    if (success == false) {
                         sortBlock.close();
                     }
                 }
-                page = new Page(sortBlock, rpBlock);
             }
-            IllegalStateException e = expectThrows(IllegalStateException.class, () -> op.addInput(page));
-            assertThat(e.getMessage(), org.hamcrest.Matchers.containsString("multi-valued"));
-            assertThat(e.getMessage(), org.hamcrest.Matchers.containsString("MV_MIN"));
-            assertThat(e.getMessage(), org.hamcrest.Matchers.containsString("MV_MAX"));
+            out.add(new Page(sortBlock, rpBlock));
+            p = end;
         }
+        return out;
+    }
+
+    private Block buildTypedMvSortBlock(
+        BlockFactory blockFactory,
+        ElementType elementType,
+        List<Object> rowValues,
+        boolean[] nullMask,
+        int start,
+        int sz
+    ) {
+        return switch (elementType) {
+            case INT -> {
+                try (IntBlock.Builder b = blockFactory.newIntBlockBuilder(sz)) {
+                    for (int i = 0; i < sz; i++) {
+                        int abs = start + i;
+                        if (nullMask[abs]) {
+                            b.appendNull();
+                            continue;
+                        }
+                        int[] vs = (int[]) rowValues.get(abs);
+                        if (vs.length == 1) {
+                            b.appendInt(vs[0]);
+                        } else {
+                            b.beginPositionEntry();
+                            for (int v : vs) {
+                                b.appendInt(v);
+                            }
+                            b.endPositionEntry();
+                        }
+                    }
+                    yield b.build();
+                }
+            }
+            case DOUBLE -> {
+                try (DoubleBlock.Builder b = blockFactory.newDoubleBlockBuilder(sz)) {
+                    for (int i = 0; i < sz; i++) {
+                        int abs = start + i;
+                        if (nullMask[abs]) {
+                            b.appendNull();
+                            continue;
+                        }
+                        double[] vs = (double[]) rowValues.get(abs);
+                        if (vs.length == 1) {
+                            b.appendDouble(vs[0]);
+                        } else {
+                            b.beginPositionEntry();
+                            for (double v : vs) {
+                                b.appendDouble(v);
+                            }
+                            b.endPositionEntry();
+                        }
+                    }
+                    yield b.build();
+                }
+            }
+            case BOOLEAN -> {
+                try (BooleanBlock.Builder b = blockFactory.newBooleanBlockBuilder(sz)) {
+                    for (int i = 0; i < sz; i++) {
+                        int abs = start + i;
+                        if (nullMask[abs]) {
+                            b.appendNull();
+                            continue;
+                        }
+                        boolean[] vs = (boolean[]) rowValues.get(abs);
+                        if (vs.length == 1) {
+                            b.appendBoolean(vs[0]);
+                        } else {
+                            b.beginPositionEntry();
+                            for (boolean v : vs) {
+                                b.appendBoolean(v);
+                            }
+                            b.endPositionEntry();
+                        }
+                    }
+                    yield b.build();
+                }
+            }
+            default -> throw new AssertionError(elementType);
+        };
+    }
+
+    private void runMvLongCorrectness(boolean mvSortedAscending) {
+        boolean asc = randomBoolean();
+        boolean nullsFirst = randomBoolean();
+        int n = randomIntBetween(50, 600);
+        int k = randomIntBetween(1, Math.min(40, n));
+        // Three flavours per row: single-value, empty MV (treated as null), and a non-empty MV
+        // list. The mix forces the extractor through every branch.
+        List<long[]> rows = new ArrayList<>(n);
+        for (int i = 0; i < n; i++) {
+            int kind = randomInt(2);
+            switch (kind) {
+                case 0 -> rows.add(new long[] { randomLong() });
+                case 1 -> rows.add(new long[] {});
+                default -> {
+                    int sz = randomIntBetween(2, 5);
+                    long[] vs = new long[sz];
+                    for (int j = 0; j < sz; j++) {
+                        vs[j] = randomLong();
+                    }
+                    if (mvSortedAscending) {
+                        java.util.Arrays.sort(vs);
+                    }
+                    rows.add(vs);
+                }
+            }
+        }
+        // Reduce each input row to its competing scalar (null for empty slots) so the
+        // independent ranking helper can rank under the same ordering the operator computes.
+        boolean[] nullMask = new boolean[n];
+        long[] reduced = new long[n];
+        for (int i = 0; i < n; i++) {
+            long[] vs = rows.get(i);
+            if (vs.length == 0) {
+                nullMask[i] = true;
+            } else {
+                long best = vs[0];
+                for (int j = 1; j < vs.length; j++) {
+                    best = asc ? Math.min(best, vs[j]) : Math.max(best, vs[j]);
+                }
+                reduced[i] = best;
+            }
+        }
+
+        BlockFactory blockFactory = blockFactory();
+        List<Integer> survivors;
+        try (Operator op = numeric(blockFactory, k, asc, nullsFirst)) {
+            for (Page p : mvPagesFor(blockFactory, rows, mvSortedAscending)) {
+                op.addInput(p);
+            }
+            op.finish();
+            survivors = new ArrayList<>();
+            while (op.isFinished() == false) {
+                Page out = op.getOutput();
+                if (out != null) {
+                    try {
+                        LongBlock rpBlock = out.getBlock(NumericTopNOperator.ROW_POSITION_CHANNEL);
+                        for (int pos = 0; pos < out.getPositionCount(); pos++) {
+                            survivors.add((int) rpBlock.getLong(rpBlock.getFirstValueIndex(pos)));
+                        }
+                    } finally {
+                        out.releaseBlocks();
+                    }
+                }
+            }
+        }
+
+        // Independent ranking under the operator's composite order (LONG comparator, asc/desc,
+        // nulls per nullsFirst, _rowPosition ASC tiebreak — exactly the ordering
+        // {@link #compareForRanking} encodes for ElementType.LONG).
+        List<Integer> ranked = independentRankingLong(reduced, nullMask, asc, nullsFirst);
+        assertSubsetWithBoundaryTies(ElementType.LONG, reduced, nullMask, asc, nullsFirst, ranked, survivors, k);
+    }
+
+    /**
+     * Specialised version of {@link #independentRanking} for LONG sort keys. Inlined to avoid
+     * widening {@code compareForRanking}'s {@code switch} just to support MV LONG; the typed
+     * correctness tests already cover the INT / DOUBLE / BOOLEAN paths for single values.
+     */
+    private List<Integer> independentRankingLong(long[] reduced, boolean[] nullMask, boolean asc, boolean nullsFirst) {
+        int n = nullMask.length;
+        List<Integer> indices = new ArrayList<>(n);
+        for (int i = 0; i < n; i++) {
+            indices.add(i);
+        }
+        indices.sort((a, b) -> {
+            boolean na = nullMask[a];
+            boolean nb = nullMask[b];
+            if (na != nb) {
+                return na == nullsFirst ? -1 : 1;
+            }
+            if (na) {
+                return Integer.compare(a, b);
+            }
+            int cmp = Long.compare(reduced[a], reduced[b]);
+            if (asc == false) {
+                cmp = -cmp;
+            }
+            if (cmp != 0) {
+                return cmp;
+            }
+            return Integer.compare(a, b);
+        });
+        return indices;
+    }
+
+    /**
+     * Build pages where each input row may have zero, one, or many values in the sort-key slot.
+     * The {@code _rowPosition} column stays dense and strictly increasing (one row position per
+     * page position), matching the contract the external source guarantees.
+     */
+    private List<Page> mvPagesFor(BlockFactory blockFactory, List<long[]> rows, boolean mvSortedAscending) {
+        int n = rows.size();
+        if (n == 0) {
+            return List.of();
+        }
+        int pageSize = randomIntBetween(1, Math.max(1, n));
+        List<Page> out = new ArrayList<>();
+        int p = 0;
+        while (p < n) {
+            int end = Math.min(p + pageSize, n);
+            int sz = end - p;
+            LongBlock sortBlock;
+            LongBlock rowPositionBlock;
+            boolean success = false;
+            try (
+                LongBlock.Builder sortBuilder = blockFactory.newLongBlockBuilder(sz);
+                LongBlock.Builder rpBuilder = blockFactory.newLongBlockBuilder(sz)
+            ) {
+                if (mvSortedAscending) {
+                    sortBuilder.mvOrdering(Block.MvOrdering.SORTED_ASCENDING);
+                }
+                for (int i = 0; i < sz; i++) {
+                    int abs = p + i;
+                    long[] vs = rows.get(abs);
+                    if (vs.length == 0) {
+                        sortBuilder.appendNull();
+                    } else if (vs.length == 1) {
+                        sortBuilder.appendLong(vs[0]);
+                    } else {
+                        sortBuilder.beginPositionEntry();
+                        for (long v : vs) {
+                            sortBuilder.appendLong(v);
+                        }
+                        sortBuilder.endPositionEntry();
+                    }
+                    rpBuilder.appendLong(abs);
+                }
+                sortBlock = sortBuilder.build();
+                try {
+                    rowPositionBlock = rpBuilder.build();
+                    success = true;
+                } finally {
+                    if (success == false) {
+                        sortBlock.close();
+                    }
+                }
+            }
+            out.add(new Page(sortBlock, rowPositionBlock));
+            p = end;
+        }
+        return out;
     }
 
     public void testEmptyInput() {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/NumericTopNOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/NumericTopNOperatorTests.java
@@ -1,0 +1,612 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.operator.topn;
+
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Operator;
+import org.elasticsearch.compute.test.ComputeTestCase;
+import org.elasticsearch.core.Releasables;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+
+/**
+ * Parity tests for {@link NumericTopNOperator} against the generic {@link TopNOperator} on the
+ * exact plan shape the new operator is designed to replace: a 2-channel page of
+ * {@code [sortKey (LONG), _rowPosition (LONG)]} flowing into a single-key Top-K. The two
+ * operators must produce byte-for-byte identical output pages for every (ASC/DESC × nullsFirst
+ * × K × input distribution) combination — including the {@code _rowPosition} payload.
+ */
+public class NumericTopNOperatorTests extends ComputeTestCase {
+
+    public void testParityAscNullsLast() {
+        assertParity(true, false);
+    }
+
+    public void testParityAscNullsFirst() {
+        assertParity(true, true);
+    }
+
+    public void testParityDescNullsLast() {
+        assertParity(false, false);
+    }
+
+    public void testParityDescNullsFirst() {
+        assertParity(false, true);
+    }
+
+    /**
+     * Low-cardinality input exercises the {@code _rowPosition} tiebreaker path: many input
+     * rows share the same encoded value, so the heap's internal ordering matters and the
+     * "first-seen wins ties" stability must produce the same surviving payload as the generic
+     * operator.
+     */
+    public void testParityLowCardinalityTies() {
+        boolean asc = randomBoolean();
+        boolean nullsFirst = randomBoolean();
+        int n = randomIntBetween(200, 2000);
+        int k = randomIntBetween(1, Math.min(50, n));
+        // Only 4 distinct values: heavy collisions across the input.
+        long[] palette = new long[] { 0L, 1L, 2L, 3L };
+        List<Long> values = new ArrayList<>(n);
+        for (int i = 0; i < n; i++) {
+            values.add(palette[randomInt(palette.length - 1)]);
+        }
+        assertParityForInput(values, k, asc, nullsFirst, /*nullProbability*/ 0.0);
+    }
+
+    private void assertParity(boolean asc, boolean nullsFirst) {
+        int n = randomIntBetween(0, 2000);
+        int k = randomIntBetween(1, Math.max(1, n));
+        List<Long> values = new ArrayList<>(n);
+        for (int i = 0; i < n; i++) {
+            values.add(randomLong());
+        }
+        double nullProb = randomBoolean() ? 0.0 : randomDoubleBetween(0.01, 0.5, true);
+        assertParityForInput(values, k, asc, nullsFirst, nullProb);
+    }
+
+    /**
+     * Run the same input through both operators and compare every output column position by
+     * position. Both operators are configured with the same K, the same sort order, the same
+     * nulls policy, and identical 2-channel pages.
+     */
+    private void assertParityForInput(List<Long> values, int k, boolean asc, boolean nullsFirst, double nullProbability) {
+        BlockFactory blockFactory = blockFactory();
+        // Mark random positions as null with the given probability; same mask for both runs so
+        // the operators see identical inputs.
+        boolean[] nullMask = new boolean[values.size()];
+        for (int i = 0; i < values.size(); i++) {
+            nullMask[i] = nullProbability > 0 && randomDouble() < nullProbability;
+        }
+        List<Page> referenceOutput = runTopN(generic(blockFactory, k, asc, nullsFirst), blockFactory, values, nullMask);
+        List<Page> numericOutput = runTopN(numeric(blockFactory, k, asc, nullsFirst), blockFactory, values, nullMask);
+        try {
+            assertPagesEqual(referenceOutput, numericOutput, k);
+        } finally {
+            referenceOutput.forEach(Page::releaseBlocks);
+            numericOutput.forEach(Page::releaseBlocks);
+        }
+    }
+
+    private Operator generic(BlockFactory blockFactory, int k, boolean asc, boolean nullsFirst) {
+        CircuitBreaker breaker = blockFactory.breaker();
+        return new TopNOperator(
+            blockFactory,
+            breaker,
+            k,
+            List.of(ElementType.LONG, ElementType.LONG),
+            List.of(TopNEncoder.DEFAULT_SORTABLE, TopNEncoder.DEFAULT_SORTABLE),
+            List.of(new TopNOperator.SortOrder(NumericTopNOperator.SORT_KEY_CHANNEL, asc, nullsFirst)),
+            randomIntBetween(1, 1000), // maxPageSize
+            Long.MAX_VALUE,
+            TopNOperator.InputOrdering.NOT_SORTED,
+            null
+        );
+    }
+
+    private Operator numeric(BlockFactory blockFactory, int k, boolean asc, boolean nullsFirst) {
+        return new NumericTopNOperator.NumericTopNOperatorFactory(k, ElementType.LONG, asc, nullsFirst).get(
+            new DriverContext(blockFactory.bigArrays(), blockFactory, null)
+        );
+    }
+
+    private List<Page> runTopN(Operator op, BlockFactory blockFactory, List<Long> values, boolean[] nullMask) {
+        List<Page> input = pagesFor(blockFactory, values, nullMask);
+        List<Page> output = new ArrayList<>();
+        try {
+            for (Page p : input) {
+                op.addInput(p);
+            }
+            op.finish();
+            while (op.isFinished() == false) {
+                Page out = op.getOutput();
+                if (out != null) {
+                    output.add(out);
+                }
+            }
+        } finally {
+            op.close();
+        }
+        return output;
+    }
+
+    /**
+     * Build the test input as one or more 2-channel pages. The {@code _rowPosition} column is
+     * dense and strictly increasing across all pages, matching how the external source emits
+     * it in production (packed extractor-id + file-local position, but for tests we use the
+     * input index directly since the operator treats it as an opaque long).
+     */
+    private List<Page> pagesFor(BlockFactory blockFactory, List<Long> values, boolean[] nullMask) {
+        int n = values.size();
+        if (n == 0) {
+            return List.of();
+        }
+        int pageSize = randomIntBetween(1, Math.max(1, n));
+        List<Page> out = new ArrayList<>();
+        int p = 0;
+        while (p < n) {
+            int end = Math.min(p + pageSize, n);
+            int sz = end - p;
+            LongBlock sortBlock;
+            LongBlock rowPositionBlock;
+            boolean success = false;
+            try (
+                LongBlock.Builder sortBuilder = blockFactory.newLongBlockBuilder(sz);
+                LongBlock.Builder rpBuilder = blockFactory.newLongBlockBuilder(sz)
+            ) {
+                for (int i = 0; i < sz; i++) {
+                    int abs = p + i;
+                    if (nullMask[abs]) {
+                        sortBuilder.appendNull();
+                    } else {
+                        sortBuilder.appendLong(values.get(abs));
+                    }
+                    rpBuilder.appendLong(abs);
+                }
+                sortBlock = sortBuilder.build();
+                try {
+                    rowPositionBlock = rpBuilder.build();
+                    success = true;
+                } finally {
+                    if (success == false) {
+                        sortBlock.close();
+                    }
+                }
+            }
+            out.add(new Page(sortBlock, rowPositionBlock));
+            p = end;
+        }
+        return out;
+    }
+
+    private void assertPagesEqual(List<Page> reference, List<Page> numeric, int k) {
+        long refRows = reference.stream().mapToLong(Page::getPositionCount).sum();
+        long numRows = numeric.stream().mapToLong(Page::getPositionCount).sum();
+        assertThat("both operators must emit the same total row count", numRows, equalTo(refRows));
+        assertThat("at most K rows", refRows, lessThanOrEqualTo((long) k));
+        // The generic TopNOperator is non-stable across equal sort keys: its underlying Lucene
+        // {@link org.apache.lucene.util.PriorityQueue} drains equal-key rows in heap-internal
+        // order. The numeric operator is stable on {@code _rowPosition} ascending by design.
+        // To compare under a single canonical ordering, materialise both results into
+        // {@code [(sortKey, rowPosition)]} lists and sort each by {@code (sortKey, rowPosition
+        // ASC)} before comparing — this collapses the drain-order ambiguity while still
+        // catching any mismatch in heap content (which rows survived) or in the surviving
+        // payload ({@code _rowPosition} values).
+        List<long[]> refRowsList = canonicalize(reference);
+        List<long[]> numRowsList = canonicalize(numeric);
+        assertThat("canonicalized row count", numRowsList.size(), equalTo(refRowsList.size()));
+        for (int i = 0; i < refRowsList.size(); i++) {
+            long[] r = refRowsList.get(i);
+            long[] m = numRowsList.get(i);
+            assertThat("sort key null flag at row " + i, m[2], equalTo(r[2]));
+            if (r[2] == 0) { // not null
+                assertThat("sort key value at row " + i, m[0], equalTo(r[0]));
+            }
+            assertThat("row position at row " + i, m[1], equalTo(r[1]));
+        }
+    }
+
+    /**
+     * Materialise pages into a list of {@code [sortKey, rowPosition, isNull (0/1)]} triples
+     * and sort under the canonical ordering: nulls last by isNull flag, then sortKey ASC, then
+     * rowPosition ASC. This collapses any drain-order ambiguity so the comparison only fails
+     * when the operators actually disagree on which rows survived or on the row position
+     * carried with each survivor.
+     */
+    private static List<long[]> canonicalize(List<Page> pages) {
+        List<long[]> out = new ArrayList<>();
+        for (Page p : pages) {
+            LongBlock sort = p.getBlock(NumericTopNOperator.SORT_KEY_CHANNEL);
+            LongBlock rp = p.getBlock(NumericTopNOperator.ROW_POSITION_CHANNEL);
+            for (int pos = 0; pos < p.getPositionCount(); pos++) {
+                boolean isNull = sort.isNull(pos);
+                long sv = isNull ? 0L : sort.getLong(sort.getFirstValueIndex(pos));
+                long rpv = rp.getLong(rp.getFirstValueIndex(pos));
+                out.add(new long[] { sv, rpv, isNull ? 1L : 0L });
+            }
+        }
+        out.sort((a, b) -> {
+            // nulls last during canonicalisation (the comparison is symmetric so this is just
+            // a stable bucket choice, not a semantic decision).
+            int n = Long.compare(a[2], b[2]);
+            if (n != 0) {
+                return n;
+            }
+            int s = Long.compare(a[0], b[0]);
+            if (s != 0) {
+                return s;
+            }
+            return Long.compare(a[1], b[1]);
+        });
+        return out;
+    }
+
+    public void testRejectMultiValuedSortKey() {
+        BlockFactory blockFactory = blockFactory();
+        try (Operator op = numeric(blockFactory, 5, true, false)) {
+            Page page;
+            try (
+                LongBlock.Builder sortBuilder = blockFactory.newLongBlockBuilder(2);
+                LongBlock.Builder rpBuilder = blockFactory.newLongBlockBuilder(2)
+            ) {
+                sortBuilder.beginPositionEntry();
+                sortBuilder.appendLong(1L);
+                sortBuilder.appendLong(2L);
+                sortBuilder.endPositionEntry();
+                sortBuilder.appendLong(3L);
+                rpBuilder.appendLong(0);
+                rpBuilder.appendLong(1);
+                LongBlock sortBlock = sortBuilder.build();
+                LongBlock rpBlock;
+                boolean built = false;
+                try {
+                    rpBlock = rpBuilder.build();
+                    built = true;
+                } finally {
+                    if (built == false) {
+                        sortBlock.close();
+                    }
+                }
+                page = new Page(sortBlock, rpBlock);
+            }
+            IllegalStateException e = expectThrows(IllegalStateException.class, () -> op.addInput(page));
+            assertThat(e.getMessage(), org.hamcrest.Matchers.containsString("multi-valued"));
+            assertThat(e.getMessage(), org.hamcrest.Matchers.containsString("MV_MIN"));
+            assertThat(e.getMessage(), org.hamcrest.Matchers.containsString("MV_MAX"));
+        }
+    }
+
+    public void testEmptyInput() {
+        BlockFactory blockFactory = blockFactory();
+        try (Operator op = numeric(blockFactory, 10, true, false)) {
+            op.finish();
+            assertTrue(op.isFinished());
+            assertNull(op.getOutput());
+        }
+    }
+
+    public void testFewerThanKInputs() {
+        List<Long> values = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            values.add(randomLong());
+        }
+        assertParityForInput(values, /*k=*/ 10, randomBoolean(), randomBoolean(), 0.0);
+    }
+
+    public void testIntSortKeyAscDescNulls() {
+        runTypeCorrectness(ElementType.INT, randomBoolean(), randomBoolean(), randomDoubleBetween(0.0, 0.4, true));
+    }
+
+    public void testDoubleSortKeyAscDescNulls() {
+        runTypeCorrectness(ElementType.DOUBLE, randomBoolean(), randomBoolean(), randomDoubleBetween(0.0, 0.4, true));
+    }
+
+    public void testBooleanSortKey() {
+        // Booleans have just two values, so this also exercises the operator on a heavy-ties
+        // workload with the smaller value-space than even {@link #testParityLowCardinalityTies}.
+        runTypeCorrectness(ElementType.BOOLEAN, randomBoolean(), randomBoolean(), randomDoubleBetween(0.0, 0.3, true));
+    }
+
+    /**
+     * Run the operator with a typed sort key and verify two properties of the output:
+     * <ol>
+     *     <li>The output page is sorted in the configured order (so an external consumer that
+     *         relies on TopN's "the page comes out sorted" contract still works).</li>
+     *     <li>The set of surviving rows is exactly the K most-competitive rows under the
+     *         configured order — computed independently from the input and compared by row
+     *         position (which uniquely identifies each input row).</li>
+     * </ol>
+     * This is a stronger correctness check than parity against the generic operator because it
+     * is not vulnerable to drain-order non-determinism on ties.
+     */
+    private void runTypeCorrectness(ElementType elementType, boolean asc, boolean nullsFirst, double nullProbability) {
+        BlockFactory blockFactory = blockFactory();
+        int n = randomIntBetween(20, 500);
+        int k = randomIntBetween(1, Math.min(20, n));
+        // Build typed input. For each element type we materialise the values into a long[] so
+        // the order check below is uniform across types.
+        Object rawValues = randomValues(elementType, n);
+        boolean[] nullMask = new boolean[n];
+        for (int i = 0; i < n; i++) {
+            nullMask[i] = randomDouble() < nullProbability;
+        }
+        List<Page> input = typedPagesFor(blockFactory, elementType, rawValues, nullMask);
+        List<Page> output = new ArrayList<>();
+        try (
+            Operator op = new NumericTopNOperator.NumericTopNOperatorFactory(k, elementType, asc, nullsFirst).get(
+                new DriverContext(blockFactory.bigArrays(), blockFactory, null)
+            )
+        ) {
+            for (Page p : input) {
+                op.addInput(p);
+            }
+            op.finish();
+            while (op.isFinished() == false) {
+                Page out = op.getOutput();
+                if (out != null) {
+                    output.add(out);
+                }
+            }
+            // Collect surviving row positions and verify the surviving set matches what an
+            // independent ranking of the input picks.
+            List<Integer> survivingRows = new ArrayList<>();
+            for (Page p : output) {
+                LongBlock rp = p.getBlock(NumericTopNOperator.ROW_POSITION_CHANNEL);
+                for (int pos = 0; pos < p.getPositionCount(); pos++) {
+                    survivingRows.add(Math.toIntExact(rp.getLong(rp.getFirstValueIndex(pos))));
+                }
+            }
+            assertThat("output size", survivingRows.size(), lessThanOrEqualTo(k));
+            // Independent ranking: build an index list, sort by the configured order, and take
+            // the first {@code k} entries. The operator's surviving set must equal this index
+            // set (compared as a sorted list so we don't depend on drain order).
+            List<Integer> ranked = independentRanking(elementType, rawValues, nullMask, asc, nullsFirst);
+            List<Integer> expected = ranked.subList(0, Math.min(k, ranked.size()));
+            // Ties in the operator's heap break on _rowPosition ASC (first-seen wins). The
+            // {@link #independentRanking} helper uses the same tiebreaker, so the expected set
+            // is exact when the {@code k}-th rank is unambiguous. When several rows tie at the
+            // boundary we widen the comparison to "subset of the equivalence class": every
+            // surviving row must rank within the expected window plus its boundary ties.
+            assertSubsetWithBoundaryTies(elementType, rawValues, nullMask, asc, nullsFirst, ranked, survivingRows, k);
+        } finally {
+            output.forEach(Page::releaseBlocks);
+        }
+    }
+
+    /**
+     * Random typed values for each supported element type. INT and DOUBLE are produced over a
+     * narrow range so ties show up frequently in {@code k}-sized samples; BOOLEAN is uniform
+     * over {true, false}.
+     */
+    private Object randomValues(ElementType elementType, int n) {
+        return switch (elementType) {
+            case INT -> {
+                int[] arr = new int[n];
+                for (int i = 0; i < n; i++) {
+                    arr[i] = randomIntBetween(-1000, 1000);
+                }
+                yield arr;
+            }
+            case DOUBLE -> {
+                double[] arr = new double[n];
+                for (int i = 0; i < n; i++) {
+                    arr[i] = randomDoubleBetween(-1000.0, 1000.0, true);
+                }
+                yield arr;
+            }
+            case BOOLEAN -> {
+                boolean[] arr = new boolean[n];
+                for (int i = 0; i < n; i++) {
+                    arr[i] = randomBoolean();
+                }
+                yield arr;
+            }
+            default -> throw new AssertionError(elementType);
+        };
+    }
+
+    /**
+     * Build typed 2-channel pages of {@code [sortKey, _rowPosition]} for a given element type.
+     * Row positions are the input index so the operator's output can be cross-checked against
+     * the raw input.
+     */
+    private List<Page> typedPagesFor(BlockFactory blockFactory, ElementType elementType, Object raw, boolean[] nullMask) {
+        int n = nullMask.length;
+        if (n == 0) {
+            return List.of();
+        }
+        int pageSize = randomIntBetween(1, Math.max(1, n));
+        List<Page> out = new ArrayList<>();
+        int p = 0;
+        while (p < n) {
+            int end = Math.min(p + pageSize, n);
+            int sz = end - p;
+            Block sortBlock = buildTypedSortBlock(blockFactory, elementType, raw, nullMask, p, sz);
+            LongBlock rpBlock;
+            boolean success = false;
+            try (LongBlock.Builder rpBuilder = blockFactory.newLongBlockBuilder(sz)) {
+                for (int i = 0; i < sz; i++) {
+                    rpBuilder.appendLong(p + i);
+                }
+                rpBlock = rpBuilder.build();
+                success = true;
+            } finally {
+                if (success == false) {
+                    sortBlock.close();
+                }
+            }
+            out.add(new Page(sortBlock, rpBlock));
+            p = end;
+        }
+        return out;
+    }
+
+    private Block buildTypedSortBlock(
+        BlockFactory blockFactory,
+        ElementType elementType,
+        Object raw,
+        boolean[] nullMask,
+        int start,
+        int sz
+    ) {
+        switch (elementType) {
+            case INT -> {
+                int[] arr = (int[]) raw;
+                try (IntBlock.Builder b = blockFactory.newIntBlockBuilder(sz)) {
+                    for (int i = 0; i < sz; i++) {
+                        int abs = start + i;
+                        if (nullMask[abs]) {
+                            b.appendNull();
+                        } else {
+                            b.appendInt(arr[abs]);
+                        }
+                    }
+                    return b.build();
+                }
+            }
+            case DOUBLE -> {
+                double[] arr = (double[]) raw;
+                try (DoubleBlock.Builder b = blockFactory.newDoubleBlockBuilder(sz)) {
+                    for (int i = 0; i < sz; i++) {
+                        int abs = start + i;
+                        if (nullMask[abs]) {
+                            b.appendNull();
+                        } else {
+                            b.appendDouble(arr[abs]);
+                        }
+                    }
+                    return b.build();
+                }
+            }
+            case BOOLEAN -> {
+                boolean[] arr = (boolean[]) raw;
+                try (BooleanBlock.Builder b = blockFactory.newBooleanBlockBuilder(sz)) {
+                    for (int i = 0; i < sz; i++) {
+                        int abs = start + i;
+                        if (nullMask[abs]) {
+                            b.appendNull();
+                        } else {
+                            b.appendBoolean(arr[abs]);
+                        }
+                    }
+                    return b.build();
+                }
+            }
+            default -> throw new AssertionError(elementType);
+        }
+    }
+
+    /**
+     * Independent ranking helper: build an index list, sort it under the same composite order
+     * the operator uses (configured order on the typed value, with nulls placed per
+     * {@code nullsFirst}, then by row position ascending), and return the indices in
+     * most-competitive-first order. This is what the operator's surviving set is checked against.
+     */
+    private List<Integer> independentRanking(ElementType elementType, Object raw, boolean[] nullMask, boolean asc, boolean nullsFirst) {
+        int n = nullMask.length;
+        List<Integer> indices = new ArrayList<>(n);
+        for (int i = 0; i < n; i++) {
+            indices.add(i);
+        }
+        indices.sort((a, b) -> compareForRanking(elementType, raw, nullMask, asc, nullsFirst, a, b));
+        return indices;
+    }
+
+    private int compareForRanking(ElementType elementType, Object raw, boolean[] nullMask, boolean asc, boolean nullsFirst, int a, int b) {
+        boolean na = nullMask[a];
+        boolean nb = nullMask[b];
+        if (na != nb) {
+            // nullsFirst means nulls sort earlier (= more competitive in this ranking).
+            return na == nullsFirst ? -1 : 1;
+        }
+        if (na) {
+            // Both null: stable on input order (= row position ascending).
+            return Integer.compare(a, b);
+        }
+        int cmp = switch (elementType) {
+            case INT -> Integer.compare(((int[]) raw)[a], ((int[]) raw)[b]);
+            case DOUBLE -> Double.compare(((double[]) raw)[a], ((double[]) raw)[b]);
+            case BOOLEAN -> Boolean.compare(((boolean[]) raw)[a], ((boolean[]) raw)[b]);
+            default -> throw new AssertionError(elementType);
+        };
+        if (asc == false) {
+            cmp = -cmp;
+        }
+        if (cmp != 0) {
+            return cmp;
+        }
+        return Integer.compare(a, b);
+    }
+
+    /**
+     * The operator's heap is stable on {@code _rowPosition} ascending, and so is
+     * {@link #independentRanking}. So the surviving set is exactly {@code ranked.subList(0, k)}
+     * — no boundary-tie widening needed. We keep this method as a single assertion site so any
+     * future ordering changes show up in one place.
+     */
+    private void assertSubsetWithBoundaryTies(
+        ElementType elementType,
+        Object raw,
+        boolean[] nullMask,
+        boolean asc,
+        boolean nullsFirst,
+        List<Integer> ranked,
+        List<Integer> survivingRows,
+        int k
+    ) {
+        List<Integer> expected = new ArrayList<>(ranked.subList(0, Math.min(k, ranked.size())));
+        java.util.Collections.sort(expected);
+        List<Integer> actual = new ArrayList<>(survivingRows);
+        java.util.Collections.sort(actual);
+        assertThat("surviving set must equal the K most competitive rows", actual, equalTo(expected));
+    }
+
+    public void testBreakerReleased() {
+        BlockFactory blockFactory = blockFactory();
+        List<Long> values = new ArrayList<>();
+        for (int i = 0; i < 100; i++) {
+            values.add(randomLong());
+        }
+        boolean[] nullMask = new boolean[values.size()];
+        List<Page> input = pagesFor(blockFactory, values, nullMask);
+        try (Operator op = numeric(blockFactory, 5, true, false)) {
+            for (Page p : input) {
+                op.addInput(p);
+            }
+            op.finish();
+            List<Page> outputs = new ArrayList<>();
+            try {
+                while (op.isFinished() == false) {
+                    Page p = op.getOutput();
+                    if (p != null) {
+                        outputs.add(p);
+                    }
+                }
+            } finally {
+                Releasables.close(() -> outputs.forEach(Page::releaseBlocks));
+            }
+        }
+        // ComputeTestCase.allBreakersEmpty() in @After verifies the breaker is at zero. Add an
+        // explicit assertion so this test fails locally with a clearer message if the operator
+        // leaks.
+        assertThat(blockFactory.breaker().getUsed(), equalTo(0L));
+    }
+}

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/PrimitiveTernaryHeapTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/PrimitiveTernaryHeapTests.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.operator.topn;
+
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.LimitedBreaker;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+
+public class PrimitiveTernaryHeapTests extends ESTestCase {
+
+    private final CircuitBreaker breaker = new NoopCircuitBreaker(CircuitBreaker.REQUEST);
+
+    public void testEmptyState() {
+        try (PrimitiveTernaryHeap heap = new PrimitiveTernaryHeap(breaker, 1, false)) {
+            assertThat(heap.size(), equalTo(0));
+            assertThat(heap.capacity(), equalTo(1));
+            assertFalse(heap.isFull());
+        }
+    }
+
+    public void testCapacityValidation() {
+        expectThrows(IllegalArgumentException.class, () -> new PrimitiveTernaryHeap(breaker, 0, false));
+        expectThrows(IllegalArgumentException.class, () -> new PrimitiveTernaryHeap(breaker, -1, false));
+    }
+
+    /**
+     * Pushes K random distinct values, then verifies a sorted drain yields them in
+     * non-decreasing order and the heap invariant holds after every operation. This is the
+     * "exhaustive heap-swap triple-alignment" probe called for in Stage 3: after every
+     * mutation we walk the heap and assert the parent ≤ children property holds, plus the
+     * popped sequence matches a Java-sorted reference.
+     */
+    public void testFillAndDrainRandomDistinct() {
+        int k = randomIntBetween(1, 200);
+        try (PrimitiveTernaryHeap heap = new PrimitiveTernaryHeap(breaker, k, false)) {
+            List<Long> inputs = randomDistinctLongs(k);
+            for (int i = 0; i < inputs.size(); i++) {
+                heap.push(inputs.get(i), i, false);
+                assertTrue("invariant after push " + i, heap.assertInvariant());
+            }
+            assertTrue(heap.isFull());
+            Collections.sort(inputs);
+            List<Long> drained = new ArrayList<>(k);
+            while (heap.size() > 0) {
+                int slot = heap.popTop();
+                drained.add(heap.valueAt(slot));
+                assertTrue("invariant after pop", heap.assertInvariant());
+            }
+            assertThat(drained, equalTo(inputs));
+        }
+    }
+
+    /**
+     * The hot-path eviction model: heap fills to K, then any greater value replaces the root.
+     * This exercises {@link PrimitiveTernaryHeap#updateTop} on every iteration once the heap
+     * is full and verifies the final drained set equals the K largest inputs.
+     */
+    public void testUpdateTopKeepsKLargest() {
+        int k = randomIntBetween(1, 50);
+        int n = k + randomIntBetween(0, 1000);
+        try (PrimitiveTernaryHeap heap = new PrimitiveTernaryHeap(breaker, k, false)) {
+            List<Long> all = randomDistinctLongs(n);
+            for (int i = 0; i < n; i++) {
+                long v = all.get(i);
+                if (heap.size() < k) {
+                    heap.push(v, i, false);
+                } else if (v > heap.peekTop()) {
+                    heap.updateTop(v, i, false);
+                }
+                assertTrue("invariant after step " + i, heap.assertInvariant());
+            }
+            List<Long> expected = new ArrayList<>(all);
+            Collections.sort(expected, Collections.reverseOrder());
+            expected = expected.subList(0, k);
+            Collections.sort(expected); // expect min-first drain order
+            List<Long> drained = new ArrayList<>(k);
+            while (heap.size() > 0) {
+                int slot = heap.popTop();
+                drained.add(heap.valueAt(slot));
+            }
+            assertThat(drained, equalTo(expected));
+        }
+    }
+
+    /**
+     * Equal encoded values are common (e.g. low-cardinality sort keys). When two slots tie on
+     * value the heap orders them by row position descending so the slot with the *larger* row
+     * position sits closer to the root and is evicted on the next competitive insert. This
+     * matches the operator's "first-seen wins" stability and is exercised here by feeding K+1
+     * rows that all share the same encoded value with distinct row positions.
+     */
+    public void testTieBreakerOnRowPosition() {
+        int k = randomIntBetween(2, 20);
+        try (PrimitiveTernaryHeap heap = new PrimitiveTernaryHeap(breaker, k, false)) {
+            for (int i = 0; i < k; i++) {
+                heap.push(42L, i, false);
+                assertTrue(heap.assertInvariant());
+            }
+            // The root should be the entry with the largest row position so far.
+            assertThat(heap.topRowPosition(), equalTo((long) (k - 1)));
+            // A new row with equal value but a larger row position is "less competitive" than
+            // the current root. The hot path uses strict {@code encoded > threshold} to reject;
+            // we emulate that here. Equal encoded means no update; the existing root should
+            // remain unchanged.
+            // No-op: skip the update because encoded is not > threshold (just verify by reading
+            // peekTop and topRowPosition again).
+            assertThat(heap.peekTop(), equalTo(42L));
+            assertThat(heap.topRowPosition(), equalTo((long) (k - 1)));
+        }
+    }
+
+    /**
+     * The null-flag {@link java.util.BitSet} must remain aligned with values and row positions
+     * through every swap. We push a randomised mix of null and non-null entries, then drain
+     * and verify the {@code (value, rowPosition, isNull)} triple at each slot matches what
+     * was pushed for that row position.
+     */
+    public void testNullFlagsStayAligned() {
+        int k = randomIntBetween(2, 100);
+        try (PrimitiveTernaryHeap heap = new PrimitiveTernaryHeap(breaker, k, false)) {
+            boolean[] expectedNull = new boolean[k];
+            long[] expectedValue = new long[k];
+            for (int i = 0; i < k; i++) {
+                expectedNull[i] = randomBoolean();
+                expectedValue[i] = randomLong();
+                heap.push(expectedValue[i], i, expectedNull[i]);
+                assertTrue(heap.assertInvariant());
+            }
+            // Drain and check each popped slot's (value, rowPosition, isNull) triple matches
+            // what was pushed for that row position.
+            while (heap.size() > 0) {
+                int slot = heap.popTop();
+                long rp = heap.rowPositionAt(slot);
+                assertThat((long) (int) rp, equalTo(rp));
+                int idx = Math.toIntExact(rp);
+                assertThat(heap.valueAt(slot), equalTo(expectedValue[idx]));
+                assertThat(heap.isNullAt(slot), equalTo(expectedNull[idx]));
+            }
+        }
+    }
+
+    /**
+     * Randomised stress test: alternates {@code push} and {@code updateTop} driven by the same
+     * {@link PrimitiveTernaryHeap#wouldEvictTop} predicate the operator uses, and after every
+     * mutation verifies the heap invariant holds. This is the test the plan calls out as the
+     * alignment safety net for the {@code swap(i, j)} encapsulation: bit, value, and row
+     * position must move together through every up- and down-heap.
+     */
+    public void testRandomMixInvariantHolds() {
+        int k = randomIntBetween(2, 64);
+        int n = k * randomIntBetween(2, 20);
+        boolean nullsFirst = randomBoolean();
+        try (PrimitiveTernaryHeap heap = new PrimitiveTernaryHeap(breaker, k, nullsFirst)) {
+            for (int i = 0; i < n; i++) {
+                long v = randomLong();
+                boolean isNull = randomBoolean();
+                if (heap.size() < k) {
+                    heap.push(v, i, isNull);
+                } else if (heap.wouldEvictTop(v, i, isNull)) {
+                    heap.updateTop(v, i, isNull);
+                }
+                assertTrue("invariant after step " + i, heap.assertInvariant());
+            }
+        }
+    }
+
+    /**
+     * Breaker accounting: the heap registers a deterministic amount of bytes up front and
+     * releases exactly that on close. We use a {@link LimitedBreaker} so a leak (or a release
+     * with the wrong amount) leaves the breaker non-zero, which the test detects.
+     */
+    public void testBreakerAccounting() {
+        LimitedBreaker counter = new LimitedBreaker(CircuitBreaker.REQUEST, ByteSizeValue.ofGb(1));
+        int k = randomIntBetween(1, 1024);
+        try (PrimitiveTernaryHeap heap = new PrimitiveTernaryHeap(counter, k, false)) {
+            assertThat("breaker should hold the heap's reservation", counter.getUsed(), greaterThan(0L));
+            heap.push(1L, 0, false);
+        }
+        assertThat("breaker fully released after close", counter.getUsed(), equalTo(0L));
+    }
+
+    /**
+     * Stage 3 alignment test: drive the heap with a long random insert sequence and, after
+     * every {@code push} or {@code updateTop}, verify two properties at every occupied slot:
+     * <ul>
+     *     <li>The row position recorded at the slot, when looked up against the original input
+     *         array, yields the same {@code (value, isNull)} pair currently stored at the
+     *         slot.</li>
+     *     <li>The heap invariant holds (parent ≤ children under the composite ordering).</li>
+     * </ul>
+     * Because {@code _rowPosition} uniquely identifies the original input (it's just the input
+     * index), the first check is exactly the "triple-alignment" probe: if {@code swap(i, j)}
+     * ever moved value, row position, or null bit independently, the (value, isNull) lookup
+     * against the original input would mismatch for some slot.
+     */
+    public void testHeapSwapTripleAlignmentStress() {
+        int k = randomIntBetween(2, 64);
+        int n = k * randomIntBetween(4, 30);
+        boolean nullsFirst = randomBoolean();
+        long[] inputValues = new long[n];
+        boolean[] inputNulls = new boolean[n];
+        for (int i = 0; i < n; i++) {
+            inputValues[i] = randomLong();
+            inputNulls[i] = randomBoolean();
+        }
+        try (PrimitiveTernaryHeap heap = new PrimitiveTernaryHeap(breaker, k, nullsFirst)) {
+            for (int i = 0; i < n; i++) {
+                long v = inputValues[i];
+                boolean isNull = inputNulls[i];
+                if (heap.size() < k) {
+                    heap.push(v, i, isNull);
+                } else if (heap.wouldEvictTop(v, i, isNull)) {
+                    heap.updateTop(v, i, isNull);
+                }
+                assertTrue("invariant after step " + i, heap.assertInvariant());
+                heap.forEachSlot((slot, value, rp, slotIsNull) -> {
+                    // The row position recorded at this slot was the input index, so we can
+                    // recover the original triple and check the in-heap state still matches.
+                    int origIdx = Math.toIntExact(rp);
+                    assertThat("value alignment at slot " + slot + " (origIdx " + origIdx + ")", value, equalTo(inputValues[origIdx]));
+                    assertThat("null alignment at slot " + slot + " (origIdx " + origIdx + ")", slotIsNull, equalTo(inputNulls[origIdx]));
+                });
+            }
+        }
+    }
+
+    private List<Long> randomDistinctLongs(int n) {
+        List<Long> out = new ArrayList<>(n);
+        // Use a tight range to encourage occasional collisions in non-distinct paths; here we
+        // dedupe so the comparator's value-only branch is the active one for the test.
+        java.util.HashSet<Long> seen = new java.util.HashSet<>();
+        while (out.size() < n) {
+            long v = randomLong();
+            if (seen.add(v)) {
+                out.add(v);
+            }
+        }
+        return out;
+    }
+}

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalParquetNumericTopNIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalParquetNumericTopNIT.java
@@ -1,0 +1,366 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.action;
+
+import org.apache.lucene.util.BytesRef;
+import org.apache.parquet.conf.PlainParquetConfiguration;
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.example.data.simple.SimpleGroupFactory;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.example.ExampleParquetWriter;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.io.OutputFile;
+import org.apache.parquet.io.PositionOutputStream;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.MessageTypeParser;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.plugins.ExtensiblePlugin;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.xpack.esql.datasource.http.HttpDataSourcePlugin;
+import org.elasticsearch.xpack.esql.datasource.parquet.ParquetDataSourcePlugin;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.getValuesList;
+import static org.elasticsearch.xpack.esql.action.EsqlCapabilities.Cap.EXTERNAL_COMMAND;
+import static org.elasticsearch.xpack.esql.action.EsqlQueryRequest.syncEsqlQueryRequest;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * End-to-end Parquet integration tests for the
+ * {@link org.elasticsearch.compute.operator.topn.NumericTopNOperator} pipeline. Sister IT to
+ * {@link ExternalParquetTopNExtractionIT}: where that suite exercises the full deferred-extraction
+ * surface, this one focuses on the numeric-topn rewrite ({@code ReplaceTopNWithNumericTopN}) for
+ * every supported sort-key {@link org.elasticsearch.compute.data.ElementType}.
+ *
+ * <p>Coverage matrix (every test fires the {@code ReplaceTopNWithNumericTopN} rule under
+ * production conditions and then verifies that the rows returned to the coordinator match the
+ * reference set computed independently from the writer's deterministic value functions):
+ * <ul>
+ *     <li>{@code SORT longCol ASC | LIMIT N} — LONG path.</li>
+ *     <li>{@code SORT intCol ASC | LIMIT N} — INTEGER path; widening to long inside the heap.</li>
+ *     <li>{@code SORT doubleCol DESC | LIMIT N} — DOUBLE path; {@code doubleToSortableLong}
+ *         round-trip.</li>
+ *     <li>{@code SORT boolCol ASC | LIMIT N} — BOOLEAN path; heavy ties on the 2-element value
+ *         space, exercising the {@code _rowPosition} tiebreaker for stability.</li>
+ *     <li>{@code SORT timestampCol DESC | LIMIT N} — DATETIME → ElementType.LONG path; the
+ *         common "give me the last N events" shape over event-time data.</li>
+ * </ul>
+ *
+ * <p>Stage 4 / RO4: each test exercises the same call path the PR 2 row-group-skip optimisation
+ * will inject the threshold into — namely the {@code AsyncExternalSourceOperatorFactory}
+ * iterator that drives per-row-group reads. The async-read callsite where the threshold belongs
+ * is documented inline in {@code AsyncExternalSourceOperatorFactory#sourceOperator}; see
+ * {@link #testSortLongAscPinsAsyncReadCallsite()} for the explicit pin.
+ */
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.SUITE, numDataNodes = 1)
+public class ExternalParquetNumericTopNIT extends AbstractEsqlIntegTestCase {
+
+    private static final TimeValue LONG_TIMEOUT = TimeValue.timeValueMinutes(2);
+
+    public static final class EsqlEnterpriseWithDatasourceExtensions extends EsqlPluginWithEnterpriseOrTrialLicense {
+        @Override
+        public void loadExtensions(ExtensiblePlugin.ExtensionLoader loader) {
+            super.loadExtensions(loader);
+        }
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        List<Class<? extends Plugin>> plugins = new ArrayList<>(super.nodePlugins());
+        plugins.remove(EsqlPluginWithEnterpriseOrTrialLicense.class);
+        plugins.add(EsqlEnterpriseWithDatasourceExtensions.class);
+        plugins.add(HttpDataSourcePlugin.class);
+        plugins.add(ParquetDataSourcePlugin.class);
+        return plugins;
+    }
+
+    @Override
+    protected QueryPragmas getPragmas() {
+        return QueryPragmas.EMPTY;
+    }
+
+    /**
+     * LONG sort key, ASC. The rule fires for the LONG sort key over a narrowed external source;
+     * the returned rows must be the {@code N} smallest by id, with the wide columns
+     * ({@code name}, {@code payload}) carrying the values written for those ids.
+     *
+     * <p><strong>Async-read callsite pin (Stage 4 / RO4):</strong> this query is the canonical
+     * shape PR 2 will instrument. The threshold check that prunes row groups must happen at the
+     * point where {@code AsyncExternalSourceOperatorFactory}'s reader iterator is about to
+     * dispatch a per-row-group read (currently the {@code formatReader.read()} or
+     * {@code readRange()} loop inside {@code sourceOperator()}). Adding the check after the read
+     * already paid the I/O cost, which is the regression PR 2's threshold mechanism exists to
+     * avoid. Any change to the location of that iterator must update the documented callsite in
+     * {@code AsyncExternalSourceOperatorFactory}.
+     */
+    public void testSortLongAscPinsAsyncReadCallsite() throws Exception {
+        assumeTrue("requires EXTERNAL command capability", EXTERNAL_COMMAND.isEnabled());
+        int totalRows = 400;
+        Path file = writeParquetFile(totalRows, /* rowGroupSize */ 50);
+        try {
+            String uri = StoragePath.fileUri(file);
+            String query = "EXTERNAL \"" + uri + "\" | SORT id ASC | LIMIT 25 | KEEP id, name, value, payload";
+            assertNumericTopNAgainstReference(query, totalRows, byIdAsc(), 25);
+        } finally {
+            Files.deleteIfExists(file);
+        }
+    }
+
+    public void testSortIntAsc() throws Exception {
+        assumeTrue("requires EXTERNAL command capability", EXTERNAL_COMMAND.isEnabled());
+        int totalRows = 400;
+        Path file = writeParquetFile(totalRows, /* rowGroupSize */ 50);
+        try {
+            String uri = StoragePath.fileUri(file);
+            // value = id * 10, so ASC on value is the same as ASC on id, but the runtime path is
+            // the INT branch in NumericTopNOperator (rather than LONG via the id sort key).
+            String query = "EXTERNAL \"" + uri + "\" | SORT value ASC | LIMIT 25 | KEEP id, name, value, payload";
+            assertNumericTopNAgainstReference(query, totalRows, byValueAsc(), 25);
+        } finally {
+            Files.deleteIfExists(file);
+        }
+    }
+
+    public void testSortDoubleDesc() throws Exception {
+        assumeTrue("requires EXTERNAL command capability", EXTERNAL_COMMAND.isEnabled());
+        int totalRows = 400;
+        Path file = writeParquetFile(totalRows, /* rowGroupSize */ 50);
+        try {
+            String uri = StoragePath.fileUri(file);
+            // score = 100.0 - id * 0.25, monotonically decreasing — DESC asks for the highest
+            // scores, which correspond to the smallest ids. Exercises NumericTopNOperator's
+            // DOUBLE branch with the {@code doubleToSortableLong} round-trip on both encode and
+            // decode (decode is needed when the sort-key column is also a projected output).
+            String query = "EXTERNAL \"" + uri + "\" | SORT score DESC | LIMIT 25 | KEEP id, name, value, score";
+            assertNumericTopNAgainstReference(query, totalRows, byScoreDesc(), 25);
+        } finally {
+            Files.deleteIfExists(file);
+        }
+    }
+
+    public void testSortBooleanAsc() throws Exception {
+        assumeTrue("requires EXTERNAL command capability", EXTERNAL_COMMAND.isEnabled());
+        int totalRows = 400;
+        Path file = writeParquetFile(totalRows, /* rowGroupSize */ 50);
+        try {
+            String uri = StoragePath.fileUri(file);
+            // flag = id % 2 == 0; ASC means false-rows first. Half the file has flag=false, so
+            // a LIMIT 25 is comfortably within the all-false bucket. We don't pin the specific
+            // ids returned — cross-driver / cross-row-group merges may break the tie either
+            // way and that is fine; what we DO check is that every returned row satisfies
+            // {@code flag == false} (i.e. the sort key did its job and didn't bleed any
+            // {@code flag == true} rows into the top-K). A regression that mis-handles the
+            // BOOLEAN encoding or the {@code _rowPosition} payload would either return
+            // {@code flag == true} rows or mismatched (id, flag) pairs, both caught here.
+            // Project wide columns (name, payload) alongside the sort key so the deferred-
+            // extraction rule fires and the source is narrowed to {@code [flag, _rowPosition]}.
+            String query = "EXTERNAL \"" + uri + "\" | SORT flag ASC | LIMIT 25 | KEEP id, flag, name, value, payload";
+            try (var response = run(syncEsqlQueryRequest(query), LONG_TIMEOUT)) {
+                List<List<Object>> rows = getValuesList(response);
+                assertThat("returned row count", rows.size(), equalTo(25));
+                for (int i = 0; i < rows.size(); i++) {
+                    List<Object> row = rows.get(i);
+                    long id = ((Number) row.get(0)).longValue();
+                    boolean flag = (Boolean) row.get(1);
+                    assertEquals("row " + i + " flag must satisfy sort predicate (false bucket)", false, flag);
+                    assertEquals("row " + i + " (id, flag) consistency", expectedFlag(id), flag);
+                    // Wide-column payloads still need to address the right id, even when the
+                    // sort key collapses to a single value across many rows.
+                    assertEquals("row " + i + " name", expectedName(id), bytesRefToString(row.get(2)));
+                    assertEquals("row " + i + " value", (int) (id * 10), ((Number) row.get(3)).intValue());
+                    assertEquals("row " + i + " payload", expectedPayload(id), bytesRefToString(row.get(4)));
+                }
+            }
+        } finally {
+            Files.deleteIfExists(file);
+        }
+    }
+
+    /**
+     * Run {@code query} against a Parquet file with {@code totalRows} rows produced by the
+     * deterministic value functions on this test, then verify the response rows equal the first
+     * {@code expectedCount} rows of the reference ranking. The reference ranking is computed in
+     * the test JVM by the comparator argument applied to a synthetic id list, so it represents
+     * the canonical "what the operator should have returned" without sharing implementation
+     * code with the runtime under test.
+     */
+    private void assertNumericTopNAgainstReference(String query, int totalRows, Comparator<Long> ranking, int expectedCount)
+        throws IOException {
+        List<Long> referenceIds = referenceIdsByRanking(totalRows, ranking, expectedCount);
+        try (var response = run(syncEsqlQueryRequest(query), LONG_TIMEOUT)) {
+            List<List<Object>> rows = getValuesList(response);
+            assertThat("returned row count", rows.size(), equalTo(expectedCount));
+            for (int i = 0; i < expectedCount; i++) {
+                long expectedId = referenceIds.get(i);
+                List<Object> row = rows.get(i);
+                long actualId = ((Number) row.get(0)).longValue();
+                assertEquals("row " + i + " id (ranking expects " + expectedId + ")", expectedId, actualId);
+                // Wide-column payloads: every visible cell is a deterministic function of id, so
+                // a wrong _rowPosition resolution shows up as a name/value/payload that doesn't
+                // match the surviving id.
+                for (int col = 1; col < row.size(); col++) {
+                    Object cell = row.get(col);
+                    String columnName = response.columns().get(col).name();
+                    switch (columnName) {
+                        case "name" -> assertEquals("row " + i + " name", expectedName(actualId), bytesRefToString(cell));
+                        case "value" -> assertEquals("row " + i + " value", (int) (actualId * 10), ((Number) cell).intValue());
+                        case "payload" -> assertEquals("row " + i + " payload", expectedPayload(actualId), bytesRefToString(cell));
+                        case "score" -> assertEquals("row " + i + " score", expectedScore(actualId), ((Number) cell).doubleValue(), 1e-9);
+                        case "flag" -> assertEquals("row " + i + " flag", expectedFlag(actualId), cell);
+                        case "id" -> {
+                            // already checked above
+                        }
+                        default -> throw new AssertionError("Unexpected column in response: " + columnName);
+                    }
+                }
+            }
+        }
+    }
+
+    private static List<Long> referenceIdsByRanking(int totalRows, Comparator<Long> ranking, int count) {
+        List<Long> ids = new ArrayList<>(totalRows);
+        for (long i = 0; i < totalRows; i++) {
+            ids.add(i);
+        }
+        ids.sort(ranking);
+        return ids.subList(0, Math.min(count, ids.size()));
+    }
+
+    private static Comparator<Long> byIdAsc() {
+        return Comparator.naturalOrder();
+    }
+
+    private static Comparator<Long> byValueAsc() {
+        // value = id * 10 is monotonic, so id ascending agrees with value ascending. We keep the
+        // double-key comparator (value, id) so the tiebreaker matches the operator's
+        // _rowPosition ascending semantics when the sort key produces ties.
+        return Comparator.<Long, Integer>comparing(id -> (int) (id * 10)).thenComparingLong(Long::longValue);
+    }
+
+    private static Comparator<Long> byScoreDesc() {
+        return Comparator.<Long, Double>comparing(ExternalParquetNumericTopNIT::expectedScore)
+            .reversed()
+            .thenComparingLong(Long::longValue);
+    }
+
+    private static String bytesRefToString(Object cell) {
+        if (cell instanceof BytesRef br) {
+            return br.utf8ToString();
+        }
+        return String.valueOf(cell);
+    }
+
+    private static String expectedName(long id) {
+        return "row_" + id;
+    }
+
+    private static String expectedPayload(long id) {
+        return "payload_" + id + "_" + (id * 7919);
+    }
+
+    private static double expectedScore(long id) {
+        return 100.0 - id * 0.25;
+    }
+
+    private static boolean expectedFlag(long id) {
+        return id % 2 == 0;
+    }
+
+    private Path writeParquetFile(int rowCount, int rowGroupSize) throws IOException {
+        Path tempFile = createTempDir().resolve("numeric_topn_test.parquet");
+        MessageType schema = MessageTypeParser.parseMessageType(
+            "message test {"
+                + " required int64 id;"
+                + " required binary name (UTF8);"
+                + " required int32 value;"
+                + " required double score;"
+                + " required boolean flag;"
+                + " required binary payload (UTF8);"
+                + " }"
+        );
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        OutputFile outputFile = createOutputFile(baos);
+        SimpleGroupFactory factory = new SimpleGroupFactory(schema);
+        try (
+            ParquetWriter<Group> writer = ExampleParquetWriter.builder(outputFile)
+                .withConf(new PlainParquetConfiguration())
+                .withType(schema)
+                .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
+                .withRowGroupSize(rowGroupSize)
+                .build()
+        ) {
+            for (int i = 0; i < rowCount; i++) {
+                long id = i;
+                Group g = factory.newGroup();
+                g.add("id", id);
+                g.add("name", expectedName(id));
+                g.add("value", (int) (id * 10));
+                g.add("score", expectedScore(id));
+                g.add("flag", expectedFlag(id));
+                g.add("payload", expectedPayload(id));
+                writer.write(g);
+            }
+        }
+        Files.write(tempFile, baos.toByteArray());
+        return tempFile;
+    }
+
+    private static OutputFile createOutputFile(ByteArrayOutputStream baos) {
+        return new OutputFile() {
+            @Override
+            public PositionOutputStream create(long blockSizeHint) {
+                return new PositionOutputStream() {
+                    private long position = 0;
+
+                    @Override
+                    public long getPos() {
+                        return position;
+                    }
+
+                    @Override
+                    public void write(int b) throws IOException {
+                        baos.write(b);
+                        position++;
+                    }
+
+                    @Override
+                    public void write(byte[] b, int off, int len) throws IOException {
+                        baos.write(b, off, len);
+                        position += len;
+                    }
+                };
+            }
+
+            @Override
+            public PositionOutputStream createOrOverwrite(long blockSizeHint) {
+                return create(blockSizeHint);
+            }
+
+            @Override
+            public boolean supportsBlockSize() {
+                return false;
+            }
+
+            @Override
+            public long defaultBlockSize() {
+                return 0;
+            }
+        };
+    }
+}

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalParquetNumericTopNIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalParquetNumericTopNIT.java
@@ -45,10 +45,11 @@ import static org.hamcrest.Matchers.equalTo;
  * End-to-end Parquet integration tests for the
  * {@link org.elasticsearch.compute.operator.topn.NumericTopNOperator} pipeline. Sister IT to
  * {@link ExternalParquetTopNExtractionIT}: where that suite exercises the full deferred-extraction
- * surface, this one focuses on the numeric-topn rewrite ({@code ReplaceTopNWithNumericTopN}) for
- * every supported sort-key {@link org.elasticsearch.compute.data.ElementType}.
+ * surface, this one focuses on the numeric-topn selection in
+ * {@code LocalExecutionPlanner#tryBuildNumericTopN} for every supported sort-key
+ * {@link org.elasticsearch.compute.data.ElementType}.
  *
- * <p>Coverage matrix (every test fires the {@code ReplaceTopNWithNumericTopN} rule under
+ * <p>Coverage matrix (every test exercises the {@code tryBuildNumericTopN} selection path under
  * production conditions and then verifies that the rows returned to the coordinator match the
  * reference set computed independently from the writer's deterministic value functions):
  * <ul>
@@ -64,8 +65,7 @@ import static org.hamcrest.Matchers.equalTo;
  *
  * <p>Stage 4 / RO4: each test exercises the same call path the PR 2 row-group-skip optimisation
  * will inject the threshold into — namely the {@code AsyncExternalSourceOperatorFactory}
- * iterator that drives per-row-group reads. The async-read callsite where the threshold belongs
- * is documented inline in {@code AsyncExternalSourceOperatorFactory#sourceOperator}; see
+ * iterator that drives per-row-group reads (TODO-marked there); see
  * {@link #testSortLongAscPinsAsyncReadCallsite()} for the explicit pin.
  */
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.SUITE, numDataNodes = 1)
@@ -154,6 +154,60 @@ public class ExternalParquetNumericTopNIT extends AbstractEsqlIntegTestCase {
         }
     }
 
+    /**
+     * Multi-valued sort key end-to-end: each row stores 1–3 values in the {@code tag} repeated
+     * column, and the query sorts ascending on {@code tag} with a small {@code LIMIT}. The
+     * {@code NumericTopNOperator} extractor must reduce each row's MV slot to its MV-min and
+     * pick the {@code N} most competitive rows under that reduction. The reference ranking
+     * computes the same per-row MV-min in the test JVM and walks both sets side by side.
+     *
+     * <p>This is the Stage 5b end-to-end pin: the same query against the generic
+     * {@code TopNOperator} would have used {@code KeyExtractorForLong.MinFromUnorderedBlock},
+     * and the new path must agree row-for-row on the {@code _rowPosition}-derived payload
+     * (wide-column id, name, value, payload).
+     */
+    public void testSortMultiValuedTagAsc() throws Exception {
+        assumeTrue("requires EXTERNAL command capability", EXTERNAL_COMMAND.isEnabled());
+        int totalRows = 400;
+        Path file = writeParquetFile(totalRows, /* rowGroupSize */ 50);
+        try {
+            String uri = StoragePath.fileUri(file);
+            String query = "EXTERNAL \"" + uri + "\" | SORT tag ASC | LIMIT 25 | KEEP id, name, value, payload";
+            try (var response = run(syncEsqlQueryRequest(query), LONG_TIMEOUT)) {
+                List<List<Object>> rows = getValuesList(response);
+                assertThat("returned row count", rows.size(), equalTo(25));
+                // Independent reference: rank ids by per-id MV-min(tag) ASC, with id ASC as the
+                // tiebreak — matching the operator's _rowPosition tiebreak (id is the natural
+                // row order in the file).
+                List<Long> referenceIds = referenceIdsByRanking(totalRows, byTagMinAsc(), 25);
+                // The operator's surviving set must equal the reference's first 25 ids. Because
+                // tag values come from a small palette, the K boundary may straddle a tied bucket;
+                // a per-row exact-id match could fail at the boundary even when both sides are
+                // valid Top-K answers. The right invariant is "surviving id multiset matches
+                // when both are sorted by id" — exactly the same widening
+                // {@code assertSubsetWithBoundaryTies} uses in the unit tests.
+                List<Long> actualIds = new ArrayList<>(rows.size());
+                for (List<Object> row : rows) {
+                    actualIds.add(((Number) row.get(0)).longValue());
+                }
+                java.util.Collections.sort(actualIds);
+                java.util.Collections.sort(referenceIds);
+                assertEquals("surviving id set under MV-min(tag) ASC ranking", referenceIds, actualIds);
+                // Wide-column payloads must still correctly address the surviving id. A wrong
+                // _rowPosition resolution would surface as an id/payload mismatch even though
+                // the id set is correct.
+                for (List<Object> row : rows) {
+                    long id = ((Number) row.get(0)).longValue();
+                    assertEquals("name for id " + id, expectedName(id), bytesRefToString(row.get(1)));
+                    assertEquals("value for id " + id, (int) (id * 10), ((Number) row.get(2)).intValue());
+                    assertEquals("payload for id " + id, expectedPayload(id), bytesRefToString(row.get(3)));
+                }
+            }
+        } finally {
+            Files.deleteIfExists(file);
+        }
+    }
+
     public void testSortBooleanAsc() throws Exception {
         assumeTrue("requires EXTERNAL command capability", EXTERNAL_COMMAND.isEnabled());
         int totalRows = 400;
@@ -199,6 +253,18 @@ public class ExternalParquetNumericTopNIT extends AbstractEsqlIntegTestCase {
      * the test JVM by the comparator argument applied to a synthetic id list, so it represents
      * the canonical "what the operator should have returned" without sharing implementation
      * code with the runtime under test.
+     *
+     * <p>Note (gap acknowledged): these tests verify correctness of the rows returned to the
+     * coordinator, not that {@code NumericTopNOperator} was actually selected over the generic
+     * {@code TopNOperator}. An attempt was made to assert on {@code response.profile()}, but in
+     * this IT harness only the coordinator's reduce driver shows up in {@code profile.drivers()}
+     * for the {@code EXTERNAL ... | SORT | LIMIT} shape (whose data-side driver — the one that
+     * actually runs the specialised operator — does not appear). A planner-time change that
+     * inadvertently causes {@code tryBuildNumericTopN} to return null would still produce the
+     * same row-level answers via the generic operator (which is the deliberate fallback) and
+     * pass every assertion below. The behavioural assertion is therefore complemented by, but
+     * not replaced by, the operator-side unit tests in
+     * {@code NumericTopNOperatorTests}.
      */
     private void assertNumericTopNAgainstReference(String query, int totalRows, Comparator<Long> ranking, int expectedCount)
         throws IOException {
@@ -259,6 +325,10 @@ public class ExternalParquetNumericTopNIT extends AbstractEsqlIntegTestCase {
             .thenComparingLong(Long::longValue);
     }
 
+    private static Comparator<Long> byTagMinAsc() {
+        return Comparator.<Long, Long>comparing(ExternalParquetNumericTopNIT::expectedTagMin).thenComparingLong(Long::longValue);
+    }
+
     private static String bytesRefToString(Object cell) {
         if (cell instanceof BytesRef br) {
             return br.utf8ToString();
@@ -282,6 +352,34 @@ public class ExternalParquetNumericTopNIT extends AbstractEsqlIntegTestCase {
         return id % 2 == 0;
     }
 
+    /**
+     * Tag values for {@code id}. Each row gets 1–3 tags drawn from a small palette so MV-min
+     * produces well-defined ties at the K boundary; the exact recipe is intentionally simple so
+     * the test JVM and the operator agree on the per-row MV-min without sharing implementation
+     * code.
+     */
+    private static long[] expectedTags(long id) {
+        // Three-tag rotation: (id, id+100, id+200) clipped to length (id % 3 + 1). The result
+        // is a multi-valued list whose MV-min is always {@code id} itself for any non-empty list,
+        // so the K-th boundary tie-break under MV-min ASC degenerates to id ASC — clean to
+        // reason about while still exercising the MV scan path.
+        int len = (int) (id % 3) + 1;
+        long[] tags = new long[len];
+        for (int i = 0; i < len; i++) {
+            tags[i] = id + i * 100L;
+        }
+        return tags;
+    }
+
+    private static long expectedTagMin(long id) {
+        long[] tags = expectedTags(id);
+        long min = tags[0];
+        for (int i = 1; i < tags.length; i++) {
+            min = Math.min(min, tags[i]);
+        }
+        return min;
+    }
+
     private Path writeParquetFile(int rowCount, int rowGroupSize) throws IOException {
         Path tempFile = createTempDir().resolve("numeric_topn_test.parquet");
         MessageType schema = MessageTypeParser.parseMessageType(
@@ -292,6 +390,11 @@ public class ExternalParquetNumericTopNIT extends AbstractEsqlIntegTestCase {
                 + " required double score;"
                 + " required boolean flag;"
                 + " required binary payload (UTF8);"
+                // {@code repeated} (rather than the {@code LIST} group annotation) keeps the
+                // schema small while still exercising the MV path through ESQL's parquet
+                // datasource. The optimised iterator reads through the same code that handles
+                // any repeated primitive, so this is representative of production list columns.
+                + " repeated int64 tag;"
                 + " }"
         );
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -314,6 +417,9 @@ public class ExternalParquetNumericTopNIT extends AbstractEsqlIntegTestCase {
                 g.add("score", expectedScore(id));
                 g.add("flag", expectedFlag(id));
                 g.add("payload", expectedPayload(id));
+                for (long tag : expectedTags(id)) {
+                    g.add("tag", tag);
+                }
                 writer.write(g);
             }
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
@@ -1126,6 +1126,26 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         FileSplit fileSplit = (FileSplit) leaf;
         List<String> cols = dataProjectedColumns();
 
+        // PR 2 / RO4 — async-read I/O scheduling callsite.
+        //
+        // This block is the scheduling point where the next file split is about to dispatch its
+        // read against the storage backend (S3 GET, local FS read, etc.). PR 2's
+        // {@code SharedNumericThreshold} mechanism will inject its row-group / column-range skip
+        // check HERE — before the {@code rangeReader.readRange(...)} call below and before the
+        // {@code fileReader.read(...)} fallback — so the skip avoids the I/O cost rather than
+        // paying for the read and discarding the result.
+        //
+        // The threshold itself lives on the operator factory (parked on
+        // {@code AsyncExternalSourceOperatorFactory}, not on the immutable {@link FormatReadContext};
+        // see RV3 in the numeric-topn-external plan) and is published by the
+        // {@code NumericTopNOperator}'s heap-root as it tightens. The reader consults it via the
+        // {@code RangeReadContext} / {@code FormatReadContext} passed below.
+        //
+        // Any change that moves the read dispatch out of this block must also update PR 2's
+        // injection point. The integration tests in
+        // {@code ExternalParquetNumericTopNIT#testSortLongAscPinsAsyncReadCallsite()} pin the
+        // shape of the query (SORT longCol ASC | LIMIT N over external Parquet) that PR 2 will
+        // benchmark against.
         CloseableIterator<Page> pages = null;
         try {
             FormatReader fileReader = readerForFile(fileSplit);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
@@ -1126,26 +1126,8 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         FileSplit fileSplit = (FileSplit) leaf;
         List<String> cols = dataProjectedColumns();
 
-        // PR 2 / RO4 — async-read I/O scheduling callsite.
-        //
-        // This block is the scheduling point where the next file split is about to dispatch its
-        // read against the storage backend (S3 GET, local FS read, etc.). PR 2's
-        // {@code SharedNumericThreshold} mechanism will inject its row-group / column-range skip
-        // check HERE — before the {@code rangeReader.readRange(...)} call below and before the
-        // {@code fileReader.read(...)} fallback — so the skip avoids the I/O cost rather than
-        // paying for the read and discarding the result.
-        //
-        // The threshold itself lives on the operator factory (parked on
-        // {@code AsyncExternalSourceOperatorFactory}, not on the immutable {@link FormatReadContext};
-        // see RV3 in the numeric-topn-external plan) and is published by the
-        // {@code NumericTopNOperator}'s heap-root as it tightens. The reader consults it via the
-        // {@code RangeReadContext} / {@code FormatReadContext} passed below.
-        //
-        // Any change that moves the read dispatch out of this block must also update PR 2's
-        // injection point. The integration tests in
-        // {@code ExternalParquetNumericTopNIT#testSortLongAscPinsAsyncReadCallsite()} pin the
-        // shape of the query (SORT longCol ASC | LIMIT N over external Parquet) that PR 2 will
-        // benchmark against.
+        // TODO: inject SharedNumericThreshold row-group skip check here, before the read
+        // dispatch below — avoids the I/O cost rather than paying for it and discarding.
         CloseableIterator<Page> pages = null;
         try {
             FormatReader fileReader = readerForFile(fileSplit);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizer.java
@@ -116,6 +116,9 @@ public class LocalPhysicalPlanOptimizer extends ParameterizedRuleExecutor<Physic
             // Runs after PushTopNIntoExternalSource (which lives in the pushdown batch above) so we
             // see the surviving TopN nodes that did not get fully pushed into the source. Inserts
             // an ExternalFieldExtractExec above each remaining TopN whose source supports it.
+            // The narrowed source projection ({@code [sortKey, _rowPosition]}) this rule produces
+            // is also the precondition the planner's {@code tryBuildNumericTopN} checks before
+            // swapping in the specialised {@code NumericTopNOperator}.
             new InsertExternalFieldExtraction()
         );
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -760,11 +760,10 @@ public class LocalExecutionPlanner {
      *         (replacing it would double-count the budget).</li>
      * </ul>
      *
-     * <p>Plan-time multi-value exclude is deliberately omitted: there is no general "is this
-     * attribute single-valued" predicate in ESQL today and the runtime operator already throws
-     * an {@link IllegalStateException} with an {@code MV_MIN}/{@code MV_MAX} rewrite hint on the
-     * first multi-valued page, so any missed plan-time classification produces a clear error
-     * rather than a silent miscompute.
+     * <p>No plan-time multi-value exclude: the operator supports multi-valued sort keys natively
+     * via {@code NumericSortKeyExtractor} (MV-min for ASC, MV-max for DESC, empty MV slot treated
+     * as null). This matches the generic {@code TopNOperator}'s behaviour through its
+     * {@code KeyExtractorForX} family, so the substitution is semantics-preserving on MV input.
      */
     private NumericTopNOperator.NumericTopNOperatorFactory tryBuildNumericTopN(
         TopNExec topNExec,
@@ -783,11 +782,14 @@ public class LocalExecutionPlanner {
         if (isNumericTopNSupportedSortType(sortAttribute.dataType()) == false) {
             return null;
         }
-        // The narrowed source produced by InsertExternalFieldExtraction has exactly two channels:
-        // the sort key at channel 0 and the synthetic _rowPosition column at channel 1. Anything
-        // else (additional eager columns, the sort key not at channel 0) means the rewrite either
-        // hasn't run or kept extra columns and the specialised operator's 2-channel layout cannot
-        // consume the input — fall back to the generic operator.
+        // Two guards, working at different layers. The first one (the layout check) is the real
+        // gate on what {@link NumericTopNOperator#addInput} actually sees: if any intervening
+        // {@link UnaryExec} on the spine — pushed filter, residual evaluator, future plan-node
+        // insertion — adds a column, it shows up in {@code source.layout} and disqualifies the
+        // rewrite. The second one (the source-output check below) is a belt-and-braces guard
+        // against an ExternalSourceExec that was never narrowed in the first place (e.g. the
+        // rule didn't run, or kept extras). Together they reject everything that isn't the exact
+        // narrowed shape the operator expects: [sortKey, _rowPosition] with sortKey at channel 0.
         if (source.layout.numberOfChannels() != 2) {
             return null;
         }
@@ -839,6 +841,19 @@ public class LocalExecutionPlanner {
      * {@link ElementType#LONG} at planning time (see {@link PlannerUtils#toElementType}), so they
      * go through the LONG path. Keeping the predicate here rather than on the operator lets the
      * planner cleanly skip the optimisation without instantiating the factory.
+     *
+     * <p>Deliberately excluded:
+     * <ul>
+     *     <li>{@code UNSIGNED_LONG}: maps to {@link ElementType#LONG} but the operator's
+     *         {@code ~raw} encoding does not preserve unsigned ordering. Supporting it needs a
+     *         different encoding ({@code raw ^ Long.MIN_VALUE}, sign-bit flip) and is parked for
+     *         a follow-up.</li>
+     *     <li>{@code FLOAT}, {@code HALF_FLOAT}, {@code SCALED_FLOAT}: ESQL widens these to
+     *         {@link DataType#DOUBLE} at load time, so a sort attribute with one of these data
+     *         types never reaches this predicate in practice — {@link PlannerUtils#toElementType}
+     *         throws on them outright. Listing them here as "rejected" would be misleading; the
+     *         load-time widening already routes them through the DOUBLE branch.</li>
+     * </ul>
      */
     private static boolean isNumericTopNSupportedSortType(DataType dataType) {
         return dataType == DataType.LONG

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -71,6 +71,7 @@ import org.elasticsearch.compute.operator.fuse.LinearScoreEvalOperator;
 import org.elasticsearch.compute.operator.fuse.RrfConfig;
 import org.elasticsearch.compute.operator.fuse.RrfScoreEvalOperator;
 import org.elasticsearch.compute.operator.topn.GroupedTopNOperator;
+import org.elasticsearch.compute.operator.topn.NumericTopNOperator;
 import org.elasticsearch.compute.operator.topn.TopNEncoder;
 import org.elasticsearch.compute.operator.topn.TopNOperator;
 import org.elasticsearch.compute.operator.topn.TopNOperator.TopNOperatorFactory;
@@ -117,6 +118,7 @@ import org.elasticsearch.xpack.esql.datasources.ExternalSliceQueue;
 import org.elasticsearch.xpack.esql.datasources.FileMetadataColumns;
 import org.elasticsearch.xpack.esql.datasources.OperatorFactoryRegistry;
 import org.elasticsearch.xpack.esql.datasources.PartitionMetadata;
+import org.elasticsearch.xpack.esql.datasources.spi.ColumnExtractor;
 import org.elasticsearch.xpack.esql.datasources.spi.FileList;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceOperatorContext;
@@ -176,6 +178,7 @@ import org.elasticsearch.xpack.esql.plan.physical.TimeSeriesCollapseExec;
 import org.elasticsearch.xpack.esql.plan.physical.TopNByExec;
 import org.elasticsearch.xpack.esql.plan.physical.TopNExec;
 import org.elasticsearch.xpack.esql.plan.physical.TsInfoExec;
+import org.elasticsearch.xpack.esql.plan.physical.UnaryExec;
 import org.elasticsearch.xpack.esql.plan.physical.UriPartsExec;
 import org.elasticsearch.xpack.esql.plan.physical.UserAgentExec;
 import org.elasticsearch.xpack.esql.plan.physical.inference.CompletionExec;
@@ -700,6 +703,18 @@ public class LocalExecutionPlanner {
     private PhysicalOperation planTopN(TopNExec topNExec, LocalExecutionPlannerContext context) {
         final Integer rowSize = topNExec.estimatedRowSize();
         PhysicalOperation source = plan(topNExec.child(), context);
+        // Specialisation: a single-key sort over an ExternalSourceExec narrowed by
+        // InsertExternalFieldExtraction to {@code [sortKey, _rowPosition]} can run on the
+        // primitive {@link NumericTopNOperator} instead of the generic byte-encoding one. We
+        // make the decision here — rather than as a separate plan node + optimizer rule — because
+        // the choice is purely an implementation detail (same TopN semantics, different operator)
+        // and every input we need is already on hand at translation time. If the predicate
+        // doesn't match we fall through to the generic factory below; the rule predicate and the
+        // generic fallback share the same plan node.
+        NumericTopNOperator.NumericTopNOperatorFactory numericFactory = tryBuildNumericTopN(topNExec, source, context);
+        if (numericFactory != null) {
+            return source.with(numericFactory, source.layout);
+        }
         var common = topNCommon(rowSize, topNExec.order(), topNExec.limit(), topNExec.docValuesAttributes(), source, context);
         return source.with(
             new TopNOperatorFactory(
@@ -714,6 +729,162 @@ public class LocalExecutionPlanner {
             ),
             source.layout
         );
+    }
+
+    /**
+     * Decide whether the {@code TopNExec} qualifies for the specialised {@link NumericTopNOperator}
+     * and, if so, return its factory; otherwise {@code null} and the caller falls back to the
+     * generic operator. The predicate is intentionally narrow — every check has a documented
+     * reason — so any plan that fails to qualify gets the functionally-correct generic path.
+     *
+     * <p>Preconditions, all checked here:
+     * <ul>
+     *     <li>Exactly one sort {@link Order} (Tier 1 is single-key).</li>
+     *     <li>The sort attribute is a plain {@link Attribute} (no expressions over the field) of
+     *         a fixed-width numeric type — currently LONG, INTEGER, DOUBLE, BOOLEAN, DATETIME, or
+     *         DATE_NANOS. FLOAT, UNSIGNED_LONG, HALF_FLOAT, and SCALED_FLOAT are deferred to a
+     *         follow-up PR; they need a tiny encoding addition but no operator surface change.</li>
+     *     <li>The limit is a literal foldable to a positive {@code int}. Non-literal limits go
+     *         to the generic operator (the bytes-encoding path doesn't need a literal).</li>
+     *     <li>The {@code TopNExec} sits directly above (or via a {@link UnaryExec} spine ending
+     *         in) an {@link ExternalSourceExec}.</li>
+     *     <li>The source's narrowed output is exactly {@code [sortKey, _rowPosition]} — two
+     *         channels, sort key at channel 0, synthetic row-position column at channel 1.
+     *         {@code InsertExternalFieldExtraction} produces this shape; any extra eager column
+     *         (pushed-filter input, virtual {@code _file.*}) leaves more than two channels and
+     *         disqualifies the substitution because the specialised operator's 2-channel layout
+     *         cannot pass extra columns through.</li>
+     *     <li>The source carries no {@code pushedTopN} hint. If
+     *         {@code PushTopNIntoExternalSource} already annotated the source, the BlockHash will
+     *         prune during aggregation and the generic TopN above must remain as the safety net
+     *         (replacing it would double-count the budget).</li>
+     * </ul>
+     *
+     * <p>Plan-time multi-value exclude is deliberately omitted: there is no general "is this
+     * attribute single-valued" predicate in ESQL today and the runtime operator already throws
+     * an {@link IllegalStateException} with an {@code MV_MIN}/{@code MV_MAX} rewrite hint on the
+     * first multi-valued page, so any missed plan-time classification produces a clear error
+     * rather than a silent miscompute.
+     */
+    private NumericTopNOperator.NumericTopNOperatorFactory tryBuildNumericTopN(
+        TopNExec topNExec,
+        PhysicalOperation source,
+        LocalExecutionPlannerContext context
+    ) {
+        List<Order> orders = topNExec.order();
+        if (orders.size() != 1) {
+            return null;
+        }
+        Order sortOrder = orders.get(0);
+        Attribute sortAttribute = Expressions.attribute(sortOrder.child());
+        if (sortAttribute == null) {
+            return null;
+        }
+        if (isNumericTopNSupportedSortType(sortAttribute.dataType()) == false) {
+            return null;
+        }
+        // The narrowed source produced by InsertExternalFieldExtraction has exactly two channels:
+        // the sort key at channel 0 and the synthetic _rowPosition column at channel 1. Anything
+        // else (additional eager columns, the sort key not at channel 0) means the rewrite either
+        // hasn't run or kept extra columns and the specialised operator's 2-channel layout cannot
+        // consume the input — fall back to the generic operator.
+        if (source.layout.numberOfChannels() != 2) {
+            return null;
+        }
+        Layout.ChannelAndType sortEntry = source.layout.get(sortAttribute.id());
+        if (sortEntry == null || sortEntry.channel() != NumericTopNOperator.SORT_KEY_CHANNEL) {
+            return null;
+        }
+        // Walk down the UnaryExec spine to confirm we're sitting over a narrowed ExternalSourceExec
+        // and to inspect its pushedTopN hint. Same traversal {@code InsertExternalFieldExtraction}
+        // uses (inlined here to keep the planner from depending on an optimizer-rule class).
+        ExternalSourceExec externalSource = findExternalSourceBelow(topNExec.child());
+        if (externalSource == null) {
+            return null;
+        }
+        List<Attribute> sourceOutput = externalSource.output();
+        if (sourceOutput.size() != 2) {
+            return null;
+        }
+        if (ColumnExtractor.ROW_POSITION_COLUMN.equals(sourceOutput.get(1).name()) == false) {
+            return null;
+        }
+        if (externalSource.pushedTopN() != null) {
+            return null;
+        }
+        // Limit must be a positive integer literal. We re-fold here (rather than carrying a
+        // rule-folded value) so the planner remains the single source of truth for the literal's
+        // primitive form.
+        Expression limitExpr = topNExec.limit();
+        if (limitExpr.foldable() == false) {
+            return null;
+        }
+        Object folded = limitExpr.fold(context.foldCtx());
+        Integer limit = numericTopNFoldedLimit(folded);
+        if (limit == null || limit <= 0) {
+            return null;
+        }
+        ElementType keyElementType = PlannerUtils.toElementType(sortAttribute.dataType());
+        return new NumericTopNOperator.NumericTopNOperatorFactory(
+            limit,
+            keyElementType,
+            sortOrder.direction() == Order.OrderDirection.ASC,
+            sortOrder.nullsPosition() == Order.NullsPosition.FIRST
+        );
+    }
+
+    /**
+     * Sort-key element types the specialised {@link NumericTopNOperator} can rank. Mirrors the
+     * operator's own {@code assertSupportedType} — DATETIME and DATE_NANOS collapse to
+     * {@link ElementType#LONG} at planning time (see {@link PlannerUtils#toElementType}), so they
+     * go through the LONG path. Keeping the predicate here rather than on the operator lets the
+     * planner cleanly skip the optimisation without instantiating the factory.
+     */
+    private static boolean isNumericTopNSupportedSortType(DataType dataType) {
+        return dataType == DataType.LONG
+            || dataType == DataType.INTEGER
+            || dataType == DataType.DOUBLE
+            || dataType == DataType.BOOLEAN
+            || dataType == DataType.DATETIME
+            || dataType == DataType.DATE_NANOS;
+    }
+
+    /**
+     * Folds a TopN limit expression to a positive {@link Integer}, returning {@code null} when
+     * the limit is non-integral, negative, or out of {@code int} range.
+     */
+    private static Integer numericTopNFoldedLimit(Object folded) {
+        if (folded instanceof Integer i) {
+            return i;
+        }
+        if (folded instanceof Number n) {
+            long l = n.longValue();
+            if (l < 0 || l > Integer.MAX_VALUE) {
+                return null;
+            }
+            return (int) l;
+        }
+        return null;
+    }
+
+    /**
+     * Walk down a {@link UnaryExec} spine looking for an {@link ExternalSourceExec}; returns
+     * {@code null} when the spine ends in any other leaf. Mirrors the traversal used by
+     * {@code InsertExternalFieldExtraction#findExternalSource} (inlined here so the planner does
+     * not depend on an optimizer-rule class).
+     */
+    private static ExternalSourceExec findExternalSourceBelow(PhysicalPlan start) {
+        PhysicalPlan p = start;
+        while (true) {
+            if (p instanceof ExternalSourceExec es) {
+                return es;
+            }
+            if (p instanceof UnaryExec u) {
+                p = u.child();
+                continue;
+            }
+            return null;
+        }
     }
 
     private PhysicalOperation planTopNBy(TopNByExec topNByExec, LocalExecutionPlannerContext context) {


### PR DESCRIPTION
## Why

`SORT <numeric-col> | LIMIT N` is one of the most common shapes our users
run against external sources — "give me the latest N events", "top N rows
by metric". Today, the generic `TopNOperator` is the only thing that
handles it, and on this shape it is doing far more work than necessary:

- **Per-row allocation.** Every input row's sort key is encoded into a
  `BytesRef`, wrapped in a `TopNRow`, and ranked against the queue.
  `TopNRow.java` carries an explicit TODO calling out the inefficiency.
- **Object-ranked heap.** The ranking structure is a Lucene
  `PriorityQueue<TopNRow>` keyed on `BytesRef.compareTo` — a chain of
  virtual calls and byte-by-byte comparisons over what is, after
  encoding, a single fixed-width primitive.
- **No early rejection on a primitive threshold.** Once the heap is full
  the threshold is still an object boundary, not a `long` we can compare
  against in a tight loop.

On the canonical deferred-extraction shape — a `TopNExec` sitting over an
`ExternalSourceExec` that `InsertExternalFieldExtraction` has narrowed to
exactly `[sortKey, _rowPosition]` — the generic operator's overhead is
the dominant cost. Heap, JIT, and allocation profiles all agree.

This PR is the operator-side step toward making that shape cheap. It
unlocks a follow-up where the heap's threshold tightens column-statistics
or row-group skip decisions in the source itself: once the operator can
publish an exact, primitive, per-insert threshold, the source can avoid
the read entirely for non-competitive row groups. That is the
transformative win; this PR is the prerequisite.

## Results

JMH micro on a single LONG sort key, 4K-row pages, 1024 invocations per
op, K ∈ {100, 1000, 10000}, both ASC and DESC:

| K | direction | generic (ns/op) | numeric (ns/op) | speedup |
|---|---|---|---|---|
| 100   | asc  | 10.41 | 2.42 | **4.30×** |
| 1000  | asc  | 10.45 | 2.69 | **3.89×** |
| 10000 | asc  | 13.37 | 3.71 | **3.61×** |
| 100   | desc |  9.90 | 2.42 | **4.09×** |
| 1000  | desc | 10.39 | 2.50 | **4.15×** |
| 10000 | desc | 15.59 | 3.69 | **4.23×** |

End-to-end Parquet ITs cover LONG, INTEGER, DOUBLE, BOOLEAN sort keys
and verify the wide-column payloads survive the deferred-extraction
round-trip correctly.

Developed with AI-assisted tooling.