### PR TITLE
Fix precision error in DiversifyingChildrenIVFKnnFloatSlicedVectorQueryTests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -611,9 +611,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.ndjson.NdJsonFormatSpecIT
   method: test {csv-spec:external-basic.inlineStatsMaxSalary [AZURE]}
   issue: https://github.com/elastic/elasticsearch/issues/150791
-- class: org.elasticsearch.search.vectors.DiversifyingChildrenIVFKnnFloatSlicedVectorQueryTests
-  method: testScoringWithMultipleChildren
-  issue: https://github.com/elastic/elasticsearch/issues/150813
 - class: org.elasticsearch.xpack.esql.qa.csv.ExternalCsvMultiNodePushdownIT
   method: testCountStarColdThenWarmShortCircuitsAcrossNodes
   issue: https://github.com/elastic/elasticsearch/issues/150594

--- a/server/src/test/java/org/elasticsearch/search/vectors/AbstractDiversifyingChildrenIVFKnnVectorQueryTestCase.java
+++ b/server/src/test/java/org/elasticsearch/search/vectors/AbstractDiversifyingChildrenIVFKnnVectorQueryTestCase.java
@@ -252,15 +252,15 @@ abstract class AbstractDiversifyingChildrenIVFKnnVectorQueryTestCase extends Luc
                 IndexSearcher searcher = new IndexSearcher(reader);
                 BitSetProducer parentFilter = parentFilter(searcher.getIndexReader());
                 Query query = getDiversifyingChildrenKnnQuery("field", new float[] { 2, 2 }, null, 3, parentFilter);
-                assertScorerResults(searcher, query, new float[] { 1f, 1f / 51f }, new String[] { "2", "7" }, 2);
+                assertScorerResults(searcher, query, new float[] { 1f, 1f / 51f }, new String[] { "2", "7" }, 2, 0.0001f);
 
                 query = getDiversifyingChildrenKnnQuery("field", new float[] { 6, 6 }, null, 3, parentFilter);
-                assertScorerResults(searcher, query, new float[] { 1f / 3f, 1f / 3f }, new String[] { "5", "7" }, 2);
+                assertScorerResults(searcher, query, new float[] { 1f / 3f, 1f / 3f }, new String[] { "5", "7" }, 2, 0.0001f);
                 query = getDiversifyingChildrenKnnQuery("field", new float[] { 6, 6 }, Queries.ALL_DOCS_INSTANCE, 20, parentFilter);
-                assertScorerResults(searcher, query, new float[] { 1f / 3f, 1f / 3f }, new String[] { "5", "7" }, 2);
+                assertScorerResults(searcher, query, new float[] { 1f / 3f, 1f / 3f }, new String[] { "5", "7" }, 2, 0.0001f);
 
                 query = getDiversifyingChildrenKnnQuery("field", new float[] { 6, 6 }, Queries.ALL_DOCS_INSTANCE, 1, parentFilter);
-                assertScorerResults(searcher, query, new float[] { 1f / 3f, 1f / 3f }, new String[] { "5", "7" }, 1);
+                assertScorerResults(searcher, query, new float[] { 1f / 3f, 1f / 3f }, new String[] { "5", "7" }, 1, 0.0001f);
             }
         }
     }
@@ -346,7 +346,7 @@ abstract class AbstractDiversifyingChildrenIVFKnnVectorQueryTestCase extends Luc
         assertEquals(expectedId, actualId);
     }
 
-    void assertScorerResults(IndexSearcher searcher, Query query, float[] possibleScores, String[] possibleIds, int count)
+    void assertScorerResults(IndexSearcher searcher, Query query, float[] possibleScores, String[] possibleIds, int count, float delta)
         throws IOException {
         IndexReader reader = searcher.getIndexReader();
         Query rewritten = query.rewrite(searcher);
@@ -364,7 +364,7 @@ abstract class AbstractDiversifyingChildrenIVFKnnVectorQueryTestCase extends Luc
             assertNotEquals(NO_MORE_DOCS, docId);
             String actualId = reader.storedFields().document(docId).get("id");
             assertTrue(idToScore.containsKey(actualId));
-            assertEquals(idToScore.get(actualId), scorer.score(), 0.0001);
+            assertEquals(idToScore.get(actualId), scorer.score(), delta);
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/search/vectors/DiversifyingChildrenIVFKnnFloatSlicedVectorQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/search/vectors/DiversifyingChildrenIVFKnnFloatSlicedVectorQueryTests.java
@@ -21,12 +21,16 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.Weight;
 import org.apache.lucene.search.join.BitSetProducer;
 import org.apache.lucene.search.join.QueryBitSetProducer;
 import org.apache.lucene.store.Directory;
@@ -45,11 +49,15 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.BooleanSupplier;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static com.carrotsearch.randomizedtesting.RandomizedTest.randomFloat;
 import static com.carrotsearch.randomizedtesting.RandomizedTest.rarely;
+import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
 import static org.hamcrest.Matchers.equalTo;
 
 /** Tests for {@link DiversifyingChildrenIVFKnnFloatSlicedVectorQuery}. */
@@ -235,6 +243,28 @@ public class DiversifyingChildrenIVFKnnFloatSlicedVectorQueryTests extends Abstr
                 query = getDiversifyingChildrenKnnQuery("field", new float[] { 6, 6 }, Queries.ALL_DOCS_INSTANCE, 1, parentFilter);
                 assertScorerResults(searcher, query, new float[] { 1f / 3f, 1f / 3f }, new String[] { "5", "7" }, 1);
             }
