### PR TITLE
Try waiting for updated settings in Semantic Field test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -606,9 +606,6 @@ tests:
 - class: org.elasticsearch.xpack.downsample.DataStreamLifecycleDownsampleIT
   method: testUpdateDownsampleSamplingMode
   issue: https://github.com/elastic/elasticsearch/issues/150478
-- class: org.elasticsearch.xpack.inference.integration.SemanticTextFieldMappingLegacyFormatIT
-  method: testLegacyFormatInferenceIdUpdate
-  issue: https://github.com/elastic/elasticsearch/issues/150481
 - class: org.elasticsearch.xpack.stateless.recovery.BlockRefreshUponIndexCreationIT
   method: testRefreshesAreBlockedUntilBlockIsRemoved
   issue: https://github.com/elastic/elasticsearch/issues/150492

--- a/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/integration/SemanticTextLegacyFormatTestCase.java
+++ b/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/integration/SemanticTextLegacyFormatTestCase.java
@@ -15,6 +15,7 @@ import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.CheckedRunnable;
 import org.elasticsearch.index.mapper.InferenceMetadataFieldsMapper;
 import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
 import org.elasticsearch.inference.SimilarityMeasure;
@@ -34,6 +35,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.xpack.inference.Utils.storeDenseModel;
@@ -186,21 +188,29 @@ public abstract class SemanticTextLegacyFormatTestCase extends ESIntegTestCase {
      * @param shouldExist whether model_settings is expected to be present
      */
     @SuppressWarnings("unchecked")
-    protected void assertMappingModelSettings(String index, String fieldName, boolean shouldExist) {
-        GetMappingsResponse mappingsResponse = client().admin().indices().prepareGetMappings(TEST_REQUEST_TIMEOUT, index).get();
-        MappingMetadata mappingMetadata = mappingsResponse.getMappings().get(index);
-        assertThat(mappingMetadata, notNullValue());
-        Map<String, Object> mappingSource = mappingMetadata.getSourceAsMap();
-        Map<String, Object> properties = (Map<String, Object>) mappingSource.get("properties");
-        assertThat("properties should not be null", properties, notNullValue());
-        Map<String, Object> fieldMapping = (Map<String, Object>) properties.get(fieldName);
-        assertThat("field mapping for [" + fieldName + "] should not be null", fieldMapping, notNullValue());
+    protected void assertMappingModelSettings(String index, String fieldName, boolean shouldExist) throws Exception {
+        CheckedRunnable<Exception> assertion = () -> {
+            GetMappingsResponse mappingsResponse = client().admin().indices().prepareGetMappings(TEST_REQUEST_TIMEOUT, index).get();
+            MappingMetadata mappingMetadata = mappingsResponse.getMappings().get(index);
+            assertThat(mappingMetadata, notNullValue());
+            Map<String, Object> mappingSource = mappingMetadata.getSourceAsMap();
+            Map<String, Object> properties = (Map<String, Object>) mappingSource.get("properties");
+            assertThat("properties should not be null", properties, notNullValue());
+            Map<String, Object> fieldMapping = (Map<String, Object>) properties.get(fieldName);
+            assertThat("field mapping for [" + fieldName + "] should not be null", fieldMapping, notNullValue());
 
-        boolean modelSettingsPresent = fieldMapping.containsKey("model_settings");
+            boolean modelSettingsPresent = fieldMapping.containsKey("model_settings");
+            if (shouldExist) {
+                assertTrue("model_settings should be present in [" + fieldName + "] mapping", modelSettingsPresent);
+            } else {
+                assertFalse("model_settings should not be present in [" + fieldName + "] mapping before first doc", modelSettingsPresent);
+            }
+        };
+
         if (shouldExist) {
-            assertTrue("model_settings should be present in [" + fieldName + "] mapping", modelSettingsPresent);
+            assertBusy(assertion, 5, TimeUnit.SECONDS);
         } else {
-            assertFalse("model_settings should not be present in [" + fieldName + "] mapping before first doc", modelSettingsPresent);
+            assertion.run();
         }
     }
 


### PR DESCRIPTION
The failure in https://github.com/elastic/elasticsearch/issues/150481 maybe because the mappings had not been updated yet. This change wraps the check in `assertMappingModelSettings` in an assertBusy


Closes https://github.com/elastic/elasticsearch/issues/150481