### PR TITLE
ES|QL: Add support for CSV tests to define request pragmas

### DIFF
--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
@@ -496,6 +496,7 @@ public abstract class EsqlSpecTestCase extends ESRestTestCase {
             pragmaBuilder.put(QueryPragmas.FIELD_EXTRACT_PREFERENCE.getKey(), preference.toString()).build();
         }
         addRandomPragma(pragmaBuilder);
+        testCase.pragmas.forEach(pragmaBuilder::put);
 
         Settings pragma = pragmaBuilder.build();
         if (pragma.isEmpty() == false) {

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvSpecReader.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvSpecReader.java
@@ -8,8 +8,10 @@
 package org.elasticsearch.xpack.esql;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 
@@ -20,6 +22,7 @@ public final class CsvSpecReader {
     public static SpecReader.Parser specParser() {
         var ctx = new ParserContext();
         ctx.addOptionParser(new Capability(ctx));
+        ctx.addOptionParser(new Pragma(ctx));
         ctx.addOptionParser(new RequestStored(ctx));
         ctx.addOptionParser(new RequestTimeFilter(ctx));
         ctx.addOptionParser(new Warning(ctx));
@@ -47,6 +50,7 @@ public final class CsvSpecReader {
         private final List<String> requiredCapabilitiesLocalCluster = new ArrayList<>();
         private final List<String> missingCapabilitiesRemoteCluster = new ArrayList<>();
         private final List<SpecReader.Parser> optionParsers = new ArrayList<>();
+        private final Map<String, String> pragmas = new HashMap<>();
         WhenLoadsRequestedToStored requestStored = WhenLoadsRequestedToStored.IGNORE_VALUE_ORDER;
         String requestTimeRangeGte;
         String requestTimeRangeLte;
@@ -80,6 +84,7 @@ public final class CsvSpecReader {
                 testCase.requiredCapabilities = List.copyOf(requiredCapabilities);
                 testCase.requiredCapabilitiesLocalCluster = List.copyOf(requiredCapabilitiesLocalCluster);
                 testCase.missingCapabilitiesRemoteCluster = List.copyOf(missingCapabilitiesRemoteCluster);
+                testCase.pragmas = Map.copyOf(pragmas);
                 testCase.requestStored = requestStored;
                 testCase.requestTimeRangeGte = requestTimeRangeGte;
                 testCase.requestTimeRangeLte = requestTimeRangeLte;
@@ -241,6 +246,26 @@ public final class CsvSpecReader {
         }
     }
 
+    record Pragma(ParserContext state) implements SpecReader.Parser {
+        @Override
+        public Object parse(String line) {
+            String lower = line.toLowerCase(Locale.ROOT);
+            if (lower.startsWith("pragma:")) {
+                String pragma = lower.substring("pragma:".length()).trim();
+                int separator = pragma.indexOf('=');
+                if (separator < 0) {
+                    throw new IllegalArgumentException("Invalid pragma: [" + pragma + "], it must be in the form of key=value");
+                }
+
+                String key = pragma.substring(0, separator).trim();
+                String value = pragma.substring(separator + 1).trim();
+                state.pragmas.put(key, value);
+                return Boolean.TRUE;
+            }
+            return null;
+        }
+    }
+
     /**
      * Marks a test as expected to fail under the {@code keyword}-to-{@code flattened} variant
      * ({@code CsvFlattenedKeywordIT}) because it exercises a known limitation of
@@ -303,6 +328,11 @@ public final class CsvSpecReader {
          * driver ignores this field.
          */
         public String skipFlattenedRewrite;
+
+        /**
+         * Pragmas that must be sent.
+         */
+        public Map<String, String> pragmas = new HashMap<>();
 
         /**
          * Returns the warning headers expected to be added by the test. To declare such a header, use the `warning:definition` format

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/match-function.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/match-function.csv-spec
@@ -1134,3 +1134,101 @@ from all_types
 
 constant_keyword-foo:keyword | keyword:keyword
 ;
+
+matchOnRuntimeText
+
+required_capability: match_function
+required_capability: match_support_runtime_text
+
+pragma: runtime_lexical_search=true
+
+FROM books
+| EVAL content = to_text(concat(title, " ", description))
+| WHERE match(content, "Tolkien")
+| SORT book_no
+| LIMIT 3
+| KEEP book_no, title
+;
+
+book_no:keyword | title:text
+1463            | Realms of Tolkien: Images of Middle-earth
+2130            | The J. R. R. Tolkien Audio Collection
+2301            | Smith of Wootton Major & Farmer Giles of Ham
+;
+
+matchOnRuntimeTextAndIndexedField
+
+required_capability: match_function
+required_capability: match_support_runtime_text
+
+pragma: runtime_lexical_search=true
+
+FROM books
+| EVAL content = to_text(concat(title, " ", description))
+| WHERE match(content, "Tolkien") OR match(title, "Brothers Karamazov")
+| SORT book_no
+| LIMIT 3
+| KEEP book_no, title
+;
+
+book_no:keyword | title:text
+1211            | The brothers Karamazov
+1463            | Realms of Tolkien: Images of Middle-earth
+1985            | Brothers Karamazov
+;
+
+
+matchOnTextWithRow
+
+required_capability: match_function
+required_capability: match_support_runtime_text
+
+pragma: runtime_lexical_search=true
+
+ROW content = to_text(["This is a brown fox", "This is a brown dog", "This dog is really brown"])
+| MV_EXPAND content
+| WHERE match(content, "dog")
+| SORT content
+;
+
+content:text
+This dog is really brown
+This is a brown dog
+;
+
+matchOnTextWithRowAndNullValues
+
+required_capability: match_function
+required_capability: match_support_runtime_text
+
+pragma: runtime_lexical_search=true
+
+ROW content = ["This is a brown fox", "This is a brown dog", "This dog is really brown"]
+| MV_EXPAND content
+| EVAL content = to_text(case(content == "This is a brown dog", null, content))
+| WHERE match(content, "dog")
+| SORT content
+;
+
+content:text
+This dog is really brown
+;
+
+matchOnTextWithRowAndMultiValues
+
+required_capability: match_function
+required_capability: match_support_runtime_text
+
+pragma: runtime_lexical_search=true
+
+ROW content = ["This is a brown fox", "This is a brown dog", "This dog is really brown"]
+| MV_EXPAND content
+| EVAL content = to_text(mv_append(content, "extra"))
+| WHERE match(content, "dog")
+| SORT content
+;
+
+content:text
+[This dog is really brown, extra]
+[This is a brown dog, extra]
+;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/match-operator.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/match-operator.csv-spec
@@ -1049,3 +1049,101 @@ from all_types
 
 constant_keyword-foo:keyword | keyword:keyword
 ;
+
+matchOnRuntimeText
+
+required_capability: match_function
+required_capability: match_support_runtime_text
+
+pragma: runtime_lexical_search=true
+
+FROM books
+| EVAL content = to_text(concat(title, " ", description))
+| WHERE content:"Tolkien"
+| SORT book_no
+| LIMIT 3
+| KEEP book_no, title
+;
+
+book_no:keyword | title:text
+1463            | Realms of Tolkien: Images of Middle-earth
+2130            | The J. R. R. Tolkien Audio Collection
+2301            | Smith of Wootton Major & Farmer Giles of Ham
+;
+
+matchOnRuntimeTextAndIndexedField
+
+required_capability: match_function
+required_capability: match_support_runtime_text
+
+pragma: runtime_lexical_search=true
+
+FROM books
+| EVAL content = to_text(concat(title, " ", description))
+| WHERE content:"Tolkien" OR title:"Brothers Karamazov"
+| SORT book_no
+| LIMIT 3
+| KEEP book_no, title
+;
+
+book_no:keyword | title:text
+1211            | The brothers Karamazov
+1463            | Realms of Tolkien: Images of Middle-earth
+1985            | Brothers Karamazov
+;
+
+
+matchOnTextWithRow
+
+required_capability: match_function
+required_capability: match_support_runtime_text
+
+pragma: runtime_lexical_search=true
+
+ROW content = to_text(["This is a brown fox", "This is a brown dog", "This dog is really brown"])
+| MV_EXPAND content
+| WHERE content:"dog"
+| SORT content
+;
+
+content:text
+This dog is really brown
+This is a brown dog
+;
+
+matchOnTextWithRowAndNullValues
+
+required_capability: match_function
+required_capability: match_support_runtime_text
+
+pragma: runtime_lexical_search=true
+
+ROW content = ["This is a brown fox", "This is a brown dog", "This dog is really brown"]
+| MV_EXPAND content
+| EVAL content = to_text(case(content == "This is a brown dog", null, content))
+| WHERE content:"dog"
+| SORT content
+;
+
+content:text
+This dog is really brown
+;
+
+matchOnTextWithRowAndMultiValues
+
+required_capability: match_function
+required_capability: match_support_runtime_text
+
+pragma: runtime_lexical_search=true
+
+ROW content = ["This is a brown fox", "This is a brown dog", "This dog is really brown"]
+| MV_EXPAND content
+| EVAL content = to_text(mv_append(content, "extra"))
+| WHERE content:"dog"
+| SORT content
+;
+
+content:text
+[This dog is really brown, extra]
+[This is a brown dog, extra]
+;

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvIT.java
@@ -320,11 +320,16 @@ public class CsvIT extends ESTestCase {
         if (testCase.requestTimeRangeGte != null && testCase.requestTimeRangeGte.isEmpty() == false) {
             request.filter(new RangeQueryBuilder("@timestamp").gte(testCase.requestTimeRangeGte).lte(testCase.requestTimeRangeLte));
         }
+
+        Settings.Builder pragmaSettings = Settings.builder();
         if (randomBoolean()) {
-            Settings.Builder pragmaSettings = Settings.builder();
             pragmaSettings.put("max_concurrent_shards_per_node", randomBoolean() ? 1 : between(2, 10));
+        }
+        testCase.pragmas.forEach(pragmaSettings::put);
+        if (pragmaSettings.build().isEmpty() == false) {
             request.acceptedPragmaRisks(true).pragmas(new QueryPragmas(pragmaSettings.build()));
         }
+
         var listener = new ResponseListener(cluster.getInstance(TransportService.class).getThreadPool());
         cluster.client().execute(EsqlQueryAction.INSTANCE, request, listener);
         // Using a longer timeout here as test infrastructure might populate data lazily while request is in progress.

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/MatchFunctionIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/MatchFunctionIT.java
@@ -14,7 +14,6 @@ import org.elasticsearch.client.internal.IndicesAdminClient;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.xpack.esql.VerificationException;
 import org.elasticsearch.xpack.esql.action.AbstractEsqlIntegTestCase;
-import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.hamcrest.Matchers;
 import org.junit.Before;
 
@@ -23,7 +22,6 @@ import java.util.function.Consumer;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.getValuesList;
-import static org.elasticsearch.xpack.esql.action.EsqlQueryRequest.syncEsqlQueryRequest;
 import static org.hamcrest.CoreMatchers.containsString;
 
 //@TestLogging(value = "org.elasticsearch.xpack.esql:TRACE,org.elasticsearch.compute:TRACE", reason = "debug")
@@ -430,111 +428,6 @@ public class MatchFunctionIT extends AbstractEsqlIntegTestCase {
                     List.of("The quick brown fox jumps over the lazy dog", 6, 6, "The quick brown fox jumps over the lazy dog")
                 )
             );
-        }
-    }
-
-    public void testMatchWithRow() {
-        assumeTrue("requires query pragmas", canUseQueryPragmas());
-        assumeTrue("requires runtime search support", EsqlCapabilities.Cap.MATCH_SUPPORT_RUNTIME_TEXT.isEnabled());
-        var query = """
-            ROW content = to_text(["This is a brown fox", "This is a brown dog", "This dog is really brown"])
-            | MV_EXPAND content
-            | WHERE match(content, "dog")
-            | SORT content
-            """;
-        var pragmas = new QueryPragmas(Settings.builder().put(QueryPragmas.RUNTIME_LEXICAL_SEARCH.getKey(), true).build());
-
-        try (var resp = run(syncEsqlQueryRequest(query).pragmas(pragmas))) {
-            assertColumnNames(resp.columns(), List.of("content"));
-            assertColumnTypes(resp.columns(), List.of("text"));
-            assertValues(resp.values(), List.of(List.of("This dog is really brown"), List.of("This is a brown dog")));
-        }
-    }
-
-    public void testMatchWithRowAndMultiValues() {
-        assumeTrue("requires query pragmas", canUseQueryPragmas());
-        assumeTrue("requires runtime search support", EsqlCapabilities.Cap.MATCH_SUPPORT_RUNTIME_TEXT.isEnabled());
-        var query = """
-            ROW content = ["This is a brown fox", "This is a brown dog", "This dog is really brown"]
-            | MV_EXPAND content
-            | EVAL content = to_text(mv_append(content, "extra"))
-            | WHERE match(content, "dog")
-            | SORT content
-            """;
-        var pragmas = new QueryPragmas(Settings.builder().put(QueryPragmas.RUNTIME_LEXICAL_SEARCH.getKey(), true).build());
-
-        try (var resp = run(syncEsqlQueryRequest(query).pragmas(pragmas))) {
-            assertColumnNames(resp.columns(), List.of("content"));
-            assertColumnTypes(resp.columns(), List.of("text"));
-            assertValues(
-                resp.values(),
-                List.of(List.of(List.of("This dog is really brown", "extra")), List.of(List.of("This is a brown dog", "extra")))
-            );
-        }
-    }
-
-    public void testMatchWithRowAndNullValues() {
-        assumeTrue("requires query pragmas", canUseQueryPragmas());
-        assumeTrue("requires runtime search support", EsqlCapabilities.Cap.MATCH_SUPPORT_RUNTIME_TEXT.isEnabled());
-        var query = """
-            ROW content = ["This is a brown fox", "This is a brown dog", "This dog is really brown"]
-            | MV_EXPAND content
-            | EVAL content = to_text(case(content == "This is a brown dog", null, content))
-            | WHERE match(content, "dog")
-            | SORT content
-            """;
-        var pragmas = new QueryPragmas(Settings.builder().put(QueryPragmas.RUNTIME_LEXICAL_SEARCH.getKey(), true).build());
-
-        try (var resp = run(syncEsqlQueryRequest(query).pragmas(pragmas))) {
-            assertColumnNames(resp.columns(), List.of("content"));
-            assertColumnTypes(resp.columns(), List.of("text"));
-            assertValues(resp.values(), List.of(List.of("This dog is really brown")));
-        }
-    }
-
-    public void testMatchRuntimeExpression() {
-        assumeTrue("requires query pragmas", canUseQueryPragmas());
-        assumeTrue("requires runtime search support", EsqlCapabilities.Cap.MATCH_SUPPORT_RUNTIME_TEXT.isEnabled());
-        var query = """
-            FROM test
-            | EVAL new_content = to_text(concat(content, " and a white cat"))
-            | WHERE match(new_content, "fox")
-            | SORT new_content
-            | KEEP new_content
-            """;
-
-        var pragmas = new QueryPragmas(Settings.builder().put(QueryPragmas.RUNTIME_LEXICAL_SEARCH.getKey(), true).build());
-
-        try (var resp = run(syncEsqlQueryRequest(query).pragmas(pragmas))) {
-            assertColumnNames(resp.columns(), List.of("new_content"));
-            assertColumnTypes(resp.columns(), List.of("text"));
-            assertValues(
-                resp.values(),
-                List.of(
-                    List.of("The quick brown fox jumps over the lazy dog and a white cat"),
-                    List.of("This is a brown fox and a white cat")
-                )
-            );
-        }
-    }
-
-    public void testRuntimeMatchWithIndexedFieldMatch() {
-        assumeTrue("requires query pragmas", canUseQueryPragmas());
-        assumeTrue("requires runtime search support", EsqlCapabilities.Cap.MATCH_SUPPORT_RUNTIME_TEXT.isEnabled());
-        var query = """
-            FROM test
-            | EVAL new_content = to_text(concat(content, " and a white cat"))
-            | WHERE match(new_content, "fox") OR match(content, "cat")
-            | SORT id
-            | KEEP id
-            """;
-
-        var pragmas = new QueryPragmas(Settings.builder().put(QueryPragmas.RUNTIME_LEXICAL_SEARCH.getKey(), true).build());
-
-        try (var resp = run(syncEsqlQueryRequest(query).pragmas(pragmas))) {
-            assertColumnNames(resp.columns(), List.of("id"));
-            assertColumnTypes(resp.columns(), List.of("integer"));
-            assertValues(resp.values(), List.of(List.of(1), List.of(5), List.of(6)));
         }
     }
 


### PR DESCRIPTION
With https://github.com/elastic/elasticsearch/pull/148628 we introduced initial support to run match on runtime text expressions using Lucene's `MemoryIndex`.
The feature is available under snapshot and behind a pragma.
We decided to guard the feature behind a pragma, because full text functions have a series of complex validations that we wanted to continue to properly test.
If we simply enabled this feature **only** behind a snapshot capability, the current validation tests we have for Match would only be run for release tests which are not run on every build.

One issue with https://github.com/elastic/elasticsearch/pull/148628, is that we could not add csv tests since we don't have support to send pragmas with this testing framework. We initially added only integration tests in `MatchFunctionIT`.

We need to add more tests as we develop lexical search at runtime (for all data types in match, match_phrase, scoring support etc). CSV tests are faster to write and run in more scenarios than `MatchFunctionIT`.

When we release lexical search at runtime, we can simply change the default value of the pragma or remove `pragma: runtime_lexical_search=true` from the CSV tests. We will have CSV test coverage, we will not have to build that as part of releasing this feature.

