### PR TITLE
ES|QL|DS: ndjson - avoid String allocation in KEYWORD value decoder

### DIFF
--- a/docs/changelog/149992.yaml
+++ b/docs/changelog/149992.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 149992
+summary: "ES|QL|DS: ndjson - avoid String allocation in KEYWORD value decoder"
+type: enhancement

--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoder.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoder.java
@@ -42,6 +42,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.SkipWarnings;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.CharBuffer;
 import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.HashMap;
@@ -572,7 +573,7 @@ public class NdJsonPageDecoder implements Closeable {
      * delegates to {@link org.elasticsearch.common.util.BytesRefArray#append(BytesRef)} and copies
      * before returning); the next call to this method overwrites the scratch.
      */
-    private BytesRef toScratchBytesRef(String value) {
+    private BytesRef toScratchBytesRef(CharSequence value) {
         int maxLen = UnicodeUtil.maxUTF8Length(value.length());
         if (keywordScratch.bytes.length < maxLen) {
             keywordScratch.bytes = new byte[maxLen];
@@ -805,13 +806,8 @@ public class NdJsonPageDecoder implements Closeable {
                     }
                 }
                 case KEYWORD -> {
-                    // Be lenient, this is a catch-all type
-                    var str = parser.getValueAsString();
-                    if (str != null) {
-                        ((BytesRefBlock.Builder) blockBuilder).appendBytesRef(toScratchBytesRef(str));
-                    } else {
-                        unexpectedValue(blockBuilder, parser, inArray);
-                    }
+                    var chars = CharBuffer.wrap(parser.getTextCharacters(), parser.getTextOffset(), parser.getTextLength());
+                    ((BytesRefBlock.Builder) blockBuilder).appendBytesRef(toScratchBytesRef(chars));
                 }
                 default -> throw new IllegalArgumentException("Unsupported data type: " + dataType);
             }

--- a/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIteratorTests.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIteratorTests.java
@@ -819,6 +819,37 @@ public class NdJsonPageIteratorTests extends ESTestCase {
         }
     }
 
+    public void testMixedValuesToString() throws IOException {
+        var blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(new NoopCircuitBreaker("none")).build();
+
+        String ndjson = """
+            {"id": 1, "data": "a"}
+            {"id": 2, "data": 1}
+            {"id": 3, "data": 2.3}
+            {"id": 4, "data": null}
+            {"id": 5, "data": true}
+            {"id": 6, "data": false}
+            """;
+
+        var reader = new NdJsonFormatReader(null, blockFactory);
+        var object = new BytesStorageObject("file:///test.ndjson", ndjson.getBytes(StandardCharsets.UTF_8));
+
+        try (var iterator = reader.read(object, List.of("id", "data"), 100)) {
+            assertTrue(iterator.hasNext());
+            var page = iterator.next();
+            assertPage(page, """
+                      INT      |   BYTES_REF  \s
+                ---------------+---------------
+                1              |a             \s
+                2              |1             \s
+                3              |2.3           \s
+                4              |null          \s
+                5              |true          \s
+                6              |false         \s
+                """);
+        }
+    }
+
     public void testNestedObject() throws IOException {
         var blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(new NoopCircuitBreaker("none")).build();
 


### PR DESCRIPTION
Avoid a `String` allocation for each `KEYWORD` value by wrapping `parser.getTextCharacters()` in a `CharBuffer`.

Fixes elastic/esql-planning#848