### PR TITLE
[9.3] Fix Nynorsk stemmer UnsupportedOperationException (#150345)

### DIFF
--- a/docs/changelog/150345.yaml
+++ b/docs/changelog/150345.yaml
@@ -1,0 +1,7 @@
+area: Analysis
+issues: []
+pr: 150345
+summary: Fix Nynorsk stemmer `UnsupportedOperationException`. The `light_nynorsk`
+  and `minimal_nynorsk` stemmers no longer fail with an HTTP 500 error during index
+  creation due to passing an immutable map to Lucene's analysis factory.
+type: bug

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/StemmerTokenFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/StemmerTokenFilterFactory.java
@@ -79,7 +79,8 @@ import org.tartarus.snowball.ext.SwedishStemmer;
 import org.tartarus.snowball.ext.TurkishStemmer;
 
 import java.io.IOException;
-import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 public class StemmerTokenFilterFactory extends AbstractTokenFilterFactory {
 
@@ -242,12 +243,10 @@ public class StemmerTokenFilterFactory extends AbstractTokenFilterFactory {
 
                 // Norwegian (Nynorsk) stemmers
             } else if ("light_nynorsk".equalsIgnoreCase(language) || "lightNynorsk".equalsIgnoreCase(language)) {
-                NorwegianLightStemFilterFactory factory = new NorwegianLightStemFilterFactory(Collections.singletonMap("variant", "nn"));
+                NorwegianLightStemFilterFactory factory = new NorwegianLightStemFilterFactory(new HashMap<>(Map.of("variant", "nn")));
                 return factory.create(tokenStream);
             } else if ("minimal_nynorsk".equalsIgnoreCase(language) || "minimalNynorsk".equalsIgnoreCase(language)) {
-                NorwegianMinimalStemFilterFactory factory = new NorwegianMinimalStemFilterFactory(
-                    Collections.singletonMap("variant", "nn")
-                );
+                NorwegianMinimalStemFilterFactory factory = new NorwegianMinimalStemFilterFactory(new HashMap<>(Map.of("variant", "nn")));
                 return factory.create(tokenStream);
                 // Persian stemmers
             } else if ("persian".equalsIgnoreCase(language)) {

--- a/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/StemmerTokenFilterFactoryTests.java
+++ b/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/StemmerTokenFilterFactoryTests.java
@@ -141,6 +141,29 @@ public class StemmerTokenFilterFactoryTests extends ESTokenStreamTestCase {
         return analyzer;
     }
 
+    public void testNynorskStemmers() throws IOException {
+        for (String language : new String[] { "light_nynorsk", "lightNynorsk", "minimal_nynorsk", "minimalNynorsk" }) {
+            IndexVersion v = IndexVersionUtils.randomVersion();
+            Settings settings = Settings.builder()
+                .put("index.analysis.filter.my_nynorsk.type", "stemmer")
+                .put("index.analysis.filter.my_nynorsk.language", language)
+                .put("index.analysis.analyzer.my_nynorsk.tokenizer", "whitespace")
+                .put("index.analysis.analyzer.my_nynorsk.filter", "my_nynorsk")
+                .put(SETTING_VERSION_CREATED, v)
+                .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toString())
+                .build();
+
+            ESTestCase.TestAnalysis analysis = AnalysisTestsHelper.createTestAnalysisFromSettings(settings, PLUGIN);
+            TokenFilterFactory tokenFilter = analysis.tokenFilter.get("my_nynorsk");
+            assertThat(tokenFilter, instanceOf(StemmerTokenFilterFactory.class));
+            Tokenizer tokenizer = new WhitespaceTokenizer();
+            tokenizer.setReader(new StringReader("jenta"));
+            // Constructing the filter must not throw (see https://github.com/elastic/elasticsearch/issues/150341)
+            TokenStream create = tokenFilter.create(tokenizer);
+            assertNotNull(create);
+        }
+    }
+
     public void testKpDeprecation() throws IOException {
         IndexVersion v = IndexVersionUtils.randomVersion();
         Settings settings = Settings.builder()


### PR DESCRIPTION
Backports the following commits to 9.3:
 - Fix Nynorsk stemmer UnsupportedOperationException (#150345)