### PR TITLE
[9.4] Fix ManualSlicingReindexIT testReindexWithSourceUpdatesBetweenSlices …

### DIFF
--- a/modules/reindex/src/javaRestTest/java/org/elasticsearch/index/reindex/ManualSlicingReindexIT.java
+++ b/modules/reindex/src/javaRestTest/java/org/elasticsearch/index/reindex/ManualSlicingReindexIT.java
@@ -62,8 +62,11 @@ public class ManualSlicingReindexIT extends ESRestTestCase {
     public void testReindexWithSourceUpdatesBetweenSlices() throws IOException {
         int docCount = randomIntBetween(500, 1000);
         String sourceIndex = randomAlphanumericOfLength(randomIntBetween(3, 5)).toLowerCase(Locale.ROOT);
-        String dest1 = randomAlphanumericOfLength(randomIntBetween(3, 5)).toLowerCase(Locale.ROOT);
-        String dest2 = randomAlphanumericOfLength(randomIntBetween(3, 5)).toLowerCase(Locale.ROOT);
+        String dest1 = randomValueOtherThan(sourceIndex, () -> randomAlphanumericOfLength(randomIntBetween(3, 5)).toLowerCase(Locale.ROOT));
+        String dest2 = randomValueOtherThanMany(
+            index -> index.equals(sourceIndex) || index.equals(dest1),
+            () -> randomAlphanumericOfLength(randomIntBetween(3, 5)).toLowerCase(Locale.ROOT)
+        );
 
         createIndex(sourceIndex, Settings.builder().put("index.number_of_shards", 1).put("index.number_of_replicas", 0).build());
         bulkIndexSource(sourceIndex, docCount, 0);

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -327,9 +327,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.expression.function.scalar.spatial.StSimplifyPreserveTopologyTests
   method: "testEvaluateInManyThreads {TestCase=geo_shape with tolerance[long]. #2}"
   issue: https://github.com/elastic/elasticsearch/issues/150079
-- class: org.elasticsearch.index.reindex.ManualSlicingReindexIT
-  method: testReindexWithSourceUpdatesBetweenSlices
-  issue: https://github.com/elastic/elasticsearch/issues/150315
 
 # Examples:
 #


### PR DESCRIPTION
Fixes a name clash due to randomization in the ManualSlicingReindexIT test class.

Backport of https://github.com/elastic/elasticsearch/pull/150511
