### PR TITLE
[9.3] Fix flaky binary DV tests that could generate empty document lists (#145649)

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesFormatTests.java
@@ -135,7 +135,7 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
         boolean sparse = randomBoolean();
         int numBlocksBound = 10;
         // Since average size is 25b will hit count threshold rather than size threshold, so use count threshold compute needed docs.
-        int numNonNullValues = randomIntBetween(0, numBlocksBound * BLOCK_COUNT_THRESHOLD);
+        int numNonNullValues = randomIntBetween(1, numBlocksBound * BLOCK_COUNT_THRESHOLD);
 
         List<String> binaryValues = new ArrayList<>();
         int numNonNull = 0;
@@ -156,7 +156,7 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
     public void testBlockWiseBinarySmallValues() throws Exception {
         boolean sparse = randomBoolean();
         int numBlocksBound = 5;
-        int numNonNullValues = randomIntBetween(0, numBlocksBound * BLOCK_COUNT_THRESHOLD);
+        int numNonNullValues = randomIntBetween(1, numBlocksBound * BLOCK_COUNT_THRESHOLD);
 
         List<String> binaryValues = new ArrayList<>();
         int numNonNull = 0;
@@ -178,7 +178,7 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
         List<String> binaryValues = new ArrayList<>();
         int numSequences = 10;
         for (int i = 0; i < numSequences; i++) {
-            int numInSequence = randomIntBetween(0, 3 * BLOCK_COUNT_THRESHOLD);
+            int numInSequence = randomIntBetween(1, 3 * BLOCK_COUNT_THRESHOLD);
             boolean emptySequence = randomBoolean();
             for (int j = 0; j < numInSequence; j++) {
                 binaryValues.add(emptySequence ? "" : randomAlphaOfLengthBetween(0, 5));
@@ -190,7 +190,7 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
     public void testBlockWiseBinaryLargeValues() throws Exception {
         boolean sparse = randomBoolean();
         int numBlocksBound = 5;
-        int binaryDataSize = randomIntBetween(0, numBlocksBound * BLOCK_BYTES_THRESHOLD);
+        int binaryDataSize = randomIntBetween(1, numBlocksBound * BLOCK_BYTES_THRESHOLD);
         List<String> binaryValues = new ArrayList<>();
         int totalSize = 0;
         while (totalSize < binaryDataSize) {
@@ -207,6 +207,7 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
     }
 
     public void assertBinaryValues(List<String> binaryValues) throws Exception {
+        assert binaryValues.isEmpty() == false : "binaryValues must be non-empty";
         String timestampField = "@timestamp";
         String hostnameField = "host.name";
         long baseTimestamp = 1704067200000L;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Fix flaky binary DV tests that could generate empty document lists (#145649)](https://github.com/elastic/elasticsearch/pull/145649)

<!--- Backport version: 9.6.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)