### PR TITLE
Fixed numeric block loader regression caused by a megamorphic read()

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/AbstractNumericBlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/AbstractNumericBlockLoader.java
@@ -11,10 +11,10 @@ package org.elasticsearch.index.mapper.blockloader.docvalues;
 
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.index.SortedNumericDocValues;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.io.stream.ByteArrayStreamInput;
 import org.elasticsearch.core.Releasables;
-import org.elasticsearch.index.mapper.BlockLoader;
 import org.elasticsearch.index.mapper.FieldArrayContext;
 import org.elasticsearch.index.mapper.blockloader.ConstantNull;
 import org.elasticsearch.index.mapper.blockloader.docvalues.tracking.NumericDvSingletonOrSorted;
@@ -27,14 +27,16 @@ import java.io.IOException;
 /**
  * Shared base for the numeric-family block loaders.
  * <p>
- * Exposes three nested reader shapes produced by {@link #reader}:
+ * {@link #reader} picks one of three reader shapes for the segment. Each shape is supplied by the concrete loader through an abstract
+ * hook so that the per-document loop lives in a type-specific {@code read} method that the JIT compiles monomorphically; a single shared
+ * loop would see every numeric type and go megamorphic.
  * <ul>
- *     <li>{@link Singleton} — single-valued numeric doc values; can use the {@code tryDirectRead} fast path</li>
+ *     <li>{@link Singleton} — single-valued numeric doc values/li>
  *     <li>{@link Sorted} — multi-valued in natural (sorted) order</li>
  *     <li>{@link ArrayOrder} — multi-valued in index-time arrival order via a companion offsets field</li>
  * </ul>
  */
-public abstract class AbstractNumericBlockLoader<B extends BlockLoader.Builder> extends BlockDocValuesReader.DocValuesBlockLoader {
+public abstract class AbstractNumericBlockLoader extends BlockDocValuesReader.DocValuesBlockLoader {
 
     protected final String fieldName;
     protected final String readerName;
@@ -69,98 +71,57 @@ public abstract class AbstractNumericBlockLoader<B extends BlockLoader.Builder> 
                 throw e;
             }
             if (offsets != null) {
-                return new ArrayOrder<>(this, readerName, dv.sorted(), offsets);
+                return arrayOrderReader(dv.sorted(), offsets);
             }
         }
 
         // Doc values are single-valued
         if (dv.singleton() != null) {
-            return new Singleton<>(this, readerName, dv.singleton());
+            return singletonReader(dv.singleton());
         }
 
         // Otherwise, doc values are multi-valued but without offsets
         return sortedReader(dv.sorted());
     }
 
