### PR TITLE
AGGS: Limit buckets of date_histogram on range

### DIFF
--- a/docs/changelog/150111.yaml
+++ b/docs/changelog/150111.yaml
@@ -1,0 +1,5 @@
+area: Aggregations
+issues: []
+pr: 150111
+summary: "AGGS: Limit buckets of `date_histogram` on range"
+type: bug

--- a/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/date_histogram.yml
+++ b/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/date_histogram.yml
@@ -225,6 +225,13 @@ setup:
 
 ---
 "date_histogram on range exceeds bucket limit":
+  - requires:
+      capabilities:
+        - method: POST
+          path: /_search
+          capabilities: [ date_histogram_date_range_bucket_limit ]
+      test_runner_features: [capabilities]
+      reason: "date_histogram on date_range now limits buckets per document to prevent OOM and infinite loops"
   - do:
       catch: /exceeded the maximum number of buckets per document \[10000\]/
       search:
@@ -240,6 +247,13 @@ setup:
 
 ---
 "date_histogram on range with unbounded upper date":
+  - requires:
+      capabilities:
+        - method: POST
+          path: /_search
+          capabilities: [ date_histogram_date_range_bucket_limit ]
+      test_runner_features: [capabilities]
+      reason: "date_histogram on date_range now limits buckets per document to prevent OOM and infinite loops"
   - do:
       catch: /exceeded the maximum number of buckets per document \[10000\]/
       search:
@@ -255,6 +269,13 @@ setup:
 
 ---
 "date_histogram on range with unbounded upper date one second buckets":
+  - requires:
+      capabilities:
+        - method: POST
+          path: /_search
+          capabilities: [ date_histogram_date_range_bucket_limit ]
+      test_runner_features: [capabilities]
+      reason: "date_histogram on date_range now limits buckets per document to prevent OOM and infinite loops"
   - do:
       catch: /exceeded the maximum number of buckets per document \[10000\]/
       search:

--- a/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/date_histogram.yml
+++ b/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/date_histogram.yml
@@ -155,6 +155,120 @@ setup:
   - match: { aggregations.histo.buckets.12.doc_count: 1 }
 
 ---
+"date_histogram on range":
+  - requires:
+      cluster_features: ["gte_v7.2.0"]
+      reason: date_histogram on date_range field
+
+  - do:
+      search:
+        index: test_date_hist
+        body:
+          size: 0
+          query:
+            range:
+              range:
+                gte: "2016-01-01"
+                lte: "2016-04-01"
+                relation: within
+          aggs:
+            histo:
+              date_histogram:
+                field: range
+                calendar_interval: month
+
+  - match: { hits.total.value: 4 }
+  - length: { aggregations.histo.buckets: 3 }
+  - match: { aggregations.histo.buckets.0.key_as_string: "2016-01-01T00:00:00.000Z" }
+  - match: { aggregations.histo.buckets.0.doc_count: 2 }
+  - match: { aggregations.histo.buckets.1.key_as_string: "2016-02-01T00:00:00.000Z" }
+  - match: { aggregations.histo.buckets.1.doc_count: 1 }
+  - match: { aggregations.histo.buckets.2.key_as_string: "2016-03-01T00:00:00.000Z" }
+  - match: { aggregations.histo.buckets.2.doc_count: 1 }
+
+---
+"date_histogram on range near bucket limit":
+  - requires:
+      cluster_features: ["gte_v7.2.0"]
+      reason: date_histogram on date_range field
+
+  # Index a doc that spans exactly 9000 months (Jan 2016 - Dec 2765), just under
+  # the 10,000-bucket limit, to confirm that queries near the limit still succeed.
+  - do:
+      index:
+        index: test_date_hist
+        id: near-limit-doc
+        refresh: true
+        body:
+          range:
+            gte: "2016-01-01"
+            lte: "2765-12-31"
+
+  - do:
+      search:
+        index: test_date_hist
+        body:
+          size: 0
+          query:
+            ids:
+              values: ["near-limit-doc"]
+          aggs:
+            histo:
+              date_histogram:
+                field: range
+                calendar_interval: month
+
+  - match: { hits.total.value: 1 }
+  - length: { aggregations.histo.buckets: 9000 }
+  - match: { aggregations.histo.buckets.0.key_as_string: "2016-01-01T00:00:00.000Z" }
+  - match: { aggregations.histo.buckets.0.doc_count: 1 }
+
+---
+"date_histogram on range exceeds bucket limit":
+  - do:
+      catch: /exceeded the maximum number of buckets per document \[10000\]/
+      search:
+        index: test_date_hist
+        allow_partial_search_results: false
+        body:
+          size: 0
+          aggs:
+            histo:
+              date_histogram:
+                field: range
+                calendar_interval: month
+
+---
+"date_histogram on range with unbounded upper date":
+  - do:
+      catch: /exceeded the maximum number of buckets per document \[10000\]/
+      search:
+        index: test_date_hist
+        allow_partial_search_results: false
+        body:
+          size: 0
+          aggs:
+            histo:
+              date_histogram:
+                field: range
+                fixed_interval: "1000000d"
+
+---
+"date_histogram on range with unbounded upper date one second buckets":
+  - do:
+      catch: /exceeded the maximum number of buckets per document \[10000\]/
+      search:
+        index: test_date_hist
+        allow_partial_search_results: false
+        body:
+          size: 0
+          aggs:
+            histo:
+              date_histogram:
+                field: range
+                fixed_interval: "1s"
+
+---
 "date_histogram with hard_bounds outside data under a parent agg":
   - requires:
       cluster_features: ["search.aggs.date_histogram.hard_bounds_outside_data_fix"]

