### PR TITLE
Maintain array order for ip, text, and match only text fields in columnar mode

### DIFF
--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
@@ -42,6 +42,7 @@ import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.lucene.search.AutomatonQueries;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.unit.Fuzziness;
+import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.IndexVersions;
@@ -58,12 +59,14 @@ import org.elasticsearch.index.fielddata.plain.BytesBinaryIndexFieldData;
 import org.elasticsearch.index.fielddata.plain.SortedSetOrdinalsIndexFieldData;
 import org.elasticsearch.index.fieldvisitor.StoredFieldLoader;
 import org.elasticsearch.index.mapper.BinaryDocValuesSyntheticFieldLoaderLayer;
+import org.elasticsearch.index.mapper.BinaryWithOffsetsDocValuesSyntheticFieldLoaderLayer;
 import org.elasticsearch.index.mapper.BlockLoader;
 import org.elasticsearch.index.mapper.BlockSourceReader;
 import org.elasticsearch.index.mapper.BlockStoredFieldsReader;
 import org.elasticsearch.index.mapper.CompositeSyntheticFieldLoader;
 import org.elasticsearch.index.mapper.DocValuesFieldFactory;
 import org.elasticsearch.index.mapper.DocumentParserContext;
+import org.elasticsearch.index.mapper.FieldArrayContext;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.IndexType;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
@@ -154,6 +157,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
         private final TextParams.Analyzers analyzers;
         private final boolean storedFieldInBinaryFormat;
         private final boolean usesBinaryDocValuesForFallbackFields;
+        private final IndexMode indexMode;
 
         private Builder(
             String name,
@@ -161,7 +165,8 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
             IndexAnalyzers indexAnalyzers,
             boolean storedFieldInBinaryFormat,
             boolean isWithinMultiField,
-            boolean usesBinaryDocValuesForFallbackFields
+            boolean usesBinaryDocValuesForFallbackFields,
+            IndexMode indexMode
         ) {
             super(name, indexCreatedVersion, isWithinMultiField);
 
@@ -175,6 +180,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
             );
             this.storedFieldInBinaryFormat = storedFieldInBinaryFormat;
             this.usesBinaryDocValuesForFallbackFields = usesBinaryDocValuesForFallbackFields;
+            this.indexMode = indexMode;
         }
 
         public Builder(String name, MappingParserContext context) {
@@ -184,7 +190,8 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
                 context.getIndexAnalyzers(),
                 isSyntheticSourceStoredFieldInBinaryFormat(context.indexVersionCreated()),
                 context.isWithinMultiField(),
-                usesBinaryDocValuesForFallbackFields(context.getIndexSettings())
+                usesBinaryDocValuesForFallbackFields(context.getIndexSettings()),
+                context.getIndexSettings().getMode()
             );
         }
 
@@ -208,9 +215,18 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
                 && indexSettings.useTimeSeriesDocValuesFormat();
         }
 
+        // The companion ".offsets" field name, used to reconstruct array order and null positions in strict-columnar mode; null otherwise.
+        private String offsetsFieldName;
+
         boolean usesBinaryDocValues() {
-            return docValuesParameters.getValue().enabled()
-                && docValuesParameters.getValue().cardinality() == FieldMapper.DocValuesParameter.Values.Cardinality.HIGH;
+            if (docValuesParameters.getValue().enabled() == false) {
+                return false;
+            }
+            // Columnar multi-value fields route through binary doc values. Other fields use binary storage only for HIGH cardinality.
+            if (docValuesParameters.getValue().multiValue() && indexMode.isStrictColumnar()) {
+                return true;
+            }
+            return docValuesParameters.getValue().cardinality() == FieldMapper.DocValuesParameter.Values.Cardinality.HIGH;
         }
 
         private MatchOnlyTextFieldType buildFieldType(MapperBuilderContext context, MultiFields multiFields) {
@@ -232,7 +248,8 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
                 indexCreatedVersion(),
                 indexed.get(),
                 docValuesParameters.getValue().enabled(),
-                usesBinaryDocValues()
+                usesBinaryDocValues(),
+                offsetsFieldName != null
             );
         }
 
