### PR TITLE
Support multi_value=false in generative tests

### DIFF
--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
@@ -84,6 +84,7 @@ import org.elasticsearch.index.mapper.TextParams;
 import org.elasticsearch.index.mapper.TextSearchInfo;
 import org.elasticsearch.index.mapper.ValueFetcher;
 import org.elasticsearch.index.mapper.blockloader.DelegatingBlockLoader;
+import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromBinaryBlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromBinaryMultiSeparateCountBlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromCustomBinaryBlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromOrdsBlockLoader;
@@ -247,9 +248,9 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
                 usesBinaryDocValuesForFallbackFields,
                 indexCreatedVersion(),
                 indexed.get(),
-                docValuesParameters.getValue().enabled(),
                 usesBinaryDocValues(),
-                offsetsFieldName != null
+                offsetsFieldName != null,
+                docValuesParameters.getValue()
             );
         }
 
@@ -292,6 +293,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
         private final boolean usesBinaryDocValues;
         // Whether the block loader must emit values in indexed array order (via the offsets sidecar) rather than sorted doc-values order.
         private final boolean readInArrayOrder;
+        private final FieldMapper.DocValuesParameter.Values docValuesParams;
 
         public MatchOnlyTextFieldType(
             String name,
@@ -305,11 +307,11 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
             boolean usesBinaryDocValuesForFallbackFields,
             IndexVersion indexVersion,
             boolean indexed,
-            boolean hasDocValues,
             boolean usesBinaryDocValues,
-            boolean readInArrayOrder
+            boolean readInArrayOrder,
+            FieldMapper.DocValuesParameter.Values docValuesParams
         ) {
-            super(name, IndexType.terms(indexed, hasDocValues), false, tsi, meta, isSyntheticSource, withinMultiField);
+            super(name, IndexType.terms(indexed, docValuesParams.enabled()), false, tsi, meta, isSyntheticSource, withinMultiField);
             this.indexAnalyzer = Objects.requireNonNull(indexAnalyzer);
             this.textFieldType = new TextFieldType(name, isSyntheticSource, withinMultiField, syntheticSourceDelegate);
             this.storedFieldInBinaryFormat = storedFieldInBinaryFormat;
@@ -317,6 +319,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
             this.indexVersion = indexVersion;
             this.usesBinaryDocValues = usesBinaryDocValues;
             this.readInArrayOrder = readInArrayOrder;
+            this.docValuesParams = docValuesParams;
         }
 
         public MatchOnlyTextFieldType(String name) {
@@ -334,7 +337,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
                 true,
                 false,
                 false,
-                false
+                DEFAULT_DOC_VALUES_PARAMS
             );
         }
 
