### PR TITLE
Add HTTPS tests for `repository-s3`

### DIFF
--- a/modules/repository-s3/build.gradle
+++ b/modules/repository-s3/build.gradle
@@ -62,6 +62,7 @@ dependencies {
 
   testImplementation project(':test:fixtures:s3-fixture')
   testImplementation "software.amazon.awssdk:endpoints-spi:${versions.awsv2sdk}"
+  testImplementation project(':test:fixtures:tls-utils')
 
   internalClusterTestImplementation project(':test:fixtures:aws-fixture-utils')
   internalClusterTestImplementation project(':test:fixtures:minio-fixture')
@@ -71,6 +72,7 @@ dependencies {
   yamlRestTestImplementation project(':test:fixtures:aws-fixture-utils')
   yamlRestTestImplementation project(':test:fixtures:s3-fixture')
   yamlRestTestImplementation project(':test:fixtures:testcontainer-utils')
+  yamlRestTestImplementation project(':test:fixtures:tls-utils')
   yamlRestTestImplementation project(':test:framework')
   yamlRestTestRuntimeOnly "org.slf4j:slf4j-simple:${versions.slf4j}"
 
@@ -81,6 +83,7 @@ dependencies {
   javaRestTestImplementation project(':test:fixtures:minio-fixture')
   javaRestTestImplementation project(':test:fixtures:s3-fixture')
   javaRestTestImplementation project(':test:fixtures:testcontainer-utils')
+  javaRestTestImplementation project(':test:fixtures:tls-utils')
   javaRestTestImplementation project(':test:framework')
   javaRestTestRuntimeOnly "org.slf4j:slf4j-simple:${versions.slf4j}"
 }

--- a/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3BasicCredentialsRestIT.java
+++ b/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3BasicCredentialsRestIT.java
@@ -38,6 +38,7 @@ public class RepositoryS3BasicCredentialsRestIT extends AbstractRepositoryS3Rest
     private static final Supplier<String> regionSupplier = new DynamicRegionSupplier();
     private static final S3HttpFixture s3Fixture = new S3HttpFixture(
         true,
+        null,
         BUCKET,
         BASE_PATH,
         S3ConsistencyModel::randomConsistencyModel,

--- a/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3ConditionalWritesUnsupportedRestIT.java
+++ b/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3ConditionalWritesUnsupportedRestIT.java
@@ -55,6 +55,7 @@ public class RepositoryS3ConditionalWritesUnsupportedRestIT extends AbstractRepo
 
     private static final S3HttpFixture s3Fixture = new S3HttpFixture(
         true,
+        null,
         BUCKET,
         BASE_PATH,
         S3ConsistencyModel::randomConsistencyModel,

--- a/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3ContentIntegrityRestIT.java
+++ b/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3ContentIntegrityRestIT.java
@@ -42,6 +42,7 @@ public class RepositoryS3ContentIntegrityRestIT extends AbstractRepositoryS3Rest
     private static final Supplier<String> regionSupplier = new DynamicRegionSupplier();
     private static final S3HttpFixture s3Fixture = new S3HttpFixture(
         true,
+        null,
         BUCKET,
         BASE_PATH,
         S3ConsistencyModel::randomConsistencyModel,

--- a/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3EcsCredentialsRestIT.java
+++ b/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3EcsCredentialsRestIT.java
@@ -46,6 +46,7 @@ public class RepositoryS3EcsCredentialsRestIT extends AbstractRepositoryS3RestTe
 
     private static final S3HttpFixture s3Fixture = new S3HttpFixture(
         true,
+        null,
         BUCKET,
         BASE_PATH,
         S3ConsistencyModel::randomConsistencyModel,

--- a/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3ImdsV2CredentialsRestIT.java
+++ b/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3ImdsV2CredentialsRestIT.java
@@ -45,6 +45,7 @@ public class RepositoryS3ImdsV2CredentialsRestIT extends AbstractRepositoryS3Res
 
     private static final S3HttpFixture s3Fixture = new S3HttpFixture(
         true,
+        null,
         BUCKET,
         BASE_PATH,
         S3ConsistencyModel::randomConsistencyModel,

--- a/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3OverHttpsRestIT.java
+++ b/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3OverHttpsRestIT.java
@@ -12,11 +12,16 @@ package org.elasticsearch.repositories.s3;
 import fixture.aws.DynamicRegionSupplier;
 import fixture.s3.S3ConsistencyModel;
 import fixture.s3.S3HttpFixture;
+import fixture.s3.S3HttpHandler;
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+import com.sun.net.httpserver.HttpHandler;
 
+import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.fixtures.testcontainers.TestContainersThreadFilter;
+import org.elasticsearch.test.fixtures.tls.TestTlsCertificate;
+import org.elasticsearch.test.fixtures.tls.TestTrustStore;
 import org.junit.ClassRule;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
@@ -24,45 +29,56 @@ import org.junit.rules.TestRule;
 import java.util.function.Supplier;
 
 import static fixture.aws.AwsCredentialsUtils.fixedAccessKey;
-import static org.hamcrest.Matchers.startsWith;
+import static org.hamcrest.Matchers.equalTo;
 
 @ThreadLeakFilters(filters = { TestContainersThreadFilter.class })
-public class RepositoryS3ExplicitProtocolRestIT extends AbstractRepositoryS3RestTestCase {
+public class RepositoryS3OverHttpsRestIT extends AbstractRepositoryS3RestTestCase {
 
-    private static final String PREFIX = getIdentifierPrefix("RepositoryS3ExplicitProtocolRestIT");
+    private static final String PREFIX = getIdentifierPrefix("RepositoryS3OverHttpsRestIT");
     private static final String BUCKET = PREFIX + "bucket";
     private static final String BASE_PATH = PREFIX + "base_path";
     private static final String ACCESS_KEY = PREFIX + "access-key";
     private static final String SECRET_KEY = PREFIX + "secret-key";
-    private static final String CLIENT = "explicit_protocol_client";
+    private static final String CLIENT = "https_s3_client";
+
+    protected static final TestTlsCertificate testTlsCertificate = TestTlsCertificate.generate("localhost");
+
+    protected static final TestTrustStore trustStore = new TestTrustStore(testTlsCertificate::getPemCertificateStream);
 
     private static final Supplier<String> regionSupplier = new DynamicRegionSupplier();
+
     private static final S3HttpFixture s3Fixture = new S3HttpFixture(
         true,
-        null,
+        testTlsCertificate,
         BUCKET,
         BASE_PATH,
         S3ConsistencyModel::randomConsistencyModel,
         fixedAccessKey(ACCESS_KEY, regionSupplier, "s3")
-    );
-
-    private static String getEndpoint() {
-        final var s3FixtureAddress = s3Fixture.getAddress();
-        assertThat(s3FixtureAddress, startsWith("http://"));
-        return "\"" + s3FixtureAddress.substring("http://".length()) + "\"";
-    }
+    ) {
+        @SuppressForbidden(reason = "implementing HTTP server for test fixture")
+        @Override
+        protected HttpHandler createHandler() {
+            final var delegate = asInstanceOf(S3HttpHandler.class, super.createHandler());
+            return exchange -> {
+                delegate.assertContentSha256Header(exchange, equalTo("UNSIGNED-PAYLOAD"));
+                delegate.handle(exchange);
+            };
+        }
+    };
 
     public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
         .module("repository-s3")
         .systemProperty("aws.region", regionSupplier)
         .keystore("s3.client." + CLIENT + ".access_key", ACCESS_KEY)
         .keystore("s3.client." + CLIENT + ".secret_key", SECRET_KEY)
-        .setting("s3.client." + CLIENT + ".endpoint", RepositoryS3ExplicitProtocolRestIT::getEndpoint)
-        .setting("s3.client." + CLIENT + ".protocol", () -> "http")
+        .setting("s3.client." + CLIENT + ".endpoint", s3Fixture::getAddress)
+        .setting("s3.client." + CLIENT + ".disable_chunked_encoding", () -> randomFrom("true", "false"), ignored -> randomBoolean())
+        .setting("s3.client." + CLIENT + ".path_style_access", "true")
+        .apply(builder -> trustStore.apply(builder, true))
         .build();
 
     @ClassRule
-    public static TestRule ruleChain = RuleChain.outerRule(s3Fixture).around(cluster);
+    public static TestRule ruleChain = RuleChain.outerRule(s3Fixture).around(trustStore).around(cluster);
 
     @Override
     protected String getTestRestCluster() {

--- a/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3RestReloadCredentialsIT.java
+++ b/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3RestReloadCredentialsIT.java
@@ -42,6 +42,7 @@ public class RepositoryS3RestReloadCredentialsIT extends ESRestTestCase {
 
     public static final S3HttpFixture s3Fixture = new S3HttpFixture(
         true,
+        null,
         BUCKET,
         BASE_PATH,
         S3ConsistencyModel::randomConsistencyModel,

--- a/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3SessionCredentialsRestIT.java
+++ b/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3SessionCredentialsRestIT.java
@@ -36,6 +36,7 @@ public class RepositoryS3SessionCredentialsRestIT extends AbstractRepositoryS3Re
 
     private static final S3HttpFixture s3Fixture = new S3HttpFixture(
         true,
+        null,
         BUCKET,
         BASE_PATH,
         S3ConsistencyModel::randomConsistencyModel,

--- a/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3StsCredentialsReloadRestIT.java
+++ b/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3StsCredentialsReloadRestIT.java
@@ -52,6 +52,7 @@ public class RepositoryS3StsCredentialsReloadRestIT extends ESRestTestCase {
 
     private static final S3HttpFixture s3HttpFixture = new S3HttpFixture(
         true,
+        null,
         BUCKET,
         BASE_PATH,
         S3ConsistencyModel::randomConsistencyModel,

--- a/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3StsCredentialsRestIT.java
+++ b/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3StsCredentialsRestIT.java
@@ -41,6 +41,7 @@ public class RepositoryS3StsCredentialsRestIT extends AbstractRepositoryS3RestTe
 
     private static final S3HttpFixture s3HttpFixture = new S3HttpFixture(
         true,
+        null,
         BUCKET,
         BASE_PATH,
         S3ConsistencyModel::randomConsistencyModel,

--- a/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3WireLoggingRestIT.java
+++ b/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3WireLoggingRestIT.java
@@ -48,6 +48,7 @@ public class RepositoryS3WireLoggingRestIT extends AbstractRepositoryS3RestTestC
     private static final Supplier<String> regionSupplier = new DynamicRegionSupplier();
     private static final S3HttpFixture s3Fixture = new S3HttpFixture(
         true,
+        null,
         BUCKET,
         BASE_PATH,
         S3ConsistencyModel::randomConsistencyModel,

--- a/modules/repository-s3/src/test/java/org/elasticsearch/repositories/s3/AddPurposeCustomQueryParameterTests.java
+++ b/modules/repository-s3/src/test/java/org/elasticsearch/repositories/s3/AddPurposeCustomQueryParameterTests.java
@@ -104,6 +104,7 @@ public class AddPurposeCustomQueryParameterTests extends ESSingleNodeTestCase {
     ) throws Throwable {
         final var httpFixture = new S3HttpFixture(
             true,
+            null,
             bucket,
             basePath,
             S3ConsistencyModel::randomConsistencyModel,

--- a/modules/repository-s3/src/yamlRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3ClientYamlTestSuiteIT.java
+++ b/modules/repository-s3/src/yamlRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3ClientYamlTestSuiteIT.java
@@ -34,6 +34,7 @@ public class RepositoryS3ClientYamlTestSuiteIT extends AbstractRepositoryS3Clien
 
     private static final S3HttpFixture s3Fixture = new S3HttpFixture(
         true,
+        null,
         "bucket",
         "base_path_integration_tests",
         S3ConsistencyModel::randomConsistencyModel,

--- a/test/fixtures/s3-fixture/build.gradle
+++ b/test/fixtures/s3-fixture/build.gradle
@@ -17,4 +17,5 @@ dependencies {
   }
   implementation project(':test:framework')
   implementation project(':test:fixtures:aws-fixture-utils')
+  implementation project(':test:fixtures:tls-utils')
 }

--- a/test/fixtures/s3-fixture/src/main/java/fixture/s3/S3HttpFixture.java
+++ b/test/fixtures/s3-fixture/src/main/java/fixture/s3/S3HttpFixture.java
@@ -11,29 +11,41 @@ package fixture.s3;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
+import com.sun.net.httpserver.HttpsConfigurator;
+import com.sun.net.httpserver.HttpsServer;
 
 import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.ssl.KeyStoreUtil;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.test.TestEsExecutors;
+import org.elasticsearch.test.fixtures.tls.TestTlsCertificate;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.rules.ExternalResource;
 
 import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.security.SecureRandom;
+import java.security.cert.Certificate;
 import java.util.Objects;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiPredicate;
 import java.util.function.Supplier;
 
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.SSLContext;
+
 import static fixture.aws.AwsCredentialsUtils.ANY_REGION;
 import static fixture.aws.AwsCredentialsUtils.checkAuthorization;
 import static fixture.aws.AwsCredentialsUtils.fixedAccessKey;
-import static fixture.aws.AwsFixtureUtils.getLocalFixtureAddress;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.startsWith;
@@ -46,22 +58,33 @@ public class S3HttpFixture extends ExternalResource {
     private ExecutorService executorService;
 
     private final boolean enabled;
+    @Nullable // if using HTTP
+    private final TestTlsCertificate tlsCertificate;
     private final String bucket;
     private final String basePath;
     private final BiPredicate<String, String> authorizationPredicate;
     private final Supplier<S3ConsistencyModel> consistencyModel;
 
     public S3HttpFixture(boolean enabled, Supplier<S3ConsistencyModel> consistencyModel) {
-        this(enabled, "bucket", "base_path_integration_tests", consistencyModel, fixedAccessKey("s3_test_access_key", ANY_REGION, "s3"));
+        this(
+            enabled,
+            null,
+            "bucket",
+            "base_path_integration_tests",
+            consistencyModel,
+            fixedAccessKey("s3_test_access_key", ANY_REGION, "s3")
+        );
     }
 
     public S3HttpFixture(
         boolean enabled,
+        @Nullable /* to use HTTP */ TestTlsCertificate tlsCertificate,
         String bucket,
         String basePath,
         Supplier<S3ConsistencyModel> consistencyModel,
         BiPredicate<String, String> authorizationPredicate
     ) {
+        this.tlsCertificate = tlsCertificate;
         this.enabled = enabled;
         this.bucket = bucket;
         this.basePath = basePath;
@@ -88,8 +111,14 @@ public class S3HttpFixture extends ExternalResource {
     }
 
     public String getAddress() {
-        String host = InetAddresses.toUriString(server.getAddress().getAddress());
-        return "http://" + host + ":" + server.getAddress().getPort();
+        return Strings.format(
+            "%s://%s:%d",
+            tlsCertificate == null ? "http" : "https",
+            tlsCertificate == null
+                ? InetAddresses.toUriString(server.getAddress().getAddress())
+                : server.getAddress().getAddress().getHostName(),
+            server.getAddress().getPort()
+        );
     }
 
     public void stop(int delay) {
@@ -109,7 +138,24 @@ public class S3HttpFixture extends ExternalResource {
                 new ThreadContext(Settings.EMPTY)
             );
 
-            this.server = HttpServer.create(getLocalFixtureAddress(), 0);
+            if (tlsCertificate == null) {
+                this.server = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+            } else {
+                final SSLContext sslContext = SSLContext.getInstance("TLS");
+                sslContext.init(
+                    new KeyManager[] {
+                        KeyStoreUtil.createKeyManager(
+                            new Certificate[] { tlsCertificate.certificate() },
+                            tlsCertificate.privateKey(),
+                            null
+                        ) },
+                    null,
+                    new SecureRandom()
+                );
+                final var httpsServer = HttpsServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+                this.server = httpsServer;
+                httpsServer.setHttpsConfigurator(new HttpsConfigurator(sslContext));
+            }
             this.server.createContext("/", Objects.requireNonNull(createHandler()));
             this.server.setExecutor(executorService);
             server.start();

--- a/x-pack/plugin/searchable-snapshots/qa/s3/build.gradle
+++ b/x-pack/plugin/searchable-snapshots/qa/s3/build.gradle
@@ -15,6 +15,7 @@ dependencies {
   javaRestTestImplementation project(":test:framework")
   javaRestTestImplementation project(':test:fixtures:aws-fixture-utils')
   javaRestTestImplementation project(':test:fixtures:s3-fixture')
+  javaRestTestImplementation project(':test:fixtures:tls-utils')
 }
 
 restResources {

--- a/x-pack/plugin/searchable-snapshots/qa/s3/src/javaRestTest/java/org/elasticsearch/xpack/searchablesnapshots/s3/S3SearchableSnapshotsCredentialsReloadIT.java
+++ b/x-pack/plugin/searchable-snapshots/qa/s3/src/javaRestTest/java/org/elasticsearch/xpack/searchablesnapshots/s3/S3SearchableSnapshotsCredentialsReloadIT.java
@@ -50,6 +50,7 @@ public class S3SearchableSnapshotsCredentialsReloadIT extends ESRestTestCase {
 
     public static final S3HttpFixture s3Fixture = new S3HttpFixture(
         true,
+        null,
         BUCKET,
         BASE_PATH,
         S3ConsistencyModel::randomConsistencyModel,

--- a/x-pack/plugin/snapshot-repo-test-kit/qa/s3/build.gradle
+++ b/x-pack/plugin/snapshot-repo-test-kit/qa/s3/build.gradle
@@ -12,6 +12,7 @@ dependencies {
   javaRestTestImplementation testArtifact(project(xpackModule('snapshot-repo-test-kit')))
   javaRestTestImplementation project(':test:fixtures:s3-fixture')
   javaRestTestImplementation project(':test:fixtures:aws-fixture-utils')
+  javaRestTestImplementation project(':test:fixtures:tls-utils')
 }
 
 restResources {

--- a/x-pack/plugin/snapshot-repo-test-kit/qa/s3/src/javaRestTest/java/org/elasticsearch/repositories/blobstore/testkit/analyze/AbstractS3RepositoryAnalysisRestTestCase.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/qa/s3/src/javaRestTest/java/org/elasticsearch/repositories/blobstore/testkit/analyze/AbstractS3RepositoryAnalysisRestTestCase.java
@@ -37,6 +37,7 @@ public abstract class AbstractS3RepositoryAnalysisRestTestCase extends AbstractR
         RepositoryAnalysisHttpFixture(S3ConsistencyModel consistencyModel) {
             super(
                 USE_FIXTURE,
+                null,
                 "bucket",
                 "base_path_integration_tests",
                 () -> consistencyModel,


### PR DESCRIPTION
The AWS SDK behaves slightly differently depending on whether it is
using HTTP or HTTPS. This commit adds a basic test which uses HTTPS.