@@ -243,6 +260,12 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
 
         @Override
         public MatchOnlyTextFieldMapper build(MapperBuilderContext context) {
+            this.offsetsFieldName = FieldArrayContext.getOffsetsFieldName(
+                context,
+                indexMode.isStrictColumnar(),
+                docValuesParameters.getValue().multiValue(),
+                this
+            );
             BuilderParams builderParams = builderParams(this, context);
             MatchOnlyTextFieldType tft = buildFieldType(context, builderParams.multiFields());
             return new MatchOnlyTextFieldMapper(leafName(), Defaults.FIELD_TYPE, tft, builderParams, this);
@@ -267,6 +290,8 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
         private final boolean usesBinaryDocValuesForFallbackFields;
         private final IndexVersion indexVersion;
         private final boolean usesBinaryDocValues;
+        // Whether the block loader must emit values in indexed array order (via the offsets sidecar) rather than sorted doc-values order.
+        private final boolean readInArrayOrder;
 
         public MatchOnlyTextFieldType(
             String name,
@@ -281,7 +306,8 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
             IndexVersion indexVersion,
             boolean indexed,
             boolean hasDocValues,
-            boolean usesBinaryDocValues
+            boolean usesBinaryDocValues,
+            boolean readInArrayOrder
         ) {
             super(name, IndexType.terms(indexed, hasDocValues), false, tsi, meta, isSyntheticSource, withinMultiField);
             this.indexAnalyzer = Objects.requireNonNull(indexAnalyzer);
@@ -290,6 +316,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
             this.usesBinaryDocValuesForFallbackFields = usesBinaryDocValuesForFallbackFields;
             this.indexVersion = indexVersion;
             this.usesBinaryDocValues = usesBinaryDocValues;
+            this.readInArrayOrder = readInArrayOrder;
         }
 
         public MatchOnlyTextFieldType(String name) {
@@ -305,6 +332,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
                 false,
                 IndexVersion.current(),
                 true,
+                false,
                 false,
                 false
             );
@@ -870,7 +898,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
             // Check if we can load from doc values
             if (hasDocValues()) {
                 if (usesBinaryDocValues) {
-                    return new BytesRefsFromBinaryMultiSeparateCountBlockLoader(name());
+                    return new BytesRefsFromBinaryMultiSeparateCountBlockLoader(name(), readInArrayOrder);
                 } else {
                     return new BytesRefsFromOrdsBlockLoader(name(), blContext.ordinalsByteSize());
                 }
@@ -1009,6 +1037,9 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
     private final FieldMapper.DocValuesParameter.Values docValuesParameters;
     private final DocValuesFieldFactory dvFactory;
     private final boolean indexed;
+    private final IndexMode indexMode;
+    // The companion ".offsets" field used to reconstruct array order and null positions in strict-columnar mode; null otherwise.
+    private final String offsetsFieldName;
 
     private MatchOnlyTextFieldMapper(
         String simpleName,
@@ -1032,6 +1063,13 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
         // match_only_text does not use doc values skippers
         this.dvFactory = new DocValuesFieldFactory(this.docValuesParameters.multiValue(), false, this.indexCreatedVersion);
         this.indexed = builder.indexed.get();
+        this.indexMode = builder.indexMode;
+        this.offsetsFieldName = builder.offsetsFieldName;
+    }
+
+    @Override
+    public String getOffsetFieldName() {
+        return offsetsFieldName;
     }
 
     @Override
@@ -1047,7 +1085,8 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
             indexAnalyzers,
             storedFieldInBinaryFormat,
             fieldType().isWithinMultiField(),
-            usesBinaryDocValuesForFallbackFields
+            usesBinaryDocValuesForFallbackFields,
+            indexMode
         ).init(this);
     }
 
@@ -1063,8 +1102,13 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
     @Override
     protected void parseCreateField(DocumentParserContext context) throws IOException {
         final var value = context.parser().optimizedTextOrNull();
+        final boolean recordOffsets = FieldArrayContext.shouldRecordOffsets(context, offsetsFieldName, docValuesParameters.multiValue());
 
         if (value == null) {
+            // Record the null slot so synthetic source can rebuild the array with its nulls in the original positions (columnar mode).
+            if (recordOffsets) {
+                context.getOffSetContext().recordNull(offsetsFieldName);
+            }
             return;
         }
 
@@ -1094,6 +1138,10 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
         } else {
             // only add to field names when doc_values are disabled (doc_values track field existence implicitly)
             context.addToFieldNames(fieldType().name());
+        }
+
+        if (recordOffsets) {
+            context.getOffSetContext().recordOffset(offsetsFieldName, new BytesRef(utfBytes.bytes(), utfBytes.offset(), utfBytes.length()));
         }
 
         // match only text isn't stored, so if synthetic source needs to be supported, we must find an alternative way of loading the field
