### PR TITLE
[ES|QL] Keep LIMIT BY above MV_EXPAND when needed

### DIFF
--- a/docs/changelog/149911.yaml
+++ b/docs/changelog/149911.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 148513
+pr: 149911
+summary: Keep LIMIT BY above MV_EXPAND when needed
+type: bug

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
@@ -491,7 +491,6 @@ public abstract class GenerativeRestTest extends ESRestTestCase implements Query
         ctx -> isForkTopNIndexOutOfBoundsBug(ctx.normalizedErrorMessage, ctx.query),
         ctx -> isForkOptimizedIncorrectlyBug(ctx.normalizedErrorMessage, ctx.query),
         ctx -> isRenameMvExpandOrderByBug(ctx.normalizedErrorMessage, ctx.query),
-        ctx -> isLimitByMvExpandBug(ctx.normalizedErrorMessage, ctx.query),
         ctx -> isInlineStatsMvExpandOrderByBug(ctx.normalizedErrorMessage, ctx.query),
         ctx -> isChangePointLimitByBug(ctx.normalizedErrorMessage, ctx.query),
         ctx -> isAggregateAbsentToStringSubqueryLookupJoinBug(ctx.normalizedErrorMessage, ctx.query),
@@ -1070,27 +1069,6 @@ public abstract class GenerativeRestTest extends ESRestTestCase implements Query
         ".*Plan \\[(?:LimitBy|TopNBy)\\[.*optimized incorrectly due to missing references.*",
         Pattern.DOTALL
     );
-
-    private static final Pattern LIMIT_BY_COMMAND_PATTERN = Pattern.compile("(?i)\\|\\s*LIMIT\\s+\\S+\\s+BY\\b");
-    private static final Pattern DEDUP_COMMAND_PATTERN = Pattern.compile("(?i)\\|\\s*DEDUP\\b");
-
-    /**
-     * See https://github.com/elastic/elasticsearch/issues/148513
-     * <p>
-     * The same root cause manifests as either {@code LimitBy[...]} (no upstream SORT) or {@code TopNBy[...]}
-     * (when an upstream SORT gets combined with the LIMIT BY into a TopNBy). DEDUP uses the same LimitBy
-     * plan internally, so it has the same missing-reference failure after MV_EXPAND.
-     */
-    static boolean isLimitByMvExpandBug(String errorMessage, String query) {
-        if (errorMessage == null || query == null) {
-            return false;
-        }
-        if (OPTIMIZED_INCORRECTLY_LIMITBY_PATTERN.matcher(errorMessage).matches() == false) {
-            return false;
-        }
-        return MV_EXPAND_COMMAND_PATTERN.matcher(query).find()
-            && (LIMIT_BY_COMMAND_PATTERN.matcher(query).find() || DEDUP_COMMAND_PATTERN.matcher(query).find());
-    }
 
     private static final Pattern INLINE_STATS_COMMAND_PATTERN = Pattern.compile("(?i)\\|\\s*INLINE\\s+STATS\\b");
     private static final Pattern DROP_RENAME_KEEP_COMMAND_PATTERN = Pattern.compile("(?i)\\|\\s*(?:DROP|RENAME|KEEP)\\b");

