### PR TITLE
Fix TopNOperatorTests#testSplitOnSize

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -271,9 +271,6 @@ tests:
 - class: org.elasticsearch.xpack.ml.integration.ForecastIT
   method: testOverflowToDisk
   issue: https://github.com/elastic/elasticsearch/issues/148606
-- class: org.elasticsearch.compute.operator.topn.TopNOperatorTests
-  method: testSplitOnSize
-  issue: https://github.com/elastic/elasticsearch/issues/148613
 - class: org.elasticsearch.smoketest.SmokeTestWatcherTestSuiteIT
   method: testMonitorClusterHealth
   issue: https://github.com/elastic/elasticsearch/issues/148615

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/TopNOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/TopNOperatorTests.java
@@ -2200,10 +2200,13 @@ public class TopNOperatorTests extends OperatorTestCase {
                 try (Page out = op.getOutput()) {
                     totalPositions += out.getPositionCount();
                     if (totalPositions < expectedTotal) {
-                        assertThat(out.ramBytesUsedByBlocks(), both(greaterThanOrEqualTo(minPageSize)).and(lessThanOrEqualTo(maxPageSize)));
-                    } else {
-                        assertThat(out.ramBytesUsedByBlocks(), lessThanOrEqualTo(maxPageSize));
+                        // We can over-allocate to one page for BytesRefArray that requires less than one page.
+                        // So don't check the min page size if jumboPageBytes is less than a page.
+                        if (minPageSize >= PageCacheRecycler.PAGE_SIZE_IN_BYTES) {
+                            assertThat(out.ramBytesUsedByBlocks(), greaterThanOrEqualTo(minPageSize));
+                        }
                     }
+                    assertThat(out.ramBytesUsedByBlocks(), lessThanOrEqualTo(maxPageSize));
                 }
             }
             assertThat(totalPositions, equalTo(expectedTotal));


### PR DESCRIPTION
We can over-allocate to one page for BytesRefArray that requires less than one page. So don't check the min page size if jumboPageBytes is less than a page.


Closes #148767
Closes #148613