### PR TITLE
[9.4] [ES|QL] Make subquery with mixed data type across branches behave more consistently with nullify (#150704)

### DIFF
--- a/docs/changelog/150704.yaml
+++ b/docs/changelog/150704.yaml
@@ -1,0 +1,9 @@
+area: ES|QL
+issues:
+ - 150640
+ - 150641
+ - 150644
+ - 150645
+pr: 150704
+summary: Make subquery with counter type not present in all branches behave more consistently
+type: bug

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/EsqlTestUtils.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/EsqlTestUtils.java
@@ -1655,6 +1655,15 @@ public final class EsqlTestUtils {
         // find the main from command, ignoring pipes inside subqueries
         List<String> mainFromCommandAndTheRest = splitIgnoringParentheses(query, "|");
         String mainFrom = mainFromCommandAndTheRest.get(0).strip();
+        // Strip any leading SET statements (e.g. "SET unmapped_fields=\"nullify\";") so that the
+        // source command (FROM/TS) is correctly detected. The original SET prefix is re-prepended
+        // to the rewritten source command to preserve the original query semantics.
+        var setMatcher = SET_SPLIT_PATTERN.matcher(mainFrom);
+        String setStatements = "";
+        if (setMatcher.find()) {
+            setStatements = mainFrom.substring(0, setMatcher.end());
+            mainFrom = mainFrom.substring(setMatcher.end()).strip();
+        }
         List<String> theRest = mainFromCommandAndTheRest.size() > 1
             ? mainFromCommandAndTheRest.subList(1, mainFromCommandAndTheRest.size())
             : List.of();
@@ -1686,8 +1695,8 @@ public final class EsqlTestUtils {
                 transformed.add(remoteIndex);
             }
         }
-        // rebuild from command from transformed index patterns and subqueries
-        String transformedFrom = "FROM " + String.join(", ", transformed) + metadata;
+        // rebuild source command from transformed index patterns and subqueries, prepending any SET statements
+        String transformedFrom = setStatements + " FROM " + String.join(", ", transformed) + metadata;
         // rebuild the whole query
         mainFromCommandAndTheRest.set(0, transformedFrom);
         testQuery = String.join(" | ", mainFromCommandAndTheRest);

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/EsqlTestUtils.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/EsqlTestUtils.java
@@ -1696,7 +1696,7 @@ public final class EsqlTestUtils {
             }
         }
         // rebuild source command from transformed index patterns and subqueries, prepending any SET statements
-        String transformedFrom = setStatements + " FROM " + String.join(", ", transformed) + metadata;
+        String transformedFrom = setStatements + "FROM " + String.join(", ", transformed) + metadata;
         // rebuild the whole query
         mainFromCommandAndTheRest.set(0, transformedFrom);
         testQuery = String.join(" | ", mainFromCommandAndTheRest);

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/subquery.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/subquery.csv-spec
@@ -1392,3 +1392,190 @@ FROM multi_column_joinable, (FROM multi_column_joinable)
 cnt:long
 34
 ;
+
+subqueryInFromWithRenameMissingField
+required_capability: subquery_in_from_command
+
+FROM books, (from languages)
+| KEEP language_code
+| RENAME language_code as x
+| KEEP *
+| SORT x
+| LIMIT 1
+;
+
+x:integer
+1
+;
+
+subqueryInFromWithRenameMissingCounterField
+required_capability: subquery_in_from_command
+required_capability: subquery_in_from_command_union_types_implicit_casting_inconsistent_after_rename
+
+FROM k8s-downsampled, (from many_numbers)
+| KEEP network.total_bytes_in, network.eth0.tx
+| RENAME network.total_bytes_in as x, network.eth0.tx as y
+| KEEP *
+| SORT x
+| LIMIT 1
+;
+
+x:long | y:aggregate_metric_double
+210    | {"min":201.0,"max":582.0,"sum":1794.0,"value_count":6}
+;
+
+subqueryInFromWithRenameMissingCounterFieldWithNullify
+required_capability: subquery_in_from_command
+required_capability: subquery_in_from_command_union_types_implicit_casting_inconsistent_after_rename
+required_capability: optional_fields_nullify_tech_preview
+
+SET unmapped_fields="nullify"\;
+FROM k8s-downsampled, (from many_numbers)
+| KEEP network.total_bytes_in, network.eth0.tx
+| RENAME network.total_bytes_in as x, network.eth0.tx as y
+| KEEP *
+| SORT x
+| LIMIT 1
+;
+
+x:long | y:aggregate_metric_double
+210    | {"min":201.0,"max":582.0,"sum":1794.0,"value_count":6}
+;
+
+subqueryInFromWithRenameChainMissingCounterField
+required_capability: subquery_in_from_command
+required_capability: subquery_in_from_command_union_types_implicit_casting_inconsistent_after_rename
+
+FROM k8s, (from many_numbers)
+| KEEP network.total_bytes_in
+| RENAME network.total_bytes_in as x, x as y
+| RENAME y as z
+| KEEP *
+| SORT z
+| LIMIT 1
+;
+
+z:long
+3
+;
+
+subqueryInFromWithRenameChainMissingCounterFieldWithNullify
+required_capability: subquery_in_from_command
+required_capability: subquery_in_from_command_union_types_implicit_casting_inconsistent_after_rename
+required_capability: optional_fields_nullify_tech_preview
+
+SET unmapped_fields="nullify"\;
+FROM k8s, (from many_numbers)
+| KEEP network.total_bytes_in
+| RENAME network.total_bytes_in as x, x as y
+| RENAME y as z
+| KEEP *
+| SORT z
+| LIMIT 1
+;
+
+z:long
+3
+;
+
+subqueryInFromWithRenameOnMixedDateAndDateNanos
+required_capability: subquery_in_from_command
+required_capability: subquery_in_from_command_union_types_implicit_casting_inconsistent_after_rename
+
+FROM sample_data, (FROM sample_data_ts_nanos)
+| KEEP @timestamp
+| RENAME @timestamp AS x
+| KEEP *
+| SORT x
+| LIMIT 1
+;
+
+x:date_nanos
+2023-10-23T12:15:03.360000000Z
+;
+
+subqueryInFromWithRenameChainOnMixedDateAndDateNanos
+required_capability: subquery_in_from_command
+required_capability: subquery_in_from_command_union_types_implicit_casting_inconsistent_after_rename
+
+FROM sample_data, (FROM sample_data_ts_nanos)
+| KEEP @timestamp
+| RENAME @timestamp AS x, x AS y
+| KEEP y
+| SORT y
+| LIMIT 1
+;
+
+y:date_nanos
+2023-10-23T12:15:03.360000000Z
+;
+
+subqueryInFromWithDoubleRenameOnMixedDateAndDateNanos
+required_capability: subquery_in_from_command
+required_capability: subquery_in_from_command_union_types_implicit_casting_inconsistent_after_rename
+
+FROM sample_data, (FROM sample_data_ts_nanos)
+| KEEP @timestamp
+| RENAME @timestamp AS x
+| RENAME x AS y
+| KEEP *
+| SORT y
+| LIMIT 1
+;
+
+y:date_nanos
+2023-10-23T12:15:03.360000000Z
+;
+
+subqueryInFromWithRenameAndExplicitCastOnMixedDateAndLong
+required_capability: subquery_in_from_command
+required_capability: subquery_in_from_command_union_types_implicit_casting_inconsistent_after_rename
+
+FROM sample_data, (FROM sample_data_ts_long)
+| EVAL @timestamp = @timestamp::long
+| KEEP @timestamp
+| RENAME @timestamp AS x
+| KEEP *
+| SORT x
+| LIMIT 1
+;
+
+x:long
+1698063303360
+;
+
+subqueryInFromWithRenameChainAndExplicitCastOnMixedDateAndLong
+required_capability: subquery_in_from_command
+required_capability: subquery_in_from_command_union_types_implicit_casting_inconsistent_after_rename
+
+FROM sample_data, (FROM sample_data_ts_long)
+| EVAL @timestamp = @timestamp::long
+| KEEP @timestamp
+| RENAME @timestamp AS x, x AS y
+| KEEP y
+| SORT y
+| LIMIT 1
+;
+
+y:long
+1698063303360
+;
+
+subqueryInFromWithDoubleRenameAndExplicitCastOnMixedDateAndLong
+required_capability: subquery_in_from_command
+required_capability: subquery_in_from_command_union_types_implicit_casting_inconsistent_after_rename
+
+FROM sample_data, (FROM sample_data_ts_long)
+| EVAL @timestamp = @timestamp::long
+| KEEP @timestamp
+| RENAME @timestamp AS x
+| RENAME x AS y
+| KEEP *
+| SORT y
+| LIMIT 1
+;
+
+y:long
+1698063303360
+;
+

--- a/x-pack/plugin/esql/qa/testFixtures/src/test/java/org/elasticsearch/xpack/esql/EsqlTestUtilsTests.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/test/java/org/elasticsearch/xpack/esql/EsqlTestUtilsTests.java
@@ -148,4 +148,37 @@ public class EsqlTestUtilsTests extends ESTestCase {
             equalTo("FROM *:sample_data_ts_nanos,sample_data_ts_nanos, *:sample_data,sample_data")
         );
     }
