### PR TITLE
Entitlement: cover MethodHandles.Lookup class-definition methods

### DIFF
--- a/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/JvmActions.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/JvmActions.java
@@ -13,6 +13,7 @@ import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.entitlement.qa.entitled.EntitledPlugin;
 
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Locale;
@@ -22,6 +23,7 @@ import javax.xml.parsers.SAXParserFactory;
 
 import static org.elasticsearch.entitlement.qa.test.EntitlementTest.ExpectedAccess.ALWAYS_ALLOWED;
 import static org.elasticsearch.entitlement.qa.test.EntitlementTest.ExpectedAccess.ALWAYS_DENIED;
+import static org.elasticsearch.entitlement.qa.test.EntitlementTest.ExpectedAccess.ES_MODULES_ONLY;
 import static org.elasticsearch.entitlement.qa.test.EntitlementTest.ExpectedAccess.PLUGINS;
 
 @SuppressForbidden(reason = "testing entitlements")
@@ -106,6 +108,21 @@ class JvmActions {
     @EntitlementTest(expectedAccess = ALWAYS_DENIED)
     static void thread$$setDefaultUncaughtExceptionHandler() {
         Thread.setDefaultUncaughtExceptionHandler(Thread.getDefaultUncaughtExceptionHandler());
+    }
+
+    @EntitlementTest(expectedAccess = ES_MODULES_ONLY, expectedExceptionIfDenied = IllegalAccessException.class)
+    static void defineClass() throws IllegalAccessException {
+        MethodHandles.lookup().defineClass(new byte[0]);
+    }
+
+    @EntitlementTest(expectedAccess = ES_MODULES_ONLY, expectedExceptionIfDenied = IllegalAccessException.class)
+    static void defineHiddenClass() throws IllegalAccessException {
+        MethodHandles.lookup().defineHiddenClass(new byte[0], false);
+    }
+
+    @EntitlementTest(expectedAccess = ES_MODULES_ONLY, expectedExceptionIfDenied = IllegalAccessException.class)
+    static void defineHiddenClassWithClassData() throws IllegalAccessException {
+        MethodHandles.lookup().defineHiddenClassWithClassData(new byte[0], "data", false);
     }
 
     @EntitlementTest(expectedAccess = ALWAYS_ALLOWED)

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/config/ClassLoaderInstrumentation.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/config/ClassLoaderInstrumentation.java
@@ -13,6 +13,7 @@ import org.elasticsearch.entitlement.rules.EntitlementRulesBuilder;
 import org.elasticsearch.entitlement.rules.Policies;
 import org.elasticsearch.entitlement.runtime.registry.InternalInstrumentationRegistry;
 
+import java.lang.invoke.MethodHandles;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.net.URLStreamHandlerFactory;
@@ -53,6 +54,22 @@ public class ClassLoaderInstrumentation implements InstrumentationConfig {
             rule.protectedCtor().enforce(Policies::createClassLoader).elseThrowNotEntitled();
             rule.protectedCtor(ClassLoader.class).enforce(Policies::createClassLoader).elseThrowNotEntitled();
             rule.protectedCtor(String.class, ClassLoader.class).enforce(Policies::createClassLoader).elseThrowNotEntitled();
+        });
+
+        builder.on(MethodHandles.Lookup.class, rule -> {
+            rule.calling(MethodHandles.Lookup::defineClass, byte[].class)
+                .enforce(Policies::createClassLoader)
+                .elseThrow(e -> new IllegalAccessException(e.getMessage()));
+            rule.calling(MethodHandles.Lookup::defineHiddenClass, byte[].class, Boolean.class, MethodHandles.Lookup.ClassOption[].class)
+                .enforce(Policies::createClassLoader)
+                .elseThrow(e -> new IllegalAccessException(e.getMessage()));
+            rule.calling(
+                MethodHandles.Lookup::defineHiddenClassWithClassData,
+                byte[].class,
+                Object.class,
+                Boolean.class,
+                MethodHandles.Lookup.ClassOption[].class
+            ).enforce(Policies::createClassLoader).elseThrow(e -> new IllegalAccessException(e.getMessage()));
         });
     }
 }


### PR DESCRIPTION
Backport of #149502 to 9.3.

Guards `java.lang.invoke.MethodHandles.Lookup`: `defineClass`, `defineHiddenClass`, and `defineHiddenClassWithClassData` with `create_class_loader`.
