### PR TITLE
StatelessReshardIT: use safe variants of blocking methods

### DIFF
--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/reshard/StatelessReshardIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/reshard/StatelessReshardIT.java
@@ -314,7 +314,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
 
         // flushing here ensures that the initial copy phase does some work, rather than relying entirely on catching new commits after
         // resharding has begun.
-        var flushResponse = indicesAdmin().prepareFlush(indexName).setForce(true).setWaitIfOngoing(true).get();
+        var flushResponse = indicesAdmin().prepareFlush(indexName).setForce(true).setWaitIfOngoing(true).get(SAFE_AWAIT_TIMEOUT);
         assertNoFailures(flushResponse);
 
         final var initialIndexMetadata = indexMetadata(clusterService().state(), index);
@@ -348,13 +348,9 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         // will generate some in this window without explicit synchronization.
         var splitSourceService = internalCluster().getInstance(SplitSourceService.class, indexNode);
         splitSourceService.setPreHandoffHook(() -> {
-            try {
-                logger.info("waiting for prehandoff latch");
-                preHandoffLatch.await(SAFE_AWAIT_TIMEOUT.seconds(), TimeUnit.SECONDS);
-                logger.info("prehandoff latch released");
-            } catch (InterruptedException e) {
-                throw new RuntimeException(e);
-            }
+            logger.info("waiting for prehandoff latch");
+            safeAwait(preHandoffLatch);
+            logger.info("prehandoff latch released");
         });
 
         // there should be split metadata at some point during resharding
@@ -370,12 +366,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         assert reshardingMetadata.shardCountAfter() == multiple;
 
         // wait for initial copy to start
-        try {
-            postCopyLatch.await(SAFE_AWAIT_TIMEOUT.seconds(), TimeUnit.SECONDS);
-        } catch (InterruptedException e) {
-            logger.info("interrupted");
-            throw new RuntimeException(e);
-        }
+        safeAwait(postCopyLatch);
 
         // index some more documents and flush to generate new commits
         final int postCopyDocs = randomIntBetween(10, 20);
@@ -416,7 +407,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         // verify that the index metadata returned matches the expected multiple of shards
         checkNumberOfShardsSetting(indexNode, index.getName(), multiple);
 
-        var search = prepareSearchAll(indexName).get();
+        var search = prepareSearchAll(indexName).get(SAFE_AWAIT_TIMEOUT);
         assertHitCount(search, totalNumberOfDocumentsInIndex);
 
         // all documents should be on their owning shards
@@ -469,7 +460,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         if (searchTestType == SearchTestType.ESQL_WITH_LOOKUP_JOIN) {
             createIndex(ESQL_JOIN_INDEX, indexSettings(1, 1).put(MODE.getKey(), IndexMode.LOOKUP.getName()).build());
 
-            prepareIndex(ESQL_JOIN_INDEX).setSource(Map.of(ESQL_JOIN_FIELD, ESQL_JOIN_FIELD_VALUE)).get();
+            prepareIndex(ESQL_JOIN_INDEX).setSource(Map.of(ESQL_JOIN_FIELD, ESQL_JOIN_FIELD_VALUE)).get(SAFE_AWAIT_TIMEOUT);
             assertNoFailures(refresh(ESQL_JOIN_INDEX));
         }
 
@@ -489,7 +480,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         var initialIndexedDocuments = indexDocuments(searchTestType, indexName, documentsPerRound, idSupplier, wouldBeAfterSplitRouting);
         allIndexedDocuments.putAll(initialIndexedDocuments);
 
-        var flushResponse = indicesAdmin().prepareFlush(indexName).setForce(true).setWaitIfOngoing(true).get();
+        var flushResponse = indicesAdmin().prepareFlush(indexName).setForce(true).setWaitIfOngoing(true).get(SAFE_AWAIT_TIMEOUT);
         assertNoFailures(flushResponse);
 
         // Search works before resharding.
@@ -504,23 +495,19 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
 
         MockTransportService indexTransportService = MockTransportService.getInstance(indexNode);
         indexTransportService.addSendBehavior((connection, requestId, action, request, options) -> {
-            try {
-                if (TransportUpdateSplitTargetShardStateAction.TYPE.name().equals(action)) {
-                    if (handOffStarted.getCount() > 0) {
-                        handOffStarted.countDown();
-                    }
-                    stateTransitionBlock.await();
+            if (TransportUpdateSplitTargetShardStateAction.TYPE.name().equals(action)) {
+                if (handOffStarted.getCount() > 0) {
+                    handOffStarted.countDown();
                 }
-                connection.sendRequest(requestId, action, request, options);
-            } catch (InterruptedException | BrokenBarrierException e) {
-                throw new RuntimeException(e);
+                safeAwait(stateTransitionBlock);
             }
+            connection.sendRequest(requestId, action, request, options);
         });
 
         awaitClusterState(searchCoordinator, clusterState -> indexMetadata(clusterState, index).getReshardingMetadata() != null);
 
         // wait for all target shards to arrive at handoff point
-        handOffStarted.await();
+        safeAwait(handOffStarted);
 
         // All target shards are in CLONE state.
         // At this point the handoff is in progress, all target shards received handoff requests
@@ -565,9 +552,9 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         refreshThread.start();
 
         // unblock HANDOFF transition
-        stateTransitionBlock.await();
+        safeAwait(stateTransitionBlock);
 
-        duringHandoffIndexingThread.join(SAFE_AWAIT_TIMEOUT.millis());
+        safeJoin(duringHandoffIndexingThread);
 
         awaitClusterState(
             searchCoordinator,
@@ -617,7 +604,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         // and so can't really assert much here.
 
         // unblock SPLIT transition
-        stateTransitionBlock.await();
+        safeAwait(stateTransitionBlock);
 
         awaitClusterState(
             searchCoordinator,
@@ -632,7 +619,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         // Transition of target shards to DONE state is blocked, all targets are in SPLIT state.
 
         // Refresh that was blocked earlier should now complete.
-        refreshThread.join(SAFE_AWAIT_TIMEOUT.millis());
+        safeJoin(refreshThread);
 
         // As mentioned the source shard was refreshed shortly after the handoff and so we won't necessarily see all
         // documents indexed on the source shard here.
@@ -650,7 +637,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         // because it is done before transition to DONE and `startStateTransitionBlock.await()` above
         // guarantees that all target shards sent the request to transition to DONE.
         // So this test does not directly exercise search filters, those are covered in other tests.
-        var splitRefresh = client(searchCoordinator).admin().indices().prepareRefresh(indexName).get();
+        var splitRefresh = client(searchCoordinator).admin().indices().prepareRefresh(indexName).get(SAFE_AWAIT_TIMEOUT);
         assertEquals(Arrays.toString(splitRefresh.getShardFailures()), multiple, splitRefresh.getTotalShards());
         assertEquals(Arrays.toString(splitRefresh.getShardFailures()), multiple, splitRefresh.getSuccessfulShards());
 
@@ -661,11 +648,11 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         allIndexedDocuments.putAll(splitIndexedDocuments);
 
         // Sanity check that the indexing above worked.
-        client(searchCoordinator).admin().indices().prepareRefresh(indexName).get();
+        client(searchCoordinator).admin().indices().prepareRefresh(indexName).get(SAFE_AWAIT_TIMEOUT);
         assertSearchResults(searchCoordinator, indexName, searchTestType, equalTo(multiple), equalTo(allIndexedDocuments.keySet()));
 
         // unblock DONE transition
-        stateTransitionBlock.await();
+        safeAwait(stateTransitionBlock);
 
         awaitClusterState(searchCoordinator, clusterState -> {
             var metadata = indexMetadata(clusterState, index);
@@ -686,7 +673,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         });
 
         // All target shards and the source shard are DONE.
-        var doneRefresh = client(searchCoordinator).admin().indices().prepareRefresh(indexName).get();
+        var doneRefresh = client(searchCoordinator).admin().indices().prepareRefresh(indexName).get(SAFE_AWAIT_TIMEOUT);
         assertEquals(multiple, doneRefresh.getTotalShards());
         assertEquals(multiple, doneRefresh.getSuccessfulShards());
 
@@ -698,7 +685,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         allIndexedDocuments.putAll(doneIndexedDocuments);
 
         // Sanity check that the indexing above worked.
-        client(searchCoordinator).admin().indices().prepareRefresh(indexName).get();
+        client(searchCoordinator).admin().indices().prepareRefresh(indexName).get(SAFE_AWAIT_TIMEOUT);
         assertSearchResults(searchCoordinator, indexName, searchTestType, equalTo(multiple), equalTo(allIndexedDocuments.keySet()));
 
         waitForReshardCompletion(indexName);
@@ -832,11 +819,11 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
                 var source = Map.of("field", randomUnicodeOfCodepointLengthBetween(1, 25));
                 bulkRequest.add(indexRequest.setSource(source));
             }
-            var bulkResponse = bulkRequest.get();
+            var bulkResponse = bulkRequest.get(SAFE_AWAIT_TIMEOUT);
             assertNoFailures(bulkResponse);
         }
 
-        var flushResponse = indicesAdmin().prepareFlush(indexName).setForce(true).setWaitIfOngoing(true).get();
+        var flushResponse = indicesAdmin().prepareFlush(indexName).setForce(true).setWaitIfOngoing(true).get(SAFE_AWAIT_TIMEOUT);
         assertNoFailures(flushResponse);
 
         refresh(indexName);
@@ -857,23 +844,19 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
 
         MockTransportService indexTransportService = MockTransportService.getInstance(indexNode);
         indexTransportService.addSendBehavior((connection, requestId, action, request, options) -> {
-            try {
-                if (TransportUpdateSplitTargetShardStateAction.TYPE.name().equals(action)) {
-                    if (handOffStarted.getCount() > 0) {
-                        handOffStarted.countDown();
-                    }
-                    stateTransitionBlock.await();
+            if (TransportUpdateSplitTargetShardStateAction.TYPE.name().equals(action)) {
+                if (handOffStarted.getCount() > 0) {
+                    handOffStarted.countDown();
                 }
-                connection.sendRequest(requestId, action, request, options);
-            } catch (InterruptedException | BrokenBarrierException e) {
-                throw new RuntimeException(e);
+                safeAwait(stateTransitionBlock);
             }
+            connection.sendRequest(requestId, action, request, options);
         });
 
         awaitClusterState(searchNode, clusterState -> indexMetadata(clusterState, index).getReshardingMetadata() != null);
 
         // wait for all target shards to arrive at handoff point
-        handOffStarted.await();
+        safeAwait(handOffStarted);
 
         // Don't refresh since it is blocked anyway, covered in other tests.
 
@@ -889,7 +872,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         });
 
         // unblock HANDOFF transition
-        stateTransitionBlock.await();
+        safeAwait(stateTransitionBlock);
 
         // Wait for recovery of the target shard to complete because a flush is performed during recovery
         // and we don't want to block it.
@@ -927,19 +910,15 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
                 long blobSize,
                 boolean failIfAlreadyExists
             ) throws IOException {
-                try {
-                    if (commitUploadLatch.getCount() > 0) {
-                        commitUploadLatch.await();
-                    }
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
+                if (commitUploadLatch.getCount() > 0) {
+                    safeAwait(commitUploadLatch);
                 }
                 super.blobContainerWriteBlobAtomic(originalRunnable, purpose, blobName, inputStream, blobSize, failIfAlreadyExists);
             }
         });
 
         // unblock SPLIT transition
