### PR TITLE
Fix template mistake in logs-elasticsearch.querylog@mappings.json

### DIFF
--- a/x-pack/plugin/core/template-resources/src/main/resources/activitylog/logs-elasticsearch.querylog@mappings.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/activitylog/logs-elasticsearch.querylog@mappings.json
@@ -9,10 +9,12 @@
               "type": "long",
               "index": false
             }
-          },
+          }
+        },
+        {
           "elasticsearch_querylog_esql_profile_longs": {
             "path_match": "elasticsearch.querylog.esql.profile.*",
-            "match_mapping_type": ["long", "integer", "short", "byte"],
+            "match_mapping_type": ["long"],
             "mapping": {
               "type": "long",
               "index": false


### PR DESCRIPTION
Relates to #150697

Causes following errors at startup:

```
[2026-06-04T18:12:08,089][WARN ][o.e.x.c.t.IndexTemplateRegistry] [runTask-0] error adding index template [logs-elasticsearch.querylog@mappings] for [stack]org.elasticsearch.index.mapper.MapperParsingException: Failed to parse mapping: A dynamic template must be defined with a name
        at org.elasticsearch.server@9.5.0-SNAPSHOT/org.elasticsearch.index.mapper.MapperService.doMerge(MapperService.java:609)
        at org.elasticsearch.server@9.5.0-SNAPSHOT/org.elasticsearch.index.mapper.MapperService.merge(MapperService.java:577)
        at org.elasticsearch.server@9.5.0-SNAPSHOT/org.elasticsearch.cluster.metadata.MetadataIndexTemplateService.lambda$validateTemplate$37(MetadataIndexTemplateService.java:2089)
        at org.elasticsearch.server@9.5.0-SNAPSHOT/org.elasticsearch.indices.IndicesService.withTempIndexService(IndicesService.java:780)
        at org.elasticsearch.server@9.5.0-SNAPSHOT/org.elasticsearch.cluster.metadata.MetadataIndexTemplateService.validateTemplate(MetadataIndexTemplateService.java:2087)
        at org.elasticsearch.server@9.5.0-SNAPSHOT/org.elasticsearch.cluster.metadata.MetadataIndexTemplateService.addComponentTemplate(MetadataIndexTemplateService.java:369)
        at org.elasticsearch.server@9.5.0-SNAPSHOT/org.elasticsearch.cluster.metadata.MetadataIndexTemplateService$3.execute(MetadataIndexTemplateService.java:290)
        at org.elasticsearch.server@9.5.0-SNAPSHOT/org.elasticsearch.cluster.metadata.MetadataIndexTemplateService$TemplateClusterStateUpdateTask.execute(MetadataIndexTemplateService.java:176)
        at org.elasticsearch.server@9.5.0-SNAPSHOT/org.elasticsearch.cluster.metadata.MetadataIndexTemplateService$1.executeTask(MetadataIndexTemplateService.java:152)
        at org.elasticsearch.server@9.5.0-SNAPSHOT/org.elasticsearch.cluster.metadata.MetadataIndexTemplateService$1.executeTask(MetadataIndexTemplateService.java:149)
        at org.elasticsearch.server@9.5.0-SNAPSHOT/org.elasticsearch.cluster.SimpleBatchedExecutor.execute(SimpleBatchedExecutor.java:71)
        at org.elasticsearch.server@9.5.0-SNAPSHOT/org.elasticsearch.cluster.service.MasterService.innerExecuteTasks(MasterService.java:1240)
        at org.elasticsearch.server@9.5.0-SNAPSHOT/org.elasticsearch.cluster.service.MasterService.executeTasks(MasterService.java:1203)
        at org.elasticsearch.server@9.5.0-SNAPSHOT/org.elasticsearch.cluster.service.MasterService.executeAndPublishBatch(MasterService.java:364)
        at org.elasticsearch.server@9.5.0-SNAPSHOT/org.elasticsearch.cluster.service.MasterService$BatchingTaskQueue$Processor.lambda$run$2(MasterService.java:1989)
        at org.elasticsearch.server@9.5.0-SNAPSHOT/org.elasticsearch.action.ActionListener.run(ActionListener.java:490)
        at org.elasticsearch.server@9.5.0-SNAPSHOT/org.elasticsearch.cluster.service.MasterService$BatchingTaskQueue$Processor.run(MasterService.java:1986)
        at org.elasticsearch.server@9.5.0-SNAPSHOT/org.elasticsearch.cluster.service.MasterService$5.lambda$doRun$0(MasterService.java:1510)
        at org.elasticsearch.server@9.5.0-SNAPSHOT/org.elasticsearch.action.ActionListener.run(ActionListener.java:490)
        at org.elasticsearch.server@9.5.0-SNAPSHOT/org.elasticsearch.cluster.service.MasterService$5.doRun(MasterService.java:1488)
        at org.elasticsearch.server@9.5.0-SNAPSHOT/org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:1114)
        at org.elasticsearch.server@9.5.0-SNAPSHOT/org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:27)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
        at java.base/java.lang.Thread.run(Thread.java:1516)
Caused by: org.elasticsearch.index.mapper.MapperParsingException: A dynamic template must be defined with a name
        at org.elasticsearch.server@9.5.0-SNAPSHOT/org.elasticsearch.index.mapper.RootObjectMapper.processField(RootObjectMapper.java:497)
        at org.elasticsearch.server@9.5.0-SNAPSHOT/org.elasticsearch.index.mapper.RootObjectMapper.parse(RootObjectMapper.java:442)
        at org.elasticsearch.server@9.5.0-SNAPSHOT/org.elasticsearch.index.mapper.MappingParser.parseToBuilder(MappingParser.java:150)
        at org.elasticsearch.server@9.5.0-SNAPSHOT/org.elasticsearch.index.mapper.MapperService.doMerge(MapperService.java:607)
        ... 24 more
```