### PR TITLE
[9.4] Stop swallowing exceptions in RecordingApmServer (#150133)

### DIFF
--- a/test/external-modules/apm-integration/build.gradle
+++ b/test/external-modules/apm-integration/build.gradle
@@ -20,10 +20,6 @@ esplugin {
 // let the javaRestTest see the classpath of main
 GradleUtils.extendSourceSet(project, "main", "javaRestTest", tasks.named("javaRestTest"))
 
-tasks.named("test").configure {
-  enabled = false
-}
-
 tasks.named('javaRestTest').configure {
   def buildParams = project.rootProject.extensions.getByName('buildParams')
   it.onlyIf("snapshot build") { buildParams.snapshotBuild }
@@ -33,4 +29,5 @@ dependencies {
   clusterModules project(':modules:apm')
   implementation project(':libs:logging')
   javaRestTestImplementation "io.opentelemetry.proto:opentelemetry-proto:1.7.0-alpha"
+  testImplementation sourceSets.javaRestTest.output
 }

--- a/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/RecordingApmServer.java
+++ b/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/RecordingApmServer.java
@@ -100,15 +100,6 @@ public class RecordingApmServer extends ExternalResource {
                             }
                         }
                     }
-                } catch (Throwable t) {
-                    // The lifetime of HttpServer makes message handling "brittle": we need to start handling and recording received
-                    // messages before the test starts running. We should also stop handling them before the test ends (and the test
-                    // cluster is torn down), or we may run into IOException as the communication channel is interrupted.
-                    // Coordinating the lifecycle of the mock HttpServer and of the test ES cluster is difficult and error-prone, so
-                    // we just handle Throwable and don't care (log, but don't care): if we have an error in communicating to/from
-                    // the mock server while the test is running, the test would fail anyway as the expected messages will not arrive, and
-                    // if we have an error outside the test scope (before or after) that is OK.
-                    logger.warn("failed to parse request", t);
                 }
             }
             exchange.sendResponseHeaders(201, 0);

--- a/test/external-modules/apm-integration/src/test/java/org/elasticsearch/test/apmintegration/RecordingApmServerTests.java
+++ b/test/external-modules/apm-integration/src/test/java/org/elasticsearch/test/apmintegration/RecordingApmServerTests.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.test.apmintegration;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Tests for {@link RecordingApmServer}.
+ */
+public class RecordingApmServerTests extends ESTestCase {
+
+    /**
+     * Regression test for <a href="https://github.com/elastic/elasticsearch/issues/149945">#149945</a>.
+     * <p>
+     * Sends a chunked POST where the connection closes after the terminating {@code 0\r\n} but
+     * before the required trailing {@code \r\n}.  This causes {@code consumeCRLF()} inside
+     * {@code ChunkedInputStream} to throw after {@code eof} has already been set to {@code true}.
+     * Without the fix, the resulting {@link AssertionError} in the JDK HTTP-server dispatcher
+     * thread is captured by {@link org.apache.lucene.tests.util.LuceneTestCase} and fails this test.
+     */
+    public void testTruncatedChunkedBodyDoesNotCrashDispatcher() throws Exception {
+        RecordingApmServer server = new RecordingApmServer();
+        try {
+            server.before();
+        } catch (Throwable t) {
+            throw new RuntimeException(t);
+        }
+        int port = server.getPort();
+
+        try (Socket socket = new Socket(InetAddress.getByName("127.0.0.1"), port)) {
+            OutputStream out = socket.getOutputStream();
+            out.write(
+                ("POST /intake/v2/events HTTP/1.1\r\n"
+                    + "Host: 127.0.0.1:"
+                    + port
+                    + "\r\n"
+                    + "Transfer-Encoding: chunked\r\n"
+                    + "Content-Type: application/x-ndjson\r\n"
+                    + "\r\n"
+                    + "5\r\nhello\r\n"
+                    + "0\r\n"  // terminating chunk header — missing the required trailing \r\n
+                ).getBytes(StandardCharsets.US_ASCII)
+            );
+            out.flush();
+            socket.shutdownOutput(); // FIN: causes consumeCRLF() to see EOF and throw
+        }
+
+        server.after();
+    }
+}


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Stop swallowing exceptions in RecordingApmServer (#150133)