### PR TITLE
Unmute incorrectly muted resharding PIT tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -409,15 +409,6 @@ tests:
 - class: org.elasticsearch.index.codec.vectors.diskbbq.ES920DiskBBQVectorsFormatTests
   method: testOneRepeatedVector
   issue: https://github.com/elastic/elasticsearch/issues/149254
-- class: org.elasticsearch.xpack.stateless.reshard.StatelessReshardingPitSearchIT
-  method: testPitRelocationDuringReshard
-  issue: https://github.com/elastic/elasticsearch/issues/149271
-- class: org.elasticsearch.xpack.stateless.reshard.StatelessReshardingPitSearchIT
-  method: testLongLivedPitRelocation
-  issue: https://github.com/elastic/elasticsearch/issues/149272
-- class: org.elasticsearch.xpack.stateless.reshard.StatelessReshardingPitSearchIT
-  method: testReshardedLongLivedPitRelocation
-  issue: https://github.com/elastic/elasticsearch/issues/149273
 - class: org.elasticsearch.ingest.geoip.GeoIpDownloaderCliIT
   method: testIpLocationServiceLifecycle
   issue: https://github.com/elastic/elasticsearch/issues/149284


### PR DESCRIPTION
There were incorrectly re-muted in https://github.com/elastic/elasticsearch/pull/148028.
