### PR TITLE
[9.4] Fix MapperParsingException warning during startup (#150774)

### DIFF
--- a/x-pack/plugin/core/template-resources/src/main/resources/activitylog/logs-elasticsearch.querylog@mappings.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/activitylog/logs-elasticsearch.querylog@mappings.json
@@ -9,10 +9,12 @@
               "type": "long",
               "index": false
             }
-          },
+          }
+        },
+        {
           "elasticsearch_querylog_esql_profile_longs": {
             "path_match": "elasticsearch.querylog.esql.profile.*",
-            "match_mapping_type": ["long", "integer", "short", "byte"],
+            "match_mapping_type": "long",
             "mapping": {
               "type": "long",
               "index": false

--- a/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/QueryLoggingTemplateRegistry.java
+++ b/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/QueryLoggingTemplateRegistry.java
@@ -34,8 +34,9 @@ public class QueryLoggingTemplateRegistry extends IndexTemplateRegistry {
     // version 2: limit query to 32k
     // version 3: add esql.filter
     // version 4: move filter to main body
-    // version 5: add esql.profile longs mapping
-    public static final int INDEX_TEMPLATE_VERSION = 5;
+    // version 5: add esql.profile longs mapping (broken — two templates merged into one array entry)
+    // version 6: fix dynamic_templates to use one array entry per template
+    public static final int INDEX_TEMPLATE_VERSION = 6;
 
     public static final String QUERY_LOGGING_TEMPLATE_VERSION_VARIABLE = "xpack.stack.querylog.template.version";
 

--- a/x-pack/plugin/stack/src/test/java/org/elasticsearch/xpack/stack/QueryLoggingTemplateRegistryTests.java
+++ b/x-pack/plugin/stack/src/test/java/org/elasticsearch/xpack/stack/QueryLoggingTemplateRegistryTests.java
@@ -7,7 +7,9 @@
 
 package org.elasticsearch.xpack.stack;
 
+import org.elasticsearch.cluster.metadata.ComponentTemplate;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ClusterServiceUtils;
 import org.elasticsearch.test.ESTestCase;
@@ -15,7 +17,15 @@ import org.elasticsearch.test.client.NoOpClient;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentParserConfiguration;
+import org.elasticsearch.xcontent.XContentType;
 import org.junit.After;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.not;
@@ -59,5 +69,66 @@ public class QueryLoggingTemplateRegistryTests extends ESTestCase {
         );
         assertThat(registry.getComposableTemplateConfigs(), not(anEmptyMap()));
         assertThat(registry.getComponentTemplateConfigs(), not(anEmptyMap()));
+    }
+
+    public void testMappingsComponentTemplateHasValidDynamicTemplates() throws IOException {
+        threadPool = new TestThreadPool(getClass().getName());
+        ClusterService clusterService = ClusterServiceUtils.createClusterService(threadPool);
+        QueryLoggingTemplateRegistry registry = new QueryLoggingTemplateRegistry(
+            Settings.EMPTY,
+            clusterService,
+            threadPool,
+            new NoOpClient(threadPool),
+            NamedXContentRegistry.EMPTY
+        );
+        ComponentTemplate mappingsTemplate = registry.getComponentTemplateConfigs()
+            .get(QueryLoggingTemplateRegistry.QUERY_LOGGING_MAPPINGS_NAME);
+        assertNotNull(mappingsTemplate);
+        CompressedXContent mappings = mappingsTemplate.template().mappings();
+        assertNotNull(mappings);
+
+        Set<String> validMatchMappingTypes = Set.of("object", "string", "long", "double", "boolean", "date", "binary");
+        try (XContentParser parser = XContentType.JSON.xContent().createParser(XContentParserConfiguration.EMPTY, mappings.string())) {
+            Map<String, Object> mappingsMap = parser.map();
+            @SuppressWarnings("unchecked")
+            List<Object> dynamicTemplates = (List<Object>) mappingsMap.get("dynamic_templates");
+            if (dynamicTemplates != null) {
+                for (int i = 0; i < dynamicTemplates.size(); i++) {
+                    @SuppressWarnings("unchecked")
+                    Map<String, Object> entry = (Map<String, Object>) dynamicTemplates.get(i);
+                    assertEquals(
+                        "dynamic_templates[" + i + "] must have exactly one key (its name), but had: " + entry.keySet(),
+                        1,
+                        entry.size()
+                    );
+                    @SuppressWarnings("unchecked")
+                    Map<String, Object> templateDef = (Map<String, Object>) entry.values().iterator().next();
+                    Object matchMappingType = templateDef.get("match_mapping_type");
+                    if (matchMappingType instanceof String s) {
+                        assertTrue(
+                            "dynamic_templates["
+                                + i
+                                + "].match_mapping_type ["
+                                + s
+                                + "] is not a valid type; valid: "
+                                + validMatchMappingTypes,
+                            validMatchMappingTypes.contains(s)
+                        );
+                    } else if (matchMappingType instanceof List<?> list) {
+                        for (Object t : list) {
+                            assertTrue(
+                                "dynamic_templates["
+                                    + i
+                                    + "].match_mapping_type ["
+                                    + t
+                                    + "] is not a valid type; valid: "
+                                    + validMatchMappingTypes,
+                                validMatchMappingTypes.contains(t)
+                            );
+                        }
+                    }
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Fix MapperParsingException warning during startup (#150774)