### PR TITLE
Add support for nested sliced queries in DenseVectorFieldMapper

### DIFF
--- a/qa/vector/src/main/java/org/elasticsearch/test/knn/KnnSearcher.java
+++ b/qa/vector/src/main/java/org/elasticsearch/test/knn/KnnSearcher.java
@@ -768,9 +768,9 @@ public class KnnSearcher {
                     filterQuery,
                     visitRatio,
                     doPrecondition,
+                    searchParameters.overSamplingFactor(),
                     PARTITION_ID_FIELD,
-                    partition,
-                    searchParameters.overSamplingFactor()
+                    partition
                 );
             } else {
                 knnQuery = new IVFKnnFloatVectorQuery(

--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
@@ -86,6 +86,7 @@ import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.lookup.Source;
 import org.elasticsearch.search.vectors.DenseVectorQuery;
+import org.elasticsearch.search.vectors.DiversifyingChildrenIVFKnnFloatSlicedVectorQuery;
 import org.elasticsearch.search.vectors.DiversifyingChildrenIVFKnnFloatVectorQuery;
 import org.elasticsearch.search.vectors.DiversifyingParentBlockQuery;
 import org.elasticsearch.search.vectors.ESDiversifyingChildrenByteKnnVectorQuery;
@@ -3329,23 +3330,34 @@ public class DenseVectorFieldMapper extends FieldMapper {
                 float defaultVisitRatio = (float) (bbqIndexOptions.defaultVisitPercentage / 100d);
                 float visitRatio = visitPercentage == null ? defaultVisitRatio : (float) (visitPercentage / 100d);
                 float overSampleFactor = rescore ? oversample : 1.0f;
-                if (sliceEnabled && parentFilter != null) {
-                    throw new IllegalArgumentException("[" + SliceIndexing.PARAM_NAME + "] is not supported for nested KNN queries");
-                }
-                final String singleSliceRouting = parentFilter == null ? extractSingleSliceRouting(sliceRouting, sliceEnabled) : null;
+                final String singleSliceRouting = extractSingleSliceRouting(sliceRouting, sliceEnabled);
                 if (singleSliceRouting != null) {
-                    knnQuery = new IVFKnnFloatSlicedVectorQuery(
-                        name(),
-                        queryVector,
-                        adjustedK,
-                        numCands,
-                        filter,
-                        visitRatio,
-                        bbqIndexOptions.doPrecondition(),
-                        RoutingFieldMapper.NAME,
-                        new BytesRef(singleSliceRouting),
-                        overSampleFactor
-                    );
+                    knnQuery = parentFilter != null
+                        ? new DiversifyingChildrenIVFKnnFloatSlicedVectorQuery(
+                            name(),
+                            queryVector,
+                            adjustedK,
+                            numCands,
+                            filter,
+                            parentFilter,
+                            visitRatio,
+                            bbqIndexOptions.doPrecondition(),
+                            overSampleFactor,
+                            RoutingFieldMapper.NAME,
+                            new BytesRef(singleSliceRouting)
+                        )
+                        : new IVFKnnFloatSlicedVectorQuery(
+                            name(),
+                            queryVector,
+                            adjustedK,
+                            numCands,
+                            filter,
+                            visitRatio,
+                            bbqIndexOptions.doPrecondition(),
+                            overSampleFactor,
+                            RoutingFieldMapper.NAME,
+                            new BytesRef(singleSliceRouting)
+                        );
                 } else {
                     knnQuery = parentFilter != null
                         ? new DiversifyingChildrenIVFKnnFloatVectorQuery(

--- a/server/src/main/java/org/elasticsearch/search/vectors/DiversifyingChildrenIVFKnnFloatSlicedVectorQuery.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/DiversifyingChildrenIVFKnnFloatSlicedVectorQuery.java
@@ -32,9 +32,9 @@ public class DiversifyingChildrenIVFKnnFloatSlicedVectorQuery extends IVFKnnFloa
      * @param childFilter      filter applied to child hits
      * @param parentsFilter    bit set of parent documents for join diversification
      * @param visitRatio       IVF visit ratio
+     * @param overSampleFactor the oversample multiplier applied to the original k
      * @param sliceField       index-sort slice field (e.g. {@code _routing})
      * @param sliceId          slice term to restrict the search doc id space
-     * @param overSampleFactor the oversample multiplier applied to the original k
      */
     public DiversifyingChildrenIVFKnnFloatSlicedVectorQuery(
         String field,
@@ -45,11 +45,11 @@ public class DiversifyingChildrenIVFKnnFloatSlicedVectorQuery extends IVFKnnFloa
         BitSetProducer parentsFilter,
         float visitRatio,
         boolean doPrecondition,
+        float overSampleFactor,
         String sliceField,
-        BytesRef sliceId,
-        float overSampleFactor
+        BytesRef sliceId
     ) {
-        super(field, query, k, numCands, childFilter, visitRatio, doPrecondition, sliceField, sliceId, overSampleFactor);
+        super(field, query, k, numCands, childFilter, visitRatio, doPrecondition, overSampleFactor, sliceField, sliceId);
         this.parentsFilter = Objects.requireNonNull(parentsFilter);
     }
 

--- a/server/src/main/java/org/elasticsearch/search/vectors/IVFKnnFloatSlicedVectorQuery.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/IVFKnnFloatSlicedVectorQuery.java
@@ -42,9 +42,9 @@ public class IVFKnnFloatSlicedVectorQuery extends IVFKnnFloatVectorQuery {
      * @param numCands the number of nearest neighbors to gather per shard
      * @param filter the filter to apply to the results
      * @param visitRatio the ratio of vectors to score for the IVF search strategy
+     * @param overSampleFactor the oversample multiplier applied to the original k
      * @param sliceField the field used for slicing the index
      * @param sliceId the slice to be search
-     * @param overSampleFactor the oversample multiplier applied to the original k
      */
     public IVFKnnFloatSlicedVectorQuery(
         String field,
@@ -54,9 +54,9 @@ public class IVFKnnFloatSlicedVectorQuery extends IVFKnnFloatVectorQuery {
         Query filter,
         float visitRatio,
         boolean doPrecondition,
+        float overSampleFactor,
         String sliceField,
-        BytesRef sliceId,
-        float overSampleFactor
+        BytesRef sliceId
     ) {
         super(field, query, k, numCands, filter, visitRatio, doPrecondition, overSampleFactor);
         this.sliceField = Objects.requireNonNull(sliceField);

--- a/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldTypeTests.java
@@ -24,11 +24,11 @@ import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper.DenseVector
 import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper.VectorSimilarity;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.vectors.DenseVectorQuery;
+import org.elasticsearch.search.vectors.DiversifyingChildrenIVFKnnFloatSlicedVectorQuery;
 import org.elasticsearch.search.vectors.DiversifyingChildrenIVFKnnFloatVectorQuery;
 import org.elasticsearch.search.vectors.DiversifyingParentBlockQuery;
 import org.elasticsearch.search.vectors.ESKnnByteVectorQuery;
 import org.elasticsearch.search.vectors.ESKnnFloatVectorQuery;
-import org.elasticsearch.search.vectors.IVFKnnFloatSlicedVectorQuery;
 import org.elasticsearch.search.vectors.IVFKnnFloatVectorQuery;
 import org.elasticsearch.search.vectors.RescoreKnnVectorQuery;
 import org.elasticsearch.search.vectors.VectorData;
@@ -929,6 +929,7 @@ public class DenseVectorFieldTypeTests extends FieldTypeTestCase {
     }
 
     public void testBBQIVFUsesSlicedQueryForSingleSliceRouting() {
+        BitSetProducer parentFilter = random().nextBoolean() ? null : context -> null;
         DenseVectorFieldType fieldType = createBBQIVFFloatFieldType();
         Query query = fieldType.createKnnQuery(
             VectorData.fromFloats(testQueryVector(64)),
@@ -938,59 +939,22 @@ public class DenseVectorFieldTypeTests extends FieldTypeTestCase {
             null,
             null,
             null,
-            null,
+            parentFilter,
             randomFrom(DenseVectorFieldMapper.FilterHeuristic.values()),
             randomBoolean(),
             "s1"
         );
-        assertThat(query, instanceOf(IVFKnnFloatSlicedVectorQuery.class));
+        if (parentFilter == null) {
+            assertThat(query, instanceOf(IVFKnnFloatVectorQuery.class));
+        } else {
+            assertThat(query, instanceOf(DiversifyingChildrenIVFKnnFloatSlicedVectorQuery.class));
+        }
         assertThat(query.toString("ignored"), containsString("_routing=s1"));
     }
 
     public void testBBQIVFRejectsMissingSliceForKnnWhenSliceEnabled() {
+        BitSetProducer parentFilter = random().nextBoolean() ? null : context -> null;
         DenseVectorFieldType fieldType = createBBQIVFFloatFieldType();
-        IllegalArgumentException exception = expectThrows(
-            IllegalArgumentException.class,
-            () -> fieldType.createKnnQuery(
-                VectorData.fromFloats(testQueryVector(64)),
-                5,
-                10,
-                10f,
-                null,
-                null,
-                null,
-                null,
-                randomFrom(DenseVectorFieldMapper.FilterHeuristic.values()),
-                randomBoolean(),
-                true,
-                null
-            )
-        );
-        assertThat(exception.getMessage(), containsString("[_slice] is required for KNN queries when [index.slice.enabled] is true"));
-    }
-
-    public void testBBQIVFFallsBackWhenSliceRoutingMissingAndSliceDisabled() {
-        DenseVectorFieldType fieldType = createBBQIVFFloatFieldType();
-        Query query = fieldType.createKnnQuery(
-            VectorData.fromFloats(testQueryVector(64)),
-            5,
-            10,
-            10f,
-            null,
-            null,
-            null,
-            null,
-            randomFrom(DenseVectorFieldMapper.FilterHeuristic.values()),
-            randomBoolean(),
-            false,
-            null
-        );
-        assertThat(query, instanceOf(IVFKnnFloatVectorQuery.class));
-    }
-
-    public void testBBQIVFRejectsNestedSliceForKnn() {
-        DenseVectorFieldType fieldType = createBBQIVFFloatFieldType();
-        BitSetProducer parentFilter = context -> null;
         IllegalArgumentException exception = expectThrows(
             IllegalArgumentException.class,
             () -> fieldType.createKnnQuery(
@@ -1005,13 +969,38 @@ public class DenseVectorFieldTypeTests extends FieldTypeTestCase {
                 randomFrom(DenseVectorFieldMapper.FilterHeuristic.values()),
                 randomBoolean(),
                 true,
-                "s1"
+                null
             )
         );
-        assertThat(exception.getMessage(), containsString("[_slice] is not supported for nested KNN queries"));
+        assertThat(exception.getMessage(), containsString("[_slice] is required for KNN queries when [index.slice.enabled] is true"));
+    }
+
+    public void testBBQIVFFallsBackWhenSliceRoutingMissingAndSliceDisabled() {
+        BitSetProducer parentFilter = random().nextBoolean() ? null : context -> null;
+        DenseVectorFieldType fieldType = createBBQIVFFloatFieldType();
+        Query query = fieldType.createKnnQuery(
+            VectorData.fromFloats(testQueryVector(64)),
+            5,
+            10,
+            10f,
+            null,
+            null,
+            null,
+            parentFilter,
+            randomFrom(DenseVectorFieldMapper.FilterHeuristic.values()),
+            randomBoolean(),
+            false,
+            null
+        );
+        if (parentFilter == null) {
+            assertThat(query, instanceOf(IVFKnnFloatVectorQuery.class));
+        } else {
+            assertThat(query, instanceOf(DiversifyingChildrenIVFKnnFloatVectorQuery.class));
+        }
     }
 
     public void testBBQIVFRejectsBlankSliceForKnn() {
+        BitSetProducer parentFilter = random().nextBoolean() ? null : context -> null;
         DenseVectorFieldType fieldType = createBBQIVFFloatFieldType();
         IllegalArgumentException exception = expectThrows(
             IllegalArgumentException.class,
@@ -1023,7 +1012,7 @@ public class DenseVectorFieldTypeTests extends FieldTypeTestCase {
                 null,
                 null,
                 null,
-                null,
+                parentFilter,
                 randomFrom(DenseVectorFieldMapper.FilterHeuristic.values()),
                 randomBoolean(),
                 "   "
@@ -1033,6 +1022,7 @@ public class DenseVectorFieldTypeTests extends FieldTypeTestCase {
     }
 
     public void testBBQIVFRejectsSliceAllForKnn() {
+        BitSetProducer parentFilter = random().nextBoolean() ? null : context -> null;
         DenseVectorFieldType fieldType = createBBQIVFFloatFieldType();
         IllegalArgumentException exception = expectThrows(
             IllegalArgumentException.class,
@@ -1044,7 +1034,7 @@ public class DenseVectorFieldTypeTests extends FieldTypeTestCase {
                 null,
                 null,
                 null,
-                null,
+                parentFilter,
                 randomFrom(DenseVectorFieldMapper.FilterHeuristic.values()),
                 randomBoolean(),
                 "_all"
@@ -1054,6 +1044,7 @@ public class DenseVectorFieldTypeTests extends FieldTypeTestCase {
     }
 
     public void testBBQIVFRejectsMultiValueSliceForKnn() {
+        BitSetProducer parentFilter = random().nextBoolean() ? null : context -> null;
         DenseVectorFieldType fieldType = createBBQIVFFloatFieldType();
         IllegalArgumentException exception = expectThrows(
             IllegalArgumentException.class,
@@ -1065,7 +1056,7 @@ public class DenseVectorFieldTypeTests extends FieldTypeTestCase {
                 null,
                 null,
                 null,
-                null,
+                parentFilter,
                 randomFrom(DenseVectorFieldMapper.FilterHeuristic.values()),
                 randomBoolean(),
                 "s1,s2"

--- a/server/src/test/java/org/elasticsearch/search/vectors/DiversifyingChildrenIVFKnnFloatSlicedVectorQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/search/vectors/DiversifyingChildrenIVFKnnFloatSlicedVectorQueryTests.java
@@ -86,9 +86,9 @@ public class DiversifyingChildrenIVFKnnFloatSlicedVectorQueryTests extends Abstr
             parentBitSet,
             0,
             random().nextBoolean(),
+            1f,
             RoutingFieldMapper.NAME,
-            SLICE_ZERO,
-            1f
+            SLICE_ZERO
         );
     }
 
@@ -427,9 +427,9 @@ public class DiversifyingChildrenIVFKnnFloatSlicedVectorQueryTests extends Abstr
                             parents,
                             1.0f,
                             random().nextBoolean(),
+                            1f,
                             RoutingFieldMapper.NAME,
-                            new BytesRef("" + slice),
-                            1f
+                            new BytesRef("" + slice)
                         );
                         TopDocs topDocs = searcher.search(kvq, k);
                         assertEquals(expectedDocs, topDocs.scoreDocs.length);
@@ -450,9 +450,9 @@ public class DiversifyingChildrenIVFKnnFloatSlicedVectorQueryTests extends Abstr
                         parents,
                         1.0f,
                         random().nextBoolean(),
+                        1f,
                         RoutingFieldMapper.NAME,
-                        new BytesRef("invalid"),
-                        1f
+                        new BytesRef("invalid")
                     );
                     TopDocs topDocs = searcher.search(kvq, 3);
                     assertEquals(0, topDocs.scoreDocs.length);
@@ -480,9 +480,9 @@ public class DiversifyingChildrenIVFKnnFloatSlicedVectorQueryTests extends Abstr
             parent -> null,
             0.1f,
             false,
+            1f,
             RoutingFieldMapper.NAME,
-            SLICE_ZERO,
-            1f
+            SLICE_ZERO
         );
         assertEquals(
             "DiversifyingChildrenIVFKnnFloatSlicedVectorQuery:vec[0.5,...][4][" + RoutingFieldMapper.NAME + "=0]",

--- a/server/src/test/java/org/elasticsearch/search/vectors/IVFKnnFloatSlicedVectorQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/search/vectors/IVFKnnFloatSlicedVectorQueryTests.java
@@ -59,9 +59,9 @@ public class IVFKnnFloatSlicedVectorQueryTests extends AbstractIVFKnnVectorQuery
             queryFilter,
             visitRatio,
             random().nextBoolean(),
+            1.0f,
             SLICE_FIELD,
-            querySlice,
-            1.0f
+            querySlice
         );
     }
 
@@ -272,9 +272,9 @@ public class IVFKnnFloatSlicedVectorQueryTests extends AbstractIVFKnnVectorQuery
                             filterQuery,
                             1.0f,
                             random().nextBoolean(),
+                            1.0f,
                             SLICE_FIELD,
-                            new BytesRef("" + slice),
-                            1.0f
+                            new BytesRef("" + slice)
                         );
                         TopDocs topDocs = searcher.search(kvq, k);
                         assertEquals(expectedDocs, topDocs.scoreDocs.length);
@@ -294,9 +294,9 @@ public class IVFKnnFloatSlicedVectorQueryTests extends AbstractIVFKnnVectorQuery
                         filterQuery,
                         1.0f,
                         random().nextBoolean(),
+                        1.0f,
                         SLICE_FIELD,
-                        new BytesRef("invalid"),
-                        1.0f
+                        new BytesRef("invalid")
                     );
                     TopDocs topDocs = searcher.search(kvq, 3);
                     assertEquals(0, topDocs.scoreDocs.length);


### PR DESCRIPTION
Nested queries over sliced index are already supported but they were never wired to the mapper. This PR adds the plumbing.

I am refactoring a bit the parameters for sliced queries so the slice parameter is the last one. This is in preparation for supporting multiple slices.