### PR TITLE
Switch Stream to iterator when retrieving handlers, since the caller is expecting an iterator anyway. 

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/path/PathTrie.java
+++ b/server/src/main/java/org/elasticsearch/common/path/PathTrie.java
@@ -11,7 +11,6 @@ package org.elasticsearch.common.path;
 
 import org.elasticsearch.common.collect.Iterators;
 
-import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -19,7 +18,6 @@ import java.util.Map;
 import java.util.function.BinaryOperator;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
-import java.util.stream.Stream;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableMap;
@@ -345,12 +343,12 @@ public class PathTrie<T> {
     }
 
     /**
-     * Returns a stream of the objects stored in the {@code PathTrie}, using
+     * Returns an iterator over the objects stored in the {@code PathTrie}, using
      * all possible {@code TrieMatchingMode} modes. The {@code paramSupplier}
      * is called for each mode to supply a new map of parameters.
      */
-    public Stream<T> retrieveAll(String path, Supplier<Map<String, String>> paramSupplier) {
-        return Arrays.stream(TrieMatchingMode.values()).map(m -> retrieve(path, paramSupplier.get(), m));
+    public Iterator<T> retrieveAll(String path, Supplier<Map<String, String>> paramSupplier) {
+        return Iterators.map(Iterators.forArray(TrieMatchingMode.values()), m -> retrieve(path, paramSupplier.get(), m));
     }
 
     public Iterator<T> allNodeValues() {

--- a/server/src/main/java/org/elasticsearch/rest/RestController.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestController.java
@@ -825,7 +825,7 @@ public class RestController implements HttpServerTransport.Dispatcher {
         // we use rawPath since we don't want to decode it while processing the path resolution
         // so we can handle things like:
         // my_index/my_type/http%3A%2F%2Fwww.google.com
-        return handlers.retrieveAll(rawPath, paramsSupplier).iterator();
+        return handlers.retrieveAll(rawPath, paramsSupplier);
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/common/path/PathTrieTests.java
+++ b/server/src/test/java/org/elasticsearch/common/path/PathTrieTests.java
@@ -101,7 +101,6 @@ public class PathTrieTests extends ESTestCase {
         assertThat(trie.retrieve("/v/x/c", params), equalTo("test6"));
     }
 
-    // https://github.com/elastic/elasticsearch/pull/17916
     public void testWildcardMatchingModes() {
         PathTrie<String> trie = new PathTrie<>(NO_DECODER);
         trie.insert("{testA}", "test1");

--- a/server/src/test/java/org/elasticsearch/common/path/PathTrieTests.java
+++ b/server/src/test/java/org/elasticsearch/common/path/PathTrieTests.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.common.path;
 
+import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.path.PathTrie.TrieMatchingMode;
 import org.elasticsearch.rest.RestUtils;
 import org.elasticsearch.test.ESTestCase;
@@ -120,31 +121,31 @@ public class PathTrieTests extends ESTestCase {
         assertThat(trie.retrieve("/a", params, TrieMatchingMode.WILDCARD_ROOT_NODES_ALLOWED), equalTo("test1"));
         assertThat(trie.retrieve("/a", params, TrieMatchingMode.WILDCARD_LEAF_NODES_ALLOWED), equalTo("test1"));
         assertThat(trie.retrieve("/a", params, TrieMatchingMode.WILDCARD_NODES_ALLOWED), equalTo("test1"));
-        assertThat(trie.retrieveAll("/a", () -> params).toList(), contains(null, "test1", "test1", "test1"));
+        assertThat(Iterators.toList(trie.retrieveAll("/a", () -> params)), contains(null, "test1", "test1", "test1"));
 
         assertThat(trie.retrieve("/a/b", params, TrieMatchingMode.EXPLICIT_NODES_ONLY), nullValue());
         assertThat(trie.retrieve("/a/b", params, TrieMatchingMode.WILDCARD_ROOT_NODES_ALLOWED), equalTo("test4"));
         assertThat(trie.retrieve("/a/b", params, TrieMatchingMode.WILDCARD_LEAF_NODES_ALLOWED), equalTo("test3"));
         assertThat(trie.retrieve("/a/b", params, TrieMatchingMode.WILDCARD_NODES_ALLOWED), equalTo("test3"));
-        assertThat(trie.retrieveAll("/a/b", () -> params).toList(), contains(null, "test4", "test3", "test3"));
+        assertThat(Iterators.toList(trie.retrieveAll("/a/b", () -> params)), contains(null, "test4", "test3", "test3"));
 
         assertThat(trie.retrieve("/a/b/c", params, TrieMatchingMode.EXPLICIT_NODES_ONLY), nullValue());
         assertThat(trie.retrieve("/a/b/c", params, TrieMatchingMode.WILDCARD_ROOT_NODES_ALLOWED), equalTo("test5"));
         assertThat(trie.retrieve("/a/b/c", params, TrieMatchingMode.WILDCARD_LEAF_NODES_ALLOWED), equalTo("test7"));
         assertThat(trie.retrieve("/a/b/c", params, TrieMatchingMode.WILDCARD_NODES_ALLOWED), equalTo("test7"));
-        assertThat(trie.retrieveAll("/a/b/c", () -> params).toList(), contains(null, "test5", "test7", "test7"));
+        assertThat(Iterators.toList(trie.retrieveAll("/a/b/c", () -> params)), contains(null, "test5", "test7", "test7"));
 
         assertThat(trie.retrieve("/x/y/z", params, TrieMatchingMode.EXPLICIT_NODES_ONLY), nullValue());
         assertThat(trie.retrieve("/x/y/z", params, TrieMatchingMode.WILDCARD_ROOT_NODES_ALLOWED), nullValue());
         assertThat(trie.retrieve("/x/y/z", params, TrieMatchingMode.WILDCARD_LEAF_NODES_ALLOWED), nullValue());
         assertThat(trie.retrieve("/x/y/z", params, TrieMatchingMode.WILDCARD_NODES_ALLOWED), equalTo("test9"));
-        assertThat(trie.retrieveAll("/x/y/z", () -> params).toList(), contains(null, null, null, "test9"));
+        assertThat(Iterators.toList(trie.retrieveAll("/x/y/z", () -> params)), contains(null, null, null, "test9"));
 
         assertThat(trie.retrieve("/d/e/f", params, TrieMatchingMode.EXPLICIT_NODES_ONLY), nullValue());
         assertThat(trie.retrieve("/d/e/f", params, TrieMatchingMode.WILDCARD_ROOT_NODES_ALLOWED), nullValue());
         assertThat(trie.retrieve("/d/e/f", params, TrieMatchingMode.WILDCARD_LEAF_NODES_ALLOWED), nullValue());
         assertThat(trie.retrieve("/d/e/f", params, TrieMatchingMode.WILDCARD_NODES_ALLOWED), equalTo("test10"));
-        assertThat(trie.retrieveAll("/d/e/f", () -> params).toList(), contains(null, null, null, "test10"));
+        assertThat(Iterators.toList(trie.retrieveAll("/d/e/f", () -> params)), contains(null, null, null, "test10"));
     }
 
     // https://github.com/elastic/elasticsearch/pull/17916


### PR DESCRIPTION
`PathTrie#retrieveAll` returned a `Stream`, but its only caller (`RestController#getAllHandlers`) just called
 ` .iterator()` on it. Now returns an Iterator<T> built via the lighter` Iterators.map/forArray`
  helpers, matching the codebase's Iterators-over-Stream convention.