### PR TITLE
Update dependency licenses task to use AbstractDependenciesTask configuration

### DIFF
--- a/modules/workload-identity/build.gradle
+++ b/modules/workload-identity/build.gradle
@@ -6,6 +6,7 @@
  * your election, the "Elastic License 2.0", the "GNU Affero General Public
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
+import org.elasticsearch.gradle.internal.AbstractDependenciesTask
 
 esplugin {
   description = 'Client for the workload-identity-issuer service, which mints short-lived OIDC JWTs used to authenticate to customer-owned cloud resources.'
@@ -47,8 +48,8 @@ esplugin.bundleSpec.into("spi") {
   from(configurations.spi)
 }
 
-tasks.named("dependencyLicenses").configure {
-  mapping from: /http.*/, to: 'httpclient'
+tasks.withType(AbstractDependenciesTask).configureEach {
+  mapping from: /httpcore|httpcore-nio|httpasyncclient/, to: 'httpclient'
 }
 
 tasks.named("thirdPartyAudit").configure {


### PR DESCRIPTION
This is needed to cover both `dependencyLicenses` precommit check and the `dependenciesInfo` task (run by the DRA release pipeline).

Related to the changes introduced in #149767.