### PR TITLE
[ESQL] Introduce RecordSplitter SPI

### DIFF
--- a/docs/changelog/149996.yaml
+++ b/docs/changelog/149996.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 149996
+summary: Introduce `RecordSplitter` SPI
+type: enhancement

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/DelegatingRecordSplitter.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/DelegatingRecordSplitter.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.spi;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Objects;
+
+final class DelegatingRecordSplitter implements RecordSplitter {
+
+    private final SegmentableFormatReader reader;
+
+    DelegatingRecordSplitter(SegmentableFormatReader reader) {
+        this.reader = Objects.requireNonNull(reader);
+    }
+
+    @Override
+    public long findNextRecordBoundary(InputStream stream) throws IOException {
+        long consumed = reader.findNextRecordBoundary(stream);
+        assert consumed != RECORD_TOO_LARGE : "SegmentableFormatReader cannot report RecordSplitter.RECORD_TOO_LARGE";
+        return consumed;
+    }
+
+    @Override
+    public int findLastRecordBoundary(byte[] buf, int offset, int length) throws IOException {
+        Objects.checkFromIndexSize(offset, length, buf.length);
+        int boundary = offset == 0
+            ? reader.findLastRecordBoundary(buf, length)
+            : reader.findLastRecordBoundary(Arrays.copyOfRange(buf, offset, offset + length), length);
+        assert boundary != RECORD_TOO_LARGE : "SegmentableFormatReader cannot report RecordSplitter.RECORD_TOO_LARGE";
+        return boundary < 0 || offset == 0 ? boundary : offset + boundary;
+    }
+
+    @Override
+    public int maxRecordBytes() {
+        return SegmentableFormatReader.DEFAULT_MAX_RECORD_BYTES;
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/DelegatingRecordSplitter.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/DelegatingRecordSplitter.java
@@ -30,6 +30,7 @@ final class DelegatingRecordSplitter implements RecordSplitter {
     @Override
     public int findLastRecordBoundary(byte[] buf, int offset, int length) throws IOException {
         Objects.checkFromIndexSize(offset, length, buf.length);
+        // The legacy reader method is offset-unaware; copy only in the bridge path that adapts it.
         int boundary = offset == 0
             ? reader.findLastRecordBoundary(buf, length)
             : reader.findLastRecordBoundary(Arrays.copyOfRange(buf, offset, offset + length), length);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/RecordSplitter.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/RecordSplitter.java
@@ -52,13 +52,6 @@ public interface RecordSplitter {
     }
 
     /**
-     * Whether this splitter can find the last record boundary by scanning backward through a buffer.
-     */
-    default boolean allowsReverseScan() {
-        return false;
-    }
-
-    /**
      * Maximum bytes a single record may occupy before the splitter reports {@link #RECORD_TOO_LARGE}.
      */
     int maxRecordBytes();

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/RecordSplitter.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/RecordSplitter.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.spi;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Finds format-specific record boundaries for splittable row-oriented external data sources.
+ * <p>
+ * Implementations are used in two different contexts: stream-based planning code that skips
+ * forward to the next complete record, and byte-array chunking code that slices an already-read
+ * buffer at the last complete record.
+ */
+public interface RecordSplitter {
+
+    /**
+     * Returned by {@link #findNextRecordBoundary(InputStream)} when a scanner exceeds
+     * {@link #maxRecordBytes()} before finding a record boundary. Distinct from EOF ({@code -1}).
+     */
+    long RECORD_TOO_LARGE = -2L;
+
+    /**
+     * Scans forward from the current stream position until the next complete record boundary.
+     *
+     * @return the number of bytes consumed, {@code -1} if EOF is reached before a boundary,
+     *         or {@link #RECORD_TOO_LARGE} if the next record exceeds {@link #maxRecordBytes()}
+     */
+    long findNextRecordBoundary(InputStream stream) throws IOException;
+
+    /**
+     * Returns the index of the byte that terminates the last complete record within
+     * {@code buf[offset..offset + length)}, or {@code -1} if no complete record terminates inside
+     * that range.
+     * <p>
+     * When the range ends inside an open record, implementations must return the previous complete
+     * record boundary, not a byte inside the open tail.
+     */
+    int findLastRecordBoundary(byte[] buf, int offset, int length) throws IOException;
+
+    /**
+     * Returns the index of the byte that terminates the last complete record within
+     * {@code buf[0..length)}, or {@code -1} if no complete record terminates inside that range.
+     */
+    default int findLastRecordBoundary(byte[] buf, int length) throws IOException {
+        return findLastRecordBoundary(buf, 0, length);
+    }
+
+    /**
+     * Whether this splitter can find the last record boundary by scanning backward through a buffer.
+     */
+    default boolean allowsReverseScan() {
+        return false;
+    }
+
+    /**
+     * Maximum bytes a single record may occupy before the splitter reports {@link #RECORD_TOO_LARGE}.
+     */
+    int maxRecordBytes();
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/RegexRecordSplitter.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/RegexRecordSplitter.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.spi;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Test-only splitter used by contract tests to prove the SPI is not specialized to newline
+ * delimiters. This class intentionally has no production callers.
+ */
+@SuppressWarnings("unused")
+final class RegexRecordSplitter implements RecordSplitter {
+
+    private final Pattern terminatorPattern;
+    private final int maxRecordBytes;
+
+    RegexRecordSplitter(String terminatorRegex, int maxRecordBytes) {
+        if (maxRecordBytes <= 0) {
+            throw new IllegalArgumentException("maxRecordBytes must be positive");
+        }
+        this.terminatorPattern = Pattern.compile(Objects.requireNonNull(terminatorRegex));
+        this.maxRecordBytes = maxRecordBytes;
+    }
+
+    @Override
+    public long findNextRecordBoundary(InputStream stream) throws IOException {
+        StringBuilder consumedBytes = new StringBuilder();
+        int next;
+        while ((next = stream.read()) != -1) {
+            consumedBytes.append((char) (next & 0xFF));
+            if (consumedBytes.length() > maxRecordBytes) {
+                return RECORD_TOO_LARGE;
+            }
+            if (terminates(consumedBytes)) {
+                return consumedBytes.length();
+            }
+        }
+        return -1;
+    }
+
+    @Override
+    public int findLastRecordBoundary(byte[] buf, int offset, int length) {
+        Objects.checkFromIndexSize(offset, length, buf.length);
+        String chunk = new String(buf, offset, length, StandardCharsets.ISO_8859_1);
+        Matcher matcher = terminatorPattern.matcher(chunk);
+        int lastBoundary = -1;
+        while (matcher.find()) {
+            if (matcher.start() == matcher.end()) {
+                throw new IllegalArgumentException("terminatorRegex must not match an empty sequence");
+            }
+            lastBoundary = offset + matcher.end() - 1;
+        }
+        return lastBoundary;
+    }
+
+    @Override
+    public int maxRecordBytes() {
+        return maxRecordBytes;
+    }
+
+    private boolean terminates(CharSequence consumedBytes) {
+        Matcher matcher = terminatorPattern.matcher(consumedBytes);
+        while (matcher.find()) {
+            if (matcher.start() == matcher.end()) {
+                throw new IllegalArgumentException("terminatorRegex must not match an empty sequence");
+            }
+            if (matcher.end() == consumedBytes.length()) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/SegmentableFormatReader.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/SegmentableFormatReader.java
@@ -32,6 +32,16 @@ public interface SegmentableFormatReader extends FormatReader {
     int DEFAULT_MAX_RECORD_BYTES = 64 * 1024 * 1024;
 
     /**
+     * Returns the record-boundary splitter for this reader.
+     */
+    default RecordSplitter recordSplitter() {
+        return new DelegatingRecordSplitter(this);
+    }
+
+    // TODO(phase-1.2): once recordSplitter() is the canonical entry point, remove these legacy
+    // find* methods and route callers through recordSplitter().
+
+    /**
      * Scans forward from the current position in the stream to find the start of
      * the next complete record. Returns the number of bytes consumed (skipped)
      * to reach that boundary.

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/spi/DelegatingRecordSplitterContractTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/spi/DelegatingRecordSplitterContractTests.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.spi;
+
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.CloseableIterator;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+import static org.hamcrest.Matchers.instanceOf;
+
+public class DelegatingRecordSplitterContractTests extends RecordSplitterContractTests {
+
+    @Override
+    protected RecordSplitter newSplitter() {
+        return new DelegatingRecordSplitter(new NewlineSegmentableFormatReader());
+    }
+
+    @Override
+    protected Fixtures fixtures() {
+        return new Fixtures(bytes("\n"), true, false, false, false);
+    }
+
+    public void testSegmentableFormatReaderHookReturnsDelegatingSplitter() {
+        assertThat(new NewlineSegmentableFormatReader().recordSplitter(), instanceOf(DelegatingRecordSplitter.class));
+    }
+
+    public void testFindLastRecordBoundaryOverrideIsPreserved() throws IOException {
+        byte[] input = bytes("xxone\ntwo\n");
+        RecordSplitter splitter = new DelegatingRecordSplitter(new OverridingFindLastRecordBoundaryReader());
+
+        assertEquals(2, splitter.findLastRecordBoundary(input, 0, input.length));
+        assertEquals(4, splitter.findLastRecordBoundary(input, 2, input.length - 2));
+    }
+
+    private static class NewlineSegmentableFormatReader implements SegmentableFormatReader, NoConfigFormatReader {
+
+        @Override
+        public long findNextRecordBoundary(InputStream stream) throws IOException {
+            long consumed = 0;
+            int next;
+            while ((next = stream.read()) != -1) {
+                consumed++;
+                if (next == '\n') {
+                    return consumed;
+                }
+            }
+            return -1;
+        }
+
+        @Override
+        public SourceMetadata metadata(StorageObject object) {
+            throw new UnsupportedOperationException("test reader");
+        }
+
+        @Override
+        public CloseableIterator<Page> read(StorageObject object, FormatReadContext context) {
+            throw new UnsupportedOperationException("test reader");
+        }
+
+        @Override
+        public String formatName() {
+            return "newline";
+        }
+
+        @Override
+        public List<String> fileExtensions() {
+            return List.of(".txt");
+        }
+
+        @Override
+        public void close() {}
+    }
+
+    private static class OverridingFindLastRecordBoundaryReader extends NewlineSegmentableFormatReader {
+        @Override
+        public int findLastRecordBoundary(byte[] buf, int length) {
+            return 2;
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/spi/RecordSplitterContractTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/spi/RecordSplitterContractTests.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.spi;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+public abstract class RecordSplitterContractTests extends ESTestCase {
+
+    protected abstract RecordSplitter newSplitter();
+
+    protected abstract Fixtures fixtures();
+
+    public void testEmptyInputReturnsEof() throws IOException {
+        RecordSplitter splitter = newSplitter();
+        assertEquals(-1L, splitter.findNextRecordBoundary(new ByteArrayInputStream(new byte[0])));
+        assertEquals(-1, splitter.findLastRecordBoundary(new byte[0], 0, 0));
+    }
+
+    public void testEofBeforeAnyTerminatorReturnsEof() throws IOException {
+        assertEquals(-1L, newSplitter().findNextRecordBoundary(new ByteArrayInputStream(bytes("unterminated"))));
+    }
+
+    public void testSingleLfTerminatedRecordConsumesThroughTerminator() throws IOException {
+        byte[] input = terminatedRecord("row");
+        assertEquals(3L + fixtures().recordTerminatorBytes(), newSplitter().findNextRecordBoundary(new ByteArrayInputStream(input)));
+    }
+
+    public void testCrLfTerminatorWhenSupported() throws IOException {
+        assumeTrue("splitter does not support CRLF", fixtures().handlesCRLF());
+
+        assertEquals(5L, newSplitter().findNextRecordBoundary(new ByteArrayInputStream(bytes("row\r\nnext"))));
+    }
+
+    public void testLoneCrTerminatorWhenSupported() throws IOException {
+        assumeTrue("splitter does not support lone CR", fixtures().handlesLoneCR());
+
+        assertEquals(4L, newSplitter().findNextRecordBoundary(new ByteArrayInputStream(bytes("row\rnext"))));
+    }
+
+    public void testEmbeddedTerminatorWhenSupported() throws IOException {
+        assumeTrue("splitter does not support embedded terminators", fixtures().canEmbedTerminatorInRecord());
+
+        byte[] input = recordWithEmbeddedTerminator();
+        assertEquals(recordWithEmbeddedTerminatorBytes(), newSplitter().findNextRecordBoundary(new ByteArrayInputStream(input)));
+    }
+
+    public void testRecordTooLargeSentinelWhenSupported() throws IOException {
+        RecordSplitter splitter = newSplitter();
+        if (fixtures().canReturnRecordTooLarge() == false) {
+            long consumed = splitter.findNextRecordBoundary(new ByteArrayInputStream(bytes("unterminated")));
+            assertFalse("bridge splitters must not produce RECORD_TOO_LARGE", consumed == RecordSplitter.RECORD_TOO_LARGE);
+            return;
+        }
+
+        assumeTrue("contract test avoids allocating very large records", splitter.maxRecordBytes() < 1024 * 1024);
+        assertEquals(
+            RecordSplitter.RECORD_TOO_LARGE,
+            splitter.findNextRecordBoundary(new ByteArrayInputStream(repeatedByte('x', splitter.maxRecordBytes() + 1)))
+        );
+    }
+
+    public void testFindLastRecordBoundaryMatchesForwardScan() throws IOException {
+        byte[] payload = concat(terminatedRecord("first"), terminatedRecord("second"), bytes("tail"));
+        int expectedBoundary = driveForwardToLastBoundary(newSplitter(), payload);
+
+        RecordSplitter splitter = newSplitter();
+        assertEquals(expectedBoundary, splitter.findLastRecordBoundary(payload, 0, payload.length));
+        assertEquals(expectedBoundary, splitter.findLastRecordBoundary(payload, payload.length));
+
+        byte[] prefix = bytes("xx");
+        byte[] prefixedPayload = concat(prefix, payload);
+        assertEquals(prefix.length + expectedBoundary, splitter.findLastRecordBoundary(prefixedPayload, prefix.length, payload.length));
+    }
+
+    protected byte[] recordWithEmbeddedTerminator() {
+        throw new UnsupportedOperationException("subclasses with embedded terminators must provide a fixture");
+    }
+
+    protected int recordWithEmbeddedTerminatorBytes() {
+        return recordWithEmbeddedTerminator().length;
+    }
+
+    protected byte[] terminatedRecord(String record) {
+        return concat(bytes(record), fixtures().recordTerminator());
+    }
+
+    protected static byte[] bytes(String value) {
+        return value.getBytes(StandardCharsets.UTF_8);
+    }
+
+    protected static byte[] concat(byte[]... chunks) {
+        int length = Arrays.stream(chunks).mapToInt(chunk -> chunk.length).sum();
+        byte[] result = new byte[length];
+        int offset = 0;
+        for (byte[] chunk : chunks) {
+            System.arraycopy(chunk, 0, result, offset, chunk.length);
+            offset += chunk.length;
+        }
+        return result;
+    }
+
+    protected static byte[] repeatedByte(char value, int count) {
+        byte[] bytes = new byte[count];
+        Arrays.fill(bytes, (byte) value);
+        return bytes;
+    }
+
+    private static int driveForwardToLastBoundary(RecordSplitter splitter, byte[] input) throws IOException {
+        int cumulative = 0;
+        int lastBoundary = -1;
+        while (cumulative < input.length) {
+            long consumed = splitter.findNextRecordBoundary(new ByteArrayInputStream(input, cumulative, input.length - cumulative));
+            if (consumed < 0) {
+                return lastBoundary;
+            }
+            assertTrue("splitter must make progress", consumed > 0);
+            assertTrue("splitter consumed past the buffer", consumed <= input.length - cumulative);
+            cumulative += Math.toIntExact(consumed);
+            lastBoundary = cumulative - 1;
+        }
+        return lastBoundary;
+    }
+
+    protected record Fixtures(
+        byte[] recordTerminator,
+        boolean handlesCRLF,
+        boolean handlesLoneCR,
+        boolean canEmbedTerminatorInRecord,
+        boolean canReturnRecordTooLarge
+    ) {
+        protected int recordTerminatorBytes() {
+            return recordTerminator.length;
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/spi/RegexRecordSplitter.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/spi/RegexRecordSplitter.java
@@ -14,11 +14,6 @@ import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-/**
- * Test-only splitter used by contract tests to prove the SPI is not specialized to newline
- * delimiters. This class intentionally has no production callers.
- */
-@SuppressWarnings("unused")
 final class RegexRecordSplitter implements RecordSplitter {
 
     private final Pattern terminatorPattern;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/spi/RegexRecordSplitterContractTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/spi/RegexRecordSplitterContractTests.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.spi;
+
+public class RegexRecordSplitterContractTests extends RecordSplitterContractTests {
+
+    private static final String TERMINATOR = "---\n";
+
+    @Override
+    protected RecordSplitter newSplitter() {
+        return new RegexRecordSplitter(TERMINATOR, 16);
+    }
+
+    @Override
+    protected Fixtures fixtures() {
+        return new Fixtures(bytes(TERMINATOR), false, false, false, true);
+    }
+}


### PR DESCRIPTION
Adds a small record-boundary splitter SPI for external datasource
readers so follow-up CSV and NDJSON work can centralize splitting
without rewiring existing production callers in this change.

Developed with AI-assisted tooling