### PR TITLE
Reindexing rename resume bulk by scroll response

### DIFF
--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractResumeBulkByScrollAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractResumeBulkByScrollAction.java
@@ -58,7 +58,11 @@ public abstract class AbstractResumeBulkByScrollAction<Request extends AbstractB
     }
 
     @Override
-    protected void doExecute(Task task, ResumeBulkByPaginatedSearchRequest request, ActionListener<ResumeBulkByPaginatedSearchResponse> listener) {
+    protected void doExecute(
+        Task task,
+        ResumeBulkByPaginatedSearchRequest request,
+        ActionListener<ResumeBulkByPaginatedSearchResponse> listener
+    ) {
         // ResumeBulkByPaginatedSearchRequest.validate() rejects requests with no ResumeInfo
         assert request.getDelegate().getResumeInfo().isPresent();
         final ResumeInfo resumeInfo = request.getDelegate().getResumeInfo().get();

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractResumeBulkByScrollAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractResumeBulkByScrollAction.java
@@ -20,7 +20,7 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.index.reindex.AbstractBulkByPaginatedSearchRequest;
 import org.elasticsearch.index.reindex.BulkByPaginatedSearchResponse;
 import org.elasticsearch.index.reindex.ResumeBulkByPaginatedSearchRequest;
-import org.elasticsearch.index.reindex.ResumeBulkByScrollResponse;
+import org.elasticsearch.index.reindex.ResumeBulkByPaginatedSearchResponse;
 import org.elasticsearch.index.reindex.ResumeInfo;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
@@ -31,9 +31,9 @@ import org.elasticsearch.transport.TransportService;
 import java.util.concurrent.Executor;
 
 /// Abstract transport action for resuming BulkByScrollAction operations asynchronously. Delegates to the corresponding action on the local
-/// node, then returns a [ResumeBulkByScrollResponse] containing the task id of the delegate action.
+/// node, then returns a [ResumeBulkByPaginatedSearchResponse] containing the task id of the delegate action.
 public abstract class AbstractResumeBulkByScrollAction<Request extends AbstractBulkByPaginatedSearchRequest<Request>> extends
-    HandledTransportAction<ResumeBulkByPaginatedSearchRequest, ResumeBulkByScrollResponse> {
+    HandledTransportAction<ResumeBulkByPaginatedSearchRequest, ResumeBulkByPaginatedSearchResponse> {
 
     private static final Logger logger = LogManager.getLogger(AbstractResumeBulkByScrollAction.class);
 
@@ -58,7 +58,7 @@ public abstract class AbstractResumeBulkByScrollAction<Request extends AbstractB
     }
 
     @Override
-    protected void doExecute(Task task, ResumeBulkByPaginatedSearchRequest request, ActionListener<ResumeBulkByScrollResponse> listener) {
+    protected void doExecute(Task task, ResumeBulkByPaginatedSearchRequest request, ActionListener<ResumeBulkByPaginatedSearchResponse> listener) {
         // ResumeBulkByPaginatedSearchRequest.validate() rejects requests with no ResumeInfo
         assert request.getDelegate().getResumeInfo().isPresent();
         final ResumeInfo resumeInfo = request.getDelegate().getResumeInfo().get();
@@ -74,6 +74,6 @@ public abstract class AbstractResumeBulkByScrollAction<Request extends AbstractB
             taskId
         );
 
-        listener.onResponse(new ResumeBulkByScrollResponse(taskId));
+        listener.onResponse(new ResumeBulkByPaginatedSearchResponse(taskId));
     }
 }

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/Reindexer.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/Reindexer.java
@@ -65,7 +65,7 @@ import org.elasticsearch.index.reindex.ReindexRequest;
 import org.elasticsearch.index.reindex.RejectAwareActionListener;
 import org.elasticsearch.index.reindex.RemoteInfo;
 import org.elasticsearch.index.reindex.ResumeBulkByPaginatedSearchRequest;
-import org.elasticsearch.index.reindex.ResumeBulkByScrollResponse;
+import org.elasticsearch.index.reindex.ResumeBulkByPaginatedSearchResponse;
 import org.elasticsearch.index.reindex.ResumeInfo;
 import org.elasticsearch.index.reindex.ResumeReindexAction;
 import org.elasticsearch.index.reindex.TaskRelocatedException;
@@ -644,7 +644,7 @@ public class Reindexer {
     /// relocation), and the metrics agent stops publishing on SIGTERM — so any source-side metric would be dropped.
     ///
     /// Visible for testing.
-    static ActionListener<ResumeBulkByScrollResponse> relocationResponseLoggingListener(final BulkByPaginatedSearchTask task) {
+    static ActionListener<ResumeBulkByPaginatedSearchResponse> relocationResponseLoggingListener(final BulkByPaginatedSearchTask task) {
         return ActionListener.assertOnce(ActionListener.wrap(resp -> {
             logger.info("reindex task [{}] relocation succeeded on source node", task.getId());
         }, e -> {
@@ -746,7 +746,7 @@ public class Reindexer {
     ActionListener<BulkByPaginatedSearchResponse> listenerWithRelocations(
         final BulkByPaginatedSearchTask task,
         final ReindexRequest request,
-        final ActionListener<ResumeBulkByScrollResponse> onRelocationResponseListener,
+        final ActionListener<ResumeBulkByPaginatedSearchResponse> onRelocationResponseListener,
         final ActionListener<BulkByPaginatedSearchResponse> listener
     ) {
         final boolean isRelocationHandledByLeader = getReindexParent(task).isPresent();
@@ -799,7 +799,7 @@ public class Reindexer {
                 new ResumeInfo(resumeInfo.relocationOrigin(), resumeInfo.worker(), resumeInfo.slices(), sourceTaskResult)
             );
             final ResumeBulkByPaginatedSearchRequest resumeRequest = new ResumeBulkByPaginatedSearchRequest(request);
-            final ActionListener<ResumeBulkByScrollResponse> relocationListener = ActionListener.wrap(resp -> {
+            final ActionListener<ResumeBulkByPaginatedSearchResponse> relocationListener = ActionListener.wrap(resp -> {
                 onRelocationResponseListener.onResponse(resp);
                 l.onFailure(new TaskRelocatedException(resumeInfo.relocationOrigin().originalTaskId(), resp.getTaskId()));
             }, e -> {
@@ -820,7 +820,7 @@ public class Reindexer {
                 nodeToRelocateToNode,
                 ResumeReindexAction.NAME,
                 resumeRequest,
-                new ActionListenerResponseHandler<>(relocationListener, ResumeBulkByScrollResponse::new, threadPool.generic())
+                new ActionListenerResponseHandler<>(relocationListener, ResumeBulkByPaginatedSearchResponse::new, threadPool.generic())
             );
         });
     }

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/TransportResumeReindexAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/TransportResumeReindexAction.java
@@ -17,7 +17,7 @@ import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.index.reindex.ReindexAction;
 import org.elasticsearch.index.reindex.ReindexRequest;
 import org.elasticsearch.index.reindex.ResumeBulkByPaginatedSearchRequest;
-import org.elasticsearch.index.reindex.ResumeBulkByScrollResponse;
+import org.elasticsearch.index.reindex.ResumeBulkByPaginatedSearchResponse;
 import org.elasticsearch.index.reindex.ResumeReindexAction;
 import org.elasticsearch.injection.guice.Inject;
 import org.elasticsearch.tasks.Task;
@@ -49,7 +49,7 @@ public class TransportResumeReindexAction extends AbstractResumeBulkByScrollActi
     }
 
     @Override
-    protected void doExecute(Task task, ResumeBulkByPaginatedSearchRequest request, ActionListener<ResumeBulkByScrollResponse> listener) {
+    protected void doExecute(Task task, ResumeBulkByPaginatedSearchRequest request, ActionListener<ResumeBulkByPaginatedSearchResponse> listener) {
         final ReindexRequest reindexRequest = (ReindexRequest) request.getDelegate();
         reindexMetrics.recordRelocation(reindexRequest.getRemoteInfo() != null, ReindexMetrics.resolveSlicingMode(reindexRequest));
         super.doExecute(task, request, listener);

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/TransportResumeReindexAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/TransportResumeReindexAction.java
@@ -49,7 +49,11 @@ public class TransportResumeReindexAction extends AbstractResumeBulkByScrollActi
     }
 
     @Override
-    protected void doExecute(Task task, ResumeBulkByPaginatedSearchRequest request, ActionListener<ResumeBulkByPaginatedSearchResponse> listener) {
+    protected void doExecute(
+        Task task,
+        ResumeBulkByPaginatedSearchRequest request,
+        ActionListener<ResumeBulkByPaginatedSearchResponse> listener
+    ) {
         final ReindexRequest reindexRequest = (ReindexRequest) request.getDelegate();
         reindexMetrics.recordRelocation(reindexRequest.getRemoteInfo() != null, ReindexMetrics.resolveSlicingMode(reindexRequest));
         super.doExecute(task, request, listener);

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexerTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexerTests.java
@@ -63,7 +63,7 @@ import org.elasticsearch.index.reindex.ReindexAction;
 import org.elasticsearch.index.reindex.ReindexRequest;
 import org.elasticsearch.index.reindex.RemoteInfo;
 import org.elasticsearch.index.reindex.ResumeBulkByPaginatedSearchRequest;
-import org.elasticsearch.index.reindex.ResumeBulkByScrollResponse;
+import org.elasticsearch.index.reindex.ResumeBulkByPaginatedSearchResponse;
 import org.elasticsearch.index.reindex.ResumeInfo;
 import org.elasticsearch.index.reindex.ResumeReindexAction;
 import org.elasticsearch.index.reindex.TaskRelocatedException;
@@ -392,8 +392,8 @@ public class ReindexerTests extends ESTestCase {
 
         final TransportService transportService = mock(TransportService.class);
         doAnswer(invocation -> {
-            TransportResponseHandler<ResumeBulkByScrollResponse> handler = invocation.getArgument(3);
-            handler.handleResponse(new ResumeBulkByScrollResponse(new TaskId("target-node:123")));
+            TransportResponseHandler<ResumeBulkByPaginatedSearchResponse> handler = invocation.getArgument(3);
+            handler.handleResponse(new ResumeBulkByPaginatedSearchResponse(new TaskId("target-node:123")));
             return null;
         }).when(transportService)
             .sendRequest(eq(targetNode), eq(ResumeReindexAction.NAME), any(ResumeBulkByPaginatedSearchRequest.class), any());
@@ -406,7 +406,7 @@ public class ReindexerTests extends ESTestCase {
 
         final ResumeInfo.RelocationOrigin origin = new ResumeInfo.RelocationOrigin(new TaskId("source-node", 987), randomNonNegativeLong());
         final PlainActionFuture<BulkByPaginatedSearchResponse> future = new PlainActionFuture<>();
-        final ActionListener<ResumeBulkByScrollResponse> relocationListener = spy(ActionListener.noop());
+        final ActionListener<ResumeBulkByPaginatedSearchResponse> relocationListener = spy(ActionListener.noop());
         final ActionListener<BulkByPaginatedSearchResponse> wrapped = reindexer.listenerWithRelocations(
             task,
             reindexRequest(),
@@ -429,8 +429,8 @@ public class ReindexerTests extends ESTestCase {
     public void testRelocationLoggingListenerLogsSuccess() {
         // Dashboards depend on this exact WARN/INFO wording;
         final BulkByPaginatedSearchTask task = createNonSlicedWorkerTask();
-        final ActionListener<ResumeBulkByScrollResponse> listener = Reindexer.relocationResponseLoggingListener(task);
-        final ResumeBulkByScrollResponse response = new ResumeBulkByScrollResponse(new TaskId("target-node:123"));
+        final ActionListener<ResumeBulkByPaginatedSearchResponse> listener = Reindexer.relocationResponseLoggingListener(task);
+        final ResumeBulkByPaginatedSearchResponse response = new ResumeBulkByPaginatedSearchResponse(new TaskId("target-node:123"));
 
         try (var mockLog = MockLog.capture(Reindexer.class)) {
             mockLog.addExpectation(
@@ -458,7 +458,7 @@ public class ReindexerTests extends ESTestCase {
     public void testRelocationLoggingListenerLogsFailure() {
         // Dashboards depend on this exact WARN wording;
         final BulkByPaginatedSearchTask task = createNonSlicedWorkerTask();
-        final ActionListener<ResumeBulkByScrollResponse> listener = Reindexer.relocationResponseLoggingListener(task);
+        final ActionListener<ResumeBulkByPaginatedSearchResponse> listener = Reindexer.relocationResponseLoggingListener(task);
         final Exception e = new IllegalStateException(randomAlphaOfLength(5));
 
         try (var mockLog = MockLog.capture(Reindexer.class)) {
@@ -489,7 +489,7 @@ public class ReindexerTests extends ESTestCase {
     public void testRelocationLoggingListenerDoesNotLogForTaskCancelledException() {
         // Cancellation is expected user action, not a relocation failure — neither the warn nor the info should fire.
         final BulkByPaginatedSearchTask task = createNonSlicedWorkerTask();
-        final ActionListener<ResumeBulkByScrollResponse> listener = Reindexer.relocationResponseLoggingListener(task);
+        final ActionListener<ResumeBulkByPaginatedSearchResponse> listener = Reindexer.relocationResponseLoggingListener(task);
 
         try (var mockLog = MockLog.capture(Reindexer.class)) {
             mockLog.addExpectation(
@@ -511,8 +511,8 @@ public class ReindexerTests extends ESTestCase {
     public void testRelocationLoggingListenerCalledForBothSuccessAndFailureFails() {
         // assertOnce wrapping still applies: calling both onResponse and onFailure must throw.
         final BulkByPaginatedSearchTask task = createNonSlicedWorkerTask();
-        final ActionListener<ResumeBulkByScrollResponse> listener = Reindexer.relocationResponseLoggingListener(task);
-        final ResumeBulkByScrollResponse response = new ResumeBulkByScrollResponse(new TaskId("target-node:123"));
+        final ActionListener<ResumeBulkByPaginatedSearchResponse> listener = Reindexer.relocationResponseLoggingListener(task);
+        final ResumeBulkByPaginatedSearchResponse response = new ResumeBulkByPaginatedSearchResponse(new TaskId("target-node:123"));
         final Exception e = new IllegalStateException(randomAlphaOfLength(5));
         if (randomBoolean()) {
             listener.onResponse(response);
@@ -542,8 +542,8 @@ public class ReindexerTests extends ESTestCase {
             assertThat(sourceTaskResult.getTask().taskId(), equalTo(new TaskId("source-node", 987)));
             assertTrue("source task result should be completed", sourceTaskResult.isCompleted());
 
-            TransportResponseHandler<ResumeBulkByScrollResponse> handler = invocation.getArgument(3);
-            handler.handleResponse(new ResumeBulkByScrollResponse(new TaskId("target-node:123")));
+            TransportResponseHandler<ResumeBulkByPaginatedSearchResponse> handler = invocation.getArgument(3);
+            handler.handleResponse(new ResumeBulkByPaginatedSearchResponse(new TaskId("target-node:123")));
             return null;
         }).when(transportService)
             .sendRequest(eq(targetNode), eq(ResumeReindexAction.NAME), any(ResumeBulkByPaginatedSearchRequest.class), any());
@@ -555,7 +555,7 @@ public class ReindexerTests extends ESTestCase {
         task.requestRelocation();
 
         final PlainActionFuture<BulkByPaginatedSearchResponse> future = new PlainActionFuture<>();
-        final ActionListener<ResumeBulkByScrollResponse> resumeListener = spy(ActionListener.noop());
+        final ActionListener<ResumeBulkByPaginatedSearchResponse> resumeListener = spy(ActionListener.noop());
         final ActionListener<BulkByPaginatedSearchResponse> wrapped = reindexer.listenerWithRelocations(
             task,
             reindexRequest(),
@@ -769,7 +769,7 @@ public class ReindexerTests extends ESTestCase {
         task.ensureCancellable();
 
         final PlainActionFuture<BulkByPaginatedSearchResponse> future = new PlainActionFuture<>();
-        final PlainActionFuture<org.elasticsearch.index.reindex.ResumeBulkByScrollResponse> onRelocationFuture = new PlainActionFuture<>();
+        final PlainActionFuture<ResumeBulkByPaginatedSearchResponse> onRelocationFuture = new PlainActionFuture<>();
         final ActionListener<BulkByPaginatedSearchResponse> wrapped = reindexer.listenerWithRelocations(
             task,
             reindexRequest(),
@@ -3236,8 +3236,8 @@ public class ReindexerTests extends ESTestCase {
         final TransportService transportService = mock(TransportService.class);
         doAnswer(invocation -> {
             capturedRequest.set(invocation.getArgument(2));
-            TransportResponseHandler<ResumeBulkByScrollResponse> handler = invocation.getArgument(3);
-            handler.handleResponse(new ResumeBulkByScrollResponse(new TaskId("target-node:123")));
+            TransportResponseHandler<ResumeBulkByPaginatedSearchResponse> handler = invocation.getArgument(3);
+            handler.handleResponse(new ResumeBulkByPaginatedSearchResponse(new TaskId("target-node:123")));
             return null;
         }).when(transportService)
             .sendRequest(eq(RELOCATION_TARGET_NODE), eq(ResumeReindexAction.NAME), any(ResumeBulkByPaginatedSearchRequest.class), any());

--- a/server/src/main/java/org/elasticsearch/index/reindex/ResumeBulkByPaginatedSearchResponse.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/ResumeBulkByPaginatedSearchResponse.java
@@ -17,15 +17,15 @@ import org.elasticsearch.tasks.TaskId;
 import java.io.IOException;
 import java.util.Objects;
 
-public class ResumeBulkByScrollResponse extends ActionResponse {
+public class ResumeBulkByPaginatedSearchResponse extends ActionResponse {
 
     private final TaskId taskId;
 
-    public ResumeBulkByScrollResponse(TaskId taskId) {
+    public ResumeBulkByPaginatedSearchResponse(TaskId taskId) {
         this.taskId = Objects.requireNonNull(taskId, "taskId");
     }
 
-    public ResumeBulkByScrollResponse(StreamInput in) throws IOException {
+    public ResumeBulkByPaginatedSearchResponse(StreamInput in) throws IOException {
         this.taskId = TaskId.readFromStream(in);
     }
 

--- a/server/src/main/java/org/elasticsearch/index/reindex/ResumeReindexAction.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/ResumeReindexAction.java
@@ -11,7 +11,7 @@ package org.elasticsearch.index.reindex;
 
 import org.elasticsearch.action.ActionType;
 
-public class ResumeReindexAction extends ActionType<ResumeBulkByScrollResponse> {
+public class ResumeReindexAction extends ActionType<ResumeBulkByPaginatedSearchResponse> {
 
     public static final ResumeReindexAction INSTANCE = new ResumeReindexAction();
     public static final String NAME = "indices:data/write/reindex/resume";

--- a/server/src/test/java/org/elasticsearch/index/reindex/ResumeBulkByPaginatedSearchResponseWireSerializingTests.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/ResumeBulkByPaginatedSearchResponseWireSerializingTests.java
@@ -28,25 +28,25 @@ public class ResumeBulkByPaginatedSearchResponseWireSerializingTests extends Abs
 
     @Override
     protected Wrapper createTestInstance() {
-        return new Wrapper(new ResumeBulkByScrollResponse(new TaskId(randomAlphaOfLength(8), randomNonNegativeLong())));
+        return new Wrapper(new ResumeBulkByPaginatedSearchResponse(new TaskId(randomAlphaOfLength(8), randomNonNegativeLong())));
     }
 
     @Override
     protected Wrapper mutateInstance(Wrapper instance) throws IOException {
         TaskId origId = instance.response.getTaskId();
         TaskId newId = randomValueOtherThan(origId, () -> new TaskId(randomAlphaOfLength(10), randomNonNegativeLong()));
-        return new Wrapper(new ResumeBulkByScrollResponse(newId));
+        return new Wrapper(new ResumeBulkByPaginatedSearchResponse(newId));
     }
 
     static final class Wrapper implements Writeable {
-        private final ResumeBulkByScrollResponse response;
+        private final ResumeBulkByPaginatedSearchResponse response;
 
-        Wrapper(ResumeBulkByScrollResponse response) {
+        Wrapper(ResumeBulkByPaginatedSearchResponse response) {
             this.response = response;
         }
 
         Wrapper(StreamInput in) throws IOException {
-            this.response = new ResumeBulkByScrollResponse(in);
+            this.response = new ResumeBulkByPaginatedSearchResponse(in);
         }
 
         @Override


### PR DESCRIPTION
Now that reindexing uses both scroll and point-in-time search, all scroll exclusive references need to be removed. This is step 8 of https://github.com/elastic/elasticsearch-team/issues/2406.

Relates: https://github.com/elastic/elasticsearch-team/issues/2406