@@ -898,6 +901,10 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
             // Check if we can load from doc values
             if (hasDocValues()) {
                 if (usesBinaryDocValues) {
+                    if (docValuesParams.multiValue() == false) {
+                        // Single-valued binary doc values are written as plain (no separate counts column), so read them as plain.
+                        return new BytesRefsFromBinaryBlockLoader(name());
+                    }
                     return new BytesRefsFromBinaryMultiSeparateCountBlockLoader(name(), readInArrayOrder);
                 } else {
                     return new BytesRefsFromOrdsBlockLoader(name(), blContext.ordinalsByteSize());

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldBlockLoaderTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldBlockLoaderTests.java
@@ -33,10 +33,12 @@ public class MatchOnlyTextFieldBlockLoaderTests extends BinaryDVBlockLoaderTestC
             return valuesInSortedOrder(value);
         }
 
-        // Without doc values, synthetic source reconstructs the field from a per-field fallback. Multi fields don't get that fallback,
-        // so nothing can be loaded for them; the binary fallback returns sorted order while the stored fallback preserves source order.
+        // Without doc values, a genuinely synthetic source reconstructs the field from a per-field fallback. Multi fields don't get that
+        // fallback, so nothing can be loaded for them. Columnar-stored source, by contrast, keeps a real stored _source blob, so a multi
+        // field still resolves to its parent's reconstructed value. Either way the binary fallback returns sorted order while the stored
+        // fallback preserves source order.
         if (params.syntheticSource() || params.isColumnarStored()) {
-            if (testContext.isMultifield()) {
+            if (testContext.isMultifield() && params.syntheticSource()) {
                 return null;
             }
             return params.binaryDocValues() ? valuesInSortedOrder(value) : valuesInSourceOrder(value);

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldBlockLoaderTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldBlockLoaderTests.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.mapper.extras;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.datageneration.FieldType;
+import org.elasticsearch.index.mapper.BinaryDVBlockLoaderTestCase;
+import org.elasticsearch.plugins.Plugin;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public class MatchOnlyTextFieldBlockLoaderTests extends BinaryDVBlockLoaderTestCase {
+
+    public MatchOnlyTextFieldBlockLoaderTests(Params params) {
+        super(FieldType.MATCH_ONLY_TEXT.toString(), params);
+    }
+
+    @Override
+    protected Object expected(Map<String, Object> fieldMapping, Object value, TestContext testContext) {
+        // match_only_text only enables doc values when the single-value handler forces them on, in which case the document is
+        // single-valued; doc values come back in sorted order, which for a single value is also its source order.
+        if (hasDocValues(fieldMapping, false)) {
+            return valuesInSortedOrder(value);
+        }
+
+        // Without doc values, synthetic source reconstructs the field from a per-field fallback. Multi fields don't get that fallback,
+        // so nothing can be loaded for them; the binary fallback returns sorted order while the stored fallback preserves source order.
+        if (params.syntheticSource() || params.isColumnarStored()) {
+            if (testContext.isMultifield()) {
+                return null;
+            }
+            return params.binaryDocValues() ? valuesInSortedOrder(value) : valuesInSourceOrder(value);
+        }
+
+        // Non-synthetic source loads the value back from stored _source in its original order.
+        return valuesInSourceOrder(value);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Object valuesInSortedOrder(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof String s) {
+            return new BytesRef(s);
+        }
+        var resultList = ((List<String>) value).stream().filter(Objects::nonNull).map(BytesRef::new).sorted().toList();
+        return maybeFoldList(resultList);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Object valuesInSourceOrder(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof String s) {
+            return new BytesRef(s);
+        }
+        var resultList = ((List<String>) value).stream().filter(Objects::nonNull).map(BytesRef::new).toList();
+        return maybeFoldList(resultList);
+    }
+
+    @Override
+    protected Collection<? extends Plugin> getPlugins() {
+        return List.of(new MapperExtrasPlugin());
+    }
+}

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldTypeTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldTypeTests.java
@@ -81,6 +81,13 @@ import static org.mockito.Mockito.when;
 
 public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
 
+    // Doc values disabled, the match_only_text default; HIGH cardinality and multiValue are irrelevant when enabled is false.
+    private static final FieldMapper.DocValuesParameter.Values DOC_VALUES_DISABLED = new FieldMapper.DocValuesParameter.Values(
+        false,
+        FieldMapper.DocValuesParameter.Values.Cardinality.HIGH,
+        true
+    );
+
     public void testTermQuery() {
         MappedFieldType ft = new MatchOnlyTextFieldType("field");
         assertEquals(new ConstantScoreQuery(new TermQuery(new Term("field", "foo"))), ft.termQuery("foo", null));
@@ -260,7 +267,7 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
             true,
             false,
             false,
-            new FieldMapper.DocValuesParameter.Values(false, FieldMapper.DocValuesParameter.Values.Cardinality.HIGH, true)
+            DOC_VALUES_DISABLED
         );
 
         // when
@@ -286,7 +293,7 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
             true,
             false,
             false,
-            new FieldMapper.DocValuesParameter.Values(false, FieldMapper.DocValuesParameter.Values.Cardinality.HIGH, true)
+            DOC_VALUES_DISABLED
         );
 
         // when
@@ -319,7 +326,7 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
             true,
             false,
             false,
-            new FieldMapper.DocValuesParameter.Values(false, FieldMapper.DocValuesParameter.Values.Cardinality.HIGH, true)
+            DOC_VALUES_DISABLED
         );
 
         // when
@@ -370,7 +377,7 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
             true,
             false,
             false,
-            new FieldMapper.DocValuesParameter.Values(false, FieldMapper.DocValuesParameter.Values.Cardinality.HIGH, true)
+            DOC_VALUES_DISABLED
         );
 
         // when
@@ -424,7 +431,7 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
             true,
             false,
             false,
-            new FieldMapper.DocValuesParameter.Values(false, FieldMapper.DocValuesParameter.Values.Cardinality.HIGH, true)
+            DOC_VALUES_DISABLED
         );
 
         // when
@@ -463,7 +470,7 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
             true,
             false,
             false,
-            new FieldMapper.DocValuesParameter.Values(false, FieldMapper.DocValuesParameter.Values.Cardinality.HIGH, true)
+            DOC_VALUES_DISABLED
         );
 
         var mockedSearchLookup = mock(SearchLookup.class);
@@ -515,7 +522,7 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
             true,
             false,
             false,
-            new FieldMapper.DocValuesParameter.Values(false, FieldMapper.DocValuesParameter.Values.Cardinality.HIGH, true)
+            DOC_VALUES_DISABLED
         );
 
         // when
@@ -543,7 +550,7 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
             true,
             false,
             false,
-            new FieldMapper.DocValuesParameter.Values(false, FieldMapper.DocValuesParameter.Values.Cardinality.HIGH, true)
+            DOC_VALUES_DISABLED
         );
 
         // when
@@ -571,7 +578,7 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
             true,
             false,
             false,
