### PR TITLE
Unmute BooleanFieldBlockLoaderTests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -626,15 +626,6 @@ tests:
 - class: org.elasticsearch.test.apmintegration.OTelMetricsBufferingIT
   method: testExplicitMetrics
   issue: https://github.com/elastic/elasticsearch/issues/150302
-- class: org.elasticsearch.index.mapper.blockloader.BooleanFieldBlockLoaderTests
-  method: testBlockLoaderWithCranky {preference=Params[syntheticSource=true, preference=NONE, indexMode=columnar]}
-  issue: https://github.com/elastic/elasticsearch/issues/150308
-- class: org.elasticsearch.index.mapper.blockloader.BooleanFieldBlockLoaderTests
-  method: testBlockLoaderWithCranky {preference=Params[syntheticSource=true, preference=STORED, indexMode=columnar]}
-  issue: https://github.com/elastic/elasticsearch/issues/150309
-- class: org.elasticsearch.index.mapper.blockloader.BooleanFieldBlockLoaderTests
-  method: testBlockLoaderWithCranky {preference=Params[syntheticSource=true, preference=DOC_VALUES, indexMode=columnar]}
-  issue: https://github.com/elastic/elasticsearch/issues/150310
 - class: org.elasticsearch.xpack.esql.expression.function.grouping.BucketColumnMetadataIT
   method: testRenameBucketColumnHasNoMetadata
   issue: https://github.com/elastic/elasticsearch/issues/150311


### PR DESCRIPTION
These were fixed by https://github.com/elastic/elasticsearch/pull/150293, but got muted before the PR was merged.

Fixes:
- https://github.com/elastic/elasticsearch/issues/150310
- https://github.com/elastic/elasticsearch/issues/150309
- https://github.com/elastic/elasticsearch/issues/150308