### PR TITLE
[9.4] Fix integ tests broken by disabled built-in role sync (#150067)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -115,9 +115,6 @@ tests:
 - class: org.elasticsearch.packaging.test.DebMetadataTests
   method: test05CheckLintian
   issue: https://github.com/elastic/elasticsearch/issues/142819
-- class: org.elasticsearch.xpack.security.support.MetadataFlattenedMigrationIntegTests
-  method: testMigrationWithConcurrentUpdates
-  issue: https://github.com/elastic/elasticsearch/issues/143674
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeMetricsIT
   method: test
   issue: https://github.com/elastic/elasticsearch/issues/143697

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/support/MetadataFlattenedMigrationIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/support/MetadataFlattenedMigrationIntegTests.java
@@ -62,8 +62,8 @@ public class MetadataFlattenedMigrationIntegTests extends SecurityIntegTestCase 
         internalCluster().startNode();
         ensureGreen();
 
-        waitForMigrationCompletion();
         var roles = createRoles();
+        waitForMigrationCompletion();
         final var nativeRoleStore = internalCluster().getInstance(NativeRolesStore.class);
         PlainActionFuture<Void> roleUpdatesCompleteListener = new PlainActionFuture<>();
         ExecutorService executor = Executors.newSingleThreadExecutor();

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/transport/filter/IpFilteringIntegrationTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/transport/filter/IpFilteringIntegrationTests.java
@@ -15,8 +15,6 @@ import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
 import org.elasticsearch.test.ESIntegTestCase.Scope;
 import org.elasticsearch.test.SecurityIntegTestCase;
 import org.elasticsearch.transport.Transport;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.BeforeClass;
 
 import java.io.IOException;
@@ -56,16 +54,6 @@ public class IpFilteringIntegrationTests extends SecurityIntegTestCase {
             .put("transport.profiles.client.xpack.security.filter.deny", "_all")
             .put(IPFilter.TRANSPORT_FILTER_DENY_SETTING.getKey(), "_all")
             .build();
-    }
-
-    @Before
-    public void waitForSecurityIndex() throws Exception {
-        assertSecurityIndexActive();
-    }
-
-    @After
-    public void cleanupSecurityIndex() throws Exception {
-        super.deleteSecurityIndex();
     }
 
     public void testThatIpFilteringIsIntegratedIntoNettyPipelineViaHttp() throws Exception {


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Fix integ tests broken by disabled built-in role sync (#150067)