### PR TITLE
Fixing IndexingShardRelocationIT.testPreferredNodeIdsAreUsedDuringRelocation()

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -588,9 +588,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
   method: test {csv-spec:approximation.Subqueries with stats by}
   issue: https://github.com/elastic/elasticsearch/issues/149842
-- class: org.elasticsearch.xpack.stateless.recovery.IndexingShardRelocationIT
-  method: testPreferredNodeIdsAreUsedDuringRelocation
-  issue: https://github.com/elastic/elasticsearch/issues/149851
 - class: org.elasticsearch.indices.state.OpenCloseIndexIT
   method: testTranslogStats
   issue: https://github.com/elastic/elasticsearch/issues/149852

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/recovery/IndexingShardRelocationIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/recovery/IndexingShardRelocationIT.java
@@ -885,6 +885,7 @@ public class IndexingShardRelocationIT extends AbstractStatelessPluginIntegTestC
                 .put(IndexSettings.INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING.getKey(), ByteSizeValue.ofGb(1L))
                 .put(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(), TimeValue.MINUS_ONE)
                 .put(MaxRetryAllocationDecider.SETTING_ALLOCATION_MAX_RETRY.getKey(), 0)
+                .put(MergePolicyConfig.INDEX_MERGE_ENABLED, false)
                 .build()
         );
         ensureGreen(indexName);


### PR DESCRIPTION
Background segment merges could complete between the test's refresh (which creates beforeGeneration) and the source's pre-flush during relocation, creating an unexpected extra commit that throws off the pre-computed generation numbers. Disabling merges eliminates this race window (and is the same fix we already have in testRelocatingIndexShardFetchesFirstRegionOnly()).
Closes #149851