-    /**
-     * Builds the reader for multi-valued, sorted-order doc values. The default returns a vanilla {@link Sorted}; multi-value reduction
-     * loaders (Mv max/min) override this hook to inject a custom {@link Sorted} subclass with reduction logic.
-     */
-    protected ColumnAtATimeReader sortedReader(TrackingSortedNumericDocValues docValues) {
-        return new Sorted<>(this, readerName, docValues);
+    protected abstract ColumnAtATimeReader singletonReader(TrackingNumericDocValues docValues);
+
+    protected abstract ColumnAtATimeReader sortedReader(TrackingSortedNumericDocValues docValues);
+
+    protected abstract ColumnAtATimeReader arrayOrderReader(TrackingSortedNumericDocValues values, TrackingSortedDocValues offsets);
+
+    @Override
+    public String toString() {
+        return readerName + "[" + fieldName + "]";
     }
 
-    /** Allocates the typed reader-side builder. */
-    protected abstract B newBuilder(BlockFactory factory, int expectedCount);
-
-    /** Appends a single non-null value, converting from the raw {@code long} bits stored in the doc values. */
-    protected abstract void appendValue(B builder, long rawValue);
-
     /**
-     * Optional fast path through {@link BlockLoader.OptionalColumnAtATimeReader#tryRead} for single-valued reads. Default returns
-     * {@code null} to skip the fast path.
+     * Each subclass overrides {@code read} in full: the per-doc append is the hot path, so a shared loop would see every type and go
+     * megamorphic. Unlike {@link ArrayOrder} there is no type-independent work to hoist into a base {@code read}.
      */
-    protected BlockLoader.Block tryDirectRead(
-        BlockLoader.OptionalColumnAtATimeReader direct,
-        BlockFactory factory,
-        Docs docs,
-        int offset,
-        boolean nullsFiltered
-    ) throws IOException {
-        return null;
-    }
+    public abstract static class Singleton extends BlockDocValuesReader implements BlockDocValuesReader.NumericDocValuesAccessor {
 
-    public static final class Singleton<B extends BlockLoader.Builder> extends BlockDocValuesReader
-        implements
-            BlockDocValuesReader.NumericDocValuesAccessor {
-
-        private final AbstractNumericBlockLoader<B> loader;
         private final String name;
-        private final TrackingNumericDocValues numericDocValues;
+        protected final TrackingNumericDocValues numericDocValues;
 
-        Singleton(AbstractNumericBlockLoader<B> loader, String name, TrackingNumericDocValues numericDocValues) {
+        protected Singleton(String name, TrackingNumericDocValues numericDocValues) {
             super(null);
-            this.loader = loader;
             this.name = name + ".Singleton";
             this.numericDocValues = numericDocValues;
         }
 
         @Override
-        public BlockLoader.Block read(BlockLoader.BlockFactory factory, BlockLoader.Docs docs, int offset, boolean nullsFiltered)
-            throws IOException {
-            // Attempt a fast path through OptionalColumnAtATimeReader
-            if (numericDocValues.docValues() instanceof BlockLoader.OptionalColumnAtATimeReader direct) {
-                BlockLoader.Block result = loader.tryDirectRead(direct, factory, docs, offset, nullsFiltered);
-                if (result != null) {
-                    return result;
-                }
-            }
-
-            try (B builder = loader.newBuilder(factory, docs.count() - offset)) {
-                for (int i = offset; i < docs.count(); i++) {
-                    int doc = docs.get(i);
-                    if (numericDocValues.docValues().advanceExact(doc)) {
-                        loader.appendValue(builder, numericDocValues.docValues().longValue());
-                    } else {
-                        builder.appendNull();
-                    }
-                }
-                return builder.build();
-            }
-        }
-
-        @Override
-        public int docId() {
+        public final int docId() {
             return numericDocValues.docValues().docID();
         }
 
         @Override
-        public NumericDocValues numericDocValues() {
+        public final NumericDocValues numericDocValues() {
             return numericDocValues.docValues();
         }
 
         @Override
-        public String toString() {
+        public final String toString() {
             return name;
         }
 
@@ -170,50 +131,19 @@ public abstract class AbstractNumericBlockLoader<B extends BlockLoader.Builder> 
         }
     }
 
-    public static class Sorted<B extends BlockLoader.Builder> extends BlockDocValuesReader {
+    /**
+     * Each subclass overrides {@code read} in full rather than sharing a base loop: the {@code MvMin}/{@code MvMax} reducers extend this
+     * with their own {@code read}, and like {@link Singleton} there is little type-independent work to hoist.
+     */
+    public abstract static class Sorted extends BlockDocValuesReader {
 
-        private final AbstractNumericBlockLoader<B> loader;
         private final String name;
         protected final TrackingSortedNumericDocValues values;
 
-        protected Sorted(AbstractNumericBlockLoader<B> loader, String name, TrackingSortedNumericDocValues values) {
+        protected Sorted(String name, TrackingSortedNumericDocValues values) {
             super(null);
-            this.loader = loader;
             this.name = name + ".Sorted";
             this.values = values;
-        }
-
-        @Override
-        public BlockLoader.Block read(BlockLoader.BlockFactory factory, BlockLoader.Docs docs, int offset, boolean nullsFiltered)
-            throws IOException {
-            try (B builder = loader.newBuilder(factory, docs.count() - offset)) {
-                for (int i = offset; i < docs.count(); i++) {
-                    readSortedDoc(docs.get(i), builder);
-                }
-                return builder.build();
-            }
-        }
-
-        protected void readSortedDoc(int doc, B builder) throws IOException {
-            if (values.docValues().advanceExact(doc) == false) {
-                builder.appendNull();
-                return;
-            }
-            int count = values.docValues().docValueCount();
-            if (count == 1) {
-                loader.appendValue(builder, values.docValues().nextValue());
-                return;
-            }
-            builder.beginPositionEntry();
-            for (int v = 0; v < count; v++) {
-                loader.appendValue(builder, values.docValues().nextValue());
-            }
-            builder.endPositionEntry();
-        }
-
-        /** Convenience pass-through used by Mv-fused subclasses that override {@link #readSortedDoc}. */
-        protected final void appendValue(B builder, long rawValue) {
-            loader.appendValue(builder, rawValue);
         }
 
         @Override
@@ -232,34 +162,28 @@ public abstract class AbstractNumericBlockLoader<B extends BlockLoader.Builder> 
         }
     }
 
-    public static final class ArrayOrder<B extends BlockLoader.Builder> extends BlockDocValuesReader {
+    abstract static class ArrayOrder<B extends Builder> extends BlockDocValuesReader {
 
-        private final AbstractNumericBlockLoader<B> loader;
         private final String name;
-        private final TrackingSortedNumericDocValues values;
-        private final TrackingSortedDocValues offsets;
-        private final Sorted<B> sortedFallback;
-
+        protected final TrackingSortedNumericDocValues values;
+        protected final TrackingSortedDocValues offsets;
         private final ByteArrayStreamInput scratch = new ByteArrayStreamInput();
 
-        ArrayOrder(
-            AbstractNumericBlockLoader<B> loader,
-            String name,
-            TrackingSortedNumericDocValues values,
-            TrackingSortedDocValues offsets
-        ) {
+        protected ArrayOrder(String name, TrackingSortedNumericDocValues values, TrackingSortedDocValues offsets) {
             super(null);
-            this.loader = loader;
             this.name = name + ".ArrayOrder";
             this.values = values;
             this.offsets = offsets;
-            this.sortedFallback = new Sorted<>(loader, name, values);
         }
 
+        /**
+         * The shared {@code read} loop, the offsets decode, the all-null handling, and the per-doc value materialization live here; the
+         * per-type subclass supplies only the builder, the sorted fallback, and the {@link #emit} loop so the value-append stays in
+         * type-specific code and compiles monomorphically rather than going through a megamorphic callback.
+         */
         @Override
-        public BlockLoader.Block read(BlockLoader.BlockFactory factory, BlockLoader.Docs docs, int offset, boolean nullsFiltered)
-            throws IOException {
-            try (B builder = loader.newBuilder(factory, docs.count() - offset)) {
+        public final Block read(BlockFactory factory, Docs docs, int offset, boolean nullsFiltered) throws IOException {
+            try (B builder = newBuilder(factory, docs.count() - offset)) {
                 for (int i = offset; i < docs.count(); i++) {
                     readDoc(docs.get(i), builder);
                 }
@@ -272,12 +196,13 @@ public abstract class AbstractNumericBlockLoader<B extends BlockLoader.Builder> 
 
             // no offsets were recorded - fallback to the sorted path
             if (offsetToOrd == null) {
-                sortedFallback.readSortedDoc(docId, builder);
+                readSortedFallback(docId, builder);
                 return;
             }
 
+            SortedNumericDocValues docValues = values.docValues();
             // no values arrived (all slots null) — emit a single null position
-            if (values.docValues().advanceExact(docId) == false) {
+            if (docValues.advanceExact(docId) == false) {
                 assert OffsetsAwareBlockLoaderHelper.allNulls(offsetToOrd);
                 builder.appendNull();
                 return;
@@ -298,7 +223,7 @@ public abstract class AbstractNumericBlockLoader<B extends BlockLoader.Builder> 
                 materialized[i - duplicates] = value;
             }
 
-            OffsetsAwareBlockLoaderHelper.emit(offsetToOrd, builder, ord -> loader.appendValue(builder, materialized[ord]));
+            emit(offsetToOrd, builder, materialized);
         }
 
         @Override
@@ -317,5 +242,21 @@ public abstract class AbstractNumericBlockLoader<B extends BlockLoader.Builder> 
             // sortedFallback wraps `values` and owns no other resources, so closing it would double-release `values`.
             Releasables.close(values, offsets);
         }
+
+        /**
+         * Creates the type-specific builder sized for the block.
+         */
+        protected abstract B newBuilder(BlockFactory factory, int count);
+
+        /**
+         * Emits the doc in natural (sorted) order when no offsets were recorded for it, delegating to the type's sorted reader.
+         */
+        protected abstract void readSortedFallback(int docId, B builder) throws IOException;
+
+        /**
+         * Appends the doc's values in arrival order, indexing into {@code materialized} by ord. Kept in the subclass so the append is
+         * monomorphic; use {@link OffsetsAwareBlockLoaderHelper#countNonNull} to pick the position shape before appending.
+         */
+        protected abstract void emit(int[] offsetToOrd, B builder, long[] materialized) throws IOException;
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/BooleansBlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/BooleansBlockLoader.java
@@ -9,9 +9,16 @@
 
 package org.elasticsearch.index.mapper.blockloader.docvalues;
 
-import org.elasticsearch.index.mapper.BlockLoader;
+import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.elasticsearch.index.mapper.FieldArrayContext;
+import org.elasticsearch.index.mapper.blockloader.docvalues.tracking.TrackingNumericDocValues;
+import org.elasticsearch.index.mapper.blockloader.docvalues.tracking.TrackingSortedDocValues;
+import org.elasticsearch.index.mapper.blockloader.docvalues.tracking.TrackingSortedNumericDocValues;
 
-public class BooleansBlockLoader extends AbstractNumericBlockLoader<BlockLoader.BooleanBuilder> {
+import java.io.IOException;
+
+public class BooleansBlockLoader extends AbstractNumericBlockLoader {
 
     public BooleansBlockLoader(String fieldName) {
         this(fieldName, false);
@@ -27,17 +34,116 @@ public class BooleansBlockLoader extends AbstractNumericBlockLoader<BlockLoader.
     }
 
     @Override
-    protected BooleanBuilder newBuilder(BlockFactory factory, int expectedCount) {
-        return factory.booleansFromDocValues(expectedCount);
+    protected ColumnAtATimeReader singletonReader(TrackingNumericDocValues docValues) {
+        return new Singleton(readerName, docValues);
     }
 
     @Override
-    protected void appendValue(BooleanBuilder builder, long rawValue) {
-        builder.appendBoolean(rawValue != 0);
+    protected ColumnAtATimeReader sortedReader(TrackingSortedNumericDocValues docValues) {
+        return new Sorted(readerName, docValues);
     }
 
     @Override
-    public String toString() {
-        return "BooleansFromDocValues[" + fieldName + "]";
+    protected ColumnAtATimeReader arrayOrderReader(TrackingSortedNumericDocValues values, TrackingSortedDocValues offsets) {
+        return new ArrayOrder(readerName, values, offsets);
+    }
+
+    static final class Singleton extends AbstractNumericBlockLoader.Singleton {
+        Singleton(String name, TrackingNumericDocValues numericDocValues) {
+            super(name, numericDocValues);
+        }
+
+        @Override
+        public Block read(BlockFactory factory, Docs docs, int offset, boolean nullsFiltered) throws IOException {
+            NumericDocValues docValues = numericDocValues.docValues();
+            try (BooleanBuilder builder = factory.booleansFromDocValues(docs.count() - offset)) {
+                for (int i = offset; i < docs.count(); i++) {
+                    int doc = docs.get(i);
+                    if (docValues.advanceExact(doc)) {
+                        builder.appendBoolean(docValues.longValue() != 0);
+                    } else {
+                        builder.appendNull();
+                    }
+                }
+                return builder.build();
+            }
+        }
+    }
+
+    static final class Sorted extends AbstractNumericBlockLoader.Sorted {
+        Sorted(String name, TrackingSortedNumericDocValues values) {
+            super(name, values);
+        }
+
+        @Override
+        public Block read(BlockFactory factory, Docs docs, int offset, boolean nullsFiltered) throws IOException {
+            try (BooleanBuilder builder = factory.booleansFromDocValues(docs.count() - offset)) {
+                for (int i = offset; i < docs.count(); i++) {
+                    readSortedDoc(docs.get(i), builder);
+                }
+                return builder.build();
+            }
+        }
+
+        void readSortedDoc(int doc, BooleanBuilder builder) throws IOException {
+            SortedNumericDocValues docValues = values.docValues();
+            if (docValues.advanceExact(doc) == false) {
+                builder.appendNull();
+                return;
+            }
+            int count = docValues.docValueCount();
+            if (count == 1) {
+                builder.appendBoolean(docValues.nextValue() != 0);
+                return;
+            }
+            builder.beginPositionEntry();
+            for (int v = 0; v < count; v++) {
+                builder.appendBoolean(docValues.nextValue() != 0);
+            }
+            builder.endPositionEntry();
+        }
+    }
+
+    static final class ArrayOrder extends AbstractNumericBlockLoader.ArrayOrder<BooleanBuilder> {
+        private final Sorted sortedFallback;
+
+        ArrayOrder(String name, TrackingSortedNumericDocValues values, TrackingSortedDocValues offsets) {
+            super(name, values, offsets);
+            this.sortedFallback = new Sorted(name, values);
+        }
+
+        @Override
+        protected BooleanBuilder newBuilder(BlockFactory factory, int count) {
+            return factory.booleansFromDocValues(count);
+        }
+
+        @Override
+        protected void readSortedFallback(int docId, BooleanBuilder builder) throws IOException {
+            sortedFallback.readSortedDoc(docId, builder);
+        }
+
+        @Override
+        protected void emit(int[] offsetToOrd, BooleanBuilder builder, long[] materialized) {
+            int nonNullCount = OffsetsAwareBlockLoaderHelper.countNonNull(offsetToOrd);
+            if (nonNullCount == 0) {
+                builder.appendNull();
+                return;
+            }
+            if (nonNullCount == 1) {
+                for (int ord : offsetToOrd) {
+                    if (ord != FieldArrayContext.NULL_ORD) {
+                        builder.appendBoolean(materialized[ord] != 0);
+                        return;
+                    }
+                }
+            }
+            builder.beginPositionEntry();
+            for (int ord : offsetToOrd) {
+                if (ord != FieldArrayContext.NULL_ORD) {
+                    builder.appendBoolean(materialized[ord] != 0);
+                }
+            }
+            builder.endPositionEntry();
+        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/DoublesBlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/DoublesBlockLoader.java
@@ -9,11 +9,16 @@
 
 package org.elasticsearch.index.mapper.blockloader.docvalues;
 
-import org.elasticsearch.index.mapper.BlockLoader;
+import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.elasticsearch.index.mapper.FieldArrayContext;
+import org.elasticsearch.index.mapper.blockloader.docvalues.tracking.TrackingNumericDocValues;
+import org.elasticsearch.index.mapper.blockloader.docvalues.tracking.TrackingSortedDocValues;
+import org.elasticsearch.index.mapper.blockloader.docvalues.tracking.TrackingSortedNumericDocValues;
 
 import java.io.IOException;
 
-public class DoublesBlockLoader extends AbstractNumericBlockLoader<BlockLoader.DoubleBuilder> {
+public class DoublesBlockLoader extends AbstractNumericBlockLoader {
     protected final BlockDocValuesReader.ToDouble toDouble;
 
     public DoublesBlockLoader(String fieldName, BlockDocValuesReader.ToDouble toDouble) {
@@ -31,23 +36,136 @@ public class DoublesBlockLoader extends AbstractNumericBlockLoader<BlockLoader.D
     }
 
     @Override
-    protected DoubleBuilder newBuilder(BlockFactory factory, int expectedCount) {
-        return factory.doublesFromDocValues(expectedCount);
+    protected ColumnAtATimeReader singletonReader(TrackingNumericDocValues docValues) {
+        return new Singleton(readerName, docValues, toDouble);
     }
 
     @Override
-    protected void appendValue(DoubleBuilder builder, long rawValue) {
-        builder.appendDouble(toDouble.convert(rawValue));
+    protected ColumnAtATimeReader sortedReader(TrackingSortedNumericDocValues docValues) {
+        return new Sorted(readerName, docValues, toDouble);
     }
 
     @Override
-    protected Block tryDirectRead(OptionalColumnAtATimeReader direct, BlockFactory factory, Docs docs, int offset, boolean nullsFiltered)
-        throws IOException {
-        return direct.tryRead(factory, docs, offset, nullsFiltered, toDouble, false, false);
+    protected ColumnAtATimeReader arrayOrderReader(TrackingSortedNumericDocValues values, TrackingSortedDocValues offsets) {
+        return new ArrayOrder(readerName, values, offsets, toDouble);
     }
 
-    @Override
-    public String toString() {
-        return "DoublesFromDocValues[" + fieldName + "]";
+    static final class Singleton extends AbstractNumericBlockLoader.Singleton {
+        private final BlockDocValuesReader.ToDouble toDouble;
+
+        Singleton(String name, TrackingNumericDocValues numericDocValues, BlockDocValuesReader.ToDouble toDouble) {
+            super(name, numericDocValues);
+            this.toDouble = toDouble;
+        }
+
+        @Override
+        public Block read(BlockFactory factory, Docs docs, int offset, boolean nullsFiltered) throws IOException {
+            NumericDocValues docValues = numericDocValues.docValues();
+            // Attempt a fast path through OptionalColumnAtATimeReader
+            if (docValues instanceof OptionalColumnAtATimeReader direct) {
+                Block result = direct.tryRead(factory, docs, offset, nullsFiltered, toDouble, false, false);
+                if (result != null) {
+                    return result;
+                }
+            }
+            try (DoubleBuilder builder = factory.doublesFromDocValues(docs.count() - offset)) {
+                for (int i = offset; i < docs.count(); i++) {
+                    int doc = docs.get(i);
+                    if (docValues.advanceExact(doc)) {
+                        builder.appendDouble(toDouble.convert(docValues.longValue()));
+                    } else {
+                        builder.appendNull();
+                    }
+                }
+                return builder.build();
+            }
+        }
+    }
+
+    static final class Sorted extends AbstractNumericBlockLoader.Sorted {
+        private final BlockDocValuesReader.ToDouble toDouble;
+
+        Sorted(String name, TrackingSortedNumericDocValues values, BlockDocValuesReader.ToDouble toDouble) {
+            super(name, values);
+            this.toDouble = toDouble;
+        }
+
+        @Override
+        public Block read(BlockFactory factory, Docs docs, int offset, boolean nullsFiltered) throws IOException {
+            try (DoubleBuilder builder = factory.doublesFromDocValues(docs.count() - offset)) {
+                for (int i = offset; i < docs.count(); i++) {
+                    readSortedDoc(docs.get(i), builder);
+                }
+                return builder.build();
+            }
+        }
+
+        void readSortedDoc(int doc, DoubleBuilder builder) throws IOException {
+            SortedNumericDocValues docValues = values.docValues();
+            if (docValues.advanceExact(doc) == false) {
+                builder.appendNull();
+                return;
+            }
+            int count = docValues.docValueCount();
+            if (count == 1) {
+                builder.appendDouble(toDouble.convert(docValues.nextValue()));
+                return;
+            }
+            builder.beginPositionEntry();
+            for (int v = 0; v < count; v++) {
+                builder.appendDouble(toDouble.convert(docValues.nextValue()));
+            }
+            builder.endPositionEntry();
+        }
+    }
+
+    static final class ArrayOrder extends AbstractNumericBlockLoader.ArrayOrder<DoubleBuilder> {
+        private final BlockDocValuesReader.ToDouble toDouble;
+        private final Sorted sortedFallback;
+
+        ArrayOrder(
+            String name,
+            TrackingSortedNumericDocValues values,
+            TrackingSortedDocValues offsets,
+            BlockDocValuesReader.ToDouble toDouble
+        ) {
+            super(name, values, offsets);
+            this.toDouble = toDouble;
+            this.sortedFallback = new Sorted(name, values, toDouble);
+        }
+
+        @Override
+        protected DoubleBuilder newBuilder(BlockFactory factory, int count) {
+            return factory.doublesFromDocValues(count);
+        }
+
+        @Override
+        protected void readSortedFallback(int docId, DoubleBuilder builder) throws IOException {
+            sortedFallback.readSortedDoc(docId, builder);
+        }
+
+        @Override
+        protected void emit(int[] offsetToOrd, DoubleBuilder builder, long[] materialized) {
+            int nonNullCount = OffsetsAwareBlockLoaderHelper.countNonNull(offsetToOrd);
+            if (nonNullCount == 0) {
+                builder.appendNull();
+                return;
+            }
+            if (nonNullCount == 1) {
+                for (int ord : offsetToOrd) {
+                    if (ord != FieldArrayContext.NULL_ORD) {
+                        builder.appendDouble(toDouble.convert(materialized[ord]));
+                        return;
+                    }
+                }
+            }
+            builder.beginPositionEntry();
+            for (int ord : offsetToOrd) {
+                if (ord != FieldArrayContext.NULL_ORD) {
+                    builder.appendDouble(toDouble.convert(materialized[ord]));
+                }
+            }
+            builder.endPositionEntry();
+        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/IntsBlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/IntsBlockLoader.java
@@ -9,14 +9,19 @@
 
 package org.elasticsearch.index.mapper.blockloader.docvalues;
 
-import org.elasticsearch.index.mapper.BlockLoader;
+import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.elasticsearch.index.mapper.FieldArrayContext;
+import org.elasticsearch.index.mapper.blockloader.docvalues.tracking.TrackingNumericDocValues;
+import org.elasticsearch.index.mapper.blockloader.docvalues.tracking.TrackingSortedDocValues;
+import org.elasticsearch.index.mapper.blockloader.docvalues.tracking.TrackingSortedNumericDocValues;
 
 import java.io.IOException;
 
 /**
  * Loads {@code int}s from doc values.
  */
-public class IntsBlockLoader extends AbstractNumericBlockLoader<BlockLoader.IntBuilder> {
+public class IntsBlockLoader extends AbstractNumericBlockLoader {
     public IntsBlockLoader(String fieldName) {
         this(fieldName, false);
     }
@@ -31,23 +36,123 @@ public class IntsBlockLoader extends AbstractNumericBlockLoader<BlockLoader.IntB
     }
 
     @Override
-    protected IntBuilder newBuilder(BlockFactory factory, int expectedCount) {
-        return factory.intsFromDocValues(expectedCount);
+    protected ColumnAtATimeReader singletonReader(TrackingNumericDocValues docValues) {
+        return new Singleton(readerName, docValues);
     }
 
     @Override
-    protected void appendValue(IntBuilder builder, long rawValue) {
-        builder.appendInt(Math.toIntExact(rawValue));
+    protected ColumnAtATimeReader sortedReader(TrackingSortedNumericDocValues docValues) {
+        return new Sorted(readerName, docValues);
     }
 
     @Override
-    protected Block tryDirectRead(OptionalColumnAtATimeReader direct, BlockFactory factory, Docs docs, int offset, boolean nullsFiltered)
-        throws IOException {
-        return direct.tryRead(factory, docs, offset, nullsFiltered, null, true, false);
+    protected ColumnAtATimeReader arrayOrderReader(TrackingSortedNumericDocValues values, TrackingSortedDocValues offsets) {
+        return new ArrayOrder(readerName, values, offsets);
     }
 
-    @Override
-    public String toString() {
-        return "IntsFromDocValues[" + fieldName + "]";
+    static final class Singleton extends AbstractNumericBlockLoader.Singleton {
+        Singleton(String name, TrackingNumericDocValues numericDocValues) {
+            super(name, numericDocValues);
+        }
+
+        @Override
+        public Block read(BlockFactory factory, Docs docs, int offset, boolean nullsFiltered) throws IOException {
+            NumericDocValues docValues = numericDocValues.docValues();
+            // Attempt a fast path through OptionalColumnAtATimeReader
+            if (docValues instanceof OptionalColumnAtATimeReader direct) {
+                Block result = direct.tryRead(factory, docs, offset, nullsFiltered, null, true, false);
+                if (result != null) {
+                    return result;
+                }
+            }
+            try (IntBuilder builder = factory.intsFromDocValues(docs.count() - offset)) {
+                for (int i = offset; i < docs.count(); i++) {
+                    int doc = docs.get(i);
+                    if (docValues.advanceExact(doc)) {
+                        builder.appendInt(Math.toIntExact(docValues.longValue()));
+                    } else {
+                        builder.appendNull();
+                    }
+                }
+                return builder.build();
+            }
+        }
+    }
+
+    static final class Sorted extends AbstractNumericBlockLoader.Sorted {
+        Sorted(String name, TrackingSortedNumericDocValues values) {
+            super(name, values);
+        }
+
+        @Override
+        public Block read(BlockFactory factory, Docs docs, int offset, boolean nullsFiltered) throws IOException {
+            try (IntBuilder builder = factory.intsFromDocValues(docs.count() - offset)) {
+                for (int i = offset; i < docs.count(); i++) {
+                    readSortedDoc(docs.get(i), builder);
+                }
+                return builder.build();
+            }
+        }
+
+        void readSortedDoc(int doc, IntBuilder builder) throws IOException {
+            SortedNumericDocValues docValues = values.docValues();
+            if (docValues.advanceExact(doc) == false) {
+                builder.appendNull();
+                return;
+            }
+            int count = docValues.docValueCount();
+            if (count == 1) {
+                builder.appendInt(Math.toIntExact(docValues.nextValue()));
+                return;
+            }
+            builder.beginPositionEntry();
+            for (int v = 0; v < count; v++) {
+                builder.appendInt(Math.toIntExact(docValues.nextValue()));
+            }
+            builder.endPositionEntry();
+        }
+    }
+
+    static final class ArrayOrder extends AbstractNumericBlockLoader.ArrayOrder<IntBuilder> {
+        private final Sorted sortedFallback;
+
+        ArrayOrder(String name, TrackingSortedNumericDocValues values, TrackingSortedDocValues offsets) {
+            super(name, values, offsets);
+            this.sortedFallback = new Sorted(name, values);
+        }
+
+        @Override
+        protected IntBuilder newBuilder(BlockFactory factory, int count) {
+            return factory.intsFromDocValues(count);
+        }
+
+        @Override
+        protected void readSortedFallback(int docId, IntBuilder builder) throws IOException {
+            sortedFallback.readSortedDoc(docId, builder);
+        }
+
+        @Override
+        protected void emit(int[] offsetToOrd, IntBuilder builder, long[] materialized) {
+            int nonNullCount = OffsetsAwareBlockLoaderHelper.countNonNull(offsetToOrd);
+            if (nonNullCount == 0) {
+                builder.appendNull();
+                return;
+            }
+            if (nonNullCount == 1) {
+                for (int ord : offsetToOrd) {
+                    if (ord != FieldArrayContext.NULL_ORD) {
+                        builder.appendInt(Math.toIntExact(materialized[ord]));
+                        return;
+                    }
+                }
+            }
+            builder.beginPositionEntry();
+            for (int ord : offsetToOrd) {
+                if (ord != FieldArrayContext.NULL_ORD) {
+                    builder.appendInt(Math.toIntExact(materialized[ord]));
+                }
+            }
+            builder.endPositionEntry();
+        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/LongsBlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/LongsBlockLoader.java
@@ -9,11 +9,19 @@
 
 package org.elasticsearch.index.mapper.blockloader.docvalues;
 
-import org.elasticsearch.index.mapper.BlockLoader;
+import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.elasticsearch.index.mapper.FieldArrayContext;
+import org.elasticsearch.index.mapper.blockloader.docvalues.tracking.TrackingNumericDocValues;
+import org.elasticsearch.index.mapper.blockloader.docvalues.tracking.TrackingSortedDocValues;
+import org.elasticsearch.index.mapper.blockloader.docvalues.tracking.TrackingSortedNumericDocValues;
 
 import java.io.IOException;
 
-public class LongsBlockLoader extends AbstractNumericBlockLoader<BlockLoader.LongBuilder> {
+/**
+ * Loads {@code long}s from doc values.
+ */
+public class LongsBlockLoader extends AbstractNumericBlockLoader {
     public LongsBlockLoader(String fieldName) {
         this(fieldName, false);
     }
@@ -28,23 +36,123 @@ public class LongsBlockLoader extends AbstractNumericBlockLoader<BlockLoader.Lon
     }
 
     @Override
-    protected LongBuilder newBuilder(BlockFactory factory, int expectedCount) {
-        return factory.longsFromDocValues(expectedCount);
+    protected ColumnAtATimeReader singletonReader(TrackingNumericDocValues docValues) {
+        return new Singleton(readerName, docValues);
     }
 
     @Override
-    protected void appendValue(LongBuilder builder, long rawValue) {
-        builder.appendLong(rawValue);
+    protected ColumnAtATimeReader sortedReader(TrackingSortedNumericDocValues docValues) {
+        return new Sorted(readerName, docValues);
     }
 
     @Override
-    protected Block tryDirectRead(OptionalColumnAtATimeReader direct, BlockFactory factory, Docs docs, int offset, boolean nullsFiltered)
-        throws IOException {
-        return direct.tryRead(factory, docs, offset, nullsFiltered, null, false, false);
+    protected ColumnAtATimeReader arrayOrderReader(TrackingSortedNumericDocValues values, TrackingSortedDocValues offsets) {
+        return new ArrayOrder(readerName, values, offsets);
     }
 
-    @Override
-    public String toString() {
-        return "LongsFromDocValues[" + fieldName + "]";
+    static final class Singleton extends AbstractNumericBlockLoader.Singleton {
+        Singleton(String name, TrackingNumericDocValues numericDocValues) {
+            super(name, numericDocValues);
+        }
+
+        @Override
+        public Block read(BlockFactory factory, Docs docs, int offset, boolean nullsFiltered) throws IOException {
+            NumericDocValues docValues = numericDocValues.docValues();
+            // Attempt a fast path through OptionalColumnAtATimeReader
+            if (docValues instanceof OptionalColumnAtATimeReader direct) {
+                Block result = direct.tryRead(factory, docs, offset, nullsFiltered, null, false, false);
+                if (result != null) {
+                    return result;
+                }
+            }
+            try (LongBuilder builder = factory.longsFromDocValues(docs.count() - offset)) {
+                for (int i = offset; i < docs.count(); i++) {
+                    int doc = docs.get(i);
+                    if (docValues.advanceExact(doc)) {
+                        builder.appendLong(docValues.longValue());
+                    } else {
+                        builder.appendNull();
+                    }
+                }
+                return builder.build();
+            }
+        }
+    }
+
+    static final class Sorted extends AbstractNumericBlockLoader.Sorted {
+        Sorted(String name, TrackingSortedNumericDocValues values) {
+            super(name, values);
+        }
+
+        @Override
+        public Block read(BlockFactory factory, Docs docs, int offset, boolean nullsFiltered) throws IOException {
+            try (LongBuilder builder = factory.longsFromDocValues(docs.count() - offset)) {
+                for (int i = offset; i < docs.count(); i++) {
+                    readSortedDoc(docs.get(i), builder);
+                }
+                return builder.build();
+            }
+        }
+
+        void readSortedDoc(int doc, LongBuilder builder) throws IOException {
+            SortedNumericDocValues docValues = values.docValues();
+            if (docValues.advanceExact(doc) == false) {
+                builder.appendNull();
+                return;
+            }
+            int count = docValues.docValueCount();
+            if (count == 1) {
+                builder.appendLong(docValues.nextValue());
+                return;
+            }
+            builder.beginPositionEntry();
+            for (int v = 0; v < count; v++) {
+                builder.appendLong(docValues.nextValue());
+            }
+            builder.endPositionEntry();
+        }
+    }
+
+    static final class ArrayOrder extends AbstractNumericBlockLoader.ArrayOrder<LongBuilder> {
+        private final Sorted sortedFallback;
+
+        ArrayOrder(String name, TrackingSortedNumericDocValues values, TrackingSortedDocValues offsets) {
+            super(name, values, offsets);
+            this.sortedFallback = new Sorted(name, values);
+        }
+
+        @Override
+        protected LongBuilder newBuilder(BlockFactory factory, int count) {
+            return factory.longsFromDocValues(count);
+        }
+
+        @Override
+        protected void readSortedFallback(int docId, LongBuilder builder) throws IOException {
+            sortedFallback.readSortedDoc(docId, builder);
+        }
+
+        @Override
+        protected void emit(int[] offsetToOrd, LongBuilder builder, long[] materialized) {
+            int nonNullCount = OffsetsAwareBlockLoaderHelper.countNonNull(offsetToOrd);
+            if (nonNullCount == 0) {
+                builder.appendNull();
+                return;
+            }
+            if (nonNullCount == 1) {
+                for (int ord : offsetToOrd) {
+                    if (ord != FieldArrayContext.NULL_ORD) {
+                        builder.appendLong(materialized[ord]);
+                        return;
+                    }
+                }
+            }
+            builder.beginPositionEntry();
+            for (int ord : offsetToOrd) {
+                if (ord != FieldArrayContext.NULL_ORD) {
+                    builder.appendLong(materialized[ord]);
+                }
+            }
+            builder.endPositionEntry();
+        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/OffsetsAwareBlockLoaderHelper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/OffsetsAwareBlockLoaderHelper.java
@@ -79,6 +79,20 @@ final class OffsetsAwareBlockLoaderHelper {
     }
 
     /**
+     * Counts the non-null slots in {@code offsetToOrd}. Callers use this to choose the position shape (null / lone value / multi-value)
+     * before appending, so the value-append loop can stay in type-specific code and compile monomorphically.
+     */
+    static int countNonNull(int[] offsetToOrd) {
+        int nonNullCount = 0;
+        for (int ord : offsetToOrd) {
+            if (ord != FieldArrayContext.NULL_ORD) {
+                nonNullCount++;
+            }
+        }
+        return nonNullCount;
+    }
+
+    /**
      * Asserts every slot is null.
      */
     static boolean allNulls(int[] offsetToOrd) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/MvMaxBooleansBlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/MvMaxBooleansBlockLoader.java
@@ -9,7 +9,7 @@
 
 package org.elasticsearch.index.mapper.blockloader.docvalues.fn;
 
-import org.elasticsearch.index.mapper.BlockLoader;
+import org.apache.lucene.index.SortedNumericDocValues;
 import org.elasticsearch.index.mapper.blockloader.docvalues.AbstractNumericBlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BooleansBlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.tracking.TrackingSortedNumericDocValues;
@@ -28,15 +28,22 @@ public class MvMaxBooleansBlockLoader extends BooleansBlockLoader {
 
     @Override
     protected ColumnAtATimeReader sortedReader(TrackingSortedNumericDocValues docValues) {
-        return new AbstractNumericBlockLoader.Sorted<>(this, "MvMaxBooleansFromDocValues", docValues) {
+        // Own read loop so the per-document append compiles monomorphically rather than going megamorphic through a shared reader.
+        return new AbstractNumericBlockLoader.Sorted("MvMaxBooleansFromDocValues", docValues) {
             @Override
-            protected void readSortedDoc(int doc, BlockLoader.BooleanBuilder builder) throws IOException {
-                if (values.docValues().advanceExact(doc) == false) {
-                    builder.appendNull();
-                    return;
+            public Block read(BlockFactory factory, Docs docs, int offset, boolean nullsFiltered) throws IOException {
+                SortedNumericDocValues docValues = values.docValues();
+                try (BooleanBuilder builder = factory.booleansFromDocValues(docs.count() - offset)) {
+                    for (int i = offset; i < docs.count(); i++) {
+                        if (docValues.advanceExact(docs.get(i)) == false) {
+                            builder.appendNull();
+                            continue;
+                        }
+                        discardAllButLast(docValues);
+                        builder.appendBoolean(docValues.nextValue() != 0);
+                    }
+                    return builder.build();
                 }
-                discardAllButLast(values.docValues());
-                appendValue(builder, values.docValues().nextValue());
             }
         };
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/MvMaxDoublesFromDocValuesBlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/MvMaxDoublesFromDocValuesBlockLoader.java
@@ -9,7 +9,7 @@
 
 package org.elasticsearch.index.mapper.blockloader.docvalues.fn;
 
-import org.elasticsearch.index.mapper.BlockLoader;
+import org.apache.lucene.index.SortedNumericDocValues;
 import org.elasticsearch.index.mapper.blockloader.docvalues.AbstractNumericBlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BlockDocValuesReader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.DoublesBlockLoader;
@@ -29,15 +29,22 @@ public class MvMaxDoublesFromDocValuesBlockLoader extends DoublesBlockLoader {
 
     @Override
     protected ColumnAtATimeReader sortedReader(TrackingSortedNumericDocValues docValues) {
-        return new AbstractNumericBlockLoader.Sorted<>(this, "MvMaxDoublesFromDocValues", docValues) {
+        // Own read loop so the per-document append compiles monomorphically rather than going megamorphic through a shared reader.
+        return new AbstractNumericBlockLoader.Sorted("MvMaxDoublesFromDocValues", docValues) {
             @Override
-            protected void readSortedDoc(int doc, BlockLoader.DoubleBuilder builder) throws IOException {
-                if (values.docValues().advanceExact(doc) == false) {
-                    builder.appendNull();
-                    return;
+            public Block read(BlockFactory factory, Docs docs, int offset, boolean nullsFiltered) throws IOException {
+                SortedNumericDocValues docValues = values.docValues();
+                try (DoubleBuilder builder = factory.doublesFromDocValues(docs.count() - offset)) {
+                    for (int i = offset; i < docs.count(); i++) {
+                        if (docValues.advanceExact(docs.get(i)) == false) {
+                            builder.appendNull();
+                            continue;
+                        }
+                        discardAllButLast(docValues);
+                        builder.appendDouble(toDouble.convert(docValues.nextValue()));
+                    }
+                    return builder.build();
                 }
-                discardAllButLast(values.docValues());
-                appendValue(builder, values.docValues().nextValue());
             }
         };
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/MvMaxIntsFromDocValuesBlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/MvMaxIntsFromDocValuesBlockLoader.java
@@ -9,7 +9,7 @@
 
 package org.elasticsearch.index.mapper.blockloader.docvalues.fn;
 
-import org.elasticsearch.index.mapper.BlockLoader;
+import org.apache.lucene.index.SortedNumericDocValues;
 import org.elasticsearch.index.mapper.blockloader.docvalues.AbstractNumericBlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.IntsBlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.tracking.TrackingSortedNumericDocValues;
@@ -28,15 +28,22 @@ public class MvMaxIntsFromDocValuesBlockLoader extends IntsBlockLoader {
 
     @Override
     protected ColumnAtATimeReader sortedReader(TrackingSortedNumericDocValues docValues) {
-        return new AbstractNumericBlockLoader.Sorted<>(this, "MvMaxIntsFromDocValues", docValues) {
+        // Own read loop so the per-document append compiles monomorphically rather than going megamorphic through a shared reader.
+        return new AbstractNumericBlockLoader.Sorted("MvMaxIntsFromDocValues", docValues) {
             @Override
-            protected void readSortedDoc(int doc, BlockLoader.IntBuilder builder) throws IOException {
-                if (values.docValues().advanceExact(doc) == false) {
-                    builder.appendNull();
-                    return;
+            public Block read(BlockFactory factory, Docs docs, int offset, boolean nullsFiltered) throws IOException {
+                SortedNumericDocValues docValues = values.docValues();
+                try (IntBuilder builder = factory.intsFromDocValues(docs.count() - offset)) {
+                    for (int i = offset; i < docs.count(); i++) {
+                        if (docValues.advanceExact(docs.get(i)) == false) {
+                            builder.appendNull();
+                            continue;
+                        }
+                        discardAllButLast(docValues);
+                        builder.appendInt(Math.toIntExact(docValues.nextValue()));
+                    }
+                    return builder.build();
                 }
-                discardAllButLast(values.docValues());
-                appendValue(builder, values.docValues().nextValue());
             }
         };
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/MvMaxLongsFromDocValuesBlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/MvMaxLongsFromDocValuesBlockLoader.java
@@ -10,7 +10,6 @@
 package org.elasticsearch.index.mapper.blockloader.docvalues.fn;
 
 import org.apache.lucene.index.SortedNumericDocValues;
-import org.elasticsearch.index.mapper.BlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.AbstractNumericBlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.LongsBlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.tracking.TrackingSortedNumericDocValues;
@@ -27,15 +26,22 @@ public class MvMaxLongsFromDocValuesBlockLoader extends LongsBlockLoader {
 
     @Override
     protected ColumnAtATimeReader sortedReader(TrackingSortedNumericDocValues docValues) {
-        return new AbstractNumericBlockLoader.Sorted<>(this, "MvMaxLongsFromDocValues", docValues) {
+        // Own read loop so the per-document append compiles monomorphically rather than going megamorphic through a shared reader.
+        return new AbstractNumericBlockLoader.Sorted("MvMaxLongsFromDocValues", docValues) {
             @Override
-            protected void readSortedDoc(int doc, BlockLoader.LongBuilder builder) throws IOException {
-                if (values.docValues().advanceExact(doc) == false) {
-                    builder.appendNull();
-                    return;
+            public Block read(BlockFactory factory, Docs docs, int offset, boolean nullsFiltered) throws IOException {
+                SortedNumericDocValues docValues = values.docValues();
+                try (LongBuilder builder = factory.longsFromDocValues(docs.count() - offset)) {
+                    for (int i = offset; i < docs.count(); i++) {
+                        if (docValues.advanceExact(docs.get(i)) == false) {
+                            builder.appendNull();
+                            continue;
+                        }
+                        discardAllButLast(docValues);
+                        builder.appendLong(docValues.nextValue());
+                    }
+                    return builder.build();
                 }
-                discardAllButLast(values.docValues());
-                appendValue(builder, values.docValues().nextValue());
             }
         };
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/MvMinBooleansBlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/MvMinBooleansBlockLoader.java
@@ -9,7 +9,7 @@
 
 package org.elasticsearch.index.mapper.blockloader.docvalues.fn;
 
-import org.elasticsearch.index.mapper.BlockLoader;
+import org.apache.lucene.index.SortedNumericDocValues;
 import org.elasticsearch.index.mapper.blockloader.docvalues.AbstractNumericBlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BooleansBlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.tracking.TrackingSortedNumericDocValues;
@@ -26,14 +26,22 @@ public class MvMinBooleansBlockLoader extends BooleansBlockLoader {
 
     @Override
     protected ColumnAtATimeReader sortedReader(TrackingSortedNumericDocValues docValues) {
-        return new AbstractNumericBlockLoader.Sorted<>(this, "MvMinBooleansFromDocValues", docValues) {
+        // Own read loop so the per-document append compiles monomorphically rather than going megamorphic through a shared reader.
+        return new AbstractNumericBlockLoader.Sorted("MvMinBooleansFromDocValues", docValues) {
             @Override
-            protected void readSortedDoc(int doc, BlockLoader.BooleanBuilder builder) throws IOException {
-                if (values.docValues().advanceExact(doc) == false) {
-                    builder.appendNull();
-                    return;
+            public Block read(BlockFactory factory, Docs docs, int offset, boolean nullsFiltered) throws IOException {
+                SortedNumericDocValues docValues = values.docValues();
+                try (BooleanBuilder builder = factory.booleansFromDocValues(docs.count() - offset)) {
+                    for (int i = offset; i < docs.count(); i++) {
+                        if (docValues.advanceExact(docs.get(i)) == false) {
+                            builder.appendNull();
+                            continue;
+                        }
+                        // doc values are sorted ascending, so the first is the minimum
+                        builder.appendBoolean(docValues.nextValue() != 0);
+                    }
+                    return builder.build();
                 }
-                appendValue(builder, values.docValues().nextValue());
             }
         };
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/MvMinDoublesFromDocValuesBlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/MvMinDoublesFromDocValuesBlockLoader.java
@@ -9,7 +9,7 @@
 
 package org.elasticsearch.index.mapper.blockloader.docvalues.fn;
 
-import org.elasticsearch.index.mapper.BlockLoader;
+import org.apache.lucene.index.SortedNumericDocValues;
 import org.elasticsearch.index.mapper.blockloader.docvalues.AbstractNumericBlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BlockDocValuesReader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.DoublesBlockLoader;
@@ -27,14 +27,22 @@ public class MvMinDoublesFromDocValuesBlockLoader extends DoublesBlockLoader {
 
     @Override
     protected ColumnAtATimeReader sortedReader(TrackingSortedNumericDocValues docValues) {
-        return new AbstractNumericBlockLoader.Sorted<>(this, "MvMinDoublesFromDocValues", docValues) {
+        // Own read loop so the per-document append compiles monomorphically rather than going megamorphic through a shared reader.
+        return new AbstractNumericBlockLoader.Sorted("MvMinDoublesFromDocValues", docValues) {
             @Override
-            protected void readSortedDoc(int doc, BlockLoader.DoubleBuilder builder) throws IOException {
-                if (values.docValues().advanceExact(doc) == false) {
-                    builder.appendNull();
-                    return;
+            public Block read(BlockFactory factory, Docs docs, int offset, boolean nullsFiltered) throws IOException {
+                SortedNumericDocValues docValues = values.docValues();
+                try (DoubleBuilder builder = factory.doublesFromDocValues(docs.count() - offset)) {
+                    for (int i = offset; i < docs.count(); i++) {
+                        if (docValues.advanceExact(docs.get(i)) == false) {
+                            builder.appendNull();
+                            continue;
+                        }
+                        // doc values are sorted ascending, so the first is the minimum
+                        builder.appendDouble(toDouble.convert(docValues.nextValue()));
+                    }
+                    return builder.build();
                 }
-                appendValue(builder, values.docValues().nextValue());
             }
         };
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/MvMinIntsFromDocValuesBlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/MvMinIntsFromDocValuesBlockLoader.java
@@ -9,7 +9,7 @@
 
 package org.elasticsearch.index.mapper.blockloader.docvalues.fn;
 
-import org.elasticsearch.index.mapper.BlockLoader;
+import org.apache.lucene.index.SortedNumericDocValues;
 import org.elasticsearch.index.mapper.blockloader.docvalues.AbstractNumericBlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.IntsBlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.tracking.TrackingSortedNumericDocValues;
@@ -26,14 +26,22 @@ public class MvMinIntsFromDocValuesBlockLoader extends IntsBlockLoader {
 
     @Override
     protected ColumnAtATimeReader sortedReader(TrackingSortedNumericDocValues docValues) {
-        return new AbstractNumericBlockLoader.Sorted<>(this, "MvMinIntsFromDocValues", docValues) {
+        // Own read loop so the per-document append compiles monomorphically rather than going megamorphic through a shared reader.
+        return new AbstractNumericBlockLoader.Sorted("MvMinIntsFromDocValues", docValues) {
             @Override
-            protected void readSortedDoc(int doc, BlockLoader.IntBuilder builder) throws IOException {
-                if (values.docValues().advanceExact(doc) == false) {
-                    builder.appendNull();
-                    return;
+            public Block read(BlockFactory factory, Docs docs, int offset, boolean nullsFiltered) throws IOException {
+                SortedNumericDocValues docValues = values.docValues();
+                try (IntBuilder builder = factory.intsFromDocValues(docs.count() - offset)) {
+                    for (int i = offset; i < docs.count(); i++) {
+                        if (docValues.advanceExact(docs.get(i)) == false) {
+                            builder.appendNull();
+                            continue;
+                        }
+                        // doc values are sorted ascending, so the first is the minimum
+                        builder.appendInt(Math.toIntExact(docValues.nextValue()));
+                    }
+                    return builder.build();
                 }
-                appendValue(builder, values.docValues().nextValue());
             }
         };
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/MvMinLongsFromDocValuesBlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/MvMinLongsFromDocValuesBlockLoader.java
@@ -9,7 +9,7 @@
 
 package org.elasticsearch.index.mapper.blockloader.docvalues.fn;
 
-import org.elasticsearch.index.mapper.BlockLoader;
+import org.apache.lucene.index.SortedNumericDocValues;
 import org.elasticsearch.index.mapper.blockloader.docvalues.AbstractNumericBlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.LongsBlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.tracking.TrackingSortedNumericDocValues;
@@ -26,14 +26,22 @@ public class MvMinLongsFromDocValuesBlockLoader extends LongsBlockLoader {
 
     @Override
     protected ColumnAtATimeReader sortedReader(TrackingSortedNumericDocValues docValues) {
-        return new AbstractNumericBlockLoader.Sorted<>(this, "MvMinLongsFromDocValues", docValues) {
+        // Own read loop so the per-document append compiles monomorphically rather than going megamorphic through a shared reader.
+        return new AbstractNumericBlockLoader.Sorted("MvMinLongsFromDocValues", docValues) {
             @Override
-            protected void readSortedDoc(int doc, BlockLoader.LongBuilder builder) throws IOException {
-                if (values.docValues().advanceExact(doc) == false) {
-                    builder.appendNull();
-                    return;
+            public Block read(BlockFactory factory, Docs docs, int offset, boolean nullsFiltered) throws IOException {
+                SortedNumericDocValues docValues = values.docValues();
+                try (LongBuilder builder = factory.longsFromDocValues(docs.count() - offset)) {
+                    for (int i = offset; i < docs.count(); i++) {
+                        if (docValues.advanceExact(docs.get(i)) == false) {
+                            builder.appendNull();
+                            continue;
+                        }
+                        // doc values are sorted ascending, so the first is the minimum
+                        builder.appendLong(docValues.nextValue());
+                    }
+                    return builder.build();
                 }
-                appendValue(builder, values.docValues().nextValue());
             }
         };
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperTests.java
@@ -882,7 +882,7 @@ public class DateFieldMapperTests extends MapperTestCase {
                 LeafReaderContext context = reader.leaves().get(0);
                 // One big doc block
                 CircuitBreaker breaker = newLimitedBreaker(ByteSizeValue.ofMb(1));
-                try (var columnReader = (AbstractNumericBlockLoader.Singleton<?>) blockLoader.columnAtATimeReader(context).apply(breaker)) {
+                try (var columnReader = (AbstractNumericBlockLoader.Singleton) blockLoader.columnAtATimeReader(context).apply(breaker)) {
                     assertThat(columnReader.numericDocValues(), instanceOf(BlockLoader.OptionalColumnAtATimeReader.class));
                     var docBlock = TestBlock.docs(IntStream.range(from, to).toArray());
                     var block = (TestBlock) columnReader.read(TestBlock.factory(), docBlock, 0, false);
@@ -893,7 +893,7 @@ public class DateFieldMapperTests extends MapperTestCase {
                 }
                 // Smaller doc blocks
                 int docBlockSize = 1000;
-                try (var columnReader = (AbstractNumericBlockLoader.Singleton<?>) blockLoader.columnAtATimeReader(context).apply(breaker)) {
+                try (var columnReader = (AbstractNumericBlockLoader.Singleton) blockLoader.columnAtATimeReader(context).apply(breaker)) {
                     assertThat(columnReader.numericDocValues(), instanceOf(BlockLoader.OptionalColumnAtATimeReader.class));
                     for (int i = from; i < to; i += docBlockSize) {
                         var docBlock = TestBlock.docs(IntStream.range(i, i + docBlockSize).toArray());
@@ -906,7 +906,7 @@ public class DateFieldMapperTests extends MapperTestCase {
                     }
                 }
                 // One smaller doc block:
-                try (var columnReader = (AbstractNumericBlockLoader.Singleton<?>) blockLoader.columnAtATimeReader(context).apply(breaker)) {
+                try (var columnReader = (AbstractNumericBlockLoader.Singleton) blockLoader.columnAtATimeReader(context).apply(breaker)) {
                     assertThat(columnReader.numericDocValues(), instanceOf(BlockLoader.OptionalColumnAtATimeReader.class));
                     var docBlock = TestBlock.docs(IntStream.range(1010, 2020).toArray());
                     var block = (TestBlock) columnReader.read(TestBlock.factory(), docBlock, 0, false);
@@ -917,7 +917,7 @@ public class DateFieldMapperTests extends MapperTestCase {
                     }
                 }
                 // Read two tiny blocks:
-                try (var columnReader = (AbstractNumericBlockLoader.Singleton<?>) blockLoader.columnAtATimeReader(context).apply(breaker)) {
+                try (var columnReader = (AbstractNumericBlockLoader.Singleton) blockLoader.columnAtATimeReader(context).apply(breaker)) {
                     assertThat(columnReader.numericDocValues(), instanceOf(BlockLoader.OptionalColumnAtATimeReader.class));
                     var docBlock = TestBlock.docs(IntStream.range(32, 64).toArray());
                     var block = (TestBlock) columnReader.read(TestBlock.factory(), docBlock, 0, false);

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
@@ -1811,17 +1811,17 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
 
     public void testSingletonIntBulkBlockReading() throws IOException {
         assumeTrue("field type supports bulk singleton int reading", supportsBulkIntBlockReading());
-        testSingletonBulkBlockReading(columnAtATimeReader -> (AbstractNumericBlockLoader.Singleton<?>) columnAtATimeReader);
+        testSingletonBulkBlockReading(columnAtATimeReader -> (AbstractNumericBlockLoader.Singleton) columnAtATimeReader);
     }
 
     public void testSingletonLongBulkBlockReading() throws IOException {
         assumeTrue("field type supports bulk singleton long reading", supportsBulkLongBlockReading());
-        testSingletonBulkBlockReading(columnAtATimeReader -> (AbstractNumericBlockLoader.Singleton<?>) columnAtATimeReader);
+        testSingletonBulkBlockReading(columnAtATimeReader -> (AbstractNumericBlockLoader.Singleton) columnAtATimeReader);
     }
 
     public void testSingletonDoubleBulkBlockReading() throws IOException {
         assumeTrue("field type supports bulk singleton double reading", supportsBulkDoubleBlockReading());
-        testSingletonBulkBlockReading(columnAtATimeReader -> (AbstractNumericBlockLoader.Singleton<?>) columnAtATimeReader);
+        testSingletonBulkBlockReading(columnAtATimeReader -> (AbstractNumericBlockLoader.Singleton) columnAtATimeReader);
     }
 
     private void testSingletonBulkBlockReading(Function<BlockLoader.ColumnAtATimeReader, BlockDocValuesReader> readerCast)


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch-benchmarks/issues/3212