### PR TITLE
Fix KeyRotationIT race condition

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -788,6 +788,3 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.ndjson.NdJsonCompressedFormatSpecIT
   method: test {csv-spec:external-basic.aggregateCount [ndjson.zstd/LOCAL]}
   issue: https://github.com/elastic/elasticsearch/issues/150723
-- class: org.elasticsearch.xpack.encryption.KeyRotationIT
-  method: testInitialInstallProducesSingleActiveKeyWithEmptyHandlerProgress
-  issue: https://github.com/elastic/elasticsearch/issues/150725

--- a/x-pack/plugin/encryption/src/internalClusterTest/java/org/elasticsearch/xpack/encryption/KeyRotationIT.java
+++ b/x-pack/plugin/encryption/src/internalClusterTest/java/org/elasticsearch/xpack/encryption/KeyRotationIT.java
@@ -18,6 +18,7 @@ import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.common.xcontent.ChunkedToXContentHelper;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.plugins.Plugin;
@@ -38,6 +39,8 @@ import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -54,6 +57,8 @@ import static org.hamcrest.Matchers.notNullValue;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 3, supportsDedicatedMasters = false)
 public class KeyRotationIT extends SecurityIntegTestCase {
+
+    private final List<Integer> keyAddEvents = new CopyOnWriteArrayList<>();
 
     @Override
     protected boolean addMockHttpTransport() {
@@ -84,12 +89,30 @@ public class KeyRotationIT extends SecurityIntegTestCase {
     }
 
     @Before
-    public void waitForProjectEncryptionKeyInstalled() throws Exception {
+    public void setup() throws Exception {
+        // Check feature flag
         assumeTrue(
             "project encryption key feature flag must be enabled",
             ProjectEncryptionKeyService.PROJECT_ENCRYPTION_KEY_FEATURE_FLAG.isEnabled()
         );
+        // Add listener that registers PEK changes
+        internalCluster().clusterService().addListener(event -> {
+            if (event.changedCustomProjectMetadataSet().contains(ProjectEncryptionKeyMetadata.TYPE) == false) {
+                return;
+            }
+            ProjectEncryptionKeyMetadata curr = event.state().metadata().getSingleProjectCustom(ProjectEncryptionKeyMetadata.TYPE);
+            if (curr == null) {
+                return;
+            }
+            ProjectEncryptionKeyMetadata prev = event.previousState().metadata().getSingleProjectCustom(ProjectEncryptionKeyMetadata.TYPE);
+            Set<String> prevKeys = prev != null ? prev.getKeys().keySet() : Set.of();
+            var diff = Sets.difference(curr.getKeys().keySet(), prevKeys);
+            if (!diff.isEmpty()) {
+                keyAddEvents.add(diff.size());
+            }
+        });
         ensureGreen();
+        // Wait for first PEK install
         assertBusy(() -> assertThat(metadataOnMaster(), notNullValue()));
     }
 
@@ -159,12 +182,13 @@ public class KeyRotationIT extends SecurityIntegTestCase {
         }
     }
 
-    public void testInitialInstallProducesSingleActiveKeyWithEmptyHandlerProgress() {
-        ProjectEncryptionKeyMetadata metadata = metadataOnMaster();
-        assertThat(metadata, notNullValue());
-        assertThat("install should produce exactly one key", metadata.getKeys().keySet(), hasSize(1));
-        assertThat("the single installed key must be the active one", metadata.getKeys().keySet(), hasItem(metadata.getActiveKeyId()));
-        assertThat("no handlers are registered in this IT, so handlerKeyIds must be empty", metadata.getHandlerKeyIds(), anEmptyMap());
+    public void testEachInstallOrRotationAddsExactlyOneNewKey() throws Exception {
+        // Wait for two install or rotation events
+        assertBusy(() -> assertThat(keyAddEvents, hasSize(greaterThanOrEqualTo(2))), 30, TimeUnit.SECONDS);
+        for (int count : keyAddEvents) {
+            assertThat("each install or rotation must add exactly one key", count, equalTo(1));
+        }
+        assertThat("no handlers registered, handlerKeyIds must be empty", metadataOnMaster().getHandlerKeyIds(), anEmptyMap());
     }
 
     public void testRotationCycleWithNoHandlers() throws Exception {


### PR DESCRIPTION
Resolves: https://github.com/elastic/elasticsearch/issues/150725

`testInitialInstallProducesSingleActiveKeyWithEmptyHandlerProgress` had a race condition if a rotation happened before the test checked that exactly one key was installed. 

I've changed the approach to use a listener that registers each key change event and makes sure only a single key was added. This event can be an install or a rotation depending on if the listener is registered before or after the first install happens. 