### PR TITLE
Fix async search in-flight context race in tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -573,12 +573,6 @@ tests:
   method: "builds distribution from branches via archives extractedAssemble [bwcDistVersion: 8.2.1, bwcProject: major3, expectedAssembleTaskName:
     extractedAssemble, #2]"
   issue: https://github.com/elastic/elasticsearch/issues/150410
-- class: org.elasticsearch.xpack.search.AsyncSearchActionIT
-  method: testRestartAfterCompletion
-  issue: https://github.com/elastic/elasticsearch/issues/150417
-- class: org.elasticsearch.xpack.search.AsyncSearchActionIT
-  method: testCCSCheckCompatibility
-  issue: https://github.com/elastic/elasticsearch/issues/150418
 - class: org.elasticsearch.xpack.dlm.frozen.DLMFrozenTransitionWithSecurityIT
   method: testCanTransitionIndex
   issue: https://github.com/elastic/elasticsearch/issues/149770

--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchIntegTestCase.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchIntegTestCase.java
@@ -154,8 +154,13 @@ public abstract class AsyncSearchIntegTestCase extends ESIntegTestCase {
         ensureAllSearchContextsReleased();
 
         internalCluster().restartNode(node.getName(), new InternalTestCluster.RestartCallback() {});
-        unpauseMaintenanceService();
+        // Ensure shards are ready before unpausing the maintenance service. If we unpaused first,
+        // the maintenance service could dispatch a DeleteByQueryRequest to a shard that is still
+        // INITIALIZING, hitting the waitForSearchReady path. The resulting reader context would be
+        // registered after ensureAllSearchContextsReleased() passes, causing a spurious
+        // assertNoInFlightContext() failure in subsequent-test teardown.
         ensureYellow(ASYNC_RESULTS_INDEX, indexName);
+        unpauseMaintenanceService();
     }
 
     protected AsyncSearchResponse submitAsyncSearch(SubmitAsyncSearchRequest request) throws ExecutionException, InterruptedException {


### PR DESCRIPTION
`restartTaskNode` unpaused the maintenance service before shards were ready, so it dispatched a search to a still-recovering shard. The search was suspended via `waitForSearchReady` until the shard became ready, but by then `ensureAllSearchContextsReleased()` had already passed seeing no contexts, and the reader context was registered too late, surfacing in the next test's teardown.

The fix swaps the two calls so shards are fully started before the maintenance service is unpaused.

Closes #150417
Closes #150418
