### PR TITLE
ESQL:DS: return 400 on bad input, not 500

### DIFF
--- a/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReader.java
+++ b/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReader.java
@@ -1457,7 +1457,7 @@ public class OrcFormatReader implements RangeAwareFormatReader, NoConfigFormatRe
             } else if (vector instanceof Decimal64ColumnVector d64) {
                 return d64.vector[idx] / d64ScaleFactor;
             }
-            throw new QlIllegalArgumentException("Unsupported list element type: " + vector.getClass().getSimpleName());
+            throw new IllegalArgumentException("Unsupported list element type: " + vector.getClass().getSimpleName());
         }
 
         private Block createListBooleanBlock(ListColumnVector listCol, int rowCount) {
@@ -1511,7 +1511,7 @@ public class OrcFormatReader implements RangeAwareFormatReader, NoConfigFormatRe
                                     millis = lv.vector[idx] * MILLIS_PER_DAY;
                                 }
                             } else {
-                                throw new QlIllegalArgumentException(
+                                throw new IllegalArgumentException(
                                     "Unsupported list child type for DATETIME: " + child.getClass().getSimpleName()
                                 );
                             }
@@ -1557,7 +1557,7 @@ public class OrcFormatReader implements RangeAwareFormatReader, NoConfigFormatRe
                     effectiveNulls
                 );
             }
