### PR TITLE
Fix division of max_docs between slices in reindex

### DIFF
--- a/docs/changelog/150808.yaml
+++ b/docs/changelog/150808.yaml
@@ -1,0 +1,5 @@
+area: Reindex
+issues: []
+pr: 150808
+summary: Fix division of `max_docs` between slices in reindex
+type: bug

--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/80_slices.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/80_slices.yml
@@ -57,6 +57,302 @@
   - match: {slices.4.throttled_millis: 0}
 
 ---
+"Multiple slices with max_docs":
+  - do:
+      indices.create:
+        index: source
+        body:
+          settings:
+            index:
+              number_of_shards: 1
+  - do:
+      index:
+        index:   source
+        id:      "1"
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   source
+        id:      "2"
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   source
+        id:      "3"
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   source
+        id:      "4"
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   source
+        id:      "5"
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   source
+        id:      "6"
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   source
+        id:      "7"
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   source
+        id:      "8"
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   source
+        id:      "9"
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   source
+        id:      "10"
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   source
+        id:      "11"
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   source
+        id:      "12"
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   source
+        id:      "13"
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   source
+        id:      "14"
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   source
+        id:      "15"
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   source
+        id:      "16"
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   source
+        id:      "17"
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   source
+        id:      "18"
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   source
+        id:      "19"
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   source
+        id:      "20"
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   source
+        id:      "21"
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   source
+        id:      "22"
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   source
+        id:      "23"
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   source
+        id:      "24"
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   source
+        id:      "25"
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   source
+        id:      "26"
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   source
+        id:      "27"
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   source
+        id:      "28"
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   source
+        id:      "29"
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   source
+        id:      "30"
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   source
+        id:      "31"
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   source
+        id:      "32"
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   source
+        id:      "33"
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   source
+        id:      "34"
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   source
+        id:      "35"
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   source
+        id:      "36"
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   source
+        id:      "37"
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   source
+        id:      "38"
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   source
+        id:      "39"
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   source
+        id:      "40"
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   source
+        id:      "41"
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   source
+        id:      "42"
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   source
+        id:      "43"
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   source
+        id:      "44"
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   source
+        id:      "45"
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   source
+        id:      "46"
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   source
+        id:      "47"
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   source
+        id:      "48"
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   source
+        id:      "49"
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   source
+        id:      "50"
+        body:    { "text": "test" }
+  - do:
+      indices.refresh: {}
+
+  - do:
+      reindex:
+        slices: 5
+        max_docs: 13
+        body:
+          source:
+            index: source
+          dest:
+            index: dest
+  - match: {created: 13}
+  - match: {updated: 0}
+  - match: {version_conflicts: 0}
+  - match: {failures: []}
+  - match: {throttled_millis: 0}
+  - gte: { took: 0 }
+  - is_false: task
+  - is_false: deleted
+  - length: {slices: 5}
+  - match: {slices.0.updated: 0}
+  - match: {slices.0.version_conflicts: 0}
+  - match: {slices.0.throttled_millis: 0}
+  - match: {slices.1.updated: 0}
+  - match: {slices.1.version_conflicts: 0}
+  - match: {slices.1.throttled_millis: 0}
+  - match: {slices.2.updated: 0}
+  - match: {slices.2.version_conflicts: 0}
+  - match: {slices.2.throttled_millis: 0}
+  - match: {slices.3.updated: 0}
+  - match: {slices.3.version_conflicts: 0}
+  - match: {slices.3.throttled_millis: 0}
+  - match: {slices.4.updated: 0}
+  - match: {slices.4.version_conflicts: 0}
+  - match: {slices.4.throttled_millis: 0}
+
+---
 "Multiple slices with wait_for_completion=false":
   - skip:
       features: warnings

--- a/server/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByPaginatedSearchRequest.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByPaginatedSearchRequest.java
@@ -504,6 +504,7 @@ public abstract class AbstractBulkByPaginatedSearchRequest<Self extends Abstract
             );
         }
 
+        int sliceId = request.getSearchRequest().source().slice().getId();
         request.setAbortOnVersionConflict(abortOnVersionConflict)
             .setRefresh(refresh)
             .setTimeout(timeout)
@@ -519,16 +520,19 @@ public abstract class AbstractBulkByPaginatedSearchRequest<Self extends Abstract
         // Copy resume info for the slice from leader to the slice request
         if (this.getResumeInfo().isPresent()) {
             ResumeInfo resumeInfo = this.getResumeInfo().get();
-            int sliceId = request.getSearchRequest().source().slice().getId();
             if (resumeInfo.isSliceCompleted(sliceId) == false) {
                 request.setResumeInfo(new ResumeInfo(resumeInfo.relocationOrigin(), resumeInfo.getSlice(sliceId).get().resumeInfo(), null));
             }
         }
 
         if (maxDocs != MAX_DOCS_ALL_MATCHES) {
-            // maxDocs is split between workers. This means the maxDocs might round
-            // down!
-            request.setMaxDocs(maxDocs / totalSlices);
+            // Split maxDocs between workers. We start by giving each slice maxDocs / totalSlices. That rounds down, so that would get
+            // maxDocs % totalSlices too few in total. So we add an extra docs to the first maxDocs % totalSlices slices.
+            // Note that, if the total number of docs in the source is just a little bit more than max_docs, we may still end up reindexing
+            // fewer than max_docs into the destination, because we might slice unevenly so some slices have fewer than maxDocsForSlice.
+            // But if the total number of docs in the source is a lot more than max_docs, we should end up reindexing max_docs.
+            int maxDocsForSlice = maxDocs / totalSlices + ((sliceId < maxDocs % totalSlices) ? 1 : 0);
+            request.setMaxDocs(maxDocsForSlice);
         }
         // Set the parent task so this task is cancelled if we cancel the parent
         request.setParentTask(slicingTask);

