### PR TITLE
[Test] Unmute tests whose GitHub issues have been closed

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -41,24 +41,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
   method: test {csv-spec:spatial.convertFromStringParseError}
   issue: https://github.com/elastic/elasticsearch/issues/139213
-- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecForceStoredLoadingIT
-  method: test {csv-spec:boolean.convertFromIntAndLong}
-  issue: https://github.com/elastic/elasticsearch/issues/141375
-- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecForceStoredLoadingIT
-  method: test {csv-spec:keep.whereWithEvalGeneratedValue}
-  issue: https://github.com/elastic/elasticsearch/issues/141375
-- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecForceStoredLoadingIT
-  method: test {csv-spec:topN.sortingOnNumbersFromStrings}
-  issue: https://github.com/elastic/elasticsearch/issues/141375
-- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecForceStoredLoadingIT
-  method: test {csv-spec:drop.whereWithEvalGeneratedValue_DropHeight}
-  issue: https://github.com/elastic/elasticsearch/issues/141375
-- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecForceStoredLoadingIT
-  method: test {csv-spec:rename.renameIntertwinedWithSort}
-  issue: https://github.com/elastic/elasticsearch/issues/141375
-- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecForceStoredLoadingIT
-  method: test {csv-spec:ints.convertStringToBaseIndexGroup7}
-  issue: https://github.com/elastic/elasticsearch/issues/141375
 - class: org.elasticsearch.xpack.analytics.cumulativecardinality.CumulativeCardinalityAggregatorTests
   method: testSimple
   issue: https://github.com/elastic/elasticsearch/issues/142408
@@ -92,9 +74,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
   method: test {csv-spec:spatial_shapes.convertFromStringParseError}
   issue: https://github.com/elastic/elasticsearch/issues/144672
-- class: org.elasticsearch.xpack.transform.transforms.ClientTransformIndexerTests
-  method: testDisablePitWhenCrossProjectSearchIsEnabled
-  issue: https://github.com/elastic/elasticsearch/issues/144822
 - class: org.elasticsearch.action.admin.indices.diskusage.IndexDiskUsageAnalyzerTests
   method: testKnnVectors
   issue: https://github.com/elastic/elasticsearch/issues/145377
@@ -104,9 +83,6 @@ tests:
 - class: org.elasticsearch.xpack.autoscaling.storage.ReactiveStorageIT
   method: testScaleWhileShrinking
   issue: https://github.com/elastic/elasticsearch/issues/145669
-- class: org.elasticsearch.cluster.routing.allocation.decider.WriteLoadConstraintDeciderIT
-  method: testAverageWriteLoadMetricIsPublished
-  issue: https://github.com/elastic/elasticsearch/issues/145855
 - class: org.elasticsearch.xpack.esql.action.CrossClusterQueryAllCombinationsSkipUnavailableIT
   method: test
   issue: https://github.com/elastic/elasticsearch/issues/145884
@@ -125,12 +101,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
   method: test {csv-spec:lookup-join.mvKeywordFieldJoinWarningsFromLeftSide}
   issue: https://github.com/elastic/elasticsearch/issues/145904
-- class: org.elasticsearch.xpack.sql.qa.jdbc.single_node.SingleNodeJdbcWarningsIT
-  method: testSingleDeprecationWarning
-  issue: https://github.com/elastic/elasticsearch/issues/145933
-- class: org.elasticsearch.xpack.sql.qa.jdbc.single_node.SingleNodeJdbcResultSetIT
-  method: testGettingValidNumbersWithCastingFromUnsignedLong
-  issue: https://github.com/elastic/elasticsearch/issues/145934
 - class: org.elasticsearch.action.RejectionActionIT
   method: testSimulatedSearchRejectionLoad
   issue: https://github.com/elastic/elasticsearch/issues/146022
@@ -143,15 +113,9 @@ tests:
 - class: org.elasticsearch.cluster.remote.test.RemoteClustersIT
   method: testHAProxyModeConnectionWorks
   issue: https://github.com/elastic/elasticsearch/issues/139171
-- class: org.elasticsearch.xpack.entsearch.EnterpriseSearchRestIT
-  method: test {p0=entsearch/rules/40_rule_query_search/Perform a rule query with an organic query that must be rewritten to another query type}
-  issue: https://github.com/elastic/elasticsearch/issues/146106
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativePromQLIT
   method: test
   issue: https://github.com/elastic/elasticsearch/issues/146923
