### PR TITLE
Optionally exclude semantic field from _source

### DIFF
--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractAsyncBulkByPaginatedSearchAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractAsyncBulkByPaginatedSearchAction.java
@@ -338,7 +338,7 @@ public abstract class AbstractAsyncBulkByPaginatedSearchAction<
             // always include vectors in the response unless explicitly set
             var fetchSource = sourceBuilder.fetchSource();
             if (fetchSource == null) {
-                sourceBuilder.fetchSource(FetchSourceContext.FETCH_ALL_SOURCE_EXCLUDE_INFERENCE_FIELDS);
+                sourceBuilder.fetchSource(FetchSourceContext.FETCH_SOURCE_WITH_VECTORS);
             } else if (fetchSource.excludeVectors() == null) {
                 sourceBuilder.excludeVectors(false);
             }

--- a/server/src/main/java/org/elasticsearch/index/get/ShardGetService.java
+++ b/server/src/main/java/org/elasticsearch/index/get/ShardGetService.java
@@ -381,7 +381,7 @@ public final class ShardGetService extends AbstractIndexShardComponent {
         Map<String, DocumentField> metadataFields = null;
         DocIdAndVersion docIdAndVersion = get.docIdAndVersion();
 
-        var res = maybeExcludeVectorFields(mappingLookup, indexSettings, fetchSourceContext, null);
+        var res = maybeExcludeLargeFields(mappingLookup, indexSettings, fetchSourceContext, null);
         if (res.v1() != fetchSourceContext) {
             fetchSourceContext = res.v1();
         }
@@ -533,7 +533,66 @@ public final class ShardGetService extends AbstractIndexShardComponent {
      * unless vectors are explicitly requested to be included in the source.
      * Returns {@code null} when vectors should not be filtered out.
      */
-    public static Tuple<FetchSourceContext, SourceFilter> maybeExcludeVectorFields(
+    private static Tuple<FetchSourceContext, SourceFilter> maybeExcludeSemanticFields(
+        MappingLookup mappingLookup,
+        FetchSourceContext fetchSourceContext,
+        FetchFieldsContext fetchFieldsContext
+    ) {
+        if (fetchSourceContext != null && fetchSourceContext.includeSemanticFields()) {
+            return Tuple.tuple(fetchSourceContext, null);
+        }
+        // exclude semantic field if not explicitly requested by fields
+        var fetchFieldsAut = fetchFieldsContext != null && !fetchFieldsContext.fields().isEmpty()
+            ? new CharacterRunAutomaton(
+            Regex.simpleMatchToAutomaton(fetchFieldsContext.fields().stream().map(f -> f.field).toArray(String[]::new))
+        )
+            : null;
+
+        SourceFilter filter = fetchSourceContext != null ? fetchSourceContext.filter() : null;
+
+        List<String> lateExcludes = new ArrayList<>();
+        var excludes = mappingLookup.getFullNameToFieldType().values().stream().filter(f -> f.typeName().equals("semantic")).filter(f -> {
+            // Keep the fields that are explicitly included and not explicitly excluded
+            if (filter != null && filter.isExplicitlyIncluded(f.name())) {
+                return filter.isPathFiltered(f.name(), false);
+            }
+            // Exclude the field specified by the `fields` option
+            if (fetchFieldsAut != null && fetchFieldsAut.run(f.name())) {
+                lateExcludes.add(f.name() + ".value");
+                return false;
+            }
+            return true;
+        }).map(fld -> fld.name() + ".value").toList();
+
+        var sourceFilter = excludes.isEmpty() ? null : new SourceFilter(new String[] {}, excludes.toArray(String[]::new));
+        if (!lateExcludes.isEmpty()) {
+            /**
+             * Adds the semantic fields specified by the `fields` option to the excludes list of the fetch source context.
+             * This ensures that semantic fields are available to sub-fetch phases, but excluded during the {@link FetchSourcePhase}.
+             */
+            if (fetchSourceContext != null && fetchSourceContext.excludes() != null) {
+                lateExcludes.addAll(Arrays.asList(fetchSourceContext.excludes()));
+            }
+            var newFetchSourceContext = fetchSourceContext == null
+                ? FetchSourceContext.of(true, false, null, lateExcludes.toArray(String[]::new))
+                : FetchSourceContext.of(
+                fetchSourceContext.fetchSource(),
+                fetchSourceContext.excludeVectors(),
+                fetchSourceContext.excludeInferenceFields(),
+                fetchSourceContext.includes(),
+                lateExcludes.toArray(String[]::new)
+            );
+            return Tuple.tuple(newFetchSourceContext, sourceFilter);
+        }
+        return Tuple.tuple(fetchSourceContext, sourceFilter);
+    }
+
+    /**
+     * Returns a {@link SourceFilter} that excludes vector fields not associated with semantic text fields,
+     * unless vectors are explicitly requested to be included in the source.
+     * Returns {@code null} when vectors should not be filtered out.
+     */
+    private static Tuple<FetchSourceContext, SourceFilter> maybeExcludeVectorFields(
         MappingLookup mappingLookup,
         IndexSettings indexSettings,
         FetchSourceContext fetchSourceContext,
@@ -580,17 +639,36 @@ public final class ShardGetService extends AbstractIndexShardComponent {
                 lateExcludes.addAll(Arrays.asList(fetchSourceContext.excludes()));
             }
             var newFetchSourceContext = fetchSourceContext == null
-                ? FetchSourceContext.of(true, false, null, lateExcludes.toArray(String[]::new))
+                ? FetchSourceContext.of(true, false, false, null, lateExcludes.toArray(String[]::new))
                 : FetchSourceContext.of(
                     fetchSourceContext.fetchSource(),
                     fetchSourceContext.excludeVectors(),
                     fetchSourceContext.excludeInferenceFields(),
+                    fetchSourceContext.includeSemanticFields(),
                     fetchSourceContext.includes(),
                     lateExcludes.toArray(String[]::new)
                 );
             return Tuple.tuple(newFetchSourceContext, sourceFilter);
         }
         return Tuple.tuple(fetchSourceContext, sourceFilter);
+    }
+
+    public static Tuple<FetchSourceContext, SourceFilter> maybeExcludeLargeFields(
+        MappingLookup mappingLookup,
+        IndexSettings indexSettings,
+        FetchSourceContext fetchSourceContext,
+        FetchFieldsContext fetchFieldsContext
+    ) {
+        var excludeVectors = maybeExcludeVectorFields(mappingLookup, indexSettings, fetchSourceContext, fetchFieldsContext);
+        var excludeSemanticFields = maybeExcludeSemanticFields(mappingLookup, excludeVectors.v1(), fetchFieldsContext);
+        final Set<String> excludes = new HashSet<>();
+        if (excludeVectors.v2() != null) {
+            excludes.addAll(Arrays.asList(excludeVectors.v2().getExcludes()));
+        }
+        if (excludeSemanticFields.v2() != null) {
+            excludes.addAll(Arrays.asList(excludeSemanticFields.v2().getExcludes()));
+        }
+        return Tuple.tuple(excludeSemanticFields.v1(), new SourceFilter(new String[] {}, excludes.toArray(String[]::new)));
     }
 
     private static DocumentField loadIgnoredMetadataField(final DocIdAndVersion docIdAndVersion) throws IOException {

--- a/server/src/main/java/org/elasticsearch/index/get/ShardGetService.java
+++ b/server/src/main/java/org/elasticsearch/index/get/ShardGetService.java
@@ -544,8 +544,8 @@ public final class ShardGetService extends AbstractIndexShardComponent {
         // exclude semantic field if not explicitly requested by fields
         var fetchFieldsAut = fetchFieldsContext != null && !fetchFieldsContext.fields().isEmpty()
             ? new CharacterRunAutomaton(
-            Regex.simpleMatchToAutomaton(fetchFieldsContext.fields().stream().map(f -> f.field).toArray(String[]::new))
-        )
+                Regex.simpleMatchToAutomaton(fetchFieldsContext.fields().stream().map(f -> f.field).toArray(String[]::new))
+            )
             : null;
 
         SourceFilter filter = fetchSourceContext != null ? fetchSourceContext.filter() : null;
@@ -576,12 +576,12 @@ public final class ShardGetService extends AbstractIndexShardComponent {
             var newFetchSourceContext = fetchSourceContext == null
                 ? FetchSourceContext.of(true, false, null, lateExcludes.toArray(String[]::new))
                 : FetchSourceContext.of(
-                fetchSourceContext.fetchSource(),
-                fetchSourceContext.excludeVectors(),
-                fetchSourceContext.excludeInferenceFields(),
-                fetchSourceContext.includes(),
-                lateExcludes.toArray(String[]::new)
-            );
+                    fetchSourceContext.fetchSource(),
+                    fetchSourceContext.excludeVectors(),
+                    fetchSourceContext.excludeInferenceFields(),
+                    fetchSourceContext.includes(),
+                    lateExcludes.toArray(String[]::new)
+                );
             return Tuple.tuple(newFetchSourceContext, sourceFilter);
         }
         return Tuple.tuple(fetchSourceContext, sourceFilter);

--- a/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
@@ -63,7 +63,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.IntConsumer;
 import java.util.function.Supplier;
 
-import static org.elasticsearch.index.get.ShardGetService.maybeExcludeVectorFields;
+import static org.elasticsearch.index.get.ShardGetService.maybeExcludeLargeFields;
 import static org.elasticsearch.index.get.ShardGetService.shouldExcludeInferenceFieldsFromSource;
 
 /**
@@ -272,12 +272,12 @@ public final class FetchPhase {
     ) {
         var lookup = context.getSearchExecutionContext().getMappingLookup();
 
-        // Optionally remove sparse and dense vector fields early to:
+        // Optionally remove sparse or dense vector fields and base64 values of semantic fields early to:
         // - Reduce the in-memory size of the source
         // - Speed up retrieval of the synthetic source
-        // Note: These vectors will no longer be accessible via _source for any sub-fetch processors,
+        // Note: In case of vectors, these vectors will no longer be accessible via _source for any sub-fetch processors,
         // but they are typically accessed through doc values instead (e.g: re-scorer).
-        var res = maybeExcludeVectorFields(
+        var res = maybeExcludeLargeFields(
             context.getSearchExecutionContext().getMappingLookup(),
             context.getSearchExecutionContext().getIndexSettings(),
             context.fetchSourceContext(),

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchSourceContext.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchSourceContext.java
@@ -42,6 +42,7 @@ import java.util.Objects;
 public class FetchSourceContext implements Writeable, ToXContentObject {
 
     public static final ParseField EXCLUDE_VECTORS_FIELD = new ParseField("exclude_vectors");
+    public static final ParseField INCLUDE_SEMANTICS_FIELD = new ParseField("include_semantic_fields_base64");
     public static final ParseField INCLUDES_FIELD = new ParseField("includes", "include");
     public static final ParseField EXCLUDES_FIELD = new ParseField("excludes", "exclude");
 
@@ -51,9 +52,13 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
     private static final TransportVersion SEARCH_SOURCE_EXCLUDE_INFERENCE_FIELDS_PARAM = TransportVersion.fromName(
         "search_source_exclude_inference_fields_param"
     );
+    private static final TransportVersion SEARCH_SOURCE_INCLUDE_SEMANTIC_FIELDS_PARAM = TransportVersion.fromName(
+        "search_source_exclude_inference_fields_param"
+    );
 
     public static final FetchSourceContext FETCH_SOURCE = new FetchSourceContext(
         true,
+        null,
         null,
         null,
         Strings.EMPTY_ARRAY,
@@ -63,6 +68,15 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
         true,
         false,
         false,
+        true,
+        Strings.EMPTY_ARRAY,
+        Strings.EMPTY_ARRAY
+    );
+    public static final FetchSourceContext FETCH_SOURCE_WITH_VECTORS = new FetchSourceContext(
+        true,
+        false,
+        true,
+        false,
         Strings.EMPTY_ARRAY,
         Strings.EMPTY_ARRAY
     );
@@ -70,12 +84,14 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
         true,
         false,
         true,
+        true,
         Strings.EMPTY_ARRAY,
         Strings.EMPTY_ARRAY
     );
 
     public static final FetchSourceContext DO_NOT_FETCH_SOURCE = new FetchSourceContext(
         false,
+        null,
         null,
         null,
         Strings.EMPTY_ARRAY,
@@ -86,6 +102,7 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
     private final String[] excludes;
     private final Boolean excludeVectors;
     private final Boolean excludeInferenceFields;
+    private final boolean includeSemanticFields;
 
     public static FetchSourceContext of(boolean fetchSource) {
         return fetchSource ? FETCH_SOURCE : DO_NOT_FETCH_SOURCE;
@@ -111,25 +128,39 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
         @Nullable String[] includes,
         @Nullable String[] excludes
     ) {
+        return of(fetchSource, excludeVectors, excludeInferenceFields, null, includes, excludes);
+    }
+
+    public static FetchSourceContext of(
+        boolean fetchSource,
+        Boolean excludeVectors,
+        Boolean excludeInferenceFields,
+        Boolean includeSemanticFields,
+        @Nullable String[] includes,
+        @Nullable String[] excludes
+    ) {
         if (excludeVectors == null
             && excludeInferenceFields == null
+            && includeSemanticFields == null
             && (includes == null || includes.length == 0)
             && (excludes == null || excludes.length == 0)) {
             return of(fetchSource);
         }
-        return new FetchSourceContext(fetchSource, excludeVectors, excludeInferenceFields, includes, excludes);
+        return new FetchSourceContext(fetchSource, excludeVectors, excludeInferenceFields, includeSemanticFields, includes, excludes);
     }
 
     private FetchSourceContext(
         boolean fetchSource,
         @Nullable Boolean excludeVectors,
         @Nullable Boolean excludeInferenceFields,
+        @Nullable Boolean includeSemanticFields,
         @Nullable String[] includes,
         @Nullable String[] excludes
     ) {
         this.fetchSource = fetchSource;
         this.excludeVectors = excludeVectors;
         this.excludeInferenceFields = excludeInferenceFields;
+        this.includeSemanticFields = includeSemanticFields != null && includeSemanticFields;
         this.includes = includes == null ? Strings.EMPTY_ARRAY : includes;
         this.excludes = excludes == null ? Strings.EMPTY_ARRAY : excludes;
     }
@@ -140,9 +171,12 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
         final Boolean excludeInferenceFields = in.getTransportVersion().supports(SEARCH_SOURCE_EXCLUDE_INFERENCE_FIELDS_PARAM)
             ? in.readOptionalBoolean()
             : null;
+        final Boolean includeSemanticFields = in.getTransportVersion().supports(SEARCH_SOURCE_INCLUDE_SEMANTIC_FIELDS_PARAM)
+            ? in.readOptionalBoolean()
+            : null;
         final String[] includes = in.readStringArray();
         final String[] excludes = in.readStringArray();
-        return of(fetchSource, excludeVectors, excludeInferenceFields, includes, excludes);
+        return of(fetchSource, excludeVectors, excludeInferenceFields, includeSemanticFields, includes, excludes);
     }
 
     @Override
@@ -153,6 +187,9 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
         }
         if (out.getTransportVersion().supports(SEARCH_SOURCE_EXCLUDE_INFERENCE_FIELDS_PARAM)) {
             out.writeOptionalBoolean(excludeInferenceFields);
+        }
+        if (out.getTransportVersion().supports(SEARCH_SOURCE_EXCLUDE_INFERENCE_FIELDS_PARAM)) {
+            out.writeOptionalBoolean(includeSemanticFields);
         }
         out.writeStringArray(includes);
         out.writeStringArray(excludes);
@@ -172,6 +209,10 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
 
     public Boolean excludeInferenceFields() {
         return this.excludeInferenceFields;
+    }
+
+    public Boolean includeSemanticFields() {
+        return this.includeSemanticFields;
     }
 
     public String[] includes() {
@@ -220,13 +261,14 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
         }
 
         Boolean excludeVectors = request.paramAsBoolean("_source_exclude_vectors", null);
-
+        Boolean includeSemanticFields = request.paramAsBoolean("_source_include_semantic_fields_base64", null);
         if (excludeVectors != null || fetchSource != null || sourceIncludes != null || sourceExcludes != null) {
             // Match fromXContent: exclude_inference_fields is not exposed at the REST layer and defaults to exclude_vectors.
             return FetchSourceContext.of(
                 fetchSource == null || fetchSource,
                 excludeVectors,
                 excludeVectors,
+                includeSemanticFields,
                 sourceIncludes,
                 sourceExcludes
             );
@@ -242,6 +284,7 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
         XContentParser.Token token = parser.currentToken();
         boolean fetchSource = true;
         Boolean excludeVectors = null;
+        Boolean includeSemanticFields = null;
         String[] includes = Strings.EMPTY_ARRAY;
         String[] excludes = Strings.EMPTY_ARRAY;
         if (token == XContentParser.Token.VALUE_BOOLEAN) {
@@ -278,6 +321,8 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
                         excludes = new String[] { parser.text() };
                     } else if (EXCLUDE_VECTORS_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                         excludeVectors = parser.booleanValue();
+                    } else if (INCLUDE_SEMANTICS_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
+                        includeSemanticFields = parser.booleanValue();
                     } else {
                         throw new ParsingException(
                             parser.getTokenLocation(),
@@ -288,6 +333,8 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
                 } else if (token == XContentParser.Token.VALUE_BOOLEAN) {
                     if (EXCLUDE_VECTORS_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                         excludeVectors = parser.booleanValue();
+                    } else if (INCLUDE_SEMANTICS_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
+                        includeSemanticFields = parser.booleanValue();
                     } else {
                         throw new ParsingException(
                             parser.getTokenLocation(),
@@ -321,7 +368,7 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
             );
         }
         // The exclude_inference_fields option is not exposed at the REST layer and defaults to the exclude_vectors value.
-        return FetchSourceContext.of(fetchSource, excludeVectors, excludeVectors, includes, excludes);
+        return FetchSourceContext.of(fetchSource, excludeVectors, excludeVectors, includeSemanticFields, includes, excludes);
     }
 
     private static String[] parseStringArray(XContentParser parser, String currentFieldName) throws IOException {
@@ -350,6 +397,7 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
             if (excludeVectors != null) {
                 builder.field(EXCLUDE_VECTORS_FIELD.getPreferredName(), excludeVectors);
             }
+            builder.field(INCLUDE_SEMANTICS_FIELD.getPreferredName(), includeSemanticFields);
             builder.array(INCLUDES_FIELD.getPreferredName(), includes);
             builder.array(EXCLUDES_FIELD.getPreferredName(), excludes);
             builder.endObject();
@@ -369,6 +417,7 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
         if (fetchSource != that.fetchSource) return false;
         if (excludeVectors != that.excludeVectors) return false;
         if (excludeInferenceFields != that.excludeInferenceFields) return false;
+        if (includeSemanticFields != that.includeSemanticFields) return false;
         if (Arrays.equals(excludes, that.excludes) == false) return false;
         if (Arrays.equals(includes, that.includes) == false) return false;
 
@@ -377,7 +426,7 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
 
     @Override
     public int hashCode() {
-        int result = Objects.hash(fetchSource, excludeVectors, excludeInferenceFields);
+        int result = Objects.hash(fetchSource, excludeVectors, excludeInferenceFields, includeSemanticFields);
         result = 31 * result + Arrays.hashCode(includes);
         result = 31 * result + Arrays.hashCode(excludes);
         return result;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
@@ -110,7 +110,7 @@ import java.util.function.Function;
 
 import static org.elasticsearch.common.lucene.search.Queries.newNonNestedFilter;
 import static org.elasticsearch.compute.lucene.query.LuceneSourceOperator.NO_LIMIT;
-import static org.elasticsearch.index.get.ShardGetService.maybeExcludeVectorFields;
+import static org.elasticsearch.index.get.ShardGetService.maybeExcludeLargeFields;
 
 public class EsPhysicalOperationProviders extends AbstractPhysicalOperationProviders {
     private static final Logger logger = LogManager.getLogger(EsPhysicalOperationProviders.class);
@@ -647,7 +647,7 @@ public class EsPhysicalOperationProviders extends AbstractPhysicalOperationProvi
             var filter = sourcePaths != null ? new SourceFilter(sourcePaths.toArray(new String[0]), null) : null;
             // Apply vector exclusion logic similar to ShardGetService
             var fetchSourceContext = filter != null ? FetchSourceContext.of(true, null, filter.getIncludes(), filter.getExcludes()) : null;
-            var result = maybeExcludeVectorFields(mappingLookup, indexSettings, fetchSourceContext, null);
+            var result = maybeExcludeLargeFields(mappingLookup, indexSettings, fetchSourceContext, null);
             var vectorFilter = result.v2();
             if (vectorFilter != null) {
                 var includes = filter != null ? filter.getIncludes() : new String[0];


### PR DESCRIPTION
Exclude semantic field's`value` from returned `_source` controlled by `include_semantic_fields_base64`