--- a/server/src/main/java/org/elasticsearch/rest/action/search/SearchCapabilities.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/search/SearchCapabilities.java
@@ -67,6 +67,8 @@ public final class SearchCapabilities {
     private static final String KNN_QUERY_VECTOR_BASE64 = "knn_query_vector_base64";
     private static final String AGGREGATE_METRIC_DOUBLE_DEFAULTS_TO_AVERAGE = "aggregate_metric_double_defaults_to_average";
     private static final String KNN_RETRIEVER_OPTIONAL_NUM_CANDIDATES = "knn_retriever_optional_num_candidates";
+    /** {@code date_histogram} on a {@code date_range} field limits each document to at most 10 000 buckets. */
+    private static final String DATE_HISTOGRAM_DATE_RANGE_BUCKET_LIMIT = "date_histogram_date_range_bucket_limit";
 
     public static final Set<String> CAPABILITIES;
     static {
@@ -103,6 +105,7 @@ public final class SearchCapabilities {
         capabilities.add(KNN_QUERY_VECTOR_BASE64);
         capabilities.add(AGGREGATE_METRIC_DOUBLE_DEFAULTS_TO_AVERAGE);
         capabilities.add(KNN_RETRIEVER_OPTIONAL_NUM_CANDIDATES);
+        capabilities.add(DATE_HISTOGRAM_DATE_RANGE_BUCKET_LIMIT);
         CAPABILITIES = Set.copyOf(capabilities);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateRangeHistogramAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateRangeHistogramAggregator.java
@@ -50,6 +50,8 @@ import static java.lang.Long.min;
  */
 class DateRangeHistogramAggregator extends BucketsAggregator {
 
+    private static final int MAX_BUCKETS_PER_DOC = 10_000;
+
     private final ValuesSource.Range valuesSource;
     private final DocValueFormat formatter;
     private final Rounding rounding;
@@ -130,6 +132,7 @@ class DateRangeHistogramAggregator extends BucketsAggregator {
                     long previousKey = Long.MIN_VALUE;
                     final List<RangeFieldMapper.Range> ranges = rangeType.decodeRanges(values.binaryValue());
                     long previousFrom = Long.MIN_VALUE;
+                    int bucketsCollected = 0;
                     for (RangeFieldMapper.Range range : ranges) {
                         Long from = (Long) range.getFrom();
                         // The encoding should ensure that this assert is always true.
@@ -145,6 +148,16 @@ class DateRangeHistogramAggregator extends BucketsAggregator {
                             if (key == previousKey) {
                                 continue;
                             }
+                            if (bucketsCollected >= MAX_BUCKETS_PER_DOC) {
+                                throw new IllegalArgumentException(
+                                    "date_histogram on date_range field ["
+                                        + name
+                                        + "] exceeded the maximum number of buckets per document ["
+                                        + MAX_BUCKETS_PER_DOC
+                                        + "]"
+                                );
+                            }
+                            bucketsCollected++;
                             // Bucket collection identical to NumericHistogramAggregator, could be refactored
                             long bucketOrd = bucketOrds.add(owningBucketOrd, key);
                             if (bucketOrd < 0) { // already seen


### PR DESCRIPTION
When you run _search's `date_histogram` agg on a `date_range` field it collects each document into *each* range.

For example, if you had a range from `2000-01-01 to 3000-01-01` and did a range of `1 year` it'd collect 3000 buckets. I you use a longer range and a smaller bucket, well, you get far more buckets. Worse, if you use a very *large* bucket size then you can trigger an overflow in the date rounding and end up in the same buckets over and over again and be stuck in an infinite loop.

As much as we'd love to prevent the overflow, we should guard against a huge number of buckets. This does this by limiting the number of buckets each document can live in to 10,000. That'll prevent circuit breaking errors from small ranges. And it'll fail nicely on the overflow.
