### PR TITLE
[9.4] Fix flake in `ReindexRequestTests` et al (#150904)

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/reindex/AbstractBulkByScrollRequestTestCase.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/AbstractBulkByScrollRequestTestCase.java
@@ -49,7 +49,7 @@ public abstract class AbstractBulkByScrollRequestTestCase<R extends AbstractBulk
 
         // it's not important how many slices there are, we just need a number for forSlice
         int actualSlices = between(2, 1000);
-        int sliceId = between(0, actualSlices);
+        int sliceId = between(0, actualSlices - 1);
         original.setSlices(randomBoolean() ? actualSlices : AbstractBulkByScrollRequest.AUTO_SLICES);
 
         TaskId slicingTask = new TaskId(randomAlphaOfLength(5), randomLong());


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Fix flake in &#x60;ReindexRequestTests&#x60; et al (#150904)](https://github.com/elastic/elasticsearch/pull/150904)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)