### PR TITLE
Handle stale get/mget with refresh requests

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/get/TransportGetAction.java
+++ b/server/src/main/java/org/elasticsearch/action/get/TransportGetAction.java
@@ -202,7 +202,8 @@ public class TransportGetAction extends TransportSingleShardAction<GetRequest, G
                 request.versionType(),
                 request.fetchSourceContext(),
                 request.isForceSyntheticSource(),
-                request.getSplitShardCountSummary()
+                request.getSplitShardCountSummary(),
+                request.refresh()
             );
         return new GetResponse(result);
     }

--- a/server/src/main/java/org/elasticsearch/action/get/TransportGetFromTranslogAction.java
+++ b/server/src/main/java/org/elasticsearch/action/get/TransportGetFromTranslogAction.java
@@ -73,7 +73,8 @@ public class TransportGetFromTranslogAction extends HandledTransportAction<
                         getRequest.versionType(),
                         getRequest.fetchSourceContext(),
                         getRequest.isForceSyntheticSource(),
-                        getRequest.getSplitShardCountSummary()
+                        getRequest.getSplitShardCountSummary(),
+                        getRequest.refresh()
                     );
                 long segmentGeneration = -1;
                 if (result == null) {

--- a/server/src/main/java/org/elasticsearch/action/get/TransportShardMultiGetAction.java
+++ b/server/src/main/java/org/elasticsearch/action/get/TransportShardMultiGetAction.java
@@ -340,7 +340,8 @@ public class TransportShardMultiGetAction extends TransportSingleShardAction<Mul
                     item.fetchSourceContext(),
                     request.isForceSyntheticSource(),
                     mget,
-                    request.getSplitShardCountSummary()
+                    request.getSplitShardCountSummary(),
+                    request.refresh()
                 );
             response.add(request.locations.get(location), new GetResponse(getResult));
         } catch (RuntimeException e) {

--- a/server/src/main/java/org/elasticsearch/action/get/TransportShardMultiGetFomTranslogAction.java
+++ b/server/src/main/java/org/elasticsearch/action/get/TransportShardMultiGetFomTranslogAction.java
@@ -77,7 +77,8 @@ public class TransportShardMultiGetFomTranslogAction extends HandledTransportAct
                                 item.versionType(),
                                 item.fetchSourceContext(),
                                 multiGetShardRequest.isForceSyntheticSource(),
-                                SplitShardCountSummary.UNSET
+                                SplitShardCountSummary.UNSET,
+                                multiGetShardRequest.refresh()
                             );
                         GetResponse getResponse = null;
                         if (result == null) {

--- a/server/src/main/java/org/elasticsearch/index/get/ShardGetService.java
+++ b/server/src/main/java/org/elasticsearch/index/get/ShardGetService.java
@@ -110,7 +110,8 @@ public final class ShardGetService extends AbstractIndexShardComponent {
             versionType,
             fetchSourceContext,
             forceSyntheticSource,
-            SplitShardCountSummary.UNSET
+            SplitShardCountSummary.UNSET,
+            false
         );
     }
 
