### PR TITLE
[ESQL] Harden numeric TopN thresholds

### DIFF
--- a/docs/changelog/149926.yaml
+++ b/docs/changelog/149926.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 149926
+summary: Share numeric TopN thresholds
+type: enhancement

--- a/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReader.java
+++ b/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReader.java
@@ -778,6 +778,8 @@ public class OrcFormatReader implements RangeAwareFormatReader, NoConfigFormatRe
         private final long[] startRows;
         private final boolean[] active;
         private final boolean[] hasStats;
+        private final boolean[] nullOnly;
+        private final long[] nullCounts;
         private final long[] rawMins;
         private final long[] rawMaxs;
 
@@ -786,6 +788,8 @@ public class OrcFormatReader implements RangeAwareFormatReader, NoConfigFormatRe
             long[] startRows,
             boolean[] active,
             boolean[] hasStats,
+            boolean[] nullOnly,
+            long[] nullCounts,
             long[] rawMins,
             long[] rawMaxs
         ) {
@@ -793,6 +797,8 @@ public class OrcFormatReader implements RangeAwareFormatReader, NoConfigFormatRe
             this.startRows = startRows;
             this.active = active;
             this.hasStats = hasStats;
+            this.nullOnly = nullOnly;
+            this.nullCounts = nullCounts;
             this.rawMins = rawMins;
             this.rawMaxs = rawMaxs;
         }
@@ -814,6 +820,8 @@ public class OrcFormatReader implements RangeAwareFormatReader, NoConfigFormatRe
             long[] startRows = new long[stripes.size() + 1];
             boolean[] active = new boolean[stripes.size()];
             boolean[] hasStats = new boolean[stripes.size()];
+            boolean[] nullOnly = new boolean[stripes.size()];
+            long[] nullCounts = new long[stripes.size()];
             long[] rawMins = new long[stripes.size()];
             long[] rawMaxs = new long[stripes.size()];
             long row = 0L;
@@ -833,16 +841,21 @@ public class OrcFormatReader implements RangeAwareFormatReader, NoConfigFormatRe
                         long nulls = stripe.getNumberOfRows() - stats.getNumberOfValues();
                         Long min = rawMin(stats, sortType, threshold.elementType());
                         Long max = rawMax(stats, sortType, threshold.elementType());
-                        if (nulls == 0 && min != null && max != null) {
+                        if (min != null && max != null) {
                             hasStats[i] = true;
+                            nullCounts[i] = nulls;
                             rawMins[i] = min;
                             rawMaxs[i] = max;
+                        } else if (stats.getNumberOfValues() == 0 && nulls > 0) {
+                            hasStats[i] = true;
+                            nullOnly[i] = true;
+                            nullCounts[i] = nulls;
                         }
                     }
                 }
             }
             startRows[stripes.size()] = row;
