### PR TITLE
Drop unmapped dynamic:false fields in columnar index modes

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get/130_columnar_source.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get/130_columnar_source.yml
@@ -367,3 +367,88 @@ dynamic mapping - columnar stored:
       _source:
         kwd: foo
         num: 42
+
+---
+
+dynamic false drops unmapped fields - columnar synthetic source:
+  - requires:
+      cluster_features: ["mapper.columnar.drops_dynamic_false_fields"]
+      reason: "columnar mode drops unmapped dynamic:false fields rather than storing in ignored source"
+
+  - do:
+      indices.create:
+        index: test
+        body:
+          settings:
+            index.mode: columnar
+            index.mapping.source.mode: synthetic
+          mappings:
+            dynamic: false
+            properties:
+              kwd:
+                type: keyword
+
+  - do:
+      index:
+        index: test
+        id: 1
+        refresh: true
+        body:
+          kwd: mapped_value
+          unmapped_leaf: dropped
+          unmapped_obj:
+            key: also_dropped
+
+  - do:
+      get:
+        index: test
+        id: 1
+  - match: {found: true}
+  - match:
+      _source:
+        kwd: mapped_value
+  - is_false: _source.unmapped_leaf
+  - is_false: _source.unmapped_obj
+
+---
+
+dynamic false drops unmapped fields - columnar stored source:
+  - requires:
+      cluster_features: ["mapper.columnar.drops_dynamic_false_fields"]
+      reason: "columnar mode drops unmapped dynamic:false fields rather than storing in ignored source"
+
+  - do:
+      indices.create:
+        index: test
+        body:
+          settings:
+            index.mode: columnar
+            index.mapping.source.mode: columnar_stored
+          mappings:
+            dynamic: false
+            properties:
+              kwd:
+                type: keyword
+
+  - do:
+      index:
+        index: test
+        id: 1
+        refresh: true
+        body:
+          kwd: mapped_value
+          unmapped_leaf: dropped
+          unmapped_arr:
+            - 1
+            - 2
+
+  - do:
+      get:
+        index: test
+        id: 1
+  - match: {found: true}
+  - match:
+      _source:
+        kwd: mapped_value
+  - is_false: _source.unmapped_leaf
+  - is_false: _source.unmapped_arr

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -570,7 +570,8 @@ public final class DocumentParser {
         // For [subobjects:false], intermediate objects get flattened so we can't skip parsing children.
         if (context.dynamic() == ObjectMapper.Dynamic.FALSE && context.parent().subobjects() != ObjectMapper.Subobjects.DISABLED) {
             failIfMatchesRoutingPath(context, currentFieldName);
-            if (context.canAddIgnoredField()) {
+            // In columnar index modes, unmapped fields under dynamic:false are dropped entirely
+            if (context.canAddIgnoredField() && context.indexSettings().getMode().isStrictColumnar() == false) {
                 context.addIgnoredField(
                     IgnoredSourceFieldMapper.NameValue.fromContext(
                         context,
@@ -674,7 +675,8 @@ public final class DocumentParser {
     private static void parseArrayDynamic(DocumentParserContext context, String currentFieldName) throws IOException {
         ensureNotStrict(context, currentFieldName);
         if (context.dynamic() == ObjectMapper.Dynamic.FALSE) {
-            if (context.canAddIgnoredField()) {
+            // In columnar index modes, unmapped fields under dynamic:false are dropped entirely
+            if (context.canAddIgnoredField() && context.indexSettings().getMode().isStrictColumnar() == false) {
                 context.addIgnoredField(
                     IgnoredSourceFieldMapper.NameValue.fromContext(
                         context,
@@ -914,7 +916,8 @@ public final class DocumentParser {
         ensureNotStrict(context, currentFieldName);
         if (context.dynamic() == ObjectMapper.Dynamic.FALSE) {
             failIfMatchesRoutingPath(context, currentFieldName);
-            if (context.canAddIgnoredField()) {
+            // In columnar index modes, unmapped fields under dynamic:false are dropped entirely
+            if (context.canAddIgnoredField() && context.indexSettings().getMode().isStrictColumnar() == false) {
                 context.addIgnoredField(
                     IgnoredSourceFieldMapper.NameValue.fromContext(
                         context,

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
@@ -112,6 +112,7 @@ public class MapperFeatures implements FeatureSpecification {
         "mapper.keyword.columnar_default_high_cardinality"
     );
     static final NodeFeature COLUMNAR_MAINTAIN_ARRAY_ORDER_IP_TEXT = new NodeFeature("mapper.columnar.maintain_array_order_ip_text");
+    public static final NodeFeature COLUMNAR_DROPS_DYNAMIC_FALSE_FIELDS = new NodeFeature("mapper.columnar.drops_dynamic_false_fields");
 
     @Override
     public Set<NodeFeature> getTestFeatures() {
@@ -189,7 +190,8 @@ public class MapperFeatures implements FeatureSpecification {
             COLUMNAR_MAINTAIN_ARRAY_ORDER,
             COLUMNAR_REJECTS_RUNTIME_DYNAMIC,
             KEYWORD_COLUMNAR_DEFAULT_HIGH_CARDINALITY,
-            COLUMNAR_MAINTAIN_ARRAY_ORDER_IP_TEXT
+            COLUMNAR_MAINTAIN_ARRAY_ORDER_IP_TEXT,
+            COLUMNAR_DROPS_DYNAMIC_FALSE_FIELDS
         );
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.plugins.MapperPlugin;
 import org.elasticsearch.plugins.Plugin;
@@ -971,6 +972,41 @@ public class DocumentParserTests extends MapperServiceTestCase {
         DocumentMapper mapper = createDocumentMapper(topMapping(b -> b.field("dynamic", "false")));
         ParsedDocument doc = mapper.parse(source(b -> b.nullField("bar")));
         assertEquals(0, doc.rootDoc().getFields("bar").size());
+    }
+
+    // In columnar mode, unmapped fields with dynamic:false must be dropped entirely rather than
+    // stored in _ignored_source (documented data loss, not a bug).
+    public void testColumnarDynamicFalseValueDropped() throws Exception {
+        assumeTrue("columnar index mode requires snapshot build", IndexMode.COLUMNAR_FEATURE_FLAG.isEnabled());
+        DocumentMapper mapper = createColumnarModeDocumentMapper(topMapping(b -> b.field("dynamic", "false")));
+        ParsedDocument doc = mapper.parse(source(b -> b.field("unmapped_field", "some_value")));
+        assertEquals(0, doc.rootDoc().getFields("unmapped_field").size());
+        assertNull(
+            "unmapped dynamic:false leaf must not be stored in _ignored_source in columnar mode",
+            doc.rootDoc().getField(IgnoredSourceFieldMapper.NAME)
+        );
+    }
+
+    public void testColumnarDynamicFalseObjectDropped() throws Exception {
+        assumeTrue("columnar index mode requires snapshot build", IndexMode.COLUMNAR_FEATURE_FLAG.isEnabled());
+        DocumentMapper mapper = createColumnarModeDocumentMapper(topMapping(b -> b.field("dynamic", "false")));
+        ParsedDocument doc = mapper.parse(source(b -> b.startObject("unmapped_obj").field("key", "value").endObject()));
+        assertEquals(0, doc.rootDoc().getFields("unmapped_obj.key").size());
+        assertNull(
+            "unmapped dynamic:false object must not be stored in _ignored_source in columnar mode",
+            doc.rootDoc().getField(IgnoredSourceFieldMapper.NAME)
+        );
+    }
+
+    public void testColumnarDynamicFalseArrayDropped() throws Exception {
+        assumeTrue("columnar index mode requires snapshot build", IndexMode.COLUMNAR_FEATURE_FLAG.isEnabled());
+        DocumentMapper mapper = createColumnarModeDocumentMapper(topMapping(b -> b.field("dynamic", "false")));
+        ParsedDocument doc = mapper.parse(source(b -> b.startArray("unmapped_arr").value(1).value(2).endArray()));
+        assertEquals(0, doc.rootDoc().getFields("unmapped_arr").size());
+        assertNull(
+            "unmapped dynamic:false array must not be stored in _ignored_source in columnar mode",
+            doc.rootDoc().getField(IgnoredSourceFieldMapper.NAME)
+        );
     }
 
     public void testDynamicStrictNull() throws Exception {


### PR DESCRIPTION
In columnar index modes (`COLUMNAR` and `LOGSDB_COLUMNAR`), unmapped fields encountered while parsing a document with `dynamic: false` were being stored in `_ignored_source` so they could be reconstructed via synthetic source. However, we've decided that in this `dynamic: false` case, columnar mode explicitly will not preserve unmapped fields.

This PR guards all three `dynamic: false` branches in `DocumentParser` (leaf value, object, and array) with `isStrictColumnar()`, so that in columnar mode the parser simply skips the field instead of recording it to ignored source. A new `COLUMNAR_DROPS_DYNAMIC_FALSE_FIELDS` node feature is added to gate YAML REST tests, along with unit tests covering all three field shapes.