### PR TITLE
ESQL: Add capability to long-range error

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/topN.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/topN.csv-spec
@@ -191,6 +191,7 @@ network.bytes_in:long | @timestamp:datetime      | cluster:keyword | pod:keyword
 
 topNLongRangeWildcardSort
 required_capability: date_range_field_type_v6
+required_capability: fix_topn_long_range_encoding
 
 // Exact query for https://github.com/elastic/elasticsearch/issues/150383.
 // The STATS makes the wildcard query result stable while still materializing

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -3024,6 +3024,12 @@ public class EsqlCapabilities {
         EQUALITY_DATE_RANGE(DATE_RANGE_FIELD_TYPE_V6.isEnabled()),
 
         /**
+         * Fix TopN encoding/decoding of {@code long_range} values.
+         * <a href="https://github.com/elastic/elasticsearch/issues/150383">#150383</a>
+         */
+        FIX_TOPN_LONG_RANGE_ENCODING(DATE_RANGE_FIELD_TYPE_V6.isEnabled()),
+
+        /**
          * Support for ESQL parameters in PromQL label matchers:
          * <a href="https://github.com/elastic/elasticsearch/issues/148620">#148620</a>
          */


### PR DESCRIPTION
The fix shipped in https://github.com/elastic/elasticsearch/issues/150383 was missing a capability, so it now fails in mixed cluster tests.

After this, merge this one for serverless: https://github.com/elastic/elasticsearch-serverless/pull/6925