### PR TITLE
[ES|QL] Preserve synthetic union conversion attributes through project rewrites

### DIFF
--- a/docs/changelog/149910.yaml
+++ b/docs/changelog/149910.yaml
@@ -1,6 +1,5 @@
 area: ES|QL
-issues:
- - 149509
+issues: []
 pr: 149910
 summary: Preserve synthetic union conversion attributes through project rewrites
 type: bug

--- a/docs/changelog/149910.yaml
+++ b/docs/changelog/149910.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 149509
+pr: 149910
+summary: Preserve synthetic union conversion attributes through project rewrites
+type: bug

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -258,7 +258,6 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
             new InsertFromAggregateMetricDouble(),
             new ResolveImplicitTimeSeriesIdentityGrouping(),
             new ResolveUnionTypesInUnionAll(),
-            new PropagateSyntheticAttributesThroughProjects(),
             new ResolveUnmapped()
         ),
         new Batch<>(
@@ -3546,32 +3545,20 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
      * {@code DROP} omits these attributes, downstream references become unbound and optimization fails
      * with missing-reference errors.
      */
-    private static class PropagateSyntheticAttributesThroughProjects extends Rule<LogicalPlan, LogicalPlan> {
-        @Override
-        public LogicalPlan apply(LogicalPlan plan) {
-            return plan.resolved() ? carryOverSyntheticAttributesThroughProjects(plan) : plan;
-        }
-    }
-
     private static LogicalPlan carryOverSyntheticAttributesThroughProjects(LogicalPlan plan) {
-        AttributeSet.Builder requiredByAncestors = plan.outputSet().asBuilder();
-        return plan.transformDown(p -> {
-            LogicalPlan updated = p;
-            if (p instanceof Project project) {
-                List<Attribute> syntheticAttributesToCarryOver = new ArrayList<>();
-                for (Attribute attr : project.inputSet()) {
-                    if (attr.synthetic() && requiredByAncestors.contains(attr) && project.outputSet().contains(attr) == false) {
-                        syntheticAttributesToCarryOver.add(attr);
-                    }
-                }
-                if (syntheticAttributesToCarryOver.isEmpty() == false) {
-                    List<NamedExpression> newProjections = new ArrayList<>(project.projections());
-                    newProjections.addAll(syntheticAttributesToCarryOver);
-                    updated = new Project(project.source(), project.child(), newProjections);
+        return plan.transformUp(Project.class, p -> {
+            List<Attribute> syntheticAttributesToCarryOver = new ArrayList<>();
+            for (Attribute attr : p.inputSet()) {
+                if (attr.synthetic() && p.outputSet().contains(attr) == false) {
+                    syntheticAttributesToCarryOver.add(attr);
                 }
             }
-            requiredByAncestors.addAll(updated.references());
-            return updated;
+            if (syntheticAttributesToCarryOver.isEmpty()) {
+                return p;
+            }
+            List<NamedExpression> newProjections = new ArrayList<>(p.projections());
+            newProjections.addAll(syntheticAttributesToCarryOver);
+            return new Project(p.source(), p.child(), newProjections);
         });
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -258,6 +258,7 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
             new InsertFromAggregateMetricDouble(),
             new ResolveImplicitTimeSeriesIdentityGrouping(),
             new ResolveUnionTypesInUnionAll(),
+            new PropagateSyntheticAttributesThroughProjects(),
             new ResolveUnmapped()
         ),
         new Batch<>(
@@ -3019,7 +3020,9 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                     : unionAll
             );
 
-            // Carry over the synthetic convert-function attributes added to UnionAll output through Project above it.
+            // Synthetic conversion attributes introduced in UnionAll output must survive intermediate
+            // RENAME/KEEP/DROP projects above the UnionAll until UnionTypesCleanup strips synthetics from
+            // user-visible output.
             if (convertFunctionsToAttributes.isEmpty() == false) {
                 planWithConvertFunctionsPushedDown = carryOverSyntheticAttributesThroughProjects(planWithConvertFunctionsPushedDown);
             }
@@ -3535,32 +3538,40 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
     }
 
     /**
-     * Carry over synthetic attributes that are present in a {@link Project}'s input set but missing from its
-     * projections, by appending them to the projection list. Used by the union-types resolution rules to
-     * propagate newly introduced synthetic {@code $$<field>$converted_to$<type>} attributes (from either
-     * multi-typed {@link EsRelation} fields or {@link UnionAll} branches) through intermediate
-     * {@link Project} nodes that were resolved before the synthetic existed (typically those produced by
-     * {@code RENAME}, {@code KEEP}, or {@code DROP}). Without this, downstream references inserted above
-     * the {@link Project} would have no binding and the optimizer's plan consistency check would later
-     * fail with missing references.
-     *
-     * <p>Used by both {@code ResolveUnionTypes} (for multi-typed EsRelation fields) and
-     * {@code ResolveUnionTypesInUnionAll} (for type conflicts across {@link UnionAll} branches).
+     * Ensure synthetic attributes already present in a {@link Project}'s input remain projected.
+     * <p>
+     * Multiple analysis rules create synthetic attributes (e.g. union-type conversion placeholders
+     * named {@code $$<field>$converted_to$<type>}) and then rewrite expressions above to reference
+     * them. If an intermediate {@link Project} created by commands like {@code RENAME}/{@code KEEP}/
+     * {@code DROP} omits these attributes, downstream references become unbound and optimization fails
+     * with missing-reference errors.
      */
+    private static class PropagateSyntheticAttributesThroughProjects extends Rule<LogicalPlan, LogicalPlan> {
+        @Override
+        public LogicalPlan apply(LogicalPlan plan) {
+            return plan.resolved() ? carryOverSyntheticAttributesThroughProjects(plan) : plan;
+        }
+    }
+
     private static LogicalPlan carryOverSyntheticAttributesThroughProjects(LogicalPlan plan) {
-        return plan.transformUp(Project.class, p -> {
-            List<Attribute> syntheticAttributesToCarryOver = new ArrayList<>();
-            for (Attribute attr : p.inputSet()) {
-                if (attr.synthetic() && p.outputSet().contains(attr) == false) {
-                    syntheticAttributesToCarryOver.add(attr);
+        AttributeSet.Builder requiredByAncestors = plan.outputSet().asBuilder();
+        return plan.transformDown(p -> {
+            LogicalPlan updated = p;
+            if (p instanceof Project project) {
+                List<Attribute> syntheticAttributesToCarryOver = new ArrayList<>();
+                for (Attribute attr : project.inputSet()) {
+                    if (attr.synthetic() && requiredByAncestors.contains(attr) && project.outputSet().contains(attr) == false) {
+                        syntheticAttributesToCarryOver.add(attr);
+                    }
+                }
+                if (syntheticAttributesToCarryOver.isEmpty() == false) {
+                    List<NamedExpression> newProjections = new ArrayList<>(project.projections());
+                    newProjections.addAll(syntheticAttributesToCarryOver);
+                    updated = new Project(project.source(), project.child(), newProjections);
                 }
             }
-            if (syntheticAttributesToCarryOver.isEmpty()) {
-                return p;
-            }
-            List<NamedExpression> newProjections = new ArrayList<>(p.projections());
-            newProjections.addAll(syntheticAttributesToCarryOver);
-            return new Project(p.source(), p.child(), newProjections);
+            requiredByAncestors.addAll(updated.references());
+            return updated;
         });
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
@@ -45,6 +45,8 @@ import org.elasticsearch.xpack.esql.core.expression.UnsupportedAttribute;
 import org.elasticsearch.xpack.esql.core.expression.predicate.operator.comparison.BinaryComparison;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.type.EsField;
+import org.elasticsearch.xpack.esql.core.type.InvalidMappedField;
 import org.elasticsearch.xpack.esql.core.type.PotentiallyUnmappedKeywordEsField;
 import org.elasticsearch.xpack.esql.core.util.DateUtils;
 import org.elasticsearch.xpack.esql.core.util.Holder;
@@ -166,6 +168,7 @@ import org.elasticsearch.xpack.esql.rule.RuleExecutor;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -11362,6 +11365,89 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
         var testAnalyzer = EsqlTestUtils.analyzer().addIndex(IndexResolution.valid(mixedIndex));
         var plan = logicalOptimizerWithLatestVersion.optimize(testAnalyzer.query("TS * | STATS count(events_received)"));
         assertNotNull(plan);
+    }
+
+    /**
+     * Invariant: analyzer-generated synthetic conversion attributes must remain addressable even if users define
+     * attributes with similar names.
+     * Defect: synthetic and user-defined naming overlap previously caused missing references.
+     * Expected: both the synthetic conversion attribute and user-facing fields survive optimization.
+     */
+    public void testSyntheticUnionConversionAttributeSurvivesUserShadowing() {
+        LinkedHashMap<String, Set<String>> typesToIndices = new LinkedHashMap<>();
+        typesToIndices.put("ip", Set.of("testidx"));
+        typesToIndices.put("keyword", Set.of("testidx2"));
+
+        EsField clientIpField = new InvalidMappedField("client_ip", typesToIndices);
+        EsIndex index = new EsIndex(
+            "testidx*",
+            Map.of("client_ip", clientIpField),
+            Map.of("testidx", IndexMode.STANDARD, "testidx2", IndexMode.STANDARD),
+            Map.of(),
+            Map.of()
+        );
+        var testAnalyzer = EsqlTestUtils.analyzer().addIndex(IndexResolution.valid(index));
+
+        LogicalPlan plan = logicalOptimizerWithLatestVersion.optimize(testAnalyzer.query("""
+            FROM testidx*
+            | EVAL `$$client_ip$converted_to$ip` = "1.1.1.1"::ip
+            | EVAL x = client_ip::ip
+            | EVAL y = `$$client_ip$converted_to$ip`
+            """));
+
+        List<String> outputNames = plan.output().stream().map(Attribute::name).toList();
+        assertThat(outputNames, hasItems("x", "y", "$$client_ip$converted_to$ip"));
+        assertEquals(1, outputNames.stream().filter("$$client_ip$converted_to$ip"::equals).count());
+    }
+
+    /**
+     * Invariant: synthetic conversion attributes introduced for UNION type resolution must survive intermediate
+     * project-style operators (RENAME/KEEP/DROP) until downstream rewrites finish.
+     * Defect: project-style operators dropped synthetic attributes, causing missing references in later stats.
+     * Expected: plan resolves successfully and exposes only user-visible output attributes.
+     */
+    public void testProjectsCarrySyntheticUnionAttributesUntilStatsRewrite() {
+        assumeTrue("Requires subquery in FROM command support", EsqlCapabilities.Cap.SUBQUERY_IN_FROM_COMMAND.isEnabled());
+
+        var testAnalyzer = EsqlTestUtils.analyzer()
+            .addIndex("multi_column_joinable", "mapping-multi_column_joinable.json")
+            .addLookupIndex("multi_column_joinable_lookup", "mapping-multi_column_joinable_lookup.json");
+
+        LogicalPlan plan = logicalOptimizerWithLatestVersion.optimize(testAnalyzer.query("""
+            FROM multi_column_joinable, (FROM multi_column_joinable)
+            | RENAME extra2 AS other2
+            | LOOKUP JOIN multi_column_joinable_lookup ON id_int, other2
+            | MV_EXPAND other2
+            | STATS absent(to_string(id_int))
+            """));
+
+        assertTrue(plan.resolved());
+        assertTrue(plan.output().stream().noneMatch(Attribute::synthetic));
+    }
+
+    /**
+     * Invariant: COUNT_DISTINCT_OVER_TIME should resolve cleanly across mixed source patterns in TS mode.
+     * Defect: mixed-source expansions could trigger missing-reference failures in optimization.
+     * Expected: plan resolves and retains the expected user output schema.
+     */
+    public void testCountDistinctOverTimeResolvesAcrossMixedSourcePatterns() {
+        var mixedSources = new EsIndex(
+            "k8s_stored_source,k8s*,emplo*",
+            EsqlTestUtils.loadMapping("k8s-mappings.json"),
+            Map.of("k8s_stored_source", IndexMode.TIME_SERIES, "k8s", IndexMode.TIME_SERIES, "employees", IndexMode.STANDARD),
+            Map.of("", List.of("k8s_stored_source", "k8s*", "emplo*")),
+            Map.of("", List.of("k8s_stored_source", "k8s", "employees"))
+        );
+        var testAnalyzer = EsqlTestUtils.analyzer().addIndex(IndexResolution.valid(mixedSources));
+
+        LogicalPlan plan = logicalOptimizerWithLatestVersion.optimize(testAnalyzer.query("""
+            TS k8s_stored_source, k8s*, emplo*
+            | STATS c = count_distinct_over_time(network.cost)
+            | SORT c DESC
+            """));
+        assertTrue(plan.resolved());
+        assertThat(Expressions.names(plan.output()), hasItems("c"));
+        assertTrue(plan.output().stream().noneMatch(Attribute::synthetic));
     }
 
     public void testTsWildcardWithRateAggregate() {


### PR DESCRIPTION
## Summary

Follow-up to #149775.

This PR hardens analyzer handling for union-type synthetic conversion attributes by ensuring they survive intermediate project-style rewrites until final cleanup.

Specifically:
- centralizes synthetic-attribute carryover through `Project`-style nodes in `Analyzer`
- applies the same carryover logic to both union-type resolution paths
- limits propagation to resolved plans to preserve expected verifier behavior on unresolved queries
- keeps propagation demand-driven so only ancestor-required synthetic attributes are carried

## Why

`ResolveUnionTypes*` can introduce synthetic attributes such as `$$field$converted_to$type` and rewrite upstream expressions to reference them.
If intermediate `RENAME`/`KEEP`/`DROP`-style projections omit those attributes, downstream nodes fail with missing references during optimization.

This is the same bug family as #149775/#149509, generalized into a shared analyzer invariant.

Refs #149619
Refs #110964