### PR TITLE
Fix flaky PrometheusHistogramQuantile malformed bound warning test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -704,9 +704,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.ndjson.NdJsonCompressedFormatSpecIT
   method: test {csv-spec:external-basic.fileMetadataWildcardKeepExcludesVirtualColumns [ndjson.zstd/GCS]}
   issue: https://github.com/elastic/elasticsearch/issues/150653
-- class: org.elasticsearch.compute.aggregation.PrometheusHistogramQuantileAggregatorFunctionTests
-  method: testWarnsAndSkipsUnparseableBound
-  issue: https://github.com/elastic/elasticsearch/issues/150654
 - class: org.elasticsearch.xpack.esql.qa.ndjson.NdJsonCompressedFormatSpecIT
   method: test {csv-spec:external-basic.aggregateCount [ndjson.gz/GCS]}
   issue: https://github.com/elastic/elasticsearch/issues/150657

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/PrometheusHistogramQuantileAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/PrometheusHistogramQuantileAggregatorFunctionTests.java
@@ -11,24 +11,14 @@ import org.elasticsearch.compute.aggregation.PrometheusHistogramQuantileStates.B
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.DoubleBlock;
-import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.Page;
-import org.elasticsearch.compute.operator.Driver;
-import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.SourceOperator;
-import org.elasticsearch.compute.test.TestDriverFactory;
-import org.elasticsearch.compute.test.TestDriverRunner;
-import org.elasticsearch.compute.test.TestResultPageSinkOperator;
 import org.elasticsearch.compute.test.TestWarningsSource;
-import org.elasticsearch.compute.test.operator.blocksource.ListRowsBlockSourceOperator;
 import org.junit.Before;
 
-import java.util.ArrayList;
 import java.util.List;
 
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasItem;
 
 public class PrometheusHistogramQuantileAggregatorFunctionTests extends AggregatorFunctionTestCase {
     private double quantile;
@@ -73,42 +63,6 @@ public class PrometheusHistogramQuantileAggregatorFunctionTests extends Aggregat
         List<Bucket> buckets = PrometheusHistogramQuantileTestHelpers.bucketsFromPages(input, 0, 1);
         double expected = PrometheusHistogramQuantileTestHelpers.expectedQuantile(quantile, buckets);
         assertQuantileResult((DoubleBlock) result, 0, expected);
-    }
-
-    public void testWarnsAndSkipsUnparseableBound() {
-        DriverContext driverContext = driverContext();
-        // A valid two-bucket histogram plus a malformed `le` label, which must be skipped with a warning.
-        List<List<Object>> rows = List.of(List.of(2.0, "1.0"), List.of(4.0, "+Inf"), List.of(1.0, "not_a_number"));
-        List<Page> results = new ArrayList<>();
-        List<String> warnings = new ArrayList<>();
-        try (
-            Driver driver = TestDriverFactory.create(
-                driverContext,
-                new ListRowsBlockSourceOperator(driverContext.blockFactory(), List.of(ElementType.DOUBLE, ElementType.BYTES_REF), rows),
-                List.of(simple().get(driverContext)),
-                new TestResultPageSinkOperator(results::add),
-                () -> warnings.addAll(threadContext.getResponseHeaders().getOrDefault("Warning", List.of()))
-            )
-        ) {
-            new TestDriverRunner().run(driver);
-        }
-
-        // The bad bucket is dropped rather than failing the query: a single result is still produced.
-        assertThat(results.size(), equalTo(1));
-        assertThat(
-            ((DoubleBlock) results.get(0).getBlock(0)).getDouble(0),
-            equalTo(
-                PrometheusHistogramQuantileStates.bucketQuantile(
-                    quantile,
-                    List.of(new Bucket(1.0, 2.0), new Bucket(Double.POSITIVE_INFINITY, 4.0))
-                )
-            )
-        );
-        // The warning names the offending `le` value, mirroring Prometheus' "bad bucket label" warning.
-        assertThat(
-            warnings,
-            hasItem(containsString("java.lang.NumberFormatException: bucket label [le] has a malformed value of [not_a_number]"))
-        );
     }
 
     static void assertQuantileResult(DoubleBlock result, int position, double expected) {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/PrometheusHistogramQuantileStatesTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/PrometheusHistogramQuantileStatesTests.java
@@ -19,7 +19,9 @@ import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
 import org.elasticsearch.compute.test.ComputeTestCase;
+import org.elasticsearch.compute.test.TestWarningsSource;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.indices.CrankyCircuitBreakerService;
 
@@ -136,9 +138,10 @@ public class PrometheusHistogramQuantileStatesTests extends ComputeTestCase {
     public void testCombineSkipsUnparseableBound() {
         BlockFactory blockFactory = blockFactory();
         DriverContext driverContext = new DriverContext(blockFactory.bigArrays(), blockFactory, null);
+        Warnings warnings = Warnings.createWarnings(DriverContext.WarningsMode.COLLECT, TestWarningsSource.INSTANCE);
 
         // Prometheus warns and skips malformed `le` buckets, preserving the valid buckets for the same histogram.
-        try (var state = new SingleState(blockFactory.breaker(), 0.5)) {
+        try (var state = new SingleState(blockFactory.breaker(), 0.5, warnings)) {
             PrometheusHistogramQuantileAggregator.combine(state, 2.0, new BytesRef("1.0"));
             PrometheusHistogramQuantileAggregator.combine(state, 1.0, new BytesRef("not_a_number"));
             PrometheusHistogramQuantileAggregator.combine(state, 4.0, new BytesRef("+Inf"));
@@ -147,6 +150,10 @@ public class PrometheusHistogramQuantileStatesTests extends ComputeTestCase {
                 assertThat(result.getDouble(0), equalTo(1.0));
             }
         }
+        assertWarnings(
+            "Line 1:1: evaluation of [source] failed, treating result as null. Only first 20 failures recorded.",
+            "Line 1:1: java.lang.NumberFormatException: bucket label [le] has a malformed value of [not_a_number]"
+        );
     }
 
     public void testBucketQuantileNaNQuantile() {


### PR DESCRIPTION
`PrometheusHistogramQuantileAggregatorFunctionTests.testWarnsAndSkipsUnparseableBound` was flaky (#150654): the aggregator skipped malformed `le` labels and still produced the right quantile, but the warning assertion often failed because it scraped `Warning` headers after an async `TestDriverRunner` run. `TestDriverRunner` executes drivers on thread-pool workers (with seed-dependent thread count), while response headers live in thread-local `ThreadContext` storage, so the callback could read an empty list on a different thread than the one that registered the warning.

We moved warning coverage into `PrometheusHistogramQuantileStatesTests.testCombineSkipsUnparseableBound`, calling `combine` directly on the test thread and asserting with `assertWarnings()` — the same pattern used by other compute aggregator tests (e.g. `RateDoubleGroupingAggregatorFunctionTests`). That is sufficient because the warning is emitted in `PrometheusHistogramQuantileStates.add` when parsing the `le` label, which `combine` exercises directly; a driver integration test would not add meaningful coverage and would risk the same flake (as with the similarly structured `SumLongAggregatorFunctionTests.testOverflowFails`). Removed the driver test and unmuted.

Closes #150654.