### PR TITLE
Fix NumberFieldBlockLoaderTestCase for non-latin Unicode digits in ignored_source path

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/NumberFieldBlockLoaderTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/NumberFieldBlockLoaderTestCase.java
@@ -141,4 +141,29 @@ public abstract class NumberFieldBlockLoaderTestCase<T extends Number> extends B
         runner.mapperService(createMapperService(settings.build(), XContentFactory.jsonBuilder().map(mapping.raw())));
         runner.run(expected);
     }
+
+    public void testBlockLoaderNonLatinDigit_parseFromSource() throws IOException {
+        runner.breaker(newLimitedBreaker(TEST_BREAKER_SIZE));
+
+        String value = "\u1a90";
+
+        runner.document(Map.of("field", value));
+        runner.fieldName("field");
+
+        var fieldMapping = new HashMap<String, Object>();
+        fieldMapping.put("type", fieldType);
+        fieldMapping.put("ignore_malformed", "true");
+        fieldMapping.put("doc_values", false);
+        if (fieldType.equals(FieldType.SCALED_FLOAT.toString())) {
+            fieldMapping.put("scaling_factor", "1");
+        }
+
+        var mapping = new Mapping(Map.of("_doc", Map.of("properties", Map.of("field", fieldMapping))), Map.of("field", fieldMapping));
+
+        Object expected = expected(mapping.lookup().get("field"), value, new TestContext(false, false));
+
+        var settings = getSettingsForParams();
+        runner.mapperService(createMapperService(settings.build(), XContentFactory.jsonBuilder().map(mapping.raw())));
+        runner.run(expected);
+    }
 }

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/NumberFieldBlockLoaderTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/NumberFieldBlockLoaderTestCase.java
@@ -34,16 +34,23 @@ public abstract class NumberFieldBlockLoaderTestCase<T extends Number> extends B
             || params.preference() == MappedFieldType.FieldExtractPreference.DOC_VALUES
             || params.syntheticSource();
 
