### PR TITLE
Fix issues with MappedFieldType#termQuery(...) if field is single valued.

### DIFF
--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldTypeTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldTypeTests.java
@@ -582,6 +582,10 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
         assertThat(blockLoader, Matchers.instanceOf(BytesRefsFromCustomBinaryBlockLoader.class));
     }
 
+    public void testTermQueryWithBinaryDocValues() throws IOException {
+        assertTermQueryWithBinaryDocValues(binaryDocValuesOnly());
+    }
+
     public void testPrefixQueryDocValuesOnly() {
         MatchOnlyTextFieldType sortedSet = sortedSetDocValuesOnly();
         MatchOnlyTextFieldType binary = binaryDocValuesOnly();

--- a/server/src/main/java/org/elasticsearch/lucene/queries/AbstractBinaryDocValuesQuery.java
+++ b/server/src/main/java/org/elasticsearch/lucene/queries/AbstractBinaryDocValuesQuery.java
@@ -50,13 +50,16 @@ abstract class AbstractBinaryDocValuesQuery extends Query {
             @Override
             public ScorerSupplier scorerSupplier(LeafReaderContext context) throws IOException {
                 final BinaryDocValues values = context.reader().getBinaryDocValues(fieldName);
-                final NumericDocValues counts = context.reader().getNumericDocValues(fieldName + COUNT_FIELD_SUFFIX);
-
                 if (values == null) {
                     return null;
                 }
-
-                final var iterator = multiValuedIterator(values, counts, matcher, matchCost());
+                final NumericDocValues counts = context.reader().getNumericDocValues(fieldName + COUNT_FIELD_SUFFIX);
+                final DocIdSetIterator iterator;
+                if (counts != null) {
+                    iterator = multiValuedIterator(values, counts, matcher, matchCost);
+                } else {
+                    iterator = singleValuedIterator(values, matcher, matchCost);
+                }
                 return new DefaultScorerSupplier(new ConstantScoreScorer(score(), scoreMode, iterator));
             }
 
@@ -89,6 +92,22 @@ abstract class AbstractBinaryDocValuesQuery extends Query {
             public boolean matches() throws IOException {
                 values.advance(counts.docID());
                 return reader.match(values.binaryValue(), counts.longValue(), predicate);
+            }
+
+            @Override
+            public float matchCost() {
+                return cost;
+            }
+        });
+    }
+
+    static DocIdSetIterator singleValuedIterator(BinaryDocValues values, Predicate<BytesRef> predicate, float cost) {
+        return TwoPhaseIterator.asDocIdSetIterator(new TwoPhaseIterator(values) {
+            final MultiValueSeparateCountBinaryDocValuesReader reader = new MultiValueSeparateCountBinaryDocValuesReader();
+
+            @Override
+            public boolean matches() throws IOException {
+                return reader.match(values.binaryValue(), 1, predicate);
             }
 
             @Override

--- a/server/src/main/java/org/elasticsearch/lucene/queries/BinaryDocValuesLengthQuery.java
+++ b/server/src/main/java/org/elasticsearch/lucene/queries/BinaryDocValuesLengthQuery.java
@@ -50,7 +50,6 @@ final class BinaryDocValuesLengthQuery extends Query {
             @Override
             public ScorerSupplier scorerSupplier(LeafReaderContext context) throws IOException {
                 final BinaryDocValues values = context.reader().getBinaryDocValues(fieldName);
-
                 if (values == null) {
                     return null;
                 }
@@ -58,15 +57,18 @@ final class BinaryDocValuesLengthQuery extends Query {
                 String countsFieldName = fieldName + COUNT_FIELD_SUFFIX;
                 final NumericDocValues counts = context.reader().getNumericDocValues(countsFieldName);
                 DocValuesSkipper countsSkipper = context.reader().getDocValuesSkipper(countsFieldName);
-                assert countsSkipper != null : "no skipper for counts field [" + countsFieldName + "]";
                 final DocIdSetIterator iterator;
-                if (countsSkipper.maxValue() == 1 && values instanceof BlockLoader.OptionalLengthReader direct) {
+                if ((countsSkipper == null || countsSkipper.maxValue() == 1) && values instanceof BlockLoader.OptionalLengthReader direct) {
                     // tryLengthIterator returns a TwoPhaseIterator-backed iterator (see the contract on
                     // BlockLoader.OptionalLengthReader), so sub-segment slicing scales with cores.
                     iterator = direct.tryLengthIterator(length);
                 } else {
                     Predicate<BytesRef> lengthPredicate = bytes -> bytes.length == length;
-                    iterator = AbstractBinaryDocValuesQuery.multiValuedIterator(values, counts, lengthPredicate, matchCost());
+                    if (countsSkipper != null) {
+                        iterator = AbstractBinaryDocValuesQuery.multiValuedIterator(values, counts, lengthPredicate, matchCost);
+                    } else {
+                        iterator = AbstractBinaryDocValuesQuery.singleValuedIterator(values, lengthPredicate, matchCost);
+                    }
                 }
 
                 return ConstantScoreScorerSupplier.fromIterator(iterator, score(), scoreMode, context.reader().maxDoc());

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldTypeTests.java
@@ -64,7 +64,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import static org.hamcrest.Matchers.in;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldTypeTests.java
@@ -64,6 +64,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import static org.hamcrest.Matchers.in;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
@@ -97,6 +98,30 @@ public class KeywordFieldTypeTests extends FieldTypeTestCase {
         MappedFieldType unsearchable = new KeywordFieldType("field", false, false, Collections.emptyMap());
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> unsearchable.termQuery("bar", MOCK_CONTEXT));
         assertEquals("Cannot search on field [field] since it is not indexed nor has doc values.", e.getMessage());
+    }
+
+    public void testTermQueryWithSingleValueDocValues() throws IOException {
+        Settings settings = Settings.builder()
+            .put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current())
+            .put(IndexSettings.USE_TIME_SERIES_DOC_VALUES_FORMAT_SETTING.getKey(), true)
+            .put(FieldMapper.DOC_VALUES_MULTI_VALUE_SETTING.getKey(), false)
+            .build();
+        IndexSettings indexSettings = new IndexSettings(
+            IndexMetadata.builder("index").settings(settings).numberOfShards(1).numberOfReplicas(0).build(),
+            Settings.EMPTY
+        );
+        KeywordFieldMapper.Builder builder = new KeywordFieldMapper.Builder("field", indexSettings);
+        builder.docValues(FieldMapper.DocValuesParameter.Values.Cardinality.HIGH);
+        builder.indexed(false);
+        KeywordFieldType ft = new KeywordFieldType(
+            "field",
+            IndexType.docValuesOnly(),
+            TextSearchInfo.SIMPLE_MATCH_ONLY,
+            null,
+            builder,
+            false
+        );
+        assertTermQueryWithBinaryDocValues(ft);
     }
 
     public void testTermQueryHighCardinality() {

--- a/server/src/test/java/org/elasticsearch/index/mapper/TextFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TextFieldTypeTests.java
@@ -766,6 +766,10 @@ public class TextFieldTypeTests extends FieldTypeTestCase {
         );
     }
 
+    public void testTermQueryWithBinaryDocValues() throws IOException {
+        assertTermQueryWithBinaryDocValues(binaryDocValuesOnly());
+    }
+
     public void testPrefixQueryDocValuesOnly() {
         // SortedSet DV, case-sensitive → PrefixQuery with DOC_VALUES_REWRITE
         TextFieldType ft = sortedSetDocValuesOnly();

--- a/server/src/test/java/org/elasticsearch/lucene/queries/BinaryDocValuesLengthQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/queries/BinaryDocValuesLengthQueryTests.java
@@ -8,6 +8,7 @@
  */
 package org.elasticsearch.lucene.queries;
 
+import org.apache.lucene.document.BinaryDocValuesField;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.index.IndexReader;
@@ -29,6 +30,37 @@ import java.util.Set;
 public class BinaryDocValuesLengthQueryTests extends ESTestCase {
 
     public void testSingleValued() throws Exception {
+        String fieldName = "field";
+        int numDocs = randomIntBetween(1, 100);
+        List<BytesRef> values = new ArrayList<>();
+        int[] lengthToCount = new int[11];
+        for (int i = 0; i < numDocs; i++) {
+            var val = new BytesRef(randomAlphaOfLength(between(0, 10)));
+            values.add(val);
+            lengthToCount[val.length]++;
+        }
+
+        try (Directory dir = newDirectory()) {
+            try (RandomIndexWriter writer = new RandomIndexWriter(random(), dir)) {
+                for (var val : values) {
+                    Document document = new Document();
+                    document.add(new BinaryDocValuesField("field", val));
+                    writer.addDocument(document);
+                }
+
+                // search
+                try (IndexReader reader = writer.getReader()) {
+                    IndexSearcher searcher = newSearcher(reader);
+                    for (int len = 0; len <= 10; len++) {
+                        long numMatches = searcher.count(new BinaryDocValuesLengthQuery(fieldName, len));
+                        assertEquals(lengthToCount[len], numMatches);
+                    }
+                }
+            }
+        }
+    }
+
+    public void testMultiValueFieldWithOneValue() throws Exception {
         String fieldName = "field";
         int numDocs = randomIntBetween(1, 100);
         List<BytesRef> values = new ArrayList<>();

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/FieldTypeTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/FieldTypeTestCase.java
@@ -8,6 +8,9 @@
  */
 package org.elasticsearch.index.mapper;
 
+import org.apache.lucene.document.BinaryDocValuesField;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.DocValuesSkipIndexType;
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.FieldInfo;
@@ -16,6 +19,9 @@ import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.query.SearchExecutionContext;
@@ -133,6 +139,52 @@ public abstract class FieldTypeTestCase extends ESTestCase {
                 return null;
             }
         };
+    }
+
+    /**
+     * Indexes four document shapes (foo×2, bar×1, empty-string×1) per iteration using
+     * {@link BinaryDocValuesField} and verifies that {@link MappedFieldType#termQuery} returns
+     * the correct hit counts. Use this for field types whose {@code termQuery} falls back to binary
+     * doc values (e.g. high-cardinality keyword or text fields).
+     */
+    protected void assertTermQueryWithBinaryDocValues(MappedFieldType ft) throws IOException {
+        try (Directory dir = newDirectory()) {
+            int indexIters = randomIntBetween(1, 10);
+            try (RandomIndexWriter writer = new RandomIndexWriter(random(), dir)) {
+                for (int i = 0; i < indexIters; i++) {
+                    Document doc = new Document();
+                    doc.add(new BinaryDocValuesField(ft.name(), new BytesRef("foo")));
+                    writer.addDocument(doc);
+
+                    doc = new Document();
+                    doc.add(new BinaryDocValuesField(ft.name(), new BytesRef("bar")));
+                    writer.addDocument(doc);
+
+                    doc = new Document();
+                    doc.add(new BinaryDocValuesField(ft.name(), new BytesRef("foo")));
+                    writer.addDocument(doc);
+
+                    doc = new Document();
+                    doc.add(new BinaryDocValuesField(ft.name(), new BytesRef("")));
+                    writer.addDocument(doc);
+                }
+            }
+            try (DirectoryReader reader = DirectoryReader.open(dir)) {
+                var searcher = newSearcher(reader);
+
+                var topDocs = searcher.search(ft.termQuery("foo", MOCK_CONTEXT), 10);
+                assertEquals(2 * indexIters, topDocs.totalHits.value());
+
+                topDocs = searcher.search(ft.termQuery("bar", MOCK_CONTEXT), 10);
+                assertEquals(indexIters, topDocs.totalHits.value());
+
+                topDocs = searcher.search(ft.termQuery("", MOCK_CONTEXT), 10);
+                assertEquals(indexIters, topDocs.totalHits.value());
+
+                topDocs = searcher.search(ft.termQuery("baz", MOCK_CONTEXT), 10);
+                assertEquals(0, topDocs.totalHits.value());
+            }
+        }
     }
 
     public FieldInfo getFieldInfoWithName(String name) {


### PR DESCRIPTION
The query logic was assuming that an adjacent count exists and fetching skipper or iterator resulted in various NPEs.

## Summary

- Adds a reusable `assertTermQueryWithBinaryDocValues(MappedFieldType)` helper in `FieldTypeTestCase` that indexes documents via `BinaryDocValuesField` and verifies `termQuery` hit counts; used from `KeywordFieldTypeTests`, `TextFieldTypeTests`, and `MatchOnlyTextFieldTypeTests`
- Fixes a bug in `AbstractBinaryDocValuesQuery.singleValuedIterator`: `matches()` was calling `values.advance(values.docID())` where `values` is already the `TwoPhaseIterator` approximation and is already positioned at the current doc — this violated the `DocIdSetIterator` contract (`target > docID()`) and was caught by `AssertingBinaryDocValues`
- Extends `BinaryDocValuesLengthQuery` to support plain single-valued `BinaryDocValues` (no counts field) by routing through `singleValuedIterator` when no counts skipper is present

## Test plan

- [ ] `KeywordFieldTypeTests#testTermQueryWithSingleValueDocValues`
- [ ] `TextFieldTypeTests#testTermQueryWithBinaryDocValues`
- [ ] `MatchOnlyTextFieldTypeTests#testTermQueryWithBinaryDocValues`
- [ ] `BinaryDocValuesLengthQueryTests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)