--- a/server/src/test/java/org/elasticsearch/index/reindex/AbstractBulkByPaginatedSearchRequestTestCase.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/AbstractBulkByPaginatedSearchRequestTestCase.java
@@ -11,10 +11,14 @@ package org.elasticsearch.index.reindex;
 
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.support.ActiveShardCount;
+import org.elasticsearch.search.slice.SliceBuilder;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.test.AbstractXContentTestCase;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.ToXContent;
+
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.equalTo;
 
 /**
  * Shared superclass for testing reindex and friends. In particular it makes sure to test the slice features.
@@ -46,10 +50,13 @@ public abstract class AbstractBulkByPaginatedSearchRequestTestCase<R extends Abs
         // it's not important how many slices there are, we just need a number for forSlice
         int actualSlices = between(2, 1000);
         int activeSlices = between(1, actualSlices);
+        int sliceId = between(0, actualSlices);
         original.setSlices(randomBoolean() ? actualSlices : AbstractBulkByPaginatedSearchRequest.AUTO_SLICES);
 
         TaskId slicingTask = new TaskId(randomAlphaOfLength(5), randomLong());
-        SearchRequest sliceRequest = new SearchRequest();
+        SearchRequest sliceRequest = new SearchRequest(original.getSearchRequest());
+        SliceBuilder sliceBuilder = new SliceBuilder(sliceId, actualSlices);
+        sliceRequest.source(sliceRequest.source().shallowCopy().slice(sliceBuilder));
         R forSliced = original.forSlice(slicingTask, sliceRequest, actualSlices, activeSlices);
         assertEquals(original.isAbortOnVersionConflict(), forSliced.isAbortOnVersionConflict());
         assertEquals(original.isRefresh(), forSliced.isRefresh());
@@ -65,13 +72,19 @@ public abstract class AbstractBulkByPaginatedSearchRequestTestCase<R extends Abs
             forSliced.getRequestsPerSecond(),
             Float.MIN_NORMAL
         );
-        assertEquals(
-            "max_docs is split evenly between all slices",
-            original.getMaxDocs() == AbstractBulkByPaginatedSearchRequest.MAX_DOCS_ALL_MATCHES
-                ? AbstractBulkByPaginatedSearchRequest.MAX_DOCS_ALL_MATCHES
-                : original.getMaxDocs() / actualSlices,
-            forSliced.getMaxDocs()
-        );
+        if (original.getMaxDocs() == AbstractBulkByPaginatedSearchRequest.MAX_DOCS_ALL_MATCHES) {
+            assertEquals(
+                "max_docs of MAX_DOCS_ALL_MATCHES is propagated to all children",
+                AbstractBulkByPaginatedSearchRequest.MAX_DOCS_ALL_MATCHES,
+                forSliced.getMaxDocs()
+            );
+        } else {
+            assertThat(
+                "max_docs is split evenly between all slices",
+                forSliced.getMaxDocs(),
+                anyOf(equalTo(original.getMaxDocs() / actualSlices), equalTo(original.getMaxDocs() / actualSlices + 1))
+            );
+        }
         assertEquals(slicingTask, forSliced.getParentTask());
         assertArrayEquals(
             "sourceIndicesForDescription should be copied to slice",
@@ -80,6 +93,26 @@ public abstract class AbstractBulkByPaginatedSearchRequestTestCase<R extends Abs
         );
 
         extraForSliceAssertions(original, forSliced);
+    }
+
+    public void testForSlice_maxDocsSumsCorrectly() {
+        R original = newRequest();
+        int originalMaxDocs = between(0, Integer.MAX_VALUE);
+        original.setMaxDocs(originalMaxDocs);
+        TaskId slicingTask = new TaskId(randomAlphaOfLength(5), randomLong());
+
+        int actualSlices = between(2, 1000);
+        int activeSlices = between(1, actualSlices);
+
+        int maxDocsForSlices = 0;
+        for (int sliceId = 0; sliceId < actualSlices; sliceId++) {
+            SearchRequest sliceRequest = new SearchRequest(original.getSearchRequest());
+            SliceBuilder sliceBuilder = new SliceBuilder(sliceId, actualSlices);
+            sliceRequest.source(sliceRequest.source().shallowCopy().slice(sliceBuilder));
+            R forSliced = original.forSlice(slicingTask, sliceRequest, actualSlices, activeSlices);
+            maxDocsForSlices += forSliced.getMaxDocs();
+        }
+        assertThat("Sum of max docs over all slices equals original max docs", maxDocsForSlices, equalTo(originalMaxDocs));
     }
 
     protected abstract R newRequest();


### PR DESCRIPTION
Previously, when dividing max_docs between the slices of a sliced reindex, we rounded down, guaranteeing that we'd get too few docs if it doesn't divide exactly.

This fixes this by adding back the missing docs.

Note that, if the total number of docs in the source is just a little bit more than `max_docs`, we may still end up reindexing fewer than `max_docs` into the destination, because we might slice unevenly so some slices have fewer than `maxDocsForSlice`. But if the total number of docs in the source is a lot more than `max_docs`, we should end up reindexing `max_docs` now, as users likely expect, which we wouldn't before.

Closes elastic/elasticsearch-team#4190
