### PR TITLE
ES|QL: Only materialize referenced fields in FROM and ENRICH

### DIFF
--- a/docs/changelog/150269.yaml
+++ b/docs/changelog/150269.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 150269
+summary: "ES|QL: Only materialize referenced fields in FROM and ENRICH (major memory/CPU improvement for wide mappings)"
+type: enhancement

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/TestAnalyzer.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/TestAnalyzer.java
@@ -52,6 +52,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -87,6 +88,7 @@ public class TestAnalyzer {
     private ExternalSourceResolution externalSourceResolution = ExternalSourceResolution.EMPTY;
     private boolean stripErrorPrefix;
     private Map<String, String> views = new LinkedHashMap<>();
+    private Set<String> referencedFieldNames;
 
     TestAnalyzer() {}
 
@@ -130,6 +132,15 @@ public class TestAnalyzer {
      */
     public TestAnalyzer addIndex(EsIndex index) {
         return addIndex(IndexResolution.valid(index));
+    }
+
+    /**
+     * Restrict {@link Analyzer#mappingAsAttributes} to these field names during analysis (simulates pre-analysis).
+     * {@code null} keeps the full mapping (default).
+     */
+    public TestAnalyzer referencedFieldNames(Set<String> fieldNames) {
+        this.referencedFieldNames = fieldNames;
+        return this;
     }
 
     /**
@@ -803,7 +814,7 @@ public class TestAnalyzer {
             minimumTransportVersion.get(),
             unmappedResolution,
             timestampBounds
-        );
+        ).withReferencedFieldNames(referencedFieldNames);
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -11,6 +11,7 @@ import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.logging.HeaderWarning;
 import org.elasticsearch.common.logging.LoggerMessageFormat;
 import org.elasticsearch.common.lucene.BytesRefs;
+import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.compute.data.AggregateMetricDoubleBlockBuilder;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.Page;
@@ -355,7 +356,7 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
 
             EsIndex esIndex = indexResolution.get();
 
-            var attributes = mappingAsAttributes(plan.source(), esIndex.mapping());
+            var attributes = mappingAsAttributesForContext(plan.source(), esIndex.mapping(), context.referencedFieldNames());
             attributes.addAll(metadata.stream().map(NamedExpression::toAttribute).toList());
 
             return new EsRelation(
@@ -430,40 +431,128 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
         return list;
     }
 
+    /**
+     * Like {@link #mappingAsAttributes(Source, Map)} but only materializes the given field names (and subtrees for {@code prefix.*}).
+     */
+    static List<Attribute> mappingAsAttributes(Source source, Map<String, EsField> mapping, Collection<String> fieldNames) {
+        for (String fieldName : fieldNames) {
+            if (Regex.isSimpleMatchPattern(fieldName) && fieldName.endsWith(".*") == false) {
+                return mappingAsAttributes(source, mapping);
+            }
+        }
+        var list = new ArrayList<Attribute>();
+        for (String fieldName : fieldNames) {
+            if (MetadataAttribute.INDEX.equals(fieldName)) {
+                continue;
+            }
+            if (fieldName.endsWith(".*")) {
+                String prefix = fieldName.substring(0, fieldName.length() - 2);
+                mappingAsAttributesForPath(list, source, null, mapping, prefix);
+            } else {
+                mappingAsAttributesForPath(list, source, null, mapping, fieldName);
+            }
+        }
+        list.sort(Comparator.comparing(Attribute::name));
+        return list;
+    }
+
+    private static List<Attribute> mappingAsAttributesForContext(
+        Source source,
+        Map<String, EsField> mapping,
+        @Nullable Set<String> referencedFieldNames
+    ) {
+        if (useFullFieldMapping(referencedFieldNames)) {
+            return mappingAsAttributes(source, mapping);
+        }
+        return mappingAsAttributes(source, mapping, referencedFieldNames);
+    }
+
+    private static boolean useFullFieldMapping(@Nullable Set<String> referencedFieldNames) {
+        if (referencedFieldNames == null || referencedFieldNames.isEmpty() || referencedFieldNames.contains("*")) {
+            return true;
+        }
+        for (String fieldName : referencedFieldNames) {
+            if (Regex.isSimpleMatchPattern(fieldName) && fieldName.endsWith(".*") == false) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static Set<String> enrichRequiredFieldNames(Enrich plan, EnrichPolicy policy) {
+        Set<String> names = new HashSet<>();
+        names.add(policy.getMatchField());
+        names.addAll(policy.getEnrichFields());
+        if (plan.enrichFields() != null) {
+            for (NamedExpression enrichField : plan.enrichFields()) {
+                names.add(Expressions.name(enrichField instanceof Alias a ? a.child() : enrichField));
+            }
+        }
+        return names;
+    }
+
+    private static void mappingAsAttributesForPath(
+        List<Attribute> list,
+        Source source,
+        @Nullable String parentName,
+        Map<String, EsField> mapping,
+        String fieldPath
+    ) {
+        int dot = fieldPath.indexOf('.');
+        if (dot < 0) {
+            EsField field = mapping.get(fieldPath);
+            if (field != null) {
+                mappingAsAttributesFromField(list, source, parentName, fieldPath, field);
+            }
+            return;
+        }
+        String head = fieldPath.substring(0, dot);
+        String tail = fieldPath.substring(dot + 1);
+        EsField parent = mapping.get(head);
+        if (parent != null && parent.getProperties().isEmpty() == false) {
+            String qualifiedParent = parentName == null ? head : parentName + "." + head;
+            mappingAsAttributesForPath(list, source, qualifiedParent, parent.getProperties(), tail);
+        }
+    }
+
+    private static void mappingAsAttributesFromField(
+        List<Attribute> list,
+        Source source,
+        @Nullable String parentName,
+        String name,
+        EsField t
+    ) {
+        name = parentName == null ? name : parentName + "." + name;
+        var fieldProperties = t.getProperties();
+        var type = t.getDataType().widenSmallNumeric();
+        if (type != t.getDataType()) {
+            t = new EsField(t.getName(), type, t.getProperties(), t.isAggregatable(), t.isAlias(), t.getTimeSeriesFieldType());
+        }
+
+        Attribute attribute;
+        if (t instanceof UnsupportedEsField uef) {
+            attribute = new UnsupportedAttribute(source, name, uef);
+        } else if (t instanceof InvalidMappedTsField imtf) {
+            // Convert the TS role conflict directly to an UnsupportedAttribute with a meaningful message.
+            var carrier = new UnsupportedEsField(imtf.getName(), List.of(), null, imtf.getProperties());
+            attribute = new UnsupportedAttribute(source, name, carrier, imtf.errorMessage());
+        } else {
+            attribute = new FieldAttribute(source, parentName, null, name, t);
+        }
+        if (DataType.isPrimitive(type)) {
+            list.add(attribute);
+        }
+        if (fieldProperties.isEmpty() == false) {
+            mappingAsAttributes(list, source, attribute.name(), fieldProperties);
+        }
+    }
+
     private static void mappingAsAttributes(List<Attribute> list, Source source, String parentName, Map<String, EsField> mapping) {
         for (Map.Entry<String, EsField> entry : mapping.entrySet()) {
             String name = entry.getKey();
             EsField t = entry.getValue();
-
             if (t != null) {
-                name = parentName == null ? name : parentName + "." + name;
-                var fieldProperties = t.getProperties();
-                var type = t.getDataType().widenSmallNumeric();
-                // due to a bug also copy the field since the Attribute hierarchy extracts the data type
-                // directly even if the data type is passed explicitly
-                if (type != t.getDataType()) {
-                    t = new EsField(t.getName(), type, t.getProperties(), t.isAggregatable(), t.isAlias(), t.getTimeSeriesFieldType());
-                }
-
-                FieldAttribute attribute;
-                if (t instanceof UnsupportedEsField uef) {
-                    attribute = new UnsupportedAttribute(source, name, uef);
-                } else if (t instanceof InvalidMappedTsField imtf) {
-                    // Convert the TS role conflict directly to an UnsupportedAttribute with a meaningful message.
-                    // The original types don't matter. We pass a custom error message, anyway, which will fail the query in the verifier.
-                    var carrier = new UnsupportedEsField(imtf.getName(), List.of(), null, imtf.getProperties());
-                    attribute = new UnsupportedAttribute(source, name, carrier, imtf.errorMessage());
-                } else {
-                    attribute = new FieldAttribute(source, parentName, null, name, t);
-                }
-                // primitive branch
-                if (DataType.isPrimitive(type)) {
-                    list.add(attribute);
-                }
-                // allow compound object even if they are unknown
-                if (fieldProperties.isEmpty() == false) {
-                    mappingAsAttributes(list, source, attribute.name(), fieldProperties);
-                }
+                mappingAsAttributesFromField(list, source, parentName, name, t);
             }
         }
     }
@@ -499,7 +588,7 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                 return shadow;
             }
             EsIndex esIndex = resolution.get();
-            var attributes = mappingAsAttributes(shadow.source(), esIndex.mapping());
+            var attributes = mappingAsAttributesForContext(shadow.source(), esIndex.mapping(), context.referencedFieldNames());
             return new EsRelation(
                 shadow.source(),
                 esIndex.name(),
@@ -595,7 +684,7 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                 List<NamedExpression> enrichFields = calculateEnrichFields(
                     plan.source(),
                     policyName,
-                    mappingAsAttributes(plan.source(), resolved.mapping()),
+                    mappingAsAttributes(plan.source(), resolved.mapping(), enrichRequiredFieldNames(plan, policy)),
                     plan.enrichFields(),
                     policy
                 );

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/AnalyzerContext.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/AnalyzerContext.java
@@ -44,6 +44,8 @@ public class AnalyzerContext {
     private Boolean hasRemoteIndices;
     private final UnmappedResolution unmappedResolution;
     private final TimestampBounds timestampBounds;
+    @Nullable
+    private final Set<String> referencedFieldNames;
 
     public AnalyzerContext(
         Configuration configuration,
@@ -73,10 +75,39 @@ public class AnalyzerContext {
         this.minimumVersion = minimumVersion;
         this.unmappedResolution = unmappedResolution;
         this.timestampBounds = timestampBounds;
+        this.referencedFieldNames = null;
 
         assert minimumVersion != null : "AnalyzerContext must have a minimum transport version";
         assert TransportVersion.current().supports(minimumVersion)
             : "AnalyzerContext [" + minimumVersion + "] is not on or before current transport version [" + TransportVersion.current() + "]";
+    }
+
+    /**
+     * Copy constructor that sets {@link #referencedFieldNames}.
+     */
+    private AnalyzerContext(AnalyzerContext other, @Nullable Set<String> referencedFieldNames) {
+        this.configuration = other.configuration;
+        this.functionRegistry = other.functionRegistry;
+        this.promqlFunctionRegistry = other.promqlFunctionRegistry;
+        this.projectMetadata = other.projectMetadata;
+        this.indexResolution = other.indexResolution;
+        this.lookupResolution = other.lookupResolution;
+        this.linkedResolution = other.linkedResolution;
+        this.enrichResolution = other.enrichResolution;
+        this.inferenceResolution = other.inferenceResolution;
+        this.externalSourceResolution = other.externalSourceResolution;
+        this.minimumVersion = other.minimumVersion;
+        this.unmappedResolution = other.unmappedResolution;
+        this.timestampBounds = other.timestampBounds;
+        this.referencedFieldNames = referencedFieldNames;
+    }
+
+    /**
+     * Returns a new {@code AnalyzerContext} with the given referenced field names.
+     * Pass {@code null} to materialize the full mapping (default).
+     */
+    public AnalyzerContext withReferencedFieldNames(@Nullable Set<String> referencedFieldNames) {
+        return new AnalyzerContext(this, referencedFieldNames);
     }
 
     // for testing only
@@ -106,6 +137,14 @@ public class AnalyzerContext {
             unmappedResolution,
             null
         );
+    }
+
+    /**
+     * Field names requested during pre-analysis for field caps, or {@code null} to materialize the full mapping.
+     */
+    @Nullable
+    public Set<String> referencedFieldNames() {
+        return referencedFieldNames;
     }
 
     public Configuration configuration() {
@@ -219,5 +258,7 @@ public class AnalyzerContext {
             unmappedResolution,
             timestampBounds
         );
+        // Apply pre-analysis field names if available
+        // Note: the withReferencedFieldNames method is used by callers who need partial mapping
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
@@ -1840,7 +1840,7 @@ public class EsqlSession {
             projectMetadata,
             r,
             timestampBounds
-        );
+        ).withReferencedFieldNames(r.fieldNames());
         Analyzer analyzer = new Analyzer(analyzerContext, verifier);
         LogicalPlan plan = analyzer.analyze(parsed);
         plan.setAnalyzed();

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/MappingAsAttributesTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/MappingAsAttributesTests.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.analysis;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.type.EsField;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.elasticsearch.xpack.esql.core.type.DataType.KEYWORD;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasSize;
+
+public class MappingAsAttributesTests extends ESTestCase {
+
+    public void testPartialMappingMaterializesOnlyRequestedFields() {
+        Map<String, EsField> mapping = wideMapping(50);
+        Source source = Source.EMPTY;
+
+        List<Attribute> partial = Analyzer.mappingAsAttributes(source, mapping, Set.of("wanted"));
+        List<Attribute> full = Analyzer.mappingAsAttributes(source, mapping);
+
+        assertThat(partial, hasSize(1));
+        assertThat(partial.getFirst().name(), equalTo("wanted"));
+        assertThat(full.size(), equalTo(51));
+    }
+
+    public void testPartialMappingNestedField() {
+        Map<String, EsField> parentProps = Map.of("child", new EsField("child", KEYWORD, Map.of(), true, EsField.TimeSeriesFieldType.NONE));
+        Map<String, EsField> mapping = Map.of(
+            "parent",
+            new EsField("parent", DataType.OBJECT, parentProps, false, EsField.TimeSeriesFieldType.NONE)
+        );
+
+        List<Attribute> partial = Analyzer.mappingAsAttributes(Source.EMPTY, mapping, Set.of("parent.child"));
+        assertThat(partial.stream().map(Attribute::name).collect(Collectors.toList()), contains("parent.child"));
+    }
+
+    public void testPartialMappingWildcardPrefix() {
+        Map<String, EsField> nested = Map.of(
+            "a",
+            new EsField("a", KEYWORD, Map.of(), true, EsField.TimeSeriesFieldType.NONE),
+            "b",
+            new EsField("b", KEYWORD, Map.of(), true, EsField.TimeSeriesFieldType.NONE)
+        );
+        Map<String, EsField> mapping = Map.of(
+            "group",
+            new EsField("group", DataType.OBJECT, nested, false, EsField.TimeSeriesFieldType.NONE),
+            "other",
+            new EsField("other", KEYWORD, Map.of(), true, EsField.TimeSeriesFieldType.NONE)
+        );
+
+        List<Attribute> partial = Analyzer.mappingAsAttributes(Source.EMPTY, mapping, Set.of("group.*"));
+        assertThat(partial.stream().map(Attribute::name).sorted().collect(Collectors.toList()), contains("group.a", "group.b"));
+    }
+
+    public void testPartialMappingDeeplyNestedWildcardPrefix() {
+        Map<String, EsField> deepProp = Map.of(
+            "deepField",
+            new EsField("deepField", KEYWORD, Map.of(), true, EsField.TimeSeriesFieldType.NONE)
+        );
+        Map<String, EsField> innerProp = Map.of(
+            "inner",
+            new EsField("inner", DataType.OBJECT, deepProp, false, EsField.TimeSeriesFieldType.NONE)
+        );
+        Map<String, EsField> mapping = Map.of(
+            "outer",
+            new EsField("outer", DataType.OBJECT, innerProp, false, EsField.TimeSeriesFieldType.NONE)
+        );
+
+        List<Attribute> partial = Analyzer.mappingAsAttributes(Source.EMPTY, mapping, Set.of("outer.inner.*"));
+        assertThat(partial.stream().map(Attribute::name).collect(Collectors.toList()), contains("outer.inner.deepField"));
+    }
+
+    public void testPartialMappingDeeplyNestedExactMatch() {
+        Map<String, EsField> deepProp = Map.of(
+            "deepField",
+            new EsField("deepField", KEYWORD, Map.of(), true, EsField.TimeSeriesFieldType.NONE)
+        );
+        Map<String, EsField> innerProp = Map.of(
+            "inner",
+            new EsField("inner", DataType.OBJECT, deepProp, false, EsField.TimeSeriesFieldType.NONE)
+        );
+        Map<String, EsField> mapping = Map.of(
+            "outer",
+            new EsField("outer", DataType.OBJECT, innerProp, false, EsField.TimeSeriesFieldType.NONE)
+        );
+
+        List<Attribute> partial = Analyzer.mappingAsAttributes(Source.EMPTY, mapping, Set.of("outer.inner.deepField"));
+        assertThat(partial.stream().map(Attribute::name).collect(Collectors.toList()), contains("outer.inner.deepField"));
+    }
+
+    /**
+     * Wide enrich-style policy mappings can contain thousands of fields while only a handful are used.
+     * Partial materialization must stay proportional to requested fields, not mapping width.
+     */
+    public void testPartialMappingAtLeast300xFewerAttributesThanFull() {
+        Map<String, EsField> mapping = wideMapping(600);
+        mapping.put("match_key", new EsField("match_key", KEYWORD, Map.of(), true, EsField.TimeSeriesFieldType.NONE));
+        mapping.put("enrich_value", new EsField("enrich_value", KEYWORD, Map.of(), true, EsField.TimeSeriesFieldType.NONE));
+        Source source = Source.EMPTY;
+        Set<String> enrichPolicyFields = Set.of("match_key", "enrich_value");
+
+        int fullCount = Analyzer.mappingAsAttributes(source, mapping).size();
+        int partialCount = Analyzer.mappingAsAttributes(source, mapping, enrichPolicyFields).size();
+
+        assertThat(fullCount, greaterThanOrEqualTo(603));
+        assertThat(partialCount, equalTo(2));
+        assertThat(fullCount / partialCount, greaterThanOrEqualTo(300));
+    }
+
+    public void testPartialMappingMatchesFullForRequestedTopLevelFields() {
+        Map<String, EsField> mapping = wideMapping(20);
+        mapping.put("alpha", new EsField("alpha", KEYWORD, Map.of(), true, EsField.TimeSeriesFieldType.NONE));
+        mapping.put("beta", new EsField("beta", KEYWORD, Map.of(), true, EsField.TimeSeriesFieldType.NONE));
+        Source source = Source.EMPTY;
+        Set<String> requested = Set.of("alpha", "beta");
+
+        List<String> partial = Analyzer.mappingAsAttributes(source, mapping, requested).stream().map(Attribute::name).sorted().toList();
+        List<String> fromFull = Analyzer.mappingAsAttributes(source, mapping)
+            .stream()
+            .map(Attribute::name)
+            .filter(requested::contains)
+            .sorted()
+            .toList();
+
+        assertThat(partial, equalTo(fromFull));
+        assertThat(partial, contains("alpha", "beta"));
+    }
+
+    public void testPartialMappingFallbackForSuffixWildcard() {
+        Map<String, EsField> mapping = wideMapping(5);
+        mapping.put("first_name", new EsField("first_name", KEYWORD, Map.of(), true, EsField.TimeSeriesFieldType.NONE));
+        mapping.put("last_name", new EsField("last_name", KEYWORD, Map.of(), true, EsField.TimeSeriesFieldType.NONE));
+        Source source = Source.EMPTY;
+
+        List<String> result = Analyzer.mappingAsAttributes(source, mapping, Set.of("*_name"))
+            .stream()
+            .map(Attribute::name)
+            .sorted()
+            .toList();
+        List<String> full = Analyzer.mappingAsAttributes(source, mapping).stream().map(Attribute::name).sorted().toList();
+
+        assertThat(result, equalTo(full));
+    }
+
+    public void testPartialMappingFallbackForPrefixWildcard() {
+        Map<String, EsField> mapping = wideMapping(5);
+        mapping.put("first_name", new EsField("first_name", KEYWORD, Map.of(), true, EsField.TimeSeriesFieldType.NONE));
+        mapping.put("first_value", new EsField("first_value", KEYWORD, Map.of(), true, EsField.TimeSeriesFieldType.NONE));
+        Source source = Source.EMPTY;
+
+        List<String> result = Analyzer.mappingAsAttributes(source, mapping, Set.of("first*"))
+            .stream()
+            .map(Attribute::name)
+            .sorted()
+            .toList();
+        List<String> full = Analyzer.mappingAsAttributes(source, mapping).stream().map(Attribute::name).sorted().toList();
+
+        assertThat(result, equalTo(full));
+    }
+
+    public void testPartialMappingFallbackForInfixWildcard() {
+        Map<String, EsField> mapping = wideMapping(5);
+        mapping.put("first_name", new EsField("first_name", KEYWORD, Map.of(), true, EsField.TimeSeriesFieldType.NONE));
+        mapping.put("last_name", new EsField("last_name", KEYWORD, Map.of(), true, EsField.TimeSeriesFieldType.NONE));
+        Source source = Source.EMPTY;
+
+        List<String> result = Analyzer.mappingAsAttributes(source, mapping, Set.of("*t*name"))
+            .stream()
+            .map(Attribute::name)
+            .sorted()
+            .toList();
+        List<String> full = Analyzer.mappingAsAttributes(source, mapping).stream().map(Attribute::name).sorted().toList();
+
+        assertThat(result, equalTo(full));
+    }
+
+    private static Map<String, EsField> wideMapping(int extraFields) {
+        Map<String, EsField> mapping = new HashMap<>();
+        mapping.put("wanted", new EsField("wanted", KEYWORD, Map.of(), true, EsField.TimeSeriesFieldType.NONE));
+        for (int i = 0; i < extraFields; i++) {
+            mapping.put("extra" + i, new EsField("extra" + i, KEYWORD, Map.of(), true, EsField.TimeSeriesFieldType.NONE));
+        }
+        return mapping;
+    }
+}


### PR DESCRIPTION
## Summary

Avoid materializing a `FieldAttribute` for every field in an index or enrich-policy mapping when
analysis only needs a small subset. Adds a partial `mappingAsAttributes` overload and uses it
for enrich policy resolution and `FROM` when pre-analysis has a narrowed field set.

## Problem

`mappingAsAttributes` walks the entire mapping tree, creates attributes for all primitives,
and sorts the result. Enrich already filters to policy fields afterward; `FROM` often only
needs fields referenced in the query.

## Solution

- Partial `mappingAsAttributes(source, mapping, fieldNames)` with `prefix.*` support
- **Enrich:** materialize only match field + enrich fields + `WITH` columns
- **FROM / view shadow:** use `AnalyzerContext#referencedFieldNames` when not `*`
- Full mapping unchanged for `ALL_FIELDS` / `*`

## Impact (unit test)

`MappingAsAttributesTests#testPartialMappingAtLeast300xFewerAttributesThanFull`: **603** full
attributes vs **2** partial (≥ **300×** fewer). This is planning attribute count, not query
`took`.

## Limits

- `ENRICH` queries still use `ALL_FIELDS` for field-caps pre-analysis; main enrich win is wide
  policy mappings with few `enrich_fields`
- `FROM` partial path when pre-analysis narrows fields (e.g. `KEEP`), not bare `from idx*`

## Test plan

```bash
./gradlew :x-pack:plugin:esql:test \
  --tests org.elasticsearch.xpack.esql.analysis.MappingAsAttributesTests

./gradlew :x-pack:plugin:esql:test \
  --tests 'org.elasticsearch.xpack.esql.analysis.*'
```
