### PR TITLE
Filter index modes by transport version in node stats

### DIFF
--- a/docs/changelog/149949.yaml
+++ b/docs/changelog/149949.yaml
@@ -1,0 +1,6 @@
+pr: 149949
+summary: Filter index modes by transport version in node stats
+area: Infra/Metrics
+type: bug
+issues:
+ - 149399

--- a/server/src/main/java/org/elasticsearch/index/IndexMode.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexMode.java
@@ -879,6 +879,22 @@ public enum IndexMode {
         };
     }
 
+    /**
+     * Whether this index mode can be serialized to a node on the given transport version. Feature-flagged modes were
+     * introduced in specific transport versions, and {@link #writeTo} refuses to send them to older nodes. Callers that
+     * may target mixed-version nodes (for example node stats during a rolling upgrade) should drop unsupported modes
+     * before writing rather than letting the whole response fail.
+     */
+    public static boolean isWriteableTo(IndexMode indexMode, TransportVersion version) {
+        if ((indexMode == COLUMNAR || indexMode == LOGSDB_COLUMNAR) && version.supports(COLUMNAR_INDEX_MODES_ADDED) == false) {
+            return false;
+        }
+        if (indexMode == VECTORDB_DOCUMENT && version.supports(VECTORDB_DOCUMENT_INDEX_MODE) == false) {
+            return false;
+        }
+        return true;
+    }
+
     public static void writeTo(IndexMode indexMode, StreamOutput out) throws IOException {
         if ((indexMode == COLUMNAR || indexMode == LOGSDB_COLUMNAR)
             && out.getTransportVersion().supports(COLUMNAR_INDEX_MODES_ADDED) == false) {

--- a/server/src/main/java/org/elasticsearch/monitor/metrics/IndexModeStatsActionType.java
+++ b/server/src/main/java/org/elasticsearch/monitor/metrics/IndexModeStatsActionType.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.monitor.metrics;
 
+import org.elasticsearch.TransportVersion;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.action.support.ActionFilters;
@@ -114,7 +115,18 @@ public final class IndexModeStatsActionType extends ActionType<IndexModeStatsAct
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
-            out.writeMap(stats, (o, m) -> IndexMode.writeTo(m, o), (o, s) -> s.writeTo(o));
+            final TransportVersion version = out.getTransportVersion();
+            Map<IndexMode, IndexStats> writeableStats = stats;
+            if (stats.keySet().stream().anyMatch(mode -> IndexMode.isWriteableTo(mode, version) == false)) {
+                // Drop modes the target node predates so a mixed-version rolling upgrade does not fail the whole response.
+                writeableStats = new EnumMap<>(IndexMode.class);
+                for (Map.Entry<IndexMode, IndexStats> entry : stats.entrySet()) {
+                    if (IndexMode.isWriteableTo(entry.getKey(), version)) {
+                        writeableStats.put(entry.getKey(), entry.getValue());
+                    }
+                }
+            }
+            out.writeMap(writeableStats, (o, m) -> IndexMode.writeTo(m, o), (o, s) -> s.writeTo(o));
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/monitor/metrics/IndexModeStatsActionTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/monitor/metrics/IndexModeStatsActionTypeTests.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.monitor.metrics;
+
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.index.IndexMode;
+import org.elasticsearch.monitor.metrics.IndexModeStatsActionType.NodeResponse;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.TransportVersionUtils;
+
+import java.io.IOException;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+public class IndexModeStatsActionTypeTests extends ESTestCase {
+
+    /**
+     * A within-minor rolling upgrade can serialize a node's index-mode stats to a node on an older transport version
+     * that does not understand a feature-flagged mode (e.g. {@code columnar}). The stats response must drop the
+     * unsupported mode instead of letting {@link IndexMode#writeTo} fail the whole response. See #149399.
+     */
+    public void testNodeResponseDropsUnsupportedModesOnOlderTransportVersion() throws IOException {
+        assumeTrue("columnar index mode requires snapshot build", IndexMode.COLUMNAR_FEATURE_FLAG.isEnabled());
+
+        DiscoveryNode node = DiscoveryNodeUtils.create("node-1");
+        Map<IndexMode, IndexStats> stats = new EnumMap<>(IndexMode.class);
+        stats.put(IndexMode.STANDARD, new IndexStats());
+        stats.put(IndexMode.COLUMNAR, new IndexStats());
+        NodeResponse response = new NodeResponse(node, stats);
+
+        TransportVersion older = TransportVersionUtils.getPreviousVersion(IndexMode.COLUMNAR_INDEX_MODES_ADDED);
+        NodeResponse deserialized = copyWriteable(response, new NamedWriteableRegistry(List.of()), in -> new NodeResponse(in, node), older);
+        assertNotNull(deserialized);
+    }
+
+    public void testIsWriteableTo() {
+        TransportVersion beforeColumnar = TransportVersionUtils.getPreviousVersion(IndexMode.COLUMNAR_INDEX_MODES_ADDED);
+        // Feature-flagged modes that predate the target version must be reported as not writeable so callers drop them.
+        assertFalse(IndexMode.isWriteableTo(IndexMode.COLUMNAR, beforeColumnar));
+        assertFalse(IndexMode.isWriteableTo(IndexMode.LOGSDB_COLUMNAR, beforeColumnar));
+        // Modes that exist on every compatible version are always writeable.
+        assertTrue(IndexMode.isWriteableTo(IndexMode.STANDARD, beforeColumnar));
+        assertTrue(IndexMode.isWriteableTo(IndexMode.TIME_SERIES, beforeColumnar));
+        assertTrue(IndexMode.isWriteableTo(IndexMode.LOGSDB, beforeColumnar));
+        assertTrue(IndexMode.isWriteableTo(IndexMode.LOOKUP, beforeColumnar));
+        // Once the target version supports the mode it becomes writeable.
+        assertTrue(IndexMode.isWriteableTo(IndexMode.COLUMNAR, IndexMode.COLUMNAR_INDEX_MODES_ADDED));
+
+        TransportVersion beforeVectordb = TransportVersionUtils.getPreviousVersion(IndexMode.VECTORDB_DOCUMENT_INDEX_MODE);
+        assertFalse(IndexMode.isWriteableTo(IndexMode.VECTORDB_DOCUMENT, beforeVectordb));
+        assertTrue(IndexMode.isWriteableTo(IndexMode.VECTORDB_DOCUMENT, IndexMode.VECTORDB_DOCUMENT_INDEX_MODE));
+    }
+}


### PR DESCRIPTION
## Summary
`IndexModeStatsActionType.NodeResponse` serialized the full index-mode stats map. During a within-minor rolling upgrade, sending a feature-flagged mode (for example `columnar`) to a node on an older transport version made `IndexMode.writeTo` throw, failing the entire stats response. This filters the stats map by the stream's transport version before writing, dropping modes the target node does not support.

Closes #149399

## What changed
- Add `IndexMode.isWriteableTo(mode, version)`, mirroring the transport-version guards already in `IndexMode.writeTo`.
- `IndexModeStatsActionType.NodeResponse.writeTo` drops unsupported modes before serializing the stats map.

## Tests
- `testIsWriteableTo` asserts feature-flagged modes (`columnar`, `logsdb_columnar`, `vectordb_document`) are not writeable to transport versions predating them, while always-available modes are.
- `testNodeResponseDropsUnsupportedModesOnOlderTransportVersion` round-trips a `NodeResponse` containing `columnar` through a pre-columnar transport version; this threw before the fix.
