### PR TITLE
SQL: fix flaky testAsyncTextPaginated test (#150618)

### DIFF
--- a/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/rest/RestSqlTestCase.java
+++ b/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/rest/RestSqlTestCase.java
@@ -1536,9 +1536,12 @@ public abstract class RestSqlTestCase extends BaseRestSqlTestCase implements Err
         final Map<String, String> acceptMap = Map.of("txt", "text/plain", "csv", "text/csv", "tsv", "text/tab-separated-values");
         final int fetchSize = randomIntBetween(1, 10);
         final int fetchCount = randomIntBetween(1, 9);
-        bulkLoadTestData(fetchSize * fetchCount); // NB: product needs to stay below 100, for txt format tests
+        bulkLoadTestData(fetchSize * fetchCount);
 
-        String format = randomFrom(acceptMap.keySet());
+        // Paginating an async txt query is currently unsupported: continuation pages fetched via the async GET endpoint
+        // lose the text formatter and return empty (https://github.com/elastic/elasticsearch/issues/150617).
+        // Only exercise txt for single-page runs.
+        String format = fetchCount > 1 ? randomFrom("csv", "tsv") : randomFrom(acceptMap.keySet());
         String mode = randomMode();
         String cursor = null;
         for (int i = 0; i <= fetchCount; i++) { // the last iteration (the equality in `<=`) checks on no-cursor & no-results


### PR DESCRIPTION
The test fails in case a 'txt' request requires async pagination. Since this functionality isn't supported yet (#150617), restrict text requests to a single fetch.

(cherry picked from commit a1a580a35ce6ef5299c9bbe43f423fc1635da3c3)
