### PR TITLE
Update s3-repository-settings.md

### DIFF
--- a/docs/reference/elasticsearch/configuration-reference/s3-repository-settings.md
+++ b/docs/reference/elasticsearch/configuration-reference/s3-repository-settings.md
@@ -19,7 +19,7 @@ For step-by-step setup instructions, refer to [S3 repository](docs-content://dep
 
 ## Client settings [repository-s3-client-settings]
 
-The S3 client used to connect to S3 has a number of available settings. The settings have the form `s3.client.CLIENT_NAME.SETTING_NAME`. By default, `s3` repositories use a client named `default`, but this can be modified using the [repository setting](#repository-s3-repository-settings) `client`. For example, to use an S3 client named `my-alternate-client`, register the repository as follows:
+The S3 client used to connect to S3 has a number of available settings. The settings have the form `s3.client.${CLIENT_NAME}.SETTING_NAME`. By default, `s3` repositories use a client named `default`, but this can be modified using the [repository setting](#repository-s3-repository-settings) `client`. For example, to use an S3 client named `my-alternate-client`, register the repository as follows:
 
 ```console
 PUT _snapshot/my_s3_repository
@@ -61,56 +61,56 @@ Define the relevant secure settings in each node's keystore before starting the 
 
 The following list contains the available S3 client settings. Those that must be stored in the keystore are marked as "secure" and are **reloadable**; the other settings belong in the `elasticsearch.yml` file.
 
-`s3.client.CLIENT_NAME.region`
+`s3.client.${CLIENT_NAME}.region`
 :   Determines the region to use to sign requests made to the service. Also determines the regional endpoint to which {{es}} sends its requests, unless you specify a particular endpoint using the `endpoint` setting. If not set, {{es}} will attempt to determine the region automatically using the AWS SDK. {{es}} must use the correct region to sign requests because this value is required by [the S3 request-signing process](https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html).
 
     If you are using an [S3-compatible service](docs-content://deploy-manage/tools/snapshot-and-restore/s3-repository.md#repository-s3-compatible-services) then it is unlikely the AWS SDK will be able to determine the correct region name automatically, so you must set it manually. Your service's region name is under the control of your service administrator and need not refer to a real AWS region, but the value to which you configure this setting must match the region name your service expects.
 
-`s3.client.CLIENT_NAME.access_key` ([Secure](docs-content://deploy-manage/security/secure-settings.md), [reloadable](docs-content://deploy-manage/security/secure-settings.md#reloadable-secure-settings))
+`s3.client.${CLIENT_NAME}.access_key` ([Secure](docs-content://deploy-manage/security/secure-settings.md), [reloadable](docs-content://deploy-manage/security/secure-settings.md#reloadable-secure-settings))
 :   An S3 access key. If set, the `secret_key` setting must also be specified. If unset, the client will use the instance or container role instead.
 
-`s3.client.CLIENT_NAME.secret_key` ([Secure](docs-content://deploy-manage/security/secure-settings.md), [reloadable](docs-content://deploy-manage/security/secure-settings.md#reloadable-secure-settings))
+`s3.client.${CLIENT_NAME}.secret_key` ([Secure](docs-content://deploy-manage/security/secure-settings.md), [reloadable](docs-content://deploy-manage/security/secure-settings.md#reloadable-secure-settings))
 :   An S3 secret key. If set, the `access_key` setting must also be specified.
 
-`s3.client.CLIENT_NAME.session_token` ([Secure](docs-content://deploy-manage/security/secure-settings.md), [reloadable](docs-content://deploy-manage/security/secure-settings.md#reloadable-secure-settings))
+`s3.client.${CLIENT_NAME}.session_token` ([Secure](docs-content://deploy-manage/security/secure-settings.md), [reloadable](docs-content://deploy-manage/security/secure-settings.md#reloadable-secure-settings))
 :   An S3 session token. If set, the `access_key` and `secret_key` settings must also be specified.
 
-`s3.client.CLIENT_NAME.endpoint`
+`s3.client.${CLIENT_NAME}.endpoint`
 :   The S3 service endpoint to connect to. This defaults to the regional endpoint corresponding to the configured `region`, but the [AWS documentation](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region) lists alternative S3 endpoints. If you are using an [S3-compatible service](docs-content://deploy-manage/tools/snapshot-and-restore/s3-repository.md#repository-s3-compatible-services) then you should set this to the service's endpoint. The endpoint should specify the protocol and host name, e.g. `https://s3.ap-southeast-4.amazonaws.com`, `http://minio.local:9000`.
 
     When using HTTPS, this repository type validates the repository's certificate chain using the JVM-wide truststore. Ensure that the root certificate authority is in this truststore using the JVM's `keytool` tool. If you have a custom certificate authority for your S3 repository and you use the {{es}} [bundled JDK](docs-content://deploy-manage/deploy/self-managed/installing-elasticsearch.md#jvm-version), then you will need to reinstall your CA certificate every time you upgrade {{es}}.
 
-`s3.client.CLIENT_NAME.protocol` {applies_to}`stack: deprecated 8.19`
+`s3.client.${CLIENT_NAME}.protocol` {applies_to}`stack: deprecated 8.19`
 :   The protocol scheme to use to connect to S3, if `endpoint` is set to an incomplete URL which does not specify the scheme. Valid values are either `http` or `https`. Defaults to `https`. Avoid using this setting. Instead, set the `endpoint` setting to a fully-qualified URL that starts with either `http://` or `https://`.
 
-`s3.client.CLIENT_NAME.proxy.host`
+`s3.client.${CLIENT_NAME}.proxy.host`
 :   The host name of a proxy to connect to S3 through.
 
-`s3.client.CLIENT_NAME.proxy.port`
+`s3.client.${CLIENT_NAME}.proxy.port`
 :   The port of a proxy to connect to S3 through.
 
-`s3.client.CLIENT_NAME.proxy.scheme`
+`s3.client.${CLIENT_NAME}.proxy.scheme`
 :   The scheme to use for the proxy connection to S3. Valid values are either `http` or `https`. Defaults to `http`. This setting allows to specify the protocol used for communication with the proxy server.
 
-`s3.client.CLIENT_NAME.proxy.username` ([Secure](docs-content://deploy-manage/security/secure-settings.md), [reloadable](docs-content://deploy-manage/security/secure-settings.md#reloadable-secure-settings))
+`s3.client.${CLIENT_NAME}.proxy.username` ([Secure](docs-content://deploy-manage/security/secure-settings.md), [reloadable](docs-content://deploy-manage/security/secure-settings.md#reloadable-secure-settings))
 :   The username to connect to the `proxy.host` with.
 
-`s3.client.CLIENT_NAME.proxy.password` ([Secure](docs-content://deploy-manage/security/secure-settings.md), [reloadable](docs-content://deploy-manage/security/secure-settings.md#reloadable-secure-settings))
+`s3.client.${CLIENT_NAME}.proxy.password` ([Secure](docs-content://deploy-manage/security/secure-settings.md), [reloadable](docs-content://deploy-manage/security/secure-settings.md#reloadable-secure-settings))
 :   The password to connect to the `proxy.host` with.
 
-`s3.client.CLIENT_NAME.read_timeout`
+`s3.client.${CLIENT_NAME}.read_timeout`
 :   ([time value](/reference/elasticsearch/rest-apis/api-conventions.md#time-units)) The maximum time {{es}} will wait to receive the next byte of data over an established, open connection to the repository before it closes the connection. The default value is 50 seconds.
 
-`s3.client.CLIENT_NAME.max_connections`
+`s3.client.${CLIENT_NAME}.max_connections`
 :   The maximum number of concurrent connections to S3. The default value is `50`.
 
-`s3.client.CLIENT_NAME.max_retries`
+`s3.client.${CLIENT_NAME}.max_retries`
 :   The number of retries to use when an S3 request fails. The default value is `3`.
 
-`s3.client.CLIENT_NAME.connection_max_idle_time`
+`s3.client.${CLIENT_NAME}.connection_max_idle_time`
 :   ([time value](/reference/elasticsearch/rest-apis/api-conventions.md#time-units)) The timeout after which {{es}} will close an idle connection. The default value is 60 seconds.
 
-`s3.client.CLIENT_NAME.path_style_access`
+`s3.client.${CLIENT_NAME}.path_style_access`
 :   Whether to force the use of the path style access pattern. If `true`, the path style access pattern will be used. If `false`, the access pattern will be automatically determined by the AWS Java SDK (See [AWS documentation](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/AmazonS3Builder.html#setPathStyleAccessEnabled-java.lang.Boolean-) for details). Defaults to `false`.
 
 ::::{note}
@@ -120,7 +120,7 @@ In versions `7.0`, `7.1`, `7.2` and `7.3` all bucket operations used the [now-de
 ::::
 
 
-`s3.client.CLIENT_NAME.disable_chunked_encoding`
+`s3.client.${CLIENT_NAME}.disable_chunked_encoding`
 :   Whether chunked encoding should be disabled or not. If `false`, chunked encoding is enabled and will be used where appropriate. If `true`, chunked encoding is disabled and will not be used, which may mean that snapshot operations consume more resources and take longer to complete. It should only be set to `true` if you are using a storage service that does not support chunked encoding. See the [AWS Java SDK documentation](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/AmazonS3Builder.html#disableChunkedEncoding--) for details. Defaults to `false`.
 
 


### PR DESCRIPTION
using `CLIENT_NAME` is confusing

```
s3.client.CLIENT_NAME.secret_key
```

The breaking changes [docs](https://www.elastic.co/docs/release-notes/elasticsearch/breaking-changes#elasticsearch-9.1.0-breaking-changes) of 9.1.0 uses `${CLIENT_NAME}`

```
s3.client.${CLIENT_NAME}.secret_key
```

We should use `${CLIENT_NAME}` in the main docs as well

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
