### PR TITLE
Unmute `StatelessCoordinationTests#testAckListenerReceivesNacksIfPublicationTimesOut`

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -279,9 +279,6 @@ tests:
 - class: org.elasticsearch.xpack.stateless.cache.StatelessOnlinePrewarmingIT
   method: testShardPrewarming
   issue: https://github.com/elastic/elasticsearch/issues/147838
-- class: org.elasticsearch.xpack.stateless.cluster.coordination.StatelessCoordinationTests
-  method: testAckListenerReceivesNacksIfPublicationTimesOut
-  issue: https://github.com/elastic/elasticsearch/issues/147839
 - class: org.elasticsearch.xpack.stateless.commits.StatelessClusterIntegrityStressIT
   method: testRandomActivities
   issue: https://github.com/elastic/elasticsearch/issues/147841


### PR DESCRIPTION
Fixed by #140514
Closes #147839
