### PR TITLE
Rename AbstractResumeBulkByScrollAction to AbstractResumeBulkByPaginatedSearchAction

### DIFF
--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractResumeBulkByPaginatedSearchAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractResumeBulkByPaginatedSearchAction.java
@@ -32,16 +32,16 @@ import java.util.concurrent.Executor;
 
 /// Abstract transport action for resuming BulkByScrollAction operations asynchronously. Delegates to the corresponding action on the local
 /// node, then returns a [ResumeBulkByPaginatedSearchResponse] containing the task id of the delegate action.
-public abstract class AbstractResumeBulkByScrollAction<Request extends AbstractBulkByPaginatedSearchRequest<Request>> extends
+public abstract class AbstractResumeBulkByPaginatedSearchAction<Request extends AbstractBulkByPaginatedSearchRequest<Request>> extends
     HandledTransportAction<ResumeBulkByPaginatedSearchRequest, ResumeBulkByPaginatedSearchResponse> {
 
-    private static final Logger logger = LogManager.getLogger(AbstractResumeBulkByScrollAction.class);
+    private static final Logger logger = LogManager.getLogger(AbstractResumeBulkByPaginatedSearchAction.class);
 
     private final ClusterService clusterService;
     private final ActionType<BulkByPaginatedSearchResponse> delegateAction;
     private final NodeClient nodeClient;
 
-    protected AbstractResumeBulkByScrollAction(
+    protected AbstractResumeBulkByPaginatedSearchAction(
         String actionName,
         TransportService transportService,
         ActionFilters actionFilters,

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/TransportResumeReindexAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/TransportResumeReindexAction.java
@@ -23,7 +23,7 @@ import org.elasticsearch.injection.guice.Inject;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
 
-public class TransportResumeReindexAction extends AbstractResumeBulkByScrollAction<ReindexRequest> {
+public class TransportResumeReindexAction extends AbstractResumeBulkByPaginatedSearchAction<ReindexRequest> {
 
     private final ReindexMetrics reindexMetrics;
 


### PR DESCRIPTION
Now that reindexing uses both scroll and point-in-time search, all scroll exclusive references need to be removed. This is step 8 of https://github.com/elastic/elasticsearch-team/issues/2406.

Relates: https://github.com/elastic/elasticsearch-team/issues/2406

