### PR TITLE
Fix delay in KeyRotationCoordinator during password rotation

### DIFF
--- a/x-pack/plugin/encryption/src/main/java/org/elasticsearch/xpack/encryption/KeyRotationCoordinator.java
+++ b/x-pack/plugin/encryption/src/main/java/org/elasticsearch/xpack/encryption/KeyRotationCoordinator.java
@@ -208,9 +208,21 @@ class KeyRotationCoordinator implements LocalNodeMasterListener, Closeable {
 
     /**
      * Re-binds the coordinator to the password material in {@code settings} (after a secure-settings reload).
+     * Immediately schedules a password-id check on the generic thread pool to avoid a listener-ordering race where
+     * {@link #onClusterStateChanged} fires before the reload updates {@code cachedSettings}, causing the mismatch
+     * to go undetected until the next periodic tick.
      */
     void reload(Settings settings) {
         this.cachedSettings = ProjectEncryptionKeyPasswordSettings.cloneSettings(settings);
+        threadPool.generic().execute(() -> {
+            if (closed) return;
+            ClusterState state = clusterService.state();
+            if (state.blocks().hasGlobalBlock(GatewayService.STATE_NOT_RECOVERED_BLOCK)
+                || state.nodes().isLocalNodeElectedMaster() == false) {
+                return;
+            }
+            checkPasswordId(getCurrentMetadata(state), state);
+        });
     }
 
     @Override
@@ -239,10 +251,15 @@ class KeyRotationCoordinator implements LocalNodeMasterListener, Closeable {
         if (event.localNodeMaster() == false) {
             return;
         }
+        checkPasswordId(getCurrentMetadata(state), state);
+    }
 
-        ProjectEncryptionKeyMetadata metadata = getCurrentMetadata(state);
+    /**
+     * Checks whether the active password id in {@code cachedSettings} matches the one persisted in {@code metadata}, and schedules an
+     * install or password rotation if not.
+     */
+    private void checkPasswordId(@Nullable ProjectEncryptionKeyMetadata metadata, ClusterState state) {
         String activePasswordId = ProjectEncryptionKeyPasswordSettings.getActivePasswordId(cachedSettings);
-
         if (metadata == null) {
             // Install runs only if (a) all nodes support PEK, and (b) the operator has configured an active password the master can use
             // to wrap the initial key.
@@ -251,10 +268,27 @@ class KeyRotationCoordinator implements LocalNodeMasterListener, Closeable {
             }
             return;
         }
-
         // Password rotation: same plaintext PEK material, re-wrapped under a new password.
         if (activePasswordId != null && activePasswordId.equals(metadata.getPasswordId()) == false) {
             schedulePasswordRotation(metadata, activePasswordId);
+        }
+    }
+
+    /**
+     * Drives time-based key rotation (begin a new rotation if due) and retirement of expired non-active keys.
+     */
+    private void advanceKeyLifecycle(ProjectEncryptionKeyMetadata metadata, long now) {
+        if (rotationDisabled()) {
+            return;
+        }
+        long activeKeyAge = now - metadata.getGeneratedAt(metadata.getActiveKeyId());
+        if (activeKeyAge >= rotationInterval.millis()) {
+            logger.info("project encryption key due for rotation (active key generated {} ago)", TimeValue.timeValueMillis(activeKeyAge));
+            submitBeginRotation(metadata);
+        }
+        long retireCutoff = now - GRACE_TICKS * checkInterval.millis();
+        if (metadata.findRetireableKeyIds(retireCutoff).isEmpty() == false) {
+            submitRetireKeys(retireCutoff);
         }
     }
 
@@ -286,38 +320,14 @@ class KeyRotationCoordinator implements LocalNodeMasterListener, Closeable {
         if (state.blocks().hasGlobalBlock(GatewayService.STATE_NOT_RECOVERED_BLOCK) || state.nodes().isLocalNodeElectedMaster() == false) {
             return;
         }
-
         ProjectEncryptionKeyMetadata metadata = getCurrentMetadata(state);
-        String activePasswordId = ProjectEncryptionKeyPasswordSettings.getActivePasswordId(cachedSettings);
-
+        checkPasswordId(metadata, state);
         if (metadata == null) {
-            if (activePasswordId != null && checkPekFeatureAvailable(state)) {
-                scheduleInstall(activePasswordId);
-            }
             return;
         }
-
         long now = threadPool.absoluteTimeInMillis();
         rotate(metadata, now);
-
-        if (activePasswordId != null && activePasswordId.equals(metadata.getPasswordId()) == false) {
-            schedulePasswordRotation(metadata, activePasswordId);
-        }
-
-        if (rotationDisabled()) {
-            return;
-        }
-
-        long activeKeyAge = now - metadata.getGeneratedAt(metadata.getActiveKeyId());
-        if (activeKeyAge >= rotationInterval.millis()) {
-            logger.info("project encryption key due for rotation (active key generated {} ago)", TimeValue.timeValueMillis(activeKeyAge));
-            submitBeginRotation(metadata);
-        }
-
-        long retireCutoff = now - GRACE_TICKS * checkInterval.millis();
-        if (metadata.findRetireableKeyIds(retireCutoff).isEmpty() == false) {
-            submitRetireKeys(retireCutoff);
-        }
+        advanceKeyLifecycle(metadata, now);
     }
 
     private void rotate(ProjectEncryptionKeyMetadata metadata, long now) {

--- a/x-pack/plugin/encryption/src/main/java/org/elasticsearch/xpack/encryption/KeyRotationCoordinator.java
+++ b/x-pack/plugin/encryption/src/main/java/org/elasticsearch/xpack/encryption/KeyRotationCoordinator.java
@@ -221,7 +221,7 @@ class KeyRotationCoordinator implements LocalNodeMasterListener, Closeable {
                 || state.nodes().isLocalNodeElectedMaster() == false) {
                 return;
             }
-            checkPasswordId(getCurrentMetadata(state), state);
+            checkPasswordId(state);
         });
     }
 
