### PR TITLE
[9.4] Add query filter to more query types (#150127)

### DIFF
--- a/docs/changelog/150127.yaml
+++ b/docs/changelog/150127.yaml
@@ -1,0 +1,5 @@
+area: "Infra/Logging"
+issues: []
+pr: 150127
+summary: Add query filter logging to SQL and EQL queries
+type: enhancement

--- a/server/src/main/java/org/elasticsearch/common/logging/activity/QueryLoggerContext.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/activity/QueryLoggerContext.java
@@ -9,15 +9,20 @@
 
 package org.elasticsearch.common.logging.activity;
 
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.RemoteClusterAware;
 import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xcontent.XContentType;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -82,5 +87,24 @@ public abstract class QueryLoggerContext extends ActivityLoggerContext {
     public Map<String, Long> getCountsByStatus(Map<String, String> clusters) {
         // Group by status and count how many statuses of each kind there are
         return clusters.values().stream().collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
+    }
+
+    protected QueryBuilder queryFilter() {
+        return null;
+    }
+
+    public Optional<String> getFilter() {
+        return filterToLogString(queryFilter());
+    }
+
+    public static Optional<String> filterToLogString(QueryBuilder filter) {
+        if (filter == null) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(XContentHelper.toXContent(filter, XContentType.JSON, FORMAT_PARAMS, true).utf8ToString());
+        } catch (IOException e) {
+            return Optional.empty();
+        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/common/logging/activity/QueryLogging.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/activity/QueryLogging.java
@@ -37,6 +37,8 @@ public interface QueryLogging {
      * Is this search only targeting system indices?
      */
     String QUERY_FIELD_IS_SYSTEM = ES_QUERY_FIELDS_PREFIX + "is_system";
+    /** Query filter */
+    String QUERY_FIELD_FILTER = ES_QUERY_FIELDS_PREFIX + "filter";
 
     /**
      * This is the name Log4j logger will use.

--- a/x-pack/plugin/core/template-resources/src/main/resources/activitylog/logs-elasticsearch.querylog@mappings.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/activitylog/logs-elasticsearch.querylog@mappings.json
@@ -98,11 +98,6 @@
                     "profile": {
                       "dynamic": true,
                       "type": "object"
-                    },
-                    "filter": {
-                      "type": "keyword",
-                      "index": false,
-                      "ignore_above": 32765
                     }
                   }
                 },
@@ -135,6 +130,11 @@
                   "index": false
                 },
                 "query": {
+                  "type": "keyword",
+                  "index": false,
+                  "ignore_above": 32765
+                },
+                "filter": {
                   "type": "keyword",
                   "index": false,
                   "ignore_above": 32765

--- a/x-pack/plugin/eql/src/internalClusterTest/java/org/elasticsearch/xpack/eql/action/EqlLoggingIT.java
+++ b/x-pack/plugin/eql/src/internalClusterTest/java/org/elasticsearch/xpack/eql/action/EqlLoggingIT.java
@@ -19,10 +19,13 @@ import org.elasticsearch.cluster.routing.RoutingNodesHelper;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.common.logging.AccumulatingMockAppender;
 import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.logging.activity.QueryLoggerContext;
 import org.elasticsearch.common.logging.activity.QueryLogging;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.IndexNotFoundException;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.test.ActivityLoggingUtils;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.xpack.core.async.DeleteAsyncResultRequest;
@@ -39,6 +42,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.elasticsearch.common.logging.activity.QueryLogging.ES_QUERY_FIELDS_PREFIX;
+import static org.elasticsearch.common.logging.activity.QueryLogging.QUERY_FIELD_FILTER;
 import static org.elasticsearch.common.logging.activity.QueryLogging.QUERY_FIELD_INDICES;
 import static org.elasticsearch.common.logging.activity.QueryLogging.QUERY_FIELD_RESULT_COUNT;
 import static org.elasticsearch.common.logging.activity.QueryLogging.QUERY_FIELD_SHARDS;
@@ -100,6 +104,28 @@ public class EqlLoggingIT extends AbstractEqlBlockingIntegTestCase {
         assertMessageSuccess(message, EqlLogContext.TYPE, query);
         assertThat(message.get(QUERY_FIELD_INDICES), equalTo("test"));
         assertThat(message.get(QUERY_FIELD_RESULT_COUNT), equalTo(success ? "1" : "0"));
+    }
+
+    public void testEqlLoggingFilter() throws Exception {
+        prepareIndex();
+        QueryBuilder filter = new TermQueryBuilder("host", "192.168.0.1");
+        String query = "my_event where i >= 0";
+        EqlSearchRequest request = new EqlSearchRequest().indices("test")
+            .query(query)
+            .eventCategoryField("event_type")
+            .filter(filter)
+            .waitForCompletionTimeout(TimeValue.THIRTY_SECONDS);
+
+        EqlSearchResponse response = client().execute(EqlSearchAction.INSTANCE, request).get();
+        try {
+            var message = getMessageData(appender.getLastEventAndReset());
+            assertMessageSuccess(message, EqlLogContext.TYPE, query);
+            assertThat(message.get(QUERY_FIELD_INDICES), equalTo("test"));
+            assertThat(message.get(QUERY_FIELD_RESULT_COUNT), equalTo("5"));
+            assertThat(message.get(QUERY_FIELD_FILTER), equalTo(QueryLoggerContext.filterToLogString(filter).get()));
+        } finally {
+            decRef(response);
+        }
     }
 
     public void testEqlFailureLogging() throws Exception {
@@ -206,7 +232,18 @@ public class EqlLoggingIT extends AbstractEqlBlockingIntegTestCase {
 
     private void prepareIndex(int numberOfShards) throws Exception {
         var createRequest = indicesAdmin().prepareCreate("test")
-            .setMapping("val", "type=integer", "event_type", "type=keyword", "@timestamp", "type=date", "i", "type=integer");
+            .setMapping(
+                "val",
+                "type=integer",
+                "event_type",
+                "type=keyword",
+                "@timestamp",
+                "type=date",
+                "i",
+                "type=integer",
+                "host",
+                "type=keyword"
+            );
         if (numberOfShards > 1) {
             createRequest.setSettings(
                 Settings.builder()
@@ -228,6 +265,7 @@ public class EqlLoggingIT extends AbstractEqlBlockingIntegTestCase {
                         .field("event_type", "my_event")
                         .field("@timestamp", "2020-04-09T12:35:48Z")
                         .field("i", i)
+                        .field("host", "192.168.0.1")
                         .endObject()
                 )
             );

--- a/x-pack/plugin/eql/src/internalClusterTest/java/org/elasticsearch/xpack/eql/action/EqlLoggingIT.java
+++ b/x-pack/plugin/eql/src/internalClusterTest/java/org/elasticsearch/xpack/eql/action/EqlLoggingIT.java
@@ -117,15 +117,11 @@ public class EqlLoggingIT extends AbstractEqlBlockingIntegTestCase {
             .waitForCompletionTimeout(TimeValue.THIRTY_SECONDS);
 
         EqlSearchResponse response = client().execute(EqlSearchAction.INSTANCE, request).get();
-        try {
-            var message = getMessageData(appender.getLastEventAndReset());
-            assertMessageSuccess(message, EqlLogContext.TYPE, query);
-            assertThat(message.get(QUERY_FIELD_INDICES), equalTo("test"));
-            assertThat(message.get(QUERY_FIELD_RESULT_COUNT), equalTo("5"));
-            assertThat(message.get(QUERY_FIELD_FILTER), equalTo(QueryLoggerContext.filterToLogString(filter).get()));
-        } finally {
-            decRef(response);
-        }
+        var message = getMessageData(appender.getLastEventAndReset());
+        assertMessageSuccess(message, EqlLogContext.TYPE, query);
+        assertThat(message.get(QUERY_FIELD_INDICES), equalTo("test"));
+        assertThat(message.get(QUERY_FIELD_RESULT_COUNT), equalTo("5"));
+        assertThat(message.get(QUERY_FIELD_FILTER), equalTo(QueryLoggerContext.filterToLogString(filter).get()));
     }
 
     public void testEqlFailureLogging() throws Exception {

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/logging/EqlLogContext.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/logging/EqlLogContext.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.eql.logging;
 import org.elasticsearch.action.ResolvedIndexExpressions;
 import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.common.logging.activity.QueryLoggerContext;
+import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.RemoteClusterAware;
 import org.elasticsearch.xpack.eql.action.EqlSearchRequest;
@@ -71,6 +72,11 @@ public class EqlLogContext extends QueryLoggerContext {
     private static int getFailedShards(EqlSearchResponse response) {
         long failedShards = Arrays.stream(response.shardFailures()).map(ShardSearchFailure::shard).distinct().count();
         return Math.clamp(failedShards, 0, Integer.MAX_VALUE);
+    }
+
+    @Override
+    protected QueryBuilder queryFilter() {
+        return request.filter();
     }
 
     // CCS stuff

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/logging/EqlLogProducer.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/logging/EqlLogProducer.java
@@ -22,6 +22,8 @@ public class EqlLogProducer implements ActivityLogProducer<EqlLogContext> {
         msg.field(QueryLogging.QUERY_FIELD_QUERY, context.getQuery());
         msg.field(QueryLogging.QUERY_FIELD_INDICES, context.getIndices());
         msg.field(QueryLogging.QUERY_FIELD_RESULT_COUNT, context.getResultCount());
+        context.getFilter().ifPresent(filter -> msg.field(QueryLogging.QUERY_FIELD_FILTER, filter));
+
         var remotes = context.remoteClusterAliases();
         if (remotes.isEmpty() == false) {
             msg.field(QueryLogging.QUERY_FIELD_REMOTE_COUNT, remotes.size());

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlQueryLoggingIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlQueryLoggingIT.java
@@ -15,6 +15,7 @@ import org.elasticsearch.cluster.routing.RoutingNodesHelper;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.common.logging.AccumulatingMockAppender;
 import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.logging.activity.QueryLoggerContext;
 import org.elasticsearch.common.logging.activity.QueryLogging;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.TermQueryBuilder;
@@ -29,6 +30,7 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 
+import static org.elasticsearch.common.logging.activity.QueryLogging.QUERY_FIELD_FILTER;
 import static org.elasticsearch.common.logging.activity.QueryLogging.QUERY_FIELD_INDICES;
 import static org.elasticsearch.common.logging.activity.QueryLogging.QUERY_FIELD_QUERY;
 import static org.elasticsearch.common.logging.activity.QueryLogging.QUERY_FIELD_RESULT_COUNT;
@@ -125,9 +127,9 @@ public class EsqlQueryLoggingIT extends AbstractEsqlIntegTestCase {
             }
             assertThat(message.get(QUERY_FIELD_RESULT_COUNT), equalTo(Long.toString(hits)));
             if (filter != null) {
-                assertThat(message.get(EsqlLogProducer.FILTER_FIELD), equalTo(EsqlLogContext.filterToLogString(filter)));
+                assertThat(message.get(QUERY_FIELD_FILTER), equalTo(QueryLoggerContext.filterToLogString(filter).get()));
             } else {
-                assertNull(message.get(EsqlLogProducer.FILTER_FIELD));
+                assertNull(message.get(QUERY_FIELD_FILTER));
             }
             assertThat(message.get(QUERY_FIELD_INDICES), equalTo(expectedIndices));
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/querylog/EsqlLogContext.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/querylog/EsqlLogContext.java
@@ -9,18 +9,15 @@ package org.elasticsearch.xpack.esql.querylog;
 
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.logging.activity.QueryLoggerContext;
-import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.RemoteClusterAware;
-import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.esql.action.EsqlExecutionInfo;
 import org.elasticsearch.xpack.esql.action.EsqlQueryProfile;
 import org.elasticsearch.xpack.esql.action.EsqlQueryRequest;
 import org.elasticsearch.xpack.esql.action.EsqlQueryResponse;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
@@ -114,18 +111,8 @@ public class EsqlLogContext extends QueryLoggerContext {
             .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().getStatus().toString()));
     }
 
-    Optional<String> getFilter() {
-        return Optional.ofNullable(filterToLogString(request.filter()));
-    }
-
-    public static String filterToLogString(QueryBuilder filter) {
-        if (filter == null) {
-            return null;
-        }
-        try {
-            return XContentHelper.toXContent(filter, XContentType.JSON, FORMAT_PARAMS, true).utf8ToString();
-        } catch (IOException e) {
-            return null;
-        }
+    @Override
+    protected QueryBuilder queryFilter() {
+        return request.filter();
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/querylog/EsqlLogProducer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/querylog/EsqlLogProducer.java
@@ -19,7 +19,6 @@ import java.util.Optional;
 public class EsqlLogProducer implements ActivityLogProducer<EsqlLogContext> {
 
     public static final String PROFILE_PREFIX = QueryLogging.ES_QUERY_FIELDS_PREFIX + "esql.profile.";
-    public static final String FILTER_FIELD = QueryLogging.ES_QUERY_FIELDS_PREFIX + "esql.filter";
 
     @Override
     public Optional<ESLogMessage> produce(EsqlLogContext context, ActionLoggingFields additionalFields) {
@@ -36,7 +35,7 @@ public class EsqlLogProducer implements ActivityLogProducer<EsqlLogContext> {
                 }
             }
         });
-        context.getFilter().ifPresent(filter -> msg.field(FILTER_FIELD, filter));
+        context.getFilter().ifPresent(filter -> msg.field(QueryLogging.QUERY_FIELD_FILTER, filter));
 
         var clusters = context.getClusters();
         var remotes = context.getRemoteClusterAliases(clusters);

--- a/x-pack/plugin/sql/src/internalClusterTest/java/org/elasticsearch/xpack/sql/action/SqlLoggingIT.java
+++ b/x-pack/plugin/sql/src/internalClusterTest/java/org/elasticsearch/xpack/sql/action/SqlLoggingIT.java
@@ -15,8 +15,11 @@ import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.common.logging.AccumulatingMockAppender;
 import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.logging.activity.QueryLoggerContext;
 import org.elasticsearch.common.logging.activity.QueryLogging;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.test.ActivityLoggingUtils;
 import org.elasticsearch.xpack.core.async.DeleteAsyncResultRequest;
 import org.elasticsearch.xpack.core.async.GetAsyncResultRequest;
@@ -35,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.elasticsearch.common.logging.activity.QueryLogging.ES_QUERY_FIELDS_PREFIX;
+import static org.elasticsearch.common.logging.activity.QueryLogging.QUERY_FIELD_FILTER;
 import static org.elasticsearch.common.logging.activity.QueryLogging.QUERY_FIELD_RESULT_COUNT;
 import static org.elasticsearch.test.ActivityLoggingUtils.assertMessageFailure;
 import static org.elasticsearch.test.ActivityLoggingUtils.assertMessageSuccess;
@@ -96,6 +100,24 @@ public class SqlLoggingIT extends AbstractSqlBlockingIntegTestCase {
         assertThat(sqlMessage.get(QUERY_FIELD_RESULT_COUNT), equalTo("2"));
     }
 
+    public void testSqlLoggingFilter() {
+        prepareIndex();
+        QueryBuilder filter = new TermQueryBuilder("host", "192.168.0.1");
+        String query = "SELECT host FROM test LIMIT 100";
+        SqlQueryResponse response = new SqlQueryRequestBuilder(client()).query(query)
+            .filter(filter)
+            .mode(Mode.JDBC)
+            .version(SqlVersions.SERVER_COMPAT_VERSION.toString())
+            .get();
+        assertThat(response.size(), equalTo(2L));
+        assertThat(appender.events.size(), equalTo(2));
+
+        var sqlMessage = getMessageData(appender.events.get(1));
+        assertMessageSuccess(sqlMessage, SqlLogContext.TYPE, query);
+        assertThat(sqlMessage.get(QUERY_FIELD_RESULT_COUNT), equalTo("2"));
+        assertThat(sqlMessage.get(QUERY_FIELD_FILTER), equalTo(QueryLoggerContext.filterToLogString(filter).get()));
+    }
+
     public void testSqlFailureLogging() {
         String query = "SELECT data, count FROM test ORDER BY count";
         expectThrows(VerificationException.class, () -> new SqlQueryRequestBuilder(client()).query(query).get());
@@ -151,10 +173,10 @@ public class SqlLoggingIT extends AbstractSqlBlockingIntegTestCase {
     }
 
     private void prepareIndex() {
-        assertAcked(indicesAdmin().prepareCreate("test").get());
+        assertAcked(indicesAdmin().prepareCreate("test").setMapping("host", "type=keyword").get());
         client().prepareBulk()
-            .add(new IndexRequest("test").id("1").source("data", "bar", "count", 42))
-            .add(new IndexRequest("test").id("2").source("data", "baz", "count", 43))
+            .add(new IndexRequest("test").id("1").source("data", "bar", "count", 42, "host", "192.168.0.1"))
+            .add(new IndexRequest("test").id("2").source("data", "baz", "count", 43, "host", "192.168.0.1"))
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
             .get();
         ensureYellow("test");

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/logging/SqlLogContext.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/logging/SqlLogContext.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.sql.logging;
 
 import org.elasticsearch.common.logging.activity.QueryLoggerContext;
+import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.xpack.sql.action.SqlQueryRequest;
 import org.elasticsearch.xpack.sql.action.SqlQueryResponse;
@@ -43,5 +44,10 @@ public class SqlLogContext extends QueryLoggerContext {
     public String[] getIndices() {
         // TODO: figure out how to extract indices for SQL
         return null;
+    }
+
+    @Override
+    protected QueryBuilder queryFilter() {
+        return request.filter();
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/logging/SqlLogProducer.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/logging/SqlLogProducer.java
@@ -19,6 +19,7 @@ public class SqlLogProducer implements ActivityLogProducer<SqlLogContext> {
     @Override
     public Optional<ESLogMessage> produce(SqlLogContext context, ActionLoggingFields additionalFields) {
         ESLogMessage msg = produceCommon(context, QueryLogging.ES_QUERY_FIELDS_PREFIX, additionalFields);
+        context.getFilter().ifPresent(filter -> msg.field(QueryLogging.QUERY_FIELD_FILTER, filter));
         return Optional.of(
             msg.field(QueryLogging.QUERY_FIELD_QUERY, context.getQuery())
                 .field(QueryLogging.QUERY_FIELD_RESULT_COUNT, context.getResultCount())

--- a/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/QueryLoggingTemplateRegistry.java
+++ b/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/QueryLoggingTemplateRegistry.java
@@ -33,7 +33,8 @@ public class QueryLoggingTemplateRegistry extends IndexTemplateRegistry {
     // version 1: initial template
     // version 2: limit query to 32k
     // version 3: add esql.filter
-    public static final int INDEX_TEMPLATE_VERSION = 3;
+    // version 4: move filter to main body
+    public static final int INDEX_TEMPLATE_VERSION = 4;
 
     public static final String QUERY_LOGGING_TEMPLATE_VERSION_VARIABLE = "xpack.stack.querylog.template.version";
 


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Add query filter to more query types (#150127)