### PR TITLE
ESQL: Silence warnings during build

### DIFF
--- a/x-pack/plugin/esql-datasource-csv/qa/build.gradle
+++ b/x-pack/plugin/esql-datasource-csv/qa/build.gradle
@@ -154,6 +154,8 @@ csvBasenamesForTsv.each { baseName ->
     args = [csvSynced.path, tsvOut.path]
     inputs.file(csvSynced)
     outputs.file(tsvOut)
+    systemProperty 'slf4j.provider', 'org.slf4j.nop.NOPServiceProvider'
+    systemProperty 'slf4j.internal.verbosity', 'WARN'
   }
   generateStandaloneTsvTasks.add(tasks.named(taskName))
 }
@@ -171,6 +173,8 @@ tasks.register('generateMultifileSplitTsv_employees', JavaExec) {
   args = [tsvMultifileSplitCsv.path, tsvMultifileSplitDir.path, '3']
   inputs.file(tsvMultifileSplitCsv)
   outputs.dir(tsvMultifileSplitDir)
+  systemProperty 'slf4j.provider', 'org.slf4j.nop.NOPServiceProvider'
+  systemProperty 'slf4j.internal.verbosity', 'WARN'
 }
 generateStandaloneTsvTasks.add(tasks.named('generateMultifileSplitTsv_employees'))
 

--- a/x-pack/plugin/esql-datasource-iceberg/qa/build.gradle
+++ b/x-pack/plugin/esql-datasource-iceberg/qa/build.gradle
@@ -90,6 +90,7 @@ standaloneParquetFromCsv.each { baseName ->
     inputs.file(csvInput)
     outputs.file(parquetOut)
     systemProperty 'slf4j.provider', 'org.slf4j.nop.NOPServiceProvider'
+    systemProperty 'slf4j.internal.verbosity', 'WARN'
   }
   generateIcebergStandaloneParquetTasks.add(tasks.named(taskName))
 }

--- a/x-pack/plugin/esql-datasource-ndjson/qa/build.gradle
+++ b/x-pack/plugin/esql-datasource-ndjson/qa/build.gradle
@@ -69,6 +69,7 @@ standaloneNdjsonFromCsv.each { baseName ->
     inputs.file(csvInput)
     outputs.file(ndjsonOut)
     systemProperty 'slf4j.provider', 'org.slf4j.nop.NOPServiceProvider'
+    systemProperty 'slf4j.internal.verbosity', 'WARN'
   }
   generateStandaloneNdjsonTasks.add(tasks.named(taskName))
 }
@@ -87,6 +88,7 @@ tasks.register('generateMultifileSplitNdjson_employees', JavaExec) {
   inputs.file(multifileSplitCsv)
   outputs.dir(multifileSplitDir)
   systemProperty 'slf4j.provider', 'org.slf4j.nop.NOPServiceProvider'
+  systemProperty 'slf4j.internal.verbosity', 'WARN'
 }
 generateStandaloneNdjsonTasks.add(tasks.named('generateMultifileSplitNdjson_employees'))
 

--- a/x-pack/plugin/esql-datasource-orc/qa/build.gradle
+++ b/x-pack/plugin/esql-datasource-orc/qa/build.gradle
@@ -97,6 +97,7 @@ csvToOrcFixtures.each { baseName ->
     inputs.file(csvFile)
     outputs.file(orcFile)
     systemProperty 'slf4j.provider', 'org.slf4j.nop.NOPServiceProvider'
+    systemProperty 'slf4j.internal.verbosity', 'WARN'
   }
   generateOrcTasks.add(tasks.named(taskName))
 }
@@ -115,6 +116,7 @@ tasks.register('generateMultifileSplitOrc_employees', JavaExec) {
   inputs.file(multifileSplitCsv)
   outputs.dir(multifileSplitDir)
   systemProperty 'slf4j.provider', 'org.slf4j.nop.NOPServiceProvider'
+  systemProperty 'slf4j.internal.verbosity', 'WARN'
 }
 generateOrcTasks.add(tasks.named('generateMultifileSplitOrc_employees'))
 