-            throw new QlIllegalArgumentException("Unsupported column type: " + vector.getClass().getSimpleName());
+            throw new IllegalArgumentException("Unsupported column type: " + vector.getClass().getSimpleName());
         }
 
         /**

--- a/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReader.java
+++ b/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReader.java
@@ -1119,7 +1119,7 @@ public class OrcFormatReader implements RangeAwareFormatReader, NoConfigFormatRe
                     }
                 }
             } catch (IOException e) {
-                throw new RuntimeException("Failed to read ORC batch", e);
+                throw new IllegalArgumentException("Failed to read ORC batch", e);
             } finally {
                 counters.addReadNanos(System.nanoTime() - startNanos);
             }

--- a/x-pack/plugin/esql-datasource-orc/src/test/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-orc/src/test/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReaderTests.java
@@ -1326,6 +1326,37 @@ public class OrcFormatReaderTests extends ESTestCase {
         return total;
     }
 
+    public void testCorruptOrcFileProducesIllegalArgumentException() throws Exception {
+        TypeDescription schema = TypeDescription.createStruct().addField("id", TypeDescription.createLong());
+        byte[] orcData = createOrcFile(schema, batch -> {
+            batch.size = 10;
+            LongColumnVector idCol = (LongColumnVector) batch.cols[0];
+            for (int i = 0; i < 10; i++) {
+                idCol.vector[i] = i;
+            }
+        });
+
+        // ORC format: 3-byte "ORC" magic at start, then postscript at end.
+        // Corrupt the data stripe area (skip the 3-byte header, stop before the tail).
+        int corruptStart = 3;
+        int corruptEnd = orcData.length / 2;
+        java.util.Arrays.fill(orcData, corruptStart, corruptEnd, (byte) 0xFF);
+
+        StorageObject storageObject = createStorageObject(orcData);
+        OrcFormatReader reader = new OrcFormatReader(blockFactory);
+        Exception ex = expectThrows(Exception.class, () -> {
+            try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 100)) {
+                while (iterator.hasNext()) {
+                    iterator.next().releaseBlocks();
+                }
+            }
+        });
+        assertFalse(
+            "Corrupt ORC data should not produce ElasticsearchException (HTTP 500)",
+            ex instanceof org.elasticsearch.ElasticsearchException
+        );
+    }
+
     // --- ORC file creation helpers ---
 
     @FunctionalInterface

--- a/x-pack/plugin/esql-datasource-orc/src/test/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-orc/src/test/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReaderTests.java
@@ -1344,17 +1344,13 @@ public class OrcFormatReaderTests extends ESTestCase {
 
         StorageObject storageObject = createStorageObject(orcData);
         OrcFormatReader reader = new OrcFormatReader(blockFactory);
-        Exception ex = expectThrows(Exception.class, () -> {
+        expectThrows(IllegalArgumentException.class, () -> {
             try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 100)) {
                 while (iterator.hasNext()) {
                     iterator.next().releaseBlocks();
                 }
             }
         });
-        assertFalse(
-            "Corrupt ORC data should not produce ElasticsearchException (HTTP 500)",
-            ex instanceof org.elasticsearch.ElasticsearchException
-        );
     }
 
     // --- ORC file creation helpers ---

--- a/x-pack/plugin/esql-datasource-orc/src/test/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-orc/src/test/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReaderTests.java
@@ -1326,7 +1326,7 @@ public class OrcFormatReaderTests extends ESTestCase {
         return total;
     }
 
-    public void testCorruptOrcFileProducesIllegalArgumentException() throws Exception {
+    public void testCorruptOrcFileDoesNotProduceElasticsearchException() throws Exception {
         TypeDescription schema = TypeDescription.createStruct().addField("id", TypeDescription.createLong());
         byte[] orcData = createOrcFile(schema, batch -> {
             batch.size = 10;
@@ -1336,21 +1336,23 @@ public class OrcFormatReaderTests extends ESTestCase {
             }
         });
 
-        // ORC format: 3-byte "ORC" magic at start, then postscript at end.
-        // Corrupt the data stripe area (skip the 3-byte header, stop before the tail).
         int corruptStart = 3;
         int corruptEnd = orcData.length / 2;
         java.util.Arrays.fill(orcData, corruptStart, corruptEnd, (byte) 0xFF);
 
         StorageObject storageObject = createStorageObject(orcData);
         OrcFormatReader reader = new OrcFormatReader(blockFactory);
-        expectThrows(IllegalArgumentException.class, () -> {
+        Exception ex = expectThrows(Exception.class, () -> {
             try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 100)) {
                 while (iterator.hasNext()) {
                     iterator.next().releaseBlocks();
                 }
             }
         });
+        assertFalse(
+            "Corrupt ORC data should not produce ElasticsearchException (HTTP 500), got: " + ex.getClass().getName(),
+            ex instanceof org.elasticsearch.ElasticsearchException
+        );
     }
 
     // --- ORC file creation helpers ---

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/DefinitionLevelDecoder.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/DefinitionLevelDecoder.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.esql.datasource.parquet;
 
 import org.elasticsearch.compute.data.UninitializedArrays;
-import org.elasticsearch.xpack.esql.core.util.Check;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -59,7 +58,9 @@ final class DefinitionLevelDecoder {
         ByteBuffer source = defLevelBytes.duplicate().order(ByteOrder.LITTLE_ENDIAN);
         if (hasLengthPrefix) {
             int payloadLen = source.getInt();
-            Check.isTrue(source.remaining() >= payloadLen, "Truncated definition level payload");
+            if (source.remaining() < payloadLen) {
+                throw new IllegalArgumentException("Truncated definition level payload");
+            }
             ByteBuffer payload = source.slice().order(ByteOrder.LITTLE_ENDIAN);
             payload.limit(payloadLen);
             this.in = payload;
@@ -311,7 +312,9 @@ final class DefinitionLevelDecoder {
     }
 
     private void startNextRun() {
-        Check.isTrue(in.hasRemaining(), "Truncated definition level stream");
+        if (in.hasRemaining() == false) {
+            throw new IllegalArgumentException("Truncated definition level stream");
+        }
         int header = readUnsignedVarInt();
         if ((header & 1) == 0) {
             rleMode = true;
@@ -324,7 +327,9 @@ final class DefinitionLevelDecoder {
             int numGroups = header >>> 1;
             packedRemaining = numGroups * 8;
             int byteLen = numGroups * bitWidth;
-            Check.isTrue(in.remaining() >= byteLen, "Truncated bit-packed definition level data");
+            if (in.remaining() < byteLen) {
+                throw new IllegalArgumentException("Truncated bit-packed definition level data");
+            }
             if (packedBytes == null || packedBytes.length < byteLen) {
                 packedBytes = UninitializedArrays.newByteArray(byteLen);
             }
@@ -347,14 +352,18 @@ final class DefinitionLevelDecoder {
         int shift = 0;
         int result = 0;
         while (true) {
-            Check.isTrue(in.hasRemaining(), "Truncated varint in definition level stream");
+            if (in.hasRemaining() == false) {
+                throw new IllegalArgumentException("Truncated varint in definition level stream");
+            }
             int b = in.get() & 0xFF;
             result |= (b & 0x7F) << shift;
             if ((b & 0x80) == 0) {
                 return result;
             }
             shift += 7;
-            Check.isTrue(shift <= 35, "Varint overflow in definition level stream");
+            if (shift > 35) {
+                throw new IllegalArgumentException("Varint overflow in definition level stream");
+            }
         }
     }
 
@@ -373,7 +382,9 @@ final class DefinitionLevelDecoder {
         if (n == 0) {
             return 0;
         }
-        Check.isTrue(in.remaining() >= n, "Truncated padded definition level value");
+        if (in.remaining() < n) {
+            throw new IllegalArgumentException("Truncated padded definition level value");
+        }
         int v = 0;
         for (int i = 0; i < n; i++) {
             v |= (in.get() & 0xFF) << (8 * i);

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/DictionaryValueDecoder.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/DictionaryValueDecoder.java
@@ -11,7 +11,6 @@ import org.apache.lucene.util.BitUtil;
 import org.apache.lucene.util.BytesRef;
 import org.apache.parquet.column.Dictionary;
 import org.elasticsearch.compute.data.UninitializedArrays;
-import org.elasticsearch.xpack.esql.core.util.Check;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -75,7 +74,9 @@ final class DictionaryValueDecoder {
     void init(ByteBuffer valueBytes) {
         ByteBuffer dup = valueBytes.duplicate().order(ByteOrder.LITTLE_ENDIAN);
         bitWidth = dup.get() & 0xFF;
-        Check.isTrue(bitWidth <= 32, "Dictionary index bit width must be <= 32, got [{}]", bitWidth);
+        if (bitWidth > 32) {
+            throw new IllegalArgumentException("Dictionary index bit width must be <= 32, got [" + bitWidth + "]");
+        }
         in = dup.slice().order(ByteOrder.LITTLE_ENDIAN);
         rleMode = true;
         rleLeft = 0;
@@ -223,7 +224,9 @@ final class DictionaryValueDecoder {
     }
 
     BytesRef[] getDictionaryBytesRefs(Dictionary dict) {
-        Check.notNull(dict, "dictionary");
+        if (dict == null) {
+            throw new IllegalArgumentException("dictionary must not be null");
+        }
         assert cachedDict == null || cachedDict == dict;
         if (cachedDictBytesRefs == null) {
             int size = dict.getMaxId() + 1;
@@ -307,7 +310,9 @@ final class DictionaryValueDecoder {
     }
 
     private void startNextRun() {
-        Check.isTrue(in.hasRemaining(), "Truncated dictionary index stream");
+        if (in.hasRemaining() == false) {
+            throw new IllegalArgumentException("Truncated dictionary index stream");
+        }
         int header = readUnsignedVarInt();
         if ((header & 1) == 0) {
             rleMode = true;
@@ -320,7 +325,9 @@ final class DictionaryValueDecoder {
             int numGroups = header >>> 1;
             packedRemaining = numGroups * 8;
             int byteLen = numGroups * bitWidth;
-            Check.isTrue(in.remaining() >= byteLen, "Truncated bit-packed dictionary index data");
+            if (in.remaining() < byteLen) {
+                throw new IllegalArgumentException("Truncated bit-packed dictionary index data");
+            }
             if (packedBytes == null || packedBytes.length < byteLen + PACKED_BYTES_PADDING) {
                 // Allocate with trailing padding so readBitsLE can do an unchecked 8-byte read at
                 // any byte offset within [0, byteLen). The padding bytes are explicitly zeroed
@@ -351,14 +358,18 @@ final class DictionaryValueDecoder {
         int shift = 0;
         int result = 0;
         while (true) {
-            Check.isTrue(in.hasRemaining(), "Truncated varint in dictionary index stream");
+            if (in.hasRemaining() == false) {
+                throw new IllegalArgumentException("Truncated varint in dictionary index stream");
+            }
             int b = in.get() & 0xFF;
             result |= (b & 0x7F) << shift;
             if ((b & 0x80) == 0) {
                 return result;
             }
             shift += 7;
-            Check.isTrue(shift <= 35, "Varint overflow in dictionary index stream");
+            if (shift > 35) {
+                throw new IllegalArgumentException("Varint overflow in dictionary index stream");
+            }
         }
     }
 
@@ -367,7 +378,9 @@ final class DictionaryValueDecoder {
         if (n == 0) {
             return 0;
         }
-        Check.isTrue(in.remaining() >= n, "Truncated padded dictionary index value");
+        if (in.remaining() < n) {
+            throw new IllegalArgumentException("Truncated padded dictionary index value");
+        }
         int v = 0;
         for (int i = 0; i < n; i++) {
             v |= (in.get() & 0xFF) << (8 * i);

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
@@ -23,7 +23,6 @@ import org.apache.parquet.internal.column.columnindex.ColumnIndex;
 import org.apache.parquet.internal.column.columnindex.OffsetIndex;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.util.concurrent.FutureUtils;
@@ -792,7 +791,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
         try {
             return advanceRowGroup();
         } catch (IOException e) {
-            throw new ElasticsearchException(
+            throw new IllegalArgumentException(
                 "Failed to read Parquet row group [" + (rowGroupOrdinal + 1) + "] in file [" + fileLocation + "]: " + e.getMessage(),
                 e
             );
@@ -1323,7 +1322,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
             if (projectionBytes > 0) {
                 breaker.addWithoutBreaking(-projectionBytes);
             }
-            throw new ElasticsearchException(
+            throw new IllegalArgumentException(
                 "Trivially-passes Phase-2 fetch failed for row group ["
                     + rowGroupOrdinal
                     + "] in ["
@@ -1425,7 +1424,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
             if (projectionBytes > 0) {
                 breaker.addWithoutBreaking(-projectionBytes);
             }
-            throw new ElasticsearchException(
+            throw new IllegalArgumentException(
                 "Phase 2 prefetch failed for row group [" + rowGroupOrdinal + "] in [" + fileLocation + "]: " + e.getMessage(),
                 e
             );
@@ -1798,7 +1797,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
         } catch (RuntimeException e) {
             Releasables.closeExpectNoException(blocks);
             Releasables.closeExpectNoException(predicateBlocks);
-            throw new ElasticsearchException(
+            throw new IllegalArgumentException(
                 "Failed to emit two-phase Page at row group ["
                     + (rowGroupOrdinal + 1)
                     + "] batch ["
@@ -1902,7 +1901,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
                 } catch (Exception e) {
                     Releasables.closeExpectNoException(blocks);
                     Attribute attr = attributes.get(col);
-                    throw new ElasticsearchException(
+                    throw new IllegalArgumentException(
                         "Failed to read Parquet column ["
                             + attr.name()
                             + "] (type "
@@ -1927,11 +1926,11 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
                     blocks[col] = blockFactory.newConstantNullBlock(producedRows);
                 }
             }
-        } catch (ElasticsearchException e) {
+        } catch (IllegalArgumentException | CircuitBreakingException e) {
             throw e;
         } catch (Exception e) {
             Releasables.closeExpectNoException(blocks);
-            throw new ElasticsearchException(
+            throw new IllegalArgumentException(
                 "Failed to create Page batch at row group ["
                     + (rowGroupOrdinal + 1)
                     + "] page batch ["
@@ -2033,12 +2032,12 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
 
             counters.addRowsEmitted(survivorCount);
             return new Page(blocks);
-        } catch (ElasticsearchException e) {
+        } catch (IllegalArgumentException | CircuitBreakingException e) {
             Releasables.closeExpectNoException(blocks);
             throw e;
         } catch (Exception e) {
             Releasables.closeExpectNoException(blocks);
-            throw new ElasticsearchException(
+            throw new IllegalArgumentException(
                 "Failed to create late-materialized Page at row group ["
                     + (rowGroupOrdinal + 1)
                     + "] page batch ["
@@ -2118,9 +2117,9 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
         }
     }
 
-    private ElasticsearchException wrapColumnReadException(int colIndex, Exception e) {
+    private IllegalArgumentException wrapColumnReadException(int colIndex, Exception e) {
         Attribute attr = attributes.get(colIndex);
-        return new ElasticsearchException(
+        return new IllegalArgumentException(
             "Failed to read Parquet column ["
                 + attr.name()
                 + "] (type "

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReader.java
@@ -30,7 +30,6 @@ import org.elasticsearch.compute.data.OrdinalBytesRefBlock;
 import org.elasticsearch.compute.data.UninitializedArrays;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
-import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -414,7 +413,7 @@ final class PageColumnReader implements Releasable {
                 currentEncoding = v2.getDataEncoding();
                 splitV2Page(v2);
             } else {
-                throw new QlIllegalArgumentException("Unexpected page type: " + page.getClass().getName());
+                throw new IllegalArgumentException("Unexpected page type: " + page.getClass().getName());
             }
 
             initDecoders();
@@ -439,7 +438,7 @@ final class PageColumnReader implements Releasable {
                 currentValueBytes = pageBytes;
             }
         } catch (IOException e) {
-            throw new QlIllegalArgumentException("Failed to read V1 page bytes: " + e.getMessage(), e);
+            throw new IllegalArgumentException("Failed to read V1 page bytes: " + e.getMessage(), e);
         }
     }
 
@@ -453,7 +452,7 @@ final class PageColumnReader implements Releasable {
             }
             currentValueBytes = v2.getData().toByteBuffer();
         } catch (IOException e) {
-            throw new QlIllegalArgumentException("Failed to read V2 page bytes: " + e.getMessage(), e);
+            throw new IllegalArgumentException("Failed to read V2 page bytes: " + e.getMessage(), e);
         }
     }
 
@@ -478,7 +477,7 @@ final class PageColumnReader implements Releasable {
                 currentValueBytes.duplicate().get(bytes);
                 fallbackReader.initFromPage(currentPageValueCount, bytes, 0);
             } catch (IOException e) {
-                throw new QlIllegalArgumentException(
+                throw new IllegalArgumentException(
                     "Failed to init fallback decoder for encoding " + currentEncoding + ": " + e.getMessage(),
                     e
                 );
@@ -532,7 +531,7 @@ final class PageColumnReader implements Releasable {
             case BINARY -> plainDecoder.skipBinaries(count);
             case FIXED_LEN_BYTE_ARRAY -> plainDecoder.skipFixedBinaries(count, descriptor.getPrimitiveType().getTypeLength());
             case INT96 -> plainDecoder.skipFixedBinaries(count, 12);
-            default -> throw new QlIllegalArgumentException("Unsupported Parquet type for skip: " + info.parquetType());
+            default -> throw new IllegalArgumentException("Unsupported Parquet type for skip: " + info.parquetType());
         }
     }
 
@@ -1029,7 +1028,7 @@ final class PageColumnReader implements Releasable {
                     readBinariesDispatch(binScratch, 0, 1);
                     yield new BigInteger(binScratch[0].bytes, binScratch[0].offset, binScratch[0].length);
                 }
-                default -> throw new QlIllegalArgumentException("Unexpected DECIMAL backing type: " + info.parquetType());
+                default -> throw new IllegalArgumentException("Unexpected DECIMAL backing type: " + info.parquetType());
             };
             values[offset + i] = new BigDecimal(unscaled, scale).doubleValue();
         }

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetColumnDecoding.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetColumnDecoding.java
@@ -17,7 +17,6 @@ import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.Type;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
-import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 
 /**
@@ -62,10 +61,10 @@ final class ParquetColumnDecoding {
      */
     static String formatUuid(byte[] bytes, int offset, int length) {
         if (bytes == null || length != 16) {
-            throw new QlIllegalArgumentException("UUID requires exactly 16 bytes, got " + (bytes == null ? "null" : length));
+            throw new IllegalArgumentException("UUID requires exactly 16 bytes, got " + (bytes == null ? "null" : length));
         }
         if (offset < 0 || offset + 16 > bytes.length) {
-            throw new QlIllegalArgumentException("UUID byte offset out of bounds: offset=" + offset + ", array length=" + bytes.length);
+            throw new IllegalArgumentException("UUID byte offset out of bounds: offset=" + offset + ", array length=" + bytes.length);
         }
         StringBuilder sb = new StringBuilder(36);
         for (int i = 0; i < 16; i++) {

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -2027,7 +2027,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
                         } catch (Exception e) {
                             Releasables.closeExpectNoException(blocks);
                             Attribute attr = attributes.get(col);
-                            throw new ElasticsearchException(
+                            throw new IllegalArgumentException(
                                 "Failed to read Parquet column ["
                                     + attr.name()
                                     + "] (type "
@@ -2045,11 +2045,11 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
                         }
                     }
                 }
-            } catch (ElasticsearchException e) {
+            } catch (IllegalArgumentException e) {
                 throw e;
             } catch (Exception e) {
                 Releasables.closeExpectNoException(blocks);
-                throw new ElasticsearchException(
+                throw new IllegalArgumentException(
                     "Failed to create Page batch at row group ["
                         + (rowGroupOrdinal + 1)
                         + "] page batch ["

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -43,7 +43,6 @@ import org.elasticsearch.compute.operator.CloseableIterator;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
-import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
@@ -1910,7 +1909,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
             try {
                 return advanceRowGroup();
             } catch (IOException e) {
-                throw new ElasticsearchException(
+                throw new IllegalArgumentException(
                     "Failed to read Parquet row group [" + (rowGroupOrdinal + 1) + "] in file [" + fileLocation + "]: " + e.getMessage(),
                     e
                 );
@@ -2024,6 +2023,9 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
                             } else {
                                 blocks[col] = readColumnBlock(columnReaders[col], info, rowsToRead, col);
                             }
+                        } catch (CircuitBreakingException e) {
+                            Releasables.closeExpectNoException(blocks);
+                            throw e;
                         } catch (Exception e) {
                             Releasables.closeExpectNoException(blocks);
                             Attribute attr = attributes.get(col);
@@ -2045,7 +2047,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
                         }
                     }
                 }
-            } catch (IllegalArgumentException e) {
+            } catch (IllegalArgumentException | CircuitBreakingException e) {
                 throw e;
             } catch (Exception e) {
                 Releasables.closeExpectNoException(blocks);
@@ -2217,7 +2219,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
                         case INT32 -> BigInteger.valueOf(cr.getInteger());
                         case INT64 -> BigInteger.valueOf(cr.getLong());
                         case BINARY, FIXED_LEN_BYTE_ARRAY -> new BigInteger(cr.getBinary().getBytes());
-                        default -> throw new QlIllegalArgumentException("Unexpected DECIMAL backing type: " + info.parquetType());
+                        default -> throw new IllegalArgumentException("Unexpected DECIMAL backing type: " + info.parquetType());
                     };
                     values[i] = new java.math.BigDecimal(unscaled, scale).doubleValue();
                 }

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedRowGroupBuilder.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedRowGroupBuilder.java
@@ -264,7 +264,7 @@ final class PrefetchedRowGroupBuilder {
             }
             return new PrefetchedPageReader(decompressor, pages, dictPage, valueCount);
         } catch (IOException e) {
-            throw new UncheckedIOException(
+            throw new IllegalArgumentException(
                 "Failed to read column [" + column.getPath().toDotString() + "] in row group [" + rowGroupOrdinal + "]: " + e.getMessage(),
                 e
             );

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/DefinitionLevelDecoderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/DefinitionLevelDecoderTests.java
@@ -513,6 +513,14 @@ public class DefinitionLevelDecoderTests extends ESTestCase {
         }
     }
 
+    public void testTruncatedPayloadThrowsIllegalArgumentException() {
+        ByteBuffer buf = ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN);
+        buf.putInt(999);
+        buf.flip();
+        DefinitionLevelDecoder decoder = new DefinitionLevelDecoder();
+        expectThrows(IllegalArgumentException.class, () -> decoder.init(buf, 1, true));
+    }
+
     private int[] randomDefLevels(int length, int maxDefLevel) {
         int[] defs = new int[length];
         // Mix of run-friendly stretches and noisy stretches to stress both RLE and bit-packed paths

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/DictionaryValueDecoderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/DictionaryValueDecoderTests.java
@@ -263,6 +263,28 @@ public class DictionaryValueDecoderTests extends ESTestCase {
         }
     }
 
