### PR TITLE
[9.4] Ignore local .pi folder (#150306)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@
 # Prefix slash ensures these are only ignored at the same level as this file
 /.cursor/
 
+# pi agent harness
+.pi
+
 # intellij files
 .idea/
 *.iml


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Ignore local .pi folder (#150306)