### PR TITLE
ES93BFloat16FlatVectorsReader: remove SEQUENTIAL advice in getMergeInstance

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/es93/ES93BFloat16FlatVectorsReader.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/es93/ES93BFloat16FlatVectorsReader.java
@@ -171,13 +171,6 @@ public final class ES93BFloat16FlatVectorsReader extends FlatVectorsReader {
     }
 
     @Override
-    public FlatVectorsReader getMergeInstance() throws IOException {
-        // Update the read advice since vectors are guaranteed to be accessed sequentially for merge
-        vectorData.updateIOContext(dataContext.withHints(DataAccessHint.SEQUENTIAL));
-        return this;
-    }
-
-    @Override
     public void search(String field, float[] target, KnnCollector knnCollector, AcceptDocs acceptDocs) throws IOException {
         scoreAndCollectAll(knnCollector, acceptDocs, getFloatVectorValues(field).scorer(target));
     }


### PR DESCRIPTION
When we call `updateIOContext`, we affect all usage of the `vectorData` during the segment merge, which means rescoring io will result in `RescoreKnnVectorQuery` will result in `SEQUENTIAL` instead of `RANDOM` read advice, which leads to increased read ahead and changed mmap caching semantics.

This PR removes the override of `getMergeInstance()` to match most other child classes that rely on the default `FlatVectorsReader#getMergeInstance()` implementation, with the exception of the `Lucene99FlatVectorsReader`.

The expected change is an increase in the possibility of cache misses on the segment merge path while maintaining more predictable read performance within the `RescoreKnnVectorQuery` query path.