### PR TITLE
Slice: fix off-by-one error for slice refactor

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -571,21 +571,6 @@ tests:
 - class: org.elasticsearch.reindex.management.ReindexManagementClientYamlTestSuiteIT
   method: test {yaml=reindex/30_cancel_reindex/Cancel running reindex returns response and GET confirms completed}
   issue: https://github.com/elastic/elasticsearch/issues/150054
-- class: org.elasticsearch.search.vectors.DiversifyingChildrenIVFKnnFloatSlicedVectorQueryTests
-  method: testSlicesSparse
-  issue: https://github.com/elastic/elasticsearch/issues/150065
-- class: org.elasticsearch.search.vectors.IVFKnnFloatSlicedVectorQueryTests
-  method: testSlicesSparse
-  issue: https://github.com/elastic/elasticsearch/issues/150068
-- class: org.elasticsearch.index.codec.vectors.diskbbq.next.ESNextDiskBBQVectorsFormatTests
-  method: testSlicesSparse
-  issue: https://github.com/elastic/elasticsearch/issues/150070
-- class: org.elasticsearch.search.vectors.IVFKnnFloatSlicedVectorQueryTests
-  method: testSlicesSparseWithFilter
-  issue: https://github.com/elastic/elasticsearch/issues/150073
-- class: org.elasticsearch.search.vectors.IVFKnnFloatSlicedVectorQueryTests
-  method: testDifferentReader
-  issue: https://github.com/elastic/elasticsearch/issues/150068
 - class: org.elasticsearch.xpack.esql.datasource.parquet.PageColumnReaderCorrectnessTests
   method: testRandomSchema
   issue: https://github.com/elastic/elasticsearch/issues/150077
@@ -622,9 +607,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.heap_attack.HeapAttackIT
   method: testGroupOnManyLongs
   issue: https://github.com/elastic/elasticsearch/issues/150104
-- class: org.elasticsearch.search.vectors.DiversifyingChildrenIVFKnnFloatSlicedVectorQueryTests
-  method: testSlicesSparseWithFilter
-  issue: https://github.com/elastic/elasticsearch/issues/150106
 - class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecForceStoredLoadingIT
   method: test {csv-spec:k8s-timeseries-promql.scalar_float_div_fraction}
   issue: https://github.com/elastic/elasticsearch/issues/150108
@@ -664,24 +646,12 @@ tests:
 - class: org.elasticsearch.xpack.stateless.reshard.StatelessReshardMixedOperationsIT
   method: testMixedOperationsDuringSplitWithDisruption
   issue: https://github.com/elastic/elasticsearch/issues/147842
-- class: org.elasticsearch.index.codec.vectors.diskbbq.next.ESNextDiskBBQVectorsFormatTests
-  method: testSlicesSparseWithFilter
-  issue: https://github.com/elastic/elasticsearch/issues/150126
-- class: org.elasticsearch.index.codec.vectors.diskbbq.next.ESNextDiskBBQVectorsFormatTests
-  method: testSlicesDenseWithFilter
-  issue: https://github.com/elastic/elasticsearch/issues/150152
 - class: org.elasticsearch.simdvec.internal.vectorization.MSBitToBitESNextOSQVectorsScorerTests
   method: testSymmetric1BitDotProductMatchesNativeWhenSupported
   issue: https://github.com/elastic/elasticsearch/issues/150155
 - class: org.elasticsearch.xpack.stateless.cache.SharedBlobCacheWarmingServiceIT
   method: testCacheIsWarmedDuringMerge
   issue: https://github.com/elastic/elasticsearch/issues/150158
-- class: org.elasticsearch.search.vectors.DiversifyingChildrenIVFKnnFloatSlicedVectorQueryTests
-  method: testSlicesDense
-  issue: https://github.com/elastic/elasticsearch/issues/150165
-- class: org.elasticsearch.index.codec.vectors.diskbbq.next.ESNextDiskBBQVectorsFormatTests
-  method: testSlicesDense
-  issue: https://github.com/elastic/elasticsearch/issues/150166
 - class: org.elasticsearch.gradle.internal.transport.TransportVersionGenerationFuncTest
   method: merge conflicts in latest files can be regenerated
   issue: https://github.com/elastic/elasticsearch/issues/150174
@@ -691,15 +661,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
   method: test {csv-spec:k8s-timeseries-count-distinct-over-time.valuesNull}
   issue: https://github.com/elastic/elasticsearch/issues/150188
-- class: org.elasticsearch.search.vectors.IVFKnnFloatSlicedVectorQueryTests
-  method: testFilterWithNoVectorMatches
-  issue: https://github.com/elastic/elasticsearch/issues/150190
-- class: org.elasticsearch.search.vectors.IVFKnnFloatSlicedVectorQueryTests
-  method: testDimensionMismatch
-  issue: https://github.com/elastic/elasticsearch/issues/150191
-- class: org.elasticsearch.search.vectors.IVFKnnFloatSlicedVectorQueryTests
-  method: testSearchBoost
-  issue: https://github.com/elastic/elasticsearch/issues/150211
 - class: org.elasticsearch.xpack.stateless.cache.SearchCommitPrefetcherIT
   method: testSearchNodePrefetchesOnlyLatestGenerationOnFirstCommitNotifcation
   issue: https://github.com/elastic/elasticsearch/issues/150214

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/next/ESNextDiskBBQVectorsReader.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/next/ESNextDiskBBQVectorsReader.java
@@ -738,7 +738,7 @@ public class ESNextDiskBBQVectorsReader extends IVFVectorsReader<ESNextDiskBBQVe
             int endDoc;
             if (acceptDocs == null) {
                 startDoc = 0;
-                endDoc = values.ordToDoc(values.size() - 1);
+                endDoc = values.ordToDoc(values.size() - 1) + 1;
             } else {
                 ESAcceptDocs.SliceAcceptDocs sliceAcceptDocs = acceptDocs.sliceAcceptDocs();
                 startDoc = sliceAcceptDocs.startDoc();


### PR DESCRIPTION
PR https://github.com/elastic/elasticsearch/pull/150002 did a small slice refactor, but missed an off-by-one place that tests caught.

Effectively, when there was just "one slice" and one doc in that slice we may miss hitting it.

closes: https://github.com/elastic/elasticsearch/issues/150065
closes: https://github.com/elastic/elasticsearch/issues/150068
closes: https://github.com/elastic/elasticsearch/issues/150070
closes: https://github.com/elastic/elasticsearch/issues/150073
closes: https://github.com/elastic/elasticsearch/issues/150106
closes: https://github.com/elastic/elasticsearch/issues/150126
closes: https://github.com/elastic/elasticsearch/issues/150152
closes: https://github.com/elastic/elasticsearch/issues/150165
closes: https://github.com/elastic/elasticsearch/issues/150166
closes: https://github.com/elastic/elasticsearch/issues/150190
closes: https://github.com/elastic/elasticsearch/issues/150191
closes: https://github.com/elastic/elasticsearch/issues/150211