### PR TITLE
RescoreKnnVectorQuery: use task executor for concurrent rescoring

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/vectors/RescoreKnnVectorQuery.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/RescoreKnnVectorQuery.java
@@ -28,15 +28,14 @@ import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.VectorScorer;
 import org.elasticsearch.common.lucene.search.Queries;
-import org.elasticsearch.core.CheckedRunnable;
 import org.elasticsearch.search.profile.query.QueryProfiler;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.Callable;
 
 /**
  * A Lucene {@link Query} that applies vector-based rescoring to an inner query's results.
@@ -203,8 +202,6 @@ public abstract class RescoreKnnVectorQuery extends Query implements QueryProfil
     }
 
     private static class DirectRescoreKnnVectorQuery extends Query {
-        private static final int PREFETCH_BUFFER_SIZE = 100;
-
         private final float[] floatTarget;
         private final String fieldName;
         private final Query innerQuery;
@@ -228,8 +225,7 @@ public abstract class RescoreKnnVectorQuery extends Query implements QueryProfil
             }
             assert innerRewritten.getClass() != MatchAllDocsQuery.class;
 
-            List<ScoreDoc> results = new ArrayList<>(10);
-            List<CheckedRunnable<IOException>> buffer = new LinkedList<>();
+            List<Callable<ScoreDoc>> callables = new ArrayList<>();
             for (var leaf : indexSearcher.getIndexReader().leaves()) {
                 var knnVectorValues = leaf.reader().getFloatVectorValues(fieldName);
                 if (knnVectorValues == null) {
@@ -245,17 +241,12 @@ public abstract class RescoreKnnVectorQuery extends Query implements QueryProfil
                 if (scorer == null) {
                     continue;
                 }
-                var filterIterator = scorer.iterator();
-                rescoreIndividually(leaf.docBase, knnVectorValues, buffer, results, filterIterator);
+                rescoreIndividually(leaf.docBase, knnVectorValues, callables, scorer.iterator());
             }
 
-            for (var runnable : buffer) {
-                runnable.run();
-            }
-            buffer.clear();
-            // Remove any remaining sentinel values
-            ScoreDoc[] arrayResults = results.toArray(new ScoreDoc[0]);
-            return new KnnScoreDocQuery(arrayResults, indexSearcher.getIndexReader());
+            List<ScoreDoc> taskResults = indexSearcher.getTaskExecutor().invokeAll(callables);
+            ScoreDoc[] results = taskResults.stream().filter(Objects::nonNull).toArray(ScoreDoc[]::new);
+            return new KnnScoreDocQuery(results, indexSearcher.getIndexReader());
         }
 
         @Override
@@ -279,14 +270,15 @@ public abstract class RescoreKnnVectorQuery extends Query implements QueryProfil
         }
 
         /**
-         * Adds rescoring work to {@code buffer}. If {@code buffer} is non-empty after this call,
-         * the caller must run the queued {@link CheckedRunnable}s to materialize results into {@code queue}.
+         * Populates {@code callables} with one scoring task per matching document. Each callable
+         * uses its own independent {@link VectorScorer} (via {@link FloatVectorValues#copy()}) so
+         * the task executor can run them concurrently. Prefetch hints are issued on the calling
+         * thread before each callable is added, so IO is pipelined with task execution.
          */
         private void rescoreIndividually(
             int docBase,
             FloatVectorValues knnVectorValues,
-            List<CheckedRunnable<IOException>> buffer,
-            List<ScoreDoc> queue,
+            List<Callable<ScoreDoc>> callables,
             DocIdSetIterator filterIterator
         ) throws IOException {
             final int vectorByteSize = knnVectorValues.getVectorByteLength();
@@ -295,31 +287,21 @@ public abstract class RescoreKnnVectorQuery extends Query implements QueryProfil
 
             KnnVectorValues.DocIndexIterator vectorIter = knnVectorValues.iterator();
             DocIdSetIterator conjunction = ConjunctionUtils.intersectIterators(List.of(vectorIter, filterIterator));
-            // using bulk doesn't get us anywhere; this is expected to be extremely sparse
-            VectorScorer scorer = knnVectorValues.rescorer(floatTarget);
             int doc;
             while ((doc = conjunction.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
                 assert doc == vectorIter.docID();
                 final int docID = doc;
                 final int ord = vectorIter.index();
 
-                if (buffer.size() == PREFETCH_BUFFER_SIZE) {
-                    for (var runnable : buffer) {
-                        runnable.run();
-                    }
-                    buffer.clear();
-                }
-
                 if (input != null) {
                     input.prefetch((long) ord * vectorByteSize, vectorByteSize);
                 }
-                buffer.add(() -> {
-                    int target = scorer.iterator().advance(docID);
+                callables.add(() -> {
+                    VectorScorer taskScorer = knnVectorValues.copy().rescorer(floatTarget);
+                    int target = taskScorer.iterator().advance(docID);
                     assert target == docID;
-                    float score = scorer.score();
-                    if (Float.isNaN(score) == false) {
-                        queue.add(new ScoreDoc(docID + docBase, score));
-                    }
+                    float score = taskScorer.score();
+                    return Float.isNaN(score) ? null : new ScoreDoc(docID + docBase, score);
                 });
             }
         }


### PR DESCRIPTION
## Motivation

tl;dr: pushing rescoring to a the task thread pool resulted in some increased QPS with mixed results for p95 tail latency

While reviewing benchmarks, I observed that in memory constrained deployments, we spend a significant amount of time in the `RescoreKnnVectorQuery` hitting major page faults and reading from disk, even with the prefetching logic. The current implementation fetches vectors serially, which likely under-utilizes the disk's throughput capacity. Given that major page faults should allow the OS to context switching during loading, it seems possible that the overhead of dispatching to the index searcher's `task executor` could provide a real improvement.

Note however that we wouldn't necessarily want the vector comparisons themselves to be on more threads than physical cores, so an alternative implementation could consider using `MADV_POPULATE_READ` to synchronously trigger the read on the thread pool, then compute the similarity scores on the calling thread based on the assumption that the read from disk is much more expensive than the full precision similarity scores.

## Initial Benchmark Results

Here are the initial results of a benchmark. This benchmark was run on `gcp::c4a_highcpu-8-lssd-16-2x375GiB_nvme_local` hardware with 8 gb heap. The first set of results is based on a build of the parent commit for this PR and the second based on this PR.

```
================================================================================
BENCHMARK RESULTS SUMMARY
Experiment: elasticsearch-bbq-disk - meesho-search-catalog-embedding-128-filters
================================================================================

Precision vs Performance Trade-off:
--------------------------------------------------
Precision  QPS      P50 (ms)   P95 (ms)
--------------------------------------------------
0.95       195.8    40.043     55.017
0.94       400.1    18.857     28.506
0.90       491.8    14.877     24.989
0.89       468.3    16.265     25.462
0.85       645.1    10.899     21.800
0.82       659.4    10.726     21.030

QPS vs Precision Trade-off - elasticsearch-bbq-disk - meesho-search-catalog-embedding-128-filters (up and to the right is better):

   659 │●            ●
       │
       │                                    ●
   480 │                               ●
       │                                                      ●
       │
   300 │
       │                                                           ●
       │
   120 │
       │
       │
     0 │
       └────────────────────────────────────────────────────────────
        0.820          0.853          0.886          0.919
        Precision (0.0 = 0%, 1.0 = 100%)

=====

Precision vs Performance Trade-off:
--------------------------------------------------
Precision  QPS      P50 (ms)   P95 (ms)
--------------------------------------------------
0.95       196.9    35.138     71.621
0.94       398.4    17.201     35.442
0.90       551.8    12.829     24.350
0.89       490.7    14.168     28.368
0.85       707.9    9.931      19.347
0.82       774.2    9.152      16.507

QPS vs Precision Trade-off - elasticsearch-bbq-disk - meesho-search-catalog-embedding-128-filters (up and to the right is better):

   774 │●            ●
       │
       │
   563 │                                    ●
       │                               ●
       │                                                      ●
   352 │
       │
       │                                                           ●
   141 │
       │
       │
     0 │
       └────────────────────────────────────────────────────────────
        0.820          0.853          0.886          0.919
        Precision (0.0 = 0%, 1.0 = 100%)
================================================================================
```