-        stateTransitionBlock.await();
+        safeAwait(stateTransitionBlock);
 
         awaitClusterState(
             searchNode,
@@ -985,7 +964,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         }
 
         // unblock DONE transition
-        stateTransitionBlock.await();
+        safeAwait(stateTransitionBlock);
 
         awaitClusterState(searchNode, clusterState -> {
             var metadata = indexMetadata(clusterState, index);
@@ -1086,7 +1065,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         // once we've started blocking commit notifications, wait a bit before releasing them so that if resharding were going
         // to move to DONE without waiting for the notifications, we'd (probably) catch it here. Maybe there's a better way?
         // This works reliably on my laptop to catch the failure if the refresh is disabled.
-        notificationBlocked.await(SAFE_AWAIT_TIMEOUT.millis(), TimeUnit.MILLISECONDS);
+        safeAwait(notificationBlocked);
         // do it in the background so we can start waiting for DONE concurrently and run search immediately afterwards.
         final var unblockThread = new Thread(() -> {
             try {
@@ -1104,7 +1083,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
 
         waitForReshardCompletion(indexName);
         assertHitCount(prepareSearchAll(indexName), numDocs);
-        unblockThread.join();
+        safeJoin(unblockThread);
     }
 
     /*
@@ -1140,13 +1119,8 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
                     try {
                         if (splitStateRequest.getNewTargetShardState() == IndexReshardingState.Split.TargetShardState.SPLIT) {
                             // wait for search shard cluster block to be in place before releasing SPLIT
-                            searchClusterService.getClusterApplierService().runOnApplierThread("get", Priority.IMMEDIATE, state -> {
-                                try {
-                                    completedSearch.await(SAFE_AWAIT_TIMEOUT.seconds(), TimeUnit.SECONDS);
-                                } catch (InterruptedException e) {
-                                    throw new RuntimeException(e);
-                                }
-                            }, ActionListener.noop());
+                            searchClusterService.getClusterApplierService()
+                                .runOnApplierThread("get", Priority.IMMEDIATE, state -> safeAwait(completedSearch), ActionListener.noop());
                         }
                     } catch (Exception e) {
                         throw new RuntimeException(e);
@@ -1169,7 +1143,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
 
         // issue search from the unblocked indexNode as coordinator
         logger.info("issuing search before stale node sees split");
-        final var searchResponse = prepareSearchAll(indexNode, indexName).get();
+        final var searchResponse = prepareSearchAll(indexNode, indexName).get(SAFE_AWAIT_TIMEOUT);
         logger.info("search before stale node sees split complete");
         completedSearch.countDown();
 
@@ -1242,11 +1216,11 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
                 var source = Map.of("field", shardAndRouting.getValue());
                 bulkRequest.add(indexRequest.setSource(source));
             }
-            var bulkResponse = bulkRequest.get();
+            var bulkResponse = bulkRequest.get(SAFE_AWAIT_TIMEOUT);
             assertNoFailures(bulkResponse);
         }
 
-        var flushResponse = indicesAdmin().prepareFlush(indexName).setForce(true).setWaitIfOngoing(true).get();
+        var flushResponse = indicesAdmin().prepareFlush(indexName).setForce(true).setWaitIfOngoing(true).get(SAFE_AWAIT_TIMEOUT);
         assertNoFailures(flushResponse);
 
         refresh(indexName);
@@ -1258,20 +1232,16 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
 
         MockTransportService indexTransportService = MockTransportService.getInstance(indexNode);
         indexTransportService.addSendBehavior((connection, requestId, action, request, options) -> {
-            try {
-                if (TransportUpdateSplitTargetShardStateAction.TYPE.name().equals(action)) {
-                    stateTransitionBlock.await();
-                }
-                connection.sendRequest(requestId, action, request, options);
-            } catch (InterruptedException | BrokenBarrierException e) {
-                throw new RuntimeException(e);
+            if (TransportUpdateSplitTargetShardStateAction.TYPE.name().equals(action)) {
+                safeAwait(stateTransitionBlock);
             }
+            connection.sendRequest(requestId, action, request, options);
         });
 
         awaitClusterState(searchNode, clusterState -> clusterState.getMetadata().indexMetadata(index).getReshardingMetadata() != null);
 
         // transition to HANDOFF
-        stateTransitionBlock.await();
+        safeAwait(stateTransitionBlock);
 
         // Wait for recovery of the target shard to complete because a flush is performed during recovery
         // and we don't want to block it.
@@ -1291,19 +1261,15 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
                 long blobSize,
                 boolean failIfAlreadyExists
             ) throws IOException {
-                try {
-                    if (commitUploadLatch.getCount() > 0) {
-                        commitUploadLatch.await();
-                    }
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
+                if (commitUploadLatch.getCount() > 0) {
+                    safeAwait(commitUploadLatch);
                 }
                 super.blobContainerWriteBlobAtomic(originalRunnable, purpose, blobName, inputStream, blobSize, failIfAlreadyExists);
             }
         });
         try {
             // transition to SPLIT
-            stateTransitionBlock.await();
+            safeAwait(stateTransitionBlock);
 
             awaitClusterState(
                 searchNode,
@@ -1361,7 +1327,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         }
 
         // unblock transition to DONE
-        stateTransitionBlock.await();
+        safeAwait(stateTransitionBlock);
 
         waitForReshardCompletion(indexName);
     }
@@ -1428,7 +1394,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
             GetSettingsResponse postReshardSettingsResponse = client().admin()
                 .indices()
                 .prepareGetSettings(TEST_REQUEST_TIMEOUT, indexName)
-                .get();
+                .get(SAFE_AWAIT_TIMEOUT);
             assertThat(
                 IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.get(postReshardSettingsResponse.getIndexToSettings().get(indexName)),
                 equalTo(2)
@@ -1467,7 +1433,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
             .indices()
             .prepareUpdateSettings(indexName)
             .setSettings(Settings.builder().put(ShardsLimitAllocationDecider.INDEX_TOTAL_SHARDS_PER_NODE_SETTING.getKey(), (String) null))
-            .get();
+            .get(SAFE_AWAIT_TIMEOUT);
 
         waitForReshardCompletion(indexName);
     }
@@ -1684,12 +1650,8 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
             if (actionToBlock.equals(action)) {
                 // signal that get has been prepared so resharding can start
                 getPrepared.countDown();
-                try {
-                    docUpdated.await(SAFE_AWAIT_TIMEOUT.millis(), TimeUnit.MILLISECONDS);
-                    logger.info("sending blocked {}", actionToBlock);
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
-                }
+                safeAwait(docUpdated);
+                logger.info("sending blocked {}", actionToBlock);
             }
             connection.sendRequest(requestId, action, request, options);
         });
@@ -1720,13 +1682,13 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         getShard1Thread.start();
 
         // don't start resharding until get is waiting on search shard
-        getPrepared.await(SAFE_AWAIT_TIMEOUT.millis(), TimeUnit.MILLISECONDS);
+        safeAwait(getPrepared);
         final var reshardRequest = new ReshardIndexRequest(indexName, 2);
         client().execute(TransportReshardAction.TYPE, reshardRequest).actionGet(SAFE_AWAIT_TIMEOUT);
-        atSplit.await(SAFE_AWAIT_TIMEOUT.millis(), TimeUnit.MILLISECONDS);
+        safeAwait(atSplit);
         indexDoc(indexName, shard1docId, "field", "shard1_v1");
         docUpdated.countDown();
-        getShard1Thread.join(SAFE_AWAIT_TIMEOUT.millis());
+        safeJoin(getShard1Thread);
 
         assertThat(getShard1Response.get().isExists(), is(true));
         assertThat(getShard1Response.get().getSource().get("field"), equalTo("shard1_v1"));
@@ -2035,7 +1997,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         GetSettingsResponse postReshardSettingsResponse = client().admin()
             .indices()
             .prepareGetSettings(TEST_REQUEST_TIMEOUT, indexName)
-            .get();
+            .get(SAFE_AWAIT_TIMEOUT);
 
         assertThat(
             IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.get(postReshardSettingsResponse.getIndexToSettings().get(indexName)),
@@ -2116,7 +2078,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
                 try {
                     Thread.sleep(randomIntBetween(0, 200));
 
-                    var response = indicesAdmin().prepareClose(indexName).get();
+                    var response = indicesAdmin().prepareClose(indexName).get(SAFE_AWAIT_TIMEOUT);
                     assertEquals(1, response.getIndices().size());
                     var indexResponse = response.getIndices().get(0);
                     assertEquals(indexName, indexResponse.getIndex().getName());
@@ -2144,7 +2106,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         GetSettingsResponse postReshardSettingsResponse = client().admin()
             .indices()
             .prepareGetSettings(TEST_REQUEST_TIMEOUT, indexName)
-            .get();
+            .get(SAFE_AWAIT_TIMEOUT);
 
         var expectedNumberOfShards = success.get() ? 2 : 1;
         assertThat(
@@ -2214,7 +2176,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         GetSettingsResponse postReshardSettingsResponse = client().admin()
             .indices()
             .prepareGetSettings(TEST_REQUEST_TIMEOUT, indexName)
-            .get();
+            .get(SAFE_AWAIT_TIMEOUT);
 
         assertThat(
             IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.get(postReshardSettingsResponse.getIndexToSettings().get(indexName)),
@@ -2320,7 +2282,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
                 "cpu",
                 "type=long,time_series_metric=gauge"
             )
-            .get();
+            .get(SAFE_AWAIT_TIMEOUT);
         ensureGreen(timeSeriesIndexName);
         assertReshardNonstandardIndexFails(timeSeriesIndexName, IndexMode.TIME_SERIES);
 
@@ -2410,12 +2372,8 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         CountDownLatch handoffLatch = new CountDownLatch(1);
         mockTransportService.addSendBehavior((connection, requestId, action, request1, options) -> {
             if (TransportUpdateSplitTargetShardStateAction.TYPE.name().equals(action) && handoffAttemptedLatch.getCount() != 0) {
-                try {
-                    handoffAttemptedLatch.countDown();
-                    handoffLatch.await();
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
-                }
+                handoffAttemptedLatch.countDown();
+                safeAwait(handoffLatch);
             }
             connection.sendRequest(requestId, action, request1, options);
         });
@@ -2423,7 +2381,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         client(indexNode).execute(TransportReshardAction.TYPE, new ReshardIndexRequest(indexName)).actionGet();
 
         // Wait for the first handoff attempt to trigger an UpdateSplitTargetShardStateAction on the target shard
-        handoffAttemptedLatch.await();
+        safeAwait(handoffAttemptedLatch);
 
         IndexShard indexShard = findIndexShard(index, 0);
         indexShard.failShard("broken", new Exception("boom local"));
@@ -2459,12 +2417,8 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         CountDownLatch handoffLatch = new CountDownLatch(1);
         mockTransportService.addSendBehavior((connection, requestId, action, request1, options) -> {
             if (TransportUpdateSplitTargetShardStateAction.TYPE.name().equals(action) && handoffAttemptedLatch.getCount() != 0) {
-                try {
-                    handoffAttemptedLatch.countDown();
-                    handoffLatch.await();
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
-                }
+                handoffAttemptedLatch.countDown();
+                safeAwait(handoffLatch);
             }
             connection.sendRequest(requestId, action, request1, options);
         });
@@ -2472,7 +2426,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         client(indexNode).execute(TransportReshardAction.TYPE, new ReshardIndexRequest(indexName)).actionGet();
 
         // Wait for the first handoff attempt (UpdateSplitTargetShardStateAction sent to target shard)
-        handoffAttemptedLatch.await();
+        safeAwait(handoffAttemptedLatch);
 
         // Delete the index while handoff is in progress
         assertAcked(client().admin().indices().delete(new DeleteIndexRequest(indexName)).actionGet());
@@ -2483,7 +2437,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         // Index must be gone from cluster state
         IndexNotFoundException inf = expectThrows(
             IndexNotFoundException.class,
-            () -> client().admin().indices().prepareGetIndex(TEST_REQUEST_TIMEOUT).setIndices(indexName).get()
+            () -> client().admin().indices().prepareGetIndex(TEST_REQUEST_TIMEOUT).setIndices(indexName).get(SAFE_AWAIT_TIMEOUT)
         );
 
         assertThat(inf.getMessage(), equalTo("no such index [" + indexName + "]"));
@@ -2525,13 +2479,9 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         CountDownLatch proceedAfterShardFailure = new CountDownLatch(1);
         mockTransportService.addSendBehavior((connection, requestId, action, request1, options) -> {
             if (TransportUpdateSplitTargetShardStateAction.TYPE.name().equals(action) && stateChangeAttemptedLatch.getCount() != 0) {
-                try {
-                    stateChangeAttemptedLatch.countDown();
-                    if (stateChangeAttemptedLatch.getCount() == 0) {
-                        proceedAfterShardFailure.await();
-                    }
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
+                stateChangeAttemptedLatch.countDown();
+                if (stateChangeAttemptedLatch.getCount() == 0) {
+                    safeAwait(proceedAfterShardFailure);
                 }
             }
             connection.sendRequest(requestId, action, request1, options);
@@ -2539,15 +2489,15 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
 
         client(indexNode).execute(TransportReshardAction.TYPE, new ReshardIndexRequest(indexName)).actionGet();
 
-        stateChangeAttemptedLatch.await();
+        safeAwait(stateChangeAttemptedLatch);
 
         assertBusy(() -> {
-            ClusterState state = client().admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
+            ClusterState state = client().admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get(SAFE_AWAIT_TIMEOUT).getState();
             final ProjectState projectState = state.projectState(state.metadata().projectFor(index).id());
             assertThat(projectState.routingTable().index(index).shard(1).primaryShard().allocationId(), notNullValue());
         });
 
-        ClusterState state = client().admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
+        ClusterState state = client().admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get(SAFE_AWAIT_TIMEOUT).getState();
         final ProjectState projectState = state.projectState(state.metadata().projectFor(index).id());
         final ShardRouting shardRouting = projectState.routingTable().index(index).shard(1).primaryShard();
         final long currentPrimaryTerm = getCurrentPrimaryTerm(index, 1);
@@ -2607,7 +2557,10 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         final String targetShardRoutingValue = makeRoutingValueForShard(indexRoutingPostSplit, 1);
 
         // Index to setup and apply mappings.
-        client(sourceNode).prepareIndex(indexName).setRouting(sourceShardRoutingValue).setSource("field", "value_target").get();
+        client(sourceNode).prepareIndex(indexName)
+            .setRouting(sourceShardRoutingValue)
+            .setSource("field", "value_target")
+            .get(SAFE_AWAIT_TIMEOUT);
 
         // Start the second index node which will host the target shard
         String targetNode = startIndexNode();
@@ -2674,7 +2627,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         client(masterNode).execute(TransportReshardAction.TYPE, new ReshardIndexRequest(indexName)).actionGet();
 
         // Wait for the handoff failure to have occurred
-        handoffFailedLatch.await();
+        safeAwait(handoffFailedLatch);
 
         try {
             // At this point:
@@ -2691,7 +2644,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
                 () -> client(sourceNode).prepareIndex(indexName)
                     .setRouting(targetShardRoutingValue)
                     .setSource("field", "value_target")
-                    .get()
+                    .get(SAFE_AWAIT_TIMEOUT)
             );
             thread.start();
 
@@ -2700,7 +2653,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
             sourceTransport.clearAllRules();
             targetTransport.clearAllRules();
 
-            thread.join();
+            safeJoin(thread);
 
             // Without correct HANDOFF handling on the source shard, the document meant for the target shard also ends up being indexed
             // to the source shard post HANDOFF.
@@ -2750,19 +2703,15 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         CountDownLatch handoffLatch = new CountDownLatch(1);
         mockTransportService.addSendBehavior((connection, requestId, action, request1, options) -> {
             if (TransportReshardSplitAction.SPLIT_HANDOFF_ACTION_NAME.equals(action) && handoffAttemptedLatch.getCount() != 0) {
-                try {
-                    handoffAttemptedLatch.countDown();
-                    handoffLatch.await();
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
-                }
+                handoffAttemptedLatch.countDown();
+                safeAwait(handoffLatch);
             }
             connection.sendRequest(requestId, action, request1, options);
         });
 
         client(indexNode).execute(TransportReshardAction.TYPE, new ReshardIndexRequest(indexName)).actionGet();
 
-        handoffAttemptedLatch.await();
+        safeAwait(handoffAttemptedLatch);
 
         ensureRed(indexName);
 
@@ -2799,7 +2748,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
             GetSettingsResponse postReshardSettingsResponse = client().admin()
                 .indices()
                 .prepareGetSettings(TEST_REQUEST_TIMEOUT, indexName)
-                .get();
+                .get(SAFE_AWAIT_TIMEOUT);
             assertThat(
                 IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.get(postReshardSettingsResponse.getIndexToSettings().get(indexName)),
                 equalTo(2)
@@ -2809,7 +2758,12 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         Index index = resolveIndex(indexName);
 
         assertBusy(() -> {
-            ClusterState state = client().admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).setMetadata(true).get().getState();
+            ClusterState state = client().admin()
+                .cluster()
+                .prepareState(TEST_REQUEST_TIMEOUT)
+                .setMetadata(true)
+                .get(SAFE_AWAIT_TIMEOUT)
+                .getState();
             final ProjectState projectState = state.projectState(state.metadata().projectFor(index).id());
             final IndexMetadata indexMetadata = projectState.metadata().getIndexSafe(index);
             final IndexReshardingMetadata reshardingMetadata = indexMetadata.getReshardingMetadata();
@@ -2833,7 +2787,12 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(50));
 
         // Assert still handoff and has not transitioned to SPLIT
-        ClusterState state = client().admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).setMetadata(true).get().getState();
+        ClusterState state = client().admin()
+            .cluster()
+            .prepareState(TEST_REQUEST_TIMEOUT)
+            .setMetadata(true)
+            .get(SAFE_AWAIT_TIMEOUT)
+            .getState();
         final ProjectState projectState = state.projectState(state.metadata().projectFor(index).id());
         final IndexMetadata indexMetadata = projectState.metadata().getIndexSafe(index);
         final IndexReshardingMetadata reshardingMetadata = indexMetadata.getReshardingMetadata();
@@ -2845,7 +2804,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
             .indices()
             .prepareUpdateSettings(indexName)
             .setSettings(Settings.builder().put(ShardsLimitAllocationDecider.INDEX_TOTAL_SHARDS_PER_NODE_SETTING.getKey(), (String) null))
-            .get();
+            .get(SAFE_AWAIT_TIMEOUT);
 
         waitForReshardCompletion(indexName);
     }
@@ -2876,7 +2835,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
             GetSettingsResponse postReshardSettingsResponse = client().admin()
                 .indices()
                 .prepareGetSettings(TEST_REQUEST_TIMEOUT, indexName)
-                .get();
+                .get(SAFE_AWAIT_TIMEOUT);
             assertThat(
                 IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.get(postReshardSettingsResponse.getIndexToSettings().get(indexName)),
                 equalTo(2)
@@ -2911,7 +2870,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
             .indices()
             .prepareUpdateSettings(indexName)
             .setSettings(Settings.builder().put(ShardsLimitAllocationDecider.INDEX_TOTAL_SHARDS_PER_NODE_SETTING.getKey(), (String) null))
-            .get();
+            .get(SAFE_AWAIT_TIMEOUT);
     }
 
     // only one resharding operation on a given index should be allowed to be in flight at a time
@@ -3032,19 +2991,15 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         CountDownLatch handoffLatch = new CountDownLatch(1);
         mockTransportService.addSendBehavior((connection, requestId, action, request1, options) -> {
             if (TransportReshardSplitAction.SPLIT_HANDOFF_ACTION_NAME.equals(action) && handoffAttemptedLatch.getCount() != 0) {
-                try {
-                    handoffAttemptedLatch.countDown();
-                    handoffLatch.await();
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
-                }
+                handoffAttemptedLatch.countDown();
+                safeAwait(handoffLatch);
             }
             connection.sendRequest(requestId, action, request1, options);
         });
 
         client(indexNode).execute(TransportReshardAction.TYPE, new ReshardIndexRequest(indexName)).actionGet();
 
-        handoffAttemptedLatch.await();
+        safeAwait(handoffAttemptedLatch);
 
         // Now index a document that belongs to the target shard and verify that it goes to the source shard id.
         IndexMetadata indexMetadata = clusterService().state().projectState().metadata().index(indexName);
@@ -3064,7 +3019,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
             .indices()
             .prepareUpdateSettings(indexName)
             .setSettings(Settings.builder().put(ShardsLimitAllocationDecider.INDEX_TOTAL_SHARDS_PER_NODE_SETTING.getKey(), (String) null))
-            .get();
+            .get(SAFE_AWAIT_TIMEOUT);
     }
 
     // Test that documents are always routed to source shard before target shards are in handoff
@@ -3108,19 +3063,15 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         final var preHandoffLatch = new CountDownLatch(1);
         var splitSourceService = internalCluster().getInstance(SplitSourceService.class, indexNode);
         splitSourceService.setPreHandoffHook(() -> {
-            try {
-                logger.info("waiting for prehandoff latch");
-                preHandoffEnteredLatch.countDown();
-                preHandoffLatch.await(SAFE_AWAIT_TIMEOUT.seconds(), TimeUnit.SECONDS);
-                logger.info("prehandoff latch released");
-            } catch (InterruptedException e) {
-                throw new RuntimeException(e);
-            }
+            logger.info("waiting for prehandoff latch");
+            preHandoffEnteredLatch.countDown();
+            safeAwait(preHandoffLatch);
+            logger.info("prehandoff latch released");
         });
 
         client(indexNode).execute(TransportReshardAction.TYPE, new ReshardIndexRequest(indexName)).actionGet();
 
-        preHandoffEnteredLatch.await(SAFE_AWAIT_TIMEOUT.seconds(), TimeUnit.SECONDS);
+        safeAwait(preHandoffEnteredLatch);
 
         // Now index a document that belongs to the target shard and verify that it goes to the source shard id.
         IndexMetadata indexMetadata = clusterService().state().projectState().metadata().index(indexName);
@@ -3137,7 +3088,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         GetSettingsResponse postReshardSettingsResponse = client().admin()
             .indices()
             .prepareGetSettings(TEST_REQUEST_TIMEOUT, indexName)
-            .get();
+            .get(SAFE_AWAIT_TIMEOUT);
 
         assertThat(
             IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.get(postReshardSettingsResponse.getIndexToSettings().get(indexName)),
@@ -3159,7 +3110,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
             .indices()
             .prepareUpdateSettings(indexName)
             .setSettings(Settings.builder().put(ShardsLimitAllocationDecider.INDEX_TOTAL_SHARDS_PER_NODE_SETTING.getKey(), (String) null))
-            .get();
+            .get(SAFE_AWAIT_TIMEOUT);
     }
 
     // Test race where a target shard gets marked as splitting and copies the source directory in the middle of an upload
@@ -3182,11 +3133,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
                 ) throws IOException {
                     if (reshardStarted.get()) {
                         startSplitLatch.countDown();
-                        try {
-                            uploadLatch.await();
-                        } catch (InterruptedException e) {
-                            throw new RuntimeException(e);
-                        }
+                        safeAwait(uploadLatch);
                     }
                     originalRunnable.run();
                 }
@@ -3207,11 +3154,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         var indexTransportService = MockTransportService.getInstance(indexNode);
         indexTransportService.addSendBehavior((connection, requestId, action, request, options) -> {
             if (TransportReshardSplitAction.START_SPLIT_ACTION_NAME.equals(action)) {
-                try {
-                    startSplitLatch.await();
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
-                }
+                safeAwait(startSplitLatch);
             }
             connection.sendRequest(requestId, action, request, options);
         });
@@ -3221,7 +3164,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         reshardStarted.set(true);
 
         // upload will unblock split and wait for pre-handoff hook
-        var flushResponse = indicesAdmin().prepareFlush(indexName).setForce(true).setWaitIfOngoing(true).get();
+        var flushResponse = indicesAdmin().prepareFlush(indexName).setForce(true).setWaitIfOngoing(true).get(SAFE_AWAIT_TIMEOUT);
         assertNoFailures(flushResponse);
 
         waitForReshardCompletion(indexName);
@@ -3340,11 +3283,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
                 long blobSize
             ) throws IOException {
                 restartLatch.countDown();
-                try {
-                    copyLatch.await();
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
-                }
+                safeAwait(copyLatch);
                 super.blobContainerCopyBlob(originalRunnable, purpose, sourceBlobContainer, sourceBlobName, blobName, blobSize);
             }
         };
@@ -3383,7 +3322,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         client(indexNodeA).execute(TransportReshardAction.TYPE, new ReshardIndexRequest(indexName)).actionGet();
 
         // Wait until source shard is stuck copying
-        restartLatch.await();
+        safeAwait(restartLatch);
         internalCluster().restartNode(indexNodeB);
 
         ensureStableCluster(4);
@@ -3415,14 +3354,10 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
                     // Copies from the old and new source shard have interfered
                     testFailure.compareAndSet(null, new AssertionError("Copy still in progress: " + blobName));
                 }
-                try {
-                    // Block only the copy of latest blob from the old source shard
-                    if (blobToBlock.get().equals(blobName) && blockedFirstCopy.getAndSet(true) == false) {
-                        relocateLatch.countDown();
-                        copyLatch.await();
-                    }
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
+                // Block only the copy of latest blob from the old source shard
+                if (blobToBlock.get().equals(blobName) && blockedFirstCopy.getAndSet(true) == false) {
+                    relocateLatch.countDown();
+                    safeAwait(copyLatch);
                 }
                 super.blobContainerCopyBlob(originalRunnable, purpose, sourceBlobContainer, sourceBlobName, blobName, blobSize);
                 copiesInProgress.remove(blobName);
@@ -3472,7 +3407,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         client(sourceShardOldNode).execute(TransportReshardAction.TYPE, new ReshardIndexRequest(indexName)).actionGet();
 
         // Wait until old source shard is stuck copying
-        relocateLatch.await();
+        safeAwait(relocateLatch);
 
         var targetShardNodeId = new AtomicReference<String>();
         awaitClusterState(state -> {
@@ -3555,7 +3490,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
                     try {
                         if (splitStateRequest.getNewTargetShardState() == IndexReshardingState.Split.TargetShardState.SPLIT) {
                             splitAttempted.countDown();
-                            splitBlocked.await();
+                            safeAwait(splitBlocked);
                         } else if (splitStateRequest.getNewTargetShardState() == IndexReshardingState.Split.TargetShardState.DONE) {
                             if (doneAttempted.getCount() > 0) {
                                 doneAttempted.countDown();
@@ -3572,16 +3507,11 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         client(indexNode).execute(TransportReshardAction.TYPE, new ReshardIndexRequest(indexName)).actionGet();
 
         // Wait for HANDOFF to complete normally and then start delaying cluster state updates on one node.
-        splitAttempted.await();
+        safeAwait(splitAttempted);
 
         var clusterStateApplicationBlock = new CountDownLatch(1);
-        internalCluster().getInstance(ClusterService.class, nodeWithBlockedClusterStateProcessing).addHighPriorityApplier(event -> {
-            try {
-                clusterStateApplicationBlock.await();
-            } catch (InterruptedException e) {
-                throw new RuntimeException(e);
-            }
-        });
+        internalCluster().getInstance(ClusterService.class, nodeWithBlockedClusterStateProcessing)
+            .addHighPriorityApplier(event -> safeAwait(clusterStateApplicationBlock));
 
         try {
             // Unblock application of SPLIT state - it should not succeed because we are waiting for an ack.
@@ -3590,19 +3520,15 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
             assertFalse(doneAttempted.await(200, TimeUnit.MILLISECONDS));
 
             var doneAttemptedWaiter = new Thread(() -> {
-                try {
-                    doneAttempted.await();
-                    assertEquals(0, clusterStateApplicationBlock.getCount());
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
-                }
+                safeAwait(doneAttempted);
+                assertEquals(0, clusterStateApplicationBlock.getCount());
             });
             doneAttemptedWaiter.start();
 
             // Unblock stuck node to receive the update.
             clusterStateApplicationBlock.countDown();
 
-            doneAttemptedWaiter.join(SAFE_AWAIT_TIMEOUT.millis());
+            safeJoin(doneAttemptedWaiter);
 
             waitForReshardCompletion(indexName);
             ensureGreen(indexName);
@@ -3676,11 +3602,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         var indexNodeTransportService = MockTransportService.getInstance(indexNode);
         indexNodeTransportService.addSendBehavior((connection, requestId, action, request, options) -> {
             if (TransportUpdateSplitSourceShardStateAction.TYPE.name().equals(action)) {
-                try {
-                    changeSourceShardStateAttempts.await();
-                } catch (InterruptedException | BrokenBarrierException e) {
-                    throw new RuntimeException(e);
-                }
+                safeAwait(changeSourceShardStateAttempts);
 
                 if (sourceShardMoveToDoneBlocked.get()) {
                     moveToDoneFailures.countDown();
@@ -3694,9 +3616,9 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
 
         // Wait for all search shards to attempt to transition to READY_FOR_CLEANUP meaning that all target shards (for all sources)
         // are now DONE.
-        changeSourceShardStateAttempts.await();
+        safeAwait(changeSourceShardStateAttempts);
         // Make sure we completed this "round" of source shard logic.
-        moveToDoneFailures.await();
+        safeAwait(moveToDoneFailures);
 
         // Now source shards will retry the entire state machine including waiting for target shards to be DONE.
         // That check should fast-succeed even though there are no cluster state changes happening at this time.
@@ -3707,9 +3629,9 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         // So we expect all source shards to arrive at the transition to READY_FOR_CLEANUP state again and this time we'll allow them to
         // proceed.
         sourceShardMoveToDoneBlocked.set(false);
-        changeSourceShardStateAttempts.await();
+        safeAwait(changeSourceShardStateAttempts);
         // After READY_FOR_CLEANUP all source shards will proceed to DONE.
-        changeSourceShardStateAttempts.await();
+        safeAwait(changeSourceShardStateAttempts);
 
         waitForReshardCompletion(indexName);
     }
@@ -3763,13 +3685,9 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
                 TransportRequest actualRequest = MasterNodeRequestHelper.unwrapTermOverride(request);
 
                 if (actualRequest instanceof SplitStateRequest splitStateRequest) {
-                    try {
-                        if (splitStateRequest.getNewTargetShardState() == IndexReshardingState.Split.TargetShardState.SPLIT) {
-                            splitAttempted.countDown();
-                            splitBlocked.await();
-                        }
-                    } catch (Exception e) {
-                        throw new RuntimeException(e);
+                    if (splitStateRequest.getNewTargetShardState() == IndexReshardingState.Split.TargetShardState.SPLIT) {
+                        splitAttempted.countDown();
+                        safeAwait(splitBlocked);
                     }
                 }
             }
@@ -3779,7 +3697,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         client(masterNode).execute(TransportReshardAction.TYPE, new ReshardIndexRequest(indexName)).actionGet();
 
         // Wait for HANDOFF to complete normally and then start delaying cluster state updates on one node.
-        splitAttempted.await();
+        safeAwait(splitAttempted);
 
         var coordinator = startSearchNode();
         updateClusterSettings(Settings.builder().put("cluster.routing.allocation.exclude._name", coordinator));
@@ -3790,7 +3708,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         sourceSearchShardNodeTransportService.addRequestHandlingBehavior(
             PublicationTransportHandler.PUBLISH_STATE_ACTION_NAME,
             (handler, req, channel, task) -> {
-                clusterStateApplicationBlock.await();
+                safeAwait(clusterStateApplicationBlock);
                 handler.messageReceived(req, channel, task);
             }
         );
@@ -3854,21 +3772,17 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         var coordinatorTransportService = MockTransportService.getInstance(coordinator);
         coordinatorTransportService.addSendBehavior((connection, requestId, action, request, options) -> {
             if (SearchTransportService.QUERY_ACTION_NAME.equals(action)) {
-                try {
-                    searchInitiated.countDown();
-                    searchBlock.await();
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
-                }
+                searchInitiated.countDown();
+                safeAwait(searchBlock);
             }
             connection.sendRequest(requestId, action, request, options);
         });
 
         try (var searchExecutor = Executors.newSingleThreadExecutor()) {
             var searchFuture = searchExecutor.submit(
-                () -> prepareSearchAll(coordinator, indexName).setSearchType(SearchType.QUERY_THEN_FETCH).get()
+                () -> prepareSearchAll(coordinator, indexName).setSearchType(SearchType.QUERY_THEN_FETCH).get(SAFE_AWAIT_TIMEOUT)
             );
-            searchInitiated.await();
+            safeAwait(searchInitiated);
 
             var sourceIndexShardNode = clusterService().state()
                 .nodes()
@@ -3884,13 +3798,9 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
                     TransportRequest actualRequest = MasterNodeRequestHelper.unwrapTermOverride(request);
 
                     if (actualRequest instanceof TransportUpdateSplitSourceShardStateAction.Request sourceStateRequest) {
-                        try {
-                            if (sourceStateRequest.getState() == IndexReshardingState.Split.SourceShardState.DONE) {
-                                sourceShardMoveToDoneAttempted.countDown();
-                                sourceShardMoveToDoneBlocked.await();
-                            }
-                        } catch (Exception e) {
-                            throw new RuntimeException(e);
+                        if (sourceStateRequest.getState() == IndexReshardingState.Split.SourceShardState.DONE) {
+                            sourceShardMoveToDoneAttempted.countDown();
+                            safeAwait(sourceShardMoveToDoneBlocked);
                         }
                     }
                 }
@@ -3902,7 +3812,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
             // Wait for the source index shard to attempt to move to DONE state.
             // That means that it already applied READY_TO_CLEANUP state and ensured that the search shard
             // is aware of it.
-            sourceShardMoveToDoneAttempted.await();
+            safeAwait(sourceShardMoveToDoneAttempted);
 
             try {
                 searchBlock.countDown();
@@ -3951,12 +3861,12 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         var id1 = client(coordinator).prepareIndex(indexName)
             .setRouting(shard0RoutingValue)
             .setSource("field", "source_value")
-            .get()
+            .get(SAFE_AWAIT_TIMEOUT)
             .getId();
         var id2 = client(coordinator).prepareIndex(indexName)
             .setRouting(shard1RoutingValue)
             .setSource("field", "target_value")
-            .get()
+            .get(SAFE_AWAIT_TIMEOUT)
             .getId();
         refresh(indexName);
 
@@ -3964,14 +3874,14 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
             .setRouting(shard0RoutingValue)
             .setQuery(QueryBuilders.matchQuery("field", "source_value"))
             .setFetchSource(true)
-            .get();
+            .get(SAFE_AWAIT_TIMEOUT);
         assertTrue(sourceShardReferenceResponse.isExists());
         assertTrue(sourceShardReferenceResponse.isMatch());
         var targetShardReferenceResponse = client(coordinator).prepareExplain(indexName, id2)
             .setRouting(shard1RoutingValue)
             .setQuery(QueryBuilders.matchQuery("field", "target_value"))
             .setFetchSource(true)
-            .get();
+            .get(SAFE_AWAIT_TIMEOUT);
         assertTrue(targetShardReferenceResponse.isExists());
         assertTrue(targetShardReferenceResponse.isMatch());
 
@@ -3991,18 +3901,10 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
                 if (actualRequest instanceof SplitStateRequest splitStateRequest) {
                     if (splitStateRequest.getNewTargetShardState() == IndexReshardingState.Split.TargetShardState.SPLIT) {
                         attemptingSplit.countDown();
-                        try {
-                            splitBlocked.await();
-                        } catch (InterruptedException e) {
-                            throw new RuntimeException(e);
-                        }
+                        safeAwait(splitBlocked);
                     } else if (splitStateRequest.getNewTargetShardState() == IndexReshardingState.Split.TargetShardState.DONE) {
                         attemptingDone.countDown();
-                        try {
-                            doneBlocked.await();
-                        } catch (InterruptedException e) {
-                            throw new RuntimeException(e);
-                        }
+                        safeAwait(doneBlocked);
                     }
                 }
             }
@@ -4011,36 +3913,36 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
 
         client(masterNode).execute(TransportReshardAction.TYPE, new ReshardIndexRequest(indexName)).actionGet();
 
-        attemptingSplit.await();
+        safeAwait(attemptingSplit);
 
         var sourceShardHandoffResponse = client(coordinator).prepareExplain(indexName, id1)
             .setRouting(shard0RoutingValue)
             .setQuery(QueryBuilders.matchQuery("field", "source_value"))
             .setFetchSource(true)
-            .get();
+            .get(SAFE_AWAIT_TIMEOUT);
         assertEquals(sourceShardReferenceResponse, sourceShardHandoffResponse);
         var targetShardHandoffResponse = client(coordinator).prepareExplain(indexName, id2)
             .setRouting(shard1RoutingValue)
             .setQuery(QueryBuilders.matchQuery("field", "target_value"))
             .setFetchSource(true)
-            .get();
+            .get(SAFE_AWAIT_TIMEOUT);
         assertEquals(targetShardReferenceResponse, targetShardHandoffResponse);
 
         splitBlocked.countDown();
-        attemptingDone.await();
+        safeAwait(attemptingDone);
 
         try {
             var sourceShardSplitResponse = client(coordinator).prepareExplain(indexName, id1)
                 .setRouting(shard0RoutingValue)
                 .setQuery(QueryBuilders.matchQuery("field", "source_value"))
                 .setFetchSource(true)
-                .get();
+                .get(SAFE_AWAIT_TIMEOUT);
             assertEquals(sourceShardReferenceResponse, sourceShardSplitResponse);
             var targetShardSplitResponse = client(coordinator).prepareExplain(indexName, id2)
                 .setRouting(shard1RoutingValue)
                 .setQuery(QueryBuilders.matchQuery("field", "target_value"))
                 .setFetchSource(true)
-                .get();
+                .get(SAFE_AWAIT_TIMEOUT);
             assertEquals(targetShardReferenceResponse, targetShardSplitResponse);
         } finally {
             doneBlocked.countDown();
@@ -4070,7 +3972,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         // to test the retry logic for stale requests.
         var documentId = makeIdThatRoutesToShard(indexRoutingPostSplit, 1);
         var document = Map.of("field", randomAlphaOfLength(10));
-        prepareIndex(indexName).setId(documentId).setSource(document).get().getId();
+        prepareIndex(indexName).setId(documentId).setSource(document).get(SAFE_AWAIT_TIMEOUT).getId();
 
         refresh(indexName);
         assertHitCount(prepareSearchAll(indexName), 1);
@@ -4081,12 +3983,8 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         var coordinatorTransportService = MockTransportService.getInstance(coordinator);
         coordinatorTransportService.addSendBehavior((connection, requestId, action, request, options) -> {
             if (action.equals(TransportExplainAction.TYPE.name() + "[s]")) {
-                try {
-                    explainInitiated.countDown();
-                    explainBlock.await();
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
-                }
+                explainInitiated.countDown();
+                safeAwait(explainBlock);
             }
             connection.sendRequest(requestId, action, request, options);
         });
@@ -4096,9 +3994,9 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
                 () -> client(coordinator).prepareExplain(indexName, documentId)
                     .setFetchSource(true)
                     .setQuery(QueryBuilders.matchAllQuery())
-                    .get()
+                    .get(SAFE_AWAIT_TIMEOUT)
             );
-            explainInitiated.await();
+            safeAwait(explainInitiated);
 
             var sourceIndexShardNode = clusterService().state()
                 .nodes()
@@ -4114,13 +4012,9 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
                     TransportRequest actualRequest = MasterNodeRequestHelper.unwrapTermOverride(request);
 
                     if (actualRequest instanceof TransportUpdateSplitSourceShardStateAction.Request sourceStateRequest) {
-                        try {
-                            if (sourceStateRequest.getState() == IndexReshardingState.Split.SourceShardState.DONE) {
-                                sourceShardMoveToDoneAttempted.countDown();
-                                sourceShardMoveToDoneBlocked.await();
-                            }
-                        } catch (Exception e) {
-                            throw new RuntimeException(e);
+                        if (sourceStateRequest.getState() == IndexReshardingState.Split.SourceShardState.DONE) {
+                            sourceShardMoveToDoneAttempted.countDown();
+                            safeAwait(sourceShardMoveToDoneBlocked);
                         }
                     }
                 }
@@ -4132,7 +4026,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
             // Wait for the source index shard to attempt to move to DONE state.
             // That means that it already applied READY_TO_CLEANUP state and ensured that the search shard
             // is aware of it.
-            sourceShardMoveToDoneAttempted.await();
+            safeAwait(sourceShardMoveToDoneAttempted);
 
             try {
                 explainBlock.countDown();
@@ -4176,16 +4070,20 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         var id1 = makeIdThatRoutesToShard(afterSplitRouting, 0);
         var id2 = makeIdThatRoutesToShard(afterSplitRouting, 1);
 
-        client(coordinator).prepareIndex(indexName).setId(id1).setSource("field", "source_value").get();
-        client(coordinator).prepareIndex(indexName).setId(id2).setSource("field", "target_value").get();
+        client(coordinator).prepareIndex(indexName).setId(id1).setSource("field", "source_value").get(SAFE_AWAIT_TIMEOUT);
+        client(coordinator).prepareIndex(indexName).setId(id2).setSource("field", "target_value").get(SAFE_AWAIT_TIMEOUT);
         refresh(indexName);
 
-        TermVectorsResponse sourceShardReferenceResponse = client(coordinator).prepareTermVectors(indexName, id1).setRealtime(false).get();
+        TermVectorsResponse sourceShardReferenceResponse = client(coordinator).prepareTermVectors(indexName, id1)
+            .setRealtime(false)
+            .get(SAFE_AWAIT_TIMEOUT);
         assertTrue(sourceShardReferenceResponse.isExists());
         assertEquals(1, sourceShardReferenceResponse.getFields().size());
         assertEquals("field", sourceShardReferenceResponse.getFields().iterator().next());
 
-        TermVectorsResponse targetShardReferenceResponse = client(coordinator).prepareTermVectors(indexName, id2).setRealtime(false).get();
+        TermVectorsResponse targetShardReferenceResponse = client(coordinator).prepareTermVectors(indexName, id2)
+            .setRealtime(false)
+            .get(SAFE_AWAIT_TIMEOUT);
         assertTrue(targetShardReferenceResponse.isExists());
         assertEquals(1, targetShardReferenceResponse.getFields().size());
         assertEquals("field", targetShardReferenceResponse.getFields().iterator().next());
@@ -4194,7 +4092,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
             .setIndex(indexName)
             .setDoc(XContentBuilder.builder(XContentType.JSON.xContent()).startObject().field("field", "artificial_value").endObject())
             .setRealtime(false)
-            .get();
+            .get(SAFE_AWAIT_TIMEOUT);
         assertTrue(artificialDocumentReferenceResponse.isExists());
         assertTrue(artificialDocumentReferenceResponse.isArtificial());
         assertEquals(1, artificialDocumentReferenceResponse.getFields().size());
@@ -4216,18 +4114,10 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
                 if (actualRequest instanceof SplitStateRequest splitStateRequest) {
                     if (splitStateRequest.getNewTargetShardState() == IndexReshardingState.Split.TargetShardState.SPLIT) {
                         attemptingSplit.countDown();
-                        try {
-                            splitBlocked.await();
-                        } catch (InterruptedException e) {
-                            throw new RuntimeException(e);
-                        }
+                        safeAwait(splitBlocked);
                     } else if (splitStateRequest.getNewTargetShardState() == IndexReshardingState.Split.TargetShardState.DONE) {
                         attemptingDone.countDown();
-                        try {
-                            doneBlocked.await();
-                        } catch (InterruptedException e) {
-                            throw new RuntimeException(e);
-                        }
+                        safeAwait(doneBlocked);
                     }
                 }
             }
@@ -4238,12 +4128,12 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
 
         safeAwait(attemptingSplit);
 
-        var sourceShardHandoffResponse = client(coordinator).prepareTermVectors(indexName, id1).setRealtime(false).get();
+        var sourceShardHandoffResponse = client(coordinator).prepareTermVectors(indexName, id1).setRealtime(false).get(SAFE_AWAIT_TIMEOUT);
         assertTrue(sourceShardHandoffResponse.isExists());
         assertEquals(1, sourceShardHandoffResponse.getFields().size());
         assertEquals("field", sourceShardHandoffResponse.getFields().iterator().next());
 
-        var targetShardHandoffResponse = client(coordinator).prepareTermVectors(indexName, id2).setRealtime(false).get();
+        var targetShardHandoffResponse = client(coordinator).prepareTermVectors(indexName, id2).setRealtime(false).get(SAFE_AWAIT_TIMEOUT);
         assertTrue(targetShardHandoffResponse.isExists());
         assertEquals(1, targetShardHandoffResponse.getFields().size());
         assertEquals("field", targetShardHandoffResponse.getFields().iterator().next());
@@ -4252,7 +4142,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
             .setIndex(indexName)
             .setDoc(XContentBuilder.builder(XContentType.JSON.xContent()).startObject().field("field", "artificial_value").endObject())
             .setRealtime(false)
-            .get();
+            .get(SAFE_AWAIT_TIMEOUT);
         assertTrue(artificialDocumentHandoffResponse.isExists());
         assertTrue(artificialDocumentHandoffResponse.isArtificial());
         assertEquals(1, artificialDocumentHandoffResponse.getFields().size());
@@ -4262,12 +4152,16 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         safeAwait(attemptingDone);
 
         try {
-            var sourceShardSplitResponse = client(coordinator).prepareTermVectors(indexName, id1).setRealtime(false).get();
+            var sourceShardSplitResponse = client(coordinator).prepareTermVectors(indexName, id1)
+                .setRealtime(false)
+                .get(SAFE_AWAIT_TIMEOUT);
             assertTrue(sourceShardSplitResponse.isExists());
             assertEquals(1, sourceShardSplitResponse.getFields().size());
             assertEquals("field", sourceShardSplitResponse.getFields().iterator().next());
 
-            var targetShardSplitResponse = client(coordinator).prepareTermVectors(indexName, id2).setRealtime(false).get();
+            var targetShardSplitResponse = client(coordinator).prepareTermVectors(indexName, id2)
+                .setRealtime(false)
+                .get(SAFE_AWAIT_TIMEOUT);
             assertTrue(targetShardSplitResponse.isExists());
             assertEquals(1, targetShardSplitResponse.getFields().size());
             assertEquals("field", targetShardSplitResponse.getFields().iterator().next());
@@ -4276,7 +4170,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
                 .setIndex(indexName)
                 .setDoc(XContentBuilder.builder(XContentType.JSON.xContent()).startObject().field("field", "artificial_value").endObject())
                 .setRealtime(false)
-                .get();
+                .get(SAFE_AWAIT_TIMEOUT);
             assertTrue(artificialDocumentSplitResponse.isExists());
             assertTrue(artificialDocumentSplitResponse.isArtificial());
             assertEquals(1, artificialDocumentSplitResponse.getFields().size());
@@ -4313,7 +4207,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         // to test the retry logic for stale requests.
         var documentId = makeIdThatRoutesToShard(indexRoutingPostSplit, 1);
         var document = Map.of("field", randomAlphaOfLength(10));
-        prepareIndex(indexName).setId(documentId).setSource(document).get().getId();
+        prepareIndex(indexName).setId(documentId).setSource(document).get(SAFE_AWAIT_TIMEOUT).getId();
 
         refresh(indexName);
         assertHitCount(prepareSearchAll(indexName), 1);
@@ -4324,19 +4218,17 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         var coordinatorTransportService = MockTransportService.getInstance(coordinator);
         coordinatorTransportService.addSendBehavior((connection, requestId, action, request, options) -> {
             if (action.equals(TermVectorsAction.NAME + "[s]")) {
-                try {
-                    shardOperationInitiated.countDown();
-                    shardOperationBlocked.await();
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
-                }
+                shardOperationInitiated.countDown();
+                safeAwait(shardOperationBlocked);
             }
             connection.sendRequest(requestId, action, request, options);
         });
 
         try (var executor = Executors.newSingleThreadExecutor()) {
-            var future = executor.submit(() -> client(coordinator).prepareTermVectors(indexName, documentId).setRealtime(false).get());
-            shardOperationInitiated.await();
+            var future = executor.submit(
+                () -> client(coordinator).prepareTermVectors(indexName, documentId).setRealtime(false).get(SAFE_AWAIT_TIMEOUT)
+            );
+            safeAwait(shardOperationInitiated);
 
             var sourceIndexShardNode = clusterService().state()
                 .nodes()
@@ -4352,13 +4244,9 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
                     TransportRequest actualRequest = MasterNodeRequestHelper.unwrapTermOverride(request);
 
                     if (actualRequest instanceof TransportUpdateSplitSourceShardStateAction.Request sourceStateRequest) {
-                        try {
-                            if (sourceStateRequest.getState() == IndexReshardingState.Split.SourceShardState.DONE) {
-                                sourceShardMoveToDoneAttempted.countDown();
-                                sourceShardMoveToDoneBlocked.await();
-                            }
-                        } catch (Exception e) {
-                            throw new RuntimeException(e);
+                        if (sourceStateRequest.getState() == IndexReshardingState.Split.SourceShardState.DONE) {
+                            sourceShardMoveToDoneAttempted.countDown();
+                            safeAwait(sourceShardMoveToDoneBlocked);
                         }
                     }
                 }
@@ -4370,7 +4258,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
             // Wait for the source index shard to attempt to move to DONE state.
             // That means that it already applied READY_TO_CLEANUP state and ensured that the search shard
             // is aware of it.
-            sourceShardMoveToDoneAttempted.await();
+            safeAwait(sourceShardMoveToDoneAttempted);
 
             try {
                 shardOperationBlocked.countDown();
@@ -4411,11 +4299,11 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         // A document that routes to the target shard post split.
         String document1Id = makeIdThatRoutesToShard(afterSplitRouting, 1, "1");
 
-        client(coordinator).prepareIndex(indexName).setId(document1Id).setSource("field", "value").get();
+        client(coordinator).prepareIndex(indexName).setId(document1Id).setSource("field", "value").get(SAFE_AWAIT_TIMEOUT);
 
         // Note that we don't refresh since this is realtime.
 
-        var preSplitResponse = client(coordinator).prepareTermVectors(indexName, document1Id).setRealtime(true).get();
+        var preSplitResponse = client(coordinator).prepareTermVectors(indexName, document1Id).setRealtime(true).get(SAFE_AWAIT_TIMEOUT);
         assertTrue(preSplitResponse.isExists());
         assertEquals(1, preSplitResponse.getFields().size());
         assertEquals("field", preSplitResponse.getFields().iterator().next());
@@ -4425,25 +4313,21 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         var doneBlocked = new CountDownLatch(1);
         MockTransportService indexTransportService = MockTransportService.getInstance(indexNode);
         indexTransportService.addSendBehavior((connection, requestId, action, request, options) -> {
-            try {
-                if (TransportUpdateSplitTargetShardStateAction.TYPE.name().equals(action)) {
-                    TransportRequest actualRequest = MasterNodeRequestHelper.unwrapTermOverride(request);
-                    if (actualRequest instanceof SplitStateRequest splitStateRequest) {
-                        if (splitStateRequest.getNewTargetShardState() == IndexReshardingState.Split.TargetShardState.HANDOFF) {
-                            handoffStarted.countDown();
-                            handoffBlocked.await();
-                        } else if (splitStateRequest.getNewTargetShardState() == IndexReshardingState.Split.TargetShardState.DONE) {
-                            // This test assumes that indexing is successful, so the term vector read also succeeds.
-                            // But bulk shard indexing might fail if resharding completes after the coordinator issues the request,
-                            // but before it reaches the data node.
-                            doneBlocked.await();
-                        }
+            if (TransportUpdateSplitTargetShardStateAction.TYPE.name().equals(action)) {
+                TransportRequest actualRequest = MasterNodeRequestHelper.unwrapTermOverride(request);
+                if (actualRequest instanceof SplitStateRequest splitStateRequest) {
+                    if (splitStateRequest.getNewTargetShardState() == IndexReshardingState.Split.TargetShardState.HANDOFF) {
+                        handoffStarted.countDown();
+                        safeAwait(handoffBlocked);
+                    } else if (splitStateRequest.getNewTargetShardState() == IndexReshardingState.Split.TargetShardState.DONE) {
+                        // This test assumes that indexing is successful, so the term vector read also succeeds.
+                        // But bulk shard indexing might fail if resharding completes after the coordinator issues the request,
+                        // but before it reaches the data node.
+                        safeAwait(doneBlocked);
                     }
                 }
-                connection.sendRequest(requestId, action, request, options);
-            } catch (InterruptedException e) {
-                throw new RuntimeException(e);
             }
+            connection.sendRequest(requestId, action, request, options);
         });
 
         String document2Id = makeIdThatRoutesToShard(afterSplitRouting, 1, "2");
@@ -4458,39 +4342,37 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
                 int count = termVectorShardRequests.incrementAndGet();
                 logger.info("TermVectors [s] request #{} to [{}]", count, connection.getNode().getName());
                 if (count == 1) {
-                    try {
-                        readInitiated.countDown();
-                        readBlocked.await();
-                    } catch (InterruptedException e) {
-                        throw new RuntimeException(e);
-                    }
+                    readInitiated.countDown();
+                    safeAwait(readBlocked);
                 }
             }
             connection.sendRequest(requestId, action, request, options);
         });
 
         try (var executor = Executors.newFixedThreadPool(2)) {
-            var readFuture = executor.submit(() -> client(coordinator).prepareTermVectors(indexName, document2Id).setRealtime(true).get());
-            readInitiated.await();
+            var readFuture = executor.submit(
+                () -> client(coordinator).prepareTermVectors(indexName, document2Id).setRealtime(true).get(SAFE_AWAIT_TIMEOUT)
+            );
+            safeAwait(readInitiated);
 
             client(masterNode).execute(TransportReshardAction.TYPE, new ReshardIndexRequest(indexName)).actionGet();
 
-            handoffStarted.await();
+            safeAwait(handoffStarted);
 
             // Now we will index the document and it should be resplit to the target shard.
             var indexFuture = executor.submit(
-                () -> client(coordinator).prepareIndex(indexName).setId(document2Id).setSource("field", "value2").get()
+                () -> client(coordinator).prepareIndex(indexName).setId(document2Id).setSource("field", "value2").get(SAFE_AWAIT_TIMEOUT)
             );
 
             // Once we unblock handoff the write should complete.
             handoffBlocked.countDown();
-            indexFuture.get();
+            safeGet(indexFuture);
 
             // And now we perform the "stale" read.
             readBlocked.countDown();
 
             // It should still be successful.
-            var response = readFuture.get();
+            var response = safeGet(readFuture);
             if (response.isExists() == false) {
                 var index = resolveIndex(indexName);
                 var reshardMeta = indexMetadata(clusterService().state(), index).getReshardingMetadata();
@@ -4529,15 +4411,15 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         String document1Id = makeIdThatRoutesToShard(afterSplitRouting, 0, "1");
         String document2Id = makeIdThatRoutesToShard(afterSplitRouting, 1, "2");
 
-        client(coordinator).prepareIndex(indexName).setId(document1Id).setSource("field", "value").get();
-        client(coordinator).prepareIndex(indexName).setId(document2Id).setSource("field", "value2").get();
+        client(coordinator).prepareIndex(indexName).setId(document1Id).setSource("field", "value").get(SAFE_AWAIT_TIMEOUT);
+        client(coordinator).prepareIndex(indexName).setId(document2Id).setSource("field", "value2").get(SAFE_AWAIT_TIMEOUT);
 
         // Note that we don't refresh since this is realtime.
 
         var preSplitResponse = client(coordinator).prepareMultiTermVectors()
             .add(new TermVectorsRequest(indexName, document1Id).realtime(true))
             .add(new TermVectorsRequest(indexName, document2Id).realtime(true))
-            .get();
+            .get(SAFE_AWAIT_TIMEOUT);
         var document1PreSplitResponse = preSplitResponse.getResponses()[0].getResponse();
         assertTrue(document1PreSplitResponse.isExists());
         assertEquals(1, document1PreSplitResponse.getFields().size());
@@ -4552,25 +4434,21 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         var doneBlocked = new CountDownLatch(1);
         MockTransportService indexTransportService = MockTransportService.getInstance(indexNode);
         indexTransportService.addSendBehavior((connection, requestId, action, request, options) -> {
-            try {
-                if (TransportUpdateSplitTargetShardStateAction.TYPE.name().equals(action)) {
-                    TransportRequest actualRequest = MasterNodeRequestHelper.unwrapTermOverride(request);
-                    if (actualRequest instanceof SplitStateRequest splitStateRequest) {
-                        if (splitStateRequest.getNewTargetShardState() == IndexReshardingState.Split.TargetShardState.HANDOFF) {
-                            handoffStarted.countDown();
-                            handoffBlocked.await();
-                        } else if (splitStateRequest.getNewTargetShardState() == IndexReshardingState.Split.TargetShardState.DONE) {
-                            // This test assumes that indexing is successful, so the term vector read also succeeds.
-                            // But bulk shard indexing might fail if resharding completes after the coordinator issues the request,
-                            // but before it reaches the data node.
-                            doneBlocked.await();
-                        }
+            if (TransportUpdateSplitTargetShardStateAction.TYPE.name().equals(action)) {
+                TransportRequest actualRequest = MasterNodeRequestHelper.unwrapTermOverride(request);
+                if (actualRequest instanceof SplitStateRequest splitStateRequest) {
+                    if (splitStateRequest.getNewTargetShardState() == IndexReshardingState.Split.TargetShardState.HANDOFF) {
+                        handoffStarted.countDown();
+                        safeAwait(handoffBlocked);
+                    } else if (splitStateRequest.getNewTargetShardState() == IndexReshardingState.Split.TargetShardState.DONE) {
+                        // This test assumes that indexing is successful, so the term vector read also succeeds.
+                        // But bulk shard indexing might fail if resharding completes after the coordinator issues the request,
+                        // but before it reaches the data node.
+                        safeAwait(doneBlocked);
                     }
                 }
-                connection.sendRequest(requestId, action, request, options);
-            } catch (InterruptedException e) {
-                throw new RuntimeException(e);
             }
+            connection.sendRequest(requestId, action, request, options);
         });
 
         // Document queued to be indexed on the target shard.
@@ -4582,12 +4460,8 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         var coordinatorTransportService = MockTransportService.getInstance(coordinator);
         coordinatorTransportService.addSendBehavior((connection, requestId, action, request, options) -> {
             if (action.equals(TransportShardMultiTermsVectorAction.TYPE.name() + "[s]")) {
-                try {
-                    readInitiated.countDown();
-                    readBlocked.await();
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
-                }
+                readInitiated.countDown();
+                safeAwait(readBlocked);
             }
             connection.sendRequest(requestId, action, request, options);
         });
@@ -4598,27 +4472,27 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
                     .add(new TermVectorsRequest(indexName, document1Id).realtime(true))
                     .add(new TermVectorsRequest(indexName, document2Id).realtime(true))
                     .add(new TermVectorsRequest(indexName, document3Id).realtime(true))
-                    .get()
+                    .get(SAFE_AWAIT_TIMEOUT)
             );
-            readInitiated.await();
+            safeAwait(readInitiated);
 
             client(masterNode).execute(TransportReshardAction.TYPE, new ReshardIndexRequest(indexName)).actionGet();
 
-            handoffStarted.await();
+            safeAwait(handoffStarted);
 
             // Now we will index the document and it should be resplit to the target shard.
             var indexFuture = executor.submit(
-                () -> client(coordinator).prepareIndex(indexName).setId(document3Id).setSource("field", "value3").get()
+                () -> client(coordinator).prepareIndex(indexName).setId(document3Id).setSource("field", "value3").get(SAFE_AWAIT_TIMEOUT)
             );
 
             // Once we unblock handoff the write should complete.
             handoffBlocked.countDown();
-            indexFuture.get();
+            safeGet(indexFuture);
 
             // And now we perform the "stale" read.
             readBlocked.countDown();
 
-            var response = readFuture.get();
+            var response = safeGet(readFuture);
             // We retry the operation because it is stale and get a legit response.
             var document1Response = response.getResponses()[0].getResponse();
             assertTrue(document1Response.isExists());
@@ -4709,7 +4583,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
             .cluster()
             .prepareState(TEST_REQUEST_TIMEOUT)
             .setMetadata(true)
-            .get()
+            .get(SAFE_AWAIT_TIMEOUT)
             .getState()
             .getMetadata()
             .findIndex(index)
@@ -4754,7 +4628,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         final var reshardingMetadata = client(nodeName).admin()
             .cluster()
             .prepareState(TEST_REQUEST_TIMEOUT)
-            .get()
+            .get(SAFE_AWAIT_TIMEOUT)
             .getState()
             .getMetadata()
             .indexMetadata(index)
@@ -4784,7 +4658,7 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
     }
 
     private static void closeIndices(final CloseIndexRequestBuilder requestBuilder) {
-        final CloseIndexResponse response = requestBuilder.get();
+        final CloseIndexResponse response = requestBuilder.get(SAFE_AWAIT_TIMEOUT);
         assertThat(response.isAcknowledged(), is(true));
         assertThat(response.isShardsAcknowledged(), is(true));
 


### PR DESCRIPTION
It shortens the code and also makes test failures easier to read.