-- class: org.elasticsearch.xpack.eql.qa.ccs_rolling_upgrade.EqlCcsRollingUpgradeIT
-  method: testSequences
-  issue: https://github.com/elastic/elasticsearch/issues/146263
 - class: org.elasticsearch.cluster.routing.allocation.decider.WriteLoadConstraintDeciderIT
   method: testMaxQueueLatencyMetricIsPublished
   issue: https://github.com/elastic/elasticsearch/issues/146283
@@ -161,39 +125,18 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
   method: test {csv-spec:stats.sumAsSurrogateWithOverflowGroupingRow}
   issue: https://github.com/elastic/elasticsearch/issues/146376
-- class: org.elasticsearch.xpack.esql.qa.single_node.RestEsqlIT
-  method: testForceSleepsProfile {SYNC}
-  issue: https://github.com/elastic/elasticsearch/issues/146377
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=mget/60_realtime_refresh/Realtime Refresh}
   issue: https://github.com/elastic/elasticsearch/issues/146410
-- class: org.elasticsearch.lucene.FullClusterRestartSystemIndexCompatibilityIT
-  method: testAsyncSearchIndexMigration {p0=9.5.0}
-  issue: https://github.com/elastic/elasticsearch/issues/146848
-- class: org.elasticsearch.lucene.FullClusterRestartSystemIndexCompatibilityIT
-  method: testAsyncSearchIndexMigration {p0=8.19.0}
-  issue: https://github.com/elastic/elasticsearch/issues/146849
 - class: org.elasticsearch.xpack.ml.integration.DatafeedJobsIT
   method: testStopLookback_forceTrue_closeJobFalse
   issue: https://github.com/elastic/elasticsearch/issues/146955
-- class: org.elasticsearch.index.mapper.KeywordOffsetDocValuesLoaderTests
-  method: testOffsetArrayRandomHighCardinality
-  issue: https://github.com/elastic/elasticsearch/issues/147085
-- class: org.elasticsearch.index.mapper.IpOffsetDocValuesLoaderTests
-  method: testOffsetArrayRandomHighCardinality
-  issue: https://github.com/elastic/elasticsearch/issues/147086
-- class: org.elasticsearch.xpack.esql.tree.EsqlNodeSubclassTests
-  method: testReplaceChildren {class org.elasticsearch.xpack.esql.plan.physical.ExchangeSinkExec}
-  issue: https://github.com/elastic/elasticsearch/issues/147164
 - class: org.elasticsearch.xpack.prometheus.PrometheusMetadataRestIT
   method: testMultipleEntriesForSameMetricAcrossStreams
   issue: https://github.com/elastic/elasticsearch/issues/147170
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=search.vectors/41_knn_search_byte_quantized_bfloat16/KNN Vector similarity search only}
   issue: https://github.com/elastic/elasticsearch/issues/147251
-- class: org.elasticsearch.xpack.core.transform.transforms.pivot.ScriptConfigTests
-  method: testFromXContent
-  issue: https://github.com/elastic/elasticsearch/issues/147543
 - class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecForceStoredLoadingIT
   method: test {csv-spec:fuse.fuseWithRowLinearAndMultiValueGroupColumn}
   issue: https://github.com/elastic/elasticsearch/issues/147613
@@ -206,9 +149,6 @@ tests:
 - class: org.elasticsearch.compute.aggregation.blockhash.BlockHashRandomizedTests
   method: testWithCranky {forcePackedHash=false groups=2 maxValuesPerPosition=1 dups=0 allowedTypes=[Basic[elementType=LONG], Basic[elementType=INT]]}
   issue: https://github.com/elastic/elasticsearch/issues/147732
-- class: org.elasticsearch.search.suggest.completion.CategoryQueryContextTests
-  method: testNullCategoryIsIllegal
-  issue: https://github.com/elastic/elasticsearch/issues/147762
 - class: org.elasticsearch.xpack.esql.expression.function.scalar.spatial.StSimplifyPreserveTopologyTests
   method: testEvaluateBlockWithNulls
   issue: https://github.com/elastic/elasticsearch/issues/147773
@@ -274,18 +214,9 @@ tests:
 - class: org.elasticsearch.xpack.stateless.cache.SearchCommitPrefetcherIT
   method: testForceCommitPrefetch
   issue: https://github.com/elastic/elasticsearch/issues/147847