@@ -251,14 +251,15 @@ class KeyRotationCoordinator implements LocalNodeMasterListener, Closeable {
         if (event.localNodeMaster() == false) {
             return;
         }
-        checkPasswordId(getCurrentMetadata(state), state);
+        checkPasswordId(state);
     }
 
     /**
      * Checks whether the active password id in {@code cachedSettings} matches the one persisted in {@code metadata}, and schedules an
      * install or password rotation if not.
      */
-    private void checkPasswordId(@Nullable ProjectEncryptionKeyMetadata metadata, ClusterState state) {
+    private void checkPasswordId(ClusterState state) {
+        var metadata = getCurrentMetadata(state);
         String activePasswordId = ProjectEncryptionKeyPasswordSettings.getActivePasswordId(cachedSettings);
         if (metadata == null) {
             // Install runs only if (a) all nodes support PEK, and (b) the operator has configured an active password the master can use
@@ -320,8 +321,9 @@ class KeyRotationCoordinator implements LocalNodeMasterListener, Closeable {
         if (state.blocks().hasGlobalBlock(GatewayService.STATE_NOT_RECOVERED_BLOCK) || state.nodes().isLocalNodeElectedMaster() == false) {
             return;
         }
+        checkPasswordId(state);
+
         ProjectEncryptionKeyMetadata metadata = getCurrentMetadata(state);
-        checkPasswordId(metadata, state);
         if (metadata == null) {
             return;
         }

--- a/x-pack/plugin/encryption/src/test/java/org/elasticsearch/xpack/encryption/KeyRotationCoordinatorTests.java
+++ b/x-pack/plugin/encryption/src/test/java/org/elasticsearch/xpack/encryption/KeyRotationCoordinatorTests.java
@@ -267,7 +267,7 @@ public class KeyRotationCoordinatorTests extends ESTestCase {
         );
     }
 
-    public void testTickInstallsKeyAfterReloadActivatesPasswordWithoutClusterStateChange() {
+    public void testReloadImmediatelyTriggersInstallWhenActivePasswordActivated() {
         FeatureService featureService = mock(FeatureService.class);
         when(featureService.clusterHasFeature(any(), any())).thenReturn(true);
         // Construct with empty settings: no active password is configured, so the listener path cannot install yet.
@@ -282,12 +282,11 @@ public class KeyRotationCoordinatorTests extends ESTestCase {
         );
 
         coordinator.reload(settingsWithActivePassword());
-        coordinator.tick();
 
         verify(taskQueue).submitTask(eq("install-project-encryption-key"), isA(KeyRotationCoordinator.InstallKeyTask.class), any());
     }
 
-    public void testTickRotatesPasswordAfterReloadWithoutClusterStateChange() {
+    public void testReloadImmediatelyTriggersPasswordRotationWhenActivePasswordIdChanges() {
         FeatureService featureService = mock(FeatureService.class);
         when(featureService.clusterHasFeature(any(), any())).thenReturn(true);
 
@@ -307,7 +306,38 @@ public class KeyRotationCoordinatorTests extends ESTestCase {
         rotated.setString(ProjectEncryptionKeyPasswordSettings.PASSWORD_PREFIX + "v2", "new-password-fips");
         coordinator.reload(Settings.builder().setSecureSettings(rotated).build());
 
-        coordinator.tick();
+        verify(taskQueue).submitTask(
+            eq("rotate-project-encryption-key-password"),
+            isA(KeyRotationCoordinator.RotatePasswordTask.class),
+            any()
+        );
+    }
+
+    public void testReloadTriggersRotationAfterOnClusterStateChangedFiredWithStaleSettings() {
+        FeatureService featureService = mock(FeatureService.class);
+        when(featureService.clusterHasFeature(any(), any())).thenReturn(true);
+
+        // Pre-wrap a key under PASSWORD_ID so the rewrap path has something real to unwrap.
+        byte[] plaintextKey = randomKey();
+        ProjectEncryptionKeyMetadata.KeyEntry wrappedEntry = new ProjectEncryptionKeyMetadata.KeyEntry(
+            PasswordBasedEncryption.wrap(plaintextKey, PASSWORD_ID, PASSWORD_VALUE.toCharArray()).payload(),
+            0L
+        );
+        ProjectEncryptionKeyMetadata existing = new ProjectEncryptionKeyMetadata(Map.of("k1", wrappedEntry), "k1", PASSWORD_ID);
+        ClusterState state = clusterStateWith(existing, true);
+        // Coordinator starts with v1 as active — matching the metadata, so no rotation yet.
+        setup(state, 0L, TimeValue.timeValueDays(30), TimeValue.timeValueMinutes(1), featureService);
+
+        // onClusterStateChanged fires first while cachedSettings still reflects the old active password (v1).
+        coordinator.onClusterStateChanged(new ClusterChangedEvent("test", state, clusterStateWith(null, true)));
+        verify(taskQueue, never()).submitTask(anyString(), any(), any());
+
+        // reload() now delivers new settings (v2 active). It must immediately detect the mismatch and submit the rotation.
+        MockSecureSettings rotated = new MockSecureSettings();
+        rotated.setString(ProjectEncryptionKeyPasswordSettings.ACTIVE_PASSWORD_ID_KEY, "v2");
+        rotated.setString(ProjectEncryptionKeyPasswordSettings.PASSWORD_PREFIX + PASSWORD_ID, PASSWORD_VALUE);
+        rotated.setString(ProjectEncryptionKeyPasswordSettings.PASSWORD_PREFIX + "v2", "new-password-fips");
+        coordinator.reload(Settings.builder().setSecureSettings(rotated).build());
 
         verify(taskQueue).submitTask(
             eq("rotate-project-encryption-key-password"),


### PR DESCRIPTION
Fixes a delay in KeyRotationCoordinator: 

I'm observing a delay of several minutes between a new active_password_id landing in file-settings and KeyRotationCoordinator submitting the rewrap.

Two back-to-back rotations:
```
cycle 1
  07:37:06   file-settings applied with new active_password_id = X1
  07:41:11   KeyRotationCoordinator: submitting password rotation [old] -> [X1]
             +4m05s
```
```
cycle 2
  07:46:34   file-settings applied with new active_password_id = X2
  07:49:47   KeyRotationCoordinator: submitting password rotation [X1] -> [X2]
             +3m13sClaude analysis is:
```

Neither came from the 1h tick(), both look bystander-triggered by later unrelated cluster-state events.

There is a listener-ordering race: on the cluster-state change that bumps cluster_secrets, KeyRotationCoordinator.onClusterStateChanged fires before ClusterStateSecretsListener has called KeyRotationCoordinator.reload(...), so it reads stale cachedSettings, sees no mismatch, no-op. reload only swaps cachedSettings, no re-evaluation, so the coordinator then waits for the next cluster-state event (worst case the 1h check_interval).