### PR TITLE
[9.4] Validate inference embedding model before checking for existing uses (#150150)

### DIFF
--- a/docs/changelog/150150.yaml
+++ b/docs/changelog/150150.yaml
@@ -1,0 +1,7 @@
+area: Inference
+issues:
+ - 147062
+ - 150084
+pr: 150150
+summary: Validate inference embedding model before checking for existing uses
+type: bug

--- a/x-pack/plugin/inference/qa/inference-service-tests/build.gradle
+++ b/x-pack/plugin/inference/qa/inference-service-tests/build.gradle
@@ -11,6 +11,9 @@ dependencies {
 
   // Access public test classes/utilities from x-pack:inference tests
   javaRestTestImplementation(testArtifact(project(xpackModule('inference'))))
+
+  // Added this to have access to TestDenseInferenceServiceExtension within the tests
+  javaRestTestImplementation(project(":x-pack:plugin:inference:qa:test-service-plugin"))
 }
 
 tasks.named("javaRestTest").configure {

--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceBaseRestTest.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceBaseRestTest.java
@@ -199,6 +199,21 @@ public class InferenceBaseRestTest extends ESRestTestCase {
             """, dimensions);
     }
 
+    static String mockTextEmbeddingServiceModelConfig_NoDimensions() {
+        return Strings.format("""
+            {
+              "task_type": "text_embedding",
+              "service": "text_embedding_test_service",
+              "service_settings": {
+                "model": "my_dense_vector_model",
+                "api_key": "abc64"
+              },
+              "task_settings": {
+              }
+            }
+            """);
+    }
+
     static String mockRerankServiceModelConfig() {
         return """
             {
@@ -231,6 +246,21 @@ public class InferenceBaseRestTest extends ESRestTestCase {
               }
             }
             """, dimensions);
+    }
+
+    static String mockEmbeddingServiceModelConfig_NoDimensions() {
+        return Strings.format("""
+            {
+              "task_type": "embedding",
+              "service": "text_embedding_test_service",
+              "service_settings": {
+                "model": "my_dense_vector_model",
+                "api_key": "abc64"
+              },
+              "task_settings": {
+              }
+            }
+            """);
     }
 
     static void deleteModel(String modelId) throws IOException {

--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceCrudIT.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceCrudIT.java
@@ -573,7 +573,7 @@ public class InferenceCrudIT extends InferenceBaseRestTest {
         assertThat(singleModel.get("task_type"), is(EMBEDDING.toString()));
         try {
             var input = List.of(
-                new InferenceString(DataType.IMAGE, DataFormat.BASE64, "data:image/jpeg;base64," + randomAlphaOfLength(5)),
+                new InferenceString(DataType.IMAGE, DataFormat.BASE64, "data:image/jpeg;base64," + randomAlphaOfLength(4)),
                 new InferenceString(DataType.TEXT, randomAlphaOfLength(15))
             );
             var resultMap = embedding(modelId, input);

--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceCrudIT.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceCrudIT.java
@@ -24,6 +24,7 @@ import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.results.EmbeddingResults;
 import org.elasticsearch.xpack.core.inference.results.GenericDenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.inference.mock.TestDenseInferenceServiceExtension;
 
 import java.io.IOException;
 import java.util.Iterator;
@@ -397,6 +398,89 @@ public class InferenceCrudIT extends InferenceBaseRestTest {
         deleteIndex(indexName2);
 
         deleteModel(otherEndpointId, "force=true");
+    }
+
+    public void testCreateEndpoint_WithInferenceIdReferencedBySemanticText_DimensionsNotSpecified() throws IOException {
+        final String endpointId = "endpoint_referenced_by_semantic_text";
+        final String indexName = randomAlphaOfLength(10).toLowerCase();
+
+        // Create an index using the endpoint ID before creating the endpoint
+        putSemanticText(endpointId, endpointId, indexName);
+
+        // Create a model without dimensions specified
+        putModel(endpointId, mockTextEmbeddingServiceModelConfig_NoDimensions(), TEXT_EMBEDDING);
+
+        // Index a document with the semantic text field into the index
+        var request = new Request("PUT", indexName + "/_create/1");
+        request.setJsonEntity("{\"inference_field\": \"value\"}");
+        assertStatusOkOrCreated(client().performRequest(request));
+
+        assertStatusOkOrCreated(client().performRequest(new Request("GET", "_refresh")));
+
+        deleteModel(endpointId, "force=true");
+
+        // Try to create an inference endpoint with the same ID but different dimensions
+        // from when the document with the semantic text field was indexed
+        var differentDimensions = TestDenseInferenceServiceExtension.DEFAULT_EMBEDDING_DIMENSIONS * 2;
+        ResponseException responseException = assertThrows(
+            ResponseException.class,
+            () -> putModel(endpointId, mockTextEmbeddingServiceModelConfig(differentDimensions), TEXT_EMBEDDING)
+        );
+        var expectedMessage = Strings.format(
+            "Inference endpoint [%s] could not be created because the inference_id is being used in mappings with incompatible settings "
+                + "for indices: [%s]. Please either use a different inference_id or update the index mappings to refer to a different "
+                + "inference_id.",
+            endpointId,
+            indexName
+        );
+        assertThat(responseException.getMessage(), containsString(expectedMessage));
+
+        deleteIndex(indexName);
+    }
+
+    public void testCreateEndpoint_DoesValidationCallBeforeCheckingExistingUses() throws IOException {
+        final String endpointId = "endpoint_referenced_by_semantic_text";
+        final String indexName = randomAlphaOfLength(10).toLowerCase();
+
+        // Create an index using the endpoint ID before creating the endpoint
+        putSemanticText(endpointId, endpointId, indexName);
+
+        // Create a model without dimensions specified
+        String modelConfig = mockTextEmbeddingServiceModelConfig_NoDimensions();
+        putModel(endpointId, modelConfig, TEXT_EMBEDDING);
+
+        // Index a document with the semantic text field into the index
+        var request = new Request("PUT", indexName + "/_create/1");
+        request.setJsonEntity("{\"inference_field\": \"value\"}");
+        assertStatusOkOrCreated(client().performRequest(request));
+
+        assertStatusOkOrCreated(client().performRequest(new Request("GET", "_refresh")));
+
+        deleteModel(endpointId, "force=true");
+
+        // Try to create an inference endpoint with the same ID but different dimensions
+        // from when the document with the semantic text field was indexed, but force the validation to fail
+        var differentDimensions = TestDenseInferenceServiceExtension.DEFAULT_EMBEDDING_DIMENSIONS * 2;
+        var requestBody = Strings.format("""
+            {
+              "task_type": "text_embedding",
+              "service": "text_embedding_test_service",
+              "service_settings": {
+                "model": "my_dense_vector_model",
+                "api_key": "abc64",
+                "dimensions": %s
+              },
+              "task_settings": {
+                "should_fail_validation": true
+              }
+            }
+            """, differentDimensions);
+        var responseException = assertThrows(ResponseException.class, () -> putModel(endpointId, requestBody, TEXT_EMBEDDING));
+
+        // We expect the error message to be from the validation, not the incompatible mappings
+        assertThat(responseException.getMessage(), containsString("validation call intentionally failed based on task settings"));
+
+        deleteIndex(indexName);
     }
 
     public void testUnsupportedStream() throws Exception {

--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/MockDenseInferenceServiceIT.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/MockDenseInferenceServiceIT.java
@@ -18,6 +18,7 @@ import org.junit.After;
 import org.junit.Before;
 
 import java.io.IOException;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 
@@ -103,7 +104,11 @@ public class MockDenseInferenceServiceIT extends InferenceBaseRestTest {
         var inference = embedding(
             inferenceEntityId,
             List.of(
-                new InferenceString(DataType.IMAGE, DataFormat.BASE64, "data:image/jpeg;base64," + randomAlphaOfLength(5)),
+                new InferenceString(
+                    DataType.IMAGE,
+                    DataFormat.BASE64,
+                    "data:image/jpeg;base64," + Base64.getEncoder().encodeToString(randomByteArrayOfLength(5))
+                ),
                 new InferenceString(DataType.TEXT, randomAlphaOfLength(10)),
                 new InferenceString(DataType.TEXT, randomAlphaOfLength(15))
             )
@@ -159,7 +164,7 @@ public class MockDenseInferenceServiceIT extends InferenceBaseRestTest {
             assertThat(serviceSettings.get("dimensions"), is(DEFAULT_EMBEDDING_DIMENSIONS));
         }
 
-        var input = List.of(InferenceString.ofText(randomAlphaOfLength(10)));
+        var input = List.of(new InferenceString(DataType.TEXT, randomAlphaOfLength(10)));
         var resultMap = embedding(inferenceEntityId, input);
         @SuppressWarnings("unchecked")
         var embeddings = (List<Map<String, List<Float>>>) resultMap.get(GenericDenseEmbeddingFloatResults.EMBEDDINGS);

--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/MockDenseInferenceServiceIT.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/MockDenseInferenceServiceIT.java
@@ -11,15 +11,35 @@ import org.elasticsearch.inference.DataFormat;
 import org.elasticsearch.inference.DataType;
 import org.elasticsearch.inference.InferenceString;
 import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.EmbeddingResults;
+import org.elasticsearch.xpack.core.inference.results.GenericDenseEmbeddingFloatResults;
+import org.junit.After;
+import org.junit.Before;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
+import static org.elasticsearch.xpack.inference.mock.TestDenseInferenceServiceExtension.DEFAULT_EMBEDDING_DIMENSIONS;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
 public class MockDenseInferenceServiceIT extends InferenceBaseRestTest {
 
+    private String inferenceEntityId;
+
+    @Before
+    public void init() {
+        inferenceEntityId = randomIdentifier();
+    }
+
+    @After
+    public void shutdown() throws IOException {
+        deleteModel(inferenceEntityId);
+    }
+
     public void testMockService() throws IOException {
-        String inferenceEntityId = "test-mock";
         var putModel = putModel(inferenceEntityId, mockTextEmbeddingServiceModelConfig(), TaskType.TEXT_EMBEDDING);
         var model = getModels(inferenceEntityId, TaskType.TEXT_EMBEDDING).get(0);
 
@@ -39,7 +59,6 @@ public class MockDenseInferenceServiceIT extends InferenceBaseRestTest {
     }
 
     public void testMockServiceWithMultipleInputs() throws IOException {
-        String inferenceEntityId = "test-mock-with-multi-inputs";
         putModel(inferenceEntityId, mockTextEmbeddingServiceModelConfig(), TaskType.TEXT_EMBEDDING);
 
         // The response is randomly generated, the input can be anything
@@ -53,7 +72,6 @@ public class MockDenseInferenceServiceIT extends InferenceBaseRestTest {
     }
 
     public void testMockService_withEmbeddingTask() throws IOException {
-        String inferenceEntityId = "test-mock-embedding";
         var putModel = putModel(inferenceEntityId, mockEmbeddingServiceModelConfig(), TaskType.EMBEDDING);
         var model = getModels(inferenceEntityId, TaskType.EMBEDDING).getFirst();
 
@@ -79,7 +97,6 @@ public class MockDenseInferenceServiceIT extends InferenceBaseRestTest {
     }
 
     public void testMockServiceWithMultipleInputs_withEmbeddingTask() throws IOException {
-        String inferenceEntityId = "test-mock-with-multi-inputs-embedding";
         putModel(inferenceEntityId, mockEmbeddingServiceModelConfig(), TaskType.EMBEDDING);
 
         // The response is randomly generated, the input can be anything
@@ -97,7 +114,6 @@ public class MockDenseInferenceServiceIT extends InferenceBaseRestTest {
 
     @SuppressWarnings("unchecked")
     public void testMockService_DoesNotReturnSecretsInGetResponse() throws IOException {
-        String inferenceEntityId = "test-mock";
         var putModel = putModel(inferenceEntityId, mockTextEmbeddingServiceModelConfig(), TaskType.TEXT_EMBEDDING);
         var model = getModels(inferenceEntityId, TaskType.TEXT_EMBEDDING).get(0);
 
@@ -108,5 +124,45 @@ public class MockDenseInferenceServiceIT extends InferenceBaseRestTest {
         var putServiceSettings = (Map<String, Object>) putModel.get("service_settings");
         assertNull(putServiceSettings.get("api_key"));
         assertNotNull(putServiceSettings.get("model"));
+    }
+
+    public void testMockService_DimensionsNotSpecified_TextEmbedding() throws IOException {
+        var putModel = putModel(inferenceEntityId, mockTextEmbeddingServiceModelConfig_NoDimensions(), TaskType.TEXT_EMBEDDING);
+        var model = getModels(inferenceEntityId, TaskType.TEXT_EMBEDDING).get(0);
+
+        for (var modelMap : List.of(putModel, model)) {
+            assertEquals(inferenceEntityId, modelMap.get("inference_id"));
+            assertEquals(TaskType.TEXT_EMBEDDING, TaskType.fromString((String) modelMap.get("task_type")));
+            assertEquals("text_embedding_test_service", modelMap.get("service"));
+            @SuppressWarnings("unchecked")
+            Map<String, Object> serviceSettings = (Map<String, Object>) modelMap.get("service_settings");
+            assertThat(serviceSettings.get("dimensions"), is(DEFAULT_EMBEDDING_DIMENSIONS));
+        }
+
+        var input = List.of(randomAlphaOfLength(10));
+        var resultMap = infer(inferenceEntityId, input);
+        @SuppressWarnings("unchecked")
+        var embeddings = (List<Map<String, List<Float>>>) resultMap.get(DenseEmbeddingFloatResults.TEXT_EMBEDDING);
+        assertThat(embeddings.getFirst().get(EmbeddingResults.EMBEDDING), hasSize(DEFAULT_EMBEDDING_DIMENSIONS));
+    }
+
+    public void testMockService_DimensionsNotSpecified_Embedding() throws IOException {
+        var putModel = putModel(inferenceEntityId, mockEmbeddingServiceModelConfig_NoDimensions(), TaskType.EMBEDDING);
+        var model = getModels(inferenceEntityId, TaskType.EMBEDDING).get(0);
+
+        for (var modelMap : List.of(putModel, model)) {
+            assertEquals(inferenceEntityId, modelMap.get("inference_id"));
+            assertEquals(TaskType.EMBEDDING, TaskType.fromString((String) modelMap.get("task_type")));
+            assertEquals("text_embedding_test_service", modelMap.get("service"));
+            @SuppressWarnings("unchecked")
+            Map<String, Object> serviceSettings = (Map<String, Object>) modelMap.get("service_settings");
+            assertThat(serviceSettings.get("dimensions"), is(DEFAULT_EMBEDDING_DIMENSIONS));
+        }
+
+        var input = List.of(InferenceString.ofText(randomAlphaOfLength(10)));
+        var resultMap = embedding(inferenceEntityId, input);
+        @SuppressWarnings("unchecked")
+        var embeddings = (List<Map<String, List<Float>>>) resultMap.get(GenericDenseEmbeddingFloatResults.EMBEDDINGS);
+        assertThat(embeddings.getFirst().get(EmbeddingResults.EMBEDDING), hasSize(DEFAULT_EMBEDDING_DIMENSIONS));
     }
 }

--- a/x-pack/plugin/inference/qa/test-service-plugin/src/main/java/org/elasticsearch/xpack/inference/mock/TestDenseInferenceServiceExtension.java
+++ b/x-pack/plugin/inference/qa/test-service-plugin/src/main/java/org/elasticsearch/xpack/inference/mock/TestDenseInferenceServiceExtension.java
@@ -16,9 +16,9 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.util.LazyInitializable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
-import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
 import org.elasticsearch.inference.ChunkInferenceInput;
 import org.elasticsearch.inference.ChunkedInference;
+import org.elasticsearch.inference.DataFormat;
 import org.elasticsearch.inference.EmbeddingRequest;
 import org.elasticsearch.inference.InferenceServiceConfiguration;
 import org.elasticsearch.inference.InferenceServiceExtension;
@@ -39,12 +39,21 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.core.inference.results.ChunkedInferenceEmbedding;
+import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingBitResults;
+import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingByteResults;
 import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingResults;
+import org.elasticsearch.xpack.core.inference.results.EmbeddingByteResults;
+import org.elasticsearch.xpack.core.inference.results.EmbeddingResults;
+import org.elasticsearch.xpack.core.inference.results.GenericDenseEmbeddingBitResults;
+import org.elasticsearch.xpack.core.inference.results.GenericDenseEmbeddingByteResults;
 import org.elasticsearch.xpack.core.inference.results.GenericDenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.inference.services.ServiceUtils;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -52,7 +61,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import static org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper.*;
+
 public class TestDenseInferenceServiceExtension implements InferenceServiceExtension {
+
+    public static final int DEFAULT_EMBEDDING_DIMENSIONS = 128;
+
     @Override
     public List<Factory> getInferenceServiceFactories() {
         return List.of(TestInferenceService::new);
@@ -129,12 +143,11 @@ public class TestDenseInferenceServiceExtension implements InferenceServiceExten
                 listener.onFailure(new RuntimeException("validation call intentionally failed based on task settings"));
                 return;
             }
-            switch (model.getConfigurations().getTaskType()) {
-                case TEXT_EMBEDDING, EMBEDDING -> {
-                    ServiceSettings modelServiceSettings = model.getServiceSettings();
-                    listener.onResponse(makeTextEmbeddingResults(input, modelServiceSettings));
-                }
-                default -> listener.onFailure(
+            if (Objects.requireNonNull(model.getConfigurations().getTaskType()) == TaskType.TEXT_EMBEDDING) {
+                ServiceSettings modelServiceSettings = model.getServiceSettings();
+                listener.onResponse(makeTextEmbeddingResults(input, modelServiceSettings));
+            } else {
+                listener.onFailure(
                     new ElasticsearchStatusException(
                         TaskType.unsupportedTaskTypeErrorMsg(model.getConfigurations().getTaskType(), name()),
                         RestStatus.BAD_REQUEST
@@ -160,6 +173,11 @@ public class TestDenseInferenceServiceExtension implements InferenceServiceExten
             TimeValue timeout,
             ActionListener<InferenceServiceResults> listener
         ) {
+            if (Objects.equals((((TestTaskSettings) model.getTaskSettings()).shouldFailValidation()), Boolean.TRUE)) {
+                listener.onFailure(new RuntimeException("validation call intentionally failed based on task settings"));
+                return;
+            }
+
             if (model.getConfigurations().getTaskType() == TaskType.EMBEDDING) {
                 ServiceSettings modelServiceSettings = model.getServiceSettings();
                 listener.onResponse(makeGenericEmbeddingResults(request.inputs(), modelServiceSettings));
@@ -196,60 +214,125 @@ public class TestDenseInferenceServiceExtension implements InferenceServiceExten
             }
         }
 
-        private DenseEmbeddingFloatResults makeTextEmbeddingResults(List<String> input, ServiceSettings serviceSettings) {
-            List<DenseEmbeddingFloatResults.Embedding> embeddings = new ArrayList<>();
-            for (String inputString : input) {
-                List<Float> floatEmbeddings = generateEmbedding(
-                    inputString,
-                    serviceSettings.dimensions(),
-                    serviceSettings.elementType(),
-                    serviceSettings.similarity()
+        @Override
+        public Model updateModelWithEmbeddingDetails(Model model, int embeddingSize) {
+            if (model instanceof TestServiceModel testServiceModel) {
+                var serviceSettings = testServiceModel.getServiceSettings();
+
+                var updatedServiceSettings = new TestServiceSettings(
+                    serviceSettings.modelId(),
+                    embeddingSize,
+                    serviceSettings.similarity(),
+                    serviceSettings.elementType()
                 );
-                embeddings.add(DenseEmbeddingFloatResults.Embedding.of(floatEmbeddings));
+
+                return new TestServiceModel(
+                    testServiceModel.getInferenceEntityId(),
+                    testServiceModel.getTaskType(),
+                    testServiceModel.getConfigurations().getService(),
+                    updatedServiceSettings,
+                    testServiceModel.getTaskSettings(),
+                    testServiceModel.getSecretSettings()
+                );
+            } else {
+                throw ServiceUtils.invalidModelTypeForUpdateModelWithEmbeddingDetails(model.getClass());
             }
-            return new DenseEmbeddingFloatResults(embeddings);
         }
 
-        private GenericDenseEmbeddingFloatResults makeGenericEmbeddingResults(
-            List<InferenceStringGroup> input,
-            ServiceSettings serviceSettings
-        ) {
-            List<GenericDenseEmbeddingFloatResults.Embedding> embeddings = new ArrayList<>();
+        private DenseEmbeddingResults<?> makeTextEmbeddingResults(List<String> input, ServiceSettings serviceSettings) {
+            List<List<Float>> floatEmbeddings = new ArrayList<>();
+            for (String inputString : input) {
+                floatEmbeddings.add(
+                    generateEmbedding(
+                        inputString,
+                        serviceSettings.dimensions(),
+                        serviceSettings.elementType(),
+                        serviceSettings.similarity()
+                    )
+                );
+            }
+
+            return switch (serviceSettings.elementType()) {
+                case FLOAT, BFLOAT16 -> new DenseEmbeddingFloatResults(
+                    floatEmbeddings.stream().map(DenseEmbeddingFloatResults.Embedding::of).toList()
+                );
+                case BYTE -> new DenseEmbeddingByteResults(
+                    floatEmbeddings.stream()
+                        .map(floats -> EmbeddingByteResults.Embedding.of(floats.stream().map(f -> (byte) f.floatValue()).toList()))
+                        .toList()
+                );
+                case BIT -> new DenseEmbeddingBitResults(
+                    floatEmbeddings.stream()
+                        .map(floats -> EmbeddingByteResults.Embedding.of(floats.stream().map(f -> (byte) f.floatValue()).toList()))
+                        .toList()
+                );
+            };
+        }
+
+        private DenseEmbeddingResults<?> makeGenericEmbeddingResults(List<InferenceStringGroup> input, ServiceSettings serviceSettings) {
+            List<List<Float>> averagedEmbeddings = new ArrayList<>();
             for (var inputContent : input) {
                 // For multiple inputs that generate one embedding, average the embeddings for each input
                 List<InferenceString> inferenceStrings = inputContent.inferenceStrings();
-                List<Float> averagedFloatEmbeddings = inferenceStrings.stream()
-                    .map(
-                        inferenceString -> generateEmbedding(
-                            inferenceString.value(),
-                            serviceSettings.dimensions(),
-                            serviceSettings.elementType(),
-                            serviceSettings.similarity()
-                        )
-                    )
-                    .reduce((list1, list2) -> {
-                        List<Float> summedValues = new ArrayList<>(list1.size());
-                        for (int i = 0; i < list1.size(); i++) {
-                            summedValues.add(list1.get(i) + list2.get(i));
+                List<Float> averagedFloatEmbeddings = inferenceStrings.stream().map(inferenceString -> {
+                    String inputValue = inferenceString.value();
+                    if (inferenceString.dataFormat() == DataFormat.BASE64) {
+                        // Check for base64 data URI format and extract the base64 content if it exists,
+                        // otherwise treat the entire string as base64 content
+                        String[] split = inputValue.split("base64,");
+                        if (split.length > 1) {
+                            inputValue = split[1];
                         }
-                        return summedValues;
-                    })
-                    .orElse(Collections.emptyList())
-                    .stream()
-                    .map(f -> f / inferenceStrings.size())
-                    .toList();
-                embeddings.add(GenericDenseEmbeddingFloatResults.Embedding.of(averagedFloatEmbeddings));
+
+                        inputValue = new String(Base64.getDecoder().decode(inputValue), StandardCharsets.UTF_8);
+                    }
+                    List<Float> embedding = generateEmbedding(
+                        inputValue,
+                        serviceSettings.dimensions(),
+                        serviceSettings.elementType(),
+                        serviceSettings.similarity()
+                    );
+                    if (inferenceString.isImage()) {
+                        return embedding.stream().map(f -> -f).toList();
+                    }
+                    return embedding;
+                }).reduce((list1, list2) -> {
+                    List<Float> summedValues = new ArrayList<>(list1.size());
+                    for (int i = 0; i < list1.size(); i++) {
+                        summedValues.add(list1.get(i) + list2.get(i));
+                    }
+                    return summedValues;
+                }).orElse(Collections.emptyList()).stream().map(f -> f / inferenceStrings.size()).toList();
+                averagedEmbeddings.add(averagedFloatEmbeddings);
             }
-            return new GenericDenseEmbeddingFloatResults(embeddings);
+
+            return switch (serviceSettings.elementType()) {
+                case FLOAT, BFLOAT16 -> {
+                    var floatEmbeddings = averagedEmbeddings.stream().map(GenericDenseEmbeddingFloatResults.Embedding::of).toList();
+                    yield new GenericDenseEmbeddingFloatResults(floatEmbeddings);
+                }
+                case BYTE -> {
+                    var byteEmbeddings = averagedEmbeddings.stream()
+                        .map(floats -> EmbeddingByteResults.Embedding.of(floats.stream().map(f -> (byte) f.floatValue()).toList()))
+                        .toList();
+                    yield new GenericDenseEmbeddingByteResults(byteEmbeddings);
+                }
+                case BIT -> {
+                    var bitEmbeddings = averagedEmbeddings.stream()
+                        .map(floats -> EmbeddingByteResults.Embedding.of(floats.stream().map(f -> (byte) f.floatValue()).toList()))
+                        .toList();
+                    yield new GenericDenseEmbeddingBitResults(bitEmbeddings);
+                }
+            };
         }
 
         private List<ChunkedInference> makeChunkedResults(List<ChunkInferenceInput> inputs, ServiceSettings serviceSettings) {
             var results = new ArrayList<ChunkedInference>();
             for (ChunkInferenceInput input : inputs) {
                 List<ChunkedInput> chunkedInput = chunkInputs(input);
-                List<DenseEmbeddingFloatResults.Chunk> chunks = chunkedInput.stream()
+                List<EmbeddingResults.Chunk> chunks = chunkedInput.stream()
                     .map(
-                        c -> new DenseEmbeddingFloatResults.Chunk(
+                        c -> new EmbeddingResults.Chunk(
                             makeTextEmbeddingResults(List.of(c.input()), serviceSettings).embeddings().get(0),
                             new ChunkedInference.TextOffset(c.startOffset(), c.endOffset())
                         )
@@ -295,14 +378,14 @@ public class TestDenseInferenceServiceExtension implements InferenceServiceExten
          * </p>
          *
          * @param input             The input string
-         * @param dimensions        The embedding dimension count
+         * @param dimensions        The embedding dimension count. If null, {@link #DEFAULT_EMBEDDING_DIMENSIONS} will be used
          * @param similarityMeasure The similarity measure
          * @return An embedding
          */
         private static List<Float> generateEmbedding(
             String input,
-            int dimensions,
-            DenseVectorFieldMapper.ElementType elementType,
+            @Nullable Integer dimensions,
+            ElementType elementType,
             SimilarityMeasure similarityMeasure
         ) {
             int embeddingLength = getEmbeddingLength(elementType, dimensions);
@@ -330,7 +413,14 @@ public class TestDenseInferenceServiceExtension implements InferenceServiceExten
         }
 
         // Copied from DenseVectorFieldMapperTestUtils due to dependency restrictions
-        private static int getEmbeddingLength(DenseVectorFieldMapper.ElementType elementType, int dimensions) {
+        private static int getEmbeddingLength(ElementType elementType, @Nullable Integer dimensions) {
+            if (dimensions == null) {
+                dimensions = DEFAULT_EMBEDDING_DIMENSIONS;
+            }
+            return getDimensionsForElementType(elementType, dimensions);
+        }
+
+        private static int getDimensionsForElementType(ElementType elementType, int dimensions) {
             return switch (elementType) {
                 case FLOAT, BFLOAT16, BYTE -> dimensions;
                 case BIT -> {
@@ -376,9 +466,9 @@ public class TestDenseInferenceServiceExtension implements InferenceServiceExten
 
     public record TestServiceSettings(
         String model,
-        Integer dimensions,
-        SimilarityMeasure similarity,
-        DenseVectorFieldMapper.ElementType elementType
+        @Nullable Integer dimensions,
+        @Nullable SimilarityMeasure similarity,
+        @Nullable ElementType elementType
     ) implements ServiceSettings {
 
         static final String NAME = "test_text_embedding_service_settings";
@@ -396,9 +486,6 @@ public class TestDenseInferenceServiceExtension implements InferenceServiceExten
             }
 
             Integer dimensions = (Integer) map.remove("dimensions");
-            if (dimensions == null) {
-                validationException.addValidationError("missing dimensions");
-            }
 
             SimilarityMeasure similarity = null;
             String similarityStr = (String) map.remove("similarity");
@@ -406,10 +493,10 @@ public class TestDenseInferenceServiceExtension implements InferenceServiceExten
                 similarity = SimilarityMeasure.fromString(similarityStr);
             }
 
-            DenseVectorFieldMapper.ElementType elementType = null;
+            ElementType elementType = null;
             String elementTypeStr = (String) map.remove("element_type");
             if (elementTypeStr != null) {
-                elementType = DenseVectorFieldMapper.ElementType.fromString(elementTypeStr);
+                elementType = ElementType.fromString(elementTypeStr);
             }
 
             validationException.throwIfValidationErrorsExist();
@@ -420,9 +507,9 @@ public class TestDenseInferenceServiceExtension implements InferenceServiceExten
         public TestServiceSettings(StreamInput in) throws IOException {
             this(
                 in.readString(),
-                in.readInt(),
+                in.readOptionalVInt(),
                 in.readOptionalEnum(SimilarityMeasure.class),
-                in.readOptionalEnum(DenseVectorFieldMapper.ElementType.class)
+                in.readOptionalEnum(ElementType.class)
             );
         }
 
@@ -430,7 +517,9 @@ public class TestDenseInferenceServiceExtension implements InferenceServiceExten
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.startObject();
             builder.field("model", model);
-            builder.field("dimensions", dimensions);
+            if (dimensions != null) {
+                builder.field("dimensions", dimensions);
+            }
             if (similarity != null) {
                 builder.field("similarity", similarity);
             }
@@ -454,7 +543,7 @@ public class TestDenseInferenceServiceExtension implements InferenceServiceExten
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeString(model);
-            out.writeInt(dimensions);
+            out.writeOptionalVInt(dimensions);
             out.writeOptionalEnum(similarity);
             out.writeOptionalEnum(elementType);
         }
@@ -470,8 +559,8 @@ public class TestDenseInferenceServiceExtension implements InferenceServiceExten
         }
 
         @Override
-        public DenseVectorFieldMapper.ElementType elementType() {
-            return elementType != null ? elementType : DenseVectorFieldMapper.ElementType.FLOAT;
+        public ElementType elementType() {
+            return elementType != null ? elementType : ElementType.FLOAT;
         }
 
         @Override

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportPutInferenceModelAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportPutInferenceModelAction.java
@@ -244,37 +244,39 @@ public class TransportPutInferenceModelAction extends TransportMasterNodeAction<
             )
         );
 
-        ActionListener<Model> modelValidatingListener = listener.delegateFailureAndWrap((delegate, model) -> {
+        ActionListener<Model> existingUsesListener = storeModelListener.delegateFailureAndWrap((delegate, model) -> {
+            // Execute in another thread because checking for existing uses requires reading from indices
+            threadPool.executor(UTILITY_THREAD_POOL_NAME).execute(() -> checkForExistingUsesOfInferenceId(metadata, model, delegate));
+        });
+
+        ActionListener<Model> modelValidatingListener = existingUsesListener.delegateFailureAndWrap((delegate, model) -> {
             if (skipValidationAndStart) {
-                storeModelListener.onResponse(model);
+                delegate.onResponse(model);
             } else {
-                ModelValidatorBuilder.buildModelValidator(model.getTaskType(), service)
-                    .validate(service, model, timeout, storeModelListener);
+                ModelValidatorBuilder.buildModelValidator(model.getTaskType(), service).validate(service, model, timeout, delegate);
             }
         });
 
-        ActionListener<Model> existingUsesListener = listener.delegateFailureAndWrap((delegate, model) -> {
-            // Execute in another thread because checking for existing uses requires reading from indices
-            threadPool.executor(UTILITY_THREAD_POOL_NAME)
-                .execute(() -> checkForExistingUsesOfInferenceId(metadata, model, modelValidatingListener));
-        });
-
-        service.parseRequestConfig(inferenceEntityId, taskType, config, existingUsesListener);
+        service.parseRequestConfig(inferenceEntityId, taskType, config, modelValidatingListener);
     }
 
     private void checkForExistingUsesOfInferenceId(Metadata metadata, Model model, ActionListener<Model> modelValidatingListener) {
-        Set<String> inferenceEntityIdSet = Set.of(model.getInferenceEntityId());
-        Set<String> indicesWithIncompatibleMappings = findIndicesWithIncompatibleMappings(model, metadata, inferenceEntityIdSet);
+        try {
+            Set<String> inferenceEntityIdSet = Set.of(model.getInferenceEntityId());
+            Set<String> indicesWithIncompatibleMappings = findIndicesWithIncompatibleMappings(model, metadata, inferenceEntityIdSet);
 
-        if (indicesWithIncompatibleMappings.isEmpty()) {
-            modelValidatingListener.onResponse(model);
-        } else {
-            modelValidatingListener.onFailure(
-                new ElasticsearchStatusException(
-                    buildErrorString(model.getInferenceEntityId(), indicesWithIncompatibleMappings),
-                    RestStatus.BAD_REQUEST
-                )
-            );
+            if (indicesWithIncompatibleMappings.isEmpty()) {
+                modelValidatingListener.onResponse(model);
+            } else {
+                modelValidatingListener.onFailure(
+                    new ElasticsearchStatusException(
+                        buildErrorString(model.getInferenceEntityId(), indicesWithIncompatibleMappings),
+                        RestStatus.BAD_REQUEST
+                    )
+                );
+            }
+        } catch (Exception ex) {
+            modelValidatingListener.onFailure(ex);
         }
     }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Validate inference embedding model before checking for existing uses (#150150)](https://github.com/elastic/elasticsearch/pull/150150)
 - [Update TestDenseInferenceServiceExtension to return embeddings that use the correct element type (#150236)
](https://github.com/elastic/elasticsearch/pull/150236)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)