-- class: org.elasticsearch.xpack.stateless.engine.RefreshNodeCreditManagerTests
-  method: testPeriodicWarning
-  issue: https://github.com/elastic/elasticsearch-serverless/issues/6518
 - class: org.elasticsearch.backwards.RareTermsIT
   method: testSingleValuedString
   issue: https://github.com/elastic/elasticsearch/issues/147853
-- class: org.elasticsearch.search.internal.CancellableBulkScorerTests
-  method: testIntervalGrowsGeometrically
-  issue: https://github.com/elastic/elasticsearch/issues/147872
-- class: org.elasticsearch.xpack.stateless.StatelessMergeIT
-  method: testOnlyForceMergesAreAllowedDuringRelocation
-  issue: https://github.com/elastic/elasticsearch/issues/147880
 - class: org.elasticsearch.xpack.stateless.StatelessHollowIndexShardsIT
   method: testDataStreamStatsActionBroadcastedToSearchNodesOnly
   issue: https://github.com/elastic/elasticsearch/issues/147973
@@ -304,21 +235,12 @@ tests:
 - class: org.elasticsearch.xpack.stateless.StatelessHollowIndexShardsIT
   method: testStressWithRelocationFailures
   issue: https://github.com/elastic/elasticsearch/issues/148129
-- class: org.elasticsearch.xpack.stateless.StatelessRealTimeTermVectorsIT
-  method: testDocsNotInLiveVersionMapDoNotRefresh
-  issue: https://github.com/elastic/elasticsearch/issues/148138
-- class: org.elasticsearch.index.engine.LuceneChangesSnapshotTests
-  method: testUpdateAndReadChangesConcurrently
-  issue: https://github.com/elastic/elasticsearch/issues/148145
 - class: org.elasticsearch.index.codec.vectors.cluster.HierarchicalKMeansTests
   method: testHKmeans
   issue: https://github.com/elastic/elasticsearch/issues/147482
 - class: org.elasticsearch.xpack.stateless.reshard.StatelessReshardIT
   method: testTermVectorsApiRealtimeGet
   issue: https://github.com/elastic/elasticsearch/issues/148175
-- class: org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsIntegTests
-  method: testCreateAndRestoreSearchableSnapshot
-  issue: https://github.com/elastic/elasticsearch/issues/148217
 - class: org.elasticsearch.xpack.stateless.allocation.EstimatedHeapUsageAllocationDeciderIT
   method: testEstimatedHeapHighWatermarkMonitorTriggersReroute
   issue: https://github.com/elastic/elasticsearch/issues/148246
@@ -331,9 +253,6 @@ tests:
 - class: org.elasticsearch.index.mapper.DateRangeDocValuesLoaderTests
   method: testEmptyRangesAppendsNull
   issue: https://github.com/elastic/elasticsearch/issues/148378
-- class: org.elasticsearch.xpack.stateless.cache.SearchCommitPrefetcherIT
-  method: testCommitPrefetching
-  issue: https://github.com/elastic/elasticsearch/issues/148476
 - class: org.elasticsearch.compute.data.BlockAccountingTests
   method: testBytesRefVector
   issue: https://github.com/elastic/elasticsearch/issues/148481
@@ -349,12 +268,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.multi_node.GenerativeUnmappedLoadIT
   method: test
   issue: https://github.com/elastic/elasticsearch/issues/148619
-- class: org.elasticsearch.xpack.stateless.commits.IndexCommitTimestampFieldRangeTests
-  method: testFieldValueRangeForBatchedCompoundCommit
-  issue: https://github.com/elastic/elasticsearch/issues/148961
-- class: org.elasticsearch.xpack.stateless.snapshots.StatelessSnapshotIT
-  method: testSnapshotFailsCleanlyWhenShardClosesDuringDisconnect
-  issue: https://github.com/elastic/elasticsearch/issues/149032
 - class: org.elasticsearch.packaging.test.BootstrapCheckTests
   method: test20RunWithBootstrapChecks
   issue: https://github.com/elastic/elasticsearch/issues/149040
@@ -367,33 +280,12 @@ tests:
 - class: org.elasticsearch.xpack.stateless.StatelessCommitServiceIT
   method: testRetainCommitForReadersAfterShardMovedAway
   issue: https://github.com/elastic/elasticsearch/issues/149083
