### PR TITLE
[9.4] fix: NPE on null zeroTermsQuery in cross_fields query (#149935)

### DIFF
--- a/docs/changelog/149935.yaml
+++ b/docs/changelog/149935.yaml
@@ -1,0 +1,6 @@
+pr: 149935
+summary: Guard against null zeroTermsQuery in cross_fields multi_match
+area: Search
+type: bug
+issues:
+ - 149934

--- a/server/src/main/java/org/elasticsearch/index/search/MultiMatchQueryParser.java
+++ b/server/src/main/java/org/elasticsearch/index/search/MultiMatchQueryParser.java
@@ -152,7 +152,9 @@ public class MultiMatchQueryParser extends MatchQueryParser {
             Query query = builder.createBooleanQuery(representativeField, value.toString(), occur);
             if (query == null) {
                 query = zeroTermsQuery.asQuery();
-                query.visit(queryVisitor);
+                if (query != null) {
+                    query.visit(queryVisitor);
+                }
             }
 
             query = Queries.maybeApplyMinimumShouldMatch(query, minimumShouldMatch);

--- a/server/src/test/java/org/elasticsearch/index/search/MultiMatchQueryParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/search/MultiMatchQueryParserTests.java
@@ -31,6 +31,7 @@ import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.MockFieldMapper.FakeFieldType;
 import org.elasticsearch.index.query.MultiMatchQueryBuilder;
 import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.index.query.ZeroTermsQueryOption;
 import org.elasticsearch.index.search.MultiMatchQueryParser.FieldAndBoost;
 import org.elasticsearch.lucene.queries.BlendedTermQuery;
 import org.elasticsearch.plugins.Plugin;
@@ -393,5 +394,21 @@ public class MultiMatchQueryParserTests extends ESSingleNodeTestCase {
             0.0f
         );
         assertThat(query, equalTo(expected));
+    }
+
+    public void testCrossFieldsZeroTokensDoesNotThrow() throws IOException {
+        SearchExecutionContext searchExecutionContext = indexService.newSearchExecutionContext(randomInt(20), 0, null, () -> {
+            throw new UnsupportedOperationException();
+        }, null, emptyMap(), null, null);
+
+        Map<String, Float> fieldNames = new HashMap<>();
+        fieldNames.put("name.first", 1.0f);
+        fieldNames.put("name.last", 1.0f);
+
+        MultiMatchQueryParser parser = new MultiMatchQueryParser(searchExecutionContext, QueryVisitor.EMPTY_VISITOR);
+        parser.setZeroTermsQuery(ZeroTermsQueryOption.NULL);
+
+        Query query = parser.parse(MultiMatchQueryBuilder.Type.CROSS_FIELDS, fieldNames, ".", null);
+        assertNull(query);
     }
 }


### PR DESCRIPTION
Backports the following commits to 9.4:
 - fix: NPE on null zeroTermsQuery in cross_fields query (#149935)