### PR TITLE
Make the MetricsRecorder copy recorded attributes

### DIFF
--- a/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/RecordingOtelMeter.java
+++ b/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/RecordingOtelMeter.java
@@ -38,7 +38,6 @@ import io.opentelemetry.context.Context;
 import org.elasticsearch.telemetry.InstrumentType;
 import org.elasticsearch.telemetry.MetricRecorder;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Queue;
@@ -316,7 +315,7 @@ public class RecordingOtelMeter implements Meter {
 
         @Override
         public void add(long value) {
-            recorder.call(instrument, name, value, null);
+            recorder.call(instrument, name, value, Map.of());
         }
 
         @Override
@@ -380,7 +379,7 @@ public class RecordingOtelMeter implements Meter {
 
         @Override
         public void add(double value) {
-            recorder.call(instrument, name, value, null);
+            recorder.call(instrument, name, value, Map.of());
         }
 
         @Override
@@ -417,10 +416,10 @@ public class RecordingOtelMeter implements Meter {
 
         Map<String, Object> toMap(Attributes attributes) {
             if (attributes == null) {
-                return null;
+                return Map.of();
             }
             if (attributes.isEmpty()) {
-                return Collections.emptyMap();
+                return Map.of();
             }
             Map<String, Object> map = new HashMap<>(attributes.size());
             attributes.forEach((k, v) -> map.put(k.getKey(), v));
@@ -526,7 +525,7 @@ public class RecordingOtelMeter implements Meter {
 
         @Override
         public void record(double value) {
-            recorder.call(instrument, name, value, null);
+            recorder.call(instrument, name, value, Map.of());
         }
 
         @Override
@@ -597,7 +596,7 @@ public class RecordingOtelMeter implements Meter {
 
         @Override
         public void record(long value) {
-            recorder.call(instrument, name, value, null);
+            recorder.call(instrument, name, value, Map.of());
         }
 
         @Override
@@ -644,7 +643,7 @@ public class RecordingOtelMeter implements Meter {
 
         @Override
         public void record(double value) {
-            recorder.call(getInstrument(), name, value, null);
+            recorder.call(getInstrument(), name, value, Map.of());
         }
 
         @Override
@@ -691,7 +690,7 @@ public class RecordingOtelMeter implements Meter {
 
         @Override
         public void record(long value) {
-            recorder.call(getInstrument(), name, value, null);
+            recorder.call(getInstrument(), name, value, Map.of());
         }
 
         @Override

--- a/test/framework/src/main/java/org/elasticsearch/telemetry/MetricRecorder.java
+++ b/test/framework/src/main/java/org/elasticsearch/telemetry/MetricRecorder.java
@@ -101,7 +101,7 @@ public class MetricRecorder<I> {
      * Record a call made to the registered instrument represented by the {@link InstrumentType} enum.
      */
     public void call(InstrumentType instrumentType, String name, Number value, Map<String, Object> attributes) {
-        metrics.get(instrumentType).call(name, new Measurement(value, attributes, instrumentType.isDouble));
+        metrics.get(instrumentType).call(name, new Measurement(value, Map.copyOf(attributes), instrumentType.isDouble));
     }
 
     /**


### PR DESCRIPTION
This PR makes the `MetricsReporter` copy the attributes before it saves them in its internal state: without the copy, the `Map` reference could be modified after it's registered and cause strange errors in tests.