### PR TITLE
[Test] Unmute testAutoconfigFailedPasswordPromotion

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -346,9 +346,6 @@ tests:
 - class: org.elasticsearch.xpack.stateless.StatelessHollowIndexShardsIT
   method: testStressWithoutFailures
   issue: https://github.com/elastic/elasticsearch/issues/148310
-- class: org.elasticsearch.xpack.security.authc.esnative.ReservedRealmElasticAutoconfigIntegTests
-  method: testAutoconfigFailedPasswordPromotion
-  issue: https://github.com/elastic/elasticsearch/issues/122668
 - class: org.elasticsearch.xpack.esql.analysis.VerifierTests
   method: testFlattenedSorting
   issue: https://github.com/elastic/elasticsearch/issues/148374


### PR DESCRIPTION
The flake was caused by the queryable-built-in-roles synchronizer recreating the `.security` index between `deleteSecurityIndexIfExists()` and the cluster `read_only_allow_delete` block, so authentication returned 401 instead of the expected 503. The #149494 disabled that synchronizer in internal cluster tests, which removes the race.

Closes #122668
