### PR TITLE
Add ESET PROTECT device vulnerability source index to kibana_system role

### DIFF
--- a/docs/changelog/150369.yaml
+++ b/docs/changelog/150369.yaml
@@ -1,0 +1,5 @@
+area: Security
+issues: []
+pr: 150369
+summary: Add ESET PROTECT device vulnerability source index to kibana_system role
+type: enhancement

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
@@ -569,7 +569,8 @@ class KibanaOwnedReservedRoleDescriptors {
                         "logs-tenable_io.vulnerability-*",
                         "logs-rapid7_insightvm.vulnerability-*",
                         "logs-rapid7_insightvm.asset_vulnerability-*",
-                        "logs-carbon_black_cloud.asset_vulnerability_summary-*"
+                        "logs-carbon_black_cloud.asset_vulnerability_summary-*",
+                        "logs-eset_protect.device_vulnerability-*"
                     )
                     .privileges("read", "view_index_metadata")
                     .build(),


### PR DESCRIPTION
Adds logs-eset_protect.device_vulnerability-* to the CDR transform source index privileges in KibanaOwnedReservedRoleDescriptors#kibanaSystem.

The ESET PROTECT integration (elastic/integrations#19139) ships a latest transform (latest_cdr_vuln) that reads from logs-eset_protect.device_vulnerability-* and writes to security_solution-eset_protect.vulnerability_latest*. Without this addition, the kibana_system user lacks read on the source index and the transform cannot start.