### PR TITLE
Blob store prefetching: Allow for all nodes

### DIFF
--- a/docs/changelog/150175.yaml
+++ b/docs/changelog/150175.yaml
@@ -1,0 +1,5 @@
+area: Search
+issues: []
+pr: 150175
+summary: "Blob store prefetching: Allow for all nodes"
+type: enhancement

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/cache/StatelessSharedBlobCacheService.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/cache/StatelessSharedBlobCacheService.java
@@ -12,8 +12,6 @@ import org.elasticsearch.action.support.RefCountingListener;
 import org.elasticsearch.blobcache.BlobCacheMetrics;
 import org.elasticsearch.blobcache.common.ByteRange;
 import org.elasticsearch.blobcache.shared.SharedBlobCacheService;
-import org.elasticsearch.cluster.node.DiscoveryNode;
-import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
@@ -48,7 +46,6 @@ public class StatelessSharedBlobCacheService extends SharedBlobCacheService<File
 
     private final Executor shardReadThreadPoolExecutor;
     private final PluggableDirectoryMetricsHolder<BlobStoreCacheDirectoryMetrics> metricsHolder;
-    private final boolean hasSearchRole;
 
     public StatelessSharedBlobCacheService(
         NodeEnvironment environment,
@@ -60,7 +57,6 @@ public class StatelessSharedBlobCacheService extends SharedBlobCacheService<File
         super(environment, settings, threadPool, IO_EXECUTOR, blobCacheMetrics);
         this.shardReadThreadPoolExecutor = threadPool.executor(StatelessPlugin.SHARD_READ_THREAD_POOL);
         this.metricsHolder = metricsHolder;
-        this.hasSearchRole = DiscoveryNode.hasRole(settings, DiscoveryNodeRole.SEARCH_ROLE);
     }
 
     // for tests
@@ -75,7 +71,6 @@ public class StatelessSharedBlobCacheService extends SharedBlobCacheService<File
         super(environment, settings, threadPool, IO_EXECUTOR, blobCacheMetrics, relativeTimeInNanosSupplier);
         this.shardReadThreadPoolExecutor = IO_EXECUTOR;
         this.metricsHolder = metricsHolder;
