### PR TITLE
[9.4] [ML] Scope scroll clear retries in ML datafeeds to CCS and bound orphan queue (#149146)

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/DataExtractorUtils.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/DataExtractorUtils.java
@@ -118,6 +118,60 @@ public final class DataExtractorUtils {
         return List.copyOf(result);
     }
 
+    /**
+     * Picks the better of two linked-cluster snapshots for CCS-aware datafeeds.
+     * <p>
+     * A single realtime extraction run can issue many searches (scroll pages, composite pages,
+     * chunked windows). Later responses sometimes attach slimmer {@link SearchResponse#getClusters()}
+     * metadata than earlier ones even though the coordinating view still spans more remotes.
+     * Preferring the snapshot with more <em>distinct</em> cluster aliases (and, on ties, more
+     * {@link LinkedClusterState.Status#AVAILABLE} entries) prevents {@code remote_cluster_stats}
+     * from losing a newly linked remote until the datafeed is restarted.
+     */
+    public static List<LinkedClusterState> preferRicherLinkedClusterStates(
+        List<LinkedClusterState> bestSoFar,
+        List<LinkedClusterState> candidate
+    ) {
+        if (candidate == null || candidate.isEmpty()) {
+            return bestSoFar == null || bestSoFar.isEmpty() ? List.of() : bestSoFar;
+        }
+        if (bestSoFar == null || bestSoFar.isEmpty()) {
+            return List.copyOf(candidate);
+        }
+        return richerLinkedClusterStates(bestSoFar, candidate);
+    }
+
+    private static List<LinkedClusterState> richerLinkedClusterStates(
+        List<LinkedClusterState> bestSoFar,
+        List<LinkedClusterState> candidate
+    ) {
+        int candidateDistinct = distinctAliasCount(candidate);
+        int bestDistinct = distinctAliasCount(bestSoFar);
+        if (candidateDistinct != bestDistinct) {
+            return candidateDistinct > bestDistinct ? List.copyOf(candidate) : bestSoFar;
+        }
+        int candidateAvailable = countAvailable(candidate);
+        int bestAvailable = countAvailable(bestSoFar);
+        if (candidateAvailable != bestAvailable) {
+            return candidateAvailable > bestAvailable ? List.copyOf(candidate) : bestSoFar;
+        }
+        return bestSoFar;
+    }
+
+    private static int distinctAliasCount(List<LinkedClusterState> states) {
+        return (int) states.stream().map(LinkedClusterState::alias).distinct().count();
+    }
+
+    private static int countAvailable(List<LinkedClusterState> states) {
+        int n = 0;
+        for (LinkedClusterState s : states) {
+            if (s.status() == LinkedClusterState.Status.AVAILABLE) {
+                n++;
+            }
+        }
+        return n;
+    }
+
     private static LinkedClusterState.Status mapStatus(SearchResponse.Cluster.Status clusterStatus) {
         return switch (clusterStatus) {
             case SUCCESSFUL, RUNNING, PARTIAL -> LinkedClusterState.Status.AVAILABLE;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ScrollDataExtractor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ScrollDataExtractor.java
@@ -17,6 +17,7 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchScrollRequestBuilder;
 import org.elasticsearch.action.search.TransportClearScrollAction;
 import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.search.SearchHit;
@@ -96,6 +97,7 @@ class ScrollDataExtractor implements DataExtractor {
         clearScroll();
         List<String> scrollIdsToRetry = List.copyOf(failedClearScrollIds);
         failedClearScrollIds.clear();
+        // Second attempt for those same ids before handing off to the factory.
         for (String orphanedScrollId : scrollIdsToRetry) {
             clearScrollLoggingExceptions(orphanedScrollId);
         }
@@ -286,19 +288,33 @@ class ScrollDataExtractor implements DataExtractor {
         scrollId = null;
     }
 
+    /**
+     * Clears a scroll id, logging and optionally queuing for factory retry when clear fails.
+     * <p>
+     * Cross-cluster search (CCS) is inferred from {@link #lastLinkedClusterStates}: if this extractor
+     * has observed remote-cluster metadata during its lifetime (via {@link DataExtractorUtils#preferRicherLinkedClusterStates}),
+     * failed clears are treated as CCS. That snapshot never shrinks when later responses omit cluster metadata,
+     * so it is a lifetime proxy, not a per-scroll-id remote check. Remote scroll contexts can outlive a brief outage
+     * and are queued for retry; local contexts are left to expire without queuing.
+     */
     private void clearScrollLoggingExceptions(String scrollId) {
-        try {
-            innerClearScroll(scrollId);
-        } catch (Exception e) {
-            logger.error(() -> "[" + context.jobId + "] Failed to clear scroll", e);
-            if (scrollId != null) {
-                failedClearScrollIds.add(scrollId);
-            }
+        if (scrollId == null) {
+            return;
+        }
+        if (innerClearScroll(scrollId)) {
+            return;
+        }
+        boolean isCcsScroll = lastLinkedClusterStates.isEmpty() == false;
+        if (isCcsScroll) {
+            logger.info("[{}] CCS scroll context could not be cleared, will retry [{}]", context.jobId, scrollId);
+            failedClearScrollIds.add(scrollId);
+        } else {
+            logger.debug("[{}] Transient scroll clear failure, context will expire on its own [{}]", context.jobId, scrollId);
         }
     }
 
-    private void innerClearScroll(String scrollId) {
-        if (scrollId != null) {
+    private boolean innerClearScroll(String scrollId) {
+        try {
             ClearScrollRequest request = new ClearScrollRequest();
             request.addScrollId(scrollId);
             ClientHelper.executeWithHeaders(
@@ -307,6 +323,10 @@ class ScrollDataExtractor implements DataExtractor {
                 client,
                 () -> client.execute(TransportClearScrollAction.TYPE, request).actionGet()
             );
+            return response.isSucceeded();
+        } catch (Exception e) {
+            logger.debug(() -> Strings.format("[%s] Scroll clear request threw exception [%s]", context.jobId, scrollId), e);
+            return false;
         }
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ScrollDataExtractor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ScrollDataExtractor.java
@@ -11,6 +11,7 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.search.ClearScrollRequest;
+import org.elasticsearch.action.search.ClearScrollResponse;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
@@ -58,6 +59,7 @@ class ScrollDataExtractor implements DataExtractor {
     private final Client client;
     private final ScrollDataExtractorContext context;
     private final DatafeedTimingStatsReporter timingStatsReporter;
+    private final ScrollDataExtractorFactory factory;
     private String scrollId;
     private boolean isCancelled;
     private boolean hasNext;
@@ -67,10 +69,16 @@ class ScrollDataExtractor implements DataExtractor {
     private List<LinkedClusterState> lastLinkedClusterStates = List.of();
     private final List<String> failedClearScrollIds = new ArrayList<>();
 
-    ScrollDataExtractor(Client client, ScrollDataExtractorContext dataExtractorContext, DatafeedTimingStatsReporter timingStatsReporter) {
+    ScrollDataExtractor(
+        Client client,
+        ScrollDataExtractorContext dataExtractorContext,
+        DatafeedTimingStatsReporter timingStatsReporter,
+        ScrollDataExtractorFactory factory
+    ) {
         this.client = Objects.requireNonNull(client);
         this.context = Objects.requireNonNull(dataExtractorContext);
         this.timingStatsReporter = Objects.requireNonNull(timingStatsReporter);
+        this.factory = Objects.requireNonNull(factory);
         hasNext = true;
         searchHasShardFailure = false;
     }
@@ -100,6 +108,18 @@ class ScrollDataExtractor implements DataExtractor {
         // Second attempt for those same ids before handing off to the factory.
         for (String orphanedScrollId : scrollIdsToRetry) {
             clearScrollLoggingExceptions(orphanedScrollId);
+        }
+        // Transfer any IDs that still couldn't be cleared (e.g. due to ongoing network disruption)
+        // to the long-lived factory so they can be retried when the next extractor connects.
+        if (failedClearScrollIds.isEmpty() == false) {
+            factory.addOrphanedScrollIds(List.copyOf(failedClearScrollIds));
+            failedClearScrollIds.clear();
+        }
+        // Also retry any scroll IDs previously orphaned by other extractors. This is especially
+        // important when the datafeed is shutting down and no further initScroll() calls will
+        // happen to trigger the retry there. If the network has since recovered, these will clear.
+        if (factory.hasOrphanedScrollIds()) {
+            factory.retryClearOrphanedScrollIds();
         }
     }
 
@@ -135,12 +155,18 @@ class ScrollDataExtractor implements DataExtractor {
     }
 
     protected InputStream initScroll(long startTimestamp) throws IOException {
+        if (factory.hasOrphanedScrollIds()) {
+            factory.retryClearOrphanedScrollIds();
+        }
         logger.debug("[{}] Initializing scroll with start time [{}]", context.jobId, startTimestamp);
         SearchResponse searchResponse = executeSearchRequest(buildSearchRequest(startTimestamp));
         try {
             logger.debug("[{}] Search response was obtained", context.jobId);
             timingStatsReporter.reportSearchDuration(searchResponse.getTook());
-            lastLinkedClusterStates = DataExtractorUtils.extractLinkedClusterStates(searchResponse);
+            lastLinkedClusterStates = DataExtractorUtils.preferRicherLinkedClusterStates(
+                lastLinkedClusterStates,
+                DataExtractorUtils.extractLinkedClusterStates(searchResponse)
+            );
             scrollId = searchResponse.getScrollId();
             return processAndConsumeSearchHits(searchResponse.getHits());
         } finally {
@@ -258,7 +284,10 @@ class ScrollDataExtractor implements DataExtractor {
             }
             logger.debug("[{}] Search response was obtained", context.jobId);
             timingStatsReporter.reportSearchDuration(searchResponse.getTook());
-            lastLinkedClusterStates = DataExtractorUtils.extractLinkedClusterStates(searchResponse);
+            lastLinkedClusterStates = DataExtractorUtils.preferRicherLinkedClusterStates(
+                lastLinkedClusterStates,
+                DataExtractorUtils.extractLinkedClusterStates(searchResponse)
+            );
             scrollId = searchResponse.getScrollId();
             return processAndConsumeSearchHits(searchResponse.getHits());
         } finally {
@@ -317,14 +346,14 @@ class ScrollDataExtractor implements DataExtractor {
         try {
             ClearScrollRequest request = new ClearScrollRequest();
             request.addScrollId(scrollId);
-            ClientHelper.executeWithHeaders(
+            ClearScrollResponse response = ClientHelper.executeWithHeaders(
                 context.queryContext.headers,
                 ClientHelper.ML_ORIGIN,
                 client,
                 () -> client.execute(TransportClearScrollAction.TYPE, request).actionGet()
             );
             return response.isSucceeded();
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             logger.debug(() -> Strings.format("[%s] Scroll clear request threw exception [%s]", context.jobId, scrollId), e);
             return false;
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ScrollDataExtractorFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ScrollDataExtractorFactory.java
@@ -6,12 +6,17 @@
  */
 package org.elasticsearch.xpack.ml.datafeed.extractor.scroll;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.fieldcaps.FieldCapabilities;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesRequest;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesResponse;
 import org.elasticsearch.action.fieldcaps.TransportFieldCapabilitiesAction;
+import org.elasticsearch.action.search.ClearScrollRequest;
+import org.elasticsearch.action.search.ClearScrollResponse;
+import org.elasticsearch.action.search.TransportClearScrollAction;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.core.TimeValue;
@@ -37,6 +42,8 @@ import java.util.Optional;
 import java.util.Set;
 
 public class ScrollDataExtractorFactory implements DataExtractorFactory {
+
+    private static final Logger logger = LogManager.getLogger(ScrollDataExtractorFactory.class);
 
     // This field type is not supported for scrolling datafeeds.
     private static final String AGGREGATE_METRIC_DOUBLE = "aggregate_metric_double";
@@ -114,6 +121,29 @@ public class ScrollDataExtractorFactory implements DataExtractorFactory {
         return orphanedScrolls.isEmpty() == false;
     }
 
+    private boolean tryClearOrphanedScroll(String scrollId) {
+        try {
+            ClearScrollRequest request = new ClearScrollRequest();
+            request.addScrollId(scrollId);
+            ClearScrollResponse response = ClientHelper.executeWithHeaders(
+                datafeedConfig.getHeaders(),
+                ClientHelper.ML_ORIGIN,
+                client,
+                () -> client.execute(TransportClearScrollAction.TYPE, request).actionGet()
+            );
+            return response.isSucceeded();
+        } catch (RuntimeException e) {
+            logger.debug(() -> Strings.format("[%s] Orphaned scroll clear failed for [{}]", job.getId(), scrollId), e);
+            return false;
+        }
+    }
+
+    private void requeueOrphanedScroll(OrphanedScroll entry) {
+        int newRetries = entry.retryAttempts() + 1;
+        logger.debug("[{}] Retry {} for orphaned scroll [{}] still failed", job.getId(), newRetries, entry.scrollId());
+        orphanedScrolls.addLast(new OrphanedScroll(entry.scrollId(), entry.createdAtMillis(), newRetries));
+    }
+
     /**
      * Attempts to clear every queued orphaned scroll ID. Successfully cleared IDs are removed.
      * Entries that are stale (age exceeds {@link #ORPHAN_TTL_MILLIS}) or have exhausted their
@@ -136,25 +166,8 @@ public class ScrollDataExtractorFactory implements DataExtractorFactory {
                 );
                 continue;
             }
-            try {
-                ClearScrollRequest request = new ClearScrollRequest();
-                request.addScrollId(entry.scrollId());
-                ClearScrollResponse response = ClientHelper.executeWithHeaders(
-                    datafeedConfig.getHeaders(),
-                    ClientHelper.ML_ORIGIN,
-                    client,
-                    () -> client.execute(TransportClearScrollAction.TYPE, request).actionGet()
-                );
-                if (response.isSucceeded() == false) {
-                    throw new ElasticsearchException("Clear scroll returned failure for scroll [{}]", entry.scrollId());
-                }
-            } catch (Exception e) {
-                int newRetries = entry.retryAttempts() + 1;
-                logger.debug(
-                    () -> Strings.format("[%s] Retry %d for orphaned scroll [%s] still failed", job.getId(), newRetries, entry.scrollId()),
-                    e
-                );
-                orphanedScrolls.addLast(new OrphanedScroll(entry.scrollId(), entry.createdAtMillis(), newRetries));
+            if (tryClearOrphanedScroll(entry.scrollId()) == false) {
+                requeueOrphanedScroll(entry);
             }
         }
     }
@@ -178,7 +191,7 @@ public class ScrollDataExtractorFactory implements DataExtractorFactory {
             datafeedConfig.getIndicesOptions(),
             datafeedConfig.getRuntimeMappings()
         );
-        return new ScrollDataExtractor(client, dataExtractorContext, timingStatsReporter);
+        return new ScrollDataExtractor(client, dataExtractorContext, timingStatsReporter, this);
     }
 
     public static void create(

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ScrollDataExtractorFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ScrollDataExtractorFactory.java
@@ -13,6 +13,8 @@ import org.elasticsearch.action.fieldcaps.FieldCapabilitiesRequest;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesResponse;
 import org.elasticsearch.action.fieldcaps.TransportFieldCapabilitiesAction;
 import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -26,6 +28,9 @@ import org.elasticsearch.xpack.ml.datafeed.DatafeedTimingStatsReporter;
 import org.elasticsearch.xpack.ml.datafeed.extractor.DataExtractor;
 import org.elasticsearch.xpack.ml.datafeed.extractor.DataExtractorFactory;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -36,6 +41,13 @@ public class ScrollDataExtractorFactory implements DataExtractorFactory {
     // This field type is not supported for scrolling datafeeds.
     private static final String AGGREGATE_METRIC_DOUBLE = "aggregate_metric_double";
 
+    // Package-private record so tests can inspect queue contents
+    record OrphanedScroll(String scrollId, long createdAtMillis, int retryAttempts) {}
+
+    static final int MAX_ORPHAN_QUEUE_SIZE = 64;
+    static final int MAX_ORPHAN_RETRIES = 5;
+    static final long ORPHAN_TTL_MILLIS = TimeValue.timeValueMinutes(60).millis();
+
     private final Client client;
     private final DatafeedConfig datafeedConfig;
     private final QueryBuilder extraFilters;
@@ -44,7 +56,14 @@ public class ScrollDataExtractorFactory implements DataExtractorFactory {
     private final NamedXContentRegistry xContentRegistry;
     private final DatafeedTimingStatsReporter timingStatsReporter;
 
-    private ScrollDataExtractorFactory(
+    /**
+     * Scroll IDs that could not be cleared during a previous network disruption.
+     * These survive across extractor lifetimes and are retried when the next
+     * extractor successfully connects to the remote cluster.
+     */
+    final Deque<OrphanedScroll> orphanedScrolls = new ArrayDeque<>();
+
+    ScrollDataExtractorFactory(
         Client client,
         DatafeedConfig datafeedConfig,
         QueryBuilder extraFilters,
@@ -60,6 +79,84 @@ public class ScrollDataExtractorFactory implements DataExtractorFactory {
         this.extractedFields = Objects.requireNonNull(extractedFields);
         this.xContentRegistry = xContentRegistry;
         this.timingStatsReporter = Objects.requireNonNull(timingStatsReporter);
+    }
+
+    /**
+     * Records scroll IDs that a destroyed extractor could not clear during a network disruption (typically CCS).
+     * <p>
+     * Queuing is bounded: at most {@value #MAX_ORPHAN_QUEUE_SIZE} newest entries are retained.
+     * {@link #retryClearOrphanedScrollIds()} is invoked when a new extractor starts
+     * ({@link ScrollDataExtractor#initScroll(long)}) or during {@link ScrollDataExtractor#destroy()}; each
+     * entry is dropped after {@link #ORPHAN_TTL_MILLIS} milliseconds since enqueue or after {@value #MAX_ORPHAN_RETRIES}
+     * consecutive failed clears.
+     */
+    void addOrphanedScrollIds(List<String> scrollIds) {
+        long now = System.currentTimeMillis();
+        for (String scrollId : scrollIds) {
+            if (orphanedScrolls.size() >= MAX_ORPHAN_QUEUE_SIZE) {
+                OrphanedScroll eldest = orphanedScrolls.poll();  // removes head (eldest)
+                if (eldest != null) {
+                    logger.debug(
+                        "[{}] Orphan scroll queue overflow, dropping eldest entry aged {}ms",
+                        job.getId(),
+                        now - eldest.createdAtMillis()
+                    );
+                }
+            }
+            orphanedScrolls.add(new OrphanedScroll(scrollId, now, 0));
+        }
+    }
+
+    /**
+     * Returns {@code true} if there are orphaned scroll IDs waiting to be cleared.
+     */
+    boolean hasOrphanedScrollIds() {
+        return orphanedScrolls.isEmpty() == false;
+    }
+
+    /**
+     * Attempts to clear every queued orphaned scroll ID. Successfully cleared IDs are removed.
+     * Entries that are stale (age exceeds {@link #ORPHAN_TTL_MILLIS}) or have exhausted their
+     * retry budget (>= {@link #MAX_ORPHAN_RETRIES}) are evicted without attempting a clear.
+     */
+    void retryClearOrphanedScrollIds() {
+        long now = System.currentTimeMillis();
+        for (int remaining = orphanedScrolls.size(); remaining > 0; remaining--) {
+            OrphanedScroll entry = orphanedScrolls.pollFirst();
+            if (entry == null) {
+                break;
+            }
+            if (now - entry.createdAtMillis() > ORPHAN_TTL_MILLIS || entry.retryAttempts() >= MAX_ORPHAN_RETRIES) {
+                logger.info(
+                    "[{}] Giving up on orphaned CCS scroll context [{}] after {} retries / {}ms — remote scroll may persist until TTL",
+                    job.getId(),
+                    entry.scrollId(),
+                    entry.retryAttempts(),
+                    now - entry.createdAtMillis()
+                );
+                continue;
+            }
+            try {
+                ClearScrollRequest request = new ClearScrollRequest();
+                request.addScrollId(entry.scrollId());
+                ClearScrollResponse response = ClientHelper.executeWithHeaders(
+                    datafeedConfig.getHeaders(),
+                    ClientHelper.ML_ORIGIN,
+                    client,
+                    () -> client.execute(TransportClearScrollAction.TYPE, request).actionGet()
+                );
+                if (response.isSucceeded() == false) {
+                    throw new ElasticsearchException("Clear scroll returned failure for scroll [{}]", entry.scrollId());
+                }
+            } catch (Exception e) {
+                int newRetries = entry.retryAttempts() + 1;
+                logger.debug(
+                    () -> Strings.format("[%s] Retry %d for orphaned scroll [%s] still failed", job.getId(), newRetries, entry.scrollId()),
+                    e
+                );
+                orphanedScrolls.addLast(new OrphanedScroll(entry.scrollId(), entry.createdAtMillis(), newRetries));
+            }
+        }
     }
 
     @Override

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ScrollDataExtractorFactoryTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ScrollDataExtractorFactoryTests.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.datafeed.extractor.scroll;
+
+import org.elasticsearch.action.ActionFuture;
+import org.elasticsearch.action.search.ClearScrollRequest;
+import org.elasticsearch.action.search.ClearScrollResponse;
+import org.elasticsearch.action.search.TransportClearScrollAction;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xcontent.NamedXContentRegistry;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedTimingStats;
+import org.elasticsearch.xpack.core.ml.job.config.Job;
+import org.elasticsearch.xpack.ml.datafeed.DatafeedTimingStatsReporter;
+import org.elasticsearch.xpack.ml.datafeed.DatafeedTimingStatsReporter.DatafeedTimingStatsPersister;
+import org.elasticsearch.xpack.ml.extractor.DocValueField;
+import org.elasticsearch.xpack.ml.extractor.ExtractedField;
+import org.elasticsearch.xpack.ml.extractor.TimeField;
+import org.junit.Before;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ScrollDataExtractorFactoryTests extends ESTestCase {
+
+    private Client client;
+    private DatafeedConfig datafeedConfig;
+    private Job job;
+    private TimeBasedExtractedFields extractedFields;
+    private DatafeedTimingStatsReporter timingStatsReporter;
+
+    @Before
+    public void setUpTests() {
+        ThreadPool threadPool = mock(ThreadPool.class);
+        when(threadPool.getThreadContext()).thenReturn(new ThreadContext(Settings.EMPTY));
+        client = mock(Client.class);
+        when(client.threadPool()).thenReturn(threadPool);
+
+        datafeedConfig = mock(DatafeedConfig.class);
+        when(datafeedConfig.getHeaders()).thenReturn(Collections.emptyMap());
+        job = mock(Job.class);
+        when(job.getId()).thenReturn("factory-test-job");
+
+        ExtractedField timeField = new TimeField("time", ExtractedField.Method.DOC_VALUE);
+        extractedFields = new TimeBasedExtractedFields(
+            timeField,
+            Arrays.asList(timeField, new DocValueField("field_1", Collections.singleton("keyword")))
+        );
+        timingStatsReporter = new DatafeedTimingStatsReporter(
+            new DatafeedTimingStats(job.getId()),
+            mock(DatafeedTimingStatsPersister.class)
+        );
+    }
+
+    private ScrollDataExtractorFactory newFactory() {
+        return new ScrollDataExtractorFactory(
+            client,
+            datafeedConfig,
+            null,
+            job,
+            extractedFields,
+            NamedXContentRegistry.EMPTY,
+            timingStatsReporter
+        );
+    }
+
+    public void testCcsOrphanPastTtlShouldBeRemovedWithoutClearScrollCall() {
+        ScrollDataExtractorFactory factory = newFactory();
+        factory.orphanedScrolls.addLast(
+            new ScrollDataExtractorFactory.OrphanedScroll(
+                "scroll-id-old",
+                System.currentTimeMillis() - ScrollDataExtractorFactory.ORPHAN_TTL_MILLIS - 1,
+                0
+            )
+        );
+
+        factory.retryClearOrphanedScrollIds();
+
+        verify(client, never()).execute(same(TransportClearScrollAction.TYPE), any(ClearScrollRequest.class));
+        assertThat(factory.orphanedScrolls.stream().anyMatch(o -> o.scrollId().equals("scroll-id-old")), is(false));
+    }
+
+    public void testCcsOrphanAtRetryLimitShouldBeRemovedWithoutClearScrollCall() {
+        ScrollDataExtractorFactory factory = newFactory();
+        factory.orphanedScrolls.addLast(
+            new ScrollDataExtractorFactory.OrphanedScroll(
+                "scroll-at-retry-limit",
+                System.currentTimeMillis(),
+                ScrollDataExtractorFactory.MAX_ORPHAN_RETRIES  // exactly at the limit: >= triggers eviction
+            )
+        );
+
+        factory.retryClearOrphanedScrollIds();
+
+        verify(client, never()).execute(same(TransportClearScrollAction.TYPE), any(ClearScrollRequest.class));
+        assertThat(factory.orphanedScrolls.stream().anyMatch(o -> o.scrollId().equals("scroll-at-retry-limit")), is(false));
+    }
+
+    public void testCcsOrphanOverRetryLimitShouldBeRemovedWithoutClearScrollCall() {
+        ScrollDataExtractorFactory factory = newFactory();
+        factory.orphanedScrolls.addLast(
+            new ScrollDataExtractorFactory.OrphanedScroll(
+                "scroll-too-many-retries",
+                System.currentTimeMillis(),
+                ScrollDataExtractorFactory.MAX_ORPHAN_RETRIES + 1
+            )
+        );
+
+        factory.retryClearOrphanedScrollIds();
+
+        verify(client, never()).execute(same(TransportClearScrollAction.TYPE), any(ClearScrollRequest.class));
+        assertThat(factory.orphanedScrolls.stream().anyMatch(o -> o.scrollId().equals("scroll-too-many-retries")), is(false));
+    }
+
+    public void testOrphanQueueAtCapacityShouldDropOldestOnEnqueue() {
+        ScrollDataExtractorFactory factory = newFactory();
+        for (int i = 0; i < ScrollDataExtractorFactory.MAX_ORPHAN_QUEUE_SIZE + 1; i++) {
+            factory.addOrphanedScrollIds(List.of("scroll-" + i));
+        }
+        assertThat(factory.orphanedScrolls.size(), is(ScrollDataExtractorFactory.MAX_ORPHAN_QUEUE_SIZE));
+        assertThat(factory.orphanedScrolls.stream().anyMatch(o -> o.scrollId().equals("scroll-0")), is(false));
+        assertThat(
+            factory.orphanedScrolls.stream()
+                .anyMatch(o -> o.scrollId().equals("scroll-" + ScrollDataExtractorFactory.MAX_ORPHAN_QUEUE_SIZE)),
+            is(true)
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testCcsOrphanSuccessfullyClearedShouldBeRemovedFromQueue() {
+        ScrollDataExtractorFactory factory = newFactory();
+        factory.orphanedScrolls.addLast(new ScrollDataExtractorFactory.OrphanedScroll("scroll-recoverable", System.currentTimeMillis(), 0));
+
+        ActionFuture<ClearScrollResponse> successFuture = mock(ActionFuture.class);
+        when(successFuture.actionGet()).thenReturn(new ClearScrollResponse(true, 1));
+        when(client.execute(same(TransportClearScrollAction.TYPE), any(ClearScrollRequest.class))).thenReturn((ActionFuture) successFuture);
+
+        factory.retryClearOrphanedScrollIds();
+
+        assertThat(factory.orphanedScrolls.isEmpty(), is(true));
+    }
+}

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ScrollDataExtractorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ScrollDataExtractorTests.java
@@ -11,6 +11,7 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.search.ClearScrollRequest;
+import org.elasticsearch.action.search.ClearScrollResponse;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
@@ -71,16 +72,20 @@ import static java.util.Collections.emptyMap;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class ScrollDataExtractorTests extends ESTestCase {
 
     private Client client;
+    private ScrollDataExtractorFactory scrollDataExtractorFactory;
     private List<ActionRequestBuilder<?, SearchResponse>> capturedSearchRequests;
     private List<String> capturedContinueScrollIds;
     private ArgumentCaptor<ClearScrollRequest> capturedClearScrollRequests;
@@ -107,7 +112,7 @@ public class ScrollDataExtractorTests extends ESTestCase {
         }
 
         TestDataExtractor(ScrollDataExtractorContext context) {
-            super(client, context, timingStatsReporter);
+            super(client, context, timingStatsReporter, scrollDataExtractorFactory);
         }
 
         @Override
@@ -184,10 +189,13 @@ public class ScrollDataExtractorTests extends ESTestCase {
         scrollSize = 1000;
 
         capturedClearScrollRequests = ArgumentCaptor.forClass(ClearScrollRequest.class);
+        ActionFuture<ClearScrollResponse> successfulClearScrollFuture = mock(ActionFuture.class);
+        when(successfulClearScrollFuture.actionGet()).thenReturn(new ClearScrollResponse(true, 1));
         when(client.execute(same(TransportClearScrollAction.TYPE), capturedClearScrollRequests.capture())).thenReturn(
-            mock(ActionFuture.class)
+            successfulClearScrollFuture
         );
         timingStatsReporter = new DatafeedTimingStatsReporter(new DatafeedTimingStats(jobId), mock(DatafeedTimingStatsPersister.class));
+        scrollDataExtractorFactory = mock(ScrollDataExtractorFactory.class);
     }
 
     public void testSinglePageExtraction() throws IOException {
@@ -554,36 +562,6 @@ public class ScrollDataExtractorTests extends ESTestCase {
         );
         assertThat(searchRequest, not(containsString("\"track_total_hits\":false")));
         assertThat(searchRequest, not(containsString("\"sort\"")));
-    }
-
-    public void testGetSummarySetsProjectRouting() {
-        String projectRouting = "_alias:prod-*";
-        ScrollDataExtractorContext context = createContext(1000L, 2300L, projectRouting);
-        TestDataExtractor extractor = new TestDataExtractor(context);
-        extractor.setNextResponse(createSummaryResponse(1001L, 2299L, 10L));
-
-        DataSummary summary = extractor.getSummary();
-        assertThat(summary.earliestTime(), equalTo(1001L));
-        assertThat(summary.latestTime(), equalTo(2299L));
-        assertThat(summary.totalHits(), equalTo(10L));
-
-        assertThat(capturedSearchRequests.size(), equalTo(1));
-        SearchRequest request = (SearchRequest) capturedSearchRequests.get(0).request();
-        assertThat(request.getProjectRouting(), equalTo(projectRouting));
-    }
-
-    public void testExtractionSetsProjectRouting() throws IOException {
-        String projectRouting = "_project._region:us-*";
-        ScrollDataExtractorContext context = createContext(1000L, 2000L, projectRouting);
-        TestDataExtractor extractor = new TestDataExtractor(context);
-        extractor.setNextResponse(createSearchResponse(Arrays.asList(1100L), Arrays.asList("a1"), Arrays.asList("b1")));
-
-        assertThat(extractor.hasNext(), is(true));
-        extractor.next();
-
-        assertThat(capturedSearchRequests.size(), greaterThanOrEqualTo(1));
-        SearchRequest request = (SearchRequest) capturedSearchRequests.get(0).request();
-        assertThat(request.getProjectRouting(), equalTo(projectRouting));
     }
 
     @SuppressWarnings("unchecked")

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ScrollDataExtractorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ScrollDataExtractorTests.java
@@ -36,8 +36,11 @@ import org.elasticsearch.search.aggregations.metrics.Min;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xcontent.NamedXContentRegistry;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedTimingStats;
 import org.elasticsearch.xpack.core.ml.datafeed.SearchInterval;
+import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.ml.datafeed.DatafeedTimingStatsReporter;
 import org.elasticsearch.xpack.ml.datafeed.DatafeedTimingStatsReporter.DatafeedTimingStatsPersister;
 import org.elasticsearch.xpack.ml.datafeed.extractor.DataExtractor;
@@ -67,6 +70,8 @@ import java.util.stream.Collectors;
 import static java.util.Collections.emptyMap;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.mockito.ArgumentMatchers.same;
@@ -95,6 +100,10 @@ public class ScrollDataExtractorTests extends ESTestCase {
 
         TestDataExtractor(long start, long end) {
             this(createContext(start, end));
+        }
+
+        TestDataExtractor(long start, long end, ScrollDataExtractorFactory factory) {
+            super(client, createContext(start, end), timingStatsReporter, factory);
         }
 
         TestDataExtractor(ScrollDataExtractorContext context) {
@@ -547,6 +556,226 @@ public class ScrollDataExtractorTests extends ESTestCase {
         assertThat(searchRequest, not(containsString("\"sort\"")));
     }
 
+    public void testGetSummarySetsProjectRouting() {
+        String projectRouting = "_alias:prod-*";
+        ScrollDataExtractorContext context = createContext(1000L, 2300L, projectRouting);
+        TestDataExtractor extractor = new TestDataExtractor(context);
+        extractor.setNextResponse(createSummaryResponse(1001L, 2299L, 10L));
+
+        DataSummary summary = extractor.getSummary();
+        assertThat(summary.earliestTime(), equalTo(1001L));
+        assertThat(summary.latestTime(), equalTo(2299L));
+        assertThat(summary.totalHits(), equalTo(10L));
+
+        assertThat(capturedSearchRequests.size(), equalTo(1));
+        SearchRequest request = (SearchRequest) capturedSearchRequests.get(0).request();
+        assertThat(request.getProjectRouting(), equalTo(projectRouting));
+    }
+
+    public void testExtractionSetsProjectRouting() throws IOException {
+        String projectRouting = "_project._region:us-*";
+        ScrollDataExtractorContext context = createContext(1000L, 2000L, projectRouting);
+        TestDataExtractor extractor = new TestDataExtractor(context);
+        extractor.setNextResponse(createSearchResponse(Arrays.asList(1100L), Arrays.asList("a1"), Arrays.asList("b1")));
+
+        assertThat(extractor.hasNext(), is(true));
+        extractor.next();
+
+        assertThat(capturedSearchRequests.size(), greaterThanOrEqualTo(1));
+        SearchRequest request = (SearchRequest) capturedSearchRequests.get(0).request();
+        assertThat(request.getProjectRouting(), equalTo(projectRouting));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testDestroyTransfersFailedScrollIdsToFactory() throws IOException {
+        // Make all ClearScroll attempts fail to simulate an ongoing network disruption
+        ActionFuture<Object> failingFuture = mock(ActionFuture.class);
+        when(failingFuture.actionGet()).thenThrow(new ElasticsearchException("network disruption"));
+        when(client.execute(same(TransportClearScrollAction.TYPE), any(ClearScrollRequest.class))).thenReturn((ActionFuture) failingFuture);
+
+        TestDataExtractor extractor = new TestDataExtractor(1000L, 2000L);
+
+        // Get a scroll ID by fetching the first page
+        SearchResponse response1 = createCcsSearchResponse(
+            Arrays.asList(1100L, 1200L),
+            Arrays.asList("a1", "a2"),
+            Arrays.asList("b1", "b2")
+        );
+        extractor.setNextResponse(response1);
+        extractor.next();
+
+        // Trigger an error on continue-scroll; clearScroll() will fail → ID lands in failedClearScrollIds
+        extractor.setNextResponseToError(new ElasticsearchException("boom"));
+        // Second error for the retry in tryNextStream (searchHasShardFailure path)
+        extractor.setNextResponseToError(new ElasticsearchException("boom"));
+        expectThrows(ElasticsearchException.class, extractor::next);
+
+        // destroy() retries the IDs from failedClearScrollIds; they still fail → transferred to factory
+        extractor.destroy();
+
+        verify(scrollDataExtractorFactory).addOrphanedScrollIds(anyList());
+    }
+
+    public void testDestroyRetriesFactoryOrphanedScrollIds() throws IOException {
+        // Return false during initScroll() so that call is skipped, then true during destroy().
+        when(scrollDataExtractorFactory.hasOrphanedScrollIds()).thenReturn(false, true);
+
+        TestDataExtractor extractor = new TestDataExtractor(1000L, 2000L);
+
+        SearchResponse response1 = createSearchResponse(Arrays.asList(1100L, 1200L), Arrays.asList("a1", "a2"), Arrays.asList("b1", "b2"));
+        extractor.setNextResponse(response1);
+        SearchResponse response2 = createEmptySearchResponse();
+        extractor.setNextResponse(response2);
+
+        extractor.next();
+        extractor.next(); // exhaust the scroll
+
+        extractor.destroy();
+
+        verify(scrollDataExtractorFactory).retryClearOrphanedScrollIds();
+    }
+
+    public void testDestroySkipsRetryWhenNoFactoryOrphans() throws IOException {
+        when(scrollDataExtractorFactory.hasOrphanedScrollIds()).thenReturn(false);
+
+        TestDataExtractor extractor = new TestDataExtractor(1000L, 2000L);
+
+        SearchResponse response1 = createSearchResponse(Arrays.asList(1100L, 1200L), Arrays.asList("a1", "a2"), Arrays.asList("b1", "b2"));
+        extractor.setNextResponse(response1);
+        SearchResponse response2 = createEmptySearchResponse();
+        extractor.setNextResponse(response2);
+
+        extractor.next();
+        extractor.next(); // exhaust the scroll
+
+        extractor.destroy();
+
+        verify(scrollDataExtractorFactory, never()).retryClearOrphanedScrollIds();
+    }
+
+    public void testInitScrollTriggersRetryWhenOrphansExist() throws IOException {
+        when(scrollDataExtractorFactory.hasOrphanedScrollIds()).thenReturn(true);
+
+        TestDataExtractor extractor = new TestDataExtractor(1000L, 2000L);
+
+        SearchResponse response1 = createSearchResponse(Arrays.asList(1100L, 1200L), Arrays.asList("a1", "a2"), Arrays.asList("b1", "b2"));
+        extractor.setNextResponse(response1);
+        SearchResponse response2 = createEmptySearchResponse();
+        extractor.setNextResponse(response2);
+
+        extractor.next(); // triggers initScroll()
+
+        verify(scrollDataExtractorFactory).retryClearOrphanedScrollIds();
+    }
+
+    public void testInitScrollSkipsRetryWhenNoOrphans() throws IOException {
+        when(scrollDataExtractorFactory.hasOrphanedScrollIds()).thenReturn(false);
+
+        TestDataExtractor extractor = new TestDataExtractor(1000L, 2000L);
+
+        SearchResponse response1 = createSearchResponse(Arrays.asList(1100L, 1200L), Arrays.asList("a1", "a2"), Arrays.asList("b1", "b2"));
+        extractor.setNextResponse(response1);
+        SearchResponse response2 = createEmptySearchResponse();
+        extractor.setNextResponse(response2);
+
+        extractor.next(); // triggers initScroll()
+
+        verify(scrollDataExtractorFactory, never()).retryClearOrphanedScrollIds();
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testLocalScrollClearWithSucceededFalseShouldNotQueueOrphan() throws IOException {
+        ActionFuture<ClearScrollResponse> failedClearFuture = mock(ActionFuture.class);
+        when(failedClearFuture.actionGet()).thenReturn(new ClearScrollResponse(false, 0));
+        when(client.execute(same(TransportClearScrollAction.TYPE), any(ClearScrollRequest.class))).thenReturn(
+            (ActionFuture) failedClearFuture
+        );
+
+        TestDataExtractor extractor = new TestDataExtractor(1000L, 2000L);
+
+        SearchResponse response1 = createSearchResponse(Arrays.asList(1100L), Arrays.asList("a1"), Arrays.asList("b1"));
+        when(response1.getClusters()).thenReturn(null);
+        extractor.setNextResponse(response1);
+        extractor.next();
+
+        SearchResponse response2 = createEmptySearchResponse();
+        when(response2.getClusters()).thenReturn(null);
+        extractor.setNextResponse(response2);
+        extractor.next();
+
+        extractor.destroy();
+
+        verify(scrollDataExtractorFactory, never()).addOrphanedScrollIds(anyList());
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testLocalScrollClearTransportExceptionShouldNotQueueOrphan() throws IOException {
+        ActionFuture<ClearScrollResponse> throwingClearFuture = mock(ActionFuture.class);
+        when(throwingClearFuture.actionGet()).thenThrow(new ElasticsearchException("network disruption"));
+        when(client.execute(same(TransportClearScrollAction.TYPE), any(ClearScrollRequest.class))).thenReturn(
+            (ActionFuture) throwingClearFuture
+        );
+
+        TestDataExtractor extractor = new TestDataExtractor(1000L, 2000L);
+
+        SearchResponse response1 = createSearchResponse(Arrays.asList(1100L), Arrays.asList("a1"), Arrays.asList("b1"));
+        when(response1.getClusters()).thenReturn(null);
+        extractor.setNextResponse(response1);
+        extractor.next();
+
+        SearchResponse response2 = createEmptySearchResponse();
+        when(response2.getClusters()).thenReturn(null);
+        extractor.setNextResponse(response2);
+        extractor.next();
+
+        extractor.destroy();
+
+        verify(scrollDataExtractorFactory, never()).addOrphanedScrollIds(anyList());
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testCcsScrollClearWithSucceededFalseShouldQueueOrphanWithMetadata() throws IOException {
+        ActionFuture<ClearScrollResponse> failedClearFuture = mock(ActionFuture.class);
+        when(failedClearFuture.actionGet()).thenReturn(new ClearScrollResponse(false, 0));
+        when(client.execute(same(TransportClearScrollAction.TYPE), any(ClearScrollRequest.class))).thenReturn(
+            (ActionFuture) failedClearFuture
+        );
+
+        ScrollDataExtractorFactory realFactory = createRealScrollDataExtractorFactory();
+        TestDataExtractor extractor = new TestDataExtractor(1000L, 2000L, realFactory);
+
+        SearchResponse ccsResponse = createCcsSearchResponse(Arrays.asList(1100L), Arrays.asList("a1"), Arrays.asList("b1"));
+        extractor.setNextResponse(ccsResponse);
+        extractor.next();
+
+        SearchResponse response2 = createEmptySearchResponse();
+        extractor.setNextResponse(response2);
+        extractor.next();
+        extractor.destroy();
+
+        assertThat(realFactory.orphanedScrolls.isEmpty(), is(false));
+        ScrollDataExtractorFactory.OrphanedScroll orphan = realFactory.orphanedScrolls.peek();
+        assertThat(orphan.scrollId(), equalTo(response2.getScrollId()));
+        // Contract: destroy() calls retryClearOrphanedScrollIds(); if clear still fails, retry count must advance.
+        assertThat(orphan.retryAttempts(), greaterThan(0));
+    }
+
+    private ScrollDataExtractorFactory createRealScrollDataExtractorFactory() {
+        DatafeedConfig datafeedConfig = mock(DatafeedConfig.class);
+        when(datafeedConfig.getHeaders()).thenReturn(Collections.emptyMap());
+        Job job = mock(Job.class);
+        when(job.getId()).thenReturn(jobId);
+        return new ScrollDataExtractorFactory(
+            client,
+            datafeedConfig,
+            null,
+            job,
+            extractedFields,
+            NamedXContentRegistry.EMPTY,
+            timingStatsReporter
+        );
+    }
+
     private ScrollDataExtractorContext createContext(long start, long end) {
         return new ScrollDataExtractorContext(
             jobId,
@@ -585,6 +814,15 @@ public class ScrollDataExtractorTests extends ESTestCase {
         when(searchResponse.getHits()).thenReturn(searchHits.asUnpooled());
         searchHits.decRef();
         when(searchResponse.getTook()).thenReturn(TimeValue.timeValueMillis(randomNonNegativeLong()));
+        return searchResponse;
+    }
+
+    private SearchResponse createCcsSearchResponse(List<Long> timestamps, List<String> field1Values, List<String> field2Values) {
+        SearchResponse searchResponse = createSearchResponse(timestamps, field1Values, field2Values);
+        Map<String, SearchResponse.Cluster> clusterInfo = new HashMap<>();
+        clusterInfo.put("remote", new SearchResponse.Cluster("remote", "*", false, null));
+        SearchResponse.Clusters realClusters = new SearchResponse.Clusters(clusterInfo);
+        when(searchResponse.getClusters()).thenReturn(realClusters);
         return searchResponse;
     }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[ML] Scope scroll clear retries in ML datafeeds to CCS and bound orphan queue (#149146)](https://github.com/elastic/elasticsearch/pull/149146)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)