### PR TITLE
Disable eager global ordinals on indexing tier

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexService.java
@@ -267,7 +267,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
                 this.indexSortSupplier = () -> null;
             }
             indexFieldData.setListener(new FieldDataCacheListener(this));
-            this.warmer = new IndexWarmer(threadPool, indexFieldData, bitsetFilterCache.createListener(threadPool));
+            this.warmer = new IndexWarmer(threadPool, indexFieldData, indexSettings, bitsetFilterCache.createListener(threadPool));
             this.indexCache = new IndexCache(queryCache, bitsetFilterCache);
         } else {
             assert indexAnalyzers == null;

--- a/server/src/main/java/org/elasticsearch/index/IndexWarmer.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexWarmer.java
@@ -42,7 +42,9 @@ public final class IndexWarmer {
     IndexWarmer(ThreadPool threadPool, IndexFieldDataService indexFieldDataService, IndexSettings indexSettings, Listener... listeners) {
         ArrayList<Listener> list = new ArrayList<>();
         final Executor executor = threadPool.executor(ThreadPool.Names.WARMER);
-        list.add(new FieldDataWarmer(executor, indexFieldDataService, shouldWarmGlobalOrdinals(indexSettings)));
+        if (shouldWarmGlobalOrdinals(indexSettings)) {
+            list.add(new FieldDataWarmer(executor, indexFieldDataService));
+        }
 
         Collections.addAll(list, listeners);
         this.listeners = Collections.unmodifiableList(list);
@@ -109,19 +111,14 @@ public final class IndexWarmer {
 
         private final Executor executor;
         private final IndexFieldDataService indexFieldDataService;
-        private final boolean eagerGlobalOrdinals;
 
-        FieldDataWarmer(Executor executor, IndexFieldDataService indexFieldDataService, boolean eagerGlobalOrdinals) {
+        FieldDataWarmer(Executor executor, IndexFieldDataService indexFieldDataService) {
             this.executor = executor;
             this.indexFieldDataService = indexFieldDataService;
-            this.eagerGlobalOrdinals = eagerGlobalOrdinals;
         }
 
         @Override
         public TerminationHandle warmReader(final IndexShard indexShard, final ElasticsearchDirectoryReader reader) {
-            if (eagerGlobalOrdinals == false) {
-                return TerminationHandle.NO_WAIT;
-            }
             final MapperService mapperService = indexShard.mapperService();
             final Map<String, MappedFieldType> warmUpGlobalOrdinals = new HashMap<>();
             for (MappedFieldType fieldType : mapperService.getEagerGlobalOrdinalsFields()) {

--- a/server/src/main/java/org/elasticsearch/index/IndexWarmer.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexWarmer.java
@@ -11,6 +11,8 @@ package org.elasticsearch.index;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.common.lucene.index.ElasticsearchDirectoryReader;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.fielddata.FieldDataContext;
@@ -37,10 +39,10 @@ public final class IndexWarmer {
 
     private final List<Listener> listeners;
 
-    IndexWarmer(ThreadPool threadPool, IndexFieldDataService indexFieldDataService, Listener... listeners) {
+    IndexWarmer(ThreadPool threadPool, IndexFieldDataService indexFieldDataService, IndexSettings indexSettings, Listener... listeners) {
         ArrayList<Listener> list = new ArrayList<>();
         final Executor executor = threadPool.executor(ThreadPool.Names.WARMER);
-        list.add(new FieldDataWarmer(executor, indexFieldDataService));
+        list.add(new FieldDataWarmer(executor, indexFieldDataService, shouldWarmGlobalOrdinals(indexSettings)));
 
         Collections.addAll(list, listeners);
         this.listeners = Collections.unmodifiableList(list);
@@ -95,18 +97,31 @@ public final class IndexWarmer {
         TerminationHandle warmReader(IndexShard indexShard, ElasticsearchDirectoryReader reader);
     }
 
+    static boolean shouldWarmGlobalOrdinals(IndexSettings settings) {
+        boolean isStateless = DiscoveryNode.isStateless(settings.getNodeSettings());
+        if (isStateless) {
+            return DiscoveryNode.hasRole(settings.getNodeSettings(), DiscoveryNodeRole.SEARCH_ROLE);
+        }
+        return true;
+    }
+
     private static class FieldDataWarmer implements IndexWarmer.Listener {
 
         private final Executor executor;
         private final IndexFieldDataService indexFieldDataService;
+        private final boolean eagerGlobalOrdinals;
 
-        FieldDataWarmer(Executor executor, IndexFieldDataService indexFieldDataService) {
+        FieldDataWarmer(Executor executor, IndexFieldDataService indexFieldDataService, boolean eagerGlobalOrdinals) {
             this.executor = executor;
             this.indexFieldDataService = indexFieldDataService;
+            this.eagerGlobalOrdinals = eagerGlobalOrdinals;
         }
 
         @Override
         public TerminationHandle warmReader(final IndexShard indexShard, final ElasticsearchDirectoryReader reader) {
+            if (eagerGlobalOrdinals == false) {
+                return TerminationHandle.NO_WAIT;
+            }
             final MapperService mapperService = indexShard.mapperService();
             final Map<String, MappedFieldType> warmUpGlobalOrdinals = new HashMap<>();
             for (MappedFieldType fieldType : mapperService.getEagerGlobalOrdinalsFields()) {

--- a/server/src/test/java/org/elasticsearch/index/IndexWarmerTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexWarmerTests.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index;
+
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.node.NodeRoleSettings;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.IndexSettingsModule;
+
+import java.util.List;
+
+import static org.elasticsearch.cluster.node.DiscoveryNode.STATELESS_ENABLED_SETTING_NAME;
+
+public class IndexWarmerTests extends ESTestCase {
+
+    public void testShouldWarmGlobalOrdinals() {
+        for (var hasIndexRole : List.of(true, false)) {
+            for (var isStateless : List.of(true, false)) {
+                boolean result = IndexWarmer.shouldWarmGlobalOrdinals(indexWarmerSettings(isStateless, hasIndexRole));
+                if (isStateless) {
+                    assertEquals(hasIndexRole == false, result);
+                } else {
+                    assertTrue(result);
+                }
+            }
+        }
+    }
+
+    private IndexSettings indexWarmerSettings(boolean isStateless, boolean hasIndexRole) {
+        var nodeSettingsBuilder = Settings.builder()
+            .putList(
+                NodeRoleSettings.NODE_ROLES_SETTING.getKey(),
+                hasIndexRole ? DiscoveryNodeRole.INDEX_ROLE.roleName() : DiscoveryNodeRole.SEARCH_ROLE.roleName()
+            )
+            .put(STATELESS_ENABLED_SETTING_NAME, isStateless);
+
+        return IndexSettingsModule.newIndexSettings(
+            new org.elasticsearch.index.Index("index", IndexMetadata.INDEX_UUID_NA_VALUE),
+            Settings.EMPTY,
+            nodeSettingsBuilder.build()
+        );
+    }
+}


### PR DESCRIPTION
Eager global ordinals were loaded on the indexing tier (stateless), but it does not need it, fixed.

Assisted by claude code.
