### PR TITLE
Remove 1-byte pre-allocation in BytesRefArray

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -265,9 +265,6 @@ tests:
 - class: org.elasticsearch.index.mapper.DateRangeDocValuesLoaderTests
   method: testEmptyRangesAppendsNull
   issue: https://github.com/elastic/elasticsearch/issues/148378
-- class: org.elasticsearch.compute.data.BlockAccountingTests
-  method: testBytesRefVector
-  issue: https://github.com/elastic/elasticsearch/issues/148481
 - class: org.elasticsearch.xpack.ml.integration.ForecastIT
   method: testOverflowToDisk
   issue: https://github.com/elastic/elasticsearch/issues/148606

--- a/server/src/main/java/org/elasticsearch/common/util/BytesRefArray.java
+++ b/server/src/main/java/org/elasticsearch/common/util/BytesRefArray.java
@@ -495,7 +495,7 @@ public final class BytesRefArray extends AbstractRefCounted implements Accountab
             boolean success = false;
             try {
                 if (initialSize < HALF_PAGE_SIZE) {
-                    final int bytesLength = Math.max(1, (int) initialSize);
+                    final int bytesLength = (int) initialSize;
                     bigArrays.adjustBreaker(bytesLength, false);
                     pages[0] = currentPage = new byte[bytesLength];
                     pageCount = 1;


### PR DESCRIPTION
Today we pre-allocate an array of one byte for initial size of zero. This is not an issue, but accounting tests are not happy; so this commit removes that pre-allocation.

Closes #148481