### PR TITLE
Additional remote index and view resolution tests

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterViewIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterViewIT.java
@@ -14,6 +14,7 @@ import org.elasticsearch.xpack.esql.view.PutViewAction;
 import org.junit.Before;
 
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
 import static java.util.concurrent.TimeUnit.*;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
@@ -98,7 +99,7 @@ public class CrossClusterViewIT extends AbstractCrossClusterTestCase {
             client(clusterAlias).execute(
                 PutViewAction.INSTANCE,
                 new PutViewAction.Request(TimeValue.THIRTY_SECONDS, TimeValue.THIRTY_SECONDS, new View(viewName, query))
-            ).actionGet(30, SECONDS)
+            ).actionGet(30, TimeUnit.SECONDS)
         );
     }
 

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterViewIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterViewIT.java
@@ -16,7 +16,6 @@ import org.junit.Before;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
-import static java.util.concurrent.TimeUnit.*;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterViewIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterViewIT.java
@@ -7,16 +7,18 @@
 
 package org.elasticsearch.xpack.esql.action;
 
-import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.cluster.metadata.View;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.transport.NoSuchRemoteClusterException;
 import org.elasticsearch.xpack.esql.view.PutViewAction;
 import org.junit.Before;
 
 import java.io.IOException;
 
+import static java.util.concurrent.TimeUnit.*;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 
 public class CrossClusterViewIT extends AbstractCrossClusterTestCase {
 
@@ -28,58 +30,66 @@ public class CrossClusterViewIT extends AbstractCrossClusterTestCase {
     }
 
     public void testRemoteViewWildcardMatchFailsQuery() {
-        Exception e = expectThrows(Exception.class, () -> runQuery("FROM cluster-a:logs-*", null));
-        Throwable cause = ExceptionsHelper.unwrapCause(e);
-        assertThat(
-            cause.getMessage(),
+        expectThrows(
+            Exception.class,
             containsString(
                 "ES|QL queries with remote views are not supported. Matched [cluster-a:logs-mobile, cluster-a:logs-web]."
                     + " Remove them from the query pattern or exclude them with"
                     + " [cluster-a:-logs-mobile,cluster-a:-logs-web] if matched by a wildcard."
-            )
+            ),
+            () -> runQuery("FROM cluster-a:logs-*", null)
         );
     }
 
     public void testRemoteViewConcreteMatchFailsQuery() {
-        Exception e = expectThrows(Exception.class, () -> runQuery("FROM cluster-a:logs-web", null));
-        Throwable cause = ExceptionsHelper.unwrapCause(e);
-        assertThat(
-            cause.getMessage(),
+        expectThrows(
+            Exception.class,
             containsString(
                 "ES|QL queries with remote views are not supported. Matched [cluster-a:logs-web]."
                     + " Remove them from the query pattern or exclude them with [cluster-a:-logs-web] if matched by a wildcard."
-            )
+            ),
+            () -> runQuery("FROM cluster-a:logs-web", null)
         );
     }
 
     public void testRemoteViewExcludedSucceeds() {
         try (var resp = runQuery("FROM cluster-a:logs-*,cluster-a:-logs-web,cluster-a:-logs-mobile", null)) {
-            assertNotNull(resp);
+            assertOk(resp);
         }
     }
 
     public void testAllViewsOnRemoteExcludedSucceeds() {
         try (var resp = runQuery("FROM cluster*:logs-*,-cluster-a:*,remote-b:*", null)) {
-            assertNotNull(resp);
+            assertOk(resp);
         }
     }
 
     public void testRemoteViewFailsOnOneCluster() {
-        Exception e = expectThrows(Exception.class, () -> runQuery("FROM cluster-a:logs-*,remote-b:logs-*", null));
-        Throwable cause = ExceptionsHelper.unwrapCause(e);
-        assertThat(
-            cause.getMessage(),
+        Exception e = expectThrows(
+            Exception.class,
             containsString(
                 "ES|QL queries with remote views are not supported. Matched [cluster-a:logs-mobile, cluster-a:logs-web]."
                     + " Remove them from the query pattern or exclude them with"
                     + " [cluster-a:-logs-mobile,cluster-a:-logs-web] if matched by a wildcard."
-            )
+            ),
+            () -> runQuery("FROM cluster-a:logs-*,remote-b:logs-*", null)
         );
     }
 
     public void testNoRemoteViewsQuerySucceeds() {
         try (var resp = runQuery("FROM remote-b:logs-*", null)) {
-            assertNotNull(resp);
+            assertOk(resp);
+        }
+    }
+
+    public void testUnknownRemote() {
+        expectThrows(
+            NoSuchRemoteClusterException.class,
+            containsString("no such remote cluster: [no_such_remote]"),
+            () -> runQuery("FROM no_such_remote:logs-web", null)
+        );
+        try (var resp = runQuery("FROM no_such_*:logs-web", null)) {
+            assertOk(resp);
         }
     }
 
@@ -88,7 +98,11 @@ public class CrossClusterViewIT extends AbstractCrossClusterTestCase {
             client(clusterAlias).execute(
                 PutViewAction.INSTANCE,
                 new PutViewAction.Request(TimeValue.THIRTY_SECONDS, TimeValue.THIRTY_SECONDS, new View(viewName, query))
-            ).actionGet(30, java.util.concurrent.TimeUnit.SECONDS)
+            ).actionGet(30, SECONDS)
         );
+    }
+
+    private static void assertOk(EsqlQueryResponse response) {
+        assertThat(response.isPartial(), equalTo(false));
     }
 }

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterViewIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterViewIT.java
@@ -65,7 +65,7 @@ public class CrossClusterViewIT extends AbstractCrossClusterTestCase {
     }
 
     public void testRemoteViewFailsOnOneCluster() {
-        Exception e = expectThrows(
+        expectThrows(
             Exception.class,
             containsString(
                 "ES|QL queries with remote views are not supported. Matched [cluster-a:logs-mobile, cluster-a:logs-web]."

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/RemoteIndexResolutionIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/RemoteIndexResolutionIT.java
@@ -132,6 +132,10 @@ public class RemoteIndexResolutionIT extends AbstractCrossClusterTestCase {
             containsString("no such remote cluster: [fake]"),
             () -> run(syncEsqlQueryRequest("FROM fake:index-1 METADATA _index"))
         );
+        try (var response = run(syncEsqlQueryRequest("FROM fake*:index-1 METADATA _index"))) {
+            assertOk(response);
+            assertResultConcreteIndices(response); // empty
+        }
     }
 
     public void testResolutionWithFilter() {


### PR DESCRIPTION
This change adds additional index+view resolution coverage for remote clusters as well as makes assertions stricter.