### PR TITLE
ES|QL PromQL: implicit to_counter() for counter functions on plain numerics

### DIFF
--- a/docs/changelog/149977.yaml
+++ b/docs/changelog/149977.yaml
@@ -1,0 +1,5 @@
+area: PromQL
+issues: []
+pr: 149977
+summary: "ES|QL PromQL: implicit to_counter() for counter functions on plain numerics"
+type: enhancement

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-promql.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-promql.csv-spec
@@ -1095,3 +1095,131 @@ PROMQL index=k8s step=1h result=(scalar(sum(network.cost)) + 1);
 result:double | step:datetime
 62.0          | 2024-05-10T00:00:00.000Z
 ;
+
+// PromQL rate/increase/irate accept plain numeric range vectors. ES|QL wraps non-counter
+// inputs with to_counter() during translation so counter functions work on plain numerics.
+rate_on_plain_numeric_long
+required_capability: promql_command_v0
+required_capability: promql_implicit_to_counter
+required_capability: rate_with_interpolation_v2
+// network.bytes_in is plain long (no counter mapping); implicit to_counter() enables rate().
+PROMQL index=k8s step=1m rate_bytes_in=(round(avg(rate(network.bytes_in[1m])), 0.001))
+| SORT rate_bytes_in DESC, step DESC | LIMIT 10;
+
+rate_bytes_in:double | step:datetime
+18.146               | 2024-05-10T00:20:00.000Z
+15.921000000000001   | 2024-05-10T00:10:00.000Z
+15.22                | 2024-05-10T00:17:00.000Z
+14.16                | 2024-05-10T00:04:00.000Z
+12.856               | 2024-05-10T00:11:00.000Z
+11.636000000000001   | 2024-05-10T00:00:00.000Z
+11.299               | 2024-05-10T00:18:00.000Z
+10.665000000000001   | 2024-05-10T00:19:00.000Z
+10.087               | 2024-05-10T00:09:00.000Z
+9.859                | 2024-05-10T00:06:00.000Z
+;
+
+rate_on_plain_numeric_gauge
+required_capability: promql_command_v0
+required_capability: promql_implicit_to_counter
+required_capability: rate_with_interpolation_v2
+// network.eth0.tx is mapped as gauge (integer); implicit to_counter() enables rate().
+PROMQL index=k8s step=1m rate_tx=(round(avg(rate(network.eth0.tx[1m])), 0.001))
+| SORT rate_tx DESC, step DESC | LIMIT 10;
+
+rate_tx:double | step:datetime
+2.828          | 2024-05-10T00:04:00.000Z
+2.684          | 2024-05-10T00:11:00.000Z
+2.559          | 2024-05-10T00:10:00.000Z
+2.116          | 2024-05-10T00:12:00.000Z
+1.915          | 2024-05-10T00:13:00.000Z
+1.838          | 2024-05-10T00:07:00.000Z
+1.564          | 2024-05-10T00:17:00.000Z
+1.538          | 2024-05-10T00:00:00.000Z
+1.407          | 2024-05-10T00:06:00.000Z
+1.401          | 2024-05-10T00:18:00.000Z
+;
+
+rate_on_counter_field
+required_capability: promql_command_v0
+required_capability: promql_implicit_to_counter
+required_capability: rate_with_interpolation_v2
+// network.total_bytes_in is counter_long; implicit to_counter() is a no-op.
+PROMQL index=k8s step=5m rate_bytes_in=(round(avg by (cluster) (rate(network.total_bytes_in[5m])), 0.001))
+| SORT rate_bytes_in DESC, step, cluster | LIMIT 10;
+
+rate_bytes_in:double | step:datetime            | cluster:keyword
+25.832               | 2024-05-10T00:20:00.000Z | prod
+15.427               | 2024-05-10T00:15:00.000Z | qa
+13.765               | 2024-05-10T00:05:00.000Z | qa
+12.737               | 2024-05-10T00:15:00.000Z | prod
+8.152000000000001    | 2024-05-10T00:20:00.000Z | qa
+7.822                | 2024-05-10T00:10:00.000Z | qa
+7.5360000000000005   | 2024-05-10T00:10:00.000Z | prod
+7.17                 | 2024-05-10T00:05:00.000Z | staging
+6.831                | 2024-05-10T00:10:00.000Z | staging
+6.022                | 2024-05-10T00:15:00.000Z | staging
+;
+
+increase_on_plain_numeric_gauge
+required_capability: promql_command_v0
+required_capability: promql_implicit_to_counter
+required_capability: rate_with_interpolation_v3
+// network.eth0.tx is mapped as gauge (integer); implicit to_counter() enables increase().
+PROMQL index=k8s step=1m increase_tx=(round(avg(increase(network.eth0.tx[1m])), 0.001))
+| SORT increase_tx DESC, step DESC | LIMIT 10;
+
+increase_tx:double | step:datetime
+110.259            | 2024-05-10T00:07:00.000Z
+100.49000000000001 | 2024-05-10T00:04:00.000Z
+97.73100000000001  | 2024-05-10T00:11:00.000Z
+93.247             | 2024-05-10T00:17:00.000Z
+92.281             | 2024-05-10T00:00:00.000Z
+81.574             | 2024-05-10T00:18:00.000Z
+79.368             | 2024-05-10T00:09:00.000Z
+78.333             | 2024-05-10T00:19:00.000Z
+72.68              | 2024-05-10T00:15:00.000Z
+70.18900000000001  | 2024-05-10T00:14:00.000Z
+;
+
+increase_on_plain_numeric_long
+required_capability: promql_command_v0
+required_capability: promql_implicit_to_counter
+required_capability: rate_with_interpolation_v3
+// network.bytes_in is plain long (no counter mapping); implicit to_counter() enables increase().
+PROMQL index=k8s step=1m increase_bytes_in=(round(avg(increase(network.bytes_in[1m])), 0.001))
+| SORT increase_bytes_in DESC, step DESC | LIMIT 10;
+
+increase_bytes_in:double | step:datetime
+911.77                   | 2024-05-10T00:17:00.000Z
+698.188                  | 2024-05-10T00:00:00.000Z
+645.7230000000001        | 2024-05-10T00:18:00.000Z
+639.902                  | 2024-05-10T00:19:00.000Z
+599.2520000000001        | 2024-05-10T00:09:00.000Z
+596.931                  | 2024-05-10T00:04:00.000Z
+568.997                  | 2024-05-10T00:06:00.000Z
+561.376                  | 2024-05-10T00:07:00.000Z
+507.112                  | 2024-05-10T00:11:00.000Z
+495.012                  | 2024-05-10T00:15:00.000Z
+;
+
+irate_on_plain_numeric_long
+required_capability: promql_command_v0
+required_capability: promql_implicit_to_counter
+required_capability: rate_with_interpolation_v2
+// network.bytes_in is plain long (no counter mapping); implicit to_counter() enables irate().
+PROMQL index=k8s step=1m irate_bytes_in=(round(avg(irate(network.bytes_in[1m])), 0.001))
+| SORT irate_bytes_in DESC, step DESC | LIMIT 10;
+
+irate_bytes_in:double | step:datetime
+127.656               | 2024-05-10T00:09:00.000Z
+114.419               | 2024-05-10T00:22:00.000Z
+100.233               | 2024-05-10T00:02:00.000Z
+94.0                  | 2024-05-10T00:00:00.000Z
+77.313                | 2024-05-10T00:11:00.000Z
+51.588                | 2024-05-10T00:19:00.000Z
+33.17                 | 2024-05-10T00:15:00.000Z
+31.231                | 2024-05-10T00:04:00.000Z
+29.088                | 2024-05-10T00:17:00.000Z
+29.0                  | 2024-05-10T00:07:00.000Z
+;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -2177,6 +2177,13 @@ public class EsqlCapabilities {
         PROMQL_IMPLICIT_RANGE_SELECTOR,
 
         /**
+         * PromQL counter functions ({@code rate}, {@code increase}, {@code irate}) accept plain numeric range
+         * vectors and are translated with an implicit {@code to_counter()} wrap when the metric is not
+         * already counter-typed.
+         */
+        PROMQL_IMPLICIT_TO_COUNTER,
+
+        /**
          * Support for PromQL {@code without} grouping.
          */
         PROMQL_WITHOUT_GROUPING,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/PromqlCommand.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/PromqlCommand.java
@@ -526,6 +526,8 @@ public class PromqlCommand extends UnaryPlan
      * Only checks when the function's direct child is a RangeSelector, because InstantSelectors
      * are implicitly wrapped in LastOverTime during translation, which converts counter types
      * to their numeric base types. RangeSelectors pass the raw field type through to the function.
+     * Functions with {@link PromqlFunctionDefinition.CounterSupport#REQUIRED} accept plain numeric
+     * metrics and are wrapped with {@code to_counter()} during translation.
      */
     private static void validateCounterSupport(PromqlFunctionCall functionCall, Failures failures) {
         if (functionCall.child() instanceof RangeSelector s && s.series() instanceof FieldAttribute seriesField) {
@@ -540,17 +542,6 @@ public class PromqlCommand extends UnaryPlan
                         functionCall,
                         "function [{}] does not support counter metric [{}] of type [{}];"
                             + " use rate() or increase() to convert counters first [{}]",
-                        functionCall.functionName(),
-                        seriesField.name(),
-                        seriesType.typeName(),
-                        functionCall.sourceText()
-                    )
-                );
-            } else if (DataType.isCounter(seriesType) == false && counterSupport == PromqlFunctionDefinition.CounterSupport.REQUIRED) {
-                failures.add(
-                    fail(
-                        functionCall,
-                        "function [{}] requires a counter metric, but [{}] has type [{}] [{}]",
                         functionCall.functionName(),
                         seriesField.name(),
                         seriesType.typeName(),

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/PromqlFunctionCall.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/PromqlFunctionCall.java
@@ -12,6 +12,8 @@ import org.elasticsearch.xpack.esql.core.capabilities.Resolvables;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToCounter;
 import org.elasticsearch.xpack.esql.expression.promql.function.FunctionType;
 import org.elasticsearch.xpack.esql.expression.promql.function.PromqlFunctionDefinition;
 import org.elasticsearch.xpack.esql.expression.promql.function.PromqlFunctionRegistry;
@@ -107,6 +109,14 @@ public abstract sealed class PromqlFunctionCall extends UnaryPlan implements Pro
      */
     public Expression buildEsqlFunction(Expression target, PromqlFunctionRegistry.PromqlContext ctx) {
         try {
+            // PromQL rate/increase/irate accept any numeric range vector. ES|QL's underlying functions
+            // require counter-typed inputs, so plain numerics (e.g. a gauge mapped as long) are wrapped
+            // with to_counter() here. Counter-typed fields are passed through unchanged.
+            if (target != null
+                && definition.counterSupport() == PromqlFunctionDefinition.CounterSupport.REQUIRED
+                && DataType.isCounter(target.dataType()) == false) {
+                target = new ToCounter(source(), target);
+            }
             return definition.esqlBuilder().build(source(), target, ctx, parameters());
         } catch (Exception e) {
             throw new ParsingException(source(), "Error building ESQL function for [{}]: {}", functionName(), e.getMessage());

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/promql/PromqlVerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/promql/PromqlVerifierTests.java
@@ -209,11 +209,9 @@ public class PromqlVerifierTests extends ESTestCase {
     }
 
     public void testGaugeMetricWithCounterOnlyFunction() {
-        // network.connections is a gauge - rate() requires counter metrics
-        tsdb.error(
-            "PROMQL index=test step=5m rate(network.connections[5m])",
-            containsString("function [rate] requires a counter metric, but [network.connections] has type [long]")
-        );
+        // network.connections is a gauge; rate() auto-wraps plain numerics with to_counter()
+        var plan = tsdb.query("PROMQL index=test step=5m rate(network.connections[5m])");
+        assertTrue("rate() on a plain numeric gauge should be valid (implicit to_counter wrap)", plan.resolved());
     }
 
     public void testRateOnNonNumericField() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlPlanFunctionCallTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlPlanFunctionCallTests.java
@@ -11,19 +11,25 @@ import org.elasticsearch.xpack.esql.EsqlTestUtils;
 import org.elasticsearch.xpack.esql.core.expression.Alias;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expressions;
+import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.FoldContext;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.LastOverTime;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.Rate;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Sum;
 import org.elasticsearch.xpack.esql.expression.function.grouping.Bucket;
+import org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToCounter;
 import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNotNull;
 import org.elasticsearch.xpack.esql.expression.promql.function.PromqlFunctionRegistry;
+import org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.TranslatePromqlToEsqlPlan;
 import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
 import org.elasticsearch.xpack.esql.plan.logical.Eval;
 import org.elasticsearch.xpack.esql.plan.logical.Filter;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.Project;
 import org.elasticsearch.xpack.esql.plan.logical.TimeSeriesAggregate;
+import org.elasticsearch.xpack.esql.plan.logical.promql.PromqlCommand;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -32,10 +38,13 @@ import java.util.List;
 
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.TEST_PROMQL_FUNCTION_REGISTRY;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.as;
+import static org.elasticsearch.xpack.esql.core.type.DataType.isCounter;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class PromqlPlanFunctionCallTests extends AbstractPromqlPlanOptimizerTests {
 
@@ -149,6 +158,33 @@ public class PromqlPlanFunctionCallTests extends AbstractPromqlPlanOptimizerTest
         assertConstantResult("clamp_max(vector(5), 10)", equalTo(5.0));
         assertConstantResult("clamp_max(vector(15), 10)", equalTo(10.0));
         assertConstantResult("clamp_max(vector(10), 10)", equalTo(10.0));
+    }
+
+    public void testCounterRequiredFunctionWrapsPlainNumericWithToCounter() {
+        // network.eth0.tx is mapped as a gauge (k8s-mappings.json)
+        Rate rate = rateFromPromql("PROMQL index=k8s step=5m rate=(rate(network.eth0.tx[5m]))");
+
+        ToCounter toCounter = as(rate.field(), ToCounter.class);
+        FieldAttribute field = as(toCounter.field(), FieldAttribute.class);
+        assertThat(field.name(), equalTo("network.eth0.tx"));
+        assertFalse(isCounter(field.dataType()));
+    }
+
+    public void testCounterRequiredFunctionSkipsWrapForCounterInput() {
+        // network.total_bytes_in is mapped as a counter (k8s-mappings.json)
+        Rate rate = rateFromPromql("PROMQL index=k8s step=5m rate=(rate(network.total_bytes_in[5m]))");
+
+        FieldAttribute field = as(rate.field(), FieldAttribute.class);
+        assertThat(field.name(), equalTo("network.total_bytes_in"));
+        assertTrue(isCounter(field.dataType()));
+    }
+
+    private Rate rateFromPromql(String query) {
+        LogicalPlan analyzed = planPromql(query, false);
+        PromqlCommand promql = analyzed.collect(PromqlCommand.class).getFirst();
+        LogicalPlan translated = new TranslatePromqlToEsqlPlan().apply(promql, logicalOptimizerCtx);
+        TimeSeriesAggregate tsAggregate = translated.collect(TimeSeriesAggregate.class).getFirst();
+        return tsAggregate.aggregates().getFirst().collect(Rate.class).getFirst();
     }
 
     /**


### PR DESCRIPTION
## Summary

PromQL `rate()`, `increase()`, and `irate()` accept any numeric range vector in Prometheus, but the ES|QL PromQL translation previously rejected non-counter (plain numeric) fields for these functions with a hard error.

- Removes the verifier error for plain numeric inputs to counter-required functions
- Adds an implicit `to_counter()` wrap in `PromqlFunctionCall.buildEsqlFunction()` when a counter-required function receives a non-counter field, so the underlying ES|QL aggregate can operate on it correctly
- Adds a `PROMQL_IMPLICIT_TO_COUNTER` capability flag to gate the new behaviour
- Adds csv-spec integration tests covering `rate`, `increase`, and `irate` on gauge-mapped `long`, gauge-mapped `integer`, and `counter_long` inputs
- Adds unit tests verifying the `to_counter()` wrap is injected for plain numeric fields and skipped for counter-typed fields