-- class: org.elasticsearch.xpack.esql.qa.csv.CsvFormatSpecIT
-  method: test {csv-spec:csv-headerless.multiFileHeaderlessReadSchemaPreventsTypeDrift [LOCAL]}
-  issue: https://github.com/elastic/elasticsearch/issues/149126
-- class: org.elasticsearch.xpack.esql.qa.csv.CsvFormatSpecIT
-  method: test {csv-spec:csv-union-by-name.multiFileUnionByNameRecipe [LOCAL]}
-  issue: https://github.com/elastic/elasticsearch/issues/149127
 - class: org.elasticsearch.xpack.stateless.cache.SharedBlobCacheWarmingServiceIT
   method: testSearchShardShouldRecoverWhenWarmingFailsOnGetConnection
   issue: https://github.com/elastic/elasticsearch/issues/149195
-- class: org.elasticsearch.xpack.stateless.snapshots.StatelessSnapshotStressTestsIT
-  method: testRandomActivitiesStatelessSnapshotEnabled
-  issue: https://github.com/elastic/elasticsearch/issues/149215
 - class: org.elasticsearch.xpack.esql.optimizer.rules.logical.local.ReplaceDateTruncBucketWithRoundToTests
   method: testRightClosedBucketIsNotSubstituted
   issue: https://github.com/elastic/elasticsearch/issues/149133
-- class: org.elasticsearch.xpack.inference.action.filter.ShardBulkInferenceActionFilterIT
-  method: testSemanticTextItemFailures {useLegacyFormat=false useSyntheticSource=false}
-  issue: https://github.com/elastic/elasticsearch/issues/149250
-- class: org.elasticsearch.xpack.inference.action.filter.ShardBulkInferenceActionFilterIT
-  method: testSemanticTextItemFailures {useLegacyFormat=false useSyntheticSource=true}
-  issue: https://github.com/elastic/elasticsearch/issues/149251
-- class: org.elasticsearch.index.codec.vectors.diskbbq.ES920DiskBBQVectorsFormatTests
-  method: testOneRepeatedVector
-  issue: https://github.com/elastic/elasticsearch/issues/149254
-- class: org.elasticsearch.ingest.geoip.GeoIpDownloaderCliIT
-  method: testIpLocationServiceLifecycle
-  issue: https://github.com/elastic/elasticsearch/issues/149284
 - class: org.elasticsearch.compute.operator.exchange.ExchangeServiceTests
   method: testBasic
   issue: https://github.com/elastic/elasticsearch/issues/149338
@@ -740,18 +632,9 @@ tests:
 - class: org.elasticsearch.indices.memory.breaker.HierarchyCircuitBreakerTelemetryIT
   method: testCircuitBreakerTripCountMetric
   issue: https://github.com/elastic/elasticsearch/issues/150700
-- class: org.elasticsearch.index.IndexingPressureIT
-  method: testWritesWillSucceedIfBelowThreshold
-  issue: https://github.com/elastic/elasticsearch/issues/150701
-- class: org.elasticsearch.index.IndexingPressureIT
-  method: testWriteCanRejectOnReplicaBasedOnMaxDocumentSize
-  issue: https://github.com/elastic/elasticsearch/issues/150703
 - class: org.elasticsearch.xpack.esql.qa.ndjson.NdJsonCompressedFormatSpecIT
   method: test {csv-spec:external-basic.fileMetadataWildcardKeepExcludesVirtualColumns [ndjson.zst/S3]}
   issue: https://github.com/elastic/elasticsearch/issues/150705
-- class: org.elasticsearch.index.IndexingPressureIT
-  method: testUpdatePreparedExpansionRejectedWhenExceedingPrimaryLimit
-  issue: https://github.com/elastic/elasticsearch/issues/150706
 - class: org.elasticsearch.xpack.stateless.reshard.StatelessReshardDisruptionIT
   method: testReshardWithDisruption
   issue: https://github.com/elastic/elasticsearch/issues/150708


