### PR TITLE
Unmute testRenameBucketColumnHasNoMetadata

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -608,9 +608,6 @@ tests:
 - class: org.elasticsearch.test.apmintegration.OTelMetricsBufferingIT
   method: testExplicitMetrics
   issue: https://github.com/elastic/elasticsearch/issues/150302
-- class: org.elasticsearch.xpack.esql.expression.function.grouping.BucketColumnMetadataIT
-  method: testRenameBucketColumnHasNoMetadata
-  issue: https://github.com/elastic/elasticsearch/issues/150311
 - class: org.elasticsearch.repositories.gcs.GoogleCloudStorageBlobContainerRetriesTests
   method: testWriteLargeBlob
   issue: https://github.com/elastic/elasticsearch/issues/150356


### PR DESCRIPTION
As described in https://github.com/elastic/elasticsearch/issues/150311#issuecomment-4600708818 all failures are caused by unrelated issues. Unmuting.

Related #150311