### PR TITLE
Reuse docs ids array in LuceneOperator

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/query/LuceneSourceOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/query/LuceneSourceOperator.java
@@ -12,7 +12,6 @@ import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.CollectionTerminatedException;
 import org.apache.lucene.search.ConstantScoreQuery;
-import org.apache.lucene.search.DocIdStream;
 import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.LeafCollector;
 import org.apache.lucene.search.MatchAllDocsQuery;
@@ -421,7 +420,6 @@ public class LuceneSourceOperator extends LuceneOperator {
     protected void describe(StringBuilder sb) {
         sb.append(", remainingDocs = ").append(remainingDocs);
     }
-
 
     private static class IntArrayPool implements Releasable {
         private int[] pool;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/query/LuceneSourceOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/query/LuceneSourceOperator.java
@@ -12,6 +12,7 @@ import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.CollectionTerminatedException;
 import org.apache.lucene.search.ConstantScoreQuery;
+import org.apache.lucene.search.DocIdStream;
 import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.LeafCollector;
 import org.apache.lucene.search.MatchAllDocsQuery;
@@ -21,6 +22,8 @@ import org.apache.lucene.search.PointInSetQuery;
 import org.apache.lucene.search.PointRangeQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Scorable;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BlockUtils;
@@ -35,6 +38,7 @@ import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.Limiter;
 import org.elasticsearch.compute.operator.SourceOperator;
 import org.elasticsearch.core.RefCounted;
+import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
@@ -56,11 +60,12 @@ import static org.elasticsearch.compute.lucene.query.LuceneSliceQueue.Partitioni
 public class LuceneSourceOperator extends LuceneOperator {
     private static final Logger log = LogManager.getLogger(LuceneSourceOperator.class);
 
-    private int currentPagePos = 0;
     private int remainingDocs;
     private final Limiter limiter;
 
-    private IntVector.Builder docsBuilder;
+    private final IntArrayPool docIdsPool;
+    private int[] docIds;
+    private int currentPagePos = 0;
     private DoubleVector.Builder scoreBuilder;
     private final LeafCollector leafCollector;
     private final int minPageSize;
@@ -245,7 +250,6 @@ public class LuceneSourceOperator extends LuceneOperator {
         int estimatedSize = Math.min(limit, maxPageSize);
         boolean success = false;
         try {
-            this.docsBuilder = blockFactory.newIntVectorBuilder(estimatedSize);
             if (needsScore) {
                 scoreBuilder = blockFactory.newDoubleVectorBuilder(estimatedSize);
                 this.leafCollector = new ScoringCollector();
@@ -253,6 +257,7 @@ public class LuceneSourceOperator extends LuceneOperator {
                 scoreBuilder = null;
                 this.leafCollector = new LimitingCollector();
             }
+            this.docIdsPool = new IntArrayPool(blockFactory.breaker());
             success = true;
         } finally {
             if (success == false) {
@@ -269,8 +274,7 @@ public class LuceneSourceOperator extends LuceneOperator {
         public void collect(int doc) throws IOException {
             if (remainingDocs > 0) {
                 --remainingDocs;
-                docsBuilder.appendInt(doc);
-                currentPagePos++;
+                docIds[currentPagePos++] = doc;
             } else {
                 throw new CollectionTerminatedException();
             }
@@ -313,6 +317,9 @@ public class LuceneSourceOperator extends LuceneOperator {
             if (scorer == null) {
                 return null;
             }
+            if (docIds == null) {
+                docIds = docIdsPool.getOrAllocate(maxPageSize);
+            }
             final int remainingDocsStart = remainingDocs = limiter.remaining();
             try {
                 scorer.scoreNextRange(
@@ -342,8 +349,7 @@ public class LuceneSourceOperator extends LuceneOperator {
                     int shardId = scorer.shardContext().index();
                     shard = blockFactory.newConstantIntVector(shardId, currentPagePos);
                     leaf = blockFactory.newConstantIntVector(scorer.leafReaderContext().ord, currentPagePos);
-                    docs = buildDocsVector(currentPagePos);
-                    docsBuilder = blockFactory.newIntVectorBuilder(Math.min(remainingDocs, maxPageSize));
+                    docs = buildDocsVector();
                     int b = 0;
                     blocks[b++] = new DocVector(refCounteds, shard, leaf, docs, DocVector.config().singleSegmentNonDecreasing(true))
                         .asBlock();
@@ -370,20 +376,13 @@ public class LuceneSourceOperator extends LuceneOperator {
         }
     }
 
-    private IntVector buildDocsVector(int upToPositions) {
-        final IntVector docs = docsBuilder.build();
-        assert docs.getPositionCount() >= upToPositions : docs.getPositionCount() + " < " + upToPositions;
-        if (docs.getPositionCount() == upToPositions) {
-            return docs;
-        }
-        try (docs) {
-            try (var slice = blockFactory.newIntVectorFixedBuilder(upToPositions)) {
-                for (int i = 0; i < upToPositions; i++) {
-                    slice.appendInt(docs.getInt(i));
-                }
-                return slice.build();
-            }
-        }
+    private IntVector buildDocsVector() {
+        final var docIds = this.docIds;
+        this.docIds = null;
+        final var arrayPool = this.docIdsPool; // avoid holding reference to this
+        final IntVector docs = blockFactory.newIntArrayVector(docIds, currentPagePos);
+        docs.attachReleasable(() -> arrayPool.put(docIds));
+        return docs;
     }
 
     private DoubleVector buildScoresVector(int upToPositions) {
@@ -415,11 +414,48 @@ public class LuceneSourceOperator extends LuceneOperator {
 
     @Override
     public void additionalClose() {
-        Releasables.close(docsBuilder, scoreBuilder);
+        Releasables.close(scoreBuilder, docIdsPool);
     }
 
     @Override
     protected void describe(StringBuilder sb) {
         sb.append(", remainingDocs = ").append(remainingDocs);
+    }
+
+
+    private static class IntArrayPool implements Releasable {
+        private int[] pool;
+        private long usedBytes;
+        private final CircuitBreaker breaker;
+
+        IntArrayPool(CircuitBreaker breaker) {
+            this.breaker = breaker;
+        }
+
+        int[] getOrAllocate(int size) {
+            int[] arr = this.pool;
+            this.pool = null;
+            if (arr == null || arr.length < size) {
+                final long newBytes = RamUsageEstimator.alignObjectSize(
+                    (long) RamUsageEstimator.NUM_BYTES_ARRAY_HEADER + (long) Integer.BYTES * size
+                );
+                if (newBytes > usedBytes) {
+                    breaker.addEstimateBytesAndMaybeBreak(newBytes - usedBytes, "int[]");
+                    usedBytes = newBytes;
+                }
+                arr = new int[size];
+            }
+            return arr;
+        }
+
+        void put(int[] arr) {
+            // the pool can be tolerated with races, where we just allocate a new array
+            this.pool = arr;
+        }
+
+        @Override
+        public void close() {
+            breaker.addWithoutBreaking(-usedBytes);
+        }
     }
 }


### PR DESCRIPTION
In LuceneOperator, we allocate doc-ID vectors (backed by int arrays) that are short-lived - they don't survive more than a single cycle. We could reuse them by using a release callback. Marking this as a non-issue since this improvement is small. I will follow-up with similar changes for block loaders.