### PR TITLE
Unmute TransportVersionGenerationFuncTest.merge conflicts in latest files can be regenerated

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -565,9 +565,6 @@ tests:
 - class: org.elasticsearch.xpack.stateless.cache.SharedBlobCacheWarmingServiceIT
   method: testCacheIsWarmedDuringMerge
   issue: https://github.com/elastic/elasticsearch/issues/150158
-- class: org.elasticsearch.gradle.internal.transport.TransportVersionGenerationFuncTest
-  method: merge conflicts in latest files can be regenerated
-  issue: https://github.com/elastic/elasticsearch/issues/150174
 - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
   method: test {csv-spec:k8s-timeseries-count-distinct-over-time.countDistinctNull}
   issue: https://github.com/elastic/elasticsearch/issues/150187


### PR DESCRIPTION
Fixed by #150304, but mute was left over.
