### PR TITLE
[9.4] Update TransformIndexer Exception

### DIFF
--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
@@ -556,7 +556,7 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
                 listener.onFailure(
                     new RetentionPolicyException(
                         "found [{}] version conflicts when deleting documents as part of the retention policy.",
-                        bulkByScrollResponse.getDeleted()
+                        bulkByScrollResponse.getVersionConflicts()
                     )
                 );
                 return;


### PR DESCRIPTION
There was a bug where the `BulkByPaginatedSearchResponse.getDeleted()` field was being passed into the exception message rather than the version conflicts

