### PR TITLE
Fixing StatelessFileDeletionIT.testLatestCommitDependenciesUsesTheRightGenerations()

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -596,9 +596,6 @@ tests:
 - class: org.elasticsearch.snapshots.SnapshotsServiceIT
   method: testDeleteSnapshotWhenNotWaitingForCompletion
   issue: https://github.com/elastic/elasticsearch/issues/150257
-- class: org.elasticsearch.xpack.stateless.commits.StatelessFileDeletionIT
-  method: testLatestCommitDependenciesUsesTheRightGenerations
-  issue: https://github.com/elastic/elasticsearch/issues/150287
 - class: org.elasticsearch.xpack.stateless.recovery.PointInTimeRelocationIT
   method: testPointInTimeRelocationClosingSourceContexts
   issue: https://github.com/elastic/elasticsearch/issues/150288

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/commits/StatelessFileDeletionIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/commits/StatelessFileDeletionIT.java
@@ -1513,7 +1513,7 @@ public class StatelessFileDeletionIT extends AbstractStatelessPluginIntegTestCas
         ensureStableCluster(3);
 
         var indexName = randomIdentifier();
-        createIndex(indexName, 1, 1);
+        createIndex(indexName, indexSettings(1, 1).put(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(), -1).build());
 
         var stateless = internalCluster().getInstance(PluginsService.class, indexNode)
             .filterPlugins(TestStatelessPlugin.class)


### PR DESCRIPTION
This disables automatic refresh in testLatestCommitDependenciesUsesTheRightGenerations(), to bring it inline with the other tests in the class.
Note: I haven't been able to reproduce the failure, but the automatic refresh is the only red flag I see. So I think it's worth doing, even if the failure comes back.
Closes #150287