### PR TITLE
Fix `GenerationalDocValuesIT#testBackgroundMergeCanRetainDeletedGenerationalFile`

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -498,9 +498,6 @@ tests:
 - class: org.elasticsearch.xpack.stateless.StatelessRealTimeGetIT
   method: testStress
   issue: https://github.com/elastic/elasticsearch/issues/147850
-- class: org.elasticsearch.xpack.stateless.lucene.GenerationalDocValuesIT
-  method: testBackgroundMergeCanRetainDeletedGenerationalFile
-  issue: https://github.com/elastic/elasticsearch/issues/149626
 - class: org.elasticsearch.xpack.ml.integration.RevertModelSnapshotIT
   method: testRevertModelSnapshot
   issue: https://github.com/elastic/elasticsearch/issues/147383

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/lucene/GenerationalDocValuesIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/lucene/GenerationalDocValuesIT.java
@@ -57,6 +57,7 @@ import org.elasticsearch.xpack.stateless.cache.reader.CacheBlobReaderService;
 import org.elasticsearch.xpack.stateless.cache.reader.MeteringCacheBlobReader;
 import org.elasticsearch.xpack.stateless.cache.reader.MutableObjectStoreUploadTracker;
 import org.elasticsearch.xpack.stateless.cache.reader.ObjectStoreCacheBlobReader;
+import org.elasticsearch.xpack.stateless.cluster.coordination.StatelessClusterConsistencyService;
 import org.elasticsearch.xpack.stateless.commits.BatchedCompoundCommit;
 import org.elasticsearch.xpack.stateless.commits.BlobFile;
 import org.elasticsearch.xpack.stateless.commits.BlobFileRanges;
@@ -478,6 +479,7 @@ public class GenerationalDocValuesIT extends AbstractStatelessPluginIntegTestCas
                 .put(StatelessCommitService.STATELESS_UPLOAD_MAX_AMOUNT_COMMITS.getKey(), 100)
                 // Need at least 2 threads as we will block two
                 .put("thread_pool." + ThreadPool.Names.MERGE + ".max", randomIntBetween(2, 4))
+                .put(StatelessClusterConsistencyService.DELAYED_CLUSTER_CONSISTENCY_INTERVAL_SETTING.getKey(), "100ms")
                 .build()
         );
 


### PR DESCRIPTION
Needs a shorter `s.translog.delayed_cluster_consistency_check.interval`
to ensure that the commit whose deletion we are awaiting can complete in
the expected timeframe.

Closes #149626