### PR TITLE
PromQL: Fix without() retaining non-dimension labels (#149793)

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/mapper/TimeSeriesMetadataFieldBlockLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TimeSeriesMetadataFieldBlockLoaderTests.java
@@ -281,16 +281,51 @@ public class TimeSeriesMetadataFieldBlockLoaderTests extends MapperServiceTestCa
     }
 
     /**
+     * Verify that the `withoutFields` parameter correctly excludes labels from the output.
+     * When using PromQL's `without(instance)` clause, the `instance` label must not appear
+     * in the emitted `_timeseries` JSON.
+     */
+    public void testWithoutFieldsExcludesLabelsFromOutput() throws IOException {
+        BytesReference cbor = bytes(XContentType.CBOR, b -> {
+            b.field("@timestamp", "2021-04-28T18:50:00Z");
+            b.startObject("labels");
+            b.field("__name__", "go_gc_cleanups_executed_cleanups_total");
+            b.field("instance", "localhost:9090");
+            b.field("job", "prometheus");
+            b.endObject();
+            b.startObject("metrics");
+            b.field("go_gc_cleanups_executed_cleanups_total", 1.0);
+            b.endObject();
+        });
+        BytesRef value = readTimeSeriesValue(
+            TSDB_PROMETHEUS_LIKE_SETTINGS,
+            PROMETHEUS_LIKE_MAPPING,
+            sourceToParse(cbor, XContentType.CBOR),
+            Set.of("labels.instance")
+        );
+        Map<String, Object> parsed = parseJsonObject(value);
+        assertThat(parsed.keySet(), equalTo(Set.of("labels")));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> labels = (Map<String, Object>) parsed.get("labels");
+        assertThat(labels, equalTo(Map.of("__name__", "go_gc_cleanups_executed_cleanups_total", "job", "prometheus")));
+    }
+
+    /**
      * Build the {@code _timeseries} block loader, index a single document, and return the {@link BytesRef}
      * the loader writes into a one-row block. This mirrors how the production code wires
      * {@link TimeSeriesMetadataFieldBlockLoader} into a row-stride read at search time.
      */
     private BytesRef readTimeSeriesValue(Settings settings, String mapping, SourceToParse sourceToParse) throws IOException {
+        return readTimeSeriesValue(settings, mapping, sourceToParse, Set.of());
+    }
+
+    private BytesRef readTimeSeriesValue(Settings settings, String mapping, SourceToParse sourceToParse, Set<String> withoutFields)
+        throws IOException {
         MapperService mapperService = createMapperService(settings, mapping);
         BlockLoader loader = mapperService.documentMapper()
             .sourceMapper()
             .fieldType()
-            .blockLoader(new TestBlockLoaderContext(mapperService, new BlockLoaderFunctionConfig.TimeSeriesMetadata(false, Set.of())));
+            .blockLoader(new TestBlockLoaderContext(mapperService, new BlockLoaderFunctionConfig.TimeSeriesMetadata(false, withoutFields)));
         assertThat(loader, instanceOf(TimeSeriesMetadataFieldBlockLoader.class));
 
         AtomicReference<BytesRef> result = new AtomicReference<>();

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-promql-without.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-promql-without.csv-spec
@@ -255,6 +255,26 @@ result:double | step:datetime            | cluster:keyword
 ;
 
 
+// Regression: `by` on a concrete label directly over a `without`-over-selector. The inner
+// `without (pod)` must surface the concrete `cluster` dimension (not only `_timeseries`) so the
+// outer `by (cluster)` can group on it. If `cluster` were not pushed down to the inner aggregate
+// it would be null-filled, collapsing every cluster into a single null group. Equivalent to
+// `by_over_without_over_by`, whose innermost `by (cluster, region, pod)` is a per-series no-op.
+by_over_without_over_selector_surfaces_label
+required_capability: promql_command_v0
+required_capability: fix_promql_time_bucket_v2
+required_capability: promql_nested_aggregates
+required_capability: promql_without_grouping
+PROMQL index=k8s step=1h result=(sum by (cluster) (sum without (pod) (network.cost)))
+| SORT result;
+
+result:double | step:datetime            | cluster:keyword
+15.875        | 2024-05-10T01:00:00.000Z | staging
+18.625        | 2024-05-10T01:00:00.000Z | prod
+26.5          | 2024-05-10T01:00:00.000Z | qa
+;
+
+
 // `by` cannot restore a label already removed by `without`.
 by_cannot_resurrect_removed_label
 required_capability: promql_command_v0
@@ -297,4 +317,38 @@ PROMQL index=k8s step=1h result=(scalar(max(sum without (pod, region) (avg_over_
 
 result:double     | step:datetime
 20.76903735632184 | 2024-05-10T01:00:00.000Z
+;
+
+
+// ------------------------------------------------
+// Excluded labels must NOT appear in the _timeseries output
+// ------------------------------------------------
+
+// `without(pod)` must exclude `pod` from the _timeseries label set.
+without_excludes_pod_from_timeseries
+required_capability: promql_command_v0
+required_capability: fix_promql_time_bucket_v2
+required_capability: promql_nested_aggregates
+required_capability: promql_without_grouping
+PROMQL index=k8s step=1h result=(sum without (pod) (network.cost{cluster="staging"}))
+| EVAL has_pod = _timeseries LIKE "*pod*"
+| KEEP result, _timeseries, has_pod;
+
+result:double | _timeseries:keyword                            | has_pod:boolean
+15.875        | "{""cluster"":""staging"",""region"":""us""}"  | false
+;
+
+
+// `without(pod, region)` must exclude both labels from the _timeseries label set.
+without_excludes_multiple_labels_from_timeseries
+required_capability: promql_command_v0
+required_capability: fix_promql_time_bucket_v2
+required_capability: promql_nested_aggregates
+required_capability: promql_without_grouping
+PROMQL index=k8s step=1h result=(sum without (pod, region) (network.cost{cluster="staging"}))
+| EVAL has_pod = _timeseries LIKE "*pod*", has_region = _timeseries LIKE "*region*"
+| KEEP result, _timeseries, has_pod, has_region;
+
+result:double | _timeseries:keyword         | has_pod:boolean | has_region:boolean
+15.875        | "{""cluster"":""staging""}" | false           | false
 ;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-promql-without.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-promql-without.csv-spec
@@ -213,6 +213,7 @@ required_capability: promql_command_v0
 required_capability: fix_promql_time_bucket_v2
 required_capability: promql_nested_aggregates
 required_capability: promql_without_grouping
+required_capability: fix_promql_without_output
 PROMQL index=k8s step=1h result=(sum without (pod) (sum by (cluster, region, pod) (network.cost)))
 | SORT result;
 

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-promql-without.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-promql-without.csv-spec
@@ -216,10 +216,10 @@ required_capability: promql_without_grouping
 PROMQL index=k8s step=1h result=(sum without (pod) (sum by (cluster, region, pod) (network.cost)))
 | SORT result;
 
-result:double | step:datetime            | _timeseries:keyword
-15.875        | 2024-05-10T01:00:00.000Z | "{""cluster"":""staging"",""region"":""us""}"
-18.625        | 2024-05-10T01:00:00.000Z | "{""cluster"":""prod"",""region"":[""eu"",""us""]}"
-26.5          | 2024-05-10T01:00:00.000Z | "{""cluster"":""qa""}"
+result:double | step:datetime            | cluster:keyword | region:keyword
+15.875        | 2024-05-10T01:00:00.000Z | staging         | us
+18.625        | 2024-05-10T01:00:00.000Z | prod            | [eu, us]
+26.5          | 2024-05-10T01:00:00.000Z | qa              | null
 ;
 
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -2271,6 +2271,14 @@ public class EsqlCapabilities {
         PROMQL_WITHOUT_GROUPING,
 
         /**
+         * Corrected output shape for PromQL {@code without}: a {@code without} over a concrete-output child (e.g.
+         * {@code sum without(pod) (sum by(cluster,region,pod) (...))}) projects the child's concrete grouping columns
+         * minus the excluded labels, rather than the opaque {@code _timeseries} column. Gates the affected csv-spec
+         * tests so mixed-version clusters skip them on older nodes that still emit {@code _timeseries}.
+         */
+        FIX_PROMQL_WITHOUT_OUTPUT,
+
+        /**
          * PromQL label matchers that accept the empty string (e.g. {@code {label=""}} or {@code {label!="foo"}})
          * also match time series where the label is absent ({@code NULL}), per PromQL spec.
          */

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/grouping/TimeSeriesWithout.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/grouping/TimeSeriesWithout.java
@@ -11,8 +11,8 @@ import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xpack.esql.core.expression.Alias;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
-import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.MetadataAttribute;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.expression.Nullability;
@@ -157,19 +157,12 @@ public class TimeSeriesWithout extends GroupingFunction.NonEvaluatableGroupingFu
 
     @Override
     protected TypeResolution resolveType() {
+        // Excluded labels are matched by name, so any label reference is acceptable - including labels that are not
+        // (or not yet known to be) dimensions. Excluding a label that is absent from a series is simply a no-op.
         for (Expression field : children()) {
-            if (field instanceof FieldAttribute fa) {
-                if (fa.isDimension() == false) {
-                    return new TypeResolution(ENTRY.name + " requires dimension fields, but [" + fa.sourceText() + "] is not a dimension");
-                }
-            } else {
+            if (field instanceof Attribute == false) {
                 return new TypeResolution(
-                    ENTRY.name
-                        + " requires dimension field names, got ["
-                        + field.sourceText()
-                        + "] of type ["
-                        + field.dataType().typeName()
-                        + "]"
+                    ENTRY.name + " requires label names, got [" + field.sourceText() + "] of type [" + field.dataType().typeName() + "]"
                 );
             }
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/promql/PromqlAttributesTranslationContext.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/promql/PromqlAttributesTranslationContext.java
@@ -10,10 +10,11 @@ package org.elasticsearch.xpack.esql.optimizer.rules.logical.promql;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.MetadataAttribute;
+import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -28,13 +29,14 @@ import java.util.function.Predicate;
  * and resolves it against real columns only at the very end.
  *
  * <h2>Abstract domain: label sets</h2>
- * A label set is a plain {@code List<Attribute>}, with the single sentinel {@code ALL} standing for the full universe
- * {@code T} ("every runtime label") - the one set we can never enumerate at plan time. {@code T} is realised physically
- * by the opaque {@code _timeseries} grouping key (see {@code TranslateTimeSeriesWithout}), which is why it contributes
- * no concrete columns when resolved. The static {@code union}/{@code intersect}/{@code minus} helpers implement set
- * algebra over these values (labels are compared by field name). {@code T} minus a finite set stays {@code T}: the
- * removed labels are never listed, and - because every {@code BY} forces a finite scope down its subtree - that
- * complement is never observed, so a single {@code ALL} sentinel is enough.
+ * A label set is a plain {@code List<Attribute>} plus two "top" sentinels: {@code UNIVERSE} for the full label universe
+ * {@code T} ("every runtime label") - the one set we can never enumerate at plan time - and {@code SCALAR} for a
+ * subtree that exposes no series identity at all (a literal/scalar or a bare {@code NONE}). {@code T} is realised
+ * physically by the opaque {@code _timeseries} grouping key (see {@code TranslateTimeSeriesWithout}), which is why it
+ * contributes no concrete columns when resolved. The static {@code union}/{@code intersect}/{@code minus} helpers
+ * implement set algebra over these values (labels are compared by field name). {@code T} minus a finite set stays
+ * {@code T}: the removed labels are never listed, and - because every {@code BY} forces a finite scope down its
+ * subtree - that complement is never observed, so a single {@code UNIVERSE} sentinel is enough.
  *
  * <h2>The two attributes</h2>
  * The translation is an <em>L-attributed</em> syntax-directed definition. Two attributes flow through the aggregate
@@ -100,28 +102,140 @@ import java.util.function.Predicate;
  */
 public final class PromqlAttributesTranslationContext {
 
+    /**
+     * The full label universe {@code T} ("every runtime label"): the one set we never enumerate at plan time. It is
+     * realised physically by the opaque {@code _timeseries} grouping key, so it contributes no concrete columns.
+     */
+    private static final List<Attribute> UNIVERSE = List.of(new ReferenceAttribute(Source.EMPTY, ":U", DataType.NULL));
+
+    /**
+     * The <b>scalar</b> sentinel: a subtree that exposes no series identity at all (a literal/scalar, or a bare
+     * {@code NONE} aggregate that collapses every series into one). Like {@code UNIVERSE} it is "top" for the set
+     * operations - a {@code BY} stacked on top keeps its declared keys - but, unlike {@code UNIVERSE}, it must
+     * <b>not</b> materialise a {@code _timeseries} grouping. Telling it apart from {@code UNIVERSE} is what lets an
+     * empty {@code without ()} (which retains the full universe {@code T}) be distinguished from {@code none()}
+     * (which retains nothing).
+     */
+    private static final List<Attribute> SCALAR = List.of(new ReferenceAttribute(Source.EMPTY, ":S", DataType.NULL));
+
     private PromqlAttributesTranslationContext() {}
 
-    /**
-     * The full label universe {@code T} ("every runtime label"): the one set we never enumerate. It is realised
-     * physically by the opaque {@code _timeseries} grouping key, so it contributes no concrete columns. Represented as
-     * {@code null} to keep the carrier a plain {@code List<Attribute>}; the set helpers below give it its meaning.
-     */
-    private static final List<Attribute> ALL = null;
-
-    /**
-     * The <b>scalar</b> sentinel: a subtree that exposes no series identity at all (a literal/scalar, or a bare {@code NONE}
-     * aggregate that collapses every series into one). Like {@code T} it is "top" for the set operations - a {@code BY}
-     * stacked on top keeps its declared keys ({@code intersect} returns them) - but unlike {@code T} it must <b>not</b>
-     * materialise a {@code _timeseries} grouping. Distinguishing it from {@code T} is what lets an empty {@code without ()}
-     * (which retains the full label set {@code T}) be told apart from {@code none()} (which retains nothing). It is a unique
-     * instance compared by identity; no finite list ever equals it.
-     */
-    private static final List<Attribute> SCALAR = Collections.unmodifiableList(new ArrayList<>());
-
-    /** Whether {@code set} is one of the two "top" sentinels ({@code T} or scalar) rather than a finite, enumerable set. */
+    /** Whether {@code set} is one of the two top sentinels ({@code UNIVERSE} or {@code SCALAR}) rather than a finite, enumerable set. */
     private static boolean isTop(List<Attribute> set) {
-        return set == ALL || set == SCALAR;
+        return set == UNIVERSE || set == SCALAR;
+    }
+
+    // label-set algebra:
+
+    /**
+     * Collapse a raw label list to its canonical set by field name: at most one attribute per field name, first
+     * occurrence wins, insertion order preserved. Every external finite list is funnelled through here before it is
+     * stored, so the algebra below can assume its inputs are already duplicate-free.
+     */
+    private static List<Attribute> canonicalizeByFieldName(List<Attribute> labels) {
+        assert isTop(labels) == false : "canonicalizeByFieldName expects a finite list, not a top sentinel";
+        List<Attribute> result = new ArrayList<>();
+        Set<String> seen = new LinkedHashSet<>();
+        for (Attribute attr : labels) {
+            if (seen.add(canonicalName(attr))) {
+                result.add(attr);
+            }
+        }
+        return result;
+    }
+
+    /** {@code a | b} by field name, order-preserving ({@code a} first). Both operands are finite. */
+    static List<Attribute> union(List<Attribute> a, List<Attribute> b) {
+        assert isTop(a) == false && isTop(b) == false : "union expects finite operands, not a top sentinel";
+        List<Attribute> result = new ArrayList<>();
+        Set<String> seen = new LinkedHashSet<>();
+        for (Attribute attr : a) {
+            if (seen.add(canonicalName(attr))) {
+                result.add(attr);
+            }
+        }
+        for (Attribute attr : b) {
+            if (seen.add(canonicalName(attr))) {
+                result.add(attr);
+            }
+        }
+        return result;
+    }
+
+    /** {@code a & b}. {@code a} may be a top sentinel ({@code T} or scalar; then the result is exactly {@code b}); {@code b} is finite. */
+    private static List<Attribute> intersect(List<Attribute> a, List<Attribute> b) {
+        assert isTop(b) == false : "intersect expects a finite right operand, not a top sentinel";
+        if (isTop(a)) {
+            return new ArrayList<>(b);
+        }
+        Set<String> names = fieldNames(b);
+        return filter(a, attr -> names.contains(canonicalName(attr)));
+    }
+
+    /** {@code a \ b}. {@code a} may be a top sentinel (top minus a finite set stays that same sentinel); {@code b} is finite. */
+    private static List<Attribute> minus(List<Attribute> a, List<Attribute> b) {
+        assert isTop(b) == false : "minus expects a finite right operand, not a top sentinel";
+        if (isTop(a)) {
+            return a;
+        }
+        Set<String> names = fieldNames(b);
+        return filter(a, attr -> names.contains(canonicalName(attr)) == false);
+    }
+
+    /** The member with this field name, or {@code null} (always {@code null} for {@code T}). */
+    static Attribute findByFieldName(List<Attribute> set, String name) {
+        if (isTop(set)) {
+            return null;
+        }
+        for (Attribute attr : set) {
+            if (canonicalName(attr).equals(name)) {
+                return attr;
+            }
+        }
+        return null;
+    }
+
+    /** The concrete members, or the empty list for a top sentinel ({@code T} or scalar). */
+    private static List<Attribute> asList(List<Attribute> set) {
+        return isTop(set) ? List.of() : set;
+    }
+
+    private static Set<String> fieldNames(List<Attribute> set) {
+        Set<String> names = new LinkedHashSet<>(set.size());
+        for (Attribute attr : set) {
+            names.add(canonicalName(attr));
+        }
+        return names;
+    }
+
+    private static List<Attribute> filter(List<Attribute> set, Predicate<Attribute> keep) {
+        List<Attribute> result = new ArrayList<>();
+        for (Attribute attr : set) {
+            if (keep.test(attr)) {
+                result.add(attr);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Canonical name used by the label algebra: a {@link FieldAttribute} uses its field name, everything else falls
+     * back to {@link Attribute#name()}. PromQL refers to labels by bare names ({@code le}, {@code job}), while TSDB
+     * dimensions that store Prometheus labels can be exposed as {@code labels.le} / {@code labels.job}. Strip that
+     * storage prefix so {@code by}, {@code without}, intersection, and difference compare PromQL label keys rather than
+     * backing field names (and so exclusion names match the dimensions the {@code _timeseries} block loader enumerates).
+     */
+    static String canonicalName(Attribute attr) {
+        return stripIgnorePrefix((attr instanceof FieldAttribute fa) ? fa.fieldName().string() : attr.name());
+    }
+
+    private static String stripIgnorePrefix(String name) {
+        return name.startsWith("labels.") ? name.substring("labels.".length()) : name;
+    }
+
+    /** The concrete dimension fields among {@code attributes} (used to seed a child demand from a selector's output). */
+    static List<Attribute> filterDimensionAttributes(List<Attribute> attributes) {
+        return attributes.stream().filter(a -> a instanceof FieldAttribute fa && fa.isDimension()).toList();
     }
 
     /**
@@ -131,7 +245,7 @@ public final class PromqlAttributesTranslationContext {
      */
     public static final class InheritedAttributes {
 
-        /** {@code G}: the labels still in scope and required from below ({@code ALL} until a {@code BY} narrows it). */
+        /** {@code G}: the labels still in scope and required from below ({@code UNIVERSE} until a {@code BY} narrows it). */
         private final List<Attribute> required;
         /** {@code X}: every dimension dropped by a {@code WITHOUT} on the way down, for the innermost {@code _timeseries}. */
         private final List<Attribute> accumulatedExclusions;
@@ -143,7 +257,7 @@ public final class PromqlAttributesTranslationContext {
 
         /** Everything in scope ({@code G=T}), nothing excluded. */
         public static InheritedAttributes unconstrained() {
-            return new InheritedAttributes(ALL, List.of());
+            return new InheritedAttributes(UNIVERSE, List.of());
         }
 
         /**
@@ -185,7 +299,7 @@ public final class PromqlAttributesTranslationContext {
      */
     public static final class SynthesizedAttributes {
 
-        /** {@code G}: the labels this subtree exposes as grouping keys ({@code ALL} for a literal/scalar). */
+        /** {@code G}: the labels this subtree exposes as grouping keys ({@code SCALAR} for a literal/scalar). */
         private final List<Attribute> grouping;
         /** {@code O}: the labels a {@code BY} promises to expose. Empty unless this shape came from a {@code BY}. */
         private final List<Attribute> output;
@@ -286,29 +400,43 @@ public final class PromqlAttributesTranslationContext {
          */
         private ResolvedAttributes translateAgainst(List<Attribute> available, List<Attribute> excludedDimensions) {
             List<Attribute> projected = projected();
-            Attribute ts = findByFieldName(available, MetadataAttribute.TIMESERIES);
-            // Grouping by the full runtime label set T (a WITHOUT, including the empty `without ()`) is the opaque
-            // `_timeseries` identity. When the available columns don't already carry one, surface a `_timeseries`
-            // grouping key here so the plan builder lowers it like any other `_timeseries` - its (possibly empty)
-            // exclusion set comes from excludedDimensions. The scalar sentinel deliberately does not match: a
-            // scalar/NONE collapse must NOT carry a `_timeseries`.
-            if (ts == null && projected == ALL) {
-                ts = FieldAttribute.timeSeriesAttribute(Source.EMPTY);
-            }
-            List<Attribute> resolved = resolveAgainst(projected, available);
-            List<Attribute> missing = asList(minus(projected, resolved));
+            var timeseries = findByFieldName(available, MetadataAttribute.TIMESERIES);
 
-            if (ts != null) {
-                List<Attribute> attrs = new ArrayList<>();
-                for (Attribute attr : resolved) {
-                    if (MetadataAttribute.isTimeSeriesAttributeName(attr.name()) == false) {
-                        attrs.add(attr);
+            /*
+             * `without` means "group by the runtime label set", represented by `_timeseries`.
+             * If the input plan does not expose `_timeseries` yet, synthesize it here so the
+             * plan builder can lower it normally. Do not do this for the scalar/NONE sentinel.
+             */
+            if (timeseries == null && projected == UNIVERSE) {
+                timeseries = FieldAttribute.timeSeriesAttribute(Source.EMPTY);
+            }
+
+            var resolved = new ArrayList<Attribute>();
+
+            if (isTop(projected) == false) {
+                if (available == UNIVERSE) {
+                    resolved.addAll(projected);
+                } else {
+                    resolved.ensureCapacity(projected.size());
+                    for (Attribute attr : projected) {
+                        Attribute match = available.contains(attr) ? attr : findByFieldName(available, canonicalName(attr));
+
+                        if (match != null) {
+                            resolved.add(match);
+                        }
                     }
                 }
-                return new ResolvedAttributes(List.of(ts), attrs, missing, excludedDimensions);
             }
 
-            return new ResolvedAttributes(resolved, List.of(), missing, excludedDimensions);
+            var missing = asList(minus(projected, resolved));
+
+            if (timeseries == null) {
+                return new ResolvedAttributes(resolved, List.of(), missing, excludedDimensions);
+            }
+
+            resolved.removeIf(attr -> MetadataAttribute.isTimeSeriesAttributeName(attr.name()));
+
+            return new ResolvedAttributes(List.of(timeseries), resolved, missing, excludedDimensions);
         }
     }
 
@@ -351,146 +479,4 @@ public final class PromqlAttributesTranslationContext {
          */
         List<Attribute> excludedDimensions
     ) {}
-
-    // ----------------------------------------------------------------
-    // Label-set algebra: total operations over List<Attribute>, with the ALL sentinel for the universe T.
-    // Labels are compared by field name; the operands marked "finite" are never ALL.
-    // ----------------------------------------------------------------
-
-    /**
-     * Collapse a raw label list to its canonical set by field name: at most one attribute per field name, first
-     * occurrence wins, insertion order preserved. Every external finite list is funnelled through here before it is
-     * stored, so the algebra below can assume its inputs are already duplicate-free.
-     */
-    private static List<Attribute> canonicalizeByFieldName(List<Attribute> labels) {
-        assert isTop(labels) == false : "canonicalizeByFieldName expects a finite list, not a top sentinel";
-        List<Attribute> result = new ArrayList<>();
-        Set<String> seen = new LinkedHashSet<>();
-        for (Attribute attr : labels) {
-            if (seen.add(fieldName(attr))) {
-                result.add(attr);
-            }
-        }
-        return result;
-    }
-
-    /** {@code a | b} by field name, order-preserving ({@code a} first). Both operands are finite. */
-    static List<Attribute> union(List<Attribute> a, List<Attribute> b) {
-        assert isTop(a) == false && isTop(b) == false : "union expects finite operands, not a top sentinel";
-        List<Attribute> result = new ArrayList<>();
-        Set<String> seen = new LinkedHashSet<>();
-        for (Attribute attr : a) {
-            if (seen.add(fieldName(attr))) {
-                result.add(attr);
-            }
-        }
-        for (Attribute attr : b) {
-            if (seen.add(fieldName(attr))) {
-                result.add(attr);
-            }
-        }
-        return result;
-    }
-
-    /** {@code a & b}. {@code a} may be a top sentinel ({@code T} or scalar; then the result is exactly {@code b}); {@code b} is finite. */
-    private static List<Attribute> intersect(List<Attribute> a, List<Attribute> b) {
-        assert isTop(b) == false : "intersect expects a finite right operand, not a top sentinel";
-        if (isTop(a)) {
-            return new ArrayList<>(b);
-        }
-        Set<String> names = fieldNames(b);
-        return filter(a, attr -> names.contains(fieldName(attr)));
-    }
-
-    /** {@code a \ b}. {@code a} may be a top sentinel (top minus a finite set stays that same sentinel); {@code b} is finite. */
-    private static List<Attribute> minus(List<Attribute> a, List<Attribute> b) {
-        assert isTop(b) == false : "minus expects a finite right operand, not a top sentinel";
-        if (isTop(a)) {
-            return a;
-        }
-        Set<String> names = fieldNames(b);
-        return filter(a, attr -> names.contains(fieldName(attr)) == false);
-    }
-
-    /**
-     * The concrete columns {@code set} contributes when resolved against the labels {@code available} actually carries.
-     * {@code T} contributes none: it is realised by the opaque {@code _timeseries} grouping, not by enumerating the
-     * universe. A finite set keeps the identical attribute when present, otherwise substitutes the member of
-     * {@code available} sharing its field name, dropping entries with no match.
-     */
-    private static List<Attribute> resolveAgainst(List<Attribute> set, List<Attribute> available) {
-        if (isTop(set)) {
-            return List.of();
-        }
-        if (available == ALL) {
-            return new ArrayList<>(set);
-        }
-        List<Attribute> resolved = new ArrayList<>();
-        for (Attribute attr : set) {
-            if (available.contains(attr)) {
-                resolved.add(attr);
-                continue;
-            }
-            Attribute byName = findByFieldName(available, fieldName(attr));
-            if (byName != null) {
-                resolved.add(byName);
-            }
-        }
-        return resolved;
-    }
-
-    /** The member with this field name, or {@code null} (always {@code null} for {@code T}). */
-    static Attribute findByFieldName(List<Attribute> set, String name) {
-        if (isTop(set)) {
-            return null;
-        }
-        for (Attribute attr : set) {
-            if (fieldName(attr).equals(name)) {
-                return attr;
-            }
-        }
-        return null;
-    }
-
-    /** The concrete members, or the empty list for a top sentinel ({@code T} or scalar). */
-    private static List<Attribute> asList(List<Attribute> set) {
-        return isTop(set) ? List.of() : set;
-    }
-
-    private static Set<String> fieldNames(List<Attribute> set) {
-        Set<String> names = new LinkedHashSet<>();
-        for (Attribute attr : set) {
-            names.add(fieldName(attr));
-        }
-        return names;
-    }
-
-    private static List<Attribute> filter(List<Attribute> set, Predicate<Attribute> keep) {
-        List<Attribute> result = new ArrayList<>();
-        for (Attribute attr : set) {
-            if (keep.test(attr)) {
-                result.add(attr);
-            }
-        }
-        return result;
-    }
-
-    /**
-     * Canonical name used by the label algebra: a {@link FieldAttribute} uses its field name, everything else falls
-     * back to {@link Attribute#name()}. PromQL refers to labels by bare names ({@code le}, {@code job}), while TSDB
-     * dimensions that store Prometheus labels can be exposed as {@code labels.le} / {@code labels.job}. Strip that
-     * storage prefix so {@code by}, {@code without}, intersection, and difference compare PromQL label keys rather than
-     * backing field names (and so exclusion names match the dimensions the {@code _timeseries} block loader enumerates).
-     */
-    static String fieldName(Attribute attr) {
-        String name = attr instanceof FieldAttribute fieldAttr ? fieldAttr.fieldName().string() : attr.name();
-        return name.startsWith(PROMETHEUS_LABELS_PREFIX) ? name.substring(PROMETHEUS_LABELS_PREFIX.length()) : name;
-    }
-
-    private static final String PROMETHEUS_LABELS_PREFIX = "labels.";
-
-    /** The concrete dimension fields among {@code attributes} (used to seed a child demand from a selector's output). */
-    static List<Attribute> dimensionAttributes(List<Attribute> attributes) {
-        return attributes.stream().filter(a -> a instanceof FieldAttribute fa && fa.isDimension()).toList();
-    }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/promql/PromqlAttributesTranslationContext.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/promql/PromqlAttributesTranslationContext.java
@@ -10,8 +10,10 @@ package org.elasticsearch.xpack.esql.optimizer.rules.logical.promql;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.MetadataAttribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -108,6 +110,21 @@ public final class PromqlAttributesTranslationContext {
     private static final List<Attribute> ALL = null;
 
     /**
+     * The <b>scalar</b> sentinel: a subtree that exposes no series identity at all (a literal/scalar, or a bare {@code NONE}
+     * aggregate that collapses every series into one). Like {@code T} it is "top" for the set operations - a {@code BY}
+     * stacked on top keeps its declared keys ({@code intersect} returns them) - but unlike {@code T} it must <b>not</b>
+     * materialise a {@code _timeseries} grouping. Distinguishing it from {@code T} is what lets an empty {@code without ()}
+     * (which retains the full label set {@code T}) be told apart from {@code none()} (which retains nothing). It is a unique
+     * instance compared by identity; no finite list ever equals it.
+     */
+    private static final List<Attribute> SCALAR = Collections.unmodifiableList(new ArrayList<>());
+
+    /** Whether {@code set} is one of the two "top" sentinels ({@code T} or scalar) rather than a finite, enumerable set. */
+    private static boolean isTop(List<Attribute> set) {
+        return set == ALL || set == SCALAR;
+    }
+
+    /**
      * The <b>inherited</b> attribute: the scope a subtree must preserve, threaded down the aggregate chain. An
      * {@code InheritedAttributes} is produced by {@link #unconstrained()} above the outermost aggregate and narrowed by each
      * aggregate before being handed to its child. The leaf selector ends the descent with {@link #reflect()}.
@@ -129,9 +146,15 @@ public final class PromqlAttributesTranslationContext {
             return new InheritedAttributes(ALL, List.of());
         }
 
-        /** {@code BY(W)}: only {@code W} stays in scope; accumulated exclusions are carried through unchanged. */
+        /**
+         * {@code BY(W)}: only {@code W} stays in scope, and the accumulated exclusions are <b>cleared</b>. A {@code BY}
+         * fixes its subtree's output to concrete keys, so any outer {@code WITHOUT} applies over those concrete labels
+         * (handled by the outer aggregate), not as a leaf {@code _timeseries} exclusion. Carrying the outer exclusions
+         * past a {@code BY} would wrongly inject a {@code _timeseries} into the inner concrete aggregate, making it group
+         * by {@code identity \ excluded} instead of {@code W} and leaking every other label.
+         */
         public InheritedAttributes including(List<Attribute> attributes) {
-            return new InheritedAttributes(canonicalizeByFieldName(attributes), accumulatedExclusions);
+            return new InheritedAttributes(canonicalizeByFieldName(attributes), List.of());
         }
 
         /** {@code WITHOUT(E)}: {@code E} drops out of scope ({@code G \ E}) and joins the accumulated exclusions. */
@@ -180,11 +203,12 @@ public final class PromqlAttributesTranslationContext {
         }
 
         /**
-         * The shape of a subtree that exposes no specific grouping (a literal selector, a scalar). It carries the full
-         * set {@code T} so that a {@code BY} stacked directly on top keeps its declared keys.
+         * The shape of a subtree that exposes no specific grouping (a literal selector, a scalar, a bare {@code NONE}
+         * aggregate). It carries the {@code SCALAR} sentinel: top-like for set operations (so a {@code BY} stacked directly
+         * on top keeps its declared keys) but, unlike {@code T}, it does not materialise a {@code _timeseries} grouping.
          */
         public static SynthesizedAttributes none() {
-            return new SynthesizedAttributes(ALL, List.of(), List.of());
+            return new SynthesizedAttributes(SCALAR, List.of(), List.of());
         }
 
         /** A shape built directly from a known label set, e.g., a bare selector's output. */
@@ -263,6 +287,14 @@ public final class PromqlAttributesTranslationContext {
         private ResolvedAttributes translateAgainst(List<Attribute> available, List<Attribute> excludedDimensions) {
             List<Attribute> projected = projected();
             Attribute ts = findByFieldName(available, MetadataAttribute.TIMESERIES);
+            // Grouping by the full runtime label set T (a WITHOUT, including the empty `without ()`) is the opaque
+            // `_timeseries` identity. When the available columns don't already carry one, surface a `_timeseries`
+            // grouping key here so the plan builder lowers it like any other `_timeseries` - its (possibly empty)
+            // exclusion set comes from excludedDimensions. The scalar sentinel deliberately does not match: a
+            // scalar/NONE collapse must NOT carry a `_timeseries`.
+            if (ts == null && projected == ALL) {
+                ts = FieldAttribute.timeSeriesAttribute(Source.EMPTY);
+            }
             List<Attribute> resolved = resolveAgainst(projected, available);
             List<Attribute> missing = asList(minus(projected, resolved));
 
@@ -331,7 +363,7 @@ public final class PromqlAttributesTranslationContext {
      * stored, so the algebra below can assume its inputs are already duplicate-free.
      */
     private static List<Attribute> canonicalizeByFieldName(List<Attribute> labels) {
-        assert labels != ALL : "canonicalizeByFieldName expects a finite list, not T";
+        assert isTop(labels) == false : "canonicalizeByFieldName expects a finite list, not a top sentinel";
         List<Attribute> result = new ArrayList<>();
         Set<String> seen = new LinkedHashSet<>();
         for (Attribute attr : labels) {
@@ -344,7 +376,7 @@ public final class PromqlAttributesTranslationContext {
 
     /** {@code a | b} by field name, order-preserving ({@code a} first). Both operands are finite. */
     static List<Attribute> union(List<Attribute> a, List<Attribute> b) {
-        assert a != ALL && b != ALL : "union expects finite operands, not T";
+        assert isTop(a) == false && isTop(b) == false : "union expects finite operands, not a top sentinel";
         List<Attribute> result = new ArrayList<>();
         Set<String> seen = new LinkedHashSet<>();
         for (Attribute attr : a) {
@@ -360,21 +392,21 @@ public final class PromqlAttributesTranslationContext {
         return result;
     }
 
-    /** {@code a & b}. {@code a} may be {@code T} (then the result is exactly {@code b}); {@code b} is finite. */
+    /** {@code a & b}. {@code a} may be a top sentinel ({@code T} or scalar; then the result is exactly {@code b}); {@code b} is finite. */
     private static List<Attribute> intersect(List<Attribute> a, List<Attribute> b) {
-        assert b != ALL : "intersect expects a finite right operand, not T";
-        if (a == ALL) {
+        assert isTop(b) == false : "intersect expects a finite right operand, not a top sentinel";
+        if (isTop(a)) {
             return new ArrayList<>(b);
         }
         Set<String> names = fieldNames(b);
         return filter(a, attr -> names.contains(fieldName(attr)));
     }
 
-    /** {@code a \ b}. {@code a} may be {@code T} ({@code T} minus a finite set stays {@code T}); {@code b} is finite. */
+    /** {@code a \ b}. {@code a} may be a top sentinel (top minus a finite set stays that same sentinel); {@code b} is finite. */
     private static List<Attribute> minus(List<Attribute> a, List<Attribute> b) {
-        assert b != ALL : "minus expects a finite right operand, not T";
-        if (a == ALL) {
-            return ALL;
+        assert isTop(b) == false : "minus expects a finite right operand, not a top sentinel";
+        if (isTop(a)) {
+            return a;
         }
         Set<String> names = fieldNames(b);
         return filter(a, attr -> names.contains(fieldName(attr)) == false);
@@ -387,7 +419,7 @@ public final class PromqlAttributesTranslationContext {
      * {@code available} sharing its field name, dropping entries with no match.
      */
     private static List<Attribute> resolveAgainst(List<Attribute> set, List<Attribute> available) {
-        if (set == ALL) {
+        if (isTop(set)) {
             return List.of();
         }
         if (available == ALL) {
@@ -409,7 +441,7 @@ public final class PromqlAttributesTranslationContext {
 
     /** The member with this field name, or {@code null} (always {@code null} for {@code T}). */
     static Attribute findByFieldName(List<Attribute> set, String name) {
-        if (set == ALL) {
+        if (isTop(set)) {
             return null;
         }
         for (Attribute attr : set) {
@@ -420,9 +452,9 @@ public final class PromqlAttributesTranslationContext {
         return null;
     }
 
-    /** The concrete members, or the empty list for {@code T}. */
+    /** The concrete members, or the empty list for a top sentinel ({@code T} or scalar). */
     private static List<Attribute> asList(List<Attribute> set) {
-        return set == ALL ? List.of() : set;
+        return isTop(set) ? List.of() : set;
     }
 
     private static Set<String> fieldNames(List<Attribute> set) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/promql/TranslatePromqlToEsqlPlan.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/promql/TranslatePromqlToEsqlPlan.java
@@ -15,7 +15,6 @@ import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.core.expression.Alias;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
-import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.FoldContext;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.MetadataAttribute;
@@ -711,9 +710,7 @@ public final class TranslatePromqlToEsqlPlan extends AnalyzerRules.Parameterized
         // exclusions).
         var translation = synthesizedAttributes.translateLeaf(pathExclusions);
 
-        // Only concrete dimension fields can be excluded from the `_timeseries` grouping; non-dimension labels are dropped.
-        List<Attribute> excludedDimensions = dimensionAttributes(translation.excludedDimensions());
-        boolean needsTimeSeriesGrouping = hasTSGrouping(translation.groupings()) || excludedDimensions.isEmpty() == false;
+        boolean needsTimeSeriesGrouping = hasTSGrouping(translation.groupings()) || translation.excludedDimensions().isEmpty() == false;
         // TranslateTimeSeriesAggregate splits this node into two phases, replacing inner
         // TimeSeriesAggregateFunctions (e.g. LastOverTime) with references to phase-1 results.
         // The phase-2 expression must remain a valid AggregateFunction inside the Aggregate node.
@@ -735,7 +732,7 @@ public final class TranslatePromqlToEsqlPlan extends AnalyzerRules.Parameterized
         aggregates.add(ctx.stepAttr());
 
         if (needsTimeSeriesGrouping) {
-            var function = new TimeSeriesWithout(source, new ArrayList<Expression>(excludedDimensions));
+            var function = new TimeSeriesWithout(source, new ArrayList<>(new ArrayList<Expression>(translation.excludedDimensions())));
             var expression = function.createNamedExpression();
             groupings.add(expression);
             aggregates.add(expression.toAttribute());
@@ -762,11 +759,6 @@ public final class TranslatePromqlToEsqlPlan extends AnalyzerRules.Parameterized
 
     private static boolean hasTSGrouping(List<Attribute> groupings) {
         return groupings.stream().anyMatch(attribute -> MetadataAttribute.isTimeSeriesAttributeName(attribute.name()));
-    }
-
-    /** Keep only concrete dimension fields; non-dimension labels cannot be excluded from the {@code _timeseries} grouping. */
-    private static List<Attribute> dimensionAttributes(List<Attribute> attributes) {
-        return attributes.stream().filter(a -> a instanceof FieldAttribute fa && fa.isDimension()).toList();
     }
 
     /** Outer aggregation over an already-aggregated child. */

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/promql/TranslatePromqlToEsqlPlan.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/promql/TranslatePromqlToEsqlPlan.java
@@ -710,6 +710,8 @@ public final class TranslatePromqlToEsqlPlan extends AnalyzerRules.Parameterized
         // exclusions).
         var translation = synthesizedAttributes.translateLeaf(pathExclusions);
 
+        // Empty `without ()` retains the full label set T: translateLeaf surfaces a `_timeseries` grouping key for it
+        // (with an empty exclusion set), so hasTSGrouping already covers it - no separate full-label-set signal needed.
         boolean needsTimeSeriesGrouping = hasTSGrouping(translation.groupings()) || translation.excludedDimensions().isEmpty() == false;
         // TranslateTimeSeriesAggregate splits this node into two phases, replacing inner
         // TimeSeriesAggregateFunctions (e.g. LastOverTime) with references to phase-1 results.
@@ -732,7 +734,16 @@ public final class TranslatePromqlToEsqlPlan extends AnalyzerRules.Parameterized
         aggregates.add(ctx.stepAttr());
 
         if (needsTimeSeriesGrouping) {
-            var function = new TimeSeriesWithout(source, new ArrayList<>(new ArrayList<Expression>(translation.excludedDimensions())));
+            // Resolve each excluded label to the concrete dimension column the child exposes, so the exclusion names
+            // match the backing dimension fields the `_timeseries` block loader enumerates: PromQL `pod` must become the
+            // stored dimension `labels.pod` for Prometheus passthrough data, otherwise the bare key never matches and
+            // the label leaks into the output. A label absent from the child stays unresolved and is simply a no-op.
+            List<Expression> excluded = new ArrayList<>(translation.excludedDimensions().size());
+            for (Attribute label : translation.excludedDimensions()) {
+                Attribute resolved = findAttributeByPromqlLabelName(plan.output(), promqlLabelKey(label));
+                excluded.add(resolved != null ? resolved : label);
+            }
+            var function = new TimeSeriesWithout(source, excluded);
             var expression = function.createNamedExpression();
             groupings.add(expression);
             aggregates.add(expression.toAttribute());
@@ -773,7 +784,9 @@ public final class TranslatePromqlToEsqlPlan extends AnalyzerRules.Parameterized
 
         var translation = labels.translate(plan.output());
 
-        if (labels.hasExclusions() && hasTSGrouping(translation.groupings())) {
+        if (labels.hasExclusions()) {
+            // A WITHOUT regroup (whether the child exposes `_timeseries` or only concrete labels) must pack its carried
+            // dimensions before aggregating: a multi-valued dimension would otherwise split the row and double-count.
             // Pack all carried dimensions before the aggregate to prevent multi-valued splitting,
             // then Unpack after. This covers keys (_timeseries or concrete), attributes (labels
             // to pass through), and missing labels (null-synthesized for BY over WITHOUT).

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/promql/TranslatePromqlToEsqlPlan.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/promql/TranslatePromqlToEsqlPlan.java
@@ -95,6 +95,7 @@ import static org.elasticsearch.xpack.esql.core.expression.MetadataAttribute.isT
 import static org.elasticsearch.xpack.esql.expression.function.aggregate.AggregateFunction.withFilter;
 import static org.elasticsearch.xpack.esql.expression.predicate.Predicates.combineAnd;
 import static org.elasticsearch.xpack.esql.expression.predicate.Predicates.combineAndNullable;
+import static org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.PromqlAttributesTranslationContext.canonicalName;
 
 /**
  * Translates PromQL logical plan into ESQL plan.
@@ -346,10 +347,10 @@ public final class TranslatePromqlToEsqlPlan extends AnalyzerRules.Parameterized
         LogicalPlan childPlan = childResult.plan();
         boolean childAlreadyAggregated = findAggregate(childResult.plan(), Aggregate.class) != null;
         Attribute upperBound = childAlreadyAggregated
-            ? findAttributeByPromqlLabelName(childResult.synthesizedAttributes().declared(), HistogramQuantile.LE_LABEL)
+            ? findAttributeByLabelName(childResult.synthesizedAttributes().declared(), HistogramQuantile.LE_LABEL)
             : null;
         if (upperBound == null && childAlreadyAggregated) {
-            upperBound = findAttributeByPromqlLabelName(childResult.plan().output(), HistogramQuantile.LE_LABEL);
+            upperBound = findAttributeByLabelName(childResult.plan().output(), HistogramQuantile.LE_LABEL);
         }
         SynthesizedAttributes exportLabels;
         if (upperBound == null) {
@@ -402,22 +403,30 @@ public final class TranslatePromqlToEsqlPlan extends AnalyzerRules.Parameterized
     }
 
     private static InheritedAttributes histogramQuantileChildLabels(HistogramQuantile histogramQuantile) {
-        List<Attribute> childLabels = PromqlAttributesTranslationContext.dimensionAttributes(histogramQuantile.child().output());
+        List<Attribute> childLabels = PromqlAttributesTranslationContext.filterDimensionAttributes(histogramQuantile.child().output());
         List<Attribute> demand = childLabels.isEmpty() ? histogramQuantile.child().output() : childLabels;
         return InheritedAttributes.unconstrained().including(demand);
     }
 
-    private static Attribute findAttributeByPromqlLabelName(List<Attribute> attributes, String labelName) {
-        for (Attribute attribute : attributes) {
-            if (promqlLabelKey(attribute).equals(labelName)) {
-                return attribute;
+    private static Attribute findAttributeByLabelName(List<Attribute> attributes, String labelName) {
+        // Prometheus passthrough dimensions surface under two names: the concrete field (e.g. `labels.pod`) and a short
+        // alias (`pod`). `canonicalName` strips the passthrough prefix, so both match `labelName`. The `_timeseries`
+        // block loader excludes by the concrete dimension field name, so we must resolve to the concrete (prefixed)
+        // attribute and never to the bare alias - otherwise the exclusion name never matches and the label leaks. The
+        // bare attribute is the right answer only when no prefixed variant exists (a top-level dimension), so keep it
+        // as a fallback. Without this preference the result depended on the alphabetical order of `attributes`: labels
+        // sorting after `labels.` (e.g. `pod`) happened to hit the concrete field first, while earlier ones (`cluster`,
+        // `job`, `instance`) hit the alias and leaked.
+        Attribute bareMatch = null;
+        for (var attr : attributes) {
+            if (canonicalName(attr).equals(labelName)) {
+                if (attr.name().equals(labelName) == false) {
+                    return attr;
+                }
+                bareMatch = attr;
             }
         }
-        return null;
-    }
-
-    private static String promqlLabelKey(Attribute attr) {
-        return PromqlAttributesTranslationContext.fieldName(attr);
+        return bareMatch;
     }
 
     private static Expression histogramQuantileUpperBound(Source source, Attribute upperBound) {
@@ -740,7 +749,7 @@ public final class TranslatePromqlToEsqlPlan extends AnalyzerRules.Parameterized
             // the label leaks into the output. A label absent from the child stays unresolved and is simply a no-op.
             List<Expression> excluded = new ArrayList<>(translation.excludedDimensions().size());
             for (Attribute label : translation.excludedDimensions()) {
-                Attribute resolved = findAttributeByPromqlLabelName(plan.output(), promqlLabelKey(label));
+                Attribute resolved = findAttributeByLabelName(plan.output(), canonicalName(label));
                 excluded.add(resolved != null ? resolved : label);
             }
             var function = new TimeSeriesWithout(source, excluded);
@@ -890,7 +899,7 @@ public final class TranslatePromqlToEsqlPlan extends AnalyzerRules.Parameterized
     }
 
     private static Alias aliasExistingPromqlLabel(Source source, LogicalPlan plan, Attribute attribute) {
-        Attribute existing = findAttributeByPromqlLabelName(plan.output(), promqlLabelKey(attribute));
+        Attribute existing = findAttributeByLabelName(plan.output(), canonicalName(attribute));
         return existing == null ? nullAlias(attribute) : new Alias(source, attribute.name(), existing, attribute.id());
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/AcrossSeriesAggregate.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/AcrossSeriesAggregate.java
@@ -18,8 +18,10 @@ import org.elasticsearch.xpack.esql.expression.promql.function.FunctionType;
 import org.elasticsearch.xpack.esql.expression.promql.function.PromqlFunctionDefinition;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * Represents a PromQL aggregate function call that operates across multiple time series.
@@ -105,13 +107,23 @@ public final class AcrossSeriesAggregate extends PromqlFunctionCall {
     }
 
     /**
-     * {@code WITHOUT} uses a dynamic {@code _timeseries} output because the
-     * concrete retained labels are not known until lowering time. {@code BY}
-     * and {@code NONE} export concrete labels or nothing.
+     * {@code WITHOUT} over a non-enumerable child (a selector / full series identity) uses a dynamic
+     * {@code _timeseries} output, because the concrete retained labels are not known until lowering time.
+     * {@code WITHOUT} over a concrete-output child (a {@code BY}/{@code NONE} aggregate) instead exposes that child's
+     * concrete labels minus the excluded ones - the {@code WITHOUT} is a plain re-grouping over known columns, so it
+     * must NOT claim a {@code _timeseries} the plan never produces. {@code BY} and {@code NONE} export concrete labels
+     * or nothing.
      */
     @Override
     public List<Attribute> output() {
         if (grouping == Grouping.WITHOUT) {
+            if (child() instanceof AcrossSeriesAggregate childAggregate && childAggregate.grouping() != Grouping.WITHOUT) {
+                Set<String> excluded = new HashSet<>();
+                for (Attribute label : groupings) {
+                    excluded.add(labelKey(label));
+                }
+                return childAggregate.output().stream().filter(a -> excluded.contains(labelKey(a)) == false).toList();
+            }
             return List.of(timeseriesAttribute);
         }
         // A label that resolved to a metric field is not a real label, so translation drops it from the
@@ -121,6 +133,15 @@ public final class AcrossSeriesAggregate extends PromqlFunctionCall {
             .filter(a -> a.resolved() && a.dataType() != DataType.NULL)
             .filter(a -> a instanceof FieldAttribute fieldAttribute ? fieldAttribute.isMetric() == false : true)
             .toList();
+    }
+
+    /**
+     * The PromQL label key of an attribute: a {@link FieldAttribute}'s backing field name with the Prometheus
+     * {@code labels.} passthrough prefix stripped (so {@code labels.pod} compares equal to a bare {@code pod}).
+     */
+    private static String labelKey(Attribute attr) {
+        String name = attr instanceof FieldAttribute fieldAttribute ? fieldAttribute.fieldName().string() : attr.name();
+        return name.startsWith("labels.") ? name.substring("labels.".length()) : name;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/grouping/TimeSeriesWithoutTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/grouping/TimeSeriesWithoutTests.java
@@ -80,19 +80,18 @@ public class TimeSeriesWithoutTests extends AbstractScalarFunctionTestCase {
         assertThat(without.resolveType().resolved(), equalTo(true));
     }
 
-    public void testResolveTypeRejectsNonDimensionField() {
-        // field(...) builds a plain (non-dimension) field attribute.
+    public void testResolveTypeAcceptsNonDimensionField() {
+        // #149793: excluded labels are matched by name, so a non-dimension field is accepted - excluding a label that
+        // is not a dimension (or not present at all) is simply a no-op, not an error.
         TimeSeriesWithout without = new TimeSeriesWithout(Source.EMPTY, List.of(field("not_a_dimension", DataType.KEYWORD)));
-        Expression.TypeResolution resolution = without.resolveType();
-        assertThat(resolution.unresolved(), equalTo(true));
-        assertThat(resolution.message(), containsString("is not a dimension"));
+        assertThat(without.resolveType().resolved(), equalTo(true));
     }
 
     public void testResolveTypeRejectsNonFieldExpression() {
         TimeSeriesWithout without = new TimeSeriesWithout(Source.EMPTY, List.of(new Literal(Source.EMPTY, 1, DataType.INTEGER)));
         Expression.TypeResolution resolution = without.resolveType();
         assertThat(resolution.unresolved(), equalTo(true));
-        assertThat(resolution.message(), containsString("requires dimension field names"));
+        assertThat(resolution.message(), containsString("requires label names"));
         assertThat(resolution.message(), containsString("integer"));
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlPlanSelectorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlPlanSelectorTests.java
@@ -84,16 +84,10 @@ public class PromqlPlanSelectorTests extends AbstractPromqlPlanOptimizerTests {
                 + "(http_request_duration_seconds_bucket)))"
         );
 
+        // `le` is dropped and `cluster` retained: the output carries cluster, not le. (The histogram regroup packs its
+        // carried dimensions for multi-value safety, so the grouping keys are packed aliases - assert on the output.)
         assertThat(outputColumns(plan), equalTo(List.of("result", "step", "cluster")));
         assertThat(collectHistogramQuantiles(plan), hasSize(1));
-
-        Aggregate histogramAggregate = plan.collect(Aggregate.class)
-            .stream()
-            .filter(aggregate -> aggregate instanceof TimeSeriesAggregate == false)
-            .findFirst()
-            .orElseThrow();
-        assertThat(groupingKeyNames(histogramAggregate), hasItem("cluster"));
-        assertThat(groupingKeyNames(histogramAggregate), not(hasItem("le")));
     }
 
     public void testHistogramQuantileRateDoesNotResolveImplicitLe() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlPlanWithoutGroupingTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlPlanWithoutGroupingTests.java
@@ -55,6 +55,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 
@@ -87,6 +88,28 @@ public class PromqlPlanWithoutGroupingTests extends AbstractPromqlPlanOptimizerT
             .orElse(null);
         assertNotNull(timeSeriesMetadata);
         assertThat(timeSeriesMetadata.excludedFields(), hasItem("pod"));
+    }
+
+    /**
+     * Regression for #149793: {@code without(label)} must exclude the label by name even when it does not resolve to a
+     * dimension {@link org.elasticsearch.xpack.esql.core.expression.FieldAttribute}. Before the fix, the dimension-only
+     * filter silently dropped such exclusions, so labels like Prometheus {@code instance} were retained in the
+     * {@code _timeseries} output. Here {@code event} is a mapped non-dimension field, exercising that path.
+     */
+    public void testWithoutExcludesNonDimensionLabelByName() {
+        var plan = logicalOptimizerWithLatestVersion.optimize(
+            planPromql("PROMQL index=k8s step=1h result=(sum without (pod, event) (network.bytes_in))", false)
+        );
+
+        var timeSeriesMetadata = plan.collect(EsRelation.class)
+            .stream()
+            .flatMap(relation -> relation.output().stream())
+            .filter(TimeSeriesMetadataAttribute.class::isInstance)
+            .map(TimeSeriesMetadataAttribute.class::cast)
+            .findFirst()
+            .orElse(null);
+        assertNotNull(timeSeriesMetadata);
+        assertThat(timeSeriesMetadata.excludedFields(), hasItems("pod", "event"));
     }
 
     public void testWithoutGroupingSurvivesDataNodePlanSerialization() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlPlanWithoutGroupingTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlPlanWithoutGroupingTests.java
@@ -91,6 +91,53 @@ public class PromqlPlanWithoutGroupingTests extends AbstractPromqlPlanOptimizerT
     }
 
     /**
+     * In PromQL {@code without ()} (empty parens) means "group by every label", i.e. the full runtime label set - not
+     * "no grouping". The innermost aggregate must therefore still own a {@code _timeseries} grouping key (with an empty
+     * exclusion set), otherwise the final PromQL projection references a {@code _timeseries} the plan never produced.
+     */
+    public void testTopLevelWithoutEmptyProducesTimeSeriesOutput() {
+        var plan = logicalOptimizerWithLatestVersion.optimize(
+            planPromql("PROMQL index=k8s step=1h result=(sum without () (network.bytes_in))", false)
+        );
+
+        assertThat(plan.output().stream().map(Attribute::name).toList(), equalTo(List.of("result", "step", MetadataAttribute.TIMESERIES)));
+
+        var timeSeriesMetadata = plan.collect(EsRelation.class)
+            .stream()
+            .flatMap(relation -> relation.output().stream())
+            .filter(TimeSeriesMetadataAttribute.class::isInstance)
+            .map(TimeSeriesMetadataAttribute.class::cast)
+            .findFirst()
+            .orElse(null);
+        assertNotNull(timeSeriesMetadata);
+        assertThat(timeSeriesMetadata.excludedFields(), empty());
+    }
+
+    /**
+     * Negative pin: a bare aggregate with no grouping clause ({@code sum(...)}) collapses every series into one result,
+     * so it must NOT carry a {@code _timeseries} grouping. Guards against the {@code without ()} fix over-triggering.
+     */
+    public void testBareAggregateDoesNotProduceTimeSeriesOutput() {
+        var plan = logicalOptimizerWithLatestVersion.optimize(
+            planPromql("PROMQL index=k8s step=1h result=(sum (network.bytes_in))", false)
+        );
+
+        assertThat(plan.output().stream().map(Attribute::name).toList(), not(hasItem(MetadataAttribute.TIMESERIES)));
+    }
+
+    /**
+     * Negative pin: {@code by ()} (empty parens) groups by nothing - the dual of {@code without ()} - and must NOT carry
+     * a {@code _timeseries} grouping either.
+     */
+    public void testByEmptyDoesNotProduceTimeSeriesOutput() {
+        var plan = logicalOptimizerWithLatestVersion.optimize(
+            planPromql("PROMQL index=k8s step=1h result=(sum by () (network.bytes_in))", false)
+        );
+
+        assertThat(plan.output().stream().map(Attribute::name).toList(), not(hasItem(MetadataAttribute.TIMESERIES)));
+    }
+
+    /**
      * Regression for #149793: {@code without(label)} must exclude the label by name even when it does not resolve to a
      * dimension {@link org.elasticsearch.xpack.esql.core.expression.FieldAttribute}. Before the fix, the dimension-only
      * filter silently dropped such exclusions, so labels like Prometheus {@code instance} were retained in the
@@ -206,20 +253,23 @@ public class PromqlPlanWithoutGroupingTests extends AbstractPromqlPlanOptimizerT
         assertThat(functionConfig.withoutFields(), hasItem("pod"));
     }
 
-    public void testNestedWithoutOverByProducesTimeSeriesOutput() {
+    public void testNestedWithoutOverByProducesConcreteOutput() {
+        // `without(pod)` over `by(cluster,region,pod)` drops pod from the concrete BY keys: the result is grouped by
+        // {cluster, region}, not the opaque `_timeseries` identity (which would leak every other label).
         var plan = planPromql("PROMQL index=k8s step=1h result=(sum without (pod) (sum by (cluster, region, pod) (network.cost)))");
-        assertThat(plan.output().stream().map(Attribute::name).toList(), equalTo(List.of("result", "step", MetadataAttribute.TIMESERIES)));
+        assertThat(plan.output().stream().map(Attribute::name).toList(), equalTo(List.of("result", "step", "cluster", "region")));
     }
 
-    public void testNestedWithoutOverByInnerByHasTimeSeriesWithout() {
+    public void testNestedWithoutOverByHasNoTimeSeriesGrouping() {
+        // The inner BY enumerates concrete labels, so the outer WITHOUT is a concrete re-grouping over those keys - no
+        // `_timeseries` identity is needed (or produced) anywhere in the plan.
         LogicalPlan analyzed = planPromql(
             "PROMQL index=k8s step=1h result=(sum without (pod) (sum by (cluster, region, pod) (network.cost)))",
             false
         );
         EsRelation esRelation = analyzed.collect(EsRelation.class).getFirst();
         var tsmaList = esRelation.expressions().stream().filter(field -> field instanceof TimeSeriesMetadataAttribute).toList();
-        assertThat(tsmaList, hasSize(1));
-        assertEquals(((TimeSeriesMetadataAttribute) tsmaList.getFirst()).excludedFields(), Set.of("pod"));
+        assertThat(tsmaList, hasSize(0));
     }
 
     public void testParentBySynthesizesConsumedBindingFromWithoutCarrier() {
@@ -250,9 +300,10 @@ public class PromqlPlanWithoutGroupingTests extends AbstractPromqlPlanOptimizerT
         assertThat(e.getMessage(), containsString("nested WITHOUT over WITHOUT is not supported at this time"));
     }
 
-    public void testNestedWithoutOverPartialByProducesTimeSeriesOutput() {
+    public void testNestedWithoutOverPartialByProducesConcreteOutput() {
+        // `without(pod)` over `by(cluster,pod)` drops pod, leaving the concrete {cluster}.
         var plan = planPromql("PROMQL index=k8s step=1h result=(sum without (pod) (sum by (cluster, pod) (network.cost)))");
-        assertThat(plan.output().stream().map(Attribute::name).toList(), equalTo(List.of("result", "step", MetadataAttribute.TIMESERIES)));
+        assertThat(plan.output().stream().map(Attribute::name).toList(), equalTo(List.of("result", "step", "cluster")));
     }
 
     public void testAvgOverWithoutRangeAggregationPlans() {
@@ -287,27 +338,18 @@ public class PromqlPlanWithoutGroupingTests extends AbstractPromqlPlanOptimizerT
         assertThat(plan.output().stream().map(Attribute::name).toList(), equalTo(List.of("result", "step")));
     }
 
-    public void testWithoutAbsentLabelIsNoOp() {
+    public void testWithoutAbsentLabelRetainsFullLabelSet() {
+        // `without(<absent label>)` excludes a label that is not present in the series - a no-op exclusion, equivalent
+        // to `without ()`. It therefore groups by the full runtime label set, so the inner aggregate MUST own a
+        // `_timeseries` grouping (with no real exclusion); it is not collapsed away. (Pre-#149793 this wrongly dropped
+        // the unmapped label and produced no `_timeseries`.)
         LogicalPlan analyzed = planPromql(
             "PROMQL index=k8s step=1h result=(sum by (cluster) (sum without (does_not_exist) (network.cost)))",
             false
         );
-        TimeSeriesAggregate innerAggregate = analyzed.collect(TimeSeriesAggregate.class).getFirst();
-        assertThat(
-            innerAggregate.aggregates()
-                .stream()
-                .filter(
-                    aggregate -> Alias.unwrap(aggregate) instanceof DimensionValues values
-                        && values.field() instanceof FieldAttribute field
-                        && field.name().equals("cluster")
-                )
-                .toList(),
-            hasSize(1)
-        );
-        // TimeSeriesMetadataAttribute shouldn't be getting created if without has unmapped label
         EsRelation esRelation = analyzed.collect(EsRelation.class).getFirst();
         var tsmaList = esRelation.expressions().stream().filter(field -> field instanceof TimeSeriesMetadataAttribute).toList();
-        assertThat(tsmaList, hasSize(0));
+        assertThat(tsmaList, hasSize(1));
     }
 
     public void testWithoutAllKnownLabelsProducesEmptyGrouping() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/promql/PromqlAttributesTranslationContextTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/promql/PromqlAttributesTranslationContextTests.java
@@ -63,14 +63,15 @@ public class PromqlAttributesTranslationContextTests extends ESTestCase {
         SynthesizedAttributes afterAvgWithout = SynthesizedAttributes.foldExcluding(List.of(REGION), leaf);
         SynthesizedAttributes afterWithout = SynthesizedAttributes.foldExcluding(List.of(POD), afterAvgWithout);
 
-        // innermost physical aggregate groups by _timeseries and drops every excluded dimension at once
+        // innermost physical aggregate groups by the full label set (the `_timeseries` identity) and drops every
+        // excluded dimension at once
         ResolvedAttributes innermost = afterAvgWithout.translateLeaf(demandForSelector.pathExclusions());
-        assertThat(names(innermost.groupings()), empty());
+        assertThat(names(innermost.groupings()), equalTo(Set.of("_timeseries")));
         assertThat(names(innermost.excludedDimensions()), equalTo(Set.of("pod", "region")));
 
-        // the outermost aggregate has nothing concrete left to group on
+        // the outermost aggregate still groups by the full label set (no concrete keys), i.e. `_timeseries`
         ResolvedAttributes outermost = afterWithout.translate(afterAvgWithout.declared());
-        assertThat(names(outermost.groupings()), empty());
+        assertThat(names(outermost.groupings()), equalTo(Set.of("_timeseries")));
         assertThat(names(outermost.absent()), empty());
     }
 
@@ -115,10 +116,12 @@ public class PromqlAttributesTranslationContextTests extends ESTestCase {
         SynthesizedAttributes afterBy = SynthesizedAttributes.foldIncluding(List.of(CLUSTER, REGION), afterAvgWithout);
         SynthesizedAttributes afterWithout = SynthesizedAttributes.foldExcluding(List.of(CLUSTER), afterBy);
 
-        // the single bottom grouping must exclude both dimensions that any WITHOUT removed
+        // The intervening BY(cluster,region) clears the inherited exclusions, so only the WITHOUT(region) below the BY
+        // reaches the leaf; the outer WITHOUT(cluster) applies over the BY's concrete keys, not at the leaf. (This exact
+        // query - two WITHOUTs with a BY between - is rejected in practice; this only pins the algebra composition.)
         ResolvedAttributes innermost = afterAvgWithout.translateLeaf(demandForSelector.pathExclusions());
         assertThat(names(innermost.groupings()), equalTo(Set.of("cluster")));
-        assertThat(names(innermost.excludedDimensions()), equalTo(Set.of("cluster", "region")));
+        assertThat(names(innermost.excludedDimensions()), equalTo(Set.of("region")));
 
         ResolvedAttributes outermost = afterWithout.translate(afterBy.declared());
         assertThat(names(outermost.groupings()), empty());
@@ -137,9 +140,11 @@ public class PromqlAttributesTranslationContextTests extends ESTestCase {
         SynthesizedAttributes afterBy = SynthesizedAttributes.foldIncluding(List.of(CLUSTER, POD), leaf);
         SynthesizedAttributes afterWithout = SynthesizedAttributes.foldExcluding(List.of(POD), afterBy);
 
+        // The BY(cluster,pod) clears the inherited exclusions, so the leaf has none: the outer WITHOUT(pod) drops pod
+        // from the BY's concrete keys (handled at the outer aggregate), not via a leaf `_timeseries` exclusion.
         ResolvedAttributes innermost = afterBy.translateLeaf(demandForSelector.pathExclusions());
         assertThat(names(innermost.groupings()), equalTo(Set.of("cluster", "pod")));
-        assertThat(names(innermost.excludedDimensions()), equalTo(Set.of("pod")));
+        assertThat(names(innermost.excludedDimensions()), empty());
 
         ResolvedAttributes outermost = afterWithout.translate(afterBy.declared());
         assertThat(names(outermost.groupings()), equalTo(Set.of("cluster")));

--- a/x-pack/plugin/prometheus/src/javaRestTest/java/org/elasticsearch/xpack/prometheus/PrometheusEsqlTimeSeriesRestIT.java
+++ b/x-pack/plugin/prometheus/src/javaRestTest/java/org/elasticsearch/xpack/prometheus/PrometheusEsqlTimeSeriesRestIT.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.prometheus;
 import org.apache.http.HttpHeaders;
 import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.entity.ContentType;
+import org.apache.http.message.BasicNameValuePair;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.test.rest.ObjectPath;
@@ -19,6 +20,7 @@ import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.prometheus.proto.RemoteWrite;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
@@ -73,6 +75,55 @@ public class PrometheusEsqlTimeSeriesRestIT extends AbstractPrometheusRestIT {
         assertThat(parsedLabels, hasEntry("__name__", metricName));
         assertThat(parsedLabels, hasEntry("instance", "localhost:9090"));
         assertThat(parsedLabels, hasEntry("job", "prometheus"));
+    }
+
+    /**
+     * Regression test for PromQL {@code without(<label>)} over Prometheus remote-write data. Labels are stored under a
+     * {@code labels} passthrough field, so each dimension surfaces both as a concrete field ({@code labels.pod}) and a
+     * short alias ({@code pod}); the {@code _timeseries} block loader excludes a dropped dimension by its concrete
+     * field name. A regression in the PromQL translator made label resolution pick whichever name sorted first in the
+     * leaf output, so dimensions lexically before {@code "labels"} ({@code cluster}, {@code job}, {@code instance})
+     * resolved to the bare alias and leaked back into the output, while later ones ({@code pod}, {@code region}) dropped
+     * correctly. Only a real passthrough mapping exercises this; the ES|QL unit fixtures use top-level dimensions.
+     */
+    public void testWithoutDropsEveryLabelRegardlessOfName() throws Exception {
+        long timestamp = System.currentTimeMillis();
+        // job/instance are constant, cluster/pod/region vary; the labels span both sides of the "labels" prefix
+        // lexically: cluster/instance/job < labels < pod/region.
+        sendRemoteWrite("app_mem", series("a", "p1", "r1"), 1.0, timestamp);
+        sendRemoteWrite("app_mem", series("a", "p2", "r2"), 2.0, timestamp);
+        sendRemoteWrite("app_mem", series("b", "p1", "r2"), 3.0, timestamp);
+        sendRemoteWrite("app_mem", series("b", "p2", "r1"), 4.0, timestamp);
+
+        for (String dropped : List.of("pod", "region", "cluster", "job", "instance")) {
+            ObjectPath response = rangeQuery("sum without(" + dropped + ") (app_mem)", timestamp);
+            List<Map<String, Object>> result = response.evaluate("data.result");
+            assertThat("expected at least one output series for without(" + dropped + ")", result.isEmpty(), equalTo(false));
+            for (Map<String, Object> seriesResult : result) {
+                @SuppressWarnings("unchecked")
+                Map<String, Object> metric = (Map<String, Object>) seriesResult.get("metric");
+                assertThat(
+                    "without(" + dropped + ") must drop [" + dropped + "] but it leaked: " + metric,
+                    metric.containsKey(dropped),
+                    equalTo(false)
+                );
+            }
+        }
+    }
+
+    private static Map<String, String> series(String cluster, String pod, String region) {
+        return Map.of("job", "test_job", "instance", "localhost:9090", "cluster", cluster, "pod", pod, "region", region);
+    }
+
+    private ObjectPath rangeQuery(String query, long centerTimestamp) throws IOException {
+        Request request = prometheusReadRequest(
+            "/_prometheus/api/v1/query_range",
+            new BasicNameValuePair("query", query),
+            new BasicNameValuePair("start", Instant.ofEpochMilli(centerTimestamp - 60_000L).toString()),
+            new BasicNameValuePair("end", Instant.ofEpochMilli(centerTimestamp + 60_000L).toString()),
+            new BasicNameValuePair("step", "30s")
+        );
+        return ObjectPath.createFromResponse(client().performRequest(request));
     }
 
     private void sendRemoteWrite(String metricName, Map<String, String> labels, double value, long timestamp) throws IOException {

--- a/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/rest/PrometheusQueryResponseListener.java
+++ b/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/rest/PrometheusQueryResponseListener.java
@@ -246,7 +246,11 @@ class PrometheusQueryResponseListener implements ActionListener<EsqlQueryRespons
             writeMetricFromSeriesJson(builder, seriesJson);
         } else {
             for (int i = DIMENSION_COL_START_IDX; i < stepColIdx; i++) {
-                builder.field(columns.get(i).name(), values[i] != null ? values[i].toString() : "");
+                // Omit null labels (e.g. a null-filled missing BY label) rather than emitting "". PromQL distinguishes
+                // an absent label from one whose value is empty; this mirrors writeMetricFields on the _timeseries path.
+                if (values[i] != null) {
+                    builder.field(columns.get(i).name(), values[i].toString());
+                }
             }
         }
         builder.endObject(); // metric

--- a/x-pack/plugin/prometheus/src/test/java/org/elasticsearch/xpack/prometheus/rest/PrometheusQueryResponseListenerTests.java
+++ b/x-pack/plugin/prometheus/src/test/java/org/elasticsearch/xpack/prometheus/rest/PrometheusQueryResponseListenerTests.java
@@ -21,12 +21,14 @@ import org.elasticsearch.xpack.prometheus.rest.PrometheusQueryResponseListener.Q
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.nullValue;
 
 public class PrometheusQueryResponseListenerTests extends ESTestCase {
 
@@ -67,6 +69,39 @@ public class PrometheusQueryResponseListenerTests extends ESTestCase {
             assertThat(path.evaluate("data.result.1.metric.job"), equalTo("prometheus"));
             assertThat(path.evaluate("data.result.1.values.0"), equalTo(List.of(1735689600.0, "3.0")));
             assertThat(path.evaluate("data.result.1.values.1"), equalTo(List.of(1735689660.0, "4.0")));
+        }
+    }
+
+    // A null label value (e.g. a BY label null-filled because it was absent from a series) must be OMITTED from the
+    // Prometheus `metric` object, not serialized as an empty string. PromQL distinguishes an absent label from a label
+    // whose value is "". This mirrors the `_timeseries` JSON path, which only emits non-null entries.
+    public void testConvertRangeQueryOmitsNullIndividualLabels() throws IOException {
+        List<TestColumnInfo> columns = List.of(
+            new TestColumnInfo("value", "double"),
+            new TestColumnInfo("__name__", "keyword"),
+            new TestColumnInfo("instance", "keyword"),
+            new TestColumnInfo("job", "keyword"),
+            new TestColumnInfo("step", "long")
+        );
+
+        // Second series has no `instance` label (null), simulating a null-filled missing BY label.
+        List<List<Object>> rows = List.of(
+            List.of(List.of(1.5, 2.0), "http_requests_total", "localhost:9090", "prometheus", List.of(1735689600000L, 1735689660000L)),
+            Arrays.asList(List.of(3.0, 4.0), "http_requests_total", null, "prometheus", List.of(1735689600000L, 1735689660000L))
+        );
+
+        EsqlResponse response = new TestEsqlResponse(columns, rows);
+        try (XContentBuilder builder = PrometheusQueryResponseListener.convertToPrometheusJson(response, "matrix", QueryMode.RANGE)) {
+            ObjectPath path = toObjectPath(builder);
+            assertSuccessMatrix(path);
+
+            assertThat(path.evaluate("data.result"), hasSize(2));
+            // First series keeps its present labels.
+            assertThat(path.evaluate("data.result.0.metric.instance"), equalTo("localhost:9090"));
+            // Second series: `instance` is null -> the key must be absent, not "".
+            assertThat(path.evaluate("data.result.1.metric.__name__"), equalTo("http_requests_total"));
+            assertThat(path.evaluate("data.result.1.metric.job"), equalTo("prometheus"));
+            assertThat(path.evaluate("data.result.1.metric.instance"), nullValue());
         }
     }
 


### PR DESCRIPTION
### What

This diff closes #149793 where `without(L)` only excluded `l`-s resolved to a dimensional `FieldAttribute` only; labels arriving as non-dimension or unresolved attributes were dropped from the exclusion set and so leaked back into the output series.
