### PR TITLE
Remove unnecessary constructor arguments from maps

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/custom/InputTypeTranslator.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/custom/InputTypeTranslator.java
@@ -39,7 +39,7 @@ public class InputTypeTranslator implements ToXContentFragment, Writeable {
 
         Map<String, Object> inputTypeTranslation = Objects.requireNonNullElse(
             extractOptionalMap(map, INPUT_TYPE_TRANSLATOR, validationException),
-            new HashMap<>(Map.of())
+            new HashMap<>()
         );
 
         Map<String, Object> translationMap = extractOptionalMap(inputTypeTranslation, TRANSLATION, validationException);

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/embeddings/AlibabaCloudSearchEmbeddingsTaskSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/embeddings/AlibabaCloudSearchEmbeddingsTaskSettingsTests.java
@@ -56,7 +56,7 @@ public class AlibabaCloudSearchEmbeddingsTaskSettingsTests extends AbstractWireS
     public void testFromMap_WhenInputTypeIsNull() {
         InputType inputType = null;
         MatcherAssert.assertThat(
-            AlibabaCloudSearchEmbeddingsTaskSettings.fromMap(new HashMap<>(Map.of())),
+            AlibabaCloudSearchEmbeddingsTaskSettings.fromMap(new HashMap<>()),
             is(new AlibabaCloudSearchEmbeddingsTaskSettings(inputType))
         );
     }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/sparse/AlibabaCloudSearchSparseTaskSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/sparse/AlibabaCloudSearchSparseTaskSettingsTests.java
@@ -58,7 +58,7 @@ public class AlibabaCloudSearchSparseTaskSettingsTests extends AbstractWireSeria
     public void testFromMap_WhenInputTypeIsNull() {
         InputType inputType = null;
         MatcherAssert.assertThat(
-            AlibabaCloudSearchSparseTaskSettings.fromMap(new HashMap<>(Map.of())),
+            AlibabaCloudSearchSparseTaskSettings.fromMap(new HashMap<>()),
             is(new AlibabaCloudSearchSparseTaskSettings(inputType, null))
         );
     }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AmazonBedrockServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AmazonBedrockServiceTests.java
@@ -518,7 +518,7 @@ public class AmazonBedrockServiceTests extends InferenceServiceTestCase {
             var settingsMap = createEmbeddingsRequestSettingsMap(REGION_VALUE, MODEL_VALUE, "amazontitan", null, false, null, null);
             var secretSettingsMap = getAmazonBedrockSecretSettingsMap(ACCESS_KEY_VALUE, SECRET_KEY_VALUE);
 
-            var persistedConfig = getPersistedConfigMap(settingsMap, new HashMap<>(Map.of()), secretSettingsMap);
+            var persistedConfig = getPersistedConfigMap(settingsMap, new HashMap<>(), secretSettingsMap);
 
             var model = service.parsePersistedConfig(
                 new UnparsedModel(
@@ -548,12 +548,7 @@ public class AmazonBedrockServiceTests extends InferenceServiceTestCase {
             var settingsMap = createEmbeddingsRequestSettingsMap(REGION_VALUE, MODEL_VALUE, "amazontitan", null, false, null, null);
             var secretSettingsMap = getAmazonBedrockSecretSettingsMap(ACCESS_KEY_VALUE, SECRET_KEY_VALUE);
 
-            var persistedConfig = getPersistedConfigMap(
-                settingsMap,
-                new HashMap<>(Map.of()),
-                createRandomChunkingSettingsMap(),
-                secretSettingsMap
-            );
+            var persistedConfig = getPersistedConfigMap(settingsMap, new HashMap<>(), createRandomChunkingSettingsMap(), secretSettingsMap);
 
             var model = service.parsePersistedConfig(
                 new UnparsedModel(
@@ -642,7 +637,7 @@ public class AmazonBedrockServiceTests extends InferenceServiceTestCase {
             var settingsMap = createEmbeddingsRequestSettingsMap(REGION_VALUE, MODEL_VALUE, "amazontitan", null, false, null, null);
             var secretSettingsMap = getAmazonBedrockSecretSettingsMap(ACCESS_KEY_VALUE, SECRET_KEY_VALUE);
 
-            var persistedConfig = getPersistedConfigMap(settingsMap, new HashMap<>(Map.of()), secretSettingsMap);
+            var persistedConfig = getPersistedConfigMap(settingsMap, new HashMap<>(), secretSettingsMap);
             persistedConfig.config().put("extra_key", "value");
 
             var model = service.parsePersistedConfig(
@@ -673,7 +668,7 @@ public class AmazonBedrockServiceTests extends InferenceServiceTestCase {
             var secretSettingsMap = getAmazonBedrockSecretSettingsMap(ACCESS_KEY_VALUE, SECRET_KEY_VALUE);
             secretSettingsMap.put("extra_key", "value");
 
-            var persistedConfig = getPersistedConfigMap(settingsMap, new HashMap<>(Map.of()), secretSettingsMap);
+            var persistedConfig = getPersistedConfigMap(settingsMap, new HashMap<>(), secretSettingsMap);
 
             var model = service.parsePersistedConfig(
                 new UnparsedModel(
@@ -702,7 +697,7 @@ public class AmazonBedrockServiceTests extends InferenceServiceTestCase {
             var settingsMap = createEmbeddingsRequestSettingsMap(REGION_VALUE, MODEL_VALUE, "amazontitan", null, false, null, null);
             var secretSettingsMap = getAmazonBedrockSecretSettingsMap(ACCESS_KEY_VALUE, SECRET_KEY_VALUE);
 
-            var persistedConfig = getPersistedConfigMap(settingsMap, new HashMap<>(Map.of()), secretSettingsMap);
+            var persistedConfig = getPersistedConfigMap(settingsMap, new HashMap<>(), secretSettingsMap);
             persistedConfig.secrets().put("extra_key", "value");
 
             var model = service.parsePersistedConfig(
@@ -733,7 +728,7 @@ public class AmazonBedrockServiceTests extends InferenceServiceTestCase {
             settingsMap.put("extra_key", "value");
             var secretSettingsMap = getAmazonBedrockSecretSettingsMap(ACCESS_KEY_VALUE, SECRET_KEY_VALUE);
 
-            var persistedConfig = getPersistedConfigMap(settingsMap, new HashMap<>(Map.of()), secretSettingsMap);
+            var persistedConfig = getPersistedConfigMap(settingsMap, new HashMap<>(), secretSettingsMap);
 
             var model = service.parsePersistedConfig(
                 new UnparsedModel(
@@ -825,12 +820,7 @@ public class AmazonBedrockServiceTests extends InferenceServiceTestCase {
             var settingsMap = createEmbeddingsRequestSettingsMap(REGION_VALUE, MODEL_VALUE, "amazontitan", null, false, null, null);
             var secretSettingsMap = getAmazonBedrockSecretSettingsMap(ACCESS_KEY_VALUE, SECRET_KEY_VALUE);
 
-            var persistedConfig = getPersistedConfigMap(
-                settingsMap,
-                new HashMap<>(Map.of()),
-                createRandomChunkingSettingsMap(),
-                secretSettingsMap
-            );
+            var persistedConfig = getPersistedConfigMap(settingsMap, new HashMap<>(), createRandomChunkingSettingsMap(), secretSettingsMap);
 
             var model = service.parsePersistedConfig(
                 new UnparsedModel(INFERENCE_ID_VALUE, TaskType.TEXT_EMBEDDING, AmazonBedrockService.NAME, persistedConfig.config(), null)
@@ -852,7 +842,7 @@ public class AmazonBedrockServiceTests extends InferenceServiceTestCase {
             var settingsMap = createEmbeddingsRequestSettingsMap(REGION_VALUE, MODEL_VALUE, "amazontitan", null, false, null, null);
             var secretSettingsMap = getAmazonBedrockSecretSettingsMap(ACCESS_KEY_VALUE, SECRET_KEY_VALUE);
 
-            var persistedConfig = getPersistedConfigMap(settingsMap, new HashMap<>(Map.of()), secretSettingsMap);
+            var persistedConfig = getPersistedConfigMap(settingsMap, new HashMap<>(), secretSettingsMap);
 
             var model = service.parsePersistedConfig(
                 new UnparsedModel(INFERENCE_ID_VALUE, TaskType.TEXT_EMBEDDING, AmazonBedrockService.NAME, persistedConfig.config(), null)
@@ -912,7 +902,7 @@ public class AmazonBedrockServiceTests extends InferenceServiceTestCase {
             var settingsMap = createEmbeddingsRequestSettingsMap(REGION_VALUE, MODEL_VALUE, "amazontitan", null, false, null, null);
             var secretSettingsMap = getAmazonBedrockSecretSettingsMap(ACCESS_KEY_VALUE, SECRET_KEY_VALUE);
 
-            var persistedConfig = getPersistedConfigMap(settingsMap, new HashMap<>(Map.of()), secretSettingsMap);
+            var persistedConfig = getPersistedConfigMap(settingsMap, new HashMap<>(), secretSettingsMap);
 
             var thrownException = expectThrows(
                 ElasticsearchStatusException.class,
@@ -940,7 +930,7 @@ public class AmazonBedrockServiceTests extends InferenceServiceTestCase {
             var settingsMap = createEmbeddingsRequestSettingsMap(REGION_VALUE, MODEL_VALUE, "amazontitan", null, false, null, null);
             var secretSettingsMap = getAmazonBedrockSecretSettingsMap(ACCESS_KEY_VALUE, SECRET_KEY_VALUE);
 
-            var persistedConfig = getPersistedConfigMap(settingsMap, new HashMap<>(Map.of()), secretSettingsMap);
+            var persistedConfig = getPersistedConfigMap(settingsMap, new HashMap<>(), secretSettingsMap);
             persistedConfig.config().put("extra_key", "value");
 
             var model = service.parsePersistedConfig(
@@ -963,7 +953,7 @@ public class AmazonBedrockServiceTests extends InferenceServiceTestCase {
             settingsMap.put("extra_key", "value");
             var secretSettingsMap = getAmazonBedrockSecretSettingsMap(ACCESS_KEY_VALUE, SECRET_KEY_VALUE);
 
-            var persistedConfig = getPersistedConfigMap(settingsMap, new HashMap<>(Map.of()), secretSettingsMap);
+            var persistedConfig = getPersistedConfigMap(settingsMap, new HashMap<>(), secretSettingsMap);
             persistedConfig.config().put("extra_key", "value");
 
             var model = service.parsePersistedConfig(

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/completion/AmazonBedrockCompletionTaskSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/completion/AmazonBedrockCompletionTaskSettingsTests.java
@@ -33,7 +33,7 @@ import static org.hamcrest.Matchers.is;
 public class AmazonBedrockCompletionTaskSettingsTests extends AbstractBWCWireSerializationTestCase<AmazonBedrockCompletionTaskSettings> {
 
     public void testFromMap_ReturnsEmptySettings_WhenTheMapIsEmpty() {
-        var settings = AmazonBedrockCompletionTaskSettings.fromMap(new HashMap<>(Map.of()));
+        var settings = AmazonBedrockCompletionTaskSettings.fromMap(new HashMap<>());
         assertThat(settings, is(AmazonBedrockCompletionTaskSettings.EMPTY_SETTINGS));
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/anthropic/AnthropicServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/anthropic/AnthropicServiceTests.java
@@ -116,7 +116,7 @@ public class AnthropicServiceTests extends InferenceServiceTestCase {
                 TaskType.SPARSE_EMBEDDING,
                 getRequestConfigMap(
                     new HashMap<>(Map.of(ServiceFields.MODEL_ID, MODEL_NAME_VALUE)),
-                    new HashMap<>(Map.of()),
+                    new HashMap<>(),
                     getSecretSettingsMap(API_KEY_VALUE)
                 ),
                 failureListener

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/anthropic/completion/AnthropicChatCompletionRequestTaskSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/anthropic/completion/AnthropicChatCompletionRequestTaskSettingsTests.java
@@ -19,7 +19,7 @@ import static org.hamcrest.Matchers.is;
 public class AnthropicChatCompletionRequestTaskSettingsTests extends ESTestCase {
 
     public void testFromMap_ReturnsEmptySettings_WhenTheMapIsEmpty() {
-        var settings = AnthropicChatCompletionRequestTaskSettings.fromMap(new HashMap<>(Map.of()));
+        var settings = AnthropicChatCompletionRequestTaskSettings.fromMap(new HashMap<>());
         assertNull(settings.maxTokens());
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/anthropic/completion/AnthropicChatCompletionTaskSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/anthropic/completion/AnthropicChatCompletionTaskSettingsTests.java
@@ -106,7 +106,7 @@ public class AnthropicChatCompletionTaskSettingsTests extends AbstractBWCWireSer
     public void testFromMap_WithoutMaxTokens_ThrowsException() {
         var thrownException = expectThrows(
             ValidationException.class,
-            () -> AnthropicChatCompletionTaskSettings.fromMap(new HashMap<>(Map.of()), ConfigurationParseContext.REQUEST)
+            () -> AnthropicChatCompletionTaskSettings.fromMap(new HashMap<>(), ConfigurationParseContext.REQUEST)
         );
 
         assertThat(

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureaistudio/completion/AzureAiStudioChatCompletionRequestTaskSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureaistudio/completion/AzureAiStudioChatCompletionRequestTaskSettingsTests.java
@@ -24,7 +24,7 @@ import static org.hamcrest.Matchers.is;
 
 public class AzureAiStudioChatCompletionRequestTaskSettingsTests extends ESTestCase {
     public void testFromMap_ReturnsEmptySettings_WhenTheMapIsEmpty() {
-        var settings = AzureAiStudioChatCompletionRequestTaskSettings.fromMap(new HashMap<>(Map.of()));
+        var settings = AzureAiStudioChatCompletionRequestTaskSettings.fromMap(new HashMap<>());
         assertThat(settings, is(AzureAiStudioChatCompletionRequestTaskSettings.EMPTY_SETTINGS));
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureaistudio/embeddings/AzureAiStudioEmbeddingsRequestTaskSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureaistudio/embeddings/AzureAiStudioEmbeddingsRequestTaskSettingsTests.java
@@ -20,7 +20,7 @@ import static org.hamcrest.Matchers.is;
 public class AzureAiStudioEmbeddingsRequestTaskSettingsTests extends ESTestCase {
 
     public void testFromMap_ReturnsEmptySettings_WhenTheMapIsEmpty() {
-        var settings = AzureAiStudioEmbeddingsRequestTaskSettings.fromMap(new HashMap<>(Map.of()));
+        var settings = AzureAiStudioEmbeddingsRequestTaskSettings.fromMap(new HashMap<>());
         assertThat(settings, is(AzureAiStudioEmbeddingsRequestTaskSettings.EMPTY_SETTINGS));
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureaistudio/embeddings/AzureAiStudioEmbeddingsTaskSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureaistudio/embeddings/AzureAiStudioEmbeddingsTaskSettingsTests.java
@@ -69,7 +69,7 @@ public class AzureAiStudioEmbeddingsTaskSettingsTests extends AbstractBWCWireSer
     }
 
     public void testFromMap_MissingUser_DoesNotThrowException() {
-        var taskSettings = AzureAiStudioEmbeddingsTaskSettings.fromMap(new HashMap<>(Map.of()));
+        var taskSettings = AzureAiStudioEmbeddingsTaskSettings.fromMap(new HashMap<>());
         assertNull(taskSettings.user());
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureaistudio/rerank/AzureAiStudioRerankRequestTaskSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureaistudio/rerank/AzureAiStudioRerankRequestTaskSettingsTests.java
@@ -27,7 +27,7 @@ public class AzureAiStudioRerankRequestTaskSettingsTests extends ESTestCase {
 
     public void testFromMap_ReturnsEmptySettings_WhenTheMapIsEmpty() {
         assertThat(
-            AzureAiStudioRerankRequestTaskSettings.fromMap(new HashMap<>(Map.of())),
+            AzureAiStudioRerankRequestTaskSettings.fromMap(new HashMap<>()),
             is(AzureAiStudioRerankRequestTaskSettings.EMPTY_SETTINGS)
         );
     }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureaistudio/rerank/AzureAiStudioRerankTaskSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureaistudio/rerank/AzureAiStudioRerankTaskSettingsTests.java
@@ -111,7 +111,7 @@ public class AzureAiStudioRerankTaskSettingsTests extends AbstractBWCWireSeriali
     }
 
     public void testFromMap_WithNoValues_DoesNotThrowException() {
-        final var taskMap = AzureAiStudioRerankTaskSettings.fromMap(new HashMap<>(Map.of()));
+        final var taskMap = AzureAiStudioRerankTaskSettings.fromMap(new HashMap<>());
         assertNull(taskMap.returnDocuments());
         assertNull(taskMap.topN());
     }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureopenai/AzureOpenAiTaskSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureopenai/AzureOpenAiTaskSettingsTests.java
@@ -166,7 +166,7 @@ public abstract class AzureOpenAiTaskSettingsTests<T extends AzureOpenAiTaskSett
 
     public void testFromMap_isEmpty() {
         {
-            var emptyMap = createFromMap(new HashMap<>(Map.of()), randomContext());
+            var emptyMap = createFromMap(new HashMap<>(), randomContext());
             assertTrue(emptyMap.isEmpty());
         }
         {
@@ -208,7 +208,7 @@ public abstract class AzureOpenAiTaskSettingsTests<T extends AzureOpenAiTaskSett
     }
 
     public void testFromMap_MissingUser_DoesNotThrowException() {
-        var taskSettings = createFromMap(new HashMap<>(Map.of()), ConfigurationParseContext.REQUEST);
+        var taskSettings = createFromMap(new HashMap<>(), ConfigurationParseContext.REQUEST);
         assertTrue(taskSettings.user().isUndefined());
     }
 
@@ -300,7 +300,7 @@ public abstract class AzureOpenAiTaskSettingsTests<T extends AzureOpenAiTaskSett
     }
 
     public void testFromMap_WithRequestContext_ReturnsEmptySettings_WhenMapIsEmpty() {
-        var settings = createFromMap(new HashMap<>(Map.of()), ConfigurationParseContext.REQUEST);
+        var settings = createFromMap(new HashMap<>(), ConfigurationParseContext.REQUEST);
         assertTrue(settings.isEmpty());
         assertTrue(settings.user().isUndefined());
         assertThat(settings.headers(), sameInstance(Headers.UNDEFINED_INSTANCE));

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/cohere/embeddings/CohereEmbeddingsTaskSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/cohere/embeddings/CohereEmbeddingsTaskSettingsTests.java
@@ -67,10 +67,7 @@ public class CohereEmbeddingsTaskSettingsTests extends AbstractWireSerializingTe
     }
 
     public void testFromMap_CreatesEmptySettings_WhenAllFieldsAreNull() {
-        MatcherAssert.assertThat(
-            CohereEmbeddingsTaskSettings.fromMap(new HashMap<>(Map.of())),
-            is(new CohereEmbeddingsTaskSettings(null, null))
-        );
+        MatcherAssert.assertThat(CohereEmbeddingsTaskSettings.fromMap(new HashMap<>()), is(new CohereEmbeddingsTaskSettings(null, null)));
     }
 
     public void testFromMap_CreatesEmptySettings_WhenMapIsNull() {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/completion/ElasticInferenceServiceCompletionServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/completion/ElasticInferenceServiceCompletionServiceSettingsTests.java
@@ -103,7 +103,7 @@ public class ElasticInferenceServiceCompletionServiceSettingsTests extends Abstr
     public void testFromMap_MissingModelId_ThrowsException() {
         ValidationException validationException = expectThrows(
             ValidationException.class,
-            () -> ElasticInferenceServiceCompletionServiceSettings.fromMap(new HashMap<>(Map.of()), ConfigurationParseContext.REQUEST)
+            () -> ElasticInferenceServiceCompletionServiceSettings.fromMap(new HashMap<>(), ConfigurationParseContext.REQUEST)
         );
 
         assertThat(validationException.getMessage(), containsString("does not contain the required setting [model_id]"));

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googleaistudio/GoogleAiStudioServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googleaistudio/GoogleAiStudioServiceTests.java
@@ -108,7 +108,7 @@ public class GoogleAiStudioServiceTests extends InferenceServiceTestCase {
                 TaskType.COMPLETION,
                 getRequestConfigMap(
                     new HashMap<>(Map.of(ServiceFields.MODEL_ID, MODEL_ID_VALUE)),
-                    new HashMap<>(Map.of()),
+                    new HashMap<>(),
                     getSecretSettingsMap(API_KEY_VALUE)
                 ),
                 modelListener
@@ -131,7 +131,7 @@ public class GoogleAiStudioServiceTests extends InferenceServiceTestCase {
                 TaskType.TEXT_EMBEDDING,
                 getRequestConfigMap(
                     new HashMap<>(Map.of(ServiceFields.MODEL_ID, MODEL_ID_VALUE)),
-                    new HashMap<>(Map.of()),
+                    new HashMap<>(),
                     getSecretSettingsMap(API_KEY_VALUE)
                 ),
                 modelListener
@@ -155,7 +155,7 @@ public class GoogleAiStudioServiceTests extends InferenceServiceTestCase {
                 TaskType.TEXT_EMBEDDING,
                 getRequestConfigMap(
                     new HashMap<>(Map.of(ServiceFields.MODEL_ID, MODEL_ID_VALUE)),
-                    new HashMap<>(Map.of()),
+                    new HashMap<>(),
                     createRandomChunkingSettingsMap(),
                     getSecretSettingsMap(API_KEY_VALUE)
                 ),
@@ -180,7 +180,7 @@ public class GoogleAiStudioServiceTests extends InferenceServiceTestCase {
                 TaskType.TEXT_EMBEDDING,
                 getRequestConfigMap(
                     new HashMap<>(Map.of(ServiceFields.MODEL_ID, MODEL_ID_VALUE)),
-                    new HashMap<>(Map.of()),
+                    new HashMap<>(),
                     getSecretSettingsMap(API_KEY_VALUE)
                 ),
                 modelListener
@@ -200,7 +200,7 @@ public class GoogleAiStudioServiceTests extends InferenceServiceTestCase {
                 TaskType.SPARSE_EMBEDDING,
                 getRequestConfigMap(
                     new HashMap<>(Map.of(ServiceFields.MODEL_ID, MODEL_ID_VALUE)),
-                    new HashMap<>(Map.of()),
+                    new HashMap<>(),
                     getSecretSettingsMap(API_KEY_VALUE)
                 ),
                 failureListener

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googleaistudio/completion/GoogleAiStudioCompletionModelTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googleaistudio/completion/GoogleAiStudioCompletionModelTests.java
@@ -32,7 +32,7 @@ public class GoogleAiStudioCompletionModelTests extends ESTestCase {
             TaskType.COMPLETION,
             "service",
             new HashMap<>(Map.of("model_id", "model")),
-            new HashMap<>(Map.of()),
+            new HashMap<>(),
             null,
             ConfigurationParseContext.PERSISTENT
         );

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/GoogleVertexAiServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/GoogleVertexAiServiceTests.java
@@ -309,7 +309,7 @@ public class GoogleVertexAiServiceTests extends InferenceServiceTestCase {
                 TaskType.RERANK,
                 getRequestConfigMap(
                     new HashMap<>(Map.of(GoogleVertexAiServiceFields.PROJECT_ID, projectId)),
-                    new HashMap<>(Map.of()),
+                    new HashMap<>(),
                     getSecretSettingsMap(serviceAccountJson)
                 ),
                 modelListener
@@ -338,7 +338,7 @@ public class GoogleVertexAiServiceTests extends InferenceServiceTestCase {
                             "project"
                         )
                     ),
-                    new HashMap<>(Map.of()),
+                    new HashMap<>(),
                     getSecretSettingsMap("{}")
                 ),
                 failureListener

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/IbmWatsonxServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/IbmWatsonxServiceTests.java
@@ -138,7 +138,7 @@ public class IbmWatsonxServiceTests extends InferenceServiceTestCase {
                             API_VERSION_VALUE
                         )
                     ),
-                    new HashMap<>(Map.of()),
+                    new HashMap<>(),
                     getSecretSettingsMap(API_KEY_VALUE)
                 ),
                 modelListener
@@ -174,7 +174,7 @@ public class IbmWatsonxServiceTests extends InferenceServiceTestCase {
                             API_VERSION_VALUE
                         )
                     ),
-                    new HashMap<>(Map.of()),
+                    new HashMap<>(),
                     getSecretSettingsMap(API_KEY_VALUE)
                 ),
                 modelListener
@@ -212,7 +212,7 @@ public class IbmWatsonxServiceTests extends InferenceServiceTestCase {
                             API_VERSION_VALUE
                         )
                     ),
-                    new HashMap<>(Map.of()),
+                    new HashMap<>(),
                     createRandomChunkingSettingsMap(),
                     getSecretSettingsMap(API_KEY_VALUE)
                 ),
@@ -233,7 +233,7 @@ public class IbmWatsonxServiceTests extends InferenceServiceTestCase {
                 TaskType.SPARSE_EMBEDDING,
                 getRequestConfigMap(
                     new HashMap<>(Map.of(ServiceFields.MODEL_ID, "model")),
-                    new HashMap<>(Map.of()),
+                    new HashMap<>(),
                     getSecretSettingsMap("secret")
                 ),
                 failureListener

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/jinaai/embeddings/JinaAIEmbeddingsTaskSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/jinaai/embeddings/JinaAIEmbeddingsTaskSettingsTests.java
@@ -94,7 +94,7 @@ public class JinaAIEmbeddingsTaskSettingsTests extends AbstractBWCWireSerializat
     }
 
     public void testFromMap_CreatesEmptySettings_WhenAllFieldsAreNull() {
-        assertThat(JinaAIEmbeddingsTaskSettings.fromMap(new HashMap<>(Map.of())), is(new JinaAIEmbeddingsTaskSettings((InputType) null)));
+        assertThat(JinaAIEmbeddingsTaskSettings.fromMap(new HashMap<>()), is(new JinaAIEmbeddingsTaskSettings((InputType) null)));
     }
 
     public void testFromMap_CreatesEmptySettings_WhenMapIsNull() {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/OpenAiTaskSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/OpenAiTaskSettingsTests.java
@@ -145,7 +145,7 @@ public abstract class OpenAiTaskSettingsTests<T extends OpenAiTaskSettings<T>> e
     }
 
     public void testFromMap_MissingUser_DoesNotThrowException() {
-        var taskSettings = createFromMap(new HashMap<>(Map.of()));
+        var taskSettings = createFromMap(new HashMap<>());
         assertNull(taskSettings.user());
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsRequestTaskSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsRequestTaskSettingsTests.java
@@ -23,7 +23,7 @@ public class OpenAiEmbeddingsRequestTaskSettingsTests extends ESTestCase {
     }
 
     public void testFromMap_ReturnsEmptySettings_WhenTheMapIsEmpty() {
-        var settings = OpenAiEmbeddingsRequestTaskSettings.fromMap(new HashMap<>(Map.of()));
+        var settings = OpenAiEmbeddingsRequestTaskSettings.fromMap(new HashMap<>());
         assertNull(settings.user());
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/voyageai/embeddings/VoyageAIEmbeddingsTaskSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/voyageai/embeddings/VoyageAIEmbeddingsTaskSettingsTests.java
@@ -64,7 +64,7 @@ public class VoyageAIEmbeddingsTaskSettingsTests extends AbstractWireSerializing
 
     public void testFromMap_CreatesEmptySettings_WhenAllFieldsAreNull() {
         MatcherAssert.assertThat(
-            VoyageAIEmbeddingsTaskSettings.fromMap(new HashMap<>(Map.of())),
+            VoyageAIEmbeddingsTaskSettings.fromMap(new HashMap<>()),
             is(new VoyageAIEmbeddingsTaskSettings((InputType) null, null))
         );
     }


### PR DESCRIPTION
This commit replaces uses of HashMap constructors that use the canonical empty Map as an argument to use the no-arg constructor instead.