### PR TITLE
Tolerate transient 503 in deleteView during BWC teardown

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
@@ -800,8 +800,9 @@ public class CsvTestsDataLoader {
             client.performRequest(new Request("DELETE", "/_query/view/" + viewName));
         } catch (ResponseException e) {
             int code = e.getResponse().getStatusLine().getStatusCode();
-            // On older servers the view listing succeeds when it should not, so we get here when we should not, hence the 400 and 500
-            if (code != 404 && code != 400 && code != 410 && code != 500) {
+            // On older servers the view listing succeeds when it should not, so we get here when we should not, hence the 400 and 500.
+            // 503 (master_not_discovered_exception) is transient and can occur in BWC mixed-cluster tests after node restarts.
+            if (code != 404 && code != 400 && code != 410 && code != 500 && code != 503) {
                 logger.info("View delete error: {}", e.getMessage());
                 throw e;
             }


### PR DESCRIPTION
During BWC mixed-cluster tests, `DELETE /_query/view/{name}` can transiently return 503 (master_not_discovered_exception) while master election is in progress after a node restart. Added 503 to the list of tolerated codes.

Closes #150434