### PR TITLE
[8.19] Making enterprise ip location modified date consistent with non-enterprise (#149638)

### DIFF
--- a/docs/changelog/149638.yaml
+++ b/docs/changelog/149638.yaml
@@ -1,0 +1,5 @@
+area: Ingest Node
+issues: []
+pr: 149638
+summary: Making enterprise IP location modified date consistent with non-enterprise
+type: bug

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/EnterpriseGeoIpTaskState.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/EnterpriseGeoIpTaskState.java
@@ -37,11 +37,11 @@ import static org.elasticsearch.ingest.geoip.GeoIpDownloader.GEOIP_DOWNLOADER;
 import static org.elasticsearch.persistent.PersistentTasksCustomMetadata.getTaskWithId;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 
-class EnterpriseGeoIpTaskState implements PersistentTaskState, VersionedNamedWriteable {
+public class EnterpriseGeoIpTaskState implements PersistentTaskState, VersionedNamedWriteable {
 
     private static final ParseField DATABASES = new ParseField("databases");
 
-    static final EnterpriseGeoIpTaskState EMPTY = new EnterpriseGeoIpTaskState(Map.of());
+    public static final EnterpriseGeoIpTaskState EMPTY = new EnterpriseGeoIpTaskState(Map.of());
 
     @SuppressWarnings("unchecked")
     private static final ConstructingObjectParser<EnterpriseGeoIpTaskState, Void> PARSER = new ConstructingObjectParser<>(
@@ -146,7 +146,7 @@ class EnterpriseGeoIpTaskState implements PersistentTaskState, VersionedNamedWri
      * @return the geoip downloader's task state or null if there is not a state to read
      */
     @Nullable
-    static EnterpriseGeoIpTaskState getEnterpriseGeoIpTaskState(ClusterState state) {
+    public static EnterpriseGeoIpTaskState getEnterpriseGeoIpTaskState(ClusterState state) {
         PersistentTasksCustomMetadata.PersistentTask<?> task = getTaskWithId(state, EnterpriseGeoIpTask.ENTERPRISE_GEOIP_DOWNLOADER);
         return (task == null) ? null : (EnterpriseGeoIpTaskState) task.getState();
     }

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/direct/TransportGetDatabaseConfigurationAction.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/direct/TransportGetDatabaseConfigurationAction.java
@@ -19,6 +19,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.ingest.geoip.DatabaseNodeService;
+import org.elasticsearch.ingest.geoip.EnterpriseGeoIpTaskState;
 import org.elasticsearch.ingest.geoip.GeoIpTaskState;
 import org.elasticsearch.ingest.geoip.IngestGeoIpMetadata;
 import org.elasticsearch.injection.guice.Inject;
@@ -175,19 +176,33 @@ public class TransportGetDatabaseConfigurationAction extends TransportNodesActio
     private static Collection<DatabaseConfigurationMetadata> getMaxmindDatabases(ClusterService clusterService, String id) {
         List<DatabaseConfigurationMetadata> maxmindDatabases = new ArrayList<>();
         final IngestGeoIpMetadata geoIpMeta = clusterService.state().metadata().custom(IngestGeoIpMetadata.TYPE, IngestGeoIpMetadata.EMPTY);
+        EnterpriseGeoIpTaskState enterpriseTaskState = EnterpriseGeoIpTaskState.getEnterpriseGeoIpTaskState(projectMetadata);
         if (Regex.isSimpleMatchPattern(id)) {
             for (Map.Entry<String, DatabaseConfigurationMetadata> entry : geoIpMeta.getDatabases().entrySet()) {
                 if (Regex.simpleMatch(id, entry.getKey())) {
-                    maxmindDatabases.add(entry.getValue());
+                    maxmindDatabases.add(withLastUpdate(entry.getValue(), enterpriseTaskState));
                 }
             }
         } else {
             DatabaseConfigurationMetadata meta = geoIpMeta.getDatabases().get(id);
             if (meta != null) {
-                maxmindDatabases.add(meta);
+                maxmindDatabases.add(withLastUpdate(meta, enterpriseTaskState));
             }
         }
         return maxmindDatabases;
+    }
+
+    // non-private for unit testing
+    static DatabaseConfigurationMetadata withLastUpdate(DatabaseConfigurationMetadata meta, EnterpriseGeoIpTaskState enterpriseTaskState) {
+        if (enterpriseTaskState == null) {
+            return meta;
+        }
+        String databaseFileName = meta.database().name() + ".mmdb";
+        GeoIpTaskState.Metadata taskMetadata = enterpriseTaskState.getDatabases().get(databaseFileName);
+        if (taskMetadata == null) {
+            return meta;
+        }
+        return new DatabaseConfigurationMetadata(meta.database(), meta.version(), taskMetadata.lastUpdate());
     }
 
     @Override

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/direct/TransportGetDatabaseConfigurationAction.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/direct/TransportGetDatabaseConfigurationAction.java
@@ -176,7 +176,7 @@ public class TransportGetDatabaseConfigurationAction extends TransportNodesActio
     private static Collection<DatabaseConfigurationMetadata> getMaxmindDatabases(ClusterService clusterService, String id) {
         List<DatabaseConfigurationMetadata> maxmindDatabases = new ArrayList<>();
         final IngestGeoIpMetadata geoIpMeta = clusterService.state().metadata().custom(IngestGeoIpMetadata.TYPE, IngestGeoIpMetadata.EMPTY);
-        EnterpriseGeoIpTaskState enterpriseTaskState = EnterpriseGeoIpTaskState.getEnterpriseGeoIpTaskState(projectMetadata);
+        EnterpriseGeoIpTaskState enterpriseTaskState = EnterpriseGeoIpTaskState.getEnterpriseGeoIpTaskState(clusterService.state());
         if (Regex.isSimpleMatchPattern(id)) {
             for (Map.Entry<String, DatabaseConfigurationMetadata> entry : geoIpMeta.getDatabases().entrySet()) {
                 if (Regex.simpleMatch(id, entry.getKey())) {

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/direct/TransportGetDatabaseConfigurationActionTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/direct/TransportGetDatabaseConfigurationActionTests.java
@@ -10,6 +10,8 @@
 package org.elasticsearch.ingest.geoip.direct;
 
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.ingest.geoip.EnterpriseGeoIpTaskState;
+import org.elasticsearch.ingest.geoip.GeoIpTaskState;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.ArrayList;
@@ -104,6 +106,43 @@ public class TransportGetDatabaseConfigurationActionTests extends ESTestCase {
             DatabaseConfigurationMetadata result = deduplicated.iterator().next();
             assertThat(result, equalTo(nodeResponses.get(1).getDatabases().get(0)));
         }
+    }
+
+    public void testWithLastUpdate() {
+        DatabaseConfiguration config = new DatabaseConfiguration("my-db-id", "GeoLite2-City", new DatabaseConfiguration.Maxmind("test"));
+        long putTime = 1000L;
+        DatabaseConfigurationMetadata meta = new DatabaseConfigurationMetadata(config, 1, putTime);
+
+        // null task state returns the original metadata unchanged
+        assertThat(TransportGetDatabaseConfigurationAction.withLastUpdate(meta, null).modifiedDate(), equalTo(putTime));
+
+        // task state with no matching database returns the original metadata unchanged
+        EnterpriseGeoIpTaskState emptyTaskState = EnterpriseGeoIpTaskState.EMPTY;
+        assertThat(TransportGetDatabaseConfigurationAction.withLastUpdate(meta, emptyTaskState).modifiedDate(), equalTo(putTime));
+
+        // task state with a matching database returns the lastUpdate from the task state
+        long downloadTime = 5000L;
+        GeoIpTaskState.Metadata taskMeta = new GeoIpTaskState.Metadata(downloadTime, 0, 5, "md5", downloadTime, null);
+        EnterpriseGeoIpTaskState taskState = EnterpriseGeoIpTaskState.EMPTY.put("GeoLite2-City.mmdb", taskMeta);
+        DatabaseConfigurationMetadata result = TransportGetDatabaseConfigurationAction.withLastUpdate(meta, taskState);
+        assertThat(result.modifiedDate(), equalTo(downloadTime));
+        assertThat(result.database(), equalTo(config));
+        assertThat(result.version(), equalTo(1L));
+
+        // ipinfo provider works the same way
+        DatabaseConfiguration ipinfoConfig = new DatabaseConfiguration(
+            "my-ipinfo-id",
+            "standard_privacy",
+            new DatabaseConfiguration.Ipinfo()
+        );
+        DatabaseConfigurationMetadata ipinfoMeta = new DatabaseConfigurationMetadata(ipinfoConfig, 2, putTime);
+        long ipinfoDownloadTime = 7000L;
+        GeoIpTaskState.Metadata ipinfoTaskMeta = new GeoIpTaskState.Metadata(ipinfoDownloadTime, 0, 5, "md5", ipinfoDownloadTime, null);
+        EnterpriseGeoIpTaskState ipinfoTaskState = EnterpriseGeoIpTaskState.EMPTY.put("standard_privacy.mmdb", ipinfoTaskMeta);
+        DatabaseConfigurationMetadata ipinfoResult = TransportGetDatabaseConfigurationAction.withLastUpdate(ipinfoMeta, ipinfoTaskState);
+        assertThat(ipinfoResult.modifiedDate(), equalTo(ipinfoDownloadTime));
+        assertThat(ipinfoResult.database(), equalTo(ipinfoConfig));
+        assertThat(ipinfoResult.version(), equalTo(2L));
     }
 
     private NodeResponse generateTestNodeResponse(List<String> databaseNames) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Making enterprise ip location modified date consistent with non-enterprise (#149638)](https://github.com/elastic/elasticsearch/pull/149638)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)