### PR TITLE
[Inference API] Unmute and rename Mistral unified completion not-found test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -764,9 +764,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.ndjson.NdJsonCompressedFormatSpecIT
   method: test {csv-spec:external-basic.aggregateCount [ndjson.gz/S3]}
   issue: https://github.com/elastic/elasticsearch/issues/150710
-- class: org.elasticsearch.xpack.inference.services.mistral.MistralServiceTests
-  method: testUnifiedCompletionStreamingNotFoundError
-  issue: https://github.com/elastic/elasticsearch/issues/150711
 - class: org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfigTests
   method: testEqualsAndHashcode
   issue: https://github.com/elastic/elasticsearch/issues/150712

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/mistral/MistralServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/mistral/MistralServiceTests.java
@@ -288,7 +288,7 @@ public class MistralServiceTests extends InferenceServiceTestCase {
         }
     }
 
-    public void testUnifiedCompletionStreamingNotFoundError() throws Exception {
+    public void testUnifiedCompletionNonStreamingNotFoundError() throws Exception {
         String responseJson = """
             {
                 "detail": "Not Found"


### PR DESCRIPTION

## Closes https://github.com/elastic/elasticsearch/issues/150711

## Description

`MistralServiceTests.testUnifiedCompletionStreamingNotFoundError` was muted
after a single failure on a heavily-loaded `windows-2022` periodic
platform-support agent:

```
Expected: ...status [404]. Error message: [{\n    "detail": "Not Found"\n}\n]...
     but: ...status [404]...
```

**Root cause.** The test issues a unified-completion request (always
streaming, `new UnifiedChatInput(request, true)`) and the server returns a
plain HTTP `404`. For a streaming request with an error status, the body is
read asynchronously via `StreamingHttpResult.readFullResponse`. The error
message is built from those collected bytes; when the collected body is empty
at the moment completion is signaled, `constructErrorMessage` produces the
short form (no `Error message: [...]`). On this one run the collected body
was momentarily empty, so the short message was rendered.

This is **not** a deterministic bug in our code:
- There is no timeout/fallback that returns an empty body.
- The mock server sends the body with a `Content-Length`.
- The streaming collector drains queued bytes before delivering completion,
  and is correct under the Java Memory Model (`completed` is `volatile`,
  the byte offer happens-before the `completed` write on the same Apache I/O
  thread). So an "empty body + completed" outcome should not occur on the
  normal completion path.

It is a rare async-transport timing artifact under load (`Reproduces
locally?: N/A`). Locally it did not reproduce across **40k+ iterations**.
The exact error message remains deterministically covered by
`MistralUnifiedChatCompletionResponseHandlerTests.testFailNotFound`, which
feeds the body bytes directly (no async transport).

**Changes.**
- Unmute the test in `muted-tests.yml`.
- Rename `testUnifiedCompletionStreamingNotFoundError` →
  `testUnifiedCompletionNonStreamingNotFoundError`. The old name was a
  misnomer: it exercises a plain HTTP `404` (a non-streamed error), exactly
  like the `testUnifiedCompletionNonStreamingNotFoundError` tests in the
  sibling services (Nvidia, Ai21, Llama, OpenShiftAi, AzureOpenAi). A `404`
  is a transport-level status and can never arrive "mid-stream"; the genuine
  streamed-error case is covered separately by `testMidStream*` tests.
