### PR TITLE
Fix TranslogIndexBatchTests release tests

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/translog/TranslogIndexBatchTests.java
+++ b/server/src/test/java/org/elasticsearch/index/translog/TranslogIndexBatchTests.java
@@ -64,7 +64,9 @@ public class TranslogIndexBatchTests extends ESTestCase {
     @After
     public void tearDown() throws Exception {
         try {
-            translog.close();
+            if (translog != null) {
+                translog.close();
+            }
         } finally {
             super.tearDown();
         }


### PR DESCRIPTION
When running in a release build, the `assumeTrue` feature-flag check in `setUp()` means we quit running the test before the translog is instantiated. But `tearDown()` is still called, and it tries to call `close()` on the null translog. The solution is a simple null-check.

Fixes #150419
