### PR TITLE
SQL: fix test check on open search contexts (#150509)

### DIFF
--- a/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/rest/RestSqlTestCase.java
+++ b/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/rest/RestSqlTestCase.java
@@ -998,7 +998,7 @@ public abstract class RestSqlTestCase extends BaseRestSqlTestCase implements Err
         assertEquals(expected, response.v1());
     }
 
-    public void testNextPageText() throws IOException {
+    public void testNextPageText() throws Exception {
         executeQueryWithNextPage("text/plain", "     text      |    number     |      sum      \n", "%-15s|%-15d|%-15d\n");
     }
 
@@ -1048,7 +1048,7 @@ public abstract class RestSqlTestCase extends BaseRestSqlTestCase implements Err
         assertEquals(expected, response.v1());
     }
 
-    public void testNextPageCSV() throws IOException {
+    public void testNextPageCSV() throws Exception {
         executeQueryWithNextPage("text/csv; header=present", "text,number,sum\r\n", "%s,%d,%d\r\n");
     }
 
@@ -1102,7 +1102,7 @@ public abstract class RestSqlTestCase extends BaseRestSqlTestCase implements Err
         assertEquals(expected, response.v1());
     }
 
-    public void testNextPageTSV() throws IOException {
+    public void testNextPageTSV() throws Exception {
         executeQueryWithNextPage("text/tab-separated-values", "text\tnumber\tsum\n", "%s\t%d\t%d\n");
     }
 
@@ -1388,7 +1388,7 @@ public abstract class RestSqlTestCase extends BaseRestSqlTestCase implements Err
         client().performRequest(request);
     }
 
-    private void executeQueryWithNextPage(String format, String expectedHeader, String expectedLineFormat) throws IOException {
+    private void executeQueryWithNextPage(String format, String expectedHeader, String expectedLineFormat) throws Exception {
         int size = 20;
         String[] docs = new String[size];
         for (int i = 0; i < size; i++) {
@@ -1432,7 +1432,7 @@ public abstract class RestSqlTestCase extends BaseRestSqlTestCase implements Err
             }
         }
 
-        assertEquals(0, getNumberOfSearchContexts(provisioningClient(), "test"));
+        assertBusy(() -> assertEquals(0, getNumberOfSearchContexts(provisioningClient(), "test")));
     }
 
     private void bulkLoadTestData(int count) throws IOException {


### PR DESCRIPTION
This fixes the way we check on open contexts (async) after tests.

(cherry picked from commit 7ab26fdd171f220e7b851c12b3f69a129aa88358)
