### PR TITLE
[9.3] Don't apply time zones to epoch-based timestamps (#148663)

### DIFF
--- a/docs/changelog/148663.yaml
+++ b/docs/changelog/148663.yaml
@@ -1,0 +1,5 @@
+area: Infra/Core
+issues: []
+pr: 148663
+summary: Don't apply time zones to epoch-based timestamps
+type: bug

--- a/server/src/main/java/org/elasticsearch/common/time/JavaDateMathParser.java
+++ b/server/src/main/java/org/elasticsearch/common/time/JavaDateMathParser.java
@@ -209,17 +209,21 @@ public class JavaDateMathParser implements DateMathParser {
         try {
             if (timeZone == null) {
                 return DateFormatters.from(formatter.apply(value)).toInstant();
-            } else {
-                TemporalAccessor accessor = formatter.apply(value);
-                // Use the offset if provided, otherwise fall back to the zone, or null.
-                ZoneOffset offset = TemporalQueries.offset().queryFrom(accessor);
-                ZoneId zoneId = offset == null ? TemporalQueries.zoneId().queryFrom(accessor) : ZoneId.ofOffset("", offset);
-                if (zoneId != null) {
-                    timeZone = zoneId;
-                }
-
-                return DateFormatters.from(accessor).withZoneSameLocal(timeZone).toInstant();
             }
+            TemporalAccessor accessor = formatter.apply(value);
+            // Prefer offset over zone ID: an explicit offset is unambiguous, whereas a named
+            // zone requires knowing the date to resolve DST. Avoid TemporalQueries.zone(),
+            // which has the opposite precedence (see commit 6f47fa3d).
+            ZoneOffset offset = TemporalQueries.offset().queryFrom(accessor);
+            ZoneId zoneId = offset == null ? TemporalQueries.zoneId().queryFrom(accessor) : ZoneId.ofOffset("", offset);
+            if (zoneId != null) {
+                timeZone = zoneId;
+            } else if (accessor.isSupported(ChronoField.INSTANT_SECONDS) && accessor.isSupported(ChronoField.YEAR) == false) {
+                // epoch_millis/epoch_second inputs are bare numbers with no zone info, so zoneId
+                // is always null here. They are UTC by definition; time_zone must not shift them.
+                return DateFormatters.from(accessor).toInstant();
+            }
+            return DateFormatters.from(accessor).withZoneSameLocal(timeZone).toInstant();
         } catch (IllegalArgumentException | DateTimeException e) {
             throw new ElasticsearchParseException(
                 "failed to parse date field [{}] with format [{}]: [{}]",

--- a/server/src/test/java/org/elasticsearch/common/time/JavaDateMathParserTests.java
+++ b/server/src/test/java/org/elasticsearch/common/time/JavaDateMathParserTests.java
@@ -27,6 +27,7 @@ import java.util.function.LongSupplier;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 
 public class JavaDateMathParserTests extends ESTestCase {
 
@@ -183,6 +184,54 @@ public class JavaDateMathParserTests extends ESTestCase {
         // and timezone in the date has priority
         assertDateMathEquals("2014-05-30T20:21+03:00", "2014-05-30T17:21:00.000", 0, false, ZoneId.of("-08:00"));
         assertDateMathEquals("2014-05-30T20:21Z", "2014-05-30T20:21:00.000", 0, false, ZoneId.of("-08:00"));
+    }
+
+    /**
+     * Epoch values are absolute instants in UTC by definition, so the {@code time_zone} parameter
+     * must not shift them. Regression test for SDH-9946: when Discover/KQL injected the browser's
+     * non-UTC zone into a query whose value happened to be an epoch number, the parsed instant
+     * was shifted by the offset.
+     */
+    public void testEpochIgnoresTimeZone() {
+        DateMathParser millisParser = DateFormatter.forPattern("epoch_millis").toDateMathParser();
+        long epochMillis = 1776338120239L; // 2026-04-16T11:15:20.239Z
+        Instant expected = Instant.ofEpochMilli(epochMillis);
+        assertThat(millisParser.parse("1776338120239", () -> 0L, false, ZoneOffset.UTC), equalTo(expected));
+        assertThat(millisParser.parse("1776338120239", () -> 0L, false, ZoneOffset.ofHours(2)), equalTo(expected));
+        assertThat(millisParser.parse("1776338120239", () -> 0L, false, ZoneOffset.ofHours(-5)), equalTo(expected));
+        assertThat(millisParser.parse("1776338120239", () -> 0L, false, ZoneId.of("Europe/Prague")), equalTo(expected));
+        assertThat(millisParser.parse("1776338120239", () -> 0L, false, (ZoneId) null), equalTo(expected));
+
+        DateMathParser secondsParser = DateFormatter.forPattern("epoch_second").toDateMathParser();
+        Instant expectedSeconds = Instant.ofEpochSecond(1776338120L);
+        assertThat(secondsParser.parse("1776338120", () -> 0L, false, ZoneOffset.UTC), equalTo(expectedSeconds));
+        assertThat(secondsParser.parse("1776338120", () -> 0L, false, ZoneOffset.ofHours(2)), equalTo(expectedSeconds));
+    }
+
+    /**
+     * Round-up parsing must also not shift epoch inputs in a non-UTC time zone.
+     */
+    public void testEpochRoundUpIgnoresTimeZone() {
+        DateMathParser millisParser = DateFormatter.forPattern("epoch_millis").toDateMathParser();
+        Instant noZone = millisParser.parse("1776338120239", () -> 0L, true, (ZoneId) null);
+        Instant zoned = millisParser.parse("1776338120239", () -> 0L, true, ZoneOffset.ofHours(2));
+        // The round-up parser pads with end-of-second nanos, so we only assert that the
+        // zoned and zone-free results agree -- not the exact instant value.
+        assertThat(zoned, equalTo(noZone));
+        assertThat(zoned.truncatedTo(ChronoUnit.MILLIS), equalTo(Instant.ofEpochMilli(1776338120239L)));
+    }
+
+    /**
+     * Regression guard: date math with {@code now} must continue to honor the time zone
+     * parameter (per the documented contract for date math rounding).
+     */
+    public void testNowDateMathStillRespectsTimeZone() {
+        long fixedNow = 1776338120239L; // 2026-04-16T11:15:20.239Z
+        Instant utc = parser.parse("now/d", () -> fixedNow, false, ZoneOffset.UTC);
+        Instant plus2 = parser.parse("now/d", () -> fixedNow, false, ZoneOffset.ofHours(2));
+        // now/d rounded down to start-of-day differs between UTC and +02:00 because the local
+        // calendar day boundary is shifted; the time_zone parameter must still affect this.
+        assertThat(plus2, is(not(equalTo(utc))));
     }
 
     public void testBasicMath() {


### PR DESCRIPTION
Backports the following commits to 9.3:
 - Don't apply time zones to epoch-based timestamps (#148663)