### PR TITLE
[Inference API] Adding volatile to Stream publisher to avoid future bugs

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/StreamingHttpResultPublisher.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/StreamingHttpResultPublisher.java
@@ -256,9 +256,9 @@ class StreamingHttpResultPublisher implements HttpAsyncResponseConsumer<Void> {
         private final HttpSettings settings;
         private final AtomicLong bytesInQueue = new AtomicLong(0);
         private final Object ioLock = new Object();
-        private IOControl savedIoControl;
+        private volatile IOControl savedIoControl;
         // true once shutdownProducer() is called
-        private boolean shutdown = false;
+        private volatile boolean shutdown = false;
 
         private ApacheClientBackpressure(HttpSettings settings) {
             this.settings = settings;


### PR DESCRIPTION
In the PR here: https://github.com/elastic/elasticsearch/pull/150789

`volatile` was removed and wasn't added for the flag. Technically I don't think it's needed:

- The flag doesn't need it because it's only accessed in a synchronized block
- `savedIoControl` _might_ need it because that _is_ accessed outside a synchronized block. I think it is safe because of the way we are using `contentQueue` for offer/poll which should make the write available in another thread

To be safe though, I'm going to add it back.

Note: I'm not adding 9.4 because I already have a backport of the previous PR and I pushed the changes there already to include `volatile`: https://github.com/elastic/elasticsearch/pull/150817