### PR TITLE
Enable missing feature flags in DataStreamsClientYamlTestSuiteIT

### DIFF
--- a/modules/data-streams/src/yamlRestTest/java/org/elasticsearch/datastreams/DataStreamsClientYamlTestSuiteIT.java
+++ b/modules/data-streams/src/yamlRestTest/java/org/elasticsearch/datastreams/DataStreamsClientYamlTestSuiteIT.java
@@ -51,6 +51,8 @@ public class DataStreamsClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase 
             .user("x_pack_rest_user", "x-pack-test-password")
             .feature(FeatureFlag.LOGS_STREAM)
             .feature(FeatureFlag.COLUMNAR_INDEX_MODE_FEATURE_FLAG)
+            .feature(FeatureFlag.EXTENDED_DOC_VALUES_PARAMS)
+            .feature(FeatureFlag.INDEX_DISABLED_BY_DEFAULT)
             .systemProperty("es.queryable_built_in_roles_enabled", "false");
         if (initTestSeed().nextBoolean()) {
             clusterBuilder.setting("xpack.license.self_generated.type", "trial");


### PR DESCRIPTION
Adds `EXTENDED_DOC_VALUES_PARAMS` and `INDEX_DISABLED_BY_DEFAULT` feature flags to the `DataStreamsClientYamlTestSuiteIT` cluster, fixing release-mode failures in the `290_columnar` YAML tests. Follows the pattern from #150432, which fixed the same issue in other test clusters.