### PR TITLE
[9.4] Add filter capture for ESQL query (#149535)

### DIFF
--- a/docs/changelog/149535.yaml
+++ b/docs/changelog/149535.yaml
@@ -1,0 +1,5 @@
+area: "ES|QL"
+issues: []
+pr: 149535
+summary: Add filter capture for ESQL query
+type: enhancement

--- a/server/src/main/java/org/elasticsearch/action/search/SearchLogContext.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchLogContext.java
@@ -14,9 +14,7 @@ import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.logging.activity.QueryLoggerContext;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.tasks.Task;
-import org.elasticsearch.xcontent.ToXContent;
 
-import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
@@ -29,10 +27,6 @@ public class SearchLogContext extends QueryLoggerContext {
     private final NamedWriteableRegistry namedWriteableRegistry;
     // Cached index names
     private String[] indexNames = null;
-    // Cached "isSystem" flag
-    private Boolean isSystemSearch = null;
-
-    public static final ToXContent.Params FORMAT_PARAMS = new ToXContent.MapParams(Collections.singletonMap("pretty", "false"));
 
     private SearchLogContext(
         Task task,

--- a/server/src/main/java/org/elasticsearch/common/logging/activity/QueryLoggerContext.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/activity/QueryLoggerContext.java
@@ -12,9 +12,11 @@ package org.elasticsearch.common.logging.activity;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.RemoteClusterAware;
+import org.elasticsearch.xcontent.ToXContent;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -26,6 +28,8 @@ import java.util.stream.Collectors;
 public abstract class QueryLoggerContext extends ActivityLoggerContext {
     // Cached "isSystem" flag
     private Boolean isSystemSearch = null;
+
+    public static final ToXContent.Params FORMAT_PARAMS = new ToXContent.MapParams(Collections.singletonMap("pretty", "false"));
 
     protected QueryLoggerContext(Task task, String type, long tookInNanos, @Nullable Exception error) {
         super(task, type, tookInNanos, error);

--- a/x-pack/plugin/core/template-resources/src/main/resources/activitylog/logs-elasticsearch.querylog@mappings.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/activitylog/logs-elasticsearch.querylog@mappings.json
@@ -98,6 +98,11 @@
                     "profile": {
                       "dynamic": true,
                       "type": "object"
+                    },
+                    "filter": {
+                      "type": "keyword",
+                      "index": false,
+                      "ignore_above": 32765
                     }
                   }
                 },

--- a/x-pack/plugin/core/template-resources/src/main/resources/activitylog/logs-elasticsearch.querylog@mappings.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/activitylog/logs-elasticsearch.querylog@mappings.json
@@ -137,7 +137,7 @@
                 "query": {
                   "type": "keyword",
                   "index": false,
-                  "ignore_above": 2147483647
+                  "ignore_above": 32765
                 },
                 "result_count": {
                   "type": "long",

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlQueryLoggingIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlQueryLoggingIT.java
@@ -16,6 +16,8 @@ import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.common.logging.AccumulatingMockAppender;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.logging.activity.QueryLogging;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.test.ActivityLoggingUtils;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.transport.RemoteClusterService;
@@ -88,8 +90,19 @@ public class EsqlQueryLoggingIT extends AbstractEsqlIntegTestCase {
         );
     }
 
+    public void testLoggingFilter() throws Exception {
+        int numDocs = setupIndex("index-filter", "192.168.0.1");
+        QueryBuilder filter = new TermQueryBuilder("host", "192.168.0.1");
+        EsqlQueryRequest request = syncEsqlQueryRequest("FROM index-filter | LIMIT 100").filter(filter);
+        assertQuery(request, "FROM index-filter | LIMIT 100", numDocs, filter, "index-filter");
+    }
+
     private void assertQuery(String query, long hits) {
-        try (var resp = run(query)) {
+        assertQuery(syncEsqlQueryRequest(query), query, hits, null, "index-*");
+    }
+
+    private void assertQuery(EsqlQueryRequest request, String query, long hits, QueryBuilder filter, String expectedIndices) {
+        try (var resp = run(request)) {
             var message = getMessageData(appender.getLastEventAndReset());
             // When the request was randomly promoted to a PreparedEsqlQueryRequest the logged
             // query will be the plan representation rather than the original query string.
@@ -111,7 +124,12 @@ public class EsqlQueryLoggingIT extends AbstractEsqlIntegTestCase {
                 assertTrue("Expected profile field present: " + tookKey, message.containsKey(tookKey));
             }
             assertThat(message.get(QUERY_FIELD_RESULT_COUNT), equalTo(Long.toString(hits)));
-            assertThat(message.get(QUERY_FIELD_INDICES), equalTo("index-*"));
+            if (filter != null) {
+                assertThat(message.get(EsqlLogProducer.FILTER_FIELD), equalTo(EsqlLogContext.filterToLogString(filter)));
+            } else {
+                assertNull(message.get(EsqlLogProducer.FILTER_FIELD));
+            }
+            assertThat(message.get(QUERY_FIELD_INDICES), equalTo(expectedIndices));
         }
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/querylog/EsqlLogContext.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/querylog/EsqlLogContext.java
@@ -9,14 +9,18 @@ package org.elasticsearch.xpack.esql.querylog;
 
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.logging.activity.QueryLoggerContext;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.RemoteClusterAware;
+import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.esql.action.EsqlExecutionInfo;
 import org.elasticsearch.xpack.esql.action.EsqlQueryProfile;
 import org.elasticsearch.xpack.esql.action.EsqlQueryRequest;
 import org.elasticsearch.xpack.esql.action.EsqlQueryResponse;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
@@ -108,5 +112,20 @@ public class EsqlLogContext extends QueryLoggerContext {
             .entrySet()
             .stream()
             .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().getStatus().toString()));
+    }
+
+    Optional<String> getFilter() {
+        return Optional.ofNullable(filterToLogString(request.filter()));
+    }
+
+    public static String filterToLogString(QueryBuilder filter) {
+        if (filter == null) {
+            return null;
+        }
+        try {
+            return XContentHelper.toXContent(filter, XContentType.JSON, FORMAT_PARAMS, true).utf8ToString();
+        } catch (IOException e) {
+            return null;
+        }
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/querylog/EsqlLogProducer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/querylog/EsqlLogProducer.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 public class EsqlLogProducer implements ActivityLogProducer<EsqlLogContext> {
 
     public static final String PROFILE_PREFIX = QueryLogging.ES_QUERY_FIELDS_PREFIX + "esql.profile.";
+    public static final String FILTER_FIELD = QueryLogging.ES_QUERY_FIELDS_PREFIX + "esql.filter";
 
     @Override
     public Optional<ESLogMessage> produce(EsqlLogContext context, ActionLoggingFields additionalFields) {
@@ -35,6 +36,8 @@ public class EsqlLogProducer implements ActivityLogProducer<EsqlLogContext> {
                 }
             }
         });
+        context.getFilter().ifPresent(filter -> msg.field(FILTER_FIELD, filter));
+
         var clusters = context.getClusters();
         var remotes = context.getRemoteClusterAliases(clusters);
         if (remotes.isEmpty() == false) {

--- a/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/QueryLoggingTemplateRegistry.java
+++ b/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/QueryLoggingTemplateRegistry.java
@@ -30,8 +30,10 @@ public class QueryLoggingTemplateRegistry extends IndexTemplateRegistry {
     private static final Logger logger = LogManager.getLogger(QueryLoggingTemplateRegistry.class);
 
     // history (please add a comment why you increased the version here)
-    // version 1: initial placeholder
-    public static final int INDEX_TEMPLATE_VERSION = 1;
+    // version 1: initial template
+    // version 2: limit query to 32k
+    // version 3: add esql.filter
+    public static final int INDEX_TEMPLATE_VERSION = 3;
 
     public static final String QUERY_LOGGING_TEMPLATE_VERSION_VARIABLE = "xpack.stack.querylog.template.version";
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Add filter capture for ESQL query (#149535)](https://github.com/elastic/elasticsearch/pull/149535)

<!--- Backport version: 9.6.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)