### PR TITLE
Add experimental TSDB all-non-metric dimensions mode

### DIFF
--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/DataStreamIndexSettingsProvider.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/DataStreamIndexSettingsProvider.java
@@ -62,10 +62,16 @@ public class DataStreamIndexSettingsProvider implements IndexSettingProvider {
         true,
         Setting.Property.NodeScope
     );
+    public static final Setting<Boolean> EXPERIMENTAL_ALL_NON_METRIC_DIMENSIONS = Setting.boolSetting(
+        "cluster.time_series.experimental_all_non_metric_dimensions",
+        true,
+        Setting.Property.NodeScope
+    );
 
     private final CheckedFunction<IndexMetadata, MapperService, IOException> mapperServiceFactory;
     private final boolean supportSeqNoDisabled;
     private final boolean supportSyntheticId;
+    private final boolean experimentalAllNonMetricDimensions;
 
     DataStreamIndexSettingsProvider(CheckedFunction<IndexMetadata, MapperService, IOException> mapperServiceFactory) {
         this(mapperServiceFactory, Settings.EMPTY);
@@ -75,6 +81,7 @@ public class DataStreamIndexSettingsProvider implements IndexSettingProvider {
         this.mapperServiceFactory = mapperServiceFactory;
         this.supportSeqNoDisabled = SUPPORT_SEQ_NO_DISABLED.get(settings);
         this.supportSyntheticId = SUPPORT_SYNTHETIC_ID.get(settings);
+        this.experimentalAllNonMetricDimensions = EXPERIMENTAL_ALL_NON_METRIC_DIMENSIONS.get(settings);
     }
 
     @Override
@@ -150,6 +157,10 @@ public class DataStreamIndexSettingsProvider implements IndexSettingProvider {
                         additionalSettings.put(IndexSettings.SYNTHETIC_ID.getKey(), supportSyntheticId);
                     }
 
+                    if (experimentalAllNonMetricDimensions) {
+                        additionalSettings.put(IndexMetadata.EXPERIMENTAL_ALL_NON_METRIC_DIMENSIONS.getKey(), true);
+                    }
+
                     if (indexTemplateAndCreateRequestSettings.hasValue(IndexMetadata.INDEX_ROUTING_PATH.getKey()) == false
                         && combinedTemplateMappings.isEmpty() == false) {
                         List<String> dimensions = new ArrayList<>();
@@ -199,7 +210,11 @@ public class DataStreamIndexSettingsProvider implements IndexSettingProvider {
         }
         assert indexMetadata.getIndexMode() == IndexMode.TIME_SERIES;
         List<String> newIndexDimensions = new ArrayList<>(indexDimensions.size());
-        boolean matchesAllDimensions = findDimensionFields(newIndexDimensions, documentMapper);
+        boolean matchesAllDimensions = findDimensionFields(
+            newIndexDimensions,
+            documentMapper,
+            IndexMetadata.EXPERIMENTAL_ALL_NON_METRIC_DIMENSIONS.get(indexMetadata.getSettings())
+        );
         boolean hasChanges = indexDimensions.size() != newIndexDimensions.size()
             && new HashSet<>(indexDimensions).equals(new HashSet<>(newIndexDimensions)) == false;
         if (matchesAllDimensions == false) {
@@ -245,7 +260,7 @@ public class DataStreamIndexSettingsProvider implements IndexSettingProvider {
             dummyPartitionSize == 1 ? 1 : dummyPartitionSize + 1
         );
         int shardReplicas = allSettings.getAsInt(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0);
-        var finalResolvedSettings = Settings.builder()
+        var settingsBuilder = Settings.builder()
             .put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current())
             .put(allSettings)
             .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, dummyShards)
@@ -253,15 +268,18 @@ public class DataStreamIndexSettingsProvider implements IndexSettingProvider {
             .put(IndexMetadata.SETTING_INDEX_UUID, UUIDs.randomBase64UUID())
             .put(IndexSettings.MODE.getKey(), IndexMode.TIME_SERIES)
             // Avoid failing because index.routing_path is missing
-            .putList(INDEX_ROUTING_PATH.getKey(), List.of("path"))
-            .build();
+            .putList(INDEX_ROUTING_PATH.getKey(), List.of("path"));
+        if (experimentalAllNonMetricDimensions) {
+            settingsBuilder.put(IndexMetadata.EXPERIMENTAL_ALL_NON_METRIC_DIMENSIONS.getKey(), true);
+        }
+        Settings finalResolvedSettings = settingsBuilder.build();
 
         tmpIndexMetadata.settings(finalResolvedSettings);
         // Create MapperService just to extract keyword dimension fields:
         try (var mapperService = mapperServiceFactory.apply(tmpIndexMetadata.build())) {
             mapperService.merge(MapperService.SINGLE_MAPPING_NAME, combinedTemplateMappings, MapperService.MergeReason.INDEX_TEMPLATE);
             DocumentMapper documentMapper = mapperService.documentMapper();
-            return findDimensionFields(dimensions, documentMapper);
+            return findDimensionFields(dimensions, documentMapper, experimentalAllNonMetricDimensions);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -274,7 +292,11 @@ public class DataStreamIndexSettingsProvider implements IndexSettingProvider {
      * @param documentMapper the document mapper from which to extract the dimension fields
      * @return true if all potential dimension fields can be matched via the dimensions in the list, false otherwise
      */
-    private static boolean findDimensionFields(List<String> dimensions, DocumentMapper documentMapper) {
+    private static boolean findDimensionFields(
+        List<String> dimensions,
+        DocumentMapper documentMapper,
+        boolean experimentalAllNonMetricDimensions
+    ) {
         for (var objectMapper : documentMapper.mappers().objectMappers().values()) {
             if (objectMapper instanceof PassThroughObjectMapper passThroughObjectMapper) {
                 if (passThroughObjectMapper.containsDimensions()) {
@@ -283,23 +305,25 @@ public class DataStreamIndexSettingsProvider implements IndexSettingProvider {
             }
         }
         boolean matchesAllDimensions = true;
-        for (var template : documentMapper.mapping().getRoot().dynamicTemplates()) {
-            if (template.isTimeSeriesDimension() == false) {
-                continue;
-            }
-            // At this point, we don't support index.dimensions when dimensions are mapped via a dynamic template.
-            // This is because more specific matches with a higher priority can exist that exclude certain fields from being mapped as a
-            // dimension. For example:
-            // - path_match: "labels.host_ip", time_series_dimension: false
-            // - path_match: "labels.*", time_series_dimension: true
-            // In this case, "labels.host_ip" is not a dimension,
-            // and adding labels.* to index.dimensions would lead to non-dimension fields being included in the tsid.
-            // Therefore, we fall back to using index.routing_path.
-            // While this also may include non-dimension fields in the routing path,
-            // it at least guarantees that the tsid only includes dimension fields and includes all dimension fields.
-            matchesAllDimensions = false;
-            if (template.pathMatch().isEmpty() == false) {
-                dimensions.addAll(template.pathMatch());
+        if (experimentalAllNonMetricDimensions == false) {
+            for (var template : documentMapper.mapping().getRoot().dynamicTemplates()) {
+                if (template.isTimeSeriesDimension() == false) {
+                    continue;
+                }
+                // At this point, we don't support index.dimensions when dimensions are mapped via a dynamic template.
+                // This is because more specific matches with a higher priority can exist that exclude certain fields from being mapped as a
+                // dimension. For example:
+                // - path_match: "labels.host_ip", time_series_dimension: false
+                // - path_match: "labels.*", time_series_dimension: true
+                // In this case, "labels.host_ip" is not a dimension,
+                // and adding labels.* to index.dimensions would lead to non-dimension fields being included in the tsid.
+                // Therefore, we fall back to using index.routing_path.
+                // While this also may include non-dimension fields in the routing path,
+                // it at least guarantees that the tsid only includes dimension fields and includes all dimension fields.
+                matchesAllDimensions = false;
+                if (template.pathMatch().isEmpty() == false) {
+                    dimensions.addAll(template.pathMatch());
+                }
             }
         }
 

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/DataStreamsPlugin.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/DataStreamsPlugin.java
@@ -182,6 +182,7 @@ public class DataStreamsPlugin extends Plugin implements ActionPlugin, Extensibl
         pluginSettings.add(LOOK_BACK_TIME);
         pluginSettings.add(DataStreamIndexSettingsProvider.SUPPORT_SEQ_NO_DISABLED);
         pluginSettings.add(DataStreamIndexSettingsProvider.SUPPORT_SYNTHETIC_ID);
+        pluginSettings.add(DataStreamIndexSettingsProvider.EXPERIMENTAL_ALL_NON_METRIC_DIMENSIONS);
         pluginSettings.add(DataStreamLifecycleService.DATA_STREAM_LIFECYCLE_POLL_INTERVAL_SETTING);
         pluginSettings.add(DataStreamLifecycleService.DATA_STREAM_MERGE_POLICY_TARGET_FLOOR_SEGMENT_SETTING);
         pluginSettings.add(DataStreamLifecycleService.DATA_STREAM_MERGE_POLICY_TARGET_FACTOR_SETTING);

--- a/modules/data-streams/src/test/java/org/elasticsearch/datastreams/DataStreamIndexSettingsProviderTests.java
+++ b/modules/data-streams/src/test/java/org/elasticsearch/datastreams/DataStreamIndexSettingsProviderTests.java
@@ -59,7 +59,8 @@ public class DataStreamIndexSettingsProviderTests extends ESTestCase {
     @Before
     public void setup() {
         provider = new DataStreamIndexSettingsProvider(
-            im -> MapperTestUtils.newMapperService(xContentRegistry(), createTempDir(), im.getSettings(), im.getIndex().getName())
+            im -> MapperTestUtils.newMapperService(xContentRegistry(), createTempDir(), im.getSettings(), im.getIndex().getName()),
+            Settings.builder().put(DataStreamIndexSettingsProvider.EXPERIMENTAL_ALL_NON_METRIC_DIMENSIONS.getKey(), false).build()
         );
         if (randomBoolean()) {
             indexVersion = IndexVersion.current();
@@ -1224,6 +1225,102 @@ public class DataStreamIndexSettingsProviderTests extends ESTestCase {
             additionalSettings
         );
         assertFalse(additionalSettings.build().hasValue(IndexSettings.SYNTHETIC_ID.getKey()));
+    }
+
+    public void testClusterSettingsExperimentalAllNonMetricDimensionsDefault() throws Exception {
+        assumeTrue("Requires index.dimensions tsid optimization", expectedIndexDimensionsTsidOptimizationEnabled);
+        assertTrue(DataStreamIndexSettingsProvider.EXPERIMENTAL_ALL_NON_METRIC_DIMENSIONS.getDefault(Settings.EMPTY));
+
+        DataStreamIndexSettingsProvider defaultProvider = new DataStreamIndexSettingsProvider(
+            im -> MapperTestUtils.newMapperService(xContentRegistry(), createTempDir(), im.getSettings(), im.getIndex().getName())
+        );
+        String mapping = """
+            {
+                "_doc": {
+                    "properties": {
+                        "@timestamp": { "type": "date" },
+                        "host": { "type": "keyword" },
+                        "value": { "type": "long", "time_series_metric": "gauge" }
+                    }
+                }
+            }
+            """;
+        Settings.Builder additionalSettings = builder();
+        defaultProvider.provideAdditionalSettings(
+            DataStream.getDefaultBackingIndexName("metrics-app1", 1),
+            "metrics-app1",
+            IndexMode.TIME_SERIES,
+            emptyProject(),
+            Instant.now().truncatedTo(ChronoUnit.SECONDS),
+            Settings.builder().put("index.dimensions_tsid_strategy_enabled", indexDimensionsTsidStrategyEnabledSetting).build(),
+            List.of(new CompressedXContent(mapping)),
+            indexVersion,
+            additionalSettings
+        );
+        Settings result = builder().put(additionalSettings.build()).put("index.mode", "time_series").build();
+        assertThat(IndexMetadata.EXPERIMENTAL_ALL_NON_METRIC_DIMENSIONS.get(result), equalTo(true));
+        assertThat(IndexMetadata.INDEX_DIMENSIONS.get(result), containsInAnyOrder("host"));
+
+        DataStreamIndexSettingsProvider disabledProvider = new DataStreamIndexSettingsProvider(
+            im -> MapperTestUtils.newMapperService(xContentRegistry(), createTempDir(), im.getSettings(), im.getIndex().getName()),
+            Settings.builder().put(DataStreamIndexSettingsProvider.EXPERIMENTAL_ALL_NON_METRIC_DIMENSIONS.getKey(), false).build()
+        );
+        additionalSettings = builder();
+        disabledProvider.provideAdditionalSettings(
+            DataStream.getDefaultBackingIndexName("metrics-app1", 1),
+            "metrics-app1",
+            IndexMode.TIME_SERIES,
+            emptyProject(),
+            Instant.now().truncatedTo(ChronoUnit.SECONDS),
+            Settings.builder().put("index.dimensions_tsid_strategy_enabled", indexDimensionsTsidStrategyEnabledSetting).build(),
+            List.of(new CompressedXContent(mapping)),
+            indexVersion,
+            additionalSettings
+        );
+        result = builder().put(additionalSettings.build()).put("index.mode", "time_series").build();
+        assertFalse(result.hasValue(IndexMetadata.EXPERIMENTAL_ALL_NON_METRIC_DIMENSIONS.getKey()));
+        assertThat(IndexMetadata.INDEX_DIMENSIONS.get(result), empty());
+    }
+
+    public void testExperimentalAllNonMetricDimensions() throws Exception {
+        assumeTrue("Requires index.dimensions tsid optimization", expectedIndexDimensionsTsidOptimizationEnabled);
+        DataStreamIndexSettingsProvider experimentalProvider = new DataStreamIndexSettingsProvider(
+            im -> MapperTestUtils.newMapperService(xContentRegistry(), createTempDir(), im.getSettings(), im.getIndex().getName())
+        );
+        String mapping = """
+            {
+                "_doc": {
+                    "properties": {
+                        "@timestamp": {
+                            "type": "date"
+                        },
+                        "host": {
+                            "type": "keyword"
+                        },
+                        "value": {
+                            "type": "long",
+                            "time_series_metric": "gauge"
+                        }
+                    }
+                }
+            }
+            """;
+        Settings.Builder additionalSettings = builder();
+        experimentalProvider.provideAdditionalSettings(
+            DataStream.getDefaultBackingIndexName("metrics-app1", 1),
+            "metrics-app1",
+            IndexMode.TIME_SERIES,
+            emptyProject(),
+            Instant.now().truncatedTo(ChronoUnit.SECONDS),
+            Settings.builder().put("index.dimensions_tsid_strategy_enabled", indexDimensionsTsidStrategyEnabledSetting).build(),
+            List.of(new CompressedXContent(mapping)),
+            indexVersion,
+            additionalSettings
+        );
+        Settings result = builder().put(additionalSettings.build()).put("index.mode", "time_series").build();
+        assertThat(IndexMetadata.EXPERIMENTAL_ALL_NON_METRIC_DIMENSIONS.get(result), equalTo(true));
+        assertThat(IndexMetadata.INDEX_DIMENSIONS.get(result), containsInAnyOrder("host"));
+        assertThat(IndexMetadata.INDEX_ROUTING_PATH.get(result), empty());
     }
 
 }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -559,6 +559,18 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
     );
 
     /**
+     * Experimental setting populated for time series data stream backing indices when the
+     * {@code cluster.time_series.experimental_all_non_metric_dimensions} cluster setting is enabled.
+     * Treats all non-metric fields that support {@code time_series_dimension} as dimensions.
+     */
+    public static final Setting<Boolean> EXPERIMENTAL_ALL_NON_METRIC_DIMENSIONS = Setting.boolSetting(
+        "index.time_series.experimental_all_non_metric_dimensions",
+        false,
+        Setting.Property.IndexScope,
+        Property.PrivateIndex
+    );
+
+    /**
      * Legacy index setting, kept for 7.x BWC compatibility. This setting has no effect in 8.x. Do not use.
      * TODO: Remove in 9.0
      */

--- a/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
@@ -241,6 +241,7 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
                 IndexMetadata.INDEX_ROUTING_PATH,
                 IndexMetadata.INDEX_DIMENSIONS,
                 IndexMetadata.INDEX_DIMENSIONS_TSID_STRATEGY_ENABLED,
+                IndexMetadata.EXPERIMENTAL_ALL_NON_METRIC_DIMENSIONS,
                 IndexSettings.TIME_SERIES_START_TIME,
                 IndexSettings.TIME_SERIES_END_TIME,
                 IndexSettings.SEQ_NO_INDEX_OPTIONS_SETTING,

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -1293,6 +1293,7 @@ public final class IndexSettings {
     private final boolean timeSeriesEs95CodecEnabled;
     private final boolean useEs812PostingsFormat;
     private final boolean disableSequenceNumbers;
+    private final boolean experimentalAllNonMetricDimensions;
     private final boolean indexDisabledByDefault;
 
     /**
@@ -1512,6 +1513,7 @@ public final class IndexSettings {
         useEs812PostingsFormat = scopedSettings.get(USE_ES_812_POSTINGS_FORMAT);
         intraMergeParallelismEnabled = scopedSettings.get(INTRA_MERGE_PARALLELISM_ENABLED_SETTING);
         useTimeSeriesSyntheticId = scopedSettings.get(SYNTHETIC_ID);
+        experimentalAllNonMetricDimensions = scopedSettings.get(IndexMetadata.EXPERIMENTAL_ALL_NON_METRIC_DIMENSIONS);
         syntheticIdBloomFilterSettings = SyntheticIdBloomFilterSettings.fromScopedSettings(scopedSettings);
         if (indexMetadata.useTimeSeriesSyntheticId() != useTimeSeriesSyntheticId) {
             throw new IllegalArgumentException(
@@ -2289,6 +2291,13 @@ public final class IndexSettings {
      */
     public boolean useTimeSeriesSyntheticId() {
         return useTimeSeriesSyntheticId;
+    }
+
+    /**
+     * @return Whether non-metric fields with doc values should be treated as time series dimensions.
+     */
+    public boolean experimentalAllNonMetricDimensions() {
+        return experimentalAllNonMetricDimensions;
     }
 
     public SyntheticIdBloomFilterSettings syntheticIdBloomFilterSettings() {

--- a/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
@@ -132,7 +132,11 @@ public class BooleanFieldMapper extends FieldMapper {
                 m -> toType(m).fieldType().isDimension(),
                 () -> docValuesParameters.get().enabled()
             );
-            this.indexed = Parameter.indexParam(m -> toType(m).indexed, indexSettings, dimension);
+            this.indexed = Parameter.indexParam(
+                m -> toType(m).indexed,
+                indexSettings,
+                () -> TimeSeriesParams.resolveDimension(dimension.get(), indexSettings, docValuesParameters.get().enabled(), null)
+            );
             addScriptValidation(script, indexed, () -> docValuesParameters.getValue().enabled());
         }
 
@@ -186,7 +190,7 @@ public class BooleanFieldMapper extends FieldMapper {
                 nullValue.getValue(),
                 scriptValues(),
                 meta.getValue(),
-                dimension.getValue(),
+                TimeSeriesParams.resolveDimension(dimension.getValue(), indexSettings, docValuesParameters.get().enabled(), null),
                 context.isSourceSynthetic()
             );
             hasScript = script.get() != null;
@@ -551,7 +555,7 @@ public class BooleanFieldMapper extends FieldMapper {
         this.scriptValues = builder.scriptValues();
         this.scriptCompiler = builder.scriptCompiler;
         this.indexSettings = builder.indexSettings;
-        this.writeDimensionRouting = builder.dimension.getValue()
+        this.writeDimensionRouting = fieldType().isDimension()
             && builder.indexSettings.getIndexRouting() instanceof IndexRouting.ExtractFromSource efs
             && efs.extractDimensionsWhileMapping();
         this.ignoreMalformed = builder.ignoreMalformed.getValue();

--- a/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -125,7 +125,11 @@ public class IpFieldMapper extends FieldMapper {
             );
             this.script.precludesParameters(nullValue, ignoreMalformed);
             this.dimension = TimeSeriesParams.dimensionParam(m -> toType(m).dimension, () -> docValuesParameters.get().enabled());
-            this.indexed = Parameter.indexParam(m -> toType(m).indexed, indexSettings, dimension);
+            this.indexed = Parameter.indexParam(
+                m -> toType(m).indexed,
+                indexSettings,
+                () -> TimeSeriesParams.resolveDimension(dimension.get(), indexSettings, docValuesParameters.get().enabled(), null)
+            );
             addScriptValidation(script, indexed, () -> docValuesParameters.getValue().enabled());
         }
 
@@ -246,7 +250,7 @@ public class IpFieldMapper extends FieldMapper {
                     parseNullValue(),
                     scriptValues(),
                     meta.getValue(),
-                    dimension.getValue(),
+                    TimeSeriesParams.resolveDimension(dimension.getValue(), indexSettings, docValuesParameters.get().enabled(), null),
                     context.isSourceSynthetic(),
                     usesBinaryDocValues()
                 ),
@@ -673,7 +677,7 @@ public class IpFieldMapper extends FieldMapper {
         this.script = builder.script.get();
         this.scriptValues = builder.scriptValues();
         this.scriptCompiler = builder.scriptCompiler;
-        this.dimension = builder.dimension.getValue();
+        this.dimension = fieldType().isDimension();
         this.writeDimensionRouting = this.dimension
             && builder.indexSettings.getIndexRouting() instanceof IndexRouting.ExtractFromSource efs
             && efs.extractDimensionsWhileMapping();

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -291,7 +291,11 @@ public final class KeywordFieldMapper extends FieldMapper {
                 m -> toType(m).fieldType().isDimension(),
                 () -> docValuesParameters.getValue().enabled()
             ).precludesParameters(normalizer);
-            this.indexed = Parameter.indexParam(m -> toType(m).indexed, indexSettings, dimension);
+            this.indexed = Parameter.indexParam(
+                m -> toType(m).indexed,
+                indexSettings,
+                () -> TimeSeriesParams.resolveDimension(dimension.get(), indexSettings, docValuesParameters.get().enabled(), null)
+            );
             addScriptValidation(script, indexed, () -> docValuesParameters.getValue().enabled());
 
             this.ignoreAbove = Parameter.ignoreAboveParam(
@@ -612,7 +616,12 @@ public final class KeywordFieldMapper extends FieldMapper {
             );
             this.nullValue = builder.nullValue.getValue();
             this.scriptValues = builder.scriptValues();
-            this.isDimension = builder.dimension.getValue();
+            this.isDimension = TimeSeriesParams.resolveDimension(
+                builder.dimension.getValue(),
+                builder.indexSettings,
+                builder.docValuesParameters.get().enabled(),
+                null
+            );
             this.usesBinaryDocValues = builder.usesBinaryDocValues();
             this.usesBinaryDocValuesForIgnoredFields = builder.storeIgnoredFieldsInBinaryDocValues;
             this.docValuesParams = builder.docValuesParameters();
@@ -1367,7 +1376,7 @@ public final class KeywordFieldMapper extends FieldMapper {
         this.indexAnalyzers = builder.indexAnalyzers;
         this.scriptCompiler = builder.scriptCompiler;
         this.indexSettings = builder.indexSettings;
-        this.writeDimensionRouting = builder.dimension.getValue()
+        this.writeDimensionRouting = fieldType().isDimension()
             && builder.indexSettings.getIndexRouting() instanceof IndexRouting.ExtractFromSource efs
             && efs.extractDimensionsWhileMapping();
         this.forceDocValuesSkipper = builder.forceDocValuesSkipper;

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -196,7 +196,7 @@ public class NumberFieldMapper extends FieldMapper {
                     return false;
                 }
 
-                if (useTimeSeriesDocValuesSkippers(indexSettings, dimension.get())) {
+                if (useTimeSeriesDocValuesSkippers(indexSettings, resolveDimension())) {
                     return false;
                 }
                 if (indexSettings.getMode() == IndexMode.TIME_SERIES) {
@@ -250,7 +250,7 @@ public class NumberFieldMapper extends FieldMapper {
                 return IndexType.archivedPoints();
             }
             if (indexed.get() == false && docValuesParameters.get().enabled()) {
-                if (useTimeSeriesDocValuesSkippers(indexSettings, dimension.get())) {
+                if (useTimeSeriesDocValuesSkippers(indexSettings, resolveDimension())) {
                     return IndexType.skippers();
                 }
                 if (indexSettings.useDocValuesSkipper()
@@ -280,6 +280,10 @@ public class NumberFieldMapper extends FieldMapper {
 
         private Parameter<MetricType> getMetric() {
             return metric;
+        }
+
+        private boolean resolveDimension() {
+            return TimeSeriesParams.resolveDimension(dimension.get(), indexSettings, docValuesParameters.get().enabled(), metric.get());
         }
 
         public Builder allowMultipleValues(boolean allowMultipleValues) {
@@ -2150,7 +2154,12 @@ public class NumberFieldMapper extends FieldMapper {
                 builder.nullValue.getValue(),
                 builder.meta.getValue(),
                 builder.scriptValues(),
-                builder.dimension.getValue(),
+                TimeSeriesParams.resolveDimension(
+                    builder.dimension.getValue(),
+                    builder.indexSettings,
+                    builder.docValuesParameters.get().enabled(),
+                    builder.metric.getValue()
+                ),
                 builder.metric.getValue(),
                 builder.indexSettings.getMode(),
                 isSyntheticSource
@@ -2449,7 +2458,12 @@ public class NumberFieldMapper extends FieldMapper {
         this.coerce = builder.coerce.getValue();
         this.nullValue = builder.nullValue.getValue();
         this.scriptValues = builder.scriptValues();
-        this.dimension = builder.dimension.getValue();
+        this.dimension = TimeSeriesParams.resolveDimension(
+            builder.dimension.getValue(),
+            builder.indexSettings,
+            builder.docValuesParameters.get().enabled(),
+            builder.metric.getValue()
+        );
         this.writeDimensionRouting = this.dimension
             && builder.indexSettings.getIndexRouting() instanceof IndexRouting.ExtractFromSource efs
             && efs.extractDimensionsWhileMapping();

--- a/server/src/main/java/org/elasticsearch/index/mapper/TimeSeriesParams.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TimeSeriesParams.java
@@ -9,6 +9,9 @@
 
 package org.elasticsearch.index.mapper;
 
+import org.elasticsearch.index.IndexMode;
+import org.elasticsearch.index.IndexSettings;
+
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.Locale;
@@ -98,6 +101,31 @@ public final class TimeSeriesParams {
                 );
             }
         });
+    }
+
+    /**
+     * Resolves whether a field is a time series dimension, including the experimental mode that treats all
+     * non-metric fields with doc values as dimensions on time series indices.
+     */
+    public static boolean resolveDimension(
+        boolean explicitDimension,
+        IndexSettings indexSettings,
+        boolean hasDocValues,
+        MetricType metricType
+    ) {
+        if (explicitDimension) {
+            return true;
+        }
+        if (metricType != null) {
+            return false;
+        }
+        if (indexSettings.getMode() != IndexMode.TIME_SERIES) {
+            return false;
+        }
+        if (indexSettings.experimentalAllNonMetricDimensions() == false) {
+            return false;
+        }
+        return hasDocValues;
     }
 
 }


### PR DESCRIPTION
## Summary
- Adds `cluster.time_series.experimental_all_non_metric_dimensions` (default `true`) to treat non-metric fields with doc values as time series dimensions on new TSDS backing indices.
- Propagates the flag to private `index.time_series.experimental_all_non_metric_dimensions` and populates `index.dimensions` for the modern tsid-at-routing path.
- Resolves dimensions in keyword, numeric, ip, and boolean field mappers via `TimeSeriesParams.resolveDimension()` so routing, `_tsid`, and storage behavior stay aligned.

## Motivation
Supports benchmarking the performance impact of treating all non-metric identity fields as dimensions without fighting composable template priority or dynamic-template `index.dimensions` limitations.

## Usage
Enabled by default on new clusters. Disable with:

```yaml
cluster.time_series.experimental_all_non_metric_dimensions: false
```

Create a new data stream or roll over to apply to a backing index. Verify with:

```http
GET <data-stream>/_settings?filter_path=**.dimensions,**.experimental_all_non_metric_dimensions,**.routing_path
```

## Test plan
- [x] `DataStreamIndexSettingsProviderTests` (including default-on and opt-out cases)
- [ ] Manual ingest/search benchmark on a TSDS with mixed templates


Made with [Cursor](https://cursor.com)