### PR TITLE
[Test] Fix testActionStats off-by-one on powers of two

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -327,12 +327,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.expression.function.scalar.spatial.StSimplifyPreserveTopologyTests
   method: "testEvaluateInManyThreads {TestCase=geo_shape with tolerance[long]. #2}"
   issue: https://github.com/elastic/elasticsearch/issues/150079
-- class: org.elasticsearch.transport.netty4.SimpleNetty4TransportTests
-  method: testActionStats
-  issue: https://github.com/elastic/elasticsearch/issues/150162
-- class: org.elasticsearch.xpack.security.transport.netty4.SimpleSecurityNetty4ServerTransportTests
-  method: testActionStats
-  issue: https://github.com/elastic/elasticsearch/issues/150164
 
 # Examples:
 #

--- a/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -3420,14 +3420,14 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
     private static long[] getConstantMessageSizeHistogram(int count, long size) {
         final var histogram = new long[29];
         int bucket = 0;
-        long bucketLowerBound = 8;
+        long nextBucketLowestValue = 8;
         while (bucket < histogram.length) {
-            if (size <= bucketLowerBound) {
+            if (size < nextBucketLowestValue) {
                 histogram[bucket] = count;
                 return histogram;
             }
             bucket++;
-            bucketLowerBound <<= 1;
+            nextBucketLowestValue <<= 1;
         }
         throw new AssertionError("no bucket found");
     }


### PR DESCRIPTION
### Context
- `TransportActionStatsTracker` has histogram buckets of powers of two to track message sizes: https://github.com/elastic/elasticsearch/blob/a59c182f9f7e9d1bf3d6eecbc0e44f24ff91d053/server/src/main/java/org/elasticsearch/transport/TransportActionStatsTracker.java#L18-L26
- Therefore each bucket contains values from `n^2 - (n+1)^2 - 1`: https://github.com/elastic/elasticsearch/blob/a59c182f9f7e9d1bf3d6eecbc0e44f24ff91d053/server/src/main/java/org/elasticsearch/transport/TransportActionStatsTracker.java#L66
### Problem
```
org.junit.internal.ArrayComparisonFailure: arrays first differed at element [5]; expected:<1> but was:<0>
```
- The test asserts the histogram is correct by creating it's own expected histogram, it is correct for all values except powers of two, since it uses `<=` rather than `<` so it places powers of two in the previous bucket, rather than the correct next bucket
### Testing
- Deterministically fails with test seed on 9.4
- Succeeds with test seed and with fix (ran on iters for 5 minutes)
- Succeeds with random tests seeds with fix (ran on iters for 30 minutes)
### Preempting questions
- Why is this only failing now, given test was introduced in 2023?: i'm assuming since we tightened test mute criteria, and that hitting a power of two is rare, given `requestSize` is random between `[0, 1MiB]` then we have 14 choices there, that's `1.4e-5` / `0.0014%`, so without querying test history for a long while, i'm assuming it was just assumed it was a flaky failure and retried 🤷 
- Can this happen in main?: seems to me yes, the test was only muted on `9.4` since i'm guessing it hit a power of two before main, but i will make the change in main in another PR

Closes https://github.com/elastic/elasticsearch/issues/150163
Closes https://github.com/elastic/elasticsearch/issues/150162
Closes https://github.com/elastic/elasticsearch/issues/150164

Assisted by Cursor