### PR TITLE
[9.4] Fix flaky ES92GpuHnswWriteGraphTests by comparing the graphs by what matters: search quality (#149737)

### DIFF
--- a/libs/gpu-codec/src/test/java/org/elasticsearch/gpu/codec/ES92GpuHnswWriteGraphTests.java
+++ b/libs/gpu-codec/src/test/java/org/elasticsearch/gpu/codec/ES92GpuHnswWriteGraphTests.java
@@ -12,7 +12,6 @@ package org.elasticsearch.gpu.codec;
 import com.nvidia.cuvs.CagraIndexParams;
 import com.nvidia.cuvs.CuVSMatrix;
 
-import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.apache.lucene.codecs.KnnVectorsReader;
 import org.apache.lucene.codecs.KnnVectorsWriter;
@@ -28,7 +27,9 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.SegmentWriteState;
 import org.apache.lucene.index.VectorSimilarityFunction;
-import org.apache.lucene.store.ChecksumIndexInput;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.KnnFloatVectorQuery;
+import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.hnsw.HnswGraph;
@@ -39,14 +40,21 @@ import org.junit.Before;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.apache.lucene.tests.index.BaseKnnVectorsFormatTestCase.randomVector;
 import static org.elasticsearch.gpu.codec.ES92GpuHnswVectorsFormat.DEFAULT_BEAM_WIDTH;
 import static org.elasticsearch.gpu.codec.ES92GpuHnswVectorsFormat.DEFAULT_MAX_CONN;
 
 /**
- * Validates that the CPU fallback path in {@link ES92GpuHnswVectorsWriter} produces graph
- * data identical to Lucene's {@link Lucene99HnswVectorsFormat}. No GPU required.
+ * Validates that the CPU fallback path in {@link ES92GpuHnswVectorsWriter} produces
+ * equivalent results to Lucene's {@link Lucene99HnswVectorsFormat}. No GPU required.
+ *
+ * <p>For float vectors, graph topology is compared structurally (same levels, same nodes
+ * on each level) and kNN search results are compared to verify functional equivalence.
+ * Neighbor lists are not compared exactly because 1-ULP floating-point differences in
+ * vector scoring (due to JIT compilation state) can cause harmless tie-breaking divergence.
  */
 public class ES92GpuHnswWriteGraphTests extends ESTestCase {
 
@@ -75,10 +83,8 @@ public class ES92GpuHnswWriteGraphTests extends ESTestCase {
             indexVectors(gpuDir, gpuFormat, vectors, similarity);
             indexVectors(luceneDir, luceneFormat, vectors, similarity);
             try (DirectoryReader gpuReader = DirectoryReader.open(gpuDir); DirectoryReader luceneReader = DirectoryReader.open(luceneDir)) {
-                HnswGraph gpuGraph = getGraph(gpuReader);
-                HnswGraph luceneGraph = getGraph(luceneReader);
-                assertGraphsEqual(gpuGraph, luceneGraph);
-                assertVexBytesEqual(gpuDir, luceneDir);
+                assertGraphStructureEqual(getGraph(gpuReader), getGraph(luceneReader));
+                assertSearchResultsEqual(gpuReader, luceneReader, vectors);
             }
         }
     }
@@ -104,10 +110,8 @@ public class ES92GpuHnswWriteGraphTests extends ESTestCase {
             indexVectors(gpuDir, gpuFormat, vectors, sqSimilarity);
             indexVectors(luceneDir, luceneFormat, vectors, sqSimilarity);
             try (DirectoryReader gpuReader = DirectoryReader.open(gpuDir); DirectoryReader luceneReader = DirectoryReader.open(luceneDir)) {
-                HnswGraph gpuGraph = getGraph(gpuReader);
-                HnswGraph luceneGraph = getGraph(luceneReader);
-                assertGraphsEqual(gpuGraph, luceneGraph);
-                assertVexBytesEqual(gpuDir, luceneDir);
+                assertGraphStructureEqual(getGraph(gpuReader), getGraph(luceneReader));
+                assertEqualRecallAgainstBruteForce(gpuReader, luceneReader, vectors, sqSimilarity);
             }
         }
     }
@@ -135,7 +139,12 @@ public class ES92GpuHnswWriteGraphTests extends ESTestCase {
         return ((HnswGraphProvider) knnReader).getGraph(FIELD);
     }
 