-        boolean fromDocValues = hasDocValues && useDocValues;
-
-        if (value instanceof List<?> == false) {
-            return convert(value, nullValue, fieldMapping, fromDocValues);
+        ValueSource source;
+        if (hasDocValues && useDocValues) {
+            source = ValueSource.DOC_VALUES;
+        } else if (params.syntheticSource()) {
+            source = ValueSource.IGNORED_SOURCE;
+        } else {
+            source = ValueSource.STORED_SOURCE;
         }
 
-        if (fromDocValues) {
+        if (value instanceof List<?> == false) {
+            return convert(value, nullValue, fieldMapping, source);
+        }
+
+        if (source == ValueSource.DOC_VALUES) {
             // Sorted
             var resultList = ((List<Object>) value).stream()
-                .map(v -> convert(v, nullValue, fieldMapping, true))
+                .map(v -> convert(v, nullValue, fieldMapping, source))
                 .filter(Objects::nonNull)
                 .sorted()
                 .toList();
@@ -52,13 +59,19 @@ public abstract class NumberFieldBlockLoaderTestCase<T extends Number> extends B
 
         // parsing from source
         var resultList = ((List<Object>) value).stream()
-            .map(v -> convert(v, nullValue, fieldMapping, false))
+            .map(v -> convert(v, nullValue, fieldMapping, source))
             .filter(Objects::nonNull)
             .toList();
         return maybeFoldList(resultList);
     }
 
-    private T convert(Object value, T nullValue, Map<String, Object> fieldMapping, boolean fromDocValues) {
+    private enum ValueSource {
+        DOC_VALUES,
+        IGNORED_SOURCE,
+        STORED_SOURCE
+    }
+
+    private T convert(Object value, T nullValue, Map<String, Object> fieldMapping, ValueSource valueSource) {
         switch (value) {
             case null -> {
                 return nullValue;
@@ -71,7 +84,10 @@ public abstract class NumberFieldBlockLoaderTestCase<T extends Number> extends B
                 }
                 // Attempt to parse the string as a number. If that fails, the string is malformed, so return null.
                 // The two code paths in the mapper use different parsers, so we delegate to the appropriate method.
-                Number parsed = fromDocValues ? tryParseString(s) : tryParseStringFromSource(s);
+                Number parsed = switch (valueSource) {
+                    case DOC_VALUES, IGNORED_SOURCE -> tryParseString(s);
+                    case STORED_SOURCE -> tryParseStringFromSource(s);
+                };
                 if (parsed != null) {
                     return convert(parsed, fieldMapping);
                 }

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/NumberFieldBlockLoaderTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/NumberFieldBlockLoaderTestCase.java
@@ -65,9 +65,29 @@ public abstract class NumberFieldBlockLoaderTestCase<T extends Number> extends B
         return maybeFoldList(resultList);
     }
 
+    /**
+     * Identifies which code path the block loader uses to retrieve a value. The distinction matters
+     * because {@code NumberType.parse(XContentParser, boolean)} and
+     * {@code NumberType.parse(Object, boolean)} can differ in how they handle non-latin Unicode digits.
+     *
+     * <p>{@link #DOC_VALUES} and {@link #IGNORED_SOURCE} both use the {@code XContentParser}
+     * overload, so they share the same string-parsing behavior. {@link #STORED_SOURCE} uses the
+     * {@code Object} overload and may therefore produce different results for the same input.
+     */
     private enum ValueSource {
+        /** Values indexed into doc values via the {@code XContentParser} overload. */
         DOC_VALUES,
+        /**
+         * Synthetic source without doc values: values stored in {@code _ignored_source} and
+         * re-parsed by {@code NumberFallbackSyntheticSourceReader} using the {@code XContentParser}
+         * overload.
+         */
         IGNORED_SOURCE,
+        /**
+         * Non-synthetic source without doc values: values re-parsed from stored {@code _source} by
+         * the {@code SourceValueFetcher} returned from {@code NumberFieldType#sourceValueFetcher},
+         * using the {@code Object} overload.
+         */
         STORED_SOURCE
     }
 
@@ -83,7 +103,7 @@ public abstract class NumberFieldBlockLoaderTestCase<T extends Number> extends B
                     return nullValue;
                 }
                 // Attempt to parse the string as a number. If that fails, the string is malformed, so return null.
-                // The two code paths in the mapper use different parsers, so we delegate to the appropriate method.
+                // The three block loader code paths use different parsers, so we delegate to the appropriate method.
                 Number parsed = switch (valueSource) {
                     case DOC_VALUES, IGNORED_SOURCE -> tryParseString(s);
                     case STORED_SOURCE -> tryParseStringFromSource(s);
@@ -106,12 +126,13 @@ public abstract class NumberFieldBlockLoaderTestCase<T extends Number> extends B
     }
 
     /**
-     * Tries to parse a string as a number, matching the behavior used during indexing (and therefore
-     * what is stored in doc values or returned via synthetic source).
+     * Tries to parse a string as a number, matching the behavior used during indexing (doc values)
+     * and when reading from {@code _ignored_source} via {@code NumberFallbackSyntheticSourceReader}.
      * Returns null if the string cannot be parsed as a valid number.
      *
-     * <p>The default implementation uses {@link Double#parseDouble(String)}, which matches the
-     * coercion behavior of most numeric field mappers.
+     * <p>Both paths use {@code NumberType.parse(XContentParser, boolean)}. The default implementation
+     * uses {@link Double#parseDouble(String)}, which matches the coercion behavior of most numeric
+     * field mappers.
      */
     protected Number tryParseString(String s) {
         try {
@@ -123,10 +144,14 @@ public abstract class NumberFieldBlockLoaderTestCase<T extends Number> extends B
 
     /**
      * Tries to parse a string as a number, matching the behavior used when re-parsing from the
-     * original stored {@code _source}. Returns null if the string cannot be parsed as a valid number.
+     * original stored {@code _source} (via the {@code SourceValueFetcher} returned from
+     * {@code NumberFieldType#sourceValueFetcher}). Returns null if the string cannot be parsed as a
+     * valid number.
      *
-     * <p>This is intentionally separate from {@link #tryParseString(String)} because the indexing
-     * path and the stored-source re-parsing path can differ (see {@code LongFieldBlockLoaderTests}).
+     * <p>The stored-source path uses {@code NumberType.parse(Object, boolean)}.
+     *
+     * <p>This is intentionally separate from {@link #tryParseString(String)} because the two paths can
+     * differ (see {@code LongFieldBlockLoaderTests}).
      */
     protected Number tryParseStringFromSource(String s) {
         return tryParseString(s);


### PR DESCRIPTION
## Summary

A previous fix (#149438) corrected the `NumberFieldBlockLoaderTestCase#expected` logic for the doc-values vs. stored-source distinction, but did not account for the `_ignored_source` path, causing test failures when synthetic source was enabled with `doc_values: false`. This PR fixes that by introducing a `ValueSource` enum that correctly routes string coercion to the appropriate parser for each of the three block loader code paths. It also adds a targeted regression test and improves the Javadoc to explain the asymmetry.

## Background

`NumberType.LONG` has two `parse` overloads that differ in how they handle non-latin Unicode digits (e.g. `᪐` Cham digit zero, `٢` Arabic-Indic digit two). The `parse(XContentParser, boolean)` overload calls `Long.parseLong()` and accepts Unicode digits; the `parse(Object, boolean)` overload goes through `objectToDouble()` → `Double.parseDouble()` and rejects them. The three block loader code paths map to these overloads as follows:

| Source | Production path | Accepts Unicode digits? |
|---|---|---|
| `DOC_VALUES` | `NumberFieldMapper` indexes via XContentParser overload | Yes |
| `IGNORED_SOURCE` | `NumberFallbackSyntheticSourceReader.parseNonNullValue()` uses XContentParser overload | Yes |
| `STORED_SOURCE` | `SourceValueFetcher` from `NumberFieldType#sourceValueFetcher` uses Object overload | No |