### PR TITLE
[9.4] [ES|QL] PromQL convert labels ToString

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-promql.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-promql.csv-spec
@@ -838,3 +838,15 @@ result:double | step:datetime
 62.0          | 2024-05-10T00:00:00.000Z
 ;
 
+label_matching_on_non_string_label_9_4
+required_capability: promql_command_v0
+required_capability: promql_numeric_label_matching_9_4
+PROMQL index=k8s step=10m value=(sum(rate(network.total_bytes_in{network.bytes_in =~"1.."}[10m])) / sum(rate(network.total_bytes_in[10m])) * 100)
+| SORT step
+;
+
+value:double       | step:datetime
+16.279099821524305 | 2024-05-10T00:00:00.000Z
+37.69321892075542  | 2024-05-10T00:10:00.000Z
+13.896004927602956 | 2024-05-10T00:20:00.000Z
+;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -2067,6 +2067,12 @@ public class EsqlCapabilities {
         PROMQL_ABSENT_LABEL_MATCHING,
 
         /**
+         * Fix for PromQL label matching on numeric fields, because PromQL treats all labels like strings, even numerics
+         * This capability only exists on 9.4
+         */
+        PROMQL_NUMERIC_LABEL_MATCHING_9_4,
+
+        /**
          * Support for`WITHOUT` grouping function
          * that excludes specific dimensions from time-series grouping.
          */

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/promql/TranslatePromqlToEsqlPlan.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/promql/TranslatePromqlToEsqlPlan.java
@@ -19,6 +19,7 @@ import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.expression.function.Function;
 import org.elasticsearch.xpack.esql.core.expression.predicate.regex.RLikePattern;
 import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.AggregateFunction;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.LastOverTime;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Scalar;
@@ -27,6 +28,7 @@ import org.elasticsearch.xpack.esql.expression.function.aggregate.Values;
 import org.elasticsearch.xpack.esql.expression.function.grouping.Bucket;
 import org.elasticsearch.xpack.esql.expression.function.grouping.TimeSeriesWithout;
 import org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToDouble;
+import org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToString;
 import org.elasticsearch.xpack.esql.expression.function.scalar.internal.PackDimension;
 import org.elasticsearch.xpack.esql.expression.function.scalar.internal.UnpackDimension;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.EndsWith;
@@ -70,6 +72,7 @@ import org.elasticsearch.xpack.esql.plan.logical.promql.selector.LabelMatchers;
 import org.elasticsearch.xpack.esql.plan.logical.promql.selector.LiteralSelector;
 import org.elasticsearch.xpack.esql.plan.logical.promql.selector.RangeSelector;
 import org.elasticsearch.xpack.esql.plan.logical.promql.selector.Selector;
+import org.elasticsearch.xpack.esql.session.Configuration;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -591,7 +594,12 @@ public final class TranslatePromqlToEsqlPlan extends OptimizerRules.Parameterize
      * Adds label filter conditions to the context.
      */
     private TranslationResult translateSelector(Selector selector, LogicalPlan currentPlan, TranslationContext ctx) {
-        Expression matcherCondition = translateLabelMatchers(selector.source(), selector.labels(), selector.labelMatchers());
+        Expression matcherCondition = translateLabelMatchers(
+            selector.source(),
+            selector.labels(),
+            selector.labelMatchers(),
+            ctx.optimizerContext.configuration()
+        );
         Expression expr;
         if (selector instanceof LiteralSelector literalSelector) {
             expr = literalSelector.literal();
@@ -909,7 +917,12 @@ public final class TranslatePromqlToEsqlPlan extends OptimizerRules.Parameterize
      * @param labelMatchers the PromQL label matchers to translate
      * @return an ESQL Expression combining all label matcher conditions with AND
      */
-    private static Expression translateLabelMatchers(Source source, List<Expression> fields, LabelMatchers labelMatchers) {
+    private static Expression translateLabelMatchers(
+        Source source,
+        List<Expression> fields,
+        LabelMatchers labelMatchers,
+        Configuration config
+    ) {
         var matchers = labelMatchers.matchers();
         // optimization for literal selectors that don't have label matchers
         if (matchers.isEmpty()) {
@@ -924,6 +937,9 @@ public final class TranslatePromqlToEsqlPlan extends OptimizerRules.Parameterize
                 hasNameMatcher = true;
             } else {
                 Expression field = fields.get(hasNameMatcher ? i - 1 : i); // adjust index if name matcher was seen
+                if (field.resolved() && DataType.isString(field.dataType()) == false) {
+                    field = new ToString(field.source(), field, config);
+                }
                 Expression condition = translateLabelMatcher(source, field, matcher);
                 if (condition != null) {
                     conditions.add(condition);


### PR DESCRIPTION
PromQL lets you match fields that aren't strings to strings in labels (for example `numeric_field="500"`), because they are all treated as strings in the label. This fix adds a ToString conversion if we're dealing with a non-string field in the label.