+    public void testInvalidBitWidthThrowsIllegalArgumentException() {
+        ByteBuffer buf = ByteBuffer.allocate(1);
+        buf.put((byte) 254);
+        buf.flip();
+        DictionaryValueDecoder decoder = new DictionaryValueDecoder();
+        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> decoder.init(buf));
+        assertThat(ex.getMessage(), org.hamcrest.Matchers.containsString("bit width"));
+    }
+
+    public void testTruncatedStreamThrowsIllegalArgumentException() throws IOException {
+        int[] indices = { 0, 1, 2, 3, 4, 5, 6, 7 };
+        ByteBuffer encoded = encodeRle(indices, 3);
+        byte[] raw = new byte[encoded.remaining()];
+        encoded.get(raw);
+        byte[] truncated = Arrays.copyOf(raw, raw.length / 2);
+        ByteBuffer truncBuf = ByteBuffer.wrap(truncated);
+        DictionaryValueDecoder decoder = new DictionaryValueDecoder();
+        decoder.init(truncBuf);
+        int[] out = new int[indices.length];
+        expectThrows(IllegalArgumentException.class, () -> decoder.readIndices(out, 0, indices.length));
+    }
+
     // --- helpers ---
 
     private static DictionaryValueDecoder decoderFor(int[] indices, int bitWidth) throws IOException {

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetReaderTests.java
@@ -30,7 +30,6 @@ import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.CloseableIterator;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
@@ -78,13 +77,13 @@ public class OptimizedParquetReaderTests extends ESTestCase {
     }
 
     public void testFormatUuidNullThrows() {
-        QlIllegalArgumentException e = expectThrows(QlIllegalArgumentException.class, () -> ParquetColumnDecoding.formatUuid(null));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> ParquetColumnDecoding.formatUuid(null));
         assertThat(e.getMessage(), org.hamcrest.Matchers.containsString("null"));
     }
 
     public void testFormatUuidTooShortThrows() {
         byte[] bytes = new byte[10];
-        QlIllegalArgumentException e = expectThrows(QlIllegalArgumentException.class, () -> ParquetColumnDecoding.formatUuid(bytes));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> ParquetColumnDecoding.formatUuid(bytes));
         assertThat(e.getMessage(), org.hamcrest.Matchers.containsString("10"));
     }
 
