### PR TITLE
Add timestamp to BlobFileRanges

### DIFF
--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/commits/BlobFileRanges.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/commits/BlobFileRanges.java
@@ -33,14 +33,29 @@ public class BlobFileRanges {
 
     private final BlobLocation blobLocation;
     private final NavigableMap<Long, ReplicatedByteRange> replicatedRanges;
+    /**
+     * The document timestamp range of the compound commit that produced this file, or {@code null} if unknown
+     * (e.g. no {@code @timestamp} field, or this instance was constructed without a commit context).
+     */
+    @Nullable
+    private final StatelessCompoundCommit.TimestampFieldValueRange timestampRange;
 
     public BlobFileRanges(BlobLocation blobLocation) {
-        this(blobLocation, Collections.emptyNavigableMap());
+        this(blobLocation, Collections.emptyNavigableMap(), null);
     }
 
-    private BlobFileRanges(BlobLocation blobLocation, NavigableMap<Long, ReplicatedByteRange> replicatedRanges) {
+    public BlobFileRanges(BlobLocation blobLocation, @Nullable StatelessCompoundCommit.TimestampFieldValueRange timestampRange) {
+        this(blobLocation, Collections.emptyNavigableMap(), timestampRange);
+    }
+
+    private BlobFileRanges(
+        BlobLocation blobLocation,
+        NavigableMap<Long, ReplicatedByteRange> replicatedRanges,
+        @Nullable StatelessCompoundCommit.TimestampFieldValueRange timestampRange
+    ) {
         this.blobLocation = Objects.requireNonNull(blobLocation);
         this.replicatedRanges = Objects.requireNonNull(replicatedRanges);
+        this.timestampRange = timestampRange;
     }
 
     public BlobLocation blobLocation() {
@@ -65,6 +80,11 @@ public class BlobFileRanges {
 
     public long fileLength() {
         return blobLocation.fileLength();
+    }
+
+    @Nullable
+    public StatelessCompoundCommit.TimestampFieldValueRange timestampRange() {
+        return timestampRange;
     }
 
     /**
@@ -131,25 +151,30 @@ public class BlobFileRanges {
         }
         assert assertNoOverlappingReplicatedRanges(replicatedRanges);
 
+        final var timestampRange = compoundCommit.getTimestampFieldValueRange();
         var blobFileRanges = HashMap.<String, BlobFileRanges>newHashMap(internalFiles.size());
         for (var internalFile : internalFiles) {
             var blobLocation = compoundCommit.commitFiles().get(internalFile);
             assert blobLocation != null : internalFile;
             if (useReplicatedRanges == false || replicatedRanges.isEmpty()) {
-                blobFileRanges.put(internalFile, new BlobFileRanges(blobLocation));
+                blobFileRanges.put(internalFile, new BlobFileRanges(blobLocation, Collections.emptyNavigableMap(), timestampRange));
                 continue;
             }
 
             var header = replicatedRanges.floorKey(blobLocation.offset());
             var footer = replicatedRanges.floorKey(blobLocation.offset() + blobLocation.fileLength() - 1);
             if (header == null || footer == null) {
-                blobFileRanges.put(internalFile, new BlobFileRanges(blobLocation));
+                blobFileRanges.put(internalFile, new BlobFileRanges(blobLocation, Collections.emptyNavigableMap(), timestampRange));
                 continue;
             }
 
             blobFileRanges.put(
                 internalFile,
-                new BlobFileRanges(blobLocation, unmodifiableNavigableMap(replicatedRanges.subMap(header, true, footer, true)))
+                new BlobFileRanges(
+                    blobLocation,
+                    unmodifiableNavigableMap(replicatedRanges.subMap(header, true, footer, true)),
+                    timestampRange
+                )
             );
         }
         return blobFileRanges;
@@ -172,12 +197,14 @@ public class BlobFileRanges {
     public boolean equals(Object o) {
         if (o == null || getClass() != o.getClass()) return false;
         BlobFileRanges that = (BlobFileRanges) o;
-        return Objects.equals(blobLocation, that.blobLocation) && Objects.equals(replicatedRanges, that.replicatedRanges);
+        return Objects.equals(blobLocation, that.blobLocation)
+            && Objects.equals(replicatedRanges, that.replicatedRanges)
+            && Objects.equals(timestampRange, that.timestampRange);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(blobLocation, replicatedRanges);
+        return Objects.hash(blobLocation, replicatedRanges, timestampRange);
     }
 
     public String toString() {

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/lucene/SearchDirectory.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/lucene/SearchDirectory.java
@@ -166,7 +166,13 @@ public class SearchDirectory extends BlobStoreCacheDirectory {
     public boolean updateCommit(StatelessCompoundCommit newCommit, Map<String, BlobFileRanges> commitFilesRangesOverride) {
         assert blobContainer.get() != null : shardId + " must have the blob container set before any commit update";
 
-        mergeMetadata(newCommit.commitFiles(), commitFilesRangesOverride, false);
+        mergeMetadata(
+            newCommit.commitFiles(),
+            commitFilesRangesOverride,
+            false,
+            newCommit.internalFiles(),
+            newCommit.getTimestampFieldValueRange()
+        );
         // TODO: Commits may not arrive in order. However, the maximum commit we have received is the commit of this directory since the
         // TODO: files always accumulate
         return currentCommit.accumulateAndGet(newCommit, (current, contender) -> {
@@ -446,13 +452,16 @@ public class SearchDirectory extends BlobStoreCacheDirectory {
      * This is used to merge file metadata from other PIT contexts coming from other nodes.
      */
     public void mergePITReaderMetadata(Map<String, BlobLocation> commitFilesRanges) {
-        mergeMetadata(commitFilesRanges, Map.of(), true);
+        // PIT relocation, no newCommit in scope, no new timestamp to attribute right now
+        mergeMetadata(commitFilesRanges, Map.of(), true, null, null);
     }
 
     private void mergeMetadata(
         Map<String, BlobLocation> commitFilesRanges,
         Map<String, BlobFileRanges> commitFilesRangesOverride,
-        boolean pitContextRelocationTransfer
+        boolean pitContextRelocationTransfer,
+        @Nullable Set<String> newCommitInternalFiles,
+        @Nullable StatelessCompoundCommit.TimestampFieldValueRange newCommitTimestamp
     ) {
         assert assertCompareAndSetUpdatingCommitThread(null, Thread.currentThread());
 
@@ -464,9 +473,31 @@ public class SearchDirectory extends BlobStoreCacheDirectory {
             for (var entry : commitFilesRanges.entrySet()) {
                 var fileName = entry.getKey();
                 var blobLocationFromCommit = entry.getValue();
+                // Case 1: file is in the overrides map
                 BlobFileRanges commitFileRanges = commitFilesRangesOverride.get(fileName);
                 if (commitFileRanges == null) {
-                    commitFileRanges = new BlobFileRanges(blobLocationFromCommit);
+                    // Case 2: file already tracked — preserve its existing entry so the timestamp
+                    // originally stamped from the file's originating CC is retained.
+                    BlobFileRanges existingRanges = updatedMetadata.get(fileName);
+                    assert existingRanges == null || existingRanges.blobLocation().equals(blobLocationFromCommit)
+                        : "blob location for known file ["
+                            + fileName
+                            + "] changed: existing="
+                            + existingRanges.blobLocation()
+                            + ", commit="
+                            + blobLocationFromCommit;
+                    if (existingRanges != null) {
+                        commitFileRanges = existingRanges;
+                    } else {
+                        // Case 3: not previously tracked. Use newCommit's timestamp only when this file is
+                        // internal to newCommit (i.e., the commit physically wrote it). Files referenced
+                        // from older CCs have no CC context here and report unknown.
+                        StatelessCompoundCommit.TimestampFieldValueRange ts = null;
+                        if (newCommitInternalFiles != null && newCommitInternalFiles.contains(fileName)) {
+                            ts = newCommitTimestamp;
+                        }
+                        commitFileRanges = new BlobFileRanges(blobLocationFromCommit, ts);
+                    }
                 } else {
                     assert commitFileRanges.blobLocation().equals(blobLocationFromCommit)
                         : "BlobFileRanges override for ["

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/lucene/SearchDirectory.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/lucene/SearchDirectory.java
@@ -476,22 +476,16 @@ public class SearchDirectory extends BlobStoreCacheDirectory {
                 // Case 1: file is in the overrides map
                 BlobFileRanges commitFileRanges = commitFilesRangesOverride.get(fileName);
                 if (commitFileRanges == null) {
-                    // Case 2: file already tracked — preserve its existing entry so the timestamp
-                    // originally stamped from the file's originating CC is retained.
                     BlobFileRanges existingRanges = updatedMetadata.get(fileName);
-                    assert existingRanges == null || existingRanges.blobLocation().equals(blobLocationFromCommit)
-                        : "blob location for known file ["
-                            + fileName
-                            + "] changed: existing="
-                            + existingRanges.blobLocation()
-                            + ", commit="
-                            + blobLocationFromCommit;
-                    if (existingRanges != null) {
+                    if (existingRanges != null && existingRanges.blobLocation().equals(blobLocationFromCommit)) {
+                        // Case 2: file already tracked at the same location — preserve its existing entry
+                        // so the timestamp originally stamped from the file's originating CC is retained.
                         commitFileRanges = existingRanges;
                     } else {
-                        // Case 3: not previously tracked. Use newCommit's timestamp only when this file is
-                        // internal to newCommit (i.e., the commit physically wrote it). Files referenced
-                        // from older CCs have no CC context here and report unknown.
+                        // Case 3: not previously tracked, or blob location changed (e.g. file rewritten
+                        // during reshard). Use newCommit's timestamp only when this file is internal to
+                        // newCommit (i.e., the commit physically wrote it). Files referenced from older
+                        // CCs have no CC context here and report unknown.
                         StatelessCompoundCommit.TimestampFieldValueRange ts = null;
                         if (newCommitInternalFiles != null && newCommitInternalFiles.contains(fileName)) {
                             ts = newCommitTimestamp;


### PR DESCRIPTION
Add TimestampFieldValueRange field to BlobFileRanges, so that we could track the timestamps for Lucene files accessible via SearchDirectory. The final goal is to pass these timestamps down to blob cache so that we could associate each cache region with a timestamp.

Timestamps could be null if not populated. For now, we are only using timestamps with ranges on search shards. The assumption is that the normal path will call SearchDirectory.updateCommit() with blob file ranges, so the only entries in the currentMetadata with missing timestamps would be for PITs.
