### PR TITLE
Update `repository-s3` request signer

### DIFF
--- a/modules/repository-s3/build.gradle
+++ b/modules/repository-s3/build.gradle
@@ -67,6 +67,7 @@ dependencies {
 
   testImplementation project(':test:fixtures:s3-fixture')
   testImplementation "software.amazon.awssdk:endpoints-spi:${versions.awsv2sdk}"
+  testImplementation project(':test:fixtures:tls-utils')
 
   internalClusterTestImplementation project(':test:fixtures:aws-fixture-utils')
   internalClusterTestImplementation project(':test:fixtures:minio-fixture')
@@ -76,6 +77,7 @@ dependencies {
   yamlRestTestImplementation project(':test:fixtures:aws-fixture-utils')
   yamlRestTestImplementation project(':test:fixtures:s3-fixture')
   yamlRestTestImplementation project(':test:fixtures:testcontainer-utils')
+  yamlRestTestImplementation project(':test:fixtures:tls-utils')
   yamlRestTestImplementation project(':test:framework')
   yamlRestTestRuntimeOnly "org.slf4j:slf4j-simple:${versions.slf4j}"
 
@@ -86,6 +88,7 @@ dependencies {
   javaRestTestImplementation project(':test:fixtures:minio-fixture')
   javaRestTestImplementation project(':test:fixtures:s3-fixture')
   javaRestTestImplementation project(':test:fixtures:testcontainer-utils')
+  javaRestTestImplementation project(':test:fixtures:tls-utils')
   javaRestTestImplementation project(':test:framework')
   javaRestTestRuntimeOnly "org.slf4j:slf4j-simple:${versions.slf4j}"
 }

--- a/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3ContentIntegrityRestIT.java
+++ b/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3ContentIntegrityRestIT.java
@@ -9,43 +9,71 @@
 
 package org.elasticsearch.repositories.s3;
 
+import fixture.aws.ChunkedEncodingConfiguration;
+import fixture.aws.DynamicRegionSupplier;
 import fixture.s3.S3HttpFixture;
+import fixture.s3.S3HttpHandler;
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+import com.sun.net.httpserver.HttpHandler;
 
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.fixtures.testcontainers.TestContainersThreadFilter;
 import org.junit.ClassRule;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
-import static fixture.aws.AwsCredentialsUtils.ANY_REGION;
-import static fixture.aws.AwsCredentialsUtils.fixedAccessKeyAndToken;
+import java.util.function.Supplier;
+
+import static fixture.aws.AwsCredentialsUtils.fixedAccessKey;
+import static org.hamcrest.Matchers.equalTo;
 
 @ThreadLeakFilters(filters = { TestContainersThreadFilter.class })
-public class RepositoryS3SessionCredentialsRestIT extends AbstractRepositoryS3RestTestCase {
+public class RepositoryS3ContentIntegrityRestIT extends AbstractRepositoryS3RestTestCase {
 
-    private static final String PREFIX = getIdentifierPrefix("RepositoryS3SessionCredentialsRestIT");
+    private static final String PREFIX = getIdentifierPrefix("RepositoryS3ContentIntegrityRestIT");
     private static final String BUCKET = PREFIX + "bucket";
     private static final String BASE_PATH = PREFIX + "base_path";
     private static final String ACCESS_KEY = PREFIX + "access-key";
     private static final String SECRET_KEY = PREFIX + "secret-key";
-    private static final String SESSION_TOKEN = PREFIX + "session-token";
-    private static final String CLIENT = "session_credentials_client";
+    private static final String CLIENT = "content_integrity_client";
 
+    private static final Supplier<ChunkedEncodingConfiguration> chunkedEncodingConfigurationSupplier = ChunkedEncodingConfiguration
+        .randomSupplier();
+
+    private static final Supplier<String> regionSupplier = new DynamicRegionSupplier();
     private static final S3HttpFixture s3Fixture = new S3HttpFixture(
         true,
         null,
         BUCKET,
         BASE_PATH,
-        fixedAccessKeyAndToken(ACCESS_KEY, SESSION_TOKEN, ANY_REGION, "s3")
-    );
+        fixedAccessKey(ACCESS_KEY, regionSupplier, "s3")
+    ) {
+        @SuppressForbidden(reason = "implementing HTTP server for test fixture")
+        @Override
+        protected HttpHandler createHandler() {
+            final var delegate = asInstanceOf(S3HttpHandler.class, super.createHandler());
+            return exchange -> {
+                delegate.assertContentSha256Header(
+                    exchange,
+                    equalTo(
+                        chunkedEncodingConfigurationSupplier.get() == ChunkedEncodingConfiguration.DISABLED
+                            ? "STREAMING-AWS4-HMAC-SHA256-PAYLOAD"
+                            : "STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER"
+                    )
+                );
+                delegate.handle(exchange);
+            };
+        }
+    };
 
     public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
         .module("repository-s3")
+        .systemProperty("aws.region", regionSupplier)
         .keystore("s3.client." + CLIENT + ".access_key", ACCESS_KEY)
         .keystore("s3.client." + CLIENT + ".secret_key", SECRET_KEY)
-        .keystore("s3.client." + CLIENT + ".session_token", SESSION_TOKEN)
         .setting("s3.client." + CLIENT + ".endpoint", s3Fixture::getAddress)
         .build();
 
@@ -70,5 +98,10 @@ public class RepositoryS3SessionCredentialsRestIT extends AbstractRepositoryS3Re
     @Override
     protected String getClientName() {
         return CLIENT;
+    }
+
+    @Override
+    protected Settings extraRepositorySettings() {
+        return chunkedEncodingConfigurationSupplier.get().asSettings();
     }
 }

--- a/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3EcsCredentialsRestIT.java
+++ b/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3EcsCredentialsRestIT.java
@@ -43,7 +43,7 @@ public class RepositoryS3EcsCredentialsRestIT extends AbstractRepositoryS3RestTe
             .alternativeCredentialsEndpoints(Set.of("/ecs_credentials_endpoint"))
     );
 
-    private static final S3HttpFixture s3Fixture = new S3HttpFixture(true, BUCKET, BASE_PATH, dynamicCredentials::isAuthorized);
+    private static final S3HttpFixture s3Fixture = new S3HttpFixture(true, null, BUCKET, BASE_PATH, dynamicCredentials::isAuthorized);
 
     public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
         .module("repository-s3")

--- a/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3ExplicitProtocolRestIT.java
+++ b/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3ExplicitProtocolRestIT.java
@@ -38,6 +38,7 @@ public class RepositoryS3ExplicitProtocolRestIT extends AbstractRepositoryS3Rest
     private static final Supplier<String> regionSupplier = new DynamicRegionSupplier();
     private static final S3HttpFixture s3Fixture = new S3HttpFixture(
         true,
+        null,
         BUCKET,
         BASE_PATH,
         fixedAccessKey(ACCESS_KEY, regionSupplier, "s3")

--- a/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3ImdsV2CredentialsRestIT.java
+++ b/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3ImdsV2CredentialsRestIT.java
@@ -42,7 +42,7 @@ public class RepositoryS3ImdsV2CredentialsRestIT extends AbstractRepositoryS3Res
             .instanceIdentityDocument((b, p) -> b.field("region", regionSupplier.get()))
     );
 
-    private static final S3HttpFixture s3Fixture = new S3HttpFixture(true, BUCKET, BASE_PATH, dynamicCredentials::isAuthorized);
+    private static final S3HttpFixture s3Fixture = new S3HttpFixture(true, null, BUCKET, BASE_PATH, dynamicCredentials::isAuthorized);
 
     public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
         .module("repository-s3")

--- a/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3OverHttpsRestIT.java
+++ b/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3OverHttpsRestIT.java
@@ -9,13 +9,20 @@
 
 package org.elasticsearch.repositories.s3;
 
+import fixture.aws.ChunkedEncodingConfiguration;
 import fixture.aws.DynamicRegionSupplier;
 import fixture.s3.S3HttpFixture;
+import fixture.s3.S3HttpHandler;
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+import com.sun.net.httpserver.HttpHandler;
 
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.fixtures.testcontainers.TestContainersThreadFilter;
+import org.elasticsearch.test.fixtures.tls.TestTlsCertificate;
+import org.elasticsearch.test.fixtures.tls.TestTrustStore;
 import org.junit.ClassRule;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
@@ -23,25 +30,51 @@ import org.junit.rules.TestRule;
 import java.util.function.Supplier;
 
 import static fixture.aws.AwsCredentialsUtils.fixedAccessKey;
+import static org.hamcrest.Matchers.equalTo;
 
 @ThreadLeakFilters(filters = { TestContainersThreadFilter.class })
-public class RepositoryS3BasicCredentialsRestIT extends AbstractRepositoryS3RestTestCase {
+public class RepositoryS3OverHttpsRestIT extends AbstractRepositoryS3RestTestCase {
 
-    private static final String PREFIX = getIdentifierPrefix("RepositoryS3BasicCredentialsRestIT");
+    private static final String PREFIX = getIdentifierPrefix("RepositoryS3OverHttpsRestIT");
     private static final String BUCKET = PREFIX + "bucket";
     private static final String BASE_PATH = PREFIX + "base_path";
     private static final String ACCESS_KEY = PREFIX + "access-key";
     private static final String SECRET_KEY = PREFIX + "secret-key";
-    private static final String CLIENT = "basic_credentials_client";
+    private static final String CLIENT = "https_s3_client";
+
+    private static final Supplier<ChunkedEncodingConfiguration> chunkedEncodingConfigurationSupplier = ChunkedEncodingConfiguration
+        .randomSupplier();
+
+    protected static final TestTlsCertificate testTlsCertificate = TestTlsCertificate.generate("localhost");
+
+    protected static final TestTrustStore trustStore = new TestTrustStore(testTlsCertificate::getPemCertificateStream);
 
     private static final Supplier<String> regionSupplier = new DynamicRegionSupplier();
+
     private static final S3HttpFixture s3Fixture = new S3HttpFixture(
         true,
-        null,
+        testTlsCertificate,
         BUCKET,
         BASE_PATH,
         fixedAccessKey(ACCESS_KEY, regionSupplier, "s3")
-    );
+    ) {
+        @SuppressForbidden(reason = "implementing HTTP server for test fixture")
+        @Override
+        protected HttpHandler createHandler() {
+            final var delegate = asInstanceOf(S3HttpHandler.class, super.createHandler());
+            return exchange -> {
+                delegate.assertContentSha256Header(
+                    exchange,
+                    equalTo(
+                        chunkedEncodingConfigurationSupplier.get() == ChunkedEncodingConfiguration.DISABLED
+                            ? "UNSIGNED-PAYLOAD"
+                            : "STREAMING-UNSIGNED-PAYLOAD-TRAILER"
+                    )
+                );
+                delegate.handle(exchange);
+            };
+        }
+    };
 
     public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
         .module("repository-s3")
@@ -49,13 +82,12 @@ public class RepositoryS3BasicCredentialsRestIT extends AbstractRepositoryS3Rest
         .keystore("s3.client." + CLIENT + ".access_key", ACCESS_KEY)
         .keystore("s3.client." + CLIENT + ".secret_key", SECRET_KEY)
         .setting("s3.client." + CLIENT + ".endpoint", s3Fixture::getAddress)
-        .setting("s3.client." + CLIENT + ".disable_chunked_encoding", () -> randomFrom("true", "false"), ignored -> randomBoolean())
-        .systemProperty("es.insecure_network_trace_enabled", "true")
-        .setting("logger.org.apache.http.headers", "TRACE")
+        .setting("s3.client." + CLIENT + ".path_style_access", "true")
+        .apply(builder -> trustStore.apply(builder, true))
         .build();
 
     @ClassRule
-    public static TestRule ruleChain = RuleChain.outerRule(s3Fixture).around(cluster);
+    public static TestRule ruleChain = RuleChain.outerRule(s3Fixture).around(trustStore).around(cluster);
 
     @Override
     protected String getTestRestCluster() {
@@ -75,5 +107,10 @@ public class RepositoryS3BasicCredentialsRestIT extends AbstractRepositoryS3Rest
     @Override
     protected String getClientName() {
         return CLIENT;
+    }
+
+    @Override
+    protected Settings extraRepositorySettings() {
+        return chunkedEncodingConfigurationSupplier.get().asSettings();
     }
 }

--- a/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3RestReloadCredentialsIT.java
+++ b/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3RestReloadCredentialsIT.java
@@ -41,6 +41,7 @@ public class RepositoryS3RestReloadCredentialsIT extends ESRestTestCase {
 
     public static final S3HttpFixture s3Fixture = new S3HttpFixture(
         true,
+        null,
         BUCKET,
         BASE_PATH,
         mutableAccessKey(() -> repositoryAccessKey, ANY_REGION, "s3")

--- a/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3StsCredentialsRestIT.java
+++ b/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3StsCredentialsRestIT.java
@@ -37,7 +37,7 @@ public class RepositoryS3StsCredentialsRestIT extends AbstractRepositoryS3RestTe
     private static final Supplier<String> regionSupplier = new DynamicRegionSupplier();
     private static final DynamicAwsCredentials dynamicCredentials = new DynamicAwsCredentials(regionSupplier, "s3");
 
-    private static final S3HttpFixture s3HttpFixture = new S3HttpFixture(true, BUCKET, BASE_PATH, dynamicCredentials::isAuthorized);
+    private static final S3HttpFixture s3HttpFixture = new S3HttpFixture(true, null, BUCKET, BASE_PATH, dynamicCredentials::isAuthorized);
 
     private static final String WEB_IDENTITY_TOKEN_FILE_CONTENTS = """
         Atza|IQEBLjAsAhRFiXuWpUXuRvQ9PZL3GMFcYevydwIUFAHZwXZXXXXXXXXJnrulxKDHwy87oGKPznh0D6bEQZTSCzyoCtL_8S07pLpr0zMbn6w1lfVZKNTBdDans\

--- a/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3WireLoggingRestIT.java
+++ b/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3WireLoggingRestIT.java
@@ -47,6 +47,7 @@ public class RepositoryS3WireLoggingRestIT extends AbstractRepositoryS3RestTestC
     private static final Supplier<String> regionSupplier = new DynamicRegionSupplier();
     private static final S3HttpFixture s3Fixture = new S3HttpFixture(
         true,
+        null,
         BUCKET,
         BASE_PATH,
         fixedAccessKey(ACCESS_KEY, regionSupplier, "s3")

--- a/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Service.java
+++ b/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Service.java
@@ -15,12 +15,9 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProviderChain;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
-import software.amazon.awssdk.auth.signer.AwsS3V4Signer;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.awscore.retry.AwsRetryStrategy;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
-import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
-import software.amazon.awssdk.core.signer.Signer;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.http.apache.ProxyConfiguration;
@@ -109,13 +106,6 @@ class S3Service extends AbstractLifecycleComponent {
     private volatile Map<Settings, S3ClientSettings> derivedClientSettings = emptyMap();
 
     private final S3DefaultRegionHolder defaultRegionHolder;
-
-    /**
-     * Use a signer that does not require to pre-read (and checksum) the body of PutObject and UploadPart requests since we can rely on
-     * TLS for equivalent protection.
-     */
-    @SuppressWarnings("deprecation")
-    private static final Signer signer = AwsS3V4Signer.create();
 
     final CustomWebIdentityTokenCredentialsProvider webIdentityTokenCredentialsProvider;
 
@@ -375,7 +365,6 @@ class S3Service extends AbstractLifecycleComponent {
 
     static ClientOverrideConfiguration buildConfiguration(S3ClientSettings clientSettings, boolean isStateless) {
         ClientOverrideConfiguration.Builder clientOverrideConfiguration = ClientOverrideConfiguration.builder();
-        clientOverrideConfiguration.putAdvancedOption(SdkAdvancedClientOption.SIGNER, signer);
         var retryStrategyBuilder = AwsRetryStrategy.standardRetryStrategy()
             .toBuilder()
             .maxAttempts(clientSettings.maxRetries + 1 /* first attempt is not a retry */);

--- a/modules/repository-s3/src/test/java/org/elasticsearch/repositories/s3/AddPurposeCustomQueryParameterTests.java
+++ b/modules/repository-s3/src/test/java/org/elasticsearch/repositories/s3/AddPurposeCustomQueryParameterTests.java
@@ -101,7 +101,7 @@ public class AddPurposeCustomQueryParameterTests extends ESSingleNodeTestCase {
         Settings extraRepositorySettings,
         Matcher<Iterable<? super String>> queryParamMatcher
     ) throws Throwable {
-        final var httpFixture = new S3HttpFixture(true, bucket, basePath, (key, token) -> true) {
+        final var httpFixture = new S3HttpFixture(true, null, bucket, basePath, (key, token) -> true) {
 
             @SuppressForbidden(reason = "this test uses a HttpServer to emulate an S3 endpoint")
             class AssertingHandler extends S3HttpHandler {

--- a/modules/repository-s3/src/yamlRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3ClientYamlTestSuiteIT.java
+++ b/modules/repository-s3/src/yamlRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3ClientYamlTestSuiteIT.java
@@ -33,6 +33,7 @@ public class RepositoryS3ClientYamlTestSuiteIT extends AbstractRepositoryS3Clien
 
     private static final S3HttpFixture s3Fixture = new S3HttpFixture(
         true,
+        null,
         "bucket",
         "base_path_integration_tests",
         fixedAccessKey(ACCESS_KEY, ANY_REGION, "s3")

--- a/test/fixtures/aws-fixture-utils/src/main/java/fixture/aws/ChunkedEncodingConfiguration.java
+++ b/test/fixtures/aws-fixture-utils/src/main/java/fixture/aws/ChunkedEncodingConfiguration.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package fixture.aws;
+
+import org.elasticsearch.common.settings.Settings;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import static org.elasticsearch.test.ESTestCase.between;
+
+/// Specifies how the `disable_chunked_encoding` S3 client setting is configured - either `true` or `false` or omitted (default).
+public enum ChunkedEncodingConfiguration {
+
+    /// `disable_chunked_encoding: true`
+    DISABLED {
+        @Override
+        Settings.Builder apply(Settings.Builder builder) {
+            return builder.put(DISABLE_CHUNKED_ENCODING, "true");
+        }
+    },
+
+    /// `disable_chunked_encoding: false`
+    ENABLED {
+        @Override
+        Settings.Builder apply(Settings.Builder builder) {
+            return builder.put(DISABLE_CHUNKED_ENCODING, "false");
+        }
+    },
+
+    /// `disable_chunked_encoding: null` (i.e. setting omitted, use default behaviour)
+    UNSET {
+        @Override
+        Settings.Builder apply(Settings.Builder builder) {
+            return builder.putNull(DISABLE_CHUNKED_ENCODING);
+        }
+    };
+
+    private static final String DISABLE_CHUNKED_ENCODING = "disable_chunked_encoding";
+
+    abstract Settings.Builder apply(Settings.Builder builder);
+
+    public Settings asSettings() {
+        return apply(Settings.builder()).build();
+    }
+
+    public static Supplier<ChunkedEncodingConfiguration> randomSupplier() {
+        return new RandomSupplier()::getChunkedEncodingConfiguration;
+    }
+
+    /** Lazy because randomness isn't available in static context */
+    private static class RandomSupplier extends AtomicInteger {
+        ChunkedEncodingConfiguration getChunkedEncodingConfiguration() {
+            compareAndSet(0, between(1, 3));
+            return ChunkedEncodingConfiguration.values()[get() - 1];
+        }
+    }
+}

--- a/test/fixtures/s3-fixture/build.gradle
+++ b/test/fixtures/s3-fixture/build.gradle
@@ -17,4 +17,5 @@ dependencies {
   }
   implementation project(':test:framework')
   implementation project(':test:fixtures:aws-fixture-utils')
+  implementation project(':test:fixtures:tls-utils')
 }

--- a/test/fixtures/s3-fixture/src/main/java/fixture/s3/S3HttpFixture.java
+++ b/test/fixtures/s3-fixture/src/main/java/fixture/s3/S3HttpFixture.java
@@ -11,35 +11,56 @@ package fixture.s3;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
+import com.sun.net.httpserver.HttpsConfigurator;
+import com.sun.net.httpserver.HttpsServer;
 
 import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.network.InetAddresses;
+import org.elasticsearch.common.ssl.KeyStoreUtil;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.test.fixtures.tls.TestTlsCertificate;
 import org.junit.rules.ExternalResource;
 
 import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.security.SecureRandom;
+import java.security.cert.Certificate;
 import java.util.Objects;
 import java.util.function.BiPredicate;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.SSLContext;
 
 import static fixture.aws.AwsCredentialsUtils.ANY_REGION;
 import static fixture.aws.AwsCredentialsUtils.checkAuthorization;
 import static fixture.aws.AwsCredentialsUtils.fixedAccessKey;
-import static fixture.aws.AwsFixtureUtils.getLocalFixtureAddress;
 
 public class S3HttpFixture extends ExternalResource {
 
     private HttpServer server;
 
     private final boolean enabled;
+    @Nullable // if using HTTP
+    private final TestTlsCertificate tlsCertificate;
     private final String bucket;
     private final String basePath;
     private final BiPredicate<String, String> authorizationPredicate;
 
     public S3HttpFixture(boolean enabled) {
-        this(enabled, "bucket", "base_path_integration_tests", fixedAccessKey("s3_test_access_key", ANY_REGION, "s3"));
+        this(enabled, null, "bucket", "base_path_integration_tests", fixedAccessKey("s3_test_access_key", ANY_REGION, "s3"));
     }
 
-    public S3HttpFixture(boolean enabled, String bucket, String basePath, BiPredicate<String, String> authorizationPredicate) {
+    public S3HttpFixture(
+        boolean enabled,
+        @Nullable /* to use HTTP */ TestTlsCertificate tlsCertificate,
+        String bucket,
+        String basePath,
+        BiPredicate<String, String> authorizationPredicate
+    ) {
         this.enabled = enabled;
+        this.tlsCertificate = tlsCertificate;
         this.bucket = bucket;
         this.basePath = basePath;
         this.authorizationPredicate = authorizationPredicate;
@@ -63,8 +84,14 @@ public class S3HttpFixture extends ExternalResource {
     }
 
     public String getAddress() {
-        String host = InetAddresses.toUriString(server.getAddress().getAddress());
-        return "http://" + host + ":" + server.getAddress().getPort();
+        return Strings.format(
+            "%s://%s:%d",
+            tlsCertificate == null ? "http" : "https",
+            tlsCertificate == null
+                ? InetAddresses.toUriString(server.getAddress().getAddress())
+                : server.getAddress().getAddress().getHostName(),
+            server.getAddress().getPort()
+        );
     }
 
     public void stop(int delay) {
@@ -73,7 +100,24 @@ public class S3HttpFixture extends ExternalResource {
 
     protected void before() throws Throwable {
         if (enabled) {
-            this.server = HttpServer.create(getLocalFixtureAddress(), 0);
+            if (tlsCertificate == null) {
+                this.server = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+            } else {
+                final SSLContext sslContext = SSLContext.getInstance("TLS");
+                sslContext.init(
+                    new KeyManager[] {
+                        KeyStoreUtil.createKeyManager(
+                            new Certificate[] { tlsCertificate.certificate() },
+                            tlsCertificate.privateKey(),
+                            null
+                        ) },
+                    null,
+                    new SecureRandom()
+                );
+                final var httpsServer = HttpsServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+                this.server = httpsServer;
+                httpsServer.setHttpsConfigurator(new HttpsConfigurator(sslContext));
+            }
             this.server.createContext("/", Objects.requireNonNull(createHandler()));
             server.start();
         }

--- a/test/fixtures/s3-fixture/src/main/java/fixture/s3/S3HttpHandler.java
+++ b/test/fixtures/s3-fixture/src/main/java/fixture/s3/S3HttpHandler.java
@@ -50,7 +50,8 @@ import javax.xml.parsers.DocumentBuilderFactory;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.elasticsearch.test.ESTestCase.assertThat;
-import static org.hamcrest.Matchers.oneOf;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.matchesPattern;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.w3c.dom.Node.ELEMENT_NODE;
@@ -64,6 +65,8 @@ public class S3HttpHandler implements HttpHandler {
     private static final Logger logger = LogManager.getLogger(S3HttpHandler.class);
     public static final String STORAGE_CLASS_HEADER = "X-amz-storage-class";
     public static final String CONTENT_SHA256_HEADER = "X-amz-content-sha256";
+    public static final String COPY_SOURCE_HEADER = "X-amz-copy-source";
+    public static final Pattern SHA256_PATTERN = Pattern.compile("^[0-9a-f]{64}$");
 
     private final String bucket;
     private final String basePath;
@@ -160,6 +163,7 @@ public class S3HttpHandler implements HttpHandler {
                     exchange.sendResponseHeaders(RestStatus.NOT_FOUND.getStatus(), -1);
                 } else {
                     final Tuple<String, BytesReference> blob = parseRequestBody(exchange);
+                    verifyContentSha256Header(exchange, blob.v2());
                     upload.addPart(blob.v1(), blob.v2());
                     exchange.getResponseHeaders().add("ETag", blob.v1());
                     exchange.sendResponseHeaders(RestStatus.OK.getStatus(), -1);
@@ -206,13 +210,7 @@ public class S3HttpHandler implements HttpHandler {
 
             } else if (request.isPutObjectRequest()) {
                 final Tuple<String, BytesReference> blob = parseRequestBody(exchange);
-                assertThat(
-                    exchange.getRequestHeaders().getFirst(CONTENT_SHA256_HEADER),
-                    oneOf(
-                        "STREAMING-AWS4-HMAC-SHA256-PAYLOAD",
-                        MessageDigests.toHexString(MessageDigests.digest(blob.v2(), MessageDigests.sha256()))
-                    )
-                );
+                verifyContentSha256Header(exchange, blob.v2());
                 blobs.put(request.path(), blob.v2());
                 exchange.getResponseHeaders().add("ETag", blob.v1());
                 exchange.sendResponseHeaders(RestStatus.OK.getStatus(), -1);
@@ -483,6 +481,30 @@ public class S3HttpHandler implements HttpHandler {
 
     MultipartUpload getUpload(String uploadId) {
         return uploads.get(uploadId);
+    }
+
+    private static void verifyContentSha256Header(final HttpExchange exchange, BytesReference body) {
+        final var contentSha256Header = exchange.getRequestHeaders().getFirst(S3HttpHandler.CONTENT_SHA256_HEADER);
+        if (contentSha256Header != null && SHA256_PATTERN.asMatchPredicate().test(contentSha256Header)) {
+            // This header is optional and if present it may contain a special value indicating a different checksum scheme is in use, but
+            // if it's a real SHA256 checksum then it must match the request's contents.
+            assertEquals(contentSha256Header, MessageDigests.toHexString(MessageDigests.digest(body, MessageDigests.sha256())));
+        }
+    }
+
+    /**
+     * Assert that if the exchange is a {@code PutObject} or {@code UploadPart} request then {@code X-amz-content-sha256} header is present
+     * and either contains a full SHA256 hash or another value matching the provided {@link org.hamcrest.Matcher}.
+     */
+    public void assertContentSha256Header(HttpExchange exchange, org.hamcrest.Matcher<String> otherPermittedValues) {
+        final var request = parseRequest(exchange);
+        if ((request.isUploadPartRequest() || request.isPutObjectRequest())
+            && Optional.ofNullable(exchange.getRequestHeaders().get(S3HttpHandler.COPY_SOURCE_HEADER)).orElse(List.of()).isEmpty()) {
+            assertThat(
+                exchange.getRequestHeaders().getFirst(S3HttpHandler.CONTENT_SHA256_HEADER),
+                anyOf(matchesPattern(S3HttpHandler.SHA256_PATTERN), otherPermittedValues)
+            );
+        }
     }
 
     public S3Request parseRequest(HttpExchange exchange) {

--- a/x-pack/plugin/searchable-snapshots/qa/s3/build.gradle
+++ b/x-pack/plugin/searchable-snapshots/qa/s3/build.gradle
@@ -9,6 +9,7 @@ dependencies {
   javaRestTestImplementation project(":test:framework")
   javaRestTestImplementation project(':test:fixtures:aws-fixture-utils')
   javaRestTestImplementation project(':test:fixtures:s3-fixture')
+  javaRestTestImplementation project(':test:fixtures:tls-utils')
 }
 
 restResources {

--- a/x-pack/plugin/searchable-snapshots/qa/s3/src/javaRestTest/java/org/elasticsearch/xpack/searchablesnapshots/s3/S3SearchableSnapshotsCredentialsReloadIT.java
+++ b/x-pack/plugin/searchable-snapshots/qa/s3/src/javaRestTest/java/org/elasticsearch/xpack/searchablesnapshots/s3/S3SearchableSnapshotsCredentialsReloadIT.java
@@ -49,6 +49,7 @@ public class S3SearchableSnapshotsCredentialsReloadIT extends ESRestTestCase {
 
     public static final S3HttpFixture s3Fixture = new S3HttpFixture(
         true,
+        null,
         BUCKET,
         BASE_PATH,
         mutableAccessKey(() -> repositoryAccessKey, ANY_REGION, "s3")

--- a/x-pack/plugin/snapshot-repo-test-kit/qa/s3/build.gradle
+++ b/x-pack/plugin/snapshot-repo-test-kit/qa/s3/build.gradle
@@ -14,6 +14,7 @@ dependencies {
   javaRestTestImplementation testArtifact(project(xpackModule('snapshot-repo-test-kit')))
   javaRestTestImplementation project(':test:fixtures:s3-fixture')
   javaRestTestImplementation project(':test:fixtures:aws-fixture-utils')
+  javaRestTestImplementation project(':test:fixtures:tls-utils')
 }
 
 restResources {

--- a/x-pack/plugin/snapshot-repo-test-kit/qa/s3/src/javaRestTest/java/org/elasticsearch/repositories/blobstore/testkit/analyze/S3RepositoryAnalysisRestIT.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/qa/s3/src/javaRestTest/java/org/elasticsearch/repositories/blobstore/testkit/analyze/S3RepositoryAnalysisRestIT.java
@@ -35,6 +35,7 @@ public class S3RepositoryAnalysisRestIT extends AbstractRepositoryAnalysisRestTe
     private static final Supplier<String> regionSupplier = new DynamicRegionSupplier();
     public static final S3HttpFixture s3Fixture = new S3HttpFixture(
         USE_FIXTURE,
+        null,
         "bucket",
         "base_path_integration_tests",
         fixedAccessKey("s3_test_access_key", regionSupplier, "s3")


### PR DESCRIPTION
Today the `repository-s3` module overrides the request signer to work
around issues encountered during the migration to SDKv2 in #126843.
These issues have since been addressed, so with this commit we revert
this override.

Backport of #150194, #149982, and #149965 to 8.19.