### PR TITLE
Revert muting DiversifyingChildrenIVFKnnFloatSlicedVectorQueryTests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -556,9 +556,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.heap_attack.HeapAttackIT
   method: testGroupOnManyLongs
   issue: https://github.com/elastic/elasticsearch/issues/150104
-- class: org.elasticsearch.search.vectors.DiversifyingChildrenIVFKnnFloatSlicedVectorQueryTests
-  method: testSlicesSparseWithFilter
-  issue: https://github.com/elastic/elasticsearch/issues/150106
 - class: org.elasticsearch.index.query.IntervalQueryBuilderTests
   method: testCacheability
   issue: https://github.com/elastic/elasticsearch/issues/150117


### PR DESCRIPTION
Accidentally muted fixed test in https://github.com/elastic/elasticsearch/pull/150142/changes. Reverting. 