### PR TITLE
Fix MapperParsingException warning during startup

### DIFF
--- a/x-pack/plugin/core/template-resources/src/main/resources/activitylog/logs-elasticsearch.querylog@mappings.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/activitylog/logs-elasticsearch.querylog@mappings.json
@@ -14,7 +14,7 @@
         {
           "elasticsearch_querylog_esql_profile_longs": {
             "path_match": "elasticsearch.querylog.esql.profile.*",
-            "match_mapping_type": ["long", "integer", "short", "byte"],
+            "match_mapping_type": "long",
             "mapping": {
               "type": "long",
               "index": false

--- a/x-pack/plugin/core/template-resources/src/main/resources/activitylog/logs-elasticsearch.querylog@mappings.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/activitylog/logs-elasticsearch.querylog@mappings.json
@@ -9,7 +9,9 @@
               "type": "long",
               "index": false
             }
-          },
+          }
+        },
+        {
           "elasticsearch_querylog_esql_profile_longs": {
             "path_match": "elasticsearch.querylog.esql.profile.*",
             "match_mapping_type": ["long", "integer", "short", "byte"],

--- a/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/QueryLoggingTemplateRegistry.java
+++ b/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/QueryLoggingTemplateRegistry.java
@@ -34,8 +34,9 @@ public class QueryLoggingTemplateRegistry extends IndexTemplateRegistry {
     // version 2: limit query to 32k
     // version 3: add esql.filter
     // version 4: move filter to main body
-    // version 5: add esql.profile longs mapping
-    public static final int INDEX_TEMPLATE_VERSION = 5;
+    // version 5: add esql.profile longs mapping (broken — two templates merged into one array entry)
+    // version 6: fix dynamic_templates to use one array entry per template
+    public static final int INDEX_TEMPLATE_VERSION = 6;
 
     public static final String QUERY_LOGGING_TEMPLATE_VERSION_VARIABLE = "xpack.stack.querylog.template.version";
 

--- a/x-pack/plugin/stack/src/test/java/org/elasticsearch/xpack/stack/QueryLoggingTemplateRegistryTests.java
+++ b/x-pack/plugin/stack/src/test/java/org/elasticsearch/xpack/stack/QueryLoggingTemplateRegistryTests.java
@@ -80,7 +80,8 @@ public class QueryLoggingTemplateRegistryTests extends ESTestCase {
             new NoOpClient(threadPool),
             NamedXContentRegistry.EMPTY
         );
-        ComponentTemplate mappingsTemplate = registry.getComponentTemplateConfigs().get(QueryLoggingTemplateRegistry.QUERY_LOGGING_MAPPINGS_NAME);
+        ComponentTemplate mappingsTemplate = registry.getComponentTemplateConfigs()
+            .get(QueryLoggingTemplateRegistry.QUERY_LOGGING_MAPPINGS_NAME);
         assertNotNull(mappingsTemplate);
         CompressedXContent mappings = mappingsTemplate.template().mappings();
         assertNotNull(mappings);

--- a/x-pack/plugin/stack/src/test/java/org/elasticsearch/xpack/stack/QueryLoggingTemplateRegistryTests.java
+++ b/x-pack/plugin/stack/src/test/java/org/elasticsearch/xpack/stack/QueryLoggingTemplateRegistryTests.java
@@ -7,7 +7,9 @@
 
 package org.elasticsearch.xpack.stack;
 
+import org.elasticsearch.cluster.metadata.ComponentTemplate;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ClusterServiceUtils;
 import org.elasticsearch.test.ESTestCase;
@@ -15,7 +17,14 @@ import org.elasticsearch.test.client.NoOpClient;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentParserConfiguration;
+import org.elasticsearch.xcontent.XContentType;
 import org.junit.After;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.not;
@@ -59,5 +68,38 @@ public class QueryLoggingTemplateRegistryTests extends ESTestCase {
         );
         assertThat(registry.getComposableTemplateConfigs(), not(anEmptyMap()));
         assertThat(registry.getComponentTemplateConfigs(), not(anEmptyMap()));
+    }
+
+    public void testMappingsComponentTemplateHasValidDynamicTemplates() throws IOException {
+        threadPool = new TestThreadPool(getClass().getName());
+        ClusterService clusterService = ClusterServiceUtils.createClusterService(threadPool);
+        QueryLoggingTemplateRegistry registry = new QueryLoggingTemplateRegistry(
+            Settings.EMPTY,
+            clusterService,
+            threadPool,
+            new NoOpClient(threadPool),
+            NamedXContentRegistry.EMPTY
+        );
+        ComponentTemplate mappingsTemplate = registry.getComponentTemplateConfigs().get(QueryLoggingTemplateRegistry.QUERY_LOGGING_MAPPINGS_NAME);
+        assertNotNull(mappingsTemplate);
+        CompressedXContent mappings = mappingsTemplate.template().mappings();
+        assertNotNull(mappings);
+
+        try (XContentParser parser = XContentType.JSON.xContent().createParser(XContentParserConfiguration.EMPTY, mappings.string())) {
+            Map<String, Object> mappingsMap = parser.map();
+            @SuppressWarnings("unchecked")
+            List<Object> dynamicTemplates = (List<Object>) mappingsMap.get("dynamic_templates");
+            if (dynamicTemplates != null) {
+                for (int i = 0; i < dynamicTemplates.size(); i++) {
+                    @SuppressWarnings("unchecked")
+                    Map<String, Object> entry = (Map<String, Object>) dynamicTemplates.get(i);
+                    assertEquals(
+                        "dynamic_templates[" + i + "] must have exactly one key (its name), but had: " + entry.keySet(),
+                        1,
+                        entry.size()
+                    );
+                }
+            }
+        }
     }
 }

--- a/x-pack/plugin/stack/src/test/java/org/elasticsearch/xpack/stack/QueryLoggingTemplateRegistryTests.java
+++ b/x-pack/plugin/stack/src/test/java/org/elasticsearch/xpack/stack/QueryLoggingTemplateRegistryTests.java
@@ -25,6 +25,7 @@ import org.junit.After;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.not;
@@ -86,6 +87,7 @@ public class QueryLoggingTemplateRegistryTests extends ESTestCase {
         CompressedXContent mappings = mappingsTemplate.template().mappings();
         assertNotNull(mappings);
 
+        Set<String> validMatchMappingTypes = Set.of("object", "string", "long", "double", "boolean", "date", "binary");
         try (XContentParser parser = XContentType.JSON.xContent().createParser(XContentParserConfiguration.EMPTY, mappings.string())) {
             Map<String, Object> mappingsMap = parser.map();
             @SuppressWarnings("unchecked")
@@ -99,6 +101,32 @@ public class QueryLoggingTemplateRegistryTests extends ESTestCase {
                         1,
                         entry.size()
                     );
+                    @SuppressWarnings("unchecked")
+                    Map<String, Object> templateDef = (Map<String, Object>) entry.values().iterator().next();
+                    Object matchMappingType = templateDef.get("match_mapping_type");
+                    if (matchMappingType instanceof String s) {
+                        assertTrue(
+                            "dynamic_templates["
+                                + i
+                                + "].match_mapping_type ["
+                                + s
+                                + "] is not a valid type; valid: "
+                                + validMatchMappingTypes,
+                            validMatchMappingTypes.contains(s)
+                        );
+                    } else if (matchMappingType instanceof List<?> list) {
+                        for (Object t : list) {
+                            assertTrue(
+                                "dynamic_templates["
+                                    + i
+                                    + "].match_mapping_type ["
+                                    + t
+                                    + "] is not a valid type; valid: "
+                                    + validMatchMappingTypes,
+                                validMatchMappingTypes.contains(t)
+                            );
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
Noticed this warning when testing locally with `./gradlew run`: 
```
[o.e.x.c.t.IndexTemplateRegistry] [runTask-0] error adding index template [logs-elasticsearch.querylog@mappings] for [stack]org.elasticsearch.index.mapper.MapperParsingException: Failed to parse mapping: A dynamic template must be defined with a name
          at org.elasticsearch.server@9.5.0-SNAPSHOT/org.elasticsearch.index.mapper.MapperService.doMerge(MapperService.java:609)
          at org.elasticsearch.server@9.5.0-SNAPSHOT/org.elasticsearch.index.mapper.MapperService.merge(MapperService.java:577)
          at org.elasticsearch.server@9.5.0-SNAPSHOT/org.elasticsearch.cluster.metadata.MetadataIndexTemplateService.lambda$validateTemplate$37(MetadataIndexTemplateService.java:2089)
          at org.elasticsearch.server@9.5.0-SNAPSHOT/org.elasticsearch.indices.IndicesService.withTempIndexService(IndicesService.java:780)
          at org.elasticsearch.server@9.5.0-SNAPSHOT/org.elasticsearch.cluster.metadata.MetadataIndexTemplateService.validateTemplate(MetadataIndexTemplateService.java:2087)
          at org.elasticsearch.server@9.5.0-SNAPSHOT/org.elasticsearch.cluster.metadata.MetadataIndexTemplateService.addComponentTemplate(MetadataIndexTemplateService.java:369)
          at org.elasticsearch.server@9.5.0-SNAPSHOT/org.elasticsearch.cluster.metadata.MetadataIndexTemplateService$3.execute(MetadataIndexTemplateService.java:290)
          at org.elasticsearch.server@9.5.0-SNAPSHOT/org.elasticsearch.cluster.metadata.MetadataIndexTemplateService$TemplateClusterStateUpdateTask.execute(MetadataIndexTemplateService.java:176)
          at org.elasticsearch.server@9.5.0-SNAPSHOT/org.elasticsearch.cluster.metadata.MetadataIndexTemplateService$1.executeTask(MetadataIndexTemplateService.java:152)
          at org.elasticsearch.server@9.5.0-SNAPSHOT/org.elasticsearch.cluster.metadata.MetadataIndexTemplateService$1.executeTask(MetadataIndexTemplateService.java:149)
          at org.elasticsearch.server@9.5.0-SNAPSHOT/org.elasticsearch.cluster.SimpleBatchedExecutor.execute(SimpleBatchedExecutor.java:71)
          at org.elasticsearch.server@9.5.0-SNAPSHOT/org.elasticsearch.cluster.service.MasterService.innerExecuteTasks(MasterService.java:1240)
          at org.elasticsearch.server@9.5.0-SNAPSHOT/org.elasticsearch.cluster.service.MasterService.executeTasks(MasterService.java:1203)
          at org.elasticsearch.server@9.5.0-SNAPSHOT/org.elasticsearch.cluster.service.MasterService.executeAndPublishBatch(MasterService.java:364)
          at org.elasticsearch.server@9.5.0-SNAPSHOT/org.elasticsearch.cluster.service.MasterService$BatchingTaskQueue$Processor.lambda$run$2(MasterService.java:1989)
          at org.elasticsearch.server@9.5.0-SNAPSHOT/org.elasticsearch.action.ActionListener.run(ActionListener.java:490)
          at org.elasticsearch.server@9.5.0-SNAPSHOT/org.elasticsearch.cluster.service.MasterService$BatchingTaskQueue$Processor.run(MasterService.java:1986)
          at org.elasticsearch.server@9.5.0-SNAPSHOT/org.elasticsearch.cluster.service.MasterService$5.lambda$doRun$0(MasterService.java:1510)
          at org.elasticsearch.server@9.5.0-SNAPSHOT/org.elasticsearch.action.ActionListener.run(ActionListener.java:490)
          at org.elasticsearch.server@9.5.0-SNAPSHOT/org.elasticsearch.cluster.service.MasterService$5.doRun(MasterService.java:1488)
          at org.elasticsearch.server@9.5.0-SNAPSHOT/org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:1114)
          at org.elasticsearch.server@9.5.0-SNAPSHOT/org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:27)
          at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
          at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
          at java.base/java.lang.Thread.run(Thread.java:1516)
  Caused by: org.elasticsearch.index.mapper.MapperParsingException: A dynamic template must be defined with a name
          at org.elasticsearch.server@9.5.0-SNAPSHOT/org.elasticsearch.index.mapper.RootObjectMapper.processField(RootObjectMapper.java:497)
          at org.elasticsearch.server@9.5.0-SNAPSHOT/org.elasticsearch.index.mapper.RootObjectMapper.parse(RootObjectMapper.java:442)
          at org.elasticsearch.server@9.5.0-SNAPSHOT/org.elasticsearch.index.mapper.MappingParser.parseToBuilder(MappingParser.java:150)
          at org.elasticsearch.server@9.5.0-SNAPSHOT/org.elasticsearch.index.mapper.MapperService.doMerge(MapperService.java:607)
          ... 24 more
```

The issue was introduced by https://github.com/elastic/elasticsearch/pull/150697. This commit fixes the issue by: 
- `logs-elasticsearch.querylog@mappings.json` - split the two dynamic templates from one object (two keys) into two separate array elements (one key each), which is the format Elasticsearch's mapper requires.
- `QueryLoggingTemplateRegistry.java` - bumped INDEX_TEMPLATE_VERSION from 5 to 6 so any cluster that already picked up the broken version 5 template will get the fixed one re-applied.
- `QueryLoggingTemplateRegistryTests.java` - added `testMappingsComponentTemplateHasValidDynamicTemplates` which loads the parsed mappings from the registry's component template and asserts every dynamic_templates array entry has exactly one key. This would have caught the original regression in [PR #150697](https://github.com/elastic/elasticsearch/pull/150697).