### PR TITLE
[9.3] Upgrade commons-lang3 to 3.20.0 for the inference plugin (#150242)

### DIFF
--- a/docs/changelog/150242.yaml
+++ b/docs/changelog/150242.yaml
@@ -1,0 +1,5 @@
+pr: 150242
+summary: Upgrading commons-lang3 version for inference plugin
+area: Inference
+type: upgrade
+issues: []

--- a/x-pack/plugin/inference/build.gradle
+++ b/x-pack/plugin/inference/build.gradle
@@ -59,7 +59,7 @@ dependencies {
   implementation 'io.grpc:grpc-context:1.49.2'
   implementation 'io.opencensus:opencensus-api:0.31.1'
   implementation 'io.opencensus:opencensus-contrib-http-util:0.31.1'
-  implementation "org.apache.commons:commons-lang3:${versions.commons_lang3}"
+  implementation 'org.apache.commons:commons-lang3:3.20.0'
   implementation 'org.apache.commons:commons-text:1.4'
 
   /* AWS SDK v2 */


### PR DESCRIPTION
Backports the following commits to 9.3:
 - Upgrade commons-lang3 to 3.20.0 for the inference plugin (#150242)