### PR TITLE
Fix testExchangeSourceContinueOnFailure

### DIFF
--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/exchange/ExchangeServiceTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/exchange/ExchangeServiceTests.java
@@ -413,7 +413,9 @@ public class ExchangeServiceTests extends ESTestCase {
                 AtomicBoolean sinkFailed = new AtomicBoolean();
                 ActionListener<Void> oneSinkListener = refs.acquire();
                 exchangeSourceHandler.addRemoteSink((allSourcesFinished, listener) -> {
-                    if (fetched.incrementAndGet() > failAfter) {
+                    // Don't simulate failure when allSourcesFinished - the exchange source might have
+                    // already completed, and the failure can be ignored in the completion listener
+                    if (fetched.incrementAndGet() > failAfter && allSourcesFinished == false) {
                         sinkHandler.fetchPageAsync(true, listener.delegateFailure((l, r) -> {
                             failedRequests.incrementAndGet();
                             sinkFailed.set(true);


### PR DESCRIPTION
The test failed in this sequence:

1. fetchPageAsync returns `finished=true`
2. ExchangeSourceHandler finishes the buffer
3. Driver finishes ExchangeSourceOperator
4. Closing ExchangeSourceOperator leads to finishEarly in ExchangeSourceHandler
5. RemoteSink#close calls fetchPageAsync (allSourcesFinished=true), the simulated failure can be ignored in the completion listener as it already completed

This is not an issue in production because the ExchangeSourceHandler has already completed; handling this failure is optional.

Closes #150552