### PR TITLE
[9.3] Move SAML metadata resolution to background thread (#150037)

### DIFF
--- a/docs/changelog/144381.yaml
+++ b/docs/changelog/144381.yaml
@@ -1,0 +1,6 @@
+area: Authentication
+issues:
+ - 138031
+pr: 144381
+summary: Move SAML metadata resolution to background thread
+type: bug

--- a/x-pack/plugin/security/qa/saml-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/saml/SamlInResponseToIT.java
+++ b/x-pack/plugin/security/qa/saml-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/saml/SamlInResponseToIT.java
@@ -13,6 +13,8 @@ import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.test.rest.ObjectPath;
 import org.elasticsearch.xcontent.json.JsonXContent;
+import org.junit.ClassRule;
+import org.junit.rules.TestRule;
 
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -27,6 +29,9 @@ import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
 
 public class SamlInResponseToIT extends SamlRestTestCase {
+
+    @ClassRule
+    public static TestRule ruleChain = buildRuleChain(true);
 
     private static final int REALM_NUMBER = 1;
 

--- a/x-pack/plugin/security/qa/saml-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/saml/SamlRestTestCase.java
+++ b/x-pack/plugin/security/qa/saml-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/saml/SamlRestTestCase.java
@@ -22,9 +22,7 @@ import org.elasticsearch.test.cluster.util.resource.Resource;
 import org.elasticsearch.test.junit.RunnableTestRuleAdapter;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.junit.AfterClass;
-import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
@@ -52,8 +50,20 @@ public class SamlRestTestCase extends ESRestTestCase {
     public static final ElasticsearchCluster cluster = initTestCluster();
     private static Path caPath;
 
-    @ClassRule
-    public static TestRule ruleChain = RuleChain.outerRule(new RunnableTestRuleAdapter(SamlRestTestCase::initWebserver)).around(cluster);
+    /**
+     * Build the rule chain for SAML rest tests.
+     * When {@code makeMetadataAvailableAtStartup} is {@code true}, metadata is served as soon as the mock server starts so the cluster's
+     * initial SAML realm load can succeed.
+     * When false, metadata is unavailable at startup (for tests that verify how the saml realm behaves when metadata could not be loaded).
+     */
+    protected static TestRule buildRuleChain(boolean makeMetadataAvailableAtStartup) {
+        return RuleChain.outerRule(new RunnableTestRuleAdapter(() -> {
+            initWebserver();
+            if (makeMetadataAvailableAtStartup) {
+                makeMetadataAvailable(1, 2, 3);
+            }
+        })).around(cluster);
+    }
 
     private static void initWebserver() {
         try {
@@ -116,6 +126,7 @@ public class SamlRestTestCase extends ESRestTestCase {
                     settings.put(prefix + ".order", String.valueOf(realmNumber));
                     settings.put(prefix + ".idp.entity_id", idpEntityId);
                     settings.put(prefix + ".idp.metadata.path", idpHttps + "metadata/" + realmNumber + ".xml");
+                    settings.put(prefix + ".idp.metadata.http.minimum_refresh", "500ms");
                     settings.put(prefix + ".sp.entity_id", "https://sp" + realmNumber + ".example.org/");
                     settings.put(prefix + ".sp.acs", acsHttps + "acs/" + realmNumber);
                     settings.put(prefix + ".attributes.principal", "urn:oid:2.5.4.3");
@@ -190,22 +201,6 @@ public class SamlRestTestCase extends ESRestTestCase {
             throw new FileNotFoundException("Cannot find classpath resource /ssl/ca.crt");
         }
         caPath = PathUtils.get(resource.toURI());
-    }
-
-    /**
-     * Make metadata available by default before each test, but make this behaviour controllable by subclasses.
-     */
-    @Before
-    public void initMetadata() {
-        if (isMetadataAvailable()) {
-            makeMetadataAvailable(1, 2, 3);
-        } else {
-            makeAllMetadataUnavailable();
-        }
-    }
-
-    protected boolean isMetadataAvailable() {
-        return true;
     }
 
     @Override

--- a/x-pack/plugin/security/qa/saml-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/saml/SamlServiceProviderMetadataIT.java
+++ b/x-pack/plugin/security/qa/saml-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/saml/SamlServiceProviderMetadataIT.java
@@ -12,13 +12,17 @@ import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.test.rest.ObjectPath;
 import org.elasticsearch.xcontent.json.JsonXContent;
+import org.junit.ClassRule;
+import org.junit.rules.TestRule;
 
+import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -26,25 +30,31 @@ import static org.hamcrest.Matchers.is;
 public class SamlServiceProviderMetadataIT extends SamlRestTestCase {
 
     /**
-     * Within this class we the metadata not to be enabled at the start of each test
+     * Metadata must be unavailable at cluster startup so that "metadata has never been loaded" holds.
      */
-    @Override
-    protected boolean isMetadataAvailable() {
-        return false;
-    }
+    @ClassRule
+    public static TestRule ruleChain = SamlRestTestCase.buildRuleChain(false);
 
     public void testAuthenticationWhenMetadataIsUnreliable() throws Exception {
-        // initially, metadata in unavailable for all realms
+        // initially, metadata is unavailable for all realms
 
         final String username = randomAlphaOfLengthBetween(4, 12);
         for (int realmNumber : shuffledList(List.of(1, 2, 3))) {
-            // Authc fails because metadata has never been loaded.
+            // Authc fails because metadata has never been loaded (it was never made available for this realm).
             var ex = expectThrows(ResponseException.class, () -> samlAuthUser(realmNumber, username));
             assertThat(ex.getResponse().getStatusLine().getStatusCode(), is(401));
 
-            // Authc works once metadata is available.
+            // Make metadata available. The next auth will probably fail because the background thread hasn't tried to refresh yet.
+            // But when that auth fails, it will trigger a background refresh of the metadata, which will then mean that future auth
+            // attempts succeed (maybe not immediately, but within a short period of time).
             makeMetadataAvailable(realmNumber);
-            samlAuthUser(realmNumber, username);
+            assertBusy(() -> {
+                try {
+                    samlAuthUser(realmNumber, username);
+                } catch (IOException e) {
+                    fail(e);
+                }
+            }, 15, TimeUnit.SECONDS);
         }
 
         // Switch off all metadata

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/InternalRealms.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/InternalRealms.java
@@ -158,6 +158,7 @@ public final class InternalRealms {
             SingleSpSamlRealmSettings.TYPE,
             config -> SamlRealm.create(
                 config,
+                threadPool,
                 sslService,
                 resourceWatcherService,
                 userRoleMapper,

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/saml/SamlMetadataResolver.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/saml/SamlMetadataResolver.java
@@ -1,0 +1,497 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.security.authc.saml;
+
+import net.shibboleth.utilities.java.support.component.ComponentInitializationException;
+import net.shibboleth.utilities.java.support.resolver.CriteriaSet;
+import net.shibboleth.utilities.java.support.resolver.ResolverException;
+import net.shibboleth.utilities.java.support.xml.BasicParserPool;
+
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.common.settings.SettingsException;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.core.Strings;
+import org.elasticsearch.core.SuppressForbidden;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.watcher.FileChangesListener;
+import org.elasticsearch.watcher.FileWatcher;
+import org.elasticsearch.watcher.ResourceWatcherService;
+import org.elasticsearch.xpack.core.security.authc.RealmConfig;
+import org.elasticsearch.xpack.core.security.authc.RealmSettings;
+import org.elasticsearch.xpack.core.security.authc.saml.SamlRealmSettings;
+import org.elasticsearch.xpack.core.ssl.SSLService;
+import org.elasticsearch.xpack.core.ssl.SslProfile;
+import org.elasticsearch.xpack.security.EntitledFileWatcher;
+import org.elasticsearch.xpack.security.support.LogThrottle;
+import org.opensaml.core.criterion.EntityIdCriterion;
+import org.opensaml.saml.metadata.resolver.impl.AbstractReloadingMetadataResolver;
+import org.opensaml.saml.metadata.resolver.impl.FilesystemMetadataResolver;
+import org.opensaml.saml.metadata.resolver.impl.HTTPMetadataResolver;
+import org.opensaml.saml.saml2.metadata.EntityDescriptor;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import static org.elasticsearch.transport.Transports.assertNotTransportThread;
+import static org.elasticsearch.xpack.core.security.authc.saml.SamlRealmSettings.IDP_METADATA_HTTP_CONNECT_TIMEOUT;
+import static org.elasticsearch.xpack.core.security.authc.saml.SamlRealmSettings.IDP_METADATA_HTTP_FAIL_ON_ERROR;
+import static org.elasticsearch.xpack.core.security.authc.saml.SamlRealmSettings.IDP_METADATA_HTTP_MIN_REFRESH;
+import static org.elasticsearch.xpack.core.security.authc.saml.SamlRealmSettings.IDP_METADATA_HTTP_READ_TIMEOUT;
+import static org.elasticsearch.xpack.core.security.authc.saml.SamlRealmSettings.IDP_METADATA_HTTP_REFRESH;
+import static org.elasticsearch.xpack.core.security.authc.saml.SamlRealmSettings.IDP_METADATA_PATH;
+
+/**
+ * Encapsulates SAML IdP metadata resolution with a cached entity descriptor.
+ * After construction, resolution (including blocking HTTP or file I/O) runs on the
+ * generic thread pool or the scheduled refresh thread, so the auth hot path can read
+ * the cache without blocking on OpenSAML's metadata resolver lock. The constructing
+ * thread may run the initial {@link #updateCachedDescriptor()} during {@link #create}.
+ * The cache is updated from the resolver periodically (every 60s); the resolver itself
+ * is not forced to refresh on that schedule.
+ * For HTTP metadata, OpenSAML's resolver refreshes on its own min/max delay.
+ * For file metadata, Elasticsearch's {@link FileWatcher} is used to monitor for changes.
+ */
+final class SamlMetadataResolver implements Releasable, Supplier<EntityDescriptor> {
+
+    private static final Logger logger = LogManager.getLogger(SamlMetadataResolver.class);
+    private static final TimeValue REFRESH_INTERVAL = TimeValue.timeValueSeconds(60);
+    private static final TimeValue LOGGING_PERIOD = TimeValue.timeValueMinutes(30);
+
+    private final AbstractReloadingMetadataResolver resolver;
+    private final String entityId;
+    private final String sourceLocation;
+    private final boolean failOnError;
+    private final ThreadPool threadPool;
+
+    private final EntityDescriptor unresolvedDescriptor;
+
+    private final AtomicReference<EntityDescriptor> cachedEntity = new AtomicReference<>();
+    private final AtomicBoolean inProgress = new AtomicBoolean(false);
+    private final LogThrottle nullCacheWarnThrottle;
+    private final LogThrottle refreshFailureLogThrottle;
+
+    private final Collection<Releasable> childReleasables;
+
+    private SamlMetadataResolver(
+        AbstractReloadingMetadataResolver resolver,
+        String entityId,
+        String sourceLocation,
+        boolean failOnError,
+        ThreadPool threadPool
+    ) {
+        this.resolver = resolver;
+        this.entityId = entityId;
+        this.sourceLocation = sourceLocation;
+        this.failOnError = failOnError;
+        this.threadPool = threadPool;
+        this.unresolvedDescriptor = new UnresolvedEntity(entityId, sourceLocation);
+        this.nullCacheWarnThrottle = new LogThrottle(threadPool, LOGGING_PERIOD);
+        this.refreshFailureLogThrottle = new LogThrottle(threadPool, LOGGING_PERIOD);
+        this.childReleasables = new ArrayList<>();
+    }
+
+    private record MetadataParseResult(AbstractReloadingMetadataResolver resolver, boolean failOnError, @Nullable Releasable releasable) {}
+
+    /**
+     * Create a SAML metadata resolver, perform an initial resolve to populate the cache,
+     * and start the 60-second refresh schedule.
+     */
+    public static SamlMetadataResolver create(
+        RealmConfig config,
+        SSLService sslService,
+        ResourceWatcherService watcherService,
+        ThreadPool threadPool
+    ) throws ResolverException, ComponentInitializationException, IOException {
+        final String metadataPath = SamlRealm.require(config, SamlRealmSettings.IDP_METADATA_PATH);
+        if (metadataPath.startsWith("http://")) {
+            throw new IllegalArgumentException("The [http] protocol is not supported as it is insecure. Use [https] instead");
+        }
+
+        final AtomicReference<SamlMetadataResolver> resolverReference = new AtomicReference<>();
+        final MetadataParseResult parseResult;
+        boolean forceRefresh = false;
+        if (metadataPath.startsWith("https://")) {
+            parseResult = parseHttpMetadata(metadataPath, config, sslService);
+        } else {
+            final Consumer<Path> onFileChanged = path -> {
+                final SamlMetadataResolver m = resolverReference.get();
+                if (m != null) {
+                    m.asyncUpdateCachedDescriptor();
+                }
+            };
+            parseResult = parseFileSystemMetadata(metadataPath, config, watcherService, onFileChanged);
+            /* There's a potential race condition between when the OpenSAML file resolver reads the metadata for the first time
+             * and when we actively start monitoring the file for changes.
+             * If the file is changed in that time we either don't notice, or we discard the event. To avoid that we force
+             * a refresh of the metadata after everything is wired up. For a single file read, this is cheap and safe.
+             */
+            forceRefresh = true;
+        }
+
+        final String entityId = SamlRealm.require(config, SamlRealmSettings.IDP_ENTITY_ID);
+        final SamlMetadataResolver metadataResolver = new SamlMetadataResolver(
+            parseResult.resolver,
+            entityId,
+            metadataPath,
+            parseResult.failOnError,
+            threadPool
+        );
+        resolverReference.set(metadataResolver);
+
+        // Initial resolve to populate cache (resolver already loaded during init, no need to refresh again)
+        metadataResolver.updateCachedDescriptor();
+
+        // Start periodic refresh
+        final var refreshTask = threadPool.scheduleWithFixedDelay(
+            metadataResolver::periodicMetadataRefresh,
+            REFRESH_INTERVAL,
+            threadPool.generic()
+        );
+        metadataResolver.addChildReleasable(refreshTask::cancel);
+        if (parseResult.releasable != null) {
+            metadataResolver.addChildReleasable(parseResult.releasable);
+        }
+
+        if (forceRefresh) {
+            metadataResolver.forceRefresh();
+            metadataResolver.updateCachedDescriptor();
+        }
+        return metadataResolver;
+    }
+
+    public AbstractReloadingMetadataResolver getResolver() {
+        return resolver;
+    }
+
+    /**
+     * Returns the cached IdP {@link EntityDescriptor} when metadata has been resolved successfully.
+     * This relies on the background refresh thread, and does not block on OpenSAML or network I/O.
+     * If no entity descriptor is available (i.e. the background refresh has failed to resolve one), then this method will
+     * <ul>
+     * <li>attempt to trigger another background metadata refresh (because the realm is being used so the system should check
+     *     whether the resolution problem has been fixed)</li>
+     * <li>possibly log a warning that SAML auth will fail until metadata is available (this logging is throttled)</li>
+     * <li>return an {@link UnresolvedEntity} stand-in.</li>
+     * </ul>
+     */
+    @Override
+    public EntityDescriptor get() {
+        final EntityDescriptor descriptor = cachedEntity.get();
+        if (descriptor == null) {
+            // Trigger an immediate background refresh so a subsequent call might see resolved metadata
+            asyncUpdateCachedDescriptor();
+            if (nullCacheWarnThrottle.acquire()) {
+                logger.warn(
+                    "cannot load SAML metadata for [{}] from [{}]; SAML authentication for this realm will fail",
+                    entityId,
+                    sourceLocation
+                );
+            }
+            return unresolvedDescriptor;
+        }
+        return descriptor;
+    }
+
+    /**
+     * Called on a fixed delay on the generic executor. Syncs the cache on this thread (no extra submit).
+     */
+    private void periodicMetadataRefresh() {
+        if (inProgress.compareAndSet(false, true)) {
+            try {
+                tryUpdateCachedDescriptor(false);
+            } catch (Exception e) {
+                inProgress.compareAndSet(true, false);
+                logger.debug(() -> "SAML metadata periodic refresh failed for [" + entityId + "]", e);
+            }
+        }
+    }
+
+    /**
+     * Queues a cache sync on the generic pool (e.g. when {@link #get()} sees a null cache).
+     */
+    void asyncUpdateCachedDescriptor() {
+        if (inProgress.compareAndSet(false, true)) {
+            try {
+                threadPool.executor(ThreadPool.Names.GENERIC).submit(() -> tryUpdateCachedDescriptor(true));
+            } catch (Exception e) {
+                inProgress.compareAndSet(true, false);
+                logger.debug(() -> "SAML metadata refresh from [" + this.sourceLocation + "] failed for [" + entityId + "]", e);
+            }
+        }
+    }
+
+    /**
+     * Forcibly refresh the metadata from the underlying resolver.
+     * Happens synchronously on the calling thread.
+     * This only refreshes the metadata, it <strong>does not</strong> update the cached entity,
+     *   the caller must also call {@link #updateCachedDescriptor()} if that is needed.
+     */
+    private void forceRefresh() {
+        try {
+            resolver.refresh();
+        } catch (Exception e) {
+            logger.debug(
+                () -> Strings.format(
+                    "SAML metadata unconditional file resync: refresh from [%s] for entity [%s] failed; continuing with cache update",
+                    sourceLocation,
+                    entityId
+                ),
+                e
+            );
+        }
+    }
+
+    /**
+     * Runs on the generic pool. Syncs the cache from the resolver and clears inProgress when done.
+     */
+    private void tryUpdateCachedDescriptor(boolean refresh) {
+        try {
+            if (refresh) {
+                forceRefresh();
+            }
+            updateCachedDescriptor();
+        } finally {
+            if (inProgress.compareAndSet(true, false) == false) {
+                assert false : "Unexpected CAS state: in progress should have been true";
+                logger.warn("Unexpected CAS state: in progress should have been true");
+            }
+        }
+    }
+
+    /**
+     * Resolves the entity descriptor from the OpenSAML resolver and updates the cache.
+     * Runs only on the background thread (or during initial resolve). Never overwrites a real
+     * cached entity with an unresolved one.
+     */
+    void updateCachedDescriptor() {
+        try {
+            final EntityDescriptor descriptor = resolveEntityDescriptor();
+            cachedEntity.set(descriptor);
+        } catch (Exception e) {
+            // We intentionally don't update the cached entity descriptor here.
+            // Most of the time have an out of date descriptor is better than having
+            // no descriptor at all - in fact it's entirely possible that it's not out of date,
+            // it's just that we couldn't resolve the metadata file on this attempt.
+            maybeLog(e);
+            if (failOnError) {
+                throw ExceptionsHelper.convertToRuntime(e);
+            }
+        }
+    }
+
+    /**
+     * Log the exception. It is a warning if we haven't logged in the last {@link #LOGGING_PERIOD}, otherwise it's a debug.
+     * This prevents us from filling the logs every time we fail, but also logs errors regularly enough to be noticed
+     */
+    private void maybeLog(Exception ex) {
+        org.apache.logging.log4j.util.Supplier<String> message = () -> Strings.format("Failed to refresh SAML metadata for [%s]", entityId);
+        if (refreshFailureLogThrottle.acquire()) {
+            logger.warn(message, ex);
+        } else {
+            logger.debug(message, ex);
+        }
+    }
+
+    /**
+     * Resolves the entity descriptor from the OpenSAML resolver.
+     * If the first resolve returns null, forces a resolver refresh and retries once.
+     * Returns a non-null {@link EntityDescriptor} on success; otherwise throws (typically
+     * {@link ResolverException} or a SAML exception from {@link SamlUtils#samlException}).
+     */
+    private EntityDescriptor resolveEntityDescriptor() throws ResolverException {
+        var criteria = new CriteriaSet(new EntityIdCriterion(entityId));
+        EntityDescriptor descriptor = resolver.resolveSingle(criteria);
+        ResolverException exception = null;
+        if (descriptor == null) {
+            try {
+                resolver.refresh();
+            } catch (ResolverException e) {
+                exception = e;
+            }
+            descriptor = resolver.resolveSingle(criteria);
+        }
+        if (descriptor != null) {
+            return descriptor;
+        }
+        if (exception != null) {
+            throw exception;
+        }
+        throw SamlUtils.samlException("Cannot find metadata for entity [{}] in [{}]", entityId, sourceLocation);
+    }
+
+    @Override
+    public void close() {
+        Releasables.close(childReleasables);
+        resolver.destroy();
+    }
+
+    private void addChildReleasable(Releasable releasable) {
+        this.childReleasables.add(releasable);
+    }
+
+    private static SamlMetadataResolver.MetadataParseResult parseHttpMetadata(String metadataUrl, RealmConfig config, SSLService sslService)
+        throws ResolverException, ComponentInitializationException {
+        HttpClientBuilder builder = HttpClientBuilder.create();
+        final String sslKey = RealmSettings.realmSslPrefix(config.identifier());
+        final SslProfile sslProfile = sslService.profile(sslKey);
+        final SSLConnectionSocketFactory factory = sslProfile.connectionSocketFactory();
+        builder.setSSLSocketFactory(factory);
+
+        TimeValue connectTimeout = config.getSetting(IDP_METADATA_HTTP_CONNECT_TIMEOUT);
+        TimeValue readTimeout = config.getSetting(IDP_METADATA_HTTP_READ_TIMEOUT);
+        RequestConfig requestConfig = RequestConfig.custom()
+            .setConnectTimeout(Math.toIntExact(connectTimeout.millis()))
+            .setSocketTimeout(Math.toIntExact(readTimeout.millis()))
+            .build();
+        builder.setDefaultRequestConfig(requestConfig);
+
+        TimeValue maxRefresh = config.getSetting(IDP_METADATA_HTTP_REFRESH);
+        TimeValue minRefresh = config.getSetting(IDP_METADATA_HTTP_MIN_REFRESH);
+        if (minRefresh.compareTo(maxRefresh) > 0) {
+            if (config.hasSetting(IDP_METADATA_HTTP_MIN_REFRESH)) {
+                throw new SettingsException(
+                    "the value ({}) for [{}] cannot be greater than the value ({}) for [{}]",
+                    minRefresh.getStringRep(),
+                    RealmSettings.getFullSettingKey(config, IDP_METADATA_HTTP_MIN_REFRESH),
+                    maxRefresh.getStringRep(),
+                    RealmSettings.getFullSettingKey(config, IDP_METADATA_HTTP_REFRESH)
+                );
+            } else {
+                minRefresh = maxRefresh;
+            }
+        }
+
+        HTTPMetadataResolver resolver = new ThreadCheckingHTTPMetadataResolver(builder.build(), metadataUrl);
+        resolver.setMinRefreshDelay(Duration.ofMillis(minRefresh.millis()));
+        resolver.setMaxRefreshDelay(Duration.ofMillis(maxRefresh.millis()));
+
+        final boolean failOnError = config.getSetting(IDP_METADATA_HTTP_FAIL_ON_ERROR);
+        resolver.setFailFastInitialization(failOnError);
+
+        initialiseResolver(resolver, config);
+
+        return new MetadataParseResult(resolver, failOnError, null);
+    }
+
+    /**
+     * Ensures SAML metadata HTTP fetch does not run on transport worker threads.
+     */
+    private static final class ThreadCheckingHTTPMetadataResolver extends HTTPMetadataResolver {
+
+        ThreadCheckingHTTPMetadataResolver(final HttpClient client, final String metadataURL) throws ResolverException {
+            super(client, metadataURL);
+        }
+
+        @Override
+        protected byte[] fetchMetadata() throws ResolverException {
+            assert assertNotTransportThread("fetching SAML metadata from a URL");
+            return super.fetchMetadata();
+        }
+    }
+
+    @SuppressForbidden(reason = "uses toFile")
+    private static MetadataParseResult parseFileSystemMetadata(
+        String metadataPath,
+        RealmConfig config,
+        ResourceWatcherService watcherService,
+        Consumer<Path> onFileChange
+    ) throws ResolverException, ComponentInitializationException, IOException {
+        Objects.requireNonNull(onFileChange);
+
+        final Path path = config.env().configDir().resolve(metadataPath);
+        final FilesystemMetadataResolver resolver = new SamlFilesystemMetadataResolver(path.toFile());
+
+        for (var httpSetting : List.of(
+            IDP_METADATA_HTTP_REFRESH,
+            IDP_METADATA_HTTP_MIN_REFRESH,
+            IDP_METADATA_HTTP_FAIL_ON_ERROR,
+            IDP_METADATA_HTTP_CONNECT_TIMEOUT,
+            IDP_METADATA_HTTP_READ_TIMEOUT
+        )) {
+            if (config.hasSetting(httpSetting.apply(config.type()))) {
+                logger.info(
+                    "Ignoring setting [{}] because the IdP metadata is being loaded from a file for SAML realm [{}]",
+                    RealmSettings.getFullSettingKey(config, httpSetting.apply(config.type())),
+                    config.name()
+                );
+            }
+        }
+
+        final Duration oneDayMs = Duration.ofMillis(TimeValue.timeValueHours(24).millis());
+        resolver.setMinRefreshDelay(oneDayMs);
+        resolver.setMaxRefreshDelay(oneDayMs);
+        initialiseResolver(resolver, config);
+
+        final FileWatcher watcher = new EntitledFileWatcher(path);
+        watcher.addListener(new FileChangesListener() {
+            @Override
+            public void onFileCreated(Path file) {
+                onFileChanged(file);
+            }
+
+            @Override
+            public void onFileDeleted(Path file) {
+                onFileChanged(file);
+            }
+
+            @Override
+            public void onFileChanged(Path file) {
+                onFileChange.accept(file);
+            }
+        });
+        var handle = watcherService.add(watcher, ResourceWatcherService.Frequency.MEDIUM);
+
+        return new MetadataParseResult(resolver, true, handle::stop);
+    }
+
+    @SuppressForbidden(reason = "uses toFile")
+    private static final class SamlFilesystemMetadataResolver extends FilesystemMetadataResolver {
+
+        SamlFilesystemMetadataResolver(final java.io.File metadata) throws ResolverException {
+            super(metadata);
+        }
+
+        @Override
+        protected byte[] fetchMetadata() throws ResolverException {
+            assert assertNotTransportThread("fetching SAML metadata from a file");
+            return super.fetchMetadata();
+        }
+    }
+
+    private static void initialiseResolver(AbstractReloadingMetadataResolver resolver, RealmConfig config)
+        throws ComponentInitializationException {
+        resolver.setRequireValidMetadata(true);
+        BasicParserPool pool = new BasicParserPool();
+        pool.initialize();
+        resolver.setParserPool(pool);
+        resolver.setId(config.name());
+        try {
+            resolver.initialize();
+        } catch (ComponentInitializationException e) {
+            resolver.destroy();
+            throw SamlUtils.samlException("cannot load SAML metadata from [{}]", e, config.getSetting(IDP_METADATA_PATH));
+        }
+    }
+}

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/saml/SamlRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/saml/SamlRealm.java
@@ -9,12 +9,7 @@ package org.elasticsearch.xpack.security.authc.saml;
 import net.shibboleth.utilities.java.support.component.ComponentInitializationException;
 import net.shibboleth.utilities.java.support.resolver.CriteriaSet;
 import net.shibboleth.utilities.java.support.resolver.ResolverException;
-import net.shibboleth.utilities.java.support.xml.BasicParserPool;
 
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.config.RequestConfig;
-import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
-import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchSecurityException;
@@ -27,16 +22,12 @@ import org.elasticsearch.common.ssl.SslKeyConfig;
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.util.set.Sets;
-import org.elasticsearch.core.CheckedRunnable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
-import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.core.TimeValue;
-import org.elasticsearch.core.Tuple;
 import org.elasticsearch.license.XPackLicenseState;
-import org.elasticsearch.watcher.FileChangesListener;
-import org.elasticsearch.watcher.FileWatcher;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.watcher.ResourceWatcherService;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationResult;
@@ -49,8 +40,6 @@ import org.elasticsearch.xpack.core.security.authc.support.UserRoleMapper;
 import org.elasticsearch.xpack.core.security.user.User;
 import org.elasticsearch.xpack.core.ssl.CertParsingUtils;
 import org.elasticsearch.xpack.core.ssl.SSLService;
-import org.elasticsearch.xpack.core.ssl.SslProfile;
-import org.elasticsearch.xpack.security.EntitledFileWatcher;
 import org.elasticsearch.xpack.security.authc.Realms;
 import org.elasticsearch.xpack.security.authc.TokenService;
 import org.elasticsearch.xpack.security.authc.saml.SamlAttributes.SamlPrivateAttribute;
@@ -60,9 +49,6 @@ import org.opensaml.core.criterion.EntityIdCriterion;
 import org.opensaml.saml.common.xml.SAMLConstants;
 import org.opensaml.saml.criterion.EntityRoleCriterion;
 import org.opensaml.saml.metadata.resolver.MetadataResolver;
-import org.opensaml.saml.metadata.resolver.impl.AbstractReloadingMetadataResolver;
-import org.opensaml.saml.metadata.resolver.impl.FilesystemMetadataResolver;
-import org.opensaml.saml.metadata.resolver.impl.HTTPMetadataResolver;
 import org.opensaml.saml.metadata.resolver.impl.PredicateRoleDescriptorResolver;
 import org.opensaml.saml.saml2.core.Attribute;
 import org.opensaml.saml.saml2.core.AuthnRequest;
@@ -84,11 +70,9 @@ import org.opensaml.xmlsec.keyinfo.impl.KeyInfoResolutionContext;
 import org.opensaml.xmlsec.keyinfo.impl.provider.InlineX509DataProvider;
 
 import java.io.IOException;
-import java.nio.file.Path;
 import java.security.GeneralSecurityException;
 import java.security.PublicKey;
 import java.time.Clock;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -98,7 +82,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -112,20 +95,12 @@ import javax.net.ssl.X509KeyManager;
 
 import static org.elasticsearch.common.Strings.collectionToCommaDelimitedString;
 import static org.elasticsearch.core.Strings.format;
-import static org.elasticsearch.transport.Transports.assertNotTransportThread;
 import static org.elasticsearch.xpack.core.security.authc.saml.SamlRealmSettings.CLOCK_SKEW;
 import static org.elasticsearch.xpack.core.security.authc.saml.SamlRealmSettings.DN_ATTRIBUTE;
 import static org.elasticsearch.xpack.core.security.authc.saml.SamlRealmSettings.ENCRYPTION_KEY_ALIAS;
 import static org.elasticsearch.xpack.core.security.authc.saml.SamlRealmSettings.ENCRYPTION_SETTING_KEY;
 import static org.elasticsearch.xpack.core.security.authc.saml.SamlRealmSettings.FORCE_AUTHN;
 import static org.elasticsearch.xpack.core.security.authc.saml.SamlRealmSettings.GROUPS_ATTRIBUTE;
-import static org.elasticsearch.xpack.core.security.authc.saml.SamlRealmSettings.IDP_ENTITY_ID;
-import static org.elasticsearch.xpack.core.security.authc.saml.SamlRealmSettings.IDP_METADATA_HTTP_CONNECT_TIMEOUT;
-import static org.elasticsearch.xpack.core.security.authc.saml.SamlRealmSettings.IDP_METADATA_HTTP_FAIL_ON_ERROR;
-import static org.elasticsearch.xpack.core.security.authc.saml.SamlRealmSettings.IDP_METADATA_HTTP_MIN_REFRESH;
-import static org.elasticsearch.xpack.core.security.authc.saml.SamlRealmSettings.IDP_METADATA_HTTP_READ_TIMEOUT;
-import static org.elasticsearch.xpack.core.security.authc.saml.SamlRealmSettings.IDP_METADATA_HTTP_REFRESH;
-import static org.elasticsearch.xpack.core.security.authc.saml.SamlRealmSettings.IDP_METADATA_PATH;
 import static org.elasticsearch.xpack.core.security.authc.saml.SamlRealmSettings.IDP_SINGLE_LOGOUT;
 import static org.elasticsearch.xpack.core.security.authc.saml.SamlRealmSettings.MAIL_ATTRIBUTE;
 import static org.elasticsearch.xpack.core.security.authc.saml.SamlRealmSettings.NAMEID_ALLOW_CREATE;
@@ -162,10 +137,6 @@ public final class SamlRealm extends Realm implements Releasable {
     // Although we only use this for IDP metadata loading, the SSLServer only loads configurations where "ssl." is a top-level element
     // in the realm group configuration, so it has to have this name.
 
-    // Strictly, this shouldn't be static because it means that only 1 SAML realm per node can be refreshing metadata, but there's no reason
-    // to assume that there's any relationship between SAML realms. However, because all the metadata loading code is in static methods, we
-    // live with this limitation for now.
-    private static final AtomicBoolean REFRESHING_METADATA = new AtomicBoolean(false);
     private final List<Releasable> releasables;
 
     private final SamlAuthenticator authenticator;
@@ -197,6 +168,7 @@ public final class SamlRealm extends Realm implements Releasable {
      */
     public static SamlRealm create(
         RealmConfig config,
+        ThreadPool threadPool,
         SSLService sslService,
         ResourceWatcherService watcherService,
         UserRoleMapper roleMapper,
@@ -210,17 +182,10 @@ public final class SamlRealm extends Realm implements Releasable {
             );
         }
 
-        final Tuple<AbstractReloadingMetadataResolver, Supplier<EntityDescriptor>> tuple = initializeResolver(
-            logger,
-            config,
-            sslService,
-            watcherService
-        );
-        final AbstractReloadingMetadataResolver metadataResolver = tuple.v1();
-        final Supplier<EntityDescriptor> idpDescriptor = tuple.v2();
+        final SamlMetadataResolver metadataResolver = SamlMetadataResolver.create(config, sslService, watcherService, threadPool);
 
         final Clock clock = Clock.systemUTC();
-        final IdpConfiguration idpConfiguration = getIdpConfiguration(config, metadataResolver, idpDescriptor);
+        final IdpConfiguration idpConfiguration = getIdpConfiguration(config, metadataResolver.getResolver(), metadataResolver);
         final TimeValue maxSkew = config.getSetting(CLOCK_SKEW);
         final Predicate<Attribute> privateAttributePredicate = new SamlPrivateAttributePredicate(config);
         final SamlAuthenticator authenticator = new SamlAuthenticator(
@@ -246,13 +211,12 @@ public final class SamlRealm extends Realm implements Releasable {
             authenticator,
             logoutHandler,
             logoutResponseHandler,
-            idpDescriptor,
+            metadataResolver,
             serviceProvider,
             userAttributeNameConfiguration
         );
 
-        // the metadata resolver needs to be destroyed since it runs a timer task in the background and destroying stops it!
-        realm.releasables.add(() -> metadataResolver.destroy());
+        realm.releasables.add(metadataResolver);
 
         return realm;
     }
@@ -678,223 +642,9 @@ public final class SamlRealm extends Realm implements Releasable {
         listener.onResponse(null);
     }
 
-    static Tuple<AbstractReloadingMetadataResolver, Supplier<EntityDescriptor>> initializeResolver(
-        Logger logger,
-        RealmConfig config,
-        SSLService sslService,
-        ResourceWatcherService watcherService
-    ) throws ResolverException, ComponentInitializationException, IOException {
-        final String metadataUrl = require(config, IDP_METADATA_PATH);
-        if (metadataUrl.startsWith("http://")) {
-            throw new IllegalArgumentException("The [http] protocol is not supported as it is insecure. Use [https] instead");
-        } else if (metadataUrl.startsWith("https://")) {
-            return parseHttpMetadata(metadataUrl, config, sslService);
-        } else {
-            return parseFileSystemMetadata(logger, metadataUrl, config, watcherService);
-        }
-    }
-
-    private static Tuple<AbstractReloadingMetadataResolver, Supplier<EntityDescriptor>> parseHttpMetadata(
-        String metadataUrl,
-        RealmConfig config,
-        SSLService sslService
-    ) throws ResolverException, ComponentInitializationException {
-        final String entityId = require(config, IDP_ENTITY_ID);
-
-        HttpClientBuilder builder = HttpClientBuilder.create();
-        // ssl setup
-        final String sslKey = RealmSettings.realmSslPrefix(config.identifier());
-        final SslProfile sslProfile = sslService.profile(sslKey);
-        final SSLConnectionSocketFactory factory = sslProfile.connectionSocketFactory();
-        builder.setSSLSocketFactory(factory);
-
-        TimeValue connectTimeout = config.getSetting(IDP_METADATA_HTTP_CONNECT_TIMEOUT);
-        TimeValue readTimeout = config.getSetting(IDP_METADATA_HTTP_READ_TIMEOUT);
-        RequestConfig requestConfig = RequestConfig.custom()
-            .setConnectTimeout(Math.toIntExact(connectTimeout.millis()))
-            .setSocketTimeout(Math.toIntExact(readTimeout.millis()))
-            .build();
-        builder.setDefaultRequestConfig(requestConfig);
-
-        TimeValue maxRefresh = config.getSetting(IDP_METADATA_HTTP_REFRESH);
-        TimeValue minRefresh = config.getSetting(IDP_METADATA_HTTP_MIN_REFRESH);
-        if (minRefresh.compareTo(maxRefresh) > 0) {
-            if (config.hasSetting(IDP_METADATA_HTTP_MIN_REFRESH)) {
-                throw new SettingsException(
-                    "the value ({}) for [{}] cannot be greater than the value ({}) for [{}]",
-                    minRefresh.getStringRep(),
-                    RealmSettings.getFullSettingKey(config, IDP_METADATA_HTTP_MIN_REFRESH),
-                    maxRefresh.getStringRep(),
-                    RealmSettings.getFullSettingKey(config, IDP_METADATA_HTTP_REFRESH)
-                );
-            } else {
-                minRefresh = maxRefresh;
-            }
-        }
-
-        HTTPMetadataResolver resolver = new PrivilegedHTTPMetadataResolver(builder.build(), metadataUrl);
-        resolver.setMinRefreshDelay(Duration.ofMillis(minRefresh.millis()));
-        resolver.setMaxRefreshDelay(Duration.ofMillis(maxRefresh.millis()));
-
-        final boolean failOnError = config.getSetting(IDP_METADATA_HTTP_FAIL_ON_ERROR);
-        resolver.setFailFastInitialization(failOnError);
-
-        initialiseResolver(resolver, config);
-
-        // for some reason the resolver supports its own trust engine and custom socket factories.
-        // we do not use these as we'd rather rely on the JDK versions for TLS security!
-        return new Tuple<>(resolver, () -> resolveEntityDescriptor(resolver, entityId, metadataUrl, failOnError));
-    }
-
-    private static final class PrivilegedHTTPMetadataResolver extends HTTPMetadataResolver {
-
-        PrivilegedHTTPMetadataResolver(final HttpClient client, final String metadataURL) throws ResolverException {
-            super(client, metadataURL);
-        }
-
-        @Override
-        protected byte[] fetchMetadata() throws ResolverException {
-            assert assertNotTransportThread("fetching SAML metadata from a URL");
-            return super.fetchMetadata();
-        }
-
-    }
-
-    @SuppressForbidden(reason = "uses java.io.File")
-    private static final class SamlFilesystemMetadataResolver extends FilesystemMetadataResolver {
-
-        SamlFilesystemMetadataResolver(final java.io.File metadata) throws ResolverException {
-            super(metadata);
-        }
-
-        @Override
-        protected byte[] fetchMetadata() throws ResolverException {
-            assert assertNotTransportThread("fetching SAML metadata from a file");
-            return super.fetchMetadata();
-        }
-    }
-
-    @SuppressForbidden(reason = "uses toFile")
-    private static Tuple<AbstractReloadingMetadataResolver, Supplier<EntityDescriptor>> parseFileSystemMetadata(
-        Logger logger,
-        String metadataPath,
-        RealmConfig config,
-        ResourceWatcherService watcherService
-    ) throws ResolverException, ComponentInitializationException, IOException {
-
-        final String entityId = require(config, IDP_ENTITY_ID);
-        final Path path = config.env().configDir().resolve(metadataPath);
-        final FilesystemMetadataResolver resolver = new SamlFilesystemMetadataResolver(path.toFile());
-
-        for (var httpSetting : List.of(
-            IDP_METADATA_HTTP_REFRESH,
-            IDP_METADATA_HTTP_MIN_REFRESH,
-            IDP_METADATA_HTTP_FAIL_ON_ERROR,
-            IDP_METADATA_HTTP_CONNECT_TIMEOUT,
-            IDP_METADATA_HTTP_READ_TIMEOUT
-        )) {
-            if (config.hasSetting(httpSetting.apply(config.type()))) {
-                logger.info(
-                    "Ignoring setting [{}] because the IdP metadata is being loaded from a file",
-                    RealmSettings.getFullSettingKey(config, httpSetting.apply(config.type()))
-                );
-            }
-        }
-
-        // We don't want to rely on the internal OpenSAML refresh timer, but we can't turn it off, so just set it to run once a day.
-        // @TODO : Submit a patch to OpenSAML to optionally disable the timer
-        final Duration oneDayMs = Duration.ofMillis(TimeValue.timeValueHours(24).millis());
-        resolver.setMinRefreshDelay(oneDayMs);
-        resolver.setMaxRefreshDelay(oneDayMs);
-        initialiseResolver(resolver, config);
-
-        FileWatcher watcher = new EntitledFileWatcher(path);
-        watcher.addListener(new FileListener(logger, resolver::refresh));
-        watcherService.add(watcher, ResourceWatcherService.Frequency.MEDIUM);
-        return new Tuple<>(resolver, () -> resolveEntityDescriptor(resolver, entityId, path.toString(), true));
-    }
-
-    private static EntityDescriptor resolveEntityDescriptor(
-        AbstractReloadingMetadataResolver resolver,
-        String entityId,
-        String sourceLocation,
-        boolean failOnError
-    ) {
-        try {
-            final EntityDescriptor descriptor = resolveEntityDescriptorWithPossibleRefresh(resolver, entityId);
-            if (descriptor == null) {
-                if (failOnError) {
-                    throw SamlUtils.samlException("Cannot find metadata for entity [{}] in [{}]", entityId, sourceLocation);
-                } else {
-                    logger.warn(
-                        "cannot load SAML metadata for [{}] from [{}]; SAML authentication for this realm will fail",
-                        entityId,
-                        sourceLocation
-                    );
-                    return new UnresolvedEntity(entityId, sourceLocation);
-                }
-            }
-            return descriptor;
-        } catch (ResolverException e) {
-            throw SamlUtils.samlException("Cannot resolve entity metadata", e);
-        }
-    }
-
-    private static EntityDescriptor resolveEntityDescriptorWithPossibleRefresh(AbstractReloadingMetadataResolver resolver, String entityId)
-        throws ResolverException {
-        var criteria = new CriteriaSet(new EntityIdCriterion(entityId));
-        EntityDescriptor descriptor = resolver.resolveSingle(criteria);
-        if (descriptor == null) {
-            /*
-             * If the descriptor is null, we haven't found a metadata file with that entity id in it. This could be caused by 2 things:
-             * 1. We didn't find any metadata file (e.g. the metadata is loaded over http, and the request returned an error
-             * 2. The file does exist, but doesn't contain the entity.
-             * In either case it's worth refreshing the metadata again to see if it's now correct because it's possible that the problem
-             *    has been resolved (although if metadata is loaded from a local file we monitor it for changes anyway, so this refresh
-             *    is unlikely to have any benefit).
-             * The resolver's refresh method is synchronized, and could be a choke point if there are a lot of concurrent login attempts,
-             *    so we wrap it in a check to only call it on 1 thread. The other threads will fail due to bad metadata, but that's OK
-             *    because the metadata is (was) bad, and if the refresh works, then their next login attempt will also work.
-             * Since the dynamic refresh is a saving mechanism (we have a separate regular poll for refreshes) we prefer it to be safe
-             *    (from a thread contention point of view) rather than perfect (from a user experience point of view).
-             */
-            if (REFRESHING_METADATA.compareAndSet(false, true)) {
-                try {
-                    resolver.refresh();
-                } catch (ResolverException e) {
-                    // Refresh failed. Since there could be a lot of these and it's only a saving mechanism we log as debug
-                    // The resolver itself will log a WARN with the HTTP status etc.
-                    logger.debug(() -> "Failed to refresh SAML metadata for [" + entityId + "]", e);
-                } finally {
-                    REFRESHING_METADATA.compareAndSet(true, false);
-                }
-            }
-            descriptor = resolver.resolveSingle(criteria);
-            if (descriptor != null) {
-                logger.debug(() -> "SAML metadata for [" + entityId + "] has been successfully refreshed");
-            }
-        }
-        return descriptor;
-    }
-
     @Override
     public void close() {
         Releasables.close(releasables);
-    }
-
-    private static void initialiseResolver(AbstractReloadingMetadataResolver resolver, RealmConfig config)
-        throws ComponentInitializationException {
-        resolver.setRequireValidMetadata(true);
-        BasicParserPool pool = new BasicParserPool();
-        pool.initialize();
-        resolver.setParserPool(pool);
-        resolver.setId(config.name());
-        try {
-            resolver.initialize();
-        } catch (ComponentInitializationException e) {
-            resolver.destroy();
-            throw SamlUtils.samlException("cannot load SAML metadata from [{}]", e, config.getSetting(IDP_METADATA_PATH));
-        }
     }
 
     public String serviceProviderEntityId() {
@@ -971,36 +721,6 @@ public final class SamlRealm extends Realm implements Releasable {
 
     public SamlLogoutResponseHandler getLogoutResponseHandler() {
         return logoutResponseHandler;
-    }
-
-    private static class FileListener implements FileChangesListener {
-
-        private final Logger logger;
-        private final CheckedRunnable<Exception> onChange;
-
-        private FileListener(Logger logger, CheckedRunnable<Exception> onChange) {
-            this.logger = logger;
-            this.onChange = onChange;
-        }
-
-        @Override
-        public void onFileCreated(Path file) {
-            onFileChanged(file);
-        }
-
-        @Override
-        public void onFileDeleted(Path file) {
-            onFileChanged(file);
-        }
-
-        @Override
-        public void onFileChanged(Path file) {
-            try {
-                onChange.run();
-            } catch (Exception e) {
-                logger.warn(() -> "An error occurred while reloading file [" + file + "]", e);
-            }
-        }
     }
 
     static final class AttributeParser {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/LogThrottle.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/LogThrottle.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.security.support;
+
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import java.util.function.LongSupplier;
+
+/**
+ * Limits how often an action (such as emitting a log line) may run. Each instance tracks its own window.
+ */
+public final class LogThrottle {
+
+    private final LongSupplier relativeTimeInMillis;
+    private final long periodMs;
+
+    private volatile long lastAcquireMs = -1;
+
+    /**
+     * Constructs a new instance using {@link ThreadPool#relativeTimeInMillis()} as the time source
+     * and {@link TimeValue#millis()} as the period.
+     */
+    public LogThrottle(ThreadPool threadPool, TimeValue period) {
+        this(threadPool::relativeTimeInMillis, period.millis());
+    }
+
+    private LogThrottle(LongSupplier relativeTimeInMillis, long periodMs) {
+        this.relativeTimeInMillis = relativeTimeInMillis;
+        this.periodMs = periodMs;
+    }
+
+    /**
+     * @return {@code true} if the configured period has elapsed since the last {@code true} return
+     *         (or if this is the first time the method has been called);
+     *         updates the internal timestamp when returning {@code true}.
+     *         <p>
+     *         This method is <strong>not</strong> thread safe; concurrent {@code acquire} calls may
+     *         both observe the window as elapsed, or have other races. Use a single-caller
+     *         pattern or external synchronization if a hard guarantee is required.
+     */
+    public boolean acquire() {
+        final long now = relativeTimeInMillis.getAsLong();
+        if (lastAcquireMs < 0 || now - lastAcquireMs > periodMs) {
+            lastAcquireMs = now;
+            return true;
+        }
+        return false;
+    }
+}

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/saml/TransportSamlLogoutActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/saml/TransportSamlLogoutActionTests.java
@@ -41,7 +41,6 @@ import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.Transport;
 import org.elasticsearch.transport.TransportService;
-import org.elasticsearch.watcher.ResourceWatcherService;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.security.SecurityContext;
 import org.elasticsearch.xpack.core.security.action.saml.SamlLogoutRequest;
@@ -251,8 +250,9 @@ public class TransportSamlLogoutActionTests extends SamlTestCase {
         final RealmConfig realmConfig = new RealmConfig(realmIdentifier, settings, env, threadContext);
         samlRealm = SamlRealm.create(
             realmConfig,
+            threadPool,
             mock(SSLService.class),
-            mock(ResourceWatcherService.class),
+            mockResourceWatcherService(),
             mock(UserRoleMapper.class),
             SingleSamlSpConfiguration.create(realmConfig)
         );

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/InternalRealmsTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/InternalRealmsTests.java
@@ -15,8 +15,8 @@ import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.license.License;
 import org.elasticsearch.license.LicensedFeature;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.watcher.ResourceWatcherService;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.security.authc.InternalRealmsSettings;
 import org.elasticsearch.xpack.core.security.authc.Realm;
@@ -38,9 +38,12 @@ import org.elasticsearch.xpack.core.ssl.SSLService;
 import org.elasticsearch.xpack.security.authc.esnative.NativeUsersStore;
 import org.elasticsearch.xpack.security.authc.saml.SamlRealm;
 import org.elasticsearch.xpack.security.authc.saml.SamlRealmTests;
+import org.elasticsearch.xpack.security.authc.saml.SamlTestCase;
 import org.elasticsearch.xpack.security.authc.support.mapper.NativeRoleMappingStore;
 import org.elasticsearch.xpack.security.support.SecurityIndexManager;
 import org.hamcrest.Matchers;
+import org.junit.After;
+import org.junit.Before;
 
 import java.nio.file.Path;
 import java.util.Map;
@@ -62,13 +65,25 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 public class InternalRealmsTests extends ESTestCase {
 
+    private ThreadPool threadPool;
+
+    @Before
+    public void createThreadPool() {
+        threadPool = new TestThreadPool(getTestName());
+    }
+
+    @After
+    public void stopThreadPool() {
+        terminate(threadPool);
+    }
+
     @SuppressWarnings("unchecked")
     public void testNativeRealmRegistersIndexHealthChangeListener() throws Exception {
         SecurityIndexManager securityIndex = mock(SecurityIndexManager.class);
         Map<String, Realm.Factory> factories = InternalRealms.getFactories(
-            mock(ThreadPool.class),
+            threadPool,
             Settings.EMPTY,
-            mock(ResourceWatcherService.class),
+            SamlTestCase.mockResourceWatcherService(),
             mock(SSLService.class),
             mock(NativeUsersStore.class),
             mock(NativeRoleMappingStore.class),
@@ -94,9 +109,9 @@ public class InternalRealmsTests extends ESTestCase {
     public void testRealmsRegisterForRefreshAtRoleMapper() throws Exception {
         UserRoleMapper userRoleMapper = mock(UserRoleMapper.class);
         Map<String, Realm.Factory> factories = InternalRealms.getFactories(
-            mock(ThreadPool.class),
+            threadPool,
             Settings.EMPTY,
-            mock(ResourceWatcherService.class),
+            SamlTestCase.mockResourceWatcherService(),
             mock(SSLService.class),
             mock(NativeUsersStore.class),
             userRoleMapper,

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlMetadataResolverTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlMetadataResolverTests.java
@@ -1,0 +1,364 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.security.authc.saml;
+
+import org.elasticsearch.ElasticsearchSecurityException;
+import org.elasticsearch.common.settings.MockSecureSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.core.Tuple;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.env.TestEnvironment;
+import org.elasticsearch.test.http.MockResponse;
+import org.elasticsearch.test.http.MockWebServer;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.watcher.ResourceWatcherService;
+import org.elasticsearch.xpack.core.XPackSettings;
+import org.elasticsearch.xpack.core.security.authc.RealmConfig;
+import org.elasticsearch.xpack.core.security.authc.RealmSettings;
+import org.elasticsearch.xpack.core.security.authc.saml.SamlRealmSettings;
+import org.elasticsearch.xpack.core.security.authc.saml.SingleSpSamlRealmSettings;
+import org.elasticsearch.xpack.core.ssl.SSLService;
+import org.elasticsearch.xpack.core.ssl.TestsSSLService;
+import org.junit.Before;
+import org.opensaml.saml.common.xml.SAMLConstants;
+import org.opensaml.saml.saml2.metadata.EntityDescriptor;
+import org.opensaml.saml.saml2.metadata.IDPSSODescriptor;
+import org.opensaml.saml.saml2.metadata.SingleSignOnService;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import static org.elasticsearch.test.TestMatchers.throwableWithMessage;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Unit tests for {@link SamlMetadataResolver}.
+ */
+public class SamlMetadataResolverTests extends SamlTestCase {
+
+    private static final String REALM_NAME = "my-saml";
+    private static final String REALM_SETTINGS_PREFIX = "xpack.security.authc.realms.saml." + REALM_NAME;
+    private static final String TEST_IDP_ENTITY_ID = "http://demo_josso_1.josso.dev.docker:8081/IDBUS/JOSSO-TUTORIAL/IDP1/SAML2/MD";
+    private static final TimeValue METADATA_REFRESH = TimeValue.timeValueMillis(3000);
+
+    private Settings globalSettings;
+    private TestThreadPool threadPool;
+
+    @Before
+    public void setupEnv() throws Exception {
+        SamlUtils.initialize(logger);
+        globalSettings = Settings.builder().put("path.home", createTempDir()).build();
+        threadPool = new TestThreadPool("saml-metadata-resolver-tests", globalSettings);
+    }
+
+    @org.junit.After
+    public void shutdownThreadPool() {
+        if (threadPool != null) {
+            terminate(threadPool);
+        }
+    }
+
+    public void testReadIdpMetadataFromFile() throws Exception {
+        final Path path = getDataPath("idp1.xml");
+        Tuple<RealmConfig, SSLService> config = buildConfig(path.toString());
+        final ResourceWatcherService watcherService = mockResourceWatcherService();
+        try (SamlMetadataResolver resolver = SamlMetadataResolver.create(config.v1(), config.v2(), watcherService, threadPool)) {
+            assertIdp1MetadataParsedCorrectly(resolver.get());
+        }
+    }
+
+    public void testReadIdpMetadataFromHttps() throws Exception {
+        final Path path = getDataPath("idp1.xml");
+        final String body = Files.readString(path);
+        TestsSSLService sslService = buildTestSslService();
+        try (MockWebServer proxyServer = new MockWebServer(sslService.sslContext("xpack.security.http.ssl"), false)) {
+            proxyServer.start();
+            proxyServer.enqueue(new MockResponse().setResponseCode(200).setBody(body).addHeader("Content-Type", "application/xml"));
+            proxyServer.enqueue(new MockResponse().setResponseCode(200).setBody(body).addHeader("Content-Type", "application/xml"));
+            assertEquals(0, proxyServer.requests().size());
+
+            Tuple<RealmConfig, SSLService> config = buildConfig("https://localhost:" + proxyServer.getPort());
+            logger.info("Settings\n{}", config.v1().settings().toDelimitedString('\n'));
+            final ResourceWatcherService watcherService = mock(ResourceWatcherService.class);
+            try (SamlMetadataResolver resolver = SamlMetadataResolver.create(config.v1(), config.v2(), watcherService, threadPool)) {
+                assertThat(proxyServer.requests().size(), greaterThanOrEqualTo(1));
+                assertIdp1MetadataParsedCorrectly(resolver.get());
+            }
+        }
+    }
+
+    public void testFailOnErrorForInvalidHttpsMetadata() throws Exception {
+        TestsSSLService sslService = buildTestSslService();
+        try (MockWebServer webServer = new MockWebServer(sslService.sslContext("xpack.security.http.ssl"), false)) {
+            webServer.start();
+            webServer.enqueue(
+                new MockResponse().setResponseCode(randomIntBetween(400, 405))
+                    .setBody("No metadata available")
+                    .addHeader("Content-Type", "text/plain")
+            );
+            assertEquals(0, webServer.requests().size());
+
+            var metadataPath = "https://localhost:" + webServer.getPort();
+            final Tuple<RealmConfig, SSLService> config = buildConfig(
+                metadataPath,
+                settings -> settings.put(
+                    SingleSpSamlRealmSettings.getFullSettingKey(REALM_NAME, SamlRealmSettings.IDP_METADATA_HTTP_FAIL_ON_ERROR),
+                    true
+                )
+            );
+            final ResourceWatcherService watcherService = mock(ResourceWatcherService.class);
+            var exception = expectThrows(
+                ElasticsearchSecurityException.class,
+                () -> SamlMetadataResolver.create(config.v1(), config.v2(), watcherService, threadPool)
+            );
+            assertThat(exception, throwableWithMessage("cannot load SAML metadata from [" + metadataPath + "]"));
+        }
+    }
+
+    public void testRetryFailedHttpsMetadata() throws Exception {
+        final Path path = getDataPath("idp1.xml");
+        final String body = Files.readString(path);
+        TestsSSLService sslService = buildTestSslService();
+        doTestReloadFailedHttpsMetadata(body, sslService, true);
+        doTestReloadFailedHttpsMetadata(body, sslService, false);
+    }
+
+    /**
+     * @param testBackgroundRefresh If {@code true}, the test asserts that the metadata is automatically loaded in the background.
+     *                              If {@code false}, the test triggers activity on the realm to force a reload of the metadata.
+     */
+    private void doTestReloadFailedHttpsMetadata(String metadataBody, TestsSSLService sslService, boolean testBackgroundRefresh)
+        throws Exception {
+        try (MockWebServer webServer = new MockWebServer(sslService.sslContext("xpack.security.http.ssl"), false)) {
+            webServer.start();
+            webServer.enqueue(
+                new MockResponse().setResponseCode(randomIntBetween(400, 405))
+                    .setBody("No metadata available")
+                    .addHeader("Content-Type", "text/plain")
+            );
+            assertEquals(0, webServer.requests().size());
+
+            // Even with a long refresh we should automatically retry metadata that fails
+            final TimeValue defaultRefreshTime = TimeValue.timeValueHours(24);
+            // OpenSAML (4.0) has a bug that can attempt to set negative duration timers if the refresh is too short.
+            // Don't set this too small or we may hit "java.lang.IllegalArgumentException: Negative delay."
+            final TimeValue minimumRefreshTime = testBackgroundRefresh ? TimeValue.timeValueMillis(500) : defaultRefreshTime;
+
+            final Tuple<RealmConfig, SSLService> config = buildConfig("https://localhost:" + webServer.getPort(), builder -> {
+                builder.put(
+                    SingleSpSamlRealmSettings.getFullSettingKey(REALM_NAME, SamlRealmSettings.IDP_METADATA_HTTP_REFRESH),
+                    defaultRefreshTime.getStringRep()
+                );
+                builder.put(
+                    SingleSpSamlRealmSettings.getFullSettingKey(REALM_NAME, SamlRealmSettings.IDP_METADATA_HTTP_MIN_REFRESH),
+                    minimumRefreshTime.getStringRep()
+                );
+                if (randomBoolean()) {
+                    builder.put(
+                        SingleSpSamlRealmSettings.getFullSettingKey(REALM_NAME, SamlRealmSettings.IDP_METADATA_HTTP_FAIL_ON_ERROR),
+                        false
+                    );
+                }
+            });
+            logger.info("Settings\n{}", config.v1().settings().toDelimitedString('\n'));
+            final ResourceWatcherService watcherService = mock(ResourceWatcherService.class);
+            try (SamlMetadataResolver resolver = SamlMetadataResolver.create(config.v1(), config.v2(), watcherService, threadPool)) {
+                final int firstRequestCount = webServer.requests().size();
+                assertThat(firstRequestCount, greaterThanOrEqualTo(1));
+                assertThat(resolver.get(), instanceOf(UnresolvedEntity.class));
+
+                webServer.enqueue(
+                    new MockResponse().setResponseCode(200).setBody(metadataBody).addHeader("Content-Type", "application/xml")
+                );
+
+                // This would typically run in the background (via a scheduled task every 60s)
+                // but we don't want the test to wait that long, so we force it
+                resolver.asyncUpdateCachedDescriptor();
+
+                assertBusy(() -> assertIdp1MetadataParsedCorrectly(resolver.get()), 3, TimeUnit.SECONDS);
+            }
+        }
+    }
+
+    public void testHttpMetadataWithCustomTimeouts() throws Exception {
+        final Path path = getDataPath("idp1.xml");
+        final String body = Files.readString(path);
+        TestsSSLService sslService = buildTestSslService();
+        try (MockWebServer proxyServer = new MockWebServer(sslService.sslContext("xpack.security.http.ssl"), false)) {
+            proxyServer.start();
+            proxyServer.enqueue(new MockResponse().setResponseCode(200).setBody(body).addHeader("Content-Type", "application/xml"));
+
+            final TimeValue customConnectTimeout = TimeValue.timeValueSeconds(3);
+            final TimeValue customReadTimeout = TimeValue.timeValueSeconds(15);
+
+            Tuple<RealmConfig, SSLService> config = buildConfig("https://localhost:" + proxyServer.getPort(), builder -> {
+                builder.put(
+                    SingleSpSamlRealmSettings.getFullSettingKey(REALM_NAME, SamlRealmSettings.IDP_METADATA_HTTP_CONNECT_TIMEOUT),
+                    customConnectTimeout.getStringRep()
+                );
+                builder.put(
+                    SingleSpSamlRealmSettings.getFullSettingKey(REALM_NAME, SamlRealmSettings.IDP_METADATA_HTTP_READ_TIMEOUT),
+                    customReadTimeout.getStringRep()
+                );
+            });
+
+            // Verify settings are correctly configured
+            assertThat(config.v1().getSetting(SamlRealmSettings.IDP_METADATA_HTTP_CONNECT_TIMEOUT), equalTo(customConnectTimeout));
+            assertThat(config.v1().getSetting(SamlRealmSettings.IDP_METADATA_HTTP_READ_TIMEOUT), equalTo(customReadTimeout));
+
+            final ResourceWatcherService watcherService = mock(ResourceWatcherService.class);
+            try (SamlMetadataResolver resolver = SamlMetadataResolver.create(config.v1(), config.v2(), watcherService, threadPool)) {
+                assertThat(proxyServer.requests().size(), greaterThanOrEqualTo(1));
+                assertIdp1MetadataParsedCorrectly(resolver.get());
+            }
+        }
+    }
+
+    public void testHttpMetadataWithDefaultTimeouts() throws Exception {
+        final Path path = getDataPath("idp1.xml");
+        final String body = Files.readString(path);
+        TestsSSLService sslService = buildTestSslService();
+        try (MockWebServer proxyServer = new MockWebServer(sslService.sslContext("xpack.security.http.ssl"), false)) {
+            proxyServer.start();
+            proxyServer.enqueue(new MockResponse().setResponseCode(200).setBody(body).addHeader("Content-Type", "application/xml"));
+
+            Tuple<RealmConfig, SSLService> config = buildConfig("https://localhost:" + proxyServer.getPort());
+
+            // Verify default timeout values are used
+            assertThat(config.v1().getSetting(SamlRealmSettings.IDP_METADATA_HTTP_CONNECT_TIMEOUT), equalTo(TimeValue.timeValueSeconds(5)));
+            assertThat(config.v1().getSetting(SamlRealmSettings.IDP_METADATA_HTTP_READ_TIMEOUT), equalTo(TimeValue.timeValueSeconds(10)));
+
+            final ResourceWatcherService watcherService = mock(ResourceWatcherService.class);
+            try (SamlMetadataResolver resolver = SamlMetadataResolver.create(config.v1(), config.v2(), watcherService, threadPool)) {
+                assertThat(proxyServer.requests().size(), greaterThanOrEqualTo(1));
+                assertIdp1MetadataParsedCorrectly(resolver.get());
+            }
+        }
+    }
+
+    public void testHttpMetadataConnectionTimeout() throws Exception {
+        // Use a non-routable IP address to simulate connection timeout
+        // 192.0.2.1 is reserved for documentation and will not be routable
+        final String unreachableUrl = "https://192.0.2.1:9999/metadata.xml";
+        final TimeValue shortConnectTimeout = TimeValue.timeValueMillis(100);
+
+        Tuple<RealmConfig, SSLService> config = buildConfig(unreachableUrl, builder -> {
+            builder.put(
+                SingleSpSamlRealmSettings.getFullSettingKey(REALM_NAME, SamlRealmSettings.IDP_METADATA_HTTP_CONNECT_TIMEOUT),
+                shortConnectTimeout.getStringRep()
+            );
+            builder.put(SingleSpSamlRealmSettings.getFullSettingKey(REALM_NAME, SamlRealmSettings.IDP_METADATA_HTTP_FAIL_ON_ERROR), false);
+        });
+
+        final ResourceWatcherService watcherService = mock(ResourceWatcherService.class);
+
+        // initialization should complete even though the connection fails
+        try (SamlMetadataResolver resolver = SamlMetadataResolver.create(config.v1(), config.v2(), watcherService, threadPool)) {
+            EntityDescriptor descriptor = resolver.get();
+            assertThat(descriptor, instanceOf(UnresolvedEntity.class));
+        }
+    }
+
+    private Tuple<RealmConfig, SSLService> buildConfig(String idpMetadataPath) {
+        return buildConfig(idpMetadataPath, ignore -> {});
+    }
+
+    private Tuple<RealmConfig, SSLService> buildConfig(String idpMetadataPath, Consumer<Settings.Builder> additionalSettings) {
+        var settings = buildSettings(idpMetadataPath);
+        additionalSettings.accept(settings);
+        final RealmConfig config = realmConfigFromGlobalSettings(settings.build());
+        final SSLService sslService = new SSLService(config.env());
+        return new Tuple<>(config, sslService);
+    }
+
+    private Settings.Builder buildSettings(String idpMetadataPath) {
+        MockSecureSettings secureSettings = new MockSecureSettings();
+        final String realmType = SingleSpSamlRealmSettings.TYPE;
+        secureSettings.setString(REALM_SETTINGS_PREFIX + ".ssl.secure_key_passphrase", "testnode");
+        return Settings.builder()
+            .put(REALM_SETTINGS_PREFIX + ".ssl.verification_mode", "certificate")
+            .put(
+                REALM_SETTINGS_PREFIX + ".ssl.key",
+                getDataPath("/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.pem")
+            )
+            .put(
+                REALM_SETTINGS_PREFIX + ".ssl.certificate",
+                getDataPath("/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.crt")
+            )
+            .put(
+                REALM_SETTINGS_PREFIX + ".ssl.certificate_authorities",
+                getDataPath("/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.crt")
+            )
+            .put(SingleSpSamlRealmSettings.getFullSettingKey(REALM_NAME, SamlRealmSettings.IDP_METADATA_PATH), idpMetadataPath)
+            .put(SingleSpSamlRealmSettings.getFullSettingKey(REALM_NAME, SamlRealmSettings.IDP_ENTITY_ID), TEST_IDP_ENTITY_ID)
+            .put(
+                SingleSpSamlRealmSettings.getFullSettingKey(REALM_NAME, SamlRealmSettings.IDP_METADATA_HTTP_REFRESH),
+                METADATA_REFRESH.getStringRep()
+            )
+            .put(RealmSettings.getFullSettingKey(REALM_NAME, SamlRealmSettings.PRINCIPAL_ATTRIBUTE.apply(realmType).getAttribute()), "uid")
+            .put(XPackSettings.TOKEN_SERVICE_ENABLED_SETTING.getKey(), true)
+            .put("path.home", createTempDir())
+            .setSecureSettings(secureSettings);
+    }
+
+    private RealmConfig realmConfigFromGlobalSettings(Settings globalSettings) {
+        final Environment env = TestEnvironment.newEnvironment(globalSettings);
+        final RealmConfig.RealmIdentifier realmIdentifier = new RealmConfig.RealmIdentifier("saml", REALM_NAME);
+        return new RealmConfig(
+            realmIdentifier,
+            Settings.builder()
+                .put(globalSettings)
+                .put(RealmSettings.getFullSettingKey(realmIdentifier, RealmSettings.ORDER_SETTING), 0)
+                .build(),
+            env,
+            new org.elasticsearch.common.util.concurrent.ThreadContext(globalSettings)
+        );
+    }
+
+    private TestsSSLService buildTestSslService() throws IOException {
+        final MockSecureSettings mockSecureSettings = new MockSecureSettings();
+        mockSecureSettings.setString("xpack.security.http.ssl.secure_key_passphrase", "testnode");
+        final Settings settings = Settings.builder()
+            .put("xpack.security.http.ssl.enabled", true)
+            .put("xpack.security.http.ssl.key", getDataPath("/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.pem"))
+            .put(
+                "xpack.security.http.ssl.certificate",
+                getDataPath("/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.crt")
+            )
+            .put(
+                "xpack.security.http.ssl.certificate_authorities",
+                getDataPath("/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.crt")
+            )
+            .putList("xpack.security.http.ssl.supported_protocols", XPackSettings.DEFAULT_SUPPORTED_PROTOCOLS)
+            .put("path.home", createTempDir())
+            .setSecureSettings(mockSecureSettings)
+            .build();
+        return new TestsSSLService(TestEnvironment.newEnvironment(settings));
+    }
+
+    private void assertIdp1MetadataParsedCorrectly(EntityDescriptor descriptor) {
+        try {
+            IDPSSODescriptor idpssoDescriptor = descriptor.getIDPSSODescriptor(SAMLConstants.SAML20P_NS);
+            assertNotNull(idpssoDescriptor);
+            List<SingleSignOnService> ssoServices = idpssoDescriptor.getSingleSignOnServices();
+            assertEquals(2, ssoServices.size());
+            assertEquals(SAMLConstants.SAML2_POST_BINDING_URI, ssoServices.get(0).getBinding());
+            assertEquals(SAMLConstants.SAML2_REDIRECT_BINDING_URI, ssoServices.get(1).getBinding());
+        } catch (ElasticsearchSecurityException e) {
+            // Convert a SAML exception into an assertion failure so that we can `assertBusy` on these checks
+            throw new AssertionError("Failed to retrieve IdP metadata", e);
+        }
+    }
+}

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlRealmTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlRealmTests.java
@@ -21,8 +21,6 @@ import org.elasticsearch.core.Tuple;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.license.MockLicenseState;
-import org.elasticsearch.test.http.MockResponse;
-import org.elasticsearch.test.http.MockWebServer;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.watcher.FileWatcher;
 import org.elasticsearch.watcher.ResourceWatcherService;
@@ -47,7 +45,6 @@ import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.mockito.Mockito;
 import org.opensaml.saml.common.xml.SAMLConstants;
-import org.opensaml.saml.metadata.resolver.impl.AbstractReloadingMetadataResolver;
 import org.opensaml.saml.saml2.core.LogoutRequest;
 import org.opensaml.saml.saml2.core.NameID;
 import org.opensaml.saml.saml2.core.NameIDType;
@@ -78,7 +75,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import static org.elasticsearch.core.Strings.format;
@@ -93,8 +89,6 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -121,6 +115,7 @@ public class SamlRealmTests extends SamlTestCase {
     private Settings globalSettings;
     private Environment env;
     private ThreadContext threadContext;
+    private TestThreadPool threadPool;
 
     @Before
     public void setupEnv() throws Exception {
@@ -128,156 +123,13 @@ public class SamlRealmTests extends SamlTestCase {
         globalSettings = Settings.builder().put("path.home", createTempDir()).build();
         env = TestEnvironment.newEnvironment(globalSettings);
         threadContext = new ThreadContext(globalSettings);
+        threadPool = new TestThreadPool("saml-realm-tests", globalSettings);
     }
 
-    public void testReadIdpMetadataFromFile() throws Exception {
-        final Path path = getDataPath("idp1.xml");
-        Tuple<RealmConfig, SSLService> config = buildConfig(path.toString());
-        final ResourceWatcherService watcherService = mock(ResourceWatcherService.class);
-        Tuple<AbstractReloadingMetadataResolver, Supplier<EntityDescriptor>> tuple = SamlRealm.initializeResolver(
-            logger,
-            config.v1(),
-            config.v2(),
-            watcherService
-        );
-        try {
-            assertIdp1MetadataParsedCorrectly(tuple.v2().get());
-        } finally {
-            tuple.v1().destroy();
-        }
-    }
-
-    public void testReadIdpMetadataFromHttps() throws Exception {
-        final Path path = getDataPath("idp1.xml");
-        final String body = Files.readString(path);
-        TestsSSLService sslService = buildTestSslService();
-        try (MockWebServer proxyServer = new MockWebServer(sslService.sslContext("xpack.security.http.ssl"), false)) {
-            proxyServer.start();
-            proxyServer.enqueue(new MockResponse().setResponseCode(200).setBody(body).addHeader("Content-Type", "application/xml"));
-            proxyServer.enqueue(new MockResponse().setResponseCode(200).setBody(body).addHeader("Content-Type", "application/xml"));
-            assertEquals(0, proxyServer.requests().size());
-
-            Tuple<RealmConfig, SSLService> config = buildConfig("https://localhost:" + proxyServer.getPort());
-            logger.info("Settings\n{}", config.v1().settings().toDelimitedString('\n'));
-            final ResourceWatcherService watcherService = mock(ResourceWatcherService.class);
-            Tuple<AbstractReloadingMetadataResolver, Supplier<EntityDescriptor>> tuple = SamlRealm.initializeResolver(
-                logger,
-                config.v1(),
-                config.v2(),
-                watcherService
-            );
-
-            try {
-                final int firstRequestCount = proxyServer.requests().size();
-                assertThat(firstRequestCount, greaterThanOrEqualTo(1));
-                assertIdp1MetadataParsedCorrectly(tuple.v2().get());
-                assertBusy(() -> assertThat(proxyServer.requests().size(), greaterThan(firstRequestCount)));
-            } finally {
-                tuple.v1().destroy();
-            }
-        }
-    }
-
-    public void testFailOnErrorForInvalidHttpsMetadata() throws Exception {
-        TestsSSLService sslService = buildTestSslService();
-        try (MockWebServer webServer = new MockWebServer(sslService.sslContext("xpack.security.http.ssl"), false)) {
-            webServer.start();
-            webServer.enqueue(
-                new MockResponse().setResponseCode(randomIntBetween(400, 405))
-                    .setBody("No metadata available")
-                    .addHeader("Content-Type", "text/plain")
-            );
-            assertEquals(0, webServer.requests().size());
-
-            var metadataPath = "https://localhost:" + webServer.getPort();
-            final Tuple<RealmConfig, SSLService> config = buildConfig(
-                metadataPath,
-                settings -> settings.put(
-                    SingleSpSamlRealmSettings.getFullSettingKey(REALM_NAME, SamlRealmSettings.IDP_METADATA_HTTP_FAIL_ON_ERROR),
-                    true
-                )
-            );
-            final ResourceWatcherService watcherService = mock(ResourceWatcherService.class);
-            var exception = expectThrows(
-                ElasticsearchSecurityException.class,
-                () -> SamlRealm.initializeResolver(logger, config.v1(), config.v2(), watcherService)
-            );
-            assertThat(exception, throwableWithMessage("cannot load SAML metadata from [" + metadataPath + "]"));
-        }
-    }
-
-    public void testRetryFailedHttpsMetadata() throws Exception {
-        final Path path = getDataPath("idp1.xml");
-        final String body = Files.readString(path);
-        TestsSSLService sslService = buildTestSslService();
-        doTestReloadFailedHttpsMetadata(body, sslService, true);
-        doTestReloadFailedHttpsMetadata(body, sslService, false);
-    }
-
-    /**
-     * @param testBackgroundRefresh If {@code true}, the test asserts that the metadata is automatically loaded in the background.
-     *                              If {@code false}, the test triggers activity on the realm to force a reload of the metadata.
-     */
-    private void doTestReloadFailedHttpsMetadata(String metadataBody, TestsSSLService sslService, boolean testBackgroundRefresh)
-        throws Exception {
-        try (MockWebServer webServer = new MockWebServer(sslService.sslContext("xpack.security.http.ssl"), false)) {
-            webServer.start();
-            webServer.enqueue(
-                new MockResponse().setResponseCode(randomIntBetween(400, 405))
-                    .setBody("No metadata available")
-                    .addHeader("Content-Type", "text/plain")
-            );
-            assertEquals(0, webServer.requests().size());
-
-            // Even with a long refresh we should automatically retry metadata that fails
-            final TimeValue defaultRefreshTime = TimeValue.timeValueHours(24);
-            // OpenSAML (4.0) has a bug that can attempt to set negative duration timers if the refresh is too short.
-            // Don't set this too small or we may hit "java.lang.IllegalArgumentException: Negative delay."
-            final TimeValue minimumRefreshTime = testBackgroundRefresh ? TimeValue.timeValueMillis(500) : defaultRefreshTime;
-
-            final Tuple<RealmConfig, SSLService> config = buildConfig("https://localhost:" + webServer.getPort(), builder -> {
-                builder.put(
-                    SingleSpSamlRealmSettings.getFullSettingKey(REALM_NAME, SamlRealmSettings.IDP_METADATA_HTTP_REFRESH),
-                    defaultRefreshTime.getStringRep()
-                );
-                builder.put(
-                    SingleSpSamlRealmSettings.getFullSettingKey(REALM_NAME, SamlRealmSettings.IDP_METADATA_HTTP_MIN_REFRESH),
-                    minimumRefreshTime.getStringRep()
-                );
-                if (randomBoolean()) {
-                    builder.put(
-                        SingleSpSamlRealmSettings.getFullSettingKey(REALM_NAME, SamlRealmSettings.IDP_METADATA_HTTP_FAIL_ON_ERROR),
-                        false
-                    );
-                }
-            });
-            logger.info("Settings\n{}", config.v1().settings().toDelimitedString('\n'));
-            final ResourceWatcherService watcherService = mock(ResourceWatcherService.class);
-            Tuple<AbstractReloadingMetadataResolver, Supplier<EntityDescriptor>> tuple = SamlRealm.initializeResolver(
-                logger,
-                config.v1(),
-                config.v2(),
-                watcherService
-            );
-
-            try {
-                final int firstRequestCount = webServer.requests().size();
-                assertThat(firstRequestCount, greaterThanOrEqualTo(1));
-                assertThat(tuple.v2().get(), instanceOf(UnresolvedEntity.class));
-
-                webServer.enqueue(
-                    new MockResponse().setResponseCode(200).setBody(metadataBody).addHeader("Content-Type", "application/xml")
-                );
-                if (testBackgroundRefresh) {
-                    assertBusy(() -> assertThat(webServer.requests().size(), greaterThan(firstRequestCount)), 2, TimeUnit.SECONDS);
-                } else {
-                    // The Supplier.get() call will trigger a reload anyway
-                }
-                assertBusy(() -> assertIdp1MetadataParsedCorrectly(tuple.v2().get()), 3, TimeUnit.SECONDS);
-
-            } finally {
-                tuple.v1().destroy();
-            }
+    @org.junit.After
+    public void shutdownThreadPool() {
+        if (threadPool != null) {
+            terminate(threadPool);
         }
     }
 
@@ -299,6 +151,7 @@ public class SamlRealmTests extends SamlTestCase {
             SettingsException.class,
             () -> SamlRealm.create(
                 config,
+                threadPool,
                 sslService,
                 mock(ResourceWatcherService.class),
                 mock(UserRoleMapper.class),
@@ -351,6 +204,7 @@ public class SamlRealmTests extends SamlTestCase {
             IllegalArgumentException.class,
             () -> SamlRealm.create(
                 config,
+                threadPool,
                 sslService,
                 mock(ResourceWatcherService.class),
                 mock(UserRoleMapper.class),
@@ -1451,15 +1305,11 @@ public class SamlRealmTests extends SamlTestCase {
                 .build();
             try (ResourceWatcherService watcherService = new ResourceWatcherService(resourceWatcherSettings, testThreadPool)) {
                 Tuple<RealmConfig, SSLService> config = buildConfig(realmMetadataPath.toString());
-                Tuple<AbstractReloadingMetadataResolver, Supplier<EntityDescriptor>> tuple = SamlRealm.initializeResolver(
-                    logger,
-                    config.v1(),
-                    config.v2(),
-                    watcherService
-                );
-                try {
-                    assertIdp1MetadataParsedCorrectly(tuple.v2().get());
-                    final IdpConfiguration idpConf = SamlRealm.getIdpConfiguration(realmConfig, tuple.v1(), tuple.v2());
+                try (
+                    SamlMetadataResolver resolver = SamlMetadataResolver.create(config.v1(), config.v2(), watcherService, testThreadPool)
+                ) {
+                    assertIdp1MetadataParsedCorrectly(resolver.get());
+                    final IdpConfiguration idpConf = SamlRealm.getIdpConfiguration(realmConfig, resolver.getResolver(), resolver);
 
                     // Trigger initialized log message
                     final List<PublicKey> keys1 = idpConf.getSigningCredentials().stream().map(Credential::getPublicKey).toList();
@@ -1485,12 +1335,10 @@ public class SamlRealmTests extends SamlTestCase {
                     assertThat(Files.readString(realmMetadataPath), is(equalTo(Files.readString(updatedMetadataPath))));
                     final List<PublicKey> keys3 = idpConf.getSigningCredentials().stream().map(Credential::getPublicKey).toList();
                     assertThat(keys1, is(equalTo(keys3)));
-                } finally {
-                    tuple.v1().destroy();
                 }
             }
         } finally {
-            testThreadPool.shutdown();
+            terminate(testThreadPool);
         }
     }
 
@@ -1587,112 +1435,6 @@ public class SamlRealmTests extends SamlTestCase {
             .setSecureSettings(mockSecureSettings)
             .build();
         return new TestsSSLService(TestEnvironment.newEnvironment(settings));
-    }
-
-    public void testHttpMetadataWithCustomTimeouts() throws Exception {
-        final Path path = getDataPath("idp1.xml");
-        final String body = Files.readString(path);
-        TestsSSLService sslService = buildTestSslService();
-        try (MockWebServer proxyServer = new MockWebServer(sslService.sslContext("xpack.security.http.ssl"), false)) {
-            proxyServer.start();
-            proxyServer.enqueue(new MockResponse().setResponseCode(200).setBody(body).addHeader("Content-Type", "application/xml"));
-
-            final TimeValue customConnectTimeout = TimeValue.timeValueSeconds(3);
-            final TimeValue customReadTimeout = TimeValue.timeValueSeconds(15);
-
-            Tuple<RealmConfig, SSLService> config = buildConfig("https://localhost:" + proxyServer.getPort(), builder -> {
-                builder.put(
-                    SingleSpSamlRealmSettings.getFullSettingKey(REALM_NAME, SamlRealmSettings.IDP_METADATA_HTTP_CONNECT_TIMEOUT),
-                    customConnectTimeout.getStringRep()
-                );
-                builder.put(
-                    SingleSpSamlRealmSettings.getFullSettingKey(REALM_NAME, SamlRealmSettings.IDP_METADATA_HTTP_READ_TIMEOUT),
-                    customReadTimeout.getStringRep()
-                );
-            });
-
-            // Verify settings are correctly configured
-            assertThat(config.v1().getSetting(SamlRealmSettings.IDP_METADATA_HTTP_CONNECT_TIMEOUT), equalTo(customConnectTimeout));
-            assertThat(config.v1().getSetting(SamlRealmSettings.IDP_METADATA_HTTP_READ_TIMEOUT), equalTo(customReadTimeout));
-
-            final ResourceWatcherService watcherService = mock(ResourceWatcherService.class);
-            Tuple<AbstractReloadingMetadataResolver, Supplier<EntityDescriptor>> tuple = SamlRealm.initializeResolver(
-                logger,
-                config.v1(),
-                config.v2(),
-                watcherService
-            );
-
-            try {
-                assertThat(proxyServer.requests().size(), greaterThanOrEqualTo(1));
-                assertIdp1MetadataParsedCorrectly(tuple.v2().get());
-            } finally {
-                tuple.v1().destroy();
-            }
-        }
-    }
-
-    public void testHttpMetadataWithDefaultTimeouts() throws Exception {
-        final Path path = getDataPath("idp1.xml");
-        final String body = Files.readString(path);
-        TestsSSLService sslService = buildTestSslService();
-        try (MockWebServer proxyServer = new MockWebServer(sslService.sslContext("xpack.security.http.ssl"), false)) {
-            proxyServer.start();
-            proxyServer.enqueue(new MockResponse().setResponseCode(200).setBody(body).addHeader("Content-Type", "application/xml"));
-
-            Tuple<RealmConfig, SSLService> config = buildConfig("https://localhost:" + proxyServer.getPort());
-
-            // Verify default timeout values are used
-            assertThat(config.v1().getSetting(SamlRealmSettings.IDP_METADATA_HTTP_CONNECT_TIMEOUT), equalTo(TimeValue.timeValueSeconds(5)));
-            assertThat(config.v1().getSetting(SamlRealmSettings.IDP_METADATA_HTTP_READ_TIMEOUT), equalTo(TimeValue.timeValueSeconds(10)));
-
-            final ResourceWatcherService watcherService = mock(ResourceWatcherService.class);
-            Tuple<AbstractReloadingMetadataResolver, Supplier<EntityDescriptor>> tuple = SamlRealm.initializeResolver(
-                logger,
-                config.v1(),
-                config.v2(),
-                watcherService
-            );
-
-            try {
-                assertThat(proxyServer.requests().size(), greaterThanOrEqualTo(1));
-                assertIdp1MetadataParsedCorrectly(tuple.v2().get());
-            } finally {
-                tuple.v1().destroy();
-            }
-        }
-    }
-
-    public void testHttpMetadataConnectionTimeout() throws Exception {
-        // Use a non-routable IP address to simulate connection timeout
-        // 192.0.2.1 is reserved for documentation and will not be routable
-        final String unreachableUrl = "https://192.0.2.1:9999/metadata.xml";
-        final TimeValue shortConnectTimeout = TimeValue.timeValueMillis(100);
-
-        Tuple<RealmConfig, SSLService> config = buildConfig(unreachableUrl, builder -> {
-            builder.put(
-                SingleSpSamlRealmSettings.getFullSettingKey(REALM_NAME, SamlRealmSettings.IDP_METADATA_HTTP_CONNECT_TIMEOUT),
-                shortConnectTimeout.getStringRep()
-            );
-            builder.put(SingleSpSamlRealmSettings.getFullSettingKey(REALM_NAME, SamlRealmSettings.IDP_METADATA_HTTP_FAIL_ON_ERROR), false);
-        });
-
-        final ResourceWatcherService watcherService = mock(ResourceWatcherService.class);
-
-        // initialization should complete even though the connection fails
-        Tuple<AbstractReloadingMetadataResolver, Supplier<EntityDescriptor>> tuple = SamlRealm.initializeResolver(
-            logger,
-            config.v1(),
-            config.v2(),
-            watcherService
-        );
-
-        try {
-            EntityDescriptor descriptor = tuple.v2().get();
-            assertThat(descriptor, instanceOf(UnresolvedEntity.class));
-        } finally {
-            tuple.v1().destroy();
-        }
     }
 
     private void assertIdp1MetadataParsedCorrectly(EntityDescriptor descriptor) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlTestCase.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlTestCase.java
@@ -15,6 +15,9 @@ import org.elasticsearch.common.ssl.PemUtils;
 import org.elasticsearch.core.PathUtils;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.watcher.FileWatcher;
+import org.elasticsearch.watcher.ResourceWatcherService;
+import org.elasticsearch.watcher.WatcherHandle;
 import org.elasticsearch.xpack.core.ssl.CertParsingUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -25,6 +28,7 @@ import org.opensaml.saml.saml2.metadata.SingleSignOnService;
 import org.opensaml.security.credential.Credential;
 import org.opensaml.security.x509.impl.X509KeyManagerX509CredentialAdapter;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.security.PrivateKey;
 import java.security.cert.Certificate;
@@ -36,6 +40,9 @@ import java.util.Locale;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public abstract class SamlTestCase extends ESTestCase {
 
@@ -169,5 +176,17 @@ public abstract class SamlTestCase extends ESTestCase {
         idpDescriptor.setEntityID(idpEntityId);
         idpDescriptor.getRoleDescriptors().add(idpRole);
         return idpDescriptor;
+    }
+
+    /**
+     * Mocks the {@link ResourceWatcherService} in a way that is sufficient to support SAML testing
+     * (for example by ensuring mocked methods do not return {@code null} when the SAML realm relies on a non-null contract)
+     */
+    public static ResourceWatcherService mockResourceWatcherService() throws IOException {
+        ResourceWatcherService service = mock(ResourceWatcherService.class);
+        @SuppressWarnings("unchecked")
+        WatcherHandle<FileWatcher> handle = mock(WatcherHandle.class);
+        when(service.add(any(FileWatcher.class), any(ResourceWatcherService.Frequency.class))).thenReturn(handle);
+        return service;
     }
 }


### PR DESCRIPTION
Backports the following commits to 9.3:
 - Move SAML metadata resolution to background thread (#150037)