### PR TITLE
[9.3] In file watching tests, add 2s to guarantee a timestamp change (#149937)

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/file/AbstractFileWatchingServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/common/file/AbstractFileWatchingServiceTests.java
@@ -34,9 +34,6 @@ import java.nio.file.WatchKey;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileTime;
 import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.util.Optional;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
@@ -181,8 +178,8 @@ public class AbstractFileWatchingServiceTests extends ESTestCase {
         assertFalse(fileWatchingService.fileChanged(tmpFile));
 
         // we modify the timestamp of the file, it should trigger a change
-        Instant now = LocalDateTime.now(ZoneId.systemDefault()).toInstant(ZoneOffset.ofHours(0));
-        Files.setLastModifiedTime(tmpFile, FileTime.from(now));
+        // Use +2s to guarantee we land in a different millisecond regardless of filesystem timestamp rounding or NTP shenanigans.
+        Files.setLastModifiedTime(tmpFile, FileTime.from(Instant.now().plusSeconds(2)));
 
         assertTrue(fileWatchingService.fileChanged(tmpFile));
         assertFalse(fileWatchingService.fileChanged(tmpFile));

--- a/server/src/test/java/org/elasticsearch/reservedstate/service/FileSettingsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/reservedstate/service/FileSettingsServiceTests.java
@@ -55,9 +55,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
 import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -315,9 +312,9 @@ public class FileSettingsServiceTests extends ESTestCase {
         verify(fileSettingsService, times(1)).processFile(eq(watchedFile), eq(true));
         verify(controller, times(1)).process(any(), any(XContentParser.class), eq(ReservedStateVersionCheck.HIGHER_OR_SAME_VERSION), any());
 
-        // Touch the file to get an update
-        Instant now = LocalDateTime.now(ZoneId.systemDefault()).toInstant(ZoneOffset.ofHours(0));
-        Files.setLastModifiedTime(watchedFile, FileTime.from(now));
+        // Touch the file to get an update; use +2s to guarantee we land in a different millisecond regardless of filesystem timestamp
+        // rounding or NTP shenanigans
+        Files.setLastModifiedTime(watchedFile, FileTime.from(Instant.now().plusSeconds(2)));
 
         longAwait(processFileChangeLatch);
 

--- a/server/src/test/java/org/elasticsearch/watcher/FileWatcherTests.java
+++ b/server/src/test/java/org/elasticsearch/watcher/FileWatcherTests.java
@@ -107,8 +107,9 @@ public class FileWatcherTests extends ESTestCase {
         fileWatcher.checkAndNotify();
         assertThat(changes.notifications(), hasSize(0));
 
-        // change modification date, but not contents [we set the time in the future to guarantee a change]
-        Files.setLastModifiedTime(testFile, FileTime.fromMillis(System.currentTimeMillis() + 1));
+        // change modification date, but not contents; use +2s to guarantee we land in a different millisecond regardless of filesystem
+        // timestamp rounding or NTP shenanigans
+        Files.setLastModifiedTime(testFile, FileTime.fromMillis(System.currentTimeMillis() + 2000));
         fileWatcher.checkAndNotify();
         assertThat(changes.notifications(), contains(equalTo("onFileChanged: test.txt")));
 


### PR DESCRIPTION
Backports the following commits to 9.3:
 - In file watching tests, add 2s to guarantee a timestamp change (#149937)