### PR TITLE
Mute IVFKnnFloatSlicedVectorQueryTests.testDifferentReader

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -589,6 +589,9 @@ tests:
 - class: org.elasticsearch.search.vectors.IVFKnnFloatSlicedVectorQueryTests
   method: testSlicesSparseWithFilter
   issue: https://github.com/elastic/elasticsearch/issues/150073
+- class: org.elasticsearch.search.vectors.IVFKnnFloatSlicedVectorQueryTests
+  method: testDifferentReader
+  issue: https://github.com/elastic/elasticsearch/issues/150068
 - class: org.elasticsearch.xpack.esql.datasource.parquet.PageColumnReaderCorrectnessTests
   method: testRandomSchema
   issue: https://github.com/elastic/elasticsearch/issues/150077


### PR DESCRIPTION
## What this PR does

Adds `IVFKnnFloatSlicedVectorQueryTests.testDifferentReader` to `muted-tests.yml`, linked to the existing tracking issue #150068 (same test class, same failure family).

## Why we're muting

`testDifferentReader` is inherited from `AbstractIVFKnnVectorQueryTestCase`. The test body itself is asserting that `createWeight` against a leaf-only `IndexSearcher` throws `IllegalStateException` — a simple negative case. The CI failure is **not** about that assertion. It's surfacing during index close, from Lucene's `CheckIndex` validator:

```
org.apache.lucene.index.CheckIndex$CheckIndexException:
  Field "field" failed to search k nearest neighbors
```

Lucene's `IndexWriter` runs `CheckIndex` on close in test mode. `CheckIndex` performs a sanity kNN search on the IVF/DiskBBQ-formatted field and fails on the tiny 3-vector index this test creates. The thrown exception escapes the `try-with-resources` close path, failing the test even though its own assertion would have passed.

## Same failure family

Sibling tests in the same class are already muted with the same shape of failure:

- `IVFKnnFloatSlicedVectorQueryTests.testSlicesSparse` → #150068
- `IVFKnnFloatSlicedVectorQueryTests.testSlicesSparseWithFilter` → #150073
- `DiversifyingChildrenIVFKnnFloatSlicedVectorQueryTests.testSlicesSparse` → #150065
- `DiversifyingChildrenIVFKnnFloatSlicedVectorQueryTests.testSlicesSparseWithFilter` → #150106
- `ESNextDiskBBQVectorsFormatTests.testSlicesSparse` → #150070

Failure rate for `testDifferentReader` is lower (≈1 in 2180 = 0.05%, vs more frequent for `testSlicesSparse*`), which is why it surfaced later, but root cause is the same `CheckIndex` / IVF interaction.

Linking to #150068 rather than filing a new issue, since the Search Relevance/Vectors team is already tracking this failure family there. A dedicated tracking issue for `testDifferentReader` can be filed by that team if they want it broken out.

## Diff

Three lines added to `muted-tests.yml`, slotted next to the existing `IVFKnnFloatSlicedVectorQueryTests` entries.