### PR TITLE
Fix BlockRefreshUponIndexCreationIT.testRefreshesAreBlockedUntilBlockIsRemoved

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -250,9 +250,6 @@ tests:
 - class: org.elasticsearch.compute.aggregation.SumLongAggregatorFunctionTests
   method: testOverflowFails
   issue: https://github.com/elastic/elasticsearch/issues/150455
-- class: org.elasticsearch.xpack.stateless.recovery.BlockRefreshUponIndexCreationIT
-  method: testRefreshesAreBlockedUntilBlockIsRemoved
-  issue: https://github.com/elastic/elasticsearch/issues/150492
 - class: org.elasticsearch.xpack.ml.integration.DatafeedCcsIT
   method: testDatafeedWithCcsRemoteUnavailable
   issue: https://github.com/elastic/elasticsearch/issues/150541

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportUnpromotableShardRefreshAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportUnpromotableShardRefreshAction.java
@@ -100,9 +100,7 @@ public class TransportUnpromotableShardRefreshAction extends TransportBroadcastU
     @Override
     protected void doExecute(Task task, UnpromotableShardRefreshRequest request, ActionListener<ActionResponse.Empty> listener) {
         beforeDispatchingRequestToUnpromotableShards(request, listener.delegateFailure((l, unused) -> {
-            if (logger.isTraceEnabled()) {
-                logger.trace("dispatching refresh request for unpromotable shard {}", request.shardId());
-            }
+            logger.info("dispatching refresh request for unpromotable shard {}", request.shardId());
             super.doExecute(task, request, l);
         }));
     }
@@ -123,9 +121,12 @@ public class TransportUnpromotableShardRefreshAction extends TransportBroadcastU
             return;
         }
 
