### PR TITLE
Unmute testPEMKeyConfigReloading

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -339,9 +339,6 @@ tests:
 - class: org.elasticsearch.xpack.ml.integration.DatafeedJobsIT
   method: testStopLookback_forceTrue_closeJobFalse
   issue: https://github.com/elastic/elasticsearch/issues/146955
-- class: org.elasticsearch.xpack.core.ssl.SSLConfigurationReloaderTests
-  method: testPEMKeyConfigReloading
-  issue: https://github.com/elastic/elasticsearch/issues/150280
 - class: org.elasticsearch.index.codec.tsdb.es819.DISIAccumulatorTests
   method: testAllDocs
   issue: https://github.com/elastic/elasticsearch/issues/150292


### PR DESCRIPTION
Remove this from `muted-tests.yml`:

```
- class: org.elasticsearch.xpack.core.ssl.SSLConfigurationReloaderTests
  method: testPEMKeyConfigReloading
  issue: https://github.com/elastic/elasticsearch/issues/150280
```