### PR TITLE
[ESQL] Unmute ParquetTestingIT bad_ARROW-GH-41321

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -532,9 +532,6 @@ tests:
 - class: org.elasticsearch.xpack.stateless.engine.translog.StatelessTranslogIT
   method: testTranslogStressRecoveryTest
   issue: https://github.com/elastic/elasticsearch/issues/150297
-- class: org.elasticsearch.xpack.esql.qa.parquet.ParquetTestingIT
-  method: testParquetFile {bad_ARROW-GH-41321}
-  issue: https://github.com/elastic/elasticsearch/issues/150300
 - class: org.elasticsearch.repositories.gcs.GoogleCloudStorageBlobContainerRetriesTests
   method: testWriteLargeBlob
   issue: https://github.com/elastic/elasticsearch/issues/150356


### PR DESCRIPTION
## Summary

`ParquetTestingIT.testParquetFile {bad_ARROW-GH-41321}` is a negative test asserting that a malformed Parquet file (a `fixed_size_list_float64` column whose data page is truncated) yields a client-class **4xx** error. When the test was added (#149711) the external-source read path blanket-wrapped reader failures into a bare `RuntimeException`, so the `org.apache.parquet.io.ParquetDecodingException` ("could not read page ... in col [fixed_size_list_float64, list, item]", caused by an `EOFException` in `SingleBufferInputStream.sliceBuffers`) surfaced as **500** and the test was muted.

The error-hierarchy rework (#150251) introduced `ExternalFailures`, which classifies `ParquetDecodingException` as a client-class `ExternalClientException` (400). The malformed-data contract now holds, so the test passes again.

- **muted-tests.yml**: remove the `bad_ARROW-GH-41321` entry; no production change is required.

Verified locally under the CI seed/locale/timezone (`BF851F70EB2BA197`, `bm-ML`, `Africa/Cairo`): the isolated case and the full `testParquetFile` parameter set both pass.

Closes #150300

Developed with AI-assisted tooling