### PR TITLE
Reuse prebuilt analyzers across indices

### DIFF
--- a/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/CommonAnalysisPluginTests.java
+++ b/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/CommonAnalysisPluginTests.java
@@ -13,17 +13,57 @@ import org.apache.lucene.analysis.Tokenizer;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
+import org.elasticsearch.env.TestEnvironment;
+import org.elasticsearch.index.IndexService.IndexCreationContext;
+import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.IndexVersions;
+import org.elasticsearch.index.analysis.AnalysisRegistry;
+import org.elasticsearch.index.analysis.IndexAnalyzers;
+import org.elasticsearch.index.analysis.NamedAnalyzer;
+import org.elasticsearch.index.analysis.PreBuiltAnalyzerProviderFactory;
 import org.elasticsearch.index.analysis.TokenizerFactory;
+import org.elasticsearch.index.mapper.TextFieldMapper;
+import org.elasticsearch.indices.analysis.AnalysisModule;
+import org.elasticsearch.plugins.scanners.StablePluginsRegistry;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.IndexSettingsModule;
 import org.elasticsearch.test.index.IndexVersionUtils;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 
+import static org.hamcrest.Matchers.equalTo;
+
 public class CommonAnalysisPluginTests extends ESTestCase {
+
+    // Assert analysis-common prebuilt analyzers are reused across indices and their position gap is 100.
+    public void testPrebuiltAnalyzersAreReusedWithElasticsearchPositionIncrementGap() throws IOException {
+        Settings nodeSettings = Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), createTempDir()).build();
+        Settings indexSettings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current()).build();
+        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings("index", indexSettings);
+
+        try (CommonAnalysisPlugin plugin = new CommonAnalysisPlugin()) {
+            AnalysisRegistry registry = new AnalysisModule(
+                TestEnvironment.newEnvironment(nodeSettings),
+                List.of(plugin),
+                new StablePluginsRegistry()
+            ).getAnalysisRegistry();
+
+            IndexAnalyzers firstIndex = registry.build(IndexCreationContext.CREATE_INDEX, idxSettings);
+            IndexAnalyzers secondIndex = registry.build(IndexCreationContext.CREATE_INDEX, idxSettings);
+
+            List<PreBuiltAnalyzerProviderFactory> prebuiltAnalyzers = plugin.getPreBuiltAnalyzerProviderFactories();
+            for (int i = 0; i < 5; i++) {
+                String name = randomFrom(prebuiltAnalyzers).getName();
+                NamedAnalyzer analyzer = firstIndex.get(name);
+                assertNotNull(name, analyzer);
+                assertThat(analyzer.getPositionIncrementGap(name), equalTo(TextFieldMapper.Defaults.POSITION_INCREMENT_GAP));
+                assertSame(analyzer, secondIndex.get(name));
+            }
+        }
+    }
 
     /**
      * Check that the deprecated "nGram" filter throws exception for indices created since 7.0.0 and

--- a/server/src/main/java/org/elasticsearch/index/analysis/AnalysisRegistry.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/AnalysisRegistry.java
@@ -703,9 +703,12 @@ public final class AnalysisRegistry implements Closeable {
     ) {
         /*
          * Lucene defaults positionIncrementGap to 0 in all analyzers but
-         * Elasticsearch defaults them to 0 only before version 2.0
-         * and 100 afterwards so we override the positionIncrementGap if it
-         * doesn't match here.
+         * Elasticsearch defaults it to 100 (see TextFieldMapper.Defaults) so we
+         * override the positionIncrementGap if it doesn't match here. Prebuilt
+         * analyzers already bake in this default (see PreBuiltAnalyzerProvider),
+         * so for those this override is a no-op and the shared instance is
+         * returned unchanged; it still applies to analyzers that arrive here
+         * without the Elasticsearch default set.
          */
         int overridePositionIncrementGap = TextFieldMapper.Defaults.POSITION_INCREMENT_GAP;
         if (analyzerFactory instanceof CustomAnalyzerProvider) {

--- a/server/src/main/java/org/elasticsearch/index/analysis/PreBuiltAnalyzerProvider.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/PreBuiltAnalyzerProvider.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.index.analysis;
 
 import org.apache.lucene.analysis.Analyzer;
+import org.elasticsearch.index.mapper.TextFieldMapper;
 
 public class PreBuiltAnalyzerProvider implements AnalyzerProvider<NamedAnalyzer> {
 
@@ -19,7 +20,7 @@ public class PreBuiltAnalyzerProvider implements AnalyzerProvider<NamedAnalyzer>
         // we create the named analyzer here so the resources associated with it will be shared
         // and we won't wrap a shared analyzer with named analyzer each time causing the resources
         // to not be shared...
-        this.analyzer = new NamedAnalyzer(name, scope, analyzer);
+        this.analyzer = new NamedAnalyzer(name, scope, analyzer, TextFieldMapper.Defaults.POSITION_INCREMENT_GAP);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/index/analysis/AnalysisRegistryTests.java
+++ b/server/src/test/java/org/elasticsearch/index/analysis/AnalysisRegistryTests.java
@@ -28,6 +28,7 @@ import org.elasticsearch.index.IndexService.IndexCreationContext;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.mapper.MapperException;
+import org.elasticsearch.index.mapper.TextFieldMapper;
 import org.elasticsearch.indices.analysis.AnalysisModule;
 import org.elasticsearch.indices.analysis.AnalysisModule.AnalysisProvider;
 import org.elasticsearch.indices.analysis.PreBuiltAnalyzers;
@@ -41,6 +42,7 @@ import org.elasticsearch.test.index.IndexVersionUtils;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import static java.util.Collections.emptyMap;
@@ -315,7 +317,32 @@ public class AnalysisRegistryTests extends ESTestCase {
         final int numIters = randomIntBetween(5, 20);
         for (int i = 0; i < numIters; i++) {
             PreBuiltAnalyzers preBuiltAnalyzers = RandomPicks.randomFrom(random(), PreBuiltAnalyzers.values());
-            assertSame(indexAnalyzers.get(preBuiltAnalyzers.name()), otherIndexAnalyzers.get(preBuiltAnalyzers.name()));
+            String name = preBuiltAnalyzers.name().toLowerCase(Locale.ROOT);
+            NamedAnalyzer analyzer = indexAnalyzers.get(name);
+            NamedAnalyzer otherAnalyzer = otherIndexAnalyzers.get(name);
+            assertNotNull(analyzer);
+            assertNotNull(otherAnalyzer);
+            // the underlying built-in analyzer instance is cached globally and shared across registries
+            assertSame(analyzer.analyzer(), otherAnalyzer.analyzer());
+        }
+    }
+
+    public void testPrebuiltAnalyzersAreReusedAcrossIndices() throws IOException {
+        Settings settings = Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toString()).build();
+        Settings indexSettings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current()).build();
+        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings("index", indexSettings);
+
+        // A single node-level registry serves all indices; build two index-level IndexAnalyzers from it
+        // to simulate two indices created on the same node.
+        AnalysisRegistry registry = emptyAnalysisRegistry(settings);
+        IndexAnalyzers firstIndex = registry.build(IndexCreationContext.CREATE_INDEX, idxSettings);
+        IndexAnalyzers secondIndex = registry.build(IndexCreationContext.CREATE_INDEX, idxSettings);
+
+        for (PreBuiltAnalyzers preBuiltAnalyzers : PreBuiltAnalyzers.values()) {
+            String name = preBuiltAnalyzers.name().toLowerCase(Locale.ROOT);
+            NamedAnalyzer analyzer = firstIndex.get(name);
+            assertSame(analyzer, secondIndex.get(name));
+            assertThat(analyzer.getPositionIncrementGap(name), equalTo(TextFieldMapper.Defaults.POSITION_INCREMENT_GAP));
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/index/analysis/PreBuiltAnalyzerTests.java
+++ b/server/src/test/java/org/elasticsearch/index/analysis/PreBuiltAnalyzerTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.TextFieldMapper;
 import org.elasticsearch.indices.analysis.PreBuiltAnalyzers;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESSingleNodeTestCase;
@@ -78,6 +79,19 @@ public class PreBuiltAnalyzerTests extends ESSingleNodeTestCase {
         IndexVersion v1 = IndexVersionUtils.randomVersion();
         IndexVersion v2 = new IndexVersion(v1.id() - 1, v1.luceneVersion());
         assertSame(PreBuiltAnalyzers.STOP.getAnalyzer(v1), PreBuiltAnalyzers.STOP.getAnalyzer(v2));
+    }
+
+    public void testThatPrebuiltAnalyzersHaveElasticsearchPositionIncrementGap() {
+        // PreBuiltAnalyzerProvider bakes in the Elasticsearch default position_increment_gap (100)
+        // rather than leaving Lucene's default of 0 to be overridden later per index.
+        PreBuiltAnalyzers randomPreBuiltAnalyzer = randomFrom(PreBuiltAnalyzers.values());
+        String analyzerName = randomPreBuiltAnalyzer.name().toLowerCase(Locale.ROOT);
+        NamedAnalyzer namedAnalyzer = new PreBuiltAnalyzerProvider(
+            analyzerName,
+            AnalyzerScope.INDICES,
+            randomPreBuiltAnalyzer.getAnalyzer(IndexVersion.current())
+        ).get();
+        assertThat(namedAnalyzer.getPositionIncrementGap(analyzerName), is(TextFieldMapper.Defaults.POSITION_INCREMENT_GAP));
     }
 
     public void testThatAnalyzersAreUsedInMapping() throws IOException {


### PR DESCRIPTION
This change affects all prebuilt analyzers:

  - server core (7): keyword, standard, default, stop, whitespace, simple, classic
  - analysis-common (39): pattern, snowball, and 37 language analyzers (arabic, chinese, english, french, ... thai)

Currently, when a node starts, AnalysisRegistry creates a NamedAnalyzer(Analyzer) for each prebuilt analyzer with position gap 0 (Lucene's default). Then, whenever an index needs an analyzer of the same name, we wrap it again into NamedAnalyzer(NamedAnalyzer(Analyzer), 100) to apply Elasticsearch's default gap of 100. This produces a fresh wrapper per index (and per getAnalyzer call), even though the inner shared instance is the same.

This change bakes the gap of 100 into the NamedAnalyzer created by PreBuiltAnalyzerProvider, so AnalysisRegistry::overridePositionIncrementGap becomes a no-op for prebuilt analyzers and the single shared instance is reused across all indices. This is safe because prebuilt analyzers are INDICES-scoped and are never closed per index.

The gap-0 form was never actually used as an effective analyzer: every consumer forced it to 100. The 0 default was a version-dependent artifact - Elasticsearch used 0 only before version 2.0 and 100 from 2.0 onward. Pre-2.0 indices can no longer be read, so the 0 path is dead and the gap is now unconditionally 100.

The override in AnalysisRegistry::produceAnalyzer is kept since it still applies to analyzers that arrive without the Elasticsearch default set.