### PR TITLE
Downsampling: Add support for delta temporality on counters

### DIFF
--- a/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/DownsampleRateIT.java
+++ b/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/DownsampleRateIT.java
@@ -48,17 +48,17 @@ public class DownsampleRateIT extends DownsamplingIntegTestCase {
     private static final String DOWNSAMPLED_AGGREGATE_INDEX_NAME = "metrics-aggregated";
     private static final String DOWNSAMPLED_LAST_VALUE_INDEX_NAME = "metrics-last-value";
     private static final String MAPPING_FIELDS = """
-            "@timestamp": {
-              "type": "date"
-            },
-            "metricset": {
-              "type": "keyword",
-              "time_series_dimension": true
-            },
-            "counter": {
-              "type": "long",
-              "time_series_metric": "counter"
-            }""";
+        "@timestamp": {
+          "type": "date"
+        },
+        "metricset": {
+          "type": "keyword",
+          "time_series_dimension": true
+        },
+        "counter": {
+          "type": "long",
+          "time_series_metric": "counter"
+        }""";
     public static final String START_TIME = "2021-04-29T00:00:00Z";
     public static final String END_TIME = "2021-04-29T23:59:59Z";
 

--- a/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/DownsampleRateIT.java
+++ b/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/DownsampleRateIT.java
@@ -47,9 +47,7 @@ public class DownsampleRateIT extends DownsamplingIntegTestCase {
     private static final String INDEX_NAME = "metrics";
     private static final String DOWNSAMPLED_AGGREGATE_INDEX_NAME = "metrics-aggregated";
     private static final String DOWNSAMPLED_LAST_VALUE_INDEX_NAME = "metrics-last-value";
-    private static final String MAPPING = """
-        {
-          "properties": {
+    private static final String MAPPING_FIELDS = """
             "@timestamp": {
               "type": "date"
             },
@@ -60,10 +58,7 @@ public class DownsampleRateIT extends DownsamplingIntegTestCase {
             "counter": {
               "type": "long",
               "time_series_metric": "counter"
-            }
-          }
-        }
-        """;
+            }""";
     public static final String START_TIME = "2021-04-29T00:00:00Z";
     public static final String END_TIME = "2021-04-29T23:59:59Z";
 
@@ -163,8 +158,63 @@ public class DownsampleRateIT extends DownsamplingIntegTestCase {
         runTest(documentSpecs, "1h");
     }
 
+    public void testDeltaTemporalityRate() {
+        runTestWithTemporality(
+            List.of(
+                new DocumentSpec("pod", "delta", "2021-04-29T17:01:00.000Z", 5),
+                new DocumentSpec("pod", "delta", "2021-04-29T17:05:00.000Z", 3),
+                new DocumentSpec("pod", "delta", "2021-04-29T17:10:00.000Z", 8),
+                new DocumentSpec("pod", "delta", "2021-04-29T17:15:00.000Z", 2),
+                new DocumentSpec("pod", "delta", "2021-04-29T17:20:00.000Z", 10),
+                new DocumentSpec("pod", "delta", "2021-04-29T17:25:00.000Z", 1),
+                new DocumentSpec("pod", "delta", "2021-04-29T17:32:00.000Z", 7),
+                new DocumentSpec("pod", "delta", "2021-04-29T17:39:00.000Z", 4)
+            ),
+            "30m"
+        );
+    }
+
+    public void testMixedTemporalityRate() {
+        runTestWithTemporality(
+            List.of(
+                // cumulative TSID: monotonically increasing counter
+                new DocumentSpec("pod-cumulative", "cumulative", "2021-04-29T17:01:00.000Z", 10),
+                new DocumentSpec("pod-cumulative", "cumulative", "2021-04-29T17:05:00.000Z", 20),
+                new DocumentSpec("pod-cumulative", "cumulative", "2021-04-29T17:10:00.000Z", 35),
+                new DocumentSpec("pod-cumulative", "cumulative", "2021-04-29T17:15:00.000Z", 50),
+                new DocumentSpec("pod-cumulative", "cumulative", "2021-04-29T17:20:00.000Z", 60),
+                new DocumentSpec("pod-cumulative", "cumulative", "2021-04-29T17:25:00.000Z", 75),
+                new DocumentSpec("pod-cumulative", "cumulative", "2021-04-29T17:32:00.000Z", 90),
+                new DocumentSpec("pod-cumulative", "cumulative", "2021-04-29T17:39:00.000Z", 100),
+                // delta TSID: per-interval increments
+                new DocumentSpec("pod-delta", "delta", "2021-04-29T17:01:00.000Z", 5),
+                new DocumentSpec("pod-delta", "delta", "2021-04-29T17:05:00.000Z", 3),
+                new DocumentSpec("pod-delta", "delta", "2021-04-29T17:10:00.000Z", 8),
+                new DocumentSpec("pod-delta", "delta", "2021-04-29T17:15:00.000Z", 2),
+                new DocumentSpec("pod-delta", "delta", "2021-04-29T17:20:00.000Z", 10),
+                new DocumentSpec("pod-delta", "delta", "2021-04-29T17:25:00.000Z", 1),
+                new DocumentSpec("pod-delta", "delta", "2021-04-29T17:32:00.000Z", 7),
+                new DocumentSpec("pod-delta", "delta", "2021-04-29T17:39:00.000Z", 4)
+            ),
+            "30m"
+        );
+    }
+
     private void runTest(List<DocumentSpec> documentSpecs, String interval) {
         createIndex();
+        indexDocuments(documentSpecs);
+        downsample(new DateHistogramInterval(interval));
+        try (
+            var baseline = queryRate(INDEX_NAME);
+            var aggregateContender = queryRate(DOWNSAMPLED_AGGREGATE_INDEX_NAME);
+            var lastValueContender = queryRate(DOWNSAMPLED_LAST_VALUE_INDEX_NAME)
+        ) {
+            compareResults(baseline, aggregateContender, lastValueContender);
+        }
+    }
+
+    private void runTestWithTemporality(List<DocumentSpec> documentSpecs, String interval) {
+        createIndexWithTemporality();
         indexDocuments(documentSpecs);
         downsample(new DateHistogramInterval(interval));
         try (
@@ -246,7 +296,26 @@ public class DownsampleRateIT extends DownsamplingIntegTestCase {
                 .put(IndexSettings.TIME_SERIES_START_TIME.getKey(), START_TIME)
                 .put(IndexSettings.TIME_SERIES_END_TIME.getKey(), END_TIME)
         );
-        request.mapping(MAPPING);
+        request.mapping("{ \"properties\": {" + MAPPING_FIELDS + "}}");
+        assertAcked(client().admin().indices().create(request));
+    }
+
+    private static void createIndexWithTemporality() {
+        String temporalityField = """
+            "temporality": {
+              "type": "keyword",
+              "time_series_dimension": true
+            }""";
+        CreateIndexRequest request = new CreateIndexRequest(INDEX_NAME);
+        request.settings(
+            Settings.builder()
+                .put(IndexSettings.MODE.getKey(), IndexMode.TIME_SERIES.getName())
+                .put(IndexMetadata.INDEX_ROUTING_PATH.getKey(), "metricset,temporality")
+                .put(IndexSettings.TIME_SERIES_START_TIME.getKey(), START_TIME)
+                .put(IndexSettings.TIME_SERIES_END_TIME.getKey(), END_TIME)
+                .put(IndexSettings.TIME_SERIES_TEMPORALITY_FIELD.getKey(), "temporality")
+        );
+        request.mapping("{ \"properties\": {" + MAPPING_FIELDS + "," + temporalityField + "}}");
         assertAcked(client().admin().indices().create(request));
     }
 
@@ -256,12 +325,15 @@ public class DownsampleRateIT extends DownsamplingIntegTestCase {
             try {
                 assertThat(i.get(), lessThan(documentSpecs.size()));
                 var docSpec = documentSpecs.get(i.getAndIncrement());
-                return XContentFactory.jsonBuilder()
+                XContentBuilder builder = XContentFactory.jsonBuilder()
                     .startObject()
                     .field("@timestamp", docSpec.timestamp)
                     .field("metricset", docSpec.dimension)
-                    .field("counter", docSpec.counter)
-                    .endObject();
+                    .field("counter", docSpec.counter);
+                if (docSpec.temporality != null) {
+                    builder.field("temporality", docSpec.temporality);
+                }
+                return builder.endObject();
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
@@ -316,9 +388,13 @@ public class DownsampleRateIT extends DownsamplingIntegTestCase {
         safeAwait(listener);
     }
 
-    record DocumentSpec(String dimension, String timestamp, int counter) {
+    record DocumentSpec(String dimension, String temporality, String timestamp, int counter) {
         DocumentSpec(String timestamp, int counter) {
-            this("pod", timestamp, counter);
+            this("pod", null, timestamp, counter);
+        }
+
+        DocumentSpec(String dimension, String timestamp, int counter) {
+            this(dimension, null, timestamp, counter);
         }
     }
 

--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/DownsampleShardIndexer.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/DownsampleShardIndexer.java
@@ -33,6 +33,7 @@ import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.IndexService;
+import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.fielddata.FormattedDocValues;
 import org.elasticsearch.index.fielddata.HistogramValues;
@@ -107,6 +108,7 @@ class DownsampleShardIndexer {
     private final DownsampleShardPersistentTaskState state;
     private final String[] dimensions;
     private final AbstractFieldDownsampler.DownsamplerCountPerValueType fieldCounts;
+    private final String temporalityFieldName;
     private volatile boolean abort = false;
     ByteSizeValue downsampleBulkSize = DOWNSAMPLE_BULK_SIZE;
     ByteSizeValue downsampleMaxBytesInFlight = DOWNSAMPLE_MAX_BYTES_IN_FLIGHT;
@@ -145,6 +147,9 @@ class DownsampleShardIndexer {
                 null
             );
             this.dimensions = dimensions;
+            this.temporalityFieldName = IndexSettings.TIME_SERIES_TEMPORALITY_FIELD.get(
+                searchExecutionContext.getIndexSettings().getSettings()
+            );
             this.timestampField = (DateFieldMapper.DateFieldType) searchExecutionContext.getFieldType(config.getTimestampField());
             this.timestampFormat = timestampField.docValueFormat(null, null);
             this.rounding = config.createRounding();
@@ -383,6 +388,12 @@ class DownsampleShardIndexer {
         long lastTimestamp = Long.MAX_VALUE;
         long lastHistoTimestamp = Long.MAX_VALUE;
 
+        /**
+         * The array index of the dimension storing the temporality in {@link #dimensionDownsamplers}.
+         * {@code -1} if there is no temporality dimension.
+         */
+        private final int temporalityDimensionIndex;
+
         TimeSeriesBucketCollector(BulkProcessor2 bulkProcessor, String[] dimensions) {
             this.bulkProcessor = bulkProcessor;
             int dimensionFieldIndex = 0;
@@ -429,6 +440,17 @@ class DownsampleShardIndexer {
                     default -> throw new IllegalArgumentException("Unknown field downsampler type: " + fieldDownsampler.getClass());
                 }
             }
+
+            int resolvedTemporalityIndex = -1;
+            if (temporalityFieldName != null && temporalityFieldName.isEmpty() == false) {
+                for (int i = 0; i < dimensionDownsamplers.length; i++) {
+                    if (temporalityFieldName.equals(dimensionDownsamplers[i].name())) {
+                        resolvedTemporalityIndex = i;
+                        break;
+                    }
+                }
+            }
+            this.temporalityDimensionIndex = resolvedTemporalityIndex;
 
             this.downsampleBucketBuilder = new DownsampleBucketBuilder(
                 fieldDownsamplers,
@@ -608,11 +630,15 @@ class DownsampleShardIndexer {
                     }
                     downsampleBucketBuilder.dimensionsCollected = true;
                 }
+                Temporality temporality = Temporality.DEFAULT;
+                if (temporalityDimensionIndex != -1) {
+                    temporality = Temporality.fromDimensionValue(dimensionDownsamplers[temporalityDimensionIndex].dimensionValue());
+                }
                 if (aggregateCounterDownsamplers.length > 0) {
                     assert timestampValues != null;
                     long[] timestamps = TimestampValueFetcher.fetch(timestampValues, docIdBuffer);
                     for (int i = 0; i < aggregateCounterDownsamplers.length; i++) {
-                        aggregateCounterDownsamplers[i].collect(aggregateCounterValues[i], timestamps, docIdBuffer);
+                        aggregateCounterDownsamplers[i].collect(aggregateCounterValues[i], timestamps, docIdBuffer, temporality);
                     }
                 }
 

--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/NumericMetricFieldDownsampler.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/NumericMetricFieldDownsampler.java
@@ -177,15 +177,25 @@ abstract sealed class NumericMetricFieldDownsampler extends AbstractFieldDownsam
 
     /**
      * {@link NumericMetricFieldDownsampler} implementation for creating the required downsampling doc to support a pre-aggregated
-     *  counter metric field. This producer tracks the following:
+     *  counter metric field. For {@link Temporality#CUMULATIVE} temporality (the default), this producer tracks the following:
      * - The first value for this counter per tsid and bucket, so it can be stored in the downsampled document.
      * - The last-seen timestamp, so it can update the extraDataPoints structure which is shared across all aggregate counter producers.
+     *
+     * For {@link Temporality#DELTA} temporality, we just collect the sum of all counter values.
      * Important note: This class assumes that field values are collected and sorted by descending order by time.
+     *
+     * The behavior depends on the {@link Temporality}:
+     * <ul>
+     *     <li>{@link Temporality#CUMULATIVE} / {@link Temporality#DEFAULT}: cumulative counters with reset detection.
+     *         The oldest value in the bucket is kept and counter resets produce extra documents.</li>
+     *     <li>{@link Temporality#DELTA}: delta counters where each document represents an increment.
+     *         Values within a bucket are summed.</li>
+     * </ul>
      */
     static final class AggregateCounter extends NumericMetricFieldDownsampler {
 
         final Deque<CounterResetDataPoints.ResetPoint> resetStack = new ArrayDeque<>();
-        double downsampledValue = Double.NaN;
+        final CompensatedSum downsampledValue = new CompensatedSum();
         long lastTimestamp = -1;
         // Cross bucket value
         double previousValue = Double.NaN;
@@ -197,11 +207,16 @@ abstract sealed class NumericMetricFieldDownsampler extends AbstractFieldDownsam
             super(name, fieldData);
         }
 
-        public void collect(SortedNumericDoubleValues counterDocValues, long[] timestamps, IntArrayList docIdBuffer) throws IOException {
+        public void collect(
+            SortedNumericDoubleValues counterDocValues,
+            long[] timestamps,
+            IntArrayList docIdBuffer,
+            Temporality temporality
+        ) throws IOException {
             assert timestamps.length == docIdBuffer.size() : "timestamps and docIdBuffer should have the same size";
             for (int i = 0; i < docIdBuffer.size(); i++) {
                 int docId = docIdBuffer.get(i);
-                var currentTimestamp = timestamps[i];
+                long currentTimestamp = timestamps[i];
                 if (counterDocValues.advanceExact(docId) == false || currentTimestamp < 0) {
                     continue;
                 }
@@ -209,48 +224,59 @@ abstract sealed class NumericMetricFieldDownsampler extends AbstractFieldDownsam
                 assert docValuesCount > 0;
                 isEmpty = false;
 
-                var currentCounterValue = counterDocValues.nextValue();
-                // If this the first time we encounter a value for this tsid
-                if (Double.isNaN(previousValue)) {
-                    downsampledValue = currentCounterValue;
-                    previousValue = currentCounterValue;
-                    lastTimestamp = currentTimestamp;
-                    continue;
+                double currentCounterValue = counterDocValues.nextValue();
+                switch (temporality) {
+                    case DELTA -> collectDelta(currentCounterValue);
+                    case CUMULATIVE, DEFAULT -> collectCumulative(currentCounterValue, currentTimestamp);
                 }
-
-                // when we detect a reset, (remember that field values are collected and sorted by descending order by time)
-                if (currentCounterValue > previousValue) {
-                    // We check if we need to persist the previous value too
-                    // If timestamp -1 means that the previous value is already persisted by a previous bucket, nothing extra to persist
-                    if (lastTimestamp > 0) {
-                        // If we have a previous value in this bucket, we need to see if the last persisted value is enough to capture the
-                        // reset or not.
-                        double lastPersisted = Double.NaN;
-                        if (resetStack.isEmpty() == false) {
-                            lastPersisted = resetStack.peek().value();
-                        } else if (Double.isNaN(previousBucketValue) == false) {
-                            lastPersisted = previousBucketValue;
-                        }
-                        // If there is no known last persisted value or the last persisted is larger than the current value,
-                        // we need to store the previous document to capture the reset.
-                        if (Double.isNaN(lastPersisted) || Double.compare(currentCounterValue, lastPersisted) < 0) {
-                            resetStack.push(new CounterResetDataPoints.ResetPoint(lastTimestamp, previousValue));
-                        }
-                    }
-                    // This is the last value before reset, which we always need to persist
-                    resetStack.push(new CounterResetDataPoints.ResetPoint(currentTimestamp, currentCounterValue));
-                }
-                downsampledValue = currentCounterValue;
-                previousValue = currentCounterValue;
-                assert lastTimestamp == -1 || currentTimestamp < lastTimestamp;
-                lastTimestamp = currentTimestamp;
             }
+        }
+
+        private void collectDelta(double counterValue) {
+            downsampledValue.add(counterValue);
+        }
+
+        private void collectCumulative(double currentCounterValue, long currentTimestamp) {
+            // If this the first time we encounter a value for this tsid
+            if (Double.isNaN(previousValue)) {
+                downsampledValue.reset(currentCounterValue, 0);
+                previousValue = currentCounterValue;
+                lastTimestamp = currentTimestamp;
+                return;
+            }
+
+            // when we detect a reset, (remember that field values are collected and sorted by descending order by time)
+            if (currentCounterValue > previousValue) {
+                // We check if we need to persist the previous value too
+                // If timestamp -1 means that the previous value is already persisted by a previous bucket, nothing extra to persist
+                if (lastTimestamp > 0) {
+                    // If we have a previous value in this bucket, we need to see if the last persisted value is enough to capture the
+                    // reset or not.
+                    double lastPersisted = Double.NaN;
+                    if (resetStack.isEmpty() == false) {
+                        lastPersisted = resetStack.peek().value();
+                    } else if (Double.isNaN(previousBucketValue) == false) {
+                        lastPersisted = previousBucketValue;
+                    }
+                    // If there is no known last persisted value or the last persisted is larger than the current value,
+                    // we need to store the previous document to capture the reset.
+                    if (Double.isNaN(lastPersisted) || Double.compare(currentCounterValue, lastPersisted) < 0) {
+                        resetStack.push(new CounterResetDataPoints.ResetPoint(lastTimestamp, previousValue));
+                    }
+                }
+                // This is the last value before reset, which we always need to persist
+                resetStack.push(new CounterResetDataPoints.ResetPoint(currentTimestamp, currentCounterValue));
+            }
+            downsampledValue.reset(currentCounterValue, 0);
+            previousValue = currentCounterValue;
+            assert lastTimestamp == -1 || currentTimestamp < lastTimestamp;
+            lastTimestamp = currentTimestamp;
         }
 
         public void reset() {
             isEmpty = true;
-            previousBucketValue = downsampledValue;
-            downsampledValue = Double.NaN;
+            previousBucketValue = downsampledValue.value();
+            downsampledValue.reset(0, 0);
             lastTimestamp = -1;
             resetStack.clear();
         }
@@ -264,7 +290,7 @@ abstract sealed class NumericMetricFieldDownsampler extends AbstractFieldDownsam
         @Override
         public void write(XContentBuilder builder) throws IOException {
             if (isEmpty() == false) {
-                builder.field(name(), downsampledValue);
+                builder.field(name(), downsampledValue.value());
             }
         }
 
@@ -285,7 +311,7 @@ abstract sealed class NumericMetricFieldDownsampler extends AbstractFieldDownsam
             // It is possible that the first reset data point is the same with the first data point
             // we skip this if this is the case
             var firstResetPoint = resetStack.pop();
-            if (firstResetPoint.value() != downsampledValue) {
+            if (firstResetPoint.value() != downsampledValue.value()) {
                 counterResetDataPoints.addDataPoint(name(), firstResetPoint);
             }
             while (resetStack.isEmpty() == false) {

--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/Temporality.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/Temporality.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.downsample;
+
+/**
+ * Represents the metric temporality for a time series, controlling how counter values are interpreted during downsampling.
+ * <ul>
+ *     <li>{@link #CUMULATIVE}: counter values are monotonically increasing (reset detection applies).</li>
+ *     <li>{@link #DELTA}: counter values represent increments per interval (summed during downsampling).</li>
+ *     <li>{@link #DEFAULT}: no explicit temporality was provided; falls back to cumulative behavior for counters.</li>
+ * </ul>
+ */
+enum Temporality {
+    DELTA,
+    CUMULATIVE,
+    DEFAULT;
+
+    static Temporality fromDimensionValue(Object value) {
+        if (value == null) {
+            return DEFAULT;
+        }
+        String s = value.toString();
+        if ("delta".equals(s)) {
+            return DELTA;
+        } else if ("cumulative".equals(s)) {
+            return CUMULATIVE;
+        }
+        return DEFAULT;
+    }
+}

--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/Temporality.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/Temporality.java
@@ -9,27 +9,29 @@ package org.elasticsearch.xpack.downsample;
 
 /**
  * Represents the metric temporality for a time series, controlling how counter values are interpreted during downsampling.
- * <ul>
- *     <li>{@link #CUMULATIVE}: counter values are monotonically increasing (reset detection applies).</li>
- *     <li>{@link #DELTA}: counter values represent increments per interval (summed during downsampling).</li>
- *     <li>{@link #DEFAULT}: no explicit temporality was provided; falls back to cumulative behavior for counters.</li>
- * </ul>
  */
 enum Temporality {
     DELTA,
     CUMULATIVE,
+    /**
+     * The default temporality, which depends on the metric type: cumulative for counters, delta for histograms.
+     */
     DEFAULT;
 
     static Temporality fromDimensionValue(Object value) {
         if (value == null) {
             return DEFAULT;
         }
-        String s = value.toString();
-        if ("delta".equals(s)) {
-            return DELTA;
-        } else if ("cumulative".equals(s)) {
-            return CUMULATIVE;
+        if (value instanceof String s) {
+            if ("delta".equals(s)) {
+                return DELTA;
+            } else if ("cumulative".equals(s)) {
+                return CUMULATIVE;
+            }
+            // Use default for unknown values
+            return DEFAULT;
+        } else {
+            throw new IllegalArgumentException("Unexpected type for temporality value: " + value.getClass());
         }
-        return DEFAULT;
     }
 }

--- a/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/AggregateCounterFieldDownsamplerTests.java
+++ b/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/AggregateCounterFieldDownsamplerTests.java
@@ -31,12 +31,12 @@ public class AggregateCounterFieldDownsamplerTests extends ESTestCase {
         IntArrayList docIdBuffer = IntArrayList.from(6, 5, 4, 3, 2, 1, 0);
         long[] timeValues = new long[] { 70, 60, 50, 40, 30, 20, 10 };
         SortedNumericDoubleValues counterValues = createNumericValuesInstance(docIdBuffer, 64, 32, 16, 8, 4, 2, 1);
-        producer.collect(counterValues, timeValues, docIdBuffer);
+        producer.collect(counterValues, timeValues, docIdBuffer, randomFrom(Temporality.DEFAULT, Temporality.CUMULATIVE));
         producer.updateResetDataPoints(resetDataPoints);
-        assertThat(producer.downsampledValue, equalTo(1.0));
+        assertThat(producer.downsampledValue.value(), equalTo(1.0));
         assertThat(resetDataPoints.isEmpty(), equalTo(true));
         producer.reset();
-        assertThat(producer.downsampledValue, equalTo(Double.NaN));
+        assertThat(producer.downsampledValue.value(), equalTo(0.0));
         assertThat(producer.previousValue, equalTo(1.0));
         assertThat(producer.lastTimestamp, equalTo(-1L));
         producer.tsidReset();
@@ -55,9 +55,9 @@ public class AggregateCounterFieldDownsamplerTests extends ESTestCase {
         IntArrayList docIdBuffer = IntArrayList.from(6, 5, 4, 3, 2, 1, 0);
         long[] timeValues = new long[] { 70, 60, 50, 40, 30, 20, 10 };
         SortedNumericDoubleValues counterValues = createNumericValuesInstance(docIdBuffer, 8, 5, 16, 8, 4, 2, 1);
-        producer.collect(counterValues, timeValues, docIdBuffer);
+        producer.collect(counterValues, timeValues, docIdBuffer, randomFrom(Temporality.DEFAULT, Temporality.CUMULATIVE));
         producer.updateResetDataPoints(resetDataPoints);
-        assertThat(producer.downsampledValue, equalTo(1.0));
+        assertThat(producer.downsampledValue.value(), equalTo(1.0));
         assertThat(resetDataPoints.countResetDocuments(), equalTo(2));
         resetDataPoints.processDataPoints((timestamp, dataPoints) -> {
             assertThat(timestamp, anyOf(equalTo(60L), equalTo(50L)));
@@ -69,7 +69,7 @@ public class AggregateCounterFieldDownsamplerTests extends ESTestCase {
             }
         });
         producer.reset();
-        assertThat(producer.downsampledValue, equalTo(Double.NaN));
+        assertThat(producer.downsampledValue.value(), equalTo(0.0));
         assertThat(producer.previousValue, equalTo(1.0));
         assertThat(producer.lastTimestamp, equalTo(-1L));
         producer.tsidReset();
@@ -89,16 +89,16 @@ public class AggregateCounterFieldDownsamplerTests extends ESTestCase {
         IntArrayList docIdBuffer = IntArrayList.from(2, 1, 0);
         long[] timeValues = new long[] { 30, 20, 10 };
         SortedNumericDoubleValues counterValues = createNumericValuesInstance(docIdBuffer, 7, 0, 1);
-        producer.collect(counterValues, timeValues, docIdBuffer);
+        producer.collect(counterValues, timeValues, docIdBuffer, randomFrom(Temporality.DEFAULT, Temporality.CUMULATIVE));
         producer.updateResetDataPoints(resetDataPoints);
-        assertThat(producer.downsampledValue, equalTo(1.0));
+        assertThat(producer.downsampledValue.value(), equalTo(1.0));
         assertThat(resetDataPoints.countResetDocuments(), equalTo(1));
         resetDataPoints.processDataPoints((timestamp, dataPoints) -> {
             assertThat(timestamp, equalTo(20L));
             assertThat(dataPoints, equalTo(List.of(Tuple.tuple("my-counter", 0.0))));
         });
         producer.reset();
-        assertThat(producer.downsampledValue, equalTo(Double.NaN));
+        assertThat(producer.downsampledValue.value(), equalTo(0.0));
         assertThat(producer.previousValue, equalTo(1.0));
         assertThat(producer.lastTimestamp, equalTo(-1L));
         producer.tsidReset();
@@ -119,9 +119,9 @@ public class AggregateCounterFieldDownsamplerTests extends ESTestCase {
         IntArrayList docIdBuffer = IntArrayList.from(7, 6, 5, 4, 3, 2, 1, 0);
         long[] timeValues = new long[] { 80, 70, 60, 50, 40, 30, 20, 10 };
         SortedNumericDoubleValues counterValues = createNumericValuesInstance(docIdBuffer, 4, 2, 5, 3, 8, 4, 2, 1);
-        producer.collect(counterValues, timeValues, docIdBuffer);
+        producer.collect(counterValues, timeValues, docIdBuffer, randomFrom(Temporality.DEFAULT, Temporality.CUMULATIVE));
         producer.updateResetDataPoints(resetDataPoints);
-        assertThat(producer.downsampledValue, equalTo(1.0));
+        assertThat(producer.downsampledValue.value(), equalTo(1.0));
         assertThat(resetDataPoints.countResetDocuments(), equalTo(3));
         resetDataPoints.processDataPoints((timestamp, dataPoints) -> {
             assertThat(timestamp, anyOf(equalTo(40L), equalTo(60L), equalTo(70L)));
@@ -136,7 +136,7 @@ public class AggregateCounterFieldDownsamplerTests extends ESTestCase {
             }
         });
         producer.reset();
-        assertThat(producer.downsampledValue, equalTo(Double.NaN));
+        assertThat(producer.downsampledValue.value(), equalTo(0.0));
         assertThat(producer.previousValue, equalTo(1.0));
         assertThat(producer.lastTimestamp, equalTo(-1L));
         producer.tsidReset();
@@ -157,9 +157,9 @@ public class AggregateCounterFieldDownsamplerTests extends ESTestCase {
         IntArrayList docIdBuffer = IntArrayList.from(6, 5, 4, 3, 2, 1, 0);
         long[] timeValues = new long[] { 70, 60, 50, 40, 30, 20, 10 };
         SortedNumericDoubleValues counterValues = createNumericValuesInstance(docIdBuffer, 4, 2, 5, 3, 4, 2, 1);
-        producer.collect(counterValues, timeValues, docIdBuffer);
+        producer.collect(counterValues, timeValues, docIdBuffer, randomFrom(Temporality.DEFAULT, Temporality.CUMULATIVE));
         producer.updateResetDataPoints(resetDataPoints);
-        assertThat(producer.downsampledValue, equalTo(1.0));
+        assertThat(producer.downsampledValue.value(), equalTo(1.0));
         assertThat(resetDataPoints.countResetDocuments(), equalTo(4));
         resetDataPoints.processDataPoints((timestamp, dataPoints) -> {
             assertThat(timestamp, anyOf(equalTo(30L), equalTo(40L), equalTo(50L), equalTo(60L)));
@@ -177,7 +177,7 @@ public class AggregateCounterFieldDownsamplerTests extends ESTestCase {
             }
         });
         producer.reset();
-        assertThat(producer.downsampledValue, equalTo(Double.NaN));
+        assertThat(producer.downsampledValue.value(), equalTo(0.0));
         assertThat(producer.previousValue, equalTo(1.0));
         assertThat(producer.lastTimestamp, equalTo(-1L));
         producer.tsidReset();
@@ -199,9 +199,9 @@ public class AggregateCounterFieldDownsamplerTests extends ESTestCase {
         IntArrayList docIdBuffer = IntArrayList.from(6, 5, 4);
         long[] timeValues = new long[] { 70, 60, 50 };
         SortedNumericDoubleValues counterValues = createNumericValuesInstance(docIdBuffer, 6, 5, 4);
-        producer.collect(counterValues, timeValues, docIdBuffer);
+        producer.collect(counterValues, timeValues, docIdBuffer, randomFrom(Temporality.DEFAULT, Temporality.CUMULATIVE));
         producer.updateResetDataPoints(resetDataPoints);
-        assertThat(producer.downsampledValue, equalTo(4.0));
+        assertThat(producer.downsampledValue.value(), equalTo(4.0));
         assertThat(resetDataPoints.isEmpty(), equalTo(true));
         producer.reset();
 
@@ -209,17 +209,17 @@ public class AggregateCounterFieldDownsamplerTests extends ESTestCase {
         docIdBuffer = IntArrayList.from(3, 2, 1, 0);
         timeValues = new long[] { 40, 30, 20, 10 };
         counterValues = createNumericValuesInstance(docIdBuffer, 2, 0, 8, 7);
-        producer.collect(counterValues, timeValues, docIdBuffer);
+        producer.collect(counterValues, timeValues, docIdBuffer, randomFrom(Temporality.DEFAULT, Temporality.CUMULATIVE));
         resetDataPoints = new CounterResetDataPoints();
         producer.updateResetDataPoints(resetDataPoints);
-        assertThat(producer.downsampledValue, equalTo(7.0));
+        assertThat(producer.downsampledValue.value(), equalTo(7.0));
         assertThat(resetDataPoints.countResetDocuments(), equalTo(1));
         resetDataPoints.processDataPoints((timestamp, dataPoints) -> {
             assertThat(timestamp, equalTo(20L));
             assertThat(dataPoints, equalTo(List.of(Tuple.tuple("my-counter", 8.0))));
         });
         producer.reset();
-        assertThat(producer.downsampledValue, equalTo(Double.NaN));
+        assertThat(producer.downsampledValue.value(), equalTo(0.0));
         assertThat(producer.previousValue, equalTo(7.0));
         assertThat(producer.lastTimestamp, equalTo(-1L));
         producer.tsidReset();
@@ -241,9 +241,9 @@ public class AggregateCounterFieldDownsamplerTests extends ESTestCase {
         IntArrayList docIdBuffer = IntArrayList.from(6, 5, 4);
         long[] timeValues = new long[] { 40, 20, 10 };
         SortedNumericDoubleValues counterValues = createNumericValuesInstance(docIdBuffer, 6, 5, 4);
-        producer.collect(counterValues, timeValues, docIdBuffer);
+        producer.collect(counterValues, timeValues, docIdBuffer, randomFrom(Temporality.DEFAULT, Temporality.CUMULATIVE));
         producer.updateResetDataPoints(resetDataPoints);
-        assertThat(producer.downsampledValue, equalTo(4.0));
+        assertThat(producer.downsampledValue.value(), equalTo(4.0));
         assertThat(resetDataPoints.isEmpty(), equalTo(true));
         producer.tsidReset();
 
@@ -251,10 +251,10 @@ public class AggregateCounterFieldDownsamplerTests extends ESTestCase {
         docIdBuffer = IntArrayList.from(3, 2, 1, 0);
         timeValues = new long[] { 40, 30, 20, 10 };
         counterValues = createNumericValuesInstance(docIdBuffer, 2, 0, 8, 7);
-        producer.collect(counterValues, timeValues, docIdBuffer);
+        producer.collect(counterValues, timeValues, docIdBuffer, randomFrom(Temporality.DEFAULT, Temporality.CUMULATIVE));
         resetDataPoints = new CounterResetDataPoints();
         producer.updateResetDataPoints(resetDataPoints);
-        assertThat(producer.downsampledValue, equalTo(7.0));
+        assertThat(producer.downsampledValue.value(), equalTo(7.0));
         assertThat(resetDataPoints.countResetDocuments(), equalTo(2));
         resetDataPoints.processDataPoints((timestamp, dataPoints) -> {
             assertThat(timestamp, anyOf(equalTo(20L), equalTo(30L)));
@@ -266,11 +266,92 @@ public class AggregateCounterFieldDownsamplerTests extends ESTestCase {
             }
         });
         producer.reset();
-        assertThat(producer.downsampledValue, equalTo(Double.NaN));
+        assertThat(producer.downsampledValue.value(), equalTo(0.0));
         assertThat(producer.previousValue, equalTo(7.0));
         assertThat(producer.lastTimestamp, equalTo(-1L));
         producer.tsidReset();
         assertThat(producer.previousValue, equalTo(Double.NaN));
+    }
+
+    /**
+     * Delta temporality: values represent increments and are summed within a bucket.
+     * No reset data points are produced regardless of value patterns.
+     */
+    public void testDeltaCounterSumsValues() throws IOException {
+        CounterResetDataPoints resetDataPoints = new CounterResetDataPoints();
+        NumericMetricFieldDownsampler.AggregateCounter producer = new NumericMetricFieldDownsampler.AggregateCounter("my-counter", null);
+        IntArrayList docIdBuffer = IntArrayList.from(6, 5, 4, 3, 2, 1, 0);
+        long[] timeValues = new long[] { 70, 60, 50, 40, 30, 20, 10 };
+        // Values that would trigger reset detection in cumulative mode (5 > 3, 8 > 2), but delta just sums them
+        SortedNumericDoubleValues counterValues = createNumericValuesInstance(docIdBuffer, 8, 5, 16, 8, 4, 2, 1);
+        producer.collect(counterValues, timeValues, docIdBuffer, Temporality.DELTA);
+        producer.updateResetDataPoints(resetDataPoints);
+        assertThat(producer.downsampledValue.value(), equalTo(44.0));
+        assertThat(resetDataPoints.isEmpty(), equalTo(true));
+
+        // Reset and collect a second bucket
+        producer.reset();
+        assertThat(producer.downsampledValue.value(), equalTo(0.0));
+
+        docIdBuffer = IntArrayList.from(9, 8, 7);
+        timeValues = new long[] { 100, 90, 80 };
+        counterValues = createNumericValuesInstance(docIdBuffer, 3, 7, 10);
+        producer.collect(counterValues, timeValues, docIdBuffer, Temporality.DELTA);
+        resetDataPoints = new CounterResetDataPoints();
+        producer.updateResetDataPoints(resetDataPoints);
+        assertThat(producer.downsampledValue.value(), equalTo(20.0));
+        assertThat(resetDataPoints.isEmpty(), equalTo(true));
+    }
+
+    /**
+     * Mixed temporality across tsid changes: delta and cumulative tsids are handled independently.
+     */
+    public void testDeltaCounterWithTsidChange() throws IOException {
+        NumericMetricFieldDownsampler.AggregateCounter producer = new NumericMetricFieldDownsampler.AggregateCounter("my-counter", null);
+        CounterResetDataPoints resetDataPoints;
+
+        // tsid_1: delta — values are summed
+        IntArrayList docIdBuffer = IntArrayList.from(2, 1, 0);
+        long[] timeValues = new long[] { 30, 20, 10 };
+        SortedNumericDoubleValues counterValues = createNumericValuesInstance(docIdBuffer, 5, 3, 2);
+        producer.collect(counterValues, timeValues, docIdBuffer, Temporality.DELTA);
+        assertThat(producer.downsampledValue.value(), equalTo(10.0));
+        resetDataPoints = new CounterResetDataPoints();
+        producer.updateResetDataPoints(resetDataPoints);
+        assertThat(resetDataPoints.isEmpty(), equalTo(true));
+        producer.tsidReset();
+
+        // tsid_2: delta — starts fresh, values are summed
+        docIdBuffer = IntArrayList.from(5, 4, 3);
+        timeValues = new long[] { 30, 20, 10 };
+        counterValues = createNumericValuesInstance(docIdBuffer, 100, 200, 300);
+        producer.collect(counterValues, timeValues, docIdBuffer, Temporality.DELTA);
+        assertThat(producer.downsampledValue.value(), equalTo(600.0));
+        resetDataPoints = new CounterResetDataPoints();
+        producer.updateResetDataPoints(resetDataPoints);
+        assertThat(resetDataPoints.isEmpty(), equalTo(true));
+        producer.tsidReset();
+
+        // tsid_3: cumulative with a reset — oldest value kept, reset data points produced
+        docIdBuffer = IntArrayList.from(9, 8, 7, 6);
+        timeValues = new long[] { 40, 30, 20, 10 };
+        counterValues = createNumericValuesInstance(docIdBuffer, 2, 0, 8, 7);
+        producer.collect(counterValues, timeValues, docIdBuffer, randomFrom(Temporality.DEFAULT, Temporality.CUMULATIVE));
+        assertThat(producer.downsampledValue.value(), equalTo(7.0));
+        resetDataPoints = new CounterResetDataPoints();
+        producer.updateResetDataPoints(resetDataPoints);
+        assertThat(resetDataPoints.countResetDocuments(), equalTo(2));
+        producer.tsidReset();
+
+        // tsid_4: delta again — fully independent from the cumulative tsid
+        docIdBuffer = IntArrayList.from(12, 11, 10);
+        timeValues = new long[] { 30, 20, 10 };
+        counterValues = createNumericValuesInstance(docIdBuffer, 7, 3, 1);
+        producer.collect(counterValues, timeValues, docIdBuffer, Temporality.DELTA);
+        assertThat(producer.downsampledValue.value(), equalTo(11.0));
+        resetDataPoints = new CounterResetDataPoints();
+        producer.updateResetDataPoints(resetDataPoints);
+        assertThat(resetDataPoints.isEmpty(), equalTo(true));
     }
 
     static SortedNumericDoubleValues createNumericValuesInstance(IntArrayList docIdBuffer, double... values) {


### PR DESCRIPTION
Part of https://github.com/elastic/elasticsearch/issues/139189.

Adds support for respecting the temporality dimension for counters during downsampling.
Exponential histograms will follow in a separate PR.