### PR DESCRIPTION
The following tests have been unmuted because their tracking issues are now closed:

  • EsqlSpecForceStoredLoadingIT.test {csv-spec:boolean.convertFromIntAndLong} — #141375
  • EsqlSpecForceStoredLoadingIT.test {csv-spec:keep.whereWithEvalGeneratedValue} — #141375
  • EsqlSpecForceStoredLoadingIT.test {csv-spec:topN.sortingOnNumbersFromStrings} — #141375
  • EsqlSpecForceStoredLoadingIT.test {csv-spec:drop.whereWithEvalGeneratedValue_DropHeight} — #141375
  • EsqlSpecForceStoredLoadingIT.test {csv-spec:rename.renameIntertwinedWithSort} — #141375
  • EsqlSpecForceStoredLoadingIT.test {csv-spec:ints.convertStringToBaseIndexGroup7} — #141375
  • ClientTransformIndexerTests.testDisablePitWhenCrossProjectSearchIsEnabled — #144822
  • WriteLoadConstraintDeciderIT.testAverageWriteLoadMetricIsPublished — #145855
  • SingleNodeJdbcWarningsIT.testSingleDeprecationWarning — #145933
  • SingleNodeJdbcResultSetIT.testGettingValidNumbersWithCastingFromUnsignedLong — #145934
  • EnterpriseSearchRestIT.test {p0=entsearch/rules/40_rule_query_search/Perform a rule query with an organic query that must be rewritten to another query type} — #146106
  • EqlCcsRollingUpgradeIT.testSequences — #146263
  • RestEsqlIT.testForceSleepsProfile {SYNC} — #146377
  • FullClusterRestartSystemIndexCompatibilityIT.testAsyncSearchIndexMigration {p0=9.5.0} — #146848
  • FullClusterRestartSystemIndexCompatibilityIT.testAsyncSearchIndexMigration {p0=8.19.0} — #146849
  • KeywordOffsetDocValuesLoaderTests.testOffsetArrayRandomHighCardinality — #147085
  • IpOffsetDocValuesLoaderTests.testOffsetArrayRandomHighCardinality — #147086
  • EsqlNodeSubclassTests.testReplaceChildren {class org.elasticsearch.xpack.esql.plan.physical.ExchangeSinkExec} — #147164
  • ScriptConfigTests.testFromXContent — #147543
  • CategoryQueryContextTests.testNullCategoryIsIllegal — #147762
  • CancellableBulkScorerTests.testIntervalGrowsGeometrically — #147872
  • StatelessMergeIT.testOnlyForceMergesAreAllowedDuringRelocation — #147880
  • StatelessRealTimeTermVectorsIT.testDocsNotInLiveVersionMapDoNotRefresh — #148138
  • LuceneChangesSnapshotTests.testUpdateAndReadChangesConcurrently — #148145
  • SearchableSnapshotsIntegTests.testCreateAndRestoreSearchableSnapshot — #148217
  • SearchCommitPrefetcherIT.testCommitPrefetching — #148476
  • IndexCommitTimestampFieldRangeTests.testFieldValueRangeForBatchedCompoundCommit — #148961
  • StatelessSnapshotIT.testSnapshotFailsCleanlyWhenShardClosesDuringDisconnect — #149032
  • CsvFormatSpecIT.test {csv-spec:csv-headerless.multiFileHeaderlessReadSchemaPreventsTypeDrift [LOCAL]} — #149126
  • CsvFormatSpecIT.test {csv-spec:csv-union-by-name.multiFileUnionByNameRecipe [LOCAL]} — #149127
  • StatelessSnapshotStressTestsIT.testRandomActivitiesStatelessSnapshotEnabled — #149215
  • ShardBulkInferenceActionFilterIT.testSemanticTextItemFailures {useLegacyFormat=false useSyntheticSource=false} — #149250
  • ShardBulkInferenceActionFilterIT.testSemanticTextItemFailures {useLegacyFormat=false useSyntheticSource=true} — #149251
  • ES920DiskBBQVectorsFormatTests.testOneRepeatedVector — #149254
  • GeoIpDownloaderCliIT.testIpLocationServiceLifecycle — #149284
  • IndexingPressureIT.testWritesWillSucceedIfBelowThreshold — #150701
  • IndexingPressureIT.testWriteCanRejectOnReplicaBasedOnMaxDocumentSize — #150703
  • IndexingPressureIT.testUpdatePreparedExpansionRejectedWhenExceedingPrimaryLimit — #150706
  • RefreshNodeCreditManagerTests.testPeriodicWarning — elastic/elasticsearch-serverless#6518

Made with Cursor.