### PR TITLE
[ES|QL] Fix non-deterministic in_subquery CsvTests

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/in_subquery.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/in_subquery.csv-spec
@@ -1418,7 +1418,7 @@ FROM sample_data
 | WHERE client_ip NOT IN (FROM sample_data
                           | STATS count = count(*) BY client_ip
                           | SORT count DESC
-                          | LIMIT 2
+                          | LIMIT 1
                           | KEEP client_ip)
 | SORT @timestamp
 | KEEP @timestamp, client_ip, message
@@ -1427,6 +1427,7 @@ FROM sample_data
 @timestamp:datetime      | client_ip:ip | message:keyword
 2023-10-23T12:15:03.360Z | 172.21.2.162 | Connected to 10.1.0.3
 2023-10-23T12:27:28.948Z | 172.21.2.113 | Connected to 10.1.0.2
+2023-10-23T13:33:34.937Z | 172.21.0.5   | Disconnected
 ;
 
 keywordInKeyword
@@ -1459,7 +1460,7 @@ required_capability: where_in_subquery_without_view
 FROM apps
 | WHERE version IN (FROM apps
                     | STATS count = COUNT(*) BY version
-                    | SORT count DESC
+                    | SORT count DESC, version NULLS LAST
                     | LIMIT 2
                     | KEEP version)
 | SORT id
@@ -1468,10 +1469,11 @@ FROM apps
 
 id:integer | name:keyword | version:version
 6          | fffff        | 5.2.9
+8          | hhhhh        | 1.2.3.4
 10         | jjjjj        | 5.2.9
+12         | aaaaa        | 1.2.3.4
 14         | mmmmm        | 5.2.9
 ;
-
 
 keywordInText
 required_capability: where_in_subquery_without_view

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/in_subquery.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/in_subquery.csv-spec
@@ -2063,7 +2063,10 @@ required_capability: where_in_subquery_without_view
 required_capability: knn_function_v5
 
 FROM colors
-| WHERE id IN (FROM colors | WHERE knn(rgb_vector, [255, 0, 0]) AND primary == true | KEEP id)
+| WHERE id IN (FROM colors
+               | WHERE knn(rgb_vector, [255, 0, 0]) AND primary == true
+               | KEEP id
+               | LIMIT 60)
 | SORT color
 | KEEP color
 ;


### PR DESCRIPTION
These two queries return non-deterministic results, caught by serverless tests, modify the tests to return deterministic results.

Fixes: https://github.com/elastic/elasticsearch-serverless/issues/6851
Fixes: https://github.com/elastic/elasticsearch-serverless/issues/6852
Fixes: https://github.com/elastic/elasticsearch-serverless/issues/6853
Fixes: https://github.com/elastic/elasticsearch-serverless/issues/6854
Fixes: https://github.com/elastic/elasticsearch-serverless/issues/6855