-            return new StripeSkipTable(threshold, startRows, active, hasStats, rawMins, rawMaxs);
+            return new StripeSkipTable(threshold, startRows, active, hasStats, nullOnly, nullCounts, rawMins, rawMaxs);
         }
 
         boolean noFurtherCandidates() {
@@ -870,7 +883,9 @@ public class OrcFormatReader implements RangeAwareFormatReader, NoConfigFormatRe
                 && stripeIndex < active.length
                 && active[stripeIndex]
                 && hasStats[stripeIndex]
-                && threshold.dominates(rawMins[stripeIndex], rawMaxs[stripeIndex]);
+                && (nullOnly[stripeIndex]
+                    ? threshold.dominatesNulls(nullCounts[stripeIndex])
+                    : threshold.dominates(rawMins[stripeIndex], rawMaxs[stripeIndex], nullCounts[stripeIndex]));
         }
 
         int nextNonDominatedStripe(int fromStripe) {

--- a/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReader.java
+++ b/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReader.java
@@ -21,6 +21,8 @@ import org.apache.hadoop.hive.ql.exec.vector.TimestampColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.hadoop.hive.ql.io.sarg.PredicateLeaf;
 import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
+import org.apache.lucene.util.NumericUtils;
+import org.apache.orc.BooleanColumnStatistics;
 import org.apache.orc.ColumnStatistics;
 import org.apache.orc.DoubleColumnStatistics;
 import org.apache.orc.IntegerColumnStatistics;
@@ -35,6 +37,7 @@ import org.apache.orc.impl.OrcTail;
 import org.apache.orc.impl.ReaderImpl;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.CloseableIterator;
 import org.elasticsearch.core.Releasables;
@@ -51,6 +54,8 @@ import org.elasticsearch.xpack.esql.datasources.SourceStatisticsSerializer;
 import org.elasticsearch.xpack.esql.datasources.cache.ParsedFooterCache;
 import org.elasticsearch.xpack.esql.datasources.spi.AggregatePushdownSupport;
 import org.elasticsearch.xpack.esql.datasources.spi.ColumnBlockConversions;
+import org.elasticsearch.xpack.esql.datasources.spi.DynamicThreshold;
+import org.elasticsearch.xpack.esql.datasources.spi.DynamicThresholdAware;
 import org.elasticsearch.xpack.esql.datasources.spi.FilterPushdownSupport;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
@@ -95,7 +100,7 @@ import java.util.concurrent.ExecutionException;
  *   <li>Stripe-level split parallelism for multi-stripe files</li>
  * </ul>
  */
-public class OrcFormatReader implements RangeAwareFormatReader, NoConfigFormatReader {
+public class OrcFormatReader implements RangeAwareFormatReader, NoConfigFormatReader, DynamicThresholdAware {
 
     private static final Logger LOGGER = LogManager.getLogger(OrcFormatReader.class);
 
@@ -117,26 +122,38 @@ public class OrcFormatReader implements RangeAwareFormatReader, NoConfigFormatRe
     private final BlockFactory blockFactory;
     private final SearchArgument pushedFilter;
     private final OrcPushedExpressions pushedExpressions;
+    private final DynamicThreshold dynamicThreshold;
 
     public OrcFormatReader(BlockFactory blockFactory) {
-        this(blockFactory, null, null);
+        this(blockFactory, null, null, null);
     }
 
-    private OrcFormatReader(BlockFactory blockFactory, SearchArgument pushedFilter, OrcPushedExpressions pushedExpressions) {
+    private OrcFormatReader(
+        BlockFactory blockFactory,
+        SearchArgument pushedFilter,
+        OrcPushedExpressions pushedExpressions,
+        DynamicThreshold dynamicThreshold
+    ) {
         this.blockFactory = blockFactory;
         this.pushedFilter = pushedFilter;
         this.pushedExpressions = pushedExpressions;
+        this.dynamicThreshold = dynamicThreshold;
     }
 
     @Override
     public FormatReader withPushedFilter(Object pushedFilter) {
         if (pushedFilter instanceof SearchArgument sarg) {
-            return new OrcFormatReader(this.blockFactory, sarg, null);
+            return new OrcFormatReader(this.blockFactory, sarg, null, dynamicThreshold);
         }
         if (pushedFilter instanceof OrcPushedExpressions exprs) {
-            return new OrcFormatReader(this.blockFactory, null, exprs);
+            return new OrcFormatReader(this.blockFactory, null, exprs, dynamicThreshold);
         }
         return this;
+    }
+
+    @Override
+    public FormatReader withDynamicThreshold(DynamicThreshold threshold) {
+        return new OrcFormatReader(blockFactory, pushedFilter, pushedExpressions, threshold);
     }
 
     @Override
@@ -358,7 +375,15 @@ public class OrcFormatReader implements RangeAwareFormatReader, NoConfigFormatRe
         Reader.Options readOptions = configureReadOptions(reader, batchSize, include, schema);
         RecordReader rows = reader.rows(readOptions);
 
-        CloseableIterator<Page> iter = new OrcPageIterator(reader, rows, schema, projectedAttributes, batchSize, blockFactory);
+        CloseableIterator<Page> iter = new OrcPageIterator(
+            reader,
+            rows,
+            schema,
+            projectedAttributes,
+            batchSize,
+            blockFactory,
+            StripeSkipTable.build(reader, schema, dynamicThreshold, 0L, Long.MAX_VALUE)
+        );
         return rowLimit != NO_LIMIT ? new RowLimitingIterator(iter, rowLimit) : iter;
     }
 
@@ -470,7 +495,15 @@ public class OrcFormatReader implements RangeAwareFormatReader, NoConfigFormatRe
         readOptions.range(rangeStart, rangeEnd - rangeStart);
         RecordReader rows = reader.rows(readOptions);
 
-        return new OrcPageIterator(reader, rows, schema, projectedAttributes, batchSize, blockFactory);
+        return new OrcPageIterator(
+            reader,
+            rows,
+            schema,
+            projectedAttributes,
+            batchSize,
+            blockFactory,
+            StripeSkipTable.build(reader, schema, dynamicThreshold, rangeStart, rangeEnd)
+        );
     }
 
     private static List<Attribute> resolveProjection(List<Attribute> attributes, List<String> projectedColumns) {
@@ -740,12 +773,159 @@ public class OrcFormatReader implements RangeAwareFormatReader, NoConfigFormatRe
         visitor.visit(dottedPath, type, false);
     }
 
+    private static final class StripeSkipTable {
+        private final DynamicThreshold threshold;
+        private final long[] startRows;
+        private final boolean[] active;
+        private final boolean[] hasStats;
+        private final long[] rawMins;
+        private final long[] rawMaxs;
+
+        private StripeSkipTable(
+            DynamicThreshold threshold,
+            long[] startRows,
+            boolean[] active,
+            boolean[] hasStats,
+            long[] rawMins,
+            long[] rawMaxs
+        ) {
+            this.threshold = threshold;
+            this.startRows = startRows;
+            this.active = active;
+            this.hasStats = hasStats;
+            this.rawMins = rawMins;
+            this.rawMaxs = rawMaxs;
+        }
+
+        static StripeSkipTable build(Reader reader, TypeDescription schema, DynamicThreshold threshold, long rangeStart, long rangeEnd)
+            throws IOException {
+            if (threshold == null) {
+                return null;
+            }
+            TypeDescription sortType = buildDottedNameToType(schema).get(threshold.columnName());
+            if (sortType == null) {
+                return null;
+            }
+            List<StripeInformation> stripes = reader.getStripes();
+            List<StripeStatistics> stripeStats = reader.getStripeStatistics();
+            if (stripes.isEmpty() || stripeStats.isEmpty()) {
+                return null;
+            }
+            long[] startRows = new long[stripes.size() + 1];
+            boolean[] active = new boolean[stripes.size()];
+            boolean[] hasStats = new boolean[stripes.size()];
+            long[] rawMins = new long[stripes.size()];
+            long[] rawMaxs = new long[stripes.size()];
+            long row = 0L;
+            int columnId = sortType.getId();
+            for (int i = 0; i < stripes.size(); i++) {
+                StripeInformation stripe = stripes.get(i);
+                startRows[i] = row;
+                row += stripe.getNumberOfRows();
+                active[i] = stripe.getOffset() >= rangeStart && stripe.getOffset() < rangeEnd;
+                if (active[i] && i < stripeStats.size()) {
+                    ColumnStatistics[] columnStatistics = stripeStats.get(i).getColumnStatistics();
+                    if (columnId < columnStatistics.length) {
+                        ColumnStatistics stats = columnStatistics[columnId];
+                        if (stats == null) {
+                            continue;
+                        }
+                        long nulls = stripe.getNumberOfRows() - stats.getNumberOfValues();
+                        Long min = rawMin(stats, sortType, threshold.elementType());
+                        Long max = rawMax(stats, sortType, threshold.elementType());
+                        if (nulls == 0 && min != null && max != null) {
+                            hasStats[i] = true;
+                            rawMins[i] = min;
+                            rawMaxs[i] = max;
+                        }
+                    }
+                }
+            }
+            startRows[stripes.size()] = row;
+            return new StripeSkipTable(threshold, startRows, active, hasStats, rawMins, rawMaxs);
+        }
+
+        boolean noFurtherCandidates() {
+            return threshold.noFurtherCandidates();
+        }
+
+        int stripeIndexForRow(long rowNumber) {
+            int low = 0;
+            int high = active.length - 1;
+            while (low <= high) {
+                int mid = (low + high) >>> 1;
+                if (rowNumber < startRows[mid]) {
+                    high = mid - 1;
+                } else if (rowNumber >= startRows[mid + 1]) {
+                    low = mid + 1;
+                } else {
+                    return mid;
+                }
+            }
+            return -1;
+        }
+
+        boolean dominated(int stripeIndex) {
+            return stripeIndex >= 0
+                && stripeIndex < active.length
+                && active[stripeIndex]
+                && hasStats[stripeIndex]
+                && threshold.dominates(rawMins[stripeIndex], rawMaxs[stripeIndex]);
+        }
+
+        int nextNonDominatedStripe(int fromStripe) {
+            for (int i = fromStripe; i < active.length; i++) {
+                if (active[i] && dominated(i) == false) {
+                    return i;
+                }
+            }
+            return -1;
+        }
+
+        long stripeStartRow(int stripeIndex) {
+            return startRows[stripeIndex];
+        }
+
+        private static Long rawMin(ColumnStatistics stats, TypeDescription sortType, ElementType elementType) {
+            return switch (elementType) {
+                case LONG -> sortType.getCategory() == TypeDescription.Category.LONG && stats instanceof IntegerColumnStatistics intStats
+                    ? intStats.getMinimum()
+                    : null;
+                case INT -> sortType.getCategory() == TypeDescription.Category.INT && stats instanceof IntegerColumnStatistics intStats
+                    ? (long) intStats.getMinimum()
+                    : null;
+                case DOUBLE -> stats instanceof DoubleColumnStatistics doubleStats ? rawDouble(doubleStats.getMinimum()) : null;
+                case BOOLEAN -> stats instanceof BooleanColumnStatistics booleanStats ? (booleanStats.getFalseCount() > 0 ? 0L : 1L) : null;
+                default -> null;
+            };
+        }
+
+        private static Long rawMax(ColumnStatistics stats, TypeDescription sortType, ElementType elementType) {
+            return switch (elementType) {
+                case LONG -> sortType.getCategory() == TypeDescription.Category.LONG && stats instanceof IntegerColumnStatistics intStats
+                    ? intStats.getMaximum()
+                    : null;
+                case INT -> sortType.getCategory() == TypeDescription.Category.INT && stats instanceof IntegerColumnStatistics intStats
+                    ? (long) intStats.getMaximum()
+                    : null;
+                case DOUBLE -> stats instanceof DoubleColumnStatistics doubleStats ? rawDouble(doubleStats.getMaximum()) : null;
+                case BOOLEAN -> stats instanceof BooleanColumnStatistics booleanStats ? (booleanStats.getTrueCount() > 0 ? 1L : 0L) : null;
+                default -> null;
+            };
+        }
+
+        private static Long rawDouble(double value) {
+            return Double.isNaN(value) ? null : NumericUtils.doubleToSortableLong(value);
+        }
+    }
+
     private static class OrcPageIterator implements CloseableIterator<Page> {
         private final Reader reader;
         private final RecordReader rows;
         private final List<Attribute> attributes;
         private final BlockFactory blockFactory;
         private final VectorizedRowBatch batch;
+        private final StripeSkipTable stripeSkipTable;
         private boolean exhausted = false;
         private boolean batchReady = false;
         /**
@@ -762,13 +942,15 @@ public class OrcFormatReader implements RangeAwareFormatReader, NoConfigFormatRe
             TypeDescription schema,
             List<Attribute> attributes,
             int batchSize,
-            BlockFactory blockFactory
+            BlockFactory blockFactory,
+            StripeSkipTable stripeSkipTable
         ) {
             this.reader = reader;
             this.rows = rows;
             this.attributes = attributes;
             this.blockFactory = blockFactory;
             this.batch = schema.createRowBatch(batchSize);
+            this.stripeSkipTable = stripeSkipTable;
 
             this.fieldNameToPath = new HashMap<>(attributes.size());
             // Top-level field index, computed once for literal-name lookups.
@@ -827,16 +1009,45 @@ public class OrcFormatReader implements RangeAwareFormatReader, NoConfigFormatRe
                 return true;
             }
             try {
-                if (rows.nextBatch(batch)) {
-                    batchReady = true;
-                    return true;
-                } else {
-                    exhausted = true;
-                    return false;
+                while (true) {
+                    if (stripeSkipTable != null && stripeSkipTable.noFurtherCandidates()) {
+                        exhausted = true;
+                        return false;
+                    }
+                    if (skipDominatedStripes()) {
+                        if (exhausted) {
+                            return false;
+                        }
+                        continue;
+                    }
+                    if (rows.nextBatch(batch)) {
+                        batchReady = true;
+                        return true;
+                    } else {
+                        exhausted = true;
+                        return false;
+                    }
                 }
             } catch (IOException e) {
                 throw new RuntimeException("Failed to read ORC batch", e);
             }
+        }
+
+        private boolean skipDominatedStripes() throws IOException {
+            if (stripeSkipTable == null) {
+                return false;
+            }
+            int stripeIndex = stripeSkipTable.stripeIndexForRow(rows.getRowNumber());
+            if (stripeSkipTable.dominated(stripeIndex) == false) {
+                return false;
+            }
+            int nextStripe = stripeSkipTable.nextNonDominatedStripe(stripeIndex + 1);
+            if (nextStripe < 0) {
+                exhausted = true;
+                return true;
+            }
+            rows.seekToRow(stripeSkipTable.stripeStartRow(nextStripe));
+            return true;
         }
 
         @Override

--- a/x-pack/plugin/esql-datasource-orc/src/test/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReaderDynamicThresholdTests.java
+++ b/x-pack/plugin/esql-datasource-orc/src/test/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReaderDynamicThresholdTests.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.orc;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.RawLocalFileSystem;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
+import org.apache.orc.CompressionKind;
+import org.apache.orc.OrcFile;
+import org.apache.orc.TypeDescription;
+import org.apache.orc.Writer;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.CloseableIterator;
+import org.elasticsearch.compute.operator.topn.SharedNumericThreshold;
+import org.elasticsearch.core.SuppressForbidden;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.spi.DynamicThreshold;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.lessThan;
+
+public class OrcFormatReaderDynamicThresholdTests extends ESTestCase {
+
+    private BlockFactory blockFactory;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        OrcStorageObjectAdapter.clearCacheForTests();
+        blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(new NoopCircuitBreaker("none")).build();
+    }
+
+    public void testStripeSkipLeavesOnlyNonDominatedStripe() throws Exception {
+        byte[] data = createMultiStripeOrcFile(3, (stripeIndex, batch) -> {
+            batch.size = 100;
+            LongColumnVector id = (LongColumnVector) batch.cols[0];
+            long base = stripeIndex * 1_000L;
+            for (int i = 0; i < batch.size; i++) {
+                id.vector[i] = base + i;
+            }
+        });
+
+        List<Long> rows = readIdsWithThreshold(data, threshold(99L, true, false));
+
+        assertThat(rows.size(), equalTo(100));
+        assertTrue(rows.contains(0L));
+        assertTrue(rows.contains(99L));
+        assertFalse(rows.contains(1_000L));
+    }
+
+    public void testNoFurtherCandidatesExhaustsImmediately() throws Exception {
+        byte[] data = createMultiStripeOrcFile(2, (stripeIndex, batch) -> {
+            batch.size = 100;
+            LongColumnVector id = (LongColumnVector) batch.cols[0];
+            for (int i = 0; i < batch.size; i++) {
+                id.vector[i] = stripeIndex * 1_000L + i;
+            }
+        });
+        SharedNumericThreshold.Supplier supplier = new SharedNumericThreshold.Supplier(true, true);
+        SharedNumericThreshold channel = supplier.get();
+        channel.markNoFurtherCandidates();
+
+        List<Long> rows = readIdsWithThreshold(data, new DynamicThreshold("id", ElementType.LONG, true, true, channel));
+
+        assertThat(rows.size(), equalTo(0));
+    }
+
+    public void testNullsLastSkipsDominatedStripeWithNullsPresent() throws Exception {
+        byte[] data = createMultiStripeOrcFile(2, (stripeIndex, batch) -> {
+            batch.size = 100;
+            LongColumnVector id = (LongColumnVector) batch.cols[0];
+            id.noNulls = false;
+            long base = stripeIndex * 1_000L;
+            for (int i = 0; i < batch.size; i++) {
+                if (i % 10 == 0) {
+                    id.isNull[i] = true;
+                } else {
+                    id.vector[i] = base + i;
+                }
+            }
+        });
+
+        List<Long> rows = readIdsWithThreshold(data, threshold(99L, true, false));
+
+        assertThat(rows.size(), lessThan(200));
+        assertTrue(rows.contains(null));
+        assertTrue(rows.contains(99L));
+        assertFalse(rows.contains(1_001L));
+    }
+
+    public void testNullsFirstKeepsDominatedStripeWithNullsPresent() throws Exception {
+        byte[] data = createMultiStripeOrcFile(2, (stripeIndex, batch) -> {
+            batch.size = 100;
+            LongColumnVector id = (LongColumnVector) batch.cols[0];
+            id.noNulls = false;
+            long base = stripeIndex * 1_000L;
+            for (int i = 0; i < batch.size; i++) {
+                if (stripeIndex == 1 && i % 10 == 0) {
+                    id.isNull[i] = true;
+                } else {
+                    id.vector[i] = base + i;
+                }
+            }
+        });
+
+        List<Long> rows = readIdsWithThreshold(data, threshold(99L, true, true));
+
+        assertThat(rows.size(), equalTo(200));
+        assertTrue(rows.contains(null));
+        assertTrue(rows.contains(1_001L));
+    }
+
+    private DynamicThreshold threshold(long value, boolean ascending, boolean nullsFirst) {
+        SharedNumericThreshold.Supplier supplier = new SharedNumericThreshold.Supplier(ascending, nullsFirst);
+        SharedNumericThreshold channel = supplier.get();
+        channel.offer(value);
+        return new DynamicThreshold("id", ElementType.LONG, ascending, nullsFirst, channel);
+    }
+
+    private List<Long> readIdsWithThreshold(byte[] data, DynamicThreshold threshold) throws IOException {
+        OrcFormatReader reader = (OrcFormatReader) new OrcFormatReader(blockFactory).withDynamicThreshold(threshold);
+        try (threshold; CloseableIterator<Page> iterator = reader.read(storageObject(data), List.of("id"), 128)) {
+            List<Long> values = new ArrayList<>();
+            while (iterator.hasNext()) {
+                Page page = iterator.next();
+                try {
+                    LongBlock block = page.getBlock(0);
+                    for (int p = 0; p < block.getPositionCount(); p++) {
+                        values.add(block.isNull(p) ? null : block.getLong(block.getFirstValueIndex(p)));
+                    }
+                } finally {
+                    page.releaseBlocks();
+                }
+            }
+            return values;
+        }
+    }
+
+    private byte[] createMultiStripeOrcFile(int stripeCount, StripePopulator populator) throws IOException {
+        TypeDescription schema = TypeDescription.createStruct().addField("id", TypeDescription.createLong());
+        var tempFile = createTempFile();
+        Files.delete(tempFile);
+        Path orcPath = new Path(tempFile.toUri());
+
+        Configuration conf = new Configuration(false);
+        conf.set("orc.key.provider", "memory");
+        NoPermissionLocalFileSystem localFs = new NoPermissionLocalFileSystem();
+        localFs.setConf(conf);
+        OrcFile.WriterOptions writerOptions = OrcFile.writerOptions(conf)
+            .setSchema(schema)
+            .fileSystem(localFs)
+            .compress(CompressionKind.NONE)
+            .stripeSize(512);
+
+        try (Writer writer = OrcFile.createWriter(orcPath, writerOptions)) {
+            for (int s = 0; s < stripeCount; s++) {
+                VectorizedRowBatch batch = schema.createRowBatch();
+                populator.populate(s, batch);
+                writer.addRowBatch(batch);
+                writer.writeIntermediateFooter();
+            }
+        }
+
+        return Files.readAllBytes(tempFile);
+    }
+
+    private static StorageObject storageObject(byte[] data) {
+        return new StorageObject() {
+            @Override
+            public InputStream newStream() {
+                return new ByteArrayInputStream(data);
+            }
+
+            @Override
+            public InputStream newStream(long position, long length) {
+                int pos = (int) position;
+                int len = (int) Math.min(length, data.length - position);
+                return new ByteArrayInputStream(data, pos, len);
+            }
+
+            @Override
+            public long length() {
+                return data.length;
+            }
+
+            @Override
+            public Instant lastModified() {
+                return Instant.EPOCH;
+            }
+
+            @Override
+            public boolean exists() {
+                return true;
+            }
+
+            @Override
+            public StoragePath path() {
+                return StoragePath.of("memory://dynamic-threshold.orc");
+            }
+        };
+    }
+
+    @FunctionalInterface
+    private interface StripePopulator {
+        void populate(int stripeIndex, VectorizedRowBatch batch);
+    }
+
+    private static class NoPermissionLocalFileSystem extends RawLocalFileSystem {
+        @Override
+        @SuppressForbidden(reason = "Bypass Hadoop's LocalFSFileOutputStream to avoid Shell.<clinit>")
+        protected OutputStream createOutputStreamWithMode(Path p, boolean append, FsPermission permission) throws IOException {
+            return new FileOutputStream(pathToFile(p), append);
+        }
+
+        @Override
+        public void setPermission(Path p, FsPermission permission) {
+            // no-op: skip chmod calls that would trigger Shell
+        }
+
+        @Override
+        @SuppressForbidden(reason = "Hadoop API requires java.io.File in method signature")
+        protected boolean mkOneDirWithMode(Path p, File p2f, FsPermission permission) throws IOException {
+            return p2f.mkdir() || p2f.isDirectory();
+        }
+    }
+}

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
@@ -458,12 +458,15 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
             return false;
         }
         Statistics<?> statistics = sortColumn.getStatistics();
-        if (statistics == null || statistics.isEmpty() || statistics.hasNonNullValue() == false || statistics.getNumNulls() > 0) {
+        if (statistics == null || statistics.isEmpty()) {
             return false;
+        }
+        if (statistics.hasNonNullValue() == false) {
+            return dynamicThreshold.dominatesNulls(statistics.getNumNulls());
         }
         Long rawMin = rawValueFromStats(statistics.genericGetMin());
         Long rawMax = rawValueFromStats(statistics.genericGetMax());
-        return rawMin != null && rawMax != null && dynamicThreshold.dominates(rawMin, rawMax);
+        return rawMin != null && rawMax != null && dynamicThreshold.dominates(rawMin, rawMax, statistics.getNumNulls());
     }
 
     private RowRanges thresholdRowRanges(int rowGroupOrdinal, BlockMetaData block) {
@@ -479,6 +482,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
         List<ByteBuffer> minValues = columnIndex.getMinValues();
         List<ByteBuffer> maxValues = columnIndex.getMaxValues();
         List<Boolean> nullPages = columnIndex.getNullPages();
+        List<Long> nullCounts = columnIndex.getNullCounts();
         if (minValues.size() != pageCount || maxValues.size() != pageCount) {
             return null;
         }
@@ -487,12 +491,20 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
             long pageStart = offsetIndex.getFirstRowIndex(page);
             long pageEnd = (page + 1 < pageCount) ? offsetIndex.getFirstRowIndex(page + 1) : block.getRowCount();
             if (nullPages != null && page < nullPages.size() && Boolean.TRUE.equals(nullPages.get(page))) {
-                surviving.add(new long[] { pageStart, pageEnd });
+                if (dynamicThreshold.dominatesNulls(pageEnd - pageStart) == false) {
+                    surviving.add(new long[] { pageStart, pageEnd });
+                }
                 continue;
             }
             Long rawMin = rawValueFromPageIndex(minValues.get(page));
             Long rawMax = rawValueFromPageIndex(maxValues.get(page));
-            if (rawMin == null || rawMax == null || dynamicThreshold.dominates(rawMin, rawMax) == false) {
+            boolean hasNullCount = nullCounts != null && page < nullCounts.size();
+            if (hasNullCount == false && dynamicThreshold.nullsFirst()) {
+                surviving.add(new long[] { pageStart, pageEnd });
+                continue;
+            }
+            long nullCount = hasNullCount ? nullCounts.get(page) : 0L;
+            if (rawMin == null || rawMax == null || dynamicThreshold.dominates(rawMin, rawMax, nullCount) == false) {
                 surviving.add(new long[] { pageStart, pageEnd });
             }
         }
@@ -539,6 +551,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
         if (value == null || value.remaining() == 0) {
             return null;
         }
+        // Parquet page-index bounds use the type's plain encoding; numeric plain values are little-endian.
         ByteBuffer ordered = value.duplicate().order(ByteOrder.LITTLE_ENDIAN);
         return switch (dynamicThreshold.elementType()) {
             case LONG -> sortColumnPrimitiveType.getPrimitiveTypeName() == PrimitiveType.PrimitiveTypeName.INT64 ? ordered.getLong() : null;

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
@@ -7,23 +7,29 @@
 
 package org.elasticsearch.xpack.esql.datasource.parquet;
 
+import org.apache.lucene.util.NumericUtils;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.ColumnReader;
 import org.apache.parquet.column.impl.ColumnReadStoreImpl;
 import org.apache.parquet.column.page.PageReader;
+import org.apache.parquet.column.statistics.Statistics;
 import org.apache.parquet.compression.CompressionCodecFactory;
 import org.apache.parquet.filter2.predicate.FilterPredicate;
 import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.hadoop.metadata.BlockMetaData;
 import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
 import org.apache.parquet.hadoop.metadata.ParquetMetadata;
+import org.apache.parquet.internal.column.columnindex.ColumnIndex;
+import org.apache.parquet.internal.column.columnindex.OffsetIndex;
 import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.util.concurrent.FutureUtils;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.data.UninitializedArrays;
 import org.elasticsearch.compute.operator.CloseableIterator;
@@ -34,10 +40,13 @@ import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.datasources.spi.ColumnExtractor;
 import org.elasticsearch.xpack.esql.datasources.spi.ColumnExtractorProducer;
+import org.elasticsearch.xpack.esql.datasources.spi.DynamicThreshold;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -141,6 +150,10 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
      * full file or on a range. {@code null} iff {@link #rowPositionColumnIndex} is {@code -1}.
      */
     private final ParquetMetadata fullFooter;
+    private final DynamicThreshold dynamicThreshold;
+    private final ColumnDescriptor sortColumnDescriptor;
+    private final String sortColumnPath;
+    private final PrimitiveType sortColumnPrimitiveType;
     /**
      * High bits OR-ed into every emitted {@code _rowPosition} value once
      * {@link #setExtractorId(int)} has been called: {@code ((long) extractorId) << LOCAL_POSITION_BITS}.
@@ -279,7 +292,9 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
         ParquetPushedExpressions pushedExpressions,
         FilterPredicate triviallyPassesPredicate,
         ParquetFormatReader formatReader,
-        ParquetMetadata fullFooter
+        ParquetMetadata fullFooter,
+        DynamicThreshold dynamicThreshold,
+        ColumnDescriptor sortColumnDescriptor
     ) {
         this.reader = reader;
         this.projectedSchema = projectedSchema;
@@ -305,6 +320,10 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
             : null;
         this.formatReader = formatReader;
         this.fullFooter = fullFooter;
+        this.dynamicThreshold = dynamicThreshold;
+        this.sortColumnDescriptor = sortColumnDescriptor;
+        this.sortColumnPath = sortColumnDescriptor == null ? null : String.join(".", sortColumnDescriptor.getPath());
+        this.sortColumnPrimitiveType = sortColumnDescriptor == null ? null : sortColumnDescriptor.getPrimitiveType();
         this.codecFactory = codecFactory;
         this.pushedExpressions = pushedExpressions;
         this.isPredicateColumn = classifyPredicateColumns(attributes, columnInfos, pushedExpressions);
@@ -343,6 +362,9 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
         if (storageObject == null) {
             return;
         }
+        if (dynamicThreshold != null && dynamicThreshold.noFurtherCandidates()) {
+            return;
+        }
         int startOrdinal = nextSurvivingRowGroupOrdinal(0);
         fillPrefetchQueue(startOrdinal);
     }
@@ -362,7 +384,14 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
         Set<String> phaseColumns = useTwoPhase ? predicateColumnPaths : projectedColumnPaths;
         int nextOrdinal = fromOrdinal;
         while (pendingPrefetches.size() < prefetchDepth && nextOrdinal < rowGroups.size()) {
+            if (dynamicThreshold != null && dynamicThreshold.noFurtherCandidates()) {
+                break;
+            }
             BlockMetaData nextBlock = rowGroups.get(nextOrdinal);
+            if (rowGroupDominatedByThreshold(nextBlock)) {
+                nextOrdinal = nextSurvivingRowGroupOrdinal(nextOrdinal + 1);
+                continue;
+            }
             long prefetchBytes = ColumnChunkPrefetcher.computePrefetchBytes(nextBlock, phaseColumns);
             if (prefetchBytes <= 0) {
                 nextOrdinal = nextSurvivingRowGroupOrdinal(nextOrdinal + 1);
@@ -381,6 +410,15 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
             }
             try {
                 RowRanges nextRowRanges = allRowRanges != null && nextOrdinal < allRowRanges.length ? allRowRanges[nextOrdinal] : null;
+                RowRanges thresholdRanges = thresholdRowRanges(nextOrdinal, nextBlock);
+                if (thresholdRanges != null) {
+                    if (thresholdRanges.isEmpty()) {
+                        breaker.addWithoutBreaking(-prefetchBytes);
+                        nextOrdinal = nextSurvivingRowGroupOrdinal(nextOrdinal + 1);
+                        continue;
+                    }
+                    nextRowRanges = nextRowRanges == null ? thresholdRanges : nextRowRanges.intersect(thresholdRanges);
+                }
                 if (lateMaterialization) {
                     // Late-mat (single-phase or two-phase) handles row-level filtering itself via
                     // the survivor mask and would double-filter if ColumnIndex RowRanges were
@@ -409,6 +447,120 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
             }
             nextOrdinal = nextSurvivingRowGroupOrdinal(nextOrdinal + 1);
         }
+    }
+
+    private boolean rowGroupDominatedByThreshold(BlockMetaData block) {
+        if (dynamicThreshold == null || sortColumnPath == null || sortColumnPrimitiveType == null) {
+            return false;
+        }
+        ColumnChunkMetaData sortColumn = sortColumn(block);
+        if (sortColumn == null) {
+            return false;
+        }
+        Statistics<?> statistics = sortColumn.getStatistics();
+        if (statistics == null || statistics.isEmpty() || statistics.hasNonNullValue() == false || statistics.getNumNulls() > 0) {
+            return false;
+        }
+        Long rawMin = rawValueFromStats(statistics.genericGetMin());
+        Long rawMax = rawValueFromStats(statistics.genericGetMax());
+        return rawMin != null && rawMax != null && dynamicThreshold.dominates(rawMin, rawMax);
+    }
+
+    private RowRanges thresholdRowRanges(int rowGroupOrdinal, BlockMetaData block) {
+        if (dynamicThreshold == null || sortColumnPath == null || sortColumnPrimitiveType == null) {
+            return null;
+        }
+        ColumnIndex columnIndex = preloadedMetadata.getColumnIndex(rowGroupOrdinal, sortColumnPath);
+        OffsetIndex offsetIndex = preloadedMetadata.getOffsetIndex(rowGroupOrdinal, sortColumnPath);
+        if (columnIndex == null || offsetIndex == null) {
+            return null;
+        }
+        int pageCount = offsetIndex.getPageCount();
+        List<ByteBuffer> minValues = columnIndex.getMinValues();
+        List<ByteBuffer> maxValues = columnIndex.getMaxValues();
+        List<Boolean> nullPages = columnIndex.getNullPages();
+        if (minValues.size() != pageCount || maxValues.size() != pageCount) {
+            return null;
+        }
+        List<long[]> surviving = new ArrayList<>();
+        for (int page = 0; page < pageCount; page++) {
+            long pageStart = offsetIndex.getFirstRowIndex(page);
+            long pageEnd = (page + 1 < pageCount) ? offsetIndex.getFirstRowIndex(page + 1) : block.getRowCount();
+            if (nullPages != null && page < nullPages.size() && Boolean.TRUE.equals(nullPages.get(page))) {
+                surviving.add(new long[] { pageStart, pageEnd });
+                continue;
+            }
+            Long rawMin = rawValueFromPageIndex(minValues.get(page));
+            Long rawMax = rawValueFromPageIndex(maxValues.get(page));
+            if (rawMin == null || rawMax == null || dynamicThreshold.dominates(rawMin, rawMax) == false) {
+                surviving.add(new long[] { pageStart, pageEnd });
+            }
+        }
+        return RowRanges.fromUnsorted(surviving, block.getRowCount());
+    }
+
+    private ColumnChunkMetaData sortColumn(BlockMetaData block) {
+        for (ColumnChunkMetaData column : block.getColumns()) {
+            if (column.getPath().toDotString().equals(sortColumnPath)) {
+                return column;
+            }
+        }
+        return null;
+    }
+
+    private Long rawValueFromStats(Object value) {
+        if (value == null) {
+            return null;
+        }
+        ElementType elementType = dynamicThreshold.elementType();
+        return switch (elementType) {
+            case LONG -> sortColumnPrimitiveType.getPrimitiveTypeName() == PrimitiveType.PrimitiveTypeName.INT64
+                ? ((Number) value).longValue()
+                : null;
+            case INT -> sortColumnPrimitiveType.getPrimitiveTypeName() == PrimitiveType.PrimitiveTypeName.INT32
+                ? (long) ((Number) value).intValue()
+                : null;
+            case DOUBLE -> {
+                if (sortColumnPrimitiveType.getPrimitiveTypeName() == PrimitiveType.PrimitiveTypeName.DOUBLE
+                    || sortColumnPrimitiveType.getPrimitiveTypeName() == PrimitiveType.PrimitiveTypeName.FLOAT) {
+                    double d = ((Number) value).doubleValue();
+                    yield Double.isNaN(d) ? null : NumericUtils.doubleToSortableLong(d);
+                }
+                yield null;
+            }
+            case BOOLEAN -> sortColumnPrimitiveType.getPrimitiveTypeName() == PrimitiveType.PrimitiveTypeName.BOOLEAN
+                ? (((Boolean) value) ? 1L : 0L)
+                : null;
+            default -> null;
+        };
+    }
+
+    private Long rawValueFromPageIndex(ByteBuffer value) {
+        if (value == null || value.remaining() == 0) {
+            return null;
+        }
+        ByteBuffer ordered = value.duplicate().order(ByteOrder.LITTLE_ENDIAN);
+        return switch (dynamicThreshold.elementType()) {
+            case LONG -> sortColumnPrimitiveType.getPrimitiveTypeName() == PrimitiveType.PrimitiveTypeName.INT64 ? ordered.getLong() : null;
+            case INT -> sortColumnPrimitiveType.getPrimitiveTypeName() == PrimitiveType.PrimitiveTypeName.INT32
+                ? (long) ordered.getInt()
+                : null;
+            case DOUBLE -> switch (sortColumnPrimitiveType.getPrimitiveTypeName()) {
+                case FLOAT -> {
+                    float f = ordered.getFloat();
+                    yield Float.isNaN(f) ? null : NumericUtils.doubleToSortableLong(f);
+                }
+                case DOUBLE -> {
+                    double d = ordered.getDouble();
+                    yield Double.isNaN(d) ? null : NumericUtils.doubleToSortableLong(d);
+                }
+                default -> null;
+            };
+            case BOOLEAN -> sortColumnPrimitiveType.getPrimitiveTypeName() == PrimitiveType.PrimitiveTypeName.BOOLEAN
+                ? (ordered.get() != 0 ? 1L : 0L)
+                : null;
+            default -> null;
+        };
     }
 
     private static final long DEEPER_PREFETCH_BYTES = 32_000_000L;
@@ -599,6 +751,11 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
         if (exhausted) {
             return false;
         }
+        if (dynamicThreshold != null && dynamicThreshold.noFurtherCandidates()) {
+            exhausted = true;
+            cancelPendingPrefetch();
+            return false;
+        }
         if (rowBudget != FormatReader.NO_LIMIT && rowBudget <= 0) {
             exhausted = true;
             return false;
@@ -691,6 +848,9 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
             pageBatchIndexInRowGroup = 0;
 
             BlockMetaData block = reader.getRowGroups().get(rowGroupOrdinal);
+            if (rowGroupDominatedByThreshold(block)) {
+                continue;
+            }
             // Per-row-group trivially-passes check: when stats prove every row matches the
             // filter, the late-materialization machinery (decode predicate columns → evaluate
             // filter → compact survivors) is pure overhead. Switching to the standard path
@@ -728,6 +888,9 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
                 }
 
                 RowRanges currentRowRanges = resolveCurrentRowRanges(block);
+                if (currentRowRanges != null && currentRowRanges.isEmpty()) {
+                    continue;
+                }
                 // When late materialization is active, skip ColumnIndex page filtering — late-mat
                 // handles row-level filtering itself via the survivor mask. Applying both
                 // ColumnIndex RowRanges AND late-mat evaluation causes double-filtering that
@@ -853,18 +1016,26 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
      * stray {@code null} just in case.
      */
     private RowRanges resolveCurrentRowRanges(BlockMetaData block) {
-        if (allRowRanges == null || rowGroupOrdinal >= allRowRanges.length || allRowRanges[rowGroupOrdinal] == null) {
+        RowRanges ranges = null;
+        if (allRowRanges != null && rowGroupOrdinal < allRowRanges.length) {
+            ranges = allRowRanges[rowGroupOrdinal];
+        }
+        RowRanges thresholdRanges = thresholdRowRanges(rowGroupOrdinal, block);
+        if (thresholdRanges != null) {
+            ranges = ranges == null ? thresholdRanges : ranges.intersect(thresholdRanges);
+        }
+        if (ranges == null) {
             return null;
         }
-        assert allRowRanges[rowGroupOrdinal].totalRows() == block.getRowCount()
+        assert ranges.totalRows() == block.getRowCount()
             : "RowRanges total rows ["
-                + allRowRanges[rowGroupOrdinal].totalRows()
+                + ranges.totalRows()
                 + "] != row group row count ["
                 + block.getRowCount()
                 + "] at ordinal ["
                 + rowGroupOrdinal
                 + "]";
-        return allRowRanges[rowGroupOrdinal];
+        return ranges;
     }
 
     /**

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -57,6 +57,8 @@ import org.elasticsearch.xpack.esql.datasources.spi.ColumnBlockConversions;
 import org.elasticsearch.xpack.esql.datasources.spi.ColumnExtractor;
 import org.elasticsearch.xpack.esql.datasources.spi.ColumnExtractorAware;
 import org.elasticsearch.xpack.esql.datasources.spi.Configured;
+import org.elasticsearch.xpack.esql.datasources.spi.DynamicThreshold;
+import org.elasticsearch.xpack.esql.datasources.spi.DynamicThresholdAware;
 import org.elasticsearch.xpack.esql.datasources.spi.FilterPushdownSupport;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
@@ -103,7 +105,7 @@ import java.util.concurrent.ExecutionException;
  *   <li>Direct conversion from Parquet to ESQL blocks</li>
  * </ul>
  */
-public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtractorAware {
+public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtractorAware, DynamicThresholdAware {
 
     private static final Logger logger = LogManager.getLogger(ParquetFormatReader.class);
 
@@ -120,6 +122,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
     private final boolean forceBaselinePath;
     private final boolean optimizedReader;
     private final boolean lateMaterializationEnabled;
+    private final DynamicThreshold dynamicThreshold;
     // Shared across all iterators created by this reader: holds lazy decompressor instances and
     // pays the per-codec init cost once. The factory is stateless across files/row groups.
     private final PlainCompressionCodecFactory codecFactory = new PlainCompressionCodecFactory();
@@ -193,11 +196,11 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
     }
 
     public ParquetFormatReader(BlockFactory blockFactory) {
-        this(blockFactory, FilterCompat.NOOP, null, false, true, true);
+        this(blockFactory, FilterCompat.NOOP, null, false, true, true, null);
     }
 
     ParquetFormatReader(BlockFactory blockFactory, boolean optimizedReader) {
-        this(blockFactory, FilterCompat.NOOP, null, false, optimizedReader, true);
+        this(blockFactory, FilterCompat.NOOP, null, false, optimizedReader, true, null);
     }
 
     private ParquetFormatReader(
@@ -206,7 +209,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
         ParquetPushedExpressions pushedExpressions,
         boolean forceBaselinePath,
         boolean optimizedReader,
-        boolean lateMaterializationEnabled
+        boolean lateMaterializationEnabled,
+        DynamicThreshold dynamicThreshold
     ) {
         this.blockFactory = blockFactory;
         this.pushedFilter = pushedFilter;
@@ -214,6 +218,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
         this.forceBaselinePath = forceBaselinePath;
         this.optimizedReader = optimizedReader;
         this.lateMaterializationEnabled = lateMaterializationEnabled;
+        this.dynamicThreshold = dynamicThreshold;
     }
 
     /**
@@ -222,13 +227,29 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
      * testing against the optimized path.
      */
     ParquetFormatReader withBaselinePath() {
-        return new ParquetFormatReader(blockFactory, pushedFilter, pushedExpressions, true, optimizedReader, lateMaterializationEnabled);
+        return new ParquetFormatReader(
+            blockFactory,
+            pushedFilter,
+            pushedExpressions,
+            true,
+            optimizedReader,
+            lateMaterializationEnabled,
+            dynamicThreshold
+        );
     }
 
     @Override
     public ParquetFormatReader withPushedFilter(Object pushedFilter) {
         if (pushedFilter instanceof FilterCompat.Filter filter) {
-            return new ParquetFormatReader(blockFactory, filter, null, forceBaselinePath, optimizedReader, lateMaterializationEnabled);
+            return new ParquetFormatReader(
+                blockFactory,
+                filter,
+                null,
+                forceBaselinePath,
+                optimizedReader,
+                lateMaterializationEnabled,
+                dynamicThreshold
+            );
         }
         if (pushedFilter instanceof ParquetPushedExpressions exprs) {
             return new ParquetFormatReader(
@@ -237,10 +258,24 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
                 exprs,
                 forceBaselinePath,
                 optimizedReader,
-                lateMaterializationEnabled
+                lateMaterializationEnabled,
+                dynamicThreshold
             );
         }
         return this;
+    }
+
+    @Override
+    public FormatReader withDynamicThreshold(DynamicThreshold threshold) {
+        return new ParquetFormatReader(
+            blockFactory,
+            pushedFilter,
+            pushedExpressions,
+            forceBaselinePath,
+            optimizedReader,
+            lateMaterializationEnabled,
+            threshold
+        );
     }
 
     @Override
@@ -252,7 +287,15 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
         boolean newLateMat = parseBooleanConfig(config, CONFIG_LATE_MATERIALIZATION, lateMaterializationEnabled);
         FormatReader result = (newOptimized == optimizedReader && newLateMat == lateMaterializationEnabled)
             ? this
-            : new ParquetFormatReader(blockFactory, pushedFilter, pushedExpressions, forceBaselinePath, newOptimized, newLateMat);
+            : new ParquetFormatReader(
+                blockFactory,
+                pushedFilter,
+                pushedExpressions,
+                forceBaselinePath,
+                newOptimized,
+                newLateMat,
+                dynamicThreshold
+            );
         return Configured.fromKnownSubset(result, config, RECOGNIZED_KEYS);
     }
 
@@ -1086,8 +1129,24 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
             effectivePushed,
             triviallyPassesPredicate,
             this,
-            fullFooter
+            fullFooter,
+            dynamicThreshold,
+            resolveDynamicThresholdColumn(fileSchema, dynamicThreshold)
         );
+    }
+
+    private static ColumnDescriptor resolveDynamicThresholdColumn(MessageType schema, DynamicThreshold dynamicThreshold) {
+        if (dynamicThreshold == null) {
+            return null;
+        }
+        String columnName = dynamicThreshold.columnName();
+        for (ColumnDescriptor descriptor : schema.getColumns()) {
+            String[] path = descriptor.getPath();
+            if (String.join(".", path).equals(columnName) || (path.length == 1 && path[0].equals(columnName))) {
+                return descriptor;
+            }
+        }
+        return null;
     }
 
     /**

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetDynamicThresholdTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetDynamicThresholdTests.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.apache.parquet.conf.PlainParquetConfiguration;
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.example.data.simple.SimpleGroupFactory;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.example.ExampleParquetWriter;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.io.OutputFile;
+import org.apache.parquet.io.PositionOutputStream;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Types;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.CloseableIterator;
+import org.elasticsearch.compute.operator.topn.SharedNumericThreshold;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.spi.DynamicThreshold;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.lessThan;
+
+public class OptimizedParquetDynamicThresholdTests extends ESTestCase {
+
+    private static final MessageType REQUIRED_LONG_SCHEMA = Types.buildMessage()
+        .required(PrimitiveType.PrimitiveTypeName.INT64)
+        .named("id")
+        .named("dynamic_threshold_test");
+    private static final MessageType OPTIONAL_LONG_SCHEMA = Types.buildMessage()
+        .optional(PrimitiveType.PrimitiveTypeName.INT64)
+        .named("id")
+        .named("dynamic_threshold_test");
+
+    private BlockFactory blockFactory;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(new NoopCircuitBreaker("none")).build();
+    }
+
+    public void testRowGroupSkipWithMonotonicAscendingData() throws Exception {
+        byte[] data = writeLongParquet(REQUIRED_LONG_SCHEMA, 1L, 2 * 1024 * 1024, 1_000, i -> (long) i);
+
+        List<Long> rows = readIdsWithThreshold(data, threshold(9L, true, false));
+
+        assertThat(rows.size(), lessThan(1_000));
+        assertTrue(rows.contains(0L));
+        assertTrue(rows.contains(9L));
+        assertFalse(rows.contains(900L));
+    }
+
+    public void testPageLevelSkipWithinSingleRowGroup() throws Exception {
+        byte[] data = writeLongParquet(REQUIRED_LONG_SCHEMA, 64L * 1024 * 1024, 64, 2_000, i -> (long) i);
+
+        List<Long> rows = readIdsWithThreshold(data, threshold(9L, true, false));
+
+        assertThat(rows.size(), lessThan(2_000));
+        assertTrue(rows.contains(0L));
+        assertTrue(rows.contains(9L));
+        assertFalse(rows.contains(1_900L));
+    }
+
+    public void testSinglePageRowGroupKeepsNegativeControlRows() throws Exception {
+        byte[] data = writeLongParquet(REQUIRED_LONG_SCHEMA, 64L * 1024 * 1024, 2 * 1024 * 1024, 2_000, i -> (long) i);
+
+        List<Long> rows = readIdsWithThreshold(data, threshold(9L, true, false));
+
+        assertThat(rows.size(), equalTo(2_000));
+    }
+
+    public void testNoFurtherCandidatesExhaustsImmediately() throws Exception {
+        byte[] data = writeLongParquet(REQUIRED_LONG_SCHEMA, 1L, 64, 1_000, i -> (long) i);
+        SharedNumericThreshold.Supplier supplier = new SharedNumericThreshold.Supplier(true, true);
+        SharedNumericThreshold channel = supplier.get();
+        channel.markNoFurtherCandidates();
+
+        List<Long> rows = readIdsWithThreshold(
+            data,
+            new DynamicThreshold("id", org.elasticsearch.compute.data.ElementType.LONG, true, true, channel)
+        );
+
+        assertThat(rows.size(), equalTo(0));
+    }
+
+    public void testNullsLastCanSkipNullAndDominatedRowGroups() throws Exception {
+        byte[] data = writeLongParquet(OPTIONAL_LONG_SCHEMA, 1L, 2 * 1024 * 1024, 300, i -> i < 100 ? null : (long) i);
+
+        List<Long> rows = readIdsWithThreshold(data, threshold(109L, true, false));
+
+        assertThat(rows.size(), lessThan(300));
+        assertTrue(rows.contains(100L));
+        assertTrue(rows.contains(109L));
+        assertFalse(rows.contains(250L));
+    }
+
+    private DynamicThreshold threshold(long value, boolean ascending, boolean nullsFirst) {
+        SharedNumericThreshold.Supplier supplier = new SharedNumericThreshold.Supplier(ascending, nullsFirst);
+        SharedNumericThreshold channel = supplier.get();
+        channel.offer(value);
+        return new DynamicThreshold("id", org.elasticsearch.compute.data.ElementType.LONG, ascending, nullsFirst, channel);
+    }
+
+    private List<Long> readIdsWithThreshold(byte[] data, DynamicThreshold threshold) throws IOException {
+        try (
+            threshold;
+            CloseableIterator<Page> iterator = reader(threshold).read(storageObject(data), FormatReadContext.of(List.of("id"), 128))
+        ) {
+            List<Long> values = new ArrayList<>();
+            while (iterator.hasNext()) {
+                Page page = iterator.next();
+                try {
+                    LongBlock block = page.getBlock(0);
+                    for (int p = 0; p < block.getPositionCount(); p++) {
+                        values.add(block.isNull(p) ? null : block.getLong(block.getFirstValueIndex(p)));
+                    }
+                } finally {
+                    page.releaseBlocks();
+                }
+            }
+            return values;
+        }
+    }
+
+    private ParquetFormatReader reader(DynamicThreshold threshold) {
+        return (ParquetFormatReader) new ParquetFormatReader(blockFactory, true).withDynamicThreshold(threshold);
+    }
+
+    private byte[] writeLongParquet(MessageType schema, long rowGroupSize, int pageSize, int rows, ValueForPosition valueForPosition)
+        throws IOException {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        SimpleGroupFactory factory = new SimpleGroupFactory(schema);
+        try (
+            ParquetWriter<Group> writer = ExampleParquetWriter.builder(output(outputStream))
+                .withConf(new PlainParquetConfiguration())
+                .withCodecFactory(new PlainCompressionCodecFactory())
+                .withType(schema)
+                .withRowGroupSize(rowGroupSize)
+                .withPageSize(pageSize)
+                .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
+                .build()
+        ) {
+            for (int i = 0; i < rows; i++) {
+                Group group = factory.newGroup();
+                Long value = valueForPosition.value(i);
+                if (value != null) {
+                    group.add("id", value);
+                }
+                writer.write(group);
+            }
+        }
+        return outputStream.toByteArray();
+    }
+
+    private static OutputFile output(ByteArrayOutputStream outputStream) {
+        return new OutputFile() {
+            @Override
+            public PositionOutputStream create(long blockSizeHint) {
+                return positionOutputStream(outputStream);
+            }
+
+            @Override
+            public PositionOutputStream createOrOverwrite(long blockSizeHint) {
+                return positionOutputStream(outputStream);
+            }
+
+            @Override
+            public boolean supportsBlockSize() {
+                return false;
+            }
+
+            @Override
+            public long defaultBlockSize() {
+                return 0;
+            }
+        };
+    }
+
+    private static PositionOutputStream positionOutputStream(ByteArrayOutputStream outputStream) {
+        return new PositionOutputStream() {
+            private long position;
+
+            @Override
+            public long getPos() {
+                return position;
+            }
+
+            @Override
+            public void write(int b) {
+                outputStream.write(b);
+                position++;
+            }
+
+            @Override
+            public void write(byte[] b, int off, int len) {
+                outputStream.write(b, off, len);
+                position += len;
+            }
+        };
+    }
+
+    private static StorageObject storageObject(byte[] data) {
+        return new StorageObject() {
+            @Override
+            public InputStream newStream() {
+                return new ByteArrayInputStream(data);
+            }
+
+            @Override
+            public InputStream newStream(long position, long length) {
+                return new ByteArrayInputStream(data, (int) position, (int) length);
+            }
+
+            @Override
+            public long length() {
+                return data.length;
+            }
+
+            @Override
+            public Instant lastModified() {
+                return Instant.EPOCH;
+            }
+
+            @Override
+            public boolean exists() {
+                return true;
+            }
+
+            @Override
+            public StoragePath path() {
+                return StoragePath.of("memory://dynamic-threshold.parquet");
+            }
+        };
+    }
+
+    @FunctionalInterface
+    private interface ValueForPosition {
+        Long value(int position);
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/NumericTopNOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/NumericTopNOperator.java
@@ -292,6 +292,9 @@ public final class NumericTopNOperator implements Operator {
             threshold.markNoFurtherCandidates();
             return;
         }
+        // If the K-th heap entry is null under NULLS FIRST, there is no numeric threshold to
+        // publish yet and the heap does not track a second-best non-null bound. Readers fall
+        // back to "no numeric bound" until the heap saturates with nulls or a numeric root wins.
         if (heap.topIsNull() == false) {
             threshold.offer(decodeLong(heap.peekTop()));
             offeredCount++;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/NumericTopNOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/NumericTopNOperator.java
@@ -20,6 +20,7 @@ import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.Operator;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasables;
 
 import java.util.Locale;
@@ -55,8 +56,7 @@ import java.util.Locale;
  *         {@link NumericSortKeyExtractor} for the per-type breakdown.</li>
  * </ul>
  *
- * <p>Out of scope (deferred PRs): cross-driver shared threshold, row-group skipping in the
- * external source, multi-key sorts, byte-keyed sorts, UNSIGNED_LONG sort keys.
+ * <p>Out of scope (deferred PRs): multi-key sorts, byte-keyed sorts, UNSIGNED_LONG sort keys.
  */
 public final class NumericTopNOperator implements Operator {
 
@@ -74,9 +74,17 @@ public final class NumericTopNOperator implements Operator {
      * limit, the sort element type, and the sort order (asc/desc, nulls position) — everything
      * else (channel layout) is fixed by the planner's precondition check.
      */
-    public record NumericTopNOperatorFactory(int topCount, ElementType elementType, boolean asc, boolean nullsFirst)
-        implements
-            OperatorFactory {
+    public record NumericTopNOperatorFactory(
+        int topCount,
+        ElementType elementType,
+        boolean asc,
+        boolean nullsFirst,
+        @Nullable SharedNumericThreshold.Supplier thresholdSupplier
+    ) implements OperatorFactory {
+
+        public NumericTopNOperatorFactory(int topCount, ElementType elementType, boolean asc, boolean nullsFirst) {
+            this(topCount, elementType, asc, nullsFirst, null);
+        }
 
         public NumericTopNOperatorFactory {
             if (topCount <= 0) {
@@ -90,7 +98,21 @@ public final class NumericTopNOperator implements Operator {
 
         @Override
         public Operator get(DriverContext driverContext) {
-            return new NumericTopNOperator(driverContext.blockFactory(), driverContext.breaker(), topCount, elementType, asc, nullsFirst);
+            SharedNumericThreshold threshold = thresholdSupplier == null ? null : thresholdSupplier.get();
+            try {
+                return new NumericTopNOperator(
+                    driverContext.blockFactory(),
+                    driverContext.breaker(),
+                    topCount,
+                    elementType,
+                    asc,
+                    nullsFirst,
+                    threshold
+                );
+            } catch (Exception e) {
+                Releasables.closeExpectNoException(threshold);
+                throw e;
+            }
         }
 
         @Override
@@ -112,6 +134,8 @@ public final class NumericTopNOperator implements Operator {
     private final ElementType elementType;
     private final boolean asc;
     private final boolean nullsFirst;
+    @Nullable
+    private final SharedNumericThreshold threshold;
 
     private PrimitiveTernaryHeap heap;
     private boolean heapFull;
@@ -124,6 +148,7 @@ public final class NumericTopNOperator implements Operator {
     private int pagesEmitted;
     private long rowsReceived;
     private long rowsEmitted;
+    private int offeredCount;
 
     NumericTopNOperator(
         BlockFactory blockFactory,
@@ -133,12 +158,25 @@ public final class NumericTopNOperator implements Operator {
         boolean asc,
         boolean nullsFirst
     ) {
+        this(blockFactory, breaker, topCount, elementType, asc, nullsFirst, null);
+    }
+
+    NumericTopNOperator(
+        BlockFactory blockFactory,
+        CircuitBreaker breaker,
+        int topCount,
+        ElementType elementType,
+        boolean asc,
+        boolean nullsFirst,
+        @Nullable SharedNumericThreshold threshold
+    ) {
         this.blockFactory = blockFactory;
         this.breaker = breaker;
         this.topCount = topCount;
         this.elementType = elementType;
         this.asc = asc;
         this.nullsFirst = nullsFirst;
+        this.threshold = threshold;
         assertSupportedType(elementType);
         // Pass nullsFirst through to the heap so its composite {@code lessThan} ordering
         // handles the null bit directly. This avoids the sentinel-collision trap (encoding a
@@ -236,11 +274,27 @@ public final class NumericTopNOperator implements Operator {
             heap.push(encoded, rowPosition, isNull);
             if (heap.isFull()) {
                 heapFull = true;
+                publishThreshold();
             }
             return;
         }
         if (heap.wouldEvictTop(encoded, rowPosition, isNull)) {
             heap.updateTop(encoded, rowPosition, isNull);
+            publishThreshold();
+        }
+    }
+
+    private void publishThreshold() {
+        if (threshold == null) {
+            return;
+        }
+        if (nullsFirst && heap.nullsInHeap() == topCount) {
+            threshold.markNoFurtherCandidates();
+            return;
+        }
+        if (heap.topIsNull() == false) {
+            threshold.offer(decodeLong(heap.peekTop()));
+            offeredCount++;
         }
     }
 
@@ -418,7 +472,7 @@ public final class NumericTopNOperator implements Operator {
         // and must not be closed.
         Page pageToRelease = (output != null && output != EMPTY_OUTPUT) ? output : null;
         try {
-            Releasables.closeExpectNoException(heap);
+            Releasables.closeExpectNoException(heap, threshold);
         } finally {
             if (pageToRelease != null) {
                 pageToRelease.releaseBlocks();
@@ -430,8 +484,6 @@ public final class NumericTopNOperator implements Operator {
 
     @Override
     public Status status() {
-        // TODO: publish minCompetitiveUpdates once SharedNumericThreshold lands; null is the
-        // "not tracked" sentinel for now.
         return new TopNOperatorStatus(
             receiveNanos,
             emitNanos,
@@ -441,7 +493,7 @@ public final class NumericTopNOperator implements Operator {
             pagesEmitted,
             rowsReceived,
             rowsEmitted,
-            null
+            offeredCount
         );
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/PrimitiveTernaryHeap.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/PrimitiveTernaryHeap.java
@@ -91,6 +91,7 @@ final class PrimitiveTernaryHeap implements Releasable {
 
     private final int capacity;
     private int size;
+    private int nullsInHeap;
     /**
      * Bytes registered with {@link #breaker}; recorded so {@link #close()} can release exactly
      * what was reserved even if the constructor's last bookkeeping step is updated later.
@@ -213,8 +214,10 @@ final class PrimitiveTernaryHeap implements Releasable {
         // the downHeap fast path keys off.
         if (isNull) {
             nulls.set(size);
+            nullsInHeap++;
         }
         upHeap(size);
+        assert assertNullCount();
     }
 
     /**
@@ -224,6 +227,7 @@ final class PrimitiveTernaryHeap implements Releasable {
      */
     void updateTop(long value, long rowPosition, boolean isNull) {
         assert size > 0 : "updateTop on empty heap";
+        boolean wasNull = nulls.get(1);
         values[1] = value;
         rowPositions[1] = rowPosition;
         if (isNull) {
@@ -233,7 +237,9 @@ final class PrimitiveTernaryHeap implements Releasable {
             // root; without this the stale bit would survive into draining.
             nulls.clear(1);
         }
+        nullsInHeap += (isNull ? 1 : 0) - (wasNull ? 1 : 0);
         downHeap(1);
+        assert assertNullCount();
     }
 
     /**
@@ -247,14 +253,19 @@ final class PrimitiveTernaryHeap implements Releasable {
      */
     int popTop() {
         assert size > 0 : "popTop on empty heap";
+        boolean poppedNull = nulls.get(1);
         int popped = size;
         // Swap root with last live slot, then sift down. The popped slot at index `popped`
         // (formerly index 1) holds the popped values until the next mutation.
         swap(1, popped);
         size--;
+        if (poppedNull) {
+            nullsInHeap--;
+        }
         if (size > 0) {
             downHeap(1);
         }
+        assert assertNullCount();
         return popped;
     }
 
@@ -268,6 +279,10 @@ final class PrimitiveTernaryHeap implements Releasable {
 
     boolean isNullAt(int slot) {
         return nulls.get(slot);
+    }
+
+    int nullsInHeap() {
+        return nullsInHeap;
     }
 
     /**
@@ -292,6 +307,7 @@ final class PrimitiveTernaryHeap implements Releasable {
             boolean ni = nulls.get(i);
             boolean nj = nulls.get(j);
             if (ni != nj) {
+                // Swapping preserves the number of live nulls, so nullsInHeap is unchanged here.
                 nulls.set(i, nj);
                 nulls.set(j, ni);
             }
@@ -414,6 +430,7 @@ final class PrimitiveTernaryHeap implements Releasable {
      * in randomised sequences (Stage 3 alignment test).
      */
     boolean assertInvariant() {
+        assert assertNullCount();
         for (int parent = 1; parent <= size; parent++) {
             int firstChild = 3 * (parent - 1) + 2;
             for (int c = firstChild; c < firstChild + 3 && c <= size; c++) {
@@ -433,6 +450,17 @@ final class PrimitiveTernaryHeap implements Releasable {
                         + "]";
             }
         }
+        return true;
+    }
+
+    private boolean assertNullCount() {
+        int liveNulls = 0;
+        for (int slot = 1; slot <= size; slot++) {
+            if (nulls.get(slot)) {
+                liveNulls++;
+            }
+        }
+        assert nullsInHeap == liveNulls : "nullsInHeap [" + nullsInHeap + "] != live null bits [" + liveNulls + "]";
         return true;
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/SharedNumericThreshold.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/SharedNumericThreshold.java
@@ -24,13 +24,19 @@ import java.util.concurrent.atomic.LongAdder;
 public final class SharedNumericThreshold extends SideChannel {
     public static final class Supplier extends SideChannel.Supplier<SharedNumericThreshold> {
         private final boolean ascending;
+        private final boolean nullsFirst;
 
-        public Supplier(boolean ascending) {
+        public Supplier(boolean ascending, boolean nullsFirst) {
             this.ascending = ascending;
+            this.nullsFirst = nullsFirst;
         }
 
         public boolean ascending() {
             return ascending;
+        }
+
+        public boolean nullsFirst() {
+            return nullsFirst;
         }
 
         @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/SharedNumericThreshold.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/SharedNumericThreshold.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.operator.topn;
+
+import org.elasticsearch.compute.operator.SideChannel;
+
+import java.util.concurrent.atomic.LongAccumulator;
+import java.util.concurrent.atomic.LongAdder;
+
+/**
+ * Thread-safe, shared numeric TopN threshold for operators running on the same node.
+ * <p>
+ * Each {@link NumericTopNOperator} publishes the raw value at the top of its full heap. The
+ * accumulated value is monotonic: ascending sorts keep the smallest observed heap top and
+ * descending sorts keep the largest observed heap top. Readers can use that threshold to skip
+ * row groups or stripes whose min/max statistics prove they cannot contain a globally
+ * competitive row.
+ */
+public final class SharedNumericThreshold extends SideChannel {
+    public static final class Supplier extends SideChannel.Supplier<SharedNumericThreshold> {
+        private final boolean ascending;
+
+        public Supplier(boolean ascending) {
+            this.ascending = ascending;
+        }
+
+        public boolean ascending() {
+            return ascending;
+        }
+
+        @Override
+        protected SharedNumericThreshold build() {
+            return new SharedNumericThreshold(ascending, this);
+        }
+    }
+
+    private final boolean ascending;
+    private final LongAccumulator threshold;
+    private final LongAdder offered = new LongAdder();
+    private volatile boolean noFurtherCandidates;
+
+    private SharedNumericThreshold(boolean ascending, Supplier supplier) {
+        super(supplier);
+        this.ascending = ascending;
+        this.threshold = ascending ? new LongAccumulator(Math::min, Long.MAX_VALUE) : new LongAccumulator(Math::max, Long.MIN_VALUE);
+    }
+
+    /**
+     * Publish a raw heap-top value. The accumulator only tightens, never relaxes.
+     */
+    public void offer(long rawTopOfHeap) {
+        threshold.accumulate(rawTopOfHeap);
+        offered.increment();
+    }
+
+    public long current() {
+        return threshold.get();
+    }
+
+    /**
+     * Whether a min/max statistics range is strictly dominated by the current threshold.
+     * Equality is deliberately not skipped because row-position tiebreakers can still matter.
+     */
+    public boolean dominates(long rangeMin, long rangeMax) {
+        long current = current();
+        if (ascending) {
+            return current != Long.MAX_VALUE && rangeMin > current;
+        }
+        return current != Long.MIN_VALUE && rangeMax < current;
+    }
+
+    /**
+     * Mark the source as exhausted by K nulls under NULLS FIRST and collapse the threshold to
+     * a value that dominates every ordinary min/max range.
+     */
+    public void markNoFurtherCandidates() {
+        noFurtherCandidates = true;
+        threshold.accumulate(ascending ? Long.MIN_VALUE : Long.MAX_VALUE);
+    }
+
+    public boolean noFurtherCandidates() {
+        return noFurtherCandidates;
+    }
+
+    public long offeredCount() {
+        return offered.sum();
+    }
+
+    @Override
+    protected void closeSideChannel() {}
+}

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/NumericTopNOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/NumericTopNOperatorTests.java
@@ -56,7 +56,7 @@ public class NumericTopNOperatorTests extends ComputeTestCase {
         List<Long> values = List.of(1L, 2L, 100L, 99L, 98L);
         for (boolean asc : List.of(true, false)) {
             BlockFactory blockFactory = blockFactory();
-            SharedNumericThreshold.Supplier supplier = new SharedNumericThreshold.Supplier(asc);
+            SharedNumericThreshold.Supplier supplier = new SharedNumericThreshold.Supplier(asc, false);
             try (SharedNumericThreshold threshold = supplier.get()) {
                 Operator operator = new NumericTopNOperator.NumericTopNOperatorFactory(2, ElementType.LONG, asc, false, supplier).get(
                     new DriverContext(blockFactory.bigArrays(), blockFactory, null)
@@ -74,7 +74,7 @@ public class NumericTopNOperatorTests extends ComputeTestCase {
 
     public void testNullSaturationMarksNoFurtherCandidates() {
         for (boolean asc : List.of(true, false)) {
-            SharedNumericThreshold.Supplier supplier = new SharedNumericThreshold.Supplier(asc);
+            SharedNumericThreshold.Supplier supplier = new SharedNumericThreshold.Supplier(asc, true);
             try (SharedNumericThreshold threshold = supplier.get()) {
                 BlockFactory blockFactory = blockFactory();
                 int count = 20;
@@ -96,7 +96,7 @@ public class NumericTopNOperatorTests extends ComputeTestCase {
 
     public void testNullSaturationDoesNotMarkForNullsLast() {
         for (boolean asc : List.of(true, false)) {
-            SharedNumericThreshold.Supplier supplier = new SharedNumericThreshold.Supplier(asc);
+            SharedNumericThreshold.Supplier supplier = new SharedNumericThreshold.Supplier(asc, false);
             try (SharedNumericThreshold threshold = supplier.get()) {
                 BlockFactory blockFactory = blockFactory();
                 int count = 20;

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/NumericTopNOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/NumericTopNOperatorTests.java
@@ -52,6 +52,70 @@ public class NumericTopNOperatorTests extends ComputeTestCase {
         assertParity(false, true);
     }
 
+    public void testPublishesRawThreshold() {
+        List<Long> values = List.of(1L, 2L, 100L, 99L, 98L);
+        for (boolean asc : List.of(true, false)) {
+            BlockFactory blockFactory = blockFactory();
+            SharedNumericThreshold.Supplier supplier = new SharedNumericThreshold.Supplier(asc);
+            try (SharedNumericThreshold threshold = supplier.get()) {
+                Operator operator = new NumericTopNOperator.NumericTopNOperatorFactory(2, ElementType.LONG, asc, false, supplier).get(
+                    new DriverContext(blockFactory.bigArrays(), blockFactory, null)
+                );
+                List<Page> output = runTopN(operator, blockFactory, values, new boolean[values.size()]);
+                try {
+                    assertThat(threshold.current(), equalTo(asc ? 2L : 99L));
+                    assertThat(threshold.offeredCount(), equalTo(asc ? 1L : 3L));
+                } finally {
+                    output.forEach(Page::releaseBlocks);
+                }
+            }
+        }
+    }
+
+    public void testNullSaturationMarksNoFurtherCandidates() {
+        for (boolean asc : List.of(true, false)) {
+            SharedNumericThreshold.Supplier supplier = new SharedNumericThreshold.Supplier(asc);
+            try (SharedNumericThreshold threshold = supplier.get()) {
+                BlockFactory blockFactory = blockFactory();
+                int count = 20;
+                boolean[] nulls = new boolean[count];
+                java.util.Arrays.fill(nulls, true);
+                Operator operator = new NumericTopNOperator.NumericTopNOperatorFactory(10, ElementType.LONG, asc, true, supplier).get(
+                    new DriverContext(blockFactory.bigArrays(), blockFactory, null)
+                );
+                List<Page> output = runTopN(operator, blockFactory, java.util.Collections.nCopies(count, 0L), nulls);
+                try {
+                    assertTrue(threshold.noFurtherCandidates());
+                    assertThat(threshold.current(), equalTo(asc ? Long.MIN_VALUE : Long.MAX_VALUE));
+                } finally {
+                    output.forEach(Page::releaseBlocks);
+                }
+            }
+        }
+    }
+
+    public void testNullSaturationDoesNotMarkForNullsLast() {
+        for (boolean asc : List.of(true, false)) {
+            SharedNumericThreshold.Supplier supplier = new SharedNumericThreshold.Supplier(asc);
+            try (SharedNumericThreshold threshold = supplier.get()) {
+                BlockFactory blockFactory = blockFactory();
+                int count = 20;
+                boolean[] nulls = new boolean[count];
+                java.util.Arrays.fill(nulls, true);
+                Operator operator = new NumericTopNOperator.NumericTopNOperatorFactory(10, ElementType.LONG, asc, false, supplier).get(
+                    new DriverContext(blockFactory.bigArrays(), blockFactory, null)
+                );
+                List<Page> output = runTopN(operator, blockFactory, java.util.Collections.nCopies(count, 0L), nulls);
+                try {
+                    assertFalse(threshold.noFurtherCandidates());
+                    assertThat(threshold.current(), equalTo(asc ? Long.MAX_VALUE : Long.MIN_VALUE));
+                } finally {
+                    output.forEach(Page::releaseBlocks);
+                }
+            }
+        }
+    }
+
     /**
      * Low-cardinality input exercises the {@code _rowPosition} tiebreaker path: many input
      * rows share the same encoded value, so the heap's internal ordering matters and the

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/PrimitiveTernaryHeapTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/PrimitiveTernaryHeapTests.java
@@ -174,6 +174,7 @@ public class PrimitiveTernaryHeapTests extends ESTestCase {
                     heap.updateTop(v, i, isNull);
                 }
                 assertTrue("invariant after step " + i, heap.assertInvariant());
+                assertThat(heap.nullsInHeap(), equalTo(countNulls(heap)));
             }
         }
     }
@@ -234,6 +235,27 @@ public class PrimitiveTernaryHeapTests extends ESTestCase {
                     assertThat("value alignment at slot " + slot + " (origIdx " + origIdx + ")", value, equalTo(inputValues[origIdx]));
                     assertThat("null alignment at slot " + slot + " (origIdx " + origIdx + ")", slotIsNull, equalTo(inputNulls[origIdx]));
                 });
+                assertThat(heap.nullsInHeap(), equalTo(countNulls(heap)));
+            }
+        }
+    }
+
+    public void testNullCounterTracksPushUpdateAndPop() {
+        int k = randomIntBetween(2, 64);
+        try (PrimitiveTernaryHeap heap = new PrimitiveTernaryHeap(breaker, k, randomBoolean())) {
+            for (int i = 0; i < k; i++) {
+                heap.push(randomLong(), i, randomBoolean());
+                assertThat(heap.nullsInHeap(), equalTo(countNulls(heap)));
+            }
+            for (int i = 0; i < k * 4; i++) {
+                heap.updateTop(randomLong(), k + i, randomBoolean());
+                assertTrue(heap.assertInvariant());
+                assertThat(heap.nullsInHeap(), equalTo(countNulls(heap)));
+            }
+            while (heap.size() > 0) {
+                heap.popTop();
+                assertTrue(heap.assertInvariant());
+                assertThat(heap.nullsInHeap(), equalTo(countNulls(heap)));
             }
         }
     }
@@ -250,5 +272,15 @@ public class PrimitiveTernaryHeapTests extends ESTestCase {
             }
         }
         return out;
+    }
+
+    private static int countNulls(PrimitiveTernaryHeap heap) {
+        int[] count = new int[1];
+        heap.forEachSlot((slot, value, rowPosition, isNull) -> {
+            if (isNull) {
+                count[0]++;
+            }
+        });
+        return count[0];
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/SharedNumericThresholdTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/SharedNumericThresholdTests.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.operator.topn;
+
+import org.elasticsearch.compute.test.ComputeTestCase;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.sameInstance;
+
+public class SharedNumericThresholdTests extends ComputeTestCase {
+    public void testAscendingThresholdTightensToMinimumOffer() {
+        try (SharedNumericThreshold threshold = new SharedNumericThreshold.Supplier(true).get()) {
+            assertFalse(threshold.dominates(Long.MAX_VALUE, Long.MAX_VALUE));
+            threshold.offer(10);
+            threshold.offer(20);
+            threshold.offer(5);
+            assertThat(threshold.current(), equalTo(5L));
+            assertFalse(threshold.dominates(5, 9));
+            assertTrue(threshold.dominates(6, 9));
+        }
+    }
+
+    public void testDescendingThresholdTightensToMaximumOffer() {
+        try (SharedNumericThreshold threshold = new SharedNumericThreshold.Supplier(false).get()) {
+            assertFalse(threshold.dominates(Long.MIN_VALUE, Long.MIN_VALUE));
+            threshold.offer(10);
+            threshold.offer(20);
+            threshold.offer(5);
+            assertThat(threshold.current(), equalTo(20L));
+            assertFalse(threshold.dominates(11, 20));
+            assertTrue(threshold.dominates(11, 19));
+        }
+    }
+
+    public void testConcurrentOffers() throws Exception {
+        boolean ascending = randomBoolean();
+        SharedNumericThreshold.Supplier supplier = new SharedNumericThreshold.Supplier(ascending);
+        ExecutorService executor = Executors.newFixedThreadPool(4);
+        List<Future<?>> futures = new ArrayList<>();
+        long expected = ascending ? Long.MAX_VALUE : Long.MIN_VALUE;
+        try (SharedNumericThreshold threshold = supplier.get()) {
+            for (int t = 0; t < 4; t++) {
+                long[] values = randomLongs().limit(1_000).toArray();
+                for (long value : values) {
+                    expected = ascending ? Math.min(expected, value) : Math.max(expected, value);
+                }
+                futures.add(executor.submit(() -> {
+                    for (long value : values) {
+                        threshold.offer(value);
+                    }
+                }));
+            }
+            for (Future<?> future : futures) {
+                future.get(1, TimeUnit.MINUTES);
+            }
+            assertThat(threshold.current(), equalTo(expected));
+            assertThat(threshold.offeredCount(), equalTo(4_000L));
+        } finally {
+            executor.shutdown();
+        }
+    }
+
+    public void testMarkNoFurtherCandidatesCollapsesThreshold() {
+        try (
+            SharedNumericThreshold asc = new SharedNumericThreshold.Supplier(true).get();
+            SharedNumericThreshold desc = new SharedNumericThreshold.Supplier(false).get()
+        ) {
+            asc.markNoFurtherCandidates();
+            desc.markNoFurtherCandidates();
+            assertTrue(asc.noFurtherCandidates());
+            assertTrue(desc.noFurtherCandidates());
+            assertThat(asc.current(), equalTo(Long.MIN_VALUE));
+            assertThat(desc.current(), equalTo(Long.MAX_VALUE));
+            assertTrue(asc.dominates(0, 1));
+            assertTrue(desc.dominates(0, 1));
+        }
+    }
+
+    public void testSupplierSharesUntilLastCloseThenRebuilds() {
+        SharedNumericThreshold.Supplier supplier = new SharedNumericThreshold.Supplier(true);
+        SharedNumericThreshold first = supplier.get();
+        SharedNumericThreshold second = supplier.get();
+        assertThat(second, sameInstance(first));
+        first.close();
+        second.close();
+        SharedNumericThreshold rebuilt = supplier.get();
+        try {
+            assertThat(rebuilt, not(sameInstance(first)));
+        } finally {
+            rebuilt.close();
+        }
+    }
+}

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/SharedNumericThresholdTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/SharedNumericThresholdTests.java
@@ -22,7 +22,7 @@ import static org.hamcrest.Matchers.sameInstance;
 
 public class SharedNumericThresholdTests extends ComputeTestCase {
     public void testAscendingThresholdTightensToMinimumOffer() {
-        try (SharedNumericThreshold threshold = new SharedNumericThreshold.Supplier(true).get()) {
+        try (SharedNumericThreshold threshold = new SharedNumericThreshold.Supplier(true, false).get()) {
             assertFalse(threshold.dominates(Long.MAX_VALUE, Long.MAX_VALUE));
             threshold.offer(10);
             threshold.offer(20);
@@ -34,7 +34,7 @@ public class SharedNumericThresholdTests extends ComputeTestCase {
     }
 
     public void testDescendingThresholdTightensToMaximumOffer() {
-        try (SharedNumericThreshold threshold = new SharedNumericThreshold.Supplier(false).get()) {
+        try (SharedNumericThreshold threshold = new SharedNumericThreshold.Supplier(false, false).get()) {
             assertFalse(threshold.dominates(Long.MIN_VALUE, Long.MIN_VALUE));
             threshold.offer(10);
             threshold.offer(20);
@@ -47,7 +47,7 @@ public class SharedNumericThresholdTests extends ComputeTestCase {
 
     public void testConcurrentOffers() throws Exception {
         boolean ascending = randomBoolean();
-        SharedNumericThreshold.Supplier supplier = new SharedNumericThreshold.Supplier(ascending);
+        SharedNumericThreshold.Supplier supplier = new SharedNumericThreshold.Supplier(ascending, randomBoolean());
         ExecutorService executor = Executors.newFixedThreadPool(4);
         List<Future<?>> futures = new ArrayList<>();
         long expected = ascending ? Long.MAX_VALUE : Long.MIN_VALUE;
@@ -75,8 +75,8 @@ public class SharedNumericThresholdTests extends ComputeTestCase {
 
     public void testMarkNoFurtherCandidatesCollapsesThreshold() {
         try (
-            SharedNumericThreshold asc = new SharedNumericThreshold.Supplier(true).get();
-            SharedNumericThreshold desc = new SharedNumericThreshold.Supplier(false).get()
+            SharedNumericThreshold asc = new SharedNumericThreshold.Supplier(true, true).get();
+            SharedNumericThreshold desc = new SharedNumericThreshold.Supplier(false, true).get()
         ) {
             asc.markNoFurtherCandidates();
             desc.markNoFurtherCandidates();
@@ -90,7 +90,7 @@ public class SharedNumericThresholdTests extends ComputeTestCase {
     }
 
     public void testSupplierSharesUntilLastCloseThenRebuilds() {
-        SharedNumericThreshold.Supplier supplier = new SharedNumericThreshold.Supplier(true);
+        SharedNumericThreshold.Supplier supplier = new SharedNumericThreshold.Supplier(true, randomBoolean());
         SharedNumericThreshold first = supplier.get();
         SharedNumericThreshold second = supplier.get();
         assertThat(second, sameInstance(first));

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalParquetNumericTopNSideChannelIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalParquetNumericTopNSideChannelIT.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.action;
+
+import org.apache.lucene.util.BytesRef;
+import org.apache.parquet.conf.PlainParquetConfiguration;
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.example.data.simple.SimpleGroupFactory;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.example.ExampleParquetWriter;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.io.OutputFile;
+import org.apache.parquet.io.PositionOutputStream;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.MessageTypeParser;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.plugins.ExtensiblePlugin;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.xpack.esql.datasource.http.HttpDataSourcePlugin;
+import org.elasticsearch.xpack.esql.datasource.parquet.ParquetDataSourcePlugin;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.IntFunction;
+
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.getValuesList;
+import static org.elasticsearch.xpack.esql.action.EsqlCapabilities.Cap.EXTERNAL_COMMAND;
+import static org.elasticsearch.xpack.esql.action.EsqlQueryRequest.syncEsqlQueryRequest;
+import static org.hamcrest.Matchers.greaterThan;
+
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.SUITE, numDataNodes = 1)
+public class ExternalParquetNumericTopNSideChannelIT extends AbstractEsqlIntegTestCase {
+
+    private static final TimeValue LONG_TIMEOUT = TimeValue.timeValueMinutes(2);
+
+    public static final class EsqlEnterpriseWithDatasourceExtensions extends EsqlPluginWithEnterpriseOrTrialLicense {
+        @Override
+        public void loadExtensions(ExtensiblePlugin.ExtensionLoader loader) {
+            super.loadExtensions(loader);
+        }
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        List<Class<? extends Plugin>> plugins = new ArrayList<>(super.nodePlugins());
+        plugins.remove(EsqlPluginWithEnterpriseOrTrialLicense.class);
+        plugins.add(EsqlEnterpriseWithDatasourceExtensions.class);
+        plugins.add(HttpDataSourcePlugin.class);
+        plugins.add(ParquetDataSourcePlugin.class);
+        return plugins;
+    }
+
+    @Override
+    protected QueryPragmas getPragmas() {
+        return QueryPragmas.EMPTY;
+    }
+
+    public void testRowGroupSkipAscendingMonotonicData() throws Exception {
+        assumeTrue("requires EXTERNAL command capability", EXTERNAL_COMMAND.isEnabled());
+        Path file = writeParquetFile(1_000, 1L, 2 * 1024 * 1024, i -> (long) i);
+        try {
+            QueryResult result = runTopN(file, "id ASC", 10);
+            assertIds(result, 0, 10);
+        } finally {
+            Files.deleteIfExists(file);
+        }
+    }
+
+    public void testRowGroupSkipDescendingMonotonicData() throws Exception {
+        assumeTrue("requires EXTERNAL command capability", EXTERNAL_COMMAND.isEnabled());
+        Path file = writeParquetFile(1_000, 1L, 2 * 1024 * 1024, i -> 999L - i);
+        try {
+            QueryResult result = runTopN(file, "id DESC", 10);
+            assertDescendingIds(result, 999, 10);
+        } finally {
+            Files.deleteIfExists(file);
+        }
+    }
+
+    public void testPageLevelSkipWithinSingleRowGroup() throws Exception {
+        assumeTrue("requires EXTERNAL command capability", EXTERNAL_COMMAND.isEnabled());
+        Path file = writeParquetFile(2_000, 64L * 1024 * 1024, 64, i -> (long) i);
+        try {
+            QueryResult result = runTopN(file, "id ASC", 10);
+            assertIds(result, 0, 10);
+        } finally {
+            Files.deleteIfExists(file);
+        }
+    }
+
+    public void testSinglePageRowGroupNegativeControlReadsWholeGroup() throws Exception {
+        assumeTrue("requires EXTERNAL command capability", EXTERNAL_COMMAND.isEnabled());
+        Path file = writeParquetFile(2_000, 64L * 1024 * 1024, 2 * 1024 * 1024, i -> (long) i);
+        try {
+            QueryResult result = runTopN(file, "id ASC", 10);
+            assertIds(result, 0, 10);
+            assertThat(result.documentsFound(), greaterThan(1_500L));
+        } finally {
+            Files.deleteIfExists(file);
+        }
+    }
+
+    public void testNullsFirstEarlyTermination() throws Exception {
+        assumeTrue("requires EXTERNAL command capability", EXTERNAL_COMMAND.isEnabled());
+        Path file = writeParquetFile(1_000, 1L, 2 * 1024 * 1024, i -> i < 100 ? null : (long) i);
+        try {
+            QueryResult result = runTopN(file, "id ASC NULLS FIRST", 50);
+            assertEquals(50, result.ids().size());
+            for (Long id : result.ids()) {
+                assertNull(id);
+            }
+        } finally {
+            Files.deleteIfExists(file);
+        }
+    }
+
+    public void testNullsLastDoesNotTriggerEarlyTermination() throws Exception {
+        assumeTrue("requires EXTERNAL command capability", EXTERNAL_COMMAND.isEnabled());
+        Path file = writeParquetFile(1_000, 1L, 2 * 1024 * 1024, i -> i < 100 ? null : (long) i);
+        try {
+            QueryResult result = runTopN(file, "id ASC NULLS LAST", 10);
+            assertIds(result, 100, 10);
+            assertThat(result.documentsFound(), greaterThan(10L));
+        } finally {
+            Files.deleteIfExists(file);
+        }
+    }
+
+    public void testOverlappingRowGroupsKeepCorrectness() throws Exception {
+        assumeTrue("requires EXTERNAL command capability", EXTERNAL_COMMAND.isEnabled());
+        Path file = writeParquetFile(500, 1L, 2 * 1024 * 1024, i -> (long) ((i * 37) % 1_000));
+        try {
+            QueryResult result = runTopN(file, "id ASC", 50);
+            List<Long> expected = new ArrayList<>();
+            for (int i = 0; i < 500; i++) {
+                expected.add((long) ((i * 37) % 1_000));
+            }
+            expected.sort(Long::compareTo);
+            assertEquals(expected.subList(0, 50), result.ids());
+        } finally {
+            Files.deleteIfExists(file);
+        }
+    }
+
+    private QueryResult runTopN(Path file, String order, int limit) throws IOException {
+        String query = "EXTERNAL \"" + StoragePath.fileUri(file) + "\" | SORT " + order + " | LIMIT " + limit + " | KEEP id, payload";
+        var request = syncEsqlQueryRequest(query);
+        request.profile(true);
+        try (var response = run(request, LONG_TIMEOUT)) {
+            List<List<Object>> rows = getValuesList(response);
+            List<Long> ids = new ArrayList<>(rows.size());
+            for (List<Object> row : rows) {
+                ids.add(row.get(0) == null ? null : ((Number) row.get(0)).longValue());
+                Long id = ids.get(ids.size() - 1);
+                if (id != null) {
+                    assertEquals(payload(id), bytesRefToString(row.get(1)));
+                }
+            }
+            return new QueryResult(ids, response.documentsFound());
+        }
+    }
+
+    private static void assertIds(QueryResult result, long startInclusive, int count) {
+        assertEquals(count, result.ids().size());
+        for (int i = 0; i < count; i++) {
+            assertEquals(startInclusive + i, result.ids().get(i).longValue());
+        }
+    }
+
+    private static void assertDescendingIds(QueryResult result, long startInclusive, int count) {
+        assertEquals(count, result.ids().size());
+        for (int i = 0; i < count; i++) {
+            assertEquals(startInclusive - i, result.ids().get(i).longValue());
+        }
+    }
+
+    private Path writeParquetFile(int rowCount, long rowGroupSize, int pageSize, IntFunction<Long> valueForPosition) throws IOException {
+        Path tempFile = createTempDir().resolve("numeric_topn_side_channel.parquet");
+        MessageType schema = MessageTypeParser.parseMessageType("message test { optional int64 id; required binary payload (UTF8); }");
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        SimpleGroupFactory factory = new SimpleGroupFactory(schema);
+        try (
+            ParquetWriter<Group> writer = ExampleParquetWriter.builder(createOutputFile(baos))
+                .withConf(new PlainParquetConfiguration())
+                .withType(schema)
+                .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
+                .withRowGroupSize(rowGroupSize)
+                .withPageSize(pageSize)
+                .build()
+        ) {
+            for (int i = 0; i < rowCount; i++) {
+                Long id = valueForPosition.apply(i);
+                Group group = factory.newGroup();
+                if (id != null) {
+                    group.add("id", id);
+                    group.add("payload", payload(id));
+                } else {
+                    group.add("payload", "payload_null_" + i);
+                }
+                writer.write(group);
+            }
+        }
+        Files.write(tempFile, baos.toByteArray());
+        return tempFile;
+    }
+
+    private static OutputFile createOutputFile(ByteArrayOutputStream baos) {
+        return new OutputFile() {
+            @Override
+            public PositionOutputStream create(long blockSizeHint) {
+                return new PositionOutputStream() {
+                    private long position;
+
+                    @Override
+                    public long getPos() {
+                        return position;
+                    }
+
+                    @Override
+                    public void write(int b) throws IOException {
+                        baos.write(b);
+                        position++;
+                    }
+
+                    @Override
+                    public void write(byte[] b, int off, int len) throws IOException {
+                        baos.write(b, off, len);
+                        position += len;
+                    }
+                };
+            }
+
+            @Override
+            public PositionOutputStream createOrOverwrite(long blockSizeHint) {
+                return create(blockSizeHint);
+            }
+
+            @Override
+            public boolean supportsBlockSize() {
+                return false;
+            }
+
+            @Override
+            public long defaultBlockSize() {
+                return 0;
+            }
+        };
+    }
+
+    private static String bytesRefToString(Object cell) {
+        if (cell instanceof BytesRef br) {
+            return br.utf8ToString();
+        }
+        return String.valueOf(cell);
+    }
+
+    private static String payload(long id) {
+        return "payload_" + id;
+    }
+
+    private record QueryResult(List<Long> ids, long documentsFound) {}
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
@@ -175,6 +175,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
     @Nullable
     private volatile ElementType thresholdElementType;
     private volatile boolean thresholdAscending;
+    private volatile boolean thresholdNullsFirst;
     @Nullable
     private volatile DynamicThreshold cachedThreshold;
 
@@ -220,11 +221,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         @Nullable FilterPushdownSupport pushdownSupport,
         @Nullable Closeable onClose,
         int parallelism,
-        boolean deferredExtraction,
-        @Nullable SharedNumericThreshold.Supplier thresholdSupplier,
-        @Nullable String thresholdColumnName,
-        @Nullable ElementType thresholdElementType,
-        boolean thresholdAscending
+        boolean deferredExtraction
     ) {
         if (storageProvider == null) {
             throw new IllegalArgumentException("storageProvider cannot be null");
@@ -271,10 +268,6 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         this.onClose = onClose;
         this.parallelism = Math.max(1, parallelism);
         this.deferredExtraction = deferredExtraction;
-        this.thresholdSupplier = thresholdSupplier;
-        this.thresholdColumnName = thresholdColumnName;
-        this.thresholdElementType = thresholdElementType;
-        this.thresholdAscending = thresholdAscending;
         if (deferredExtraction && onClose != null) {
             // Hold one ref on behalf of the factory; released when operatorRefCount hits zero.
             // Each registry creation (one per driver) takes an additional ref. See deferredCloseRefCount.
@@ -338,13 +331,6 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         private Closeable onClose;
         private int parallelism = 1;
         private boolean deferredExtraction = false;
-        @Nullable
-        private SharedNumericThreshold.Supplier thresholdSupplier;
-        @Nullable
-        private String thresholdColumnName;
-        @Nullable
-        private ElementType thresholdElementType;
-        private boolean thresholdAscending;
 
         private Builder(
             StorageProvider storageProvider,
@@ -461,18 +447,6 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
             return this;
         }
 
-        public Builder numericThresholdSupplier(@Nullable SharedNumericThreshold.Supplier thresholdSupplier) {
-            this.thresholdSupplier = thresholdSupplier;
-            return this;
-        }
-
-        public Builder thresholdDescriptor(@Nullable String columnName, @Nullable ElementType elementType, boolean ascending) {
-            this.thresholdColumnName = columnName;
-            this.thresholdElementType = elementType;
-            this.thresholdAscending = ascending;
-            return this;
-        }
-
         public AsyncExternalSourceOperatorFactory build() {
             return new AsyncExternalSourceOperatorFactory(
                 storageProvider,
@@ -495,11 +469,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                 pushdownSupport,
                 onClose,
                 parallelism,
-                deferredExtraction,
-                thresholdSupplier,
-                thresholdColumnName,
-                thresholdElementType,
-                thresholdAscending
+                deferredExtraction
             );
         }
     }
@@ -512,13 +482,17 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         SharedNumericThreshold.Supplier thresholdSupplier,
         String columnName,
         ElementType elementType,
-        boolean ascending
+        boolean ascending,
+        boolean nullsFirst
     ) {
-        assert operatorRefCount.get() == 0 : "numeric threshold must be installed before source operators are created";
+        if (operatorRefCount.get() != 0) {
+            throw new IllegalStateException("numeric threshold must be installed before source operators are created");
+        }
         this.thresholdSupplier = thresholdSupplier;
         this.thresholdColumnName = columnName;
         this.thresholdElementType = elementType;
         this.thresholdAscending = ascending;
+        this.thresholdNullsFirst = nullsFirst;
         closeDynamicThreshold();
     }
 
@@ -893,7 +867,13 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                 if (thresholdColumnName == null || thresholdElementType == null) {
                     throw new IllegalStateException("numeric threshold descriptor is incomplete");
                 }
-                threshold = new DynamicThreshold(thresholdColumnName, thresholdElementType, thresholdAscending, thresholdSupplier.get());
+                threshold = new DynamicThreshold(
+                    thresholdColumnName,
+                    thresholdElementType,
+                    thresholdAscending,
+                    thresholdNullsFirst,
+                    thresholdSupplier.get()
+                );
                 cachedThreshold = threshold;
             }
             return threshold;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
@@ -11,11 +11,13 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.CloseableIterator;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.Operator;
 import org.elasticsearch.compute.operator.SourceOperator;
+import org.elasticsearch.compute.operator.topn.SharedNumericThreshold;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.logging.LogManager;
@@ -28,6 +30,8 @@ import org.elasticsearch.xpack.esql.datasources.spi.ColumnExtractor;
 import org.elasticsearch.xpack.esql.datasources.spi.ColumnExtractorAware;
 import org.elasticsearch.xpack.esql.datasources.spi.ColumnExtractorProducer;
 import org.elasticsearch.xpack.esql.datasources.spi.DecompressionCodec;
+import org.elasticsearch.xpack.esql.datasources.spi.DynamicThreshold;
+import org.elasticsearch.xpack.esql.datasources.spi.DynamicThresholdAware;
 import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
 import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
 import org.elasticsearch.xpack.esql.datasources.spi.FileList;
@@ -164,6 +168,15 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
      * {@link RangeAwareFormatReader#readRange} calls.
      */
     private final boolean batchReadCapable;
+    @Nullable
+    private volatile SharedNumericThreshold.Supplier thresholdSupplier;
+    @Nullable
+    private volatile String thresholdColumnName;
+    @Nullable
+    private volatile ElementType thresholdElementType;
+    private volatile boolean thresholdAscending;
+    @Nullable
+    private volatile DynamicThreshold cachedThreshold;
 
     /**
      * When set, the producer paths request the synthetic {@link ColumnExtractor#ROW_POSITION_COLUMN}
@@ -207,7 +220,11 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         @Nullable FilterPushdownSupport pushdownSupport,
         @Nullable Closeable onClose,
         int parallelism,
-        boolean deferredExtraction
+        boolean deferredExtraction,
+        @Nullable SharedNumericThreshold.Supplier thresholdSupplier,
+        @Nullable String thresholdColumnName,
+        @Nullable ElementType thresholdElementType,
+        boolean thresholdAscending
     ) {
         if (storageProvider == null) {
             throw new IllegalArgumentException("storageProvider cannot be null");
@@ -254,6 +271,10 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         this.onClose = onClose;
         this.parallelism = Math.max(1, parallelism);
         this.deferredExtraction = deferredExtraction;
+        this.thresholdSupplier = thresholdSupplier;
+        this.thresholdColumnName = thresholdColumnName;
+        this.thresholdElementType = thresholdElementType;
+        this.thresholdAscending = thresholdAscending;
         if (deferredExtraction && onClose != null) {
             // Hold one ref on behalf of the factory; released when operatorRefCount hits zero.
             // Each registry creation (one per driver) takes an additional ref. See deferredCloseRefCount.
@@ -317,6 +338,13 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         private Closeable onClose;
         private int parallelism = 1;
         private boolean deferredExtraction = false;
+        @Nullable
+        private SharedNumericThreshold.Supplier thresholdSupplier;
+        @Nullable
+        private String thresholdColumnName;
+        @Nullable
+        private ElementType thresholdElementType;
+        private boolean thresholdAscending;
 
         private Builder(
             StorageProvider storageProvider,
@@ -433,6 +461,18 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
             return this;
         }
 
+        public Builder numericThresholdSupplier(@Nullable SharedNumericThreshold.Supplier thresholdSupplier) {
+            this.thresholdSupplier = thresholdSupplier;
+            return this;
+        }
+
+        public Builder thresholdDescriptor(@Nullable String columnName, @Nullable ElementType elementType, boolean ascending) {
+            this.thresholdColumnName = columnName;
+            this.thresholdElementType = elementType;
+            this.thresholdAscending = ascending;
+            return this;
+        }
+
         public AsyncExternalSourceOperatorFactory build() {
             return new AsyncExternalSourceOperatorFactory(
                 storageProvider,
@@ -455,9 +495,31 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                 pushdownSupport,
                 onClose,
                 parallelism,
-                deferredExtraction
+                deferredExtraction,
+                thresholdSupplier,
+                thresholdColumnName,
+                thresholdElementType,
+                thresholdAscending
             );
         }
+    }
+
+    /**
+     * Installs the shared numeric TopN threshold. Must be called during planning, before the
+     * first {@link #get(DriverContext)} call creates source operators from this factory.
+     */
+    public synchronized void setNumericThresholdSupplier(
+        SharedNumericThreshold.Supplier thresholdSupplier,
+        String columnName,
+        ElementType elementType,
+        boolean ascending
+    ) {
+        assert operatorRefCount.get() == 0 : "numeric threshold must be installed before source operators are created";
+        this.thresholdSupplier = thresholdSupplier;
+        this.thresholdColumnName = columnName;
+        this.thresholdElementType = elementType;
+        this.thresholdAscending = ascending;
+        closeDynamicThreshold();
     }
 
     @Override
@@ -799,25 +861,64 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
      * pushed expressions reference those columns.
      */
     private FormatReader readerForFile(FileSplit fileSplit) {
-        if (pushedExpressions.isEmpty() || pushdownSupport == null) {
-            return formatReader;
+        FormatReader reader = formatReader;
+        if (pushedExpressions.isEmpty() == false && pushdownSupport != null) {
+            ColumnMapping mapping = fileSplit.columnMapping();
+            if (mapping != null) {
+                List<Expression> adapted = mapping.mapFilters(pushedExpressions, queryDataSchema);
+                if (adapted != pushedExpressions) {
+                    if (adapted.isEmpty()) {
+                        reader = formatReader.withPushedFilter(null);
+                    } else {
+                        FilterPushdownSupport.PushdownResult result = pushdownSupport.pushFilters(adapted);
+                        reader = result.hasPushedFilter()
+                            ? formatReader.withPushedFilter(result.pushedFilter())
+                            : formatReader.withPushedFilter(null);
+                    }
+                }
+            }
         }
-        ColumnMapping mapping = fileSplit.columnMapping();
-        if (mapping == null) {
-            return formatReader;
+        return readerWithDynamicThreshold(reader);
+    }
+
+    @Nullable
+    private DynamicThreshold dynamicThreshold() {
+        DynamicThreshold threshold = cachedThreshold;
+        if (threshold != null || thresholdSupplier == null) {
+            return threshold;
         }
-        List<Expression> adapted = mapping.mapFilters(pushedExpressions, queryDataSchema);
-        if (adapted == pushedExpressions) {
-            return formatReader;
+        synchronized (this) {
+            threshold = cachedThreshold;
+            if (threshold == null && thresholdSupplier != null) {
+                if (thresholdColumnName == null || thresholdElementType == null) {
+                    throw new IllegalStateException("numeric threshold descriptor is incomplete");
+                }
+                threshold = new DynamicThreshold(thresholdColumnName, thresholdElementType, thresholdAscending, thresholdSupplier.get());
+                cachedThreshold = threshold;
+            }
+            return threshold;
         }
-        if (adapted.isEmpty()) {
-            return formatReader.withPushedFilter(null);
+    }
+
+    private boolean noFurtherCandidates() {
+        DynamicThreshold threshold = dynamicThreshold();
+        return threshold != null && threshold.noFurtherCandidates();
+    }
+
+    private FormatReader readerWithDynamicThreshold(FormatReader reader) {
+        DynamicThreshold threshold = dynamicThreshold();
+        if (threshold != null && reader instanceof DynamicThresholdAware aware) {
+            return aware.withDynamicThreshold(threshold);
         }
-        FilterPushdownSupport.PushdownResult result = pushdownSupport.pushFilters(adapted);
-        if (result.hasPushedFilter()) {
-            return formatReader.withPushedFilter(result.pushedFilter());
+        return reader;
+    }
+
+    private synchronized void closeDynamicThreshold() {
+        DynamicThreshold threshold = cachedThreshold;
+        cachedThreshold = null;
+        if (threshold != null) {
+            IOUtils.closeWhileHandlingException(threshold);
         }
-        return formatReader.withPushedFilter(null);
     }
 
     private void startSliceQueueRead(AsyncExternalSourceBuffer buffer, DriverContext driverContext) {
@@ -979,6 +1080,9 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         CloseableIterator<Page> pages = state.pages;
         AsyncExternalSourceBuffer buffer = state.buffer;
         while (true) {
+            if (noFurtherCandidates()) {
+                return DrainResult.DONE;
+            }
             if (buffer.noMoreInputs()) {
                 return DrainResult.DONE;
             }
@@ -1074,6 +1178,9 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
      */
     private boolean advanceToNextUnit(ProducerState state) throws IOException {
         while (true) {
+            if (noFurtherCandidates()) {
+                return false;
+            }
             if (state.buffer.noMoreInputs()) {
                 return false;
             }
@@ -1108,6 +1215,9 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
      * process multiple splits at once via {@link RangeAwareFormatReader#readAll}.
      */
     private boolean openNextSliceQueueLeaf(ProducerState state) throws IOException {
+        if (noFurtherCandidates()) {
+            return false;
+        }
         if (batchReadCapable && state.leaves == null) {
             return openNextBatch(state);
         }
@@ -1126,8 +1236,6 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         FileSplit fileSplit = (FileSplit) leaf;
         List<String> cols = dataProjectedColumns();
 
-        // TODO: inject SharedNumericThreshold row-group skip check here, before the read
-        // dispatch below — avoids the I/O cost rather than paying for it and discarding.
         CloseableIterator<Page> pages = null;
         try {
             FormatReader fileReader = readerForFile(fileSplit);
@@ -1241,6 +1349,9 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
      * injection (incompatible with a unified batch iterator).
      */
     private boolean openNextBatch(ProducerState state) throws IOException {
+        if (noFurtherCandidates()) {
+            return false;
+        }
         int remaining = state.queue.remaining();
         if (remaining == 0) {
             return false;
@@ -1272,7 +1383,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         // so dataProjectedColumns() returns the full attribute list and no virtual-column wrapping
         // is needed.
         List<String> cols = dataProjectedColumns();
-        RangeAwareFormatReader rangeReader = (RangeAwareFormatReader) formatReader;
+        RangeAwareFormatReader rangeReader = (RangeAwareFormatReader) readerWithDynamicThreshold(formatReader);
         CloseableIterator<Page> pages = null;
         try {
             pages = rangeReader.readAll(splitRefs, cols, batchSize);
@@ -1291,6 +1402,9 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
      * have been processed.
      */
     private boolean openNextMultiFile(ProducerState state) throws IOException {
+        if (noFurtherCandidates()) {
+            return false;
+        }
         FileList files = state.fileList;
         assert files != null;
         if (state.fileIndex >= files.fileCount()) {
@@ -1314,6 +1428,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         CloseableIterator<Page> pages = null;
         try {
             StorageObject obj = storageProvider.newObject(files.path(fileIndex));
+            FormatReader fileReader = readerWithDynamicThreshold(formatReader);
             // Pull this file's coordinator-inferred schema from schemaInfo when available, so the
             // reader is pinned to the same inference the per-file ColumnMapping was built against.
             ColumnMapping mapping = null;
@@ -1326,7 +1441,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                 }
             }
             List<String> perFileCols = perFileQueryProjection(cols, perFileReadSchema);
-            pages = openWithParallelism(formatReader, obj, perFileCols, errorPolicy, false, true, perFileReadSchema);
+            pages = openWithParallelism(fileReader, obj, perFileCols, errorPolicy, false, true, perFileReadSchema);
             if (pages == null) {
                 int fileBudget = rowLimit == FormatReader.NO_LIMIT ? FormatReader.NO_LIMIT : state.rowsRemaining;
                 FormatReadContext ctx = FormatReadContext.builder()
@@ -1336,7 +1451,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                     .errorPolicy(errorPolicy)
                     .readSchema(perFileReadSchema)
                     .build();
-                pages = formatReader.read(obj, ctx);
+                pages = fileReader.read(obj, ctx);
             }
             CloseableIterator<Page> adapted = adaptSchema(pages, mapping, state.driverContext, perFileReadSchema, perFileCols);
             CloseableIterator<Page> withEncoder = wrapWithEncoderIfNeeded(adapted, perFileCols, state.driverContext);
@@ -1358,13 +1473,20 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         AsyncExternalSourceBuffer buffer,
         DriverContext driverContext
     ) {
+        if (noFurtherCandidates()) {
+            buffer.finish(false);
+            driverContext.removeAsyncAction();
+            releaseOperator();
+            return;
+        }
         FormatReadContext ctx = FormatReadContext.builder()
             .projectedColumns(projectedColumns)
             .batchSize(batchSize)
             .rowLimit(rowLimit)
             .errorPolicy(errorPolicy)
             .build();
-        formatReader.readAsync(storageObject, ctx, executor, ActionListener.wrap(iterator -> {
+        FormatReader reader = readerWithDynamicThreshold(formatReader);
+        reader.readAsync(storageObject, ctx, executor, ActionListener.wrap(iterator -> {
             consumePagesInBackground(iterator, buffer, driverContext, storageObject, projectedColumns);
         }, e -> {
             buffer.onFailure(e);
@@ -1379,17 +1501,16 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         AsyncExternalSourceBuffer buffer,
         DriverContext driverContext
     ) {
+        if (noFurtherCandidates()) {
+            buffer.finish(false);
+            driverContext.removeAsyncAction();
+            releaseOperator();
+            return;
+        }
         ActionListener<Void> failureListener = failureListener(buffer, driverContext);
         executor.execute(ActionRunnable.run(failureListener, () -> {
-            CloseableIterator<Page> pages = openWithParallelism(
-                formatReader,
-                storageObject,
-                projectedColumns,
-                errorPolicy,
-                false,
-                true,
-                null
-            );
+            FormatReader reader = readerWithDynamicThreshold(formatReader);
+            CloseableIterator<Page> pages = openWithParallelism(reader, storageObject, projectedColumns, errorPolicy, false, true, null);
             if (pages == null) {
                 FormatReadContext ctx = FormatReadContext.builder()
                     .projectedColumns(projectedColumns)
@@ -1397,7 +1518,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                     .rowLimit(rowLimit)
                     .errorPolicy(errorPolicy)
                     .build();
-                pages = formatReader.read(storageObject, ctx);
+                pages = reader.read(storageObject, ctx);
             }
             // Wrap with the deferred-extraction encoder (no-op when not enabled), then with the
             // virtual-column iterator so {@code _file.*} columns flow through the producer pipeline
@@ -1487,15 +1608,18 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
     }
 
     private void releaseOperator() {
-        if (operatorRefCount.decrementAndGet() == 0 && onClose != null) {
-            if (deferredExtraction) {
-                // Don't close onClose here — the deferred extraction path keeps using the storage
-                // (and thus the per-query budget) after the last source operator finishes
-                // producing. Release the factory's ref instead; the budget closes once every
-                // SourceExtractors registry has also been closed.
-                releaseDeferredCloseRef();
-            } else {
-                closeQuietly(onClose);
+        if (operatorRefCount.decrementAndGet() == 0) {
+            closeDynamicThreshold();
+            if (onClose != null) {
+                if (deferredExtraction) {
+                    // Don't close onClose here — the deferred extraction path keeps using the storage
+                    // (and thus the per-query budget) after the last source operator finishes
+                    // producing. Release the factory's ref instead; the budget closes once every
+                    // SourceExtractors registry has also been closed.
+                    releaseDeferredCloseRef();
+                } else {
+                    closeQuietly(onClose);
+                }
             }
         }
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/DynamicThreshold.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/DynamicThreshold.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.spi;
+
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.operator.topn.SharedNumericThreshold;
+import org.elasticsearch.core.Releasable;
+
+/**
+ * Per-query descriptor for the live numeric TopN threshold exposed to format readers.
+ */
+public final class DynamicThreshold implements Releasable {
+    private final String columnName;
+    private final ElementType elementType;
+    private final boolean ascending;
+    private final SharedNumericThreshold channel;
+
+    public DynamicThreshold(String columnName, ElementType elementType, boolean ascending, SharedNumericThreshold channel) {
+        this.columnName = columnName;
+        this.elementType = elementType;
+        this.ascending = ascending;
+        this.channel = channel;
+    }
+
+    public String columnName() {
+        return columnName;
+    }
+
+    public ElementType elementType() {
+        return elementType;
+    }
+
+    public boolean ascending() {
+        return ascending;
+    }
+
+    public boolean dominates(long rangeMin, long rangeMax) {
+        return channel.dominates(rangeMin, rangeMax);
+    }
+
+    public boolean noFurtherCandidates() {
+        return channel.noFurtherCandidates();
+    }
+
+    public long current() {
+        return channel.current();
+    }
+
+    @Override
+    public void close() {
+        channel.close();
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/DynamicThreshold.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/DynamicThreshold.java
@@ -18,12 +18,20 @@ public final class DynamicThreshold implements Releasable {
     private final String columnName;
     private final ElementType elementType;
     private final boolean ascending;
+    private final boolean nullsFirst;
     private final SharedNumericThreshold channel;
 
-    public DynamicThreshold(String columnName, ElementType elementType, boolean ascending, SharedNumericThreshold channel) {
+    public DynamicThreshold(
+        String columnName,
+        ElementType elementType,
+        boolean ascending,
+        boolean nullsFirst,
+        SharedNumericThreshold channel
+    ) {
         this.columnName = columnName;
         this.elementType = elementType;
         this.ascending = ascending;
+        this.nullsFirst = nullsFirst;
         this.channel = channel;
     }
 
@@ -35,12 +43,32 @@ public final class DynamicThreshold implements Releasable {
         return elementType;
     }
 
-    public boolean ascending() {
-        return ascending;
+    public boolean nullsFirst() {
+        return nullsFirst;
     }
 
     public boolean dominates(long rangeMin, long rangeMax) {
+        if (channel.noFurtherCandidates()) {
+            return true;
+        }
         return channel.dominates(rangeMin, rangeMax);
+    }
+
+    public boolean dominates(long rangeMin, long rangeMax, long nullCount) {
+        if (channel.noFurtherCandidates()) {
+            return true;
+        }
+        if (nullCount > 0 && nullsFirst) {
+            return false;
+        }
+        return channel.dominates(rangeMin, rangeMax);
+    }
+
+    public boolean dominatesNulls(long nullCount) {
+        if (channel.noFurtherCandidates()) {
+            return true;
+        }
+        return nullCount > 0 && nullsFirst == false && hasBound();
     }
 
     public boolean noFurtherCandidates() {
@@ -49,6 +77,10 @@ public final class DynamicThreshold implements Releasable {
 
     public long current() {
         return channel.current();
+    }
+
+    public boolean hasBound() {
+        return ascending ? current() != Long.MAX_VALUE : current() != Long.MIN_VALUE;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/DynamicThresholdAware.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/DynamicThresholdAware.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.spi;
+
+/**
+ * Capability marker for {@link FormatReader} implementations that can use a live TopN threshold.
+ * <p>
+ * Presence of this interface is the capability signal: callers use {@code instanceof
+ * DynamicThresholdAware} rather than a separate flag. Readers that cannot skip data by min/max
+ * statistics simply omit it.
+ */
+public interface DynamicThresholdAware {
+    /**
+     * Returns a reader copy that consults {@code threshold} at natural skip boundaries.
+     */
+    FormatReader withDynamicThreshold(DynamicThreshold threshold);
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -760,6 +760,8 @@ public class LocalExecutionPlanner {
      *         {@code PushTopNIntoExternalSource} already annotated the source, the BlockHash will
      *         prune during aggregation and the generic TopN above must remain as the safety net
      *         (replacing it would double-count the budget).</li>
+     *     <li>If the source operator factory is an {@link AsyncExternalSourceOperatorFactory},
+     *         the planner shares the live threshold with external format readers.</li>
      * </ul>
      *
      * <p>No plan-time multi-value exclude: the operator supports multi-valued sort keys natively
@@ -831,11 +833,10 @@ public class LocalExecutionPlanner {
         ElementType keyElementType = PlannerUtils.toElementType(sortAttribute.dataType());
         boolean asc = sortOrder.direction() == Order.OrderDirection.ASC;
         boolean nullsFirst = sortOrder.nullsPosition() == Order.NullsPosition.FIRST;
-        SharedNumericThreshold.Supplier thresholdSupplier = new SharedNumericThreshold.Supplier(asc);
+        SharedNumericThreshold.Supplier thresholdSupplier = null;
         if (source.sourceOperatorFactory instanceof AsyncExternalSourceOperatorFactory externalSourceFactory) {
-            externalSourceFactory.setNumericThresholdSupplier(thresholdSupplier, sortAttribute.name(), keyElementType, asc);
-        } else {
-            return null;
+            thresholdSupplier = new SharedNumericThreshold.Supplier(asc, nullsFirst);
+            externalSourceFactory.setNumericThresholdSupplier(thresholdSupplier, sortAttribute.name(), keyElementType, asc, nullsFirst);
         }
         return new NumericTopNOperator.NumericTopNOperatorFactory(limit, keyElementType, asc, nullsFirst, thresholdSupplier);
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -72,6 +72,7 @@ import org.elasticsearch.compute.operator.fuse.RrfConfig;
 import org.elasticsearch.compute.operator.fuse.RrfScoreEvalOperator;
 import org.elasticsearch.compute.operator.topn.GroupedTopNOperator;
 import org.elasticsearch.compute.operator.topn.NumericTopNOperator;
+import org.elasticsearch.compute.operator.topn.SharedNumericThreshold;
 import org.elasticsearch.compute.operator.topn.TopNEncoder;
 import org.elasticsearch.compute.operator.topn.TopNOperator;
 import org.elasticsearch.compute.operator.topn.TopNOperator.TopNOperatorFactory;
@@ -112,6 +113,7 @@ import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.type.EsField;
 import org.elasticsearch.xpack.esql.core.type.FunctionEsField;
 import org.elasticsearch.xpack.esql.core.util.Holder;
+import org.elasticsearch.xpack.esql.datasources.AsyncExternalSourceOperatorFactory;
 import org.elasticsearch.xpack.esql.datasources.DeferredExtractionCapable;
 import org.elasticsearch.xpack.esql.datasources.ExternalFieldExtractOperator;
 import org.elasticsearch.xpack.esql.datasources.ExternalSliceQueue;
@@ -827,12 +829,15 @@ public class LocalExecutionPlanner {
             return null;
         }
         ElementType keyElementType = PlannerUtils.toElementType(sortAttribute.dataType());
-        return new NumericTopNOperator.NumericTopNOperatorFactory(
-            limit,
-            keyElementType,
-            sortOrder.direction() == Order.OrderDirection.ASC,
-            sortOrder.nullsPosition() == Order.NullsPosition.FIRST
-        );
+        boolean asc = sortOrder.direction() == Order.OrderDirection.ASC;
+        boolean nullsFirst = sortOrder.nullsPosition() == Order.NullsPosition.FIRST;
+        SharedNumericThreshold.Supplier thresholdSupplier = new SharedNumericThreshold.Supplier(asc);
+        if (source.sourceOperatorFactory instanceof AsyncExternalSourceOperatorFactory externalSourceFactory) {
+            externalSourceFactory.setNumericThresholdSupplier(thresholdSupplier, sortAttribute.name(), keyElementType, asc);
+        } else {
+            return null;
+        }
+        return new NumericTopNOperator.NumericTopNOperatorFactory(limit, keyElementType, asc, nullsFirst, thresholdSupplier);
     }
 
     /**

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactoryThresholdTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactoryThresholdTests.java
@@ -1,0 +1,382 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.CloseableIterator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.SourceOperator;
+import org.elasticsearch.compute.operator.topn.SharedNumericThreshold;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.type.EsField;
+import org.elasticsearch.xpack.esql.datasources.glob.GlobExpander;
+import org.elasticsearch.xpack.esql.datasources.spi.DynamicThreshold;
+import org.elasticsearch.xpack.esql.datasources.spi.DynamicThresholdAware;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
+import org.elasticsearch.xpack.esql.datasources.spi.NoConfigFormatReader;
+import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageProvider;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class AsyncExternalSourceOperatorFactoryThresholdTests extends ESTestCase {
+
+    private static final BlockFactory BLOCK_FACTORY = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE)
+        .breaker(new NoopCircuitBreaker("none"))
+        .build();
+    private static final StoragePath PATH = StoragePath.of("s3://bucket/data.parquet");
+    private static final List<Attribute> ATTRIBUTES = List.of(
+        new FieldAttribute(Source.EMPTY, "value", new EsField("value", DataType.LONG, Map.of(), false, EsField.TimeSeriesFieldType.NONE))
+    );
+
+    public void testCachedThresholdIsSharedAcrossConcurrentNativeReads() {
+        ManualAsyncReader reader = new ManualAsyncReader();
+        AsyncExternalSourceOperatorFactory factory = baseFactory(reader).build();
+        installThreshold(factory, false);
+
+        SourceOperator first = factory.get(driverContext());
+        SourceOperator second = factory.get(driverContext());
+
+        assertThat(reader.thresholds.get(1), sameInstance(reader.thresholds.get(0)));
+
+        reader.completeAll();
+        first.close();
+        second.close();
+    }
+
+    public void testSetNumericThresholdSupplierAfterOperatorCreationThrows() {
+        ManualAsyncReader reader = new ManualAsyncReader();
+        AsyncExternalSourceOperatorFactory factory = baseFactory(reader).build();
+
+        SourceOperator operator = factory.get(driverContext());
+        IllegalStateException e = expectThrows(IllegalStateException.class, () -> installThreshold(factory, false));
+
+        assertThat(e.getMessage(), containsString("numeric threshold must be installed before source operators are created"));
+        reader.completeAll();
+        operator.close();
+    }
+
+    public void testNoFurtherCandidatesShortCircuitsSyncWrapperRead() {
+        CountingReader reader = new CountingReader(false);
+        AsyncExternalSourceOperatorFactory factory = baseFactory(reader).build();
+        SharedNumericThreshold threshold = installExhaustedThreshold(factory);
+
+        SourceOperator operator = factory.get(driverContext());
+
+        assertEquals(0, reader.reads.get());
+        assertTrue(operator.isFinished());
+        operator.close();
+        threshold.close();
+    }
+
+    public void testNoFurtherCandidatesShortCircuitsNativeAsyncRead() {
+        ManualAsyncReader reader = new ManualAsyncReader();
+        AsyncExternalSourceOperatorFactory factory = baseFactory(reader).build();
+        SharedNumericThreshold threshold = installExhaustedThreshold(factory);
+
+        SourceOperator operator = factory.get(driverContext());
+
+        assertEquals(0, reader.asyncReads.get());
+        assertTrue(operator.isFinished());
+        operator.close();
+        threshold.close();
+    }
+
+    public void testNoFurtherCandidatesShortCircuitsMultiFileProducer() {
+        CountingReader reader = new CountingReader(false);
+        List<StorageEntry> entries = List.of(
+            new StorageEntry(StoragePath.of("s3://bucket/data/f1.parquet"), 100, Instant.EPOCH),
+            new StorageEntry(StoragePath.of("s3://bucket/data/f2.parquet"), 100, Instant.EPOCH)
+        );
+        AsyncExternalSourceOperatorFactory factory = baseFactory(reader).fileList(
+            GlobExpander.fileListOf(entries, "s3://bucket/data/*.parquet")
+        ).build();
+        SharedNumericThreshold threshold = installExhaustedThreshold(factory);
+
+        SourceOperator operator = factory.get(driverContext());
+
+        assertEquals(0, reader.reads.get());
+        assertTrue(operator.isFinished());
+        operator.close();
+        threshold.close();
+    }
+
+    public void testNoFurtherCandidatesShortCircuitsSliceQueueProducer() {
+        CountingReader reader = new CountingReader(false);
+        FileSplit split = new FileSplit("test", PATH, 0, 100, "parquet", Map.of(FileSplitProvider.LAST_SPLIT_KEY, "true"), Map.of());
+        AsyncExternalSourceOperatorFactory factory = baseFactory(reader).sliceQueue(new ExternalSliceQueue(List.of(split))).build();
+        SharedNumericThreshold threshold = installExhaustedThreshold(factory);
+
+        SourceOperator operator = factory.get(driverContext());
+
+        assertEquals(0, reader.reads.get());
+        assertTrue(operator.isFinished());
+        operator.close();
+        threshold.close();
+    }
+
+    private static AsyncExternalSourceOperatorFactory.Builder baseFactory(FormatReader reader) {
+        return AsyncExternalSourceOperatorFactory.builder(new TestStorageProvider(), reader, PATH, ATTRIBUTES, 100, 10, Runnable::run);
+    }
+
+    private static void installThreshold(AsyncExternalSourceOperatorFactory factory, boolean nullsFirst) {
+        SharedNumericThreshold.Supplier supplier = new SharedNumericThreshold.Supplier(true, nullsFirst);
+        factory.setNumericThresholdSupplier(supplier, "value", ElementType.LONG, true, nullsFirst);
+    }
+
+    private static SharedNumericThreshold installExhaustedThreshold(AsyncExternalSourceOperatorFactory factory) {
+        SharedNumericThreshold.Supplier supplier = new SharedNumericThreshold.Supplier(true, true);
+        SharedNumericThreshold threshold = supplier.get();
+        threshold.markNoFurtherCandidates();
+        factory.setNumericThresholdSupplier(supplier, "value", ElementType.LONG, true, true);
+        return threshold;
+    }
+
+    private static DriverContext driverContext() {
+        DriverContext driverContext = mock(DriverContext.class);
+        when(driverContext.blockFactory()).thenReturn(BLOCK_FACTORY);
+        doAnswer(inv -> null).when(driverContext).addAsyncAction();
+        doAnswer(inv -> null).when(driverContext).removeAsyncAction();
+        return driverContext;
+    }
+
+    private static CloseableIterator<Page> emptyIterator() {
+        return new CloseableIterator<>() {
+            @Override
+            public boolean hasNext() {
+                return false;
+            }
+
+            @Override
+            public Page next() {
+                throw new NoSuchElementException();
+            }
+
+            @Override
+            public void close() {}
+        };
+    }
+
+    private static class CountingReader implements NoConfigFormatReader, DynamicThresholdAware {
+        private final AtomicInteger reads;
+        private final DynamicThreshold threshold;
+
+        CountingReader(boolean ignored) {
+            this(new AtomicInteger(), null);
+        }
+
+        private CountingReader(AtomicInteger reads, DynamicThreshold threshold) {
+            this.reads = reads;
+            this.threshold = threshold;
+        }
+
+        @Override
+        public FormatReader withDynamicThreshold(DynamicThreshold threshold) {
+            return new CountingReader(reads, threshold);
+        }
+
+        @Override
+        public SourceMetadata metadata(StorageObject object) {
+            return null;
+        }
+
+        @Override
+        public CloseableIterator<Page> read(StorageObject object, FormatReadContext context) {
+            assertNotNull(threshold);
+            reads.incrementAndGet();
+            return emptyIterator();
+        }
+
+        @Override
+        public String formatName() {
+            return "counting";
+        }
+
+        @Override
+        public List<String> fileExtensions() {
+            return List.of(".parquet");
+        }
+
+        @Override
+        public void close() {}
+    }
+
+    private static class ManualAsyncReader implements NoConfigFormatReader, DynamicThresholdAware {
+        private final AtomicInteger asyncReads;
+        private final List<DynamicThreshold> thresholds;
+        private final List<ActionListener<CloseableIterator<Page>>> listeners;
+        private final DynamicThreshold threshold;
+
+        ManualAsyncReader() {
+            this(new AtomicInteger(), new ArrayList<>(), new ArrayList<>(), null);
+        }
+
+        private ManualAsyncReader(
+            AtomicInteger asyncReads,
+            List<DynamicThreshold> thresholds,
+            List<ActionListener<CloseableIterator<Page>>> listeners,
+            DynamicThreshold threshold
+        ) {
+            this.asyncReads = asyncReads;
+            this.thresholds = thresholds;
+            this.listeners = listeners;
+            this.threshold = threshold;
+        }
+
+        @Override
+        public FormatReader withDynamicThreshold(DynamicThreshold threshold) {
+            thresholds.add(threshold);
+            return new ManualAsyncReader(asyncReads, thresholds, listeners, threshold);
+        }
+
+        @Override
+        public boolean supportsNativeAsync() {
+            return true;
+        }
+
+        @Override
+        public void readAsync(
+            StorageObject object,
+            FormatReadContext context,
+            java.util.concurrent.Executor executor,
+            ActionListener<CloseableIterator<Page>> listener
+        ) {
+            asyncReads.incrementAndGet();
+            listeners.add(listener);
+        }
+
+        void completeAll() {
+            List<ActionListener<CloseableIterator<Page>>> pending = List.copyOf(listeners);
+            listeners.clear();
+            for (ActionListener<CloseableIterator<Page>> listener : pending) {
+                listener.onResponse(emptyIterator());
+            }
+        }
+
+        @Override
+        public SourceMetadata metadata(StorageObject object) {
+            return null;
+        }
+
+        @Override
+        public CloseableIterator<Page> read(StorageObject object, FormatReadContext context) {
+            return emptyIterator();
+        }
+
+        @Override
+        public String formatName() {
+            return "manual-async";
+        }
+
+        @Override
+        public List<String> fileExtensions() {
+            return List.of(".parquet");
+        }
+
+        @Override
+        public void close() {}
+    }
+
+    private static class TestStorageProvider implements StorageProvider {
+        @Override
+        public StorageObject newObject(StoragePath path) {
+            return new TestStorageObject(path);
+        }
+
+        @Override
+        public StorageObject newObject(StoragePath path, long length) {
+            return new TestStorageObject(path);
+        }
+
+        @Override
+        public StorageObject newObject(StoragePath path, long length, Instant lastModified) {
+            return new TestStorageObject(path);
+        }
+
+        @Override
+        public StorageIterator listObjects(StoragePath prefix, boolean recursive) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean exists(StoragePath path) {
+            return true;
+        }
+
+        @Override
+        public List<String> supportedSchemes() {
+            return List.of("s3");
+        }
+
+        @Override
+        public void close() {}
+    }
+
+    private static class TestStorageObject implements StorageObject {
+        private final StoragePath path;
+
+        TestStorageObject(StoragePath path) {
+            this.path = path;
+        }
+
+        @Override
+        public InputStream newStream() {
+            return new ByteArrayInputStream(new byte[0]);
+        }
+
+        @Override
+        public InputStream newStream(long position, long length) {
+            return new ByteArrayInputStream(new byte[0]);
+        }
+
+        @Override
+        public long length() {
+            return 0;
+        }
+
+        @Override
+        public Instant lastModified() {
+            return Instant.EPOCH;
+        }
+
+        @Override
+        public boolean exists() {
+            return true;
+        }
+
+        @Override
+        public StoragePath path() {
+            return path;
+        }
+    }
+}


### PR DESCRIPTION
Tighten dynamic threshold pruning around null ordering so external readers can skip dominated work without dropping competitive nulls.

Adds Parquet, ORC, factory, and end-to-end coverage for the numeric TopN side channel.

Developed with AI-assisted tooling