### PR TITLE
ESQL: Skip a test that loads differently

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/boolean.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/boolean.csv-spec
@@ -208,6 +208,7 @@ row ul = [9223372036854775808, 9223372036854775807, 1, 0] | eval bool = to_bool(
 ;
 
 convertFromIntAndLong
+request_stored: skip
 from employees | sort emp_no | keep emp_no, salary_change* | eval int2bool = to_boolean(salary_change.int), long2bool = to_boolean(salary_change.long) | limit 10;
 
 emp_no:integer |salary_change:double      |salary_change.int:integer | salary_change.keyword:keyword |salary_change.long:long |int2bool:boolean          |long2bool:boolean       

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/drop.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/drop.csv-spec
@@ -34,6 +34,7 @@ avg_worked_seconds:long | birth_date:date | emp_no:integer | first_name:keyword 
 
 whereWithEvalGeneratedValue_DropHeight
 skip_flattened_rewrite: field_extract_multivalue_null
+request_stored: skip
 from employees | sort emp_no | eval x = salary / 2 | where x > 37000 | drop height*;
 
 avg_worked_seconds:long | birth_date:date | emp_no:integer | first_name:keyword | gender:keyword | hire_date:date | is_rehired:boolean | job_positions:keyword | languages:integer | languages.byte:integer | languages.long:long | languages.short:integer | last_name:keyword | salary:integer | salary_change:double | salary_change.int:integer |salary_change.keyword:keyword |salary_change.long:long | still_hired:boolean | x:integer

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/keep.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/keep.csv-spec
@@ -319,6 +319,7 @@ salary:integer
 
 whereWithEvalGeneratedValue
 skip_flattened_rewrite: field_extract_multivalue_null
+request_stored: skip
 // the result from running on ES is the one with many decimals the test that runs locally is the one rounded to 2 decimals
 // the "height" fields have the values as 1.7, 1.7000000476837158, 1.7001953125, 1.7
 from employees | eval x = salary / 2 | where x > 37000;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/rename.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/rename.csv-spec
@@ -161,6 +161,7 @@ y:integer | x:date
 renameIntertwinedWithSort
 skip_flattened_rewrite: field_extract_multivalue_null
 required_capability: fix_precision_of_scaled_float_fields
+request_stored: skip
 FROM employees | eval x = salary | rename x as y | rename y as x | sort x | rename x as y | limit 10;
 
 avg_worked_seconds:l | birth_date:date          | emp_no:i             | first_name:s         | gender:s             | height:d             | height.float:d       | height.half_float:d  | height.scaled_float:d| hire_date:date           | is_rehired:bool      | job_positions:s      | languages:i          | languages.byte:i     | languages.long:l     | languages.short:i    | last_name:s          | salary:i             | salary_change:d      | salary_change.int:i  | salary_change.keyword:s | salary_change.long:l | still_hired:bool  | y:i          

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/topN.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/topN.csv-spec
@@ -117,6 +117,7 @@ Mary              |Sluis            |[-7.82, 3.48, 8.73, 10.35]
 
 sortingOnNumbersFromStrings
 skip_flattened_rewrite: field_extract_multivalue_null
+request_stored: skip
 from employees 
 | eval long_from_string = to_long(salary_change.keyword) 
 | sort long_from_string asc nulls last, emp_no 


### PR DESCRIPTION
Skips a test that loads from _source when the _source diverges. We don't *like* that _source loading diverges in this case, but we're ok with it for now.

Closes #150761
Closes #150786
