### PR TITLE
SQL: fix test check on open search contexts

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -298,9 +298,6 @@ tests:
 - class: org.elasticsearch.xpack.stateless.StatelessMergeIT
   method: testOnlyForceMergesAreAllowedDuringRelocation
   issue: https://github.com/elastic/elasticsearch/issues/147880
-- class: org.elasticsearch.xpack.sql.qa.single_node.RestSqlIT
-  method: testNextPageText
-  issue: https://github.com/elastic/elasticsearch/issues/147950
 - class: org.elasticsearch.xpack.stateless.StatelessHollowIndexShardsIT
   method: testDataStreamStatsActionBroadcastedToSearchNodesOnly
   issue: https://github.com/elastic/elasticsearch/issues/147973

--- a/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/rest/RestSqlTestCase.java
+++ b/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/rest/RestSqlTestCase.java
@@ -1004,7 +1004,7 @@ public abstract class RestSqlTestCase extends BaseRestSqlTestCase implements Err
         assertEquals(expected, response.v1());
     }
 
-    public void testNextPageText() throws IOException {
+    public void testNextPageText() throws Exception {
         executeQueryWithNextPage("text/plain", "     text      |    number     |      sum      \n", "%-15s|%-15d|%-15d\n");
     }
 
@@ -1054,7 +1054,7 @@ public abstract class RestSqlTestCase extends BaseRestSqlTestCase implements Err
         assertEquals(expected, response.v1());
     }
 
-    public void testNextPageCSV() throws IOException {
+    public void testNextPageCSV() throws Exception {
         executeQueryWithNextPage("text/csv; header=present", "text,number,sum\r\n", "%s,%d,%d\r\n");
     }
 
@@ -1108,7 +1108,7 @@ public abstract class RestSqlTestCase extends BaseRestSqlTestCase implements Err
         assertEquals(expected, response.v1());
     }
 
-    public void testNextPageTSV() throws IOException {
+    public void testNextPageTSV() throws Exception {
         executeQueryWithNextPage("text/tab-separated-values", "text\tnumber\tsum\n", "%s\t%d\t%d\n");
     }
 
@@ -1393,7 +1393,7 @@ public abstract class RestSqlTestCase extends BaseRestSqlTestCase implements Err
         client().performRequest(request);
     }
 
-    private void executeQueryWithNextPage(String format, String expectedHeader, String expectedLineFormat) throws IOException {
+    private void executeQueryWithNextPage(String format, String expectedHeader, String expectedLineFormat) throws Exception {
         int size = 20;
         String[] docs = new String[size];
         for (int i = 0; i < size; i++) {
@@ -1437,7 +1437,7 @@ public abstract class RestSqlTestCase extends BaseRestSqlTestCase implements Err
             }
         }
 
-        assertEquals(0, getNumberOfSearchContexts(provisioningClient(), "test"));
+        assertBusy(() -> assertEquals(0, getNumberOfSearchContexts(provisioningClient(), "test")));
     }
 
     private void bulkLoadTestData(int count) throws IOException {


### PR DESCRIPTION
This fixes the way we check on open contexts (async) after tests.

Closes #147950