### PR TITLE
[Docs] Remove outdated `"E"` and `"J"` tags from `nori_part_of_speech` example

### DIFF
--- a/docs/reference/elasticsearch-plugins/analysis-nori-speech.md
+++ b/docs/reference/elasticsearch-plugins/analysis-nori-speech.md
@@ -16,9 +16,7 @@ and defaults to:
 
 ```js
 "stoptags": [
-    "E",
     "IC",
-    "J",
     "MAG", "MAJ", "MM",
     "SP", "SSC", "SSO", "SC", "SE",
     "XPN", "XSA", "XSN", "XSV",


### PR DESCRIPTION
## Summary

The default `stoptags` example in the `nori_part_of_speech` documentation still included `E` and `J`, which are no longer supported by the Lucene 10.1.0 Nori API:

[https://www.elastic.co/docs/reference/elasticsearch/plugins/analysis-nori-speech](https://www.elastic.co/docs/reference/elasticsearch/plugins/analysis-nori-speech)

This change removes those tags from the example so that the documentation matches the currently supported POS tags.


Closes #150298