### PR TITLE
Fix ExchangeServiceTests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -298,9 +298,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.optimizer.rules.logical.local.ReplaceDateTruncBucketWithRoundToTests
   method: testRightClosedBucketIsNotSubstituted
   issue: https://github.com/elastic/elasticsearch/issues/149133
-- class: org.elasticsearch.compute.operator.exchange.ExchangeServiceTests
-  method: testBasic
-  issue: https://github.com/elastic/elasticsearch/issues/149338
 - class: org.elasticsearch.xpack.stateless.CorruptionIT
   method: testConcurrentOperations
   issue: https://github.com/elastic/elasticsearch/issues/149342

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/exchange/ExchangeServiceTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/exchange/ExchangeServiceTests.java
@@ -159,7 +159,7 @@ public class ExchangeServiceTests extends ESTestCase {
         assertBusy(() -> assertTrue(sink2.waitForWriting().listener().isDone()));
         sink2.finish();
         assertTrue(sink2.isFinished());
-        assertTrue(source.isFinished());
+        assertBusy(() -> assertTrue(source.isFinished()));
         source.finish();
         ESTestCase.terminate(threadPool);
         for (Page page : pages) {


### PR DESCRIPTION
Because page fetching between exchange sinks and the exchange source is asynchronous, we need assertBusy in the test.



Closes #149338