### PR TITLE
ESQL: Fix two CASE bugs

### DIFF
--- a/docs/changelog/145968.yaml
+++ b/docs/changelog/145968.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 145968
+summary: Fixes wrong warning in expressions with unrolled multivalues
+type: bug

--- a/x-pack/plugin/esql/qa/server/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/multi_node/AggOnCaseFoldIT.java
+++ b/x-pack/plugin/esql/qa/server/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/multi_node/AggOnCaseFoldIT.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.qa.multi_node;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.WarningsHandler;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.test.TestClustersThreadFilter;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.rest.ESRestTestCase;
+import org.elasticsearch.xpack.esql.CsvTestsDataLoader;
+import org.junit.Before;
+import org.junit.ClassRule;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.elasticsearch.test.MapMatcher.assertMap;
+import static org.elasticsearch.test.MapMatcher.matchesMap;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+
+/**
+ * Tests for {@snippet lang="esql" :
+ * | STATS COUNT_DISTINCT(CASE(foldable, ...))
+ * }
+ * when foldable at different places.
+ */
+@ThreadLeakFilters(filters = TestClustersThreadFilter.class)
+public class AggOnCaseFoldIT extends ESRestTestCase {
+
+    @ClassRule
+    public static ElasticsearchCluster cluster = Clusters.testCluster(ignored -> {});
+
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
+    }
+
+    @Before
+    public void enableChangeLogging() throws IOException {
+        Request request = new Request("PUT", "/_cluster/settings");
+        request.setJsonEntity(
+            "{\"transient\": {\"logger.org.elasticsearch.xpack.esql.optimizer.LocalLogicalPlanOptimizer.changes\": \"TRACE\"}}"
+        );
+        assertOK(client().performRequest(request));
+    }
+
+    @Before
+    public void loadAndPinIndices() throws Exception {
+        assumeFalse("Cannot pin shards to specific nodes in serverless mode", isServerless());
+        CsvTestsDataLoader.loadDatasetsIntoEs(client(), List.of("event_alerts", "event_logs"));
+
+        // Pin each index to a different node so they are optimized independently of one another.
+        Request nodesRequest = new Request("GET", "/_nodes");
+        nodesRequest.addParameter("filter_path", "nodes.*.name");
+        Map<String, Object> nodesResponse = entityAsMap(client().performRequest(nodesRequest));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> nodes = (Map<String, Object>) nodesResponse.get("nodes");
+        List<String> nodeNames = new ArrayList<>();
+        for (Object nodeInfo : nodes.values()) {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> info = (Map<String, Object>) nodeInfo;
+            nodeNames.add((String) info.get("name"));
+        }
+        assertThat("Need at least 2 nodes", nodeNames.size(), greaterThanOrEqualTo(2));
+
+        Request pinAlerts = new Request("PUT", "/event_alerts/_settings");
+        pinAlerts.setJsonEntity(Strings.format("""
+            {
+              "index.routing.allocation.require._name": "%s",
+              "index.number_of_replicas": 0
+            }
+            """, nodeNames.get(0)));
+        assertOK(client().performRequest(pinAlerts));
+
+        Request pinLogs = new Request("PUT", "/event_logs/_settings");
+        pinLogs.setJsonEntity(Strings.format("""
+            {
+              "index.routing.allocation.require._name": "%s",
+              "index.number_of_replicas": 0
+            }
+            """, nodeNames.get(1)));
+        assertOK(client().performRequest(pinLogs));
+
+        ensureGreen("event_alerts");
+        ensureGreen("event_logs");
+
+        // Paranoidly wait until the shards have landed on the nodes we expect
+        Request shardsRequest = new Request("GET", "/_cat/shards/event_alerts,event_logs");
+        shardsRequest.addParameter("format", "json");
+        assertBusy(() -> {
+            List<Object> shards = entityAsList(client().performRequest(shardsRequest));
+            Map<String, List<Map<String, Object>>> shardByIndex = new HashMap<>();
+            for (Object entry : shards) {
+                @SuppressWarnings("unchecked")
+                Map<String, Object> shard = (Map<String, Object>) entry;
+                shardByIndex.computeIfAbsent((String) shard.get("index"), k -> new ArrayList<>()).add(shard);
+            }
+            String ctx = "nodeNames=" + nodeNames + " shards=" + shards;
+            List<Map<String, Object>> alertsShards = shardByIndex.get("event_alerts");
+            assertNotNull("event_alerts shards not found in: " + ctx, alertsShards);
+            for (Map<String, Object> shard : alertsShards) {
+                assertThat(ctx + " event_alerts shard must be STARTED", shard.get("state"), equalTo("STARTED"));
+                assertThat(ctx + " event_alerts shard on wrong node", shard.get("node"), equalTo(nodeNames.get(0)));
+            }
+            List<Map<String, Object>> logsShards = shardByIndex.get("event_logs");
+            assertNotNull("event_logs shards not found in: " + ctx, logsShards);
+            for (Map<String, Object> shard : logsShards) {
+                assertThat(ctx + " event_logs shard must be STARTED", shard.get("state"), equalTo("STARTED"));
+                assertThat(ctx + " event_logs shard on wrong node", shard.get("node"), equalTo(nodeNames.get(1)));
+            }
+        }, 30, TimeUnit.SECONDS);
+    }
+
+    public void testCoordinatingNodeFoldInline() throws IOException {
+        List<List<Object>> values = esql("""
+            FROM event_alerts, event_logs
+            | STATS COUNT_DISTINCT(CASE(false, username, null))
+            """);
+        assertThat(values, equalTo(List.of(List.of(0))));
+    }
+
+    public void testDataNodeFoldInline() throws IOException {
+        List<List<Object>> values = esql("""
+            FROM event_alerts, event_logs
+            | STATS COUNT_DISTINCT(CASE(event_type == "alert", username, null))
+            """);
+        assertThat(values, equalTo(List.of(List.of(0))));
+    }
+
+    public void testDataNodeFoldEval() throws IOException {
+        List<List<Object>> values = esql("""
+            FROM event_alerts, event_logs
+            | EVAL username = CASE(event_type == "alert", username, null)
+            | STATS COUNT_DISTINCT(username)
+            """);
+        assertThat(values, equalTo(List.of(List.of(0))));
+    }
+
+    public void testDataNodeFoldEvalAnd() throws IOException {
+        List<List<Object>> values = esql("""
+            FROM event_alerts, event_logs
+            | EVAL foo = CASE(event_type == "alert" AND severity > 0, username, null)
+            | STATS COUNT_DISTINCT(foo)
+            """);
+        assertThat(values, equalTo(List.of(List.of(0))));
+    }
+
+    public void testDataNodeFoldEvalAndTwoBranches() throws IOException {
+        List<List<Object>> values = esql("""
+            FROM event_alerts, event_logs
+            | EVAL foo = CASE(event_type == "alert" AND severity > 0, username,
+                              event_type == "alert" AND severity > 1, label,
+                              null)
+            | STATS COUNT_DISTINCT(foo)
+            """);
+        assertThat(values, equalTo(List.of(List.of(0))));
+    }
+
+    public void testDataNodeFoldInlineTwoBranches() throws IOException {
+        List<List<Object>> values = esql("""
+            FROM event_alerts, event_logs
+            | STATS COUNT_DISTINCT(CASE(event_type == "alert" AND severity > 0, username,
+                                        event_type == "alert" AND severity > 1, label,
+                                        null))
+            """);
+        assertThat(values, equalTo(List.of(List.of(0))));
+    }
+
+    public void testDataNodeFoldEvalOr() throws IOException {
+        List<List<Object>> values = esql("""
+            FROM event_alerts, event_logs
+            | EVAL foo = CASE(event_type == "alert" OR severity > 0, username, null)
+            | STATS COUNT_DISTINCT(foo)
+            """);
+        assertThat(values, equalTo(List.of(List.of(0))));
+    }
+
+    public void testDataNodeNotIn() throws IOException {
+        List<List<Object>> values = esql("""
+            FROM event_alerts, event_logs
+            | EVAL foo = CASE(NOT event_type IN ("login", "other"), username, null)
+            | STATS COUNT_DISTINCT(foo)
+            """);
+        assertThat(values, equalTo(List.of(List.of(0))));
+    }
+
+    public void testDataNodeMultipleCases() throws IOException {
+        List<List<Object>> values = esql("""
+            FROM event_alerts, event_logs
+            | EVAL severity_case = CASE(event_type == "alert", severity, null),
+                   username_case = CASE(event_type == "login", username, null)
+            | STATS COUNT_DISTINCT(severity_case), COUNT_DISTINCT(username_case)
+              BY ts_month = DATE_TRUNC(1 month, @timestamp)
+            | SORT ts_month
+            """);
+        assertThat(values, equalTo(List.of(List.of(3, 0, "2024-01-01T00:00:00.000Z"), List.of(0, 3, "2024-02-01T00:00:00.000Z"))));
+    }
+
+    public void testDataNodeMultipleCasesAnd() throws IOException {
+        List<List<Object>> values = esql("""
+            FROM event_alerts, event_logs
+            | EVAL case1 = CASE(event_type == "alert" AND severity > 0, username, null),
+                   case2 = CASE(NOT event_type IN ("alert", "other"), username, null)
+            | STATS COUNT_DISTINCT(case1), COUNT_DISTINCT(case2)
+              BY ts_month = DATE_TRUNC(1 month, @timestamp)
+            | SORT ts_month
+            """);
+        assertThat(values, equalTo(List.of(List.of(0, 0, "2024-01-01T00:00:00.000Z"), List.of(0, 3, "2024-02-01T00:00:00.000Z"))));
+    }
+
+    /**
+     * Returns true when the cluster is running in serverless mode, where index settings like
+     * {@code index.number_of_replicas} and shard allocation filters are not available.
+     */
+    private boolean isServerless() throws IOException {
+        for (Map<?, ?> nodeInfo : getNodesInfo(client()).values()) {
+            @SuppressWarnings("unchecked")
+            List<Map<?, ?>> modules = (List<Map<?, ?>>) nodeInfo.get("modules");
+            for (Map<?, ?> module : modules) {
+                if (module.get("name").toString().startsWith("serverless-")) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Runs an ES|QL query, asserts the result is not partial, and returns the values rows.
+     * The query may be a text block with newlines between pipe stages.
+     */
+    private List<List<Object>> esql(String query) throws IOException {
+        Request request = new Request("POST", "/_query");
+        request.setOptions(RequestOptions.DEFAULT.toBuilder().setWarningsHandler(WarningsHandler.PERMISSIVE).build());
+        String escaped = query.replace("\"", "\\\"").replace("\n", "\\n");
+        request.setJsonEntity("{\"query\": \"" + escaped + "\"}");
+        Map<String, Object> result = entityAsMap(client().performRequest(request));
+        assertMap("no partial failures", result, matchesMap().extraOk().entry("is_partial", false));
+        @SuppressWarnings("unchecked")
+        List<List<Object>> values = (List<List<Object>>) result.get("values");
+        return values;
+    }
+}

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
@@ -101,6 +101,9 @@ public class CsvTestsDataLoader {
     private static final TestDataset UL_LOGS = new TestDataset("ul_logs");
     private static final TestDataset SAMPLE_DATA = new TestDataset("sample_data");
     private static final TestDataset MV_SAMPLE_DATA = new TestDataset("mv_sample_data");
+    private static final TestDataset EVENT_ALERTS = new TestDataset("event_alerts");
+    private static final TestDataset EVENT_LOGS = new TestDataset("event_logs");
+    private static final TestDataset EVENT_EMPTY = new TestDataset("event_empty").noData();
     private static final TestDataset SAMPLE_DATA_STR = SAMPLE_DATA.withIndex("sample_data_str")
         .withTypeMapping(Map.of("client_ip", "keyword"));
     private static final TestDataset SAMPLE_DATA_TS_LONG = SAMPLE_DATA.withIndex("sample_data_ts_long")
@@ -219,6 +222,9 @@ public class CsvTestsDataLoader {
         Map.entry(SAMPLE_DATA_PARTIAL_MAPPING_NO_SOURCE.indexName, SAMPLE_DATA_PARTIAL_MAPPING_NO_SOURCE),
         Map.entry(SAMPLE_DATA_PARTIAL_MAPPING_EXCLUDED_SOURCE.indexName, SAMPLE_DATA_PARTIAL_MAPPING_EXCLUDED_SOURCE),
         Map.entry(MV_SAMPLE_DATA.indexName, MV_SAMPLE_DATA),
+        Map.entry(EVENT_ALERTS.indexName, EVENT_ALERTS),
+        Map.entry(EVENT_LOGS.indexName, EVENT_LOGS),
+        Map.entry(EVENT_EMPTY.indexName, EVENT_EMPTY),
         Map.entry(ALERTS.indexName, ALERTS),
         Map.entry(SAMPLE_DATA_STR.indexName, SAMPLE_DATA_STR),
         Map.entry(SAMPLE_DATA_TS_LONG.indexName, SAMPLE_DATA_TS_LONG),

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
@@ -543,6 +543,24 @@ public class CsvTestsDataLoader {
         );
     }
 
+    /**
+     * Load only the named datasets into ES. The names must be keys in {@link #CSV_DATASET_MAP}.
+     */
+    public static void loadDatasetsIntoEs(RestClient client, List<String> datasetNames) throws IOException {
+        Set<String> loadedDatasets = new HashSet<>();
+        for (String name : datasetNames) {
+            TestDataset dataset = CSV_DATASET_MAP.get(name);
+            if (dataset == null) {
+                throw new IllegalArgumentException("Unknown dataset: " + name);
+            }
+            load(client, dataset, logger, (restClient, indexName, indexMapping, indexSettings) -> {
+                ESRestTestCase.createIndex(restClient, indexName, indexSettings, indexMapping, null);
+            });
+            loadedDatasets.add(dataset.indexName);
+        }
+        forceMerge(client, loadedDatasets, logger);
+    }
+
     private static void loadDataSetIntoEs(
         RestClient client,
         boolean supportsIndexModeLookup,

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/conditional.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/conditional.csv-spec
@@ -404,3 +404,14 @@ ROW d = "2025-01-15T00:00:00.000Z"::DATETIME
 duration_true:datetime      | duration_false:datetime     | period_true:datetime        | period_false:datetime
 2025-01-16T00:00:00.000Z    | 2025-01-25T00:00:00.000Z    | 2025-02-15T00:00:00.000Z    | 2026-01-15T00:00:00.000Z
 ;
+
+caseOnUnrolledMultivalueNoWarnings
+required_capability: fix_unrolled_foldable_mv_warning
+ROW x=1, y=[1,2,3] | STATS CASE(y==2, 10, 1) * MIN(x) BY y | SORT y
+;
+
+CASE(y==2, 10, 1) * MIN(x):integer | y:integer
+1                                  | 1
+10                                 | 2
+1                                  | 3
+;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/data/event_alerts.csv
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/data/event_alerts.csv
@@ -1,0 +1,4 @@
+@timestamp:date,severity:integer,label:keyword
+2024-01-01T00:00:00.000Z,1,low
+2024-01-02T00:00:00.000Z,2,medium
+2024-01-03T00:00:00.000Z,3,high

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/data/event_logs.csv
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/data/event_logs.csv
@@ -1,0 +1,4 @@
+@timestamp:date,username:keyword
+2024-02-01T00:00:00.000Z,alice
+2024-02-02T00:00:00.000Z,bob
+2024-02-03T00:00:00.000Z,carol

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/mapping-event_alerts.json
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/mapping-event_alerts.json
@@ -1,0 +1,17 @@
+{
+    "properties": {
+        "@timestamp": {
+            "type": "date"
+        },
+        "event_type": {
+            "type": "constant_keyword",
+            "value": "alert"
+        },
+        "severity": {
+            "type": "integer"
+        },
+        "label": {
+            "type": "keyword"
+        }
+    }
+}

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/mapping-event_empty.json
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/mapping-event_empty.json
@@ -1,0 +1,13 @@
+{
+    "properties": {
+        "@timestamp": {
+            "type": "date"
+        },
+        "event_type": {
+            "type": "constant_keyword"
+        },
+        "severity": {
+            "type": "integer"
+        }
+    }
+}

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/mapping-event_logs.json
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/mapping-event_logs.json
@@ -1,0 +1,14 @@
+{
+    "properties": {
+        "@timestamp": {
+            "type": "date"
+        },
+        "event_type": {
+            "type": "constant_keyword",
+            "value": "login"
+        },
+        "username": {
+            "type": "keyword"
+        }
+    }
+}

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
@@ -4059,3 +4059,139 @@ a:long | languages:integer
 2      | 1
 2      | 1
 ;
+
+statsOnUnrolledMultivalueNoWarnings
+required_capability: fix_unrolled_foldable_mv_warning
+
+ROW x=1, y=[1,2,3] | STATS y + 1 BY y | SORT y
+;
+
+y + 1:integer | y:integer
+2             | 1
+3             | 2
+4             | 3
+;
+
+statsOnSingleValueGroupingExpressionNoWarnings
+required_capability: fix_unrolled_foldable_mv_warning
+
+ROW y = 1 | STATS y + 1 BY y
+;
+
+y + 1:integer | y:integer
+2             | 1
+;
+
+statsOnUnrolledMultivalueFollowedByStatsNoWarnings
+required_capability: fix_unrolled_foldable_mv_warning
+
+ROW x = 1, y = [1, 2] | STATS s = SUM(x) BY y | STATS c = COUNT(*) | LIMIT 10
+;
+
+c:long
+2
+;
+
+statsOnUnrolledMultivalueFollowedByEvalNoWarnings
+required_capability: fix_unrolled_foldable_mv_warning
+
+ROW x = 1, y = [1, 2, 3] | STATS s = SUM(x) BY y | EVAL z = y * 2 | SORT y
+;
+
+s:long | y:integer | z:integer
+1      | 1         | 2
+1      | 2         | 4
+1      | 3         | 6
+;
+
+statsOnUnrolledMultivalueFollowedByWhereNoWarnings
+required_capability: fix_unrolled_foldable_mv_warning
+
+ROW x = 1, y = [1, 2, 3] | STATS s = SUM(x) BY y | WHERE y > 1 | SORT y
+;
+
+s:long | y:integer
+1      | 2
+1      | 3
+;
+
+statsOnUnrolledMultivalueFollowedByLookupJoinNoWarnings
+required_capability: fix_unrolled_foldable_mv_warning
+required_capability: join_lookup_v12
+
+ROW x = 1, language_code = [1, 2, 3] | STATS s = SUM(x) BY language_code | LOOKUP JOIN languages_lookup ON language_code | SORT language_code
+;
+
+s:long | language_code:integer | language_name:keyword
+1      | 1                     | English
+1      | 2                     | French
+1      | 3                     | Spanish
+;
+
+statsOnNullKeyFollowedByLookupJoinNoWarnings
+required_capability: fix_unrolled_foldable_mv_warning
+required_capability: join_lookup_v12
+
+ROW language_code = null::integer | STATS c = COUNT(*) BY language_code | LOOKUP JOIN languages_lookup ON language_code
+;
+
+c:long | language_code:integer | language_name:keyword
+1      | null                  | null
+;
+
+statsAggExpressionOnMVGroupingKey
+required_capability: fix_unrolled_foldable_mv_warning
+
+ROW x = 1, y = [1, 2, 3]
+| STATS s = MAX(CASE(y == 2, 10, 1)) BY y
+| EVAL w = y * 2
+| SORT y
+;
+warning:Line 2:22: evaluation of [y == 2] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 2:22: java.lang.IllegalArgumentException: single-value function encountered multi-value
+
+s:integer | y:integer | w:integer
+1         | 1         | 2
+1         | 2         | 4
+1         | 3         | 6
+;
+
+statsAggExpressionOnMVGroupingKeyWithAlias
+required_capability: fix_unrolled_foldable_mv_warning
+
+ROW x = 1, y = [1, 2, 3]
+| EVAL z = y
+| RENAME z AS zzz
+| STATS s = MAX(CASE(y == 2, 10, 1)) BY y, x, zzz
+| EVAL w = y * 2, ww = zzz * 2
+| SORT y
+;
+warning:Line 4:22: evaluation of [y == 2] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 4:22: java.lang.IllegalArgumentException: single-value function encountered multi-value
+
+s:integer | y:integer | x:integer | zzz:integer | w:integer | ww:integer
+1         | 1         | 1         | 1           | 2         | 2
+1         | 2         | 1         | 2           | 4         | 4
+1         | 3         | 1         | 3           | 6         | 6
+;
+
+statsAggExpressionOnMultipleMVGroupingKeysNoWarnings
+required_capability: fix_unrolled_foldable_mv_warning
+
+ROW x = 1, y = [1, 2, 3], z = [0, 1, -1]
+| STATS s = MAX(MV_MAX(z) * MV_MIN(z)) BY y, x, z
+| EVAL w = y * 2, ww = z * 3
+| SORT y, z
+;
+
+s:integer | y:integer | x:integer | z:integer | w:integer | ww:integer
+-1        | 1         | 1         | -1        | 2         | -3
+-1        | 1         | 1         | 0         | 2         | 0
+-1        | 1         | 1         | 1         | 2         | 3
+-1        | 2         | 1         | -1        | 4         | -3
+-1        | 2         | 1         | 0         | 4         | 0
+-1        | 2         | 1         | 1         | 4         | 3
+-1        | 3         | 1         | -1        | 6         | -3
+-1        | 3         | 1         | 0         | 6         | 0
+-1        | 3         | 1         | 1         | 6         | 3
+;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats_count_distinct.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats_count_distinct.csv-spec
@@ -178,3 +178,136 @@ m:long  | languages:i
 20   | 5
 10   | null
 ;
+
+countDistinctOfCaseResult
+FROM employees
+| EVAL foo = CASE(languages > 1, languages)
+| STATS COUNT_DISTINCT(foo);
+
+COUNT_DISTINCT(foo):long
+4
+;
+
+countDistinctOfCaseWithLiteralFalse
+FROM employees
+| EVAL foo = CASE(false, languages)
+| STATS COUNT_DISTINCT(foo);
+
+COUNT_DISTINCT(foo):long
+0
+;
+
+countDistinctOfCaseWithDataNodeFold
+FROM employees, sample_data
+| EVAL foo = CASE(event_duration > 0, languages)
+| STATS COUNT_DISTINCT(foo);
+
+COUNT_DISTINCT(foo):long
+0
+;
+
+countDistinctOfCaseWithConstantKeywordFold
+FROM event_alerts, event_logs
+| EVAL alert_severity = CASE(event_type == "alert", severity)
+| STATS COUNT_DISTINCT(alert_severity);
+
+COUNT_DISTINCT(alert_severity):long
+3
+;
+
+countDistinctOfCaseResultExplicitNull
+FROM employees
+| EVAL foo = CASE(languages > 1, languages, null)
+| STATS COUNT_DISTINCT(foo);
+
+COUNT_DISTINCT(foo):long
+4
+;
+
+countDistinctOfCaseWithLiteralFalseExplicitNull
+FROM employees
+| EVAL foo = CASE(false, languages, null)
+| STATS COUNT_DISTINCT(foo);
+
+COUNT_DISTINCT(foo):long
+0
+;
+
+countDistinctOfCaseWithDataNodeFoldExplicitNull
+FROM employees, sample_data
+| EVAL foo = CASE(event_duration > 0, languages, null)
+| STATS COUNT_DISTINCT(foo);
+
+COUNT_DISTINCT(foo):long
+0
+;
+
+countDistinctOfCaseWithConstantKeywordFoldExplicitNull
+FROM event_alerts, event_logs
+| EVAL alert_severity = CASE(event_type == "alert", severity, null)
+| STATS COUNT_DISTINCT(alert_severity);
+
+COUNT_DISTINCT(alert_severity):long
+3
+;
+
+countDistinctOfEmptyConstantKeyword
+FROM event_empty
+| STATS COUNT_DISTINCT(severity);
+
+COUNT_DISTINCT(severity):long
+0
+;
+
+countDistinctOfCaseFoldableAnd
+FROM event_alerts, event_logs
+| EVAL foo = CASE(event_type == "alert" AND severity > 0, username)
+| STATS COUNT_DISTINCT(foo);
+
+COUNT_DISTINCT(foo):long
+0
+;
+
+countDistinctOfCaseFoldableAndExplicitNull
+FROM event_alerts, event_logs
+| EVAL foo = CASE(event_type == "alert" AND severity > 0, username, null)
+| STATS COUNT_DISTINCT(foo);
+
+COUNT_DISTINCT(foo):long
+0
+;
+
+countDistinctOfCaseNotInCondition
+FROM event_alerts, event_logs
+| EVAL foo = CASE(NOT event_type IN ("login", "other"), username, null)
+| STATS COUNT_DISTINCT(foo);
+
+COUNT_DISTINCT(foo):long
+0
+;
+
+countDistinctOfMultipleCasesWithByExpression
+FROM event_alerts, event_logs
+| EVAL severity_case = CASE(event_type == "alert", severity, null),
+       username_case = CASE(event_type == "login", username, null)
+| STATS COUNT_DISTINCT(severity_case), COUNT_DISTINCT(username_case)
+  BY ts_month = DATE_TRUNC(1 month, @timestamp)
+| SORT ts_month;
+
+COUNT_DISTINCT(severity_case):long | COUNT_DISTINCT(username_case):long | ts_month:datetime
+3                                   | 0                                   | 2024-01-01T00:00:00.000Z
+0                                   | 3                                   | 2024-02-01T00:00:00.000Z
+;
+
+countDistinctOfProductionLikePatternAndNotIn
+FROM event_alerts, event_logs
+| EVAL case1 = CASE(event_type == "alert" AND severity > 0, username, null),
+       case2 = CASE(NOT event_type IN ("alert", "other"), username, null)
+| STATS COUNT_DISTINCT(case1), COUNT_DISTINCT(case2)
+  BY ts_month = DATE_TRUNC(1 month, @timestamp)
+| SORT ts_month;
+
+COUNT_DISTINCT(case1):long | COUNT_DISTINCT(case2):long | ts_month:datetime
+0                           | 0                           | 2024-01-01T00:00:00.000Z
+0                           | 3                           | 2024-02-01T00:00:00.000Z
+;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats_count_distinct.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats_count_distinct.csv-spec
@@ -198,6 +198,8 @@ COUNT_DISTINCT(foo):long
 ;
 
 countDistinctOfCaseWithDataNodeFold
+required_capability: load_constant_keyword
+
 FROM employees, sample_data
 | EVAL foo = CASE(event_duration > 0, languages)
 | STATS COUNT_DISTINCT(foo);
@@ -207,6 +209,8 @@ COUNT_DISTINCT(foo):long
 ;
 
 countDistinctOfCaseWithConstantKeywordFold
+required_capability: load_constant_keyword
+
 FROM event_alerts, event_logs
 | EVAL alert_severity = CASE(event_type == "alert", severity)
 | STATS COUNT_DISTINCT(alert_severity);
@@ -234,6 +238,8 @@ COUNT_DISTINCT(foo):long
 ;
 
 countDistinctOfCaseWithDataNodeFoldExplicitNull
+required_capability: load_constant_keyword
+
 FROM employees, sample_data
 | EVAL foo = CASE(event_duration > 0, languages, null)
 | STATS COUNT_DISTINCT(foo);
@@ -243,6 +249,8 @@ COUNT_DISTINCT(foo):long
 ;
 
 countDistinctOfCaseWithConstantKeywordFoldExplicitNull
+required_capability: load_constant_keyword
+
 FROM event_alerts, event_logs
 | EVAL alert_severity = CASE(event_type == "alert", severity, null)
 | STATS COUNT_DISTINCT(alert_severity);
@@ -252,6 +260,8 @@ COUNT_DISTINCT(alert_severity):long
 ;
 
 countDistinctOfEmptyConstantKeyword
+required_capability: load_constant_keyword
+
 FROM event_empty
 | STATS COUNT_DISTINCT(severity);
 
@@ -260,6 +270,8 @@ COUNT_DISTINCT(severity):long
 ;
 
 countDistinctOfCaseFoldableAnd
+required_capability: load_constant_keyword
+
 FROM event_alerts, event_logs
 | EVAL foo = CASE(event_type == "alert" AND severity > 0, username)
 | STATS COUNT_DISTINCT(foo);
@@ -269,6 +281,8 @@ COUNT_DISTINCT(foo):long
 ;
 
 countDistinctOfCaseFoldableAndExplicitNull
+required_capability: load_constant_keyword
+
 FROM event_alerts, event_logs
 | EVAL foo = CASE(event_type == "alert" AND severity > 0, username, null)
 | STATS COUNT_DISTINCT(foo);
@@ -278,6 +292,8 @@ COUNT_DISTINCT(foo):long
 ;
 
 countDistinctOfCaseNotInCondition
+required_capability: load_constant_keyword
+
 FROM event_alerts, event_logs
 | EVAL foo = CASE(NOT event_type IN ("login", "other"), username, null)
 | STATS COUNT_DISTINCT(foo);
@@ -287,6 +303,8 @@ COUNT_DISTINCT(foo):long
 ;
 
 countDistinctOfMultipleCasesWithByExpression
+required_capability: load_constant_keyword
+
 FROM event_alerts, event_logs
 | EVAL severity_case = CASE(event_type == "alert", severity, null),
        username_case = CASE(event_type == "login", username, null)
@@ -300,6 +318,8 @@ COUNT_DISTINCT(severity_case):long | COUNT_DISTINCT(username_case):long | ts_mon
 ;
 
 countDistinctOfProductionLikePatternAndNotIn
+required_capability: load_constant_keyword
+
 FROM event_alerts, event_logs
 | EVAL case1 = CASE(event_type == "alert" AND severity > 0, username, null),
        case2 = CASE(NOT event_type IN ("alert", "other"), username, null)

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -2005,6 +2005,12 @@ public class EsqlCapabilities {
         FIX_UNROLLED_FOLDABLE_MV_WARNING,
 
         /**
+         * Can we load {@code constant_keyword} field values? This is supported everywhere but
+         * the unit CsvTests.
+         */
+        LOAD_CONSTANT_KEYWORD,
+
+        /**
          * Fix for SET reporting wrong line/column number (-1:-1) in validation errors.
          * see <a href="https://github.com/elastic/elasticsearch/issues/145873">ES|QL: wrong line/column number #145873</a>
          */

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -1997,6 +1997,14 @@ public class EsqlCapabilities {
         FIX_PUSH_COUNT_QUERY_AND_TAGS_WITH_MULTIPLE_AGGS,
 
         /**
+         * Fix on multi-values that were unrolled and were still producing warnings in expressions
+         * that do not accept multi-values
+         *
+         * See https://github.com/elastic/elasticsearch/issues/134706
+         */
+        FIX_UNROLLED_FOLDABLE_MV_WARNING,
+
+        /**
          * Fix for SET reporting wrong line/column number (-1:-1) in validation errors.
          * see <a href="https://github.com/elastic/elasticsearch/issues/145873">ES|QL: wrong line/column number #145873</a>
          */

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlQueryRequest.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlQueryRequest.java
@@ -319,8 +319,9 @@ public class EsqlQueryRequest extends org.elasticsearch.xpack.core.esql.action.E
         this.onSnapshotBuild = onSnapshotBuild;
     }
 
-    void acceptedPragmaRisks(boolean accepted) {
+    public EsqlQueryRequest acceptedPragmaRisks(boolean accepted) {
         this.acceptedPragmaRisks = accepted;
+        return this;
     }
 
     public EsqlQueryRequest projectRouting(String projectRouting) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/conditional/Case.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/conditional/Case.java
@@ -249,21 +249,23 @@ public final class Case extends EsqlScalarFunction {
             if (condition.condition.foldable() == false) {
                 return false;
             }
-            if (Boolean.TRUE.equals(condition.condition.fold(FoldContext.small() /* TODO remove me - use literal true?*/))) {
-                /*
-                 * `fold` can make four things here:
-                 * 1. `TRUE`
-                 * 2. `FALSE`
-                 * 3. null
-                 * 4. A list with more than one `TRUE` or `FALSE` in it.
-                 *
-                 * In the first case, we're foldable if the condition is foldable.
-                 * The multivalued field will make a warning, but eventually
-                 * become null. And null will become false. So cases 2-4 are
-                 * the same. In those cases we are foldable only if the *rest*
-                 * of the condition is foldable.
-                 */
-                return condition.value.foldable();
+            /* Given the current condition is foldable,
+                if we have already folded the condition into a Literal
+                    If True, Case is foldable if the value is foldable
+                    If False, Case is foldable if the rest of the conditions are foldable
+                Otherwise
+                    if the value is foldable and the rest of the conditions are foldable, Case is foldable
+             */
+            if (condition.condition instanceof Literal literal) {
+                if (Boolean.TRUE.equals(literal.value())) {
+                    // The condition is literally TRUE, so only the matching value needs to be foldable.
+                    return condition.value.foldable();
+                } else {
+                    continue;
+                }
+            }
+            if (condition.value.foldable() == false) {
+                return false;
             }
         }
         return elseValue.foldable();
@@ -341,9 +343,36 @@ public final class Case extends EsqlScalarFunction {
     }
 
     private Expression finishPartialFold(List<Expression> newChildren) {
+        Expression result = innerFinishPartialFold(newChildren);
+        if (result.dataType().noText().equals(dataType()) == false) {
+            throw new IllegalStateException("partiallyFold produced type [" + result.dataType() + "] but expected [" + dataType() + "]");
+        }
+        return result;
+    }
+
+    private Expression innerFinishPartialFold(List<Expression> newChildren) {
         return switch (newChildren.size()) {
+            // CASE(false, a) -> NULL
             case 0 -> new Literal(source(), null, dataType());
-            case 1 -> newChildren.get(0);
+            /*
+             * CASE(false, a, b) -> b
+             *
+             * We *must* return something of dataType or downstream stuff will
+             * blow up. `b` can be:
+             *   - dataType - return as-is
+             *   - TEXT when dataType is keyword - return as-is - which is safe because
+             *     TEXT is the same as KEYWORD everywhere that matters downstream from here
+             *   - any NULL-typed expression — cast it to dataType so callers
+             *     see the right type (e.g. KEYWORD, not NULL)
+             */
+            case 1 -> {
+                Expression child = newChildren.getFirst();
+                if (child.dataType() == NULL && dataType() != NULL) {
+                    yield new Literal(child.source(), null, dataType());
+                }
+                yield child;
+            }
+            // CASE(false, a, b, c, d) -> CASE(b, c, d)
             default -> replaceChildren(newChildren);
         };
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/RuleUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/RuleUtils.java
@@ -18,6 +18,7 @@ import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.optimizer.LogicalOptimizerContext;
+import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 
 import java.util.ArrayList;
@@ -77,28 +78,53 @@ public final class RuleUtils {
     }
 
     /**
-     * Collects references to foldables from the given logical plan, returning an {@link AttributeMap} that maps
+     * Collects references to foldable expressions from the given logical plan, returning an {@link AttributeMap} that maps
      * foldable aliases to their corresponding literal values.
+     * <p>
+     * Traverses plan nodes bottom-up. At {@link Aggregate} boundaries, multi-valued grouping keys are removed from
+     * the collected references — after GROUP BY, these attributes represent expanded single values, not the original
+     * multi-valued literals. This prevents resolving post-Aggregate expressions against stale multi-valued literals,
+     * which would produce spurious warnings and incorrect fold results.
+     * <p>
+     * Note: this MV-grouping removal is applied only at {@link Aggregate} boundaries, not at {@link
+     * org.elasticsearch.xpack.esql.plan.logical.join.InlineJoin} boundaries (i.e. {@code INLINE STATS}). For
+     * {@code INLINE STATS}, the join key is always the grouping, and callers are responsible for excluding
+     * {@code InlineJoin} plans before calling this method — see
+     * {@link org.elasticsearch.xpack.esql.optimizer.rules.logical.local.PruneLeftJoinOnNullMatchingField} for an
+     * example of that explicit exclusion.
      *
      * @param plan The logical plan to analyze.
      * @param ctx The optimizer context providing fold context.
      * @return An {@link AttributeMap} containing foldable references and their literal values.
      */
-    public static AttributeMap<Expression> foldableReferences(LogicalPlan plan, LogicalOptimizerContext ctx) {
+    public static AttributeMap<Expression> foldableReferencesSkipMVGroupings(LogicalPlan plan, LogicalOptimizerContext ctx) {
         AttributeMap.Builder<Expression> collectRefsBuilder = AttributeMap.builder();
 
-        // collect aliases bottom-up
-        plan.forEachExpressionUp(Alias.class, a -> {
-            var c = a.child();
-            boolean shouldCollect = c.foldable();
-            // try to resolve the expression based on an existing foldables
-            if (shouldCollect == false) {
-                c = c.transformUp(ReferenceAttribute.class, r -> collectRefsBuilder.build().resolve(r, r));
-                shouldCollect = c.foldable();
+        // Traverse plan nodes bottom-up, collecting foldable aliases from each node.
+        plan.forEachUp(node -> {
+            // At Aggregate boundaries, remove multi-valued grouping keys. After GROUP BY, these attributes
+            // represent expanded single values, not the original multi-valued literals.
+            if (node instanceof Aggregate aggregate) {
+                aggregate.groupings().forEach(group -> {
+                    Expression resolved = collectRefsBuilder.build().resolve(group, group);
+                    if (resolved instanceof Literal literal && literal.value() instanceof List<?>) {
+                        collectRefsBuilder.remove(group);
+                    }
+                });
             }
-            if (shouldCollect) {
-                collectRefsBuilder.put(a.toAttribute(), Literal.of(ctx.foldCtx(), c));
-            }
+
+            node.forEachExpression(Alias.class, a -> {
+                var c = a.child();
+                boolean shouldCollect = c.foldable();
+                // try to resolve the expression based on existing foldables
+                if (shouldCollect == false) {
+                    c = c.transformUp(ReferenceAttribute.class, r -> collectRefsBuilder.build().resolve(r, r));
+                    shouldCollect = c.foldable();
+                }
+                if (shouldCollect) {
+                    collectRefsBuilder.put(a.toAttribute(), Literal.of(ctx.foldCtx(), c));
+                }
+            });
         });
 
         return collectRefsBuilder.build();

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PropagateEvalFoldables.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PropagateEvalFoldables.java
@@ -9,17 +9,16 @@ package org.elasticsearch.xpack.esql.optimizer.rules.logical;
 
 import org.elasticsearch.xpack.esql.core.expression.AttributeMap;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
-import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.optimizer.LogicalOptimizerContext;
 import org.elasticsearch.xpack.esql.optimizer.rules.RuleUtils;
-import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
 import org.elasticsearch.xpack.esql.plan.logical.Eval;
 import org.elasticsearch.xpack.esql.plan.logical.Filter;
+import org.elasticsearch.xpack.esql.plan.logical.LimitBy;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.plan.logical.MMR;
+import org.elasticsearch.xpack.esql.plan.logical.Row;
 import org.elasticsearch.xpack.esql.rule.ParameterizedRule;
-
-import java.util.List;
 
 /**
  * Replace any reference attribute with its source, if it does not affect the result.
@@ -29,37 +28,17 @@ public final class PropagateEvalFoldables extends ParameterizedRule<LogicalPlan,
 
     @Override
     public LogicalPlan apply(LogicalPlan plan, LogicalOptimizerContext ctx) {
-        AttributeMap<Expression> collectRefs = RuleUtils.foldableReferences(plan, ctx);
+        AttributeMap<Expression> collectRefs = RuleUtils.foldableReferencesSkipMVGroupings(plan, ctx);
         if (collectRefs.isEmpty()) {
             return plan;
         }
-        // Build the final set of foldable references to propagate.
-        // We start with all collected foldable references, then exclude multi-value grouping keys.
-        AttributeMap.Builder<Expression> builder = AttributeMap.builder();
-        builder.putAll(collectRefs);
 
-        // Exclude multi-value (List) literals used as GROUP BY keys from propagation.
-        //
-        // Rationale: GROUP BY explodes multi-value fields into single values. For example:
-        // ROW a = [1, 2] | STATS x = a + SUM(a) BY a
-        // Before aggregation, `a` is multi-valued [1, 2]. After GROUP BY, `a` becomes single-valued
-        // (either 1 or 2 per group). If we propagate the original multi-value literal [1, 2] into
-        // expressions after the Aggregate (e.g., `x = a + SUM(a)`), this would incorrectly treat `a`
-        // as still being multi-valued, leading to wrong results.
+        // Apply the replacement inside Filter, Eval, Row and LimitBy (groupings).
+        // TODO: also allow aggregates once aggs on constants are supported.
+        // C.f. https://github.com/elastic/elasticsearch/issues/100634
         plan = plan.transformUp(p -> {
-            if (p instanceof Aggregate aggregate) {
-                aggregate.groupings().forEach(group -> {
-                    Expression resolved = collectRefs.resolve(group, group);
-                    if (resolved instanceof Literal literal && literal.value() instanceof List<?>) {
-                        builder.remove(group);
-                    }
-                });
-            }
-            // Apply the replacement inside Filter and Eval (which shouldn't make a difference)
-            // TODO: also allow aggregates once aggs on constants are supported.
-            // C.f. https://github.com/elastic/elasticsearch/issues/100634
-            if (p instanceof Filter || p instanceof Eval) {
-                p = p.transformExpressionsOnly(ReferenceAttribute.class, r -> builder.build().resolve(r, r));
+            if (p instanceof Filter || p instanceof Eval || p instanceof Row || p instanceof LimitBy || p instanceof MMR) {
+                p = p.transformExpressionsOnly(ReferenceAttribute.class, r -> collectRefs.resolve(r, r));
             }
             return p;
         });

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PropagateEvalFoldables.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PropagateEvalFoldables.java
@@ -14,9 +14,7 @@ import org.elasticsearch.xpack.esql.optimizer.LogicalOptimizerContext;
 import org.elasticsearch.xpack.esql.optimizer.rules.RuleUtils;
 import org.elasticsearch.xpack.esql.plan.logical.Eval;
 import org.elasticsearch.xpack.esql.plan.logical.Filter;
-import org.elasticsearch.xpack.esql.plan.logical.LimitBy;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
-import org.elasticsearch.xpack.esql.plan.logical.MMR;
 import org.elasticsearch.xpack.esql.plan.logical.Row;
 import org.elasticsearch.xpack.esql.rule.ParameterizedRule;
 
@@ -33,11 +31,11 @@ public final class PropagateEvalFoldables extends ParameterizedRule<LogicalPlan,
             return plan;
         }
 
-        // Apply the replacement inside Filter, Eval, Row and LimitBy (groupings).
+        // Apply the replacement inside Filter, Eval, and Row.
         // TODO: also allow aggregates once aggs on constants are supported.
         // C.f. https://github.com/elastic/elasticsearch/issues/100634
         plan = plan.transformUp(p -> {
-            if (p instanceof Filter || p instanceof Eval || p instanceof Row || p instanceof LimitBy || p instanceof MMR) {
+            if (p instanceof Filter || p instanceof Eval || p instanceof Row) {
                 p = p.transformExpressionsOnly(ReferenceAttribute.class, r -> collectRefs.resolve(r, r));
             }
             return p;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/local/PruneLeftJoinOnNullMatchingField.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/local/PruneLeftJoinOnNullMatchingField.java
@@ -47,7 +47,7 @@ public class PruneLeftJoinOnNullMatchingField extends OptimizerRules.Parameteriz
         // match the intended targets. The negative check correctly excludes InlineJoin while accepting all other
         // LEFT joins, including those originally created as LookupJoin.
         if (join.config().type() == LEFT && join instanceof InlineJoin == false) {
-            AttributeMap<Expression> attributeMap = RuleUtils.foldableReferences(join, ctx);
+            AttributeMap<Expression> attributeMap = RuleUtils.foldableReferencesSkipMVGroupings(join, ctx);
 
             for (var attr : AttributeSet.of(join.config().leftFields())) {
                 var resolved = attributeMap.resolve(attr);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
@@ -346,6 +346,10 @@ public class CsvTests extends ESTestCase {
                 testCase.requiredCapabilities.contains(EsqlCapabilities.Cap.METADATA_SCORE.capabilityName())
             );
             assumeFalseLogging(
+                "CSV tests cannot fold constant_keyword fields",
+                testCase.requiredCapabilities.contains(EsqlCapabilities.Cap.LOAD_CONSTANT_KEYWORD.capabilityName())
+            );
+            assumeFalseLogging(
                 "CSV tests cannot currently handle FORK",
                 testCase.requiredCapabilities.contains(EsqlCapabilities.Cap.FORK_V9.capabilityName())
             );

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/conditional/CaseExtraTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/conditional/CaseExtraTests.java
@@ -184,6 +184,74 @@ public class CaseExtraTests extends ESTestCase {
         assertThat(c.partiallyFold(FoldContext.small()), equalToIgnoringIds(field("last", DataType.LONG)));
     }
 
+    public void testPartialFoldTrailingTextLeadingKeyword() {
+        Case c = new Case(
+            Source.synthetic("case"),
+            new Literal(Source.EMPTY, false, DataType.BOOLEAN),
+            List.of(field("keyword_field", DataType.KEYWORD), field("text_field", DataType.TEXT))
+        );
+        assertThat(c.dataType(), equalTo(DataType.KEYWORD));
+        Expression result = c.partiallyFold(FoldContext.small());
+        assertThat(result, equalToIgnoringIds(field("text_field", DataType.TEXT)));
+        // This should be KEYWORD so it lines up with the original value.
+        // It isn't because the conversion is difficult.
+        // But it's not likely to break anything as is.
+    }
+
+    public void testPartialFoldTrailingKeywordLeadingText() {
+        Case c = new Case(
+            Source.synthetic("case"),
+            new Literal(Source.EMPTY, false, DataType.BOOLEAN),
+            List.of(field("text_field", DataType.TEXT), field("keyword_field", DataType.KEYWORD))
+        );
+        assertThat(c.dataType(), equalTo(DataType.KEYWORD));
+        Expression result = c.partiallyFold(FoldContext.small());
+        assertThat(result, equalToIgnoringIds(field("keyword_field", DataType.KEYWORD)));
+    }
+
+    public void testPartialFoldExplicitNull() {
+        Case c = new Case(
+            Source.synthetic("case"),
+            new Literal(Source.EMPTY, false, DataType.BOOLEAN),
+            List.of(field("username", DataType.KEYWORD), new Literal(Source.EMPTY, null, DataType.NULL))
+        );
+        assertThat(c.dataType(), equalTo(DataType.KEYWORD));
+        Expression result = c.partiallyFold(FoldContext.small());
+        assertThat("partiallyFold must preserve the Case's declared type, not null[NULL]", result.dataType(), equalTo(DataType.KEYWORD));
+    }
+
+    public void testPartialFoldAllFalseExplicitNull() {
+        Case c = new Case(
+            Source.synthetic("case"),
+            new Literal(Source.EMPTY, false, DataType.BOOLEAN),
+            List.of(
+                new Literal(Source.EMPTY, BytesRefs.toBytesRef("a"), DataType.KEYWORD),
+                new Literal(Source.EMPTY, false, DataType.BOOLEAN),
+                new Literal(Source.EMPTY, BytesRefs.toBytesRef("b"), DataType.KEYWORD),
+                new Literal(Source.EMPTY, null, DataType.NULL)
+            )
+        );
+        assertThat(c.dataType(), equalTo(DataType.KEYWORD));
+        Expression result = c.partiallyFold(FoldContext.small());
+        assertThat("partiallyFold must preserve the Case's declared type, not null[NULL]", result.dataType(), equalTo(DataType.KEYWORD));
+    }
+
+    public void testPartialFoldTrueBranchWithNullValue() {
+        Case c = new Case(
+            Source.synthetic("case"),
+            new Literal(Source.EMPTY, false, DataType.BOOLEAN),
+            List.of(
+                new Literal(Source.EMPTY, BytesRefs.toBytesRef("a"), DataType.KEYWORD),
+                new Literal(Source.EMPTY, true, DataType.BOOLEAN),
+                new Literal(Source.EMPTY, null, DataType.NULL),
+                new Literal(Source.EMPTY, BytesRefs.toBytesRef("b"), DataType.KEYWORD)
+            )
+        );
+        assertThat(c.dataType(), equalTo(DataType.KEYWORD));
+        Expression result = c.partiallyFold(FoldContext.small());
+        assertThat("partiallyFold must preserve the Case's declared type, not null[NULL]", result.dataType(), equalTo(DataType.KEYWORD));
+    }
+
     public void testPartialFoldLastAfterKeepingUnknown() {
         Case c = new Case(
             Source.synthetic("case"),
@@ -206,6 +274,23 @@ public class CaseExtraTests extends ESTestCase {
                 )
             )
         );
+    }
+
+    /**
+     * A CASE whose only non-else branch has a literally-FALSE condition is foldable iff the
+     * else value is foldable — the dead branch's value is irrelevant because it will never
+     * be evaluated. The {@code else { continue; }} in {@link Case#foldable()} is load-bearing
+     * here: without it, control falls through to the "value must be foldable" check and
+     * returns {@code false} for the non-foldable field in the dead branch.
+     */
+    public void testFoldableWhenDeadBranchHasNonFoldableValue() {
+        Case c = new Case(
+            Source.synthetic("case"),
+            new Literal(Source.EMPTY, false, DataType.BOOLEAN),
+            List.of(field("dead_value", DataType.LONG), new Literal(Source.EMPTY, 42L, DataType.LONG))
+        );
+        assertThat(c.foldable(), equalTo(true));
+        assertThat(c.fold(FoldContext.small()), equalTo(42L));
     }
 
     public void testEvalCase() {


### PR DESCRIPTION
Backports for
* ESQL: Fixes wrong warning in expressions with unrolled multivalues #145968
* ESQL: Fix data type of partial folded CASE #149752
