### PR TITLE
Implement striped EWMR for high-concurrency use (Experiment)

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/common/metrics/ExponentiallyWeightedMovingRateBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/common/metrics/ExponentiallyWeightedMovingRateBenchmark.java
@@ -48,7 +48,7 @@ import java.util.concurrent.TimeUnit;
 @SuppressWarnings("unused")
 public class ExponentiallyWeightedMovingRateBenchmark {
 
-    @Param({ "1", "16", "32" })
+    @Param({ "1", "4", "8", "16" })
     public int numStripes;
 
     private ExponentiallyWeightedMovingRate ewmr;
@@ -119,31 +119,17 @@ public class ExponentiallyWeightedMovingRateBenchmark {
         return ewmr.getRate(t.time);
     }
 
-    @Group("writers_016")
-    @GroupThreads(16)
+    @Group("writers_015")
+    @GroupThreads(15)
     @Benchmark
-    public void addIncrement_016(ThreadState t) {
+    public void addIncrement_015(ThreadState t) {
         ewmr.addIncrement(1.0, t.time++);
     }
 
-    @Group("writers_016")
+    @Group("writers_015")
     @GroupThreads(1)
     @Benchmark
-    public double getRate_016(ThreadState t) {
-        return ewmr.getRate(t.time);
-    }
-
-    @Group("writers_032")
-    @GroupThreads(32)
-    @Benchmark
-    public void addIncrement_032(ThreadState t) {
-        ewmr.addIncrement(1.0, t.time++);
-    }
-
-    @Group("writers_032")
-    @GroupThreads(1)
-    @Benchmark
-    public double getRate_032(ThreadState t) {
+    public double getRate_015(ThreadState t) {
         return ewmr.getRate(t.time);
     }
 }

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/common/metrics/ExponentiallyWeightedMovingRateBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/common/metrics/ExponentiallyWeightedMovingRateBenchmark.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.benchmark.common.metrics;
+
+import org.elasticsearch.common.metrics.ExponentiallyWeightedMovingRate;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Group;
+import org.openjdk.jmh.annotations.GroupThreads;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Compares {@link ExponentiallyWeightedMovingRate#addIncrement} throughput under varying write-thread counts, with one concurrent thread
+ * always calling {@link ExponentiallyWeightedMovingRate#getRate} — matching the expected production pattern where a thread pool of size N
+ * updates the rate and a single monitoring thread reads it periodically.
+ *
+ * <p>Each benchmark group pairs N writer threads with 1 reader thread. JMH reports {@code addIncrement} and {@code getRate} latencies
+ * separately within each group, so both write throughput degradation and read cost are visible. The {@code numStripes} parameter
+ * controls stripe count: {@code 1} is the unstriped baseline where all writers serialise through a single monitor; higher values
+ * distribute writes across independent monitors.
+ *
+ * <p>Run with: {@code ./gradlew :benchmarks:run --args="ExponentiallyWeightedMovingRateBenchmark"}
+ */
+@Fork(2)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+@SuppressWarnings("unused")
+public class ExponentiallyWeightedMovingRateBenchmark {
+
+    @Param({ "1", "16", "32" })
+    public int numStripes;
+
+    private ExponentiallyWeightedMovingRate ewmr;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        long now = System.nanoTime();
+        double halfLifeNanos = TimeUnit.SECONDS.toNanos(30);
+        ewmr = new ExponentiallyWeightedMovingRate(Math.log(2.0) / halfLifeNanos, now, numStripes);
+    }
+
+    /**
+     * Per-thread monotonically increasing time counter. Each thread advances its own counter independently; when multiple threads share a
+     * stripe the EWMR's per-stripe time clamping handles any apparent backwards movement from that stripe's perspective.
+     */
+    @State(Scope.Thread)
+    public static class ThreadState {
+        long time;
+
+        @Setup(Level.Trial)
+        public void setup() {
+            time = System.nanoTime();
+        }
+    }
+
+    // Each group runs N writer threads and 1 reader thread concurrently. JMH reports them separately as
+    // "writers_NNN:addIncrement_NNN" and "writers_NNN:getRate_NNN" so write and read latencies are both visible.
+
+    @Group("writers_001")
+    @GroupThreads(1)
+    @Benchmark
+    public void addIncrement_001(ThreadState t) {
+        ewmr.addIncrement(1.0, t.time++);
+    }
+
+    @Group("writers_001")
+    @GroupThreads(1)
+    @Benchmark
+    public double getRate_001(ThreadState t) {
+        return ewmr.getRate(t.time);
+    }
+
+    @Group("writers_004")
+    @GroupThreads(4)
+    @Benchmark
+    public void addIncrement_004(ThreadState t) {
+        ewmr.addIncrement(1.0, t.time++);
+    }
+
+    @Group("writers_004")
+    @GroupThreads(1)
+    @Benchmark
+    public double getRate_004(ThreadState t) {
+        return ewmr.getRate(t.time);
+    }
+
+    @Group("writers_008")
+    @GroupThreads(8)
+    @Benchmark
+    public void addIncrement_008(ThreadState t) {
+        ewmr.addIncrement(1.0, t.time++);
+    }
+
+    @Group("writers_008")
+    @GroupThreads(1)
+    @Benchmark
+    public double getRate_008(ThreadState t) {
+        return ewmr.getRate(t.time);
+    }
+
+    @Group("writers_016")
+    @GroupThreads(16)
+    @Benchmark
+    public void addIncrement_016(ThreadState t) {
+        ewmr.addIncrement(1.0, t.time++);
+    }
+
+    @Group("writers_016")
+    @GroupThreads(1)
+    @Benchmark
+    public double getRate_016(ThreadState t) {
+        return ewmr.getRate(t.time);
+    }
+
+    @Group("writers_032")
+    @GroupThreads(32)
+    @Benchmark
+    public void addIncrement_032(ThreadState t) {
+        ewmr.addIncrement(1.0, t.time++);
+    }
+
+    @Group("writers_032")
+    @GroupThreads(1)
+    @Benchmark
+    public double getRate_032(ThreadState t) {
+        return ewmr.getRate(t.time);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/common/metrics/ExponentiallyWeightedMovingRate.java
+++ b/server/src/main/java/org/elasticsearch/common/metrics/ExponentiallyWeightedMovingRate.java
@@ -29,21 +29,26 @@ import static java.lang.Math.log;
  * epoch as returned by {@link System#currentTimeMillis}, nanos since an arbitrary origin as returned by {@link System#nanoTime}, or
  * anything else. The only requirement is that the same convention must be used consistently.
  *
+ * <p>For high-concurrency use (e.g. tracking utilisation of a large thread pool), use the constructor that accepts a {@code numStripes}
+ * argument. Increments are partitioned across stripes by the calling thread's identity; {@link #getRate} sums the stripe rates. This is
+ * mathematically exact: the EWMR formula is linear in the increments, so for any partition of the increments the sum of the per-stripe
+ * rates equals the rate that would be obtained from a single instance that received all the increments. Stripes have independent monitors,
+ * so threads routing to different stripes never contend with one another on writes.
+ *
  * <p>This class is thread-safe.
  */
 public class ExponentiallyWeightedMovingRate {
 
     // The maths behind this is explained in section 2 of this document: https://github.com/user-attachments/files/19166625/ewma.pdf
 
-    // This implementation uses synchronization to provide thread safety. The synchronized code is all non-blocking, and just performs a
-    // fixed small number of floating point operations plus some memory reads and writes. If they take somewhere in the region of 10ns each,
-    // we can do up to tens of millions of QPS before the lock risks becoming a bottleneck.
+    // Mutable state lives in Stripe objects, each guarded by its own monitor, so stripes are entirely independent. addIncrement routes to
+    // a stripe selected by the calling thread's identity. With N stripes and T threads, the expected number of threads competing for any
+    // one stripe is T/N, reducing contention by the same factor compared to a single shared lock.
 
     private final double lambda;
     private final long startTime;
-    private double rate;
-    private long lastTime;
-    private boolean waitingForFirstIncrement;
+    private final Stripe[] stripes;
+    private final int stripeMask;
 
     /**
      * Constructor.
@@ -56,16 +61,33 @@ public class ExponentiallyWeightedMovingRate {
      *     of this value must match all other calls to this instance.
      */
     public ExponentiallyWeightedMovingRate(double lambda, long startTime) {
+        this(lambda, startTime, 1);
+    }
+
+    /**
+     * Constructor for high-concurrency use with independent stripes to reduce lock contention.
+     *
+     * @param lambda See {@link #ExponentiallyWeightedMovingRate(double, long)}.
+     * @param startTime See {@link #ExponentiallyWeightedMovingRate(double, long)}.
+     * @param numStripes The number of independent stripes. Must be a positive power of two. Increments are routed to a stripe by the
+     *     calling thread's identity, so a value at least as large as the number of concurrent updater threads eliminates all write
+     *     contention. {@link #getRate} sums all stripe results with cost linear in {@code numStripes}, so reads are unaffected by this
+     *     value beyond that small overhead.
+     */
+    public ExponentiallyWeightedMovingRate(double lambda, long startTime, int numStripes) {
         if (lambda < 0.0) {
             throw new IllegalArgumentException("lambda must be non-negative but was " + lambda);
         }
-        synchronized (this) {
-            this.lambda = lambda;
-            this.rate = Double.NaN; // should never be used
-            this.startTime = startTime;
-            this.lastTime = 0; // should never be used
-            this.waitingForFirstIncrement = true;
+        if (numStripes <= 0 || Integer.bitCount(numStripes) != 1) {
+            throw new IllegalArgumentException("numStripes must be a positive power of 2 but was " + numStripes);
         }
+        this.lambda = lambda;
+        this.startTime = startTime;
+        this.stripes = new Stripe[numStripes];
+        for (int i = 0; i < numStripes; i++) {
+            stripes[i] = new Stripe();
+        }
+        this.stripeMask = numStripes - 1;
     }
 
     /**
@@ -74,21 +96,16 @@ public class ExponentiallyWeightedMovingRate {
      *
      * <p>If there have been no increments yet, this returns zero.
      *
-     * <p>Otherwise, we require the time to be no earlier than the time of the previous increment, i.e. the value of {@code time}
-     * for this call must not be less than the value of {@code time} for the last call to {@link #addIncrement}. If this is not the
-     * case, the method behaves as if it had that minimum value.
+     * <p>Otherwise, we require the time to be no earlier than the time of the most recent increment seen by any stripe, i.e. the value of
+     * {@code time} for this call must not be less than the value of {@code time} for the last call to {@link #addIncrement} on any stripe.
+     * If this is not the case, the method behaves as if it had that minimum value on the stripe(s) which received later increments.
      */
     public double getRate(long time) {
-        synchronized (this) {
-            if (waitingForFirstIncrement) {
-                return 0.0;
-            } else if (time <= lastTime) {
-                return rate;
-            } else {
-                // This is the formula for R(t) given in subsection 2.6 of the document referenced above:
-                return expHelper(lastTime - startTime) * exp(-1.0 * lambda * (time - lastTime)) * rate / expHelper(time - startTime);
-            }
+        double sum = 0.0;
+        for (Stripe stripe : stripes) {
+            sum += stripe.getRate(time);
         }
+        return sum;
     }
 
     /**
@@ -120,32 +137,17 @@ public class ExponentiallyWeightedMovingRate {
      * Updates the rate to reflect that the gauge has been incremented by an amount {@code increment} at a time {@code time}. The unit and
      * offset of the time must match all other calls to this instance. The units of the increment are arbitrary but must also be consistent.
      *
-     * <p>If this is the first increment, we require it to occur after the start time for the rate calculation, i.e. the value of
-     * {@code time} must be greater than {@code startTime} passed to the constructor. If this is not the case, the method behaves as if
-     * {@code time} is {@code startTime + 1} to prevent a division by zero error.
+     * <p>The increment is applied to the stripe selected by the calling thread's identity. The following constraints are per-stripe:
      *
-     * <p>If this is not the first increment, we require it not to occur before the previous increment, i.e. the value of {@code time} for
-     * this call must be greater than or equal to the value for the previous call. If this is not the case, the method behaves as if this
-     * call's {@code time} is the same as the previous call's.
+     * <p>If this is the first increment on the selected stripe, we require it to occur after the start time for the rate calculation, i.e.
+     * the value of {@code time} must be greater than {@code startTime} passed to the constructor. If this is not the case, the method
+     * behaves as if {@code time} is {@code startTime + 1} to prevent a division by zero error.
+     *
+     * <p>If this is not the first increment on the selected stripe, we require it not to occur before the previous increment on that
+     * stripe. If this is not the case, the method behaves as if this call's {@code time} is the same as the previous call's on that stripe.
      */
     public void addIncrement(double increment, long time) {
-        synchronized (this) {
-            if (waitingForFirstIncrement) {
-                if (time <= startTime) {
-                    time = startTime + 1;
-                }
-                // This is the formula for R(t_1) given in subsection 2.6 of the document referenced above:
-                rate = increment / expHelper(time - startTime);
-                waitingForFirstIncrement = false;
-            } else {
-                if (time < lastTime) {
-                    time = lastTime;
-                }
-                // This is the formula for R(t_j+1) given in subsection 2.6 of the document referenced above:
-                rate += (increment - expHelper(time - lastTime) * rate) / expHelper(time - startTime);
-            }
-            lastTime = time;
-        }
+        stripes[(int) (Thread.currentThread().threadId() & stripeMask)].addIncrement(increment, time);
     }
 
     /**
@@ -176,5 +178,50 @@ public class ExponentiallyWeightedMovingRate {
      */
     public double getHalfLife() {
         return log(2.0) / lambda;
+    }
+
+    /**
+     * Holds the mutable EWMR state for one stripe. Each stripe is guarded by its own monitor so stripes never contend with one another.
+     *
+     * <p>The fields are padded to occupy at least 128 bytes so that adjacent Stripe objects in the array do not share a CPU cache line,
+     * avoiding false sharing between threads that route to neighbouring stripes.
+     */
+    private final class Stripe {
+        private double rate;
+        private long lastTime;
+        private boolean waitingForFirstIncrement = true;
+        // Padding to prevent false sharing. The useful fields plus object overhead occupy roughly 40 bytes; these 11 longs bring the
+        // total object size to ~128 bytes, covering both 64-byte and 128-byte cache-line architectures.
+        @SuppressWarnings("unused")
+        private long p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11;
+
+        synchronized void addIncrement(double increment, long time) {
+            if (waitingForFirstIncrement) {
+                if (time <= startTime) {
+                    time = startTime + 1;
+                }
+                // This is the formula for R(t_1) given in subsection 2.6 of the document referenced above:
+                rate = increment / expHelper(time - startTime);
+                waitingForFirstIncrement = false;
+            } else {
+                if (time < lastTime) {
+                    time = lastTime;
+                }
+                // This is the formula for R(t_j+1) given in subsection 2.6 of the document referenced above:
+                rate += (increment - expHelper(time - lastTime) * rate) / expHelper(time - startTime);
+            }
+            lastTime = time;
+        }
+
+        synchronized double getRate(long time) {
+            if (waitingForFirstIncrement) {
+                return 0.0;
+            } else if (time <= lastTime) {
+                return rate;
+            } else {
+                // This is the formula for R(t) given in subsection 2.6 of the document referenced above:
+                return expHelper(lastTime - startTime) * exp(-1.0 * lambda * (time - lastTime)) * rate / expHelper(time - startTime);
+            }
+        }
     }
 }

--- a/server/src/test/java/org/elasticsearch/common/metrics/ExponentiallyWeightedMovingRateTests.java
+++ b/server/src/test/java/org/elasticsearch/common/metrics/ExponentiallyWeightedMovingRateTests.java
@@ -214,6 +214,36 @@ public class ExponentiallyWeightedMovingRateTests extends ESTestCase {
         assertThrows(IllegalArgumentException.class, () -> new ExponentiallyWeightedMovingRate(-1.0e-6, START_TIME_IN_MILLIS));
     }
 
+    // Directly compares a 1-stripe instance with a 128-stripe instance: the same increments are applied to both from the same threads, so
+    // the striped instance's routing is exercised by real thread IDs. After every round, both instances must produce identical rates.
+    // All increments in a round share one timestamp, which means concurrent updates within a stripe reduce to pure addition (the
+    // E(time - lastTime) term is zero), so the result is independent of serialisation order and the outputs are exactly equal within the
+    // standard numerical tolerance.
+    public void testStripedEwmr_matchesUnstripedUnderConcurrentUpdates() throws InterruptedException {
+        int numStripes = 1 << randomIntBetween(1, 7); // random power of 2 in [2, 128]
+        ExponentiallyWeightedMovingRate singleStripe = new ExponentiallyWeightedMovingRate(LAMBDA, START_TIME_IN_MILLIS, 1);
+        ExponentiallyWeightedMovingRate multiStripe = new ExponentiallyWeightedMovingRate(LAMBDA, START_TIME_IN_MILLIS, numStripes);
+        int numRoundsOfIncrements = 20;
+        long intervalMillis = 10_000;
+        int numThreads = 100;
+        for (int round = 1; round <= numRoundsOfIncrements; round++) {
+            long timeInMillis = START_TIME_IN_MILLIS + round * intervalMillis;
+            double[] incrementsForRound = DoubleStream.generate(() -> randomDoubleBetween(1.0, 100.0, true)).limit(numThreads).toArray();
+            List<Thread> threads = DoubleStream.of(incrementsForRound).mapToObj(increment -> new Thread(() -> {
+                singleStripe.addIncrement(increment, timeInMillis);
+                multiStripe.addIncrement(increment, timeInMillis);
+            })).toList();
+            for (Thread thread : threads) {
+                thread.start();
+            }
+            for (Thread thread : threads) {
+                thread.join();
+            }
+            long queryTime = START_TIME_IN_MILLIS + round * intervalMillis;
+            assertThat(multiStripe.getRate(queryTime), closeTo(singleStripe.getRate(queryTime), TOLERANCE));
+        }
+    }
+
     // N.B. This test is not guaranteed to fail even if the implementation is not thread-safe. The operations are fast enough that there is
     // a chance each thread will complete before the next one has started. We use a high thread count to try to get a decent change of
     // hitting a race condition if there is one. This should be run with e.g. -Dtests.iters=20 to test thoroughly.
@@ -352,5 +382,74 @@ public class ExponentiallyWeightedMovingRateTests extends ESTestCase {
     public void testGetHalfLife_lambdaZero() {
         ExponentiallyWeightedMovingRate ewmr = new ExponentiallyWeightedMovingRate(0.0, START_TIME_IN_MILLIS);
         assertThat(ewmr.getHalfLife(), equalTo(Double.POSITIVE_INFINITY));
+    }
+
+    public void testStripedEwmr_invalidNumStripes() {
+        assertThrows(IllegalArgumentException.class, () -> new ExponentiallyWeightedMovingRate(LAMBDA, START_TIME_IN_MILLIS, 0));
+        assertThrows(IllegalArgumentException.class, () -> new ExponentiallyWeightedMovingRate(LAMBDA, START_TIME_IN_MILLIS, -1));
+        assertThrows(IllegalArgumentException.class, () -> new ExponentiallyWeightedMovingRate(LAMBDA, START_TIME_IN_MILLIS, 3));
+        assertThrows(IllegalArgumentException.class, () -> new ExponentiallyWeightedMovingRate(LAMBDA, START_TIME_IN_MILLIS, 100));
+    }
+
+    // Validates the core mathematical property that makes striping correct: the EWMR is linear in its increments, so for any partition of
+    // the increments across independent EWMR instances (with the same lambda and startTime), summing their rates gives the same result as a
+    // single instance that received all the increments. This is the fundamental identity that getRate exploits when combining stripe rates.
+    public void testStripedEwmr_sumOfIndependentStripes() {
+        ExponentiallyWeightedMovingRate s1 = new ExponentiallyWeightedMovingRate(LAMBDA, START_TIME_IN_MILLIS);
+        ExponentiallyWeightedMovingRate s2 = new ExponentiallyWeightedMovingRate(LAMBDA, START_TIME_IN_MILLIS);
+        ExponentiallyWeightedMovingRate s3 = new ExponentiallyWeightedMovingRate(LAMBDA, START_TIME_IN_MILLIS);
+        ExponentiallyWeightedMovingRate s4 = new ExponentiallyWeightedMovingRate(LAMBDA, START_TIME_IN_MILLIS);
+
+        s1.addIncrement(10.0, START_TIME_IN_MILLIS + 1000);
+        s1.addIncrement(5.0, START_TIME_IN_MILLIS + 3000);
+        s2.addIncrement(20.0, START_TIME_IN_MILLIS + 2000);
+        s3.addIncrement(15.0, START_TIME_IN_MILLIS + 1500);
+        s3.addIncrement(8.0, START_TIME_IN_MILLIS + 4000);
+        s4.addIncrement(12.0, START_TIME_IN_MILLIS + 2500);
+
+        // Reference: a single EWMR that received all the same increments, added in time order:
+        ExponentiallyWeightedMovingRate reference = new ExponentiallyWeightedMovingRate(LAMBDA, START_TIME_IN_MILLIS);
+        reference.addIncrement(10.0, START_TIME_IN_MILLIS + 1000);
+        reference.addIncrement(15.0, START_TIME_IN_MILLIS + 1500);
+        reference.addIncrement(20.0, START_TIME_IN_MILLIS + 2000);
+        reference.addIncrement(12.0, START_TIME_IN_MILLIS + 2500);
+        reference.addIncrement(5.0, START_TIME_IN_MILLIS + 3000);
+        reference.addIncrement(8.0, START_TIME_IN_MILLIS + 4000);
+
+        long queryTime = START_TIME_IN_MILLIS + 5000;
+        double sumOfStripes = s1.getRate(queryTime) + s2.getRate(queryTime) + s3.getRate(queryTime) + s4.getRate(queryTime);
+        assertThat(sumOfStripes, closeTo(reference.getRate(queryTime), TOLERANCE));
+    }
+
+    // N.B. This test is not guaranteed to fail even if the implementation is not thread-safe, but uses a high thread count and stripe count
+    // to exercise concurrency across many stripes. Run with e.g. -Dtests.iters=20 to test more thoroughly.
+    public void testStripedEwmr_threadSafe() throws InterruptedException {
+        // Use 128 stripes — a realistic value for a 128-thread pool.
+        ExponentiallyWeightedMovingRate ewmr = new ExponentiallyWeightedMovingRate(LAMBDA, START_TIME_IN_MILLIS, 128);
+        int numRoundsOfIncrements = 100;
+        long intervalMillis = 10_000;
+        // Use enough threads to exercise multiple stripes concurrently.
+        int numThreads = 1000;
+        List<Double> totalIncrementsPerRound = new ArrayList<>();
+        for (int round = 1; round <= numRoundsOfIncrements; round++) {
+            long timeInMillis = START_TIME_IN_MILLIS + round * intervalMillis;
+            double[] incrementsForRound = DoubleStream.generate(() -> randomDoubleBetween(1.0, 100.0, true)).limit(numThreads).toArray();
+            List<Thread> threads = DoubleStream.of(incrementsForRound)
+                .mapToObj(increment -> new Thread(() -> ewmr.addIncrement(increment, timeInMillis)))
+                .toList();
+            for (Thread thread : threads) {
+                thread.start();
+            }
+            for (Thread thread : threads) {
+                thread.join();
+            }
+            totalIncrementsPerRound.add(DoubleStream.of(incrementsForRound).sum());
+        }
+        // Since all increments in a round share the same timestamp, the combined rate from all stripes is equivalent to a single EWMR
+        // receiving the total increment for each round at that round's timestamp (increments at the same time accumulate by summing).
+        double expectedEwmr = IntStream.range(0, numRoundsOfIncrements)
+            .mapToDouble(i -> totalIncrementsPerRound.get(i) * exp(-1.0 * LAMBDA * (numRoundsOfIncrements - 1 - i) * intervalMillis))
+            .sum() / ((1.0 - exp(-1.0 * LAMBDA * numRoundsOfIncrements * intervalMillis)) / LAMBDA);
+        assertThat(ewmr.getRate(START_TIME_IN_MILLIS + numRoundsOfIncrements * intervalMillis), closeTo(expectedEwmr, TOLERANCE));
     }
 }


### PR DESCRIPTION
Just an experiment to see if this a) matters, b) makes things better

The thinking is we might like to calculate an ewmr for thread-pool utilisation, which would mean sizeof(thread-pool) threads potentially hammering `addIncrement`. Average task execution times seem to be in the order of 100ms or less, so a busy 32 core machine might call `addIncrement` roughly every 3ms. 

I had a 16 core GCP machine available to me so I benchmarked up to 16 threads. Our largest instances in serverless have 32 I believe.