### PR TITLE
[ESQL] Parquet pushdown for CONTAINS and ENDS_WITH

### DIFF
--- a/docs/changelog/149870.yaml
+++ b/docs/changelog/149870.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 149870
+summary: Parquet pushdown for CONTAINS and ENDS_WITH
+type: enhancement

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFilterPushdownSupport.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFilterPushdownSupport.java
@@ -15,6 +15,8 @@ import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.datasources.pushdown.PushdownPredicates;
 import org.elasticsearch.xpack.esql.datasources.spi.FilterPushdownSupport;
+import org.elasticsearch.xpack.esql.expression.function.scalar.string.Contains;
+import org.elasticsearch.xpack.esql.expression.function.scalar.string.EndsWith;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.StartsWith;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.regex.WildcardLike;
 import org.elasticsearch.xpack.esql.expression.predicate.Range;
@@ -163,49 +165,40 @@ public class ParquetFilterPushdownSupport implements FilterPushdownSupport {
      * dropped from {@code FilterExec} (pushed as {@link Pushability#YES}); others must be
      * re-checked downstream ({@link Pushability#RECHECK}).
      *
-     * <p>The two-valued bitmask path is TVL-correct by construction for predicates that
-     * map nulls to bit {@code 0}: {@link WildcardLike} on a non-null value matches the
-     * automaton; on a null value it sets bit {@code 0}. The remaining work is to ensure
-     * {@code Not(WildcardLike)} also stays TVL-correct — the late-mat evaluator does this
-     * by AND-ing out the null mask before negating
-     * (see {@link ParquetPushedExpressions#evaluateExpression}).
-     *
-     * <p><b>Why {@code Not} only allows a bare {@link WildcardLike} child.</b> The evaluator's
-     * generic {@code Not} branch is a bitwise complement on the inner mask. For
-     * {@code Not(And(...))} that means {@code ~(m1 & m2)}, which is <em>not</em>
-     * {@code NOT (a AND b)} under SQL three-valued logic — e.g. {@code (NULL AND TRUE)} is
-     * {@code UNKNOWN} (mask bit 0); the bitwise complement flips it to 1, so the row
-     * incorrectly survives. Only {@code Not(WildcardLike)} has a TVL-aware special case in
+     * <p>The two-valued bitmask path is TVL-correct by construction for predicates that map
+     * nulls to bit {@code 0}. The LIKE-family — {@link WildcardLike}, {@link StartsWith},
+     * {@code EndsWith}, {@code Contains} — satisfies this on the positive side and is also
+     * routed through a TVL-aware {@code Not} branch in
      * {@link ParquetPushedExpressions#evaluateExpression} that AND-s out the null mask before
-     * negation. Anything else under {@code Not} stays {@link Pushability#RECHECK} so that
-     * {@code FilterExec} fixes the null handling.
+     * negating, so both bare and negated forms are YES.
      *
-     * <p>Conjunctions of YES-eligible predicates are themselves YES-eligible: {@code AND} of
-     * TVL-correct masks is TVL-correct (a 0 bit on either side blocks the row, regardless of
-     * whether it came from "no-match" or "null"). {@code OR} is intentionally excluded
-     * because {@code evaluateExpression}'s {@code Or} branch returns {@code null} (i.e.
-     * "all rows survive") when an arm is unevaluable — fine for {@link Pushability#RECHECK}
-     * (where {@code FilterExec} re-checks), but unsafe for {@link Pushability#YES}.
+     * <p>Other predicate families ({@code Eq}, {@code In}, {@code Range}, {@code IsNull},
+     * {@code IsNotNull}) stay {@link Pushability#RECHECK} because the generic bitwise negate
+     * is not TVL-correct for their nulls; the {@code FilterExec} safety net applies them
+     * per-row. {@code Not(And(...))} likewise stays RECHECK — bitwise {@code ~(m1 & m2)} is
+     * not {@code NOT (a AND b)} under TVL when either arm holds null.
      *
-     * <p>Other predicate families ({@code Eq}, {@code In}, {@code Range}, {@code StartsWith},
-     * {@code IsNull}, {@code IsNotNull}) remain {@link Pushability#RECHECK}; their {@code Not}
-     * handling has the same two-valued-mask null bug as LIKE used to, and is left unchanged
-     * to keep this PR focused on the LIKE win that motivated the work.
+     * <p>{@code AND} of YES-eligible predicates is YES (a {@code 0} on either side blocks the
+     * row regardless of provenance). {@code OR} is excluded: {@code evaluateExpression}'s
+     * {@code Or} branch returns {@code null} ("all rows survive") when an arm is unevaluable,
+     * which is fine under RECHECK but unsafe under YES.
      */
     static boolean isFullyEvaluable(Expression expr) {
-        if (expr instanceof WildcardLike) {
+        if (isLikeFamily(expr)) {
             return true;
         }
         if (expr instanceof Not not) {
-            // Only Not(WildcardLike) has a TVL-aware evaluator special case. Any other inner
-            // expression would fall through to the generic two-valued negate, which is unsafe
-            // under YES (see Javadoc above for the And-under-Not example).
-            return not.field() instanceof WildcardLike;
+            // Only the LIKE-family inner predicates have a TVL-aware evaluator special case.
+            return isLikeFamily(not.field());
         }
         if (expr instanceof And and) {
             return isFullyEvaluable(and.left()) && isFullyEvaluable(and.right());
         }
         return false;
+    }
+
+    private static boolean isLikeFamily(Expression e) {
+        return e instanceof WildcardLike || e instanceof StartsWith || e instanceof Contains || e instanceof EndsWith;
     }
 
     /**
@@ -255,6 +248,12 @@ public class ParquetFilterPushdownSupport implements FilterPushdownSupport {
         }
         if (expr instanceof StartsWith sw) {
             return PushdownPredicates.isStartsWith(sw, dt -> dt == DataType.KEYWORD) && literalValueOf(sw.prefix()) != null;
+        }
+        if (expr instanceof EndsWith ew) {
+            return PushdownPredicates.isEndsWith(ew, dt -> dt == DataType.KEYWORD) && literalValueOf(ew.suffix()) != null;
+        }
+        if (expr instanceof Contains c) {
+            return PushdownPredicates.isContains(c, dt -> dt == DataType.KEYWORD) && literalValueOf(c.substr()) != null;
         }
         if (expr instanceof WildcardLike wl) {
             // Parquet has no native LIKE support; this pushdown evaluates the pattern during late

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressions.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressions.java
@@ -38,6 +38,8 @@ import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.util.ByteMatchers;
 import org.elasticsearch.xpack.esql.datasources.pushdown.StringPrefixUtils;
 import org.elasticsearch.xpack.esql.datasources.pushdown.WildcardLikeShape;
+import org.elasticsearch.xpack.esql.expression.function.scalar.string.Contains;
+import org.elasticsearch.xpack.esql.expression.function.scalar.string.EndsWith;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.StartsWith;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.regex.WildcardLike;
 import org.elasticsearch.xpack.esql.expression.predicate.Range;
@@ -205,10 +207,11 @@ final class ParquetPushedExpressions {
      * are excluded from this check on purpose — their downstream {@code FilterExec} still
      * re-applies them, masking the shortcut's over-inclusion.
      *
-     * <p>Today the only canConvert-but-not-translatable expression is {@link WildcardLike}
-     * (and {@code Not(WildcardLike)}), which is also the only YES-eligible non-comparator
-     * expression — so in practice this method returns {@code true} exactly when a {@code LIKE}
-     * conjunct is present alongside other translatable conjuncts.
+     * <p>Today the canConvert-but-not-translatable expressions are the LIKE-family predicates
+     * {@link WildcardLike}, {@code Contains}, {@code EndsWith} and any {@code Not} over them —
+     * none representable as a Parquet {@link FilterPredicate}. {@link StartsWith} and its
+     * negation both translate (bare → prefix range; negated → {@code FilterApi.not(range)}).
+     * All YES-eligible LIKE-family conjuncts that land here are untranslatable.
      *
      * <p>YES is determined here by {@link ParquetFilterPushdownSupport#isFullyEvaluable(Expression)}
      * rather than the full {@code canPush} check. The full check additionally probes
@@ -266,6 +269,14 @@ final class ParquetPushedExpressions {
             return true;
         }
         if (expr instanceof Range range && range.value() instanceof NamedExpression) {
+            return true;
+        }
+        // StartsWith is a leaf (no child sub-expressions that could untranslatably drop); its
+        // translateExpression path produces a pure prefix-range FilterPredicate, so Not(StartsWith)
+        // can safely push as FilterApi.not(range) for row-group/page pruning instead of relying
+        // solely on the late-mat evaluator. EndsWith/Contains/WildcardLike are NOT exactly
+        // translatable (they have no native FilterPredicate form at all).
+        if (expr instanceof StartsWith sw && sw.singleValueField() instanceof NamedExpression && sw.prefix().foldable()) {
             return true;
         }
         return false;
@@ -640,6 +651,10 @@ final class ParquetPushedExpressions {
             collectColumnNames(not.field(), names);
         } else if (expr instanceof StartsWith sw && sw.singleValueField() instanceof NamedExpression ne) {
             names.add(ne.name());
+        } else if (expr instanceof Contains c && c.singleValueField() instanceof NamedExpression ne) {
+            names.add(ne.name());
+        } else if (expr instanceof EndsWith ew && ew.singleValueField() instanceof NamedExpression ne) {
+            names.add(ne.name());
         } else if (expr instanceof WildcardLike wl && wl.field() instanceof NamedExpression ne) {
             names.add(ne.name());
         }
@@ -867,24 +882,24 @@ final class ParquetPushedExpressions {
             return null;
         }
         if (expr instanceof Not not) {
-            // Special case: NOT (col LIKE p) needs SQL three-valued logic so that
-            // NOT (NULL LIKE p) → UNKNOWN → row is filtered out (bit 0), not flipped
-            // to bit 1 by the generic negate. This is a hard requirement for the YES
-            // pushability of WildcardLike (see ParquetFilterPushdownSupport.isFullyEvaluable);
-            // without this branch, dropping FilterExec for NOT (LIKE) would let null rows
-            // survive the predicate, giving wrong results.
-            //
-            // Implementation: build the LIKE mask and the null mask, OR them ("matches OR
-            // null"), then negate to get "non-null AND no-match" — the TVL-correct survivor
-            // set. The mask for the inner WildcardLike already maps null rows to bit 0, so
-            // OR-ing the explicit null mask is what restores the missing TVL bit before
-            // the bitwise complement.
-            if (not.field() instanceof WildcardLike wl && wl.field() instanceof NamedExpression ne) {
-                Block block = blocks.get(ne.name());
-                if (block == null) {
-                    return null;
-                }
-                return evaluateNotWildcardLike(wl, block, rowCount, intermediateMask, dictCache);
+            // NOT (LIKE-family) needs TVL: null rows must stay filtered out, so each LIKE-family
+            // child routes through a tvlNegate helper instead of the generic bitwise negate below.
+            // YES pushability of WildcardLike/Contains/EndsWith depends on this branch.
+            if (not.field() instanceof WildcardLike wl) {
+                Block block = namedBlock(wl.field(), blocks);
+                return block == null ? null : evaluateNotWildcardLike(wl, block, rowCount, intermediateMask, dictCache);
+            }
+            if (not.field() instanceof StartsWith sw) {
+                Block block = namedBlock(sw.singleValueField(), blocks);
+                return block == null ? null : evaluateNotStartsWith(sw, block, rowCount, intermediateMask, dictCache);
+            }
+            if (not.field() instanceof Contains c) {
+                Block block = namedBlock(c.singleValueField(), blocks);
+                return block == null ? null : evaluateNotContains(c, block, rowCount, intermediateMask, dictCache);
+            }
+            if (not.field() instanceof EndsWith ew) {
+                Block block = namedBlock(ew.singleValueField(), blocks);
+                return block == null ? null : evaluateNotEndsWith(ew, block, rowCount, intermediateMask, dictCache);
             }
             WordMask inner = evaluateExpression(not.field(), blocks, rowCount, intermediateMask, dictCache);
             if (inner != null) {
@@ -893,19 +908,34 @@ final class ParquetPushedExpressions {
             }
             return null;
         }
-        if (expr instanceof StartsWith sw && sw.singleValueField() instanceof NamedExpression ne) {
-            Block block = blocks.get(ne.name());
-            if (block == null) {
-                return null;
-            }
-            return evaluateStartsWith(sw, block, rowCount, intermediateMask, dictCache);
+        if (expr instanceof StartsWith sw) {
+            Block block = namedBlock(sw.singleValueField(), blocks);
+            return block == null ? null : evaluateStartsWith(sw, block, rowCount, intermediateMask, dictCache);
         }
-        if (expr instanceof WildcardLike wl && wl.field() instanceof NamedExpression ne) {
-            Block block = blocks.get(ne.name());
-            if (block == null) {
-                return null;
-            }
-            return evaluateWildcardLike(wl, block, rowCount, intermediateMask, dictCache);
+        if (expr instanceof Contains c) {
+            Block block = namedBlock(c.singleValueField(), blocks);
+            return block == null ? null : evaluateContains(c, block, rowCount, intermediateMask, dictCache);
+        }
+        if (expr instanceof EndsWith ew) {
+            Block block = namedBlock(ew.singleValueField(), blocks);
+            return block == null ? null : evaluateEndsWith(ew, block, rowCount, intermediateMask, dictCache);
+        }
+        if (expr instanceof WildcardLike wl) {
+            Block block = namedBlock(wl.field(), blocks);
+            return block == null ? null : evaluateWildcardLike(wl, block, rowCount, intermediateMask, dictCache);
+        }
+        return null;
+    }
+
+    /**
+     * Returns the {@link Block} mapped from {@code field}'s column name, or {@code null} when
+     * {@code field} is not a {@link NamedExpression} or no block is registered. Centralises the
+     * "field-as-name → block" dispatch idiom used by every per-predicate branch above.
+     */
+    @Nullable
+    private static Block namedBlock(Expression field, Map<String, Block> blocks) {
+        if (field instanceof NamedExpression ne) {
+            return blocks.get(ne.name());
         }
         return null;
     }
@@ -1194,15 +1224,69 @@ final class ParquetPushedExpressions {
         // x86 (AVX2/AVX-512) and ARM (NEON) with partial-inlining for sizes <= 64 bytes — typical
         // URL/path prefixes ("https://", "https://www.") fit comfortably in that fast path. The
         // helper performs the length pre-check internally.
+        return evaluateLiteralPredicate(sw, block, rowCount, intermediateMask, dictCache, entry -> ByteMatchers.startsWith(entry, prefix));
+    }
+
+    private static WordMask evaluateEndsWith(
+        EndsWith ew,
+        Block block,
+        int rowCount,
+        @Nullable WordMask intermediateMask,
+        @Nullable Map<Expression, boolean[]> dictCache
+    ) {
+        Object suffixValue = literalValueOf(ew.suffix());
+        if (suffixValue == null) {
+            return null;
+        }
+        BytesRef suffix = toByteRef(suffixValue);
+        return evaluateLiteralPredicate(ew, block, rowCount, intermediateMask, dictCache, entry -> ByteMatchers.endsWith(entry, suffix));
+    }
+
+    private static WordMask evaluateContains(
+        Contains c,
+        Block block,
+        int rowCount,
+        @Nullable WordMask intermediateMask,
+        @Nullable Map<Expression, boolean[]> dictCache
+    ) {
+        Object substrValue = literalValueOf(c.substr());
+        if (substrValue == null) {
+            return null;
+        }
+        BytesRef literal = toByteRef(substrValue);
+        return evaluateLiteralPredicate(
+            c,
+            block,
+            rowCount,
+            intermediateMask,
+            dictCache,
+            entry -> ByteMatchers.containsLiteral(entry, literal)
+        );
+    }
+
+    /**
+     * Shared mask-builder for the LIKE-family literal predicates (StartsWith, EndsWith, Contains).
+     * The dictionary path ignores {@code intermediateMask}, the scalar path honors it (same
+     * contract as evaluateWildcardLike).
+     *
+     * <p><b>Cache key.</b> {@code expr} is used as an <em>identity</em> key in {@code dictCache}
+     * (intentional, matching the WildcardLike path): two structurally-equal but distinct
+     * expression instances get separate cache slots. Switching to value-equality keying would
+     * be correctness-safe but is a deliberate non-goal — it would couple cache reuse to ESQL
+     * expression equality semantics, which evolve independently of this evaluator.
+     */
+    private static WordMask evaluateLiteralPredicate(
+        Expression expr,
+        Block block,
+        int rowCount,
+        @Nullable WordMask intermediateMask,
+        @Nullable Map<Expression, boolean[]> dictCache,
+        Predicate<BytesRef> matcher
+    ) {
         if (block instanceof OrdinalBytesRefBlock obb && shouldShortCircuitOnDictionary(obb)) {
             WordMask mask = new WordMask();
             mask.reset(rowCount);
-            boolean[] dictMatches = memoizedDictionaryMatches(
-                dictCache,
-                sw,
-                obb.getDictionaryVector(),
-                entry -> ByteMatchers.startsWith(entry, prefix)
-            );
+            boolean[] dictMatches = memoizedDictionaryMatches(dictCache, expr, obb.getDictionaryVector(), matcher);
             applyDictionaryMatches(obb, dictMatches, mask, rowCount);
             return mask;
         }
@@ -1216,7 +1300,7 @@ final class ParquetPushedExpressions {
                 }
                 if (block.isNull(i) == false) {
                     BytesRef val = bb.getBytesRef(i, scratch);
-                    if (ByteMatchers.startsWith(val, prefix)) {
+                    if (matcher.test(val)) {
                         mask.set(i);
                     }
                 }
@@ -1224,6 +1308,32 @@ final class ParquetPushedExpressions {
             return mask;
         }
         return null;
+    }
+
+    /**
+     * Adds TVL-correct null handling to an already-computed match mask from a LIKE-family
+     * predicate, then negates. Shared by {@code NOT (Contains)} and {@code NOT (EndsWith)};
+     * {@link #evaluateNotWildcardLike} inlines the same algorithm. Returns {@code null} when
+     * {@code likeMask} is {@code null} (block type unsupported), preserving the conservative
+     * "all rows survive" sentinel.
+     */
+    @Nullable
+    private static WordMask tvlNegate(@Nullable WordMask likeMask, Block block, int rowCount) {
+        if (likeMask == null) {
+            return null;
+        }
+        // Set bit i for null rows so the subsequent negate turns them into 0 (filtered out).
+        // mayHaveNulls() is a cheap pre-check that lets the all-non-nulls common case skip
+        // the per-row scan; matches the WildcardLike scalar path.
+        if (block.mayHaveNulls()) {
+            for (int i = 0; i < rowCount; i++) {
+                if (block.isNull(i)) {
+                    likeMask.set(i);
+                }
+            }
+        }
+        likeMask.negate();
+        return likeMask;
     }
 
     /**
@@ -1347,6 +1457,10 @@ final class ParquetPushedExpressions {
      * automaton build only throws {@code TooComplexToDeterminize} for pathological patterns
      * far beyond {@code "*google*"}). If a future change broadens the YES-eligible set, this
      * contract must be revisited.
+     *
+     * <p>Unlike {@link #evaluateNotContains} / {@link #evaluateNotEndsWith}, this method is an
+     * instance method because it delegates to {@link #evaluateWildcardLike}, which reads the
+     * per-instance automaton/affix cache populated by {@link #automatonFor(WildcardLike)}.
      */
     private WordMask evaluateNotWildcardLike(
         WildcardLike wl,
@@ -1355,22 +1469,37 @@ final class ParquetPushedExpressions {
         @Nullable WordMask intermediateMask,
         @Nullable Map<Expression, boolean[]> dictCache
     ) {
-        WordMask likeMask = evaluateWildcardLike(wl, block, rowCount, intermediateMask, dictCache);
-        if (likeMask == null) {
-            return null;
-        }
-        // Set bit i for null rows so the subsequent negate turns them into 0 (filtered out).
-        // mayHaveNulls() is a cheap pre-check that lets the all-non-nulls common case skip
-        // the per-row scan; matches the WildcardLike scalar path.
-        if (block.mayHaveNulls()) {
-            for (int i = 0; i < rowCount; i++) {
-                if (block.isNull(i)) {
-                    likeMask.set(i);
-                }
-            }
-        }
-        likeMask.negate();
-        return likeMask;
+        return tvlNegate(evaluateWildcardLike(wl, block, rowCount, intermediateMask, dictCache), block, rowCount);
+    }
+
+    private static WordMask evaluateNotStartsWith(
+        StartsWith sw,
+        Block block,
+        int rowCount,
+        @Nullable WordMask intermediateMask,
+        @Nullable Map<Expression, boolean[]> dictCache
+    ) {
+        return tvlNegate(evaluateStartsWith(sw, block, rowCount, intermediateMask, dictCache), block, rowCount);
+    }
+
+    private static WordMask evaluateNotContains(
+        Contains c,
+        Block block,
+        int rowCount,
+        @Nullable WordMask intermediateMask,
+        @Nullable Map<Expression, boolean[]> dictCache
+    ) {
+        return tvlNegate(evaluateContains(c, block, rowCount, intermediateMask, dictCache), block, rowCount);
+    }
+
+    private static WordMask evaluateNotEndsWith(
+        EndsWith ew,
+        Block block,
+        int rowCount,
+        @Nullable WordMask intermediateMask,
+        @Nullable Map<Expression, boolean[]> dictCache
+    ) {
+        return tvlNegate(evaluateEndsWith(ew, block, rowCount, intermediateMask, dictCache), block, rowCount);
     }
 
     /**

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFilterPushdownSupportTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFilterPushdownSupportTests.java
@@ -17,6 +17,8 @@ import org.elasticsearch.xpack.esql.core.expression.predicate.regex.WildcardPatt
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.datasources.spi.FilterPushdownSupport;
+import org.elasticsearch.xpack.esql.expression.function.scalar.string.Contains;
+import org.elasticsearch.xpack.esql.expression.function.scalar.string.EndsWith;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.StartsWith;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.regex.WildcardLike;
 import org.elasticsearch.xpack.esql.expression.predicate.Range;
@@ -621,14 +623,27 @@ public class ParquetFilterPushdownSupportTests extends ESTestCase {
 
     // --- StartsWith tests ---
 
-    public void testStartsWithKeywordPushed() {
+    public void testStartsWithKeywordPushedAsYes() {
         Attribute col = attr("name", DataType.KEYWORD);
         Expression filter = new StartsWith(Source.EMPTY, col, keywordLit("alice"));
 
         FilterPushdownSupport.PushdownResult result = support.pushFilters(List.of(filter));
 
         assertTrue(result.hasPushedFilter());
-        assertEquals(1, result.remainder().size());
+        assertEquals(FilterPushdownSupport.Pushability.YES, support.canPush(filter));
+        assertEquals("StartsWith must be dropped from the remainder under YES", 0, result.remainder().size());
+    }
+
+    public void testStartsWithNegatedPushedAsYes() {
+        Attribute col = attr("name", DataType.KEYWORD);
+        Expression sw = new StartsWith(Source.EMPTY, col, keywordLit("alice"));
+        Expression filter = new Not(Source.EMPTY, sw);
+
+        FilterPushdownSupport.PushdownResult result = support.pushFilters(List.of(filter));
+
+        assertTrue(result.hasPushedFilter());
+        assertEquals(FilterPushdownSupport.Pushability.YES, support.canPush(filter));
+        assertEquals(0, result.remainder().size());
     }
 
     public void testStartsWithNonKeywordNotPushed() {
@@ -855,6 +870,164 @@ public class ParquetFilterPushdownSupportTests extends ESTestCase {
         assertTrue(result.hasPushedFilter());
         assertEquals(FilterPushdownSupport.Pushability.YES, support.canPush(filter));
         assertEquals(0, result.remainder().size());
+    }
+
+    // --- Contains tests ---
+
+    public void testContainsKeywordPushedAsYes() {
+        Attribute col = attr("url", DataType.KEYWORD);
+        Expression filter = new Contains(Source.EMPTY, col, keywordLit("google"));
+
+        FilterPushdownSupport.PushdownResult result = support.pushFilters(List.of(filter));
+
+        assertTrue(result.hasPushedFilter());
+        assertEquals(FilterPushdownSupport.Pushability.YES, support.canPush(filter));
+        assertEquals("Contains must be dropped from the remainder under YES", 0, result.remainder().size());
+    }
+
+    public void testContainsNegatedPushedAsYes() {
+        Attribute col = attr("url", DataType.KEYWORD);
+        Expression c = new Contains(Source.EMPTY, col, keywordLit("google"));
+        Expression filter = new Not(Source.EMPTY, c);
+
+        FilterPushdownSupport.PushdownResult result = support.pushFilters(List.of(filter));
+
+        assertTrue(result.hasPushedFilter());
+        assertEquals(FilterPushdownSupport.Pushability.YES, support.canPush(filter));
+        assertEquals(0, result.remainder().size());
+    }
+
+    public void testContainsNonKeywordNotPushed() {
+        Attribute col = attr("age", DataType.INTEGER);
+        Expression filter = new Contains(Source.EMPTY, col, intLit(10));
+
+        assertFalse(ParquetFilterPushdownSupport.canConvert(filter));
+    }
+
+    public void testContainsNonFoldableNotPushed() {
+        // CONTAINS(field, other_field) — non-literal substring stays on FilterExec.
+        Attribute col = attr("name", DataType.KEYWORD);
+        Attribute other = attr("substring", DataType.KEYWORD);
+        Expression filter = new Contains(Source.EMPTY, col, other);
+
+        assertFalse(ParquetFilterPushdownSupport.canConvert(filter));
+    }
+
+    public void testContainsNullSubstrNotPushed() {
+        Attribute col = attr("name", DataType.KEYWORD);
+        Expression filter = new Contains(Source.EMPTY, col, new Literal(Source.EMPTY, null, DataType.KEYWORD));
+
+        FilterPushdownSupport.PushdownResult result = support.pushFilters(List.of(filter));
+
+        assertFalse(result.hasPushedFilter());
+    }
+
+    public void testContainsOnVirtualAttributeIsNotPushed() {
+        Attribute virtual = virtualAttr("_file.name", DataType.KEYWORD);
+        Expression filter = new Contains(Source.EMPTY, virtual, keywordLit("foo"));
+        assertEquals(FilterPushdownSupport.Pushability.NO, support.canPush(filter));
+    }
+
+    public void testContainsAndEqualsAsSeparateConjuncts() {
+        Attribute url = attr("url", DataType.KEYWORD);
+        Attribute status = attr("status", DataType.LONG);
+        Expression c = new Contains(Source.EMPTY, url, keywordLit("google"));
+        Expression statusEq = new Equals(Source.EMPTY, status, longLit(200L), null);
+
+        FilterPushdownSupport.PushdownResult result = support.pushFilters(List.of(c, statusEq));
+
+        assertTrue(result.hasPushedFilter());
+        assertEquals(FilterPushdownSupport.Pushability.YES, support.canPush(c));
+        assertEquals(FilterPushdownSupport.Pushability.RECHECK, support.canPush(statusEq));
+        assertEquals("Contains must be dropped from remainder; only status = 200 RECHECK remains", 1, result.remainder().size());
+        assertTrue("remainder must be the status = 200 conjunct", result.remainder().contains(statusEq));
+        assertFalse("remainder must not contain the Contains conjunct", result.remainder().contains(c));
+    }
+
+    // --- EndsWith tests ---
+
+    public void testEndsWithKeywordPushedAsYes() {
+        Attribute col = attr("path", DataType.KEYWORD);
+        Expression filter = new EndsWith(Source.EMPTY, col, keywordLit(".log"));
+
+        FilterPushdownSupport.PushdownResult result = support.pushFilters(List.of(filter));
+
+        assertTrue(result.hasPushedFilter());
+        assertEquals(FilterPushdownSupport.Pushability.YES, support.canPush(filter));
+        assertEquals("EndsWith must be dropped from the remainder under YES", 0, result.remainder().size());
+    }
+
+    public void testEndsWithNegatedPushedAsYes() {
+        Attribute col = attr("path", DataType.KEYWORD);
+        Expression ew = new EndsWith(Source.EMPTY, col, keywordLit(".log"));
+        Expression filter = new Not(Source.EMPTY, ew);
+
+        FilterPushdownSupport.PushdownResult result = support.pushFilters(List.of(filter));
+
+        assertTrue(result.hasPushedFilter());
+        assertEquals(FilterPushdownSupport.Pushability.YES, support.canPush(filter));
+        assertEquals(0, result.remainder().size());
+    }
+
+    public void testEndsWithNonKeywordNotPushed() {
+        Attribute col = attr("age", DataType.INTEGER);
+        Expression filter = new EndsWith(Source.EMPTY, col, intLit(10));
+
+        assertFalse(ParquetFilterPushdownSupport.canConvert(filter));
+    }
+
+    public void testEndsWithNonFoldableNotPushed() {
+        Attribute col = attr("name", DataType.KEYWORD);
+        Attribute other = attr("suffix", DataType.KEYWORD);
+        Expression filter = new EndsWith(Source.EMPTY, col, other);
+
+        assertFalse(ParquetFilterPushdownSupport.canConvert(filter));
+    }
+
+    public void testEndsWithNullSuffixNotPushed() {
+        Attribute col = attr("name", DataType.KEYWORD);
+        Expression filter = new EndsWith(Source.EMPTY, col, new Literal(Source.EMPTY, null, DataType.KEYWORD));
+
+        FilterPushdownSupport.PushdownResult result = support.pushFilters(List.of(filter));
+
+        assertFalse(result.hasPushedFilter());
+    }
+
+    public void testEndsWithOnVirtualAttributeIsNotPushed() {
+        Attribute virtual = virtualAttr("_file.name", DataType.KEYWORD);
+        Expression filter = new EndsWith(Source.EMPTY, virtual, keywordLit(".log"));
+        assertEquals(FilterPushdownSupport.Pushability.NO, support.canPush(filter));
+    }
+
+    public void testNotOverAndOfContainsAndEndsWithIsRecheck() {
+        // See testNotOverAndOfWildcardLikesIsRecheck — same TVL reason.
+        Attribute url = attr("url", DataType.KEYWORD);
+        Attribute path = attr("path", DataType.KEYWORD);
+        Expression c = new Contains(Source.EMPTY, url, keywordLit("google"));
+        Expression ew = new EndsWith(Source.EMPTY, path, keywordLit(".log"));
+        Expression notAnd = new Not(Source.EMPTY, new And(Source.EMPTY, c, ew));
+
+        assertEquals(FilterPushdownSupport.Pushability.RECHECK, support.canPush(notAnd));
+
+        FilterPushdownSupport.PushdownResult result = support.pushFilters(List.of(notAnd));
+        assertTrue(result.hasPushedFilter());
+        assertEquals("RECHECK keeps the conjunct in remainder so FilterExec re-applies", 1, result.remainder().size());
+    }
+
+    public void testEndsWithAndEqualsAsSeparateConjuncts() {
+        Attribute path = attr("path", DataType.KEYWORD);
+        Attribute status = attr("status", DataType.LONG);
+        Expression ew = new EndsWith(Source.EMPTY, path, keywordLit(".log"));
+        Expression statusEq = new Equals(Source.EMPTY, status, longLit(200L), null);
+
+        FilterPushdownSupport.PushdownResult result = support.pushFilters(List.of(ew, statusEq));
+
+        assertTrue(result.hasPushedFilter());
+        assertEquals(FilterPushdownSupport.Pushability.YES, support.canPush(ew));
+        assertEquals(FilterPushdownSupport.Pushability.RECHECK, support.canPush(statusEq));
+        assertEquals("EndsWith must be dropped from remainder; only status = 200 RECHECK remains", 1, result.remainder().size());
+        assertTrue("remainder must be the status = 200 conjunct", result.remainder().contains(statusEq));
+        assertFalse("remainder must not contain the EndsWith conjunct", result.remainder().contains(ew));
     }
 
     // --- Virtual column tests ---

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressionsEvaluatorTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressionsEvaluatorTests.java
@@ -23,6 +23,8 @@ import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.expression.predicate.regex.WildcardPattern;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.function.scalar.string.Contains;
+import org.elasticsearch.xpack.esql.expression.function.scalar.string.EndsWith;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.StartsWith;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.regex.WildcardLike;
 import org.elasticsearch.xpack.esql.expression.predicate.Range;
@@ -840,6 +842,354 @@ public class ParquetPushedExpressionsEvaluatorTests extends ESTestCase {
             Expression sw = new StartsWith(Source.EMPTY, attr("s", DataType.KEYWORD), lit(new BytesRef("hello_world"), DataType.KEYWORD));
             assertSurvivors(new ParquetPushedExpressions(List.of(sw)), blocks, 2, reusable, new int[] {});
         }
+    }
+
+    public void testNotStartsWithExcludesNulls() {
+        // TVL: NOT(NULL STARTS_WITH x) is UNKNOWN -> null row must NOT survive.
+        try (var builder = blockFactory.newBytesRefBlockBuilder(4)) {
+            builder.appendBytesRef(new BytesRef("apple"));
+            builder.appendNull();
+            builder.appendBytesRef(new BytesRef("banana"));
+            builder.appendBytesRef(new BytesRef("application"));
+            Block block = builder.build();
+            Map<String, Block> blocks = Map.of("s", block);
+            WordMask reusable = new WordMask();
+
+            Expression notSw = new Not(
+                Source.EMPTY,
+                new StartsWith(Source.EMPTY, attr("s", DataType.KEYWORD), lit(new BytesRef("app"), DataType.KEYWORD))
+            );
+            // Survivors: "banana" (index 2). "apple" and "application" match the predicate; null is UNKNOWN.
+            assertSurvivors(new ParquetPushedExpressions(List.of(notSw)), blocks, 4, reusable, new int[] { 2 });
+        }
+    }
+
+    // ---- EndsWith ----
+
+    public void testEndsWithBasic() {
+        // Block: ["apple", "pineapple", "banana"]
+        try (var builder = blockFactory.newBytesRefBlockBuilder(3)) {
+            builder.appendBytesRef(new BytesRef("apple"));
+            builder.appendBytesRef(new BytesRef("pineapple"));
+            builder.appendBytesRef(new BytesRef("banana"));
+            Block block = builder.build();
+            Map<String, Block> blocks = Map.of("s", block);
+            WordMask reusable = new WordMask();
+
+            // ENDS_WITH(s, "apple") -> positions [0, 1]
+            Expression ew = new EndsWith(Source.EMPTY, attr("s", DataType.KEYWORD), lit(new BytesRef("apple"), DataType.KEYWORD));
+            assertSurvivors(new ParquetPushedExpressions(List.of(ew)), blocks, 3, reusable, new int[] { 0, 1 });
+        }
+    }
+
+    public void testEndsWithSuffixLongerThanValue() {
+        try (var builder = blockFactory.newBytesRefBlockBuilder(2)) {
+            builder.appendBytesRef(new BytesRef("hi"));
+            builder.appendBytesRef(new BytesRef("hey"));
+            Block block = builder.build();
+            Map<String, Block> blocks = Map.of("s", block);
+            WordMask reusable = new WordMask();
+
+            Expression ew = new EndsWith(Source.EMPTY, attr("s", DataType.KEYWORD), lit(new BytesRef("hello_world"), DataType.KEYWORD));
+            assertSurvivors(new ParquetPushedExpressions(List.of(ew)), blocks, 2, reusable, new int[] {});
+        }
+    }
+
+    public void testEndsWithNullValueDoesNotSurvive() {
+        try (var builder = blockFactory.newBytesRefBlockBuilder(3)) {
+            builder.appendBytesRef(new BytesRef("apple"));
+            builder.appendNull();
+            builder.appendBytesRef(new BytesRef("banana"));
+            Block block = builder.build();
+            Map<String, Block> blocks = Map.of("s", block);
+            WordMask reusable = new WordMask();
+
+            Expression ew = new EndsWith(Source.EMPTY, attr("s", DataType.KEYWORD), lit(new BytesRef("le"), DataType.KEYWORD));
+            assertSurvivors(new ParquetPushedExpressions(List.of(ew)), blocks, 3, reusable, new int[] { 0 });
+        }
+    }
+
+    public void testEndsWithOrdinalDictionaryShortCircuit() {
+        // Pinning the dictionary short-circuit path: pattern repeated to satisfy
+        // OrdinalBytesRefBlock#isDense (rows >= 2 * dictSize).
+        String[] dict = { "apple", "application", "banana", "pineapple" };
+        int[] pattern = { 0, 1, 2, 3, 0, 2 };
+        int[] ordinals = repeatPattern(pattern, 24);
+        Block block = ordinalBlock(dict, ordinals, null);
+        try (block) {
+            Map<String, Block> blocks = Map.of("s", block);
+            WordMask reusable = new WordMask();
+            // ENDS_WITH(s, "apple") matches dict entries 0 (apple) and 3 (pineapple)
+            int[] expected = positionsWithOrdinalIn(ordinals, 0, 3);
+            Expression ew = new EndsWith(Source.EMPTY, attr("s", DataType.KEYWORD), lit(new BytesRef("apple"), DataType.KEYWORD));
+            assertSurvivors(new ParquetPushedExpressions(List.of(ew)), blocks, ordinals.length, reusable, expected);
+        }
+    }
+
+    public void testEndsWithOrdinalAndScalarAgree() {
+        // Cross-check the dictionary short-circuit against the per-row scalar path.
+        // Mirrors testWildcardLikeOrdinalAndScalarAgree.
+        String[] dict = { "the", "quick", "brown", "fox.log", "jumps.tar.gz", "over.log", "lazy.dog" };
+        int rowCount = 200;
+        int[] randomOrdinals = new int[rowCount];
+        for (int i = 0; i < rowCount; i++) {
+            randomOrdinals[i] = randomIntBetween(0, dict.length - 1);
+        }
+        Block ordinalsBlock = ordinalBlock(dict, randomOrdinals, null);
+        Block plainBlock = plainBytesRefBlock(dict, randomOrdinals);
+        try (ordinalsBlock; plainBlock) {
+            Expression ew = new EndsWith(Source.EMPTY, attr("s", DataType.KEYWORD), lit(new BytesRef(".log"), DataType.KEYWORD));
+
+            WordMask ordinalMask = new ParquetPushedExpressions(List.of(ew)).evaluateFilter(
+                Map.of("s", ordinalsBlock),
+                rowCount,
+                new WordMask()
+            );
+            WordMask plainMask = new ParquetPushedExpressions(List.of(ew)).evaluateFilter(
+                Map.of("s", plainBlock),
+                rowCount,
+                new WordMask()
+            );
+            if (ordinalMask == null) {
+                assertNull("ordinal returned null (all survive); plain must also", plainMask);
+            } else {
+                assertNotNull("ordinal produced a mask; plain must too", plainMask);
+                assertArrayEquals(
+                    "EndsWith ordinal and plain masks must agree",
+                    plainMask.survivingPositions(),
+                    ordinalMask.survivingPositions()
+                );
+            }
+        }
+    }
+
+    public void testNotEndsWithOnOrdinalDictionaryAgreesWithScalar() {
+        // NOT(EndsWith) on an OrdinalBytesRefBlock with null rows must agree with the per-row
+        // scalar path: dictionary scatter + ordinal-mode null fixup must produce the same
+        // TVL-correct survivor mask as the scalar loop. Mirrors
+        // testWildcardLikeContainsLiteralNotOnOrdinalDictionaryAgreesWithAutomaton.
+        String[] dict = { "apple", "application", "banana", "pineapple" };
+        int[] pattern = { 0, 1, 2, 3, 0, 2 };
+        int[] ordinals = repeatPattern(pattern, 24);
+        boolean[] nulls = repeatBoolPattern(new boolean[] { false, true, false, false, false, true }, 24);
+        Block ordinalsBlock = ordinalBlock(dict, ordinals, nulls);
+        // Build the equivalent plain block (with nulls) to compare against.
+        try (var plainBuilder = blockFactory.newBytesRefBlockBuilder(ordinals.length)) {
+            for (int i = 0; i < ordinals.length; i++) {
+                if (nulls[i]) {
+                    plainBuilder.appendNull();
+                } else {
+                    plainBuilder.appendBytesRef(new BytesRef(dict[ordinals[i]]));
+                }
+            }
+            Block plainBlock = plainBuilder.build();
+            try (ordinalsBlock; plainBlock) {
+                Expression notEw = new Not(
+                    Source.EMPTY,
+                    new EndsWith(Source.EMPTY, attr("s", DataType.KEYWORD), lit(new BytesRef("apple"), DataType.KEYWORD))
+                );
+
+                WordMask ordinalMask = new ParquetPushedExpressions(List.of(notEw)).evaluateFilter(
+                    Map.of("s", ordinalsBlock),
+                    ordinals.length,
+                    new WordMask()
+                );
+                WordMask plainMask = new ParquetPushedExpressions(List.of(notEw)).evaluateFilter(
+                    Map.of("s", plainBlock),
+                    ordinals.length,
+                    new WordMask()
+                );
+                if (ordinalMask == null) {
+                    assertNull("ordinal returned null (all survive); plain must also", plainMask);
+                } else {
+                    assertNotNull("ordinal produced a mask; plain must too", plainMask);
+                    assertArrayEquals(
+                        "NOT(EndsWith) ordinal and plain masks must agree under TVL",
+                        plainMask.survivingPositions(),
+                        ordinalMask.survivingPositions()
+                    );
+                }
+            }
+        }
+    }
+
+    public void testNotEndsWithExcludesNulls() {
+        // TVL: NOT(NULL ENDS_WITH x) is UNKNOWN -> null row must NOT survive.
+        try (var builder = blockFactory.newBytesRefBlockBuilder(4)) {
+            builder.appendBytesRef(new BytesRef("apple"));
+            builder.appendNull();
+            builder.appendBytesRef(new BytesRef("banana"));
+            builder.appendBytesRef(new BytesRef("pineapple"));
+            Block block = builder.build();
+            Map<String, Block> blocks = Map.of("s", block);
+            WordMask reusable = new WordMask();
+
+            Expression notEw = new Not(
+                Source.EMPTY,
+                new EndsWith(Source.EMPTY, attr("s", DataType.KEYWORD), lit(new BytesRef("apple"), DataType.KEYWORD))
+            );
+            // Survivors: "banana" (index 2). "apple" and "pineapple" match the predicate; null is UNKNOWN.
+            assertSurvivors(new ParquetPushedExpressions(List.of(notEw)), blocks, 4, reusable, new int[] { 2 });
+        }
+    }
+
+    // ---- Contains ----
+
+    public void testContainsBasic() {
+        // Block: ["apple", "pineapple", "banana"]
+        try (var builder = blockFactory.newBytesRefBlockBuilder(3)) {
+            builder.appendBytesRef(new BytesRef("apple"));
+            builder.appendBytesRef(new BytesRef("pineapple"));
+            builder.appendBytesRef(new BytesRef("banana"));
+            Block block = builder.build();
+            Map<String, Block> blocks = Map.of("s", block);
+            WordMask reusable = new WordMask();
+
+            // CONTAINS(s, "app") -> positions [0, 1] ("apple" and "pineapple")
+            Expression c = new Contains(Source.EMPTY, attr("s", DataType.KEYWORD), lit(new BytesRef("app"), DataType.KEYWORD));
+            assertSurvivors(new ParquetPushedExpressions(List.of(c)), blocks, 3, reusable, new int[] { 0, 1 });
+        }
+    }
+
+    public void testContainsSubstrLongerThanValue() {
+        try (var builder = blockFactory.newBytesRefBlockBuilder(2)) {
+            builder.appendBytesRef(new BytesRef("hi"));
+            builder.appendBytesRef(new BytesRef("hey"));
+            Block block = builder.build();
+            Map<String, Block> blocks = Map.of("s", block);
+            WordMask reusable = new WordMask();
+
+            Expression c = new Contains(Source.EMPTY, attr("s", DataType.KEYWORD), lit(new BytesRef("hello_world"), DataType.KEYWORD));
+            assertSurvivors(new ParquetPushedExpressions(List.of(c)), blocks, 2, reusable, new int[] {});
+        }
+    }
+
+    public void testContainsNullValueDoesNotSurvive() {
+        try (var builder = blockFactory.newBytesRefBlockBuilder(3)) {
+            builder.appendBytesRef(new BytesRef("apple"));
+            builder.appendNull();
+            builder.appendBytesRef(new BytesRef("banana"));
+            Block block = builder.build();
+            Map<String, Block> blocks = Map.of("s", block);
+            WordMask reusable = new WordMask();
+
+            Expression c = new Contains(Source.EMPTY, attr("s", DataType.KEYWORD), lit(new BytesRef("an"), DataType.KEYWORD));
+            // "apple" does not contain "an"; "banana" does; null does not survive.
+            assertSurvivors(new ParquetPushedExpressions(List.of(c)), blocks, 3, reusable, new int[] { 2 });
+        }
+    }
+
+    public void testContainsOrdinalDictionaryShortCircuit() {
+        // Dictionary mixing long entries (above SIMD activation threshold) and short ones —
+        // mirrors testWildcardLikeContainsLiteralOrdinalDictionaryAgreesWithAutomaton.
+        String[] dict = {
+            "https://www.google.com/search?q=elasticsearch",
+            "https://www.bing.com/search?q=opensearch",
+            "https://duckduckgo.com/?q=lucene",
+            "https://www.google.com/maps/place/London",
+            "google" };
+        int rowCount = 200;
+        int[] randomOrdinals = new int[rowCount];
+        for (int i = 0; i < rowCount; i++) {
+            randomOrdinals[i] = randomIntBetween(0, dict.length - 1);
+        }
+        Block ordinalsBlock = ordinalBlock(dict, randomOrdinals, null);
+        Block plainBlock = plainBytesRefBlock(dict, randomOrdinals);
+        try (ordinalsBlock; plainBlock) {
+            Expression c = new Contains(Source.EMPTY, attr("s", DataType.KEYWORD), lit(new BytesRef("google"), DataType.KEYWORD));
+
+            WordMask ordinalMask = new ParquetPushedExpressions(List.of(c)).evaluateFilter(
+                Map.of("s", ordinalsBlock),
+                rowCount,
+                new WordMask()
+            );
+            WordMask plainMask = new ParquetPushedExpressions(List.of(c)).evaluateFilter(Map.of("s", plainBlock), rowCount, new WordMask());
+            if (ordinalMask == null) {
+                assertNull("ordinal returned null (all survive); plain must also", plainMask);
+            } else {
+                assertNotNull("ordinal produced a mask; plain must too", plainMask);
+                assertArrayEquals(plainMask.survivingPositions(), ordinalMask.survivingPositions());
+            }
+        }
+    }
+
+    public void testNotContainsOnOrdinalDictionaryAgreesWithScalar() {
+        // NOT(Contains) on an OrdinalBytesRefBlock with null rows must agree with the per-row
+        // scalar path under TVL.
+        String[] dict = { "apple", "application", "banana", "pineapple" };
+        int[] pattern = { 0, 1, 2, 3, 0, 2 };
+        int[] ordinals = repeatPattern(pattern, 24);
+        boolean[] nulls = repeatBoolPattern(new boolean[] { false, true, false, false, false, true }, 24);
+        Block ordinalsBlock = ordinalBlock(dict, ordinals, nulls);
+        try (var plainBuilder = blockFactory.newBytesRefBlockBuilder(ordinals.length)) {
+            for (int i = 0; i < ordinals.length; i++) {
+                if (nulls[i]) {
+                    plainBuilder.appendNull();
+                } else {
+                    plainBuilder.appendBytesRef(new BytesRef(dict[ordinals[i]]));
+                }
+            }
+            Block plainBlock = plainBuilder.build();
+            try (ordinalsBlock; plainBlock) {
+                Expression notC = new Not(
+                    Source.EMPTY,
+                    new Contains(Source.EMPTY, attr("s", DataType.KEYWORD), lit(new BytesRef("app"), DataType.KEYWORD))
+                );
+
+                WordMask ordinalMask = new ParquetPushedExpressions(List.of(notC)).evaluateFilter(
+                    Map.of("s", ordinalsBlock),
+                    ordinals.length,
+                    new WordMask()
+                );
+                WordMask plainMask = new ParquetPushedExpressions(List.of(notC)).evaluateFilter(
+                    Map.of("s", plainBlock),
+                    ordinals.length,
+                    new WordMask()
+                );
+                if (ordinalMask == null) {
+                    assertNull("ordinal returned null (all survive); plain must also", plainMask);
+                } else {
+                    assertNotNull("ordinal produced a mask; plain must too", plainMask);
+                    assertArrayEquals(
+                        "NOT(Contains) ordinal and plain masks must agree under TVL",
+                        plainMask.survivingPositions(),
+                        ordinalMask.survivingPositions()
+                    );
+                }
+            }
+        }
+    }
+
+    public void testNotContainsExcludesNulls() {
+        // TVL: NOT(NULL CONTAINS x) is UNKNOWN -> null row must NOT survive.
+        try (var builder = blockFactory.newBytesRefBlockBuilder(4)) {
+            builder.appendBytesRef(new BytesRef("apple"));
+            builder.appendNull();
+            builder.appendBytesRef(new BytesRef("banana"));
+            builder.appendBytesRef(new BytesRef("pineapple"));
+            Block block = builder.build();
+            Map<String, Block> blocks = Map.of("s", block);
+            WordMask reusable = new WordMask();
+
+            Expression notC = new Not(
+                Source.EMPTY,
+                new Contains(Source.EMPTY, attr("s", DataType.KEYWORD), lit(new BytesRef("app"), DataType.KEYWORD))
+            );
+            // "banana" is the only non-null row that does not contain "app"; null is UNKNOWN.
+            assertSurvivors(new ParquetPushedExpressions(List.of(notC)), blocks, 4, reusable, new int[] { 2 });
+        }
+    }
+
+    public void testContainsPredicateColumnNamesIncludesField() {
+        Expression c = new Contains(Source.EMPTY, attr("url", DataType.KEYWORD), lit(new BytesRef("google"), DataType.KEYWORD));
+        ParquetPushedExpressions pushed = new ParquetPushedExpressions(List.of(c));
+        assertEquals(java.util.Set.of("url"), pushed.predicateColumnNames());
+    }
+
+    public void testEndsWithPredicateColumnNamesIncludesField() {
+        Expression ew = new EndsWith(Source.EMPTY, attr("path", DataType.KEYWORD), lit(new BytesRef(".log"), DataType.KEYWORD));
+        ParquetPushedExpressions pushed = new ParquetPushedExpressions(List.of(ew));
+        assertEquals(java.util.Set.of("path"), pushed.predicateColumnNames());
     }
 
     // ---- Test 8: Missing predicate column (null-constant block) ----

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressionsTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressionsTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.datasource.parquet;
 
+import org.apache.lucene.util.BytesRef;
 import org.apache.parquet.filter2.predicate.FilterPredicate;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
@@ -22,6 +23,7 @@ import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.expression.predicate.regex.WildcardPattern;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.function.scalar.string.StartsWith;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.regex.WildcardLike;
 import org.elasticsearch.xpack.esql.expression.predicate.Range;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.And;
@@ -424,6 +426,54 @@ public class ParquetPushedExpressionsTests extends ESTestCase {
         ParquetPushedExpressions pushed = new ParquetPushedExpressions(List.of());
         MessageType schema = Types.buildMessage().required(INT64).named("status").named("schema");
         assertFalse("empty expression list has no YES conjuncts", pushed.hasYesConjunctOutsideFilterPredicate(schema));
+    }
+
+    public void testHasYesConjunctOutsideFilterPredicateBareStartsWith() {
+        // Bare StartsWith is YES-eligible AND translates to a prefix-range FilterPredicate, so
+        // it is NOT "outside" the predicate — the shortcut may still fire.
+        MessageType schema = Types.buildMessage()
+            .required(org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("url")
+            .named("schema");
+        Expression sw = new StartsWith(Source.EMPTY, attr("url", DataType.KEYWORD), lit(new BytesRef("https://"), DataType.KEYWORD));
+        ParquetPushedExpressions pushed = new ParquetPushedExpressions(List.of(sw));
+        assertFalse("bare StartsWith translates to a range FilterPredicate", pushed.hasYesConjunctOutsideFilterPredicate(schema));
+    }
+
+    public void testHasYesConjunctOutsideFilterPredicateNotStartsWith() {
+        // Not(StartsWith) is YES-eligible and exactly translatable (StartsWith is a leaf with a
+        // pure prefix-range FilterPredicate), so it pushes as FilterApi.not(range) and the
+        // trivially-passes shortcut stays enabled.
+        MessageType schema = Types.buildMessage()
+            .required(org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("url")
+            .named("schema");
+        Expression sw = new StartsWith(Source.EMPTY, attr("url", DataType.KEYWORD), lit(new BytesRef("https://"), DataType.KEYWORD));
+        Expression notSw = new Not(Source.EMPTY, sw);
+        ParquetPushedExpressions pushed = new ParquetPushedExpressions(List.of(notSw));
+        assertFalse(
+            "Not(StartsWith) is exactly translatable (pure leaf, no silent-drop hazard)",
+            pushed.hasYesConjunctOutsideFilterPredicate(schema)
+        );
+    }
+
+    public void testNotStartsWithTranslatesToFilterPredicate() {
+        // Asserts the actual FilterPredicate emitted for Not(StartsWith) is non-null and is a
+        // Not over the StartsWith range. Apache-mr internally expands NOT(range) into the
+        // canonical OR-of-comparators when applying row-group / page stats.
+        MessageType schema = Types.buildMessage()
+            .required(org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("url")
+            .named("schema");
+        Expression sw = new StartsWith(Source.EMPTY, attr("url", DataType.KEYWORD), lit(new BytesRef("/admin/"), DataType.KEYWORD));
+        Expression notSw = new Not(Source.EMPTY, sw);
+        ParquetPushedExpressions pushed = new ParquetPushedExpressions(List.of(notSw));
+        FilterPredicate fp = pushed.toFilterPredicate(schema);
+        assertNotNull("Not(StartsWith) must translate so row-group pruning can apply", fp);
+        assertThat(fp.toString(), containsString("not("));
     }
 
     // -----------------------------------------------------------------------------------

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetReaderFilterDifferentialTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetReaderFilterDifferentialTests.java
@@ -195,7 +195,7 @@ public class ParquetReaderFilterDifferentialTests extends ESTestCase {
     }
 
     public void testStartsWithKeyword() throws IOException {
-        // StartsWith pushes as RECHECK + translates to a prefix-range FilterPredicate.
+        // StartsWith pushes as YES + translates to a prefix-range FilterPredicate.
         // The reader must produce identical rows whether the row group is fully matched
         // (all URLs share the prefix) or partially.
         runDifferential(startsWith(URL, "https://google"));

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/pushdown/PushdownPredicates.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/pushdown/PushdownPredicates.java
@@ -12,6 +12,8 @@ import org.elasticsearch.xpack.esql.core.expression.MetadataAttribute;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.expression.VirtualAttribute;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.function.scalar.string.Contains;
+import org.elasticsearch.xpack.esql.expression.function.scalar.string.EndsWith;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.StartsWith;
 import org.elasticsearch.xpack.esql.expression.predicate.Range;
 import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNotNull;
@@ -147,5 +149,27 @@ public final class PushdownPredicates {
             && isVirtualColumn(ne) == false
             && typeSupported.test(ne.dataType())
             && sw.prefix().foldable();
+    }
+
+    /**
+     * Checks if an EndsWith expression can be pushed down: field is a single-value
+     * named expression with a supported data type, and the suffix is foldable.
+     */
+    public static boolean isEndsWith(EndsWith ew, Predicate<DataType> typeSupported) {
+        return ew.singleValueField() instanceof NamedExpression ne
+            && isVirtualColumn(ne) == false
+            && typeSupported.test(ne.dataType())
+            && ew.suffix().foldable();
+    }
+
+    /**
+     * Checks if a Contains expression can be pushed down: field is a single-value
+     * named expression with a supported data type, and the substring is foldable.
+     */
+    public static boolean isContains(Contains c, Predicate<DataType> typeSupported) {
+        return c.singleValueField() instanceof NamedExpression ne
+            && isVirtualColumn(ne) == false
+            && typeSupported.test(ne.dataType())
+            && c.substr().foldable();
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/Contains.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/Contains.java
@@ -11,12 +11,19 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.xpack.esql.capabilities.TranslationAware;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.xpack.esql.core.expression.FoldContext;
+import org.elasticsearch.xpack.esql.core.querydsl.query.Query;
+import org.elasticsearch.xpack.esql.core.querydsl.query.WildcardQuery;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.util.StringUtils;
 import org.elasticsearch.xpack.esql.expression.function.Example;
 import org.elasticsearch.xpack.esql.expression.function.FunctionAppliesTo;
 import org.elasticsearch.xpack.esql.expression.function.FunctionAppliesToLifecycle;
@@ -26,6 +33,8 @@ import org.elasticsearch.xpack.esql.expression.function.OptionalArgument;
 import org.elasticsearch.xpack.esql.expression.function.Param;
 import org.elasticsearch.xpack.esql.expression.function.scalar.EsqlScalarFunction;
 import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
+import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.LucenePushdownPredicates;
+import org.elasticsearch.xpack.esql.planner.TranslatorHandler;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -38,7 +47,7 @@ import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isStr
 /**
  * Contains function, given a string 'a' and a substring 'b', returns true if the substring 'b' is in 'a'.
  */
-public class Contains extends EsqlScalarFunction implements OptionalArgument {
+public class Contains extends EsqlScalarFunction implements OptionalArgument, TranslationAware.SingleValueTranslationAware {
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(Expression.class, "Contains", Contains::new);
     public static final FunctionDefinition DEFINITION = FunctionDefinition.def(Contains.class).binary(Contains::new).name("contains");
 
@@ -141,11 +150,32 @@ public class Contains extends EsqlScalarFunction implements OptionalArgument {
         return new ContainsEvaluator.Factory(source(), strExpr, substrExpr);
     }
 
-    Expression str() {
+    @Override
+    public Translatable translatable(LucenePushdownPredicates pushdownPredicates) {
+        return pushdownPredicates.isPushableAttribute(str) && substr.foldable() ? Translatable.YES : Translatable.NO;
+    }
+
+    @Override
+    public Query asQuery(LucenePushdownPredicates pushdownPredicates, TranslatorHandler handler) {
+        LucenePushdownPredicates.checkIsPushableAttribute(str);
+        var fieldName = handler.nameOf(str instanceof FieldAttribute fa ? fa.exactAttribute() : str);
+
+        // TODO: Get the real FoldContext here
+        var wildcardQuery = "*" + StringUtils.escapeWildcardLiteral(BytesRefs.toString(substr.fold(FoldContext.small()))) + "*";
+
+        return new WildcardQuery(source(), fieldName, wildcardQuery, false, pushdownPredicates.flags().stringLikeOnIndex());
+    }
+
+    @Override
+    public Expression singleValueField() {
         return str;
     }
 
-    Expression substr() {
+    public Expression str() {
+        return str;
+    }
+
+    public Expression substr() {
         return substr;
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/EndsWith.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/EndsWith.java
@@ -161,11 +161,11 @@ public class EndsWith extends EsqlScalarFunction implements TranslationAware.Sin
         return str;
     }
 
-    Expression str() {
+    public Expression str() {
         return str;
     }
 
-    Expression suffix() {
+    public Expression suffix() {
         return suffix;
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceRegexMatch.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceRegexMatch.java
@@ -14,6 +14,7 @@ import org.elasticsearch.xpack.esql.core.expression.predicate.regex.StringPatter
 import org.elasticsearch.xpack.esql.core.expression.predicate.regex.WildcardPattern;
 import org.elasticsearch.xpack.esql.core.util.StringUtils;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.ChangeCase;
+import org.elasticsearch.xpack.esql.expression.function.scalar.string.Contains;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.EndsWith;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.StartsWith;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.regex.WildcardLike;
@@ -81,6 +82,11 @@ public final class ReplaceRegexMatch extends OptimizerRules.OptimizerExpressionR
         String suffix = wp.extractSuffix();
         if (suffix != null && raw.equals("*" + StringUtils.escapeWildcardLiteral(suffix))) {
             return new EndsWith(wl.source(), wl.field(), Literal.keyword(wl.source(), suffix));
+        }
+        // Pure *literal* — escape-aware syntactic check via WildcardPattern.shape(); not reachable
+        // from the prefix/suffix branches above (those require single-star raw equality).
+        if (wp.shape() instanceof WildcardPattern.Shape.Contains contains) {
+            return new Contains(wl.source(), wl.field(), Literal.keyword(wl.source(), contains.literal()));
         }
         if (prefix != null) {
             return new And(wl.source(), new StartsWith(wl.source(), wl.field(), Literal.keyword(wl.source(), prefix)), wl);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/ContainsStaticTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/ContainsStaticTests.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.string;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.capabilities.TranslationAware;
+import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.querydsl.query.Query;
+import org.elasticsearch.xpack.esql.core.querydsl.query.WildcardQuery;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.type.EsField;
+import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.LucenePushdownPredicates;
+import org.elasticsearch.xpack.esql.planner.TranslatorHandler;
+import org.elasticsearch.xpack.esql.plugin.EsqlFlags;
+
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class ContainsStaticTests extends ESTestCase {
+    public void testLuceneQuery_AllLiterals_NonTranslatable() {
+        Contains function = new Contains(Source.EMPTY, Literal.keyword(Source.EMPTY, "test"), Literal.keyword(Source.EMPTY, "test"));
+
+        ESTestCase.assertThat(function.translatable(LucenePushdownPredicates.DEFAULT), equalTo(TranslationAware.Translatable.NO));
+    }
+
+    public void testLuceneQuery_NonFoldableSubstring_NonTranslatable() {
+        Contains function = new Contains(
+            Source.EMPTY,
+            new FieldAttribute(
+                Source.EMPTY,
+                "field",
+                new EsField("field", DataType.KEYWORD, Map.of(), true, EsField.TimeSeriesFieldType.NONE)
+            ),
+            new FieldAttribute(
+                Source.EMPTY,
+                "field",
+                new EsField("substring", DataType.KEYWORD, Map.of(), true, EsField.TimeSeriesFieldType.NONE)
+            )
+        );
+
+        assertThat(function.translatable(LucenePushdownPredicates.DEFAULT), equalTo(TranslationAware.Translatable.NO));
+    }
+
+    public void testLuceneQuery_FoldableSubstring_Translatable() {
+        Contains function = new Contains(
+            Source.EMPTY,
+            new FieldAttribute(
+                Source.EMPTY,
+                "field",
+                new EsField("field", DataType.KEYWORD, Map.of(), true, EsField.TimeSeriesFieldType.NONE)
+            ),
+            Literal.keyword(Source.EMPTY, "a*b?c\\")
+        );
+
+        assertThat(function.translatable(LucenePushdownPredicates.DEFAULT), equalTo(TranslationAware.Translatable.YES));
+
+        Query query = function.asQuery(LucenePushdownPredicates.DEFAULT, TranslatorHandler.TRANSLATOR_HANDLER);
+
+        assertThat(query, equalTo(new WildcardQuery(Source.EMPTY, "field", "*a\\*b\\?c\\\\*", false, true)));
+    }
+
+    public void testLuceneQuery_OnlyEscapesWildcardChars() {
+        // Characters that are special in Lucene query-parser syntax but NOT in wildcard syntax.
+        // QueryParser.escape would escape these, but our wildcard escaping must leave them untouched.
+        for (String ch : new String[] { "+", "-", "!", "(", ")", "^", "\"", "~", "/" }) {
+            Contains function = new Contains(
+                Source.EMPTY,
+                new FieldAttribute(
+                    Source.EMPTY,
+                    "field",
+                    new EsField("field", DataType.KEYWORD, Map.of(), true, EsField.TimeSeriesFieldType.NONE)
+                ),
+                Literal.keyword(Source.EMPTY, "k8s" + ch + "idx")
+            );
+
+            Query query = function.asQuery(LucenePushdownPredicates.DEFAULT, TranslatorHandler.TRANSLATOR_HANDLER);
+
+            assertThat(
+                "character '" + ch + "' must not be escaped",
+                query,
+                equalTo(new WildcardQuery(Source.EMPTY, "field", "*k8s" + ch + "idx*", false, true))
+            );
+        }
+    }
+
+    public void testLuceneQuery_StringLikeOnIndexFalse() {
+        Contains function = new Contains(
+            Source.EMPTY,
+            new FieldAttribute(
+                Source.EMPTY,
+                "field",
+                new EsField("field", DataType.KEYWORD, Map.of(), true, EsField.TimeSeriesFieldType.NONE)
+            ),
+            Literal.keyword(Source.EMPTY, "test")
+        );
+
+        var predicates = LucenePushdownPredicates.forCanMatch(null, new EsqlFlags(false));
+        Query query = function.asQuery(predicates, TranslatorHandler.TRANSLATOR_HANDLER);
+
+        assertThat(query, equalTo(new WildcardQuery(Source.EMPTY, "field", "*test*", false, false)));
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceRegexMatchTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceRegexMatchTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.xpack.esql.core.expression.predicate.regex.RLikePattern
 import org.elasticsearch.xpack.esql.core.expression.predicate.regex.RegexMatch;
 import org.elasticsearch.xpack.esql.core.expression.predicate.regex.WildcardPattern;
 import org.elasticsearch.xpack.esql.core.util.StringUtils;
+import org.elasticsearch.xpack.esql.expression.function.scalar.string.Contains;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.EndsWith;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.StartsWith;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.regex.RLike;
@@ -126,10 +127,41 @@ public class ReplaceRegexMatchTests extends ESTestCase {
         assertEquals("foo", BytesRefs.toString(sw.children().get(1).fold(FoldContext.small())));
     }
 
-    public void testLikeNoFixedPrefixUnchanged() {
+    public void testLikeContainsDecomposesToContains() {
         WildcardPattern pattern = new WildcardPattern("*foo*");
         FieldAttribute fa = getFieldAttribute();
         WildcardLike wl = new WildcardLike(EMPTY, fa, pattern);
+        Expression e = replaceRegexMatch(wl);
+        assertEquals(Contains.class, e.getClass());
+        Contains c = (Contains) e;
+        assertEquals(fa, c.children().get(0));
+        assertEquals("foo", BytesRefs.toString(c.children().get(1).fold(FoldContext.small())));
+    }
+
+    public void testLikeContainsEscapedStar() {
+        WildcardPattern pattern = new WildcardPattern("*foo\\*bar*");
+        FieldAttribute fa = getFieldAttribute();
+        WildcardLike wl = new WildcardLike(EMPTY, fa, pattern);
+        Expression e = replaceRegexMatch(wl);
+        assertEquals(Contains.class, e.getClass());
+        Contains c = (Contains) e;
+        assertEquals(fa, c.children().get(0));
+        assertEquals("foo*bar", BytesRefs.toString(c.children().get(1).fold(FoldContext.small())));
+    }
+
+    public void testLikeComplexContainsNotDecomposedToContains() {
+        // *a*b* has three unescaped stars — not a pure Contains shape; stays as WildcardLike.
+        WildcardPattern pattern = new WildcardPattern("*a*b*");
+        FieldAttribute fa = getFieldAttribute();
+        WildcardLike wl = new WildcardLike(EMPTY, fa, pattern);
+        Expression e = replaceRegexMatch(wl);
+        assertEquals(WildcardLike.class, e.getClass());
+    }
+
+    public void testCaseInsensitiveContainsLikeNotDecomposed() {
+        WildcardPattern pattern = new WildcardPattern("*foo*");
+        FieldAttribute fa = getFieldAttribute();
+        WildcardLike wl = new WildcardLike(EMPTY, fa, pattern, true);
         Expression e = replaceRegexMatch(wl);
         assertEquals(WildcardLike.class, e.getClass());
     }


### PR DESCRIPTION
Wire CONTAINS() and ENDS_WITH() through the Parquet late-mat evaluator with dictionary short-circuit and SIMD byte matchers, mirroring the existing StartsWith and WildcardLike paths.

Also decompose LIKE "*literal*" to Contains in ReplaceRegexMatch, completing the prefix/suffix/contains trifecta. Contains now implements TranslationAware so the Lucene path keeps producing the same WildcardQuery.

Developed with AI-assisted tooling