### PR TITLE
Fixing a typo in the mmdb file extension

### DIFF
--- a/modules/ip-location/src/main/java/org/elasticsearch/ingest/geoip/direct/TransportGetDatabaseConfigurationAction.java
+++ b/modules/ip-location/src/main/java/org/elasticsearch/ingest/geoip/direct/TransportGetDatabaseConfigurationAction.java
@@ -140,7 +140,7 @@ public class TransportGetDatabaseConfigurationAction extends TransportNodesActio
 
     private static String getDatabaseNameForFileName(String databaseFileName) {
         return databaseFileName.endsWith(".mmdb")
-            ? databaseFileName.substring(0, databaseFileName.length() + 1 - ".mmmdb".length())
+            ? databaseFileName.substring(0, databaseFileName.length() - ".mmdb".length())
             : databaseFileName;
     }
 


### PR DESCRIPTION
In #113498, I introduced a method to remove `.mmdb` from a database name if it existed. I misspelled `.mmdb`, but thanks to another bug in the same line of code, it actually worked fine. This removes both bugs. No functionality changes, so I'm marking this as a non-issue. But it seems worth fixing in order to avoid future confusion.