### PR TITLE
[ESQL] Add NDJSON record splitter

### DIFF
--- a/docs/changelog/150114.yaml
+++ b/docs/changelog/150114.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 150114
+summary: Add NDJSON record splitter
+type: enhancement

--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonFormatReader.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonFormatReader.java
@@ -20,6 +20,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.Configured;
 import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
+import org.elasticsearch.xpack.esql.datasources.spi.RecordSplitter;
 import org.elasticsearch.xpack.esql.datasources.spi.SegmentableFormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.SimpleSourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
@@ -43,6 +44,9 @@ import java.util.Set;
 public class NdJsonFormatReader implements SegmentableFormatReader {
 
     private static final Logger logger = LogManager.getLogger(NdJsonFormatReader.class);
+    private static final NdJsonRecordSplitter DEFAULT_RECORD_SPLITTER = new NdJsonRecordSplitter(
+        SegmentableFormatReader.DEFAULT_MAX_RECORD_BYTES
+    );
 
     public static final String SCHEMA_SAMPLE_SIZE_SETTING = "esql.datasource.ndjson.schema_sample_size";
     public static final int DEFAULT_SCHEMA_SAMPLE_SIZE = 20_000;
@@ -68,7 +72,7 @@ public class NdJsonFormatReader implements SegmentableFormatReader {
     /** Below 64 KiB, per-chunk overhead dominates parse cost; reject silly configurations early. */
     static final ByteSizeValue MIN_SEGMENT_SIZE = ByteSizeValue.ofKb(64);
 
-    /** Buffer size used to accelerate {@link #scanForTerminator} on cold (unbuffered) streams. */
+    /** Buffer size used to accelerate schema-inference line skipping on cold (unbuffered) streams. */
     private static final int SCAN_BUFFER_SIZE = 8 * 1024;
 
     static final String CONFIG_SCHEMA_SAMPLE_SIZE = "schema_sample_size";
@@ -167,7 +171,11 @@ public class NdJsonFormatReader implements SegmentableFormatReader {
         PushbackInputStream stream = new PushbackInputStream(new BufferedInputStream(raw, SCAN_BUFFER_SIZE), 1);
         if (skipFirstLine) {
             try {
-                LineScan scan = scanForTerminator(stream);
+                NdJsonRecordSplitter splitter = defaultRecordSplitter();
+                NdJsonRecordSplitter.LineScan scan = splitter.scanForTerminator(stream);
+                if (scan.consumed() == RecordSplitter.RECORD_TOO_LARGE) {
+                    throw splitter.recordTooLargeException();
+                }
                 if (scan.peekedByte() != -1) {
                     stream.unread(scan.peekedByte());
                 }
@@ -353,7 +361,8 @@ public class NdJsonFormatReader implements SegmentableFormatReader {
             trimLastPartialLine,
             effectiveSchema,
             errorPolicy,
-            counters
+            counters,
+            context.maxRecordBytes()
         );
     }
 
@@ -368,66 +377,26 @@ public class NdJsonFormatReader implements SegmentableFormatReader {
 
     @Override
     public long findNextRecordBoundary(InputStream stream) throws IOException {
-        // The caller only cares about the byte offset of the terminator; a lone CR followed by
-        // some non-LF byte may have been consumed from the stream by the scanner, but the
-        // caller discards the stream after this call so that is acceptable.
-        // Wrap cold streams to restore the 8 KB fast path; if already buffered, pass through.
-        InputStream buffered = stream instanceof BufferedInputStream ? stream : new BufferedInputStream(stream, SCAN_BUFFER_SIZE);
-        return scanForTerminator(buffered).consumed();
+        return recordSplitter().findNextRecordBoundary(stream);
     }
 
-    /**
-     * NDJSON records never contain embedded newlines, so a backward scan for a line terminator
-     * is always correct and O(1) from the end of the buffer — no per-record allocations needed.
-     * Matches the LF / CRLF / lone-CR contract of {@link #scanForTerminator}.
-     */
     @Override
     public int findLastRecordBoundary(byte[] buf, int length) {
-        for (int i = length - 1; i >= 0; i--) {
-            byte b = buf[i];
-            if (b == '\n' || b == '\r') {
-                return i;
-            }
-        }
-        return -1;
+        return defaultRecordSplitter().findLastRecordBoundary(buf, 0, length);
     }
 
-    /** Outcome of a single scan for the next record terminator. */
-    record LineScan(long consumed, int peekedByte) {
-        /** Sentinel returned when the stream ended before any terminator. */
-        static final LineScan EOF = new LineScan(-1, -1);
+    @Override
+    public RecordSplitter recordSplitter() {
+        return defaultRecordSplitter();
     }
 
-    /**
-     * Reads one byte at a time from {@code in} until a record terminator (LF, CRLF, or lone CR)
-     * is consumed. Returns {@link LineScan#consumed} as the number of bytes read through-and-
-     * including the terminator; for the lone-CR case the byte that follows (which is the first
-     * byte of the next record) is read from the stream and exposed via {@link LineScan#peekedByte}
-     * so callers can preserve it. Returns {@link LineScan#EOF} if the stream ends before any
-     * terminator is seen.
-     *
-     * <p>Single source of truth for the three NDJSON line-terminator consumers:
-     * {@link NdJsonPageIterator#skipToNextLine}, {@link #findNextRecordBoundary}, and
-     * {@link #openForSchemaInference}.
-     */
-    static LineScan scanForTerminator(InputStream in) throws IOException {
-        long consumed = 0;
-        int b;
-        while ((b = in.read()) != -1) {
-            consumed++;
-            if (b == '\n') {
-                return new LineScan(consumed, -1);
-            }
-            if (b == '\r') {
-                int next = in.read();
-                if (next == '\n') {
-                    return new LineScan(consumed + 1, -1);
-                }
-                // EOF after CR is reported as a clean terminator with no peeked byte.
-                return new LineScan(consumed, next);
-            }
-        }
-        return LineScan.EOF;
+    @Override
+    public RecordSplitter recordSplitter(int maxRecordBytes) {
+        return new NdJsonRecordSplitter(maxRecordBytes);
+    }
+
+    private static NdJsonRecordSplitter defaultRecordSplitter() {
+        return DEFAULT_RECORD_SPLITTER;
     }
 
     /**

--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIterator.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIterator.java
@@ -17,6 +17,8 @@ import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.util.Check;
 import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
+import org.elasticsearch.xpack.esql.datasources.spi.RecordSplitter;
+import org.elasticsearch.xpack.esql.datasources.spi.SegmentableFormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 
 import java.io.IOException;
@@ -62,17 +64,19 @@ final class NdJsonPageIterator implements CloseableIterator<Page> {
         boolean trimLastPartialLine,
         List<Attribute> resolvedAttributes,
         ErrorPolicy errorPolicy,
-        NdJsonReaderCounters counters
+        NdJsonReaderCounters counters,
+        int maxRecordBytes
     ) throws IOException {
         Check.isTrue(errorPolicy != null, "errorPolicy must not be null");
         Check.isTrue(counters != null, "counters must not be null");
         String sourceLocation = object.path().toString();
         InputStream inputStream = object.newStream();
+        NdJsonRecordSplitter recordSplitter = new NdJsonRecordSplitter(maxRecordBytes);
         if (skipFirstLine) {
-            skipToNextLine(inputStream);
+            skipToNextLine(inputStream, recordSplitter);
         }
         if (trimLastPartialLine) {
-            inputStream = trimLastPartialLine(inputStream, errorPolicy, sourceLocation);
+            inputStream = trimLastPartialLine(inputStream, errorPolicy, sourceLocation, recordSplitter);
         }
         this.rowLimit = rowLimit;
         if (canUseByteArrayFastPath(object)) {
@@ -202,12 +206,19 @@ final class NdJsonPageIterator implements CloseableIterator<Page> {
      *       {@link NdJsonFormatReader#read} uses to decide whether to call this method.</li>
      * </ul>
      *
-     * <p>Delegates to {@link NdJsonFormatReader#scanForTerminator} so LF/CRLF/CR are handled
+     * <p>Delegates to {@link NdJsonRecordSplitter#scanForTerminator} so LF/CRLF/CR are handled
      * uniformly; in practice the codec's finish-current-line always ends on {@code '\n'}, so
      * only the LF branch fires, but routing through one implementation removes the coupling.
      */
     static void skipToNextLine(InputStream stream) throws IOException {
-        NdJsonFormatReader.scanForTerminator(stream);
+        skipToNextLine(stream, new NdJsonRecordSplitter(SegmentableFormatReader.DEFAULT_MAX_RECORD_BYTES));
+    }
+
+    static void skipToNextLine(InputStream stream, NdJsonRecordSplitter recordSplitter) throws IOException {
+        NdJsonRecordSplitter.LineScan scan = recordSplitter.scanForTerminator(stream);
+        if (scan.consumed() == RecordSplitter.RECORD_TOO_LARGE) {
+            throw recordSplitter.recordTooLargeException();
+        }
     }
 
     /**
@@ -216,7 +227,20 @@ final class NdJsonPageIterator implements CloseableIterator<Page> {
      * when the returned stream is closed. Oversized partial lines follow {@code errorPolicy}.
      */
     static InputStream trimLastPartialLine(InputStream in, ErrorPolicy errorPolicy, String sourceLocation) {
-        // TODO: thread in a centralized error counter?
-        return new TrimLastPartialLineInputStream(in, errorPolicy, sourceLocation);
+        return trimLastPartialLine(
+            in,
+            errorPolicy,
+            sourceLocation,
+            new NdJsonRecordSplitter(SegmentableFormatReader.DEFAULT_MAX_RECORD_BYTES)
+        );
+    }
+
+    static InputStream trimLastPartialLine(
+        InputStream in,
+        ErrorPolicy errorPolicy,
+        String sourceLocation,
+        NdJsonRecordSplitter recordSplitter
+    ) {
+        return new TrimLastPartialLineInputStream(in, errorPolicy, sourceLocation, recordSplitter);
     }
 }

--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonRecordSplitter.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonRecordSplitter.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.ndjson;
+
+import org.elasticsearch.xpack.esql.datasources.spi.RecordSplitter;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Objects;
+
+/**
+ * NDJSON record-boundary splitter for byte-oriented parallel parsing.
+ */
+final class NdJsonRecordSplitter implements RecordSplitter {
+
+    private static final int SCAN_BUFFER_SIZE = 8 * 1024;
+
+    private final int maxRecordBytes;
+
+    NdJsonRecordSplitter(int maxRecordBytes) {
+        if (maxRecordBytes <= 0) {
+            throw new IllegalArgumentException("maxRecordBytes must be positive, got: " + maxRecordBytes);
+        }
+        this.maxRecordBytes = maxRecordBytes;
+    }
+
+    @Override
+    public long findNextRecordBoundary(InputStream stream) throws IOException {
+        // The caller only cares about the byte offset of the terminator; a lone CR followed by
+        // some non-LF byte may have been consumed from the stream by the scanner, but the
+        // caller discards the stream after this call so that is acceptable.
+        // Wrap cold streams to restore the 8 KB fast path; if already buffered, pass through.
+        InputStream buffered = stream instanceof BufferedInputStream ? stream : new BufferedInputStream(stream, SCAN_BUFFER_SIZE);
+        return scanForTerminator(buffered).consumed();
+    }
+
+    /**
+     * NDJSON records never contain embedded newlines, so a backward scan for a line terminator
+     * is always correct and offset-aware without copying.
+     */
+    @Override
+    public int findLastRecordBoundary(byte[] buf, int offset, int length) {
+        Objects.checkFromIndexSize(offset, length, buf.length);
+        for (int i = offset + length - 1; i >= offset; i--) {
+            byte b = buf[i];
+            if (b == '\n' || b == '\r') {
+                return i;
+            }
+        }
+        return length > maxRecordBytes ? (int) RECORD_TOO_LARGE : -1;
+    }
+
+    @Override
+    public int maxRecordBytes() {
+        return maxRecordBytes;
+    }
+
+    IOException recordTooLargeException() {
+        return new IOException("NDJSON line exceeded max_record_size [" + maxRecordBytes + "]");
+    }
+
+    /**
+     * Reads one byte at a time from {@code in} until a record terminator (LF, CRLF, or lone CR)
+     * is consumed. Returns {@link LineScan#consumed} as the number of bytes read through-and-
+     * including the terminator; for the lone-CR case the byte that follows (which is the first
+     * byte of the next record) is read from the stream and exposed via {@link LineScan#peekedByte}
+     * so callers can preserve it. Returns {@link LineScan#EOF} if the stream ends before any
+     * terminator is seen.
+     */
+    LineScan scanForTerminator(InputStream in) throws IOException {
+        long consumed = 0;
+        int b;
+        while ((b = in.read()) != -1) {
+            consumed++;
+            if (consumed > maxRecordBytes) {
+                return LineScan.RECORD_TOO_LARGE;
+            }
+            if (b == '\n') {
+                return new LineScan(consumed, -1);
+            }
+            if (b == '\r') {
+                int next = in.read();
+                if (next == '\n') {
+                    consumed++;
+                    return consumed > maxRecordBytes ? LineScan.RECORD_TOO_LARGE : new LineScan(consumed, -1);
+                }
+                // EOF after CR is reported as a clean terminator with no peeked byte.
+                return new LineScan(consumed, next);
+            }
+        }
+        return LineScan.EOF;
+    }
+
+    /** Outcome of a single scan for the next record terminator. */
+    record LineScan(long consumed, int peekedByte) {
+        /** Sentinel returned when the stream ended before any terminator. */
+        static final LineScan EOF = new LineScan(-1, -1);
+        /** Sentinel returned when scanning past the configured record-size budget. */
+        static final LineScan RECORD_TOO_LARGE = new LineScan(RecordSplitter.RECORD_TOO_LARGE, -1);
+    }
+}

--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/TrimLastPartialLineInputStream.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/TrimLastPartialLineInputStream.java
@@ -8,15 +8,17 @@
 package org.elasticsearch.xpack.esql.datasource.ndjson;
 
 import org.elasticsearch.common.logging.LoggerMessageFormat;
-import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.logging.Level;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.xpack.esql.core.util.Check;
 import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
+import org.elasticsearch.xpack.esql.datasources.spi.RecordSplitter;
+import org.elasticsearch.xpack.esql.datasources.spi.SegmentableFormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.SkipWarnings;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
@@ -26,31 +28,22 @@ import java.util.Arrays;
  * dropping a trailing partial line (split boundary). Reads the delegate lazily and keeps at most a
  * small read buffer plus any uncommitted tail after the last newline seen so far.
  *
- * <p>If a line without a delimiter exceeds {@link #MAX_CARRY_BYTES}, {@link ErrorPolicy#isStrict()}
+ * <p>If a line without a delimiter exceeds the configured {@code max_record_size}, {@link ErrorPolicy#isStrict()}
  * causes an {@link IOException}; otherwise the buffered partial line is discarded as bogus and
  * reading continues. Discards are logged like {@link NdJsonPageDecoder} parse skips:
  * {@link Level#INFO} when {@link ErrorPolicy#logErrors()} is true, otherwise {@link Level#DEBUG}.
- *
- * <p>Only line feed ({@code '\n'}) is a record boundary here. A carriage return from CRLF that is
- * split across read chunks can remain as a trailing {@code '\r'} on the emitted line (pre-existing
- * limitation for Windows-style line endings in this path).
  */
 final class TrimLastPartialLineInputStream extends InputStream {
 
     private static final Logger logger = LogManager.getLogger(TrimLastPartialLineInputStream.class);
 
     private static final int DEFAULT_TRIM_CHUNK_SIZE = 8192;
-    /** Record delimiter for trimming (LF only; see class Javadoc for CRLF). */
-    private static final char SPLIT_BOUNDARY = '\n';
-
-    static final ByteSizeValue MAX_CARRY = ByteSizeValue.ofMb(32);
-    /** Max bytes held in {@link #carry} when no {@code '\n'} has been seen yet (pathological single line). */
-    static final long MAX_CARRY_BYTES = MAX_CARRY.getBytes();
 
     private final InputStream delegate;
     private final byte[] chunk;
     private final ErrorPolicy errorPolicy;
     private final SkipWarnings skipWarnings;
+    private final NdJsonRecordSplitter recordSplitter;
 
     /** Bytes after the last {@code '\n'} observed across all chunks read so far; discarded at EOF. */
     private byte[] carry;
@@ -59,18 +52,47 @@ final class TrimLastPartialLineInputStream extends InputStream {
     private int readIdx;
     private int writeIdx;
     private boolean eof;
+    private boolean discardingOversizedPartial;
+    private boolean discardingOptionalLfAfterCr;
     private final byte[] single = new byte[1];
 
     TrimLastPartialLineInputStream(InputStream delegate, ErrorPolicy errorPolicy, String sourceLocation) {
-        this(delegate, DEFAULT_TRIM_CHUNK_SIZE, errorPolicy, sourceLocation);
+        this(
+            delegate,
+            DEFAULT_TRIM_CHUNK_SIZE,
+            errorPolicy,
+            sourceLocation,
+            new NdJsonRecordSplitter(SegmentableFormatReader.DEFAULT_MAX_RECORD_BYTES)
+        );
     }
 
     TrimLastPartialLineInputStream(InputStream delegate, int chunkSize, ErrorPolicy errorPolicy, String sourceLocation) {
+        this(delegate, chunkSize, errorPolicy, sourceLocation, new NdJsonRecordSplitter(SegmentableFormatReader.DEFAULT_MAX_RECORD_BYTES));
+    }
+
+    TrimLastPartialLineInputStream(
+        InputStream delegate,
+        ErrorPolicy errorPolicy,
+        String sourceLocation,
+        NdJsonRecordSplitter recordSplitter
+    ) {
+        this(delegate, DEFAULT_TRIM_CHUNK_SIZE, errorPolicy, sourceLocation, recordSplitter);
+    }
+
+    TrimLastPartialLineInputStream(
+        InputStream delegate,
+        int chunkSize,
+        ErrorPolicy errorPolicy,
+        String sourceLocation,
+        NdJsonRecordSplitter recordSplitter
+    ) {
         this.delegate = delegate;
         Check.isTrue(chunkSize > 0, "chunkSize must strictly positive");
         Check.isTrue(errorPolicy != null, "errorPolicy must not be null");
         this.chunk = new byte[chunkSize];
         this.errorPolicy = errorPolicy;
+        Check.isTrue(recordSplitter != null, "recordSplitter must not be null");
+        this.recordSplitter = recordSplitter;
         this.skipWarnings = SkipWarnings.of(
             errorPolicy,
             "NDJSON read from [" + sourceLocation + "] discarded an oversized partial line (policy: " + errorPolicy.modeName() + ")"
@@ -117,45 +139,94 @@ final class TrimLastPartialLineInputStream extends InputStream {
             if (n == 0) {
                 continue;
             }
-            int lastNl = -1;
-            for (int i = n - 1; i >= 0; i--) {
-                if (chunk[i] == SPLIT_BOUNDARY) {
-                    lastNl = i;
-                    break;
-                }
+            int start = skipDiscardedOversizedPartial(chunk, n);
+            if (start == n) {
+                continue;
             }
-            if (lastNl >= 0) {
+            int scanLength = n - start;
+            int lastBoundary = recordSplitter.findLastRecordBoundary(chunk, start, scanLength);
+            if (lastBoundary == RecordSplitter.RECORD_TOO_LARGE) {
+                if (errorPolicy.isStrict()) {
+                    throw carryLimitExceeded();
+                }
+                logDiscardedOversizedPartial(scanLength, "partial_line_without_delimiter");
+                carry = null;
+                discardingOversizedPartial = true;
+                continue;
+            }
+            if (lastBoundary >= 0) {
                 int carryLen = carry == null ? 0 : carry.length;
-                int emitLen = carryLen + lastNl + 1;
+                int emitLen = carryLen + (lastBoundary - start) + 1;
+                if (emitLen > recordSplitter.maxRecordBytes()) {
+                    if (errorPolicy.isStrict()) {
+                        throw carryLimitExceeded();
+                    }
+                    logDiscardedOversizedPartial(emitLen, "record_before_delimiter");
+                    carry = tailAfterBoundary(chunk, lastBoundary, n);
+                    discardingOversizedPartial = false;
+                    if (carry == null && lastBoundary == n - 1 && chunk[lastBoundary] == '\r') {
+                        discardingOptionalLfAfterCr = true;
+                    }
+                    continue;
+                }
                 ensureWritable(emitLen);
                 if (carryLen > 0) {
                     System.arraycopy(carry, 0, buffer, writeIdx, carryLen);
                     writeIdx += carryLen;
                     carry = null;
                 }
-                System.arraycopy(chunk, 0, buffer, writeIdx, lastNl + 1);
-                writeIdx += lastNl + 1;
-                if (lastNl + 1 < n) {
-                    int tailLen = n - (lastNl + 1);
-                    if (tailLen > MAX_CARRY_BYTES) {
-                        if (errorPolicy.isStrict()) {
-                            throw carryLimitExceeded();
-                        }
-                        logDiscardedOversizedPartial(tailLen, "trailing_fragment_after_delimiter");
-                        carry = null;
-                    } else {
-                        carry = Arrays.copyOfRange(chunk, lastNl + 1, n);
-                    }
-                }
+                int chunkEmitLen = lastBoundary - start + 1;
+                System.arraycopy(chunk, start, buffer, writeIdx, chunkEmitLen);
+                writeIdx += chunkEmitLen;
+                carry = tailAfterBoundary(chunk, lastBoundary, n);
                 return true;
             }
-            carry = append(carry, chunk, n);
+            carry = append(carry, chunk, start, scanLength);
         }
         return true;
     }
 
-    private static IOException carryLimitExceeded() {
-        return new IOException("NDJSON lines longer than [" + MAX_CARRY + "] are not supported");
+    private int skipDiscardedOversizedPartial(byte[] data, int n) throws IOException {
+        int start = 0;
+        if (discardingOptionalLfAfterCr) {
+            discardingOptionalLfAfterCr = false;
+            if (n > 0 && data[0] == '\n') {
+                start = 1;
+            }
+        }
+        if (discardingOversizedPartial == false) {
+            return start;
+        }
+        NdJsonRecordSplitter.LineScan scan = recordSplitter.scanForTerminator(new ByteArrayInputStream(data, start, n - start));
+        if (scan.consumed() < 0) {
+            return n;
+        }
+        discardingOversizedPartial = false;
+        int consumed = start + Math.toIntExact(scan.consumed());
+        if (consumed == n && data[n - 1] == '\r') {
+            discardingOptionalLfAfterCr = true;
+        }
+        return consumed;
+    }
+
+    private byte[] tailAfterBoundary(byte[] data, int boundary, int n) throws IOException {
+        if (boundary + 1 >= n) {
+            return null;
+        }
+        int tailLen = n - (boundary + 1);
+        if (tailLen > recordSplitter.maxRecordBytes()) {
+            if (errorPolicy.isStrict()) {
+                throw carryLimitExceeded();
+            }
+            logDiscardedOversizedPartial(tailLen, "trailing_fragment_after_delimiter");
+            discardingOversizedPartial = true;
+            return null;
+        }
+        return Arrays.copyOfRange(data, boundary + 1, n);
+    }
+
+    private IOException carryLimitExceeded() {
+        return recordSplitter.recordTooLargeException();
     }
 
     /** Same level choice as {@link NdJsonPageDecoder#onNdjsonLineParseError}. */
@@ -166,7 +237,7 @@ final class TrimLastPartialLineInputStream extends InputStream {
                 + "] of approximately ["
                 + discardedBytes
                 + "] bytes while trimming split suffix; limit is ["
-                + MAX_CARRY
+                + recordSplitter.maxRecordBytes()
                 + "]"
         );
         logger.log(
@@ -175,30 +246,31 @@ final class TrimLastPartialLineInputStream extends InputStream {
                 "Skipping NDJSON [{}] of approximately [{}] bytes while trimming split suffix; limit is [{}]",
                 kind,
                 discardedBytes,
-                MAX_CARRY
+                recordSplitter.maxRecordBytes()
             )
         );
     }
 
-    private byte[] append(byte[] prefix, byte[] data, int n) throws IOException {
+    private byte[] append(byte[] prefix, byte[] data, int offset, int n) throws IOException {
         if (n <= 0) {
             return prefix;
         }
         long newLen = (prefix == null || prefix.length == 0) ? n : (long) prefix.length + n;
-        if (newLen > MAX_CARRY_BYTES) {
+        if (newLen > recordSplitter.maxRecordBytes()) {
             if (errorPolicy.isStrict()) {
                 throw carryLimitExceeded();
             }
             long dropped = prefix == null ? 0 : (long) prefix.length;
             logDiscardedOversizedPartial(dropped + n, "partial_line_without_delimiter");
-            // Bogus line: drop the partial tail buffered so far; continue with this chunk only.
-            return Arrays.copyOfRange(data, 0, n);
+            // Bogus line: drop the partial tail buffered so far and discard through the next delimiter.
+            discardingOversizedPartial = true;
+            return null;
         }
         if (prefix == null || prefix.length == 0) {
-            return Arrays.copyOfRange(data, 0, n);
+            return Arrays.copyOfRange(data, offset, offset + n);
         }
         byte[] out = Arrays.copyOf(prefix, prefix.length + n);
-        System.arraycopy(data, 0, out, prefix.length, n);
+        System.arraycopy(data, offset, out, prefix.length, n);
         return out;
     }
 

--- a/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIteratorTests.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIteratorTests.java
@@ -331,6 +331,45 @@ public class NdJsonPageIteratorTests extends ESTestCase {
         }
     }
 
+    public void testTrimLastPartialLineCrLfAcrossSmallChunks() throws IOException {
+        byte[] payload = "aa\r\nbb\r\nPART".getBytes(StandardCharsets.UTF_8);
+        try (
+            InputStream trimmed = new TrimLastPartialLineInputStream(
+                new ByteArrayInputStream(payload),
+                3,
+                ErrorPolicy.STRICT,
+                "test://input"
+            )
+        ) {
+            assertEquals("aa\r\nbb\r\n", new String(trimmed.readAllBytes(), StandardCharsets.UTF_8));
+        }
+    }
+
+    public void testTrimLastPartialLineLoneCrAcrossSmallChunks() throws IOException {
+        byte[] payload = "aa\rbb\rPART".getBytes(StandardCharsets.UTF_8);
+        try (
+            InputStream trimmed = new TrimLastPartialLineInputStream(
+                new ByteArrayInputStream(payload),
+                3,
+                ErrorPolicy.STRICT,
+                "test://input"
+            )
+        ) {
+            assertEquals("aa\rbb\r", new String(trimmed.readAllBytes(), StandardCharsets.UTF_8));
+        }
+    }
+
+    public void testSkipFirstLineHonorsMaxRecordBytes() {
+        IOException ex = expectThrows(
+            IOException.class,
+            () -> NdJsonPageIterator.skipToNextLine(
+                new ByteArrayInputStream("partial-without-boundary".getBytes(StandardCharsets.UTF_8)),
+                new NdJsonRecordSplitter(8)
+            )
+        );
+        assertThat(ex.getMessage(), Matchers.containsString("max_record_size [8]"));
+    }
+
     /**
      * Regression: after the consumer has advanced {@code readIdx}, growing the emit buffer must use
      * {@code writeIdx + emitLen}, not {@code unread + emitLen}, or a large carry + line can write past
@@ -418,23 +457,22 @@ public class NdJsonPageIteratorTests extends ESTestCase {
         }
     }
 
-    /**
-     * Without a record delimiter, {@link TrimLastPartialLineInputStream} must not grow {@code carry}
-     * past {@link TrimLastPartialLineInputStream#MAX_CARRY_BYTES} (defends against pathological lines).
-     */
+    /** Without a record delimiter, trimming must not grow {@code carry} past the configured record-size budget. */
     public void testTrimLastPartialLineCarryExceedsMaxThrows() throws IOException {
         int chunk = 8192;
-        long streamLen = TrimLastPartialLineInputStream.MAX_CARRY_BYTES + chunk;
+        int maxRecordBytes = 16 * 1024;
+        long streamLen = maxRecordBytes + chunk;
         try (
             InputStream trimmed = new TrimLastPartialLineInputStream(
                 new FiniteBytesWithoutNewline(streamLen),
                 chunk,
                 ErrorPolicy.STRICT,
-                "test://input"
+                "test://input",
+                new NdJsonRecordSplitter(maxRecordBytes)
             )
         ) {
             IOException ex = expectThrows(IOException.class, trimmed::readAllBytes);
-            assertThat(ex.getMessage(), Matchers.containsString(TrimLastPartialLineInputStream.MAX_CARRY.toString()));
+            assertThat(ex.getMessage(), Matchers.containsString("max_record_size [" + maxRecordBytes + "]"));
         }
     }
 
@@ -444,16 +482,63 @@ public class NdJsonPageIteratorTests extends ESTestCase {
      */
     public void testTrimLastPartialLineCarryOverLimitLenientSkipsBogusLine() throws IOException {
         int chunk = 8192;
-        long streamLen = TrimLastPartialLineInputStream.MAX_CARRY_BYTES + chunk;
+        int maxRecordBytes = 16 * 1024;
+        long streamLen = maxRecordBytes + chunk;
         try (
             InputStream trimmed = new TrimLastPartialLineInputStream(
                 new FiniteBytesWithoutNewline(streamLen),
                 chunk,
                 ErrorPolicy.LENIENT,
-                "test://input"
+                "test://input",
+                new NdJsonRecordSplitter(maxRecordBytes)
             )
         ) {
             assertEquals(0, trimmed.readAllBytes().length);
+        }
+    }
+
+    public void testTrimLastPartialLineLenientDiscardsThroughDelimiterAfterOversizedLine() throws IOException {
+        byte[] payload = "aaaaaaaaa\nok\npartial".getBytes(StandardCharsets.UTF_8);
+        try (
+            InputStream trimmed = new TrimLastPartialLineInputStream(
+                new ByteArrayInputStream(payload),
+                4,
+                ErrorPolicy.LENIENT,
+                "test://input",
+                new NdJsonRecordSplitter(8)
+            )
+        ) {
+            assertEquals("ok\n", new String(trimmed.readAllBytes(), StandardCharsets.UTF_8));
+        }
+    }
+
+    public void testTrimLastPartialLineLenientDiscardsCrLfRemainderAfterOversizedLine() throws IOException {
+        byte[] payload = "aaaaaaaaa\r\nok\r\npartial".getBytes(StandardCharsets.UTF_8);
+        try (
+            InputStream trimmed = new TrimLastPartialLineInputStream(
+                new ByteArrayInputStream(payload),
+                5,
+                ErrorPolicy.LENIENT,
+                "test://input",
+                new NdJsonRecordSplitter(8)
+            )
+        ) {
+            assertEquals("ok\r\n", new String(trimmed.readAllBytes(), StandardCharsets.UTF_8));
+        }
+    }
+
+    public void testTrimLastPartialLineLenientDiscardsOversizedTailThroughDelimiter() throws IOException {
+        byte[] payload = "ok\naaaaaaaaa\nnext\npartial".getBytes(StandardCharsets.UTF_8);
+        try (
+            InputStream trimmed = new TrimLastPartialLineInputStream(
+                new ByteArrayInputStream(payload),
+                12,
+                ErrorPolicy.LENIENT,
+                "test://input",
+                new NdJsonRecordSplitter(8)
+            )
+        ) {
+            assertEquals("ok\nnext\n", new String(trimmed.readAllBytes(), StandardCharsets.UTF_8));
         }
     }
 

--- a/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonRecordSplitterContractTests.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonRecordSplitterContractTests.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.ndjson;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.spi.RecordSplitter;
+import org.elasticsearch.xpack.esql.datasources.spi.SegmentableFormatReader;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+public class NdJsonRecordSplitterContractTests extends ESTestCase {
+
+    public void testEmptyInputReturnsEof() throws IOException {
+        RecordSplitter splitter = newSplitter(128);
+        assertEquals(-1L, splitter.findNextRecordBoundary(new ByteArrayInputStream(new byte[0])));
+        assertEquals(-1, splitter.findLastRecordBoundary(new byte[0], 0, 0));
+    }
+
+    public void testEofBeforeAnyTerminatorReturnsEof() throws IOException {
+        assertEquals(-1L, newSplitter(128).findNextRecordBoundary(new ByteArrayInputStream(bytes("unterminated"))));
+    }
+
+    public void testLfConsumesThroughTerminator() throws IOException {
+        assertEquals(4L, newSplitter(128).findNextRecordBoundary(new ByteArrayInputStream(bytes("row\nnext"))));
+    }
+
+    public void testCrLfConsumesThroughBothTerminatorBytes() throws IOException {
+        assertEquals(5L, newSplitter(128).findNextRecordBoundary(new ByteArrayInputStream(bytes("row\r\nnext"))));
+    }
+
+    public void testLoneCrConsumesOnlyTheCrAndExposesPeekedByte() throws IOException {
+        NdJsonRecordSplitter splitter = newSplitter(128);
+        NdJsonRecordSplitter.LineScan scan = splitter.scanForTerminator(new ByteArrayInputStream(bytes("row\rnext")));
+
+        assertEquals(4L, scan.consumed());
+        assertEquals('n', scan.peekedByte());
+    }
+
+    public void testFindNextRecordBoundaryReportsRecordTooLarge() throws IOException {
+        RecordSplitter splitter = newSplitter(8);
+
+        assertEquals(RecordSplitter.RECORD_TOO_LARGE, splitter.findNextRecordBoundary(new ByteArrayInputStream(repeatedByte('x', 9))));
+    }
+
+    public void testFindLastRecordBoundaryReportsRecordTooLarge() throws IOException {
+        RecordSplitter splitter = newSplitter(8);
+
+        assertEquals(RecordSplitter.RECORD_TOO_LARGE, splitter.findLastRecordBoundary(repeatedByte('x', 9), 0, 9));
+    }
+
+    public void testFindLastRecordBoundaryUsesOffsetAwareReverseScan() throws IOException {
+        byte[] prefix = bytes("ignored\n");
+        byte[] payload = bytes("{\"a\":1}\n{\"b\":2}");
+        byte[] input = concat(prefix, payload);
+
+        RecordSplitter splitter = newSplitter(128);
+
+        assertEquals(prefix.length + "{\"a\":1}\n".length() - 1, splitter.findLastRecordBoundary(input, prefix.length, payload.length));
+    }
+
+    public void testFormatReaderUsesConfiguredMaxRecordBytes() throws IOException {
+        NdJsonFormatReader reader = new NdJsonFormatReader(null, null);
+        RecordSplitter splitter = reader.recordSplitter(8);
+
+        assertEquals(8, splitter.maxRecordBytes());
+        assertEquals(RecordSplitter.RECORD_TOO_LARGE, splitter.findNextRecordBoundary(new ByteArrayInputStream(repeatedByte('x', 9))));
+    }
+
+    public void testLegacyReaderMethodsDelegateToSplitter() throws IOException {
+        NdJsonFormatReader reader = new NdJsonFormatReader(null, null);
+        byte[] payload = bytes("first\nsecond");
+
+        assertEquals(6L, reader.findNextRecordBoundary(new ByteArrayInputStream(payload)));
+        assertEquals(5, reader.findLastRecordBoundary(payload, payload.length));
+    }
+
+    public void testDefaultSplitterUsesDefaultMaxRecordBytes() {
+        NdJsonFormatReader reader = new NdJsonFormatReader(null, null);
+
+        assertEquals(SegmentableFormatReader.DEFAULT_MAX_RECORD_BYTES, reader.recordSplitter().maxRecordBytes());
+    }
+
+    private static NdJsonRecordSplitter newSplitter(int maxRecordBytes) {
+        return new NdJsonRecordSplitter(maxRecordBytes);
+    }
+
+    private static byte[] bytes(String value) {
+        return value.getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static byte[] repeatedByte(char value, int count) {
+        byte[] bytes = new byte[count];
+        Arrays.fill(bytes, (byte) value);
+        return bytes;
+    }
+
+    private static byte[] concat(byte[]... chunks) {
+        int length = 0;
+        for (byte[] chunk : chunks) {
+            length += chunk.length;
+        }
+        byte[] result = new byte[length];
+        int offset = 0;
+        for (byte[] chunk : chunks) {
+            System.arraycopy(chunk, 0, result, offset, chunk.length);
+            offset += chunk.length;
+        }
+        return result;
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
@@ -1382,6 +1382,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                         .lastSplit(lastSplit)
                         .recordAligned(recordAlignedMacro)
                         .readSchema(perFileReadSchema)
+                        .maxRecordBytes(maxRecordBytes)
                         .build();
                     pages = fileReader.read(obj, ctx);
                 }
@@ -1532,6 +1533,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                     .rowLimit(fileBudget)
                     .errorPolicy(errorPolicy)
                     .readSchema(perFileReadSchema)
+                    .maxRecordBytes(maxRecordBytes)
                     .build();
                 pages = fileReader.read(obj, ctx);
             }
@@ -1616,6 +1618,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                     .batchSize(batchSize)
                     .rowLimit(rowLimit)
                     .errorPolicy(errorPolicy)
+                    .maxRecordBytes(maxRecordBytes)
                     .build();
                 pages = reader.read(storageObject, ctx);
             }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ParallelParsingCoordinator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ParallelParsingCoordinator.java
@@ -286,6 +286,7 @@ public final class ParallelParsingCoordinator {
             .firstSplit(splitIncludesFileLeader)
             .recordAligned(splitStartsAtRecordBoundary)
             .readSchema(readSchema)
+            .maxRecordBytes(maxRecordBytes)
             .build();
         if (parallelism <= 1 || fileLength < minSegment * 2) {
             return parallelReader.read(storageObject, baseCtx);
@@ -308,7 +309,8 @@ public final class ParallelParsingCoordinator {
             maxConcurrentOpenSegments,
             effectivePolicy,
             splitIncludesFileLeader,
-            readSchema
+            readSchema,
+            maxRecordBytes
         );
         // Fully constructed and published before any worker is dispatched — see OrderedParallelIterator#start.
         iterator.start();
@@ -414,6 +416,7 @@ public final class ParallelParsingCoordinator {
         private final boolean splitIncludesFileLeader;
         @org.elasticsearch.core.Nullable
         private final List<Attribute> readSchema;
+        private final int maxRecordBytes;
 
         private final List<long[]> segments;
         private final Executor executor;
@@ -437,7 +440,8 @@ public final class ParallelParsingCoordinator {
             int maxConcurrentOpenSegments,
             ErrorPolicy errorPolicy,
             boolean splitIncludesFileLeader,
-            List<Attribute> readSchema
+            List<Attribute> readSchema,
+            int maxRecordBytes
         ) {
             this.reader = reader;
             this.storageObject = storageObject;
@@ -446,6 +450,7 @@ public final class ParallelParsingCoordinator {
             this.errorPolicy = errorPolicy;
             this.splitIncludesFileLeader = splitIncludesFileLeader;
             this.readSchema = readSchema;
+            this.maxRecordBytes = maxRecordBytes;
             this.segments = segments;
             this.executor = executor;
             // Single clamp site for the effective window: the configured cap, never more than the parser
@@ -533,6 +538,7 @@ public final class ParallelParsingCoordinator {
                     .lastSplit(lastSplit)
                     .recordAligned(true)
                     .readSchema(readSchema)
+                    .maxRecordBytes(maxRecordBytes)
                     .build();
                 CloseableIterator<Page> pages = reader.read(segObj, ctx);
                 try (pages) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
@@ -140,6 +140,7 @@ public final class StreamingParallelParsingCoordinator {
                 .batchSize(batchSize)
                 .errorPolicy(effectivePolicy)
                 .readSchema(readSchema)
+                .maxRecordBytes(maxRecordBytes)
                 .build();
             return reader.read(new InputStreamStorageObject(decompressedStream), ctx);
         }
@@ -558,6 +559,7 @@ public final class StreamingParallelParsingCoordinator {
                     .lastSplit(true)
                     .recordAligned(true)
                     .readSchema(readSchema)
+                    .maxRecordBytes(maxRecordBytes)
                     .build();
                 try (CloseableIterator<Page> pages = reader.read(chunkObj, ctx)) {
                     while (pages.hasNext()) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/FormatReadContext.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/FormatReadContext.java
@@ -43,6 +43,8 @@ import java.util.List;
  *                         {@link FormatReader#withSchema}, which carries the projection. Empty
  *                         list and {@code null} both mean "no schema"; the compact constructor
  *                         collapses empty to {@code null} so readers do one check.
+ * @param maxRecordBytes   maximum bytes a single text record may occupy while split/trim code
+ *                         scans for a record boundary.
  */
 public record FormatReadContext(
     List<String> projectedColumns,
@@ -52,12 +54,16 @@ public record FormatReadContext(
     boolean firstSplit,
     boolean lastSplit,
     boolean recordAligned,
-    @Nullable List<Attribute> readSchema
+    @Nullable List<Attribute> readSchema,
+    int maxRecordBytes
 ) {
 
     public FormatReadContext {
         if (readSchema != null && readSchema.isEmpty()) {
             readSchema = null;
+        }
+        if (maxRecordBytes <= 0) {
+            throw new IllegalArgumentException("maxRecordBytes must be positive, got: " + maxRecordBytes);
         }
     }
 
@@ -76,21 +82,51 @@ public record FormatReadContext(
      * Returns a copy with a different row limit.
      */
     public FormatReadContext withRowLimit(int limit) {
-        return new FormatReadContext(projectedColumns, batchSize, limit, errorPolicy, firstSplit, lastSplit, recordAligned, readSchema);
+        return new FormatReadContext(
+            projectedColumns,
+            batchSize,
+            limit,
+            errorPolicy,
+            firstSplit,
+            lastSplit,
+            recordAligned,
+            readSchema,
+            maxRecordBytes
+        );
     }
 
     /**
      * Returns a copy with a different error policy.
      */
     public FormatReadContext withErrorPolicy(ErrorPolicy policy) {
-        return new FormatReadContext(projectedColumns, batchSize, rowLimit, policy, firstSplit, lastSplit, recordAligned, readSchema);
+        return new FormatReadContext(
+            projectedColumns,
+            batchSize,
+            rowLimit,
+            policy,
+            firstSplit,
+            lastSplit,
+            recordAligned,
+            readSchema,
+            maxRecordBytes
+        );
     }
 
     /**
      * Returns a copy configured for a split-based read.
      */
     public FormatReadContext withSplit(boolean first, boolean last) {
-        return new FormatReadContext(projectedColumns, batchSize, rowLimit, errorPolicy, first, last, recordAligned, readSchema);
+        return new FormatReadContext(
+            projectedColumns,
+            batchSize,
+            rowLimit,
+            errorPolicy,
+            first,
+            last,
+            recordAligned,
+            readSchema,
+            maxRecordBytes
+        );
     }
 
     public static Builder builder() {
@@ -110,6 +146,7 @@ public record FormatReadContext(
         private boolean recordAligned = false;
         @Nullable
         private List<Attribute> readSchema = null;
+        private int maxRecordBytes = SegmentableFormatReader.DEFAULT_MAX_RECORD_BYTES;
 
         private Builder() {}
 
@@ -158,6 +195,11 @@ public record FormatReadContext(
             return this;
         }
 
+        public Builder maxRecordBytes(int maxRecordBytes) {
+            this.maxRecordBytes = maxRecordBytes;
+            return this;
+        }
+
         public FormatReadContext build() {
             if (batchSize <= 0) {
                 throw new IllegalArgumentException("batchSize must be positive, got: " + batchSize);
@@ -170,7 +212,8 @@ public record FormatReadContext(
                 firstSplit,
                 lastSplit,
                 recordAligned,
-                readSchema
+                readSchema,
+                maxRecordBytes
             );
         }
     }


### PR DESCRIPTION
Centralize NDJSON record-boundary scanning so split planning,
trim handling, and legacy reader entry points share CR/LF semantics
and the existing max_record_size budget.

Developed with AI-assisted tooling