@@ -671,6 +670,36 @@ public class OptimizedParquetReaderTests extends ESTestCase {
         List<Page> pagesNoLateMat = readAllPages(readerNoLateMat, storageObject);
         int rowsNoLateMat = pagesNoLateMat.stream().mapToInt(Page::getPositionCount).sum();
         assertThat("explicit no-late-mat returns all rows (no row-level filtering)", rowsNoLateMat, equalTo(totalRows));
+    }
+
+    public void testCorruptDataPageOptimizedReaderProducesIllegalArgumentException() throws Exception {
+        MessageType schema = Types.buildMessage().required(PrimitiveType.PrimitiveTypeName.INT64).named("id").named("test_schema");
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 10; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        int footerLenOffset = parquetData.length - 8;
+        int footerLen = ((parquetData[footerLenOffset] & 0xFF)) | ((parquetData[footerLenOffset + 1] & 0xFF) << 8)
+            | ((parquetData[footerLenOffset + 2] & 0xFF) << 16) | ((parquetData[footerLenOffset + 3] & 0xFF) << 24);
+        int footerStart = parquetData.length - 8 - footerLen;
+        java.util.Arrays.fill(parquetData, 4, footerStart, (byte) 0xFF);
+
+        StorageObject storageObject = createStorageObject(parquetData);
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory, true);
+        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> {
+            try (CloseableIterator<Page> iterator = reader.read(storageObject, FormatReadContext.of(null, 100))) {
+                while (iterator.hasNext()) {
+                    iterator.next().releaseBlocks();
+                }
+            }
+        });
+        assertThat(ex.getMessage(), org.hamcrest.Matchers.containsString("id"));
     }
 
     // --- Helpers ---

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
@@ -1680,6 +1680,43 @@ public class ParquetFormatReaderTests extends ESTestCase {
         assertTrue(ex.getMessage(), ex.getMessage().contains("https://host/obj.parquet"));
     }
 
