### PR TITLE
[9.3] [Inference API] Fix Streaming publisher shutdown race condition (#150789)

### DIFF
--- a/docs/changelog/150789.yaml
+++ b/docs/changelog/150789.yaml
@@ -1,0 +1,6 @@
+area: Inference
+issues:
+ - 150742
+pr: 150789
+summary: "[Inference API] Fix Streaming publisher shutdown race condition"
+type: bug

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/StreamingHttpResultPublisher.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/StreamingHttpResultPublisher.java
@@ -256,7 +256,9 @@ class StreamingHttpResultPublisher implements HttpAsyncResponseConsumer<Void> {
         private final HttpSettings settings;
         private final AtomicLong bytesInQueue = new AtomicLong(0);
         private final Object ioLock = new Object();
-        private volatile IOControl savedIoControl;
+        private IOControl savedIoControl;
+        // true once shutdownProducer() is called
+        private boolean shutdown = false;
 
         private ApacheClientBackpressure(HttpSettings settings) {
             this.settings = settings;
@@ -269,9 +271,16 @@ class StreamingHttpResultPublisher implements HttpAsyncResponseConsumer<Void> {
         }
 
         private void pauseProducer(IOControl ioControl) {
-            ioControl.suspendInput();
             synchronized (ioLock) {
-                savedIoControl = ioControl;
+                if (shutdown) {
+                    // shutdownProducer() was called while we were consuming this chunk, before the IOControl
+                    // was saved. Shut down now; otherwise the suspended producer would never be resumed and
+                    // the leased connection would be held indefinitely.
+                    doShutdown(ioControl);
+                } else {
+                    ioControl.suspendInput();
+                    savedIoControl = ioControl;
+                }
             }
         }
 
@@ -296,14 +305,19 @@ class StreamingHttpResultPublisher implements HttpAsyncResponseConsumer<Void> {
 
         private void shutdownProducer() {
             synchronized (ioLock) {
+                shutdown = true;
                 if (savedIoControl != null) {
-                    try {
-                        savedIoControl.shutdown();
-                    } catch (IOException e) {
-                        logger.warn("Failed to shut down paused Apache producer after subscription cancellation", e);
-                    }
+                    doShutdown(savedIoControl);
                     savedIoControl = null;
                 }
+            }
+        }
+
+        private void doShutdown(IOControl ioControl) {
+            try {
+                ioControl.shutdown();
+            } catch (IOException e) {
+                logger.warn("Failed to shut down paused Apache producer after subscription cancellation", e);
             }
         }
     }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/StreamingHttpResultPublisherTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/StreamingHttpResultPublisherTests.java
@@ -474,6 +474,54 @@ public class StreamingHttpResultPublisherTests extends ESTestCase {
     }
 
     /**
+     * Given the subscriber cancels the subscription while consumeContent is in the middle of its read
+     * (i.e. cancel races with pauseProducer before the IOControl has been saved)
+     * When consumeContent later calls pauseProducer with the fresh IOControl
+     * Then pauseProducer detects the pending shutdown and shuts the IOControl down immediately,
+     * so the leased connection is released rather than held indefinitely.
+     *
+     * Without the fix: shutdownProducer sees savedIoControl == null and does nothing; pauseProducer
+     * then suspends and saves the IOControl — leaving the producer permanently paused with the lease held.
+     */
+    public void testCancelWhilePausingShutsDownProducer() throws IOException {
+        var subscriber = subscribe();
+
+        var ioControl = mock(IOControl.class);
+        when(settings.getMaxResponseSize()).thenReturn(ByteSizeValue.ofBytes(maxBytes - 1));
+
+        // A ContentDecoder that fires cancel() mid-read, before any bytes are written to the buffer.
+        // This reproduces the race: subscriptionCanceled is set and shutdownProducer() runs while
+        // savedIoControl is still null, then pauseProducer() is called with the real ioControl.
+        var cancelDuringRead = new ContentDecoder() {
+            boolean firstRead = true;
+
+            @Override
+            public int read(ByteBuffer byteBuffer) {
+                if (firstRead) {
+                    firstRead = false;
+                    subscriber.subscription.cancel();
+                    byteBuffer.put(message);
+                    return message.length;
+                }
+                return 0;
+            }
+
+            @Override
+            public boolean isCompleted() {
+                return true;
+            }
+        };
+
+        publisher.consumeContent(cancelDuringRead, ioControl);
+
+        // pauseProducer must detect the pending shutdown and call ioControl.shutdown() instead of
+        // suspendInput(), so the connection lease is released.
+        verify(ioControl).shutdown();
+        verify(ioControl, times(0)).suspendInput();
+        verify(ioControl, times(0)).requestInput();
+    }
+
+    /**
      * Given the Apache producer was never paused
      * When the subscriber cancels the subscription
      * Then we do not touch IOControl, since there is no saved reference and the existing consumeContent cancel


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Inference API] Fix Streaming publisher shutdown race condition (#150789)](https://github.com/elastic/elasticsearch/pull/150789)

<!--- Backport version: 12.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)