### PR TITLE
PromQL: Fix scalar integer division to preserve fractional part

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-promql.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-promql.csv-spec
@@ -1180,3 +1180,33 @@ PROMQL index=k8s step=1h result=(scalar(sum(network.cost)) + 1);
 result:double | step:datetime
 62.0          | 2024-05-10T01:00:00.000Z
 ;
+
+scalar_float_div_half
+required_capability: promql_command_v0
+required_capability: promql_scalar
+required_capability: fix_promql_scalar_float_div
+PROMQL index=k8s step=1h result=(round(vector(1/2), 0.001));
+
+result:double | step:datetime
+0.5           | 2024-05-10T00:00:00.000Z
+;
+
+scalar_float_div_fraction
+required_capability: promql_command_v0
+required_capability: promql_scalar
+required_capability: fix_promql_scalar_float_div
+PROMQL index=k8s step=1h result=(round(vector(4/6), 0.001));
+
+result:double | step:datetime
+0.667         | 2024-05-10T00:00:00.000Z
+;
+
+scalar_float_div_compound
+required_capability: promql_command_v0
+required_capability: promql_scalar
+required_capability: fix_promql_scalar_float_div
+PROMQL index=k8s step=1h result=(round(vector(1*2 + 4/6 - (10%7)^2), 0.001));
+
+result:double | step:datetime
+-6.333        | 2024-05-10T00:00:00.000Z
+;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -2919,6 +2919,14 @@ public class EsqlCapabilities {
          */
         PROMQL_LABEL_MATCHER_PARAMS,
 
+        /**
+         * Fix for PromQL scalar integer division losing the fractional part.
+         * Integer literals like {@code 4/6} were folded with integer division (result: 0)
+         * instead of float64 division (result: ~0.667).
+         * https://github.com/elastic/elasticsearch/issues/149792
+         */
+        FIX_PROMQL_SCALAR_FLOAT_DIV,
+
         // Last capability should still have a comma for fewer merge conflicts when adding new ones :)
         // This comment prevents the semicolon from being on the previous capability when Spotless formats the file.
         ;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/promql/PromqlFoldingUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/promql/PromqlFoldingUtils.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.esql.parser.promql;
 
-import org.elasticsearch.xpack.esql.core.expression.predicate.operator.arithmetic.Arithmetics;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.parser.ParsingException;
 import org.elasticsearch.xpack.esql.plan.logical.promql.operator.VectorBinaryArithmetic.ArithmeticOp;
@@ -16,157 +15,40 @@ import org.elasticsearch.xpack.esql.plan.logical.promql.operator.VectorBinaryCom
 import java.time.Duration;
 
 /**
- * Utility class for evaluating scalar arithmetic operations at parse time.
- * Handles operations between:
- * - Numbers (delegates to Arithmetics)
- * - Durations and numbers (converts to seconds, computes, converts back)
- * - Durations and durations (only for ADD/SUB)
+ * Folds scalar PromQL arithmetic and comparisons at parse time.
+ * <p>
+ * Supported operands:
+ * - number op number: evaluated as double
+ * - duration op duration: only addition and subtraction
+ * - duration op number: duration is converted to seconds, evaluated, then converted back
+ * - number op duration: only supported where PromQL duration semantics are well-defined
  */
-public class PromqlFoldingUtils {
+public abstract class PromqlFoldingUtils {
+    private PromqlFoldingUtils() {}
 
-    /**
-     * Evaluate arithmetic operation between two scalar values at parse time.
-     *
-     * @param source Source location for error messages
-     * @param left Left operand (Number or Duration)
-     * @param right Right operand (Number or Duration)
-     * @param operation The arithmetic operation
-     * @return Result value (Number or Duration)
-     */
-    public static Object evaluate(Source source, Object left, Object right, ArithmeticOp operation) {
-        // Dispatch to appropriate handler based on operand types
-        if (left instanceof Duration leftDuration) {
-            if (right instanceof Duration rightDuration) {
-                return arithmetics(source, leftDuration, rightDuration, operation);
-            } else if (right instanceof Number rightNumber) {
-                return arithmetics(source, leftDuration, rightNumber, operation);
-            }
-        } else if (left instanceof Number leftNumber) {
-            if (right instanceof Duration rightDuration) {
-                return arithmetics(source, leftNumber, rightDuration, operation);
-            } else if (right instanceof Number rightNumber) {
-                return numericArithmetics(source, leftNumber, rightNumber, operation);
-            }
+    public static Object evaluate(Source source, Object left, Object right, ArithmeticOp op) {
+        if (left instanceof Number l && right instanceof Number r) {
+            return arithmetic(l, r, op);
+        }
+        if (left instanceof Duration l && right instanceof Duration r) {
+            return arithmetic(source, l, r, op);
+        }
+        if (left instanceof Duration l && right instanceof Number r) {
+            return arithmetic(source, l, r, op);
+        }
+        if (left instanceof Number l && right instanceof Duration r) {
+            return arithmetic(source, l, r, op);
         }
 
-        throw new ParsingException(
-            source,
-            "Cannot perform arithmetic between [{}] and [{}]",
-            left.getClass().getSimpleName(),
-            right.getClass().getSimpleName()
-        );
+        throw cannotApply(source, op, left, right);
     }
 
-    /**
-     * Duration op Duration (only ADD and SUB supported).
-     */
-    private static Duration arithmetics(Source source, Duration left, Duration right, ArithmeticOp op) {
-        Duration result = switch (op) {
-            case ADD -> left.plus(right);
-            case SUB -> left.minus(right);
-            default -> throw new ParsingException(source, "Operation [{}] not supported between two durations", op);
-        };
-
-        return result;
-    }
-
-    /**
-     * Duration op Number.
-     * For ADD/SUB: Number interpreted as seconds (PromQL convention).
-     * For MUL/DIV/MOD/POW: Number is a dimensionless scalar.
-     */
-    private static Duration arithmetics(Source source, Duration duration, Number scalar, ArithmeticOp op) {
-        long durationSeconds = duration.getSeconds();
-        long scalarValue = scalar.longValue();
-
-        long resultSeconds = switch (op) {
-            case ADD -> {
-                yield Math.addExact(durationSeconds, scalarValue);
-            }
-            case SUB -> {
-                yield Math.subtractExact(durationSeconds, scalarValue);
-            }
-            case MUL -> {
-                yield Math.round(durationSeconds * scalar.doubleValue());
-            }
-            case DIV -> {
-                if (scalarValue == 0) {
-                    throw new ParsingException(source, "Cannot divide duration by zero");
-                }
-                yield Math.round(durationSeconds / scalar.doubleValue());
-            }
-            case MOD -> {
-                // Modulo operation
-                if (scalarValue == 0) {
-                    throw new ParsingException(source, "Cannot compute modulo with zero");
-                }
-                yield Math.floorMod(durationSeconds, scalarValue);
-            }
-            case POW -> {
-                // Power operation (duration ^ scalar)
-                yield Math.round(Math.pow(durationSeconds, scalarValue));
-            }
-        };
-
-        return Duration.ofSeconds(resultSeconds);
-    }
-
-    private static Duration arithmetics(Source source, Number scalar, Duration duration, ArithmeticOp op) {
-        return switch (op) {
-            case ADD -> arithmetics(source, duration, scalar, ArithmeticOp.ADD);
-            case SUB -> arithmetics(source, Duration.ofSeconds(scalar.longValue()), duration, ArithmeticOp.SUB);
-            case MUL -> arithmetics(source, duration, scalar, ArithmeticOp.MUL);
-            default -> throw new ParsingException(source, "Operation [{}] not supported with scalar on left and duration on right", op);
-        };
-    }
-
-    /**
-     * Number op Number (pure numeric operations).
-     * Delegates to Arithmetics for consistent numeric handling.
-     */
-    private static Number numericArithmetics(Source source, Number left, Number right, ArithmeticOp op) {
-        try {
-            return switch (op) {
-                case ADD -> Arithmetics.add(left, right);
-                case SUB -> Arithmetics.sub(left, right);
-                case MUL -> Arithmetics.mul(left, right);
-                case DIV -> Arithmetics.div(left, right);
-                case MOD -> Arithmetics.mod(left, right);
-                case POW -> {
-                    // Power not in Arithmetics, compute manually
-                    double result = Math.pow(left.doubleValue(), right.doubleValue());
-                    // Try to preserve integer types when possible
-                    if (Double.isFinite(result)) {
-                        if (result == (long) result) {
-                            if (result >= Integer.MIN_VALUE && result <= Integer.MAX_VALUE) {
-                                yield (int) result;
-                            }
-                            yield (long) result;
-                        }
-                    }
-                    yield result;
-                }
-            };
-        } catch (ArithmeticException e) {
-            throw new ParsingException(source, "Arithmetic error: {}", e.getMessage());
-        }
-    }
-
-    /**
-     * Evaluate comparison operation between two numbers at parse time.
-     *
-     * @param left Left operand (Number)
-     * @param right Right operand (Number)
-     * @param operation The comparison operation
-     * @return true if comparison holds, false otherwise
-     */
-    public static boolean evaluate(Source source, Object left, Object right, ComparisonOp operation) {
+    public static boolean evaluate(Source source, Object left, Object right, ComparisonOp op) {
         if (left instanceof Number ln && right instanceof Number rn) {
-            // Get double values once, reuse for comparison - avoids extra allocation
             double l = ln.doubleValue();
             double r = rn.doubleValue();
 
-            return switch (operation) {
+            return switch (op) {
                 case EQ -> l == r;
                 case NEQ -> l != r;
                 case GT -> l > r;
@@ -175,20 +57,94 @@ public class PromqlFoldingUtils {
                 case LTE -> l <= r;
             };
         }
-        throw new ParsingException(
-            source,
-            "Cannot perform comparison between [{}] and [{}]",
-            left.getClass().getSimpleName(),
-            right.getClass().getSimpleName()
-        );
+
+        throw cannotApply(source, op, left, right);
     }
 
-    /**
-     * Validate that duration is positive (PromQL requirement).
-     */
-    private static void validatePositiveDuration(Source source, Duration duration) {
-        if (duration.isNegative() || duration.isZero()) {
-            throw new ParsingException(source, "Duration must be positive, got [{}]", duration);
-        }
+    private static double arithmetic(Number left, Number right, ArithmeticOp op) {
+        double l = left.doubleValue();
+        double r = right.doubleValue();
+
+        return switch (op) {
+            case ADD -> l + r;
+            case SUB -> l - r;
+            case MUL -> l * r;
+            case DIV -> l / r;
+            case MOD -> l % r;
+            case POW -> Math.pow(l, r);
+        };
+    }
+
+    private static Duration arithmetic(Source source, Duration left, Duration right, ArithmeticOp op) {
+        return switch (op) {
+            case ADD -> left.plus(right);
+            case SUB -> left.minus(right);
+            default -> throw cannotApply(source, op, left, right);
+        };
+    }
+
+    private static Duration arithmetic(Source source, Duration duration, Number scalar, ArithmeticOp op) {
+        long seconds = duration.getSeconds();
+        long scalarSeconds = scalar.longValue();
+        double scalarValue = scalar.doubleValue();
+
+        long result = switch (op) {
+            case ADD -> Math.addExact(seconds, scalarSeconds);
+            case SUB -> Math.subtractExact(seconds, scalarSeconds);
+            case MUL -> Math.round(seconds * scalarValue);
+            case DIV -> {
+                if (scalarValue == 0d) {
+                    throw new ParsingException(source, "division of a duration by zero is not allowed");
+                }
+                yield Math.round(seconds / scalarValue);
+            }
+            case MOD -> {
+                if (scalarSeconds == 0L) {
+                    throw new ParsingException(source, "modulo of a duration by zero is not allowed");
+                }
+                yield Math.floorMod(seconds, scalarSeconds);
+            }
+            case POW -> Math.round(Math.pow(seconds, scalarValue));
+        };
+
+        return Duration.ofSeconds(result);
+    }
+
+    private static Duration arithmetic(Source source, Number scalar, Duration duration, ArithmeticOp op) {
+        return switch (op) {
+            case ADD -> arithmetic(source, duration, scalar, ArithmeticOp.ADD);
+            case SUB -> Duration.ofSeconds(Math.subtractExact(scalar.longValue(), duration.getSeconds()));
+            case MUL -> arithmetic(source, duration, scalar, ArithmeticOp.MUL);
+            default -> throw cannotApply(source, op, scalar, duration);
+        };
+    }
+
+    private static String symbol(ArithmeticOp op) {
+        return switch (op) {
+            case ADD -> "+";
+            case SUB -> "-";
+            case MUL -> "*";
+            case DIV -> "/";
+            case MOD -> "%";
+            case POW -> "^";
+        };
+    }
+
+    private static String typeName(Object value) {
+        return value instanceof Duration ? "duration" : "scalar";
+    }
+
+    private static ParsingException cannotApply(Source source, ArithmeticOp op, Object left, Object right) {
+        return new ParsingException(source, "operator [{}] is not defined for {} and {}", symbol(op), typeName(left), typeName(right));
+    }
+
+    private static ParsingException cannotApply(Source source, ComparisonOp op, Object left, Object right) {
+        return new ParsingException(
+            source,
+            "comparison operator [{}] requires scalar operands, got {} and {}",
+            op.toString().toLowerCase(java.util.Locale.ROOT),
+            typeName(left),
+            typeName(right)
+        );
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/promql/PromqlFoldingUtilsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/promql/PromqlFoldingUtilsTests.java
@@ -53,37 +53,40 @@ public class PromqlFoldingUtilsTests extends ESTestCase {
 
     // Number op Number tests
     public void testNumberAddition() {
-        evaluate(5, ADD, 3, 8);
-        evaluate(5L, ADD, 3L, 8L);
+        evaluate(5, ADD, 3, 8.0);
+        evaluate(5L, ADD, 3L, 8.0);
         evaluate(5.5, ADD, 3.5, 9.0);
     }
 
     public void testNumberSubtraction() {
-        evaluate(5, SUB, 3, 2);
-        evaluate(5L, SUB, 3L, 2L);
+        evaluate(5, SUB, 3, 2.0);
+        evaluate(5L, SUB, 3L, 2.0);
         evaluate(5.5, SUB, 3.5, 2.0);
     }
 
     public void testNumberMultiplication() {
-        evaluate(5, MUL, 3, 15);
-        evaluate(5L, MUL, 3L, 15L);
+        evaluate(5, MUL, 3, 15.0);
+        evaluate(5L, MUL, 3L, 15.0);
         evaluate(5.5, MUL, 2.0, 11.0);
     }
 
     public void testNumberDivision() {
-        evaluate(10, DIV, 2, 5);
-        evaluate(10L, DIV, 2L, 5L);
+        evaluate(10, DIV, 2, 5.0);
+        evaluate(10L, DIV, 2L, 5.0);
         evaluate(10.0, DIV, 2.0, 5.0);
+        // Fractional results must be preserved (regression: integer division produced 0)
+        evaluate(4, DIV, 6, 4.0 / 6.0);
+        evaluate(1, DIV, 3, 1.0 / 3.0);
     }
 
     public void testNumberModulo() {
-        evaluate(10, MOD, 3, 1);
-        evaluate(10L, MOD, 3L, 1L);
+        evaluate(10, MOD, 3, 1.0);
+        evaluate(10L, MOD, 3L, 1.0);
     }
 
     public void testNumberPower() {
-        evaluate(2, POW, 3, 8);  // integer result
-        evaluate(2.5, POW, 2.0, 6.25);  // double result
+        evaluate(2, POW, 3, 8.0);
+        evaluate(2.5, POW, 2.0, 6.25);
     }
 
     // Duration op Duration tests
@@ -96,8 +99,8 @@ public class PromqlFoldingUtilsTests extends ESTestCase {
     }
 
     public void testDurationInvalidOperations() {
-        error(sec(60), MUL, sec(30), "not supported between two durations");
-        error(sec(60), DIV, sec(30), "not supported between two durations");
+        error(sec(60), MUL, sec(30), "operator [*] is not defined for duration and duration");
+        error(sec(60), DIV, sec(30), "operator [/] is not defined for duration and duration");
     }
 
     // Duration op Number tests (Number interpreted as seconds for ADD/SUB, dimensionless for MUL/DIV/MOD/POW)
@@ -130,11 +133,11 @@ public class PromqlFoldingUtilsTests extends ESTestCase {
     }
 
     public void testDurationDivByZero() {
-        error(sec(60), DIV, 0, "Cannot divide duration by zero");
+        error(sec(60), DIV, 0, "division of a duration by zero is not allowed");
     }
 
     public void testDurationModByZero() {
-        error(sec(60), MOD, 0, "Cannot compute modulo with zero");
+        error(sec(60), MOD, 0, "modulo of a duration by zero is not allowed");
     }
 
     public void testNumberMulDuration() {
@@ -145,7 +148,7 @@ public class PromqlFoldingUtilsTests extends ESTestCase {
     }
 
     public void testNumberInvalidDurationOperations() {
-        error(2, DIV, sec(60), "not supported with scalar on left");
+        error(2, DIV, sec(60), "operator [/] is not defined for scalar and duration");
     }
 
     // Validation tests

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/promql/golden_tests/PromqlGoldenTests/testAdditionScalarScalar/analysis.expected
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/promql/golden_tests/PromqlGoldenTests/testAdditionScalarScalar/analysis.expected
@@ -1,6 +1,6 @@
 Limit[10000[INTEGER],false,false]
 \_PromqlCommand start=[null] end=[null] step=[PT1H] buckets=[null] scrape_interval=[PT1M] valueColumnName=[sum] promql=[<>
-LiteralSelector[2[INTEGER]]
+LiteralSelector[2.0[DOUBLE]]
 \_PlaceholderRelation[]
 <>]]
   \_EsRelation[k8s][TIME_SERIES][@timestamp{f}#0, client.ip{f}#1, cluster{f}#2, event{f}#3, event_city{f}#4, event_city_boundary{f}#5, event_location{f}#6, event_log{f}#7, event_shape{f}#8, events_received{f}#9, network.bytes_in{f}#10, network.cost{f}#11, network.eth0.currently_connected_clients{f}#12, network.eth0.firmware_version{f}#13, network.eth0.last_up{f}#14, network.eth0.rx{f}#15, network.eth0.tx{f}#16, network.eth0.up{f}#17, network.total_bytes_in{f}#18, network.total_bytes_out{f}#19, network.total_cost{f}#20, pod{f}#21, region{f}#22]


### PR DESCRIPTION
### What

When a scalar subexpression containing division appears as an operand in a binary operation with a vector, we evaluate the scalar using integer division instead of floating-point division, producing consistently wrong results. 

Closes https://github.com/elastic/elasticsearch/issues/149792