### PR TITLE
[9.4] Fix wildcard view resolution losing duplicate copies (#149418)

### DIFF
--- a/docs/changelog/149418.yaml
+++ b/docs/changelog/149418.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 149416
+pr: 149418
+summary: Fix wildcard view resolution losing duplicate copies
+type: bug

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/view/ViewResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/view/ViewResolver.java
@@ -550,18 +550,27 @@ public class ViewResolver {
         plans.put(firstKey, merged);
     }
 
-    /** Merge the unresolved relation unless the index patterns contain matching index names */
-    private static UnresolvedRelation mergeIfPossible(UnresolvedRelation main, UnresolvedRelation other) {
+    /** Merge the unresolved relation unless the index patterns contain matching index names. */
+    static UnresolvedRelation mergeIfPossible(UnresolvedRelation main, UnresolvedRelation other) {
         for (String mainPattern : main.indexPattern().indexPattern().split(",")) {
             for (String otherPattern : other.indexPattern().indexPattern().split(",")) {
                 if (mainPattern.equals(otherPattern)) {
-                    // A duplicate index name was found, fail this attempt to merge
-                    // This will cause the UnresolvedRelation to remain inside a subquery
+                    // A duplicate index name was found, fail this attempt to merge.
+                    return null;
+                }
+                // Prevent merging when a wildcard in one pattern matches a concrete name in the other.
+                // Merging would produce a single UnresolvedRelation that deduplicates the overlapping index
+                // during resolution, collapsing what should be two independent data copies into one.
+                if (Regex.isSimpleMatchPattern(otherPattern) == false && Regex.simpleMatch(mainPattern, otherPattern)) {
+                    return null;
+                }
+                if (Regex.isSimpleMatchPattern(otherPattern)
+                    && Regex.isSimpleMatchPattern(mainPattern) == false
+                    && Regex.simpleMatch(otherPattern, mainPattern)) {
                     return null;
                 }
             }
         }
-        // No duplicated index names found, let's merge into a single UnresolvedRelation, reducing the branching required to execute
         return new UnresolvedRelation(
             main.source(),
             new IndexPattern(main.indexPattern().source(), main.indexPattern().indexPattern() + "," + other.indexPattern().indexPattern()),

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/view/InMemoryViewServiceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/view/InMemoryViewServiceTests.java
@@ -179,7 +179,10 @@ public class InMemoryViewServiceTests extends AbstractStatementParserTests {
         addIndex("logs2");
         addIndex("logs3");
         LogicalPlan plan = query("FROM logs*,-logs3");
-        assertThat(replaceViews(plan), matchesPlan(query("FROM logs2,logs*,-logs3")));
+        // The view source (logs2) must remain as a separate branch from the wildcard pattern (logs*,-logs3)
+        // because logs* also matches logs2 directly — merging would deduplicate logs2 and lose one copy.
+        // The exclusion -logs3 is preserved in the wildcard branch for correct index resolution.
+        assertThat(replaceViews(plan), matchesPlan(query("FROM (FROM logs2), logs*,-logs3")));
     }
 
     /**
@@ -478,7 +481,10 @@ public class InMemoryViewServiceTests extends AbstractStatementParserTests {
         LogicalPlan plan = query("FROM *");
         // The * wildcard is preserved because concrete indices from setupTest() (emp, emp1, emp2, emp3, logs)
         // also match *, so hasNonView=true and * passes through for later field caps resolution.
-        assertThat(replaceViews(plan), matchesPlan(query("FROM emp1, emp2, emp3, *")));
+        // The view sources (emp1, emp2, emp3) are kept as a separate branch from the wildcard * because
+        // * also matches emp1/emp2/emp3 directly — merging would deduplicate those indices and collapse
+        // what should be two independent data copies (one from the view, one from the direct index) into one.
+        assertThat(replaceViews(plan), matchesPlan(query("FROM *, (FROM emp1,emp2,emp3)")));
     }
 
     public void testReplaceViewsWildcardAllNoReferencedIndices() {
@@ -508,7 +514,9 @@ public class InMemoryViewServiceTests extends AbstractStatementParserTests {
         addView("view2", "FROM emp2");
         addView("view3", "FROM emp3");
         LogicalPlan plan = query("FROM *");
-        assertThat(replaceViews(plan), matchesPlan(query("FROM emp1, emp2, emp3, *")));
+        // Same as testReplaceViewsWildcardAll: the view sources are kept separate from the wildcard
+        // because * also covers emp1/emp2/emp3 directly.
+        assertThat(replaceViews(plan), matchesPlan(query("FROM *, (FROM emp1,emp2,emp3)")));
     }
 
     public void testReplaceViewsWildcardWithIndex() {
@@ -1568,6 +1576,34 @@ public class InMemoryViewServiceTests extends AbstractStatementParserTests {
         assertThat(replaceViews(query("FROM view2, emp1")), matchesPlan(query("FROM (FROM emp1,emp1), emp1")));
         assertThat(replaceViews(query("FROM emp1, view2, emp1")), matchesPlan(query("FROM emp1, (FROM emp1, emp1), emp1")));
         assertThat(replaceViews(query("FROM emp1, view2, emp1, emp1")), matchesPlan(query("FROM emp1, (FROM emp1, emp1), emp1, emp1")));
+    }
+
+    /**
+     * Regression test for wildcard-based view resolution where both an index and a view sourcing
+     * that same index match the wildcard. The wildcard should produce two independent copies of the
+     * underlying index data — one via the direct wildcard match and one via the view — mirroring
+     * the behaviour of an explicit {@code FROM logs-1, logs-2} query.
+     * <p>
+     * Setup: index {@code logs-1}, view {@code logs-2 = FROM logs-1}.
+     * <ul>
+     *   <li>{@code FROM logs-1, logs-2} — explicit form: the view resolves to {@code FROM logs-1},
+     *       and since the explicit pattern also names {@code logs-1}, the two share the same source
+     *       index. They must remain as separate branches to preserve the duplicate.</li>
+     *   <li>{@code FROM logs-*} — wildcard form: the wildcard matches both {@code logs-1} (index)
+     *       and {@code logs-2} (view). The view's resolved {@code UnresolvedRelation("logs-1")} must
+     *       NOT be merged with the retained {@code UnresolvedRelation("logs-*")} pattern, because
+     *       {@code logs-*} matches {@code logs-1} and merging would cause index-resolution to
+     *       deduplicate the overlap, silently dropping one copy.</li>
+     * </ul>
+     */
+    public void testWildcardAndViewSharingSourceIndexProduceTwoCopies() {
+        assumeTrue("Requires views with branching support", EsqlCapabilities.Cap.VIEWS_WITH_BRANCHING.isEnabled());
+        addIndex("logs-1");
+        addView("logs-2", "FROM logs-1");
+        // Explicit form: already worked correctly before the fix — kept as a regression guard.
+        assertThat(replaceViews(query("FROM logs-1, logs-2")), matchesPlan(query("FROM logs-1, (FROM logs-1)")));
+        // Wildcard form: was broken before the fix — wildcard and view's source were incorrectly merged.
+        assertThat(replaceViews(query("FROM logs-*")), matchesPlan(query("FROM (FROM logs-1), logs-*")));
     }
 
     /**


### PR DESCRIPTION
Manual backport of https://github.com/elastic/elasticsearch/pull/149418

------
Previous work to ensure views and indexes are not de-duplicated was done at https://github.com/elastic/elasticsearch/pull/145091, however that did not properly take into account wildcards.

Fixes #149416

When a wildcard pattern matches both a concrete index and a view that sources from that same index, the query should produce **two independent copies** of the underlying data — one from the direct index match, one from the view. This is the same behaviour as explicitly naming both (e.g. `FROM logs-1, logs-2`), which already worked correctly.

For example, given index `logs-1` and view `logs-2 = FROM logs-1`:

- `FROM logs-1, logs-2` → two copies of `logs-1` data ✅ (worked before)
- `FROM logs-*` → should also produce two copies, but produced only one ❌

Both `ViewResolver` and `ViewCompaction` contain a `mergeIfPossible` helper that decides whether two `UnresolvedRelation` nodes can be safely merged into one (combining their index pattern lists). The check only prevented merging when two patterns were **identical strings**. It did not account for wildcard overlap.

When resolving `FROM logs-*`:

1. View `logs-2` resolves to `UnresolvedRelation("logs-1")`
2. The wildcard retains `UnresolvedRelation("logs-*")` for the direct index matches
3. `mergeIfPossible("logs-1", "logs-*")` found no exact-string match, so it merged them into `UnresolvedRelation("logs-1,logs-*")`
4. Index resolution then deduplicated `logs-1` (since `logs-*` already covers it), silently dropping one copy

The bug required fixing in **both** places: -
`ViewResolver.mergeCompatibleUnresolvedRelations` — performs the initial merge during resolution -
`ViewCompaction.mergeUnresolvedRelationEntries` — re-runs after compaction unwraps `NamedSubquery` nodes, where the same merge would otherwise occur again

Extended `mergeIfPossible` to refuse merging when a wildcard pattern in one `UnresolvedRelation` matches a concrete (non-wildcard) name in the other. Since the two methods were now identical, the one in `ViewCompaction` is promoted to package-private and `ViewResolver` delegates to it, eliminating the duplication.

- **`testWildcardAndViewSharingSourceIndexProduceTwoCopies`** — new test covering both the explicit form (regression guard, was already correct) and the wildcard form (was broken, now fixed)
- **`testExclusionPreservedForIndexResolution`**, **`testReplaceViewsWildcardAll`**, **`testReplaceViewsIndexWildcardAll`** — updated expected plans: these tests assumed the old merged behaviour, but the merged form was always incorrect — it caused index-resolution to collapse what should be independent data sources into one

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
