### PR TITLE
[PoC] Settings for cache boost configuration

### DIFF
--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/StatelessCacheBoostSettingsIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/StatelessCacheBoostSettingsIT.java
@@ -22,7 +22,9 @@ public class StatelessCacheBoostSettingsIT extends AbstractStatelessPluginIntegT
         logger.info("--> update level1 search power to 50");
         updateClusterSettings(
             Settings.builder()
+                // GroupSetting supports updating a single field
                 .put(StatelessCacheBoostSettings.BOOST_CONFIGURATION_LOGS.getKey() + "level1.search_power", 50)
+                // RichValueObject setting must be updated in its entirety
                 .put(StatelessCacheBoostSettings.BOOST_CONFIGURATION_METRICS.getKey(), """
                     {
                       "level0": { "age": "1d", "search_power": 200},

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/StatelessCacheBoostSettingsIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/StatelessCacheBoostSettingsIT.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.stateless;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.xpack.stateless.cache.StatelessCacheBoostSettings;
+
+public class StatelessCacheBoostSettingsIT extends AbstractStatelessPluginIntegTestCase {
+
+    public void testBoostConfiguration() {
+        final var node0 = startMasterAndIndexNode();
+        final var cacheBoostSettings = internalCluster().getInstance(StatelessCacheBoostSettings.class, node0);
+
+        logger.info("--> logs: {}", cacheBoostSettings.getBoostConfigurationLogs());
+        logger.info("--> metrics: {}", cacheBoostSettings.getBoostConfigurationMetrics());
+
+        logger.info("--> update level1 search power to 50");
+        updateClusterSettings(
+            Settings.builder()
+                .put(StatelessCacheBoostSettings.BOOST_CONFIGURATION_LOGS.getKey() + "level1.search_power", 50)
+                .put(StatelessCacheBoostSettings.BOOST_CONFIGURATION_METRICS.getKey(), """
+                    {
+                      "level0": { "age": "1d", "search_power": 200},
+                      "level1": { "age": "7d", "search_power": 50},
+                      "level2": { "age": "365d", "search_power": 10}
+                    }""")
+
+        );
+
+        logger.info("--> logs: {}", cacheBoostSettings.getBoostConfigurationLogs());
+        logger.info("--> metrics: {}", cacheBoostSettings.getBoostConfigurationMetrics());
+    }
+}

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/StatelessPlugin.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/StatelessPlugin.java
@@ -723,6 +723,7 @@ public class StatelessPlugin extends Plugin
             throw new IllegalArgumentException("Directly setting [" + nodeMemoryAttrName + "] is not permitted - it is reserved.");
         }
         settings.put(RecoverySettings.INDICES_RECOVERY_SOURCE_ENABLED_SETTING.getKey(), false);
+        // Default values for the GroupSetting
         settings.put(Settings.builder().loadFromSource("""
             {
               "level0": { "age": "1d", "search_power": 200},

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/StatelessPlugin.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/StatelessPlugin.java
@@ -121,6 +121,7 @@ import org.elasticsearch.threadpool.ScalingExecutorBuilder;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.ParseField;
+import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.XPackPlugin;
 import org.elasticsearch.xpack.core.action.XPackInfoFeatureAction;
 import org.elasticsearch.xpack.core.action.XPackUsageFeatureAction;
@@ -142,6 +143,7 @@ import org.elasticsearch.xpack.stateless.cache.DefaultWarmingRatioProviderFactor
 import org.elasticsearch.xpack.stateless.cache.SearchCommitPrefetcher;
 import org.elasticsearch.xpack.stateless.cache.SearchCommitPrefetcherDynamicSettings;
 import org.elasticsearch.xpack.stateless.cache.SharedBlobCacheWarmingService;
+import org.elasticsearch.xpack.stateless.cache.StatelessCacheBoostSettings;
 import org.elasticsearch.xpack.stateless.cache.StatelessOnlinePrewarmingService;
 import org.elasticsearch.xpack.stateless.cache.StatelessSharedBlobCacheService;
 import org.elasticsearch.xpack.stateless.cache.WarmingRatioProvider;
@@ -517,6 +519,7 @@ public class StatelessPlugin extends Plugin
     private final SetOnce<StatelessMemoryMetricsService> statelessMemoryMetricsService = new SetOnce<>();
     private final SetOnce<ShardsMappingSizeCollector> shardsMappingSizeCollector = new SetOnce<>();
     private final SetOnce<Client> clientRef = new SetOnce<>();
+    private final SetOnce<StatelessCacheBoostSettings> statelessCacheBoostSettingsRef = new SetOnce<>();
 
     private final PluggableDirectoryMetricsHolder<BlobStoreCacheDirectoryMetrics> metricHolder = new ThreadLocalDirectoryMetricHolder<>(
         BlobStoreCacheDirectoryMetrics::new
@@ -720,6 +723,12 @@ public class StatelessPlugin extends Plugin
             throw new IllegalArgumentException("Directly setting [" + nodeMemoryAttrName + "] is not permitted - it is reserved.");
         }
         settings.put(RecoverySettings.INDICES_RECOVERY_SOURCE_ENABLED_SETTING.getKey(), false);
+        settings.put(Settings.builder().loadFromSource("""
+            {
+              "level0": { "age": "1d", "search_power": 200},
+              "level1": { "age": "7d", "search_power": 100},
+              "level2": { "age": "365d", "search_power": 10}
+            }""", XContentType.JSON).normalizePrefix(StatelessCacheBoostSettings.BOOST_CONFIGURATION_LOGS.getKey()).build());
         return settings.build();
     }
 
@@ -757,6 +766,7 @@ public class StatelessPlugin extends Plugin
         );
 
         final Collection<Object> components = new ArrayList<>();
+        components.add(setAndGet(this.statelessCacheBoostSettingsRef, new StatelessCacheBoostSettings(services.clusterService())));
         var objectStoreService = setAndGet(
             this.objectStoreService,
             createObjectStoreService(settings, services.repositoriesService(), threadPool, clusterService, projectResolver.get())
@@ -1303,7 +1313,9 @@ public class StatelessPlugin extends Plugin
             ShardsMappingSizeCollector.RETRY_INITIAL_DELAY_SETTING,
             ShardsMappingSizeCollector.FIXED_HOLLOW_SHARD_MEMORY_OVERHEAD_SETTING,
             ShardsMappingSizeCollector.HOLLOW_SHARD_SEGMENT_MEMORY_OVERHEAD_SETTING,
-            StatelessSharedBlobCacheService.STATELESS_CACHE_BOOST_PREFERENCE_ENABLED_SETTING
+            StatelessSharedBlobCacheService.STATELESS_CACHE_BOOST_PREFERENCE_ENABLED_SETTING,
+            StatelessCacheBoostSettings.BOOST_CONFIGURATION_LOGS,
+            StatelessCacheBoostSettings.BOOST_CONFIGURATION_METRICS
         );
     }
 

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/cache/StatelessCacheBoostSettings.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/cache/StatelessCacheBoostSettings.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.stateless.cache;
+
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
+import org.elasticsearch.xcontent.XContentType;
+
+import java.util.List;
+
+import static org.elasticsearch.common.settings.Setting.Property.Dynamic;
+import static org.elasticsearch.common.settings.Setting.Property.NodeScope;
+
+public class StatelessCacheBoostSettings {
+
+    // Local non-registered settings for validation, shared by both GroupSetting and RichValueObject setting
+    private static final Setting<TimeValue> LEVEL_AGE = Setting.timeSetting("age", TimeValue.ZERO, TimeValue.ZERO);
+    private static final Setting<Integer> LEVEL_SP = Setting.intSetting("search_power", 0, 0);
+
+    // 1. Example for GroupSetting
+    public static final Setting<Settings> BOOST_CONFIGURATION_LOGS = Setting.groupSetting(
+        "stateless.boost_configuration.logs.",
+        BoostConfiguration::buildBoostLevelsFromSettings,
+        NodeScope,
+        Dynamic
+    );
+
+    // 2. Example for RichValueObject Setting
+    public static final Setting<BoostConfiguration> BOOST_CONFIGURATION_METRICS = new Setting<>("stateless.boost_configuration.metrics", """
+        {
+          "level0": { "age": "1d", "search_power": 200},
+          "level1": { "age": "7d", "search_power": 100},
+          "level2": { "age": "365d", "search_power": 10}
+        }""", string -> BoostConfiguration.parseFromString("metrics", string), NodeScope, Dynamic);
+
+    // Configuration classes
+    public record BoostLevel(String name, TimeValue age, int searchPower) {}
+
+    public record BoostConfiguration(String name, List<BoostLevel> levels) {
+
+        public static BoostConfiguration parseFromString(String name, String configString) {
+            final var settings = Settings.builder().loadFromSource(configString, XContentType.JSON).build();
+
+            final var levels = buildBoostLevelsFromSettings(settings);
+
+            return new BoostConfiguration(name, levels);
+        }
+
+        private static List<BoostLevel> buildBoostLevelsFromSettings(Settings settings) {
+            return settings.getAsGroups().entrySet().stream().map(entry -> {
+                final var levelName = entry.getKey();
+                final var levelSettings = entry.getValue();
+                return new BoostLevel(levelName, LEVEL_AGE.get(levelSettings), LEVEL_SP.get(levelSettings));
+            }).toList();
+        }
+
+    }
+
+    private static final Logger logger = LogManager.getLogger(StatelessCacheBoostSettings.class);
+
+    private volatile BoostConfiguration boostConfigurationLogs;
+    private volatile BoostConfiguration boostConfigurationMetrics;
+
+    public StatelessCacheBoostSettings(ClusterService clusterService) {
+        clusterService.getClusterSettings().initializeAndWatch(BOOST_CONFIGURATION_LOGS, settings -> {
+            this.boostConfigurationLogs = new BoostConfiguration("logs", BoostConfiguration.buildBoostLevelsFromSettings(settings));
+            logger.info("--> Updated boost configuration logs to : {}", boostConfigurationLogs);
+        });
+
+        clusterService.getClusterSettings().initializeAndWatch(BOOST_CONFIGURATION_METRICS, value -> {
+            this.boostConfigurationMetrics = value;
+            logger.info("--> Updated boost configuration metrics to : {}", boostConfigurationMetrics);
+        });
+    }
+
+    public BoostConfiguration getBoostConfigurationLogs() {
+        return boostConfigurationLogs;
+    }
+
+    public BoostConfiguration getBoostConfigurationMetrics() {
+        return boostConfigurationMetrics;
+    }
+}

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/cache/StatelessCacheBoostSettings.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/cache/StatelessCacheBoostSettings.java
@@ -49,20 +49,15 @@ public class StatelessCacheBoostSettings {
 
         public static BoostConfiguration parseFromString(String name, String configString) {
             final var settings = Settings.builder().loadFromSource(configString, XContentType.JSON).build();
-
-            final var levels = buildBoostLevelsFromSettings(settings);
-
-            return new BoostConfiguration(name, levels);
+            return new BoostConfiguration(name, buildBoostLevelsFromSettings(settings));
         }
 
         private static List<BoostLevel> buildBoostLevelsFromSettings(Settings settings) {
             return settings.getAsGroups().entrySet().stream().map(entry -> {
-                final var levelName = entry.getKey();
                 final var levelSettings = entry.getValue();
-                return new BoostLevel(levelName, LEVEL_AGE.get(levelSettings), LEVEL_SP.get(levelSettings));
+                return new BoostLevel(entry.getKey(), LEVEL_AGE.get(levelSettings), LEVEL_SP.get(levelSettings));
             }).toList();
         }
-
     }
 
     private static final Logger logger = LogManager.getLogger(StatelessCacheBoostSettings.class);


### PR DESCRIPTION
This PR demonstrates the two approaches of using settings for cache boost configuration:
1. GroupSetting
2. RichValueObject Setting
