### PR TITLE
Refactoring slice routing validation logic

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/shards/TransportClusterSearchShardsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/shards/TransportClusterSearchShardsAction.java
@@ -160,26 +160,14 @@ public class TransportClusterSearchShardsAction extends TransportMasterNodeReadA
         final String target = request.indices().length == 0
             ? Strings.arrayToCommaDelimitedString(concreteIndices)
             : Strings.arrayToCommaDelimitedString(request.indices());
-        if (anySliceEnabled && fromSlice == false && request.routing() != null) {
-            throw new IllegalArgumentException(
-                "[routing] is not allowed when [index.slice.enabled] is true for search shards request targeting ["
-                    + target
-                    + "], use [_slice] instead"
-            );
-        }
-        if (fromSlice && anySliceEnabled == false) {
-            throw new IllegalArgumentException(
-                "[_slice] is not allowed when [index.slice.enabled] is false for search shards request targeting [" + target + "]"
-            );
-        }
-        if (anySliceEnabled && fromSlice == false) {
-            throw new IllegalArgumentException(
-                "[_slice] is required when [index.slice.enabled] is true for search shards request targeting [" + target + "]"
-            );
-        }
-        if (fromSlice) {
-            return SliceIndexing.SLICE_ALL.equals(requestedSlice) ? null : requestedSlice;
-        }
-        return request.routing();
+        return SliceIndexing.validateAndResolveSliceRoutingRequirement(
+            anySliceEnabled,
+            fromSlice,
+            request.routing(),
+            requestedSlice,
+            "search shards request",
+            target,
+            false
+        );
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/validate/query/TransportValidateQueryAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/validate/query/TransportValidateQueryAction.java
@@ -291,27 +291,15 @@ public class TransportValidateQueryAction extends TransportBroadcastAction<
         final String target = request.indices().length == 0
             ? Strings.arrayToCommaDelimitedString(concreteIndices)
             : Strings.arrayToCommaDelimitedString(request.indices());
