### PR TITLE
[CI] Escape `$BUILDKITE_PARALLEL_JOB` in flakiness parallel-fanout dispatch

### DIFF
--- a/.buildkite/scripts/flakiness-detection/runners/buildkite.test.ts
+++ b/.buildkite/scripts/flakiness-detection/runners/buildkite.test.ts
@@ -73,10 +73,14 @@ describe("toBuildkitePipeline end-to-end", () => {
     // Each parallel batch is independently wrapped under the inner timeout.
     expect(step.env!["BATCH_COMMAND_0"]).toContain("timeout --foreground --signal=TERM --kill-after=30s 58m bash");
     expect(step.env!["BATCH_COMMAND_4"]).toContain("timeout --foreground --signal=TERM --kill-after=30s 58m bash");
-    expect(step.command).toContain("BUILDKITE_PARALLEL_JOB");
-    // The `$$` escape prevents Buildkite pipeline interpolation from trying to
-    // parse `${!VARNAME}` (bash indirect expansion) as a Buildkite variable,
-    // which fails with "Expected identifier to start with a letter, got !".
+    // Both `$$` escapes defer interpolation past BK's pipeline-upload pass:
+    //   * BUILDKITE_PARALLEL_JOB is a per-job runtime var; if not escaped, BK
+    //     substitutes empty at upload time and the indirect lookup becomes a
+    //     no-op (the bug observed on build 150689).
+    //   * `${!VARNAME}` (bash indirect expansion) can't be parsed by BK as a
+    //     variable identifier because of the leading `!`.
+    expect(step.command).toContain('$${BUILDKITE_PARALLEL_JOB}');
+    expect(step.command).not.toMatch(/[^$]\$\{BUILDKITE_PARALLEL_JOB\}/);
     expect(step.command).toContain('$${!VARNAME}');
     expect(step.command).not.toMatch(/[^$]\$\{!VARNAME\}/);
 

--- a/.buildkite/scripts/flakiness-detection/runners/buildkite.ts
+++ b/.buildkite/scripts/flakiness-detection/runners/buildkite.ts
@@ -117,7 +117,12 @@ export function toBuildkitePipeline(
       for (let i = 0; i < batches.length; i++) {
         env[`BATCH_COMMAND_${i}`] = wrapNeverFail(batches[i].command, key, cfg.timeoutInMinutes);
       }
-      step.command = 'VARNAME="BATCH_COMMAND_${BUILDKITE_PARALLEL_JOB}"; eval "$${!VARNAME}"';
+      // Both `$$` escapes defer interpolation past Buildkite's pipeline-upload
+      // pass: `$$BUILDKITE_PARALLEL_JOB` because the variable is set per-job at
+      // run time (BK substitutes empty at upload time, breaking the indirect
+      // lookup), and `$${!VARNAME}` because BK can't parse `!` as the start of
+      // a variable identifier.
+      step.command = 'VARNAME="BATCH_COMMAND_$${BUILDKITE_PARALLEL_JOB}"; eval "$${!VARNAME}"';
       step.parallelism = batches.length;
       step.env = env;
     }


### PR DESCRIPTION
## What & why

`step.command` in `toBuildkitePipeline` (the parallel-fanout dispatcher) was emitting:

```text
VARNAME="BATCH_COMMAND_${BUILDKITE_PARALLEL_JOB}"; eval "${!VARNAME}"
```

`${BUILDKITE_PARALLEL_JOB}` (single `$`) is a per-job runtime variable, but Buildkite's pipeline-upload interpolation pass runs **before** the agent injects per-job env. BK can't resolve it at upload time, so it substitutes empty. The runtime command becomes:

```text
VARNAME="BATCH_COMMAND_"; eval "${!VARNAME}"
```

Bash indirect lookup `${!VARNAME}` of the unset `$BATCH_COMMAND_` expands to empty, `eval ""` is a no-op, the job exits 0 in ~2s with zero JUnit XML, and BK reports it green.

Bug has been present since the flakiness-detection modularization commit `9003f9233a6c`. It was masked because the analyzer treats "no artifacts" the same as "no flakiness found" — silent no-op all the way through. It surfaced today only after [#150209](https://github.com/elastic/elasticsearch/pull/150209) (the wrapper-hang fix) let parallel jobs finish quickly enough to inspect the log end-to-end.

Example before the fix: [build 150689 job `019e73e0-1758`](https://buildkite.com/elastic/elasticsearch-pull-request/builds/150689#019e73e0-1758-4e3d-879b-0388f4d2c39a)

```text
$ VARNAME="BATCH_COMMAND_"; eval "${!VARNAME}"
~~~ Uploading artifacts
INFO  No files matched paths: **/build/test-results/**/TEST-*.xml
```

## Change

```diff
-step.command = 'VARNAME="BATCH_COMMAND_${BUILDKITE_PARALLEL_JOB}"; eval "$${!VARNAME}"';
+step.command = 'VARNAME="BATCH_COMMAND_$${BUILDKITE_PARALLEL_JOB}"; eval "$${!VARNAME}"';
```

`$$BUILDKITE_PARALLEL_JOB` defers interpolation past BK's upload pass; the agent then resolves it correctly to `0, 1, …` per parallel job.

## Test plan

- [x] `bun test scripts/flakiness-detection` — 109 pass / 208 expect()
- [x] New regression assertion: `step.command` must contain `$${BUILDKITE_PARALLEL_JOB}` and must not contain the unescaped form
- [x] Once merged, observe next flakiness-detection parallel-fanout step on a real PR: the job log should show `VARNAME="BATCH_COMMAND_0"` (or 1, 2, …) and produce real JUnit XML.
