### PR TITLE
[9.4] ESQL: Skip a test that loads differently (#150788)

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/boolean.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/boolean.csv-spec
@@ -208,6 +208,7 @@ row ul = [9223372036854775808, 9223372036854775807, 1, 0] | eval bool = to_bool(
 ;
 
 convertFromIntAndLong
+request_stored: skip
 from employees | sort emp_no | keep emp_no, salary_change* | eval int2bool = to_boolean(salary_change.int), long2bool = to_boolean(salary_change.long) | limit 10;
 
 emp_no:integer |salary_change:double      |salary_change.int:integer | salary_change.keyword:keyword |salary_change.long:long |int2bool:boolean          |long2bool:boolean       

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/drop.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/drop.csv-spec
@@ -33,6 +33,7 @@ avg_worked_seconds:long | birth_date:date | emp_no:integer | first_name:keyword 
 ;
 
 whereWithEvalGeneratedValue_DropHeight
+request_stored: skip
 from employees | sort emp_no | eval x = salary / 2 | where x > 37000 | drop height*;
 
 avg_worked_seconds:long | birth_date:date | emp_no:integer | first_name:keyword | gender:keyword | hire_date:date | is_rehired:boolean | job_positions:keyword | languages:integer | languages.byte:integer | languages.long:long | languages.short:integer | last_name:keyword | salary:integer | salary_change:double | salary_change.int:integer |salary_change.keyword:keyword |salary_change.long:long | still_hired:boolean | x:integer

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/keep.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/keep.csv-spec
@@ -318,6 +318,7 @@ salary:integer
 ;
 
 whereWithEvalGeneratedValue
+request_stored: skip
 // the result from running on ES is the one with many decimals the test that runs locally is the one rounded to 2 decimals
 // the "height" fields have the values as 1.7, 1.7000000476837158, 1.7001953125, 1.7
 from employees | eval x = salary / 2 | where x > 37000;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/rename.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/rename.csv-spec
@@ -160,6 +160,7 @@ y:integer | x:date
 
 renameIntertwinedWithSort
 required_capability: fix_precision_of_scaled_float_fields
+request_stored: skip
 FROM employees | eval x = salary | rename x as y | rename y as x | sort x | rename x as y | limit 10;
 
 avg_worked_seconds:l | birth_date:date          | emp_no:i             | first_name:s         | gender:s             | height:d             | height.float:d       | height.half_float:d  | height.scaled_float:d| hire_date:date           | is_rehired:bool      | job_positions:s      | languages:i          | languages.byte:i     | languages.long:l     | languages.short:i    | last_name:s          | salary:i             | salary_change:d      | salary_change.int:i  | salary_change.keyword:s | salary_change.long:l | still_hired:bool  | y:i          

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/topN.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/topN.csv-spec
@@ -116,6 +116,7 @@ Mary              |Sluis            |[-7.82, 3.48, 8.73, 10.35]
 ;
 
 sortingOnNumbersFromStrings
+request_stored: skip
 from employees 
 | eval long_from_string = to_long(salary_change.keyword) 
 | sort long_from_string asc nulls last, emp_no 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [ESQL: Skip a test that loads differently (#150788)](https://github.com/elastic/elasticsearch/pull/150788)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)