### PR TITLE
[ESQL] Extract CSV record splitter

### DIFF
--- a/docs/changelog/150048.yaml
+++ b/docs/changelog/150048.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 150048
+summary: Extract CSV record splitter
+type: enhancement

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
@@ -40,6 +40,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.Configured;
 import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
+import org.elasticsearch.xpack.esql.datasources.spi.RecordSplitter;
 import org.elasticsearch.xpack.esql.datasources.spi.SegmentableFormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.SimpleSourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.SkipWarnings;
@@ -49,7 +50,6 @@ import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 import org.elasticsearch.xpack.esql.parser.ParsingException;
 import org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter;
 
-import java.io.BufferedInputStream;
 import java.io.BufferedReader;
 import java.io.Closeable;
 import java.io.IOException;
@@ -951,254 +951,26 @@ public class CsvFormatReader implements SegmentableFormatReader {
 
     @Override
     public long findNextRecordBoundary(InputStream stream) throws IOException {
-        if (options.multiValueSyntax() != CsvFormatOptions.MultiValueSyntax.BRACKETS || options.delimiter() != ',') {
-            return findNextRecordBoundaryQuotedFieldsOnly(stream);
-        }
-        BufferedInputStream bis = stream instanceof BufferedInputStream b ? b : new BufferedInputStream(stream);
-        int markLimit = recordBoundaryMarkLimit();
-        long maxMvcSuffixBytes = Math.max(0L, markLimit - 1L);
-        return findNextRecordBoundaryBracketCommaMvc(bis, markLimit, maxMvcSuffixBytes);
+        return recordSplitter().findNextRecordBoundary(stream);
     }
 
-    /**
-     * Override the SPI default for the QuotedFieldsOnly path so the streaming segmentator gets a
-     * single-pass answer instead of dispatching the per-record scanner once per record.
-     * Bracket-comma MVC stays on the inherited default — its scanner has no per-call bulk
-     * allocation, and the bracket-region state machine (depth, leading-whitespace gating,
-     * mark limit) is non-trivial to fold into a single pass.
-     */
     @Override
     public int findLastRecordBoundary(byte[] buf, int length) throws IOException {
-        if (options.multiValueSyntax() != CsvFormatOptions.MultiValueSyntax.BRACKETS || options.delimiter() != ',') {
-            return findLastRecordBoundaryQuotedFieldsOnly(buf, length);
-        }
-        return SegmentableFormatReader.super.findLastRecordBoundary(buf, length);
+        return recordSplitter().findLastRecordBoundary(buf, length);
     }
 
-    /**
-     * Quoting rule mirrors the tokenizer {@link #readCsvRecord}: a {@code quoteChar} opens a quoted field
-     * only at field start (after an unquoted {@code delimiter} or {@code \n}, optionally past field-leading
-     * whitespace); a mid-field {@code quoteChar} is a literal and does not toggle quote state.
-     * <p>
-     * Best-effort/open-tail contract: the scan assumes the buffer begins at a record boundary and advances
-     * {@code lastBoundary} only on a true unquoted {@code \n}. So a chunk the segmentator cut mid-record
-     * yields no boundary inside that leading partial, and a genuinely unterminated quoted field keeps
-     * {@code inQuotes == true} so its trailing {@code \n}s are skipped — the rule the grow loop requires.
-     */
-    private int findLastRecordBoundaryQuotedFieldsOnly(byte[] buf, int length) {
-        if (length <= 0) {
-            return -1;
-        }
-        int lastBoundary = -1;
-        boolean inQuotes = false;
-        boolean fieldHasNonWhitespace = false;
-        byte quoteAsByte = (byte) options.quoteChar();
-        byte delimAsByte = (byte) options.delimiter();
-        for (int i = 0; i < length; i++) {
-            byte b = buf[i];
-            if (inQuotes) {
-                if (b == quoteAsByte) {
-                    if (i + 1 < length && buf[i + 1] == quoteAsByte) {
-                        // Doubled quote inside a quoted field — RFC 4180 literal, stay in quotes.
-                        i++;
-                    } else {
-                        inQuotes = false;
-                    }
-                }
-                continue;
-            }
-            if (b == '\n') {
-                // only true unquoted '\n's advance the boundary (see open-tail contract above)
-                lastBoundary = i;
-                fieldHasNonWhitespace = false;
-            } else if (b == delimAsByte) {
-                fieldHasNonWhitespace = false;
-            } else if (b == quoteAsByte && fieldHasNonWhitespace == false) {
-                inQuotes = true;
-            } else if (isAsciiCsvFieldLeadingWhitespace(b & 0xff) == false) {
-                fieldHasNonWhitespace = true;
-            }
-        }
-        return lastBoundary;
+    @Override
+    public RecordSplitter recordSplitter() {
+        return recordSplitter(SegmentableFormatReader.DEFAULT_MAX_RECORD_BYTES);
     }
 
-    /**
-     * Upper bound for {@link BufferedInputStream#mark(int)} while probing bracket MVC cells during record-boundary
-     * scans. Matches {@link CsvFormatOptions#maxFieldSize()} so an unclosed bracket cell cannot invalidate the mark
-     * before we reset and treat {@code [} as a literal byte.
-     */
-    private int recordBoundaryMarkLimit() {
-        int maxField = options.maxFieldSize();
-        if (maxField <= 0) {
-            return Math.min(64 * 1024 * 1024, Integer.MAX_VALUE - 8);
-        }
-        return Math.min(maxField + 1024, Integer.MAX_VALUE - 8);
-    }
-
-    /**
-     * Bytes consumed after an opening {@code [} until bracket depth returns to zero, or {@code -1} if EOF was reached
-     * first or the scan exceeded {@link CsvFormatOptions#maxFieldSize()} (unclosed cell).
-     */
-    private long consumeBracketMvcSuffixBytes(BufferedInputStream in, long maxSuffixBytes) throws IOException {
-        int depth = 1;
-        long bytes = 0;
-        while (depth > 0) {
-            if (bytes >= maxSuffixBytes) {
-                return -1;
-            }
-            int ib = in.read();
-            if (ib == -1) {
-                return -1;
-            }
-            bytes++;
-            byte b = (byte) ib;
-            if (b == '[') {
-                depth++;
-            } else if (b == ']') {
-                depth--;
-            }
-        }
-        return bytes;
+    @Override
+    public RecordSplitter recordSplitter(int maxRecordBytes) {
+        return new CsvRecordSplitter(options, maxRecordBytes);
     }
 
     private static boolean isAsciiCsvFieldLeadingWhitespace(int ib) {
         return ib == ' ' || ib == '\t' || ib == '\f';
-    }
-
-    /**
-     * Record boundary scan for comma-delimited CSV with bracket MVC. Newlines inside {@code [..]} or quoted fields
-     * must not end the record. Quote opening follows RFC 4180 — only at field start, optionally preceded by whitespace
-     * — so stray {@code "} chars in unquoted cells do not trigger multi-line gluing or pathological segment splits.
-     */
-    private long findNextRecordBoundaryBracketCommaMvc(BufferedInputStream bis, int markLimit, long maxMvcSuffixBytes) throws IOException {
-        long consumed = 0;
-        boolean inQuotes = false;
-        boolean fieldHasNonWhitespace = false;
-        byte quoteAsByte = (byte) options.quoteChar();
-        byte escAsByte = (byte) options.escapeChar();
-        byte delimAsByte = (byte) options.delimiter();
-
-        while (true) {
-            int ib = bis.read();
-            if (ib == -1) {
-                return -1;
-            }
-            consumed++;
-            byte b = (byte) ib;
-
-            if (inQuotes) {
-                if (b == quoteAsByte) {
-                    bis.mark(2);
-                    int ib2 = bis.read();
-                    if (ib2 == -1) {
-                        inQuotes = false;
-                        continue;
-                    }
-                    if ((byte) ib2 == quoteAsByte) {
-                        consumed++;
-                        continue;
-                    }
-                    bis.reset();
-                    inQuotes = false;
-                } else if (b == escAsByte) {
-                    bis.mark(2);
-                    int ib2 = bis.read();
-                    if (ib2 != -1 && (byte) ib2 == delimAsByte) {
-                        consumed++;
-                        continue;
-                    }
-                    bis.reset();
-                }
-                continue;
-            }
-
-            if (b == '\n') {
-                return consumed;
-            }
-            if (b == delimAsByte) {
-                fieldHasNonWhitespace = false;
-                continue;
-            }
-            if (b == quoteAsByte && fieldHasNonWhitespace == false) {
-                inQuotes = true;
-                continue;
-            }
-            if (b == '[' && fieldHasNonWhitespace == false) {
-                bis.mark(markLimit);
-                long suffix = consumeBracketMvcSuffixBytes(bis, maxMvcSuffixBytes);
-                if (suffix >= 0) {
-                    consumed += suffix;
-                    fieldHasNonWhitespace = true;
-                    continue;
-                }
-                bis.reset();
-                fieldHasNonWhitespace = true;
-                continue;
-            }
-            if (isAsciiCsvFieldLeadingWhitespace(ib & 0xff) == false) {
-                fieldHasNonWhitespace = true;
-            }
-        }
-    }
-
-    /**
-     * Returns the next byte without consuming it (or {@code -1} at EOF). Encapsulates the single-byte
-     * {@code mark}/{@code read}/{@code reset} so callers cannot invalidate the mark with a second read.
-     */
-    private static int peekByte(BufferedInputStream bis) throws IOException {
-        bis.mark(1);
-        int b = bis.read();
-        bis.reset();
-        return b;
-    }
-
-    /**
-     * Per-byte scan over a {@link BufferedInputStream} — no per-call bulk read buffer is allocated;
-     * an existing {@link BufferedInputStream} input is reused, otherwise the stream is wrapped once.
-     * Applies the same field-start quoting rule as the actual tokenizer {@link #readCsvRecord} and as
-     * {@link #findNextRecordBoundaryBracketCommaMvc}: a {@code quoteChar} opens a quoted field only at
-     * field start (optionally after field-leading whitespace); a mid-field {@code quoteChar} is a
-     * literal and does not toggle quote state. Returns the byte count up to and including the first
-     * record-terminating {@code \n} that is outside a quoted field, or {@code -1} at EOF.
-     */
-    private long findNextRecordBoundaryQuotedFieldsOnly(InputStream stream) throws IOException {
-        BufferedInputStream bis = stream instanceof BufferedInputStream b ? b : new BufferedInputStream(stream);
-        long consumed = 0;
-        boolean inQuotes = false;
-        boolean fieldHasNonWhitespace = false;
-        byte quoteAsByte = (byte) options.quoteChar();
-        byte delimAsByte = (byte) options.delimiter();
-        while (true) {
-            int ib = bis.read();
-            if (ib == -1) {
-                return -1;
-            }
-            consumed++;
-            byte b = (byte) ib;
-            if (inQuotes) {
-                if (b == quoteAsByte) {
-                    // A doubled "" is a literal (stay in quotes); a lone " closes the field. peekByte
-                    // leaves the non-doubled byte in the stream to be re-read by the next iteration.
-                    if ((byte) peekByte(bis) == quoteAsByte) {
-                        bis.read(); // consume the second quote of the doubled pair
-                        consumed++;
-                        continue;
-                    }
-                    inQuotes = false;
-                }
-                continue;
-            }
-            if (b == '\n') {
-                return consumed;
-            }
-            if (b == delimAsByte) {
-                fieldHasNonWhitespace = false;
-            } else if (b == quoteAsByte && fieldHasNonWhitespace == false) {
-                inQuotes = true;
-            } else if (isAsciiCsvFieldLeadingWhitespace(ib & 0xff) == false) {
-                fieldHasNonWhitespace = true;
-            }
-        }
     }
 
     @Override
@@ -1337,16 +1109,13 @@ public class CsvFormatReader implements SegmentableFormatReader {
      * context terminates the record — lone {@code \r} outside quotes also terminates (for
      * {@code \r}-only line-ending files) but is not included in the returned string.
      *
-     * <p>Mirrors the quoting contract of {@link #findNextRecordBoundaryBracketCommaMvc} and
-     * {@link #findNextRecordBoundaryQuotedFieldsOnly}.
+     * <p>Mirrors the quoting contract of {@link CsvRecordSplitter}.
      *
      * <p><b>Divergence from chunk-layer boundary scanners:</b>
-     * {@link #findNextRecordBoundaryBracketCommaMvc} and {@link #findNextRecordBoundaryQuotedFieldsOnly}
-     * treat lone {@code \r} outside quotes as data (only {@code \n} terminates). This method treats
-     * unquoted lone {@code \r} as a record terminator (Mac-classic line endings). The divergence is
-     * acceptable because macro-split boundaries are always re-aligned at the row layer, and Mac-classic
-     * files are vanishingly rare in modern data pipelines. A future unification under a single record
-     * splitter SPI will reconcile both layers.
+     * {@link CsvRecordSplitter} treats lone {@code \r} outside quotes as data (only {@code \n} terminates).
+     * This method treats unquoted lone {@code \r} as a record terminator (Mac-classic line endings). The divergence is
+     * acceptable because macro-split boundaries are always re-aligned at the row layer, and Mac-classic files are
+     * vanishingly rare in modern data pipelines. A future byte row-reader will reconcile both layers.
      *
      * <p>Uses the same ASCII-only whitespace predicate ({@code ' '}, {@code '\t'}, {@code '\f'}) as
      * the boundary scanners for field-start detection, via {@link #isAsciiCsvFieldLeadingWhitespace}.

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
@@ -969,7 +969,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
         return new CsvRecordSplitter(options, maxRecordBytes);
     }
 
-    private static boolean isAsciiCsvFieldLeadingWhitespace(int ib) {
+    static boolean isAsciiCsvFieldLeadingWhitespace(int ib) {
         return ib == ' ' || ib == '\t' || ib == '\f';
     }
 

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvRecordSplitter.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvRecordSplitter.java
@@ -25,6 +25,9 @@ final class CsvRecordSplitter implements RecordSplitter {
 
     CsvRecordSplitter(CsvFormatOptions options, int maxRecordBytes) {
         this.options = Objects.requireNonNull(options);
+        if (maxRecordBytes <= 0) {
+            throw new IllegalArgumentException("maxRecordBytes must be positive, got: " + maxRecordBytes);
+        }
         this.maxRecordBytes = maxRecordBytes;
     }
 
@@ -123,7 +126,7 @@ final class CsvRecordSplitter implements RecordSplitter {
                 fieldHasNonWhitespace = false;
             } else if (b == quoteAsByte && fieldHasNonWhitespace == false) {
                 inQuotes = true;
-            } else if (isAsciiCsvFieldLeadingWhitespace(b & 0xff) == false) {
+            } else if (CsvFormatReader.isAsciiCsvFieldLeadingWhitespace(b & 0xff) == false) {
                 fieldHasNonWhitespace = true;
             }
         }
@@ -167,10 +170,6 @@ final class CsvRecordSplitter implements RecordSplitter {
             }
         }
         return bytes;
-    }
-
-    private static boolean isAsciiCsvFieldLeadingWhitespace(int ib) {
-        return ib == ' ' || ib == '\t' || ib == '\f';
     }
 
     /**
@@ -255,7 +254,7 @@ final class CsvRecordSplitter implements RecordSplitter {
                 fieldHasNonWhitespace = true;
                 continue;
             }
-            if (isAsciiCsvFieldLeadingWhitespace(ib & 0xff) == false) {
+            if (CsvFormatReader.isAsciiCsvFieldLeadingWhitespace(ib & 0xff) == false) {
                 fieldHasNonWhitespace = true;
             }
         }
@@ -321,7 +320,7 @@ final class CsvRecordSplitter implements RecordSplitter {
                 fieldHasNonWhitespace = false;
             } else if (b == quoteAsByte && fieldHasNonWhitespace == false) {
                 inQuotes = true;
-            } else if (isAsciiCsvFieldLeadingWhitespace(ib & 0xff) == false) {
+            } else if (CsvFormatReader.isAsciiCsvFieldLeadingWhitespace(ib & 0xff) == false) {
                 fieldHasNonWhitespace = true;
             }
         }

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvRecordSplitter.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvRecordSplitter.java
@@ -1,0 +1,329 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.csv;
+
+import org.elasticsearch.xpack.esql.datasources.spi.RecordSplitter;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Objects;
+
+/**
+ * CSV record-boundary splitter for byte-oriented parallel parsing.
+ */
+final class CsvRecordSplitter implements RecordSplitter {
+
+    private final CsvFormatOptions options;
+    private final int maxRecordBytes;
+
+    CsvRecordSplitter(CsvFormatOptions options, int maxRecordBytes) {
+        this.options = Objects.requireNonNull(options);
+        this.maxRecordBytes = maxRecordBytes;
+    }
+
+    @Override
+    public long findNextRecordBoundary(InputStream stream) throws IOException {
+        if (options.multiValueSyntax() != CsvFormatOptions.MultiValueSyntax.BRACKETS || options.delimiter() != ',') {
+            return findNextRecordBoundaryQuotedFieldsOnly(stream);
+        }
+        BufferedInputStream bis = stream instanceof BufferedInputStream b ? b : new BufferedInputStream(stream);
+        int markLimit = recordBoundaryMarkLimit();
+        long maxMvcSuffixBytes = Math.max(0L, markLimit - 1L);
+        return findNextRecordBoundaryBracketCommaMvc(bis, markLimit, maxMvcSuffixBytes);
+    }
+
+    /**
+     * Override the SPI default for the QuotedFieldsOnly path so the streaming segmentator gets a
+     * single-pass answer instead of dispatching the per-record scanner once per record.
+     * Bracket-comma MVC stays on the forward scanner because the bracket-region state machine
+     * (depth, leading-whitespace gating, mark limit) is non-trivial to fold into a single pass.
+     */
+    @Override
+    public int findLastRecordBoundary(byte[] buf, int offset, int length) throws IOException {
+        if (length <= 0) {
+            return -1;
+        }
+        Objects.checkFromIndexSize(offset, length, buf.length);
+        if (options.multiValueSyntax() != CsvFormatOptions.MultiValueSyntax.BRACKETS || options.delimiter() != ',') {
+            return findLastRecordBoundaryQuotedFieldsOnly(buf, offset, length);
+        }
+        return findLastRecordBoundaryByForwardScan(buf, offset, length);
+    }
+
+    @Override
+    public int maxRecordBytes() {
+        return maxRecordBytes;
+    }
+
+    private int findLastRecordBoundaryByForwardScan(byte[] buf, int offset, int length) throws IOException {
+        if (length <= 0) {
+            return -1;
+        }
+        int lastBoundary = -1;
+        int cumulative = 0;
+        while (cumulative < length) {
+            long consumed = findNextRecordBoundary(new ByteArrayInputStream(buf, offset + cumulative, length - cumulative));
+            if (consumed == RECORD_TOO_LARGE) {
+                return lastBoundary >= 0 ? lastBoundary : (int) RECORD_TOO_LARGE;
+            }
+            if (consumed < 0) {
+                return lastBoundary;
+            }
+            cumulative += Math.toIntExact(consumed);
+            lastBoundary = offset + cumulative - 1;
+        }
+        return lastBoundary;
+    }
+
+    /**
+     * Quoting rule mirrors the tokenizer {@link CsvFormatReader#readCsvRecord}: a {@code quoteChar} opens a quoted field
+     * only at field start (after an unquoted {@code delimiter} or {@code \n}, optionally past field-leading
+     * whitespace); a mid-field {@code quoteChar} is a literal and does not toggle quote state.
+     * <p>
+     * Best-effort/open-tail contract: the scan assumes the buffer begins at a record boundary and advances
+     * {@code lastBoundary} only on a true unquoted {@code \n}. So a chunk the segmentator cut mid-record
+     * yields no boundary inside that leading partial, and a genuinely unterminated quoted field keeps
+     * {@code inQuotes == true} so its trailing {@code \n}s are skipped - the rule the grow loop requires.
+     */
+    private int findLastRecordBoundaryQuotedFieldsOnly(byte[] buf, int offset, int length) {
+        if (length <= 0) {
+            return -1;
+        }
+        int end = offset + length;
+        int lastBoundary = -1;
+        boolean inQuotes = false;
+        boolean fieldHasNonWhitespace = false;
+        byte quoteAsByte = (byte) options.quoteChar();
+        byte delimAsByte = (byte) options.delimiter();
+        for (int i = offset; i < end; i++) {
+            byte b = buf[i];
+            if (inQuotes) {
+                if (b == quoteAsByte) {
+                    if (i + 1 < end && buf[i + 1] == quoteAsByte) {
+                        // Doubled quote inside a quoted field - RFC 4180 literal, stay in quotes.
+                        i++;
+                    } else {
+                        inQuotes = false;
+                    }
+                }
+                continue;
+            }
+            if (b == '\n') {
+                // only true unquoted '\n's advance the boundary (see open-tail contract above)
+                lastBoundary = i;
+                fieldHasNonWhitespace = false;
+            } else if (b == delimAsByte) {
+                fieldHasNonWhitespace = false;
+            } else if (b == quoteAsByte && fieldHasNonWhitespace == false) {
+                inQuotes = true;
+            } else if (isAsciiCsvFieldLeadingWhitespace(b & 0xff) == false) {
+                fieldHasNonWhitespace = true;
+            }
+        }
+        return lastBoundary < 0 && length > maxRecordBytes ? (int) RECORD_TOO_LARGE : lastBoundary;
+    }
+
+    /**
+     * Upper bound for {@link BufferedInputStream#mark(int)} while probing bracket MVC cells during record-boundary
+     * scans. Matches {@link CsvFormatOptions#maxFieldSize()} so an unclosed bracket cell cannot invalidate the mark
+     * before we reset and treat {@code [} as a literal byte.
+     */
+    private int recordBoundaryMarkLimit() {
+        int maxField = options.maxFieldSize();
+        if (maxField <= 0) {
+            return Math.min(64 * 1024 * 1024, Integer.MAX_VALUE - 8);
+        }
+        return Math.min(maxField + 1024, Integer.MAX_VALUE - 8);
+    }
+
+    /**
+     * Bytes consumed after an opening {@code [} until bracket depth returns to zero, or {@code -1} if EOF was reached
+     * first or the scan exceeded {@link CsvFormatOptions#maxFieldSize()} (unclosed cell).
+     */
+    private long consumeBracketMvcSuffixBytes(BufferedInputStream in, long maxSuffixBytes) throws IOException {
+        int depth = 1;
+        long bytes = 0;
+        while (depth > 0) {
+            if (bytes >= maxSuffixBytes) {
+                return -1;
+            }
+            int ib = in.read();
+            if (ib == -1) {
+                return -1;
+            }
+            bytes++;
+            byte b = (byte) ib;
+            if (b == '[') {
+                depth++;
+            } else if (b == ']') {
+                depth--;
+            }
+        }
+        return bytes;
+    }
+
+    private static boolean isAsciiCsvFieldLeadingWhitespace(int ib) {
+        return ib == ' ' || ib == '\t' || ib == '\f';
+    }
+
+    /**
+     * Record boundary scan for comma-delimited CSV with bracket MVC. Newlines inside {@code [..]} or quoted fields
+     * must not end the record. Quote opening follows RFC 4180 - only at field start, optionally preceded by whitespace
+     * - so stray {@code "} chars in unquoted cells do not trigger multi-line gluing or pathological segment splits.
+     */
+    private long findNextRecordBoundaryBracketCommaMvc(BufferedInputStream bis, int markLimit, long maxMvcSuffixBytes) throws IOException {
+        long consumed = 0;
+        boolean inQuotes = false;
+        boolean fieldHasNonWhitespace = false;
+        byte quoteAsByte = (byte) options.quoteChar();
+        byte escAsByte = (byte) options.escapeChar();
+        byte delimAsByte = (byte) options.delimiter();
+
+        while (true) {
+            int ib = bis.read();
+            if (ib == -1) {
+                return -1;
+            }
+            consumed++;
+            if (consumed > maxRecordBytes) {
+                return RECORD_TOO_LARGE;
+            }
+            byte b = (byte) ib;
+
+            if (inQuotes) {
+                if (b == quoteAsByte) {
+                    bis.mark(2);
+                    int ib2 = bis.read();
+                    if (ib2 == -1) {
+                        inQuotes = false;
+                        continue;
+                    }
+                    if ((byte) ib2 == quoteAsByte) {
+                        consumed++;
+                        if (consumed > maxRecordBytes) {
+                            return RECORD_TOO_LARGE;
+                        }
+                        continue;
+                    }
+                    bis.reset();
+                    inQuotes = false;
+                } else if (b == escAsByte) {
+                    bis.mark(2);
+                    int ib2 = bis.read();
+                    if (ib2 != -1 && (byte) ib2 == delimAsByte) {
+                        consumed++;
+                        if (consumed > maxRecordBytes) {
+                            return RECORD_TOO_LARGE;
+                        }
+                        continue;
+                    }
+                    bis.reset();
+                }
+                continue;
+            }
+
+            if (b == '\n') {
+                return consumed;
+            }
+            if (b == delimAsByte) {
+                fieldHasNonWhitespace = false;
+                continue;
+            }
+            if (b == quoteAsByte && fieldHasNonWhitespace == false) {
+                inQuotes = true;
+                continue;
+            }
+            if (b == '[' && fieldHasNonWhitespace == false) {
+                bis.mark(markLimit);
+                long suffix = consumeBracketMvcSuffixBytes(bis, maxMvcSuffixBytes);
+                if (suffix >= 0) {
+                    consumed += suffix;
+                    if (consumed > maxRecordBytes) {
+                        return RECORD_TOO_LARGE;
+                    }
+                    fieldHasNonWhitespace = true;
+                    continue;
+                }
+                bis.reset();
+                fieldHasNonWhitespace = true;
+                continue;
+            }
+            if (isAsciiCsvFieldLeadingWhitespace(ib & 0xff) == false) {
+                fieldHasNonWhitespace = true;
+            }
+        }
+    }
+
+    /**
+     * Returns the next byte without consuming it (or {@code -1} at EOF). Encapsulates the single-byte
+     * {@code mark}/{@code read}/{@code reset} so callers cannot invalidate the mark with a second read.
+     */
+    private static int peekByte(BufferedInputStream bis) throws IOException {
+        bis.mark(1);
+        int b = bis.read();
+        bis.reset();
+        return b;
+    }
+
+    /**
+     * Per-byte scan over a {@link BufferedInputStream} - no per-call bulk read buffer is allocated;
+     * an existing {@link BufferedInputStream} input is reused, otherwise the stream is wrapped once.
+     * Applies the same field-start quoting rule as the actual tokenizer {@link CsvFormatReader#readCsvRecord}
+     * and as {@link #findNextRecordBoundaryBracketCommaMvc}: a {@code quoteChar} opens a quoted field only at
+     * field start (optionally after field-leading whitespace); a mid-field {@code quoteChar} is a
+     * literal and does not toggle quote state. Returns the byte count up to and including the first
+     * record-terminating {@code \n} that is outside a quoted field, or {@code -1} at EOF.
+     */
+    private long findNextRecordBoundaryQuotedFieldsOnly(InputStream stream) throws IOException {
+        BufferedInputStream bis = stream instanceof BufferedInputStream b ? b : new BufferedInputStream(stream);
+        long consumed = 0;
+        boolean inQuotes = false;
+        boolean fieldHasNonWhitespace = false;
+        byte quoteAsByte = (byte) options.quoteChar();
+        byte delimAsByte = (byte) options.delimiter();
+        while (true) {
+            int ib = bis.read();
+            if (ib == -1) {
+                return -1;
+            }
+            consumed++;
+            if (consumed > maxRecordBytes) {
+                return RECORD_TOO_LARGE;
+            }
+            byte b = (byte) ib;
+            if (inQuotes) {
+                if (b == quoteAsByte) {
+                    // A doubled "" is a literal (stay in quotes); a lone " closes the field. peekByte
+                    // leaves the non-doubled byte in the stream to be re-read by the next iteration.
+                    if ((byte) peekByte(bis) == quoteAsByte) {
+                        bis.read(); // consume the second quote of the doubled pair
+                        consumed++;
+                        if (consumed > maxRecordBytes) {
+                            return RECORD_TOO_LARGE;
+                        }
+                        continue;
+                    }
+                    inQuotes = false;
+                }
+                continue;
+            }
+            if (b == '\n') {
+                return consumed;
+            }
+            if (b == delimAsByte) {
+                fieldHasNonWhitespace = false;
+            } else if (b == quoteAsByte && fieldHasNonWhitespace == false) {
+                inQuotes = true;
+            } else if (isAsciiCsvFieldLeadingWhitespace(ib & 0xff) == false) {
+                fieldHasNonWhitespace = true;
+            }
+        }
+    }
+}

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvRecordSplitterContractTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvRecordSplitterContractTests.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.csv;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.spi.RecordSplitter;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public class CsvRecordSplitterContractTests extends ESTestCase {
+
+    public void testEmptyInputReturnsEof() throws IOException {
+        for (Case testCase : cases(128)) {
+            RecordSplitter splitter = testCase.newSplitter();
+            assertEquals(testCase.name(), -1L, splitter.findNextRecordBoundary(new ByteArrayInputStream(new byte[0])));
+            assertEquals(testCase.name(), -1, splitter.findLastRecordBoundary(new byte[0], 0, 0));
+        }
+    }
+
+    public void testEofBeforeAnyTerminatorReturnsEof() throws IOException {
+        for (Case testCase : cases(128)) {
+            assertEquals(
+                testCase.name(),
+                -1L,
+                testCase.newSplitter().findNextRecordBoundary(new ByteArrayInputStream(bytes("unterminated")))
+            );
+        }
+    }
+
+    public void testSingleLfTerminatedRecordConsumesThroughTerminator() throws IOException {
+        for (Case testCase : cases(128)) {
+            assertEquals(testCase.name(), 4L, testCase.newSplitter().findNextRecordBoundary(new ByteArrayInputStream(bytes("row\n"))));
+        }
+    }
+
+    public void testEmbeddedTerminatorInRecord() throws IOException {
+        Case quoted = quotedFieldsOnly(128);
+        assertEquals(13L, quoted.newSplitter().findNextRecordBoundary(new ByteArrayInputStream(bytes("\"multi\nline\"\n"))));
+
+        Case bracket = bracketMvc(128);
+        assertEquals(13L, bracket.newSplitter().findNextRecordBoundary(new ByteArrayInputStream(bytes("[multi\nline]\n"))));
+    }
+
+    public void testRecordTooLargeSentinel() throws IOException {
+        int maxRecordBytes = 16;
+        for (Case testCase : cases(maxRecordBytes)) {
+            assertEquals(
+                testCase.name(),
+                RecordSplitter.RECORD_TOO_LARGE,
+                testCase.newSplitter().findNextRecordBoundary(new ByteArrayInputStream(repeatedByte('x', maxRecordBytes + 1)))
+            );
+        }
+    }
+
+    public void testFindLastRecordBoundaryMatchesForwardScan() throws IOException {
+        for (Case testCase : cases(128)) {
+            byte[] payload = bytes("first\nsecond\ntail");
+            int expectedBoundary = driveForwardToLastBoundary(testCase.newSplitter(), payload);
+
+            RecordSplitter splitter = testCase.newSplitter();
+            assertEquals(testCase.name(), expectedBoundary, splitter.findLastRecordBoundary(payload, 0, payload.length));
+            assertEquals(testCase.name(), expectedBoundary, splitter.findLastRecordBoundary(payload, payload.length));
+
+            byte[] prefix = bytes("xx");
+            byte[] prefixedPayload = concat(prefix, payload);
+            assertEquals(
+                testCase.name(),
+                prefix.length + expectedBoundary,
+                splitter.findLastRecordBoundary(prefixedPayload, prefix.length, payload.length)
+            );
+        }
+    }
+
+    private static Case[] cases(int maxRecordBytes) {
+        return new Case[] { quotedFieldsOnly(maxRecordBytes), bracketMvc(maxRecordBytes) };
+    }
+
+    private static Case quotedFieldsOnly(int maxRecordBytes) {
+        return new Case("quoted-fields-only", () -> new CsvRecordSplitter(CsvFormatOptions.TSV, maxRecordBytes));
+    }
+
+    private static Case bracketMvc(int maxRecordBytes) {
+        return new Case("bracket-mvc", () -> new CsvRecordSplitter(CsvFormatOptions.DEFAULT, maxRecordBytes));
+    }
+
+    private static int driveForwardToLastBoundary(RecordSplitter splitter, byte[] input) throws IOException {
+        int cumulative = 0;
+        int lastBoundary = -1;
+        while (cumulative < input.length) {
+            long consumed = splitter.findNextRecordBoundary(new ByteArrayInputStream(input, cumulative, input.length - cumulative));
+            if (consumed < 0) {
+                return lastBoundary;
+            }
+            assertTrue("splitter must make progress", consumed > 0);
+            assertTrue("splitter consumed past the buffer", consumed <= input.length - cumulative);
+            cumulative += Math.toIntExact(consumed);
+            lastBoundary = cumulative - 1;
+        }
+        return lastBoundary;
+    }
+
+    private static byte[] bytes(String value) {
+        return value.getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static byte[] repeatedByte(char value, int count) {
+        byte[] bytes = new byte[count];
+        for (int i = 0; i < count; i++) {
+            bytes[i] = (byte) value;
+        }
+        return bytes;
+    }
+
+    private static byte[] concat(byte[]... chunks) {
+        int length = 0;
+        for (byte[] chunk : chunks) {
+            length += chunk.length;
+        }
+        byte[] result = new byte[length];
+        int offset = 0;
+        for (byte[] chunk : chunks) {
+            System.arraycopy(chunk, 0, result, offset, chunk.length);
+            offset += chunk.length;
+        }
+        return result;
+    }
+
+    private record Case(String name, SplitterSupplier supplier) {
+        private RecordSplitter newSplitter() throws IOException {
+            return supplier.get();
+        }
+    }
+
+    @FunctionalInterface
+    private interface SplitterSupplier {
+        RecordSplitter get() throws IOException;
+    }
+}

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvRecordSplitterMaxRecordSizeTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvRecordSplitterMaxRecordSizeTests.java
@@ -25,6 +25,14 @@ import java.util.List;
 
 public class CsvRecordSplitterMaxRecordSizeTests extends ESTestCase {
 
+    public void testConstructorRejectsNonPositiveMaxRecordBytes() {
+        IllegalArgumentException ex = expectThrows(
+            IllegalArgumentException.class,
+            () -> new CsvRecordSplitter(CsvFormatOptions.DEFAULT, 0)
+        );
+        assertEquals("maxRecordBytes must be positive, got: 0", ex.getMessage());
+    }
+
     public void testQuotedFieldsOnlyReturnsRecordTooLargeForUnclosedQuote() throws IOException {
         int maxRecordBytes = 32;
         RecordSplitter splitter = new CsvRecordSplitter(CsvFormatOptions.TSV, maxRecordBytes);

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvRecordSplitterMaxRecordSizeTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvRecordSplitterMaxRecordSizeTests.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.csv;
+
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.ParallelParsingCoordinator;
+import org.elasticsearch.xpack.esql.datasources.spi.RecordSplitter;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.List;
+
+public class CsvRecordSplitterMaxRecordSizeTests extends ESTestCase {
+
+    public void testQuotedFieldsOnlyReturnsRecordTooLargeForUnclosedQuote() throws IOException {
+        int maxRecordBytes = 32;
+        RecordSplitter splitter = new CsvRecordSplitter(CsvFormatOptions.TSV, maxRecordBytes);
+        byte[] bytes = bytes("\"" + "x".repeat(maxRecordBytes + 1));
+
+        assertEquals(RecordSplitter.RECORD_TOO_LARGE, splitter.findNextRecordBoundary(new ByteArrayInputStream(bytes)));
+        assertEquals(RecordSplitter.RECORD_TOO_LARGE, splitter.findLastRecordBoundary(bytes, bytes.length));
+    }
+
+    public void testBracketMvcReturnsRecordTooLargeForUnclosedBracket() throws IOException {
+        int maxRecordBytes = 32;
+        RecordSplitter splitter = new CsvRecordSplitter(CsvFormatOptions.DEFAULT, maxRecordBytes);
+        byte[] bytes = bytes("a,[" + "x".repeat(maxRecordBytes + 1));
+
+        assertEquals(RecordSplitter.RECORD_TOO_LARGE, splitter.findNextRecordBoundary(new ByteArrayInputStream(bytes)));
+        assertEquals(RecordSplitter.RECORD_TOO_LARGE, splitter.findLastRecordBoundary(bytes, bytes.length));
+    }
+
+    public void testCsvFormatReaderRecordSplitterUsesInjectedMaxRecordSize() throws IOException {
+        int maxRecordBytes = 16;
+        CsvFormatReader reader = new CsvFormatReader(blockFactory());
+        RecordSplitter splitter = reader.recordSplitter(maxRecordBytes);
+
+        assertEquals(
+            RecordSplitter.RECORD_TOO_LARGE,
+            splitter.findNextRecordBoundary(new ByteArrayInputStream(bytes("a,\"" + "x".repeat(maxRecordBytes + 1))))
+        );
+        assertEquals(maxRecordBytes, splitter.maxRecordBytes());
+    }
+
+    public void testComputeSegmentsFallsBackWhenBoundaryProbeExceedsMaxRecordSize() throws IOException {
+        int maxRecordBytes = 32;
+        String csv = "a,b\n1,\"" + "x".repeat(1024) + "\n";
+        byte[] bytes = bytes(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory());
+        StorageObject object = new ByteArrayStorageObject(bytes);
+
+        List<long[]> segments = ParallelParsingCoordinator.computeSegments(reader, object, bytes.length, 4, 1, maxRecordBytes);
+
+        assertEquals(1, segments.size());
+        assertArrayEquals(new long[] { 0, bytes.length }, segments.get(0));
+    }
+
+    private static byte[] bytes(String value) {
+        return value.getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static BlockFactory blockFactory() {
+        return BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(new NoopCircuitBreaker("test")).build();
+    }
+
+    private static class ByteArrayStorageObject implements StorageObject {
+        private final byte[] bytes;
+
+        ByteArrayStorageObject(byte[] bytes) {
+            this.bytes = bytes;
+        }
+
+        @Override
+        public InputStream newStream() {
+            return new ByteArrayInputStream(bytes);
+        }
+
+        @Override
+        public InputStream newStream(long position, long length) {
+            return new ByteArrayInputStream(bytes, Math.toIntExact(position), Math.toIntExact(length));
+        }
+
+        @Override
+        public long length() {
+            return bytes.length;
+        }
+
+        @Override
+        public Instant lastModified() {
+            return Instant.EPOCH;
+        }
+
+        @Override
+        public boolean exists() {
+            return true;
+        }
+
+        @Override
+        public StoragePath path() {
+            return StoragePath.of("mem://csv-record-splitter-max-record-size.csv");
+        }
+    }
+}

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvRecordSplitterTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvRecordSplitterTests.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.csv;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.spi.RecordSplitter;
+import org.elasticsearch.xpack.esql.datasources.spi.SegmentableFormatReader;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+
+public class CsvRecordSplitterTests extends ESTestCase {
+
+    public void testTsvFindLastRecordBoundaryWithLiteralMidFieldQuotes() throws IOException {
+        RecordSplitter splitter = splitter(CsvFormatOptions.TSV);
+        String data = "1\ta\"b\tc\n2\td\"e\"f\"g\th\n";
+        byte[] buf = bytes(data);
+
+        int boundary = splitter.findLastRecordBoundary(buf, buf.length);
+        assertEquals("must find the terminating newline of the last complete record", buf.length - 1, boundary);
+        assertEquals('\n', (char) buf[boundary]);
+    }
+
+    public void testTsvFindLastRecordBoundaryClickBenchShaped() throws IOException {
+        RecordSplitter splitter = splitter(CsvFormatOptions.TSV);
+        String row = clickBenchShapedTsvRow();
+        byte[] buf = bytes(row + row);
+
+        int boundary = splitter.findLastRecordBoundary(buf, buf.length);
+        assertEquals(buf.length - 1, boundary);
+        assertEquals('\n', (char) buf[boundary]);
+    }
+
+    public void testTsvFindNextRecordBoundaryWithLiteralMidFieldQuotes() throws IOException {
+        RecordSplitter splitter = splitter(CsvFormatOptions.TSV);
+        String row1 = "1\ta\"b\tc\n";
+        byte[] buf = bytes(row1 + "2\td\te\n");
+
+        long consumed = splitter.findNextRecordBoundary(new BufferedInputStream(new ByteArrayInputStream(buf)));
+        assertEquals(row1.length(), consumed);
+    }
+
+    public void testTsvDoubledQuoteInQuotedFieldIsLiteral() throws IOException {
+        RecordSplitter splitter = splitter(CsvFormatOptions.TSV);
+        String row1 = "\"a\"\"b\"\tc\n";
+        byte[] buf = bytes(row1 + "d\te\n");
+
+        assertEquals(row1.length(), splitter.findNextRecordBoundary(new BufferedInputStream(new ByteArrayInputStream(buf))));
+        assertEquals(buf.length - 1, splitter.findLastRecordBoundary(buf, buf.length));
+    }
+
+    public void testBracketMvcNewlineDoesNotTerminateRecord() throws IOException {
+        RecordSplitter splitter = splitter(CsvFormatOptions.DEFAULT);
+        String row1 = "before,[line1\nline2\nline3],after\n";
+        byte[] buf = bytes(row1 + "next\n");
+
+        assertEquals(row1.length(), splitter.findNextRecordBoundary(new ByteArrayInputStream(buf)));
+        assertEquals(buf.length - 1, splitter.findLastRecordBoundary(buf, buf.length));
+    }
+
+    public void testBracketMvcFindLastHonorsOffset() throws IOException {
+        RecordSplitter splitter = splitter(CsvFormatOptions.DEFAULT);
+        byte[] prefix = bytes("xx");
+        byte[] payload = bytes("a,[v1\nv2],b\nrow2,plain,c\n");
+        byte[] buf = new byte[prefix.length + payload.length];
+        System.arraycopy(prefix, 0, buf, 0, prefix.length);
+        System.arraycopy(payload, 0, buf, prefix.length, payload.length);
+
+        assertEquals(buf.length - 1, splitter.findLastRecordBoundary(buf, prefix.length, payload.length));
+    }
+
+    public void testMultiValueSyntaxNoneDoesNotTreatBracketsAsMvc() throws IOException {
+        CsvFormatOptions options = new CsvFormatOptions(
+            ',',
+            '"',
+            '\\',
+            "//",
+            "",
+            StandardCharsets.UTF_8,
+            null,
+            CsvFormatOptions.DEFAULT_MAX_FIELD_SIZE,
+            CsvFormatOptions.MultiValueSyntax.NONE,
+            true,
+            CsvFormatOptions.DEFAULT_COLUMN_PREFIX
+        );
+        RecordSplitter splitter = splitter(options);
+        byte[] buf = bytes("before,[not\nmvc],after\nnext\n");
+
+        assertEquals("before,[not\n".length(), splitter.findNextRecordBoundary(new ByteArrayInputStream(buf)));
+    }
+
+    public void testRecordBoundaryCountAgreesWithReadCsvRecord() throws IOException {
+        for (boolean tsv : new boolean[] { true, false }) {
+            CsvFormatOptions options = tsv ? CsvFormatOptions.TSV : CsvFormatOptions.DEFAULT;
+            RecordSplitter splitter = splitter(options);
+            char delim = options.delimiter();
+            boolean bracketAware = options.multiValueSyntax() == CsvFormatOptions.MultiValueSyntax.BRACKETS && delim == ',';
+
+            int rows = randomIntBetween(5, 50);
+            StringBuilder sb = new StringBuilder();
+            for (int r = 0; r < rows; r++) {
+                int cols = randomIntBetween(1, 8);
+                for (int c = 0; c < cols; c++) {
+                    if (c > 0) {
+                        sb.append(delim);
+                    }
+                    sb.append(randomFieldWithLiteralQuotes(delim));
+                }
+                sb.append('\n');
+            }
+            String data = sb.toString();
+            byte[] buf = bytes(data);
+
+            int parserRecords = 0;
+            try (BufferedReader br = new BufferedReader(new StringReader(data))) {
+                while (CsvFormatReader.readCsvRecord(br, options.quoteChar(), delim, bracketAware) != null) {
+                    parserRecords++;
+                }
+            }
+
+            int scannerRecords = 0;
+            BufferedInputStream in = new BufferedInputStream(new ByteArrayInputStream(buf));
+            while (splitter.findNextRecordBoundary(in) >= 0) {
+                scannerRecords++;
+            }
+
+            assertEquals("record count mismatch (tsv=" + tsv + ") for data:\n" + data, parserRecords, scannerRecords);
+            assertEquals(buf.length - 1, splitter.findLastRecordBoundary(buf, buf.length));
+        }
+    }
+
+    private static RecordSplitter splitter(CsvFormatOptions options) {
+        return new CsvRecordSplitter(options, SegmentableFormatReader.DEFAULT_MAX_RECORD_BYTES);
+    }
+
+    private static byte[] bytes(String value) {
+        return value.getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static String clickBenchShapedTsvRow() {
+        StringBuilder row = new StringBuilder();
+        for (int c = 0; c < 105; c++) {
+            if (c > 0) {
+                row.append('\t');
+            }
+            switch (c % 7) {
+                case 0 -> row.append(c);
+                case 3 -> row.append("http://x/?q=\"a\"&p=").append(c);
+                case 5 -> row.append("Title \"with\" quotes ").append(c);
+                default -> row.append('v').append(c);
+            }
+        }
+        row.append('\n');
+        return row.toString();
+    }
+
+    private String randomFieldWithLiteralQuotes(char delim) {
+        if (randomInt(4) == 0) {
+            StringBuilder b = new StringBuilder("\"");
+            int n = randomIntBetween(0, 6);
+            for (int i = 0; i < n; i++) {
+                int pick = randomInt(4);
+                switch (pick) {
+                    case 0 -> b.append(delim);
+                    case 1 -> b.append('\n');
+                    case 2 -> b.append("\"\"");
+                    default -> b.append((char) ('a' + randomInt(25)));
+                }
+            }
+            b.append('"');
+            return b.toString();
+        }
+        StringBuilder b = new StringBuilder();
+        b.append((char) ('a' + randomInt(25)));
+        int n = randomIntBetween(0, 8);
+        for (int i = 0; i < n; i++) {
+            b.append(randomBoolean() ? '"' : (char) ('a' + randomInt(25)));
+        }
+        return b.toString();
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
@@ -1842,7 +1842,8 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                     recordAlignedMacroSplit,
                     splitIncludesFileLeader,
                     perFileReadSchema,
-                    maxConcurrentOpenSegments
+                    maxConcurrentOpenSegments,
+                    maxRecordBytes
                 );
             }
             case STREAM_ONLY_COMPRESSED -> {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ParallelParsingCoordinator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ParallelParsingCoordinator.java
@@ -14,6 +14,7 @@ import org.elasticsearch.logging.Logger;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
+import org.elasticsearch.xpack.esql.datasources.spi.RecordSplitter;
 import org.elasticsearch.xpack.esql.datasources.spi.SegmentableFormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceOperatorContext;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
@@ -228,6 +229,39 @@ public final class ParallelParsingCoordinator {
         List<Attribute> readSchema,
         int maxConcurrentOpenSegments
     ) throws IOException {
+        return parallelRead(
+            reader,
+            storageObject,
+            projectedColumns,
+            batchSize,
+            parallelism,
+            executor,
+            errorPolicy,
+            splitStartsAtRecordBoundary,
+            splitIncludesFileLeader,
+            readSchema,
+            maxConcurrentOpenSegments,
+            SegmentableFormatReader.DEFAULT_MAX_RECORD_BYTES
+        );
+    }
+
+    /**
+     * Full-control overload that also takes the {@code max_record_size} cap used by record splitters.
+     */
+    public static CloseableIterator<Page> parallelRead(
+        SegmentableFormatReader reader,
+        StorageObject storageObject,
+        List<String> projectedColumns,
+        int batchSize,
+        int parallelism,
+        Executor executor,
+        ErrorPolicy errorPolicy,
+        boolean splitStartsAtRecordBoundary,
+        boolean splitIncludesFileLeader,
+        List<Attribute> readSchema,
+        int maxConcurrentOpenSegments,
+        int maxRecordBytes
+    ) throws IOException {
         long fileLength = storageObject.length();
         long minSegment = reader.minimumSegmentSize();
 
@@ -257,7 +291,7 @@ public final class ParallelParsingCoordinator {
             return parallelReader.read(storageObject, baseCtx);
         }
 
-        List<long[]> segments = computeSegments(parallelReader, storageObject, fileLength, parallelism, minSegment);
+        List<long[]> segments = computeSegments(parallelReader, storageObject, fileLength, parallelism, minSegment, maxRecordBytes);
 
         if (segments.size() <= 1) {
             return parallelReader.read(storageObject, baseCtx);
@@ -294,11 +328,33 @@ public final class ParallelParsingCoordinator {
         int parallelism,
         long minSegment
     ) throws IOException {
+        return computeSegments(
+            reader,
+            storageObject,
+            fileLength,
+            parallelism,
+            minSegment,
+            SegmentableFormatReader.DEFAULT_MAX_RECORD_BYTES
+        );
+    }
+
+    /**
+     * Computes byte-range segments using a splitter capped by {@code maxRecordBytes}.
+     */
+    public static List<long[]> computeSegments(
+        SegmentableFormatReader reader,
+        StorageObject storageObject,
+        long fileLength,
+        int parallelism,
+        long minSegment,
+        int maxRecordBytes
+    ) throws IOException {
         long nominalSize = fileLength / parallelism;
         if (nominalSize < minSegment) {
             nominalSize = minSegment;
         }
 
+        RecordSplitter splitter = reader.recordSplitter(maxRecordBytes);
         List<Long> boundaries = new ArrayList<>();
         boundaries.add(0L);
 
@@ -312,7 +368,7 @@ public final class ParallelParsingCoordinator {
             // Abort rather than close: findNextRecordBoundary reads only a prefix of the range
             // (fileLength - pos bytes), but close() on providers like S3 drains the remainder.
             try (Closeable abortOnExit = () -> storageObject.abortStream(stream)) {
-                long skipped = reader.findNextRecordBoundary(stream);
+                long skipped = splitter.findNextRecordBoundary(stream);
                 if (skipped < 0) {
                     break;
                 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
@@ -18,6 +18,7 @@ import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
+import org.elasticsearch.xpack.esql.datasources.spi.RecordSplitter;
 import org.elasticsearch.xpack.esql.datasources.spi.SegmentableFormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
@@ -283,6 +284,20 @@ public final class StreamingParallelParsingCoordinator {
             }
         }
 
+        private RecordSplitter recordSplitter() {
+            return reader.recordSplitter(maxRecordBytes);
+        }
+
+        private IOException recordTooLargeException() {
+            String hint = switch (reader.formatName()) {
+                case "csv", "tsv" -> "; possible unclosed quote or bracket cell";
+                default -> "";
+            };
+            return new IOException(
+                "record exceeded max_record_size [" + maxRecordBytes + "] for format [" + reader.formatName() + "]" + hint
+            );
+        }
+
         private void runSegmentator(InputStream stream, int chunkSize) {
             byte[] carry = null;
             int carryLen = 0;
@@ -315,7 +330,10 @@ public final class StreamingParallelParsingCoordinator {
                     int totalBytes = offset + Math.max(bytesRead, 0);
                     boolean isEof = bytesRead < 0 || totalBytes < buf.length;
 
-                    int lastNewline = reader.findLastRecordBoundary(buf, totalBytes);
+                    int lastNewline = recordSplitter().findLastRecordBoundary(buf, 0, totalBytes);
+                    if (lastNewline == RecordSplitter.RECORD_TOO_LARGE) {
+                        throw recordTooLargeException();
+                    }
 
                     if (lastNewline < 0) {
                         if (isEof) {
@@ -617,24 +635,17 @@ public final class StreamingParallelParsingCoordinator {
             // (a format/quoting mismatch), so fail rather than read the input without bound.
             while (true) {
                 if (len + growBy > maxRecordBytes) {
-                    throw new IOException(
-                        "no record boundary found within "
-                            + len
-                            + " bytes (max record size "
-                            + maxRecordBytes
-                            + ") for format ["
-                            + reader.formatName()
-                            + "]: the record-boundary scanner is not reporting a boundary, which usually "
-                            + "means a format/quoting mismatch (e.g. a misconfigured delimiter or quote "
-                            + "character). Aborting to avoid an unbounded read of the input stream."
-                    );
+                    throw recordTooLargeException();
                 }
                 byte[] grown = growUntilNewline(stream, buf, len, growBy);
                 if (grown.length == len) {
                     return new GrowResult(grown, -1);
                 }
                 // Rescans the whole grown buffer each iteration; total work is O(n^2), bounded by maxRecordBytes.
-                int boundary = reader.findLastRecordBoundary(grown, grown.length);
+                int boundary = recordSplitter().findLastRecordBoundary(grown, 0, grown.length);
+                if (boundary == RecordSplitter.RECORD_TOO_LARGE) {
+                    throw recordTooLargeException();
+                }
                 if (boundary >= 0) {
                     return new GrowResult(grown, boundary);
                 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
@@ -192,6 +192,8 @@ public final class StreamingParallelParsingCoordinator {
          */
         private final int maxRecordBytes;
         private final ArrayBlockingQueue<Page>[] pageQueues;
+        private volatile SegmentableFormatReader recordSplitterReader;
+        private volatile RecordSplitter recordSplitter;
 
         private final AtomicReference<Throwable> firstError = new AtomicReference<>();
         /**
@@ -285,16 +287,30 @@ public final class StreamingParallelParsingCoordinator {
         }
 
         private RecordSplitter recordSplitter() {
-            return reader.recordSplitter(maxRecordBytes);
+            SegmentableFormatReader currentReader = reader;
+            RecordSplitter currentSplitter = recordSplitter;
+            if (currentSplitter == null || recordSplitterReader != currentReader) {
+                currentSplitter = currentReader.recordSplitter(maxRecordBytes);
+                recordSplitterReader = currentReader;
+                recordSplitter = currentSplitter;
+            }
+            return currentSplitter;
         }
 
-        private IOException recordTooLargeException() {
+        private IOException recordTooLargeException(int scannedBytes) {
             String hint = switch (reader.formatName()) {
                 case "csv", "tsv" -> "; possible unclosed quote or bracket cell";
                 default -> "";
             };
             return new IOException(
-                "record exceeded max_record_size [" + maxRecordBytes + "] for format [" + reader.formatName() + "]" + hint
+                "record exceeded max_record_size ["
+                    + maxRecordBytes
+                    + "] after scanning ["
+                    + scannedBytes
+                    + "] bytes for format ["
+                    + reader.formatName()
+                    + "]"
+                    + hint
             );
         }
 
@@ -332,7 +348,7 @@ public final class StreamingParallelParsingCoordinator {
 
                     int lastNewline = recordSplitter().findLastRecordBoundary(buf, 0, totalBytes);
                     if (lastNewline == RecordSplitter.RECORD_TOO_LARGE) {
-                        throw recordTooLargeException();
+                        throw recordTooLargeException(totalBytes);
                     }
 
                     if (lastNewline < 0) {
@@ -635,7 +651,7 @@ public final class StreamingParallelParsingCoordinator {
             // (a format/quoting mismatch), so fail rather than read the input without bound.
             while (true) {
                 if (len + growBy > maxRecordBytes) {
-                    throw recordTooLargeException();
+                    throw recordTooLargeException(len);
                 }
                 byte[] grown = growUntilNewline(stream, buf, len, growBy);
                 if (grown.length == len) {
@@ -644,7 +660,7 @@ public final class StreamingParallelParsingCoordinator {
                 // Rescans the whole grown buffer each iteration; total work is O(n^2), bounded by maxRecordBytes.
                 int boundary = recordSplitter().findLastRecordBoundary(grown, 0, grown.length);
                 if (boundary == RecordSplitter.RECORD_TOO_LARGE) {
-                    throw recordTooLargeException();
+                    throw recordTooLargeException(grown.length);
                 }
                 if (boundary >= 0) {
                     return new GrowResult(grown, boundary);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/SegmentableFormatReader.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/SegmentableFormatReader.java
@@ -38,6 +38,14 @@ public interface SegmentableFormatReader extends FormatReader {
         return new DelegatingRecordSplitter(this);
     }
 
+    /**
+     * Returns the record-boundary splitter with a caller-supplied record-size cap.
+     * Implementations that cannot enforce a dynamic cap may keep the default splitter.
+     */
+    default RecordSplitter recordSplitter(int maxRecordBytes) {
+        return recordSplitter();
+    }
+
     // TODO(phase-1.2): once recordSplitter() is the canonical entry point, remove these legacy
     // find* methods and route callers through recordSplitter().
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/SegmentableFormatReader.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/SegmentableFormatReader.java
@@ -40,7 +40,9 @@ public interface SegmentableFormatReader extends FormatReader {
 
     /**
      * Returns the record-boundary splitter with a caller-supplied record-size cap.
-     * Implementations that cannot enforce a dynamic cap may keep the default splitter.
+     * Implementations that support the cap report {@link RecordSplitter#RECORD_TOO_LARGE}
+     * when a record exceeds {@code maxRecordBytes}; implementations that cannot enforce a
+     * dynamic cap may keep the default splitter.
      */
     default RecordSplitter recordSplitter(int maxRecordBytes) {
         return recordSplitter();

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinatorTests.java
@@ -717,7 +717,7 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
             );
             RuntimeException ex = expectThrows(RuntimeException.class, () -> collectLines(iterator));
             String chain = ex.toString() + (ex.getCause() != null ? " | cause: " + ex.getCause() : "");
-            assertTrue("expected a bounded grow-loop failure, got: " + chain, chain.contains("no record boundary found within"));
+            assertTrue("expected a bounded grow-loop failure, got: " + chain, chain.contains("record exceeded max_record_size"));
         } finally {
             executor.shutdownNow();
         }


### PR DESCRIPTION
Move CSV byte-boundary scanning behind the RecordSplitter SPI so
parallel planners can use the query-wide max_record_size cap instead
of the reader's legacy default. This keeps row-layer CSV parsing
unchanged while giving CSV splitter behavior direct coverage.

Developed with AI-assisted tooling