### PR TITLE
ESQL QA: enable PEK feature flag on single-node test cluster

### DIFF
--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/Clusters.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/Clusters.java
@@ -49,6 +49,8 @@ public class Clusters {
             .setting("xpack.security.enabled", Boolean.toString(securityEnabled))
             .setting("xpack.license.self_generated.type", "trial")
             .setting("path.repo", csvDataPath::toString)
+            // Enable the PEK flag so the cluster.state.encryption.* settings below register.
+            .systemProperty("es.project_encryption_key_feature_flag_enabled", "true")
             .keystore("cluster.state.encryption.password." + ENCRYPTION_PASSWORD_ID, ENCRYPTION_PASSWORD)
             .keystore("cluster.state.encryption.active_password_id", ENCRYPTION_PASSWORD_ID)
             .shared(true)


### PR DESCRIPTION
## What this is about

#148568 added `cluster.state.encryption.password.<id>` and `cluster.state.encryption.active_password_id` to the keystore in `x-pack/plugin/esql/qa/server/single-node/.../Clusters.java`, but did not also enable the `project_encryption_key` feature flag on the same builder. `EncryptionPlugin#getSettings()` returns `List.of()` when the flag is off; the flag is off by default in release-mode builds; so the keystore entries reference unknown settings and ES boots dead with

```
unknown secure setting [cluster.state.encryption.password.test] please check that any required plugins are installed
```

on every test class in `:x-pack:plugin:esql:qa:server:single-node:javaRestTest` when the release-tests run.

The bug has been latent in main since #148568 landed earlier today. The release-tests are not a required gate on every PR — that PR's checks did not include them — so the regression only surfaces on PRs whose file footprint happens to trigger `releaseTestCheckEsqlQa`.

## What this PR does

Adds one `.systemProperty(\"es.project_encryption_key_feature_flag_enabled\", \"true\")` to the same `Clusters.java` builder. Mirrors the pattern from `x-pack/plugin/encryption/qa/encryption-spi-extension/.../EncryptedDataHandlerProviderSpiIT.java`, which has been doing this since it shipped.

## Does it work?

`releaseTestCheckEsqlQa` boots the test cluster cleanly. Local sanity: `:x-pack:plugin:esql:qa:server:single-node:compileJavaRestTestJava` and `:spotlessJavaCheck` both pass. The full release-test run on this PR's CI is the live signal.

## What's in the diff

One line + one comment in `single_node/Clusters.java`. No production code, no other test clusters touched (the audit confirmed `multi-node`, `multi-clusters`, `mixed-cluster` Clusters.java siblings don't add the encryption keystore lines and don't need the flag).

## What's out of scope

- A snapshot-only gate on the keystore lines: the encryption module is supposed to ship in release; enabling the flag is the right fix, not gating.
- Adding the encryption keystore to other test clusters: #148568's intent was single-node only; we preserve that.