### PR TITLE
Revert "[Agent Builder] Hide agent builder traces from editor and viewer roles"

### DIFF
--- a/docs/changelog/149994.yaml
+++ b/docs/changelog/149994.yaml
@@ -1,5 +1,0 @@
-area: Security
-issues: []
-pr: 149994
-summary: "Hide agent builder traces indices from editor and viewer built-in roles"
-type: enhancement

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -770,7 +770,7 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
             new RoleDescriptor.IndicesPrivileges[] {
                 // Stack
                 RoleDescriptor.IndicesPrivileges.builder()
-                    .indices("/~(([.]|ilm-history-|traces-agent_builder\\.otel-|logs-agent_builder\\.otel-).*)/")
+                    .indices("/~(([.]|ilm-history-).*)/")
                     .privileges("read", "view_index_metadata")
                     .build(),
                 // Observability
@@ -834,7 +834,7 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
             new RoleDescriptor.IndicesPrivileges[] {
                 // Stack
                 RoleDescriptor.IndicesPrivileges.builder()
-                    .indices("/~(([.]|ilm-history-|traces-agent_builder\\.otel-|logs-agent_builder\\.otel-).*)/")
+                    .indices("/~(([.]|ilm-history-).*)/")
                     .privileges("read", "view_index_metadata")
                     .build(),
                 // Observability

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -3996,8 +3996,6 @@ public class ReservedRolesStoreTests extends ESTestCase {
         assertNoAccessAllowed(role, TestRestrictedIndices.SAMPLE_RESTRICTED_NAMES);
         assertNoAccessAllowed(role, "." + randomAlphaOfLengthBetween(6, 10));
         assertNoAccessAllowed(role, "ilm-history-" + randomIntBetween(0, 5));
-        assertNoAccessAllowed(role, "traces-agent_builder.otel-" + randomAlphaOfLengthBetween(3, 8));
-        assertNoAccessAllowed(role, "logs-agent_builder.otel-" + randomAlphaOfLengthBetween(3, 8));
         // Check application privileges
         assertThat(
             role.application()
@@ -4085,8 +4083,6 @@ public class ReservedRolesStoreTests extends ESTestCase {
         assertNoAccessAllowed(role, TestRestrictedIndices.SAMPLE_RESTRICTED_NAMES);
         assertNoAccessAllowed(role, "." + randomAlphaOfLengthBetween(6, 10));
         assertNoAccessAllowed(role, "ilm-history-" + randomIntBetween(0, 5));
-        assertNoAccessAllowed(role, "traces-agent_builder.otel-" + randomAlphaOfLengthBetween(3, 8));
-        assertNoAccessAllowed(role, "logs-agent_builder.otel-" + randomAlphaOfLengthBetween(3, 8));
 
         // Check application privileges
         assertThat(


### PR DESCRIPTION
Reverts elastic/elasticsearch#149994

This change makes: The Dataset Quality page became inaccessible to viewer and developer role users on Elastic Cloud Serverless observability projects — currently mitigated.

incident-3153