@@ -1156,7 +1204,12 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
     private CompositeSyntheticFieldLoader syntheticFieldLoaderFromDocValues() {
         var layers = new ArrayList<CompositeSyntheticFieldLoader.Layer>();
         if (fieldType().usesBinaryDocValues()) {
-            layers.add(new BinaryDocValuesSyntheticFieldLoaderLayer(fullPath(), indexCreatedVersion));
+            if (offsetsFieldName != null) {
+                // Columnar mode: reconstruct array order, duplicates and null positions from the offsets sidecar.
+                layers.add(new BinaryWithOffsetsDocValuesSyntheticFieldLoaderLayer(fullPath(), offsetsFieldName));
+            } else {
+                layers.add(new BinaryDocValuesSyntheticFieldLoaderLayer(fullPath(), indexCreatedVersion));
+            }
         } else {
             layers.add(new SortedSetDocValuesSyntheticFieldLoaderLayer(fullPath()) {
                 @Override

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapperTests.java
@@ -30,6 +30,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Tuple;
+import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.IndexVersions;
@@ -721,6 +722,29 @@ public class MatchOnlyTextFieldMapperTests extends MapperTestCase {
         MapperService mapperService = createMapperService(fieldMapping(b -> b.field("type", "match_only_text").field("doc_values", true)));
         MappedFieldType fieldType = mapperService.fieldType("field");
         assertTrue("doc_values should be enabled", fieldType.hasDocValues());
+    }
+
+    public void testColumnarArrayOrderRoundTrip() throws IOException {
+        assumeTrue("columnar index mode requires snapshot build", IndexMode.COLUMNAR_FEATURE_FLAG.isEnabled());
+        assumeTrue(
+            "match_only_text field doc_values feature must be enabled",
+            FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled()
+        );
+        Settings settings = Settings.builder().put(IndexSettings.MODE.getKey(), IndexMode.COLUMNAR.getName()).build();
+        DocumentMapper mapper = createMapperService(
+            settings,
+            mapping(b -> b.startObject("field").field("type", "match_only_text").field("doc_values", true).endObject())
+        ).documentMapper();
+
+        String v1 = randomAlphanumericOfLength(4);
+        String v2 = randomAlphanumericOfLength(4);
+        String v3 = randomAlphanumericOfLength(4);
+        // Duplicate v2 and an interleaved null: sorted-deduped doc-values order would reorder/collapse them and drop the null; the offsets
+        // sidecar must restore arrival order, the duplicate, and the null position.
+        assertThat(
+            syntheticSource(mapper, b -> b.array("field", v2, v1, null, v3, v2)),
+            containsString("\"field\":[\"" + v2 + "\",\"" + v1 + "\",null,\"" + v3 + "\",\"" + v2 + "\"]")
+        );
     }
 
     /**

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldTypeTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldTypeTests.java
@@ -257,6 +257,7 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
             IndexVersion.current(),
             true,
             false,
+            false,
             false
         );
 
@@ -281,6 +282,7 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
             true,
             IndexVersion.current(),
             true,
+            false,
             false,
             false
         );
@@ -313,6 +315,7 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
             true,
             IndexVersion.current(),
             true,
+            false,
             false,
             false
         );
@@ -363,6 +366,7 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
             false,
             IndexVersion.current(),
             true,
+            false,
             false,
             false
         );
@@ -417,6 +421,7 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
             IndexVersion.current(),
             true,
             false,
+            false,
             false
         );
 
@@ -454,6 +459,7 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
             false,
             IndexVersion.current(),
             true,
+            false,
             false,
             false
         );
@@ -506,6 +512,7 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
             IndexVersion.current(),
             true,
             false,
+            false,
             false
         );
 
@@ -532,6 +539,7 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
             IndexVersion.current(),
             true,
             false,
+            false,
             false
         );
 
@@ -557,6 +565,7 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
             true,
             IndexVersionUtils.getPreviousVersion(IndexVersions.DEPRECATE_INTEGRATED_COUNTS_BINARY_DOC_VALUES),
             true,
+            false,
             false,
             false
         );
@@ -659,6 +668,7 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
             IndexVersion.current(),
             false,
             true,
+            false,
             false
         );
     }
@@ -677,7 +687,8 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
             IndexVersion.current(),
             false,
             true,
-            true
+            true,
+            false
         );
     }
 

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/SourceConfirmedTextQueryTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/SourceConfirmedTextQueryTests.java
@@ -487,7 +487,8 @@ public class SourceConfirmedTextQueryTests extends ESTestCase {
                     IndexVersion.current(),
                     true,
                     true,
-                    true
+                    true,
+                    false
                 );
 
                 // NOTE: "fox brown" has both terms in the index but in the wrong order. A boolean MUST

--- a/server/src/main/java/org/elasticsearch/index/mapper/BinaryWithOffsetsDocValuesSyntheticFieldLoaderLayer.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BinaryWithOffsetsDocValuesSyntheticFieldLoaderLayer.java
@@ -26,7 +26,7 @@ import java.util.function.Function;
  * The former contains the unique values in sorted order and the latter the offsets for each instance of the values. This allows
  * synthesizing array elements in order as was specified at index time. Note that this works only for leaf arrays.
  */
-final class BinaryWithOffsetsDocValuesSyntheticFieldLoaderLayer implements CompositeSyntheticFieldLoader.DocValuesLayer {
+public final class BinaryWithOffsetsDocValuesSyntheticFieldLoaderLayer implements CompositeSyntheticFieldLoader.DocValuesLayer {
 
     private final String name;
     private final String offsetsFieldName;
@@ -37,7 +37,7 @@ final class BinaryWithOffsetsDocValuesSyntheticFieldLoaderLayer implements Compo
      * @param name              The name of the field to synthesize
      * @param offsetsFieldName  The related offset field used to correctly synthesize the field if it is a leaf array
      */
-    BinaryWithOffsetsDocValuesSyntheticFieldLoaderLayer(String name, String offsetsFieldName) {
+    public BinaryWithOffsetsDocValuesSyntheticFieldLoaderLayer(String name, String offsetsFieldName) {
         this(name, offsetsFieldName, Function.identity());
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldArrayContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldArrayContext.java
@@ -171,6 +171,24 @@ public class FieldArrayContext {
         }
 
         // multi_value = true + columnar mode path
+        var columnarOffsetsFieldName = getOffsetsFieldName(context, isStrictColumnar, multiValue, fieldMapperBuilder);
+        if (columnarOffsetsFieldName != null) {
+            return columnarOffsetsFieldName;
+        }
+
+        // Otherwise, offsets won't be recorded
+        return null;
+    }
+
+    /**
+     * Columnar variant of {@link #getOffsetsFieldName}.
+     */
+    public static String getOffsetsFieldName(
+        MapperBuilderContext context,
+        boolean isStrictColumnar,
+        boolean multiValue,
+        FieldMapper.Builder fieldMapperBuilder
+    ) {
         // Note, stored fields and nested docs will not be allowed in columnar mode - no need to check them explicitly
         // Note, doc values cannot be disabled in columnar mode
         // TODO: copy_to is disabled since copy_to forces _ignored_source to be used for synthetic source, recording offsets in addition
@@ -178,8 +196,6 @@ public class FieldArrayContext {
         if (multiValue && isStrictColumnar && context.isSourceSynthetic() && fieldMapperBuilder.copyTo.copyToFields().isEmpty()) {
             return context.buildFullName(offsetsFieldName(fieldMapperBuilder.leafName()));
         }
-
-        // Otherwise, offsets won't be recorded
         return null;
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -250,8 +250,13 @@ public class IpFieldMapper extends FieldMapper {
                 stored.getValue(),
                 this,
                 indexSettings.getIndexVersionCreated(),
-                IndexVersions.SYNTHETIC_SOURCE_STORE_ARRAYS_NATIVELY_IP
+                IndexVersions.SYNTHETIC_SOURCE_STORE_ARRAYS_NATIVELY_IP,
+                indexSettings.getMode().isStrictColumnar(),
+                docValuesParameters.getValue().multiValue()
             );
+            boolean readInArrayOrder = offsetsFieldName != null
+                && docValuesParameters.getValue().multiValue()
+                && indexSettings.getMode().isStrictColumnar();
             return new IpFieldMapper(
                 leafName(),
                 new IpFieldType(
@@ -263,7 +268,8 @@ public class IpFieldMapper extends FieldMapper {
                     meta.getValue(),
                     dimension.getValue(),
                     context.isSourceSynthetic(),
-                    usesBinaryDocValues()
+                    usesBinaryDocValues(),
+                    readInArrayOrder
                 ),
                 builderParams(this, context),
                 context.isSourceSynthetic(),
@@ -286,6 +292,7 @@ public class IpFieldMapper extends FieldMapper {
         private final boolean isSyntheticSource;
         private final boolean hasPoints;
         private final boolean usesBinaryDocValues;
+        private final boolean readInArrayOrder;
 
         public IpFieldType(
             String name,
@@ -296,7 +303,8 @@ public class IpFieldMapper extends FieldMapper {
             Map<String, String> meta,
             boolean isDimension,
             boolean isSyntheticSource,
-            boolean usesBinaryDocValues
+            boolean usesBinaryDocValues,
+            boolean readInArrayOrder
         ) {
             super(name, indexType, stored, meta);
             this.nullValue = nullValue;
@@ -305,6 +313,7 @@ public class IpFieldMapper extends FieldMapper {
             this.isSyntheticSource = isSyntheticSource;
             this.hasPoints = indexType.hasPoints();
             this.usesBinaryDocValues = usesBinaryDocValues;
+            this.readInArrayOrder = readInArrayOrder;
         }
 
         public IpFieldType(String name) {
@@ -316,7 +325,7 @@ public class IpFieldMapper extends FieldMapper {
         }
 
         public IpFieldType(String name, boolean isIndexed, boolean hasDocValues) {
-            this(name, IndexType.points(isIndexed, hasDocValues), false, null, null, Collections.emptyMap(), false, false, false);
+            this(name, IndexType.points(isIndexed, hasDocValues), false, null, null, Collections.emptyMap(), false, false, false, false);
         }
 
         @Override
@@ -532,9 +541,9 @@ public class IpFieldMapper extends FieldMapper {
                 BlockLoaderFunctionConfig cfg = blContext.blockLoaderFunctionConfig();
                 if (cfg == null) {
                     if (usesBinaryDocValues) {
-                        return new BytesRefsFromBinaryMultiSeparateCountBlockLoader(name());
+                        return new BytesRefsFromBinaryMultiSeparateCountBlockLoader(name(), readInArrayOrder);
                     } else {
-                        return new BytesRefsFromOrdsBlockLoader(name(), blContext.ordinalsByteSize());
+                        return new BytesRefsFromOrdsBlockLoader(name(), blContext.ordinalsByteSize(), readInArrayOrder);
                     }
                 }
                 return switch (cfg.function()) {
@@ -755,7 +764,7 @@ public class IpFieldMapper extends FieldMapper {
         if (address != null) {
             indexValue(context, address);
         }
-        if (offsetsFieldName != null && context.isImmediateParentAnArray() && context.canAddIgnoredField()) {
+        if (FieldArrayContext.shouldRecordOffsets(context, offsetsFieldName, docValuesParameters.multiValue())) {
             if (address != null) {
                 BytesRef sortableValue = address.binaryValue();
                 context.getOffSetContext().recordOffset(offsetsFieldName, sortableValue);

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
@@ -111,6 +111,7 @@ public class MapperFeatures implements FeatureSpecification {
     static final NodeFeature KEYWORD_COLUMNAR_DEFAULT_HIGH_CARDINALITY = new NodeFeature(
         "mapper.keyword.columnar_default_high_cardinality"
     );
+    static final NodeFeature COLUMNAR_MAINTAIN_ARRAY_ORDER_IP_TEXT = new NodeFeature("mapper.columnar.maintain_array_order_ip_text");
 
     @Override
     public Set<NodeFeature> getTestFeatures() {
@@ -187,7 +188,8 @@ public class MapperFeatures implements FeatureSpecification {
             STORE_NOT_ALLOWED_IN_COLUMNAR_INDEX_MODE,
             COLUMNAR_MAINTAIN_ARRAY_ORDER,
             COLUMNAR_REJECTS_RUNTIME_DYNAMIC,
-            KEYWORD_COLUMNAR_DEFAULT_HIGH_CARDINALITY
+            KEYWORD_COLUMNAR_DEFAULT_HIGH_CARDINALITY,
+            COLUMNAR_MAINTAIN_ARRAY_ORDER_IP_TEXT
         );
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -390,9 +390,18 @@ public final class TextFieldMapper extends FieldMapper {
             return this;
         }
 
+        // The companion ".offsets" field name, used to reconstruct array order and null positions in strict-columnar mode; null otherwise.
+        private String offsetsFieldName;
+
         boolean usesBinaryDocValues() {
-            return docValuesParameters.getValue().enabled()
-                && docValuesParameters.getValue().cardinality() == DocValuesParameter.Values.Cardinality.HIGH;
+            if (docValuesParameters.getValue().enabled() == false) {
+                return false;
+            }
+            // Columnar multi-value fields route through binary doc values. Other fields use binary storage only for HIGH cardinality.
+            if (docValuesParameters.getValue().multiValue() && indexSettings.getMode().isStrictColumnar()) {
+                return true;
+            }
+            return docValuesParameters.getValue().cardinality() == DocValuesParameter.Values.Cardinality.HIGH;
         }
 
         @Override
@@ -476,7 +485,8 @@ public final class TextFieldMapper extends FieldMapper {
                     indexCreatedVersion,
                     usesBinaryDocValuesForFallbackFields,
                     usesBinaryDocValues(),
-                    docValuesParameters.getValue()
+                    docValuesParameters.getValue(),
+                    offsetsFieldName != null
                 );
                 if (fieldData.getValue()) {
                     ft.setFielddata(true, freqFilter.getValue());
@@ -551,6 +561,12 @@ public final class TextFieldMapper extends FieldMapper {
 
         @Override
         public TextFieldMapper build(MapperBuilderContext context) {
+            this.offsetsFieldName = FieldArrayContext.getOffsetsFieldName(
+                context,
+                indexSettings.getMode().isStrictColumnar(),
+                docValuesParameters.getValue().multiValue(),
+                this
+            );
             FieldType fieldType = TextParams.buildFieldType(
                 index,
                 store,
@@ -762,6 +778,8 @@ public final class TextFieldMapper extends FieldMapper {
         private final boolean usesBinaryDocValuesForFallbackFields;
         private final boolean usesBinaryDocValues;
         private final DocValuesParameter.Values docValuesParams;
+        // Whether the block loader must emit values in indexed array order (via the offsets sidecar) rather than sorted doc-values order.
+        private final boolean readInArrayOrder;
 
         /**
          * In some configurations text fields use a sub-keyword field to provide
@@ -785,7 +803,8 @@ public final class TextFieldMapper extends FieldMapper {
             IndexVersion indexCreatedVersion,
             boolean usesBinaryDocValuesForFallbackFields,
             boolean usesBinaryDocValues,
-            DocValuesParameter.Values docValuesParams
+            DocValuesParameter.Values docValuesParams,
+            boolean readInArrayOrder
         ) {
             super(name, IndexType.terms(indexed, hasDocValues), stored, tsi, meta, isSyntheticSource, isWithinMultiField);
             this.fielddata = false;
@@ -797,6 +816,7 @@ public final class TextFieldMapper extends FieldMapper {
             this.usesBinaryDocValuesForFallbackFields = usesBinaryDocValuesForFallbackFields;
             this.usesBinaryDocValues = usesBinaryDocValues;
             this.docValuesParams = docValuesParams;
+            this.readInArrayOrder = readInArrayOrder;
         }
 
         public TextFieldType(
@@ -826,7 +846,8 @@ public final class TextFieldMapper extends FieldMapper {
                 IndexVersion.current(),
                 false,
                 false,
-                null
+                null,
+                false
             );
         }
 
@@ -848,6 +869,7 @@ public final class TextFieldMapper extends FieldMapper {
             this.usesBinaryDocValuesForFallbackFields = false;
             this.usesBinaryDocValues = false;
             this.docValuesParams = null;
+            this.readInArrayOrder = false;
         }
 
         public TextFieldType(String name, boolean isSyntheticSource, boolean isWithinMultiField) {
@@ -1371,7 +1393,7 @@ public final class TextFieldMapper extends FieldMapper {
                     if (docValuesParams != null && docValuesParams.multiValue() == false) {
                         return new BytesRefsFromBinaryBlockLoader(name());
                     }
-                    return new BytesRefsFromBinaryMultiSeparateCountBlockLoader(name());
+                    return new BytesRefsFromBinaryMultiSeparateCountBlockLoader(name(), readInArrayOrder);
                 } else {
                     return new BytesRefsFromOrdsBlockLoader(name(), blContext.ordinalsByteSize());
                 }
@@ -1598,7 +1620,24 @@ public final class TextFieldMapper extends FieldMapper {
     public static class ConstantScoreTextFieldType extends TextFieldType {
 
         public ConstantScoreTextFieldType(String name, boolean indexed, boolean stored, TextSearchInfo tsi, Map<String, String> meta) {
-            super(name, indexed, stored, false, tsi, false, false, null, meta, false, false, IndexVersion.current(), false, false, null);
+            super(
+                name,
+                indexed,
+                stored,
+                false,
+                tsi,
+                false,
+                false,
+                null,
+                meta,
+                false,
+                false,
+                IndexVersion.current(),
+                false,
+                false,
+                null,
+                false
+            );
         }
 
         public ConstantScoreTextFieldType(String name) {
@@ -1716,6 +1755,8 @@ public final class TextFieldMapper extends FieldMapper {
     private final SubFieldInfo phraseFieldInfo;
     private final boolean usesBinaryDocValuesForFallbackFields;
     private final IndexSettings indexSettings;
+    // The companion ".offsets" field used to reconstruct array order and null positions in strict-columnar mode; null otherwise.
+    private final String offsetsFieldName;
 
     private TextFieldMapper(
         String simpleName,
@@ -1754,6 +1795,12 @@ public final class TextFieldMapper extends FieldMapper {
         this.freqFilter = builder.freqFilter.getValue();
         this.fieldData = builder.fieldData.get();
         this.usesBinaryDocValuesForFallbackFields = useBinaryDocValuesForFallbackFields(builder.indexSettings);
+        this.offsetsFieldName = builder.offsetsFieldName;
+    }
+
+    @Override
+    public String getOffsetFieldName() {
+        return offsetsFieldName;
     }
 
     @Override
@@ -1802,8 +1849,13 @@ public final class TextFieldMapper extends FieldMapper {
     @Override
     protected void parseCreateField(DocumentParserContext context) throws IOException {
         final String value = context.parser().textOrNull();
+        final boolean recordOffsets = FieldArrayContext.shouldRecordOffsets(context, offsetsFieldName, docValuesParameters.multiValue());
 
         if (value == null) {
+            // Record the null slot so synthetic source can rebuild the array with its nulls in the original positions (columnar mode).
+            if (recordOffsets) {
+                context.getOffSetContext().recordNull(offsetsFieldName);
+            }
             return;
         }
 
@@ -1823,6 +1875,10 @@ public final class TextFieldMapper extends FieldMapper {
             } else {
                 dvFactory.addSortedField(context.doc(), fieldType().name(), binaryValue);
             }
+        }
+
+        if (recordOffsets) {
+            context.getOffSetContext().recordOffset(offsetsFieldName, new BytesRef(value));
         }
 
         if (isIndexed() || fieldType.stored()) {
@@ -2107,7 +2163,12 @@ public final class TextFieldMapper extends FieldMapper {
     private CompositeSyntheticFieldLoader syntheticFieldLoaderFromDocValues() {
         var layers = new ArrayList<CompositeSyntheticFieldLoader.Layer>();
         if (fieldType().usesBinaryDocValues()) {
-            layers.add(new BinaryDocValuesSyntheticFieldLoaderLayer(fullPath(), indexSettings.getIndexVersionCreated()));
+            if (offsetsFieldName != null) {
+                // Columnar mode: reconstruct array order, duplicates and null positions from the offsets sidecar.
+                layers.add(new BinaryWithOffsetsDocValuesSyntheticFieldLoaderLayer(fullPath(), offsetsFieldName));
+            } else {
+                layers.add(new BinaryDocValuesSyntheticFieldLoaderLayer(fullPath(), indexSettings.getIndexVersionCreated()));
+            }
         } else {
             layers.add(new SortedSetDocValuesSyntheticFieldLoaderLayer(fullPath()) {
                 @Override

--- a/server/src/test/java/org/elasticsearch/index/mapper/IpFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IpFieldMapperTests.java
@@ -25,7 +25,6 @@ import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexSortConfig;
-import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.script.IpFieldScript;

--- a/server/src/test/java/org/elasticsearch/index/mapper/IpFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IpFieldMapperTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexSortConfig;
+import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.script.IpFieldScript;
@@ -603,6 +604,25 @@ public class IpFieldMapperTests extends MapperTestCase {
                     + " index sort field, which requires sortable doc values"
             )
         );
+    }
+
+    public void testColumnarArrayOrderRoundTrip() throws IOException {
+        assumeTrue("columnar index mode requires snapshot build", IndexMode.COLUMNAR_FEATURE_FLAG.isEnabled());
+        Settings settings = Settings.builder().put(IndexSettings.MODE.getKey(), IndexMode.COLUMNAR.getName()).build();
+        DocumentMapper mapper = createMapperService(settings, mapping(b -> b.startObject("field").field("type", "ip").endObject()))
+            .documentMapper();
+
+        // Arrival order differs from the binary-sorted order (10.0.0.1 < 172.16.5.4 < 192.168.1.10); duplicate and null must survive.
+        String result = syntheticSource(mapper, b -> {
+            b.startArray("field");
+            b.value("192.168.1.10");
+            b.value("10.0.0.1");
+            b.nullValue();
+            b.value("172.16.5.4");
+            b.value("192.168.1.10");
+            b.endArray();
+        });
+        assertThat(result, containsString("\"field\":[\"192.168.1.10\",\"10.0.0.1\",null,\"172.16.5.4\",\"192.168.1.10\"]"));
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/index/mapper/IpFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IpFieldTypeTests.java
@@ -72,7 +72,8 @@ public class IpFieldTypeTests extends FieldTypeTestCase {
             Collections.emptyMap(),
             false,
             false,
-            true
+            true,
+            false
         );
 
         String ip = "2001:db8::2:1";
@@ -122,6 +123,7 @@ public class IpFieldTypeTests extends FieldTypeTestCase {
             null,
             null,
             Collections.emptyMap(),
+            false,
             false,
             false,
             false
@@ -357,6 +359,7 @@ public class IpFieldTypeTests extends FieldTypeTestCase {
             null,
             null,
             Collections.emptyMap(),
+            false,
             false,
             false,
             false

--- a/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
@@ -543,6 +543,53 @@ public class TextFieldMapperTests extends MapperTestCase {
         assertTrue(textMapper.fieldType().usesBinaryDocValues());
     }
 
+    public void testColumnarArrayOrderRoundTrip() throws IOException {
+        assumeTrue("columnar index mode requires snapshot build", IndexMode.COLUMNAR_FEATURE_FLAG.isEnabled());
+        assumeTrue(
+            "text field doc_values feature must be enabled",
+            FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled()
+        );
+        Settings settings = Settings.builder().put(IndexSettings.MODE.getKey(), IndexMode.COLUMNAR.getName()).build();
+        DocumentMapper mapper = createMapperService(
+            settings,
+            mapping(b -> b.startObject("field").field("type", "text").field("doc_values", true).endObject())
+        ).documentMapper();
+
+        String v1 = randomAlphanumericOfLength(4);
+        String v2 = randomAlphanumericOfLength(4);
+        String v3 = randomAlphanumericOfLength(4);
+        // Duplicate v2 and an interleaved null: sorted-deduped doc-values order would reorder/collapse them and drop the null; the offsets
+        // sidecar must restore arrival order, the duplicate, and the null position.
+        assertThat(
+            syntheticSource(mapper, b -> b.array("field", v2, v1, null, v3, v2)),
+            containsString("\"field\":[\"" + v2 + "\",\"" + v1 + "\",null,\"" + v3 + "\",\"" + v2 + "\"]")
+        );
+    }
+
+    /**
+     * A value longer than Lucene's max term length is stored directly in the binary doc values in columnar mode rather than spilling to the
+     * fallback field, so it keeps its position in the array (alongside a null) instead of being reordered relative to the shorter values.
+     */
+    public void testColumnarArrayOrderWithValueExceedMaxTermLength() throws IOException {
+        assumeTrue("columnar index mode requires snapshot build", IndexMode.COLUMNAR_FEATURE_FLAG.isEnabled());
+        assumeTrue(
+            "text field doc_values feature must be enabled",
+            FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled()
+        );
+        Settings settings = Settings.builder().put(IndexSettings.MODE.getKey(), IndexMode.COLUMNAR.getName()).build();
+        DocumentMapper mapper = createMapperService(
+            settings,
+            mapping(b -> b.startObject("field").field("type", "text").field("doc_values", true).endObject())
+        ).documentMapper();
+
+        String shortValue = randomAlphanumericOfLength(4);
+        String longValue = randomAlphanumericOfLength(40000); // exceeds IndexWriter.MAX_TERM_LENGTH (32766)
+        assertThat(
+            syntheticSource(mapper, b -> b.array("field", longValue, null, shortValue)),
+            containsString("\"field\":[\"" + longValue + "\",null,\"" + shortValue + "\"]")
+        );
+    }
+
     public void testDocValuesEnabledWithoutIndexing() throws IOException {
         assumeTrue(
             "text field doc_values feature must be enabled",

--- a/server/src/test/java/org/elasticsearch/index/mapper/TextFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TextFieldTypeTests.java
@@ -557,7 +557,8 @@ public class TextFieldTypeTests extends FieldTypeTestCase {
             IndexVersions.KEYWORD_MULTI_FIELDS_NOT_STORED_WHEN_IGNORED,
             true,
             false,
-            null
+            null,
+            false
         );
 
         // when
@@ -598,7 +599,8 @@ public class TextFieldTypeTests extends FieldTypeTestCase {
             legacyVersion,
             false,
             false,
-            null
+            null,
+            false
         );
 
         // when
@@ -638,7 +640,8 @@ public class TextFieldTypeTests extends FieldTypeTestCase {
             legacyVersion,
             true,
             false,
-            null
+            null,
+            false
         );
 
         // when
@@ -668,7 +671,8 @@ public class TextFieldTypeTests extends FieldTypeTestCase {
             IndexVersion.current(),
             false,
             false,
-            null
+            null,
+            false
         );
 
         // when
@@ -697,7 +701,8 @@ public class TextFieldTypeTests extends FieldTypeTestCase {
             IndexVersion.current(),
             false,
             true,
-            null
+            null,
+            false
         );
 
         // when
@@ -731,7 +736,8 @@ public class TextFieldTypeTests extends FieldTypeTestCase {
             IndexVersion.current(),
             false,
             false,
-            null
+            null,
+            false
         );
     }
 
@@ -751,7 +757,8 @@ public class TextFieldTypeTests extends FieldTypeTestCase {
             IndexVersion.current(),
             false,
             true,
-            null
+            null,
+            false
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/blockloader/IpFieldBlockLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/blockloader/IpFieldBlockLoaderTests.java
@@ -43,12 +43,10 @@ public class IpFieldBlockLoaderTests extends BlockLoaderTestCase {
             || params.preference() == MappedFieldType.FieldExtractPreference.DOC_VALUES
             || params.syntheticSource();
         if (hasDocValues && useDocValues) {
-            var resultList = ((List<String>) value).stream()
-                .map(v -> convert(v, nullValue))
-                .filter(Objects::nonNull)
-                .distinct()
-                .sorted()
-                .toList();
+            // Columnar index modes preserve arrival order via offsets; other modes return sorted, deduplicated doc values.
+            boolean preserveOrder = params.indexMode().isColumnar();
+            var stream = ((List<String>) value).stream().map(v -> convert(v, nullValue)).filter(Objects::nonNull);
+            var resultList = preserveOrder ? stream.toList() : stream.distinct().sorted().toList();
             return maybeFoldList(resultList);
         }
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorTests.java
@@ -1334,6 +1334,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
             Collections.emptyMap(),
             false,
             false,
+            false,
             false
         );
         testCase(iw -> {

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/300_columnar_array_ordering.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/300_columnar_array_ordering.yml
@@ -111,6 +111,148 @@ setup:
   - match: { values.0.0: [1, 3, 5] }
 
 ---
+"ip multi-value array order":
+  - do:
+      indices.create:
+        index: test_columnar
+        body:
+          settings:
+            index.mode: logsdb_columnar
+          mappings:
+            properties:
+              "@timestamp": { type: date }
+              val: { type: ip }
+  - do:
+      indices.create:
+        index: test_logsdb
+        body:
+          settings:
+            index.mode: logsdb
+          mappings:
+            properties:
+              "@timestamp": { type: date }
+              val: { type: ip }
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - { "index": { "_index": "test_columnar" } }
+          - { "@timestamp": "2024-05-10T00:00:00.000Z", "val": ["10.0.0.5", "10.0.0.1", "10.0.0.3"] }
+          - { "index": { "_index": "test_logsdb" } }
+          - { "@timestamp": "2024-05-10T00:00:00.000Z", "val": ["10.0.0.5", "10.0.0.1", "10.0.0.3"] }
+
+  - do:
+      allowed_warnings:
+        - "No limit defined, adding default limit of [1000]"
+      esql.query:
+        body:
+          query: 'FROM test_columnar | KEEP val'
+  - match: { values.0.0: ["10.0.0.5", "10.0.0.1", "10.0.0.3"] }
+
+  - do:
+      allowed_warnings:
+        - "No limit defined, adding default limit of [1000]"
+      esql.query:
+        body:
+          query: 'FROM test_logsdb | KEEP val'
+  - match: { values.0.0: ["10.0.0.1", "10.0.0.3", "10.0.0.5"] }
+
+---
+"text multi-value array order":
+  # text/match_only_text array ordering requires explicit doc_values:true; columnar mode does not force doc values on.
+  - do:
+      indices.create:
+        index: test_columnar
+        body:
+          settings:
+            index.mode: logsdb_columnar
+          mappings:
+            properties:
+              "@timestamp": { type: date }
+              val: { type: text, doc_values: true }
+  - do:
+      indices.create:
+        index: test_logsdb
+        body:
+          settings:
+            index.mode: logsdb
+          mappings:
+            properties:
+              "@timestamp": { type: date }
+              val: { type: text, doc_values: true }
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - { "index": { "_index": "test_columnar" } }
+          - { "@timestamp": "2024-05-10T00:00:00.000Z", "val": ["banana", "apple", "cherry"] }
+          - { "index": { "_index": "test_logsdb" } }
+          - { "@timestamp": "2024-05-10T00:00:00.000Z", "val": ["banana", "apple", "cherry"] }
+
+  - do:
+      allowed_warnings:
+        - "No limit defined, adding default limit of [1000]"
+      esql.query:
+        body:
+          query: 'FROM test_columnar | KEEP val'
+  - match: { values.0.0: [banana, apple, cherry] }
+
+  - do:
+      allowed_warnings:
+        - "No limit defined, adding default limit of [1000]"
+      esql.query:
+        body:
+          query: 'FROM test_logsdb | KEEP val'
+  - match: { values.0.0: [apple, banana, cherry] }
+
+---
+"match_only_text multi-value array order":
+  - do:
+      indices.create:
+        index: test_columnar
+        body:
+          settings:
+            index.mode: logsdb_columnar
+          mappings:
+            properties:
+              "@timestamp": { type: date }
+              val: { type: match_only_text, doc_values: true }
+  - do:
+      indices.create:
+        index: test_logsdb
+        body:
+          settings:
+            index.mode: logsdb
+          mappings:
+            properties:
+              "@timestamp": { type: date }
+              val: { type: match_only_text, doc_values: true }
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - { "index": { "_index": "test_columnar" } }
+          - { "@timestamp": "2024-05-10T00:00:00.000Z", "val": ["banana", "apple", "cherry"] }
+          - { "index": { "_index": "test_logsdb" } }
+          - { "@timestamp": "2024-05-10T00:00:00.000Z", "val": ["banana", "apple", "cherry"] }
+
+  - do:
+      allowed_warnings:
+        - "No limit defined, adding default limit of [1000]"
+      esql.query:
+        body:
+          query: 'FROM test_columnar | KEEP val'
+  - match: { values.0.0: [banana, apple, cherry] }
+
+  - do:
+      allowed_warnings:
+        - "No limit defined, adding default limit of [1000]"
+      esql.query:
+        body:
+          query: 'FROM test_logsdb | KEEP val'
+  - match: { values.0.0: [apple, banana, cherry] }
+
+---
 "double multi-value array order":
   - do:
       indices.create:

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/300_columnar_array_ordering.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/300_columnar_array_ordering.yml
@@ -112,6 +112,9 @@ setup:
 
 ---
 "ip multi-value array order":
+  - requires:
+      cluster_features: [ "mapper.columnar.maintain_array_order_ip_text" ]
+      reason: "Columnar array ordering for ip fields is part of the part-4 mapper wiring"
   - do:
       indices.create:
         index: test_columnar
@@ -160,6 +163,9 @@ setup:
 ---
 "text multi-value array order":
   # text/match_only_text array ordering requires explicit doc_values:true; columnar mode does not force doc values on.
+  - requires:
+      cluster_features: [ "mapper.columnar.maintain_array_order_ip_text" ]
+      reason: "Columnar array ordering for text fields is part of the part-4 mapper wiring"
   - do:
       indices.create:
         index: test_columnar
@@ -207,6 +213,9 @@ setup:
 
 ---
 "match_only_text multi-value array order":
+  - requires:
+      cluster_features: [ "mapper.columnar.maintain_array_order_ip_text" ]
+      reason: "Columnar array ordering for match_only_text fields is part of the part-4 mapper wiring"
   - do:
       indices.create:
         index: test_columnar


### PR DESCRIPTION
Nothing special to call out.