-        if (anySliceEnabled && fromSlice == false && request.routing() != null) {
-            throw new IllegalArgumentException(
-                "[routing] is not allowed when [index.slice.enabled] is true for validate query request targeting ["
-                    + target
-                    + "], use [_slice] instead"
-            );
-        }
-        if (fromSlice && anySliceEnabled == false) {
-            throw new IllegalArgumentException(
-                "[_slice] is not allowed when [index.slice.enabled] is false for validate query request targeting [" + target + "]"
-            );
-        }
-        if (anySliceEnabled && fromSlice == false) {
-            throw new IllegalArgumentException(
-                "[_slice] is required when [index.slice.enabled] is true for validate query request targeting [" + target + "]"
-            );
-        }
-        if (fromSlice) {
-            return SliceIndexing.SLICE_ALL.equals(requestedSlice) ? null : requestedSlice;
-        }
-        return request.routing();
+        return SliceIndexing.validateAndResolveSliceRoutingRequirement(
+            anySliceEnabled,
+            fromSlice,
+            request.routing(),
+            requestedSlice,
+            "validate query request",
+            target,
+            false
+        );
     }
 
     private static String explain(SearchContext context, boolean rewritten) {

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
@@ -614,23 +614,13 @@ public class TransportBulkAction extends TransportAbstractBulkAction {
             .map(indexMetadataProvider)
             .map(metadata -> IndexSettings.SLICE_ENABLED.get(metadata.getSettings()))
             .orElse(false);
-        if (sliceEnabled == false && writeRequest.isRoutingFromSlice()) {
-            throw new IllegalArgumentException(
-                "[_slice] is not allowed when [index.slice.enabled] is false for bulk item targeting [" + writeRequest.index() + "]"
-            );
-        }
-        if (sliceEnabled && writeRequest.isRoutingFromSlice() == false) {
-            if (writeRequest.routing() != null) {
-                throw new IllegalArgumentException(
-                    "[routing] is not allowed when [index.slice.enabled] is true for bulk item targeting ["
-                        + writeRequest.index()
-                        + "], use [_slice] instead"
-                );
-            }
-            throw new IllegalArgumentException(
-                "[_slice] is required when [index.slice.enabled] is true for bulk item targeting [" + writeRequest.index() + "]"
-            );
-        }
+        SliceIndexing.validateSliceRoutingRequirement(
+            sliceEnabled,
+            writeRequest.isRoutingFromSlice(),
+            writeRequest.routing(),
+            "bulk item",
+            writeRequest.index()
+        );
     }
 
     static boolean isOnlySystem(BulkRequest request, SortedMap<String, IndexAbstraction> indicesLookup, SystemIndices systemIndices) {

--- a/server/src/main/java/org/elasticsearch/action/explain/TransportExplainAction.java
+++ b/server/src/main/java/org/elasticsearch/action/explain/TransportExplainAction.java
@@ -150,23 +150,13 @@ public class TransportExplainAction extends TransportSingleShardAction<ExplainRe
         final boolean sliceEnabled = Optional.ofNullable(state.metadata().index(concreteIndex))
             .map(metadata -> IndexSettings.SLICE_ENABLED.get(metadata.getSettings()))
             .orElse(false);
-        if (sliceEnabled == false && request.isRoutingFromSlice()) {
-            throw new IllegalArgumentException(
-                "[_slice] is not allowed when [index.slice.enabled] is false for request targeting [" + request.index() + "]"
-            );
-        }
-        if (sliceEnabled && request.isRoutingFromSlice() == false) {
-            if (request.routing() != null) {
-                throw new IllegalArgumentException(
-                    "[routing] is not allowed when [index.slice.enabled] is true for request targeting ["
-                        + request.index()
-                        + "], use [_slice] instead"
-                );
-            }
-            throw new IllegalArgumentException(
-                "[_slice] is required when [index.slice.enabled] is true for request targeting [" + request.index() + "]"
-            );
-        }
+        SliceIndexing.validateSliceRoutingRequirement(
+            sliceEnabled,
+            request.isRoutingFromSlice(),
+            request.routing(),
+            "explain request",
+            request.index()
+        );
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/get/TransportGetAction.java
+++ b/server/src/main/java/org/elasticsearch/action/get/TransportGetAction.java
@@ -154,16 +154,13 @@ public class TransportGetAction extends TransportSingleShardAction<GetRequest, G
             .map(metadata -> IndexSettings.SLICE_ENABLED.get(metadata.getSettings()))
             .orElse(false);
 
-        if (sliceEnabled == false && request.isRoutingFromSlice()) {
-            throw new IllegalArgumentException(
-                "[_slice] is not allowed when [index.slice.enabled] is false for request targeting [" + request.index() + "]"
-            );
-        }
-        if (sliceEnabled && request.routing() == null) {
-            throw new IllegalArgumentException(
-                "[_slice] is required when [index.slice.enabled] is true for request targeting [" + request.index() + "]"
-            );
-        }
+        SliceIndexing.validateSliceRoutingRequirement(
+            sliceEnabled,
+            request.isRoutingFromSlice(),
+            request.routing(),
+            "request",
+            request.index()
+        );
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/get/TransportGetAction.java
+++ b/server/src/main/java/org/elasticsearch/action/get/TransportGetAction.java
@@ -158,7 +158,7 @@ public class TransportGetAction extends TransportSingleShardAction<GetRequest, G
             sliceEnabled,
             request.isRoutingFromSlice(),
             request.routing(),
-            "request",
+            "get request",
             request.index()
         );
     }

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -332,26 +332,17 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                 "[point in time] is not supported when [index.slice.enabled] is true for search request targeting [" + target + "]"
             );
         }
-        if (anySliceEnabled && fromSlice == false && searchRequest.routing() != null) {
-            throw new IllegalArgumentException(
-                "[routing] is not allowed when [index.slice.enabled] is true for search request targeting ["
-                    + target
-                    + "], use [_slice] instead"
-            );
-        }
-        if (fromSlice && anySliceEnabled == false && hasRemoteIndices == false) {
-            throw new IllegalArgumentException(
-                "[_slice] is not allowed when [index.slice.enabled] is false for search request targeting [" + target + "]"
-            );
-        }
-        if (anySliceEnabled && fromSlice == false) {
-            throw new IllegalArgumentException(
-                "[_slice] is required when [index.slice.enabled] is true for search request targeting [" + target + "]"
-            );
-        }
-        if (fromSlice) {
-            searchRequest.routing(SliceIndexing.SLICE_ALL.equals(requestedSlice) ? null : requestedSlice);
-        }
+        searchRequest.routing(
+            SliceIndexing.validateAndResolveSliceRoutingRequirement(
+                anySliceEnabled,
+                fromSlice,
+                searchRequest.routing(),
+                requestedSlice,
+                "search request",
+                target,
+                hasRemoteIndices
+            )
+        );
         return requestedSlice;
     }
 

