### PR TITLE
ES|QL: verify enrich fails with ambiguity when match field is text vs keyword

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
@@ -22,6 +22,7 @@ import org.elasticsearch.xpack.esql.core.type.DataTypeConverter;
 import org.elasticsearch.xpack.esql.core.type.EsField;
 import org.elasticsearch.xpack.esql.core.type.InvalidMappedField;
 import org.elasticsearch.xpack.esql.core.type.UnsupportedEsField;
+import org.elasticsearch.xpack.esql.enrich.ResolvedEnrichPolicy;
 import org.elasticsearch.xpack.esql.expression.function.fulltext.Kql;
 import org.elasticsearch.xpack.esql.expression.function.fulltext.Match;
 import org.elasticsearch.xpack.esql.expression.function.fulltext.MatchPhrase;
@@ -30,6 +31,7 @@ import org.elasticsearch.xpack.esql.expression.function.vector.Knn;
 import org.elasticsearch.xpack.esql.index.EsIndexGenerator;
 import org.elasticsearch.xpack.esql.index.IndexResolution;
 import org.elasticsearch.xpack.esql.parser.ParsingException;
+import org.elasticsearch.xpack.esql.plan.logical.Enrich;
 
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -127,6 +129,33 @@ public class VerifierTests extends ESTestCase {
             equalTo(
                 "1:36: Cannot use field [multi_typed_int] due to ambiguities being mapped as [2] incompatible types:"
                     + " [byte] in [test1], [long] in [test2]"
+            )
+        );
+    }
+
+    public void testEnrichOnTextKeywordConflictedMatchField() {
+        LinkedHashMap<String, Set<String>> typesToIndices = new LinkedHashMap<>();
+        typesToIndices.put("keyword", Set.of("test2"));
+        typesToIndices.put("text", Set.of("test"));
+
+        Map<String, EsField> mapping = Map.of("street", new InvalidMappedField("street", typesToIndices));
+        Map<String, EsField> enrichMapping = Map.of(
+            "street",
+            new EsField("street", KEYWORD, Map.of(), true, EsField.TimeSeriesFieldType.NONE)
+        );
+        TestAnalyzer analyzer = analyzer().addIndex("test*", IndexResolution.valid(EsIndexGenerator.esIndex("test*", mapping)))
+            .addEnrichPolicy(
+                Enrich.Mode.ANY,
+                "test-policy",
+                new ResolvedEnrichPolicy("street", EnrichPolicy.MATCH_TYPE, List.of(), Map.of("", "test2"), enrichMapping)
+            )
+            .stripErrorPrefix(true);
+
+        analyzer.error(
+            "from test* | enrich test-policy on street",
+            equalTo(
+                "1:36: Cannot use field [street] due to ambiguities being mapped as [2] incompatible types:"
+                    + " [keyword] in [test2], [text] in [test]"
             )
         );
     }


### PR DESCRIPTION
## Summary

Adds verifier coverage for `ENRICH ... ON <field>` when the match field has incompatible
mappings across source indices (**text** on one index, **keyword** on another). The query
must fail with the standard union-type **ambiguity** message, not a misleading enrich
**unsupported type** error caused by treating `InvalidMappedField` as `UNSUPPORTED` during
early enrich validation.

**Test-only change** — no production code changes.

## Background

Field caps across multiple indices can yield an `InvalidMappedField` when the same field
name maps to different types. During enrich analysis, the match field is resolved before
`UnionTypesCleanup` runs.

`Analyzer` defers enrich match-field type checks when the resolved attribute has type
conflicts (`FieldAttribute#hasTypeConflicts()`), so union-type handling can surface the
standard ambiguity message. This test guards that path for text vs keyword on MATCH enrich.

### Related tests

| Test | Scenario |
|------|----------|
| `testEnrichOnByteLongConflictedMatchField` | byte vs long → ambiguity |
| `testEnrichOnDateNanosConflictedMatchField` | date_nanos → unsupported for range |
| **`testEnrichOnTextKeywordConflictedMatchField`** (new) | text vs keyword → ambiguity |

## Test plan

```bash
./gradlew :x-pack:plugin:esql:test \
  --tests org.elasticsearch.xpack.esql.analysis.VerifierTests.testEnrichOnTextKeywordConflictedMatchField
```
