### PR TITLE
[9.4] Fix transport version test failures caused by stale git state cache (#150304)

### DIFF
--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/transport/ResolveTransportVersionConflictFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/transport/ResolveTransportVersionConflictFuncTest.groovy
@@ -28,7 +28,7 @@ class ResolveTransportVersionConflictFuncTest extends AbstractTransportVersionFu
     def "update flag works with current"() {
         given:
         referableAndReferencedTransportVersion("new_tv", "8123000")
-        file("myserver/src/main/resources/transport/latest/9.2.csv").text =
+        file("myserver/src/main/resources/transport/upper_bounds/9.2.csv").text =
             """
             <<<<<<< HEAD
             existing_92,8123000
@@ -50,7 +50,7 @@ class ResolveTransportVersionConflictFuncTest extends AbstractTransportVersionFu
     def "update flag works with multiple branches"() {
         given:
         referableAndReferencedTransportVersion("new_tv", "8123000,8012001,7123001")
-        file("myserver/src/main/resources/transport/latest/9.2.csv").text =
+        file("myserver/src/main/resources/transport/upper_bounds/9.2.csv").text =
             """
             <<<<<<< HEAD
             existing_92,8123000
@@ -58,7 +58,7 @@ class ResolveTransportVersionConflictFuncTest extends AbstractTransportVersionFu
             new_tv,8123000
             >>>>>> name
             """.strip()
-        file("myserver/src/main/resources/transport/latest/9.1.csv").text =
+        file("myserver/src/main/resources/transport/upper_bounds/9.1.csv").text =
             """
             <<<<<<< HEAD
             existing_92,8012001
@@ -66,7 +66,7 @@ class ResolveTransportVersionConflictFuncTest extends AbstractTransportVersionFu
             new_tv,8012001
             >>>>>> name
             """.strip()
-        file("myserver/src/main/resources/transport/latest/8.19.csv").text =
+        file("myserver/src/main/resources/transport/upper_bounds/8.19.csv").text =
             """
             <<<<<<< HEAD
             initial_8.19.7,7123001

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/transport/TransportVersionGenerationFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/transport/TransportVersionGenerationFuncTest.groovy
@@ -257,7 +257,7 @@ class TransportVersionGenerationFuncTest extends AbstractTransportVersionFuncTes
 
     def "merge conflicts in latest files can be regenerated"() {
         given:
-        file("myserver/src/main/resources/transport/latest/9.2.csv").text =
+        file("myserver/src/main/resources/transport/upper_bounds/9.2.csv").text =
             """
             <<<<<<< HEAD
             existing_92,8123000
@@ -266,6 +266,7 @@ class TransportVersionGenerationFuncTest extends AbstractTransportVersionFuncTes
             >>>>>> name
             """.strip()
         referableAndReferencedTransportVersion("second_tv", "8123000")
+        assert file("myserver/src/main/resources/transport/upper_bounds/9.2.csv").text.contains("<<<<<<<")
 
         when:
         def result = runGenerateAndValidateTask("--name=second_tv", ).build()
@@ -324,7 +325,8 @@ class TransportVersionGenerationFuncTest extends AbstractTransportVersionFuncTes
         referableAndReferencedTransportVersion("latest_tv", "8124000,8012002")
         transportVersionUpperBound("9.2", "latest_tv", "8124000")
         transportVersionUpperBound("9.1", "latest_tv", "8012002")
-        execute("git commit -a -m added")
+        execute("git add .")
+        execute("git commit -m added")
         execute("git checkout -b mybranch")
 
         when:

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/TransportVersionResourcesService.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/TransportVersionResourcesService.java
@@ -165,12 +165,14 @@ public abstract class TransportVersionResourcesService implements BuildService<T
             StandardCharsets.UTF_8
         );
         gitCommand("add", path.toString());
+        changedResources.set(null);
     }
 
     void deleteReferableDefinition(String name) throws IOException {
         Path path = transportResourcesDir.resolve(getDefinitionRelativePath(name, true));
         if (Files.deleteIfExists(path)) {
             gitCommand("rm", "--ignore-unmatch", path.toString());
+            changedResources.set(null);
         }
     }
 
@@ -250,6 +252,7 @@ public abstract class TransportVersionResourcesService implements BuildService<T
         Files.writeString(path, upperBound.definitionName() + "," + upperBound.definitionId().complete() + "\n", StandardCharsets.UTF_8);
 
         gitCommand("add", path.toString());
+        changedResources.set(null);
     }
 
     /** Return the path within the repository of the given latest */
@@ -271,6 +274,7 @@ public abstract class TransportVersionResourcesService implements BuildService<T
     void checkoutOriginalChange() {
         gitCommand("checkout", "--theirs", transportResourcesDir.toString());
         gitCommand("add", transportResourcesDir.toString());
+        changedResources.set(null);
     }
 
     boolean checkIfDefinitelyOnReleaseBranch(Collection<TransportVersionUpperBound> upperBounds, String currentUpperBoundName) {


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Fix transport version test failures caused by stale git state cache (#150304)