+
+    public void testConvertSubqueryToRemoteIndicesWithSetStatement() {
+        String in = """
+            SET unmapped_fields="nullify";
+            FROM k8s, (from many_numbers)
+            | KEEP network.total_bytes_in
+            | RENAME network.total_bytes_in as x, x as y
+            | RENAME y as z
+            | KEEP *
+            | SORT z
+            | LIMIT 1""";
+        String out = "SET unmapped_fields=\"nullify\";\n"
+            + "FROM *:k8s,k8s, (FROM *:many_numbers,many_numbers)"
+            + " | KEEP network.total_bytes_in"
+            + " | RENAME network.total_bytes_in as x, x as y"
+            + " | RENAME y as z"
+            + " | KEEP *"
+            + " | SORT z"
+            + " | LIMIT 1";
+        assertThat(EsqlTestUtils.convertSubqueryToRemoteIndices(in), equalTo(out));
+    }
+
+    public void testConvertSubqueryToRemoteIndicesWithMultipleSetStatements() {
+        String in = """
+            SET a=b;
+            SET c=d;
+            FROM employees, (FROM employees_incompatible | KEEP emp_no)
+            | SORT emp_no""";
+        String out = "SET a=b;\nSET c=d;\n"
+            + "FROM *:employees,employees, (FROM *:employees_incompatible,employees_incompatible | KEEP emp_no)"
+            + " | SORT emp_no";
+        assertThat(EsqlTestUtils.convertSubqueryToRemoteIndices(in), equalTo(out));
+    }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -1257,6 +1257,11 @@ public class EsqlCapabilities {
         SUBQUERY_IN_FROM_COMMAND_CARRY_OVER_SYNTHETIC_CONVERT_ATTRIBUTES,
 
         /**
+         * Fix for union types that have counter field renamed, but the data type is inconsistent with union all output.
+         */
+        SUBQUERY_IN_FROM_COMMAND_UNION_TYPES_IMPLICIT_CASTING_INCONSISTENT_AFTER_RENAME,
+
+        /**
          * Fix for {@code PruneColumns} leaving an inconsistent plan when an {@code INLINE STATS} sits above a {@code UnionAll}
          * (from a subquery in FROM) or a {@code Fork}.
          */

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -3487,12 +3487,36 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
 
         /**
          * Update the attributes referencing the updated UnionAll output.
+         * <p>
+         * Beyond updating direct attribute references (e.g. a {@code KEEP} projection that names a fork-output attribute),
+         * this also cascades the type change through {@link Alias} nodes whose child is a direct attribute reference.
+         * <p>
+         * Before the expression walk, scan the plan for {@link Alias} nodes whose immediate child is an attribute already in the update
+         * map and add a {@code {alias.id → alias.withNewType}} entry. Because the traversal is bottom-up, chained renames such as
+         * {@code x AS y, y AS z} are picked up in order. We register the alias output unconditionally (i.e. without comparing the alias'
+         * current child type against the map entry), because the alias may have been re-resolved with the updated child type
+         * (e.g. inside a {@code ResolvingProject}) while other places in the plan (e.g. an outer {@code OrderBy}) still hold a cached
+         * attribute reference, produced by {@link Alias#toAttribute()}, with the stale (pre-update) type. The subsequent
+         * {@code transformExpressionsUp} then repairs every consumer of the alias output in one pass.
          */
         private static LogicalPlan updateAttributesReferencingUpdatedUnionAllOutput(
             LogicalPlan plan,
             List<Attribute> updatedUnionAllOutput
         ) {
-            Map<NameId, Attribute> idToUpdatedAttr = updatedUnionAllOutput.stream().collect(Collectors.toMap(Attribute::id, attr -> attr));
+            Map<NameId, Attribute> idToUpdatedAttr = new HashMap<>();
+            updatedUnionAllOutput.forEach(attr -> idToUpdatedAttr.put(attr.id(), attr));
+
+            // Cascade: collect Alias nodes above the UnionAll whose child directly references a changed attribute.
+            plan.forEachExpressionUp(Alias.class, alias -> {
+                if (alias.child() instanceof Attribute childAttr) {
+                    Attribute updatedChild = idToUpdatedAttr.get(childAttr.id());
+                    if (updatedChild != null) {
+                        Attribute aliasOutput = alias.toAttribute();
+                        idToUpdatedAttr.put(aliasOutput.id(), aliasOutput.withDataType(updatedChild.dataType()));
+                    }
+                }
+            });
+
             return plan.transformExpressionsUp(Attribute.class, expr -> {
                 Attribute updated = idToUpdatedAttr.get(expr.id());
                 return (updated != null && expr.dataType() != updated.dataType()) ? updated : expr;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
@@ -6756,6 +6756,1019 @@ public class AnalyzerTests extends ESTestCase {
         }
     }
 
+    /*
+     * Limit[1000[INTEGER],false,false]
+     * \_Project[[x{r}#6]]
+     *   \_Project[[emp_no{r}#35 AS x#6]]
+     *     \_Project[[emp_no{r}#35]]
+     *       \_UnionAll[[_meta_field{r}#34, emp_no{r}#35, first_name{r}#36, gender{r}#37, hire_date{r}#38, job{r}#39, job.raw{r}#40,
+     *                   languages{r}#41, last_name{r}#42, long_noidx{r}#43, salary{r}#44, language_code{r}#45, language_name{r}#46]]
+     *         |_Project[[_meta_field{f}#14, emp_no{f}#8, first_name{f}#9, gender{f}#10, hire_date{f}#15, job{f}#16, job.raw{f}#17,
+     *                    languages{f}#11, last_name{f}#12, long_noidx{f}#18, salary{f}#13, language_code{r}#21, language_name{r}#22]]
+     *         | \_Eval[[null[INTEGER] AS language_code#21, null[KEYWORD] AS language_name#22]]
+     *         |   \_EsRelation[test][_meta_field{f}#14, emp_no{f}#8, first_name{f}#9, ge..]
+     *         \_Project[[_meta_field{r}#23, emp_no{r}#24, first_name{r}#25, gender{r}#26, hire_date{r}#27, job{r}#28, job.raw{r}#29,
+     *                    languages{r}#30, last_name{r}#31, long_noidx{r}#32, salary{r}#33, language_code{f}#19, language_name{f}#20]]
+     *           \_Eval[[null[KEYWORD] AS _meta_field#23, null[INTEGER] AS emp_no#24, null[KEYWORD] AS first_name#25,
+     *                   null[TEXT] AS gender#26, null[DATETIME] AS hire_date#27, null[TEXT] AS job#28, null[KEYWORD] AS job.raw#29,
+     *                   null[INTEGER] AS languages#30, null[KEYWORD] AS last_name#31, null[LONG] AS long_noidx#32,
+     *                   null[INTEGER] AS salary#33]]
+     *             \_Subquery[]
+     *               \_EsRelation[languages][language_code{f}#19, language_name{f}#20]
+     */
+    public void testSubqueryRenameKeepStarOnMissingColumnPreservesType() {
+        LogicalPlan plan = basic().addLanguages().query("""
+            FROM test, (FROM languages)
+            | KEEP emp_no
+            | RENAME emp_no AS x
+            | KEEP *
+            """);
+
+        Limit limit = as(plan, Limit.class);
+        Project project = as(limit.child(), Project.class);
+        List<? extends NamedExpression> projections = project.projections();
+        assertEquals(1, projections.size());
+        ReferenceAttribute x = as(projections.get(0), ReferenceAttribute.class);
+        assertEquals("x", x.name());
+        assertEquals(INTEGER, x.dataType());
+        project = as(project.child(), Project.class);
+        projections = project.projections();
+        assertEquals(1, projections.size());
+        Alias xAlias = as(projections.get(0), Alias.class);
+        assertEquals("x", xAlias.name());
+        assertEquals(INTEGER, xAlias.dataType());
+        project = as(project.child(), Project.class);
+        projections = project.projections();
+        assertEquals(1, projections.size());
+        ReferenceAttribute emp_no = as(projections.get(0), ReferenceAttribute.class);
+        assertEquals("emp_no", emp_no.name());
+        assertEquals(INTEGER, emp_no.dataType());
+        UnionAll unionAll = as(project.child(), UnionAll.class);
+        assertTrue(unionAll.output().stream().anyMatch(a -> "emp_no".equals(a.name()) && INTEGER.equals(a.dataType())));
+    }
+
+    /*
+     * Limit[1000[INTEGER],false,false]
+     * \_OrderBy[[Order[x{r}#7,ASC,LAST]]]
+     *   \_Project[[x{r}#7, y{r}#10]]
+     *     \_Project[[network.total_bytes_in{r}#79 AS x#7, network.eth0.tx{r}#77 AS y#10]]
+     *       \_Project[[network.total_bytes_in{r}#79, network.eth0.tx{r}#77]]
+     *         \_UnionAll[[@timestamp{r}#61, client.ip{r}#62, cluster{r}#63, event{r}#64, event_city{r}#65, event_city_boundary{r}#66,
+     *                   event_location{r}#67, event_log{r}#68, event_shape{r}#69, events_received{r}#70, network.bytes_in{r}#71,
+     *                   network.cost{r}#72, network.eth0.currently_connected_clients{r}#73, network.eth0.firmware_version{r}#74,
+     *                   network.eth0.last_up{r}#75, network.eth0.rx{r}#76, network.eth0.tx{r}#77, network.eth0.up{r}#78,
+     *                   network.total_bytes_in{r}#79, network.total_cost{r}#80, pod{r}#81, language_code{r}#82, language_name{r}#83]]
+     *         |_Project[[@timestamp{f}#12, client.ip{f}#16, cluster{f}#13, event{f}#17, event_city{f}#20, event_city_boundary{f}#21,
+     *                    event_location{f}#23, event_log{f}#18, event_shape{f}#22, events_received{f}#19, network.bytes_in{f}#25,
+     *                    network.cost{f}#27, network.eth0.currently_connected_clients{f}#35, network.eth0.firmware_version{f}#34,
+     *                    network.eth0.last_up{f}#33, network.eth0.rx{f}#32, network.eth0.tx{f}#31, network.eth0.up{f}#30,
+     *                    network.total_bytes_in{r}#84, network.total_cost{r}#85, pod{f}#14, language_code{r}#38, language_name{r}#39]]
+     *         | \_Eval[[TOLONG(network.total_bytes_in{f}#26) AS network.total_bytes_in#84,
+     *                   TODOUBLE(network.total_cost{f}#28) AS network.total_cost#85]]
+     *         |   \_Eval[[null[INTEGER] AS language_code#38, null[KEYWORD] AS language_name#39]]
+     *         |     \_EsRelation[k8s][@timestamp{f}#12, client.ip{f}#16, cluster{f}#13, e..]
+     *         \_Project[[@timestamp{r}#40, client.ip{r}#41, cluster{r}#42, event{r}#43, event_city{r}#44, event_city_boundary{r}#45,
+     *                    event_location{r}#46, event_log{r}#47, event_shape{r}#48, events_received{r}#49, network.bytes_in{r}#50,
+     *                    network.cost{r}#51, network.eth0.currently_connected_clients{r}#52, network.eth0.firmware_version{r}#53,
+     *                    network.eth0.last_up{r}#54, network.eth0.rx{r}#55, network.eth0.tx{r}#56, network.eth0.up{r}#57,
+     *                    network.total_bytes_in{r}#58, network.total_cost{r}#59, pod{r}#60, language_code{f}#36, language_name{f}#37]]
+     *           \_Eval[[null[DATETIME] AS @timestamp#40, null[IP] AS client.ip#41, null[KEYWORD] AS cluster#42,
+     *                   null[KEYWORD] AS event#43, null[GEO_POINT] AS event_city#44, null[GEO_SHAPE] AS event_city_boundary#45,
+     *                   null[CARTESIAN_POINT] AS event_location#46, null[TEXT] AS event_log#47, null[CARTESIAN_SHAPE] AS event_shape#48,
+     *                   null[LONG] AS events_received#49, null[LONG] AS network.bytes_in#50, null[DOUBLE] AS network.cost#51,
+     *                   null[INTEGER] AS network.eth0.currently_connected_clients#52, null[VERSION] AS network.eth0.firmware_version#53,
+     *                   null[DATE_NANOS] AS network.eth0.last_up#54, null[AGGREGATE_METRIC_DOUBLE] AS network.eth0.rx#55,
+     *                   null[AGGREGATE_METRIC_DOUBLE] AS network.eth0.tx#56, null[BOOLEAN] AS network.eth0.up#57,
+     *                   null[LONG] AS network.total_bytes_in#58, null[DOUBLE] AS network.total_cost#59, null[KEYWORD] AS pod#60]]
+     *             \_Subquery[]
+     *               \_EsRelation[languages][language_code{f}#36, language_name{f}#37]
+     */
+    public void testSubqueryRenameKeepOnMissingCounterFields() {
+        assumeTrue(
+            "Require the fix to inconsistent counter type",
+            EsqlCapabilities.Cap.SUBQUERY_IN_FROM_COMMAND_UNION_TYPES_IMPLICIT_CASTING_INCONSISTENT_AFTER_RENAME.isEnabled()
+        );
+        LogicalPlan plan = analyzer().addK8sDownsampled().addLanguages().query("""
+            FROM k8s, (FROM languages)
+            | KEEP network.total_bytes_in, network.eth0.tx
+            | RENAME network.total_bytes_in AS x, network.eth0.tx AS y
+            | KEEP *
+            | SORT x
+            """);
+
+        Limit limit = as(plan, Limit.class);
+        OrderBy orderBy = as(limit.child(), OrderBy.class);
+        List<Order> order = orderBy.order();
+        assertEquals(1, order.size());
+        ReferenceAttribute xOrder = as(order.get(0).child(), ReferenceAttribute.class);
+        assertEquals("x", xOrder.name());
+        assertEquals(LONG, xOrder.dataType());
+        Project project = as(orderBy.child(), Project.class);
+        List<? extends NamedExpression> projections = project.projections();
+        assertEquals(2, projections.size());
+        ReferenceAttribute x = as(projections.get(0), ReferenceAttribute.class);
+        ReferenceAttribute y = as(projections.get(1), ReferenceAttribute.class);
+        assertEquals("x", x.name());
+        assertEquals(LONG, x.dataType());
+        assertEquals("y", y.name());
+        assertEquals(AGGREGATE_METRIC_DOUBLE, y.dataType());
+        project = as(project.child(), Project.class);
+        projections = project.projections();
+        assertEquals(2, projections.size());
+        Alias xAlias = as(projections.get(0), Alias.class);
+        assertEquals("x", xAlias.name());
+        assertEquals(LONG, xAlias.dataType());
+        Alias yAlias = as(projections.get(1), Alias.class);
+        assertEquals("y", yAlias.name());
+        assertEquals(AGGREGATE_METRIC_DOUBLE, yAlias.dataType());
+        project = as(project.child(), Project.class);
+        projections = project.projections();
+        assertEquals(2, projections.size());
+        ReferenceAttribute total_bytes_in = as(projections.get(0), ReferenceAttribute.class);
+        assertEquals("network.total_bytes_in", total_bytes_in.name());
+        assertEquals(LONG, total_bytes_in.dataType());
+        ReferenceAttribute network_eth0_tx = as(projections.get(1), ReferenceAttribute.class);
+        assertEquals("network.eth0.tx", network_eth0_tx.name());
+        assertEquals(AGGREGATE_METRIC_DOUBLE, network_eth0_tx.dataType());
+        UnionAll unionAll = as(project.child(), UnionAll.class);
+        assertTrue(unionAll.output().stream().anyMatch(a -> "network.total_bytes_in".equals(a.name()) && LONG.equals(a.dataType())));
+        assertTrue(
+            unionAll.output().stream().anyMatch(a -> "network.eth0.tx".equals(a.name()) && AGGREGATE_METRIC_DOUBLE.equals(a.dataType()))
+        );
+    }
+
+    /*
+     * Limit[1000[INTEGER],false,false]
+     * \_OrderBy[[Order[y{r}#9,ASC,LAST]]]
+     *  \_Project[[y{r}#9]]
+     *   \_Project[[network.total_bytes_in{r}#78 AS y#9]]
+     *     \_Project[[network.total_bytes_in{r}#78]]
+     *       \_UnionAll[[@timestamp{r}#60, client.ip{r}#61, cluster{r}#62, event{r}#63, event_city{r}#64, event_city_boundary{r}#65,
+     *                   event_location{r}#66, event_log{r}#67, event_shape{r}#68, events_received{r}#69, network.bytes_in{r}#70,
+     *                   network.cost{r}#71, network.eth0.currently_connected_clients{r}#72, network.eth0.firmware_version{r}#73,
+     *                   network.eth0.last_up{r}#74, network.eth0.rx{r}#75, network.eth0.tx{r}#76, network.eth0.up{r}#77,
+     *                   network.total_bytes_in{r}#78, network.total_cost{r}#79, pod{r}#80, language_code{r}#81, language_name{r}#82]]
+     *         |_Project[[@timestamp{f}#11, client.ip{f}#15, cluster{f}#12, event{f}#16, event_city{f}#19, event_city_boundary{f}#20,
+     *                    event_location{f}#22, event_log{f}#17, event_shape{f}#21, events_received{f}#18, network.bytes_in{f}#24,
+     *                    network.cost{f}#26, network.eth0.currently_connected_clients{f}#34, network.eth0.firmware_version{f}#33,
+     *                    network.eth0.last_up{f}#32, network.eth0.rx{f}#31, network.eth0.tx{f}#30, network.eth0.up{f}#29,
+     *                    network.total_bytes_in{r}#83, network.total_cost{r}#84, pod{f}#13, language_code{r}#37, language_name{r}#38]]
+     *         | \_Eval[[TOLONG(network.total_bytes_in{f}#25) AS network.total_bytes_in#83,
+     *                   TODOUBLE(network.total_cost{f}#27) AS network.total_cost#84]]
+     *         |   \_Eval[[null[INTEGER] AS language_code#37, null[KEYWORD] AS language_name#38]]
+     *         |     \_EsRelation[k8s][@timestamp{f}#11, client.ip{f}#15, cluster{f}#12, e..]
+     *         \_Project[[@timestamp{r}#39, client.ip{r}#40, cluster{r}#41, event{r}#42, event_city{r}#43, event_city_boundary{r}#44,
+     *         event_location{r}#45, event_log{r}#46, event_shape{r}#47, events_received{r}#48, network.bytes_in{r}#49,
+     *         network.cost{r}#50, network.eth0.currently_connected_clients{r}#51, network.eth0.firmware_version{r}#52,
+     *         network.eth0.last_up{r}#53, network.eth0.rx{r}#54, network.eth0.tx{r}#55, network.eth0.up{r}#56,
+     *         network.total_bytes_in{r}#57, network.total_cost{r}#58, pod{r}#59, language_code{f}#35, language_name{f}#36]]
+     *           \_Eval[[null[DATETIME] AS @timestamp#39, null[IP] AS client.ip#40, null[KEYWORD] AS cluster#41, null[KEYWORD] AS event#42,
+     *                   null[GEO_POINT] AS event_city#43, null[GEO_SHAPE] AS event_city_boundary#44,
+     *                   null[CARTESIAN_POINT] AS event_location#45, null[TEXT] AS event_log#46, null[CARTESIAN_SHAPE] AS event_shape#47,
+     *                   null[LONG] AS events_received#48, null[LONG] AS network.bytes_in#49, null[DOUBLE] AS network.cost#50,
+     *                   null[INTEGER] AS network.eth0.currently_connected_clients#51, null[VERSION] AS network.eth0.firmware_version#52,
+     *                   null[DATE_NANOS] AS network.eth0.last_up#53, null[AGGREGATE_METRIC_DOUBLE] AS network.eth0.rx#54,
+     *                   null[AGGREGATE_METRIC_DOUBLE] AS network.eth0.tx#55, null[BOOLEAN] AS network.eth0.up#56,
+     *                   null[LONG] AS network.total_bytes_in#57, null[DOUBLE] AS network.total_cost#58, null[KEYWORD] AS pod#59]]
+     *             \_Subquery[]
+     *               \_EsRelation[languages][language_code{f}#35, language_name{f}#36]
+     */
+    public void testSubqueryRenameChainKeepStarOnMissingCounterField() {
+        assumeTrue(
+            "Require the fix to inconsistent counter type",
+            EsqlCapabilities.Cap.SUBQUERY_IN_FROM_COMMAND_UNION_TYPES_IMPLICIT_CASTING_INCONSISTENT_AFTER_RENAME.isEnabled()
+        );
+        LogicalPlan plan = analyzer().addK8sDownsampled().addLanguages().query("""
+            FROM k8s, (FROM languages)
+            | KEEP network.total_bytes_in
+            | RENAME network.total_bytes_in AS x, x as y
+            | KEEP y
+            | SORT y
+            """);
+
+        Limit limit = as(plan, Limit.class);
+        OrderBy orderBy = as(limit.child(), OrderBy.class);
+        List<Order> order = orderBy.order();
+        assertEquals(1, order.size());
+        ReferenceAttribute yOrder = as(order.get(0).child(), ReferenceAttribute.class);
+        assertEquals("y", yOrder.name());
+        assertEquals(LONG, yOrder.dataType());
+        Project project = as(orderBy.child(), Project.class);
+        List<? extends NamedExpression> projections = project.projections();
+        assertEquals(1, projections.size());
+        ReferenceAttribute y = as(projections.get(0), ReferenceAttribute.class);
+        assertEquals("y", y.name());
+        assertEquals(LONG, y.dataType());
+        project = as(project.child(), Project.class);
+        projections = project.projections();
+        assertEquals(1, projections.size());
+        Alias yAlias = as(projections.get(0), Alias.class);
+        assertEquals("y", yAlias.name());
+        assertEquals(LONG, yAlias.dataType());
+        project = as(project.child(), Project.class);
+        projections = project.projections();
+        assertEquals(1, projections.size());
+        ReferenceAttribute total_bytes_in = as(projections.get(0), ReferenceAttribute.class);
+        assertEquals("network.total_bytes_in", total_bytes_in.name());
+        assertEquals(LONG, total_bytes_in.dataType());
+        UnionAll unionAll = as(project.child(), UnionAll.class);
+        assertTrue(unionAll.output().stream().anyMatch(a -> "network.total_bytes_in".equals(a.name()) && LONG.equals(a.dataType())));
+    }
+
+    /*
+     * Limit[1000[INTEGER],false,false]
+     * \_OrderBy[[Order[y{r}#9,ASC,LAST]]]
+     *  \_Project[[y{r}#9]]
+     *   \_Project[[x{r}#6 AS y#9]]
+     *     \_Project[[network.total_bytes_in{r}#78 AS x#6]]
+     *       \_Project[[network.total_bytes_in{r}#78]]
+     *         \_UnionAll[[@timestamp{r}#60, client.ip{r}#61, cluster{r}#62, event{r}#63, event_city{r}#64, event_city_boundary{r}#65,
+     *                     event_location{r}#66, event_log{r}#67, event_shape{r}#68, events_received{r}#69, network.bytes_in{r}#70,
+     *                     network.cost{r}#71, network.eth0.currently_connected_clients{r}#72, network.eth0.firmware_version{r}#73,
+     *                     network.eth0.last_up{r}#74, network.eth0.rx{r}#75, network.eth0.tx{r}#76, network.eth0.up{r}#77,
+     *                     network.total_bytes_in{r}#78, network.total_cost{r}#79, pod{r}#80, language_code{r}#81, language_name{r}#82]]
+     *           |_Project[[@timestamp{f}#11, client.ip{f}#15, cluster{f}#12, event{f}#16, event_city{f}#19, event_city_boundary{f}#20,
+     *                      event_location{f}#22, event_log{f}#17, event_shape{f}#21, events_received{f}#18, network.bytes_in{f}#24,
+     *                      network.cost{f}#26, network.eth0.currently_connected_clients{f}#34, network.eth0.firmware_version{f}#33,
+     *                      network.eth0.last_up{f}#32, network.eth0.rx{f}#31, network.eth0.tx{f}#30, network.eth0.up{f}#29,
+     *                      network.total_bytes_in{r}#83, network.total_cost{r}#84, pod{f}#13, language_code{r}#37, language_name{r}#38]]
+     *           | \_Eval[[TOLONG(network.total_bytes_in{f}#25) AS network.total_bytes_in#83,
+     *                     TODOUBLE(network.total_cost{f}#27) AS network.total_cost#84]]
+     *           |   \_Eval[[null[INTEGER] AS language_code#37, null[KEYWORD] AS language_name#38]]
+     *           |     \_EsRelation[k8s][@timestamp{f}#11, client.ip{f}#15, cluster{f}#12, e..]
+     *           \_Project[[@timestamp{r}#39, client.ip{r}#40, cluster{r}#41, event{r}#42, event_city{r}#43, event_city_boundary{r}#44,
+     *                      event_location{r}#45, event_log{r}#46, event_shape{r}#47, events_received{r}#48, network.bytes_in{r}#49,
+     *                      network.cost{r}#50, network.eth0.currently_connected_clients{r}#51, network.eth0.firmware_version{r}#52,
+     *                      network.eth0.last_up{r}#53, network.eth0.rx{r}#54, network.eth0.tx{r}#55, network.eth0.up{r}#56,
+     *                      network.total_bytes_in{r}#57, network.total_cost{r}#58, pod{r}#59, language_code{f}#35, language_name{f}#36]]
+     *             \_Eval[[null[DATETIME] AS @timestamp#39, null[IP] AS client.ip#40, null[KEYWORD] AS cluster#41,
+     *                     null[KEYWORD] AS event#42, null[GEO_POINT] AS event_city#43, null[GEO_SHAPE] AS event_city_boundary#44,
+     *                     null[CARTESIAN_POINT] AS event_location#45, null[TEXT] AS event_log#46, null[CARTESIAN_SHAPE] AS event_shape#47,
+     *                     null[LONG] AS events_received#48, null[LONG] AS network.bytes_in#49, null[DOUBLE] AS network.cost#50,
+     *                     null[INTEGER] AS network.eth0.currently_connected_clients#51, null[VERSION] AS network.eth0.firmware_version#52,
+     *                     null[DATE_NANOS] AS network.eth0.last_up#53, null[AGGREGATE_METRIC_DOUBLE] AS network.eth0.rx#54,
+     *                     null[AGGREGATE_METRIC_DOUBLE] AS network.eth0.tx#55, null[BOOLEAN] AS network.eth0.up#56,
+     *                     null[LONG] AS network.total_bytes_in#57, null[DOUBLE] AS network.total_cost#58, null[KEYWORD] AS pod#59]]
+     *               \_Subquery[]
+     *                 \_EsRelation[languages][language_code{f}#35, language_name{f}#36]
+     */
+    public void testSubqueryDoubleRenameKeepStarOnMissingCounterField() {
+        assumeTrue(
+            "Require the fix to inconsistent counter type",
+            EsqlCapabilities.Cap.SUBQUERY_IN_FROM_COMMAND_UNION_TYPES_IMPLICIT_CASTING_INCONSISTENT_AFTER_RENAME.isEnabled()
+        );
+        LogicalPlan plan = analyzer().addK8sDownsampled().addLanguages().query("""
+            FROM k8s, (FROM languages)
+            | KEEP network.total_bytes_in
+            | RENAME network.total_bytes_in AS x
+            | RENAME x as y
+            | KEEP *
+            | SORT y
+            """);
+
+        Limit limit = as(plan, Limit.class);
+        OrderBy orderBy = as(limit.child(), OrderBy.class);
+        List<Order> order = orderBy.order();
+        assertEquals(1, order.size());
+        ReferenceAttribute yOrder = as(order.get(0).child(), ReferenceAttribute.class);
+        assertEquals("y", yOrder.name());
+        assertEquals(LONG, yOrder.dataType());
+        Project project = as(orderBy.child(), Project.class);
+        List<? extends NamedExpression> projections = project.projections();
+        assertEquals(1, projections.size());
+        ReferenceAttribute y = as(projections.get(0), ReferenceAttribute.class);
+        assertEquals("y", y.name());
+        assertEquals(LONG, y.dataType());
+        project = as(project.child(), Project.class);
+        projections = project.projections();
+        assertEquals(1, projections.size());
+        Alias yAlias = as(projections.get(0), Alias.class);
+        assertEquals("y", yAlias.name());
+        assertEquals(LONG, yAlias.dataType());
+        project = as(project.child(), Project.class);
+        projections = project.projections();
+        assertEquals(1, projections.size());
+        Alias xAlias = as(projections.get(0), Alias.class);
+        assertEquals("x", xAlias.name());
+        assertEquals(LONG, xAlias.dataType());
+        project = as(project.child(), Project.class);
+        projections = project.projections();
+        assertEquals(1, projections.size());
+        ReferenceAttribute total_bytes_in = as(projections.get(0), ReferenceAttribute.class);
+        assertEquals("network.total_bytes_in", total_bytes_in.name());
+        assertEquals(LONG, total_bytes_in.dataType());
+        UnionAll unionAll = as(project.child(), UnionAll.class);
+        assertTrue(unionAll.output().stream().anyMatch(a -> "network.total_bytes_in".equals(a.name()) && LONG.equals(a.dataType())));
+    }
+
+    /*
+     * Limit[1000[INTEGER],false,false]
+     * \_OrderBy[[Order[x{r}#7,ASC,LAST]]]
+     *   \_Project[[x{r}#7, y{r}#10]]
+     *     \_Project[[network.total_bytes_in{r}#79 AS x#7, network.eth0.tx{r}#77 AS y#10]]
+     *       \_Project[[network.total_bytes_in{r}#79, network.eth0.tx{r}#77]]
+     *         \_UnionAll[...]
+     *           |_...
+     *           \_...
+     *
+     * Same as {@link #testSubqueryRenameKeepOnMissingCounterFields()} but with {@code SET unmapped_fields="nullify"}
+     */
+    public void testSubqueryRenameKeepOnMissingCounterFieldsWithNullifyAndSort() {
+        assumeTrue(
+            "Require the fix to inconsistent counter type",
+            EsqlCapabilities.Cap.SUBQUERY_IN_FROM_COMMAND_UNION_TYPES_IMPLICIT_CASTING_INCONSISTENT_AFTER_RENAME.isEnabled()
+        );
+        assumeTrue("Requires OPTIONAL_FIELDS_NULLIFY_TECH_PREVIEW", EsqlCapabilities.Cap.OPTIONAL_FIELDS_NULLIFY_TECH_PREVIEW.isEnabled());
+        LogicalPlan plan = analyzer().addK8sDownsampled().addLanguages().statement("""
+            SET unmapped_fields="nullify";
+            FROM k8s, (FROM languages)
+            | KEEP network.total_bytes_in, network.eth0.tx
+            | RENAME network.total_bytes_in AS x, network.eth0.tx AS y
+            | KEEP *
+            | SORT x
+            """);
+
+        Limit limit = as(plan, Limit.class);
+        OrderBy orderBy = as(limit.child(), OrderBy.class);
+        List<Order> order = orderBy.order();
+        assertEquals(1, order.size());
+        ReferenceAttribute xOrder = as(order.get(0).child(), ReferenceAttribute.class);
+        assertEquals("x", xOrder.name());
+        assertEquals(LONG, xOrder.dataType());
+        Project project = as(orderBy.child(), Project.class);
+        List<? extends NamedExpression> projections = project.projections();
+        assertEquals(2, projections.size());
+        ReferenceAttribute x = as(projections.get(0), ReferenceAttribute.class);
+        ReferenceAttribute y = as(projections.get(1), ReferenceAttribute.class);
+        assertEquals("x", x.name());
+        assertEquals(LONG, x.dataType());
+        assertEquals("y", y.name());
+        assertEquals(AGGREGATE_METRIC_DOUBLE, y.dataType());
+        project = as(project.child(), Project.class);
+        projections = project.projections();
+        assertEquals(2, projections.size());
+        Alias xAlias = as(projections.get(0), Alias.class);
+        assertEquals("x", xAlias.name());
+        assertEquals(LONG, xAlias.dataType());
+        Alias yAlias = as(projections.get(1), Alias.class);
+        assertEquals("y", yAlias.name());
+        assertEquals(AGGREGATE_METRIC_DOUBLE, yAlias.dataType());
+        project = as(project.child(), Project.class);
+        projections = project.projections();
+        assertEquals(2, projections.size());
+        ReferenceAttribute total_bytes_in = as(projections.get(0), ReferenceAttribute.class);
+        assertEquals("network.total_bytes_in", total_bytes_in.name());
+        assertEquals(LONG, total_bytes_in.dataType());
+        ReferenceAttribute network_eth0_tx = as(projections.get(1), ReferenceAttribute.class);
+        assertEquals("network.eth0.tx", network_eth0_tx.name());
+        assertEquals(AGGREGATE_METRIC_DOUBLE, network_eth0_tx.dataType());
+        UnionAll unionAll = as(project.child(), UnionAll.class);
+        assertTrue(unionAll.output().stream().anyMatch(a -> "network.total_bytes_in".equals(a.name()) && LONG.equals(a.dataType())));
+        assertTrue(
+            unionAll.output().stream().anyMatch(a -> "network.eth0.tx".equals(a.name()) && AGGREGATE_METRIC_DOUBLE.equals(a.dataType()))
+        );
+    }
+
+    /*
+     * Limit[1000[INTEGER],false,false]
+     * \_OrderBy[[Order[y{r}#9,ASC,LAST]]]
+     *   \_Project[[y{r}#9]]
+     *     \_Project[[network.total_bytes_in{r}#78 AS y#9]]
+     *       \_Project[[network.total_bytes_in{r}#78]]
+     *         \_UnionAll[...]
+     *
+     * Same as {@link #testSubqueryRenameChainKeepStarOnMissingCounterField()} but with {@code SET unmapped_fields="nullify"}
+     */
+    public void testSubqueryRenameChainKeepStarOnMissingCounterFieldWithNullifyAndSort() {
+        assumeTrue(
+            "Require the fix to inconsistent counter type",
+            EsqlCapabilities.Cap.SUBQUERY_IN_FROM_COMMAND_UNION_TYPES_IMPLICIT_CASTING_INCONSISTENT_AFTER_RENAME.isEnabled()
+        );
+        assumeTrue("Requires OPTIONAL_FIELDS_NULLIFY_TECH_PREVIEW", EsqlCapabilities.Cap.OPTIONAL_FIELDS_NULLIFY_TECH_PREVIEW.isEnabled());
+        LogicalPlan plan = analyzer().addK8sDownsampled().addLanguages().statement("""
+            SET unmapped_fields="nullify";
+            FROM k8s, (FROM languages)
+            | KEEP network.total_bytes_in
+            | RENAME network.total_bytes_in AS x, x as y
+            | KEEP y
+            | SORT y
+            """);
+
+        Limit limit = as(plan, Limit.class);
+        OrderBy orderBy = as(limit.child(), OrderBy.class);
+        List<Order> order = orderBy.order();
+        assertEquals(1, order.size());
+        ReferenceAttribute yOrder = as(order.get(0).child(), ReferenceAttribute.class);
+        assertEquals("y", yOrder.name());
+        assertEquals(LONG, yOrder.dataType());
+        Project project = as(orderBy.child(), Project.class);
+        List<? extends NamedExpression> projections = project.projections();
+        assertEquals(1, projections.size());
+        ReferenceAttribute y = as(projections.get(0), ReferenceAttribute.class);
+        assertEquals("y", y.name());
+        assertEquals(LONG, y.dataType());
+        project = as(project.child(), Project.class);
+        projections = project.projections();
+        assertEquals(1, projections.size());
+        Alias yAlias = as(projections.get(0), Alias.class);
+        assertEquals("y", yAlias.name());
+        assertEquals(LONG, yAlias.dataType());
+        project = as(project.child(), Project.class);
+        projections = project.projections();
+        assertEquals(1, projections.size());
+        ReferenceAttribute total_bytes_in = as(projections.get(0), ReferenceAttribute.class);
+        assertEquals("network.total_bytes_in", total_bytes_in.name());
+        assertEquals(LONG, total_bytes_in.dataType());
+        UnionAll unionAll = as(project.child(), UnionAll.class);
+        assertTrue(unionAll.output().stream().anyMatch(a -> "network.total_bytes_in".equals(a.name()) && LONG.equals(a.dataType())));
+    }
+
+    /*
+     * Limit[1000[INTEGER],false,false]
+     * \_OrderBy[[Order[y{r}#?,ASC,LAST]]]
+     *   \_Project[[<remaining fields>, x{r}#? AS y#?]]
+     *     \_Project[[<remaining fields>, network.total_bytes_in{r}#? AS x#?]]
+     *       \_Project[[<remaining fields after DROP>]]
+     *         \_UnionAll[...]
+     *
+     * DROP variant of {@link #testSubqueryDoubleRenameKeepStarOnMissingCounterFieldWithNullifyAndSort()}.
+     */
+    public void testSubqueryDoubleRenameDropStarOnMissingCounterFieldWithNullifyAndSort() {
+        assumeTrue(
+            "Require the fix to inconsistent counter type",
+            EsqlCapabilities.Cap.SUBQUERY_IN_FROM_COMMAND_UNION_TYPES_IMPLICIT_CASTING_INCONSISTENT_AFTER_RENAME.isEnabled()
+        );
+        assumeTrue("Requires OPTIONAL_FIELDS_NULLIFY_TECH_PREVIEW", EsqlCapabilities.Cap.OPTIONAL_FIELDS_NULLIFY_TECH_PREVIEW.isEnabled());
+        LogicalPlan plan = analyzer().addK8sDownsampled().addLanguages().statement("""
+            SET unmapped_fields="nullify";
+            FROM k8s, (FROM languages)
+            | DROP @timestamp, language_*
+            | RENAME network.total_bytes_in AS x
+            | RENAME x as y
+            | KEEP *
+            | SORT y
+            """);
+
+        Limit limit = as(plan, Limit.class);
+        OrderBy orderBy = as(limit.child(), OrderBy.class);
+        List<Order> order = orderBy.order();
+        assertEquals(1, order.size());
+        ReferenceAttribute yOrder = as(order.get(0).child(), ReferenceAttribute.class);
+        assertEquals("y", yOrder.name());
+        assertEquals(LONG, yOrder.dataType());
+        Project project = as(orderBy.child(), Project.class);
+        List<? extends NamedExpression> projections = project.projections();
+        ReferenceAttribute y = as(
+            projections.stream().filter(p -> "y".equals(p.name())).findFirst().orElseThrow(),
+            ReferenceAttribute.class
+        );
+        assertEquals(LONG, y.dataType());
+        project = as(project.child(), Project.class);
+        projections = project.projections();
+        Alias yAlias = as(projections.stream().filter(p -> "y".equals(p.name())).findFirst().orElseThrow(), Alias.class);
+        assertEquals(LONG, yAlias.dataType());
+        project = as(project.child(), Project.class);
+        projections = project.projections();
+        Alias xAlias = as(projections.stream().filter(p -> "x".equals(p.name())).findFirst().orElseThrow(), Alias.class);
+        assertEquals(LONG, xAlias.dataType());
+        project = as(project.child(), Project.class);
+        projections = project.projections();
+        ReferenceAttribute totalBytesIn = as(
+            projections.stream().filter(p -> "network.total_bytes_in".equals(p.name())).findFirst().orElseThrow(),
+            ReferenceAttribute.class
+        );
+        assertEquals(LONG, totalBytesIn.dataType());
+        assertTrue("@timestamp should have been dropped", projections.stream().noneMatch(p -> "@timestamp".equals(p.name())));
+        assertTrue("language_code should have been dropped", projections.stream().noneMatch(p -> "language_code".equals(p.name())));
+        assertTrue("language_name should have been dropped", projections.stream().noneMatch(p -> "language_name".equals(p.name())));
+        UnionAll unionAll = as(project.child(), UnionAll.class);
+        assertTrue(unionAll.output().stream().anyMatch(a -> "network.total_bytes_in".equals(a.name()) && LONG.equals(a.dataType())));
+    }
+
+    /*
+     * Limit[1000[INTEGER],false,false]
+     * \_OrderBy[[Order[x{r}#?,ASC,LAST]]]
+     *   \_Project[[x{r}#?]]
+     *     \_Project[[@timestamp{r}#? AS x#?]]
+     *       \_Project[[@timestamp{r}#?]]
+     *         \_UnionAll[[@timestamp{r}#?, client_ip{r}#?, event_duration{r}#?, message{r}#?]]
+     *           |_Project[[@timestamp{r}#?, client_ip{f}#?, event_duration{f}#?, message{f}#?]]
+     *           | \_Eval[[TODATENANOS(@timestamp{f}#?) AS @timestamp#?]]
+     *           |   \_EsRelation[sample_data][@timestamp{f}#?(date), client_ip{f}#?, event_duration..]
+     *           \_Project[[@timestamp{f}#?, client_ip{f}#?, event_duration{f}#?, message{f}#?]]
+     *             \_Subquery[]
+     *               \_EsRelation[sample_data_ts_nanos][@timestamp{f}#?(date_nanos), client_ip{f}#?, event_duration..]
+     *
+     * Same pattern as {@link #testSubqueryRenameKeepOnMissingCounterFields()} but the field whose type is updated by the {@code UnionAll}
+     * resolution is {@code @timestamp}, which is mapped as {@code date} in {@code sample_data} and as {@code date_nanos} in
+     * {@code sample_data_ts_nanos}. {@code ResolveUnionTypesInUnionAll} casts the two to {@code DATE_NANOS} implicitly. The alias-cascade
+     * in {@code updateAttributesReferencingUpdatedUnionAllOutput} also transform that reference to {@code DATE_NANOS} for the plan to stay
+     * consistent.
+     */
+    public void testSubqueryRenameKeepOnDateAndDateNanosTimestamp() {
+        LogicalPlan plan = analyzer().addSampleData().addIndex(sampleDataTsNanosIndex()).query("""
+            FROM sample_data, (FROM sample_data_ts_nanos)
+            | KEEP @timestamp
+            | RENAME @timestamp AS x
+            | KEEP *
+            | SORT x
+            """);
+
+        Limit limit = as(plan, Limit.class);
+        OrderBy orderBy = as(limit.child(), OrderBy.class);
+        List<Order> order = orderBy.order();
+        assertEquals(1, order.size());
+        ReferenceAttribute xOrder = as(order.get(0).child(), ReferenceAttribute.class);
+        assertEquals("x", xOrder.name());
+        assertEquals(DATE_NANOS, xOrder.dataType());
+        Project project = as(orderBy.child(), Project.class);
+        List<? extends NamedExpression> projections = project.projections();
+        assertEquals(1, projections.size());
+        ReferenceAttribute x = as(projections.get(0), ReferenceAttribute.class);
+        assertEquals("x", x.name());
+        assertEquals(DATE_NANOS, x.dataType());
+        project = as(project.child(), Project.class);
+        projections = project.projections();
+        assertEquals(1, projections.size());
+        Alias xAlias = as(projections.get(0), Alias.class);
+        assertEquals("x", xAlias.name());
+        assertEquals(DATE_NANOS, xAlias.dataType());
+        project = as(project.child(), Project.class);
+        projections = project.projections();
+        assertEquals(1, projections.size());
+        ReferenceAttribute timestamp = as(projections.get(0), ReferenceAttribute.class);
+        assertEquals("@timestamp", timestamp.name());
+        assertEquals(DATE_NANOS, timestamp.dataType());
+        UnionAll unionAll = as(project.child(), UnionAll.class);
+        assertTrue(unionAll.output().stream().anyMatch(a -> "@timestamp".equals(a.name()) && DATE_NANOS.equals(a.dataType())));
+    }
+
+    /*
+     * Limit[1000[INTEGER],false,false]
+     * \_OrderBy[[Order[y{r}#?,ASC,LAST]]]
+     *   \_Project[[y{r}#?]]
+     *     \_Project[[@timestamp{r}#? AS y#?]]
+     *       \_Project[[@timestamp{r}#?]]
+     *         \_UnionAll[...]
+     */
+    public void testSubqueryRenameChainKeepOnDateAndDateNanosTimestamp() {
+        LogicalPlan plan = analyzer().addSampleData().addIndex(sampleDataTsNanosIndex()).query("""
+            FROM sample_data, (FROM sample_data_ts_nanos)
+            | KEEP @timestamp
+            | RENAME @timestamp AS x, x AS y
+            | KEEP y
+            | SORT y
+            """);
+
+        Limit limit = as(plan, Limit.class);
+        OrderBy orderBy = as(limit.child(), OrderBy.class);
+        List<Order> order = orderBy.order();
+        assertEquals(1, order.size());
+        ReferenceAttribute yOrder = as(order.get(0).child(), ReferenceAttribute.class);
+        assertEquals("y", yOrder.name());
+        assertEquals(DATE_NANOS, yOrder.dataType());
+        Project project = as(orderBy.child(), Project.class);
+        List<? extends NamedExpression> projections = project.projections();
+        assertEquals(1, projections.size());
+        ReferenceAttribute y = as(projections.get(0), ReferenceAttribute.class);
+        assertEquals("y", y.name());
+        assertEquals(DATE_NANOS, y.dataType());
+        project = as(project.child(), Project.class);
+        projections = project.projections();
+        assertEquals(1, projections.size());
+        Alias yAlias = as(projections.get(0), Alias.class);
+        assertEquals("y", yAlias.name());
+        assertEquals(DATE_NANOS, yAlias.dataType());
+        project = as(project.child(), Project.class);
+        projections = project.projections();
+        assertEquals(1, projections.size());
+        ReferenceAttribute timestamp = as(projections.get(0), ReferenceAttribute.class);
+        assertEquals("@timestamp", timestamp.name());
+        assertEquals(DATE_NANOS, timestamp.dataType());
+        UnionAll unionAll = as(project.child(), UnionAll.class);
+        assertTrue(unionAll.output().stream().anyMatch(a -> "@timestamp".equals(a.name()) && DATE_NANOS.equals(a.dataType())));
+    }
+
+    /*
+     * Limit[1000[INTEGER],false,false]
+     * \_OrderBy[[Order[y{r}#?,ASC,LAST]]]
+     *   \_Project[[y{r}#?]]
+     *     \_Project[[x{r}#? AS y#?]]
+     *       \_Project[[@timestamp{r}#? AS x#?]]
+     *         \_Project[[@timestamp{r}#?]]
+     *           \_UnionAll[...]
+     */
+    public void testSubqueryDoubleRenameKeepStarOnDateAndDateNanosTimestamp() {
+        LogicalPlan plan = analyzer().addSampleData().addIndex(sampleDataTsNanosIndex()).query("""
+            FROM sample_data, (FROM sample_data_ts_nanos)
+            | KEEP @timestamp
+            | RENAME @timestamp AS x
+            | RENAME x AS y
+            | KEEP *
+            | SORT y
+            """);
+
+        Limit limit = as(plan, Limit.class);
+        OrderBy orderBy = as(limit.child(), OrderBy.class);
+        List<Order> order = orderBy.order();
+        assertEquals(1, order.size());
+        ReferenceAttribute yOrder = as(order.get(0).child(), ReferenceAttribute.class);
+        assertEquals("y", yOrder.name());
+        assertEquals(DATE_NANOS, yOrder.dataType());
+        Project project = as(orderBy.child(), Project.class);
+        List<? extends NamedExpression> projections = project.projections();
+        assertEquals(1, projections.size());
+        ReferenceAttribute y = as(projections.get(0), ReferenceAttribute.class);
+        assertEquals("y", y.name());
+        assertEquals(DATE_NANOS, y.dataType());
+        project = as(project.child(), Project.class);
+        projections = project.projections();
+        assertEquals(1, projections.size());
+        Alias yAlias = as(projections.get(0), Alias.class);
+        assertEquals("y", yAlias.name());
+        assertEquals(DATE_NANOS, yAlias.dataType());
+        project = as(project.child(), Project.class);
+        projections = project.projections();
+        assertEquals(1, projections.size());
+        Alias xAlias = as(projections.get(0), Alias.class);
+        assertEquals("x", xAlias.name());
+        assertEquals(DATE_NANOS, xAlias.dataType());
+        project = as(project.child(), Project.class);
+        projections = project.projections();
+        assertEquals(1, projections.size());
+        ReferenceAttribute timestamp = as(projections.get(0), ReferenceAttribute.class);
+        assertEquals("@timestamp", timestamp.name());
+        assertEquals(DATE_NANOS, timestamp.dataType());
+        UnionAll unionAll = as(project.child(), UnionAll.class);
+        assertTrue(unionAll.output().stream().anyMatch(a -> "@timestamp".equals(a.name()) && DATE_NANOS.equals(a.dataType())));
+    }
+
+    /*
+     * Limit[1000[INTEGER],false,false]
+     * \_OrderBy[[Order[x{r}#6,ASC,LAST]]]
+     *   \_Project[[x{r}#6]]
+     *     \_Project[[@timestamp{r}#18 AS x#6]]
+     *       \_Project[[@timestamp{r}#18]]
+     *         \_UnionAll[[@timestamp{r}#18, client_ip{r}#19, event_duration{r}#20, message{r}#21]]
+     *           |_Project[[@timestamp{r}#22, client_ip{f}#11, event_duration{f}#12, message{f}#13]]
+     *           | \_Eval[[TODATENANOS(@timestamp{f}#10) AS @timestamp#22]]
+     *           |   \_EsRelation[sample_data][@timestamp{f}#10, client_ip{f}#11, event_duration{f..]
+     *           \_Project[[@timestamp{f}#14, client_ip{f}#15, event_duration{f}#16, message{f}#17]]
+     *             \_Subquery[]
+     *               \_EsRelation[sample_data_ts_nanos][@timestamp{f}#14, client_ip{f}#15, event_duration{f..]
+     *
+     * Same as {@link #testSubqueryRenameKeepOnDateAndDateNanosTimestamp()} but with {@code SET unmapped_fields="nullify"}.
+     */
+    public void testSubqueryRenameKeepOnDateAndDateNanosTimestampWithNullify() {
+        assumeTrue("Requires OPTIONAL_FIELDS_NULLIFY_TECH_PREVIEW", EsqlCapabilities.Cap.OPTIONAL_FIELDS_NULLIFY_TECH_PREVIEW.isEnabled());
+        LogicalPlan plan = analyzer().addSampleData().addIndex(sampleDataTsNanosIndex()).statement("""
+            SET unmapped_fields="nullify";
+            FROM sample_data, (FROM sample_data_ts_nanos)
+            | KEEP @timestamp
+            | RENAME @timestamp AS x
+            | KEEP *
+            | SORT x
+            """);
+
+        Limit limit = as(plan, Limit.class);
+        OrderBy orderBy = as(limit.child(), OrderBy.class);
+        List<Order> order = orderBy.order();
+        assertEquals(1, order.size());
+        ReferenceAttribute xOrder = as(order.get(0).child(), ReferenceAttribute.class);
+        assertEquals("x", xOrder.name());
+        assertEquals(DATE_NANOS, xOrder.dataType());
+        Project project = as(orderBy.child(), Project.class);
+        List<? extends NamedExpression> projections = project.projections();
+        assertEquals(1, projections.size());
+        ReferenceAttribute x = as(projections.get(0), ReferenceAttribute.class);
+        assertEquals("x", x.name());
+        assertEquals(DATE_NANOS, x.dataType());
+        project = as(project.child(), Project.class);
+        projections = project.projections();
+        assertEquals(1, projections.size());
+        Alias xAlias = as(projections.get(0), Alias.class);
+        assertEquals("x", xAlias.name());
+        assertEquals(DATE_NANOS, xAlias.dataType());
+        project = as(project.child(), Project.class);
+        projections = project.projections();
+        assertEquals(1, projections.size());
+        ReferenceAttribute timestamp = as(projections.get(0), ReferenceAttribute.class);
+        assertEquals("@timestamp", timestamp.name());
+        assertEquals(DATE_NANOS, timestamp.dataType());
+        UnionAll unionAll = as(project.child(), UnionAll.class);
+        assertTrue(unionAll.output().stream().anyMatch(a -> "@timestamp".equals(a.name()) && DATE_NANOS.equals(a.dataType())));
+    }
+
+    /*
+     * Project[[x{r}#?]]
+     * \_Limit[1000[INTEGER],false,false]
+     *   \_OrderBy[[Order[x{r}#?,ASC,LAST]]]
+     *     \_Project[[x{r}#?, $$@timestamp$converted_to$long{r$}#?]]
+     *       \_Project[[@timestamp{r}#? AS x#?, $$@timestamp$converted_to$long{r$}#?]]
+     *         \_Project[[@timestamp{r}#?, $$@timestamp$converted_to$long{r$}#?]]
+     *           \_Eval[[$$@timestamp$converted_to$long{r$}#? AS @timestamp#?]]
+     *             \_UnionAll[[!@timestamp, $$@timestamp$converted_to$long{r$}#?, client_ip{r}#?, event_duration{r}#?, message{r}#?]]
+     *               |_Project[[@timestamp{r}#?, $$@timestamp$converted_to$long{r$}#?, client_ip{f}#?, event_duration{f}#?, message{f}#?]]
+     *               | \_Eval[[null[KEYWORD] AS @timestamp#?]]
+     *               |   \_Eval[[TOLONG(@timestamp{f}#?) AS $$@timestamp$converted_to$long#?]]
+     *               |     \_EsRelation[sample_data][@timestamp{f}#?(date), client_ip{f}#?, event_duration..]
+     *               \_Project[...same shape, sample_data_ts_long...]
+     *                 \_Eval[[null[KEYWORD] AS @timestamp#?]]
+     *                   \_Eval[[TOLONG(@timestamp{f}#?) AS $$@timestamp$converted_to$long#?]]
+     *                     \_Subquery[]
+     *                       \_EsRelation[sample_data_ts_long][@timestamp{f}#?(long), client_ip{f}#?, event_duration..]
+     *
+     * Mixed {@code date}/{@code long} {@code @timestamp} variant of {@link #testSubqueryRenameKeepOnDateAndDateNanosTimestamp()}.
+     */
+    public void testSubqueryRenameKeepOnDateAndLongTimestampWithExplicitCast() {
+        LogicalPlan plan = analyzer().addSampleData().addIndex(sampleDataTsLongIndex()).query("""
+            FROM sample_data, (FROM sample_data_ts_long)
+            | EVAL @timestamp = @timestamp::long
+            | KEEP @timestamp
+            | RENAME @timestamp AS x
+            | KEEP *
+            | SORT x
+            """);
+
+        // Outer pruning Project that hides the synthetic $$@timestamp$converted_to$long attribute.
+        Project outer = as(plan, Project.class);
+        assertEquals(1, outer.projections().size());
+        ReferenceAttribute xOut = as(outer.projections().get(0), ReferenceAttribute.class);
+        assertEquals("x", xOut.name());
+        assertEquals(LONG, xOut.dataType());
+
+        Limit limit = as(outer.child(), Limit.class);
+        OrderBy orderBy = as(limit.child(), OrderBy.class);
+        List<Order> order = orderBy.order();
+        assertEquals(1, order.size());
+        ReferenceAttribute xOrder = as(order.get(0).child(), ReferenceAttribute.class);
+        assertEquals("x", xOrder.name());
+        assertEquals(LONG, xOrder.dataType());
+
+        // KEEP * — projects x (LONG) plus the carried-over synthetic LONG attribute.
+        Project project = as(orderBy.child(), Project.class);
+        assertProjectionHasLong(project, "x", ReferenceAttribute.class);
+        assertProjectionHasSyntheticTimestampLong(project);
+
+        // RENAME @timestamp AS x — alias x is LONG (cascaded from the EVAL).
+        project = as(project.child(), Project.class);
+        assertProjectionHasLong(project, "x", Alias.class);
+
+        // KEEP @timestamp — reference to the rebound @timestamp (LONG via EVAL).
+        project = as(project.child(), Project.class);
+        assertProjectionHasLong(project, "@timestamp", ReferenceAttribute.class);
+
+        // EVAL @timestamp = @timestamp::long — replaced with synthetic LONG attribute.
+        Eval eval = as(project.child(), Eval.class);
+        Alias timestampEval = as(eval.fields().stream().filter(f -> "@timestamp".equals(f.name())).findFirst().orElseThrow(), Alias.class);
+        assertEquals(LONG, timestampEval.dataType());
+        ReferenceAttribute syntheticRef = as(timestampEval.child(), ReferenceAttribute.class);
+        assertEquals(LONG, syntheticRef.dataType());
+
+        UnionAll unionAll = as(eval.child(), UnionAll.class);
+        // The original @timestamp in the UnionAll output is UnsupportedAttribute (date + long).
+        Attribute timestampAttr = unionAll.output().stream().filter(a -> "@timestamp".equals(a.name())).findFirst().orElseThrow();
+        as(timestampAttr, UnsupportedAttribute.class);
+        // The synthetic $$@timestamp$converted_to$long carries the LONG cast.
+        assertTrue(unionAll.output().stream().anyMatch(a -> isSyntheticTimestampLong(a) && LONG.equals(a.dataType())));
+    }
+
+    /*
+     * Project[[y{r}#?]]
+     * \_Limit[1000[INTEGER],false,false]
+     *   \_OrderBy[[Order[y{r}#?,ASC,LAST]]]
+     *     \_Project[[y{r}#?, $$@timestamp$converted_to$long{r$}#?]]
+     *       \_Project[[@timestamp{r}#? AS y#?, $$@timestamp$converted_to$long{r$}#?]]
+     *         \_Project[[@timestamp{r}#?, $$@timestamp$converted_to$long{r$}#?]]
+     *           \_Eval[[$$@timestamp$converted_to$long{r$}#? AS @timestamp#?]]
+     *             \_UnionAll[...]
+     *
+     * Chained {@code RENAME @timestamp AS x, x AS y} variant of the explicit-cast date/long test.
+     */
+    public void testSubqueryRenameChainKeepOnDateAndLongTimestampWithExplicitCast() {
+        LogicalPlan plan = analyzer().addSampleData().addIndex(sampleDataTsLongIndex()).query("""
+            FROM sample_data, (FROM sample_data_ts_long)
+            | EVAL @timestamp = @timestamp::long
+            | KEEP @timestamp
+            | RENAME @timestamp AS x, x AS y
+            | KEEP y
+            | SORT y
+            """);
+
+        Project outer = as(plan, Project.class);
+        assertEquals(1, outer.projections().size());
+        ReferenceAttribute yOut = as(outer.projections().get(0), ReferenceAttribute.class);
+        assertEquals("y", yOut.name());
+        assertEquals(LONG, yOut.dataType());
+
+        Limit limit = as(outer.child(), Limit.class);
+        OrderBy orderBy = as(limit.child(), OrderBy.class);
+        ReferenceAttribute yOrder = as(orderBy.order().get(0).child(), ReferenceAttribute.class);
+        assertEquals("y", yOrder.name());
+        assertEquals(LONG, yOrder.dataType());
+
+        Project project = as(orderBy.child(), Project.class);
+        assertProjectionHasLong(project, "y", ReferenceAttribute.class);
+        assertProjectionHasSyntheticTimestampLong(project);
+
+        // The chain rename collapses to a single Project: @timestamp AS y.
+        project = as(project.child(), Project.class);
+        assertProjectionHasLong(project, "y", Alias.class);
+
+        project = as(project.child(), Project.class);
+        assertProjectionHasLong(project, "@timestamp", ReferenceAttribute.class);
+
+        Eval eval = as(project.child(), Eval.class);
+        Alias timestampEval = as(eval.fields().stream().filter(f -> "@timestamp".equals(f.name())).findFirst().orElseThrow(), Alias.class);
+        assertEquals(LONG, timestampEval.dataType());
+
+        UnionAll unionAll = as(eval.child(), UnionAll.class);
+        as(unionAll.output().stream().filter(a -> "@timestamp".equals(a.name())).findFirst().orElseThrow(), UnsupportedAttribute.class);
+        assertTrue(unionAll.output().stream().anyMatch(a -> isSyntheticTimestampLong(a) && LONG.equals(a.dataType())));
+    }
+
+    /*
+     * Project[[y{r}#?]]
+     * \_Limit[1000[INTEGER],false,false]
+     *   \_OrderBy[[Order[y{r}#?,ASC,LAST]]]
+     *     \_Project[[y{r}#?, $$@timestamp$converted_to$long{r$}#?]]
+     *       \_Project[[x{r}#? AS y#?, $$@timestamp$converted_to$long{r$}#?]]
+     *         \_Project[[@timestamp{r}#? AS x#?, $$@timestamp$converted_to$long{r$}#?]]
+     *           \_Project[[@timestamp{r}#?, $$@timestamp$converted_to$long{r$}#?]]
+     *             \_Eval[[$$@timestamp$converted_to$long{r$}#? AS @timestamp#?]]
+     *               \_UnionAll[...]
+     *
+     * Two separate {@code RENAME} commands variant of the explicit-cast date/long test.
+     */
+    public void testSubqueryDoubleRenameKeepStarOnDateAndLongTimestampWithExplicitCast() {
+        LogicalPlan plan = analyzer().addSampleData().addIndex(sampleDataTsLongIndex()).query("""
+            FROM sample_data, (FROM sample_data_ts_long)
+            | EVAL @timestamp = @timestamp::long
+            | KEEP @timestamp
+            | RENAME @timestamp AS x
+            | RENAME x AS y
+            | KEEP *
+            | SORT y
+            """);
+
+        Project outer = as(plan, Project.class);
+        assertEquals(1, outer.projections().size());
+        ReferenceAttribute yOut = as(outer.projections().get(0), ReferenceAttribute.class);
+        assertEquals("y", yOut.name());
+        assertEquals(LONG, yOut.dataType());
+
+        Limit limit = as(outer.child(), Limit.class);
+        OrderBy orderBy = as(limit.child(), OrderBy.class);
+        ReferenceAttribute yOrder = as(orderBy.order().get(0).child(), ReferenceAttribute.class);
+        assertEquals("y", yOrder.name());
+        assertEquals(LONG, yOrder.dataType());
+
+        // KEEP * with y (LONG) plus the carried synthetic.
+        Project project = as(orderBy.child(), Project.class);
+        assertProjectionHasLong(project, "y", ReferenceAttribute.class);
+        assertProjectionHasSyntheticTimestampLong(project);
+
+        // RENAME x AS y (second rename).
+        project = as(project.child(), Project.class);
+        assertProjectionHasLong(project, "y", Alias.class);
+
+        // RENAME @timestamp AS x (first rename).
+        project = as(project.child(), Project.class);
+        assertProjectionHasLong(project, "x", Alias.class);
+
+        // KEEP @timestamp.
+        project = as(project.child(), Project.class);
+        assertProjectionHasLong(project, "@timestamp", ReferenceAttribute.class);
+
+        Eval eval = as(project.child(), Eval.class);
+        Alias timestampEval = as(eval.fields().stream().filter(f -> "@timestamp".equals(f.name())).findFirst().orElseThrow(), Alias.class);
+        assertEquals(LONG, timestampEval.dataType());
+
+        UnionAll unionAll = as(eval.child(), UnionAll.class);
+        as(unionAll.output().stream().filter(a -> "@timestamp".equals(a.name())).findFirst().orElseThrow(), UnsupportedAttribute.class);
+        assertTrue(unionAll.output().stream().anyMatch(a -> isSyntheticTimestampLong(a) && LONG.equals(a.dataType())));
+    }
+
+    /*
+     * Project[[x{r}#9]]
+     * \_Limit[1000[INTEGER],false,false]
+     *   \_OrderBy[[Order[x{r}#9,ASC,LAST]]]
+     *     \_Project[[x{r}#9, $$@timestamp$converted_to$long{r$}#27]]
+     *       \_Project[[@timestamp{r}#5 AS x#9, $$@timestamp$converted_to$long{r$}#27]]
+     *         \_Project[[@timestamp{r}#5, $$@timestamp$converted_to$long{r$}#27]]
+     *           \_Eval[[$$@timestamp$converted_to$long{r$}#27 AS @timestamp#5]]
+     *             \_UnionAll[[!@timestamp, $$@timestamp$converted_to$long{r$}#27, client_ip{r}#22, event_duration{r}#23, message{r}#24]]
+     *               |_Project[[@timestamp{r}#28, $$@timestamp$converted_to$long{r$}#25, client_ip{f}#14, event_duration{f}#15,
+     *                          message{f}#16]]
+     *               | \_Eval[[null[KEYWORD] AS @timestamp#28]]
+     *               |   \_Eval[[TOLONG(@timestamp{f}#13) AS $$@timestamp$converted_to$long#25]]
+     *               |     \_EsRelation[sample_data][@timestamp{f}#13, client_ip{f}#14, event_duration{f..]
+     *               \_Project[[@timestamp{r}#29, $$@timestamp$converted_to$long{r$}#26, client_ip{f}#19, event_duration{f}#20,
+     *                          message{f}#17]]
+     *                 \_Eval[[null[KEYWORD] AS @timestamp#29]]
+     *                   \_Eval[[TOLONG(@timestamp{f}#18) AS $$@timestamp$converted_to$long#26]]
+     *                     \_Subquery[]
+     *                       \_EsRelation[sample_data_ts_long][@timestamp{f}#18, client_ip{f}#19, event_duration{f..]
+     *
+     * Same shape as {@code testSubqueryRenameKeepOnDateAndLongTimestampWithExplicitCast()} with {@code SET unmapped_fields="nullify"}.
+     */
+    public void testSubqueryRenameKeepOnDateAndLongTimestampWithExplicitCastAndNullify() {
+        assumeTrue("Requires OPTIONAL_FIELDS_NULLIFY_TECH_PREVIEW", EsqlCapabilities.Cap.OPTIONAL_FIELDS_NULLIFY_TECH_PREVIEW.isEnabled());
+        LogicalPlan plan = analyzer().addSampleData().addIndex(sampleDataTsLongIndex()).statement("""
+            SET unmapped_fields="nullify";
+            FROM sample_data, (FROM sample_data_ts_long)
+            | EVAL @timestamp = @timestamp::long
+            | KEEP @timestamp
+            | RENAME @timestamp AS x
+            | KEEP *
+            | SORT x
+            """);
+
+        Project outer = as(plan, Project.class);
+        assertEquals(1, outer.projections().size());
+        ReferenceAttribute xOut = as(outer.projections().get(0), ReferenceAttribute.class);
+        assertEquals("x", xOut.name());
+        assertEquals(LONG, xOut.dataType());
+
+        Limit limit = as(outer.child(), Limit.class);
+        OrderBy orderBy = as(limit.child(), OrderBy.class);
+        ReferenceAttribute xOrder = as(orderBy.order().get(0).child(), ReferenceAttribute.class);
+        assertEquals("x", xOrder.name());
+        assertEquals(LONG, xOrder.dataType());
+
+        Project project = as(orderBy.child(), Project.class);
+        assertProjectionHasLong(project, "x", ReferenceAttribute.class);
+        assertProjectionHasSyntheticTimestampLong(project);
+
+        project = as(project.child(), Project.class);
+        assertProjectionHasLong(project, "x", Alias.class);
+
+        project = as(project.child(), Project.class);
+        assertProjectionHasLong(project, "@timestamp", ReferenceAttribute.class);
+
+        Eval eval = as(project.child(), Eval.class);
+        Alias timestampEval = as(eval.fields().stream().filter(f -> "@timestamp".equals(f.name())).findFirst().orElseThrow(), Alias.class);
+        assertEquals(LONG, timestampEval.dataType());
+
+        UnionAll unionAll = as(eval.child(), UnionAll.class);
+        as(unionAll.output().stream().filter(a -> "@timestamp".equals(a.name())).findFirst().orElseThrow(), UnsupportedAttribute.class);
+        assertTrue(unionAll.output().stream().anyMatch(a -> isSyntheticTimestampLong(a) && LONG.equals(a.dataType())));
+    }
+
+    private static void assertProjectionHasLong(Project project, String name, Class<? extends NamedExpression> kind) {
+        NamedExpression match = project.projections().stream().filter(p -> name.equals(p.name())).findFirst().orElseThrow();
+        NamedExpression typed = as(match, kind);
+        assertEquals(LONG, typed.dataType());
+    }
+
+    private static void assertProjectionHasSyntheticTimestampLong(Project project) {
+        assertTrue(
+            "expected synthetic $$@timestamp$converted_to$long attribute in projections",
+            project.projections().stream().anyMatch(p -> isSyntheticTimestampLong(p) && LONG.equals(p.dataType()))
+        );
+    }
+
+    private static boolean isSyntheticTimestampLong(NamedExpression e) {
+        // The push-down name is built by Attribute#rawTemporaryName which uses $$ delimiters and
+        // a stable suffix encoding the target type (see ResolveUnionTypesInUnionAll).
+        return e.name().contains("@timestamp") && e.name().contains("converted_to") && e.name().endsWith("long");
+    }
+
+    private static EsIndex sampleDataTsLongIndex() {
+        Map<String, EsField> mapping = Map.of(
+            "@timestamp",
+            new EsField("@timestamp", LONG, Map.of(), true, EsField.TimeSeriesFieldType.NONE),
+            "client_ip",
+            new EsField("client_ip", IP, Map.of(), true, EsField.TimeSeriesFieldType.NONE),
+            "event_duration",
+            new EsField("event_duration", LONG, Map.of(), true, EsField.TimeSeriesFieldType.NONE),
+            "message",
+            new EsField("message", KEYWORD, Map.of(), true, EsField.TimeSeriesFieldType.NONE)
+        );
+        return new EsIndex("sample_data_ts_long", mapping, Map.of("sample_data_ts_long", IndexMode.STANDARD), Map.of(), Map.of(), Map.of());
+    }
+
+    private static EsIndex sampleDataTsNanosIndex() {
+        Map<String, EsField> mapping = Map.of(
+            "@timestamp",
+            new EsField("@timestamp", DATE_NANOS, Map.of(), true, EsField.TimeSeriesFieldType.NONE),
+            "client_ip",
+            new EsField("client_ip", IP, Map.of(), true, EsField.TimeSeriesFieldType.NONE),
+            "event_duration",
+            new EsField("event_duration", LONG, Map.of(), true, EsField.TimeSeriesFieldType.NONE),
+            "message",
+            new EsField("message", KEYWORD, Map.of(), true, EsField.TimeSeriesFieldType.NONE)
+        );
+        return new EsIndex(
+            "sample_data_ts_nanos",
+            mapping,
+            Map.of("sample_data_ts_nanos", IndexMode.STANDARD),
+            Map.of(),
+            Map.of(),
+            Map.of()
+        );
+    }
+
     public void testLookupJoinOnFieldNotAnywhereElse() {
         assumeTrue(
             "requires LOOKUP JOIN ON boolean expression capability",


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[ES|QL] Make subquery with mixed data type across branches behave more consistently with nullify (#150704)](https://github.com/elastic/elasticsearch/pull/150704)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)