--- a/server/src/main/java/org/elasticsearch/action/update/TransportUpdateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/update/TransportUpdateAction.java
@@ -145,23 +145,13 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
             .map(state.metadata()::index)
             .map(metadata -> IndexSettings.SLICE_ENABLED.get(metadata.getSettings()))
             .orElse(false);
-        if (sliceEnabled == false && request.isRoutingFromSlice()) {
-            throw new IllegalArgumentException(
-                "[_slice] is not allowed when [index.slice.enabled] is false for request targeting [" + request.index() + "]"
-            );
-        }
-        if (sliceEnabled && request.isRoutingFromSlice() == false) {
-            if (request.routing() != null) {
-                throw new IllegalArgumentException(
-                    "[routing] is not allowed when [index.slice.enabled] is true for request targeting ["
-                        + request.index()
-                        + "], use [_slice] instead"
-                );
-            }
-            throw new IllegalArgumentException(
-                "[_slice] is required when [index.slice.enabled] is true for request targeting [" + request.index() + "]"
-            );
-        }
+        SliceIndexing.validateSliceRoutingRequirement(
+            sliceEnabled,
+            request.isRoutingFromSlice(),
+            request.routing(),
+            "request",
+            request.index()
+        );
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/update/TransportUpdateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/update/TransportUpdateAction.java
@@ -149,7 +149,7 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
             sliceEnabled,
             request.isRoutingFromSlice(),
             request.routing(),
-            "request",
+            "update request",
             request.index()
         );
     }

--- a/server/src/main/java/org/elasticsearch/index/SliceIndexing.java
+++ b/server/src/main/java/org/elasticsearch/index/SliceIndexing.java
@@ -122,4 +122,72 @@ public final class SliceIndexing {
         return new ParsedRouting(String.join(",", slices), true);
     }
 
+    /**
+     * Validates request-level slice/routing requirements for APIs that target a single index.
+     */
+    public static void validateSliceRoutingRequirement(
+        boolean sliceEnabled,
+        boolean routingFromSlice,
+        String routing,
+        String requestDescription,
+        String target
+    ) {
+        if (sliceEnabled == false && routingFromSlice) {
+            throw new IllegalArgumentException(
+                "[_slice] is not allowed when [index.slice.enabled] is false for " + requestDescription + " targeting [" + target + "]"
+            );
+        }
+        if (sliceEnabled && routingFromSlice == false) {
+            if (routing != null) {
+                throw new IllegalArgumentException(
+                    "[routing] is not allowed when [index.slice.enabled] is true for "
+                        + requestDescription
+                        + " targeting ["
+                        + target
+                        + "], use [_slice] instead"
+                );
+            }
+            throw new IllegalArgumentException(
+                "[_slice] is required when [index.slice.enabled] is true for " + requestDescription + " targeting [" + target + "]"
+            );
+        }
+    }
+
+    /**
+     * Validates request-level slice/routing requirements and resolves effective routing for search-style APIs.
+     */
+    public static String validateAndResolveSliceRoutingRequirement(
+        boolean anySliceEnabled,
+        boolean routingFromSlice,
+        String routing,
+        String requestedSlice,
+        String requestDescription,
+        String target,
+        boolean allowSliceWhenNoLocalSliceEnabled
+    ) {
+        if (anySliceEnabled && routingFromSlice == false && routing != null) {
+            throw new IllegalArgumentException(
+                "[routing] is not allowed when [index.slice.enabled] is true for "
+                    + requestDescription
+                    + " targeting ["
+                    + target
+                    + "], use [_slice] instead"
+            );
+        }
+        if (routingFromSlice && anySliceEnabled == false && allowSliceWhenNoLocalSliceEnabled == false) {
+            throw new IllegalArgumentException(
+                "[_slice] is not allowed when [index.slice.enabled] is false for " + requestDescription + " targeting [" + target + "]"
+            );
+        }
+        if (anySliceEnabled && routingFromSlice == false) {
+            throw new IllegalArgumentException(
+                "[_slice] is required when [index.slice.enabled] is true for " + requestDescription + " targeting [" + target + "]"
+            );
+        }
+        if (routingFromSlice) {
+            return SLICE_ALL.equals(requestedSlice) ? null : requestedSlice;
+        }
+        return routing;
+    }
+
 }


### PR DESCRIPTION
This does a minor refactor moving slice routing & enablement validation into a central location for the various APIs that require it.