### PR TITLE
[VERIFY-DO-NOT-MERGE] #150223 — parallel-fanout dispatch fix

### DIFF
--- a/.buildkite/scripts/flakiness-detection/runners/buildkite.test.ts
+++ b/.buildkite/scripts/flakiness-detection/runners/buildkite.test.ts
@@ -73,10 +73,14 @@ describe("toBuildkitePipeline end-to-end", () => {
     // Each parallel batch is independently wrapped under the inner timeout.
     expect(step.env!["BATCH_COMMAND_0"]).toContain("timeout --foreground --signal=TERM --kill-after=30s 58m bash");
     expect(step.env!["BATCH_COMMAND_4"]).toContain("timeout --foreground --signal=TERM --kill-after=30s 58m bash");
-    expect(step.command).toContain("BUILDKITE_PARALLEL_JOB");
-    // The `$$` escape prevents Buildkite pipeline interpolation from trying to
-    // parse `${!VARNAME}` (bash indirect expansion) as a Buildkite variable,
-    // which fails with "Expected identifier to start with a letter, got !".
+    // Both `$$` escapes defer interpolation past BK's pipeline-upload pass:
+    //   * BUILDKITE_PARALLEL_JOB is a per-job runtime var; if not escaped, BK
+    //     substitutes empty at upload time and the indirect lookup becomes a
+    //     no-op (the bug observed on build 150689).
+    //   * `${!VARNAME}` (bash indirect expansion) can't be parsed by BK as a
+    //     variable identifier because of the leading `!`.
+    expect(step.command).toContain('$${BUILDKITE_PARALLEL_JOB}');
+    expect(step.command).not.toMatch(/[^$]\$\{BUILDKITE_PARALLEL_JOB\}/);
     expect(step.command).toContain('$${!VARNAME}');
     expect(step.command).not.toMatch(/[^$]\$\{!VARNAME\}/);
 

--- a/.buildkite/scripts/flakiness-detection/runners/buildkite.ts
+++ b/.buildkite/scripts/flakiness-detection/runners/buildkite.ts
@@ -117,7 +117,12 @@ export function toBuildkitePipeline(
       for (let i = 0; i < batches.length; i++) {
         env[`BATCH_COMMAND_${i}`] = wrapNeverFail(batches[i].command, key, cfg.timeoutInMinutes);
       }
-      step.command = 'VARNAME="BATCH_COMMAND_${BUILDKITE_PARALLEL_JOB}"; eval "$${!VARNAME}"';
+      // Both `$$` escapes defer interpolation past Buildkite's pipeline-upload
+      // pass: `$$BUILDKITE_PARALLEL_JOB` because the variable is set per-job at
+      // run time (BK substitutes empty at upload time, breaking the indirect
+      // lookup), and `$${!VARNAME}` because BK can't parse `!` as the start of
+      // a variable identifier.
+      step.command = 'VARNAME="BATCH_COMMAND_$${BUILDKITE_PARALLEL_JOB}"; eval "$${!VARNAME}"';
       step.parallelism = batches.length;
       step.env = env;
     }

--- a/server/src/test/java/org/elasticsearch/BuildTests.java
+++ b/server/src/test/java/org/elasticsearch/BuildTests.java
@@ -30,6 +30,8 @@ import static org.hamcrest.Matchers.sameInstance;
 
 public class BuildTests extends ESTestCase {
 
+    // verification touch for flakiness parallel-fanout (#150223)
+
     /** Asking for the jar metadata should not throw exception in tests, no matter how configured */
     public void testJarMetadata() throws IOException {
         URL url = Build.getElasticsearchCodeSourceLocation();

--- a/server/src/test/java/org/elasticsearch/ElasticsearchExceptionTests.java
+++ b/server/src/test/java/org/elasticsearch/ElasticsearchExceptionTests.java
@@ -80,6 +80,8 @@ import static org.hamcrest.Matchers.startsWith;
 
 public class ElasticsearchExceptionTests extends ESTestCase {
 
+    // verification touch for flakiness parallel-fanout (#150223)
+
     public void testStatus() {
         ElasticsearchException exception = new ElasticsearchException("test");
         assertThat(exception.status(), equalTo(RestStatus.INTERNAL_SERVER_ERROR));

--- a/server/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
+++ b/server/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
@@ -146,6 +146,8 @@ import static org.hamcrest.Matchers.instanceOf;
 
 public class ExceptionSerializationTests extends ESTestCase {
 
+    // verification touch for flakiness parallel-fanout (#150223)
+
     public void testExceptionRegistration() throws IOException, URISyntaxException {
         final Set<Class<?>> notRegistered = new HashSet<>();
         final Set<Class<?>> registered = new HashSet<>();

--- a/server/src/test/java/org/elasticsearch/ExceptionsHelperTests.java
+++ b/server/src/test/java/org/elasticsearch/ExceptionsHelperTests.java
@@ -35,6 +35,8 @@ import static org.hamcrest.CoreMatchers.nullValue;
 
 public class ExceptionsHelperTests extends ESTestCase {
 
+    // verification touch for flakiness parallel-fanout (#150223)
+
     public void testMaybeError() {
         final Error outOfMemoryError = new OutOfMemoryError();
         assertError(outOfMemoryError, outOfMemoryError);

--- a/server/src/test/java/org/elasticsearch/ReleaseVersionsTests.java
+++ b/server/src/test/java/org/elasticsearch/ReleaseVersionsTests.java
@@ -17,6 +17,8 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class ReleaseVersionsTests extends ESTestCase {
 
+    // verification touch for flakiness parallel-fanout (#150223)
+
     public void testReleaseVersions() {
         IntFunction<String> versions = ReleaseVersions.generateVersionsLookup(ReleaseVersionsTests.class, 23);
 

--- a/server/src/test/java/org/elasticsearch/TransportVersionTests.java
+++ b/server/src/test/java/org/elasticsearch/TransportVersionTests.java
@@ -28,6 +28,8 @@ import static org.hamcrest.Matchers.sameInstance;
 
 public class TransportVersionTests extends ESTestCase {
 
+    // verification touch for flakiness parallel-fanout (#150223)
+
     public static class CorrectFakeVersion {
         public static final TransportVersion V_0_00_01 = new TransportVersion(199);
         public static final TransportVersion V_0_000_002 = new TransportVersion(2);

--- a/server/src/test/java/org/elasticsearch/VersionTests.java
+++ b/server/src/test/java/org/elasticsearch/VersionTests.java
@@ -29,6 +29,8 @@ import static org.hamcrest.Matchers.sameInstance;
 
 public class VersionTests extends ESTestCase {
 
+    // verification touch for flakiness parallel-fanout (#150223)
+
     public void testVersionComparison() {
         Version V_7_2_0 = Version.fromString("7.2.0");
         Version V_8_0_0 = Version.fromString("8.0.0");


### PR DESCRIPTION
## Purpose

Verification PR for #150223 — **do not merge**. This branch contains the fix from `flakiness-escape-parallel-job` plus tiny no-op touches to seven fast `:server:test` classes to force `parallelism >= 3` in the flakiness-detection parallel-fanout step.

## Related

- Fix PR: #150223
- Bug: Buildkite pipeline-upload ate `${BUILDKITE_PARALLEL_JOB}` (single `$`), so parallel jobs ran `VARNAME="BATCH_COMMAND_"; eval ""` — a silent no-op that exited green with zero JUnit XML.

## What changed (verification-only)

Touched 7 unit test files under `server/src/test/java/org/elasticsearch/` (comment-only, no behavioral change):

- `VersionTests.java`
- `TransportVersionTests.java`
- `BuildTests.java`
- `ReleaseVersionsTests.java`
- `ExceptionsHelperTests.java`
- `ElasticsearchExceptionTests.java`
- `ExceptionSerializationTests.java`

With `BATCH_CAPS.test = 3`, seven changed unit tests should batch as 3+3+1 → **parallelism = 3** for key `flakiness-detection:unit`.

## Verification criteria

After the fix, each parallel-fanout job must:

1. **Run the real wrapped gradle command** — log shows `wrapNeverFail` heredoc, `set +e`, `WRAPPED_CMD_FILE=$(mktemp)`, `timeout --foreground …`, and `.ci/scripts/run-gradle.sh` (not a 2-line empty `eval`).
2. **Distinct `BATCH_COMMAND_N` index** — `VARNAME="BATCH_COMMAND_0"`, `BATCH_COMMAND_1`, `BATCH_COMMAND_2`, not `BATCH_COMMAND_` with nothing after the underscore.
3. **Upload JUnit XML artifacts** — `Uploading artifacts` with non-zero match count for `**/build/test-results/**/TEST-*.xml`.
4. **Analyze step has real data** — `flakiness-detection:analyze` shows actual test results, not an empty/no-failures report from missing XML.

## Test plan

- [ ] Wait for `flakiness-detection` group in PR build
- [ ] Inspect parallel-fanout job logs for all 4 criteria
- [ ] Post verdict comment and close this PR (no merge)