### PR TITLE
Updating IntervalQueryBuilderTests to prevent too many clauses error

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -556,9 +556,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.heap_attack.HeapAttackIT
   method: testGroupOnManyLongs
   issue: https://github.com/elastic/elasticsearch/issues/150104
-- class: org.elasticsearch.index.query.IntervalQueryBuilderTests
-  method: testCacheability
-  issue: https://github.com/elastic/elasticsearch/issues/150117
 - class: org.elasticsearch.xpack.stateless.commits.VirtualBatchedCompoundCommitsIT
   method: testVirtualBatchedCompoundCommitChunksPressure
   issue: https://github.com/elastic/elasticsearch/issues/150123

--- a/server/src/test/java/org/elasticsearch/index/query/IntervalQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/IntervalQueryBuilderTests.java
@@ -105,13 +105,13 @@ public class IntervalQueryBuilderTests extends AbstractQueryTestCase<IntervalQue
     }
 
     static IntervalsSourceProvider.Disjunction createRandomDisjunction(int depth, boolean useScripts) {
-        int orCount = randomInt(4) + 1;
+        int orCount = randomInt(3) + 1;
         List<IntervalsSourceProvider> orSources = createRandomSourceList(depth, useScripts, orCount);
         return new IntervalsSourceProvider.Disjunction(orSources, createRandomFilter(depth + 1, useScripts));
     }
 
     static IntervalsSourceProvider.Combine createRandomCombine(int depth, boolean useScripts) {
-        int count = randomInt(4) + 1;
+        int count = randomInt(3) + 1;
         List<IntervalsSourceProvider> subSources = createRandomSourceList(depth, useScripts, count);
         boolean ordered = randomBoolean();
         int maxGaps = randomInt(5) - 1;
@@ -143,7 +143,7 @@ public class IntervalQueryBuilderTests extends AbstractQueryTestCase<IntervalQue
 
     static IntervalsSourceProvider.Match createRandomMatch(int depth, boolean useScripts) {
         String useField = rarely() ? MASKED_FIELD : null;
-        int wordCount = randomInt(4) + 1;
+        int wordCount = randomInt(3) + 1;
         List<String> words = new ArrayList<>();
         for (int i = 0; i < wordCount; i++) {
             words.add(randomRealisticUnicodeOfLengthBetween(4, 20));
@@ -841,6 +841,24 @@ public class IntervalQueryBuilderTests extends AbstractQueryTestCase<IntervalQue
                     }
                 }
             }
+        }
+    }
+
+    public void testTooManyClausesAtBuildTime() throws IOException {
+        int origBoolMaxClauseCount = IndexSearcher.getMaxClauseCount();
+        int maxClauses = 4;
+        IndexSearcher.setMaxClauseCount(maxClauses);
+        try {
+            List<IntervalsSourceProvider> sources = new ArrayList<>();
+            for (int i = 0; i < maxClauses + 1; i++) {
+                sources.add(new IntervalsSourceProvider.Match("term" + i, 0, false, "keyword", null, null));
+            }
+            IntervalsSourceProvider provider = new IntervalsSourceProvider.Disjunction(sources, null);
+            IntervalQueryBuilder queryBuilder = new IntervalQueryBuilder(TEXT_FIELD_NAME, provider);
+            SearchExecutionContext context = createSearchExecutionContext();
+            expectThrows(IndexSearcher.TooManyNestedClauses.class, () -> queryBuilder.toQuery(context));
+        } finally {
+            IndexSearcher.setMaxClauseCount(origBoolMaxClauseCount);
         }
     }
 


### PR DESCRIPTION
Similarly to https://github.com/elastic/elasticsearch/pull/137958 we reduce the randomization for IntervalQueryBuilderTests to prevent the "too many clauses" exception, and also add an explicit test to verify the above (now that the behavior changed with https://github.com/elastic/elasticsearch/pull/143220

Closes  https://github.com/elastic/elasticsearch/issues/150117

cc @iverase 