### PR TITLE
[ES|QL] Prune dead INLINE STATS branches before mapping

### DIFF
--- a/docs/changelog/149911.yaml
+++ b/docs/changelog/149911.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 148513
+pr: 149911
+summary: Keep LIMIT BY above MV_EXPAND when needed
+type: bug

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
@@ -449,7 +449,6 @@ public abstract class GenerativeRestTest extends ESRestTestCase implements Query
         ctx -> isForkTopNIndexOutOfBoundsBug(ctx.normalizedErrorMessage, ctx.query),
         ctx -> isForkOptimizedIncorrectlyBug(ctx.normalizedErrorMessage, ctx.query),
         ctx -> isRenameMvExpandOrderByBug(ctx.normalizedErrorMessage, ctx.query),
-        ctx -> isLimitByMvExpandBug(ctx.normalizedErrorMessage, ctx.query),
         ctx -> isInlineStatsMvExpandOrderByBug(ctx.normalizedErrorMessage, ctx.query),
         ctx -> isChangePointLimitByBug(ctx.normalizedErrorMessage, ctx.query),
         ctx -> isAggregateAbsentToStringSubqueryLookupJoinBug(ctx.normalizedErrorMessage, ctx.query),
@@ -1021,24 +1020,6 @@ public abstract class GenerativeRestTest extends ESRestTestCase implements Query
         ".*Plan \\[(?:LimitBy|TopNBy)\\[.*optimized incorrectly due to missing references.*",
         Pattern.DOTALL
     );
-
-    private static final Pattern LIMIT_BY_COMMAND_PATTERN = Pattern.compile("(?i)\\|\\s*LIMIT\\s+\\S+\\s+BY\\b");
-
-    /**
-     * See https://github.com/elastic/elasticsearch/issues/148513
-     * <p>
-     * The same root cause manifests as either {@code LimitBy[...]} (no upstream SORT) or {@code TopNBy[...]}
-     * (when an upstream SORT gets combined with the LIMIT BY into a TopNBy).
-     */
-    static boolean isLimitByMvExpandBug(String errorMessage, String query) {
-        if (errorMessage == null || query == null) {
-            return false;
-        }
-        if (OPTIMIZED_INCORRECTLY_LIMITBY_PATTERN.matcher(errorMessage).matches() == false) {
-            return false;
-        }
-        return MV_EXPAND_COMMAND_PATTERN.matcher(query).find() && LIMIT_BY_COMMAND_PATTERN.matcher(query).find();
-    }
 
     private static final Pattern INLINE_STATS_COMMAND_PATTERN = Pattern.compile("(?i)\\|\\s*INLINE\\s+STATS\\b");
     private static final Pattern DROP_RENAME_KEEP_COMMAND_PATTERN = Pattern.compile("(?i)\\|\\s*(?:DROP|RENAME|KEEP)\\b");

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/limit.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/limit.csv-spec
@@ -1288,3 +1288,49 @@ FROM sample_data
 2023-10-23T13:33:34.937Z | Disconnected
 2023-10-23T13:51:54.732Z | Connection error
 ;
+
+limitByMvExpandGroupingTarget
+required_capability: esql_limit_by
+
+// https://github.com/elastic/elasticsearch/issues/148513
+ROW x = [1, 1, 2, 2, 3]
+| MV_EXPAND x
+| LIMIT 1 BY x
+| SORT x
+;
+
+x:integer
+1
+2
+3
+;
+
+limitByMvExpandGroupingTargetWithSort
+required_capability: esql_limit_by
+required_capability: esql_topn_by
+
+// Same bug when SORT combines with LIMIT BY into TopNBy
+FROM employees
+| WHERE emp_no IN (10002, 10004)
+| SORT emp_no
+| LIMIT 100
+| MV_EXPAND languages
+| LIMIT 1 BY languages
+| KEEP emp_no, languages
+;
+
+emp_no:integer | languages:integer
+10002          | 5
+;
+
+limitByMvExpandScalar
+required_capability: esql_limit_by
+
+ROW x = 1
+| MV_EXPAND x
+| LIMIT 1 BY x
+;
+
+x:integer
+1
+;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneColumns.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneColumns.java
@@ -29,6 +29,7 @@ import org.elasticsearch.xpack.esql.plan.logical.Sample;
 import org.elasticsearch.xpack.esql.plan.logical.UnaryPlan;
 import org.elasticsearch.xpack.esql.plan.logical.UnionAll;
 import org.elasticsearch.xpack.esql.plan.logical.join.InlineJoin;
