### PR TITLE
Relax cluster state version check in IndicesStore shard cleanup

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
+++ b/server/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
@@ -230,6 +230,15 @@ public final class IndicesStore implements ClusterStateListener, Closeable {
         return true;
     }
 
+    static boolean shardIsAllocatedOnNode(String localNodeId, IndexShardRoutingTable indexShardRoutingTable) {
+        for (int copy = 0; copy < indexShardRoutingTable.size(); copy++) {
+            if (localNodeId.equals(indexShardRoutingTable.shard(copy).currentNodeId())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private void deleteShardIfExistElseWhere(
         ClusterName clusterName,
         DiscoveryNodes nodes,
@@ -320,18 +329,6 @@ public final class IndicesStore implements ClusterStateListener, Closeable {
                 return;
             }
 
-            ClusterState latestClusterState = clusterService.state();
-            if (clusterStateVersion != latestClusterState.getVersion()) {
-                logger.trace(
-                    "not deleting shard {}, the latest cluster state version[{}] is not equal to cluster state "
-                        + "before shard active api call [{}]",
-                    shardId,
-                    latestClusterState.getVersion(),
-                    clusterStateVersion
-                );
-                return;
-            }
-
             deleteShardStoreOnApplierThread(shardId, clusterStateVersion, IndexRemovalReason.NO_LONGER_ASSIGNED);
         }
     }
@@ -340,14 +337,18 @@ public final class IndicesStore implements ClusterStateListener, Closeable {
         clusterService.getClusterApplierService()
             .runOnApplierThread("indices_store ([" + shardId + "] active fully on other nodes)", Priority.HIGH, currentState -> {
                 if (clusterStateVersion != currentState.getVersion()) {
-                    logger.trace(
-                        "not deleting shard {}, the update task state version[{}] is not equal to cluster state before "
-                            + "shard active api call [{}]",
-                        shardId,
-                        currentState.getVersion(),
-                        clusterStateVersion
-                    );
-                    return;
+                    String localNodeId = currentState.nodes().getLocalNodeId();
+                    IndexRoutingTable indexRouting = currentState.routingTable().index(shardId.getIndex());
+                    IndexShardRoutingTable currentShardRouting = indexRouting == null
+                        ? null
+                        : indexRouting.shard(shardId.id());
+                    if (currentShardRouting != null && shardIsAllocatedOnNode(localNodeId, currentShardRouting)) {
+                        logger.trace(
+                            "not deleting shard {}, shard has been re-allocated to this node",
+                            shardId
+                        );
+                        return;
+                    }
                 }
                 try {
                     indicesService.deleteShardStore("no longer used", shardId, currentState, indexRemovalReason);

--- a/server/src/test/java/org/elasticsearch/indices/store/IndicesStoreTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/store/IndicesStoreTests.java
@@ -105,4 +105,22 @@ public class IndicesStoreTests extends ESTestCase {
         // Shard exists locally, can't delete shard
         assertFalse(IndicesStore.shardCanBeDeleted(localNode.getId(), routingTable.build()));
     }
+
+    public void testShardIsAllocatedOnNode() {
+        final var shardId = new ShardId("test", "_na_", 0);
+        final var routingTable = new IndexShardRoutingTable.Builder(shardId);
+        routingTable.addShard(
+            TestShardRouting.newShardRouting(shardId, localNode.getId(), true, ShardRoutingState.STARTED)
+        );
+        assertTrue(IndicesStore.shardIsAllocatedOnNode(localNode.getId(), routingTable.build()));
+    }
+
+    public void testShardIsNotAllocatedOnNode() {
+        final var shardId = new ShardId("test", "_na_", 0);
+        final var routingTable = new IndexShardRoutingTable.Builder(shardId);
+        routingTable.addShard(
+            TestShardRouting.newShardRouting(shardId, randomAlphaOfLength(10), true, ShardRoutingState.STARTED)
+        );
+        assertFalse(IndicesStore.shardIsAllocatedOnNode(localNode.getId(), routingTable.build()));
+    }
 }


### PR DESCRIPTION
- Fix stale shard data remaining on disk after shard relocation during node scaling
- When `runOnApplierThread` executes, the cluster state version often differs from when `clusterChanged()` fired, because unrelated cluster state updates (e.g., other shards initializing due to `auto_expand_replicas`) increment the version
- Previously, a strict version equality check caused the cleanup to be skipped entirely, and since `clusterChanged()` does not re-fire without further routing table changes, the stale data was never cleaned up
- Now, when the version differs, we fall back to checking whether the shard has been re-allocated to the local node — the only case where deletion would be unsafe — instead of unconditionally skipping deletion
- Related upstream issue: https://github.com/elastic/elasticsearch/issues/104735

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
-->