### PR TITLE
Thread overSampleFactor into DiversifyingChildren IVF

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/vectors/DiversifyingChildrenIVFKnnFloatSlicedVectorQuery.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/DiversifyingChildrenIVFKnnFloatSlicedVectorQuery.java
@@ -45,9 +45,10 @@ public class DiversifyingChildrenIVFKnnFloatSlicedVectorQuery extends IVFKnnFloa
         float visitRatio,
         boolean doPrecondition,
         String sliceField,
-        BytesRef sliceId
+        BytesRef sliceId,
+        float overSampleFactor
     ) {
-        super(field, query, k, numCands, childFilter, visitRatio, doPrecondition, sliceField, sliceId);
+        super(field, query, k, numCands, childFilter, visitRatio, doPrecondition, sliceField, sliceId, overSampleFactor);
         this.parentsFilter = Objects.requireNonNull(parentsFilter);
     }
 

--- a/server/src/test/java/org/elasticsearch/search/vectors/DiversifyingChildrenIVFKnnFloatSlicedVectorQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/search/vectors/DiversifyingChildrenIVFKnnFloatSlicedVectorQueryTests.java
@@ -87,7 +87,8 @@ public class DiversifyingChildrenIVFKnnFloatSlicedVectorQueryTests extends Abstr
             0,
             random().nextBoolean(),
             RoutingFieldMapper.NAME,
-            SLICE_ZERO
+            SLICE_ZERO,
+            1.0f
         );
     }
 
@@ -427,7 +428,8 @@ public class DiversifyingChildrenIVFKnnFloatSlicedVectorQueryTests extends Abstr
                             1.0f,
                             random().nextBoolean(),
                             RoutingFieldMapper.NAME,
-                            new BytesRef("" + slice)
+                            new BytesRef("" + slice),
+                            1.0f
                         );
                         TopDocs topDocs = searcher.search(kvq, k);
                         assertEquals(expectedDocs, topDocs.scoreDocs.length);
@@ -449,7 +451,8 @@ public class DiversifyingChildrenIVFKnnFloatSlicedVectorQueryTests extends Abstr
                         1.0f,
                         random().nextBoolean(),
                         RoutingFieldMapper.NAME,
-                        new BytesRef("invalid")
+                        new BytesRef("invalid"),
+                        1.0f
                     );
                     TopDocs topDocs = searcher.search(kvq, 3);
                     assertEquals(0, topDocs.scoreDocs.length);
@@ -478,7 +481,8 @@ public class DiversifyingChildrenIVFKnnFloatSlicedVectorQueryTests extends Abstr
             0.1f,
             false,
             RoutingFieldMapper.NAME,
-            SLICE_ZERO
+            SLICE_ZERO,
+            1.0f
         );
         assertEquals(
             "DiversifyingChildrenIVFKnnFloatSlicedVectorQuery:vec[0.5,...][4][" + RoutingFieldMapper.NAME + "=0]",


### PR DESCRIPTION
## What's failing

Commit 06394e70704 (\"Fix IVF dynamic visit ratio when rescore oversample is active #148367\") added a `float overSampleFactor` parameter to `IVFKnnFloatSlicedVectorQuery`'s constructor but left `DiversifyingChildrenIVFKnnFloatSlicedVectorQuery` — its subclass — calling the old 9-arg `super(...)`. As of that commit, main is uncompilable; every PR that has merged main since hits:

\`\`\`
DiversifyingChildrenIVFKnnFloatSlicedVectorQuery.java:50: error:
constructor IVFKnnFloatSlicedVectorQuery in class IVFKnnFloatSlicedVectorQuery
cannot be applied to given types;
\`\`\`

The two mute commits that landed afterward (#150165 for `testSlicesDense`, #150166 for `ESNextDiskBBQVectorsFormatTests`) targeted downstream test symptoms but didn't address the actual compile error, so the unblock didn't happen.

## What this PR does

- Add `float overSampleFactor` as the 11th parameter on `DiversifyingChildrenIVFKnnFloatSlicedVectorQuery`'s constructor, forwarded to `super(...)` as the 10th arg.
- Update the 4 call sites in `DiversifyingChildrenIVFKnnFloatSlicedVectorQueryTests` to pass `1.0f` (no-oversample, same literal the sibling `IVFKnnFloatSlicedVectorQueryTests` uses at line 84).

Symmetric with the parent's signature. No callers outside tests.

## Does it work?

\`\`\`
./gradlew :server:test --tests "...DiversifyingChildrenIVFKnnFloatSlicedVectorQueryTests.testToString"
BUILD SUCCESSFUL
\`\`\`

## Out of scope

- No behavior change for callers — the default \`1.0f\` preserves pre-#148367 behavior. Future callers that want to actually use oversampling with parent-child diversification can now pass their factor.