### PR TITLE
[ESQL] Convert remaining bold headers to proper headings in command docs

### DIFF
--- a/docs/reference/query-languages/esql/README.md
+++ b/docs/reference/query-languages/esql/README.md
@@ -108,7 +108,7 @@ ROW key=[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25]
 Finally include this file in the `CHANGE_POINT` command file [`_snippets/commands/layout/change_point.md`](https://github.com/elastic/elasticsearch/blob/main/docs/reference/query-languages/esql/_snippets/commands/layout/change_point.md):
 
 ```
-**Examples**
+## Examples
 
 The following example shows the detection of a step change:
 

--- a/docs/reference/query-languages/esql/_snippets/commands/layout/registered_domain.md
+++ b/docs/reference/query-languages/esql/_snippets/commands/layout/registered_domain.md
@@ -10,13 +10,13 @@ This command doesn't support multi-value inputs.
 ::::
 
 
-**Syntax**
+## Syntax
 
 ```esql
 REGISTERED_DOMAIN prefix = expression
 ```
 
-**Parameters**
+## Parameters
 
 `prefix`
 :   The prefix for the output columns. The extracted parts are available as `prefix.part_name`.
@@ -24,7 +24,7 @@ REGISTERED_DOMAIN prefix = expression
 `expression`
 :   The string expression containing the FQDN to parse.
 
-**Description**
+## Description
 
 The `REGISTERED_DOMAIN` command parses an FQDN string and extracts its parts into new columns.
 The new columns are prefixed with the specified `prefix` followed by a dot (`.`).
@@ -46,7 +46,7 @@ The following columns are created:
 If a part is missing or the input is not a valid FQDN, the corresponding column contains `null`.
 If the expression evaluates to `null` or blank, all output columns are `null`.
 
-**Examples**
+## Examples
 
 The following example parses an FQDN and extracts its parts:
 

--- a/docs/reference/query-languages/esql/_snippets/commands/layout/set.md
+++ b/docs/reference/query-languages/esql/_snippets/commands/layout/set.md
@@ -5,7 +5,7 @@ stack: preview =9.3, ga 9.4+
 
 The `SET` directive can be used to specify query settings that modify the behavior of an {{esql}} query.
 
-**Syntax**
+## Syntax
 
 ```esql
 SET setting_name = setting_value[, ..., settingN = valueN]; <query>
@@ -14,7 +14,7 @@ SET setting_name = setting_value[, ..., settingN = valueN]; <query>
 Multiple SET directives can be included in a single query, separated by semicolons.
 If the same setting is defined multiple times, the last definition takes precedence.
 
-**Allowed settings**
+## Allowed settings
 
 :::{include} ../../generated/x-pack-esql/commands/settings/toc.md
 :::

--- a/docs/reference/query-languages/esql/_snippets/commands/layout/uri_parts.md
+++ b/docs/reference/query-languages/esql/_snippets/commands/layout/uri_parts.md
@@ -10,13 +10,13 @@ This command doesn't support multi-value inputs.
 ::::
 
 
-**Syntax**
+## Syntax
 
 ```esql
 URI_PARTS prefix = expression
 ```
 
-**Parameters**
+## Parameters
 
 `prefix`
 :   The prefix for the output columns. The extracted components are available as `prefix.component`.
@@ -24,7 +24,7 @@ URI_PARTS prefix = expression
 `expression`
 :   The string expression containing the URI to parse.
 
-**Description**
+## Description
 
 The `URI_PARTS` command parses a URI string and extracts its components into new columns.
 The new columns are prefixed with the specified `prefix` followed by a dot (`.`).
@@ -67,7 +67,7 @@ If a component is missing from the URI, the corresponding column contains `null`
 If the expression evaluates to `null`, all output columns are `null`.
 If the expression is not a valid URI, a warning is issued and all output columns are `null`.
 
-**Examples**
+## Examples
 
 The following example parses a URI and extracts its parts:
 


### PR DESCRIPTION
## Summary

Follow-up to #143058

- Convert bold-text pseudo-headers to `##` headings in `registered_domain.md`, `set.md`, and `uri_parts.md`  
- Update README example to use `##` instead of `**`

Closes #140581