-            new FieldMapper.DocValuesParameter.Values(false, FieldMapper.DocValuesParameter.Values.Cardinality.HIGH, true)
+            DOC_VALUES_DISABLED
         );
 
         // when

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldTypeTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldTypeTests.java
@@ -46,6 +46,7 @@ import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.mapper.BlockLoader;
 import org.elasticsearch.index.mapper.BlockSourceReader;
+import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.FieldNamesFieldMapper;
 import org.elasticsearch.index.mapper.FieldTypeTestCase;
 import org.elasticsearch.index.mapper.IndexType;
@@ -259,7 +260,7 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
             true,
             false,
             false,
-            false
+            new FieldMapper.DocValuesParameter.Values(false, FieldMapper.DocValuesParameter.Values.Cardinality.HIGH, true)
         );
 
         // when
@@ -285,7 +286,7 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
             true,
             false,
             false,
-            false
+            new FieldMapper.DocValuesParameter.Values(false, FieldMapper.DocValuesParameter.Values.Cardinality.HIGH, true)
         );
 
         // when
@@ -318,7 +319,7 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
             true,
             false,
             false,
-            false
+            new FieldMapper.DocValuesParameter.Values(false, FieldMapper.DocValuesParameter.Values.Cardinality.HIGH, true)
         );
 
         // when
@@ -369,7 +370,7 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
             true,
             false,
             false,
-            false
+            new FieldMapper.DocValuesParameter.Values(false, FieldMapper.DocValuesParameter.Values.Cardinality.HIGH, true)
         );
 
         // when
@@ -423,7 +424,7 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
             true,
             false,
             false,
-            false
+            new FieldMapper.DocValuesParameter.Values(false, FieldMapper.DocValuesParameter.Values.Cardinality.HIGH, true)
         );
 
         // when
@@ -462,7 +463,7 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
             true,
             false,
             false,
-            false
+            new FieldMapper.DocValuesParameter.Values(false, FieldMapper.DocValuesParameter.Values.Cardinality.HIGH, true)
         );
 
         var mockedSearchLookup = mock(SearchLookup.class);
@@ -514,7 +515,7 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
             true,
             false,
             false,
-            false
+            new FieldMapper.DocValuesParameter.Values(false, FieldMapper.DocValuesParameter.Values.Cardinality.HIGH, true)
         );
 
         // when
@@ -542,7 +543,7 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
             true,
             false,
             false,
-            false
+            new FieldMapper.DocValuesParameter.Values(false, FieldMapper.DocValuesParameter.Values.Cardinality.HIGH, true)
         );
 
         // when
@@ -570,7 +571,7 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
             true,
             false,
             false,
-            false
+            new FieldMapper.DocValuesParameter.Values(false, FieldMapper.DocValuesParameter.Values.Cardinality.HIGH, true)
         );
 
         // when
@@ -671,9 +672,9 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
             false,
             IndexVersion.current(),
             false,
-            true,
             false,
-            false
+            false,
+            new FieldMapper.DocValuesParameter.Values(true, FieldMapper.DocValuesParameter.Values.Cardinality.HIGH, true)
         );
     }
 
@@ -691,8 +692,8 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
             IndexVersion.current(),
             false,
             true,
-            true,
-            false
+            false,
+            new FieldMapper.DocValuesParameter.Values(true, FieldMapper.DocValuesParameter.Values.Cardinality.HIGH, true)
         );
     }
 

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/SourceConfirmedTextQueryTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/SourceConfirmedTextQueryTests.java
@@ -49,6 +49,7 @@ import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.lucene.search.MultiPhrasePrefixQuery;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.FieldTypeTestCase;
 import org.elasticsearch.index.mapper.TextFieldMapper;
 import org.elasticsearch.index.mapper.TextSearchInfo;
@@ -487,8 +488,8 @@ public class SourceConfirmedTextQueryTests extends ESTestCase {
                     IndexVersion.current(),
                     true,
                     true,
-                    true,
-                    false
+                    false,
+                    new FieldMapper.DocValuesParameter.Values(true, FieldMapper.DocValuesParameter.Values.Cardinality.HIGH, true)
                 );
 
                 // NOTE: "fox brown" has both terms in the index but in the wrong order. A boolean MUST

--- a/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -35,6 +35,7 @@ import org.elasticsearch.index.fielddata.FieldDataContext;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.plain.SortedSetOrdinalsIndexFieldData;
 import org.elasticsearch.index.mapper.blockloader.BlockLoaderFunctionConfig;
+import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromBinaryBlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromBinaryMultiSeparateCountBlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromOrdsBlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.fn.MvMaxBytesRefsFromBinaryBlockLoader;
@@ -269,7 +270,8 @@ public class IpFieldMapper extends FieldMapper {
                     dimension.getValue(),
                     context.isSourceSynthetic(),
                     usesBinaryDocValues(),
-                    readInArrayOrder
+                    readInArrayOrder,
+                    docValuesParameters.getValue()
                 ),
                 builderParams(this, context),
                 context.isSourceSynthetic(),
