### PR TITLE
ESQL: drop shadowed project from CPS view body

### DIFF
--- a/docs/changelog/149915.yaml
+++ b/docs/changelog/149915.yaml
@@ -1,0 +1,5 @@
+pr: 149915
+summary: Exclude a linked project from a CPS view body when it owns a same-named index
+area: ES|QL
+type: bug
+issues: []

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -237,8 +237,8 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
             Limiter.ONCE,
             new ResolveConfigurationAware(),
             new ResolveTable(),
-            new ResolveViewShadow(),
             new ExcludeShadowedProjectsFromViewBody(),
+            new ResolveViewShadow(),
             new ViewCompactionPostIndexResolution(),
             new ResolveExternalRelations(),
             new PruneEmptyUnionAllBranch(),
@@ -499,71 +499,84 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                 // ViewCompactionPostIndexResolution to strip.
                 return shadow;
             }
-            EsIndex esIndex = resolution.get();
-            var attributes = mappingAsAttributes(shadow.source(), esIndex.mapping());
-            return new EsRelation(
-                shadow.source(),
-                esIndex.name(),
-                IndexMode.STANDARD,
-                esIndex.originalIndices(),
-                esIndex.concreteIndices(),
-                esIndex.indexNameWithModes(),
-                attributes.isEmpty() ? NO_FIELDS : attributes
-            );
+            return esRelationForShadow(shadow, resolution);
         }
     }
 
     /**
-     * Completes view-shadow resolution under CPS: when a {@link ViewShadowRelation} resolved to a
-     * remote <em>index</em> on a linked project (i.e. that project owns an index sharing the local
-     * view's name), the view body must not <em>also</em> run on that project. A name cannot be both
-     * a view and an index on the same project; the index wins on its own project, so the view is
-     * excluded there and the project contributes only via its index (the resolved shadow branch).
+     * Builds the {@link EsRelation} that a matched {@link ViewShadowRelation} resolves to — the remote
+     * index sharing the local view's name. Shared by {@link ResolveViewShadow} (standalone shadows)
+     * and {@link ExcludeShadowedProjectsFromViewBody} (in-union shadows).
+     */
+    private static EsRelation esRelationForShadow(ViewShadowRelation shadow, IndexResolution resolution) {
+        EsIndex esIndex = resolution.get();
+        var attributes = mappingAsAttributes(shadow.source(), esIndex.mapping());
+        return new EsRelation(
+            shadow.source(),
+            esIndex.name(),
+            IndexMode.STANDARD,
+            esIndex.originalIndices(),
+            esIndex.concreteIndices(),
+            esIndex.indexNameWithModes(),
+            attributes.isEmpty() ? NO_FIELDS : attributes
+        );
+    }
+
+    /**
+     * Resolves the {@link ViewShadowRelation}s inside a {@link ViewUnionAll} and excludes, from each
+     * local view's body, any linked project that owns an <em>index</em> sharing the view's name. A
+     * name cannot be both a view and an index on the same project; the index wins on its own project,
+     * so the view must not run there — the project contributes only via its index (the resolved shadow
+     * branch).
      * <p>
-     * The rule pairs each resolved shadow branch (keyed {@code <viewName>}{@link ViewShadowRelation#NAME_SUFFIX}
-     * inside the {@link ViewUnionAll}) with its strict body branch (keyed {@code <viewName>}) and
-     * removes the shadowed project(s) — read from the shadow's resolved {@link EsRelation#concreteIndices()}
-     * — from every {@link EsRelation} in the body subtree via {@link EsRelation#withoutClusters}. The
-     * body then fans out to origin and all other linked projects, but not the colliding one. For
-     * nested views the prune covers the whole body subtree, which is correct: if the outer view name
-     * collides on a project, none of its (possibly nested) definition runs there.
+     * Pairing is by the view name the shadow carries as a data field ({@link ViewShadowRelation#viewName()}),
+     * matched against the body branch keyed by that same view name. The shadow branch's own map key is
+     * never parsed, so the link does not depend on the {@code #shadow} suffix convention.
      * <p>
-     * Runs after {@link ResolveViewShadow} (which turns matched shadows into {@code EsRelation}s) and
-     * before {@link ViewCompactionPostIndexResolution} (which strips unmatched shadows and flattens
-     * the {@link ViewUnionAll}, discarding the {@code #shadow} name pairing this rule relies on). See
+     * This rule resolves in-union shadows itself (rather than leaving them all to {@link ResolveViewShadow})
+     * so that the exclusion is correct for nested views. Because it runs bottom-up
+     * ({@code transformUp}), an inner {@link ViewUnionAll} is fully resolved before an enclosing one is
+     * processed; so when an outer view-name collision prunes its body subtree via
+     * {@link EsRelation#withoutClusters}, any inner shadow — already an {@link EsRelation} by then — is
+     * pruned too. An outer collision therefore excludes the whole (possibly nested) view definition on
+     * that project, including inner same-named indexes. {@link ResolveViewShadow} still runs afterwards
+     * to resolve any standalone shadow not wrapped in a {@link ViewUnionAll}. See
      * <a href="https://github.com/elastic/esql-planning/issues/795">esql-planning#795</a>.
      */
