### PR TITLE
2770 Cancellable TransportWriteAction fix tests

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/index/IndexingPressureIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/IndexingPressureIT.java
@@ -256,6 +256,8 @@ public class IndexingPressureIT extends ESIntegTestCase {
         }
 
         assertFalse(postSubmissionCancellationIndexCalled.get());
+        PreIndexListenerInstallerPlugin.resetPreIndexListener();
+        primaryTransportService.clearAllRules();
     }
 
     public void testWriteIndexingPressureMetricsAreIncremented() throws Exception {


### PR DESCRIPTION
Fixing a release failed build. 

For IndexingPressureIT,  the internalCluster is shared between tests. The testCancellableTransportWriteAction() did not clean up properly. 

> [2026-06-03T21:33:07,474][INFO ][o.e.c.m.MetadataMappingService][node_t0][masterService#updateTask][T#1] [test/sq53yZkxS-G5f5d3Db2pWA] create_mapping
> juin 04, 2026 8:33:07 AM com.carrotsearch.randomizedtesting.RandomizedRunner$QueueUncaughtExceptionsHandler uncaughtException
> WARNING: Uncaught exception in thread: Thread[#3729,elasticsearch[node_t1][write][T#2],5,TGRP-IndexingPressureIT]
> java.lang.AssertionError: indexing should not run when cancelled post-submission
> 	at __randomizedtesting.SeedInfo.seed([BBA2CED8906163A5]:0)
> 	at org.junit.Assert.fail(Assert.java:89)
> 	at org.elasticsearch.index.IndexingPressureIT.lambda$testCancellableTransportWriteAction$3(IndexingPressureIT.java:192)
> 	at org.elasticsearch.index.IndexingPressureIT$InjectablePreIndexOperationListener.preIndex(IndexingPressureIT.java:924)
> 	at org.elasticsearch.index.shard.IndexingOperationListener$CompositeListener.preIndex(IndexingOperationListener.java:82)
> 
> 
