### PR TITLE
Fixed NPE in AbstractBinaryDocValuesQuery when multi_value=false and binary doc values are used

### DIFF
--- a/server/src/main/java/org/elasticsearch/lucene/queries/AbstractBinaryDocValuesQuery.java
+++ b/server/src/main/java/org/elasticsearch/lucene/queries/AbstractBinaryDocValuesQuery.java
@@ -82,6 +82,21 @@ abstract class AbstractBinaryDocValuesQuery extends Query {
         Predicate<BytesRef> predicate,
         float cost
     ) {
+        if (counts == null) {
+            // Single-valued binary doc values (multi_value=false): a plain BinaryDocValuesField is written with no .counts companion,
+            // so there is nothing to count and the binary value holds the single term verbatim. Drive the iterator off the values.
+            return TwoPhaseIterator.asDocIdSetIterator(new TwoPhaseIterator(values) {
+                @Override
+                public boolean matches() throws IOException {
+                    return predicate.test(values.binaryValue());
+                }
+
+                @Override
+                public float matchCost() {
+                    return cost;
+                }
+            });
+        }
         return TwoPhaseIterator.asDocIdSetIterator(new TwoPhaseIterator(counts) {
             final MultiValueSeparateCountBinaryDocValuesReader reader = new MultiValueSeparateCountBinaryDocValuesReader();
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
@@ -19,6 +19,8 @@ import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.IndexableFieldType;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
 import org.apache.lucene.tests.analysis.MockLowerCaseFilter;
 import org.apache.lucene.tests.analysis.MockTokenizer;
 import org.apache.lucene.util.BytesRef;
@@ -41,8 +43,10 @@ import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.analysis.PreConfiguredTokenFilter;
 import org.elasticsearch.index.analysis.TokenFilterFactory;
 import org.elasticsearch.index.analysis.TokenizerFactory;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.termvectors.TermVectorsService;
 import org.elasticsearch.indices.analysis.AnalysisModule;
+import org.elasticsearch.lucene.queries.SlowCustomBinaryDocValuesTermQuery;
 import org.elasticsearch.plugins.AnalysisPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.script.StringFieldScript;
@@ -1072,6 +1076,44 @@ public class KeywordFieldMapperTests extends MapperTestCase {
                 + "legacy index versions",
             doc.rootDoc().getFields("field.counts").isEmpty()
         );
+    }
+
+    /**
+     * A doc-values-only keyword with HIGH cardinality is queried through the binary doc values path. With {@code multi_value=false} the
+     * write path stores a plain {@code BinaryDocValuesField} with no companion {@code .counts} field, so
+     * {@link SlowCustomBinaryDocValuesTermQuery} must drive its {@code TwoPhaseIterator} off the binary values directly and match the
+     * single verbatim term rather than off an absent counts field.
+     */
+    public void testHighCardinalitySingleValuedBinaryDocValuesQueryMatches() throws IOException {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        MapperService mapperService = createMapperService(fieldMapping(b -> {
+            b.field("type", "keyword").field("index", false);
+            b.startObject("doc_values").field("cardinality", "high").field("multi_value", false).endObject();
+        }));
+
+        String value = randomAlphanumericOfLength(10);
+        ParsedDocument doc = mapperService.documentMapper().parse(source(b -> b.field("field", value)));
+
+        // The binary value is written, but no companion .counts field is written for the single-valued multi_value=false doc.
+        assertFalse("expected a binary doc values field for the value", doc.rootDoc().getFields("field").isEmpty());
+        assertTrue(
+            "single-valued multi_value=false doc must not write a .counts companion",
+            doc.rootDoc().getFields("field.counts").isEmpty()
+        );
+
+        withLuceneIndex(mapperService, iw -> iw.addDocument(doc.rootDoc()), reader -> {
+            IndexSearcher searcher = newSearcher(reader);
+            SearchExecutionContext context = createSearchExecutionContext(mapperService, searcher);
+
+            Query query = mapperService.fieldType("field").termQuery(value, context);
+            assertThat(query, instanceOf(SlowCustomBinaryDocValuesTermQuery.class));
+            // The single-valued binary doc values path drives the TwoPhaseIterator off the binary values, matching the verbatim term.
+            assertThat(searcher.count(query), equalTo(1));
+
+            // A non-matching term must not match the single-valued document.
+            Query noMatch = mapperService.fieldType("field").termQuery(value + "_absent", context);
+            assertThat(searcher.count(noMatch), equalTo(0));
+        });
     }
 
     @Override


### PR DESCRIPTION
This is not a production bug - `multi_value` is gated behind a feature flag.

Whenever `multi_value=false` we use a plain `BinaryDocValuesField`. The reason for this is simple: if we know the field is always single-valued, then there is no point in allocating extra bytes for the `.counts` companion field.

However, the absence of the `.counts` causes a NPE to be thrown from `TwoPhaseIterator` since it requires that the `DocIdSetIterator` is not null:

```Java
  protected TwoPhaseIterator(DocIdSetIterator approximation) {
    this.approximation = Objects.requireNonNull(approximation);
  }
```

In our code, we never check this and unconditionally build a `new TwoPhaseIterator(counts)`. This PR addresses that.