+        }
+    }
+
+    void assertScorerResults(IndexSearcher searcher, Query query, float[] possibleScores, String[] possibleIds, int count)
+        throws IOException {
+        IndexReader reader = searcher.getIndexReader();
+        Query rewritten = query.rewrite(searcher);
+        Weight weight = searcher.createWeight(rewritten, ScoreMode.COMPLETE, 1);
+        Scorer scorer = weight.scorer(searcher.getIndexReader().leaves().get(0));
+        // prior to advancing, score is undefined
+        assertEquals(-1, scorer.docID());
+        expectThrows(ArrayIndexOutOfBoundsException.class, scorer::score);
+        DocIdSetIterator it = scorer.iterator();
+        Map<String, Float> idToScore = IntStream.range(0, possibleIds.length)
+            .boxed()
+            .collect(Collectors.toMap(i -> possibleIds[i], i -> possibleScores[i]));
+        for (int i = 0; i < count; i++) {
+            int docId = it.nextDoc();
+            assertNotEquals(NO_MORE_DOCS, docId);
+            String actualId = reader.storedFields().document(docId).get("id");
+            assertTrue(idToScore.containsKey(actualId));
+            assertEquals(idToScore.get(actualId), scorer.score(), 0.001);
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/search/vectors/DiversifyingChildrenIVFKnnFloatSlicedVectorQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/search/vectors/DiversifyingChildrenIVFKnnFloatSlicedVectorQueryTests.java
@@ -21,16 +21,12 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.index.VectorSimilarityFunction;
-import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.search.ScoreMode;
-import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TopDocs;
-import org.apache.lucene.search.Weight;
 import org.apache.lucene.search.join.BitSetProducer;
 import org.apache.lucene.search.join.QueryBitSetProducer;
 import org.apache.lucene.store.Directory;
@@ -49,15 +45,11 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.function.BooleanSupplier;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 import static com.carrotsearch.randomizedtesting.RandomizedTest.randomFloat;
 import static com.carrotsearch.randomizedtesting.RandomizedTest.rarely;
-import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
 import static org.hamcrest.Matchers.equalTo;
 
 /** Tests for {@link DiversifyingChildrenIVFKnnFloatSlicedVectorQuery}. */
@@ -233,38 +225,16 @@ public class DiversifyingChildrenIVFKnnFloatSlicedVectorQueryTests extends Abstr
                 IndexSearcher searcher = new IndexSearcher(reader);
                 BitSetProducer parentFilter = parentFilter(searcher.getIndexReader());
                 Query query = getDiversifyingChildrenKnnQuery("field", new float[] { 2, 2 }, null, 3, parentFilter);
-                assertScorerResults(searcher, query, new float[] { 1f, 1f / 51f }, new String[] { "2", "7" }, 2);
+                assertScorerResults(searcher, query, new float[] { 1f, 1f / 51f }, new String[] { "2", "7" }, 2, 0.001f);
 
                 query = getDiversifyingChildrenKnnQuery("field", new float[] { 6, 6 }, null, 3, parentFilter);
-                assertScorerResults(searcher, query, new float[] { 1f / 3f, 1f / 3f }, new String[] { "5", "7" }, 2);
+                assertScorerResults(searcher, query, new float[] { 1f / 3f, 1f / 3f }, new String[] { "5", "7" }, 2, 0.001f);
                 query = getDiversifyingChildrenKnnQuery("field", new float[] { 6, 6 }, Queries.ALL_DOCS_INSTANCE, 20, parentFilter);
-                assertScorerResults(searcher, query, new float[] { 1f / 3f, 1f / 3f }, new String[] { "5", "7" }, 2);
+                assertScorerResults(searcher, query, new float[] { 1f / 3f, 1f / 3f }, new String[] { "5", "7" }, 2, 0.001f);
 
                 query = getDiversifyingChildrenKnnQuery("field", new float[] { 6, 6 }, Queries.ALL_DOCS_INSTANCE, 1, parentFilter);
-                assertScorerResults(searcher, query, new float[] { 1f / 3f, 1f / 3f }, new String[] { "5", "7" }, 1);
+                assertScorerResults(searcher, query, new float[] { 1f / 3f, 1f / 3f }, new String[] { "5", "7" }, 1, 0.001f);
             }
-        }
-    }
-
-    void assertScorerResults(IndexSearcher searcher, Query query, float[] possibleScores, String[] possibleIds, int count)
-        throws IOException {
-        IndexReader reader = searcher.getIndexReader();
-        Query rewritten = query.rewrite(searcher);
-        Weight weight = searcher.createWeight(rewritten, ScoreMode.COMPLETE, 1);
-        Scorer scorer = weight.scorer(searcher.getIndexReader().leaves().get(0));
-        // prior to advancing, score is undefined
-        assertEquals(-1, scorer.docID());
-        expectThrows(ArrayIndexOutOfBoundsException.class, scorer::score);
-        DocIdSetIterator it = scorer.iterator();
-        Map<String, Float> idToScore = IntStream.range(0, possibleIds.length)
-            .boxed()
-            .collect(Collectors.toMap(i -> possibleIds[i], i -> possibleScores[i]));
-        for (int i = 0; i < count; i++) {
-            int docId = it.nextDoc();
-            assertNotEquals(NO_MORE_DOCS, docId);
-            String actualId = reader.storedFields().document(docId).get("id");
-            assertTrue(idToScore.containsKey(actualId));
-            assertEquals(idToScore.get(actualId), scorer.score(), 0.001);
         }
     }
 


### PR DESCRIPTION
I could not reproduce locally this failure but it can be reproduced on a amd64 machine so it looks like is a precision issue in the way we are scoring on that CPU architecture. I cannot debug the issue as I cannot reproduce it locally but everything looks fine in the execution of the test so I expect that there is some combination where we get 0.999755859375 instead of 1.0 when scoring. 

This PR proposes to increase the delta for this test.

closes https://github.com/elastic/elasticsearch/issues/150813