### PR TITLE
[9.4] Fix prefix escape for synthetic id (#150433)

### DIFF
--- a/docs/changelog/150433.yaml
+++ b/docs/changelog/150433.yaml
@@ -1,0 +1,6 @@
+area: TSDB
+issues:
+ - 150389
+pr: 150433
+summary: Fix prefix escape for synthetic id
+type: bug

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/TSDBSyntheticIdFieldsProducer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/TSDBSyntheticIdFieldsProducer.java
@@ -201,21 +201,22 @@ public class TSDBSyntheticIdFieldsProducer extends FieldsProducer {
             return term();
         }
 
+        private static BytesRef extractTsid(BytesRef id) {
+            // The synthetic id is Uid-encoded, possibly with a 0xfd escape prefix, so we need to skip that prefix
+            // when extracting the tsid. See TsidExtractingIdFieldMapper#writeSyntheticId
+            final int escapeBytes = id.length > 0 && Byte.toUnsignedInt(id.bytes[id.offset]) >= Uid.BASE64_ESCAPE ? 1 : 0;
+            if (id.length > Long.BYTES + Integer.BYTES + escapeBytes) {
+                return TsidExtractingIdFieldMapper.extractTimeSeriesIdFromSyntheticId(id);
+            } else {
+                // Lookup whatever term `id` has been provided
+                return escapeBytes == 0 ? id : new BytesRef(id.bytes, id.offset + escapeBytes, id.length - escapeBytes);
+            }
+        }
+
         @Override
         public SeekStatus seekCeil(BytesRef id) throws IOException {
             assert id != null;
-
-            int tsIdOrd;
-            if (id != null && id.length > Long.BYTES + Integer.BYTES) {
-                // Extract and lookup the _tsid
-                tsIdOrd = docValues.lookupTsIdTerm(TsidExtractingIdFieldMapper.extractTimeSeriesIdFromSyntheticId(id));
-            } else if (id != null) {
-                // Lookup whatever term `id` has been provided
-                tsIdOrd = docValues.lookupTsIdTerm(id);
-            } else {
-                tsIdOrd = -1;
-            }
-
+            int tsIdOrd = docValues.lookupTsIdTerm(extractTsid(id));
             // _tsid not found
             if (tsIdOrd < 0) {
                 tsIdOrd = -tsIdOrd - 1;

--- a/server/src/main/java/org/elasticsearch/index/mapper/TsidExtractingIdFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TsidExtractingIdFieldMapper.java
@@ -213,11 +213,17 @@ public class TsidExtractingIdFieldMapper extends IdFieldMapper {
         return Strings.BASE_64_NO_PADDING_URL_ENCODER.encodeToString(id.bytes);
     }
 
+    // See #createSyntheticId
     public static BytesRef extractTimeSeriesIdFromSyntheticId(BytesRef id) {
         assert id.length > Long.BYTES + Integer.BYTES;
-        // See #createSyntheticId
-        byte[] tsId = new byte[Math.toIntExact(id.length - Long.BYTES - Integer.BYTES)];
-        System.arraycopy(id.bytes, id.offset, tsId, 0, tsId.length);
+        int len = Math.toIntExact(id.length - Long.BYTES - Integer.BYTES);
+        int offset = id.offset;
+        if (Byte.toUnsignedInt(id.bytes[offset]) >= Uid.BASE64_ESCAPE) {
+            offset++;
+            --len;
+        }
+        byte[] tsId = new byte[len];
+        System.arraycopy(id.bytes, offset, tsId, 0, tsId.length);
         return new BytesRef(tsId);
     }
 

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/TSDBSyntheticIdPostingsFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/TSDBSyntheticIdPostingsFormatTests.java
@@ -58,6 +58,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
+import org.junit.Before;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -84,6 +85,13 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
 public class TSDBSyntheticIdPostingsFormatTests extends ESTestCase {
+
+    private static int metricHash;
+
+    @Before
+    public void setUpMetricsNameField() throws Exception {
+        metricHash = randomIntBetween(1, 255);
+    }
 
     /**
      * Represents a time-series document
@@ -666,9 +674,10 @@ public class TSDBSyntheticIdPostingsFormatTests extends ESTestCase {
      * Builds time-series index settings.
      */
     private static IndexSettings buildIndexSettings(final String indexName) {
+        final List<String> dimensions = List.of("hostname", "metric.field", "_metric_names_hash");
         var settings = indexSettings(IndexVersion.current(), 1, 0).put(IndexSettings.SYNTHETIC_ID.getKey(), true)
             .put(IndexSettings.MODE.getKey(), IndexMode.TIME_SERIES.getName())
-            .putList(IndexMetadata.INDEX_DIMENSIONS.getKey(), List.of("hostname", "metric.field"));
+            .putList(IndexMetadata.INDEX_DIMENSIONS.getKey(), dimensions);
         if (rarely()) {
             settings.put(IndexSettings.USE_DOC_VALUES_SKIPPER.getKey(), false);
         }
@@ -693,6 +702,10 @@ public class TSDBSyntheticIdPostingsFormatTests extends ESTestCase {
                                 "time_series_metric": "counter"
                             }
                         }
+                    },
+                    "_metric_names_hash": {
+                       "type": "integer",
+                       "time_series_dimension": true
                     }
                 }
             }""").build(), Settings.EMPTY);
@@ -769,9 +782,9 @@ public class TSDBSyntheticIdPostingsFormatTests extends ESTestCase {
             {
                 source.field("field", document.metricField());
                 source.field("value", document.metricValue());
-
             }
             source.endObject();
+            source.field("_metric_names_hash", metricHash);
         }
         source.endObject();
         return source;
@@ -828,7 +841,8 @@ public class TSDBSyntheticIdPostingsFormatTests extends ESTestCase {
     }
 
     private static BytesRef buildTsId(Doc doc) {
-        return new TsidBuilder().addStringDimension("hostname", doc.hostName())
+        return new TsidBuilder().addIntDimension("_metric_names_hash", metricHash)
+            .addStringDimension("hostname", doc.hostName())
             .addStringDimension("metric.field", doc.metricField())
             .buildTsid(IndexVersion.current());
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/TsidExtractingIdFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TsidExtractingIdFieldMapperTests.java
@@ -1180,6 +1180,23 @@ public class TsidExtractingIdFieldMapperTests extends MetadataMapperTestCase {
         );
     }
 
+    public void testSyntheticId() {
+        for (int prefix = 0; prefix <= 0xff; prefix++) {
+            final byte[] tsidBytes = randomByteArrayOfLength(between(16, 20));
+            tsidBytes[0] = (byte) prefix;
+            final BytesRef tsid = new BytesRef(tsidBytes);
+            final long timestamp = randomNonNegativeLong();
+            final int routingHash = randomInt();
+
+            final String syntheticId = TsidExtractingIdFieldMapper.createSyntheticId(tsid, timestamp, routingHash);
+            final BytesRef uid = Uid.encodeId(syntheticId);
+
+            assertThat(TsidExtractingIdFieldMapper.extractTimeSeriesIdFromSyntheticId(uid), equalTo(tsid));
+            assertThat(TsidExtractingIdFieldMapper.extractTimestampFromSyntheticId(uid), equalTo(timestamp));
+            assertThat(TsidExtractingIdFieldMapper.extractRoutingHashFromSyntheticId(uid), equalTo(routingHash));
+        }
+    }
+
     private void verifyIdFromBlockLoader(String expectedId) throws IOException {
         blockLoaderTestRunner.fieldName("_id").run(new BytesRef(expectedId));
     }


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Fix prefix escape for synthetic id (#150433)