### PR TITLE
[8.19] ESQL: Make proper error on DATE_PERIOD (#149942)

### DIFF
--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/DataType.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/DataType.java
@@ -575,7 +575,13 @@ public enum DataType {
     }
 
     public static boolean isSortable(DataType t) {
-        return false == (t == SOURCE || isCounter(t) || isSpatial(t) || t == AGGREGATE_METRIC_DOUBLE);
+        return false == (t == SOURCE
+            || isCounter(t)
+            || isSpatial(t)
+            || t == AGGREGATE_METRIC_DOUBLE
+            || t == DATE_PERIOD
+            || t == TIME_DURATION
+            || t == TSID_DATA_TYPE);
     }
 
     public String nameUpper() {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Aggregate.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Aggregate.java
@@ -40,6 +40,10 @@ import java.util.Objects;
 
 import static java.util.Collections.emptyList;
 import static org.elasticsearch.xpack.esql.common.Failure.fail;
+import static org.elasticsearch.xpack.esql.core.type.DataType.AGGREGATE_METRIC_DOUBLE;
+import static org.elasticsearch.xpack.esql.core.type.DataType.DATE_PERIOD;
+import static org.elasticsearch.xpack.esql.core.type.DataType.DENSE_VECTOR;
+import static org.elasticsearch.xpack.esql.core.type.DataType.TIME_DURATION;
 import static org.elasticsearch.xpack.esql.expression.NamedExpressions.mergeOutputAttributes;
 import static org.elasticsearch.xpack.esql.plan.logical.Filter.checkFilterConditionDataType;
 
@@ -238,9 +242,7 @@ public class Aggregate extends UnaryPlan implements PostAnalysisVerificationAwar
             if (attr != null) {
                 groupRefsBuilder.add(attr);
             }
-            if (e instanceof FieldAttribute f && f.dataType().isCounter()) {
-                failures.add(fail(e, "cannot group by on [{}] type for grouping [{}]", f.dataType().typeName(), e.sourceText()));
-            }
+            checkUnsupportedStatsGroupingType(e, failures);
         });
         var groupRefs = groupRefsBuilder.build();
 
@@ -266,6 +268,22 @@ public class Aggregate extends UnaryPlan implements PostAnalysisVerificationAwar
         }
         checkCategorizeGrouping(failures);
         checkMultipleScoreAggregations(failures);
+    }
+
+    static void checkUnsupportedGroupingType(Expression e, Failures failures) {
+        if ((e instanceof FieldAttribute f && f.dataType().isCounter())
+            || e.dataType() == AGGREGATE_METRIC_DOUBLE
+            || e.dataType() == DATE_PERIOD
+            || e.dataType() == TIME_DURATION) {
+            failures.add(fail(e, "cannot group by on [{}] type for grouping [{}]", e.dataType().typeName(), e.sourceText()));
+        }
+    }
+
+    private static void checkUnsupportedStatsGroupingType(Expression e, Failures failures) {
+        checkUnsupportedGroupingType(e, failures);
+        if (e.dataType() == DENSE_VECTOR) {
+            failures.add(fail(e, "cannot group by on [{}] type for grouping [{}]", e.dataType().typeName(), e.sourceText()));
+        }
     }
 
     private void checkMultipleScoreAggregations(Failures failures) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
@@ -839,6 +839,14 @@ public class VerifierTests extends ESTestCase {
                 error("row a = to_dateperiod(\"1 " + unit + "\")")
             );
         }
+        assertThat(
+            error("ROW a = NULL::time_duration", defaultAnalyzer),
+            equalTo("1:9: cannot use [NULL::time_duration] directly in a row assignment")
+        );
+        assertThat(
+            error("ROW a = NULL::date_period", defaultAnalyzer),
+            equalTo("1:9: cannot use [NULL::date_period] directly in a row assignment")
+        );
     }
 
     public void testSubtractDateTimeFromTemporal() {
@@ -967,6 +975,50 @@ public class VerifierTests extends ESTestCase {
                 error("row x = 1 | eval y = to_dateperiod(\"1 " + unit + "\")")
             );
         }
+        assertThat(
+            error("ROW x = 1 | EVAL y = NULL::time_duration", defaultAnalyzer),
+            equalTo("1:18: EVAL does not support type [time_duration] as the return data type of expression [NULL::time_duration]")
+        );
+        assertThat(
+            error("ROW x = 1 | EVAL y = NULL::date_period", defaultAnalyzer),
+            equalTo("1:18: EVAL does not support type [date_period] as the return data type of expression [NULL::date_period]")
+        );
+    }
+
+    public void testPeriodAndDurationInStats() {
+        for (var unit : TIME_DURATIONS) {
+            assertThat(
+                error("ROW x = 1 | STATS COUNT(*) BY 1 " + unit, defaultAnalyzer),
+                equalTo("1:31: cannot group by on [time_duration] type for grouping [1 " + unit + "]")
+            );
+        }
+        for (var unit : DATE_PERIODS) {
+            assertThat(
+                error("ROW x = 1 | STATS COUNT(*) BY 1 " + unit, defaultAnalyzer),
+                equalTo("1:31: cannot group by on [date_period] type for grouping [1 " + unit + "]")
+            );
+        }
+    }
+
+    public void testPeriodAndDurationInSort() {
+        for (var unit : TIME_DURATIONS) {
+            assertThat(error("ROW x = 1 | SORT 1 " + unit, defaultAnalyzer), equalTo("1:18: cannot sort on time_duration"));
+        }
+        for (var unit : DATE_PERIODS) {
+            assertThat(error("ROW x = 1 | SORT 1 " + unit, defaultAnalyzer), equalTo("1:18: cannot sort on date_period"));
+        }
+    }
+
+    public void testPeriodAndDurationInChangePoint() {
+        assumeTrue("change_point must be enabled", EsqlCapabilities.Cap.CHANGE_POINT.isEnabled());
+        // Keys are qualifiedNames so we can't use literals; test via columns. The ROW assignment also
+        // fires an error but the CHANGE_POINT key error still appears in the output.
+        assertThat(error("""
+            ROW key = NULL::time_duration, value = 0
+            | CHANGE_POINT value ON key""", defaultAnalyzer), containsString("change point key [key] must be sortable"));
+        assertThat(error("""
+            ROW key = NULL::date_period, value = 0
+            | CHANGE_POINT value ON key""", defaultAnalyzer), containsString("change point key [key] must be sortable"));
     }
 
     public void testFilterNonBoolField() {


### PR DESCRIPTION
Backport of #149942 to 8.19.

Fixes `| STATS BY 1 HOUR` and `| SORT BY 1 HOUR` to produce a nice error message instead of a 500-level error.