### PR TITLE
Forbid index-scoped deprecated settings

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -244,6 +244,11 @@ public class Setting<T> implements ToXContentObject {
             checkPropertyRequiresIndexScope(propertiesAsSet, Property.IndexSettingDeprecatedInV9AndRemovedInV10);
             checkPropertyRequiresIndexScope(propertiesAsSet, Property.ServerlessPublic);
             checkPropertyRequiresNodeScope(propertiesAsSet);
+            if (propertiesAsSet.contains(Property.IndexScope) && propertiesAsSet.contains(Property.Deprecated)) {
+                throw new IllegalArgumentException(
+                    "index-scoped setting [" + this.key + "] can not have property [" + Property.Deprecated + "]"
+                );
+            }
             this.properties = propertiesAsSet;
         }
     }

--- a/server/src/test/java/org/elasticsearch/common/settings/SettingTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/SettingTests.java
@@ -1200,6 +1200,14 @@ public class SettingTests extends ESTestCase {
         assertThat(e, hasToString(containsString("non-index-scoped setting [foo.bar] can not have property [ServerlessPublic]")));
     }
 
+    public void testRejectIndexScopedDeprecatedSetting() {
+        final IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> Setting.simpleString("foo.bar", Property.IndexScope, Property.Deprecated)
+        );
+        assertThat(e, hasToString(containsString("index-scoped setting [foo.bar] can not have property [Deprecated]")));
+    }
+
     public void testTimeValue() {
         final TimeValue random = randomTimeValue();
 


### PR DESCRIPTION
Support for index-scoped settings depends on the index-created version,
not the current cluster version, so it isn't appropriate to use
`Property.Deprecated` for these settings. Instead we must use one of the
versioned values such as`IndexSettingDeprecatedInV9AndRemovedInV10`.

This commit adds a validation rule to forbid this inappropriate
combination of properties on settings.