### PR TITLE
[ESQL] Prune redundant stats groupings

### DIFF
--- a/docs/changelog/150030.yaml
+++ b/docs/changelog/150030.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 150030
+summary: Prune redundant stats groupings
+type: enhancement

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/type/DataType.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/type/DataType.java
@@ -735,6 +735,13 @@ public enum DataType implements Writeable {
         return t.isNumeric() || isNull(t);
     }
 
+    /**
+     * True for integer-valued data types that use integral compute blocks directly.
+     */
+    public static boolean isIntegral(DataType t) {
+        return t == INTEGER || t == LONG;
+    }
+
     public static boolean isDateTime(DataType type) {
         return type == DATETIME;
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizer.java
@@ -41,6 +41,7 @@ import org.elasticsearch.xpack.esql.optimizer.rules.logical.PruneFilters;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.PruneLiteralsInChangePointBy;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.PruneLiteralsInLimitBy;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.PruneLiteralsInOrderBy;
+import org.elasticsearch.xpack.esql.optimizer.rules.logical.PruneRedundantAggregateGroupings;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.PruneRedundantOrderBy;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.PruneRedundantSortClauses;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.PruneUnusedIndexMode;
@@ -220,6 +221,7 @@ public class LogicalPlanOptimizer extends ParameterizedRuleExecutor<LogicalPlan,
             new SplitInWithFoldableValue(),
             new PropagateEvalFoldables(),
             new ConstantFolding(),
+            new PruneRedundantAggregateGroupings(),
             /* Then deduplicate aggregations
                We need this after the constant folding
                because we could have expressions like

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneRedundantAggregateGroupings.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneRedundantAggregateGroupings.java
@@ -23,6 +23,8 @@ import org.elasticsearch.xpack.esql.plan.logical.Eval;
 import org.elasticsearch.xpack.esql.plan.logical.ExternalRelation;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.Project;
+import org.elasticsearch.xpack.esql.plan.logical.TimeSeriesAggregate;
+import org.elasticsearch.xpack.esql.plan.logical.join.StubRelation;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -39,7 +41,7 @@ public final class PruneRedundantAggregateGroupings extends OptimizerRules.Optim
 
     @Override
     protected LogicalPlan rule(Aggregate aggregate) {
-        if (aggregate.groupings().isEmpty()) {
+        if (shouldSkipAggregate(aggregate)) {
             return aggregate;
         }
 
@@ -83,6 +85,13 @@ public final class PruneRedundantAggregateGroupings extends OptimizerRules.Optim
             plan = new Project(aggregate.source(), plan, aggregate.aggregates().stream().map(NamedExpression::toAttribute).toList());
         }
         return plan;
+    }
+
+    private static boolean shouldSkipAggregate(Aggregate aggregate) {
+        // Inline stats RHS aggregates use StubRelation while their join keys still mirror the original groupings.
+        return aggregate.groupings().isEmpty()
+            || aggregate instanceof TimeSeriesAggregate
+            || aggregate.child().anyMatch(StubRelation.class::isInstance);
     }
 
     private static AttributeMap<Expression> evalAliases(LogicalPlan plan) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneRedundantAggregateGroupings.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneRedundantAggregateGroupings.java
@@ -25,19 +25,21 @@ import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.Project;
 import org.elasticsearch.xpack.esql.plan.logical.TimeSeriesAggregate;
 import org.elasticsearch.xpack.esql.plan.logical.join.StubRelation;
+import org.elasticsearch.xpack.esql.rule.Rule;
 
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static org.elasticsearch.xpack.esql.core.type.DataType.INTEGER;
-import static org.elasticsearch.xpack.esql.core.type.DataType.LONG;
+import static org.elasticsearch.xpack.esql.core.type.DataType.isIntegral;
 
 /**
  * Removes {@code STATS BY} keys that do not add grouping cardinality and rebuilds their output above the aggregation.
  */
-public final class PruneRedundantAggregateGroupings extends OptimizerRules.OptimizerRule<Aggregate> {
+public final class PruneRedundantAggregateGroupings extends OptimizerRules.OptimizerRule<Aggregate>
+    implements
+        OptimizerRules.LocalAware<Aggregate> {
 
     @Override
     protected LogicalPlan rule(Aggregate aggregate) {
@@ -60,7 +62,7 @@ public final class PruneRedundantAggregateGroupings extends OptimizerRules.Optim
             }
         }
 
-        if (prunedGroupings.isEmpty()) {
+        if (prunedGroupings.isEmpty() || newGroupings.isEmpty()) {
             return aggregate;
         }
 
@@ -85,6 +87,11 @@ public final class PruneRedundantAggregateGroupings extends OptimizerRules.Optim
             plan = new Project(aggregate.source(), plan, aggregate.aggregates().stream().map(NamedExpression::toAttribute).toList());
         }
         return plan;
+    }
+
+    @Override
+    public Rule<Aggregate, LogicalPlan> local() {
+        return null;
     }
 
     private static boolean shouldSkipAggregate(Aggregate aggregate) {
@@ -227,7 +234,7 @@ public final class PruneRedundantAggregateGroupings extends OptimizerRules.Optim
     }
 
     private static boolean isSafeIntegralAttribute(Attribute attribute) {
-        return attribute.dataType() == INTEGER || attribute.dataType() == LONG;
+        return isIntegral(attribute.dataType());
     }
 
     private static boolean isScalarFoldable(Expression expression) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneRedundantAggregateGroupings.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneRedundantAggregateGroupings.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.optimizer.rules.logical;
+
+import org.elasticsearch.xpack.esql.core.expression.Alias;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.AttributeMap;
+import org.elasticsearch.xpack.esql.core.expression.AttributeSet;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.Expressions;
+import org.elasticsearch.xpack.esql.core.expression.FoldContext;
+import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Add;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Neg;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Sub;
+import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
+import org.elasticsearch.xpack.esql.plan.logical.Eval;
+import org.elasticsearch.xpack.esql.plan.logical.ExternalRelation;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.plan.logical.Project;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.elasticsearch.xpack.esql.core.type.DataType.INTEGER;
+import static org.elasticsearch.xpack.esql.core.type.DataType.LONG;
+
+/**
+ * Removes {@code STATS BY} keys that do not add grouping cardinality and rebuilds their output above the aggregation.
+ */
+public final class PruneRedundantAggregateGroupings extends OptimizerRules.OptimizerRule<Aggregate> {
+
+    @Override
+    protected LogicalPlan rule(Aggregate aggregate) {
+        if (aggregate.groupings().isEmpty()) {
+            return aggregate;
+        }
+
+        AttributeMap<Expression> evalAliases = evalAliases(aggregate.child());
+        AttributeSet retainedGroupingAttributes = retainedGroupingAttributes(aggregate.groupings(), evalAliases);
+        AttributeSet externalAttributes = externalAttributes(aggregate.child());
+        List<Expression> newGroupings = new ArrayList<>(aggregate.groupings().size());
+        List<PrunedGrouping> prunedGroupings = new ArrayList<>();
+
+        for (Expression grouping : aggregate.groupings()) {
+            Expression replacement = replacementFor(grouping, evalAliases, retainedGroupingAttributes, externalAttributes);
+            if (replacement == null) {
+                newGroupings.add(grouping);
+            } else {
+                prunedGroupings.add(new PrunedGrouping(grouping, replacement));
+            }
+        }
+
+        if (prunedGroupings.isEmpty()) {
+            return aggregate;
+        }
+
+        List<NamedExpression> newAggregates = new ArrayList<>(aggregate.aggregates().size());
+        List<Alias> postAggregateEvals = new ArrayList<>();
+        for (NamedExpression aggregateExpression : aggregate.aggregates()) {
+            PrunedGrouping pruned = matchingPrunedGrouping(aggregateExpression, prunedGroupings);
+            if (pruned == null) {
+                newAggregates.add(aggregateExpression);
+            } else {
+                postAggregateEvals.add(reconstruct(aggregateExpression, pruned.replacement()));
+            }
+        }
+
+        LogicalPlan plan = aggregate.with(
+            pruneUnusedChildEvals(aggregate.child(), prunedGroupings, newGroupings, newAggregates),
+            newGroupings,
+            newAggregates
+        );
+        if (postAggregateEvals.isEmpty() == false) {
+            plan = new Eval(aggregate.source(), plan, postAggregateEvals);
+            plan = new Project(aggregate.source(), plan, aggregate.aggregates().stream().map(NamedExpression::toAttribute).toList());
+        }
+        return plan;
+    }
+
+    private static AttributeMap<Expression> evalAliases(LogicalPlan plan) {
+        AttributeMap.Builder<Expression> aliases = AttributeMap.builder();
+        plan.forEachDown(Eval.class, eval -> eval.fields().forEach(alias -> aliases.put(alias.toAttribute(), alias.child())));
+        return aliases.build();
+    }
+
+    private static AttributeSet retainedGroupingAttributes(List<Expression> groupings, AttributeMap<Expression> evalAliases) {
+        AttributeSet.Builder retained = AttributeSet.builder();
+        for (Expression grouping : groupings) {
+            Attribute attribute = Expressions.attribute(grouping);
+            if (attribute != null && evalAliases.containsKey(attribute) == false) {
+                retained.add(attribute);
+            }
+        }
+        return retained.build();
+    }
+
+    private static AttributeSet externalAttributes(LogicalPlan plan) {
+        AttributeSet.Builder externalAttributes = AttributeSet.builder();
+        plan.forEachDown(ExternalRelation.class, relation -> externalAttributes.addAll(relation.output()));
+        return externalAttributes.build();
+    }
+
+    private static LogicalPlan pruneUnusedChildEvals(
+        LogicalPlan child,
+        List<PrunedGrouping> prunedGroupings,
+        List<Expression> newGroupings,
+        List<NamedExpression> newAggregates
+    ) {
+        if (!(child instanceof Eval eval)) {
+            return child;
+        }
+
+        AttributeSet requiredByAggregate = Aggregate.computeReferences(newAggregates, newGroupings);
+        AttributeSet.Builder removableAttributes = AttributeSet.builder();
+        for (PrunedGrouping prunedGrouping : prunedGroupings) {
+            Attribute attribute = Expressions.attribute(prunedGrouping.grouping());
+            if (attribute != null && requiredByAggregate.contains(attribute) == false) {
+                removableAttributes.add(attribute);
+            }
+        }
+
+        if (removableAttributes.isEmpty()) {
+            return child;
+        }
+
+        List<Alias> remainingFields = eval.fields()
+            .stream()
+            .filter(alias -> removableAttributes.contains(alias.toAttribute()) == false)
+            .toList();
+        if (remainingFields.size() == eval.fields().size()) {
+            return child;
+        }
+        return remainingFields.isEmpty() ? eval.child() : new Eval(eval.source(), eval.child(), remainingFields);
+    }
+
+    private static Expression replacementFor(
+        Expression grouping,
+        AttributeMap<Expression> evalAliases,
+        AttributeSet retainedGroupingAttributes,
+        AttributeSet externalAttributes
+    ) {
+        Expression unwrapped = Alias.unwrap(grouping);
+        if (isScalarFoldable(unwrapped)) {
+            return unwrapped;
+        }
+
+        Attribute groupingAttribute = Expressions.attribute(grouping);
+        if (groupingAttribute == null) {
+            return null;
+        }
+
+        Expression definition = evalAliases.get(groupingAttribute);
+        if (definition == null) {
+            return null;
+        }
+        if (isScalarFoldable(definition)) {
+            return definition;
+        }
+
+        Expression expanded = expandAliases(definition, evalAliases, retainedGroupingAttributes, new HashSet<>());
+        if (isSafeDerivedExpression(expanded, retainedGroupingAttributes, externalAttributes)) {
+            return expanded;
+        }
+        return null;
+    }
+
+    private static Expression expandAliases(
+        Expression expression,
+        AttributeMap<Expression> evalAliases,
+        AttributeSet retainedGroupingAttributes,
+        Set<Attribute> expanding
+    ) {
+        return expression.transformUp(Attribute.class, attribute -> {
+            if (retainedGroupingAttributes.contains(attribute)) {
+                return attribute;
+            }
+            Expression replacement = evalAliases.get(attribute);
+            if (replacement == null || expanding.add(attribute) == false) {
+                return attribute;
+            }
+            try {
+                return expandAliases(replacement, evalAliases, retainedGroupingAttributes, expanding);
+            } finally {
+                expanding.remove(attribute);
+            }
+        });
+    }
+
+    private static boolean isSafeDerivedExpression(
+        Expression expression,
+        AttributeSet retainedGroupingAttributes,
+        AttributeSet externalAttributes
+    ) {
+        AttributeSet references = expression.references();
+        return references.isEmpty() == false
+            && references.subsetOf(retainedGroupingAttributes)
+            && references.subsetOf(externalAttributes)
+            && references.stream().allMatch(PruneRedundantAggregateGroupings::isSafeIntegralAttribute)
+            && expression.anyMatch(PruneRedundantAggregateGroupings::isUnsafeDerivedExpression) == false;
+    }
+
+    private static boolean isUnsafeDerivedExpression(Expression expression) {
+        if (expression instanceof Attribute) {
+            return false;
+        }
+        if (isScalarFoldable(expression)) {
+            return false;
+        }
+        return expression instanceof Add == false && expression instanceof Sub == false && expression instanceof Neg == false;
+    }
+
+    private static boolean isSafeIntegralAttribute(Attribute attribute) {
+        return attribute.dataType() == INTEGER || attribute.dataType() == LONG;
+    }
+
+    private static boolean isScalarFoldable(Expression expression) {
+        if (expression.foldable() == false) {
+            return false;
+        }
+        return expression.fold(FoldContext.small()) instanceof List<?> == false;
+    }
+
+    private static PrunedGrouping matchingPrunedGrouping(NamedExpression aggregateExpression, List<PrunedGrouping> prunedGroupings) {
+        Attribute aggregateAttribute = aggregateExpression.toAttribute();
+        Expression aggregateChild = Alias.unwrap(aggregateExpression);
+        for (PrunedGrouping prunedGrouping : prunedGroupings) {
+            Attribute groupingAttribute = Expressions.attribute(prunedGrouping.grouping());
+            if ((groupingAttribute != null && aggregateAttribute.semanticEquals(groupingAttribute))
+                || aggregateChild.semanticEquals(Alias.unwrap(prunedGrouping.grouping()))) {
+                return prunedGrouping;
+            }
+        }
+        return null;
+    }
+
+    private static Alias reconstruct(NamedExpression aggregateExpression, Expression replacement) {
+        if (aggregateExpression instanceof Alias alias) {
+            return alias.replaceChild(replacement);
+        }
+        return new Alias(
+            aggregateExpression.source(),
+            aggregateExpression.name(),
+            replacement,
+            aggregateExpression.id(),
+            aggregateExpression.synthetic()
+        );
+    }
+
+    private record PrunedGrouping(Expression grouping, Expression replacement) {}
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneColumnsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneColumnsTests.java
@@ -2434,11 +2434,11 @@ public class PruneColumnsTests extends AbstractLogicalPlanOptimizerTests {
 
         var limit = as(plan, Limit.class);
         var agg = as(limit.child(), Aggregate.class);
+        assertThat(Expressions.names(agg.groupings()), contains("extracted_first"));
         assertThat(Expressions.names(agg.aggregates()), contains("count", "extracted_first"));
         // Dissect is fully pruned since extracted_first/extracted_last are overwritten by EVAL
         var eval = as(agg.child(), Eval.class);
         assertThat(Expressions.names(eval.fields()), contains("extracted_first"));
-        // Dissect is fully pruned — next node is EsRelation, no Dissect in the tree
         as(eval.child(), EsRelation.class);
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneRedundantAggregateGroupingsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneRedundantAggregateGroupingsTests.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.optimizer.rules.logical;
+
+import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Expressions;
+import org.elasticsearch.xpack.esql.datasources.spi.FileList;
+import org.elasticsearch.xpack.esql.optimizer.AbstractLogicalPlanOptimizerTests;
+import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
+import org.elasticsearch.xpack.esql.plan.logical.Eval;
+import org.elasticsearch.xpack.esql.plan.logical.Limit;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.plan.logical.Project;
+
+import java.util.List;
+
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.analyzer;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.as;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.referenceAttribute;
+import static org.elasticsearch.xpack.esql.core.type.DataType.INTEGER;
+import static org.elasticsearch.xpack.esql.core.type.DataType.KEYWORD;
+import static org.hamcrest.Matchers.contains;
+
+public class PruneRedundantAggregateGroupingsTests extends AbstractLogicalPlanOptimizerTests {
+    private static final String S3_PATH = "s3://bucket/data.parquet";
+
+    public void testPrunesEvalConstantGrouping() {
+        var plan = plan("""
+            FROM test
+            | EVAL const1 = 1
+            | STATS c = COUNT(*) BY const1, last_name
+            """);
+
+        var project = rewrittenProject(plan);
+        assertThat(Expressions.names(project.projections()), contains("c", "const1", "last_name"));
+
+        var eval = as(project.child(), Eval.class);
+        assertThat(Expressions.names(eval.fields()), contains("const1"));
+
+        var aggregate = rewrittenAggregate(eval);
+        assertThat(Expressions.names(aggregate.groupings()), contains("last_name"));
+        assertThat(Expressions.names(aggregate.aggregates()), contains("c", "last_name"));
+    }
+
+    public void testPrunesDirectLiteralGrouping() {
+        var plan = plan("""
+            FROM test
+            | STATS c = COUNT(*) BY 1, last_name
+            """);
+
+        var project = rewrittenProject(plan);
+        assertThat(Expressions.names(project.projections()), contains("c", "1", "last_name"));
+
+        var aggregate = rewrittenAggregate(as(project.child(), Eval.class));
+        assertThat(Expressions.names(aggregate.groupings()), contains("last_name"));
+        assertThat(Expressions.names(aggregate.aggregates()), contains("c", "last_name"));
+    }
+
+    public void testDoesNotPruneMultivalueConstantGrouping() {
+        var plan = plan("""
+            FROM test
+            | EVAL mv = [1, 2]
+            | STATS c = COUNT(*) BY mv, last_name
+            """);
+
+        var aggregate = as(as(plan, Limit.class).child(), Aggregate.class);
+        assertThat(Expressions.names(aggregate.groupings()), contains("mv", "last_name"));
+    }
+
+    public void testPrunesDerivedExternalGroupings() {
+        var plan = externalPlan("""
+            EXTERNAL "s3://bucket/data.parquet"
+            | EVAL ip_m1 = ClientIP - 1, ip_m2 = ClientIP - 2, ip_m3 = ClientIP - 3
+            | STATS c = COUNT(*) BY ClientIP, ip_m1, ip_m2, ip_m3
+            """);
+
+        var project = rewrittenProject(plan);
+        assertThat(Expressions.names(project.projections()), contains("c", "ClientIP", "ip_m1", "ip_m2", "ip_m3"));
+
+        var eval = as(project.child(), Eval.class);
+        assertThat(Expressions.names(eval.fields()), contains("ip_m1", "ip_m2", "ip_m3"));
+
+        var aggregate = rewrittenAggregate(eval);
+        assertThat(Expressions.names(aggregate.groupings()), contains("ClientIP"));
+        assertThat(Expressions.names(aggregate.aggregates()), contains("c", "ClientIP"));
+    }
+
+    public void testDoesNotPruneDerivedOrdinaryIndexGrouping() {
+        var plan = plan("""
+            FROM test
+            | EVAL emp_m1 = emp_no - 1
+            | STATS c = COUNT(*) BY emp_no, emp_m1
+            """);
+
+        var aggregate = as(as(plan, Limit.class).child(), Aggregate.class);
+        assertThat(Expressions.names(aggregate.groupings()), contains("emp_no", "emp_m1"));
+    }
+
+    public void testDoesNotPruneIndependentExternalExpression() {
+        var plan = externalPlan("""
+            EXTERNAL "s3://bucket/data.parquet"
+            | EVAL other_m1 = OtherIP - 1
+            | STATS c = COUNT(*) BY ClientIP, other_m1
+            """);
+
+        var aggregate = as(as(plan, Limit.class).child(), Aggregate.class);
+        assertThat(Expressions.names(aggregate.groupings()), contains("ClientIP", "other_m1"));
+    }
+
+    public void testDoesNotPruneNonWhitelistedExternalExpression() {
+        var plan = externalPlan("""
+            EXTERNAL "s3://bucket/data.parquet"
+            | EVAL ip_mul = ClientIP * 2
+            | STATS c = COUNT(*) BY ClientIP, ip_mul
+            """);
+
+        var aggregate = as(as(plan, Limit.class).child(), Aggregate.class);
+        assertThat(Expressions.names(aggregate.groupings()), contains("ClientIP", "ip_mul"));
+    }
+
+    private LogicalPlan externalPlan(String query) {
+        assumeTrue("requires EXTERNAL command capability", EsqlCapabilities.Cap.EXTERNAL_COMMAND.isEnabled());
+        List<Attribute> schema = List.of(
+            referenceAttribute("ClientIP", INTEGER),
+            referenceAttribute("OtherIP", INTEGER),
+            referenceAttribute("URL", KEYWORD)
+        );
+        return optimize(analyzer().externalSourceResolution(S3_PATH, schema, FileList.UNRESOLVED).query(query));
+    }
+
+    private static Project rewrittenProject(LogicalPlan plan) {
+        return as(plan, Project.class);
+    }
+
+    private static Aggregate rewrittenAggregate(Eval eval) {
+        return as(as(eval.child(), Limit.class).child(), Aggregate.class);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneRedundantAggregateGroupingsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneRedundantAggregateGroupingsTests.java
@@ -69,6 +69,44 @@ public class PruneRedundantAggregateGroupingsTests extends AbstractLogicalPlanOp
         as(aggregate.child(), EsRelation.class);
     }
 
+    public void testDoesNotPruneOnlyEvalConstantGrouping() {
+        var plan = plan("""
+            FROM test
+            | EVAL const1 = 1
+            | STATS c = COUNT(*) BY const1
+            """);
+
+        var aggregate = as(as(plan, Limit.class).child(), Aggregate.class);
+        assertThat(Expressions.names(aggregate.groupings()), contains("const1"));
+        assertThat(Expressions.names(aggregate.aggregates()), contains("c", "const1"));
+        as(aggregate.child(), Eval.class);
+    }
+
+    public void testDoesNotPruneOnlyDirectLiteralGrouping() {
+        var plan = plan("""
+            FROM test
+            | STATS c = COUNT(*) BY 1
+            """);
+
+        var aggregate = as(as(plan, Limit.class).child(), Aggregate.class);
+        assertThat(Expressions.names(aggregate.groupings()), contains("1"));
+        assertThat(Expressions.names(aggregate.aggregates()), contains("c", "1"));
+        as(aggregate.child(), Eval.class);
+    }
+
+    public void testDoesNotPruneOnlyMultipleConstantGroupings() {
+        var plan = plan("""
+            FROM test
+            | EVAL const1 = 1
+            | STATS c = COUNT(*) BY const1, 2
+            """);
+
+        var aggregate = as(as(plan, Limit.class).child(), Aggregate.class);
+        assertThat(Expressions.names(aggregate.groupings()), contains("const1", "2"));
+        assertThat(Expressions.names(aggregate.aggregates()), contains("c", "const1", "2"));
+        as(aggregate.child(), Eval.class);
+    }
+
     public void testDoesNotPruneMultivalueConstantGrouping() {
         var plan = plan("""
             FROM test
@@ -92,6 +130,29 @@ public class PruneRedundantAggregateGroupingsTests extends AbstractLogicalPlanOp
 
         var eval = as(project.child(), Eval.class);
         assertThat(Expressions.names(eval.fields()), contains("ip_m1", "ip_m2", "ip_m3"));
+
+        var aggregate = rewrittenAggregate(eval);
+        assertThat(Expressions.names(aggregate.groupings()), contains("ClientIP"));
+        assertThat(Expressions.names(aggregate.aggregates()), contains("c", "ClientIP"));
+        as(aggregate.child(), ExternalRelation.class);
+        assertThat(
+            eval.fields().get(0).child(),
+            instanceOf(org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Sub.class)
+        );
+    }
+
+    public void testPrunesRecursiveDerivedExternalGrouping() {
+        var plan = externalPlan("""
+            EXTERNAL "s3://bucket/data.parquet"
+            | EVAL ip_m1 = ClientIP - 1, ip_m2 = ip_m1 - 1
+            | STATS c = COUNT(*) BY ClientIP, ip_m2
+            """);
+
+        var project = rewrittenProject(plan);
+        assertThat(Expressions.names(project.projections()), contains("c", "ClientIP", "ip_m2"));
+
+        var eval = as(project.child(), Eval.class);
+        assertThat(Expressions.names(eval.fields()), contains("ip_m2"));
 
         var aggregate = rewrittenAggregate(eval);
         assertThat(Expressions.names(aggregate.groupings()), contains("ClientIP"));

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneRedundantAggregateGroupingsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneRedundantAggregateGroupingsTests.java
@@ -13,10 +13,14 @@ import org.elasticsearch.xpack.esql.core.expression.Expressions;
 import org.elasticsearch.xpack.esql.datasources.spi.FileList;
 import org.elasticsearch.xpack.esql.optimizer.AbstractLogicalPlanOptimizerTests;
 import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
+import org.elasticsearch.xpack.esql.plan.logical.EsRelation;
 import org.elasticsearch.xpack.esql.plan.logical.Eval;
+import org.elasticsearch.xpack.esql.plan.logical.ExternalRelation;
 import org.elasticsearch.xpack.esql.plan.logical.Limit;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.Project;
+import org.elasticsearch.xpack.esql.plan.logical.join.InlineJoin;
+import org.elasticsearch.xpack.esql.plan.logical.join.StubRelation;
 
 import java.util.List;
 
@@ -26,6 +30,7 @@ import static org.elasticsearch.xpack.esql.EsqlTestUtils.referenceAttribute;
 import static org.elasticsearch.xpack.esql.core.type.DataType.INTEGER;
 import static org.elasticsearch.xpack.esql.core.type.DataType.KEYWORD;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.instanceOf;
 
 public class PruneRedundantAggregateGroupingsTests extends AbstractLogicalPlanOptimizerTests {
     private static final String S3_PATH = "s3://bucket/data.parquet";
@@ -46,6 +51,7 @@ public class PruneRedundantAggregateGroupingsTests extends AbstractLogicalPlanOp
         var aggregate = rewrittenAggregate(eval);
         assertThat(Expressions.names(aggregate.groupings()), contains("last_name"));
         assertThat(Expressions.names(aggregate.aggregates()), contains("c", "last_name"));
+        as(aggregate.child(), EsRelation.class);
     }
 
     public void testPrunesDirectLiteralGrouping() {
@@ -60,6 +66,7 @@ public class PruneRedundantAggregateGroupingsTests extends AbstractLogicalPlanOp
         var aggregate = rewrittenAggregate(as(project.child(), Eval.class));
         assertThat(Expressions.names(aggregate.groupings()), contains("last_name"));
         assertThat(Expressions.names(aggregate.aggregates()), contains("c", "last_name"));
+        as(aggregate.child(), EsRelation.class);
     }
 
     public void testDoesNotPruneMultivalueConstantGrouping() {
@@ -89,6 +96,62 @@ public class PruneRedundantAggregateGroupingsTests extends AbstractLogicalPlanOp
         var aggregate = rewrittenAggregate(eval);
         assertThat(Expressions.names(aggregate.groupings()), contains("ClientIP"));
         assertThat(Expressions.names(aggregate.aggregates()), contains("c", "ClientIP"));
+        as(aggregate.child(), ExternalRelation.class);
+        assertThat(
+            eval.fields().get(0).child(),
+            instanceOf(org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Sub.class)
+        );
+    }
+
+    public void testPartialDerivedExternalPruningKeepsNeededPreAggregateEval() {
+        var plan = externalPlan("""
+            EXTERNAL "s3://bucket/data.parquet"
+            | EVAL ip_m1 = ClientIP - 1, other_m1 = OtherIP - 1
+            | STATS c = COUNT(*) BY ClientIP, ip_m1, other_m1
+            """);
+
+        var project = rewrittenProject(plan);
+        assertThat(Expressions.names(project.projections()), contains("c", "ClientIP", "ip_m1", "other_m1"));
+
+        var postAggregateEval = as(project.child(), Eval.class);
+        assertThat(Expressions.names(postAggregateEval.fields()), contains("ip_m1"));
+
+        var aggregate = rewrittenAggregate(postAggregateEval);
+        assertThat(Expressions.names(aggregate.groupings()), contains("ClientIP", "other_m1"));
+        assertThat(Expressions.names(aggregate.aggregates()), contains("c", "ClientIP", "other_m1"));
+
+        var preAggregateEval = as(aggregate.child(), Eval.class);
+        assertThat(Expressions.names(preAggregateEval.fields()), contains("other_m1"));
+        as(preAggregateEval.child(), ExternalRelation.class);
+    }
+
+    public void testDoesNotPruneInlineStatsGroupings() {
+        assumeTrue("requires INLINE STATS command capability", EsqlCapabilities.Cap.INLINE_STATS.isEnabled());
+        var plan = plan("""
+            FROM test
+            | EVAL const1 = 1
+            | INLINE STATS c = COUNT(*) BY const1, last_name
+            """);
+
+        var inlineJoin = as(as(plan, Limit.class).child(), InlineJoin.class);
+        var aggregate = as(inlineJoin.right(), Aggregate.class);
+        assertThat(Expressions.names(aggregate.groupings()), contains("const1", "last_name"));
+        assertThat(Expressions.names(aggregate.aggregates()), contains("c", "const1", "last_name"));
+        as(aggregate.child(), StubRelation.class);
+    }
+
+    public void testDoesNotPruneInlineStatsLiteralGroupings() {
+        assumeTrue("requires INLINE STATS command capability", EsqlCapabilities.Cap.INLINE_STATS.isEnabled());
+        var plan = plan("""
+            FROM test
+            | INLINE STATS c = COUNT(*) BY 1, last_name
+            """);
+
+        var inlineJoin = as(as(plan, Limit.class).child(), InlineJoin.class);
+        var aggregate = as(inlineJoin.right(), Aggregate.class);
+        assertThat(Expressions.names(aggregate.groupings()), contains("1", "last_name"));
+        assertThat(Expressions.names(aggregate.aggregates()), contains("c", "1", "last_name"));
+        as(aggregate.child(), StubRelation.class);
     }
 
     public void testDoesNotPruneDerivedOrdinaryIndexGrouping() {

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/10_basic.yml
@@ -815,6 +815,59 @@ version is not allowed:
   - match: {values.2: [1, 43, 1, 1]}
 
 ---
+"Stats by constant":
+  - do:
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
+      esql.query:
+        body:
+          query: 'from test | stats c = count(*) by 1'
+
+  - length: { columns: 2 }
+  - match: { columns.0.name: "c" }
+  - match: { columns.1.name: "1" }
+  - length: { values: 1 }
+  - match: { values.0: [ 40, 1 ] }
+
+---
+"Stats by constant with no rows":
+  - do:
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
+      esql.query:
+        body:
+          query: 'from test | where data < 0 | stats c = count(*) by 1'
+
+  - length: { columns: 2 }
+  - match: { columns.0.name: "c" }
+  - match: { columns.1.name: "1" }
+  - length: { values: 0 }
+
+---
+"Drop all columns then stats by constant":
+  - requires:
+      test_runner_features: [ capabilities, allowed_warnings_regex ]
+      capabilities:
+        - method: POST
+          path: /_query
+          parameters: [ ]
+          capabilities: [ fix_no_columns ]
+      reason: "plans with no columns only recently supported"
+
+  - do:
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
+      esql.query:
+        body:
+          query: 'from test | keep color | drop color | eval k = 1 | stats c = count(*) by k'
+
+  - length: { columns: 2 }
+  - match: { columns.0.name: "c" }
+  - match: { columns.1.name: "k" }
+  - length: { values: 1 }
+  - match: { values.0: [ 40, 1 ] }
+
+---
 "Drop all columns with fork":
   - requires:
       test_runner_features: [ capabilities, allowed_warnings_regex ]


### PR DESCRIPTION
Remove constant and conservative external-derived grouping keys from
STATS hash aggregation while rebuilding their output columns above the
aggregation. This reduces unnecessary grouping width without changing
parent-visible output.

Developed with AI-assisted tooling