### PR TITLE
Fixed doc values leak in some block loaders

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -593,15 +593,6 @@ tests:
 - class: org.elasticsearch.snapshots.SnapshotsServiceIT
   method: testDeleteSnapshotWhenNotWaitingForCompletion
   issue: https://github.com/elastic/elasticsearch/issues/150257
-- class: org.elasticsearch.xpack.unsignedlong.UnsignedLongFieldBlockLoaderTests
-  method: testBlockLoaderOfMultiFieldWithCranky {preference=Params[syntheticSource=true, preference=DOC_VALUES, indexMode=columnar]}
-  issue: https://github.com/elastic/elasticsearch/issues/150281
-- class: org.elasticsearch.xpack.unsignedlong.UnsignedLongFieldBlockLoaderTests
-  method: testBlockLoaderOfMultiFieldWithCranky {preference=Params[syntheticSource=true, preference=NONE, indexMode=columnar]}
-  issue: https://github.com/elastic/elasticsearch/issues/150282
-- class: org.elasticsearch.xpack.unsignedlong.UnsignedLongFieldBlockLoaderTests
-  method: testBlockLoaderOfMultiFieldWithCranky {preference=Params[syntheticSource=true, preference=STORED, indexMode=columnar]}
-  issue: https://github.com/elastic/elasticsearch/issues/150283
 - class: org.elasticsearch.xpack.stateless.commits.StatelessFileDeletionIT
   method: testLatestCommitDependenciesUsesTheRightGenerations
   issue: https://github.com/elastic/elasticsearch/issues/150287

--- a/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/AbstractNumericBlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/AbstractNumericBlockLoader.java
@@ -59,7 +59,15 @@ public abstract class AbstractNumericBlockLoader<B extends BlockLoader.Builder> 
 
         // If the value is singleton, then we can skip reading offsets altogether
         if (readInArrayOrder && dv.singleton() == null) {
-            TrackingSortedDocValues offsets = TrackingSortedDocValues.get(breaker, context, FieldArrayContext.offsetsFieldName(fieldName));
+            TrackingSortedDocValues offsets;
+            try {
+                offsets = TrackingSortedDocValues.get(breaker, context, FieldArrayContext.offsetsFieldName(fieldName));
+            } catch (Exception e) {
+                // We already reserved breaker space for the doc values above. If acquiring the offsets companion fails (ex. circuit
+                // breaker) we must release that reservation here, otherwise it leaks.
+                Releasables.close(dv.sorted());
+                throw e;
+            }
             if (offsets != null) {
                 return new ArrayOrder<>(this, readerName, dv.sorted(), offsets);
             }

--- a/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/BytesRefsFromBinaryMultiSeparateCountBlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/BytesRefsFromBinaryMultiSeparateCountBlockLoader.java
@@ -56,7 +56,15 @@ public class BytesRefsFromBinaryMultiSeparateCountBlockLoader extends BlockDocVa
             return new BytesRefsFromBinaryBlockLoader.BytesRefsFromBinary(bc.binary());
         }
         if (readInArrayOrder) {
-            TrackingSortedDocValues offsets = TrackingSortedDocValues.get(breaker, context, FieldArrayContext.offsetsFieldName(fieldName));
+            TrackingSortedDocValues offsets;
+            try {
+                offsets = TrackingSortedDocValues.get(breaker, context, FieldArrayContext.offsetsFieldName(fieldName));
+            } catch (Exception e) {
+                // We already reserved breaker space for the binary and counts doc values above. If acquiring the offsets companion fails
+                // (ex. circuit breaker) we must release that reservation here, otherwise it leaks.
+                Releasables.close(bc.binary(), bc.counts());
+                throw e;
+            }
             if (offsets != null) {
                 return new ArrayOrder(bc.binary(), bc.counts(), offsets);
             }

--- a/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/BytesRefsFromOrdsBlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/BytesRefsFromOrdsBlockLoader.java
@@ -65,7 +65,15 @@ public class BytesRefsFromOrdsBlockLoader extends BlockDocValuesReader.DocValues
 
         // If the value is singleton, then we can skip reading offsets altogether
         if (readInArrayOrder && dv.singleton() == null) {
-            TrackingSortedDocValues offsets = TrackingSortedDocValues.get(breaker, context, FieldArrayContext.offsetsFieldName(fieldName));
+            TrackingSortedDocValues offsets;
+            try {
+                offsets = TrackingSortedDocValues.get(breaker, context, FieldArrayContext.offsetsFieldName(fieldName));
+            } catch (Exception e) {
+                // We already reserved breaker space for the doc values above. If acquiring the offsets companion fails (ex. circuit
+                // breaker) we must release that reservation here, otherwise it leaks.
+                Releasables.close(dv.set());
+                throw e;
+            }
             if (offsets != null) {
                 return new ArrayOrder(dv.set(), offsets);
             }

--- a/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateMetricDoubleBlockLoader.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateMetricDoubleBlockLoader.java
@@ -165,8 +165,19 @@ public class AggregateMetricDoubleBlockLoader extends BlockDocValuesReader.DocVa
                 return ConstantNull.COLUMN_READER;
             }
             NumericDvSingletonOrSorted dvSumValues = NumericDvSingletonOrSorted.get(breaker, context, sumFieldType.name());
-            NumericDvSingletonOrSorted dvValueCountValues = NumericDvSingletonOrSorted.get(breaker, context, countFieldType.name());
+            NumericDvSingletonOrSorted dvValueCountValues = null;
+            try {
+                dvValueCountValues = NumericDvSingletonOrSorted.get(breaker, context, countFieldType.name());
+            } catch (Exception e) {
+                // The sum doc values reserved breaker space above; release it if acquiring the count doc values fails (ex. circuit
+                // breaker), otherwise it leaks.
+                releaseDocValues(dvSumValues);
+                throw e;
+            }
             if (dvSumValues == null || dvValueCountValues == null) {
+                // One sub-field is missing; release whichever doc values we did acquire so their reservation isn't leaked.
+                releaseDocValues(dvSumValues);
+                releaseDocValues(dvValueCountValues);
                 return ConstantNull.COLUMN_READER;
             }
             assert dvSumValues.sorted() == null && dvValueCountValues.sorted() == null
@@ -228,6 +239,13 @@ public class AggregateMetricDoubleBlockLoader extends BlockDocValuesReader.DocVa
         @Override
         public Builder builder(BlockFactory factory, int expectedCount) {
             throw new UnsupportedOperationException("AvgBlockLoader does not have a corresponding builder");
+        }
+
+        /** Releases the breaker reservation held by the given doc values, tolerating a {@code null} holder. */
+        private static void releaseDocValues(NumericDvSingletonOrSorted docValues) {
+            if (docValues != null) {
+                Releasables.close(docValues.singleton(), docValues.sorted());
+            }
         }
     }
 }

