### PR TITLE
ESQL: Reject SPARKLINE(mv_agg)

### DIFF
--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/SparklineWithEveryAggTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/SparklineWithEveryAggTestCase.java
@@ -29,6 +29,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
 import static org.elasticsearch.test.ListMatcher.matchesList;
@@ -82,6 +83,12 @@ public abstract class SparklineWithEveryAggTestCase extends ESRestTestCase {
     }
 
     /**
+     * Aggs that return multiple values per group and so cannot be used as the first argument of SPARKLINE.
+     * These must produce an error when used INSIDE sparkline.
+     */
+    private static final Set<String> MULTI_VALUED_AGGS = Set.of("top", "sample", "values");
+
+    /**
      * Aggs whose invocations cannot be auto-generated from {@code NAME(val_long)}:
      * multi-arg, star syntax, or needing literal constants.
      */
@@ -111,10 +118,6 @@ public abstract class SparklineWithEveryAggTestCase extends ESRestTestCase {
             if (name.equals("sparkline")) {
                 continue;
             }
-            if (name.equals("top") || name.equals("sample")) {
-                // https://github.com/elastic/elasticsearch/issues/150256
-                continue;
-            }
             String invocation = HAND_CRAFTED_INVOCATIONS.getOrDefault(name, name.toUpperCase(Locale.ROOT) + "(val_long)");
             addCases(params, info, name, invocation);
         }
@@ -138,6 +141,18 @@ public abstract class SparklineWithEveryAggTestCase extends ESRestTestCase {
         // Every agg supports running ALONGSIDE and ALONGSIDE_BY
         params.add(new AggTestCase(invocation, Mode.ALONGSIDE, null, capabilitiesRequired));
         params.add(new AggTestCase(invocation, Mode.ALONGSIDE_BY, null, capabilitiesRequired));
+
+        // Multi-valued aggs fail with a "single-valued" error when used INSIDE sparkline
+        if (MULTI_VALUED_AGGS.contains(name)) {
+            List<String> capabilitiesWithRejectMv = new ArrayList<>(capabilitiesRequired);
+            capabilitiesWithRejectMv.add("fn_sparkline_reject_mv");
+            String mvError = "single-valued aggregate function";
+            params.add(new AggTestCase(invocation, Mode.INSIDE, mvError, capabilitiesWithRejectMv));
+            params.add(new AggTestCase(invocation, Mode.INSIDE_BY, mvError, capabilitiesWithRejectMv));
+            params.add(new AggTestCase(invocation, Mode.INSIDE_AND_ALONGSIDE, mvError, capabilitiesWithRejectMv));
+            params.add(new AggTestCase(invocation, Mode.INSIDE_AND_ALONGSIDE_BY, mvError, capabilitiesWithRejectMv));
+            return;
+        }
 
         // Non-numeric aggs will fail when INSIDE, INSIDE_AND_ALONGSIDE, INSIDE_BY, INSIDE_AND_ALONGSIDE_BY
         boolean numericReturn = Arrays.stream(info.returnType()).anyMatch(List.of("integer", "long", "double")::contains);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Sparkline.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Sparkline.java
@@ -11,6 +11,9 @@ import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.logging.LoggerMessageFormat;
 import org.elasticsearch.compute.operator.SparklineGenerateEmptyBucketsOperator;
+import org.elasticsearch.xpack.esql.capabilities.PostAnalysisVerificationAware;
+import org.elasticsearch.xpack.esql.common.Failure;
+import org.elasticsearch.xpack.esql.common.Failures;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
@@ -28,6 +31,7 @@ import org.elasticsearch.xpack.esql.optimizer.rules.logical.ReplaceSparklineAggr
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Locale;
 
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.ParamOrdinal.FIFTH;
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.ParamOrdinal.FIRST;
@@ -79,7 +83,7 @@ import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isWho
  *     and {@link SparklineGenerateEmptyBucketsOperator} for special implementation bits.
  * </p>
  */
-public class Sparkline extends AggregateFunction implements AggregateMetricDoubleNativeSupport {
+public class Sparkline extends AggregateFunction implements AggregateMetricDoubleNativeSupport, PostAnalysisVerificationAware {
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
         Expression.class,
         "Sparkline",
@@ -89,7 +93,8 @@ public class Sparkline extends AggregateFunction implements AggregateMetricDoubl
         .quinary(Sparkline::new, 0)
         .capabilities(
             "complex", // Fix for complex queries inside the agg inside the SPARKLINE
-            "null_alongside" // Fix for null aggs (e.g. COUNT_DISTINCT(null)) paired with SPARKLINE
+            "null_alongside", // Fix for null aggs (e.g. COUNT_DISTINCT(null)) paired with SPARKLINE
+            "reject_mv" // Rejects multi-valued aggregates (TOP, SAMPLE, VALUES) as first argument
         )
         .name("sparkline");
 
@@ -198,6 +203,23 @@ public class Sparkline extends AggregateFunction implements AggregateMetricDoubl
             return resolution;
         } else {
             return TypeResolution.TYPE_RESOLVED;
+        }
+    }
+
+    @Override
+    public void postAnalysisVerification(Failures failures) {
+        if (field() instanceof Top || field() instanceof Sample || field() instanceof Values) {
+            failures.add(
+                new Failure(
+                    this,
+                    String.format(
+                        Locale.ROOT,
+                        "first argument of [%s] must be a single-valued aggregate function, found [%s]",
+                        sourceText(),
+                        field().sourceText()
+                    )
+                )
+            );
         }
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
@@ -1837,6 +1837,27 @@ public class VerifierTests extends ESTestCase {
         );
     }
 
+    public void testSparklineRejectsMultiValuedAggs() {
+        String sparklineArgs = "hire_date, 10, \"2024-01-01\", \"2024-02-01\"";
+        defaultAnalyzer().error(
+            "from test | stats s = SPARKLINE(TOP(avg_worked_seconds, 3, \"asc\"), " + sparklineArgs + ")",
+            containsString(
+                "first argument of [SPARKLINE(TOP(avg_worked_seconds, 3, \"asc\"), "
+                    + sparklineArgs
+                    + ")] "
+                    + "must be a single-valued aggregate function, found [TOP(avg_worked_seconds, 3, \"asc\")]"
+            )
+        );
+        defaultAnalyzer().error(
+            "from test | stats s = SPARKLINE(SAMPLE(avg_worked_seconds, 3), " + sparklineArgs + ")",
+            containsString("must be a single-valued aggregate function, found [SAMPLE(avg_worked_seconds, 3)]")
+        );
+        defaultAnalyzer().error(
+            "from test | stats s = SPARKLINE(VALUES(avg_worked_seconds), " + sparklineArgs + ")",
+            containsString("must be a single-valued aggregate function, found [VALUES(avg_worked_seconds)]")
+        );
+    }
+
     public void testWeightedAvg() {
         defaultAnalyzer().error(
             "row v = [1, 2, 3] | stats w_avg = weighted_avg(v, null)",


### PR DESCRIPTION
Reject SPARKLINE aggs that contain aggregations that return multiple values.

Closes #150256