--- a/x-pack/plugin/esql-datasource-parquet/qa/build.gradle
+++ b/x-pack/plugin/esql-datasource-parquet/qa/build.gradle
@@ -80,6 +80,7 @@ csvToParquetFixtures.each { baseName ->
     inputs.file(csvInput)
     outputs.file(parquetFile)
     systemProperty 'slf4j.provider', 'org.slf4j.nop.NOPServiceProvider'
+    systemProperty 'slf4j.internal.verbosity', 'WARN'
   }
   generateParquetTasks.add(tasks.named(taskName))
 }
@@ -96,6 +97,7 @@ tasks.register('generateMultifileParquet_employees', JavaExec) {
   inputs.file(multifileEmployeesCsv)
   outputs.dir(multifileDir)
   systemProperty 'slf4j.provider', 'org.slf4j.nop.NOPServiceProvider'
+  systemProperty 'slf4j.internal.verbosity', 'WARN'
 }
 generateParquetTasks.add(tasks.named('generateMultifileParquet_employees'))
 
@@ -117,6 +119,7 @@ def multifileUbnDir = file("${parquetFixtureOutputDir}/multifile_ubn")
     inputs.file(csvInput)
     outputs.file(parquetFile)
     systemProperty 'slf4j.provider', 'org.slf4j.nop.NOPServiceProvider'
+    systemProperty 'slf4j.internal.verbosity', 'WARN'
   }
   generateParquetTasks.add(tasks.named(taskName))
 }
@@ -135,6 +138,7 @@ tasks.register('generateMultifileSplitParquet_employees', JavaExec) {
   inputs.file(multifileSplitEmployeesCsv)
   outputs.dir(multifileSplitDir)
   systemProperty 'slf4j.provider', 'org.slf4j.nop.NOPServiceProvider'
+  systemProperty 'slf4j.internal.verbosity', 'WARN'
 }
 generateParquetTasks.add(tasks.named('generateMultifileSplitParquet_employees'))
 
@@ -155,6 +159,7 @@ tasks.register('generateHivePartitionedParquet_employees', JavaExec) {
   inputs.file(hivePartitionedEmployeesCsv)
   outputs.dir(hivePartitionedDir)
   systemProperty 'slf4j.provider', 'org.slf4j.nop.NOPServiceProvider'
+  systemProperty 'slf4j.internal.verbosity', 'WARN'
 }
 generateParquetTasks.add(tasks.named('generateHivePartitionedParquet_employees'))
 

--- a/x-pack/plugin/esql/qa/server/build.gradle
+++ b/x-pack/plugin/esql/qa/server/build.gradle
@@ -96,7 +96,11 @@ dependencies {
 
   ndjsonFixtureGenerator project(':libs:x-content')
   ndjsonFixtureGenerator project(xpackModule('esql-datasource-csv'))
+  ndjsonFixtureGenerator "org.slf4j:slf4j-api:${versions.slf4j}"
+  ndjsonFixtureGenerator "org.slf4j:slf4j-nop:${versions.slf4j}"
 
   tsvFixtureGenerator project(':libs:core')
   tsvFixtureGenerator project(xpackModule('esql-datasource-csv'))
+  tsvFixtureGenerator "org.slf4j:slf4j-api:${versions.slf4j}"
+  tsvFixtureGenerator "org.slf4j:slf4j-nop:${versions.slf4j}"
 }

--- a/x-pack/plugin/esql/qa/server/compressed-parquet-fixtures.gradle
+++ b/x-pack/plugin/esql/qa/server/compressed-parquet-fixtures.gradle
@@ -43,6 +43,7 @@ compressedCodecs.each { entry ->
       inputs.file(csvInput)
       outputs.file(parquetFile)
       systemProperty 'slf4j.provider', 'org.slf4j.nop.NOPServiceProvider'
+      systemProperty 'slf4j.internal.verbosity', 'WARN'
     }
     parquetTasks.add(tasks.named(taskName))
   }