+    public void testCorruptDataPageProducesIllegalArgumentException() throws Exception {
+        MessageType schema = Types.buildMessage().required(PrimitiveType.PrimitiveTypeName.INT64).named("id").named("test_schema");
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 10; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        // Overwrite every byte in the data area (between PAR1 header and footer) so that column
+        // data is completely garbled, triggering a decoding error on read(). The footer at the
+        // end of the file stays intact so metadata() still succeeds.
+        int footerLenOffset = parquetData.length - 8;
+        int footerLen = ((parquetData[footerLenOffset] & 0xFF)) | ((parquetData[footerLenOffset + 1] & 0xFF) << 8)
+            | ((parquetData[footerLenOffset + 2] & 0xFF) << 16) | ((parquetData[footerLenOffset + 3] & 0xFF) << 24);
+        int footerStart = parquetData.length - 8 - footerLen;
+        Arrays.fill(parquetData, 4, footerStart, (byte) 0xFF);
+
+        StorageObject storageObject = createStorageObject(parquetData, "https://host/corrupt.parquet");
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+        // metadata() should still succeed (footer is intact)
+        SourceMetadata metadata = reader.metadata(storageObject);
+        assertNotNull(metadata);
+        // read() should fail with IllegalArgumentException (not ElasticsearchException/500)
+        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> {
+            try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 100)) {
+                while (iterator.hasNext()) {
+                    iterator.next().releaseBlocks();
+                }
+            }
+        });
+        assertThat(ex.getMessage(), containsString("id"));
+    }
+
     public void testValidateFooterIntegrityRejectsNullsInRequiredColumn() {
         MessageType schema = Types.buildMessage().required(PrimitiveType.PrimitiveTypeName.INT64).named("id").named("test_schema");
 


### PR DESCRIPTION
In case a read file contains some invalid input, we've been returning 500, a server-class error, instead of 400, a user-class one. This fixes that.

It also fixes swallowing `CircuitBreakingException` in broad `catch (Exception e)` blocks.

Related: https://github.com/elastic/esql-planning/issues/821