### PR TITLE
Add overall request timeout for incremental bulk

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/bulk/IncrementalBulkService.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/IncrementalBulkService.java
@@ -28,6 +28,7 @@ import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.tasks.TaskManager;
 import org.elasticsearch.telemetry.metric.LongHistogram;
 import org.elasticsearch.telemetry.metric.MeterRegistry;
+import org.elasticsearch.threadpool.Scheduler;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.ArrayList;
@@ -53,21 +54,58 @@ public class IncrementalBulkService {
         Setting.Property.NodeScope,
         Setting.Property.Dynamic
     );
+
+    /**
+     * Overall wall-clock timeout for a single incremental bulk request, measured from the moment the
+     * request session is created. A non-positive value (the default) disables the timeout. When it
+     * elapses the request's {@link Handler#bulkSessionTask} is cancelled, which causes the next chunk
+     * to fail with a {@link org.elasticsearch.tasks.TaskCancelledException}.
+     */
+    public static final Setting<TimeValue> REQUEST_TIMEOUT = Setting.timeSetting(
+        "rest.incremental_bulk.request_timeout",
+        TimeValue.MINUS_ONE,
+        TimeValue.MINUS_ONE,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
     private final Client client;
     private final AtomicBoolean enabledForTests = new AtomicBoolean(true);
     private final IndexingPressure indexingPressure;
     private final TaskManager taskManager;
     private final ThreadPool threadPool;
+    @Nullable
+    private volatile TimeValue requestTimeout;
 
     /* Capture in milliseconds because the APM histogram only has a range of 100,000 */
     private final LongHistogram chunkWaitTimeMillisHistogram;
 
+    /**
+     * Test-only constructor for callers that have no {@link ClusterSettings} to wire. Requests created by
+     * this instance never time out; production code must use the {@link ClusterSettings}-aware constructor
+     * so that {@link #REQUEST_TIMEOUT} is honoured.
+     */
     public IncrementalBulkService(
         Client client,
         IndexingPressure indexingPressure,
         MeterRegistry meterRegistry,
         TaskManager taskManager,
         ThreadPool threadPool
+    ) {
+        this(client, indexingPressure, meterRegistry, taskManager, threadPool, null);
+    }
+
+    /**
+     * @param clusterSettings used to watch {@link #REQUEST_TIMEOUT}; when {@code null} no overall request
+     *                        timeout is enforced (see the test-only constructor above).
+     */
+    public IncrementalBulkService(
+        Client client,
+        IndexingPressure indexingPressure,
+        MeterRegistry meterRegistry,
+        TaskManager taskManager,
+        ThreadPool threadPool,
+        @Nullable ClusterSettings clusterSettings
     ) {
         this.client = client;
         this.indexingPressure = indexingPressure;
@@ -78,6 +116,9 @@ public class IncrementalBulkService {
             "Total time in millis spent waiting for next chunk of a bulk request",
             "ms"
         );
+        if (clusterSettings != null) {
+            clusterSettings.initializeAndWatch(REQUEST_TIMEOUT, value -> this.requestTimeout = value);
+        }
     }
 
     public Handler newBulkRequest() {
@@ -92,7 +133,7 @@ public class IncrementalBulkService {
         Set<String> paramsUsed
     ) {
         ensureEnabled();
-        return new Handler(
+        Handler handler = new Handler(
             client,
             indexingPressure,
             waitForActiveShards,
@@ -103,6 +144,10 @@ public class IncrementalBulkService {
             taskManager,
             threadPool
         );
+        // Scheduled after construction (rather than in the Handler constructor) so the timeout callback
+        // never captures a partially-initialized Handler.
+        handler.scheduleTimeout(requestTimeout);
+        return handler;
     }
 
     private void ensureEnabled() {
@@ -155,7 +200,10 @@ public class IncrementalBulkService {
         private Exception bulkActionLevelFailure = null;
         private BulkRequest bulkRequest = null;
         private final TaskManager taskManager;
+        private final ThreadPool threadPool;
         private final CancellableTask bulkSessionTask;
+        // Cancels the request after REQUEST_TIMEOUT elapses; null when no timeout is configured.
+        private volatile Scheduler.Cancellable pendingTimeout;
 
         protected Handler(
             Client client,
@@ -194,6 +242,7 @@ public class IncrementalBulkService {
             }
 
             this.client = client;
+            this.threadPool = threadPool;
             this.waitForActiveShards = waitForActiveShards != null ? ActiveShardCount.parseString(waitForActiveShards) : null;
             this.timeout = timeout;
             this.refresh = refresh;
@@ -201,6 +250,30 @@ public class IncrementalBulkService {
             this.incrementalOperation = indexingPressure.startIncrementalCoordinating(0, 0, false);
             this.chunkWaitTimeMillisHistogram = chunkWaitTimeMillisHistogram;
             createNewBulkRequest(EMPTY_STATE);
+        }
+
+        /**
+         * Schedules cancellation of this request once {@code requestTimeout} elapses. A no-op when the
+         * timeout is null or non-positive. Called once, immediately after construction.
+         */
+        private void scheduleTimeout(@Nullable TimeValue requestTimeout) {
+            // Guard on millis(), not nanos(): ThreadPool#schedule floors the delay to whole milliseconds, so a
+            // sub-millisecond timeout would otherwise arm a zero-delay task that cancels the request immediately.
+            if (requestTimeout != null && requestTimeout.millis() > 0) {
+                pendingTimeout = threadPool.schedule(
+                    () -> cancel("request timed out after [" + requestTimeout + "]", () -> {}),
+                    requestTimeout,
+                    threadPool.generic()
+                );
+            }
+        }
+
+        /** Cancels the pending timeout, if any. Idempotent; safe to call once the request has finished. */
+        private void cancelTimeout() {
+            Scheduler.Cancellable pending = pendingTimeout;
+            if (pending != null) {
+                pending.cancel();
+            }
         }
 
         public void cancel(String reason, Runnable listener) {
@@ -263,7 +336,10 @@ public class IncrementalBulkService {
 
         public void lastItems(List<DocWriteRequest<?>> items, Releasable releasable, ActionListener<BulkResponse> listener) {
             assert bulkInProgress == false;
-            ActionListener<BulkResponse> finalListener = ActionListener.runBefore(listener, () -> taskManager.unregister(bulkSessionTask));
+            ActionListener<BulkResponse> finalListener = ActionListener.runBefore(listener, () -> {
+                cancelTimeout();
+                taskManager.unregister(bulkSessionTask);
+            });
             if (bulkActionLevelFailure != null) {
                 shortCircuitDueToTopLevelFailure(items, releasable);
                 errorResponse(finalListener);
@@ -304,6 +380,7 @@ public class IncrementalBulkService {
         public void close() {
             if (closed == false) {
                 closed = true;
+                cancelTimeout();
                 incrementalOperation.close();
                 releasables.forEach(Releasable::close);
                 releasables.clear();

--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -275,6 +275,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
         Metadata.SETTING_READ_ONLY_ALLOW_DELETE_SETTING,
         ShardLimitValidator.SETTING_CLUSTER_MAX_SHARDS_PER_NODE,
         IncrementalBulkService.INCREMENTAL_BULK,
+        IncrementalBulkService.REQUEST_TIMEOUT,
         ShardBatchIndexer.BATCH_INDEXING,
         RecoverySettings.INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING,
         RecoverySettings.INDICES_RECOVERY_RETRY_DELAY_STATE_SYNC_SETTING,

--- a/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
@@ -1108,7 +1108,8 @@ class NodeConstruction {
             indexingLimits,
             telemetryProvider.getMeterRegistry(),
             taskManager,
-            threadPool
+            threadPool,
+            clusterService.getClusterSettings()
         );
 
         final ResponseCollectorService responseCollectorService = new ResponseCollectorService(clusterService);

--- a/server/src/test/java/org/elasticsearch/action/bulk/IncrementalBulkServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/IncrementalBulkServiceTests.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.action.bulk;
+
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.DeterministicTaskQueue;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.IndexingPressure;
+import org.elasticsearch.tasks.CancellableTask;
+import org.elasticsearch.tasks.TaskId;
+import org.elasticsearch.tasks.TaskManager;
+import org.elasticsearch.telemetry.metric.MeterRegistry;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.startsWith;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests the {@link IncrementalBulkService#REQUEST_TIMEOUT} scheduling that this service adds on top of
+ * the bulk-session cancellation machinery. The downstream effect of cancellation (the next chunk failing
+ * with a {@code TaskCancelledException}) is covered by {@code IncrementalBulkIT}; here we only assert that
+ * the timeout reliably triggers cancellation and is cancelled itself once the request finishes.
+ */
+public class IncrementalBulkServiceTests extends ESTestCase {
+
+    /**
+     * Builds a service whose requests run on {@code taskQueue}'s simulated clock. A null
+     * {@code requestTimeout} configures the {@link IncrementalBulkService#REQUEST_TIMEOUT} setting to its
+     * disabled default.
+     *
+     * <p>{@code taskManager} is a mock rather than a real {@link TaskManager} because the timeout's effect
+     * is delivered through {@code cancelTaskAndDescendants}, which a bare {@code TaskManager} cannot service
+     * without a transport-wired {@code TaskCancellationService}. Mocking it lets us verify the cancellation
+     * call directly; {@code register()} is stubbed to return a real {@link CancellableTask} so the handler
+     * can be constructed and parented. {@code Client} is mocked because these tests only exercise timeout
+     * scheduling and never issue a bulk request.
+     */
+    private static IncrementalBulkService newService(DeterministicTaskQueue taskQueue, TimeValue requestTimeout, TaskManager taskManager) {
+        CancellableTask task = new CancellableTask(
+            1L,
+            IncrementalBulkService.BULK_SESSION_TASK_TYPE,
+            IncrementalBulkService.BULK_SESSION_ACTION,
+            "",
+            TaskId.EMPTY_TASK_ID,
+            Map.of()
+        );
+        when(taskManager.register(anyString(), anyString(), any())).thenReturn(task);
+        when(taskManager.getNodeId()).thenReturn("test-node");
+
+        Settings.Builder settings = Settings.builder();
+        if (requestTimeout != null) {
+            settings.put(IncrementalBulkService.REQUEST_TIMEOUT.getKey(), requestTimeout);
+        }
+        ClusterSettings clusterSettings = ClusterSettings.createBuiltInClusterSettings(settings.build());
+
+        return new IncrementalBulkService(
+            mock(Client.class),
+            new IndexingPressure(Settings.EMPTY),
+            MeterRegistry.NOOP,
+            taskManager,
+            taskQueue.getThreadPool(),
+            clusterSettings
+        );
+    }
+
+    public void testTimeoutTriggersCancellation() {
+        DeterministicTaskQueue taskQueue = new DeterministicTaskQueue();
+        TaskManager taskManager = mock(TaskManager.class);
+        IncrementalBulkService service = newService(taskQueue, TimeValue.timeValueSeconds(30), taskManager);
+
+        try (var handler = service.newBulkRequest()) {
+            assertTrue("a timeout task should be scheduled", taskQueue.hasDeferredTasks());
+
+            taskQueue.runAllTasksInTimeOrder();
+
+            verify(taskManager).cancelTaskAndDescendants(any(), startsWith("request timed out"), eq(false), any());
+        }
+    }
+
+    public void testNoTimeoutWhenDisabled() {
+        DeterministicTaskQueue taskQueue = new DeterministicTaskQueue();
+
+        // MINUS_ONE disables the timeout; a sub-millisecond value rounds down to a 0ms delay and must also be
+        // treated as disabled rather than scheduling a task that cancels the request immediately.
+        for (TimeValue timeout : new TimeValue[] { null, TimeValue.MINUS_ONE, TimeValue.timeValueNanos(500_000) }) {
+            IncrementalBulkService service = newService(taskQueue, timeout, mock(TaskManager.class));
+            try (var handler = service.newBulkRequest()) {
+                assertFalse("no timeout task should be scheduled when disabled", taskQueue.hasDeferredTasks());
+            }
+        }
+    }
+
+    public void testCloseCancelsPendingTimeout() {
+        DeterministicTaskQueue taskQueue = new DeterministicTaskQueue();
+        TaskManager taskManager = mock(TaskManager.class);
+        IncrementalBulkService service = newService(taskQueue, TimeValue.timeValueSeconds(30), taskManager);
+
+        var handler = service.newBulkRequest();
+        assertTrue(taskQueue.hasDeferredTasks());
+        handler.close();
+
+        // close() cancelled the scheduled task, so advancing past the deadline must not fire the timeout
+        taskQueue.runAllTasksInTimeOrder();
+        verify(taskManager, never()).cancelTaskAndDescendants(any(), startsWith("request timed out"), anyBoolean(), any());
+    }
+}


### PR DESCRIPTION
This PR adds an opt-in wall-clock deadline for the whole bulk request session.

**Setting:** `rest.incremental_bulk.request_timeout` (`TimeValue`, node-scoped,
dynamic). Default `-1` (disabled). Measured from session creation; on expiry the
request's bulk-session task is cancelled, so the next chunk fails with
`TaskCancelledException`.

**Implementation:** builds on the cancellable incremental-bulk session introduced
in #149648 — the timeout is just a scheduled trigger for the existing `cancel()`
path, so no new cancellation machinery. The timer is armed in `newBulkRequest`
(after the handler is fully constructed) and cancelled when the request completes
or the handler closes.

**Testing:** unit tests over a deterministic clock cover scheduling-when-enabled,
the disabled cases (default `-1` and sub-millisecond values that floor to a 0 ms
delay), and timer cancellation on close.

**Follow-ups:**
- `IncrementalBulkIT` end-to-end test asserting a deliberately slow request is
  cancelled with `TaskCancelledException` once the deadline passes.
- Evaluate a dedicated `TimeoutService` queue if per-request scheduling becomes a
  bottleneck at high in-flight depth (node-global scheduler is single-threaded,
  O(log N) insert under lock).