@@ -70,6 +71,7 @@ compressedMultifileCodecs.each { entry ->
     inputs.file(multifileSplitCsv)
     outputs.dir(codecMultifileDir)
     systemProperty 'slf4j.provider', 'org.slf4j.nop.NOPServiceProvider'
+    systemProperty 'slf4j.internal.verbosity', 'WARN'
   }
   parquetTasks.add(tasks.named(taskName))
 }

--- a/x-pack/plugin/esql/qa/server/multi-node/build.gradle
+++ b/x-pack/plugin/esql/qa/server/multi-node/build.gradle
@@ -78,6 +78,7 @@ csvToParquetFixtures.each { baseName ->
     inputs.file(csvInput)
     outputs.file(parquetFile)
     systemProperty 'slf4j.provider', 'org.slf4j.nop.NOPServiceProvider'
+    systemProperty 'slf4j.internal.verbosity', 'WARN'
   }
   generateParquetTasks.add(tasks.named(taskName))
 }

--- a/x-pack/plugin/esql/qa/server/src/ndjsonFixtureGenerator/java/org/elasticsearch/xpack/esql/datasources/NdJsonFixtureGenerator.java
+++ b/x-pack/plugin/esql/qa/server/src/ndjsonFixtureGenerator/java/org/elasticsearch/xpack/esql/datasources/NdJsonFixtureGenerator.java
@@ -14,6 +14,8 @@ import org.elasticsearch.xpack.esql.datasource.csv.CsvFixtureParser;
 import org.elasticsearch.xpack.esql.datasource.csv.CsvFixtureParser.ColumnSpec;
 import org.elasticsearch.xpack.esql.datasource.csv.CsvFixtureParser.CsvFixtureResult;
 import org.elasticsearch.xpack.esql.datasource.csv.SplitPartitioner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -50,6 +52,8 @@ public final class NdJsonFixtureGenerator {
 
     private NdJsonFixtureGenerator() {}
 
+    private static final Logger logger = LoggerFactory.getLogger(NdJsonFixtureGenerator.class);
+
     @SuppressForbidden(reason = "main method for Gradle JavaExec task needs System.err and Path.of")
     public static void main(String[] args) throws IOException {
         if (args.length == 2) {
@@ -61,7 +65,7 @@ public final class NdJsonFixtureGenerator {
             byte[] ndjson = generateFromCsv(sourcePath);
             Files.createDirectories(outputPath.getParent());
             Files.write(outputPath, ndjson);
-            System.out.println("Generated NDJSON fixture: " + outputPath);
+            logger.info("Generated NDJSON fixture: {}", outputPath);
         } else if (args.length == 3) {
             Path sourcePath = Path.of(args[0]);
             Path outputDir = Path.of(args[1]);
@@ -82,7 +86,7 @@ public final class NdJsonFixtureGenerator {
                 Path outputPath = outputDir.resolve(fileName);
                 byte[] ndjson = generateFromRows(parsed, range.from(), range.to());
                 Files.write(outputPath, ndjson);
-                System.out.println("Generated NDJSON split fixture: " + outputPath + " (rows " + range.from() + "-" + range.to() + ")");
+                logger.info("Generated NDJSON split fixture: {} (rows {}-{})", outputPath, range.from(), range.to());
             }
         } else {
             System.err.println("Usage: NdJsonFixtureGenerator <source-csv-path> <output-ndjson-path>");

--- a/x-pack/plugin/esql/qa/server/src/orcFixtureGenerator/java/org/elasticsearch/xpack/esql/datasources/OrcFixtureGenerator.java
+++ b/x-pack/plugin/esql/qa/server/src/orcFixtureGenerator/java/org/elasticsearch/xpack/esql/datasources/OrcFixtureGenerator.java
@@ -26,6 +26,8 @@ import org.apache.orc.Writer;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.xpack.esql.datasource.csv.CsvFixtureParser;
 import org.elasticsearch.xpack.esql.datasource.csv.SplitPartitioner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -53,7 +55,9 @@ public final class OrcFixtureGenerator {
 
     private OrcFixtureGenerator() {}
 
-    @SuppressForbidden(reason = "main method for Gradle JavaExec task needs System.out and Path.of")
+    private static final Logger logger = LoggerFactory.getLogger(OrcFixtureGenerator.class);
+
+    @SuppressForbidden(reason = "main method for Gradle JavaExec task needs System.err and Path.of")
     public static void main(String[] args) throws IOException {
         if (args.length == 2) {
             java.nio.file.Path sourcePath = java.nio.file.Path.of(args[0]);
@@ -64,7 +68,7 @@ public final class OrcFixtureGenerator {
             Files.createDirectories(outputPath.getParent());
             Files.deleteIfExists(outputPath);
             generate(sourcePath, outputPath);
-            System.out.println("Generated ORC fixture: " + outputPath);
+            logger.info("Generated ORC fixture: {}", outputPath);
         } else if (args.length == 3) {
             java.nio.file.Path sourcePath = java.nio.file.Path.of(args[0]);
             java.nio.file.Path outputDir = java.nio.file.Path.of(args[1]);
@@ -85,7 +89,7 @@ public final class OrcFixtureGenerator {
                 java.nio.file.Path outputPath = outputDir.resolve(fileName);
                 Files.deleteIfExists(outputPath);
                 generateFromRows(result, range.from(), range.to(), outputPath);
-                System.out.println("Generated ORC split fixture: " + outputPath + " (rows " + range.from() + "-" + range.to() + ")");
+                logger.info("Generated ORC split fixture: {} (rows {}-{})", outputPath, range.from(), range.to());
             }
         } else {
             System.err.println("Usage: OrcFixtureGenerator <source-csv-path> <output-orc-path>");

--- a/x-pack/plugin/esql/qa/server/src/parquetFixtureGenerator/java/org/elasticsearch/xpack/esql/datasources/ParquetFixtureGenerator.java
+++ b/x-pack/plugin/esql/qa/server/src/parquetFixtureGenerator/java/org/elasticsearch/xpack/esql/datasources/ParquetFixtureGenerator.java
@@ -21,6 +21,8 @@ import org.apache.parquet.schema.Types;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.xpack.esql.datasource.csv.CsvFixtureParser;
 import org.elasticsearch.xpack.esql.datasource.csv.SplitPartitioner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -58,9 +60,10 @@ public final class ParquetFixtureGenerator {
 
     private ParquetFixtureGenerator() {}
 
+    private static final Logger logger = LoggerFactory.getLogger(ParquetFixtureGenerator.class);
     private static final String HIVE_BY_FLAG = "--hive-by";
 
-    @SuppressForbidden(reason = "main method for Gradle JavaExec task needs System.out and Path.of")
+    @SuppressForbidden(reason = "main method for Gradle JavaExec task needs System.err and Path.of")
     public static void main(String[] args) throws IOException {
         if (args.length == 5 && HIVE_BY_FLAG.equals(args[2])) {
             Path sourcePath = Path.of(args[0]);
@@ -81,7 +84,7 @@ public final class ParquetFixtureGenerator {
             Files.createDirectories(outputPath.getParent());
             byte[] parquetBytes = generateFromCsv(sourcePath, 0, Integer.MAX_VALUE, codec);
             Files.write(outputPath, parquetBytes);
-            System.out.println("Generated Parquet fixture (" + codec + "): " + outputPath);
+            logger.info("Generated Parquet fixture ({}): {}", codec, outputPath);
         } else if (args.length == 3 || args.length == 4) {
             Path sourcePath = Path.of(args[0]);
             Path outputDir = Path.of(args[1]);
@@ -103,7 +106,7 @@ public final class ParquetFixtureGenerator {
                 Path outputPath = outputDir.resolve(fileName);
                 byte[] parquetBytes = generateFromRows(result, range.from(), range.to(), codec);
                 Files.write(outputPath, parquetBytes);
-                System.out.println("Generated Parquet fixture (" + codec + "): " + outputPath);
+                logger.info("Generated Parquet fixture ({}): {}", codec, outputPath);
             }
         } else {
             System.err.println("Usage: ParquetFixtureGenerator <source-csv> <output.parquet> [codec]");
@@ -123,7 +126,6 @@ public final class ParquetFixtureGenerator {
      * column is preserved in the parquet payload so the fixture can also be queried on the data column
      * itself; the partition column name is deliberately distinct to avoid colliding with that payload.
      */
-    @SuppressForbidden(reason = "Gradle JavaExec task generator writes progress to System.out")
     private static void generateHivePartitionedByColumn(
         Path sourcePath,
         Path outputDir,
@@ -164,7 +166,7 @@ public final class ParquetFixtureGenerator {
                 codec
             );
             Files.write(outputPath, bytes);
-            System.out.println("Generated Hive partition (" + codec + "): " + outputPath + " (" + e.getValue().size() + " rows)");
+            logger.info("Generated Hive partition ({}): {} ({} rows)", codec, outputPath, e.getValue().size());
         }
     }
 

--- a/x-pack/plugin/esql/qa/server/src/tsvFixtureGenerator/java/org/elasticsearch/xpack/esql/datasources/TsvFixtureGenerator.java
+++ b/x-pack/plugin/esql/qa/server/src/tsvFixtureGenerator/java/org/elasticsearch/xpack/esql/datasources/TsvFixtureGenerator.java
@@ -7,6 +7,9 @@
 
 package org.elasticsearch.xpack.esql.datasources;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.xpack.esql.datasource.csv.CsvFixtureParser;
 import org.elasticsearch.xpack.esql.datasource.csv.CsvFixtureParser.ColumnSpec;
@@ -36,6 +39,7 @@ import java.util.Locale;
  */
 public final class TsvFixtureGenerator {
 
+    private static final Logger logger = LoggerFactory.getLogger(TsvFixtureGenerator.class);
     private static final char TAB = '\t';
 
     private TsvFixtureGenerator() {}
@@ -51,7 +55,7 @@ public final class TsvFixtureGenerator {
             byte[] tsv = generateFromCsv(sourcePath);
             Files.createDirectories(outputPath.getParent());
             Files.write(outputPath, tsv);
-            System.out.println("Generated TSV fixture: " + outputPath);
+            logger.info("Generated TSV fixture: {}", outputPath);
         } else if (args.length == 3) {
             Path sourcePath = Path.of(args[0]);
             Path outputDir = Path.of(args[1]);
@@ -72,7 +76,7 @@ public final class TsvFixtureGenerator {
                 Path outputPath = outputDir.resolve(fileName);
                 byte[] tsv = generateFromRows(parsed, range.from(), range.to());
                 Files.write(outputPath, tsv);
-                System.out.println("Generated TSV split fixture: " + outputPath + " (rows " + range.from() + "-" + range.to() + ")");
+                logger.info("Generated TSV split fixture: {} (rows {}-{})", outputPath, range.from(), range.to());
             }
         } else {
             System.err.println("Usage: TsvFixtureGenerator <source-csv-path> <output-tsv-path>");

--- a/x-pack/plugin/esql/qa/server/src/tsvFixtureGenerator/java/org/elasticsearch/xpack/esql/datasources/TsvFixtureGenerator.java
+++ b/x-pack/plugin/esql/qa/server/src/tsvFixtureGenerator/java/org/elasticsearch/xpack/esql/datasources/TsvFixtureGenerator.java
@@ -7,14 +7,13 @@
 
 package org.elasticsearch.xpack.esql.datasources;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.xpack.esql.datasource.csv.CsvFixtureParser;
 import org.elasticsearch.xpack.esql.datasource.csv.CsvFixtureParser.ColumnSpec;
 import org.elasticsearch.xpack.esql.datasource.csv.CsvFixtureParser.CsvFixtureResult;
 import org.elasticsearch.xpack.esql.datasource.csv.SplitPartitioner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;


### PR DESCRIPTION
Silence a bunch of warnings the ESQL test fixtures print out during the builder. Do it using regular old slf4j logging which is already required in most of these fixtures anyway.
