### PR TITLE
Implement GET /_prometheus/api/v1/status/buildinfo

### DIFF
--- a/docs/changelog/150235.yaml
+++ b/docs/changelog/150235.yaml
@@ -1,0 +1,6 @@
+area: PromQL
+issues:
+ - 149575
+pr: 150235
+summary: Implement GET /_prometheus/api/v1/status/buildinfo
+type: enhancement

--- a/docs/changelog/150235.yaml
+++ b/docs/changelog/150235.yaml
@@ -1,6 +1,5 @@
 area: PromQL
-issues:
- - 149575
+issues: []
 pr: 150235
 summary: Implement GET /_prometheus/api/v1/status/buildinfo
 type: enhancement

--- a/docs/reference/query-languages/promql/promql-http-api.md
+++ b/docs/reference/query-languages/promql/promql-http-api.md
@@ -148,6 +148,33 @@ The `help` field is always an empty string for now (see [Limitations](promql-lim
 The `metadata` route does not support `match[]`, `start`, or `end`.
 {{es}} discovers type and unit using the {{esql}} [`METRICS_INFO`](/reference/query-languages/esql/commands/metrics-info.md) command over [time series data streams](docs-content://manage-data/data-store/data-streams/time-series-data-stream-tsds.md) (TSDS), with a fixed 24-hour lookback ending when the request runs.
 
+## Status endpoints [promql-http-api-status]
+
+### Build information [promql-http-api-buildinfo]
+
+{applies_to}`stack: preview 9.5.0` {applies_to}`serverless: preview`
+
+`GET /_prometheus/api/v1/status/buildinfo`\
+`GET /_prometheus/{index}/api/v1/status/buildinfo`
+
+Returns build information about the {{es}} instance in the standard Prometheus buildinfo format.
+Grafana queries this endpoint to identify the backend type and determine available features.
+The `{index}` segment is accepted for datasource configurations that use a scoped base URL, but it does not affect the response.
+
+Example response:
+
+```json
+{
+  "status": "success",
+  "data": {
+    "application": "Elasticsearch",
+    "version": "9.5.0",
+    "revision": "af328d7d33ae419957d8e12beec76219710760fb",
+    "buildDate": "2026-05-27T22:17:45.329682193Z"
+  }
+}
+```
+
 ## Request parameter formats [promql-http-api-parameters]
 
 Parameter encodings match the [Prometheus HTTP API](https://prometheus.io/docs/prometheus/latest/querying/api/). See the upstream [format overview](https://prometheus.io/docs/prometheus/latest/querying/api/#format-overview).

--- a/x-pack/plugin/prometheus/src/javaRestTest/java/org/elasticsearch/xpack/prometheus/PrometheusStatusBuildInfoRestIT.java
+++ b/x-pack/plugin/prometheus/src/javaRestTest/java/org/elasticsearch/xpack/prometheus/PrometheusStatusBuildInfoRestIT.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.prometheus;
+
+import org.elasticsearch.Build;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.test.rest.ObjectPath;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Integration tests for the {@code GET /_prometheus/api/v1/status/buildinfo} endpoint.
+ */
+public class PrometheusStatusBuildInfoRestIT extends AbstractPrometheusRestIT {
+
+    public void testBuildInfoResponse() throws Exception {
+        Request request = new Request("GET", "/_prometheus/api/v1/status/buildinfo");
+        addReadAuth(request);
+
+        Response response = client().performRequest(request);
+
+        assertThat(response.getStatusLine().getStatusCode(), equalTo(200));
+        assertThat(response.getEntity().getContentType().getValue(), containsString("application/json"));
+
+        ObjectPath op = ObjectPath.createFromResponse(response);
+        assertThat(op.evaluate("status"), equalTo("success"));
+        assertThat(op.evaluate("data.application"), equalTo("Elasticsearch"));
+        assertThat(op.evaluate("data.version"), equalTo(Build.current().version()));
+        assertThat(op.evaluate("data.revision"), equalTo(Build.current().hash()));
+    }
+}

--- a/x-pack/plugin/prometheus/src/javaRestTest/java/org/elasticsearch/xpack/prometheus/PrometheusStatusBuildInfoRestIT.java
+++ b/x-pack/plugin/prometheus/src/javaRestTest/java/org/elasticsearch/xpack/prometheus/PrometheusStatusBuildInfoRestIT.java
@@ -21,7 +21,15 @@ import static org.hamcrest.Matchers.equalTo;
 public class PrometheusStatusBuildInfoRestIT extends AbstractPrometheusRestIT {
 
     public void testBuildInfoResponse() throws Exception {
-        Request request = new Request("GET", "/_prometheus/api/v1/status/buildinfo");
+        assertBuildInfo("/_prometheus/api/v1/status/buildinfo");
+    }
+
+    public void testBuildInfoResponseScopedIndex() throws Exception {
+        assertBuildInfo("/_prometheus/metrics-generic.prometheus-default/api/v1/status/buildinfo");
+    }
+
+    private void assertBuildInfo(String path) throws Exception {
+        Request request = new Request("GET", path);
         addReadAuth(request);
 
         Response response = client().performRequest(request);

--- a/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/PrometheusPlugin.java
+++ b/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/PrometheusPlugin.java
@@ -29,6 +29,7 @@ import org.elasticsearch.xpack.prometheus.rest.PrometheusQueryRangeRestAction;
 import org.elasticsearch.xpack.prometheus.rest.PrometheusRemoteWriteRestAction;
 import org.elasticsearch.xpack.prometheus.rest.PrometheusRemoteWriteTransportAction;
 import org.elasticsearch.xpack.prometheus.rest.PrometheusSeriesRestAction;
+import org.elasticsearch.xpack.prometheus.rest.PrometheusStatusBuildInfoRestAction;
 
 import java.util.Collection;
 import java.util.List;
@@ -107,7 +108,8 @@ public class PrometheusPlugin extends Plugin implements ActionPlugin {
                 new PrometheusInstantQueryRestAction(),
                 new PrometheusLabelsRestAction(),
                 new PrometheusLabelValuesRestAction(),
-                new PrometheusMetadataRestAction()
+                new PrometheusMetadataRestAction(),
+                new PrometheusStatusBuildInfoRestAction()
             );
         }
         return List.of();

--- a/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/rest/PrometheusStatusBuildInfoRestAction.java
+++ b/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/rest/PrometheusStatusBuildInfoRestAction.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.prometheus.rest;
+
+import org.elasticsearch.Build;
+import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.RestResponse;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.rest.Scope;
+import org.elasticsearch.rest.ServerlessScope;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.json.JsonXContent;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.elasticsearch.rest.RestRequest.Method.GET;
+
+/**
+ * REST handler for {@code GET /_prometheus/api/v1/status/buildinfo}.
+ * Returns build information in the standard Prometheus buildinfo format.
+ * Grafana queries this endpoint to identify the backend type and determine available alerting features.
+ * Without it, Grafana shows an error when opening the "Plugin info" panel in Metrics Drilldown.
+ */
+@ServerlessScope(Scope.PUBLIC)
+public class PrometheusStatusBuildInfoRestAction extends BaseRestHandler {
+
+    @Override
+    public String getName() {
+        return "prometheus_status_buildinfo_action";
+    }
+
+    @Override
+    public List<Route> routes() {
+        return List.of(new Route(GET, "/_prometheus/api/v1/status/buildinfo"));
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+        Build build = Build.current();
+        XContentBuilder builder = JsonXContent.contentBuilder();
+        builder.startObject();
+        {
+            builder.field("status", "success");
+            builder.startObject("data");
+            {
+                builder.field("application", "Elasticsearch");
+                builder.field("version", build.version());
+                builder.field("revision", build.hash());
+                builder.field("buildDate", build.date());
+            }
+            builder.endObject();
+        }
+        builder.endObject();
+        String body = Strings.toString(builder);
+        return channel -> channel.sendResponse(new RestResponse(RestStatus.OK, "application/json", body));
+    }
+}

--- a/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/rest/PrometheusStatusBuildInfoRestAction.java
+++ b/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/rest/PrometheusStatusBuildInfoRestAction.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.List;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
+import static org.elasticsearch.xpack.esql.plan.logical.promql.PromqlCommand.DEFAULT_PROMQL_INDEX_PATTERN;
 
 /**
  * REST handler for {@code GET /_prometheus/api/v1/status/buildinfo}.
@@ -32,6 +33,8 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
  */
 @ServerlessScope(Scope.PUBLIC)
 public class PrometheusStatusBuildInfoRestAction extends BaseRestHandler {
+
+    private static final String INDEX_PARAM = "index";
 
     @Override
     public String getName() {
@@ -48,6 +51,8 @@ public class PrometheusStatusBuildInfoRestAction extends BaseRestHandler {
 
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+        // Consume optional {index} path segment; response does not depend on index scope.
+        request.param(INDEX_PARAM, DEFAULT_PROMQL_INDEX_PATTERN);
         Build build = Build.current();
         XContentBuilder builder = JsonXContent.contentBuilder();
         builder.startObject();

--- a/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/rest/PrometheusStatusBuildInfoRestAction.java
+++ b/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/rest/PrometheusStatusBuildInfoRestAction.java
@@ -40,7 +40,10 @@ public class PrometheusStatusBuildInfoRestAction extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return List.of(new Route(GET, "/_prometheus/api/v1/status/buildinfo"));
+        return List.of(
+            new Route(GET, "/_prometheus/api/v1/status/buildinfo"),
+            new Route(GET, "/_prometheus/{index}/api/v1/status/buildinfo")
+        );
     }
 
     @Override

--- a/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/rest/PrometheusStatusBuildInfoRestAction.java
+++ b/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/rest/PrometheusStatusBuildInfoRestAction.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.prometheus.rest;
 
 import org.elasticsearch.Build;
 import org.elasticsearch.client.internal.node.NodeClient;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestResponse;
@@ -68,7 +67,6 @@ public class PrometheusStatusBuildInfoRestAction extends BaseRestHandler {
             builder.endObject();
         }
         builder.endObject();
-        String body = Strings.toString(builder);
-        return channel -> channel.sendResponse(new RestResponse(RestStatus.OK, "application/json", body));
+        return channel -> channel.sendResponse(new RestResponse(RestStatus.OK, builder));
     }
 }


### PR DESCRIPTION
Grafana calls this endpoint when connecting to any Prometheus-compatible data source. Without it, two things break:

1. The "Plugin info" panel in Grafana Metrics Drilldown shows a hard error instead of version information.
2. Grafana's alerting feature discovery receives an error response instead of a graceful 404, which can disrupt alerting rule configuration flows.

The fix is a static endpoint that returns ES build info (version, git hash, build date) in the standard Prometheus buildinfo shape, with `application: "Elasticsearch"` so Grafana correctly identifies the backend as vanilla Prometheus rather than Mimir or Cortex — ensuring it doesn't attempt to use the Ruler API or other Mimir-specific features that we don't support.