### PR TITLE
[ML] Fix CPS datafeed start for unqualified flat-world indices

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/crossproject/ProjectRoutingResolver.java
+++ b/server/src/main/java/org/elasticsearch/search/crossproject/ProjectRoutingResolver.java
@@ -26,6 +26,11 @@ public interface ProjectRoutingResolver extends Closeable {
     String ORIGIN = "_origin";
 
     /**
+     * Reserved term restricting search to the local (origin) project only.
+     */
+    String LOCAL = "_local";
+
+    /**
      * Validates the provided project routing string.
      * This method is expected to throw an exception if the project routing is invalid.
      *

--- a/server/src/main/java/org/elasticsearch/search/crossproject/ProjectRoutingResolver.java
+++ b/server/src/main/java/org/elasticsearch/search/crossproject/ProjectRoutingResolver.java
@@ -26,11 +26,6 @@ public interface ProjectRoutingResolver extends Closeable {
     String ORIGIN = "_origin";
 
     /**
-     * Reserved term restricting search to the local (origin) project only.
-     */
-    String LOCAL = "_local";
-
-    /**
      * Validates the provided project routing string.
      * This method is expected to throw an exception if the project routing is invalid.
      *

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
@@ -173,6 +173,8 @@ public final class Messages {
     public static final String JOB_AUDIT_DATAFEED_CPS_KEY_REVOCATION_FAILED = "Failed to revoke internal cloud API key [{0}]";
     public static final String JOB_AUDIT_DATAFEED_CPS_KEY_CLEARED =
         "Internal cloud API key cleared on datafeed update with non-cloud credentials";
+    public static final String JOB_AUDIT_DATAFEED_CPS_MIGRATION_PROJECT_ROUTING_DEFAULTED =
+        "CPS migration: project_routing defaulted to [_local] to preserve local search scope. Use the update API to change the scope.";
     public static final String JOB_AUDIT_IDLE_JOB_CLOSED = "Job closed automatically during maintenance: datafeed was stopped"
         + " and no data was received for [{0}]. To change the idle timeout,"
         + " adjust the [xpack.ml.idle_job_auto_close_timeout] setting"

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
@@ -174,7 +174,7 @@ public final class Messages {
     public static final String JOB_AUDIT_DATAFEED_CPS_KEY_CLEARED =
         "Internal cloud API key cleared on datafeed update with non-cloud credentials";
     public static final String JOB_AUDIT_DATAFEED_CPS_MIGRATION_PROJECT_ROUTING_DEFAULTED =
-        "CPS migration: project_routing defaulted to [_local] to preserve local search scope. Use the update API to change the scope.";
+        "CPS migration: project_routing defaulted to [_alias:_origin] to preserve local search scope. Use the update API to change the scope.";
     public static final String JOB_AUDIT_IDLE_JOB_CLOSED = "Job closed automatically during maintenance: datafeed was stopped"
         + " and no data was received for [{0}]. To change the idle timeout,"
         + " adjust the [xpack.ml.idle_job_auto_close_timeout] setting"

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
@@ -174,7 +174,8 @@ public final class Messages {
     public static final String JOB_AUDIT_DATAFEED_CPS_KEY_CLEARED =
         "Internal cloud API key cleared on datafeed update with non-cloud credentials";
     public static final String JOB_AUDIT_DATAFEED_CPS_MIGRATION_PROJECT_ROUTING_DEFAULTED =
-        "CPS migration: project_routing defaulted to [_alias:_origin] to preserve local search scope. Use the update API to change the scope.";
+        "CPS migration: project_routing defaulted to [_alias:_origin] to preserve local search scope. Use the update API to change" 
+        + " the scope.";
     public static final String JOB_AUDIT_IDLE_JOB_CLOSED = "Job closed automatically during maintenance: datafeed was stopped"
         + " and no data was received for [{0}]. To change the idle timeout,"
         + " adjust the [xpack.ml.idle_job_auto_close_timeout] setting"

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
@@ -174,8 +174,8 @@ public final class Messages {
     public static final String JOB_AUDIT_DATAFEED_CPS_KEY_CLEARED =
         "Internal cloud API key cleared on datafeed update with non-cloud credentials";
     public static final String JOB_AUDIT_DATAFEED_CPS_MIGRATION_PROJECT_ROUTING_DEFAULTED =
-        "CPS migration: project_routing defaulted to [_alias:_origin] to preserve local search scope. Use the update API to change" 
-        + " the scope.";
+        "CPS migration: project_routing defaulted to [_alias:_origin] to preserve local search scope. Use the update API to change"
+            + " the scope.";
     public static final String JOB_AUDIT_IDLE_JOB_CLOSED = "Job closed automatically during maintenance: datafeed was stopped"
         + " and no data was received for [{0}]. To change the idle timeout,"
         + " adjust the [xpack.ml.idle_job_auto_close_timeout] setting"

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedAction.java
@@ -319,9 +319,10 @@ public class TransportStartDatafeedAction extends TransportMasterNodeAction<Star
 
         ActionListener<DatafeedConfig.Builder> datafeedListener = ActionListener.wrap(datafeedBuilder -> {
             DatafeedConfig datafeedConfig = datafeedBuilder.build();
+            DatafeedConfig effectiveDatafeed = DatafeedConfig.withCrossProjectModeIfEnabled(datafeedConfig, crossProjectModeDecider);
             params.setDatafeedIndices(datafeedConfig.getIndices());
             params.setJobId(datafeedConfig.getJobId());
-            params.setIndicesOptions(datafeedConfig.getIndicesOptions());
+            params.setIndicesOptions(effectiveDatafeed.getIndicesOptions());
             datafeedConfigHolder.set(datafeedConfig);
 
             jobConfigProvider.getJob(datafeedConfig.getJobId(), null, jobListener);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/CredentialTransitions.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/CredentialTransitions.java
@@ -21,6 +21,7 @@ import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.search.crossproject.CrossProjectModeDecider;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.core.ml.action.PutDatafeedAction;
@@ -90,6 +91,7 @@ public final class CredentialTransitions {
     private final Client client;
     private final NamedXContentRegistry xContentRegistry;
     private final DatafeedConfigProvider datafeedConfigProvider;
+    private final CrossProjectModeDecider crossProjectModeDecider;
 
     public CredentialTransitions(
         AnomalyDetectionAuditor auditor,
@@ -97,7 +99,8 @@ public final class CredentialTransitions {
         Supplier<CloudCredentialManager> credentialManagerSupplier,
         Client client,
         NamedXContentRegistry xContentRegistry,
-        DatafeedConfigProvider datafeedConfigProvider
+        DatafeedConfigProvider datafeedConfigProvider,
+        CrossProjectModeDecider crossProjectModeDecider
     ) {
         this.auditor = auditor;
         this.apiKeyServiceSupplier = apiKeyServiceSupplier;
@@ -105,6 +108,7 @@ public final class CredentialTransitions {
         this.client = client;
         this.xContentRegistry = xContentRegistry;
         this.datafeedConfigProvider = datafeedConfigProvider;
+        this.crossProjectModeDecider = crossProjectModeDecider;
     }
 
     public static Intent decideForUpdate(TransitionContext ctx) {
@@ -367,19 +371,20 @@ public final class CredentialTransitions {
         @Nullable CloudCredential carriedCredential,
         ActionListener<Void> listener
     ) {
+        DatafeedConfig effectiveConfig = DatafeedConfig.withCrossProjectModeIfEnabled(config, crossProjectModeDecider);
         SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().size(0);
-        QueryBuilder query = config.getParsedQuery(xContentRegistry);
+        QueryBuilder query = effectiveConfig.getParsedQuery(xContentRegistry);
         if (query != null) {
             sourceBuilder.query(query);
         }
-        if (config.getRuntimeMappings() != null && config.getRuntimeMappings().isEmpty() == false) {
-            sourceBuilder.runtimeMappings(config.getRuntimeMappings());
+        if (effectiveConfig.getRuntimeMappings() != null && effectiveConfig.getRuntimeMappings().isEmpty() == false) {
+            sourceBuilder.runtimeMappings(effectiveConfig.getRuntimeMappings());
         }
-        SearchRequest searchRequest = new SearchRequest(config.getIndices().toArray(String[]::new)).indicesOptions(
-            config.getIndicesOptions()
+        SearchRequest searchRequest = new SearchRequest(effectiveConfig.getIndices().toArray(String[]::new)).indicesOptions(
+            effectiveConfig.getIndicesOptions()
         ).source(sourceBuilder);
-        if (config.getProjectRouting() != null) {
-            searchRequest.setProjectRouting(config.getProjectRouting());
+        if (effectiveConfig.getProjectRouting() != null) {
+            searchRequest.setProjectRouting(effectiveConfig.getProjectRouting());
         }
         final CloudCredentialManager credentialManager = credentialManagerSupplier.get();
         final ThreadContext threadContext = client.threadPool().getThreadContext();

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedManager.java
@@ -124,7 +124,8 @@ public final class DatafeedManager {
             credentialManagerSupplier,
             client,
             xContentRegistry,
-            datafeedConfigProvider
+            datafeedConfigProvider,
+            crossProjectModeDecider
         );
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedManager.java
@@ -24,6 +24,7 @@ import org.elasticsearch.license.RemoteClusterLicenseChecker;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.crossproject.CrossProjectModeDecider;
+import org.elasticsearch.search.crossproject.ProjectRoutingResolver;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
@@ -97,6 +98,7 @@ public final class DatafeedManager {
     private final CrossProjectModeDecider crossProjectModeDecider;
     private final CredentialTransitions credentialTransitions;
     private final Supplier<CloudCredentialManager> credentialManagerSupplier;
+    private final AnomalyDetectionAuditor auditor;
 
     public DatafeedManager(
         DatafeedConfigProvider datafeedConfigProvider,
@@ -114,9 +116,10 @@ public final class DatafeedManager {
         this.settings = settings;
         this.crossProjectModeDecider = new CrossProjectModeDecider(settings);
         MachineLearningExtension extension = Objects.requireNonNull(mlExtension);
+        this.auditor = Objects.requireNonNull(auditor);
         this.credentialManagerSupplier = extension::getCloudCredentialManager;
         this.credentialTransitions = new CredentialTransitions(
-            Objects.requireNonNull(auditor),
+            this.auditor,
             () -> extension.getCloudApiKeyService(),
             credentialManagerSupplier,
             client,
@@ -304,9 +307,10 @@ public final class DatafeedManager {
                         update.affectsCrossProjectSearchSurface(current)
                     );
                     CredentialTransitions.Intent intent = CredentialTransitions.decideForUpdate(ctx);
+                    UpdateDatafeedAction.Request effectiveRequest = maybeDefaultProjectRoutingForMigration(request, current, intent);
                     credentialTransitions.executeUpdate(
                         intent,
-                        request,
+                        effectiveRequest,
                         current.getJobId(),
                         headers,
                         threadPool,
@@ -331,6 +335,46 @@ public final class DatafeedManager {
             ActionListener.wrap(bool -> doUpdate.run(), listener::onFailure),
             MlConfigIndex.CONFIG_INDEX_MAPPINGS_VERSION
         );
+    }
+
+    /**
+     * Returns a (possibly augmented) update request that defaults {@code project_routing} to
+     * {@link ProjectRoutingResolver#LOCAL} when all of the following are true:
+     * <ul>
+     *   <li>The credential transition is {@link CredentialTransitions.Intent#REPLACE} for a
+     *       first-time UIAM migration (no stored {@code cloudInternalCredential}).</li>
+     *   <li>The existing config has no explicit {@code project_routing} already set.</li>
+     *   <li>The incoming update does not explicitly set {@code project_routing} either.</li>
+     * </ul>
+     * The default preserves parity with the pre-migration (local-only) search scope. Post-migration
+     * updates and re-keys of already-migrated datafeeds are never affected.
+     */
+    private UpdateDatafeedAction.Request maybeDefaultProjectRoutingForMigration(
+        UpdateDatafeedAction.Request request,
+        DatafeedConfig existingConfig,
+        CredentialTransitions.Intent intent
+    ) {
+        if (intent != CredentialTransitions.Intent.REPLACE) {
+            return request;
+        }
+        if (existingConfig.getCloudInternalCredential() != null) {
+            return request;
+        }
+        if (existingConfig.getProjectRouting() != null) {
+            return request;
+        }
+        if (request.getUpdate().getProjectRouting() != null) {
+            return request;
+        }
+        logger.info(
+            "[{}] CPS migration: defaulting project_routing to [{}] to preserve local search scope",
+            existingConfig.getId(),
+            ProjectRoutingResolver.LOCAL
+        );
+        auditor.info(existingConfig.getJobId(), Messages.getMessage(Messages.JOB_AUDIT_DATAFEED_CPS_MIGRATION_PROJECT_ROUTING_DEFAULTED));
+        DatafeedUpdate augmentedUpdate = new DatafeedUpdate.Builder(request.getUpdate()).setProjectRouting(ProjectRoutingResolver.LOCAL)
+            .build();
+        return new UpdateDatafeedAction.Request(augmentedUpdate);
     }
 
     public void deleteDatafeed(DeleteDatafeedAction.Request request, ClusterState state, ActionListener<AcknowledgedResponse> listener) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedManager.java
@@ -339,7 +339,7 @@ public final class DatafeedManager {
 
     /**
      * Returns a (possibly augmented) update request that defaults {@code project_routing} to
-     * {@link ProjectRoutingResolver#LOCAL} when all of the following are true:
+     * {@code _alias:_origin} when all of the following are true:
      * <ul>
      *   <li>The credential transition is {@link CredentialTransitions.Intent#REPLACE} for a
      *       first-time UIAM migration (no stored {@code cloudInternalCredential}).</li>
@@ -369,11 +369,12 @@ public final class DatafeedManager {
         logger.info(
             "[{}] CPS migration: defaulting project_routing to [{}] to preserve local search scope",
             existingConfig.getId(),
-            ProjectRoutingResolver.LOCAL
+            "_alias:" + ProjectRoutingResolver.ORIGIN
         );
         auditor.info(existingConfig.getJobId(), Messages.getMessage(Messages.JOB_AUDIT_DATAFEED_CPS_MIGRATION_PROJECT_ROUTING_DEFAULTED));
-        DatafeedUpdate augmentedUpdate = new DatafeedUpdate.Builder(request.getUpdate()).setProjectRouting(ProjectRoutingResolver.LOCAL)
-            .build();
+        DatafeedUpdate augmentedUpdate = new DatafeedUpdate.Builder(request.getUpdate()).setProjectRouting(
+            "_alias:" + ProjectRoutingResolver.ORIGIN
+        ).build();
         return new UpdateDatafeedAction.Request(augmentedUpdate);
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedNodeSelector.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedNodeSelector.java
@@ -170,6 +170,8 @@ public class DatafeedNodeSelector {
     @Nullable
     private AssignmentFailure verifyIndicesActive() {
         boolean hasRemoteIndices = datafeedIndices.stream().anyMatch(RemoteClusterLicenseChecker::isRemoteIndex);
+        // CPS flat-world names are unqualified; data may live only on a linked project.
+        boolean cannotVerifyLocally = hasRemoteIndices || indicesOptions.resolveCrossProjectIndexExpression();
         String[] index = datafeedIndices.stream()
             // We cannot verify remote indices
             .filter(i -> RemoteClusterLicenseChecker.isRemoteIndex(i) == false)
@@ -181,7 +183,7 @@ public class DatafeedNodeSelector {
             concreteIndices = resolver.concreteIndexNames(clusterState, indicesOptions, true, index);
 
             // If we have remote indices we cannot check those. We should not fail as they may contain data.
-            if (hasRemoteIndices == false && concreteIndices.length == 0) {
+            if (cannotVerifyLocally == false && concreteIndices.length == 0) {
                 return new AssignmentFailure(
                     "cannot start datafeed ["
                         + datafeedId
@@ -192,6 +194,9 @@ public class DatafeedNodeSelector {
                 );
             }
         } catch (Exception e) {
+            if (cannotVerifyLocally) {
+                return null;
+            }
             String msg = format(
                 "failed resolving indices given [%s] and indices_options [%s]",
                 arrayToCommaDelimitedString(index),

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/CredentialTransitionsTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/CredentialTransitionsTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.search.SearchModule;
+import org.elasticsearch.search.crossproject.CrossProjectModeDecider;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
@@ -153,7 +154,8 @@ public class CredentialTransitionsTests extends ESTestCase {
             () -> credentialManager,
             delegateClient,
             xContentRegistry(),
-            mock(DatafeedConfigProvider.class)
+            mock(DatafeedConfigProvider.class),
+            new CrossProjectModeDecider(Settings.EMPTY)
         );
 
         DatafeedConfig.Builder builder = new DatafeedConfig.Builder("df", "job");
@@ -201,7 +203,8 @@ public class CredentialTransitionsTests extends ESTestCase {
             () -> credentialManager,
             client,
             xContentRegistry(),
-            mock(DatafeedConfigProvider.class)
+            mock(DatafeedConfigProvider.class),
+            new CrossProjectModeDecider(Settings.EMPTY)
         );
 
         DatafeedConfig.Builder builder = new DatafeedConfig.Builder("df", "job");
@@ -252,7 +255,8 @@ public class CredentialTransitionsTests extends ESTestCase {
             () -> credentialManager,
             client,
             xContentRegistry(),
-            mock(DatafeedConfigProvider.class)
+            mock(DatafeedConfigProvider.class),
+            new CrossProjectModeDecider(Settings.EMPTY)
         );
 
         DatafeedConfig.Builder builder = new DatafeedConfig.Builder("df", "job");
@@ -306,7 +310,8 @@ public class CredentialTransitionsTests extends ESTestCase {
             () -> credentialManager,
             client,
             xContentRegistry(),
-            mock(DatafeedConfigProvider.class)
+            mock(DatafeedConfigProvider.class),
+            new CrossProjectModeDecider(Settings.EMPTY)
         );
 
         DatafeedConfig.Builder builder = new DatafeedConfig.Builder("df", "job");

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedManagerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedManagerTests.java
@@ -104,7 +104,7 @@ public class DatafeedManagerTests extends ESTestCase {
 
     /** Ensures {@link DatafeedManager} treats the config as CPS-capable for credential minting. */
     private static void withCpsSearchSurface(DatafeedConfig.Builder builder) {
-        builder.setProjectRouting("_local");
+        builder.setProjectRouting("_alias:_origin");
     }
 
     private DatafeedManager newDatafeedManager(
@@ -926,7 +926,7 @@ public class DatafeedManagerTests extends ESTestCase {
         stubGetDatafeedConfig(datafeedConfigProvider, existingBuilder.build());
 
         DatafeedConfig clearedConfig = new DatafeedConfig.Builder("test-datafeed", "test-job").setIndices(List.of("logs-*"))
-            .setProjectRouting("_local")
+            .setProjectRouting("_alias:_origin")
             .build();
         mockRevokeSucceeds(apiKeyService);
         doAnswer(invocation -> {
@@ -1035,7 +1035,7 @@ public class DatafeedManagerTests extends ESTestCase {
         stubGetDatafeedConfig(datafeedConfigProvider, existingBuilder.build());
 
         DatafeedConfig clearedConfig = new DatafeedConfig.Builder("test-datafeed", "test-job").setIndices(List.of("logs-*"))
-            .setProjectRouting("_local")
+            .setProjectRouting("_alias:_origin")
             .build();
         mockRevokeFails(apiKeyService, new RuntimeException("revoke failed"));
         doAnswer(invocation -> {
@@ -1439,7 +1439,7 @@ public class DatafeedManagerTests extends ESTestCase {
     }
 
     @SuppressWarnings("unchecked")
-    public void testUpdateDatafeedFirstTimeMigrationShouldDefaultProjectRoutingToLocal() {
+    public void testUpdateDatafeedFirstTimeMigrationShouldDefaultProjectRoutingToOrigin() {
         Settings settings = Settings.builder().put("serverless.cross_project.enabled", true).put("xpack.security.enabled", false).build();
 
         DatafeedConfigProvider datafeedConfigProvider = mock(DatafeedConfigProvider.class);
@@ -1477,7 +1477,7 @@ public class DatafeedManagerTests extends ESTestCase {
         );
 
         assertThat(capturedUpdate.get(), notNullValue());
-        assertThat(capturedUpdate.get().getProjectRouting(), equalTo(ProjectRoutingResolver.LOCAL));
+        assertThat(capturedUpdate.get().getProjectRouting(), equalTo("_alias:" + ProjectRoutingResolver.ORIGIN));
         verify(auditor).info(eq("job-1"), eq(Messages.getMessage(Messages.JOB_AUDIT_DATAFEED_CPS_MIGRATION_PROJECT_ROUTING_DEFAULTED)));
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedManagerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedManagerTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.SearchModule;
+import org.elasticsearch.search.crossproject.ProjectRoutingResolver;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.MockLog;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -255,6 +256,54 @@ public class DatafeedManagerTests extends ESTestCase {
             mint.mintHook().accept(applied, credentialListener);
             return null;
         }).when(mock).updateDatefeedConfig(anyString(), any(), any(), any(CredentialTransitions.Change.Mint.class), any(), any());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void stubUpdateDatefeedConfigCapturesUpdateAndInvokesMintHook(
+        DatafeedConfigProvider mock,
+        DatafeedConfig storedConfig,
+        AtomicReference<DatafeedUpdate> capturedUpdate
+    ) {
+        doAnswer(invocation -> {
+            capturedUpdate.set(invocation.getArgument(1));
+            CredentialTransitions.Change.Mint mint = invocation.getArgument(3);
+            DatafeedUpdate update = invocation.getArgument(1);
+            Map<String, String> headers = invocation.getArgument(2);
+            DatafeedConfig applied = update.apply(storedConfig, headers, mockClusterStateForUpdate());
+
+            ActionListener<PersistedCloudCredential> credentialListener = ActionListener.wrap(newCred -> {
+                DatafeedConfig persisted = new DatafeedConfig.Builder(applied).setCloudInternalCredential(newCred).build();
+                invocation.<ActionListener<Tuple<DatafeedConfig, PersistedCloudCredential>>>getArgument(5)
+                    .onResponse(Tuple.tuple(persisted, storedConfig.getCloudInternalCredential()));
+            }, e -> invocation.<ActionListener<Tuple<DatafeedConfig, PersistedCloudCredential>>>getArgument(5).onFailure(e));
+
+            mint.mintHook().accept(applied, credentialListener);
+            return null;
+        }).when(mock).updateDatefeedConfig(anyString(), any(), any(), any(CredentialTransitions.Change.Mint.class), any(), any());
+    }
+
+    private static void stubUpdateMigrationPath(
+        DatafeedConfigProvider datafeedConfigProvider,
+        JobConfigProvider jobConfigProvider,
+        CloudCredentialManager credentialManager,
+        InternalCloudApiKeyService apiKeyService,
+        Client client,
+        ThreadPool threadPool,
+        DatafeedConfig storedConfig,
+        AtomicReference<DatafeedUpdate> capturedUpdate
+    ) {
+        when(credentialManager.hasCloudManagedCredential(any())).thenReturn(true);
+        when(credentialManager.extractCloudManagedCredential(any())).thenReturn(new CloudCredential(new SecureString("t".toCharArray())));
+        when(client.threadPool()).thenReturn(threadPool);
+        mockSearchProbeSucceeds(credentialManager, client);
+        mockGrantSucceeds(apiKeyService, new PersistedCloudCredential("minted-key-id", new SecureString("secret".toCharArray())));
+        stubGetDatafeedConfig(datafeedConfigProvider, storedConfig);
+        stubUpdateDatefeedConfigCapturesUpdateAndInvokesMintHook(datafeedConfigProvider, storedConfig, capturedUpdate);
+        doAnswer(invocation -> {
+            ActionListener<Boolean> listener = invocation.getArgument(1);
+            listener.onResponse(Boolean.TRUE);
+            return null;
+        }).when(jobConfigProvider).validateDatafeedJob(any(), any());
     }
 
     private static ClusterState mockClusterStateWithNoTasks() {
@@ -1387,6 +1436,203 @@ public class DatafeedManagerTests extends ESTestCase {
         );
 
         assertThat(manager.currentCallerCredential(threadPool, securityContext), nullValue());
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testUpdateDatafeedFirstTimeMigrationShouldDefaultProjectRoutingToLocal() {
+        Settings settings = Settings.builder().put("serverless.cross_project.enabled", true).put("xpack.security.enabled", false).build();
+
+        DatafeedConfigProvider datafeedConfigProvider = mock(DatafeedConfigProvider.class);
+        CloudCredentialManager credentialManager = mock(CloudCredentialManager.class);
+        InternalCloudApiKeyService apiKeyService = mock(InternalCloudApiKeyService.class);
+        MachineLearningExtension mlExtension = mockMlExtension(credentialManager, apiKeyService);
+        JobConfigProvider jobConfigProvider = mock(JobConfigProvider.class);
+        Client client = mock(Client.class);
+        ThreadPool threadPool = mock(ThreadPool.class);
+        when(threadPool.getThreadContext()).thenReturn(new ThreadContext(Settings.EMPTY));
+
+        AnomalyDetectionAuditor auditor = mockAuditor();
+        DatafeedManager manager = newDatafeedManager(datafeedConfigProvider, jobConfigProvider, settings, client, mlExtension, auditor);
+
+        DatafeedConfig legacyConfig = new DatafeedConfig.Builder("df-1", "job-1").setIndices(List.of("logs-*")).build();
+        AtomicReference<DatafeedUpdate> capturedUpdate = new AtomicReference<>();
+        stubUpdateMigrationPath(
+            datafeedConfigProvider,
+            jobConfigProvider,
+            credentialManager,
+            apiKeyService,
+            client,
+            threadPool,
+            legacyConfig,
+            capturedUpdate
+        );
+
+        UpdateDatafeedAction.Request request = new UpdateDatafeedAction.Request(new DatafeedUpdate.Builder("df-1").build());
+        manager.updateDatafeed(
+            request,
+            mockClusterStateForUpdate(),
+            null,
+            threadPool,
+            ActionListener.wrap(r -> {}, e -> fail("unexpected failure: " + e))
+        );
+
+        assertThat(capturedUpdate.get(), notNullValue());
+        assertThat(capturedUpdate.get().getProjectRouting(), equalTo(ProjectRoutingResolver.LOCAL));
+        verify(auditor).info(eq("job-1"), eq(Messages.getMessage(Messages.JOB_AUDIT_DATAFEED_CPS_MIGRATION_PROJECT_ROUTING_DEFAULTED)));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testUpdateDatafeedFirstTimeMigrationShouldNotOverrideExistingProjectRouting() {
+        Settings settings = Settings.builder().put("serverless.cross_project.enabled", true).put("xpack.security.enabled", false).build();
+
+        DatafeedConfigProvider datafeedConfigProvider = mock(DatafeedConfigProvider.class);
+        CloudCredentialManager credentialManager = mock(CloudCredentialManager.class);
+        InternalCloudApiKeyService apiKeyService = mock(InternalCloudApiKeyService.class);
+        MachineLearningExtension mlExtension = mockMlExtension(credentialManager, apiKeyService);
+        JobConfigProvider jobConfigProvider = mock(JobConfigProvider.class);
+        Client client = mock(Client.class);
+        ThreadPool threadPool = mock(ThreadPool.class);
+        when(threadPool.getThreadContext()).thenReturn(new ThreadContext(Settings.EMPTY));
+
+        DatafeedManager manager = newDatafeedManager(
+            datafeedConfigProvider,
+            jobConfigProvider,
+            settings,
+            client,
+            mlExtension,
+            mockAuditor()
+        );
+
+        DatafeedConfig legacyConfig = new DatafeedConfig.Builder("df-2", "job-2").setIndices(List.of("logs-*"))
+            .setProjectRouting("_alias:linked_project")
+            .build();
+        AtomicReference<DatafeedUpdate> capturedUpdate = new AtomicReference<>();
+        stubUpdateMigrationPath(
+            datafeedConfigProvider,
+            jobConfigProvider,
+            credentialManager,
+            apiKeyService,
+            client,
+            threadPool,
+            legacyConfig,
+            capturedUpdate
+        );
+
+        UpdateDatafeedAction.Request request = new UpdateDatafeedAction.Request(new DatafeedUpdate.Builder("df-2").build());
+        manager.updateDatafeed(
+            request,
+            mockClusterStateForUpdate(),
+            null,
+            threadPool,
+            ActionListener.wrap(r -> {}, e -> fail("unexpected failure: " + e))
+        );
+
+        assertThat(capturedUpdate.get(), notNullValue());
+        assertThat(capturedUpdate.get().getProjectRouting(), nullValue());
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testUpdateDatafeedFirstTimeMigrationShouldHonourExplicitProjectRoutingInUpdate() {
+        Settings settings = Settings.builder().put("serverless.cross_project.enabled", true).put("xpack.security.enabled", false).build();
+
+        DatafeedConfigProvider datafeedConfigProvider = mock(DatafeedConfigProvider.class);
+        CloudCredentialManager credentialManager = mock(CloudCredentialManager.class);
+        InternalCloudApiKeyService apiKeyService = mock(InternalCloudApiKeyService.class);
+        MachineLearningExtension mlExtension = mockMlExtension(credentialManager, apiKeyService);
+        JobConfigProvider jobConfigProvider = mock(JobConfigProvider.class);
+        Client client = mock(Client.class);
+        ThreadPool threadPool = mock(ThreadPool.class);
+        when(threadPool.getThreadContext()).thenReturn(new ThreadContext(Settings.EMPTY));
+
+        DatafeedManager manager = newDatafeedManager(
+            datafeedConfigProvider,
+            jobConfigProvider,
+            settings,
+            client,
+            mlExtension,
+            mockAuditor()
+        );
+
+        DatafeedConfig legacyConfig = new DatafeedConfig.Builder("df-3", "job-3").setIndices(List.of("logs-*")).build();
+        AtomicReference<DatafeedUpdate> capturedUpdate = new AtomicReference<>();
+        stubUpdateMigrationPath(
+            datafeedConfigProvider,
+            jobConfigProvider,
+            credentialManager,
+            apiKeyService,
+            client,
+            threadPool,
+            legacyConfig,
+            capturedUpdate
+        );
+
+        UpdateDatafeedAction.Request request = new UpdateDatafeedAction.Request(
+            new DatafeedUpdate.Builder("df-3").setProjectRouting("_alias:explicit").build()
+        );
+        manager.updateDatafeed(
+            request,
+            mockClusterStateForUpdate(),
+            null,
+            threadPool,
+            ActionListener.wrap(r -> {}, e -> fail("unexpected failure: " + e))
+        );
+
+        assertThat(capturedUpdate.get(), notNullValue());
+        assertThat(capturedUpdate.get().getProjectRouting(), equalTo("_alias:explicit"));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testUpdateDatafeedAlreadyMigratedShouldNotDefaultRoutingOnRekey() {
+        Settings settings = Settings.builder().put("serverless.cross_project.enabled", true).put("xpack.security.enabled", false).build();
+
+        DatafeedConfigProvider datafeedConfigProvider = mock(DatafeedConfigProvider.class);
+        CloudCredentialManager credentialManager = mock(CloudCredentialManager.class);
+        InternalCloudApiKeyService apiKeyService = mock(InternalCloudApiKeyService.class);
+        MachineLearningExtension mlExtension = mockMlExtension(credentialManager, apiKeyService);
+        JobConfigProvider jobConfigProvider = mock(JobConfigProvider.class);
+        Client client = mock(Client.class);
+        ThreadPool threadPool = mock(ThreadPool.class);
+        when(threadPool.getThreadContext()).thenReturn(new ThreadContext(Settings.EMPTY));
+
+        DatafeedManager manager = newDatafeedManager(
+            datafeedConfigProvider,
+            jobConfigProvider,
+            settings,
+            client,
+            mlExtension,
+            mockAuditor()
+        );
+
+        PersistedCloudCredential existingCred = new PersistedCloudCredential("old-key-id", new SecureString("e".toCharArray()));
+        DatafeedConfig migratedConfig = new DatafeedConfig.Builder("df-4", "job-4").setIndices(List.of("logs-*"))
+            .setCloudInternalCredential(existingCred)
+            .build();
+        AtomicReference<DatafeedUpdate> capturedUpdate = new AtomicReference<>();
+        stubUpdateMigrationPath(
+            datafeedConfigProvider,
+            jobConfigProvider,
+            credentialManager,
+            apiKeyService,
+            client,
+            threadPool,
+            migratedConfig,
+            capturedUpdate
+        );
+        mockRevokeSucceeds(apiKeyService);
+
+        UpdateDatafeedAction.Request request = new UpdateDatafeedAction.Request(
+            new DatafeedUpdate.Builder("df-4").setIndices(List.of("new-logs-*")).build()
+        );
+        manager.updateDatafeed(
+            request,
+            mockClusterStateForUpdate(),
+            null,
+            threadPool,
+            ActionListener.wrap(r -> {}, e -> fail("unexpected failure: " + e))
+        );
+
+        assertThat(capturedUpdate.get(), notNullValue());
+        assertThat(capturedUpdate.get().getProjectRouting(), nullValue());
     }
 
     /**

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedNodeSelectorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedNodeSelectorTests.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.ml.datafeed;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.DataStreamTestHelper;
@@ -457,6 +458,60 @@ public class DatafeedNodeSelectorTests extends ESTestCase {
             SearchRequest.DEFAULT_INDICES_OPTIONS
         ).selectNode(makeCandidateNodes("node_id", "other_node_id"));
         assertNotNull(result.getExecutorNode());
+    }
+
+    public void testDatafeedCpsUnqualifiedLinkedOnlyIndexIsAssignable() {
+        Job job = createScheduledJob("job_id").build(new Date());
+        DatafeedConfig df = createDatafeed("datafeed_id", job.getId(), Collections.singletonList("linked-only-flights"));
+
+        PersistentTasksCustomMetadata.Builder tasksBuilder = PersistentTasksCustomMetadata.builder();
+        addJobTask(job.getId(), "node_id", JobState.OPENED, tasksBuilder);
+        tasks = tasksBuilder.build();
+
+        givenClusterState("foo", 1, 0);
+
+        IndicesOptions cpsIndicesOptions = IndicesOptions.builder(SearchRequest.DEFAULT_INDICES_OPTIONS)
+            .crossProjectModeOptions(new IndicesOptions.CrossProjectModeOptions(true))
+            .build();
+
+        PersistentTasksCustomMetadata.Assignment result = new DatafeedNodeSelector(
+            clusterState,
+            resolver,
+            df.getId(),
+            df.getJobId(),
+            df.getIndices(),
+            cpsIndicesOptions
+        ).selectNode(makeCandidateNodes("node_id", "other_node_id"));
+        assertEquals("node_id", result.getExecutorNode());
+        new DatafeedNodeSelector(clusterState, resolver, df.getId(), df.getJobId(), df.getIndices(), cpsIndicesOptions)
+            .checkDatafeedTaskCanBeCreated();
+    }
+
+    public void testDatafeedCpsUnqualifiedWildcardWithNoLocalMatchesIsAssignable() {
+        Job job = createScheduledJob("job_id").build(new Date());
+        DatafeedConfig df = createDatafeed("datafeed_id", job.getId(), Collections.singletonList("linked-only-*"));
+
+        PersistentTasksCustomMetadata.Builder tasksBuilder = PersistentTasksCustomMetadata.builder();
+        addJobTask(job.getId(), "node_id", JobState.OPENED, tasksBuilder);
+        tasks = tasksBuilder.build();
+
+        givenClusterState("foo", 1, 0);
+
+        IndicesOptions cpsIndicesOptions = IndicesOptions.builder(SearchRequest.DEFAULT_INDICES_OPTIONS)
+            .crossProjectModeOptions(new IndicesOptions.CrossProjectModeOptions(true))
+            .build();
+
+        PersistentTasksCustomMetadata.Assignment result = new DatafeedNodeSelector(
+            clusterState,
+            resolver,
+            df.getId(),
+            df.getJobId(),
+            df.getIndices(),
+            cpsIndicesOptions
+        ).selectNode(makeCandidateNodes("node_id", "other_node_id"));
+        assertEquals("node_id", result.getExecutorNode());
+        new DatafeedNodeSelector(clusterState, resolver, df.getId(), df.getJobId(), df.getIndices(), cpsIndicesOptions)
+            .checkDatafeedTaskCanBeCreated();
     }
 
     public void testSelectNode_jobTaskStale() {


### PR DESCRIPTION
## Summary

Starting a CPS datafeed with an **unqualified** index name (flat-world, no `alias:index` prefix) failed with a 409 when that index exists only on a linked project:

```
cannot start datafeed [datafeed-test_ml] … failed resolving indices given [kibana_sample_data_flights]
and indices_options [… resolve_cross_project_index_expression=false] … no such index [kibana_sample_data_flights]
```

**What went wrong:** CPS mode is applied at runtime via `withCrossProjectModeIfEnabled`, which sets `resolve_cross_project_index_expression=true` on `IndicesOptions`. That promotion was wired into the data extractor on start, but **not** into the persistent-task params consumed by `DatafeedNodeSelector`. Node selection therefore resolved the unqualified name against the **local** cluster only. With `ignore_unavailable=false`, a linked-only index throws `IndexNotFoundException` → 409.

A datafeed using a **qualified** name (`alias:index`) worked around this: `RemoteClusterLicenseChecker.isRemoteIndex` treats it as remote, so local verification is skipped entirely. That is why `test_ml-2` could start against the same linked-only data while `test_ml` (plain `kibana_sample_data_flights`) could not.

The validate-before-mint search probe on put/update had the same gap: it built the probe `SearchRequest` from raw stored `IndicesOptions`, so put also failed when the index was linked-only.

**How this fixes it:**
- **`TransportStartDatafeedAction`** — promote CPS `IndicesOptions` into `params` before the persistent task is created, so node selection inherits cross-project resolution.
- **`DatafeedNodeSelector`** — when `resolveCrossProjectIndexExpression` is true, treat the index expression like a remote index: do not fail on empty local resolution or `IndexNotFoundException` (data may live on a linked project).
- **`CredentialTransitions.validateSearchBeforeMint`** — apply the same CPS promotion to the put/update search probe.
