### PR TITLE
[9.4] Decouple cuvs_native from cuvs_java, download from NVIDIA (#149076)

### DIFF
--- a/.buildkite/scripts/cuvs-snapshot/configure.sh
+++ b/.buildkite/scripts/cuvs-snapshot/configure.sh
@@ -16,27 +16,23 @@ if [[ -f /etc/profile.d/elastic-nvidia.sh ]]; then
   fi
 fi
 
-LIBCUVS_GCS_BUCKET="elasticsearch-cuvs-snapshots"
-
 LIBCUVS_DIR="/opt/libcuvs"
 sudo mkdir -p "$LIBCUVS_DIR"
 sudo chmod 777 "$LIBCUVS_DIR"
 
-CUVS_VERSION=$(grep 'cuvs_java' build-tools-internal/version.properties | awk '{print $3}')
+CUVS_VERSION=$(grep 'cuvs_native' build-tools-internal/version.properties | awk '{print $3}')
 
 LIBCUVS_VERSION_DIR="$LIBCUVS_DIR/$CUVS_VERSION"
 
 if [[ ! -d "$LIBCUVS_VERSION_DIR" ]]; then
-  mkdir -p $LIBCUVS_VERSION_DIR
+  mkdir -p "$LIBCUVS_VERSION_DIR"
   cd "$LIBCUVS_VERSION_DIR"
-  CUVS_ARCHIVE="libcuvs-$CUVS_VERSION.tar.gz"
-  curl -fO "https://storage.googleapis.com/$LIBCUVS_GCS_BUCKET/libcuvs/$CUVS_ARCHIVE"
-  tar -xzf "$CUVS_ARCHIVE"
+  CUVS_ARCHIVE="libcuvs-linux-x86_64-${CUVS_VERSION}_cuda12-archive.tar.xz"
+  curl -fO "https://developer.download.nvidia.com/compute/cuvs/redist/libcuvs/linux-x86_64/$CUVS_ARCHIVE"
+  tar -xJf "$CUVS_ARCHIVE"
   rm -f "$CUVS_ARCHIVE"
-  if [[ -d "$CUVS_VERSION" ]]; then
-    mv "$CUVS_VERSION/*" ./
-  fi
   cd -
 fi
 
-export LD_LIBRARY_PATH="$LIBCUVS_VERSION_DIR:${LD_LIBRARY_PATH:-}"
+CUVS_ARCHIVE_DIR="libcuvs-linux-x86_64-${CUVS_VERSION}_cuda12-archive"
+export LD_LIBRARY_PATH="$LIBCUVS_VERSION_DIR/$CUVS_ARCHIVE_DIR/lib:${LD_LIBRARY_PATH:-}"

--- a/build-tools-internal/version.properties
+++ b/build-tools-internal/version.properties
@@ -21,6 +21,7 @@ google_oauth_client = 1.34.1
 awsv2sdk            = 2.31.78
 reactive_streams    = 1.0.4
 cuvs_java           = 25.12.0
+cuvs_native         = 26.04.00.194111
 ldapsdk             = 7.0.3
 
 antlr4            = 4.13.1


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Decouple cuvs_native from cuvs_java, download from NVIDIA (#149076)](https://github.com/elastic/elasticsearch/pull/149076)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)