-    private static class ExcludeShadowedProjectsFromViewBody extends Rule<LogicalPlan, LogicalPlan> {
+    private static class ExcludeShadowedProjectsFromViewBody extends ParameterizedAnalyzerRule<ViewUnionAll, AnalyzerContext> {
 
         @Override
-        public LogicalPlan apply(LogicalPlan plan) {
-            return plan.transformUp(ViewUnionAll.class, ExcludeShadowedProjectsFromViewBody::rewrite);
-        }
-
-        private static LogicalPlan rewrite(ViewUnionAll viewUnionAll) {
-            Map<String, LogicalPlan> namedSubqueries = viewUnionAll.namedSubqueries();
-            // Per view name, the linked projects whose same-named index the shadow resolved to.
-            Map<String, Set<String>> shadowedProjectsByView = new HashMap<>();
-            for (Map.Entry<String, LogicalPlan> entry : namedSubqueries.entrySet()) {
-                String name = entry.getKey();
-                if (name.endsWith(ViewShadowRelation.NAME_SUFFIX) && entry.getValue() instanceof EsRelation shadowRelation) {
-                    String viewName = name.substring(0, name.length() - ViewShadowRelation.NAME_SUFFIX.length());
-                    shadowedProjectsByView.put(viewName, shadowRelation.concreteIndices().keySet());
+        protected LogicalPlan rule(ViewUnionAll viewUnionAll, AnalyzerContext context) {
+            // Resolve in-union shadows, collecting per view name the linked projects owning a same-named index.
+            Map<String, Set<String>> projectsByView = new HashMap<>();
+            LinkedHashMap<String, LogicalPlan> resolvedShadows = new LinkedHashMap<>();
+            for (Map.Entry<String, LogicalPlan> entry : viewUnionAll.namedSubqueries().entrySet()) {
+                LogicalPlan child = entry.getValue();
+                if (child instanceof ViewShadowRelation shadow) {
+                    IndexResolution resolution = context.optionalLinkedResolution().get(shadow.optionalLinkedPattern());
+                    if (resolution != null && resolution.isValid()) {
+                        projectsByView.computeIfAbsent(shadow.viewName(), k -> new HashSet<>())
+                            .addAll(resolution.get().concreteIndices().keySet());
+                        resolvedShadows.put(entry.getKey(), esRelationForShadow(shadow, resolution));
+                        continue;
+                    }
                 }
+                // Body branch, or an unmatched shadow left for ViewCompactionPostIndexResolution to strip.
+                resolvedShadows.put(entry.getKey(), child);
             }
-            if (shadowedProjectsByView.isEmpty()) {
+            if (projectsByView.isEmpty()) {
                 return viewUnionAll;
             }
             LinkedHashMap<String, LogicalPlan> rewritten = new LinkedHashMap<>();
-            for (Map.Entry<String, LogicalPlan> entry : namedSubqueries.entrySet()) {
-                String name = entry.getKey();
+            for (Map.Entry<String, LogicalPlan> entry : resolvedShadows.entrySet()) {
                 LogicalPlan branch = entry.getValue();
-                // Body branches carry the bare view name (no #shadow suffix); shadow branches are left as-is.
-                Set<String> shadowedProjects = shadowedProjectsByView.get(name);
-                if (shadowedProjects != null && shadowedProjects.isEmpty() == false) {
-                    branch = branch.transformUp(EsRelation.class, esRelation -> esRelation.withoutClusters(shadowedProjects));
+                // The body branch is keyed by its view name; a shadow branch's key (view name plus a
+                // suffix) never matches a projectsByView key, so shadow branches are left untouched.
+                Set<String> excluded = projectsByView.get(entry.getKey());
+                if (excluded != null && excluded.isEmpty() == false) {
+                    branch = branch.transformUp(EsRelation.class, esRelation -> esRelation.withoutClusters(excluded));
                 }
-                rewritten.put(name, branch);
+                rewritten.put(entry.getKey(), branch);
             }
             return new ViewUnionAll(viewUnionAll.source(), rewritten, viewUnionAll.output());
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -149,6 +149,7 @@ import org.elasticsearch.xpack.esql.plan.logical.UnionAll;
 import org.elasticsearch.xpack.esql.plan.logical.UnresolvedExternalRelation;
 import org.elasticsearch.xpack.esql.plan.logical.UnresolvedRelation;
 import org.elasticsearch.xpack.esql.plan.logical.ViewShadowRelation;
+import org.elasticsearch.xpack.esql.plan.logical.ViewUnionAll;
 import org.elasticsearch.xpack.esql.plan.logical.fuse.Fuse;
 import org.elasticsearch.xpack.esql.plan.logical.fuse.FuseScoreEval;
 import org.elasticsearch.xpack.esql.plan.logical.inference.Completion;
@@ -237,6 +238,7 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
             new ResolveConfigurationAware(),
             new ResolveTable(),
             new ResolveViewShadow(),
+            new ExcludeShadowedProjectsFromViewBody(),
             new ViewCompactionPostIndexResolution(),
             new ResolveExternalRelations(),
             new PruneEmptyUnionAllBranch(),
@@ -508,6 +510,62 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                 esIndex.indexNameWithModes(),
                 attributes.isEmpty() ? NO_FIELDS : attributes
             );
+        }
+    }
+
+    /**
+     * Completes view-shadow resolution under CPS: when a {@link ViewShadowRelation} resolved to a
+     * remote <em>index</em> on a linked project (i.e. that project owns an index sharing the local
+     * view's name), the view body must not <em>also</em> run on that project. A name cannot be both
+     * a view and an index on the same project; the index wins on its own project, so the view is
+     * excluded there and the project contributes only via its index (the resolved shadow branch).
+     * <p>
+     * The rule pairs each resolved shadow branch (keyed {@code <viewName>}{@link ViewShadowRelation#NAME_SUFFIX}
+     * inside the {@link ViewUnionAll}) with its strict body branch (keyed {@code <viewName>}) and
+     * removes the shadowed project(s) — read from the shadow's resolved {@link EsRelation#concreteIndices()}
+     * — from every {@link EsRelation} in the body subtree via {@link EsRelation#withoutClusters}. The
+     * body then fans out to origin and all other linked projects, but not the colliding one. For
+     * nested views the prune covers the whole body subtree, which is correct: if the outer view name
+     * collides on a project, none of its (possibly nested) definition runs there.
+     * <p>
+     * Runs after {@link ResolveViewShadow} (which turns matched shadows into {@code EsRelation}s) and
+     * before {@link ViewCompactionPostIndexResolution} (which strips unmatched shadows and flattens
+     * the {@link ViewUnionAll}, discarding the {@code #shadow} name pairing this rule relies on). See
+     * <a href="https://github.com/elastic/esql-planning/issues/795">esql-planning#795</a>.
+     */
+    private static class ExcludeShadowedProjectsFromViewBody extends Rule<LogicalPlan, LogicalPlan> {
+
+        @Override
+        public LogicalPlan apply(LogicalPlan plan) {
+            return plan.transformUp(ViewUnionAll.class, ExcludeShadowedProjectsFromViewBody::rewrite);
+        }
+
+        private static LogicalPlan rewrite(ViewUnionAll viewUnionAll) {
+            Map<String, LogicalPlan> namedSubqueries = viewUnionAll.namedSubqueries();
+            // Per view name, the linked projects whose same-named index the shadow resolved to.
+            Map<String, Set<String>> shadowedProjectsByView = new HashMap<>();
+            for (Map.Entry<String, LogicalPlan> entry : namedSubqueries.entrySet()) {
+                String name = entry.getKey();
+                if (name.endsWith(ViewShadowRelation.NAME_SUFFIX) && entry.getValue() instanceof EsRelation shadowRelation) {
+                    String viewName = name.substring(0, name.length() - ViewShadowRelation.NAME_SUFFIX.length());
+                    shadowedProjectsByView.put(viewName, shadowRelation.concreteIndices().keySet());
+                }
+            }
+            if (shadowedProjectsByView.isEmpty()) {
+                return viewUnionAll;
+            }
+            LinkedHashMap<String, LogicalPlan> rewritten = new LinkedHashMap<>();
+            for (Map.Entry<String, LogicalPlan> entry : namedSubqueries.entrySet()) {
+                String name = entry.getKey();
+                LogicalPlan branch = entry.getValue();
+                // Body branches carry the bare view name (no #shadow suffix); shadow branches are left as-is.
+                Set<String> shadowedProjects = shadowedProjectsByView.get(name);
+                if (shadowedProjects != null && shadowedProjects.isEmpty() == false) {
+                    branch = branch.transformUp(EsRelation.class, esRelation -> esRelation.withoutClusters(shadowedProjects));
+                }
+                rewritten.put(name, branch);
+            }
+            return new ViewUnionAll(viewUnionAll.source(), rewritten, viewUnionAll.output());
         }
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -470,24 +470,13 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
     }
 
     /**
-     * Resolves {@link ViewShadowRelation} nodes against {@link AnalyzerContext#optionalLinkedResolution()}.
-     * <p>
-     * Each {@code ViewShadowRelation} represents a "if a remote project has an index with this
-     * view's name, treat it as if the user wrote a remote index reference at this position"
-     * lookup. The lenient field-caps integration (deferred to a follow-up PR) populates
-     * {@code optionalLinkedResolution}, keyed by the shadow's {@link ViewShadowRelation#optionalLinkedPattern()}
-     * (view name + applicable exclusions). The full pattern is the lookup key — different
-     * exclusion lists at the same view name produce distinct {@code ViewShadowRelation}
-     * instances and may resolve differently (e.g. one comes back empty because of the
-     * exclusions, the other resolves to a remote index). This rule:
-     * <ul>
-     *   <li>If a valid {@link IndexResolution} is present for the shadow's
-     *       {@link ViewShadowRelation#optionalLinkedPattern()}, replaces the shadow with an
-     *       {@link EsRelation} built from the resolved {@link EsIndex} (same shape as
-     *       {@link ResolveTable}'s {@code resolveIndex} for a strict UR).</li>
-     *   <li>Otherwise leaves the shadow unresolved. {@link ViewCompactionPostIndexResolution}
-     *       (which runs immediately after this rule) strips any unresolved shadow.</li>
-     * </ul>
+     * Resolves a standalone {@link ViewShadowRelation} (one not inside a {@link ViewUnionAll}, which
+     * {@link ExcludeShadowedProjectsFromViewBody} handles) against
+     * {@link AnalyzerContext#optionalLinkedResolution()} — the lenient field-caps results keyed by the
+     * shadow's {@link ViewShadowRelation#optionalLinkedPattern()} (view name + applicable exclusions, so
+     * the same view at different exclusion positions can resolve differently). A valid resolution
+     * replaces the shadow with the remote index's {@link EsRelation}; otherwise the shadow is left for
+     * {@link ViewCompactionPostIndexResolution} to strip.
      */
     private static class ResolveViewShadow extends ParameterizedAnalyzerRule<ViewShadowRelation, AnalyzerContext> {
 
@@ -523,33 +512,24 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
     }
 
     /**
-     * Resolves the {@link ViewShadowRelation}s inside a {@link ViewUnionAll} and excludes, from each
-     * local view's body, any linked project that owns an <em>index</em> sharing the view's name. A
-     * name cannot be both a view and an index on the same project; the index wins on its own project,
-     * so the view must not run there — the project contributes only via its index (the resolved shadow
-     * branch).
+     * Excludes a linked project from a local view's body when that project owns an <em>index</em>
+     * sharing the view's name: the index wins on its own project, so the view must not run there and
+     * the project contributes only via its index (the resolved shadow branch). The owning projects
+     * come from the matched shadow's {@link EsRelation#concreteIndices()} and are removed from the
+     * body — paired by the view name the shadow carries — via {@link EsRelation#withoutClusters}.
      * <p>
-     * Pairing is by the view name the shadow carries as a data field ({@link ViewShadowRelation#viewName()}),
-     * matched against the body branch keyed by that same view name. The shadow branch's own map key is
-     * never parsed, so the link does not depend on the {@code #shadow} suffix convention.
-     * <p>
-     * This rule resolves in-union shadows itself (rather than leaving them all to {@link ResolveViewShadow})
-     * so that the exclusion is correct for nested views. Because it runs bottom-up
-     * ({@code transformUp}), an inner {@link ViewUnionAll} is fully resolved before an enclosing one is
-     * processed; so when an outer view-name collision prunes its body subtree via
-     * {@link EsRelation#withoutClusters}, any inner shadow — already an {@link EsRelation} by then — is
-     * pruned too. An outer collision therefore excludes the whole (possibly nested) view definition on
-     * that project, including inner same-named indexes. {@link ResolveViewShadow} still runs afterwards
-     * to resolve any standalone shadow not wrapped in a {@link ViewUnionAll}. See
-     * <a href="https://github.com/elastic/esql-planning/issues/795">esql-planning#795</a>.
+     * Resolving the in-union shadows here and running bottom-up means an inner shadow is already an
+     * {@link EsRelation} when an enclosing collision prunes its subtree, so an outer collision also
+     * excludes inner same-named indexes. {@link ResolveViewShadow} still resolves any standalone
+     * shadow. See <a href="https://github.com/elastic/esql-planning/issues/795">esql-planning#795</a>.
      */
     private static class ExcludeShadowedProjectsFromViewBody extends ParameterizedAnalyzerRule<ViewUnionAll, AnalyzerContext> {
 
         @Override
         protected LogicalPlan rule(ViewUnionAll viewUnionAll, AnalyzerContext context) {
-            // Resolve in-union shadows, collecting per view name the linked projects owning a same-named index.
+            // Resolve in-union shadows; collect, per view name, the projects owning a same-named index.
             Map<String, Set<String>> projectsByView = new HashMap<>();
-            LinkedHashMap<String, LogicalPlan> resolvedShadows = new LinkedHashMap<>();
+            LinkedHashMap<String, LogicalPlan> children = new LinkedHashMap<>();
             for (Map.Entry<String, LogicalPlan> entry : viewUnionAll.namedSubqueries().entrySet()) {
                 LogicalPlan child = entry.getValue();
                 if (child instanceof ViewShadowRelation shadow) {
@@ -557,22 +537,19 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                     if (resolution != null && resolution.isValid()) {
                         projectsByView.computeIfAbsent(shadow.viewName(), k -> new HashSet<>())
                             .addAll(resolution.get().concreteIndices().keySet());
-                        resolvedShadows.put(entry.getKey(), esRelationForShadow(shadow, resolution));
+                        children.put(entry.getKey(), esRelationForShadow(shadow, resolution));
                         continue;
                     }
                 }
-                // Body branch, or an unmatched shadow left for ViewCompactionPostIndexResolution to strip.
-                resolvedShadows.put(entry.getKey(), child);
+                children.put(entry.getKey(), child);
             }
             if (projectsByView.isEmpty()) {
                 return viewUnionAll;
             }
             LinkedHashMap<String, LogicalPlan> rewritten = new LinkedHashMap<>();
-            for (Map.Entry<String, LogicalPlan> entry : resolvedShadows.entrySet()) {
+            for (Map.Entry<String, LogicalPlan> entry : children.entrySet()) {
                 LogicalPlan branch = entry.getValue();
-                // The body branch is keyed by its view name; a shadow branch's key (view name plus a
-                // suffix) never matches a projectsByView key, so shadow branches are left untouched.
-                Set<String> excluded = projectsByView.get(entry.getKey());
+                Set<String> excluded = projectsByView.get(entry.getKey()); // null for shadow keys, so they are left as-is
                 if (excluded != null && excluded.isEmpty() == false) {
                     branch = branch.transformUp(EsRelation.class, esRelation -> esRelation.withoutClusters(excluded));
                 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -479,8 +479,7 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
      * inside a {@link ViewUnionAll}, so every shadow flows through here (an unmatched one is left for
      * {@link ViewCompactionPostIndexResolution} to strip). Running bottom-up means an inner shadow is
      * already an {@link EsRelation} when an enclosing collision prunes its subtree, so an outer
-     * collision also excludes inner same-named indexes. See
-     * <a href="https://github.com/elastic/esql-planning/issues/795">esql-planning#795</a>.
+     * collision also excludes inner same-named indexes.
      */
     private static class ExcludeShadowedProjectsFromViewBody extends ParameterizedAnalyzerRule<ViewUnionAll, AnalyzerContext> {
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -238,7 +238,6 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
             new ResolveConfigurationAware(),
             new ResolveTable(),
             new ExcludeShadowedProjectsFromViewBody(),
-            new ResolveViewShadow(),
             new ViewCompactionPostIndexResolution(),
             new ResolveExternalRelations(),
             new PruneEmptyUnionAllBranch(),
@@ -470,58 +469,18 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
     }
 
     /**
-     * Resolves a standalone {@link ViewShadowRelation} (one not inside a {@link ViewUnionAll}, which
-     * {@link ExcludeShadowedProjectsFromViewBody} handles) against
-     * {@link AnalyzerContext#optionalLinkedResolution()} — the lenient field-caps results keyed by the
-     * shadow's {@link ViewShadowRelation#optionalLinkedPattern()} (view name + applicable exclusions, so
-     * the same view at different exclusion positions can resolve differently). A valid resolution
-     * replaces the shadow with the remote index's {@link EsRelation}; otherwise the shadow is left for
-     * {@link ViewCompactionPostIndexResolution} to strip.
-     */
-    private static class ResolveViewShadow extends ParameterizedAnalyzerRule<ViewShadowRelation, AnalyzerContext> {
-
-        @Override
-        protected LogicalPlan rule(ViewShadowRelation shadow, AnalyzerContext context) {
-            IndexResolution resolution = context.optionalLinkedResolution().get(shadow.optionalLinkedPattern());
-            if (resolution == null || resolution.isValid() == false) {
-                // No remote index found (or lookup didn't run yet) — leave the shadow alone for
-                // ViewCompactionPostIndexResolution to strip.
-                return shadow;
-            }
-            return esRelationForShadow(shadow, resolution);
-        }
-    }
-
-    /**
-     * Builds the {@link EsRelation} that a matched {@link ViewShadowRelation} resolves to — the remote
-     * index sharing the local view's name. Shared by {@link ResolveViewShadow} (standalone shadows)
-     * and {@link ExcludeShadowedProjectsFromViewBody} (in-union shadows).
-     */
-    private static EsRelation esRelationForShadow(ViewShadowRelation shadow, IndexResolution resolution) {
-        EsIndex esIndex = resolution.get();
-        var attributes = mappingAsAttributes(shadow.source(), esIndex.mapping());
-        return new EsRelation(
-            shadow.source(),
-            esIndex.name(),
-            IndexMode.STANDARD,
-            esIndex.originalIndices(),
-            esIndex.concreteIndices(),
-            esIndex.indexNameWithModes(),
-            attributes.isEmpty() ? NO_FIELDS : attributes
-        );
-    }
-
-    /**
      * Excludes a linked project from a local view's body when that project owns an <em>index</em>
      * sharing the view's name: the index wins on its own project, so the view must not run there and
      * the project contributes only via its index (the resolved shadow branch). The owning projects
      * come from the matched shadow's {@link EsRelation#concreteIndices()} and are removed from the
      * body — paired by the view name the shadow carries — via {@link EsRelation#withoutClusters}.
      * <p>
-     * Resolving the in-union shadows here and running bottom-up means an inner shadow is already an
-     * {@link EsRelation} when an enclosing collision prunes its subtree, so an outer collision also
-     * excludes inner same-named indexes. {@link ResolveViewShadow} still resolves any standalone
-     * shadow. See <a href="https://github.com/elastic/esql-planning/issues/795">esql-planning#795</a>.
+     * This rule resolves the in-union shadows itself. A {@link ViewShadowRelation} is always emitted
+     * inside a {@link ViewUnionAll}, so every shadow flows through here (an unmatched one is left for
+     * {@link ViewCompactionPostIndexResolution} to strip). Running bottom-up means an inner shadow is
+     * already an {@link EsRelation} when an enclosing collision prunes its subtree, so an outer
+     * collision also excludes inner same-named indexes. See
+     * <a href="https://github.com/elastic/esql-planning/issues/795">esql-planning#795</a>.
      */
     private static class ExcludeShadowedProjectsFromViewBody extends ParameterizedAnalyzerRule<ViewUnionAll, AnalyzerContext> {
 
@@ -535,9 +494,19 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                 if (child instanceof ViewShadowRelation shadow) {
                     IndexResolution resolution = context.optionalLinkedResolution().get(shadow.optionalLinkedPattern());
                     if (resolution != null && resolution.isValid()) {
-                        projectsByView.computeIfAbsent(shadow.viewName(), k -> new HashSet<>())
-                            .addAll(resolution.get().concreteIndices().keySet());
-                        children.put(entry.getKey(), esRelationForShadow(shadow, resolution));
+                        EsIndex esIndex = resolution.get();
+                        var attributes = mappingAsAttributes(shadow.source(), esIndex.mapping());
+                        EsRelation resolved = new EsRelation(
+                            shadow.source(),
+                            esIndex.name(),
+                            IndexMode.STANDARD,
+                            esIndex.originalIndices(),
+                            esIndex.concreteIndices(),
+                            esIndex.indexNameWithModes(),
+                            attributes.isEmpty() ? NO_FIELDS : attributes
+                        );
+                        projectsByView.computeIfAbsent(shadow.viewName(), k -> new HashSet<>()).addAll(esIndex.concreteIndices().keySet());
+                        children.put(entry.getKey(), resolved);
                         continue;
                     }
                 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/EsRelation.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/EsRelation.java
@@ -11,6 +11,7 @@ import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.index.IndexMode;
+import org.elasticsearch.transport.RemoteClusterAware;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.NodeUtils;
@@ -19,6 +20,7 @@ import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -187,5 +189,35 @@ public class EsRelation extends LeafPlan {
 
     public EsRelation withIndexMode(IndexMode indexMode) {
         return new EsRelation(source(), indexPattern, indexMode, originalIndices, concreteIndices, indexNameWithModes, attrs);
+    }
+
+    /**
+     * Returns a copy of this relation with the given cluster aliases removed from its per-cluster
+     * {@link #originalIndices()} / {@link #concreteIndices()} maps, and from {@link #indexNameWithModes()}
+     * (whose keys are cluster-qualified). Since {@link #concreteIndices()} is the source of the
+     * per-cluster execution fan-out, dropping a cluster here means that cluster is no longer queried.
+     * <p>
+     * Used by view-shadow resolution under CPS: when a linked project owns an <em>index</em> with the
+     * same name as a local view, the view body must not also run on that project — a name cannot be
+     * both a view and an index on a single project, and the index wins on its own project. The
+     * shadow's resolved remote index supplies that project's data instead. See
+     * <a href="https://github.com/elastic/esql-planning/issues/795">esql-planning#795</a>.
+     */
+    public EsRelation withoutClusters(Set<String> clusterAliases) {
+        if (clusterAliases.isEmpty()) {
+            return this;
+        }
+        Map<String, List<String>> newOriginalIndices = new HashMap<>(originalIndices);
+        Map<String, List<String>> newConcreteIndices = new HashMap<>(concreteIndices);
+        newOriginalIndices.keySet().removeAll(clusterAliases);
+        newConcreteIndices.keySet().removeAll(clusterAliases);
+        Map<String, IndexMode> newIndexNameWithModes = new HashMap<>(indexNameWithModes.size());
+        for (Map.Entry<String, IndexMode> entry : indexNameWithModes.entrySet()) {
+            String clusterAlias = RemoteClusterAware.getClusterAlias(RemoteClusterAware.splitIndexName(entry.getKey()));
+            if (clusterAliases.contains(clusterAlias) == false) {
+                newIndexNameWithModes.put(entry.getKey(), entry.getValue());
+            }
+        }
+        return new EsRelation(source(), indexPattern, indexMode, newOriginalIndices, newConcreteIndices, newIndexNameWithModes, attrs);
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/EsRelation.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/EsRelation.java
@@ -192,15 +192,10 @@ public class EsRelation extends LeafPlan {
     }
 
     /**
-     * Returns a copy of this relation with the given cluster aliases removed from its per-cluster
-     * {@link #originalIndices()} / {@link #concreteIndices()} maps, and from {@link #indexNameWithModes()}
-     * (whose keys are cluster-qualified). Since {@link #concreteIndices()} is the source of the
-     * per-cluster execution fan-out, dropping a cluster here means that cluster is no longer queried.
-     * <p>
-     * Used by view-shadow resolution under CPS: when a linked project owns an <em>index</em> with the
-     * same name as a local view, the view body must not also run on that project — a name cannot be
-     * both a view and an index on a single project, and the index wins on its own project. The
-     * shadow's resolved remote index supplies that project's data instead. See
+     * Returns a copy with the given cluster aliases removed from {@link #originalIndices()},
+     * {@link #concreteIndices()} and {@link #indexNameWithModes()} (the last keyed by qualified
+     * {@code cluster:index} names). Dropping a cluster stops it being queried, since
+     * {@link #concreteIndices()} drives the per-cluster fan-out. See
      * <a href="https://github.com/elastic/esql-planning/issues/795">esql-planning#795</a>.
      */
     public EsRelation withoutClusters(Set<String> clusterAliases) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/EsRelation.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/EsRelation.java
@@ -195,8 +195,7 @@ public class EsRelation extends LeafPlan {
      * Returns a copy with the given cluster aliases removed from {@link #originalIndices()},
      * {@link #concreteIndices()} and {@link #indexNameWithModes()} (the last keyed by qualified
      * {@code cluster:index} names). Dropping a cluster stops it being queried, since
-     * {@link #concreteIndices()} drives the per-cluster fan-out. See
-     * <a href="https://github.com/elastic/esql-planning/issues/795">esql-planning#795</a>.
+     * {@link #concreteIndices()} drives the per-cluster fan-out.
      */
     public EsRelation withoutClusters(Set<String> clusterAliases) {
         if (clusterAliases.isEmpty()) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/ViewShadowRelation.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/ViewShadowRelation.java
@@ -38,8 +38,7 @@ import java.util.Objects;
  *       against that map (replacing a matched shadow with the remote index's {@code EsRelation}) and
  *       removes the owning projects from the paired view body.</li>
  *   <li>{@code ViewCompactionPostIndexResolution} strips any still-unresolved shadow, then flattens
- *       nested {@link ViewUnionAll}s and unwraps {@code NamedSubquery} wrappers. Per Strategy A in
- *       <a href="https://github.com/elastic/esql-planning/issues/543">esql-planning#543</a>, sibling
+ *       nested {@link ViewUnionAll}s and unwraps {@code NamedSubquery} wrappers. Sibling
  *       {@code EsRelation}s stay separate rather than being merged via a combined field-caps call.</li>
  * </ol>
  * <p>

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/ViewShadowRelation.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/ViewShadowRelation.java
@@ -24,35 +24,24 @@ import java.util.Objects;
  * of each resolved view's recursive substitution, inside the per-resolution-level
  * {@link ViewUnionAll}.
  * <p>
- * Lifecycle, with the parts each PR is responsible for:
+ * Lifecycle:
  * <ol>
- *   <li>Emitted during view resolution alongside the strict (recursive) resolution. The shadow
- *       and its strict sibling form the strict/lenient pair for that level.
- *       <em>(landed in the {@code ViewResolver} refactor)</em></li>
- *   <li>{@code ViewCompaction.preIndexResolution} reshapes user-written {@code Subquery}/
- *       {@code UnionAll} structures into {@link ViewUnionAll} but leaves shadows in place so
- *       PreAnalyzer can still pair each shadow with its sibling at index-resolution time.
- *       <em>(landed)</em></li>
- *   <li>{@code PreAnalyzer} collects {@code ViewShadowRelation} patterns into a separate set,
- *       and {@code EsqlSession} issues a lenient field-caps request per batch
- *       ({@code ALLOW_UNAVAILABLE_TARGETS} + project routing scoped to linked projects only —
- *       {@code IndexResolver.FLAT_WORLD_OPTIONS}). Results land in
- *       {@code AnalyzerContext.optionalLinkedResolution}, keyed by the shadow's full
- *       {@link #optionalLinkedPattern()} (view name + applicable exclusions).
- *       <em>(deferred to the lenient field-caps PR)</em></li>
- *   <li>The {@code ResolveViewShadow} analyzer rule (sibling of {@code ResolveTable}, in the
- *       Initialize batch) consults {@code AnalyzerContext.optionalLinkedResolution} for this shadow's
- *       {@link #optionalLinkedPattern()}. If a remote <em>index</em> is found the shadow is replaced
- *       with a corresponding {@code EsRelation}; otherwise the shadow is left unresolved.
- *       <em>(this PR — backed by a mocked {@code optionalLinkedResolution} map until the lenient
- *       field-caps PR provides real data)</em></li>
- *   <li>{@code ViewCompactionPostIndexResolution} runs after {@code ResolveViewShadow}: any
- *       still-unresolved shadow is stripped, then nested {@link ViewUnionAll}s are flattened
- *       and remaining {@code NamedSubquery} wrappers unwrapped. Per Strategy A in
- *       <a href="https://github.com/elastic/esql-planning/issues/543">esql-planning#543</a>,
- *       sibling {@code EsRelation}s stay separate (a {@code UnionAll}/{@link ViewUnionAll}
- *       of {@code EsRelation}s) rather than being merged via a third combined field-caps call.
- *       <em>(landed)</em></li>
+ *   <li>Emitted during view resolution alongside the strict (recursive) resolution, as the lenient
+ *       half of the strict/lenient pair for that level.</li>
+ *   <li>{@code ViewCompaction.preIndexResolution} reshapes {@code Subquery}/{@code UnionAll}
+ *       structures into {@link ViewUnionAll} but leaves shadows in place.</li>
+ *   <li>{@code PreAnalyzer} collects shadow patterns and {@code EsqlSession} runs a lenient
+ *       field-caps pass over them (linked projects only — {@code IndexResolver.FLAT_WORLD_OPTIONS}),
+ *       landing results in {@code AnalyzerContext.optionalLinkedResolution}, keyed by
+ *       {@link #optionalLinkedPattern()}.</li>
+ *   <li>In the Initialize batch, {@code ExcludeShadowedProjectsFromViewBody} resolves in-union
+ *       shadows against that map (replacing a matched shadow with the remote index's
+ *       {@code EsRelation}) and removes the owning projects from the paired view body;
+ *       {@code ResolveViewShadow} resolves any standalone shadow not inside a {@link ViewUnionAll}.</li>
+ *   <li>{@code ViewCompactionPostIndexResolution} strips any still-unresolved shadow, then flattens
+ *       nested {@link ViewUnionAll}s and unwraps {@code NamedSubquery} wrappers. Per Strategy A in
+ *       <a href="https://github.com/elastic/esql-planning/issues/543">esql-planning#543</a>, sibling
+ *       {@code EsRelation}s stay separate rather than being merged via a combined field-caps call.</li>
  * </ol>
  * <p>
  * The {@link #exclusions()} list captures any exclusion patterns that appeared <em>after</em>
@@ -75,8 +64,9 @@ public class ViewShadowRelation extends LeafPlan implements Unresolvable {
     /**
      * Suffix appended to a view name to key its shadow branch inside the per-level
      * {@link ViewUnionAll}, distinguishing it from the strict view-body branch (keyed by the bare
-     * view name). The {@code Analyzer}'s shadow-completion rule relies on this pairing to find the
-     * body that belongs to a resolved shadow.
+     * view name) so both can coexist in the named-subqueries map. It is purely a map-key
+     * disambiguator: the {@code Analyzer} pairs a shadow with its body by the view name the shadow
+     * carries ({@link #viewName()}), not by parsing this suffix.
      */
     public static final String NAME_SUFFIX = "#shadow";
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/ViewShadowRelation.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/ViewShadowRelation.java
@@ -34,10 +34,9 @@ import java.util.Objects;
  *       field-caps pass over them (linked projects only — {@code IndexResolver.FLAT_WORLD_OPTIONS}),
  *       landing results in {@code AnalyzerContext.optionalLinkedResolution}, keyed by
  *       {@link #optionalLinkedPattern()}.</li>
- *   <li>In the Initialize batch, {@code ExcludeShadowedProjectsFromViewBody} resolves in-union
- *       shadows against that map (replacing a matched shadow with the remote index's
- *       {@code EsRelation}) and removes the owning projects from the paired view body;
- *       {@code ResolveViewShadow} resolves any standalone shadow not inside a {@link ViewUnionAll}.</li>
+ *   <li>In the Initialize batch, {@code ExcludeShadowedProjectsFromViewBody} resolves the shadows
+ *       against that map (replacing a matched shadow with the remote index's {@code EsRelation}) and
+ *       removes the owning projects from the paired view body.</li>
  *   <li>{@code ViewCompactionPostIndexResolution} strips any still-unresolved shadow, then flattens
  *       nested {@link ViewUnionAll}s and unwraps {@code NamedSubquery} wrappers. Per Strategy A in
  *       <a href="https://github.com/elastic/esql-planning/issues/543">esql-planning#543</a>, sibling
@@ -60,15 +59,6 @@ import java.util.Objects;
  * <em>indices</em> with the same name as a local view.
  */
 public class ViewShadowRelation extends LeafPlan implements Unresolvable {
-
-    /**
-     * Suffix appended to a view name to key its shadow branch inside the per-level
-     * {@link ViewUnionAll}, distinguishing it from the strict view-body branch (keyed by the bare
-     * view name) so both can coexist in the named-subqueries map. It is purely a map-key
-     * disambiguator: the {@code Analyzer} pairs a shadow with its body by the view name the shadow
-     * carries ({@link #viewName()}), not by parsing this suffix.
-     */
-    public static final String NAME_SUFFIX = "#shadow";
 
     private final String viewName;
     private final List<String> exclusions;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/ViewShadowRelation.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/ViewShadowRelation.java
@@ -72,6 +72,14 @@ import java.util.Objects;
  */
 public class ViewShadowRelation extends LeafPlan implements Unresolvable {
 
+    /**
+     * Suffix appended to a view name to key its shadow branch inside the per-level
+     * {@link ViewUnionAll}, distinguishing it from the strict view-body branch (keyed by the bare
+     * view name). The {@code Analyzer}'s shadow-completion rule relies on this pairing to find the
+     * body that belongs to a resolved shadow.
+     */
+    public static final String NAME_SUFFIX = "#shadow";
+
     private final String viewName;
     private final List<String> exclusions;
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/ViewUnionAll.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/ViewUnionAll.java
@@ -51,7 +51,8 @@ public class ViewUnionAll extends UnionAll {
         return new ViewUnionAll(source(), asSubqueryMap(subPlans), output);
     }
 
-    // Currently for testing only, could also be useful for EXPLAIN and PROFILE
+    // Exposes the name→branch pairing (e.g. {@code v} body vs {@code v#shadow} lookup) that the
+    // Analyzer's ExcludeShadowedProjectsFromViewBody rule relies on; also useful for EXPLAIN/PROFILE.
     public Map<String, LogicalPlan> namedSubqueries() {
         return namedSubqueries;
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/view/ViewResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/view/ViewResolver.java
@@ -390,7 +390,7 @@ public class ViewResolver {
                     for (var view : response.views()) {
                         ViewShadowRelation shadow = viewShadows.get(view.name());
                         if (shadow != null) {
-                            subqueries.add(new ViewPlan(view.name() + ViewShadowRelation.NAME_SUFFIX, shadow));
+                            subqueries.add(new ViewPlan(view.name() + "#shadow", shadow));
                         }
                     }
                 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/view/ViewResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/view/ViewResolver.java
@@ -390,7 +390,7 @@ public class ViewResolver {
                     for (var view : response.views()) {
                         ViewShadowRelation shadow = viewShadows.get(view.name());
                         if (shadow != null) {
-                            subqueries.add(new ViewPlan(view.name() + "#shadow", shadow));
+                            subqueries.add(new ViewPlan(view.name() + ViewShadowRelation.NAME_SUFFIX, shadow));
                         }
                     }
                 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/ExcludeShadowedProjectsFromViewBodyTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/ExcludeShadowedProjectsFromViewBodyTests.java
@@ -37,10 +37,10 @@ import static org.elasticsearch.xpack.esql.EsqlTestUtils.analyzer;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.as;
 
 /**
- * Tests for the {@code Analyzer.ResolveViewShadow} and {@code ExcludeShadowedProjectsFromViewBody}
- * analyzer rules. Each test builds a small plan tree by hand (since {@link ViewShadowRelation} has no
- * surface syntax) and supplies the {@link AnalyzerContext#optionalLinkedResolution()} map directly —
- * the same map that {@code EsqlSession}'s lenient field-caps pass populates in production — to verify:
+ * Tests for the {@code Analyzer.ExcludeShadowedProjectsFromViewBody} analyzer rule. Each test builds a
+ * small plan tree by hand (since {@link ViewShadowRelation} has no surface syntax) and supplies the
+ * {@link AnalyzerContext#optionalLinkedResolution()} map directly — the same map that
+ * {@code EsqlSession}'s lenient field-caps pass populates in production — to verify:
  * <ul>
  *   <li>shadow with a valid lenient resolution → replaced with {@code EsRelation};</li>
  *   <li>shadow with no lenient entry (or an invalid resolution) → left unresolved, then stripped
@@ -59,36 +59,15 @@ import static org.elasticsearch.xpack.esql.EsqlTestUtils.as;
  * "No limit defined" warning that {@code AddImplicitLimit} adds since the test inputs are bare
  * relations.
  */
-public class ResolveViewShadowTests extends ESTestCase {
+public class ExcludeShadowedProjectsFromViewBodyTests extends ESTestCase {
 
     private static final Source EMPTY = Source.EMPTY;
     private static final String NO_LIMIT_WARNING = "No limit defined, adding default limit of [1000]";
 
     /**
-     * Shadow with a valid lenient {@link IndexResolution} → replaced with an {@link EsRelation}
-     * over the resolved remote index's mapping.
-     */
-    public void testShadowResolvesToEsRelationWhenLenientMatches() {
-        EsIndex remoteV1 = EsIndexGenerator.esIndex("v1", LoadMapping.loadMapping("mapping-one-field.json"));
-        var analyzer = analyzer().addLenientShadow(remoteV1).buildAnalyzer();
-
-        LogicalPlan plan = analyzer.analyze(new ViewShadowRelation(EMPTY, "v1", List.of()));
-
-        var limit = as(plan, Limit.class);
-        var esRelation = as(unwrapProject(limit.child()), EsRelation.class);
-        assertEquals("v1", esRelation.indexPattern());
-        // The mapping has emp_no — confirms the shadow's EsRelation carries the remote index's fields.
-        assertTrue(
-            "expected emp_no field in the resolved EsRelation, got: " + esRelation.output(),
-            esRelation.output().stream().map(Attribute::name).anyMatch("emp_no"::equals)
-        );
-        assertWarnings(NO_LIMIT_WARNING);
-    }
-
-    /**
-     * Shadow with no lenient match → falls through {@code ResolveViewShadow} unchanged. With a
-     * strict sibling in a {@link ViewUnionAll}, {@code ViewCompactionPostIndexResolution}'s strip
-     * removes the unresolved shadow; the surviving sibling is the strict {@link EsRelation}.
+     * Shadow with no lenient match → left unresolved. With a strict sibling in a
+     * {@link ViewUnionAll}, {@code ViewCompactionPostIndexResolution}'s strip removes the unresolved
+     * shadow; the surviving sibling is the strict {@link EsRelation}.
      */
     public void testShadowStrippedWhenNoLenientMatch() {
         EsIndex strictIdx = EsIndexGenerator.esIndex("strict_idx", LoadMapping.loadMapping("mapping-one-field.json"));
@@ -144,8 +123,16 @@ public class ResolveViewShadowTests extends ESTestCase {
         assertEquals("expected two children, got: " + unionAll, 2, unionAll.children().size());
         // Each child resolves to an EsRelation (possibly under analyzer-inserted Project wrappers
         // for output alignment across the UnionAll branches).
-        var indexNames = unionAll.children().stream().map(c -> as(unwrapProject(c), EsRelation.class).indexPattern()).sorted().toList();
-        assertEquals(List.of("strict_idx", "v1"), indexNames);
+        var byPattern = unionAll.children()
+            .stream()
+            .map(c -> as(unwrapProject(c), EsRelation.class))
+            .collect(Collectors.toMap(EsRelation::indexPattern, r -> r));
+        assertEquals(Set.of("strict_idx", "v1"), byPattern.keySet());
+        // The shadow's EsRelation carries the remote index's fields (the mapping has emp_no).
+        assertTrue(
+            "expected emp_no field in the shadow's EsRelation, got: " + byPattern.get("v1").output(),
+            byPattern.get("v1").output().stream().map(Attribute::name).anyMatch("emp_no"::equals)
+        );
         assertWarnings(NO_LIMIT_WARNING);
     }
 
@@ -157,14 +144,21 @@ public class ResolveViewShadowTests extends ESTestCase {
     public void testShadowLookupKeyIncludesExclusions() {
         ViewShadowRelation shadow = new ViewShadowRelation(EMPTY, "v1", List.of("-stale-*"));
         assertEquals("v1,-stale-*", shadow.optionalLinkedPattern().indexPattern());
+        EsIndex strictIdx = EsIndexGenerator.esIndex("strict_idx", LoadMapping.loadMapping("mapping-one-field.json"));
         EsIndex remoteV1 = EsIndexGenerator.esIndex("v1", LoadMapping.loadMapping("mapping-one-field.json"));
-        var analyzer = analyzer().addLenientShadow(shadow.optionalLinkedPattern(), IndexResolution.valid(remoteV1)).buildAnalyzer();
+        var analyzer = analyzer().addIndex(strictIdx)
+            .addLenientShadow(shadow.optionalLinkedPattern(), IndexResolution.valid(remoteV1))
+            .buildAnalyzer();
 
-        LogicalPlan plan = analyzer.analyze(shadow);
+        LogicalPlan plan = analyzer.analyze(viewUnionAllOf("strict_idx", strictUR("strict_idx"), shadow));
 
-        var limit = as(plan, Limit.class);
-        var esRelation = as(unwrapProject(limit.child()), EsRelation.class);
-        assertEquals("v1", esRelation.indexPattern());
+        // The shadow resolved under its full pattern key (view name + exclusions): a v1 branch is present.
+        var indexNames = as(as(plan, Limit.class).child(), ViewUnionAll.class).children()
+            .stream()
+            .map(c -> as(unwrapProject(c), EsRelation.class).indexPattern())
+            .sorted()
+            .toList();
+        assertEquals(List.of("strict_idx", "v1"), indexNames);
         assertWarnings(NO_LIMIT_WARNING);
     }
 
@@ -188,10 +182,14 @@ public class ResolveViewShadowTests extends ESTestCase {
             .addIndex(EsIndexGenerator.esIndex("strict_idx", LoadMapping.loadMapping("mapping-one-field.json")))
             .buildAnalyzer();
 
-        // matchedShadow alone: resolves to EsRelation.
-        LogicalPlan matchedPlan = analyzer.analyze(matchedShadow);
-        var matchedEs = as(unwrapProject(as(matchedPlan, Limit.class).child()), EsRelation.class);
-        assertEquals("my-data", matchedEs.indexPattern());
+        // matchedShadow in a union: its exclusion-bearing pattern resolves to a remote index.
+        LogicalPlan matchedPlan = analyzer.analyze(viewUnionAllOf("strict_idx", strictUR("strict_idx"), matchedShadow));
+        var matchedNames = as(as(matchedPlan, Limit.class).child(), ViewUnionAll.class).children()
+            .stream()
+            .map(c -> as(unwrapProject(c), EsRelation.class).indexPattern())
+            .sorted()
+            .toList();
+        assertEquals(List.of("my-data", "strict_idx"), matchedNames);
 
         // emptyShadow paired with a strict UR: stripped, leaving just the strict EsRelation.
         LogicalPlan emptyPlan = analyzer.analyze(viewUnionAllOf("strict_idx", strictUR("strict_idx"), emptyShadow));
@@ -408,11 +406,11 @@ public class ResolveViewShadowTests extends ESTestCase {
         // inner ViewUnionAll: v2 = FROM source-idx, plus v2's shadow
         LinkedHashMap<String, LogicalPlan> inner = new LinkedHashMap<>();
         inner.put("v2", strictUR("source-idx"));
-        inner.put("v2" + ViewShadowRelation.NAME_SUFFIX, new ViewShadowRelation(EMPTY, "v2", List.of()));
+        inner.put("v2#shadow", new ViewShadowRelation(EMPTY, "v2", List.of()));
         // outer ViewUnionAll: v = FROM v2, plus v's shadow
         LinkedHashMap<String, LogicalPlan> outer = new LinkedHashMap<>();
         outer.put("v", new ViewUnionAll(EMPTY, inner, List.of()));
-        outer.put("v" + ViewShadowRelation.NAME_SUFFIX, new ViewShadowRelation(EMPTY, "v", List.of()));
+        outer.put("v#shadow", new ViewShadowRelation(EMPTY, "v", List.of()));
 
         LogicalPlan plan = analyzer.analyze(new ViewUnionAll(EMPTY, outer, List.of()));
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/ExcludeShadowedProjectsFromViewBodyTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/ExcludeShadowedProjectsFromViewBodyTests.java
@@ -235,7 +235,7 @@ public class ExcludeShadowedProjectsFromViewBodyTests extends ESTestCase {
      * View {@code v1 = FROM source-idx} resolved across origin ({@code ""}) and linked project
      * {@code "P"}; the shadow shows {@code "P"} also owns an index named {@code v1}. The body must
      * drop {@code "P"} (the view stops running there) while the shadow keeps {@code "P"} — otherwise
-     * {@code "P"} is double-counted (view body + its index). See esql-planning#795.
+     * {@code "P"} is double-counted (view body + its index).
      */
     public void testViewBodyExcludesProjectOwningSameNamedIndex() {
         // Strict view body "v1": source-idx resolved on origin ("") and linked project "P".
@@ -292,7 +292,6 @@ public class ExcludeShadowedProjectsFromViewBodyTests extends ESTestCase {
     /**
      * Only the colliding project is excluded: view body on origin, {@code P} and {@code Q}; only
      * {@code P} owns a same-named index. The body keeps origin and {@code Q} and drops just {@code P}.
-     * See esql-planning#795.
      */
     public void testViewBodyExcludesOnlyTheCollidingProject() {
         EsIndex body = new EsIndex(
@@ -329,7 +328,7 @@ public class ExcludeShadowedProjectsFromViewBodyTests extends ESTestCase {
     /**
      * Edge: the colliding project is the body's only project. Excluding it leaves the body with no
      * clusters (a zero-row leaf); the project's index supplies all rows via the shadow. Whether
-     * execution treats the empty leaf as no rows is left to the integration test. See esql-planning#795.
+     * execution treats the empty leaf as no rows is left to the integration test.
      */
     public void testViewBodyEmptyWhenOnlyProjectOwnsSameNamedIndex() {
         EsIndex body = new EsIndex(
@@ -370,8 +369,7 @@ public class ExcludeShadowedProjectsFromViewBodyTests extends ESTestCase {
      * Nested case: outer view {@code v = FROM v2}, inner view {@code v2 = FROM source-idx}; project
      * {@code P} owns indexes named like both {@code v} and {@code v2}. Since {@code v} is an index on
      * {@code P}, none of {@code v}'s definition runs there — including {@code P}'s {@code v2} index, which
-     * the bottom-up pass prunes away too. {@code P} contributes only its {@code v} index. See
-     * esql-planning#795.
+     * the bottom-up pass prunes away too. {@code P} contributes only its {@code v} index.
      */
     public void testNestedViewExcludesProjectOwningOuterViewIndex() {
         Map<String, EsField> mapping = LoadMapping.loadMapping("mapping-one-field.json");

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/ResolveViewShadowTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/ResolveViewShadowTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.LoadMapping;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.EsField;
 import org.elasticsearch.xpack.esql.index.EsIndex;
 import org.elasticsearch.xpack.esql.index.EsIndexGenerator;
 import org.elasticsearch.xpack.esql.index.IndexResolution;
@@ -25,6 +26,7 @@ import org.elasticsearch.xpack.esql.plan.logical.UnresolvedRelation;
 import org.elasticsearch.xpack.esql.plan.logical.ViewShadowRelation;
 import org.elasticsearch.xpack.esql.plan.logical.ViewUnionAll;
 
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -293,6 +295,111 @@ public class ResolveViewShadowTests extends ESTestCase {
         assertFalse("body's qualified index map still references P", bodyRelation.indexNameWithModes().containsKey("P:source-idx"));
         // ...but "P" still contributes via its own index "v1" through the surviving shadow branch.
         assertEquals(Set.of("P"), shadowRelation.concreteIndices().keySet());
+
+        assertWarnings(NO_LIMIT_WARNING);
+    }
+
+    /**
+     * #795 edge: the colliding project is the view body's ONLY project. The view's source data lived
+     * only on the project that turns out to own a same-named index, so after excluding that project
+     * the body has no clusters left to run on — it contributes nothing, and the project's index (the
+     * shadow) supplies all of its rows. The body branch survives with empty per-cluster maps (a
+     * zero-row leaf); confirming execution treats that as no rows is left to the integration test.
+     */
+    public void testViewBodyEmptyWhenOnlyProjectOwnsSameNamedIndex() {
+        EsIndex body = new EsIndex(
+            "source-idx",
+            LoadMapping.loadMapping("mapping-one-field.json"),
+            Map.of("P:source-idx", IndexMode.STANDARD),
+            Map.of("P", List.of("source-idx")),
+            Map.of("P", List.of("source-idx"))
+        );
+        EsIndex remoteV1 = new EsIndex(
+            "v1",
+            LoadMapping.loadMapping("mapping-one-field.json"),
+            Map.of("P:v1", IndexMode.STANDARD),
+            Map.of("P", List.of("v1")),
+            Map.of("P", List.of("v1"))
+        );
+        var analyzer = analyzer().addIndex("source-idx", IndexResolution.valid(body))
+            .addLenientShadow(new IndexPattern(EMPTY, "v1"), IndexResolution.valid(remoteV1))
+            .buildAnalyzer();
+
+        LogicalPlan plan = analyzer.analyze(viewUnionAllOf("v1", strictUR("source-idx"), new ViewShadowRelation(EMPTY, "v1", List.of())));
+
+        var unionAll = as(as(plan, Limit.class).child(), ViewUnionAll.class);
+        Map<String, EsRelation> byPattern = unionAll.children()
+            .stream()
+            .map(child -> as(unwrapProject(child), EsRelation.class))
+            .collect(Collectors.toMap(EsRelation::indexPattern, r -> r));
+
+        // The body runs nowhere (no clusters left after excluding the only project that has the data)...
+        assertEquals("view body should have no clusters left", Set.of(), byPattern.get("source-idx").concreteIndices().keySet());
+        // ...and the project's same-named index supplies the rows via the shadow branch.
+        assertEquals(Set.of("P"), byPattern.get("v1").concreteIndices().keySet());
+
+        assertWarnings(NO_LIMIT_WARNING);
+    }
+
+    /**
+     * #795, nested case: outer view {@code v} is defined as {@code FROM v2}, an inner view over
+     * {@code source-idx}. A single linked project {@code P} owns indexes named like <em>both</em>
+     * {@code v} and {@code v2}. Because {@code v} resolves to an index on {@code P}, none of {@code v}'s
+     * definition runs on {@code P} — not the {@code source-idx} body, and not {@code P}'s {@code v2}
+     * index either; {@code P} contributes only its {@code v} index. The rule achieves this bottom-up:
+     * the inner shadow is resolved to an {@code EsRelation} before the outer collision prunes the inner
+     * subtree, so the inner {@code v2} index on {@code P} is pruned away too.
+     */
+    public void testNestedViewExcludesProjectOwningOuterViewIndex() {
+        Map<String, EsField> mapping = LoadMapping.loadMapping("mapping-one-field.json");
+        // v2 body: source-idx on origin ("") and linked project "P".
+        EsIndex sourceIdx = new EsIndex(
+            "source-idx",
+            mapping,
+            Map.of("source-idx", IndexMode.STANDARD, "P:source-idx", IndexMode.STANDARD),
+            Map.of("", List.of("source-idx"), "P", List.of("source-idx")),
+            Map.of("", List.of("source-idx"), "P", List.of("source-idx"))
+        );
+        EsIndex remoteV2 = new EsIndex(
+            "v2",
+            mapping,
+            Map.of("P:v2", IndexMode.STANDARD),
+            Map.of("P", List.of("v2")),
+            Map.of("P", List.of("v2"))
+        );
+        EsIndex remoteV = new EsIndex(
+            "v",
+            mapping,
+            Map.of("P:v", IndexMode.STANDARD),
+            Map.of("P", List.of("v")),
+            Map.of("P", List.of("v"))
+        );
+
+        var analyzer = analyzer().addIndex("source-idx", IndexResolution.valid(sourceIdx))
+            .addLenientShadow(new IndexPattern(EMPTY, "v2"), IndexResolution.valid(remoteV2))
+            .addLenientShadow(new IndexPattern(EMPTY, "v"), IndexResolution.valid(remoteV))
+            .buildAnalyzer();
+
+        // inner ViewUnionAll: v2 = FROM source-idx, plus v2's shadow
+        LinkedHashMap<String, LogicalPlan> inner = new LinkedHashMap<>();
+        inner.put("v2", strictUR("source-idx"));
+        inner.put("v2" + ViewShadowRelation.NAME_SUFFIX, new ViewShadowRelation(EMPTY, "v2", List.of()));
+        // outer ViewUnionAll: v = FROM v2, plus v's shadow
+        LinkedHashMap<String, LogicalPlan> outer = new LinkedHashMap<>();
+        outer.put("v", new ViewUnionAll(EMPTY, inner, List.of()));
+        outer.put("v" + ViewShadowRelation.NAME_SUFFIX, new ViewShadowRelation(EMPTY, "v", List.of()));
+
+        LogicalPlan plan = analyzer.analyze(new ViewUnionAll(EMPTY, outer, List.of()));
+
+        Map<String, EsRelation> byPattern = new HashMap<>();
+        plan.forEachDown(EsRelation.class, r -> byPattern.put(r.indexPattern(), r));
+
+        // The view body runs on origin only — "P" is excluded since "v" is an index there.
+        assertEquals("body must drop P", Set.of(""), byPattern.get("source-idx").concreteIndices().keySet());
+        // The inner v2 index on "P" is also excluded — the whole nested definition of v is off on "P".
+        assertEquals("inner v2 index on P must be excluded", Set.of(), byPattern.get("v2").concreteIndices().keySet());
+        // "P" contributes only via its own "v" index.
+        assertEquals(Set.of("P"), byPattern.get("v").concreteIndices().keySet());
 
         assertWarnings(NO_LIMIT_WARNING);
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/ResolveViewShadowTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/ResolveViewShadowTests.java
@@ -27,6 +27,9 @@ import org.elasticsearch.xpack.esql.plan.logical.ViewUnionAll;
 
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.analyzer;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.as;
@@ -225,6 +228,72 @@ public class ResolveViewShadowTests extends ESTestCase {
         assertEquals("expected a single surviving child after pruning", 1, unionAll.children().size());
         var esRelation = as(unwrapProject(unionAll.children().getFirst()), EsRelation.class);
         assertEquals("v1", esRelation.indexPattern());
+        assertWarnings(NO_LIMIT_WARNING);
+    }
+
+    /**
+     * elastic/esql-planning#795: when a linked project owns an index with the same name as a local
+     * view, the view body must not <em>also</em> run on that project — the project's index supplies
+     * its data instead (a name cannot be both a view and an index on one project; the index wins).
+     * <p>
+     * Setup mirrors {@code FROM v1} where {@code v1} is a local view {@code FROM source-idx}: the
+     * strict body resolved flat-world across origin ({@code ""}) and linked project {@code "P"}
+     * (both have {@code source-idx}), and the shadow shows {@code "P"} also owns an index named
+     * {@code v1}. After analysis, {@code "P"} must be gone from the body's per-cluster maps (so the
+     * view stops running there) while the shadow's {@code EsRelation} for {@code "P"} survives.
+     * <p>
+     * Fails before the {@code ExcludeShadowedProjectsFromViewBody} rule: the body retains {@code "P"},
+     * double-counting that project (view body on P + P's index).
+     */
+    public void testViewBodyExcludesProjectOwningSameNamedIndex() {
+        // Strict view body "v1": source-idx resolved on origin ("") and linked project "P".
+        EsIndex body = new EsIndex(
+            "source-idx",
+            LoadMapping.loadMapping("mapping-one-field.json"),
+            Map.of("source-idx", IndexMode.STANDARD, "P:source-idx", IndexMode.STANDARD),
+            Map.of("", List.of("source-idx"), "P", List.of("source-idx")),
+            Map.of("", List.of("source-idx"), "P", List.of("source-idx"))
+        );
+        // Shadow: linked project "P" owns an index named "v1" (the view's name).
+        EsIndex remoteV1 = new EsIndex(
+            "v1",
+            LoadMapping.loadMapping("mapping-one-field.json"),
+            Map.of("P:v1", IndexMode.STANDARD),
+            Map.of("P", List.of("v1")),
+            Map.of("P", List.of("v1"))
+        );
+
+        var analyzer = analyzer().addIndex("source-idx", IndexResolution.valid(body))
+            .addLenientShadow(new IndexPattern(EMPTY, "v1"), IndexResolution.valid(remoteV1))
+            .buildAnalyzer();
+
+        LogicalPlan plan = analyzer.analyze(viewUnionAllOf("v1", strictUR("source-idx"), new ViewShadowRelation(EMPTY, "v1", List.of())));
+
+        var limit = as(plan, Limit.class);
+        var unionAll = as(limit.child(), ViewUnionAll.class);
+        assertEquals("expected pruned body + shadow index branches", 2, unionAll.children().size());
+
+        Map<String, EsRelation> byPattern = unionAll.children()
+            .stream()
+            .map(child -> as(unwrapProject(child), EsRelation.class))
+            .collect(Collectors.toMap(EsRelation::indexPattern, r -> r));
+
+        EsRelation bodyRelation = byPattern.get("source-idx");
+        EsRelation shadowRelation = byPattern.get("v1");
+        assertNotNull("view body branch missing", bodyRelation);
+        assertNotNull("shadow remote-index branch missing", shadowRelation);
+
+        // The view body must no longer run on "P" (the project owning a same-named index)...
+        assertEquals(
+            "view body must not run on the project owning a same-named index",
+            Set.of(""),
+            bodyRelation.concreteIndices().keySet()
+        );
+        assertEquals(Set.of("source-idx"), Set.copyOf(bodyRelation.concreteIndices().get("")));
+        assertFalse("body's qualified index map still references P", bodyRelation.indexNameWithModes().containsKey("P:source-idx"));
+        // ...but "P" still contributes via its own index "v1" through the surviving shadow branch.
+        assertEquals(Set.of("P"), shadowRelation.concreteIndices().keySet());
+
         assertWarnings(NO_LIMIT_WARNING);
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/ResolveViewShadowTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/ResolveViewShadowTests.java
@@ -37,9 +37,10 @@ import static org.elasticsearch.xpack.esql.EsqlTestUtils.analyzer;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.as;
 
 /**
- * Tests for the {@code Analyzer.ResolveViewShadow} analyzer rule. Each test builds a small plan
- * tree by hand (since {@link ViewShadowRelation} has no surface syntax) and runs the analyzer
- * with mocked {@link AnalyzerContext#optionalLinkedResolution()} maps to verify the rule's behaviour:
+ * Tests for the {@code Analyzer.ResolveViewShadow} and {@code ExcludeShadowedProjectsFromViewBody}
+ * analyzer rules. Each test builds a small plan tree by hand (since {@link ViewShadowRelation} has no
+ * surface syntax) and supplies the {@link AnalyzerContext#optionalLinkedResolution()} map directly —
+ * the same map that {@code EsqlSession}'s lenient field-caps pass populates in production — to verify:
  * <ul>
  *   <li>shadow with a valid lenient resolution → replaced with {@code EsRelation};</li>
  *   <li>shadow with no lenient entry (or an invalid resolution) → left unresolved, then stripped
@@ -51,9 +52,8 @@ import static org.elasticsearch.xpack.esql.EsqlTestUtils.as;
  *       name with one exclusion list can match a remote index while another exclusion list at
  *       the same view name returns nothing.</li>
  * </ul>
- * The actual lenient field-caps integration that populates the resolution map in production is
- * deferred to a follow-up PR; this PR ensures the analyzer-side plumbing is in place and tested
- * against a mocked input.
+ * The exclusion tests ({@code testViewBody*}, {@code testNested*}) additionally verify that a linked
+ * project owning an index with a local view's name is excluded from the view body.
  * <p>
  * Each test calls {@link #assertWarnings(String...)} to acknowledge the
  * "No limit defined" warning that {@code AddImplicitLimit} adds since the test inputs are bare
@@ -234,18 +234,10 @@ public class ResolveViewShadowTests extends ESTestCase {
     }
 
     /**
-     * elastic/esql-planning#795: when a linked project owns an index with the same name as a local
-     * view, the view body must not <em>also</em> run on that project — the project's index supplies
-     * its data instead (a name cannot be both a view and an index on one project; the index wins).
-     * <p>
-     * Setup mirrors {@code FROM v1} where {@code v1} is a local view {@code FROM source-idx}: the
-     * strict body resolved flat-world across origin ({@code ""}) and linked project {@code "P"}
-     * (both have {@code source-idx}), and the shadow shows {@code "P"} also owns an index named
-     * {@code v1}. After analysis, {@code "P"} must be gone from the body's per-cluster maps (so the
-     * view stops running there) while the shadow's {@code EsRelation} for {@code "P"} survives.
-     * <p>
-     * Fails before the {@code ExcludeShadowedProjectsFromViewBody} rule: the body retains {@code "P"},
-     * double-counting that project (view body on P + P's index).
+     * View {@code v1 = FROM source-idx} resolved across origin ({@code ""}) and linked project
+     * {@code "P"}; the shadow shows {@code "P"} also owns an index named {@code v1}. The body must
+     * drop {@code "P"} (the view stops running there) while the shadow keeps {@code "P"} — otherwise
+     * {@code "P"} is double-counted (view body + its index). See esql-planning#795.
      */
     public void testViewBodyExcludesProjectOwningSameNamedIndex() {
         // Strict view body "v1": source-idx resolved on origin ("") and linked project "P".
@@ -300,11 +292,46 @@ public class ResolveViewShadowTests extends ESTestCase {
     }
 
     /**
-     * #795 edge: the colliding project is the view body's ONLY project. The view's source data lived
-     * only on the project that turns out to own a same-named index, so after excluding that project
-     * the body has no clusters left to run on — it contributes nothing, and the project's index (the
-     * shadow) supplies all of its rows. The body branch survives with empty per-cluster maps (a
-     * zero-row leaf); confirming execution treats that as no rows is left to the integration test.
+     * Only the colliding project is excluded: view body on origin, {@code P} and {@code Q}; only
+     * {@code P} owns a same-named index. The body keeps origin and {@code Q} and drops just {@code P}.
+     * See esql-planning#795.
+     */
+    public void testViewBodyExcludesOnlyTheCollidingProject() {
+        EsIndex body = new EsIndex(
+            "source-idx",
+            LoadMapping.loadMapping("mapping-one-field.json"),
+            Map.of("source-idx", IndexMode.STANDARD, "P:source-idx", IndexMode.STANDARD, "Q:source-idx", IndexMode.STANDARD),
+            Map.of("", List.of("source-idx"), "P", List.of("source-idx"), "Q", List.of("source-idx")),
+            Map.of("", List.of("source-idx"), "P", List.of("source-idx"), "Q", List.of("source-idx"))
+        );
+        EsIndex remoteV1 = new EsIndex(
+            "v1",
+            LoadMapping.loadMapping("mapping-one-field.json"),
+            Map.of("P:v1", IndexMode.STANDARD),
+            Map.of("P", List.of("v1")),
+            Map.of("P", List.of("v1"))
+        );
+        var analyzer = analyzer().addIndex("source-idx", IndexResolution.valid(body))
+            .addLenientShadow(new IndexPattern(EMPTY, "v1"), IndexResolution.valid(remoteV1))
+            .buildAnalyzer();
+
+        LogicalPlan plan = analyzer.analyze(viewUnionAllOf("v1", strictUR("source-idx"), new ViewShadowRelation(EMPTY, "v1", List.of())));
+
+        Map<String, EsRelation> byPattern = as(as(plan, Limit.class).child(), ViewUnionAll.class).children()
+            .stream()
+            .map(child -> as(unwrapProject(child), EsRelation.class))
+            .collect(Collectors.toMap(EsRelation::indexPattern, r -> r));
+
+        assertEquals("only the colliding project is dropped", Set.of("", "Q"), byPattern.get("source-idx").concreteIndices().keySet());
+        assertEquals(Set.of("P"), byPattern.get("v1").concreteIndices().keySet());
+
+        assertWarnings(NO_LIMIT_WARNING);
+    }
+
+    /**
+     * Edge: the colliding project is the body's only project. Excluding it leaves the body with no
+     * clusters (a zero-row leaf); the project's index supplies all rows via the shadow. Whether
+     * execution treats the empty leaf as no rows is left to the integration test. See esql-planning#795.
      */
     public void testViewBodyEmptyWhenOnlyProjectOwnsSameNamedIndex() {
         EsIndex body = new EsIndex(
@@ -342,13 +369,11 @@ public class ResolveViewShadowTests extends ESTestCase {
     }
 
     /**
-     * #795, nested case: outer view {@code v} is defined as {@code FROM v2}, an inner view over
-     * {@code source-idx}. A single linked project {@code P} owns indexes named like <em>both</em>
-     * {@code v} and {@code v2}. Because {@code v} resolves to an index on {@code P}, none of {@code v}'s
-     * definition runs on {@code P} — not the {@code source-idx} body, and not {@code P}'s {@code v2}
-     * index either; {@code P} contributes only its {@code v} index. The rule achieves this bottom-up:
-     * the inner shadow is resolved to an {@code EsRelation} before the outer collision prunes the inner
-     * subtree, so the inner {@code v2} index on {@code P} is pruned away too.
+     * Nested case: outer view {@code v = FROM v2}, inner view {@code v2 = FROM source-idx}; project
+     * {@code P} owns indexes named like both {@code v} and {@code v2}. Since {@code v} is an index on
+     * {@code P}, none of {@code v}'s definition runs there — including {@code P}'s {@code v2} index, which
+     * the bottom-up pass prunes away too. {@code P} contributes only its {@code v} index. See
+     * esql-planning#795.
      */
     public void testNestedViewExcludesProjectOwningOuterViewIndex() {
         Map<String, EsField> mapping = LoadMapping.loadMapping("mapping-one-field.json");


### PR DESCRIPTION
## What this is about

Under CPS, `FROM my-view` does two independent things: the view's body fans out flat-world to every linked project (the view "runs everywhere"), and a shadow lookup unions in any linked-project **index** that shares the view's name.

When one linked project owns *both* the view body's source data **and** an index named like the view, that project is counted twice — once via the view body running there, once via its same-named index. That's wrong: a name cannot be both a view and an index on a single project, and the index wins on its own project. The view must not run on that project; the project contributes only through its index.

## What this PR does

Adds an analyzer rule, `ExcludeShadowedProjectsFromViewBody`, that removes a project from a view body's `EsRelation` when that project owns an index matching the view name, via the new `EsRelation.withoutClusters`. `EsRelation.concreteIndices()` (keyed by cluster alias) is what drives the per-cluster execution fan-out, so the body then runs everywhere except the colliding project. Nested views are handled too: an outer collision excludes the whole nested definition on that project, including inner same-named indexes.

The new rule resolves the in-union shadows itself (it must, so the bottom-up pass has them as `EsRelation`s before an outer collision prunes). Since a `ViewShadowRelation` is always emitted inside a `ViewUnionAll`, that leaves the pre-existing per-node `ResolveViewShadow` rule with nothing to do in production, so this PR removes it.

Contained to the analyzer and the `EsRelation` node — no physical-plan, transport, operator, or serialization changes.

## Does it work?

`ExcludeShadowedProjectsFromViewBodyTests` covers it at the analyzer level:

- `testViewBodyExcludesProjectOwningSameNamedIndex` — the core case; verified it fails with the rule disabled (the body keeps the colliding project).
- `testViewBodyExcludesOnlyTheCollidingProject` — a non-colliding linked project is retained.
- `testViewBodyEmptyWhenOnlyProjectOwnsSameNamedIndex` — the colliding project is the body's only project; the body runs nowhere and the index supplies the rows.
- `testNestedViewExcludesProjectOwningOuterViewIndex` — outer/inner views, project owns indexes named like both; the inner same-named index is excluded too.

## What's in the diff

- `EsRelation.withoutClusters(Set<String>)` — prune cluster aliases from the per-cluster maps.
- `Analyzer.ExcludeShadowedProjectsFromViewBody` — the new rule; `ResolveViewShadow` removed as now-dead.
- Tests (renamed `ResolveViewShadowTests` → `ExcludeShadowedProjectsFromViewBodyTests`) and a changelog entry.

## What's out of scope

An end-to-end integration test against real linked projects: CPS data fan-out is not testable inside this repo (linked projects here are remote clusters), so the faithful IT belongs in `elasticsearch-serverless` alongside `ServerlessCrossProjectEsqlViewsIT`, as a companion PR that depends on this one.

## Why this is in draft

Pending the serverless companion IT and review.