### PR TITLE
Increase client timeout in ManyRequestsIT

### DIFF
--- a/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/ManyRequestsIT.java
+++ b/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/ManyRequestsIT.java
@@ -14,6 +14,7 @@ import org.apache.http.util.EntityUtils;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
@@ -38,6 +39,11 @@ public class ManyRequestsIT extends ESRestTestCase {
     @Override
     protected String getTestRestCluster() {
         return cluster.getHttpAddresses();
+    }
+
+    @Override
+    protected Settings restClientSettings() {
+        return Settings.builder().put(ESRestTestCase.CLIENT_SOCKET_TIMEOUT, "6m").build();
     }
 
     @Before


### PR DESCRIPTION
Similar to HeapAttackIT, use a longer client socket timeout in ManyRequestsIT as requests can take more than the default 60s.

Closes #150314