-        this.hasSearchRole = DiscoveryNode.hasRole(settings, DiscoveryNodeRole.SEARCH_ROLE);
     }
 
     /**
@@ -153,10 +148,6 @@ public class StatelessSharedBlobCacheService extends SharedBlobCacheService<File
             StatelessPlugin.PREWARM_THREAD_POOL,
             StatelessPlugin.FILL_VIRTUAL_BATCHED_COMPOUND_COMMIT_CACHE_THREAD_POOL
         );
-    }
-
-    public boolean hasSearchRole() {
-        return hasSearchRole;
     }
 
     public void assertInvariants() {

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/cache/reader/CacheFileReader.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/cache/reader/CacheFileReader.java
@@ -130,7 +130,6 @@ public class CacheFileReader {
                 cacheBlobReader,
                 () -> writeBuffer.get().clear(),
                 bytesCopied -> {},
-                cacheBlobReader.executorName(),
                 StatelessPlugin.SHARD_READ_THREAD_POOL,
                 StatelessPlugin.FILL_VIRTUAL_BATCHED_COMPOUND_COMMIT_CACHE_THREAD_POOL
             ),

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/cache/reader/CacheFileReader.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/cache/reader/CacheFileReader.java
@@ -63,36 +63,26 @@ public class CacheFileReader {
     private final BlobFileRanges blobFileRanges;
     private final BlobCacheMetrics blobCacheMetrics;
     private final LongSupplier relativeTimeInMillisSupplier;
-    private final boolean hasSearchRole;
 
     public CacheFileReader(
         StatelessSharedBlobCacheService.CacheFile cacheFile,
         CacheBlobReader cacheBlobReader,
         BlobFileRanges blobFileRanges,
         BlobCacheMetrics blobCacheMetrics,
-        LongSupplier relativeTimeInMillisSupplier,
-        boolean hasSearchRole
+        LongSupplier relativeTimeInMillisSupplier
     ) {
         this.cacheFile = Objects.requireNonNull(cacheFile);
         this.cacheBlobReader = Objects.requireNonNull(cacheBlobReader);
         this.blobFileRanges = Objects.requireNonNull(blobFileRanges);
         this.blobCacheMetrics = blobCacheMetrics;
         this.relativeTimeInMillisSupplier = relativeTimeInMillisSupplier;
-        this.hasSearchRole = hasSearchRole;
     }
 
     /**
      * @return a new instance that is a copy of the current instance
      */
     public CacheFileReader copy() {
-        return new CacheFileReader(
-            cacheFile.copy(),
-            cacheBlobReader,
-            blobFileRanges,
-            blobCacheMetrics,
-            relativeTimeInMillisSupplier,
-            hasSearchRole
-        );
+        return new CacheFileReader(cacheFile.copy(), cacheBlobReader, blobFileRanges, blobCacheMetrics, relativeTimeInMillisSupplier);
     }
 
     /**
@@ -124,37 +114,34 @@ public class CacheFileReader {
             blobCacheMetrics.recordPrefetch(PrefetchResult.AlreadyCached);
             return true;
         }
-        if (hasSearchRole) {
-            final int intLength = clampedLength < Integer.MAX_VALUE ? Math.toIntExact(clampedLength) : Integer.MAX_VALUE;
-            // same ranges cannot be passed to populate, as write range may extend beyond actually file length,
-            // however read range must stay within file length
-            final ByteRange rangeToWrite = cacheBlobReader.getRange(offset, intLength, remainingFileLength);
-            final ByteRange rangeToRead = ByteRange.of(offset, offset + clampedLength);
-            cacheFile.populate(rangeToWrite, rangeToRead, (channel, channelPos, relativePos, len) -> {
-                channel.prefetch(channelPos, len);
-                return len;
-            },
-                new SequentialRangeMissingHandler(
-                    "lucene-prefetch",
-                    cacheFile.getCacheKey().fileName(),
-                    rangeToWrite,
-                    cacheBlobReader,
-                    () -> writeBuffer.get().clear(),
-                    bytesCopied -> {},
-                    // IndexingShardCacheBlobReader.getRangeInputStream forbids running on SHARD_READ_THREAD_POOL because
-                    // it issues a transport call and completes the listener on a different pool.
-                    cacheBlobReader.executorName(),
-                    StatelessPlugin.FILL_VIRTUAL_BATCHED_COMPOUND_COMMIT_CACHE_THREAD_POOL
-                ),
-                "lucene-prefetch:" + cacheFile.getCacheKey().fileName(),
-                ActionListener.wrap(v -> {
-                    blobCacheMetrics.recordPrefetch(PrefetchResult.Fetched);
-                }, e -> {
-                    blobCacheMetrics.recordPrefetch(PrefetchResult.Failed);
-                    logger.debug(() -> "async prefetch failed for [" + cacheFile.getCacheKey() + "]", e);
-                })
-            );
-        }
+        final int intLength = clampedLength < Integer.MAX_VALUE ? Math.toIntExact(clampedLength) : Integer.MAX_VALUE;
+        // same ranges cannot be passed to populate, as write range may extend beyond actually file length,
+        // however read range must stay within file length
+        final ByteRange rangeToWrite = cacheBlobReader.getRange(offset, intLength, remainingFileLength);
+        final ByteRange rangeToRead = ByteRange.of(offset, offset + clampedLength);
+        cacheFile.populate(rangeToWrite, rangeToRead, (channel, channelPos, relativePos, len) -> {
+            channel.prefetch(channelPos, len);
+            return len;
+        },
+            new SequentialRangeMissingHandler(
+                "lucene-prefetch",
+                cacheFile.getCacheKey().fileName(),
+                rangeToWrite,
+                cacheBlobReader,
+                () -> writeBuffer.get().clear(),
+                bytesCopied -> {},
+                cacheBlobReader.executorName(),
+                StatelessPlugin.SHARD_READ_THREAD_POOL,
+                StatelessPlugin.FILL_VIRTUAL_BATCHED_COMPOUND_COMMIT_CACHE_THREAD_POOL
+            ),
+            "lucene-prefetch:" + cacheFile.getCacheKey().fileName(),
+            ActionListener.wrap(v -> {
+                blobCacheMetrics.recordPrefetch(PrefetchResult.Fetched);
+            }, e -> {
+                blobCacheMetrics.recordPrefetch(PrefetchResult.Failed);
+                logger.debug(() -> "async prefetch failed for [" + cacheFile.getCacheKey() + "]", e);
+            })
+        );
         return false;
     }
 

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/lucene/BlobStoreCacheDirectory.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/lucene/BlobStoreCacheDirectory.java
@@ -300,8 +300,7 @@ public abstract class BlobStoreCacheDirectory extends ByteSizeDirectory {
             getCacheBlobReader(name, blobFile),
             blobFileRanges,
             blobCacheMetrics,
-            cacheService.getThreadPool().relativeTimeInMillisSupplier(),
-            cacheService.hasSearchRole()
+            cacheService.getThreadPool().relativeTimeInMillisSupplier()
         );
         return new BlobCacheIndexInput(name, context, reader, releasable, blobFileRanges.fileLength(), blobFileRanges.fileOffset());
     }

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/cache/reader/CacheBlobReaderTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/cache/reader/CacheBlobReaderTests.java
@@ -325,8 +325,7 @@ public class CacheBlobReaderTests extends ESTestCase {
                         ),
                         new BlobFileRanges(getLastInternalLocation().getValue()),
                         BlobCacheMetrics.NOOP,
-                        System::currentTimeMillis,
-                        false
+                        System::currentTimeMillis
                     ),
                     null,
                     length,
@@ -679,8 +678,7 @@ public class CacheBlobReaderTests extends ESTestCase {
                 cacheBlobReader,
                 new BlobFileRanges(internalLocation.getValue()),
                 BlobCacheMetrics.NOOP,
-                System::currentTimeMillis,
-                false
+                System::currentTimeMillis
             );
             final long availableDataLength = BlobCacheUtils.toPageAlignedSize(vbccSize);
             try (var searchInput = new BlobCacheIndexInput("region", IOContext.DEFAULT, cacheFileReader, null, regionSize, 0)) {

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/cache/reader/CacheFileReaderTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/cache/reader/CacheFileReaderTests.java
@@ -29,9 +29,10 @@ import org.elasticsearch.xpack.searchablesnapshots.cache.common.TestUtils;
 import org.elasticsearch.xpack.stateless.StatelessPlugin;
 import org.elasticsearch.xpack.stateless.cache.StatelessSharedBlobCacheService;
 import org.elasticsearch.xpack.stateless.lucene.FileCacheKey;
+import org.junit.After;
+import org.junit.Before;
 
 import java.io.InputStream;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.elasticsearch.xpack.stateless.TestUtils.newCacheService;
@@ -47,19 +48,17 @@ public class CacheFileReaderTests extends ESTestCase {
 
     private ThreadPool threadPool;
 
-    @Override
-    public void setUp() throws Exception {
-        super.setUp();
-        threadPool = new TestThreadPool("CacheFileReaderTests", StatelessPlugin.statelessExecutorBuilders(Settings.EMPTY, true));
+    @Before
+    public void startThreadPool() throws Exception {
+        threadPool = new TestThreadPool("CacheFileReaderTests", StatelessPlugin.statelessExecutorBuilders(Settings.EMPTY, randomBoolean()));
     }
 
-    @Override
-    public void tearDown() throws Exception {
-        super.tearDown();
-        assertTrue(ThreadPool.terminate(threadPool, 10L, TimeUnit.SECONDS));
+    @After
+    public void stopThreadPool() throws Exception {
+        assertTrue(terminate(threadPool));
     }
 
-    public void testTryPrefetchOnSearchNodeFetchesAndPrefetches() throws Exception {
+    public void testTryPrefetchFetches() throws Exception {
         Settings settings = nodeSettings();
         RecordingMeterRegistry meterRegistry = new RecordingMeterRegistry();
         BlobCacheMetrics metrics = new BlobCacheMetrics(meterRegistry);
@@ -277,7 +276,6 @@ public class CacheFileReaderTests extends ESTestCase {
 
     private Settings nodeSettings() {
         return Settings.builder()
-            // .putList("node.roles", "search")
             .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toAbsolutePath())
             .putList(Environment.PATH_DATA_SETTING.getKey(), createTempDir().toAbsolutePath().toString())
             .put(

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/cache/reader/CacheFileReaderTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/cache/reader/CacheFileReaderTests.java
@@ -59,39 +59,8 @@ public class CacheFileReaderTests extends ESTestCase {
         assertTrue(ThreadPool.terminate(threadPool, 10L, TimeUnit.SECONDS));
     }
 
-    public void testTryPrefetchOnIndexingNodeIsNoOp() throws Exception {
-        Settings settings = nodeSettings("index");
-        RecordingMeterRegistry meterRegistry = new RecordingMeterRegistry();
-        BlobCacheMetrics metrics = new BlobCacheMetrics(meterRegistry);
-
-        try (
-            NodeEnvironment env = new NodeEnvironment(settings, TestEnvironment.newEnvironment(settings));
-            StatelessSharedBlobCacheService service = newCacheService(env, settings, threadPool)
-        ) {
-            String fileName = "no-op-prefetch";
-            byte[] blob = randomByteArrayOfLength(BLOB_LENGTH);
-            FileCacheKey cacheKey = new FileCacheKey(new ShardId(new Index("idx", "uid"), 0), 1L, fileName);
-            AtomicInteger fetchCount = new AtomicInteger();
-            CacheBlobReader reader = countingObjectStoreReader(fileName, blob, service.getRangeSize(), fetchCount);
-            CacheFileReader cacheFileReader = new CacheFileReader(
-                service.getCacheFile(cacheKey, blob.length, SharedBlobCacheService.CacheMissHandler.NOOP),
-                reader,
-                createBlobFileRanges(1L, 0L, 0, blob.length),
-                metrics,
-                System::currentTimeMillis,
-                service.hasSearchRole()
-            );
-
-            assertFalse("indexing node tryPrefetch must report false", cacheFileReader.tryPrefetch(0L, blob.length));
-            assertThat("indexing node must not fetch from blob store", fetchCount.get(), equalTo(0));
-            assertPrefetchMetric(meterRegistry, BlobCacheMetrics.PrefetchResult.AlreadyCached, 0);
-            assertPrefetchMetric(meterRegistry, BlobCacheMetrics.PrefetchResult.Fetched, 0);
-            assertPrefetchMetric(meterRegistry, BlobCacheMetrics.PrefetchResult.Failed, 0);
-        }
-    }
-
     public void testTryPrefetchOnSearchNodeFetchesAndPrefetches() throws Exception {
-        Settings settings = nodeSettings("search");
+        Settings settings = nodeSettings();
         RecordingMeterRegistry meterRegistry = new RecordingMeterRegistry();
         BlobCacheMetrics metrics = new BlobCacheMetrics(meterRegistry);
 
@@ -109,8 +78,7 @@ public class CacheFileReaderTests extends ESTestCase {
                 reader,
                 createBlobFileRanges(1L, 0L, 0, blob.length),
                 metrics,
-                System::currentTimeMillis,
-                service.hasSearchRole()
+                System::currentTimeMillis
             );
 
             assertFalse("first call should miss the fast path", cacheFileReader.tryPrefetch(0L, blob.length));
@@ -127,7 +95,7 @@ public class CacheFileReaderTests extends ESTestCase {
     }
 
     public void testTryPrefetchRecordsFailure() throws Exception {
-        Settings settings = nodeSettings("search");
+        Settings settings = nodeSettings();
         RecordingMeterRegistry meterRegistry = new RecordingMeterRegistry();
         BlobCacheMetrics metrics = new BlobCacheMetrics(meterRegistry);
 
@@ -154,8 +122,7 @@ public class CacheFileReaderTests extends ESTestCase {
                 reader,
                 createBlobFileRanges(1L, 0L, 0, blob.length),
                 metrics,
-                System::currentTimeMillis,
-                service.hasSearchRole()
+                System::currentTimeMillis
             );
 
             assertFalse(cacheFileReader.tryPrefetch(0L, blob.length));
@@ -166,7 +133,7 @@ public class CacheFileReaderTests extends ESTestCase {
     }
 
     public void testTryPrefetchWithOversizedFileLength() throws Exception {
-        Settings settings = nodeSettings("search");
+        Settings settings = nodeSettings();
         RecordingMeterRegistry meterRegistry = new RecordingMeterRegistry();
         BlobCacheMetrics metrics = new BlobCacheMetrics(meterRegistry);
 
@@ -184,8 +151,7 @@ public class CacheFileReaderTests extends ESTestCase {
                 reader,
                 createBlobFileRanges(1L, 0L, 0, blob.length),
                 metrics,
-                System::currentTimeMillis,
-                service.hasSearchRole()
+                System::currentTimeMillis
             );
 
             long oversizedLength = (long) blob.length * 1024L;
@@ -201,7 +167,7 @@ public class CacheFileReaderTests extends ESTestCase {
     }
 
     public void testTryPrefetchPastEOF() throws Exception {
-        Settings settings = nodeSettings("search");
+        Settings settings = nodeSettings();
         RecordingMeterRegistry meterRegistry = new RecordingMeterRegistry();
         BlobCacheMetrics metrics = new BlobCacheMetrics(meterRegistry);
 
@@ -219,8 +185,7 @@ public class CacheFileReaderTests extends ESTestCase {
                 reader,
                 createBlobFileRanges(1L, 0L, 0, blob.length),
                 metrics,
-                System::currentTimeMillis,
-                service.hasSearchRole()
+                System::currentTimeMillis
             );
 
             long offsetAtOrPastEof = randomBoolean() ? blob.length : blob.length + randomLongBetween(1L, 1024L);
@@ -233,7 +198,7 @@ public class CacheFileReaderTests extends ESTestCase {
     }
 
     public void testTryPrefetchNonPositiveLength() throws Exception {
-        Settings settings = nodeSettings("search");
+        Settings settings = nodeSettings();
         RecordingMeterRegistry meterRegistry = new RecordingMeterRegistry();
         BlobCacheMetrics metrics = new BlobCacheMetrics(meterRegistry);
 
@@ -251,8 +216,7 @@ public class CacheFileReaderTests extends ESTestCase {
                 reader,
                 createBlobFileRanges(1L, 0L, 0, blob.length),
                 metrics,
-                System::currentTimeMillis,
-                service.hasSearchRole()
+                System::currentTimeMillis
             );
 
             long nonPositiveLength = randomBoolean() ? 0L : -randomLongBetween(1L, 1024L);
@@ -265,7 +229,7 @@ public class CacheFileReaderTests extends ESTestCase {
     }
 
     public void testTryPrefetchOversizedLengthIsLimited() throws Exception {
-        Settings settings = nodeSettings("search");
+        Settings settings = nodeSettings();
         RecordingMeterRegistry meterRegistry = new RecordingMeterRegistry();
         BlobCacheMetrics metrics = new BlobCacheMetrics(meterRegistry);
 
@@ -283,8 +247,7 @@ public class CacheFileReaderTests extends ESTestCase {
                 reader,
                 createBlobFileRanges(1L, 0L, 0, blob.length),
                 metrics,
-                System::currentTimeMillis,
-                service.hasSearchRole()
+                System::currentTimeMillis
             );
 
             long midFileOffset = randomLongBetween(1L, blob.length - 1);
@@ -312,9 +275,9 @@ public class CacheFileReaderTests extends ESTestCase {
         };
     }
 
-    private Settings nodeSettings(String role) {
+    private Settings nodeSettings() {
         return Settings.builder()
-            .putList("node.roles", role)
+            // .putList("node.roles", "search")
             .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toAbsolutePath())
             .putList(Environment.PATH_DATA_SETTING.getKey(), createTempDir().toAbsolutePath().toString())
             .put(

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/lucene/BlobCacheIndexInputStressTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/lucene/BlobCacheIndexInputStressTests.java
@@ -171,8 +171,7 @@ public class BlobCacheIndexInputStressTests extends ESIndexInputTestCase {
                         ),
                         createBlobFileRanges(primaryTerm, primaryTerm, offset, checksumAndLength.length),
                         BlobCacheMetrics.NOOP,
-                        System::currentTimeMillis,
-                        false
+                        System::currentTimeMillis
                     ),
                     null,
                     checksumAndLength.length,

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/lucene/BlobCacheIndexInputTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/lucene/BlobCacheIndexInputTests.java
@@ -140,8 +140,7 @@ public class BlobCacheIndexInputTests extends ESIndexInputTestCase {
                         createBlobReader(fileName, input, sharedBlobCacheService),
                         createBlobFileRanges(primaryTerm, 0L, 0, input.length),
                         BlobCacheMetrics.NOOP,
-                        System::currentTimeMillis,
-                        false
+                        System::currentTimeMillis
                     ),
                     null,
                     input.length,
@@ -241,8 +240,7 @@ public class BlobCacheIndexInputTests extends ESIndexInputTestCase {
                     switchingReader,
                     createBlobFileRanges(termAndGen.primaryTerm(), termAndGen.generation(), 0, input.length),
                     BlobCacheMetrics.NOOP,
-                    System::currentTimeMillis,
-                    false
+                    System::currentTimeMillis
                 ),
                 null,
                 input.length,
@@ -357,8 +355,7 @@ public class BlobCacheIndexInputTests extends ESIndexInputTestCase {
                     switchingReader,
                     createBlobFileRanges(termAndGen.primaryTerm(), termAndGen.generation(), 0, input.length),
                     null,
-                    System::currentTimeMillis,
-                    false
+                    System::currentTimeMillis
                 ),
                 null,
                 input.length,
@@ -426,8 +423,7 @@ public class BlobCacheIndexInputTests extends ESIndexInputTestCase {
                     createBlobReader(fileName, input, sharedBlobCacheService),
                     createBlobFileRanges(primaryTerm, 0L, 0, input.length),
                     BlobCacheMetrics.NOOP,
-                    System::currentTimeMillis,
-                    false
+                    System::currentTimeMillis
                 ),
                 null,
                 input.length,
@@ -534,8 +530,7 @@ public class BlobCacheIndexInputTests extends ESIndexInputTestCase {
                         cacheBlobReader,
                         createBlobFileRanges(primaryTerm, generation, pos, fileLength),
                         BlobCacheMetrics.NOOP,
-                        System::currentTimeMillis,
-                        false
+                        System::currentTimeMillis
                     ),
                     null,
                     fileLength,
@@ -561,8 +556,7 @@ public class BlobCacheIndexInputTests extends ESIndexInputTestCase {
                     cacheBlobReader,
                     createBlobFileRanges(primaryTerm, generation, 0, data.length),
                     BlobCacheMetrics.NOOP,
-                    System::currentTimeMillis,
-                    false
+                    System::currentTimeMillis
                 ),
                 null,
                 data.length,
@@ -753,8 +747,7 @@ public class BlobCacheIndexInputTests extends ESIndexInputTestCase {
                     createBlobReader(fileName, input, sharedBlobCacheService),
                     createBlobFileRanges(primaryTerm, 0L, 0, input.length),
                     BlobCacheMetrics.NOOP,
-                    System::currentTimeMillis,
-                    false
+                    System::currentTimeMillis
                 ),
                 null,
                 input.length,
@@ -822,8 +815,7 @@ public class BlobCacheIndexInputTests extends ESIndexInputTestCase {
                     createBlobReader(fileName, input, sharedBlobCacheService),
                     createBlobFileRanges(primaryTerm, 0L, 0, input.length),
                     BlobCacheMetrics.NOOP,
-                    System::currentTimeMillis,
-                    false
+                    System::currentTimeMillis
                 ),
                 null,
                 input.length,
@@ -889,8 +881,7 @@ public class BlobCacheIndexInputTests extends ESIndexInputTestCase {
                     createBlobReader(fileName, input, sharedBlobCacheService),
                     createBlobFileRanges(primaryTerm, 0L, 0, input.length),
                     BlobCacheMetrics.NOOP,
-                    System::currentTimeMillis,
-                    false
+                    System::currentTimeMillis
                 ),
                 null,
                 input.length,
@@ -946,8 +937,7 @@ public class BlobCacheIndexInputTests extends ESIndexInputTestCase {
                     createBlobReader(fileName, input, sharedBlobCacheService),
                     createBlobFileRanges(primaryTerm, 0L, 0, input.length),
                     BlobCacheMetrics.NOOP,
-                    System::currentTimeMillis,
-                    false
+                    System::currentTimeMillis
                 ),
                 null,
                 input.length,
@@ -1003,8 +993,7 @@ public class BlobCacheIndexInputTests extends ESIndexInputTestCase {
                     createBlobReader(fileNameA, inputA, sharedBlobCacheService),
                     createBlobFileRanges(primaryTerm, 0L, 0, inputA.length),
                     BlobCacheMetrics.NOOP,
-                    System::currentTimeMillis,
-                    false
+                    System::currentTimeMillis
                 ),
                 null,
                 inputA.length,
@@ -1041,8 +1030,7 @@ public class BlobCacheIndexInputTests extends ESIndexInputTestCase {
                         createBlobReader(evictFileName, evictInput, sharedBlobCacheService),
                         createBlobFileRanges(primaryTerm, 0L, 0, evictInput.length),
                         BlobCacheMetrics.NOOP,
-                        System::currentTimeMillis,
-                        false
+                        System::currentTimeMillis
                     ),
                     null,
                     evictInput.length,
@@ -1095,8 +1083,7 @@ public class BlobCacheIndexInputTests extends ESIndexInputTestCase {
                 createBlobReader(fileName, input, cacheService),
                 createBlobFileRanges(primaryTerm, 0L, 0, input.length),
                 metrics,
-                System::currentTimeMillis,
-                false
+                System::currentTimeMillis
             );
 
             // First read: bypass path — exactly 1 bypass, 1 read, 1 miss
@@ -1172,8 +1159,7 @@ public class BlobCacheIndexInputTests extends ESIndexInputTestCase {
                     createBlobReader(fileName, input, sharedBlobCacheService),
                     createBlobFileRanges(primaryTerm, 0L, 0, input.length),
                     BlobCacheMetrics.NOOP,
-                    System::currentTimeMillis,
-                    false
+                    System::currentTimeMillis
                 ),
                 null,
                 input.length,
@@ -1236,8 +1222,7 @@ public class BlobCacheIndexInputTests extends ESIndexInputTestCase {
                     createBlobReader(fileName, input, sharedBlobCacheService),
                     createBlobFileRanges(primaryTerm, 0L, 0, input.length),
                     BlobCacheMetrics.NOOP,
-                    System::currentTimeMillis,
-                    false
+                    System::currentTimeMillis
                 ),
                 null,
                 input.length,
@@ -1297,8 +1282,7 @@ public class BlobCacheIndexInputTests extends ESIndexInputTestCase {
                     createBlobReader(fileName, input, sharedBlobCacheService),
                     createBlobFileRanges(primaryTerm, 0L, 0, input.length),
                     BlobCacheMetrics.NOOP,
-                    System::currentTimeMillis,
-                    false
+                    System::currentTimeMillis
                 ),
                 null,
                 input.length,
@@ -1353,8 +1337,7 @@ public class BlobCacheIndexInputTests extends ESIndexInputTestCase {
                     createBlobReader(fileNameA, inputA, sharedBlobCacheService),
                     createBlobFileRanges(primaryTerm, 0L, 0, inputA.length),
                     BlobCacheMetrics.NOOP,
-                    System::currentTimeMillis,
-                    false
+                    System::currentTimeMillis
                 ),
                 null,
                 inputA.length,
@@ -1395,8 +1378,7 @@ public class BlobCacheIndexInputTests extends ESIndexInputTestCase {
                         createBlobReader(evictFileName, evictInput, sharedBlobCacheService),
                         createBlobFileRanges(primaryTerm, 0L, 0, evictInput.length),
                         BlobCacheMetrics.NOOP,
-                        System::currentTimeMillis,
-                        false
+                        System::currentTimeMillis
                     ),
                     null,
                     evictInput.length,
@@ -1433,8 +1415,7 @@ public class BlobCacheIndexInputTests extends ESIndexInputTestCase {
             cacheBlobReader,
             createBlobFileRanges(primaryTerm, 0L, 0, (int) fileLength),
             BlobCacheMetrics.NOOP,
-            System::currentTimeMillis,
-            false
+            System::currentTimeMillis
         );
         final BlobCacheIndexInput indexInput = new BlobCacheIndexInput(
             "test-file",
@@ -1486,8 +1467,7 @@ public class BlobCacheIndexInputTests extends ESIndexInputTestCase {
             cacheBlobReader,
             createBlobFileRanges(randomNonNegativeLong(), 0L, 0, (int) fileLength),
             metrics,
-            System::currentTimeMillis,
-            true
+            System::currentTimeMillis
         );
         final BlobCacheIndexInput indexInput = new BlobCacheIndexInput(
             "test-file",
@@ -1547,8 +1527,7 @@ public class BlobCacheIndexInputTests extends ESIndexInputTestCase {
             cacheBlobReader,
             createBlobFileRanges(randomNonNegativeLong(), 0L, 0, (int) fileLength),
             metrics,
-            System::currentTimeMillis,
-            true
+            System::currentTimeMillis
         );
         final BlobCacheIndexInput indexInput = new BlobCacheIndexInput(
             "test-file",
@@ -1597,8 +1576,7 @@ public class BlobCacheIndexInputTests extends ESIndexInputTestCase {
             cacheBlobReader,
             createBlobFileRanges(randomNonNegativeLong(), 0L, 0, (int) fileLength),
             metrics,
-            System::currentTimeMillis,
-            true
+            System::currentTimeMillis
         );
         final BlobCacheIndexInput indexInput = new BlobCacheIndexInput(
             "test-file",
@@ -1637,8 +1615,7 @@ public class BlobCacheIndexInputTests extends ESIndexInputTestCase {
             cacheBlobReader,
             createBlobFileRanges(randomNonNegativeLong(), 0L, 0, (int) fileLength),
             metrics,
-            System::currentTimeMillis,
-            true
+            System::currentTimeMillis
         );
         final BlobCacheIndexInput indexInput = new BlobCacheIndexInput(
             "test-file",


### PR DESCRIPTION
Instead of just running prefetching against the blob store (or the index tier in case of a search node) when the node role is search, we can enable this feature for all stateless nodes.

Follow up for #147964