### PR TITLE
Pass overSampleFactor in DiversifyingChildrenIVFKnnFloatSliced

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/vectors/DiversifyingChildrenIVFKnnFloatSlicedVectorQuery.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/DiversifyingChildrenIVFKnnFloatSlicedVectorQuery.java
@@ -34,6 +34,7 @@ public class DiversifyingChildrenIVFKnnFloatSlicedVectorQuery extends IVFKnnFloa
      * @param visitRatio    IVF visit ratio
      * @param sliceField    index-sort slice field (e.g. {@code _routing})
      * @param sliceId       slice term to restrict the search doc id space
+     * @param overSampleFactor the oversample multiplier applied to the original k
      */
     public DiversifyingChildrenIVFKnnFloatSlicedVectorQuery(
         String field,
@@ -45,9 +46,10 @@ public class DiversifyingChildrenIVFKnnFloatSlicedVectorQuery extends IVFKnnFloa
         float visitRatio,
         boolean doPrecondition,
         String sliceField,
-        BytesRef sliceId
+        BytesRef sliceId,
+        float overSampleFactor
     ) {
-        super(field, query, k, numCands, childFilter, visitRatio, doPrecondition, sliceField, sliceId);
+        super(field, query, k, numCands, childFilter, visitRatio, doPrecondition, sliceField, sliceId, overSampleFactor);
         this.parentsFilter = Objects.requireNonNull(parentsFilter);
     }
 

--- a/server/src/main/java/org/elasticsearch/search/vectors/IVFKnnFloatSlicedVectorQuery.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/IVFKnnFloatSlicedVectorQuery.java
@@ -63,6 +63,25 @@ public class IVFKnnFloatSlicedVectorQuery extends IVFKnnFloatVectorQuery {
         this.sliceId = Objects.requireNonNull(sliceId);
     }
 
+    /**
+     * Backwards-compatible constructor preserved so older subclass checkouts (e.g. BWC builds) that
+     * predate the {@code overSampleFactor} parameter still compile. Defaults {@code overSampleFactor}
+     * to {@code 1f} (no oversampling).
+     */
+    public IVFKnnFloatSlicedVectorQuery(
+        String field,
+        float[] query,
+        int k,
+        int numCands,
+        Query filter,
+        float visitRatio,
+        boolean doPrecondition,
+        String sliceField,
+        BytesRef sliceId
+    ) {
+        this(field, query, k, numCands, filter, visitRatio, doPrecondition, sliceField, sliceId, 1f);
+    }
+
     @Override
     TopDocs getLeafResults(LeafReaderContext ctx, Weight filterWeight, IVFCollectorManager knnCollectorManager, float visitRatio)
         throws IOException {

--- a/server/src/test/java/org/elasticsearch/search/vectors/DiversifyingChildrenIVFKnnFloatSlicedVectorQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/search/vectors/DiversifyingChildrenIVFKnnFloatSlicedVectorQueryTests.java
@@ -87,7 +87,8 @@ public class DiversifyingChildrenIVFKnnFloatSlicedVectorQueryTests extends Abstr
             0,
             random().nextBoolean(),
             RoutingFieldMapper.NAME,
-            SLICE_ZERO
+            SLICE_ZERO,
+            1f
         );
     }
 
@@ -427,7 +428,8 @@ public class DiversifyingChildrenIVFKnnFloatSlicedVectorQueryTests extends Abstr
                             1.0f,
                             random().nextBoolean(),
                             RoutingFieldMapper.NAME,
-                            new BytesRef("" + slice)
+                            new BytesRef("" + slice),
+                            1f
                         );
                         TopDocs topDocs = searcher.search(kvq, k);
                         assertEquals(expectedDocs, topDocs.scoreDocs.length);
@@ -449,7 +451,8 @@ public class DiversifyingChildrenIVFKnnFloatSlicedVectorQueryTests extends Abstr
                         1.0f,
                         random().nextBoolean(),
                         RoutingFieldMapper.NAME,
-                        new BytesRef("invalid")
+                        new BytesRef("invalid"),
+                        1f
                     );
                     TopDocs topDocs = searcher.search(kvq, 3);
                     assertEquals(0, topDocs.scoreDocs.length);
@@ -478,7 +481,8 @@ public class DiversifyingChildrenIVFKnnFloatSlicedVectorQueryTests extends Abstr
             0.1f,
             false,
             RoutingFieldMapper.NAME,
-            SLICE_ZERO
+            SLICE_ZERO,
+            1f
         );
         assertEquals(
             "DiversifyingChildrenIVFKnnFloatSlicedVectorQuery:vec[0.5,...][4][" + RoutingFieldMapper.NAME + "=0]",


### PR DESCRIPTION
Follow-up to #148367.

#148367 added a new `float overSampleFactor` parameter to the `IVFKnnFloatSlicedVectorQuery` constructor. The subclass `DiversifyingChildrenIVFKnnFloatSlicedVectorQuery` was added to `main` after that PR was branched, so its constructor was not updated and `main` no longer compiles (super constructor signature mismatch).

This change:
- Adds `float overSampleFactor` as the last parameter of `DiversifyingChildrenIVFKnnFloatSlicedVectorQuery` and forwards it to `super(...)`.
- Updates the four call sites in `DiversifyingChildrenIVFKnnFloatSlicedVectorQueryTests` to pass `1f` (preserving prior behavior).

Verified locally with `./gradlew :server:compileJava :server:compileTestJava`.