### PR TITLE
[VERIFY-ONLY, DO NOT MERGE] End-to-end timeout-path verification on top of #150012

### DIFF
--- a/.buildkite/scripts/flakiness-detection/domain.ts
+++ b/.buildkite/scripts/flakiness-detection/domain.ts
@@ -141,6 +141,8 @@ export interface AgentConfig {
 
 export const DEFAULT_AGENT_CONFIG: AgentConfig = {
   agents: AGENTS,
-  timeoutInMinutes: 60,
+  // VERIFICATION-ONLY: lowered from 60 so the wrapNeverFail inner timeout (2m)
+  // fires within a couple of minutes of CI instead of ~58. Revert before merge.
+  timeoutInMinutes: 4,
   groupName: "flakiness-detection",
 };

--- a/.buildkite/scripts/flakiness-detection/runners/buildkite.test.ts
+++ b/.buildkite/scripts/flakiness-detection/runners/buildkite.test.ts
@@ -36,8 +36,8 @@ describe("toBuildkitePipeline end-to-end", () => {
     expect(step.command).toContain("exit 0");
     // Inner timeout fires 2m before outer timeout_in_minutes so the wrapper
     // still gets to annotate + exit 0 even on a stuck command.
-    expect(step.command).toContain("timeout --signal=TERM --kill-after=30s 58m bash");
-    expect(step.timeout_in_minutes).toBe(60);
+    expect(step.command).toContain("timeout --signal=TERM --kill-after=30s 2m bash");
+    expect(step.timeout_in_minutes).toBe(4);
     expect(step.agents.provider).toBe("gcp");
     expect(step.agents.machineType).toBe("n4-custom-32-98304");
   });
@@ -71,8 +71,8 @@ describe("toBuildkitePipeline end-to-end", () => {
     expect(step.env!["BATCH_COMMAND_0"]).toContain("exit 0");
     expect(step.env!["BATCH_COMMAND_1"]).toContain("exit 0");
     // Each parallel batch is independently wrapped under the inner timeout.
-    expect(step.env!["BATCH_COMMAND_0"]).toContain("timeout --signal=TERM --kill-after=30s 58m bash");
-    expect(step.env!["BATCH_COMMAND_1"]).toContain("timeout --signal=TERM --kill-after=30s 58m bash");
+    expect(step.env!["BATCH_COMMAND_0"]).toContain("timeout --signal=TERM --kill-after=30s 2m bash");
+    expect(step.env!["BATCH_COMMAND_1"]).toContain("timeout --signal=TERM --kill-after=30s 2m bash");
     expect(step.command).toContain("BUILDKITE_PARALLEL_JOB");
     // The `$$` escape prevents Buildkite pipeline interpolation from trying to
     // parse `${!VARNAME}` (bash indirect expansion) as a Buildkite variable,

--- a/.buildkite/scripts/flakiness-detection/runners/buildkite.test.ts
+++ b/.buildkite/scripts/flakiness-detection/runners/buildkite.test.ts
@@ -34,6 +34,9 @@ describe("toBuildkitePipeline end-to-end", () => {
       ".ci/scripts/run-gradle.sh -Dtests.iters=100 -Dtests.timeoutSuite=3600000! :server:test --tests org.elasticsearch.index.IndexTests"
     );
     expect(step.command).toContain("exit 0");
+    // Inner timeout fires 2m before outer timeout_in_minutes so the wrapper
+    // still gets to annotate + exit 0 even on a stuck command.
+    expect(step.command).toContain("timeout --signal=TERM --kill-after=30s 58m bash");
     expect(step.timeout_in_minutes).toBe(60);
     expect(step.agents.provider).toBe("gcp");
     expect(step.agents.machineType).toBe("n4-custom-32-98304");
@@ -67,6 +70,9 @@ describe("toBuildkitePipeline end-to-end", () => {
     expect(step.env!["BATCH_COMMAND_1"]).toContain("repeat-rest-test.sh");
     expect(step.env!["BATCH_COMMAND_0"]).toContain("exit 0");
     expect(step.env!["BATCH_COMMAND_1"]).toContain("exit 0");
+    // Each parallel batch is independently wrapped under the inner timeout.
+    expect(step.env!["BATCH_COMMAND_0"]).toContain("timeout --signal=TERM --kill-after=30s 58m bash");
+    expect(step.env!["BATCH_COMMAND_1"]).toContain("timeout --signal=TERM --kill-after=30s 58m bash");
     expect(step.command).toContain("BUILDKITE_PARALLEL_JOB");
     // The `$$` escape prevents Buildkite pipeline interpolation from trying to
     // parse `${!VARNAME}` (bash indirect expansion) as a Buildkite variable,
@@ -181,5 +187,7 @@ describe("toBuildkitePipeline", () => {
     const analyzerIdx = analyze.command.indexOf("entrypoints/analyze.ts");
     expect(installIdx).toBeLessThan(downloadIdx);
     expect(downloadIdx).toBeLessThan(analyzerIdx);
+    // Analyze step uses timeout_in_minutes: 10, so inner timeout is 8m.
+    expect(analyze.command).toContain("timeout --signal=TERM --kill-after=30s 8m bash");
   });
 });

--- a/.buildkite/scripts/flakiness-detection/runners/buildkite.ts
+++ b/.buildkite/scripts/flakiness-detection/runners/buildkite.ts
@@ -20,20 +20,44 @@ interface PipelineStep {
   artifact_paths?: string;
 }
 
+// Minutes of headroom kept between the inner `timeout` (which we own) and the
+// outer Buildkite `timeout_in_minutes` (which the agent enforces by SIGKILLing
+// the whole step). The wrapper needs to win the race so it can annotate and
+// exit 0; if the BK agent fires first the step ends up in state "timed_out".
+const NEVER_FAIL_GRACE_MINUTES = 2;
+
 // Wraps a shell command so it always exits 0. If the wrapped command exits
 // non-zero, a Buildkite warning annotation is appended so the failure is still
 // visible on the build, but the step's state stays "passed" so that Buildkite's
 // per-step and group-aggregate GitHub commit statuses report success.
 //
+// To also handle the case where the wrapped command runs past the step's
+// timeout_in_minutes, the command is run under GNU `timeout` set to fire a few
+// minutes before the BK outer timeout. When the inner timeout fires, `timeout`
+// exits 124 (SIGTERM cleanup) or 137 (SIGKILL after the grace period) and the
+// wrapper still reaches `exit 0`. Without this, the BK agent would SIGKILL the
+// whole bash process tree externally and the wrapper would never get to run.
+//
 // soft_fail is not used because Buildkite's GitHub commit-status integration
-// mirrors step.state ("failed") and ignores the soft_failed flag, so a
-// soft_fail step that exits non-zero still surfaces as a red check on the PR.
-function wrapNeverFail(command: string, contextKey: string): string {
+// mirrors step.state ("failed" / "timed_out") and ignores the soft_failed
+// flag, so a soft_fail step that exits non-zero or times out still surfaces
+// as a red check on the PR.
+function wrapNeverFail(command: string, contextKey: string, outerTimeoutMin: number): string {
+  const innerTimeoutMin = Math.max(1, outerTimeoutMin - NEVER_FAIL_GRACE_MINUTES);
   return [
     "set +e",
+    "WRAPPED_CMD_FILE=$(mktemp)",
+    // Quoted heredoc avoids any shell-expansion of the inner command at
+    // write time; variables in it are evaluated when bash runs the file.
+    "cat > \"$WRAPPED_CMD_FILE\" <<'__NEVER_FAIL_EOF__'",
     command,
+    "__NEVER_FAIL_EOF__",
+    `timeout --signal=TERM --kill-after=30s ${innerTimeoutMin}m bash "$WRAPPED_CMD_FILE"`,
     "rc=$?",
-    `if [ "$rc" -ne 0 ]; then`,
+    "rm -f \"$WRAPPED_CMD_FILE\"",
+    `if [ "$rc" -eq 124 ] || [ "$rc" -eq 137 ]; then`,
+    `  buildkite-agent annotate --style warning --context "${contextKey}-failures" --append "[$BUILDKITE_LABEL] (job $BUILDKITE_JOB_ID) timed out after ${innerTimeoutMin}m (rc=$rc) - see job log"`,
+    `elif [ "$rc" -ne 0 ]; then`,
     `  buildkite-agent annotate --style warning --context "${contextKey}-failures" --append "[$BUILDKITE_LABEL] (job $BUILDKITE_JOB_ID) exited with $rc - see job log"`,
     "fi",
     "exit 0",
@@ -77,7 +101,7 @@ export function toBuildkitePipeline(
     const step: PipelineStep = {
       label: head.label,
       key,
-      command: wrapNeverFail(head.command, key),
+      command: wrapNeverFail(head.command, key, cfg.timeoutInMinutes),
       timeout_in_minutes: cfg.timeoutInMinutes,
       agents: { ...cfg.agents },
       artifact_paths: TEST_RESULTS_ARTIFACTS,
@@ -86,7 +110,7 @@ export function toBuildkitePipeline(
     if (batches.length > 1) {
       const env: Record<string, string> = {};
       for (let i = 0; i < batches.length; i++) {
-        env[`BATCH_COMMAND_${i}`] = wrapNeverFail(batches[i].command, key);
+        env[`BATCH_COMMAND_${i}`] = wrapNeverFail(batches[i].command, key, cfg.timeoutInMinutes);
       }
       step.command = 'VARNAME="BATCH_COMMAND_${BUILDKITE_PARALLEL_JOB}"; eval "$${!VARNAME}"';
       step.parallelism = batches.length;
@@ -110,7 +134,8 @@ export function toBuildkitePipeline(
           `buildkite-agent artifact download "${TEST_RESULTS_ARTIFACTS}" .`,
           "bun .buildkite/scripts/flakiness-detection/entrypoints/analyze.ts",
         ].join("\n"),
-        "flakiness-detection:analyze"
+        "flakiness-detection:analyze",
+        10
       ),
       timeout_in_minutes: 10,
       // Intentionally no `agents:` — the analyze step is lightweight markdown

--- a/.buildkite/scripts/flakiness-detection/runners/buildkite.ts
+++ b/.buildkite/scripts/flakiness-detection/runners/buildkite.ts
@@ -49,16 +49,16 @@ function wrapNeverFail(command: string, contextKey: string, outerTimeoutMin: num
     "WRAPPED_CMD_FILE=$(mktemp)",
     // Quoted heredoc avoids any shell-expansion of the inner command at
     // write time; variables in it are evaluated when bash runs the file.
-    "cat > \"$WRAPPED_CMD_FILE\" <<'__NEVER_FAIL_EOF__'",
+    "cat > \"$$WRAPPED_CMD_FILE\" <<'__NEVER_FAIL_EOF__'",
     command,
     "__NEVER_FAIL_EOF__",
-    `timeout --signal=TERM --kill-after=30s ${innerTimeoutMin}m bash "$WRAPPED_CMD_FILE"`,
+    `timeout --signal=TERM --kill-after=30s ${innerTimeoutMin}m bash "$$WRAPPED_CMD_FILE"`,
     "rc=$?",
-    "rm -f \"$WRAPPED_CMD_FILE\"",
-    `if [ "$rc" -eq 124 ] || [ "$rc" -eq 137 ]; then`,
-    `  buildkite-agent annotate --style warning --context "${contextKey}-failures" --append "[$BUILDKITE_LABEL] (job $BUILDKITE_JOB_ID) timed out after ${innerTimeoutMin}m (rc=$rc) - see job log"`,
-    `elif [ "$rc" -ne 0 ]; then`,
-    `  buildkite-agent annotate --style warning --context "${contextKey}-failures" --append "[$BUILDKITE_LABEL] (job $BUILDKITE_JOB_ID) exited with $rc - see job log"`,
+    "rm -f \"$$WRAPPED_CMD_FILE\"",
+    `if [ "$$rc" -eq 124 ] || [ "$$rc" -eq 137 ]; then`,
+    `  buildkite-agent annotate --style warning --context "${contextKey}-failures" --append "[$$BUILDKITE_LABEL] (job $$BUILDKITE_JOB_ID) timed out after ${innerTimeoutMin}m (rc=$$rc) - see job log"`,
+    `elif [ "$$rc" -ne 0 ]; then`,
+    `  buildkite-agent annotate --style warning --context "${contextKey}-failures" --append "[$$BUILDKITE_LABEL] (job $$BUILDKITE_JOB_ID) exited with $$rc - see job log"`,
     "fi",
     "exit 0",
   ].join("\n");

--- a/libs/core/src/test/java/org/elasticsearch/core/FlakinessTimeoutVerificationTests.java
+++ b/libs/core/src/test/java/org/elasticsearch/core/FlakinessTimeoutVerificationTests.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.core;
+
+import org.elasticsearch.test.ESTestCase;
+
+/**
+ * VERIFICATION ONLY — DO NOT MERGE.
+ *
+ * Exists solely so the flakiness-detection PR pipeline picks up a changed test
+ * file and emits a real batch step running this class. The single test sleeps
+ * long enough to blow past the wrapNeverFail inner timeout (set to outer-2 via
+ * {@code DEFAULT_AGENT_CONFIG.timeoutInMinutes}). The build is expected to:
+ *
+ * <ul>
+ *   <li>have the inner GNU {@code timeout} fire (rc=124 or 137 if SIGKILL is
+ *       needed to take down the gradle daemon),</li>
+ *   <li>append a Buildkite annotation "timed out after Nm",</li>
+ *   <li>exit 0 so step.state stays "passed" and the GitHub commit status for
+ *       the step is SUCCESS.</li>
+ * </ul>
+ *
+ * Without the timeout fix this would have ended up as step.state="timed_out"
+ * and a red GitHub check on the PR.
+ */
+public class FlakinessTimeoutVerificationTests extends ESTestCase {
+
+    public void testSleepsPastInnerTimeout() throws InterruptedException {
+        // Sleep well beyond the inner timeout (outer 4m → inner 2m in this
+        // branch) so the timeout path is exercised regardless of how much
+        // setup gradle had to do before the test class started executing.
+        Thread.sleep(5L * 60L * 1000L);
+    }
+}


### PR DESCRIPTION
> :warning: **DO NOT MERGE** — verification-only PR. Close (do not merge) once CI has confirmed the timeout path behaves as expected. The actual fix lives in #150012.

## What this PR is for

#150012 makes \`wrapNeverFail\` survive Buildkite step-timeout kills by running the inner command under GNU \`timeout\` set to fire 2m before the BK outer \`timeout_in_minutes\`. This PR sits on top of #150012 and exists to **exercise that timeout path end-to-end on real CI**, since the original symptom (build 149516) can't be reproduced from the fix PR itself (it only changes the wrapper, no test files change → flakiness-detection pipeline emits nothing to run).

## How it's wired

1. Adds \`libs/core/src/test/java/org/elasticsearch/core/FlakinessTimeoutVerificationTests.java\` with a single test that \`Thread.sleep(5 * 60 * 1000)\`. The changed-files classifier picks it up as a \`test\` kind, so the flakiness-detection PR pipeline emits a real \`:libs:core:test\` batch step targeting it.
2. Lowers \`DEFAULT_AGENT_CONFIG.timeoutInMinutes\` from \`60\` to \`4\` so:
   - outer = 4m (BK enforced)
   - inner = 2m (\`wrapNeverFail\` enforced)
   - the verification step burns ~2–3 minutes of CI instead of ~58.

Both changes are isolated to this PR and must be discarded together with it.

## What success looks like in the resulting build

- \`flakiness-detection:unit\` step shows \`timeout: sending signal TERM to command 'bash ...'\` in its log around the 2-minute mark, followed by SIGKILL after the 30s grace if gradle didn't exit cleanly.
- Buildkite annotation appended: \`timed out after 2m (rc=124)\` or \`(rc=137)\`.
- Step state in the BK UI: **passed** (not \`timed_out\`).
- GitHub commit status for the step: **SUCCESS**.

## What failure would look like (i.e. the fix didn't work)

- Step state: \`timed_out\` (means the BK outer timeout fired before the inner could; the 2m grace was too tight, or \`timeout\` isn't on the agent image).
- GH commit status: red.
- No \`timed out after Nm\` annotation.

## After verification

- Close this PR without merging.
- If success: nothing else needed — #150012 is mergeable as-is.
- If failure: file findings on #150012 and adjust the grace / signal handling there.

## Commits

- \`ebb5b4540d9f\` — the actual fix (from #150012).
- \`47048f0e571d\` — this PR's verification-only changes.

Evidence link for the original problem: build [149516](https://buildkite.com/elastic/elasticsearch-pull-request/builds/149516#019e68f8-3d40-4395-af12-10dca5b2564d).