--- a/x-pack/plugin/esql/qa/server/src/test/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTestTests.java
+++ b/x-pack/plugin/esql/qa/server/src/test/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTestTests.java
@@ -14,30 +14,6 @@ import org.elasticsearch.test.ESTestCase;
  */
 public class GenerativeRestTestTests extends ESTestCase {
 
-    public void testLimitByMvExpandBugMatchesDedup() {
-        String query = "ROW x = 1 | MV_EXPAND x | DEDUP";
-        String error = "illegal_state_exception: Found 1 problem\n"
-            + "line 1:27: Plan [LimitBy[1[INTEGER],[x{r}#3594],false]] optimized incorrectly due to missing references [x{r}#3594]";
-
-        assertTrue(GenerativeRestTest.isLimitByMvExpandBug(error, query));
-    }
-
-    public void testLimitByMvExpandBugMatchesLimitBy() {
-        String query = "ROW x = 1 | MV_EXPAND x | LIMIT 1 BY x";
-        String error = "illegal_state_exception: Found 1 problem\n"
-            + "line 1:40: Plan [LimitBy[1[INTEGER],[x{r}#3594],false]] optimized incorrectly due to missing references [x{r}#3594]";
-
-        assertTrue(GenerativeRestTest.isLimitByMvExpandBug(error, query));
-    }
-
-    public void testLimitByMvExpandBugRequiresMvExpand() {
-        String query = "ROW x = 1 | DEDUP";
-        String error = "illegal_state_exception: Found 1 problem\n"
-            + "line 1:17: Plan [LimitBy[1[INTEGER],[x{r}#3594],false]] optimized incorrectly due to missing references [x{r}#3594]";
-
-        assertFalse(GenerativeRestTest.isLimitByMvExpandBug(error, query));
-    }
-
     public void testFullTextAfterSubqueryMatchesLimitInsideSubquery() {
         String query = "FROM books, (FROM books | LIMIT 1) | WHERE match(title, \"quick\")";
         String error = "verification_exception: line 1:13: [MATCH] function cannot be used after LIMIT";

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/limit.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/limit.csv-spec
@@ -1292,6 +1292,7 @@ FROM sample_data
 
 limitByMvExpandGroupingTarget
 required_capability: esql_limit_by
+required_capability: limit_by_mv_expand_grouping_fix
 
 // https://github.com/elastic/elasticsearch/issues/148513
 ROW x = [1, 1, 2, 2, 3]
@@ -1309,6 +1310,7 @@ x:integer
 limitByMvExpandGroupingTargetWithSort
 required_capability: esql_limit_by
 required_capability: esql_topn_by
+required_capability: limit_by_mv_expand_grouping_fix
 
 // Same bug when SORT combines with LIMIT BY into TopNBy
 FROM employees
@@ -1326,6 +1328,7 @@ emp_no:integer | languages:integer
 
 limitByMvExpandScalar
 required_capability: esql_limit_by
+required_capability: limit_by_mv_expand_grouping_fix
 
 ROW x = 1
 | MV_EXPAND x

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/limit.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/limit.csv-spec
@@ -1290,6 +1290,52 @@ FROM sample_data
 2023-10-23T13:51:54.732Z | Connection error
 ;
 
+limitByMvExpandGroupingTarget
+required_capability: esql_limit_by
+
+// https://github.com/elastic/elasticsearch/issues/148513
+ROW x = [1, 1, 2, 2, 3]
+| MV_EXPAND x
+| LIMIT 1 BY x
+| SORT x
+;
+
+x:integer
+1
+2
+3
+;
+
+limitByMvExpandGroupingTargetWithSort
+required_capability: esql_limit_by
+required_capability: esql_topn_by
+
+// Same bug when SORT combines with LIMIT BY into TopNBy
+FROM employees
+| WHERE emp_no IN (10002, 10004)
+| SORT emp_no
+| LIMIT 100
+| MV_EXPAND languages
+| LIMIT 1 BY languages
+| KEEP emp_no, languages
+;
+
+emp_no:integer | languages:integer
+10002          | 5
+;
+
+limitByMvExpandScalar
+required_capability: esql_limit_by
+
+ROW x = 1
+| MV_EXPAND x
+| LIMIT 1 BY x
+;
+
+x:integer
+1
+;
+
 replaceTopNWithLimitOnConstantSort
 FROM employees
 | EVAL x = null

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -2800,6 +2800,12 @@ public class EsqlCapabilities {
         LIMIT_BY_ENRICH_FIX(ESQL_LIMIT_BY.isEnabled()),
 
         /**
+         * Fix pushdown of LIMIT BY past MV_EXPAND when grouping on expanded fields.
+         * See <a href="https://github.com/elastic/elasticsearch/issues/148513">#148513</a>.
+         */
+        LIMIT_BY_MV_EXPAND_GROUPING_FIX,
+
+        /**
          * Fix window validation in time-series aggregations when TBUCKET uses a numeric target bucket count.
          */
         FIX_TBUCKET_TARGET_COUNT_WINDOW_VALIDATION,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownAndCombineLimitBy.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownAndCombineLimitBy.java
@@ -60,6 +60,9 @@ public final class PushDownAndCombineLimitBy extends OptimizerRules.Parameterize
                     return unary.replaceChild(limitBy.replaceChild(unary.child()));
                 }
             } else if (unary instanceof MvExpand) {
+                if (groupingAttrsDefinedByChild(limitBy, unary)) {
+                    return limitBy;
+                }
                 return duplicateLimitByAsFirstGrandchild(limitBy);
             } else if (unary instanceof Enrich enrich) {
                 if (groupingAttrsDefinedByChild(limitBy, enrich)) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownAndCombineLimitByGoldenTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownAndCombineLimitByGoldenTests.java
@@ -138,6 +138,18 @@ public class PushDownAndCombineLimitByGoldenTests extends GoldenTestCase {
     }
 
     /**
+     * LIMIT BY groups by the MV_EXPAND target, so it must stay above the expand and must not be
+     * duplicated below it. See https://github.com/elastic/elasticsearch/issues/148513
+     */
+    public void testLimitByNotDuplicatedPastMvExpandWhenGroupingByExpandTarget() {
+        runGoldenTest("""
+            ROW x = 1
+            | MV_EXPAND x
+            | LIMIT 1 BY x
+            """, STAGES, STATS);
+    }
+
+    /**
      * We duplicate the LIMIT BY if we limit by a shadowed join field
      */
     public void testLimitByShadowedJoinFieldDuplicated() {

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/PushDownAndCombineLimitByGoldenTests/testLimitByNotDuplicatedPastMvExpandWhenGroupingByExpandTarget/logical_optimization.expected
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/PushDownAndCombineLimitByGoldenTests/testLimitByNotDuplicatedPastMvExpandWhenGroupingByExpandTarget/logical_optimization.expected
@@ -1,0 +1,4 @@
+Limit[1000[INTEGER],false,false]
+\_LimitBy[1[INTEGER],[x{r}#0],false]
+  \_MvExpand[x{r}#1,x{r}#0]
+    \_LocalRelation[[x{r}#1],Page{blocks=[IntVectorBlock[vector=ConstantIntVector[positions=1, value=1]]]}]

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/PushDownAndCombineLimitByGoldenTests/testLimitByNotDuplicatedPastMvExpandWhenGroupingByExpandTarget/query.esql
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/PushDownAndCombineLimitByGoldenTests/testLimitByNotDuplicatedPastMvExpandWhenGroupingByExpandTarget/query.esql
@@ -1,0 +1,3 @@
+ROW x = 1
+| MV_EXPAND x
+| LIMIT 1 BY x


### PR DESCRIPTION
## Summary

This PR fixes a logical optimization bug where `LIMIT BY` could be pushed below `MV_EXPAND` even when grouping attributes are produced by the expand target.

## Why

For plans like:

```esql
ROW x = 1
| MV_EXPAND x
| LIMIT 1 BY x
```

pushing `LIMIT BY` below `MV_EXPAND` can produce unbound grouping references and fail with missing-reference errors.

This change keeps `LIMIT BY` above `MV_EXPAND` when grouping attributes are defined by the child, preserving attribute liveness through optimization.

Closes #148513