### PR TITLE
[9.4] Build competitive iterator immediately for search_after queries (#150319)

### DIFF
--- a/docs/changelog/150319.yaml
+++ b/docs/changelog/150319.yaml
@@ -1,0 +1,5 @@
+area: Logs
+issues: []
+pr: 150319
+summary: Build competitive iterator immediately for `search_after` queries
+type: enhancement

--- a/server/src/main/java/org/elasticsearch/lucene/comparators/XNumericComparator.java
+++ b/server/src/main/java/org/elasticsearch/lucene/comparators/XNumericComparator.java
@@ -200,7 +200,9 @@ public abstract class XNumericComparator<T extends Number> extends FieldComparat
         protected abstract int docCount();
 
         final void updateCompetitiveIterator() throws IOException {
-            if (hitsThresholdReached == false) {
+            // When a top value is set (search_after), we can build the competitive iterator immediately
+            // because we already know the upper bound and don't need to wait for the hits threshold.
+            if (hitsThresholdReached == false && leafTopSet == false) {
                 return;
             }
             if (leafTopSet == false && queueFull == false) {

--- a/server/src/test/java/org/elasticsearch/lucene/comparators/SkipperPruningTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/comparators/SkipperPruningTests.java
@@ -82,4 +82,97 @@ public class SkipperPruningTests extends ESTestCase {
         indexWriter.close();
         dir.close();
     }
+
+    public void testDVSkipperCompetitiveIteratorBuiltImmediatelyForSearchAfter() throws IOException {
+        Directory dir = newDirectory();
+        Sort indexSort = new Sort(new SortField("@timestamp", SortField.Type.LONG, true));
+        IndexWriterConfig iwc = new IndexWriterConfig(new MockAnalyzer(random())).setIndexSort(indexSort);
+        RandomIndexWriter indexWriter = new RandomIndexWriter(random(), dir, iwc);
+
+        int numDocs = atLeast(1000);
+        for (int i = 0; i < numDocs; i++) {
+            Document doc = new Document();
+            doc.add(NumericDocValuesField.indexedField("@timestamp", 1_000_000 + i));
+            indexWriter.addDocument(doc);
+        }
+        indexWriter.forceMerge(1);
+        IndexReader reader = indexWriter.getReader();
+
+        SortedNumericIndexFieldData fd = new SortedNumericIndexFieldData(
+            "@timestamp",
+            IndexNumericFieldData.NumericType.LONG,
+            CoreValuesSourceType.NUMERIC,
+            null,
+            IndexType.skippers()
+        );
+        LongValuesComparatorSource source = new LongValuesComparatorSource(
+            fd,
+            null,
+            MultiValueMode.MAX,
+            null,
+            IndexNumericFieldData.NumericType.LONG
+        );
+
+        var comparator = (XLongComparator) source.newComparator("@timestamp", 1, Pruning.GREATER_THAN_OR_EQUAL_TO, true);
+        // Set topValue below all indexed timestamps (simulating search_after) so no docs are competitive
+        // in a descending sort. Must be set before getLeafComparator so leafTopSet is captured correctly.
+        comparator.setTopValue(999_999L);
+
+        var leafComparator = comparator.getLeafComparator(reader.leaves().getFirst());
+        // setScorer triggers updateCompetitiveIterator in DVSkipperCompetitiveDISIBuilder.
+        // With topValue set, the competitive iterator must be built immediately even when hitsThresholdReached is false.
+        leafComparator.setScorer(null);
+
+        // All indexed timestamps are >= 1_000_000, which is above topValue=999_999, so no docs are competitive.
+        assertThat(leafComparator.competitiveIterator().nextDoc(), equalTo(DocIdSetIterator.NO_MORE_DOCS));
+
+        reader.close();
+        indexWriter.close();
+        dir.close();
+    }
+
+    public void testDVSkipperCompetitiveIteratorNotBuiltWithoutTopValueOrThreshold() throws IOException {
+        Directory dir = newDirectory();
+        Sort indexSort = new Sort(new SortField("@timestamp", SortField.Type.LONG, true));
+        IndexWriterConfig iwc = new IndexWriterConfig(new MockAnalyzer(random())).setIndexSort(indexSort);
+        RandomIndexWriter indexWriter = new RandomIndexWriter(random(), dir, iwc);
+
+        int numDocs = atLeast(1000);
+        for (int i = 0; i < numDocs; i++) {
+            Document doc = new Document();
+            doc.add(NumericDocValuesField.indexedField("@timestamp", 1_000_000 + i));
+            indexWriter.addDocument(doc);
+        }
+        indexWriter.forceMerge(1);
+        IndexReader reader = indexWriter.getReader();
+
+        SortedNumericIndexFieldData fd = new SortedNumericIndexFieldData(
+            "@timestamp",
+            IndexNumericFieldData.NumericType.LONG,
+            CoreValuesSourceType.NUMERIC,
+            null,
+            IndexType.skippers()
+        );
+        LongValuesComparatorSource source = new LongValuesComparatorSource(
+            fd,
+            null,
+            MultiValueMode.MAX,
+            null,
+            IndexNumericFieldData.NumericType.LONG
+        );
+
+        var comparator = (XLongComparator) source.newComparator("@timestamp", 1, Pruning.GREATER_THAN_OR_EQUAL_TO, true);
+        // Neither setTopValue nor hitsThresholdReached — the early-return guard must fire.
+
+        int maxDoc = reader.leaves().getFirst().reader().maxDoc();
+        var leafComparator = comparator.getLeafComparator(reader.leaves().getFirst());
+        leafComparator.setScorer(null);
+
+        // The competitive iterator must remain as all(maxDoc): cost equals maxDoc because no update was applied.
+        assertThat(leafComparator.competitiveIterator().cost(), equalTo((long) maxDoc));
+
+        reader.close();
+        indexWriter.close();
+        dir.close();
+    }
 }


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Build competitive iterator immediately for search_after queries (#150319)