### PR TITLE
Raise default cluster.max_shards_per_node to 5000

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/ShardLimitValidator.java
+++ b/server/src/main/java/org/elasticsearch/indices/ShardLimitValidator.java
@@ -45,7 +45,7 @@ import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_NUMBER_OF_S
 public class ShardLimitValidator {
     public static final Setting<Integer> SETTING_CLUSTER_MAX_SHARDS_PER_NODE = Setting.intSetting(
         "cluster.max_shards_per_node",
-        1000,
+        5000,
         1,
         Setting.Property.Dynamic,
         Setting.Property.NodeScope


### PR DESCRIPTION
The existing default was set in 2016 and our experience running the current stack internally is that we can handle a much higher limit for nodes with at least our minimum recommended resources:

https://www.elastic.co/docs/deploy-manage/deploy/elastic-cloud/elastic-cloud-hosted-planning#ec-minimum-recommendations

The existing default limit can do more harm than good, causing problems with e.g., upgrades when temporary indices are created that may cause the limit to be tripped.