+import org.elasticsearch.xpack.esql.plan.logical.join.StubRelation;
 import org.elasticsearch.xpack.esql.plan.logical.local.LocalRelation;
 import org.elasticsearch.xpack.esql.plan.logical.local.LocalSupplier;
 import org.elasticsearch.xpack.esql.planner.PlannerUtils;
@@ -77,12 +78,13 @@ public final class PruneColumns extends Rule<LogicalPlan, LogicalPlan> {
             do {
                 recheck.set(false);
                 p = switch (p) {
-                    case Aggregate agg -> pruneColumnsInAggregate(agg, used, inlineJoin);
+                    case Aggregate agg -> pruneColumnsInAggregate(agg, used, inlineJoin, recheck);
                     case InlineJoin inj -> pruneColumnsInInlineJoin(inj, used, recheck);
                     case Eval eval -> pruneColumnsInEval(eval, used, recheck);
                     case Project project -> pruneColumnsInProject(project, used, recheck);
                     case EsRelation esr -> pruneColumnsInEsRelation(esr, used);
                     case ExternalRelation ext -> pruneColumnsInExternalRelation(ext, used);
+                    case StubRelation stubRelation -> pruneColumnsInStubRelation(stubRelation, used);
                     case Fork fork -> {
                         forkPresent.set(true);
                         yield pruneColumnsInFork(fork, used);
@@ -99,7 +101,12 @@ public final class PruneColumns extends Rule<LogicalPlan, LogicalPlan> {
         });
     }
 
-    private static LogicalPlan pruneColumnsInAggregate(Aggregate aggregate, AttributeSet.Builder used, boolean inlineJoin) {
+    private static LogicalPlan pruneColumnsInAggregate(
+        Aggregate aggregate,
+        AttributeSet.Builder used,
+        boolean inlineJoin,
+        Holder<Boolean> recheck
+    ) {
         LogicalPlan p = aggregate;
         var remaining = pruneUnusedAndAddReferences(aggregate.aggregates(), used);
 
@@ -110,6 +117,7 @@ public final class PruneColumns extends Rule<LogicalPlan, LogicalPlan> {
             if (inlineJoin) {
                 // all aggregates are pruned, delegate to child plan
                 p = aggregate.child();
+                recheck.set(true);
             } else if (aggregate.groupings().isEmpty()) {
                 // We still need to have a plan that produces 1 row per group.
                 p = new LocalRelation(
@@ -130,6 +138,7 @@ public final class PruneColumns extends Rule<LogicalPlan, LogicalPlan> {
                 // already part of the IJ output (from the left-hand side): the agg can just be dropped entirely.
                 if (aggregate.groupings().containsAll(remaining)) {
                     p = aggregate.child();
+                    recheck.set(true);
                 }
                 // TODO: deal with prunning partial groupings in InlineJoin right side
             } else { // not an INLINEJOIN or there are actually aggregates to compute
@@ -218,6 +227,13 @@ public final class PruneColumns extends Rule<LogicalPlan, LogicalPlan> {
     private static LogicalPlan pruneColumnsInExternalRelation(ExternalRelation ext, AttributeSet.Builder used) {
         var remaining = pruneUnusedAndAddReferences(ext.output(), used);
         return remaining != null ? ext.withAttributes(remaining) : ext;
+    }
+
+    private static LogicalPlan pruneColumnsInStubRelation(StubRelation stubRelation, AttributeSet.Builder used) {
+        var remaining = pruneUnusedAndAddReferences(stubRelation.output(), used);
+        return remaining != null
+            ? new StubRelation(stubRelation.source(), remaining.stream().map(Expressions::attribute).toList())
+            : stubRelation;
     }
 
     // TODO: see ResolveUnmapped#patchFork comment

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownAndCombineLimitBy.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownAndCombineLimitBy.java
@@ -60,6 +60,9 @@ public final class PushDownAndCombineLimitBy extends OptimizerRules.Parameterize
                     return unary.replaceChild(limitBy.replaceChild(unary.child()));
                 }
             } else if (unary instanceof MvExpand) {
+                if (groupingAttrsDefinedByChild(limitBy, unary)) {
+                    return limitBy;
+                }
                 return duplicateLimitByAsFirstGrandchild(limitBy);
             } else if (unary instanceof Enrich enrich) {
                 if (groupingAttrsDefinedByChild(limitBy, enrich)) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
@@ -10368,6 +10368,32 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
     }
 
     /**
+     * Invariant: inline-stats right branches that contribute no remaining outputs should be pruned away before
+     * physical mapping.
+     * Defect: dead inline-stats branches could leave StubRelation in the logical tree and fail mapping.
+     * Expected: logical plan is stub-free for this query shape and physical optimization succeeds.
+     */
+    public void testInlineStatsUnusedRightBranchIsPrunedBeforePhysicalMapping() {
+        assumeTrue("INLINE STATS must be enabled", INLINE_STATS.isEnabled());
+        assumeTrue("Requires subquery in FROM command support", EsqlCapabilities.Cap.SUBQUERY_IN_FROM_COMMAND.isEnabled());
+
+        TestDataSource multiColumnJoinable = makeTestDataSource("multi_column_joinable", "mapping-multi_column_joinable.json");
+        String query = """
+            FROM multi_column_joinable, (FROM multi_column_joinable)
+            | EVAL x = id_int
+            | INLINE STATS d = max(x)
+            | STATS d2 = count(*)
+            """;
+
+        var logical = multiColumnJoinable.logicalOptimizer().optimize(multiColumnJoinable.analyzer.analyze(TEST_PARSER.parseQuery(query)));
+        assertThat(logical.toString(), not(containsString("StubRelation")));
+
+        PhysicalPlan plan = physicalPlan(query, multiColumnJoinable, false);
+        PhysicalPlan optimized = optimizedPlan(plan, multiColumnJoinable);
+        assertNotNull(optimized);
+    }
+
+    /**
      * ProjectExec[[first_name{f}#6]]
      * \_TopNExec[[Order[last_name{f}#9,ASC,LAST]],1000[INTEGER],null]
      *   \_ExchangeExec[[],false]

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownAndCombineLimitByGoldenTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownAndCombineLimitByGoldenTests.java
@@ -138,6 +138,18 @@ public class PushDownAndCombineLimitByGoldenTests extends GoldenTestCase {
     }
 
     /**
+     * LIMIT BY groups by the MV_EXPAND target, so it must stay above the expand and must not be
+     * duplicated below it. See https://github.com/elastic/elasticsearch/issues/148513
+     */
+    public void testLimitByNotDuplicatedPastMvExpandWhenGroupingByExpandTarget() {
+        runGoldenTest("""
+            ROW x = 1
+            | MV_EXPAND x
+            | LIMIT 1 BY x
+            """, STAGES, STATS);
+    }
+
+    /**
      * We duplicate the LIMIT BY if we limit by a shadowed join field
      */
     public void testLimitByShadowedJoinFieldDuplicated() {

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/PushDownAndCombineLimitByGoldenTests/testLimitByNotDuplicatedPastMvExpandWhenGroupingByExpandTarget/logical_optimization.expected
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/PushDownAndCombineLimitByGoldenTests/testLimitByNotDuplicatedPastMvExpandWhenGroupingByExpandTarget/logical_optimization.expected
@@ -1,0 +1,4 @@
+Limit[1000[INTEGER],false,false]
+\_LimitBy[1[INTEGER],[x{r}#0],false]
+  \_MvExpand[x{r}#1,x{r}#0]
+    \_LocalRelation[[x{r}#1],Page{blocks=[IntVectorBlock[vector=ConstantIntVector[positions=1, value=1]]]}]

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/PushDownAndCombineLimitByGoldenTests/testLimitByNotDuplicatedPastMvExpandWhenGroupingByExpandTarget/query.esql
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/PushDownAndCombineLimitByGoldenTests/testLimitByNotDuplicatedPastMvExpandWhenGroupingByExpandTarget/query.esql
@@ -1,0 +1,3 @@
+ROW x = 1
+| MV_EXPAND x
+| LIMIT 1 BY x


### PR DESCRIPTION
## Summary

This PR tightens logical pruning for subquery + `INLINE STATS` shapes so dead right-hand branches are removed before physical mapping.

## Why

When downstream operators stop consuming `INLINE STATS` output, dead branches could retain `StubRelation` nodes and carry stale references into physical planning.

This change:
- adds `StubRelation` pruning to `PruneColumns`
- triggers re-check pruning passes when inline-join-side aggregates collapse

That prevents unsupported/dead logical nodes from reaching physical mapping and eliminates missing-reference failures for this query family.

Closes #149589