### PR TITLE
Initial cache boost Configurations

### DIFF
--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/BoostConfiguration.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/BoostConfiguration.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.blobcache.shared;
+
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.Maps;
+import org.elasticsearch.core.TimeValue;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+public class BoostConfiguration {
+
+    // Identifier for the boost configuration, e.g. "logs".
+    private final String name;
+    private final Map<String, BoostWindow> boostWindows;
+    private final NavigableMap<Long, BoostWindow> boostWindowLookup;
+
+    public BoostConfiguration(String name, Map<String, BoostWindow> boostWindows) {
+        this.name = name;
+        this.boostWindows = Collections.unmodifiableMap(boostWindows);
+
+        // We build a map keyed by the maxAge for faster lookup. It also deduplicates if multiple windows have the same maxAge.
+        final TreeMap<Long, BoostWindow> lookup = new TreeMap<>();
+        for (BoostWindow window : boostWindows.values()) {
+            long millis = window.effectiveMaxAge().getMillis();
+            BoostWindow existing = lookup.get(millis);
+            // TODO: the cachedRatio may vary in a single window if we support both cachePowerMin and cachePowerMax
+            // One option is to still order them based on cachePowerMin
+            if (existing == null || window.cachedRatio() > existing.cachedRatio()) {
+                lookup.put(millis, window);
+            }
+        }
+        this.boostWindowLookup = Collections.unmodifiableNavigableMap(lookup);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    /**
+     *
+     * @param timeInMillisRelativeToNow The time of "now() - timestamp". Positive if in the past, negative if in the future.
+     * @return The BoostWindow that should be applied to the timestamp.
+     */
+    public BoostWindow getBoostWindow(long timeInMillisRelativeToNow) {
+        if (boostWindowLookup.isEmpty()) {
+            return null;
+        }
+        // Find the smallest effectiveMaxAge that covers timeInMillisRelativeToNow (ceiling).
+        // ceilingEntry naturally clamps to the first entry when input is below the smallest key.
+        // When input exceeds the largest key, clamp to the last entry.
+        var entry = boostWindowLookup.ceilingEntry(timeInMillisRelativeToNow);
+        return entry != null ? entry.getValue() : boostWindowLookup.lastEntry().getValue();
+    }
+
+    public BoostConfiguration withOverrides(Map<String, BoostWindow.Overrides> overridesPerWindow) {
+        if (overridesPerWindow == null) {
+            return this;
+        }
+
+        return new BoostConfiguration(
+            name,
+            Maps.transformValues(boostWindows, boostWindow -> boostWindow.withOverrides(overridesPerWindow.get(boostWindow.name())))
+        );
+    }
+
+    @Override
+    public String toString() {
+        return "BoostConfiguration{"
+            + "name='"
+            + name
+            + '\''
+            + ", boostWindows="
+            + boostWindows
+            + ", boostWindowLookup="
+            + boostWindowLookup
+            + '}';
+    }
+
+    private static final Setting<TimeValue> MAX_AGE_SETTING = Setting.timeSetting("max_age", TimeValue.ZERO, TimeValue.MINUS_ONE);
+    private static final Setting<Integer> CACHE_POWER_MIN_SETTING = Setting.intSetting("cache_power_min", 0, 0);
+    private static final Setting<TimeValue> OVERRIDE_MAX_AGE_SETTING = Setting.timeSetting(
+        "overrides.max_age",
+        TimeValue.ZERO,
+        TimeValue.ZERO
+    );
+    private static final Setting<Double> BOOST_FACTOR_MIN_SETTING = Setting.doubleSetting("overrides.boost_factor_min", 1.0, 0.0);
+
+    private static Set<String> ALLOWED_WINDOW_SETTING_KEYS = Set.of("max_age", "cache_power_min", "overrides");
+    private static Set<String> ALLOWED_OVERRIDES_SETTING_KEYS = Set.of("max_age", "boost_factor_min");
+
+    public static BoostConfiguration fromSettings(String name, Settings settings) {
+        final Map<String, BoostWindow> boostWindows = settings.getAsGroups()
+            .entrySet()
+            .stream()
+            .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, entry -> {
+                final String windowName = entry.getKey();
+                final var windowSettings = entry.getValue();
+
+                if (ALLOWED_WINDOW_SETTING_KEYS.containsAll(getFirstComponentOfSettingKeys(windowSettings)) == false) {
+                    throw new IllegalArgumentException("Invalid settings for boost window [" + windowName + "]: " + windowSettings);
+                }
+
+                final TimeValue maxAge = MAX_AGE_SETTING.get(windowSettings);
+                final int cachePowerMin = CACHE_POWER_MIN_SETTING.get(windowSettings);
+
+                BoostWindow.Overrides overrides = null;
+                final Settings overridesSettings = windowSettings.getByPrefix("overrides.");
+                if (overridesSettings.isEmpty() == false) {
+                    if (ALLOWED_OVERRIDES_SETTING_KEYS.containsAll(getFirstComponentOfSettingKeys(overridesSettings)) == false) {
+                        throw new IllegalArgumentException("Invalid settings for boost window [" + windowName + "]: " + overridesSettings);
+                    }
+                    overrides = new BoostWindow.Overrides(
+                        OVERRIDE_MAX_AGE_SETTING.exists(windowSettings) ? OVERRIDE_MAX_AGE_SETTING.get(windowSettings) : null,
+                        BOOST_FACTOR_MIN_SETTING.get(windowSettings)
+                    );
+                }
+                return new BoostWindow(windowName, maxAge, cachePowerMin, overrides);
+            }));
+        return new BoostConfiguration(name, boostWindows);
+    }
+
+    private static Set<String> getFirstComponentOfSettingKeys(Settings settings) {
+        return settings.keySet().stream().map(key -> {
+            final var idx = key.indexOf('.');
+            return idx < 0 ? key : key.substring(0, idx);
+        }).collect(Collectors.toUnmodifiableSet());
+    }
+}

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/BoostConfiguration.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/BoostConfiguration.java
@@ -19,6 +19,10 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
+/**
+ * BoostConfiguration is essentially a set of BoostWindow instances that collectively define the complete boost
+ * configuration for a certain type of data, e.g. "logs".
+ */
 public class BoostConfiguration {
 
     // Identifier for the boost configuration, e.g. "logs".
@@ -64,6 +68,11 @@ public class BoostConfiguration {
         return entry != null ? entry.getValue() : boostWindowLookup.lastEntry().getValue();
     }
 
+    /**
+     * Create a new BoostConfiguration by applying the overrides to the existing one. The passed-in
+     * overrides are meant to be finer grained, e.g. index level overrides, while the existing one is coarser grained,
+     * e.g. project wide or a single configuration wide (e.g. `logs`).
+     */
     public BoostConfiguration withOverrides(Map<String, BoostWindow.Overrides> overridesPerWindow) {
         if (overridesPerWindow == null) {
             return this;

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/BoostConfigurationsService.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/BoostConfigurationsService.java
@@ -18,6 +18,10 @@ import org.elasticsearch.common.time.TimeProvider;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+/**
+ * This service class tracks a set of BoostConfiguration and manages their updates. Consumers are
+ * meant to interact with this service to get boost configurations.
+ */
 public class BoostConfigurationsService {
 
     private static final Logger logger = LogManager.getLogger(BoostConfigurationsService.class);
@@ -44,13 +48,19 @@ public class BoostConfigurationsService {
         });
     }
 
+    /**
+     * This method is the entry point for accessing boost configuration. It returns a BoostWindow for
+     * the given index and timestamp.
+     */
     public BoostWindow getBoostWindow(IndexMetadata indexMetadata, long absoluteTimeInMillis) {
         final var ageInMillis = timeProvider.absoluteTimeInMillis() - absoluteTimeInMillis;
 
         // TODO: resolve index specific overrides
         final Map<String, BoostWindow.Overrides> overridesPerWindow = null;
 
-        return getBoostConfiguration(indexMetadata).withOverrides(overridesPerWindow).getBoostWindow(ageInMillis);
+        return getBoostConfiguration(indexMetadata) // 1. determine the BoostConfiguration to use based on, e.g. index mode
+            .withOverrides(overridesPerWindow) // 2. apply index level overrides, if any
+            .getBoostWindow(ageInMillis); // 3. determine the BoostWindow
     }
 
     // TODO: Add mapping for index to its boost configuration, e.g. based on IndexMode and boost overrides

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/BoostConfigurationsService.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/BoostConfigurationsService.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.blobcache.shared;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.time.TimeProvider;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class BoostConfigurationsService {
+
+    private static final Logger logger = LogManager.getLogger(BoostConfigurationsService.class);
+
+    public static final Setting<Settings> BOOST_CONFIGURATIONS_SETTING = Setting.groupSetting(
+        "stateless.cache_boost_preference.boost_configurations.",
+        BoostConfigurationsService::buildConfigurationMapFromSettings,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope,
+        Setting.Property.ProjectScope // this is just a placeholder for now
+    );
+
+    public static final String DEFAULT_BOOST_CONFIGURATION_NAME = "_default";
+
+    private volatile Map<String, BoostConfiguration> boostConfigurations;
+    private final TimeProvider timeProvider;
+
+    public BoostConfigurationsService(ClusterService clusterService, TimeProvider timeProvider) {
+        this.timeProvider = timeProvider;
+        clusterService.getClusterSettings().initializeAndWatch(BOOST_CONFIGURATIONS_SETTING, settings -> {
+            final var updatedBoostConfigurations = buildConfigurationMapFromSettings(settings);
+            logger.info("updating boost configurations from settings to {}", updatedBoostConfigurations);
+            this.boostConfigurations = updatedBoostConfigurations;
+        });
+    }
+
+    public BoostWindow getBoostWindow(IndexMetadata indexMetadata, long absoluteTimeInMillis) {
+        final var ageInMillis = timeProvider.absoluteTimeInMillis() - absoluteTimeInMillis;
+
+        // TODO: resolve index specific overrides
+        final Map<String, BoostWindow.Overrides> overridesPerWindow = null;
+
+        return getBoostConfiguration(indexMetadata).withOverrides(overridesPerWindow).getBoostWindow(ageInMillis);
+    }
+
+    // TODO: Add mapping for index to its boost configuration, e.g. based on IndexMode and boost overrides
+    private BoostConfiguration getBoostConfiguration(IndexMetadata indexMetadata) {
+        return boostConfigurations.get(DEFAULT_BOOST_CONFIGURATION_NAME);
+    }
+
+    private static Map<String, BoostConfiguration> buildConfigurationMapFromSettings(Settings settings) {
+        return settings.getAsGroups()
+            .entrySet()
+            .stream()
+            .collect(
+                Collectors.toUnmodifiableMap(Map.Entry::getKey, entry -> BoostConfiguration.fromSettings(entry.getKey(), entry.getValue()))
+            );
+    }
+}

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/BoostWindow.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/BoostWindow.java
@@ -10,6 +10,10 @@ package org.elasticsearch.blobcache.shared;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 
+/**
+ * BoostWindow defines the base configuration for a time window. It also stores overrides
+ * so that the methods, e.g. cachedRatio, return values taking the overrides into account.
+ */
 public class BoostWindow {
 
     private static final int CACHE_POWER_FOR_FULLY_CACHED = 200;
@@ -56,7 +60,12 @@ public class BoostWindow {
         return overrideMaxAge != null ? overrideMaxAge : maxAge;
     }
 
-    public BoostWindow withOverrides(Overrides overrides) {
+    /**
+     * This method creates a new BoostWindow by using the passed-in overrides, which is meant to be
+     * finer grained, e.g. index level overrides, while the existing one is coarser grained, e.g.
+     * project wide or a single configuration wide (e.g. `logs`).
+     */
+    public BoostWindow withOverrides(@Nullable Overrides overrides) {
         if (overrides == null) {
             return this;
         }

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/BoostWindow.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/BoostWindow.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.blobcache.shared;
+
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.TimeValue;
+
+public class BoostWindow {
+
+    private static final int CACHE_POWER_FOR_FULLY_CACHED = 200;
+    private static final double DEFAULT_BOOST_FACTOR = 1.0;
+
+    private final String name; // an arbitrary identifier for the boost window
+    private final TimeValue maxAge; // there is no minAge, the window covers everything younger than maxAge
+    private final int cachePowerMin; // min for now, but can be a range in future
+
+    @Nullable
+    private final Overrides overrides;
+
+    public BoostWindow(String name, TimeValue maxAge, int cachePowerMin) {
+        this(name, maxAge, cachePowerMin, null);
+    }
+
+    public BoostWindow(String name, TimeValue maxAge, int cachePowerMin, @Nullable Overrides overrides) {
+        assert cachePowerMin >= 0;
+        // -1 for indices with no timestamp
+        assert maxAge != null && maxAge.getMillis() >= -1 : "invalid maxAge: " + maxAge;
+        // boost factor must be non-negative
+        assert overrides == null || overrides.boostFactorMin() >= 0.0 : "invalid overrides: " + overrides;
+        // cannot override maxAge for indices with no timestamp
+        assert overrides == null || overrides.maxAge() == null || overrides.maxAge().getMillis() >= 0 : "invalid overrides: " + overrides;
+
+        this.name = name;
+        this.cachePowerMin = cachePowerMin;
+        this.maxAge = maxAge;
+        this.overrides = overrides;
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public double cachedRatio() {
+        // TODO: when we have cachePowerMax, we can choose a value between min and max based on the timestamp
+        double boostFactorMin = overrides != null ? overrides.boostFactorMin() : DEFAULT_BOOST_FACTOR;
+        return (cachePowerMin * boostFactorMin) / CACHE_POWER_FOR_FULLY_CACHED;
+    }
+
+    public TimeValue effectiveMaxAge() {
+        TimeValue overrideMaxAge = overrides != null ? overrides.maxAge() : null;
+        return overrideMaxAge != null ? overrideMaxAge : maxAge;
+    }
+
+    public BoostWindow withOverrides(Overrides overrides) {
+        if (overrides == null) {
+            return this;
+        }
+        // This simply drops old overrides (if exists) and honor the new ones
+        return new BoostWindow(name, maxAge, cachePowerMin, overrides);
+    }
+
+    @Override
+    public String toString() {
+        return "BoostWindow{"
+            + "name='"
+            + name
+            + '\''
+            + ", cachePowerMin="
+            + cachePowerMin
+            + ", maxAge="
+            + maxAge
+            + ", overrides="
+            + overrides
+            + '}';
+    }
+
+    public record Overrides(
+        TimeValue maxAge,
+        double boostFactorMin // min for now, but maybe a range in future
+    ) {}
+}

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/cache/StatelessBoostConfigurationsIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/cache/StatelessBoostConfigurationsIT.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.stateless.cache;
+
+import org.elasticsearch.blobcache.shared.BoostConfigurationsService;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.stateless.AbstractStatelessPluginIntegTestCase;
+
+public class StatelessBoostConfigurationsIT extends AbstractStatelessPluginIntegTestCase {
+
+    public void testBoostConfigurationsBasic() {
+        final var node0 = startMasterAndIndexNode();
+        final var boostConfigurationsService = internalCluster().getInstance(BoostConfigurationsService.class, node0);
+        final var threadPool = internalCluster().getInstance(ThreadPool.class, node0);
+
+        // 1. Default settings - 6 days old data in bw0 and 20 days old data in bw1
+        {
+            final var boostWindow = boostConfigurationsService.getBoostWindow(
+                null, // indexMetadata is not used for now, so null
+                threadPool.absoluteTimeInMillis() - TimeValue.timeValueDays(6).millis() // 6 days ago
+            );
+            assertEquals("bw0", boostWindow.name());
+            assertEquals(0.5d, boostWindow.cachedRatio(), 1e-9);
+            assertEquals(TimeValue.timeValueDays(7), boostWindow.effectiveMaxAge());
+        }
+        {
+            final var boostWindow = boostConfigurationsService.getBoostWindow(
+                null, // indexMetadata is not used for now, so null
+                threadPool.absoluteTimeInMillis() - TimeValue.timeValueDays(20).millis() // 20 days ago
+            );
+            assertEquals("bw1", boostWindow.name());
+            assertEquals(0.05d, boostWindow.cachedRatio(), 1e-9);
+            assertEquals(TimeValue.timeValueDays(3650), boostWindow.effectiveMaxAge());
+        }
+
+        // 2. Project overrides so that the 20 days old data is in bw0 and fully cached
+        updateClusterSettings(
+            Settings.builder()
+                .put("_default.bw0.overrides.max_age", TimeValue.timeValueDays(30))
+                .put("_default.bw0.overrides.boost_factor_min", 2.0)
+                .normalizePrefix(BoostConfigurationsService.BOOST_CONFIGURATIONS_SETTING.getKey())
+        );
+        {
+            final var boostWindow = boostConfigurationsService.getBoostWindow(
+                null, // indexMetadata is not used for now, so null
+                threadPool.absoluteTimeInMillis() - TimeValue.timeValueDays(20).millis() // 20 days ago
+            );
+            assertEquals("bw0", boostWindow.name());
+            assertEquals(1.0d, boostWindow.cachedRatio(), 1e-9);
+        }
+
+        // 3. Remove project overrides and the 20 days old data is back to bw1 with low cached ratio
+        updateClusterSettings(
+            Settings.builder().putNull(BoostConfigurationsService.BOOST_CONFIGURATIONS_SETTING.getKey() + "_default.bw0.overrides.*")
+        );
+        {
+            final var boostWindow = boostConfigurationsService.getBoostWindow(
+                null, // indexMetadata is not used for now, so null
+                threadPool.absoluteTimeInMillis() - TimeValue.timeValueDays(20).millis() // 20 days ago
+            );
+            assertEquals("bw1", boostWindow.name());
+            assertEquals(0.05d, boostWindow.cachedRatio(), 1e-9);
+            assertEquals(TimeValue.timeValueDays(3650), boostWindow.effectiveMaxAge());
+        }
+    }
+}

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/StatelessPlugin.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/StatelessPlugin.java
@@ -17,6 +17,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.create.AutoCreateAction;
 import org.elasticsearch.action.termvectors.EnsureDocsSearchableAction;
 import org.elasticsearch.blobcache.BlobCacheMetrics;
+import org.elasticsearch.blobcache.shared.BoostConfigurationsService;
 import org.elasticsearch.blobcache.shared.SharedBlobCacheService;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.client.internal.node.NodeClient;
@@ -121,6 +122,7 @@ import org.elasticsearch.threadpool.ScalingExecutorBuilder;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.ParseField;
+import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.XPackPlugin;
 import org.elasticsearch.xpack.core.action.XPackInfoFeatureAction;
 import org.elasticsearch.xpack.core.action.XPackUsageFeatureAction;
@@ -721,6 +723,16 @@ public class StatelessPlugin extends Plugin
             throw new IllegalArgumentException("Directly setting [" + nodeMemoryAttrName + "] is not permitted - it is reserved.");
         }
         settings.put(RecoverySettings.INDICES_RECOVERY_SOURCE_ENABLED_SETTING.getKey(), false);
+        settings.put(Settings.builder().loadFromSource("""
+            {
+              "_default": {
+                "bw0": { "max_age": "7d", "cache_power_min": 100},
+                "bw1": { "max_age": "3650d", "cache_power_min": 10}
+              },
+              "no_timestamp": {
+                "bw0": { "max_age": "-1", "cache_power_min": 100}
+              }
+            }""", XContentType.JSON).normalizePrefix(BoostConfigurationsService.BOOST_CONFIGURATIONS_SETTING.getKey()).build());
         return settings.build();
     }
 
@@ -1019,6 +1031,7 @@ public class StatelessPlugin extends Plugin
             }
         }
 
+        components.add(new BoostConfigurationsService(clusterService, threadPool));
         return components;
     }
 
@@ -1314,7 +1327,8 @@ public class StatelessPlugin extends Plugin
             ShardsMappingSizeCollector.FIXED_HOLLOW_SHARD_MEMORY_OVERHEAD_SETTING,
             ShardsMappingSizeCollector.HOLLOW_SHARD_SEGMENT_MEMORY_OVERHEAD_SETTING,
             StatelessSharedBlobCacheService.STATELESS_CACHE_BOOST_PREFERENCE_ENABLED_SETTING,
-            DisableSimulationRebalancingDecider.SIMULATION_REBALANCING_ENABLED_SETTING
+            DisableSimulationRebalancingDecider.SIMULATION_REBALANCING_ENABLED_SETTING,
+            BoostConfigurationsService.BOOST_CONFIGURATIONS_SETTING
         );
     }
 


### PR DESCRIPTION
This draft PR attempts to codify the current ideas to facilitate further discussions.

Key concepts introduced are:
1. BoostWindow and Overrides
2. BoostConfiguration (containing a set of BoostWindow)
3. BoostConfigurationsService (managing a set of BoostConfiguration)

The changes try to cater for the two-layer configurations, e.g.  default hardware configurations and overrides (from either users or platform). Not every detail is spelled out. The intention is to leave room for them.

Relates es-team#2894