### PR TITLE
Remove serverless preview tag from FIRST/LAST/EARLIEST/LATEST

### DIFF
--- a/docs/reference/query-languages/esql/_snippets/lists/aggregation-functions.md
+++ b/docs/reference/query-languages/esql/_snippets/lists/aggregation-functions.md
@@ -2,10 +2,10 @@
 * [`AVG`](../../functions-operators/aggregation-functions/avg.md)
 * [`COUNT`](../../functions-operators/aggregation-functions/count.md)
 * [`COUNT_DISTINCT`](../../functions-operators/aggregation-functions/count_distinct.md)
-* [`EARLIEST`](../../functions-operators/aggregation-functions/earliest.md) {applies_to}`stack: ga 9.4` {applies_to}`serverless: preview`
-* [`FIRST`](../../functions-operators/aggregation-functions/first.md) {applies_to}`stack: ga 9.4` {applies_to}`serverless: preview`
-* [`LAST`](../../functions-operators/aggregation-functions/last.md) {applies_to}`stack: ga 9.4` {applies_to}`serverless: preview`
-* [`LATEST`](../../functions-operators/aggregation-functions/latest.md) {applies_to}`stack: ga 9.4` {applies_to}`serverless: preview`
+* [`EARLIEST`](../../functions-operators/aggregation-functions/earliest.md) {applies_to}`stack: ga 9.4`
+* [`FIRST`](../../functions-operators/aggregation-functions/first.md) {applies_to}`stack: ga 9.4`
+* [`LAST`](../../functions-operators/aggregation-functions/last.md) {applies_to}`stack: ga 9.4`
+* [`LATEST`](../../functions-operators/aggregation-functions/latest.md) {applies_to}`stack: ga 9.4`
 * [`MAX`](../../functions-operators/aggregation-functions/max.md)
 * [`MEDIAN`](../../functions-operators/aggregation-functions/median.md)
 * [`MEDIAN_ABSOLUTE_DEVIATION`](../../functions-operators/aggregation-functions/median_absolute_deviation.md)


### PR DESCRIPTION
Remove serverless preview tag from FIRST/LAST/EARLIEST/LATEST

Missed in #145758 which removed preview for 9.4 GA