### PR TITLE
Fix BatchBulkIT failures on non-snapshot builds

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/BatchBulkIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/BatchBulkIT.java
@@ -41,12 +41,15 @@ import static org.hamcrest.Matchers.equalTo;
 public class BatchBulkIT extends ESIntegTestCase {
 
     @Before
-    public void requireSnapshotBuild() throws Exception {
+    public void requireSnapshotBuild() {
         assumeTrue("batch indexing requires snapshot builds", Build.current().isSnapshot());
     }
 
     @Override
     protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
+        if (Build.current().isSnapshot() == false) {
+            return super.nodeSettings(nodeOrdinal, otherSettings);
+        }
         return Settings.builder()
             .put(super.nodeSettings(nodeOrdinal, otherSettings))
             .put(ShardBatchIndexer.BATCH_INDEXING.getKey(), true)

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/BatchBulkIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/BatchBulkIT.java
@@ -25,7 +25,9 @@ import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xcontent.json.JsonXContent;
-import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.rules.TestRule;
+import org.junit.runners.model.Statement;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -36,20 +38,22 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcke
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assume.assumeTrue;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.SUITE, numDataNodes = 2, numClientNodes = 1)
 public class BatchBulkIT extends ESIntegTestCase {
 
-    @Before
-    public void requireSnapshotBuild() {
-        assumeTrue("batch indexing requires snapshot builds", Build.current().isSnapshot());
-    }
+    @ClassRule
+    public static TestRule snapshotBuildRule = (base, description) -> new Statement() {
+        @Override
+        public void evaluate() throws Throwable {
+            assumeTrue("batch indexing requires snapshot builds", Build.current().isSnapshot());
+            base.evaluate();
+        }
+    };
 
     @Override
     protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
-        if (Build.current().isSnapshot() == false) {
-            return super.nodeSettings(nodeOrdinal, otherSettings);
-        }
         return Settings.builder()
             .put(super.nodeSettings(nodeOrdinal, otherSettings))
             .put(ShardBatchIndexer.BATCH_INDEXING.getKey(), true)


### PR DESCRIPTION
This was originally fixed in: https://github.com/elastic/elasticsearch/pull/145708.
But then https://github.com/elastic/elasticsearch/pull/150548 moved:
```
assumeTrue("batch indexing requires snapshot builds", Build.current().isSnapshot())
```
to the `@Before` method which only runs after cluster initialization. As a result, the test now fails on non-snapshot builds, since the `batch_indexing` feature flag is snapshot-only.

Verified:
```
./gradlew :server:internalClusterTest --tests "org.elasticsearch.action.bulk.BatchBulkIT" -Dbuild.snapshot=false -Dtests.jvm.argline="-Dbuild.snapshot=false"
```
now succeeds.

Closes https://github.com/elastic/elasticsearch/issues/150935

---

Note: I wonder if CI checks should somehow run modified tests against non snapshot builds as well, as part of the "flakiness-detection" test 
