### PR TITLE
Configure failure store indices with auto-expand replicas

### DIFF
--- a/docs/changelog/150272.yaml
+++ b/docs/changelog/150272.yaml
@@ -1,0 +1,5 @@
+area: Data Management
+issues: [150259]
+pr: 150272
+summary: Configure failure store indices with auto-expand replicas
+type: bug

--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/lifecycle/ExplainDataStreamLifecycleIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/lifecycle/ExplainDataStreamLifecycleIT.java
@@ -15,6 +15,7 @@ import org.elasticsearch.action.admin.indices.rollover.RolloverAction;
 import org.elasticsearch.action.admin.indices.rollover.RolloverConditions;
 import org.elasticsearch.action.admin.indices.rollover.RolloverConfiguration;
 import org.elasticsearch.action.admin.indices.rollover.RolloverRequest;
+import org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
 import org.elasticsearch.action.admin.indices.template.put.TransportPutComposableIndexTemplateAction;
 import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.bulk.BulkRequest;
@@ -29,6 +30,7 @@ import org.elasticsearch.cluster.metadata.DataStreamFailureStore;
 import org.elasticsearch.cluster.metadata.DataStreamLifecycle;
 import org.elasticsearch.cluster.metadata.DataStreamOptions;
 import org.elasticsearch.cluster.metadata.DataStreamTestHelper;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Template;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Settings;
@@ -49,6 +51,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 
 import static org.elasticsearch.cluster.metadata.DataStreamTestHelper.backingIndexEqualTo;
 import static org.elasticsearch.cluster.metadata.DataStreamTestHelper.dataStreamIndexEqualTo;
@@ -426,6 +429,18 @@ public class ExplainDataStreamLifecycleIT extends ESIntegTestCase {
         // let's ensure that the failure store is initialised
         List<String> failureIndices = waitForDataStreamIndices(dataStreamName, 1, true);
         String firstGenerationFailureIndex = failureIndices.get(0);
+        GetSettingsResponse settingsResponse = client().admin()
+            .indices()
+            .prepareGetSettings(TEST_REQUEST_TIMEOUT, firstGenerationFailureIndex)
+            .get();
+
+        assertThat(
+            settingsResponse.getSetting(
+                firstGenerationFailureIndex,
+                IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS
+            ),
+            equalTo("0-1")
+        );
         assertThat(firstGenerationFailureIndex, dataStreamIndexEqualTo(dataStreamName, 2, true));
 
         // prevent new indices from being created (ie. future rollovers)
@@ -490,9 +505,8 @@ public class ExplainDataStreamLifecycleIT extends ESIntegTestCase {
                  * succeed, and there will always be an error in the error store. This behavior is subject to change in the future.
                  */
                 assertThat(response.getIndices().get(0).getError(), is(notNullValue()));
-                assertThat(response.getIndices().get(0).getError().error(), containsString("Force merge request "));
-                assertThat(response.getIndices().get(1).getError(), is(notNullValue()));
-                assertThat(response.getIndices().get(1).getError().error(), containsString("Force merge request "));
+                assertThat(Objects.requireNonNull(response.getIndices().get(0).getError()).error(), containsString("Force merge request "));
+                assertThat(response.getIndices().get(1).getError(), is(nullValue()));
             }
         });
     }

--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/lifecycle/ExplainDataStreamLifecycleIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/lifecycle/ExplainDataStreamLifecycleIT.java
@@ -434,13 +434,7 @@ public class ExplainDataStreamLifecycleIT extends ESIntegTestCase {
             .prepareGetSettings(TEST_REQUEST_TIMEOUT, firstGenerationFailureIndex)
             .get();
 
-        assertThat(
-            settingsResponse.getSetting(
-                firstGenerationFailureIndex,
-                IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS
-            ),
-            equalTo("0-1")
-        );
+        assertThat(settingsResponse.getSetting(firstGenerationFailureIndex, IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS), equalTo("0-1"));
         assertThat(firstGenerationFailureIndex, dataStreamIndexEqualTo(dataStreamName, 2, true));
 
         // prevent new indices from being created (ie. future rollovers)

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamFailureStoreDefinition.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamFailureStoreDefinition.java
@@ -64,6 +64,7 @@ public class DataStreamFailureStoreDefinition {
             // Always start with the hidden settings for a backing index.
             .put(IndexMetadata.SETTING_INDEX_HIDDEN, true)
             .put(FAILURE_STORE_DEFINITION_VERSION_SETTING.getKey(), FAILURE_STORE_DEFINITION_VERSION)
+            .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "0-1")
             .build();
 
         try {
@@ -215,6 +216,13 @@ public class DataStreamFailureStoreDefinition {
         if (refreshInterval != null) {
             builder.put(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(), refreshInterval);
         }
+
+        if (builder.keys().contains(IndexMetadata.SETTING_NUMBER_OF_REPLICAS) == false &&
+            builder.keys().contains(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS) == false) {
+
+            builder.put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "0-1");
+        }
+
         return builder;
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamFailureStoreDefinition.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamFailureStoreDefinition.java
@@ -217,8 +217,8 @@ public class DataStreamFailureStoreDefinition {
             builder.put(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(), refreshInterval);
         }
 
-        if (builder.keys().contains(IndexMetadata.SETTING_NUMBER_OF_REPLICAS) == false &&
-            builder.keys().contains(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS) == false) {
+        if (builder.keys().contains(IndexMetadata.SETTING_NUMBER_OF_REPLICAS) == false
+            && builder.keys().contains(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS) == false) {
 
             builder.put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "0-1");
         }


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

Fixes #150259 

Set index.auto_expand_replicas=0-1 for failure store indices by default, and when migrating existing indices into a failure store. Add an integration test verifying that failure store backing indices are created with the expected replica configuration.