### PR TITLE
[ESQL] Bind zstd size_t args as JAVA_LONG in FFM downcalls

### DIFF
--- a/libs/native/src/main/java/org/elasticsearch/nativeaccess/jdk/JdkZstdLibrary.java
+++ b/libs/native/src/main/java/org/elasticsearch/nativeaccess/jdk/JdkZstdLibrary.java
@@ -35,6 +35,13 @@ class JdkZstdLibrary implements ZstdLibrary {
         LoaderHelper.loadLibrary("zstd");
     }
 
+    // The size_t parameters below are bound as JAVA_LONG because libzstd's one-shot entry points
+    // take/return C `size_t` (8 bytes on every 64-bit target we ship). Binding them as JAVA_INT
+    // (as they originally were, until #150130) leaves the upper 32 bits of the argument register
+    // undefined, which libzstd reads as part of the size_t: most calls see zeroed high bits and
+    // succeed, but under some JIT/register states (observed intermittently on JDK 26) the garbage
+    // high bits make libzstd see a bogus size and fail the page compress/decompress.
+    // See #150015, #150019 and #150077.
     private static final MethodHandle compressBound$mh = downcallHandle("ZSTD_compressBound", FunctionDescriptor.of(JAVA_LONG, JAVA_LONG));
     private static final MethodHandle compress$mh = downcallHandle(
         "ZSTD_compress",

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -328,12 +328,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
   method: test {csv-spec:where-like.likePrefixSuffix}
   issue: https://github.com/elastic/elasticsearch/issues/149964
-- class: org.elasticsearch.xpack.esql.datasource.parquet.PageColumnReaderCorrectnessTests
-  method: testV2Zstd
-  issue: https://github.com/elastic/elasticsearch/issues/150015
-- class: org.elasticsearch.xpack.esql.datasource.parquet.PageColumnReaderCorrectnessTests
-  method: testV1Zstd
-  issue: https://github.com/elastic/elasticsearch/issues/150019
 - class: org.elasticsearch.xpack.stateless.StatelessRealTimeGetIT
   method: testDataVisibility
   issue: https://github.com/elastic/elasticsearch/issues/150028
@@ -346,9 +340,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecIT
   method: test {csv-spec:stats.weightedAvgWithOverflowRow}
   issue: https://github.com/elastic/elasticsearch/issues/150051
-- class: org.elasticsearch.xpack.esql.datasource.parquet.PageColumnReaderCorrectnessTests
-  method: testRandomSchema
-  issue: https://github.com/elastic/elasticsearch/issues/150077
 - class: org.elasticsearch.xpack.stateless.reshard.StatelessReshardIT
   method: testMultiTermVectorsApiRealtimeGet
   issue: https://github.com/elastic/elasticsearch/issues/150101


### PR DESCRIPTION
## Summary

The zstd FFM ABI bug behind these failures — libzstd's `size_t` length parameters were bound as `JAVA_INT` instead of `JAVA_LONG` in `JdkZstdLibrary`, leaving the upper 32 bits of the argument register undefined and intermittently failing zstd page compress/decompress (notably on JDK 26) — was already fixed in #150130.

This PR therefore makes no functional change. It only:

- **Documents** why those zstd descriptors must be bound as `JAVA_LONG` (a comment above the `MethodHandle` descriptors, crediting #150130), so the subtle ABI requirement isn't accidentally reverted.
- **Unmutes** the three `PageColumnReaderCorrectnessTests` tests that were failing on the old binding: `testV2Zstd`, `testV1Zstd`, `testRandomSchema`.

Verified locally under `-Druntime.java=26`: `spotlessJavaCheck`, `validateChangelogs`, and the full `PageColumnReaderCorrectnessTests` suite pass.

Closes #150015
Closes #150019
Closes #150077