### PR TITLE
Document default repository setting

### DIFF
--- a/docs/reference/elasticsearch/configuration-reference/snapshot-restore-settings.md
+++ b/docs/reference/elasticsearch/configuration-reference/snapshot-restore-settings.md
@@ -35,7 +35,7 @@ $$$repositories-default-repository$$$
 `repositories.default_repository` {applies_to}`stack: ga 9.4`
 :   ([Dynamic](docs-content://deploy-manage/stack-settings.md#dynamic-cluster-setting), string) A default repository to be used for snapshot and restore operations. Currently, this is only used for DLM Frozen Tier transitions but may be used by other features in the future. By default, this setting is unset, in which case DLM frozen tier transitions will not occur.
 
-    The repository must already be registered before it can be set as the default, and a read-only repository cannot be set as the default. A repository that is currently configured as the default cannot be deleted or marked as read-only; point this setting at a different repository (or clear it by setting it to an empty string) first.
+    The repository must already be registered before it can be set as the default, and a read-only repository cannot be set as the default. A repository that is currently configured as the default cannot be deleted or marked as read-only until you change the setting to a different repository or set it to an empty string.
 
 
 ## {{slm-init}} settings [_slm_init_settings]

--- a/docs/reference/elasticsearch/configuration-reference/snapshot-restore-settings.md
+++ b/docs/reference/elasticsearch/configuration-reference/snapshot-restore-settings.md
@@ -30,6 +30,13 @@ $$$snapshot-max-concurrent-ops$$$
 
     This limit applies in total to all ongoing snapshot creation, cloning, and deletion operations. {{es}} will reject any operations that would exceed this limit.
 
+$$$repositories-default-repository$$$
+
+`repositories.default_repository` {applies_to}`stack: ga 9.4`
+:   ([Dynamic](docs-content://deploy-manage/stack-settings.md#dynamic-cluster-setting), string) A default repository to be used for snapshot and restore operations. Currently, this is only used for DLM Frozen Tier transitions but may be used by other features in the future. By default, this setting is unset, in which case DLM frozen tier transitions will not occur.
+
+    The repository must already be registered before it can be set as the default, and a read-only repository cannot be set as the default. A repository that is currently configured as the default cannot be deleted or marked as read-only; point this setting at a different repository (or clear it by setting it to an empty string) first.
+
 
 ## {{slm-init}} settings [_slm_init_settings]
 
@@ -54,6 +61,3 @@ $$$slm-health-failed-snapshot-warn-threshold$$$
 
 `slm.health.failed_snapshot_warn_threshold`
 :   ([Dynamic](docs-content://deploy-manage/stack-settings.md#dynamic-cluster-setting), Long) The number of failed invocations since last successful snapshot that indicate a problem with the policy in the health api. Defaults to a health api warning after five repeated failures: `5L`.
-
-
-


### PR DESCRIPTION
This PR adds documentation for the default repository cluster setting used by DLM Frozen tier
