### PR TITLE
[9.4] Remote cluster permissions test fix randomization (#149705)

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/permission/RemoteClusterPermissionsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/permission/RemoteClusterPermissionsTests.java
@@ -267,6 +267,10 @@ public class RemoteClusterPermissionsTests extends AbstractXContentSerializingTe
             String[] privileges = generateRandomStringArray(5, 5, false, false);
             groupPrivileges.add(privileges);
             String[] clusters = generateRandomStringArray(5, 5, false, false);
+            String clusterPrefix = "g" + i + "_";
+            for (int j = 0; j < clusters.length; j++) {
+                clusters[j] = clusterPrefix + clusters[j];
+            }
             if (fuzzyCluster) {
                 for (int j = 0; j < clusters.length; j++) {
                     if (randomBoolean()) {


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Remote cluster permissions test fix randomization (#149705)