-    private void assertGraphsEqual(HnswGraph gpuGraph, HnswGraph luceneGraph) throws IOException {
+    /**
+     * Asserts that both graphs have the same structure: same number of levels,
+     * same nodes on each level. Does not compare neighbor lists, since 1-ULP
+     * floating-point differences can cause harmless tie-breaking divergence.
+     */
+    private void assertGraphStructureEqual(HnswGraph gpuGraph, HnswGraph luceneGraph) throws IOException {
         assertEquals("numLevels", luceneGraph.numLevels(), gpuGraph.numLevels());
         assertEquals("size", luceneGraph.size(), gpuGraph.size());
         assertEquals("maxConn", luceneGraph.maxConn(), gpuGraph.maxConn());
@@ -144,63 +153,78 @@ public class ES92GpuHnswWriteGraphTests extends ESTestCase {
             var luceneNodes = luceneGraph.getNodesOnLevel(level);
             var gpuNodes = gpuGraph.getNodesOnLevel(level);
             assertEquals("nodes on level " + level, luceneNodes.size(), gpuNodes.size());
-
-            while (luceneNodes.hasNext()) {
-                assertTrue("gpu should have more nodes on level " + level, gpuNodes.hasNext());
-                int luceneNode = luceneNodes.nextInt();
-                int gpuNode = gpuNodes.nextInt();
-                assertEquals("node id on level " + level, luceneNode, gpuNode);
-
-                int[] luceneNeighbors = getSortedNeighbors(luceneGraph, level, luceneNode);
-                int[] gpuNeighbors = getSortedNeighbors(gpuGraph, level, gpuNode);
-                assertArrayEquals("neighbors of node " + luceneNode + " on level " + level, luceneNeighbors, gpuNeighbors);
-            }
         }
     }
 
-    private static int[] getSortedNeighbors(HnswGraph graph, int level, int node) throws IOException {
-        graph.seek(level, node);
-        int count = graph.neighborCount();
-        int[] neighbors = new int[count];
-        for (int i = 0; i < count; i++) {
-            neighbors[i] = graph.nextNeighbor();
-        }
-        Arrays.sort(neighbors);
-        return neighbors;
-    }
+    /**
+     * Runs kNN queries against both indexes and asserts that the result sets are identical,
+     * verifying that the graphs are functionally equivalent even if neighbor lists differ
+     * slightly due to floating-point tie-breaking.
+     */
+    private void assertSearchResultsEqual(DirectoryReader gpuReader, DirectoryReader luceneReader, float[][] vectors) throws IOException {
+        int k = Math.min(10, numVectors);
+        int numQueries = Math.min(50, numVectors);
+        var gpuSearcher = new IndexSearcher(gpuReader);
+        var luceneSearcher = new IndexSearcher(luceneReader);
 
-    private void assertVexBytesEqual(Directory gpuDir, Directory luceneDir) throws IOException {
-        String gpuVex = findFileByExtension(gpuDir, "vex");
-        String luceneVex = findFileByExtension(luceneDir, "vex");
-        byte[] gpuBytes = readVexPayload(gpuDir, gpuVex);
-        byte[] luceneBytes = readVexPayload(luceneDir, luceneVex);
-        assertArrayEquals(".vex payload (graph + offsets) must be identical between GPU CPU-fallback and Lucene", luceneBytes, gpuBytes);
-    }
+        for (int q = 0; q < numQueries; q++) {
+            float[] queryVec = vectors[q];
+            var query = new KnnFloatVectorQuery(FIELD, queryVec, k);
+            TopDocs gpuDocs = gpuSearcher.search(query, k);
+            TopDocs luceneDocs = luceneSearcher.search(query, k);
 
-    private static byte[] readVexPayload(Directory dir, String fileName) throws IOException {
-        try (ChecksumIndexInput input = dir.openChecksumInput(fileName)) {
-            CodecUtil.checkHeader(
-                input,
-                "Lucene99HnswVectorsFormatIndex",
-                Lucene99HnswVectorsFormat.VERSION_START,
-                Lucene99HnswVectorsFormat.VERSION_CURRENT
-            );
-            input.skipBytes(16);
-            int suffixLen = input.readByte() & 0xFF;
-            input.skipBytes(suffixLen);
-            long headerEnd = input.getFilePointer();
-            long payloadLen = input.length() - headerEnd - CodecUtil.footerLength();
-            assertTrue("vex file too small to contain header+footer", payloadLen >= 0);
-            byte[] bytes = new byte[(int) payloadLen];
-            input.readBytes(bytes, 0, bytes.length);
-            return bytes;
+            Set<Integer> gpuIds = Arrays.stream(gpuDocs.scoreDocs).map(d -> d.doc).collect(Collectors.toSet());
+            Set<Integer> luceneIds = Arrays.stream(luceneDocs.scoreDocs).map(d -> d.doc).collect(Collectors.toSet());
+            assertEquals("kNN results for query " + q + " should match", luceneIds, gpuIds);
         }
     }
 
-    private static String findFileByExtension(Directory dir, String ext) throws IOException {
-        var l = Arrays.stream(dir.listAll()).filter(name -> name.endsWith(ext)).toList();
-        assert l.size() == 1 : "expected a list with a single element, got:" + l;
-        return l.getFirst();
+    /**
+     * Computes brute-force exact top-k for each query, then asserts that the GPU index's
+     * aggregate recall is within a small tolerance of Lucene's. Quantization means
+     * individual queries can legitimately differ, but overall quality should be comparable.
+     */
+    private void assertEqualRecallAgainstBruteForce(
+        DirectoryReader gpuReader,
+        DirectoryReader luceneReader,
+        float[][] vectors,
+        VectorSimilarityFunction sim
+    ) throws IOException {
+        int k = Math.min(10, numVectors);
+        int numQueries = Math.min(50, numVectors);
+        var gpuSearcher = new IndexSearcher(gpuReader);
+        var luceneSearcher = new IndexSearcher(luceneReader);
+
+        int gpuTotal = 0;
+        int luceneTotal = 0;
+        for (int q = 0; q < numQueries; q++) {
+            float[] queryVec = vectors[q];
+            Set<Integer> groundTruth = bruteForceTopK(vectors, queryVec, k, sim);
+
+            var query = new KnnFloatVectorQuery(FIELD, queryVec, k);
+            Set<Integer> gpuIds = Arrays.stream(gpuSearcher.search(query, k).scoreDocs).map(d -> d.doc).collect(Collectors.toSet());
+            Set<Integer> luceneIds = Arrays.stream(luceneSearcher.search(query, k).scoreDocs).map(d -> d.doc).collect(Collectors.toSet());
+
+            gpuTotal += gpuIds.stream().filter(groundTruth::contains).count();
+            luceneTotal += luceneIds.stream().filter(groundTruth::contains).count();
+        }
+        int totalPossible = numQueries * k;
+        double gpuRecall = (double) gpuTotal / totalPossible;
+        double luceneRecall = (double) luceneTotal / totalPossible;
+        assertTrue(
+            "GPU recall (" + gpuRecall + ") should be within 5% of Lucene recall (" + luceneRecall + ")",
+            gpuRecall >= luceneRecall - 0.05
+        );
+    }
+
+    private static Set<Integer> bruteForceTopK(float[][] vectors, float[] query, int k, VectorSimilarityFunction sim) {
+        record ScoredDoc(int doc, float score) {}
+        ScoredDoc[] scored = new ScoredDoc[vectors.length];
+        for (int i = 0; i < vectors.length; i++) {
+            scored[i] = new ScoredDoc(i, sim.compare(query, vectors[i]));
+        }
+        Arrays.sort(scored, (a, b) -> Float.compare(b.score, a.score));
+        return Arrays.stream(scored, 0, k).map(ScoredDoc::doc).collect(Collectors.toSet());
     }
 
     private float[][] generateVectors(int count, int dims) {

--- a/libs/gpu-codec/src/test/java/org/elasticsearch/gpu/codec/ES92GpuHnswWriteGraphTests.java
+++ b/libs/gpu-codec/src/test/java/org/elasticsearch/gpu/codec/ES92GpuHnswWriteGraphTests.java
@@ -195,8 +195,8 @@ public class ES92GpuHnswWriteGraphTests extends ESTestCase {
         var gpuSearcher = new IndexSearcher(gpuReader);
         var luceneSearcher = new IndexSearcher(luceneReader);
 
-        int gpuTotal = 0;
-        int luceneTotal = 0;
+        long gpuTotal = 0;
+        long luceneTotal = 0;
         for (int q = 0; q < numQueries; q++) {
             float[] queryVec = vectors[q];
             Set<Integer> groundTruth = bruteForceTopK(vectors, queryVec, k, sim);
@@ -208,7 +208,7 @@ public class ES92GpuHnswWriteGraphTests extends ESTestCase {
             gpuTotal += gpuIds.stream().filter(groundTruth::contains).count();
             luceneTotal += luceneIds.stream().filter(groundTruth::contains).count();
         }
-        int totalPossible = numQueries * k;
+        long totalPossible = (long) numQueries * k;
         double gpuRecall = (double) gpuTotal / totalPossible;
         double luceneRecall = (double) luceneTotal / totalPossible;
         assertTrue(


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Fix flaky ES92GpuHnswWriteGraphTests by comparing the graphs by what matters: search quality (#149737)