@@ -293,6 +295,7 @@ public class IpFieldMapper extends FieldMapper {
         private final boolean hasPoints;
         private final boolean usesBinaryDocValues;
         private final boolean readInArrayOrder;
+        private final DocValuesParameter.Values docValuesParams;
 
         public IpFieldType(
             String name,
@@ -304,7 +307,8 @@ public class IpFieldMapper extends FieldMapper {
             boolean isDimension,
             boolean isSyntheticSource,
             boolean usesBinaryDocValues,
-            boolean readInArrayOrder
+            boolean readInArrayOrder,
+            DocValuesParameter.Values docValuesParams
         ) {
             super(name, indexType, stored, meta);
             this.nullValue = nullValue;
@@ -314,6 +318,7 @@ public class IpFieldMapper extends FieldMapper {
             this.hasPoints = indexType.hasPoints();
             this.usesBinaryDocValues = usesBinaryDocValues;
             this.readInArrayOrder = readInArrayOrder;
+            this.docValuesParams = docValuesParams;
         }
 
         public IpFieldType(String name) {
@@ -325,7 +330,19 @@ public class IpFieldMapper extends FieldMapper {
         }
 
         public IpFieldType(String name, boolean isIndexed, boolean hasDocValues) {
-            this(name, IndexType.points(isIndexed, hasDocValues), false, null, null, Collections.emptyMap(), false, false, false, false);
+            this(
+                name,
+                IndexType.points(isIndexed, hasDocValues),
+                false,
+                null,
+                null,
+                Collections.emptyMap(),
+                false,
+                false,
+                false,
+                false,
+                null
+            );
         }
 
         @Override
@@ -541,6 +558,10 @@ public class IpFieldMapper extends FieldMapper {
                 BlockLoaderFunctionConfig cfg = blContext.blockLoaderFunctionConfig();
                 if (cfg == null) {
                     if (usesBinaryDocValues) {
+                        if (docValuesParams != null && docValuesParams.multiValue() == false) {
+                            // Single-valued binary doc values are written as plain (no separate counts column), so read them as plain.
+                            return new BytesRefsFromBinaryBlockLoader(name());
+                        }
                         return new BytesRefsFromBinaryMultiSeparateCountBlockLoader(name(), readInArrayOrder);
                     } else {
                         return new BytesRefsFromOrdsBlockLoader(name(), blContext.ordinalsByteSize(), readInArrayOrder);

--- a/server/src/test/java/org/elasticsearch/index/mapper/BooleanFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/BooleanFieldMapperTests.java
@@ -311,14 +311,23 @@ public class BooleanFieldMapperTests extends MapperTestCase {
     private class BooleanSyntheticSourceSupport implements SyntheticSourceSupport {
         Boolean nullValue = usually() ? null : randomBoolean();
         private boolean ignoreMalformed;
+        // boolean fields have doc_values enabled by default, so multi_value: false can always be requested when the feature is on.
+        private final boolean enforceSingleValue = FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled()
+            && randomBoolean();
 
         BooleanSyntheticSourceSupport(boolean ignoreMalformed) {
             this.ignoreMalformed = ignoreMalformed;
         }
 
         @Override
+        public boolean enforcesSingleValue() {
+            return enforceSingleValue;
+        }
+
+        @Override
         public SyntheticSourceExample example(int maxVals) throws IOException {
-            if (randomBoolean()) {
+            // When multi_value is disabled a document may only have a single value, so never take the multi-valued branch below.
+            if (enforceSingleValue || randomBoolean()) {
                 Tuple<Boolean, Boolean> v = generateValue();
                 return new SyntheticSourceExample(v.v1(), v.v2(), this::mapping);
             }
@@ -343,6 +352,11 @@ public class BooleanFieldMapperTests extends MapperTestCase {
                 b.field("null_value", nullValue);
             }
             b.field("ignore_malformed", ignoreMalformed);
+            if (enforceSingleValue) {
+                b.startObject("doc_values");
+                b.field("multi_value", false);
+                b.endObject();
+            }
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperTests.java
@@ -629,10 +629,19 @@ public class DateFieldMapperTests extends MapperTestCase {
             private final DateFormatter formatter = resolution == DateFieldMapper.Resolution.MILLISECONDS
                 ? DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER
                 : DateFieldMapper.DEFAULT_DATE_TIME_NANOS_FORMATTER;
+            // date fields have doc_values enabled by default, so multi_value: false can always be requested when the feature is on.
+            private final boolean enforceSingleValue = FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled()
+                && randomBoolean();
+
+            @Override
+            public boolean enforcesSingleValue() {
+                return enforceSingleValue;
+            }
 
             @Override
             public SyntheticSourceExample example(int maxValues) {
-                if (randomBoolean()) {
+                // When multi_value is disabled a document may only have a single value, so never take the multi-valued branch below.
+                if (enforceSingleValue || randomBoolean()) {
                     Value v = generateValue();
                     if (v.malformedOutput != null) {
                         return new SyntheticSourceExample(v.input, v.malformedOutput, this::mapping);
@@ -716,6 +725,11 @@ public class DateFieldMapperTests extends MapperTestCase {
                 }
                 if (ignoreMalformed) {
                     b.field("ignore_malformed", true);
+                }
+                if (enforceSingleValue) {
+                    b.startObject("doc_values");
+                    b.field("multi_value", false);
+                    b.endObject();
                 }
             }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/IpFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IpFieldMapperTests.java
@@ -348,14 +348,25 @@ public class IpFieldMapperTests extends MapperTestCase {
     private static class IpSyntheticSourceSupport implements SyntheticSourceSupport {
         private final InetAddress nullValue = usually() ? null : randomIp(randomBoolean());
         private final boolean ignoreMalformed;
+        // Decided once per instance so that the generated mapping is stable across the throwaway and per-document examples.
+        private final boolean extendedDocValues = FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled()
+            && randomBoolean();
+        private final String cardinality = ESTestCase.randomFrom("low", "high");
+        private final boolean enforceSingleValue = extendedDocValues && randomBoolean();
 
         private IpSyntheticSourceSupport(boolean ignoreMalformed) {
             this.ignoreMalformed = ignoreMalformed;
         }
 
         @Override
+        public boolean enforcesSingleValue() {
+            return enforceSingleValue;
+        }
+
+        @Override
         public SyntheticSourceExample example(int maxValues) {
-            if (randomBoolean()) {
+            // When multi_value is disabled a document may only have a single value, so never take the multi-valued branch below.
+            if (enforceSingleValue || randomBoolean()) {
                 Tuple<Object, Object> v = generateValue();
                 if (v.v2() instanceof InetAddress a) {
                     return new SyntheticSourceExample(v.v1(), NetworkAddress.format(a), this::mapping);
@@ -415,9 +426,12 @@ public class IpFieldMapperTests extends MapperTestCase {
             if (ignoreMalformed) {
                 b.field("ignore_malformed", true);
             }
-            if (FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled() && randomBoolean()) {
+            if (extendedDocValues) {
                 b.startObject("doc_values");
-                b.field("cardinality", ESTestCase.randomFrom("low", "high"));
+                b.field("cardinality", cardinality);
+                if (enforceSingleValue) {
+                    b.field("multi_value", false);
+                }
                 b.endObject();
             }
         }

--- a/server/src/test/java/org/elasticsearch/index/mapper/IpFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IpFieldTypeTests.java
@@ -73,7 +73,8 @@ public class IpFieldTypeTests extends FieldTypeTestCase {
             false,
             false,
             true,
-            false
+            false,
+            null
         );
 
         String ip = "2001:db8::2:1";
@@ -126,7 +127,8 @@ public class IpFieldTypeTests extends FieldTypeTestCase {
             false,
             false,
             false,
-            false
+            false,
+            null
         );
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> unsearchable.termQuery("::1", MOCK_CONTEXT));
         assertEquals("Cannot search on field [field] since it is not indexed nor has doc values.", e.getMessage());
@@ -362,7 +364,8 @@ public class IpFieldTypeTests extends FieldTypeTestCase {
             false,
             false,
             false,
-            false
+            false,
+            null
         );
         IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,

--- a/server/src/test/java/org/elasticsearch/index/mapper/blockloader/BooleanFieldBlockLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/blockloader/BooleanFieldBlockLoaderTests.java
@@ -36,7 +36,7 @@ public class BooleanFieldBlockLoaderTests extends BlockLoaderTestCase {
             return convert(value, nullValue);
         }
 
-        if ((boolean) fieldMapping.getOrDefault("doc_values", false)) {
+        if (hasDocValues(fieldMapping, false)) {
             var stream = ((List<Object>) value).stream().map(v -> convert(v, nullValue)).filter(Objects::nonNull);
             // Columnar index modes preserve arrival order via offsets
             boolean preserveOrder = params.indexMode().isColumnar();

--- a/server/src/test/java/org/elasticsearch/index/mapper/blockloader/DateFieldBlockLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/blockloader/DateFieldBlockLoaderTests.java
@@ -37,7 +37,7 @@ public class DateFieldBlockLoaderTests extends BlockLoaderTestCase {
             return convert(value, nullValue, format);
         }
 
-        if ((boolean) fieldMapping.getOrDefault("doc_values", false)) {
+        if (hasDocValues(fieldMapping, false)) {
             var stream = ((List<Object>) value).stream().map(v -> convert(v, nullValue, format)).filter(Objects::nonNull);
             // Columnar index modes preserve arrival order via offsets
             boolean preserveOrder = params.indexMode().isColumnar();

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorTests.java
@@ -1335,7 +1335,8 @@ public class TermsAggregatorTests extends AggregatorTestCase {
             false,
             false,
             false,
-            false
+            false,
+            null
         );
         testCase(iw -> {
             Document document = new Document();

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/BlockLoaderTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/BlockLoaderTestCase.java
@@ -23,9 +23,11 @@ import org.elasticsearch.datageneration.Template;
 import org.elasticsearch.datageneration.datasource.DataSourceHandler;
 import org.elasticsearch.datageneration.datasource.DataSourceRequest;
 import org.elasticsearch.datageneration.datasource.DataSourceResponse;
+import org.elasticsearch.datageneration.datasource.DefaultMappingParametersHandler;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.indices.CrankyCircuitBreakerService;
+import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentType;
 
@@ -35,6 +37,9 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -109,13 +114,107 @@ public abstract class BlockLoaderTestCase extends MapperServiceTestCase {
     protected BlockLoaderTestCase(String fieldType, Collection<DataSourceHandler> customDataSourceHandlers, Params params) {
         this.fieldType = fieldType;
         this.params = params;
-        this.customDataSourceHandlers = customDataSourceHandlers;
+        this.customDataSourceHandlers = withSingleValueDocValues(fieldType, customDataSourceHandlers);
         this.runner = new BlockLoaderTestRunner(params);
         if (randomBoolean()) {
             runner.allowDummyDocs();
         }
 
         this.fieldName = randomAlphaOfLengthBetween(5, 10);
+    }
+
+    /**
+     * Field types whose mappers enforce single-value semantics through {@code doc_values.multi_value: false}. Only these may carry the
+     * parameter, so the coordinated single-value handler below is injected for them alone.
+     */
+    private static final Set<String> SINGLE_VALUE_ENFORCING_TYPES = Set.of(
+        "keyword",
+        "text",
+        "match_only_text",
+        "long",
+        "integer",
+        "short",
+        "byte",
+        "double",
+        "float",
+        "half_float",
+        "unsigned_long",
+        "scaled_float",
+        "boolean",
+        "date",
+        "ip"
+    );
+
+    /**
+     * On a random subset of runs (feature-flag permitting), prepend a handler that forces {@code doc_values.multi_value: false} on the
+     * target field while keeping generated documents single-valued, so the enforced mapping is exercised without rejecting documents.
+     */
+    private static Collection<DataSourceHandler> withSingleValueDocValues(String fieldType, Collection<DataSourceHandler> customHandlers) {
+        boolean singleValueRun = FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled()
+            && SINGLE_VALUE_ENFORCING_TYPES.contains(fieldType)
+            && ESTestCase.randomBoolean();
+        if (singleValueRun == false) {
+            return customHandlers;
+        }
+        // Prepend so the single-value array wrapper takes precedence over any default wrapper for this run.
+        var handlers = new ArrayList<DataSourceHandler>();
+        handlers.add(new SingleValueDocValuesDataSourceHandler());
+        handlers.addAll(customHandlers);
+        return handlers;
+    }
+
+    /**
+     * Coordinated handler pairing two decisions that otherwise run independently: it forces {@code doc_values.multi_value: false} on
+     * single-value-enforcing fields and, in lock-step, never wraps values into arrays of length two or more. Without the coupling the
+     * enforced mapping would reject any document the array wrapper happened to make multi-valued.
+     */
+    private static final class SingleValueDocValuesDataSourceHandler implements DataSourceHandler {
+        @Override
+        public DataSourceResponse.LeafMappingParametersGenerator handle(DataSourceRequest.LeafMappingParametersGenerator request) {
+            if (SINGLE_VALUE_ENFORCING_TYPES.contains(request.fieldType()) == false) {
+                // Leave non-enforcing fields (e.g. multi-field subfields of other types) to the default handlers.
+                return null;
+            }
+            // Delegate directly to the default handler to keep all other generated parameters, then only rewrite doc_values.
+            var defaults = new DefaultMappingParametersHandler().handle(request);
+            if (defaults == null) {
+                return null;
+            }
+            return new DataSourceResponse.LeafMappingParametersGenerator(() -> {
+                var mapping = new HashMap<>(defaults.mappingGenerator().get());
+                mapping.put("doc_values", forceSingleValueDocValues(mapping.get("doc_values")));
+                return mapping;
+            });
+        }
+
+        @Override
+        public DataSourceResponse.ArrayWrapper handle(DataSourceRequest.ArrayWrapper request) {
+            // multi_value: false rejects documents with more than one value, so only ever emit a scalar, an empty array, or one element.
+            return new DataSourceResponse.ArrayWrapper(values -> () -> {
+                if (ESTestCase.randomBoolean()) {
+                    var size = ESTestCase.randomIntBetween(0, 1);
+                    return IntStream.range(0, size).mapToObj(i -> values.get()).toList();
+                }
+                return values.get();
+            });
+        }
+
+        @Override
+        public DataSourceResponse.ObjectArrayGenerator handle(DataSourceRequest.ObjectArrayGenerator request) {
+            // Arrays of objects would repeat a leaf field across elements, producing multiple values for it and tripping the
+            // single-value enforcement, so never wrap objects into arrays while this handler is active.
+            return new DataSourceResponse.ObjectArrayGenerator(Optional::empty);
+        }
+
+        private static Map<String, Object> forceSingleValueDocValues(Object existing) {
+            var docValues = new HashMap<String, Object>();
+            if (existing instanceof Map<?, ?> existingMap && existingMap.get("cardinality") != null) {
+                // Preserve a randomly chosen cardinality (low/high) when the default produced one.
+                docValues.put("cardinality", existingMap.get("cardinality"));
+            }
+            docValues.put("multi_value", false);
+            return docValues;
+        }
     }
 
     @Override

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/KeywordFieldSyntheticSourceSupport.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/KeywordFieldSyntheticSourceSupport.java
@@ -55,8 +55,16 @@ public class KeywordFieldSyntheticSourceSupport implements MapperTestCase.Synthe
         }
 
         return switch (ESTestCase.randomInt(allowIgnoredSource ? 2 : 1)) {
-            case 0 -> new FieldMapper.DocValuesParameter.Values(true, FieldMapper.DocValuesParameter.Values.Cardinality.LOW, true);
-            case 1 -> new FieldMapper.DocValuesParameter.Values(true, FieldMapper.DocValuesParameter.Values.Cardinality.HIGH, true);
+            case 0 -> new FieldMapper.DocValuesParameter.Values(
+                true,
+                FieldMapper.DocValuesParameter.Values.Cardinality.LOW,
+                ESTestCase.randomBoolean()
+            );
+            case 1 -> new FieldMapper.DocValuesParameter.Values(
+                true,
+                FieldMapper.DocValuesParameter.Values.Cardinality.HIGH,
+                ESTestCase.randomBoolean()
+            );
             case 2 -> FieldMapper.DocValuesParameter.Values.DISABLED;
             default -> throw new IllegalStateException();
         };
@@ -65,6 +73,11 @@ public class KeywordFieldSyntheticSourceSupport implements MapperTestCase.Synthe
     @Override
     public boolean ignoreAbove() {
         return ignoreAbove != null;
+    }
+
+    @Override
+    public boolean enforcesSingleValue() {
+        return docValues.multiValue() == false;
     }
 
     @Override
@@ -89,7 +102,8 @@ public class KeywordFieldSyntheticSourceSupport implements MapperTestCase.Synthe
         boolean flipOrder,
         boolean ignoredValuesSorted
     ) {
-        if (ESTestCase.randomBoolean()) {
+        // When multi_value is disabled a document may only have a single value, so never take the multi-valued branch below.
+        if (enforcesSingleValue() || ESTestCase.randomBoolean()) {
             Tuple<String, String> v = generateValue();
             Object sourceValue = preservesExactSource() ? v.v1() : v.v2();
             return new MapperTestCase.SyntheticSourceExample(v.v1(), sourceValue, this::mapping);
@@ -162,6 +176,9 @@ public class KeywordFieldSyntheticSourceSupport implements MapperTestCase.Synthe
             } else {
                 b.startObject("doc_values");
                 b.field("cardinality", docValues.cardinality().toString());
+                if (docValues.multiValue() == false) {
+                    b.field("multi_value", false);
+                }
                 b.endObject();
             }
         }

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
@@ -1358,6 +1358,14 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
         }
 
         /**
+         * @return true when the field enforces single-value semantics (ie. {@code doc_values.multi_value: false}). In such cases, a doc
+         * with more than one value for the field is rejected at parse time and {@link #example} must only produce single-valued documents.
+         */
+        default boolean enforcesSingleValue() {
+            return false;
+        }
+
+        /**
          * Examples that should work when source is generated from doc values.
          */
         SyntheticSourceExample example(int maxValues) throws IOException;
@@ -1766,8 +1774,9 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
     }
 
     public void testSyntheticSourceKeepArrays() throws IOException {
-        SyntheticSourceExample example = syntheticSourceSupportForKeepTests(shouldUseIgnoreMalformed(), Mapper.SourceKeepMode.ARRAYS)
-            .example(1);
+        SyntheticSourceSupport support = syntheticSourceSupportForKeepTests(shouldUseIgnoreMalformed(), Mapper.SourceKeepMode.ARRAYS);
+        assumeFalse("multi_value: false rejects documents with more than one value", support.enforcesSingleValue());
+        SyntheticSourceExample example = support.example(1);
         DocumentMapper mapperAll = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("field");
             b.field("synthetic_source_keep", randomSyntheticSourceKeep());

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapperTests.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapperTests.java
@@ -397,6 +397,9 @@ public abstract class NumberFieldMapperTests extends MapperTestCase {
         private final Long nullValue = usually() ? null : randomNumber().longValue();
         private final boolean coerce = rarely();
         private final boolean docValues = randomBoolean();
+        private final boolean enforceSingleValue = docValues
+            && FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled()
+            && randomBoolean();
 
         private final Function<Number, Number> round;
         private final boolean ignoreMalformed;
@@ -414,8 +417,14 @@ public abstract class NumberFieldMapperTests extends MapperTestCase {
         }
 
         @Override
+        public boolean enforcesSingleValue() {
+            return enforceSingleValue;
+        }
+
+        @Override
         public SyntheticSourceExample example(int maxVals) {
-            if (randomBoolean()) {
+            // When multi_value is disabled a document may only have a single value, so never take the multi-valued branch below.
+            if (enforceSingleValue || randomBoolean()) {
                 Tuple<Object, Object> v = generateValue();
                 if (preservesExactSource()) {
                     var rawInput = v.v1();
@@ -482,6 +491,10 @@ public abstract class NumberFieldMapperTests extends MapperTestCase {
             }
             if (docValues == false) {
                 b.field("doc_values", "false");
+            } else if (enforceSingleValue) {
+                b.startObject("doc_values");
+                b.field("multi_value", false);
+                b.endObject();
             }
         }
 

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/TextFieldFamilySyntheticSourceTestSetup.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/TextFieldFamilySyntheticSourceTestSetup.java
@@ -66,9 +66,18 @@ public final class TextFieldFamilySyntheticSourceTestSetup {
             return FieldMapper.DocValuesParameter.Values.DISABLED;
         }
 
+        // multi_value: false enforces single-value semantics and is only meaningful when doc_values is enabled.
         return switch (randomInt(2)) {
-            case 0 -> new FieldMapper.DocValuesParameter.Values(true, FieldMapper.DocValuesParameter.Values.Cardinality.LOW, true);
-            case 1 -> new FieldMapper.DocValuesParameter.Values(true, FieldMapper.DocValuesParameter.Values.Cardinality.HIGH, true);
+            case 0 -> new FieldMapper.DocValuesParameter.Values(
+                true,
+                FieldMapper.DocValuesParameter.Values.Cardinality.LOW,
+                randomBoolean()
+            );
+            case 1 -> new FieldMapper.DocValuesParameter.Values(
+                true,
+                FieldMapper.DocValuesParameter.Values.Cardinality.HIGH,
+                randomBoolean()
+            );
             case 2 -> FieldMapper.DocValuesParameter.Values.DISABLED;
             default -> throw new IllegalStateException();
         };
@@ -116,6 +125,17 @@ public final class TextFieldFamilySyntheticSourceTestSetup {
         @Override
         public boolean ignoreAbove() {
             return keywordMultiFieldSyntheticSourceSupport.ignoreAbove();
+        }
+
+        @Override
+        public boolean enforcesSingleValue() {
+            if (store) {
+                return false;
+            }
+            if (docValues.enabled()) {
+                return docValues.multiValue() == false;
+            }
+            return keywordMultiFieldSyntheticSourceSupport.enforcesSingleValue();
         }
 
         @Override
@@ -182,11 +202,15 @@ public final class TextFieldFamilySyntheticSourceTestSetup {
                 } else {
                     b.startObject("doc_values");
                     b.field("cardinality", docValues.cardinality().toString());
+                    if (docValues.multiValue() == false) {
+                        b.field("multi_value", false);
+                    }
                     b.endObject();
                 }
             };
 
-            if (randomBoolean()) {
+            // When multi_value is disabled a document may only have a single value, so never produce a multi-valued example.
+            if (enforcesSingleValue() || randomBoolean()) {
                 var randomString = randomString();
                 return new MapperTestCase.SyntheticSourceExample(randomString, randomString, mapping);
             }


### PR DESCRIPTION
The current generative tests don't exercise the `multi_value` path enough:
- For the synthetic source tests, `multi_value=false` is not exercised. This was because those tests generated a document with a mixed value cardinality (some fields single-valued and some multi-valued). That resulted in errors since `multi_value=false` throws on arrays.
- For the block loader tests, `multi_value` was never set in the first place.

After adding the new tests, two bugs were surfaced in block loaders of IP and match only tests fields. These have also been fixed as part of this PR. The two bugs are identical - in both cases the block loader is not `multi_value` aware and incorrectly chooses a `BytesRefsFromBinaryMultiSeparateCountBlockLoader` for single-valued fields.

Addresses https://github.com/elastic/logs-program/issues/122