### PR TITLE
ESQL: Handle deeply nested RLIKE patterns

### DIFF
--- a/docs/changelog/149948.yaml
+++ b/docs/changelog/149948.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+  - 149838
+pr: 149948
+summary: Prevent StackOverflowError for deeply nested RLIKE patterns
+type: bug

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/predicate/regex/AbstractStringPattern.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/predicate/regex/AbstractStringPattern.java
@@ -26,6 +26,8 @@ public abstract class AbstractStringPattern implements StringPattern {
             return doCreateAutomaton(ignoreCase);
         } catch (TooComplexToDeterminizeException e) {
             throw new IllegalArgumentException("Pattern was too complex to determinize", e);
+        } catch (StackOverflowError e) {
+            throw new IllegalArgumentException("Pattern was too deeply nested", e);
         }
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/core/expression/predicate/regex/StringPatternTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/core/expression/predicate/regex/StringPatternTests.java
@@ -10,6 +10,8 @@ package org.elasticsearch.xpack.esql.core.expression.predicate.regex;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.core.util.StringUtils;
 
+import static org.hamcrest.Matchers.instanceOf;
+
 public class StringPatternTests extends ESTestCase {
 
     private WildcardPattern like(String pattern) {
@@ -277,5 +279,12 @@ public class StringPatternTests extends ESTestCase {
 
         e = expectThrows(IllegalArgumentException.class, () -> like("*a?????????????").createAutomaton(false));
         assertEquals("Pattern was too complex to determinize", e.getMessage());
+    }
+
+    public void testDeeplyNestedRegexPattern() {
+        String pattern = "(".repeat(100_000) + "a" + ")".repeat(100_000);
+        var e = expectThrows(IllegalArgumentException.class, () -> rlike(pattern).createAutomaton(false));
+        assertEquals("Pattern was too deeply nested", e.getMessage());
+        assertThat(e.getCause(), instanceOf(StackOverflowError.class));
     }
 }


### PR DESCRIPTION
## Summary

Close #149838.

Deeply nested regular expressions used with ES|QL `RLIKE` can cause
Lucene's `RegExp.toAutomaton()` processing to throw a
`StackOverflowError`. Since this error was not handled by ES|QL, the
request failed as an internal server error instead of reporting an
invalid user-supplied pattern.

This change catches `StackOverflowError` in
`AbstractStringPattern.createAutomaton()`, alongside the existing
`TooComplexToDeterminizeException` handling, and converts it to an
`IllegalArgumentException` with a clear message.

A regression test verifies that a deeply nested `RLIKE` pattern is
reported as an `IllegalArgumentException` while preserving the original
`StackOverflowError` as its cause.

## Testing

- `./gradlew :x-pack:plugin:esql:test --tests org.elasticsearch.xpack.esql.core.expression.predicate.regex.StringPatternTests`
- `./gradlew :x-pack:plugin:esql:spotlessJavaCheck`