@@ -123,7 +124,8 @@ public final class ShardGetService extends AbstractIndexShardComponent {
         VersionType versionType,
         FetchSourceContext fetchSourceContext,
         boolean forceSyntheticSource,
-        SplitShardCountSummary splitShardCountSummary
+        SplitShardCountSummary splitShardCountSummary,
+        boolean refresh
     ) throws IOException {
         return doGet(
             id,
@@ -137,6 +139,7 @@ public final class ShardGetService extends AbstractIndexShardComponent {
             fetchSourceContext,
             forceSyntheticSource,
             splitShardCountSummary,
+            refresh,
             indexShard::get
         );
     }
@@ -150,7 +153,8 @@ public final class ShardGetService extends AbstractIndexShardComponent {
         FetchSourceContext fetchSourceContext,
         boolean forceSyntheticSource,
         MultiEngineGet mget,
-        SplitShardCountSummary splitShardCountSummary
+        SplitShardCountSummary splitShardCountSummary,
+        boolean refresh
     ) throws IOException {
         return doGet(
             id,
@@ -164,6 +168,7 @@ public final class ShardGetService extends AbstractIndexShardComponent {
             fetchSourceContext,
             forceSyntheticSource,
             splitShardCountSummary,
+            refresh,
             mget::get
         );
     }
@@ -180,6 +185,7 @@ public final class ShardGetService extends AbstractIndexShardComponent {
         FetchSourceContext fetchSourceContext,
         boolean forceSyntheticSource,
         SplitShardCountSummary splitShardCountSummary,
+        boolean refresh,
         BiFunction<Engine.Get, SplitShardCountSummary, Engine.GetResult> engineGetOperator
     ) throws IOException {
         currentMetric.inc();
@@ -222,7 +228,7 @@ public final class ShardGetService extends AbstractIndexShardComponent {
             } else {
                 missingMetric.inc(System.nanoTime() - now);
             }
-            if (getResult == null || getResult.isExists() == false || realtime) {
+            if (getResult == null || getResult.isExists() == false || realtime || refresh) {
                 if (splitShardCountSummary.equals(SplitShardCountSummary.UNSET)) {
                     // TODO, this should only be possible temporarily, until we've ensured that all callers provide a valid summary.
                     return getResult;
@@ -271,7 +277,8 @@ public final class ShardGetService extends AbstractIndexShardComponent {
         VersionType versionType,
         FetchSourceContext fetchSourceContext,
         boolean forceSyntheticSource,
-        SplitShardCountSummary splitShardCountSummary
+        SplitShardCountSummary splitShardCountSummary,
+        boolean refresh
     ) throws IOException {
         return doGet(
             id,
@@ -285,6 +292,7 @@ public final class ShardGetService extends AbstractIndexShardComponent {
             fetchSourceContext,
             forceSyntheticSource,
             splitShardCountSummary,
+            refresh,
             indexShard::getFromTranslog
         );
     }
@@ -302,6 +310,7 @@ public final class ShardGetService extends AbstractIndexShardComponent {
             fetchSourceContext,
             false,
             SplitShardCountSummary.UNSET,
+            false,
             indexShard::get
         );
     }

--- a/server/src/test/java/org/elasticsearch/index/shard/ShardGetServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/ShardGetServiceTests.java
@@ -280,7 +280,8 @@ public class ShardGetServiceTests extends IndexShardTestCase {
                 VersionType.INTERNAL,
                 FetchSourceContext.FETCH_SOURCE,
                 false,
-                SplitShardCountSummary.UNSET
+                SplitShardCountSummary.UNSET,
+                false
             );
         if (testGet2.sourceRef() == null) {
             assertThat("", equalTo(expectedResult));
@@ -309,7 +310,8 @@ public class ShardGetServiceTests extends IndexShardTestCase {
                 VersionType.INTERNAL,
                 FetchSourceContext.FETCH_SOURCE,
                 false,
-                SplitShardCountSummary.UNSET
+                SplitShardCountSummary.UNSET,
+                false
             );
         if (testGet2.sourceRef() == null) {
             assertThat("", equalTo(expectedResult));
@@ -371,7 +373,8 @@ public class ShardGetServiceTests extends IndexShardTestCase {
                 VersionType.INTERNAL,
                 FetchSourceContext.FETCH_SOURCE,
                 false,
-                SplitShardCountSummary.UNSET
+                SplitShardCountSummary.UNSET,
+                false
             );
         assertNull(getResult);
         var lastUnsafeGeneration = engine.getLastUnsafeSegmentGenerationForGets();
@@ -397,7 +400,8 @@ public class ShardGetServiceTests extends IndexShardTestCase {
                 VersionType.INTERNAL,
                 FetchSourceContext.FETCH_SOURCE,
                 false,
-                SplitShardCountSummary.UNSET
+                SplitShardCountSummary.UNSET,
+                false
             );
         assertNull(getResult);
         // But normal get would still work!
@@ -411,7 +415,8 @@ public class ShardGetServiceTests extends IndexShardTestCase {
                 VersionType.INTERNAL,
                 FetchSourceContext.FETCH_SOURCE,
                 false,
-                SplitShardCountSummary.UNSET
+                SplitShardCountSummary.UNSET,
+                false
             );
         assertNotNull(getResult);
         assertTrue(getResult.isExists());
@@ -431,7 +436,8 @@ public class ShardGetServiceTests extends IndexShardTestCase {
                 VersionType.INTERNAL,
                 FetchSourceContext.FETCH_SOURCE,
                 false,
-                SplitShardCountSummary.UNSET
+                SplitShardCountSummary.UNSET,
+                false
             );
         assertTrue(getResult.isExists());
         assertEquals(engine.getLastUnsafeSegmentGenerationForGets(), lastUnsafeGeneration);
@@ -444,7 +450,8 @@ public class ShardGetServiceTests extends IndexShardTestCase {
                 VersionType.INTERNAL,
                 FetchSourceContext.FETCH_SOURCE,
                 false,
-                SplitShardCountSummary.UNSET
+                SplitShardCountSummary.UNSET,
+                false
             );
         assertNull(getResult);
         assertEquals(engine.getLastUnsafeSegmentGenerationForGets(), lastUnsafeGeneration);
@@ -471,7 +478,8 @@ public class ShardGetServiceTests extends IndexShardTestCase {
                 VersionType.INTERNAL,
                 FetchSourceContext.FETCH_SOURCE,
                 false,
-                SplitShardCountSummary.UNSET
+                SplitShardCountSummary.UNSET,
+                false
             );
         assertNull(getResult);
         var lastUnsafeGeneration2 = engine.getLastUnsafeSegmentGenerationForGets();

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/reshard/StatelessReshardIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/reshard/StatelessReshardIT.java
@@ -20,6 +20,7 @@ import org.elasticsearch.action.admin.cluster.reroute.ClusterRerouteUtils;
 import org.elasticsearch.action.admin.indices.close.CloseIndexRequestBuilder;
 import org.elasticsearch.action.admin.indices.close.CloseIndexResponse;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.elasticsearch.action.admin.indices.refresh.TransportShardRefreshAction;
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
 import org.elasticsearch.action.admin.indices.shrink.ResizeType;
 import org.elasticsearch.action.admin.indices.shrink.TransportResizeAction;
@@ -1640,7 +1641,8 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
 
     // A successful realtime get should return the latest value of a doc regardless of refresh.
     // It may fail if it has been routed to a stale shard due to concurrent resharding.
-    public void testRealtimeGet() throws InterruptedException {
+    // A get with a refresh has similar expectations to a realtime get.
+    private void testRealtimeGetOrGetWithRefresh(boolean testRefresh) throws InterruptedException {
         startMasterOnlyNode();
         final var searchNode = startSearchNode();
         final var indexNode = startIndexNode();
@@ -1648,7 +1650,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         ensureStableCluster(3);
 
         final String indexName = "test-realtime-get";
-        createIndex(indexName, indexSettings(1, 1).build());
+        createIndex(indexName, indexSettings(1, 1).put(INDEX_REFRESH_INTERVAL_SETTING.getKey(), TimeValue.MINUS_ONE).build());
         ensureGreen(indexName);
 
         final var index = resolveIndex(indexName);
@@ -1660,7 +1662,11 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         final var shard1docId = makeIdThatRoutesToShard(indexRoutingPostSplit, 1);
         indexDoc(indexName, shard1docId, "field", "shard1_v0");
 
-        var response = client().prepareGet(indexName, shard1docId).setRealtime(true).execute().actionGet();
+        var response = client().prepareGet(indexName, shard1docId)
+            .setRealtime(testRefresh == false)
+            .setRefresh(testRefresh)
+            .execute()
+            .actionGet();
         assertThat(response.isExists(), is(true));
         assertThat(response.getSource().get("field"), equalTo("shard1_v0"));
 
@@ -1671,14 +1677,15 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         final var indexNodeTransportService = MockTransportService.getInstance(indexNode);
         final var searchNodeTransportService = MockTransportService.getInstance(searchNode);
 
+        final var actionToBlock = testRefresh ? TransportShardRefreshAction.NAME : TransportGetFromTranslogAction.NAME;
         searchNodeTransportService.addSendBehavior((connection, requestId, action, request, options) -> {
-            // block get_from_translog until resharding reaches SPLIT so that the arriving request will be stale
-            if ((TransportGetFromTranslogAction.NAME).equals(action)) {
+            // block get until resharding reaches SPLIT so that the arriving request will be stale
+            if (actionToBlock.equals(action)) {
                 // signal that get has been prepared so resharding can start
                 getPrepared.countDown();
                 try {
                     docUpdated.await(SAFE_AWAIT_TIMEOUT.millis(), TimeUnit.MILLISECONDS);
-                    logger.info("sending blocked get from translog");
+                    logger.info("sending blocked {}", actionToBlock);
                 } catch (InterruptedException e) {
                     throw new RuntimeException(e);
                 }
@@ -1702,7 +1709,11 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         final var getShard1Response = new AtomicReference<GetResponse>();
         final var getShard1Thread = new Thread(
             () -> getShard1Response.set(
-                client(searchNode).prepareGet(indexName, shard1docId).setRealtime(true).execute().actionGet(SAFE_AWAIT_TIMEOUT)
+                client(searchNode).prepareGet(indexName, shard1docId)
+                    .setRealtime(testRefresh == false)
+                    .setRefresh(testRefresh)
+                    .execute()
+                    .actionGet(SAFE_AWAIT_TIMEOUT)
             )
         );
         getShard1Thread.start();
@@ -1720,6 +1731,14 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         assertThat(getShard1Response.get().getSource().get("field"), equalTo("shard1_v1"));
 
         waitForReshardCompletion(indexName);
+    }
+
+    public void testRealTimeGet() throws InterruptedException {
+        testRealtimeGetOrGetWithRefresh(false);
+    }
+
+    public void testGetWithRefresh() throws InterruptedException {
+        testRealtimeGetOrGetWithRefresh(true);
     }
 
     // A successful realtime multiget should return the latest values of docs regardless of refresh.
@@ -1811,8 +1830,67 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         final var reshardRequest = new ReshardIndexRequest(indexName, 2);
         client().execute(TransportReshardAction.TYPE, reshardRequest).actionGet(SAFE_AWAIT_TIMEOUT);
         waitForReshardCompletion(indexName);
+    }
+
+    // A successful multiget with refresh should return the latest values of docs
+    public void testMultiGetWithRefresh() {
+        startMasterOnlyNode();
+        final var searchNode = startSearchNode();
+        final var indexNode = startIndexNode();
+        ensureStableCluster(3);
+
+        final String indexName = "test-multiget-with-refresh";
+        createIndex(indexName, indexSettings(1, 1).put(INDEX_REFRESH_INTERVAL_SETTING.getKey(), TimeValue.MINUS_ONE).build());
+        ensureGreen(indexName);
+
+        final var index = resolveIndex(indexName);
+        final var indexRoutingPostSplit = postSplitRouting(clusterService().state(), index, 2);
+
+        // Document that routes to target shard after split.
+        final var shard1docId = makeIdThatRoutesToShard(indexRoutingPostSplit, 1);
+        indexDoc(indexName, shard1docId, "field", "shard1_v0");
+
+        final var SHARD_MGET_ACTION = TransportShardMultiGetAction.TYPE.name() + "[s]";
+        final var mgetPrepared = new CountDownLatch(1);
+        final var reshardDone = new CountDownLatch(1);
+        final var transportService = MockTransportService.getInstance(indexNode);
+        transportService.addSendBehavior((connection, requestId, action, request, options) -> {
+            if (SHARD_MGET_ACTION.equals(action)) {
+                mgetPrepared.countDown();
+                safeAwait(reshardDone);
+            }
+            connection.sendRequest(requestId, action, request, options);
+        });
+
+        final var mgetResponse = new AtomicReference<MultiGetResponse>();
+        final var mgetThread = new Thread(
+            () -> mgetResponse.set(
+                client(indexNode).prepareMultiGet()
+                    .add(indexName, shard1docId)
+                    .setRealtime(false)
+                    .setRefresh(true)
+                    .execute()
+                    .actionGet(SAFE_AWAIT_TIMEOUT)
+            )
+        );
+        mgetThread.start();
+
+        safeAwait(mgetPrepared);
+        client().execute(TransportReshardAction.TYPE, new ReshardIndexRequest(indexName, 2)).actionGet(SAFE_AWAIT_TIMEOUT);
+        awaitClusterState(
+            searchNode,
+            clusterState -> indexMetadata(clusterState, index).getReshardingMetadata()
+                .getSplit()
+                .targetStateAtLeast(1, IndexReshardingState.Split.TargetShardState.HANDOFF)
+        );
+        indexDoc(indexName, shard1docId, "field", "shard1_v1");
+        reshardDone.countDown();
 
         safeJoin(mgetThread);
+        waitForReshardCompletion(indexName);
+        MultiGetItemResponse itemResponse = mgetResponse.get().getResponses()[0];
+        assertThat(itemResponse.getResponse().isExists(), is(true));
+        assertEquals("shard1_v1", itemResponse.getResponse().getSource().get("field"));
     }
 
     public void testReshardMustMatchExpectedNumberOfShards() {


### PR DESCRIPTION
Handle stale get/mget requests with refresh since the expectations are similar to a real-time get