--- a/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateMetricDoubleAvgBlockLoaderTests.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateMetricDoubleAvgBlockLoaderTests.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.aggregatemetric.mapper;
+
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.index.mapper.BlockLoader;
+import org.elasticsearch.index.mapper.NumberFieldMapper;
+import org.elasticsearch.index.mapper.TestBlock;
+import org.elasticsearch.indices.CrankyCircuitBreakerService;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.EnumMap;
+import java.util.List;
+
+import static org.elasticsearch.xpack.aggregatemetric.mapper.AggregateMetricDoubleFieldMapper.subfieldName;
+import static org.hamcrest.Matchers.equalTo;
+
+public class AggregateMetricDoubleAvgBlockLoaderTests extends ESTestCase {
+
+    private static final String FIELD = "field";
+
+    /**
+     * Drive {@code AvgBlockLoader.reader} under a cranky breaker many times. Whether or not the breaker trips on a given attempt, once the
+     * returned reader (if any) is closed the breaker must always be back to zero - a non-zero reading means an acquired reservation leaked.
+     */
+    public void testReaderUnderCrankyBreakerDoesNotLeak() throws IOException {
+        try (Directory dir = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), dir)) {
+            int docCount = randomIntBetween(1, 50);
+            for (int i = 0; i < docCount; i++) {
+                iw.addDocument(
+                    List.of(
+                        new NumericDocValuesField(
+                            subfieldName(FIELD, AggregateMetricDoubleFieldMapper.Metric.sum),
+                            Double.doubleToLongBits(randomDouble())
+                        ),
+                        new NumericDocValuesField(
+                            subfieldName(FIELD, AggregateMetricDoubleFieldMapper.Metric.value_count),
+                            randomIntBetween(1, 1000)
+                        )
+                    )
+                );
+            }
+            iw.forceMerge(1);
+
+            try (DirectoryReader reader = iw.getReader()) {
+                LeafReaderContext ctx = getOnlyLeafReader(reader).getContext();
+                var loader = new AggregateMetricDoubleBlockLoader.AvgBlockLoader(metricFields());
+                var cranky = new CrankyCircuitBreakerService.CrankyCircuitBreaker();
+                BlockLoader.Docs docs = TestBlock.docs(ctx);
+
+                // The breaker trips one twentieth of the time per acquisition, so iterate enough that the "trip on the second acquisition"
+                // case is hit many times over.
+                for (int attempt = 0; attempt < 2000; attempt++) {
+                    try (BlockLoader.ColumnAtATimeReader r = loader.reader(cranky, ctx)) {
+                        try (TestBlock ignored = (TestBlock) r.read(TestBlock.factory(), docs, 0, false)) {
+                            // reading exercises the reader; the block is built with the test factory, not the cranky breaker
+                        }
+                    } catch (CircuitBreakingException e) {
+                        // expected on some attempts - the reservation handling under the trip is exactly what we assert below
+                    }
+                    assertThat("breaker leaked on attempt " + attempt, cranky.getUsed(), equalTo(0L));
+                }
+            }
+        }
+    }
+
+    private static EnumMap<AggregateMetricDoubleFieldMapper.Metric, NumberFieldMapper.NumberFieldType> metricFields() {
+        var metricFields = new EnumMap<AggregateMetricDoubleFieldMapper.Metric, NumberFieldMapper.NumberFieldType>(
+            AggregateMetricDoubleFieldMapper.Metric.class
+        );
+        metricFields.put(
+            AggregateMetricDoubleFieldMapper.Metric.sum,
+            new NumberFieldMapper.NumberFieldType(
+                subfieldName(FIELD, AggregateMetricDoubleFieldMapper.Metric.sum),
+                NumberFieldMapper.NumberType.DOUBLE
+            )
+        );
+        metricFields.put(
+            AggregateMetricDoubleFieldMapper.Metric.value_count,
+            new NumberFieldMapper.NumberFieldType(
+                subfieldName(FIELD, AggregateMetricDoubleFieldMapper.Metric.value_count),
+                NumberFieldMapper.NumberType.INTEGER
+            )
+        );
+        return metricFields;
+    }
+}


### PR DESCRIPTION
Block loaders that load multiple doc values fields need to release them all when one of the fields fails to load, otherwise you end up with a leak. The new offsets-aware block loaders are in scope because they load two dv fields: the actual data and the offsets. The aggregate metric double block loader is also in scope because it also loads two dv fields: sums and values.

Addresses:
- https://github.com/elastic/elasticsearch/issues/150283
- https://github.com/elastic/elasticsearch/issues/150282
- https://github.com/elastic/elasticsearch/issues/150281