### PR TITLE
Fix index balance metrics assertion

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/IndexBalanceMetricsTaskExecutor.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/IndexBalanceMetricsTaskExecutor.java
@@ -208,8 +208,6 @@ public final class IndexBalanceMetricsTaskExecutor extends PersistentTasksExecut
         PersistentTasksCustomMetadata.PersistentTask<TaskParams> taskInProgress,
         Map<String, String> headers
     ) {
-        assert INDEX_BALANCE_METRICS_ENABLED_SETTING.get(clusterService.getSettings())
-            : "index balance metrics task requires [" + INDEX_BALANCE_METRICS_ENABLED_SETTING.getKey() + "] to be enabled";
         return new Task(
             id,
             type,


### PR DESCRIPTION
[CI failure](https://gradle-enterprise.elastic.co/s/pk3zs4r5hrans/tests/task/:qa:stateful:x-pack:plugin:logsdb:qa:rolling-upgrade:javaRestTest/details/org.elasticsearch.xpack.logsdb.TSDBSyntheticIdUpgradeIT/testRollingUpgrade?top-execution=1)

The createTask() now simply creates the Task object without checking the local setting — the lifecycle manager on the master is the right place to control whether the task exists in cluster state at all.

The fatal error was caused by the assert firing on index nodes during a rolling upgrade, where those nodes had INDEX_BALANCE_METRICS_ENABLED_SETTING=false (default) because the StatelessPlugin.additionalSettings() override either wasn't applied yet or wasn't present in their running code version. Removing the assert means createTask() will succeed on any node the framework assigns it to, which is the correct behaviour since nodeOperation() handles the actual scheduling logic.