+        logger.info("shard [{}] unpromotable refresh blocked by INDEX_REFRESH_BLOCK, waiting", request.shardId());
+
         clusterStateObserver.waitForNextChange(new ClusterStateObserver.Listener() {
             @Override
             public void onNewClusterState(ClusterState state) {
+                logger.info("INDEX_REFRESH_BLOCK removed for shard [{}], dispatching unpromotable refresh", request.shardId());
                 listener.onResponse(null);
             }
 
@@ -179,14 +180,12 @@ public class TransportUnpromotableShardRefreshAction extends TransportBroadcastU
 
         ActionListener.run(responseListener, listener -> {
             shard.waitForPrimaryTermAndGeneration(primaryTerm, segmentGeneration, listener.map(l -> {
-                if (logger.isTraceEnabled()) {
-                    logger.trace(
-                        "refreshed unpromotable shard {} for requested primary term {} and segment generation {}",
-                        request.shardId(),
-                        primaryTerm,
-                        segmentGeneration
-                    );
-                }
+                logger.info(
+                    "refreshed unpromotable shard {} for requested primary term {} and segment generation {}",
+                    request.shardId(),
+                    primaryTerm,
+                    segmentGeneration
+                );
                 return ActionResponse.Empty.INSTANCE;
             }));
         });

--- a/server/src/main/java/org/elasticsearch/action/support/broadcast/unpromotable/TransportBroadcastUnpromotableAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/broadcast/unpromotable/TransportBroadcastUnpromotableAction.java
@@ -25,6 +25,8 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.Strings;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportChannel;
 import org.elasticsearch.transport.TransportRequestHandler;
@@ -38,6 +40,8 @@ import java.util.concurrent.Executor;
 
 public abstract class TransportBroadcastUnpromotableAction<Request extends BroadcastUnpromotableRequest, Response extends ActionResponse>
     extends HandledTransportAction<Request, Response> {
+
+    public static final Logger debugLogger = LogManager.getLogger(TransportBroadcastUnpromotableAction.class);
 
     protected final ClusterService clusterService;
     protected final TransportService transportService;
@@ -77,6 +81,7 @@ public abstract class TransportBroadcastUnpromotableAction<Request extends Broad
     @Override
     protected void doExecute(Task task, Request request, ActionListener<Response> listener) {
         final var unpromotableShards = request.indexShardRoutingTable.assignedUnpromotableShards();
+        debugLogger.info("TransportBroadcastUnpromotableAction: sending {} action to shards {}", this.getClass(), unpromotableShards);
         final var responses = new ArrayList<Response>(unpromotableShards.size());
 
         try (var listeners = new RefCountingListener(listener.map(v -> combineUnpromotableShardResponses(responses)))) {
@@ -92,6 +97,7 @@ public abstract class TransportBroadcastUnpromotableAction<Request extends Broad
                             responses.add(response);
                         }
                     });
+                    debugLogger.info("TransportBroadcastUnpromotableAction: sending {} request to node {}", request, node);
                     transportService.sendRequest(
                         node,
                         transportUnpromotableAction,

--- a/server/src/main/java/org/elasticsearch/action/support/replication/PostWriteRefresh.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/PostWriteRefresh.java
@@ -9,6 +9,8 @@
 
 package org.elasticsearch.action.support.replication;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.lucene.store.AlreadyClosedException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionListenerResponseHandler;
@@ -29,6 +31,8 @@ import org.elasticsearch.transport.TransportService;
 import java.util.concurrent.Executor;
 
 public class PostWriteRefresh {
+
+    private static final Logger logger = LogManager.getLogger(PostWriteRefresh.class);
 
     public static final String POST_WRITE_REFRESH_ORIGIN = "post_write_refresh";
     public static final String FORCED_REFRESH_AFTER_INDEX = "refresh_flag_index";

--- a/server/src/main/java/org/elasticsearch/action/support/replication/PostWriteRefresh.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/PostWriteRefresh.java
@@ -114,7 +114,14 @@ public class PostWriteRefresh {
             return;
         }
 
+        logger.debug("shard [{}] WAIT_UNTIL: waiting for flush before dispatching unpromotable refresh", indexShard.shardId());
+
         engineOrNull.addFlushListener(location, listener.delegateFailureAndWrap((l, generation) -> {
+            logger.debug(
+                "shard [{}] WAIT_UNTIL: flush reached generation [{}], sending unpromotable refresh",
+                indexShard.shardId(),
+                generation
+            );
             try (
                 ThreadContext.StoredContext ignore = transportService.getThreadPool()
                     .getThreadContext()

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/StatelessIndexEventListener.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/StatelessIndexEventListener.java
@@ -423,6 +423,11 @@ class StatelessIndexEventListener implements IndexEventListener {
             searchDirectory,
             indexShard.getOperationPrimaryTerm()
         );
+        logger.info(
+            "beforeRecoveryOnSearchShard: {} read search shard state from object store: {}",
+            indexShard.shardId(),
+            batchedCompoundCommit == null ? "null (empty commit)" : batchedCompoundCommit.primaryTermAndGeneration()
+        );
         assert batchedCompoundCommit == null || batchedCompoundCommit.shardId().equals(indexShard.shardId())
             : batchedCompoundCommit.shardId() + " != " + indexShard.shardId();
 
@@ -434,6 +439,7 @@ class StatelessIndexEventListener implements IndexEventListener {
             indexShard.shardId(),
             listener.<RegisterCommitResponse>delegateFailure((l, response) -> {
                 var lastUploaded = response.getLatestUploadedBatchedCompoundCommitTermAndGen();
+                logger.info("beforeRecoveryOnSearchShard: {} last uploaded is: {}", indexShard.shardId(), lastUploaded);
                 var nodeId = response.getNodeId();
                 assert nodeId != null : response;
 

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/action/TransportNewCommitNotificationAction.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/action/TransportNewCommitNotificationAction.java
@@ -81,7 +81,7 @@ public class TransportNewCommitNotificationAction extends TransportBroadcastUnpr
         if (logger.isTraceEnabled()) {
             logger.trace("received new commit notification request [{}]", request);
         } else {
-            logger.debug(
+            logger.info(
                 "received new commit notification request for shard [{}], term [{}], generation [{}]",
                 request.shardId(),
                 request.getTerm(),

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/commits/StatelessCommitService.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/commits/StatelessCommitService.java
@@ -734,7 +734,8 @@ public class StatelessCommitService extends AbstractLifecycleComponent implement
                 // for initializing shards, the applied state may not yet be available in `ClusterService.state()`.
                 // however, except for peer recovery, we can safely assume no search shards.
                 logger.info(
-                    "{} skipping CC commit notification for generation [{}]: routingTableEmpty={}, initializingNoSearch={}, commitAfterReloc={}",
+                    "{} skipping CC commit notification for generation [{}]: routingTableEmpty={}, "
+                        + "initializingNoSearch={}, commitAfterReloc={}",
                     shardId,
                     generation,
                     shardRoutingTable.isEmpty(),

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/commits/StatelessCommitService.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/commits/StatelessCommitService.java
@@ -635,9 +635,18 @@ public class StatelessCommitService extends AbstractLifecycleComponent implement
                     if (globalCheckpoint != UNASSIGNED_SEQ_NO) {
                         assert waitingForGlobalCheckpoint <= globalCheckpoint
                             : "only advanced to [" + globalCheckpoint + "] while waiting for [" + waitingForGlobalCheckpoint + "]";
+                        logger.info(
+                            "GCP advanced to [{}], satisfied wait for [{}], sending commit notification",
+                            globalCheckpoint,
+                            waitingForGlobalCheckpoint
+                        );
                         l.onResponse(null);
                     } else {
                         if (e instanceof TimeoutException) {
+                            logger.info(
+                                "GCP listener timed out waiting for [{}], triggering translog sync and re-registering without timeout",
+                                waitingForGlobalCheckpoint
+                            );
                             try {
                                 // TODO: ideally we'd pass the checkpoint to the translog replicator sync call so it ensures seqnos up to
                                 // the given one are persisted. This'd avoid the need for provoking the sync of higher seqnos unnecessarily.
@@ -724,6 +733,14 @@ public class StatelessCommitService extends AbstractLifecycleComponent implement
             if (shardRoutingTable.isEmpty() || commitState.isInitializingNoSearch() || commitAfterRelocationStarted) {
                 // for initializing shards, the applied state may not yet be available in `ClusterService.state()`.
                 // however, except for peer recovery, we can safely assume no search shards.
+                logger.info(
+                    "{} skipping CC commit notification for generation [{}]: routingTableEmpty={}, initializingNoSearch={}, commitAfterReloc={}",
+                    shardId,
+                    generation,
+                    shardRoutingTable.isEmpty(),
+                    commitState.isInitializingNoSearch(),
+                    commitAfterRelocationStarted
+                );
                 commitState.notifyCommitNotificationSuccessListeners(generation);
             } else {
                 // Fetch these values up front for consistent relative values: `virtualBcc` and `commitState` may be modified later in
@@ -738,6 +755,12 @@ public class StatelessCommitService extends AbstractLifecycleComponent implement
                 // of the local checkpoint in the commit.
                 try {
                     var maxSeqNo = Long.parseLong(reference.getIndexCommit().getUserData().get(SequenceNumbers.MAX_SEQ_NO));
+                    logger.info(
+                        "{} waiting for GCP >= [{}] before sending commit notification for generation [{}]",
+                        shardId,
+                        maxSeqNo,
+                        generation
+                    );
                     addGlobalCheckpointListener(
                         commitState.addGlobalCheckpointListenerFunction,
                         commitState.triggerTranslogReplicator,
@@ -2248,6 +2271,12 @@ public class StatelessCommitService extends AbstractLifecycleComponent implement
                     + state;
 
             lastNewCommitNotificationSentTimestamp = threadPool.relativeTimeInMillis();
+            logger.info(
+                "{} sending CC commit notification for generation [{}] to [{}] search shards",
+                shardId,
+                lastCompoundCommit.generation(),
+                shardRoutingTable.assignedUnpromotableShards().size()
+            );
             statelessCommitNotificationPublisher.sendNewCommitNotification(
                 shardRoutingTable,
                 lastCompoundCommit,

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/commits/StatelessCommitService.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/commits/StatelessCommitService.java
@@ -28,6 +28,7 @@ import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.TriConsumer;
 import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
@@ -909,6 +910,16 @@ public class StatelessCommitService extends AbstractLifecycleComponent implement
         bccAgeHistogram.record(threadPool.relativeTimeInMillis() - virtualBcc.getCreationTimeInMillis());
         recordBccTimestampRangeMetric(virtualBcc);
 
+        try {
+            Thread.sleep(Randomness.createSecure().nextInt(0, 200));
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        logger.info(
+            "createAndRunCommitUpload: {} starting BCC upload for {}",
+            virtualBcc.getShardId(),
+            virtualBcc.getPrimaryTermAndGeneration()
+        );
         bccUpload.run();
     }
 
@@ -945,7 +956,9 @@ public class StatelessCommitService extends AbstractLifecycleComponent implement
                         uploadedBcc,
                         virtualBcc.getLastPendingCompoundCommit().getCommitReference().getTranslogReleaseEndFile()
                     );
+                    logger.info("newUploadTaskListener: finished uploading blob {}", virtualBcc);
                     commitState.sendNewUploadedCommitNotification(blobReference, uploadedBcc);
+                    logger.info("newUploadTaskListener: upload notification sent for blob {}", virtualBcc);
                 } catch (Exception e) {
                     // TODO: we should assert false here once we fix ES-8336
                     logger.warn(
@@ -1884,6 +1897,16 @@ public class StatelessCommitService extends AbstractLifecycleComponent implement
                 // We do this prior to adding to pending upload generations since we rely on this for search commit registration.
                 blobReference = createBlobReference(expectedVirtualBcc);
 
+                try {
+                    Thread.sleep(Randomness.createSecure().nextInt(0, 200));
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+                logger.info(
+                    "{} adding generation [{}] to pendingUploadBccGenerations (blob not yet in object store)",
+                    shardId,
+                    expectedVirtualBcc.getPrimaryTermAndGeneration().generation()
+                );
                 final var previous = pendingUploadBccGenerations.put(
                     expectedVirtualBcc.getPrimaryTermAndGeneration().generation(),
                     expectedVirtualBcc
@@ -2136,6 +2159,13 @@ public class StatelessCommitService extends AbstractLifecycleComponent implement
                         + "] for shard "
                         + shardId;
                 latestUploadedBcc = uploadedBcc;
+                logger.info(
+                    "{} BCC upload complete: generation [{}] (term+gen {}) now visible in object store; removed from pendingUploadBccGenerations={}",
+                    shardId,
+                    newGeneration,
+                    uploadedBcc.primaryTermAndGeneration(),
+                    isUpload
+                );
                 if (isUpload) {
                     // Remove the BCC from the pending list *after* upload consumers but *before* generation listeners are fired
                     var removed = pendingUploadBccGenerations.remove(newBccGeneration);

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/engine/SearchEngine.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/engine/SearchEngine.java
@@ -732,7 +732,7 @@ public class SearchEngine extends Engine {
                             .collect(Collectors.toSet());
                     }
                     searchDirectory.retainFiles(filesToRetain);
-                    logger.debug("segments updated from generation [{}] to [{}]", current.getGeneration(), next.getGeneration());
+                    logger.info("segments updated from generation [{}] to [{}]", current.getGeneration(), next.getGeneration());
                     callSegmentGenerationListeners(
                         new PrimaryTermAndGeneration(primaryTerm(reader.getIndexCommit()), reader.getIndexCommit().getGeneration())
                     );
@@ -1373,6 +1373,12 @@ public class SearchEngine extends Engine {
      * @throws AlreadyClosedException if the engine is closed
      */
     boolean addOrExecuteSegmentGenerationListener(PrimaryTermAndGeneration minPrimaryTermGeneration, ActionListener<Long> listener) {
+        logger.info(
+            "{} trying to register generation listener: need [{}], have [{}]",
+            shardId,
+            minPrimaryTermGeneration,
+            getCurrentPrimaryTermAndGeneration()
+        );
         try {
             ensureOpen();
             // check current state first - not strictly necessary, but a little more efficient than what happens next
@@ -1405,6 +1411,12 @@ public class SearchEngine extends Engine {
                 } // else someone else executed it for us.
                 return false;
             }
+            logger.info(
+                "{} registered generation listener: need [{}], have [{}]",
+                shardId,
+                minPrimaryTermGeneration,
+                getCurrentPrimaryTermAndGeneration()
+            );
             return true;
         } catch (Exception e) {
             listener.onFailure(e);
@@ -1425,6 +1437,7 @@ public class SearchEngine extends Engine {
     }
 
     private void callSegmentGenerationListeners(PrimaryTermAndGeneration currentTermGen) {
+        logger.info("{} calling generation listeners at [{}]", shardId, currentTermGen);
         final var iterator = segmentGenerationListeners.entrySet().iterator();
         while (iterator.hasNext()) {
             var entry = iterator.next();

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/engine/SearchEngine.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/engine/SearchEngine.java
@@ -497,7 +497,7 @@ public class SearchEngine extends Engine {
      * is visible to searches.
      */
     public void onCommitNotification(NewCommitNotification notification, ActionListener<Void> listener) {
-        logger.trace(
+        logger.info(
             "{} received new commit notification [bcc={}, cc={}] with latest uploaded {} from node [{}] and cluster state version [{}]",
             shardId,
             notification.batchedCompoundCommitGeneration(),
@@ -682,6 +682,12 @@ public class SearchEngine extends Engine {
 
             private void doUpdateInternalState(NewCommitNotification latestNotification, SegmentInfos current) throws IOException {
                 final StatelessCompoundCommit latestCommit = latestNotification.compoundCommit();
+                logger.info(
+                    "{} doUpdateInternalState: applying commit [{}], current gen [{}]",
+                    shardId,
+                    latestCommit.primaryTermAndGeneration(),
+                    current.getGeneration()
+                );
                 final SegmentInfos next = Lucene.readSegmentInfos(directory);
                 setSequenceNumbers(next);
 

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/recovery/RemoveRefreshClusterBlockService.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/recovery/RemoveRefreshClusterBlockService.java
@@ -389,7 +389,7 @@ public class RemoveRefreshClusterBlockService implements ClusterStateListener {
 
             @Override
             public void taskSucceeded(RemoveRefreshBlockClusterStateUpdateTask task, Void unused) {
-                logger.debug("Refresh blocks removed successfully for indices: {}", task.indicesByProject);
+                logger.info("Refresh blocks removed successfully for indices: {}", task.indicesByProject);
             }
         };
 }


### PR DESCRIPTION
🚧  WIP

Trying to [repro](https://gradle-enterprise.elastic.co/scans/tests?search.publicHostnames=inespot-ci-test&search.startTimeMax=1780631999999&search.startTimeMin=1780372800000&search.timeZoneId=America%2FNew_York&tests.container=org.elasticsearch.xpack.stateless.recovery.BlockRefreshUponIndexCreationIT&tests.test=testRefreshesAreBlockedUntilBlockIsRemoved)

Closes: https://github.com/elastic/elasticsearch/issues/150492
