### PR TITLE
Fix key rotation integration release tests

### DIFF
--- a/x-pack/plugin/encryption/src/internalClusterTest/java/org/elasticsearch/xpack/encryption/KeyRotationIT.java
+++ b/x-pack/plugin/encryption/src/internalClusterTest/java/org/elasticsearch/xpack/encryption/KeyRotationIT.java
@@ -55,14 +55,6 @@ import static org.hamcrest.Matchers.notNullValue;
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 3, supportsDedicatedMasters = false)
 public class KeyRotationIT extends SecurityIntegTestCase {
 
-    @Before
-    public void checkFeatureFlag() {
-        assumeTrue(
-            "project encryption key feature flag must be enabled",
-            ProjectEncryptionKeyService.PROJECT_ENCRYPTION_KEY_FEATURE_FLAG.isEnabled()
-        );
-    }
-
     @Override
     protected boolean addMockHttpTransport() {
         return false;
@@ -93,6 +85,10 @@ public class KeyRotationIT extends SecurityIntegTestCase {
 
     @Before
     public void waitForProjectEncryptionKeyInstalled() throws Exception {
+        assumeTrue(
+            "project encryption key feature flag must be enabled",
+            ProjectEncryptionKeyService.PROJECT_ENCRYPTION_KEY_FEATURE_FLAG.isEnabled()
+        );
         ensureGreen();
         assertBusy(() -> assertThat(metadataOnMaster(), notNullValue()));
     }

--- a/x-pack/plugin/encryption/src/internalClusterTest/java/org/elasticsearch/xpack/encryption/KeyRotationViaClusterSecretsIT.java
+++ b/x-pack/plugin/encryption/src/internalClusterTest/java/org/elasticsearch/xpack/encryption/KeyRotationViaClusterSecretsIT.java
@@ -68,14 +68,6 @@ public class KeyRotationViaClusterSecretsIT extends ESIntegTestCase {
 
     private final AtomicLong fileSettingsVersionCounter = new AtomicLong(1);
 
-    @Before
-    public void checkFeatureFlag() {
-        assumeTrue(
-            "project encryption key feature flag must be enabled",
-            ProjectEncryptionKeyService.PROJECT_ENCRYPTION_KEY_FEATURE_FLAG.isEnabled()
-        );
-    }
-
     @Override
     protected boolean addMockHttpTransport() {
         return false;
@@ -105,6 +97,10 @@ public class KeyRotationViaClusterSecretsIT extends ESIntegTestCase {
 
     @Before
     public void waitForInitialPekInstall() throws Exception {
+        assumeTrue(
+            "project encryption key feature flag must be enabled",
+            ProjectEncryptionKeyService.PROJECT_ENCRYPTION_KEY_FEATURE_FLAG.isEnabled()
+        );
         ensureGreen();
         assertBusy(() -> assertThat(metadataOnMaster(), notNullValue()));
     }


### PR DESCRIPTION
`@Before` methods in the same class can run in any order so the `waitForProjectEncryptionKeyInstalled` could run before we knew that a PEK was actually supposed to be installed. Move the feature flag check to the single `@Before`.