### PR TITLE
Add query template mapping pattern for numeric fields

### DIFF
--- a/x-pack/plugin/core/template-resources/src/main/resources/activitylog/logs-elasticsearch.querylog@mappings.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/activitylog/logs-elasticsearch.querylog@mappings.json
@@ -9,6 +9,14 @@
               "type": "long",
               "index": false
             }
+          },
+          "elasticsearch_querylog_esql_profile_longs": {
+            "path_match": "elasticsearch.querylog.esql.profile.*",
+            "match_mapping_type": ["long", "integer", "short", "byte"],
+            "mapping": {
+              "type": "long",
+              "index": false
+            }
           }
         }
       ],

--- a/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/QueryLoggingTemplateRegistry.java
+++ b/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/QueryLoggingTemplateRegistry.java
@@ -34,7 +34,8 @@ public class QueryLoggingTemplateRegistry extends IndexTemplateRegistry {
     // version 2: limit query to 32k
     // version 3: add esql.filter
     // version 4: move filter to main body
-    public static final int INDEX_TEMPLATE_VERSION = 4;
+    // version 5: add esql.profile longs mapping
+    public static final int INDEX_TEMPLATE_VERSION = 5;
 
     public static final String QUERY_LOGGING_TEMPLATE_VERSION_VARIABLE = "xpack.stack.querylog.template.version";
 


### PR DESCRIPTION
All numeric fields are mapped to long, explicitly. 