### PR TITLE
Fix BlockHashRandomizedTests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -146,15 +146,9 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecForceStoredLoadingIT
   method: test {csv-spec:fuse.fuseWithRowLinearAndMultiValueGroupColumn}
   issue: https://github.com/elastic/elasticsearch/issues/147613
-- class: org.elasticsearch.compute.aggregation.blockhash.BlockHashRandomizedTests
-  method: test {forcePackedHash=false groups=2 maxValuesPerPosition=1 dups=0 allowedTypes=[Basic[elementType=LONG], Basic[elementType=INT]]}
-  issue: https://github.com/elastic/elasticsearch/issues/147654
 - class: org.elasticsearch.xpack.transform.integration.TransformCrossProjectIT
   method: testUpdateTransformWithProjectRouting
   issue: https://github.com/elastic/elasticsearch/issues/147655
-- class: org.elasticsearch.compute.aggregation.blockhash.BlockHashRandomizedTests
-  method: testWithCranky {forcePackedHash=false groups=2 maxValuesPerPosition=1 dups=0 allowedTypes=[Basic[elementType=LONG], Basic[elementType=INT]]}
-  issue: https://github.com/elastic/elasticsearch/issues/147732
 - class: org.elasticsearch.xpack.esql.expression.function.scalar.spatial.StSimplifyPreserveTopologyTests
   method: testEvaluateBlockWithNulls
   issue: https://github.com/elastic/elasticsearch/issues/147773

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/LongIntAdaptiveBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/LongIntAdaptiveBlockHash.java
@@ -81,6 +81,15 @@ public final class LongIntAdaptiveBlockHash extends AdaptiveBlockHash {
         return intBlock.asVector();
     }
 
+    // for testing
+    int effectiveEmitBatchSize() {
+        if (current instanceof LongIntVectorOnlyBlockHash) {
+            return vectorBatchSize;
+        } else {
+            return emitBatchSize;
+        }
+    }
+
     final class LongIntVectorOnlyBlockHash extends BlockHash {
         private final LongLongHashTable longLongHash;
         private final long batchUsedBytes;

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/BlockHashRandomizedTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/BlockHashRandomizedTests.java
@@ -200,9 +200,13 @@ public class BlockHashRandomizedTests extends ComputeTestCase {
                          * page (the vector/vector fast path). Page sizes are assumed safe, so
                          * emitting exactly positionCount in one shot is acceptable.
                          */
+                        int effectiveEmitBatchSize = emitBatchSize;
+                        if (blockHash instanceof LongIntAdaptiveBlockHash adaptive) {
+                            effectiveEmitBatchSize = adaptive.effectiveEmitBatchSize();
+                        }
                         assertThat(
                             ordsAndKeys.ords().getTotalValueCount(),
-                            either(lessThanOrEqualTo(emitBatchSize)).or(equalTo(positionCount))
+                            either(lessThanOrEqualTo(effectiveEmitBatchSize)).or(equalTo(positionCount))
                         );
                     }
                     batchCount[0]++;


### PR DESCRIPTION
The effective emit batch size in LongIntAdaptiveBlockHash can differ from the specified emitBatchSize.

Closes #147654
Closes #147732