### PR TITLE
Fix KeyRotationIT failure in release builds

### DIFF
--- a/x-pack/plugin/encryption/src/internalClusterTest/java/org/elasticsearch/xpack/encryption/KeyRotationIT.java
+++ b/x-pack/plugin/encryption/src/internalClusterTest/java/org/elasticsearch/xpack/encryption/KeyRotationIT.java
@@ -69,11 +69,13 @@ public class KeyRotationIT extends SecurityIntegTestCase {
 
     @Override
     protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
-        return Settings.builder()
-            .put(super.nodeSettings(nodeOrdinal, otherSettings))
-            .put(KeyRotationCoordinator.ROTATION_INTERVAL_SETTING.getKey(), TimeValue.timeValueSeconds(5))
-            .put(KeyRotationCoordinator.CHECK_INTERVAL_SETTING.getKey(), TimeValue.timeValueSeconds(1))
-            .build();
+        Settings.Builder builder = Settings.builder().put(super.nodeSettings(nodeOrdinal, otherSettings));
+        // The encryption settings are only registered when the feature flag is enabled
+        if (ProjectEncryptionKeyService.PROJECT_ENCRYPTION_KEY_FEATURE_FLAG.isEnabled()) {
+            builder.put(KeyRotationCoordinator.ROTATION_INTERVAL_SETTING.getKey(), TimeValue.timeValueSeconds(5))
+                .put(KeyRotationCoordinator.CHECK_INTERVAL_SETTING.getKey(), TimeValue.timeValueSeconds(1));
+        }
+        return builder.build();
     }
 
     @Override


### PR DESCRIPTION
The encryption key-rotation settings are only registered when the `project_encryption_key` feature flag is enabled, which is off in release builds. `KeyRotationIT` added them to `nodeSettings()` unconditionally, so node construction failed settings validation with "unknown setting [xpack.encryption.key_rotation.*]" before the `checkFeatureFlag()` `assumeTrue` guard could skip the test (cluster setup runs in a superclass `@Before`, ahead of the subclass guard).

Gate the settings on the feature flag in `nodeSettings()`, mirroring `EncryptionPlugin#getSettings()`. In release builds the node now builds cleanly and the tests skip as intended.

Closes #150422 