### PR TITLE
[CI] Raise smart-retry history file cap to 100MB

### DIFF
--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/test/rerun/InternalTestRerunPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/test/rerun/InternalTestRerunPluginFuncTest.groovy
@@ -140,8 +140,14 @@ class InternalTestRerunPluginFuncTest extends AbstractGradleFuncTest {
     def "rejects oversized failed-test-history file"() {
         given:
         simpleTestSetup()
-        def largeContent = '{"successfulTasks":["' + ('x'.multiply(10 * 1024 * 1024)) + '"]}'
-        file(".failed-test-history.json") << largeContent
+        // The size check runs before JSON parsing, so content validity is irrelevant here. Write a file
+        // just over the 100MB cap in 1MB chunks to avoid allocating the whole payload in memory.
+        file(".failed-test-history.json").withOutputStream { out ->
+            byte[] chunk = new byte[1024 * 1024]
+            for (int i = 0; i < 101; i++) {
+                out.write(chunk)
+            }
+        }
 
         when:
         def result = gradleRunner("test", "--warning-mode", "all").buildAndFail()

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rerun/InternalTestRerunPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rerun/InternalTestRerunPlugin.java
@@ -48,7 +48,8 @@ public abstract class InternalTestRerunPlugin implements Plugin<Project> {
 
     public static final String FAILED_TEST_HISTORY_FILENAME = ".failed-test-history.json";
 
-    private static final long MAX_JSON_FILE_SIZE = 10 * 1024 * 1024;
+    // Guard against OOM: the entire file is read into memory and held for the whole build in the long-lived Gradle daemon.
+    private static final long MAX_JSON_FILE_SIZE = 100 * 1024 * 1024;
 
     @Override
     public void apply(Project project) {


### PR DESCRIPTION
## Summary

Quick unblock for PR builds failing at Gradle configuration time with:

```
> Could not create task ':x-pack:plugin:esql:internalClusterTest'.
   > Failed to create service 'retryTests'.
      > Could not create an instance of type ...InternalTestRerunPlugin$RetryTestsBuildService.
         > Failed test history file too large: 92278210 bytes (max: 10485760 bytes)
```

(seen in [elasticsearch-pull-request build 151931](https://buildkite.com/elastic/elasticsearch-pull-request/builds/151931), job `part-3`).

### Root cause
Since #148919, the smart-retry `.failed-test-history.json` records every **successful** task/test rather than failures, so the file size scales with the number of passing tests. On a retry of a large suite the file reached ~92MB (the run reported *"Skipping 1852 successful tasks and 529479 individual tests"*), exceeding the existing 10MB guard in `RetryTestsBuildService`. The guard throws during build-service creation, which fails the entire Gradle invocation before any test runs — so the retry hard-fails instead of speeding up.

### Change
- Raise `MAX_JSON_FILE_SIZE` from 10MB to 100MB and add a short comment explaining the guard exists to protect the long-lived Gradle daemon from OOM (the file is read fully into memory and held for the whole build).
- Update the `rejects oversized failed-test-history file` func test to generate a >100MB file in 1MB chunks (avoids allocating the payload in memory).

### Follow-up (not in this PR)
This raises the ceiling but does not fix the growth: the success-list scales with total test count and will exceed any fixed cap over time. A durable fix should shrink the payload — e.g. gzip the file, drop pretty-printing, or store only failures/task-level success.

## Test plan
- [x] `./gradlew :build-tools-internal:integTest --tests "org.elasticsearch.gradle.internal.test.rerun.InternalTestRerunPluginFuncTest"` passes (incl. the oversized-file rejection at the new cap).
- [x] `./gradlew :build-tools-internal:spotlessApply` clean.