### PR TITLE
[Inference API] Fix Streaming publisher shutdown race condition

### DIFF
--- a/docs/changelog/150789.yaml
+++ b/docs/changelog/150789.yaml
@@ -1,0 +1,6 @@
+area: Inference
+issues:
+ - 150742
+pr: 150789
+summary: "[Inference API] Fix Streaming publisher shutdown race condition"
+type: bug

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -155,9 +155,6 @@ tests:
 - class: org.elasticsearch.ingest.geoip.ConsumerAwareIpDatabaseDownloadIT
   method: testConsumerScopedDownloads
   issue: https://github.com/elastic/elasticsearch/issues/150231
-- class: org.elasticsearch.xpack.inference.external.http.HttpClientTests
-  method: testStream_CancelAfterPauseReleasesConnection
-  issue: https://github.com/elastic/elasticsearch/issues/150742
 - class: org.elasticsearch.xpack.esql.spatial.SpatialPushDownGeoShapeIT
   method: testQuantizedXY
   issue: https://github.com/elastic/elasticsearch/issues/150782

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/StreamingHttpResultPublisher.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/StreamingHttpResultPublisher.java
@@ -256,7 +256,10 @@ class StreamingHttpResultPublisher implements HttpAsyncResponseConsumer<Void> {
         private final HttpSettings settings;
         private final AtomicLong bytesInQueue = new AtomicLong(0);
         private final Object ioLock = new Object();
-        private volatile IOControl savedIoControl;
+        // guarded by ioLock
+        private IOControl savedIoControl;
+        // guarded by ioLock; true once shutdownProducer() is called
+        private boolean shutdown = false;
 
         private ApacheClientBackpressure(HttpSettings settings) {
             this.settings = settings;
@@ -269,9 +272,16 @@ class StreamingHttpResultPublisher implements HttpAsyncResponseConsumer<Void> {
         }
 
         private void pauseProducer(IOControl ioControl) {
-            ioControl.suspendInput();
             synchronized (ioLock) {
-                savedIoControl = ioControl;
+                if (shutdown) {
+                    // shutdownProducer() was called while we were consuming this chunk, before the IOControl
+                    // was saved. Shut down now; otherwise the suspended producer would never be resumed and
+                    // the leased connection would be held indefinitely.
+                    doShutdown(ioControl);
+                } else {
+                    ioControl.suspendInput();
+                    savedIoControl = ioControl;
+                }
             }
         }
 
@@ -296,14 +306,19 @@ class StreamingHttpResultPublisher implements HttpAsyncResponseConsumer<Void> {
 
         private void shutdownProducer() {
             synchronized (ioLock) {
+                shutdown = true;
                 if (savedIoControl != null) {
-                    try {
-                        savedIoControl.shutdown();
-                    } catch (IOException e) {
-                        logger.warn("Failed to shut down paused Apache producer after subscription cancellation", e);
-                    }
+                    doShutdown(savedIoControl);
                     savedIoControl = null;
                 }
+            }
+        }
+
+        private void doShutdown(IOControl ioControl) {
+            try {
+                ioControl.shutdown();
+            } catch (IOException e) {
+                logger.warn("Failed to shut down paused Apache producer after subscription cancellation", e);
             }
         }
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/StreamingHttpResultPublisher.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/StreamingHttpResultPublisher.java
@@ -256,9 +256,8 @@ class StreamingHttpResultPublisher implements HttpAsyncResponseConsumer<Void> {
         private final HttpSettings settings;
         private final AtomicLong bytesInQueue = new AtomicLong(0);
         private final Object ioLock = new Object();
-        // guarded by ioLock
         private IOControl savedIoControl;
-        // guarded by ioLock; true once shutdownProducer() is called
+        // true once shutdownProducer() is called
         private boolean shutdown = false;
 
         private ApacheClientBackpressure(HttpSettings settings) {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/StreamingHttpResultPublisherTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/StreamingHttpResultPublisherTests.java
@@ -474,6 +474,54 @@ public class StreamingHttpResultPublisherTests extends ESTestCase {
     }
 
     /**
+     * Given the subscriber cancels the subscription while consumeContent is in the middle of its read
+     * (i.e. cancel races with pauseProducer before the IOControl has been saved)
+     * When consumeContent later calls pauseProducer with the fresh IOControl
+     * Then pauseProducer detects the pending shutdown and shuts the IOControl down immediately,
+     * so the leased connection is released rather than held indefinitely.
+     *
+     * Without the fix: shutdownProducer sees savedIoControl == null and does nothing; pauseProducer
+     * then suspends and saves the IOControl — leaving the producer permanently paused with the lease held.
+     */
+    public void testCancelWhilePausingShutsDownProducer() throws IOException {
+        var subscriber = subscribe();
+
+        var ioControl = mock(IOControl.class);
+        when(settings.getMaxResponseSize()).thenReturn(ByteSizeValue.ofBytes(maxBytes - 1));
+
+        // A ContentDecoder that fires cancel() mid-read, before any bytes are written to the buffer.
+        // This reproduces the race: subscriptionCanceled is set and shutdownProducer() runs while
+        // savedIoControl is still null, then pauseProducer() is called with the real ioControl.
+        var cancelDuringRead = new ContentDecoder() {
+            boolean firstRead = true;
+
+            @Override
+            public int read(ByteBuffer byteBuffer) {
+                if (firstRead) {
+                    firstRead = false;
+                    subscriber.subscription.cancel();
+                    byteBuffer.put(message);
+                    return message.length;
+                }
+                return 0;
+            }
+
+            @Override
+            public boolean isCompleted() {
+                return true;
+            }
+        };
+
+        publisher.consumeContent(cancelDuringRead, ioControl);
+
+        // pauseProducer must detect the pending shutdown and call ioControl.shutdown() instead of
+        // suspendInput(), so the connection lease is released.
+        verify(ioControl).shutdown();
+        verify(ioControl, times(0)).suspendInput();
+        verify(ioControl, times(0)).requestInput();
+    }
+
+    /**
      * Given the Apache producer was never paused
      * When the subscriber cancels the subscription
      * Then we do not touch IOControl, since there is no saved reference and the existing consumeContent cancel


### PR DESCRIPTION
This PR fixes a race condition with the shutdown logic.

Fixes https://github.com/elastic/elasticsearch/issues/150742

### Root cause

Two threads race in `StreamingHttpResultPublisher`
(`x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/StreamingHttpResultPublisher.java`):

- **Apache IO thread** — `consumeContent` (line 75): passes the `subscriptionCanceled.get()` check
  at line 77 (still `false`), reads the chunk, then `addBytesAndMaybePause` → `pauseProducer`
  (lines 271-276) does `ioControl.suspendInput()` and sets `savedIoControl = ioControl`.
- **Client thread** — `Flow.Subscription#cancel()` (lines 209-216): sets `subscriptionCanceled = true`
  and calls `backpressure.shutdownProducer()`.

When `cancel()` lands in the window *after* line 77 but *before* `pauseProducer` saves the
`IOControl`, `shutdownProducer()` sees `savedIoControl == null` (line 299) and does nothing. The
producer then ends up **suspended with `savedIoControl` set and the subscription canceled**, and
nothing ever tears it down:
- `consumeContent` is never called again (input is suspended),
- `shutdownProducer` already ran (idempotent via `compareAndSet`),
- `resumeProducer`/`subtractBytesAndMaybeUnpause` never run (subscriber canceled, never requests).

The connection stays leased indefinitely → `assertBusy(leased == 0)` times out → flaky failure.

<details><summary>Detailed breakdown of race condition</summary>

The race window is between suspendInput() (outside the lock) and the synchronized block. The Apache IO thread calls
  suspendInput(), then cancel() fires on the client thread, shutdownProducer() acquires the lock, sees savedIoControl ==
  null, does nothing, and releases the lock. Then the Apache IO thread acquires the lock and sets savedIoControl =
  ioControl — too late.

  Apache IO thread is inside consumeContent:
  1. Line 77: subscriptionCanceled.get() → false (cancel hasn't fired yet), so it continues
  2. Reads the chunk, calls addBytesAndMaybePause → enters pauseProducer
  3. Pauses here — hasn't yet executed suspendInput() or savedIoControl = ioControl

  Client thread fires cancel() in this gap:
  1. subscriptionCanceled.compareAndSet(false, true) → succeeds
  2. Calls shutdownProducer() → checks savedIoControl → it's still null → does nothing, returns

  Apache IO thread resumes pauseProducer:
  1. Calls suspendInput() — producer is now paused
  2. Sets savedIoControl = ioControl — reference saved

  Now the system is stuck:
  - consumeContent won't be called again (input suspended)
  - shutdownProducer already ran but was a no-op (cancel is idempotent via compareAndSet)
  - resumeProducer won't run (subscriber canceled, never calls request())

  So savedIoControl sits there with input suspended and nobody ever calls shutdown() or requestInput() on it — the
  connection lease is held forever.

  The fix closes this by making pauseProducer check the shutdown flag under the same lock that shutdownProducer sets it
  under. Whichever thread wins the lock, the other sees the correct state and the shutdown always happens.

</details>