### PR TITLE
Fix EsqlSpecForceStoredLoadingIT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -143,9 +143,6 @@ tests:
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=search.vectors/41_knn_search_byte_quantized_bfloat16/KNN Vector similarity search only}
   issue: https://github.com/elastic/elasticsearch/issues/147251
-- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecForceStoredLoadingIT
-  method: test {csv-spec:fuse.fuseWithRowLinearAndMultiValueGroupColumn}
-  issue: https://github.com/elastic/elasticsearch/issues/147613
 - class: org.elasticsearch.xpack.transform.integration.TransformCrossProjectIT
   method: testUpdateTransformWithProjectRouting
   issue: https://github.com/elastic/elasticsearch/issues/147655
@@ -644,30 +641,12 @@ tests:
 - class: org.elasticsearch.xpack.stateless.StatelessMergeIT
   method: testOnlyForceMergesAreAllowedDuringRelocation
   issue: https://github.com/elastic/elasticsearch/issues/150925
-- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecForceStoredLoadingIT
-  method: test {csv-spec:subquery.subqueryInFromWithRenameMissingCounterFieldWithNullify}
-  issue: https://github.com/elastic/elasticsearch/issues/150943
-- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecForceStoredLoadingIT
-  method: test {csv-spec:subquery.subqueryInFromWithRenameChainMissingCounterFieldWithNullify}
-  issue: https://github.com/elastic/elasticsearch/issues/150963
 - class: org.elasticsearch.xpack.esql.expression.function.scalar.spatial.StBufferTests
   method: "testEvaluateInManyThreads {TestCase=geo_shape with distance[double]. #2}"
   issue: https://github.com/elastic/elasticsearch/issues/150965
 - class: org.elasticsearch.reindex.management.ReindexRelocationIT
   method: testNonSlicedRemoteReindexRelocation
   issue: https://github.com/elastic/elasticsearch/issues/150966
-- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecForceStoredLoadingIT
-  method: test {csv-spec:subquery.subqueryInFromWithRenameChainMissingCounterField}
-  issue: https://github.com/elastic/elasticsearch/issues/150968
-- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecForceStoredLoadingIT
-  method: test {csv-spec:stats.sumExpressionWithConstantThreeClausesShareOneSvPair}
-  issue: https://github.com/elastic/elasticsearch/issues/150969
-- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecForceStoredLoadingIT
-  method: test {csv-spec:date.dateMinusNull}
-  issue: https://github.com/elastic/elasticsearch/issues/150970
-- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecForceStoredLoadingIT
-  method: test {csv-spec:fuse.fuseWithLinearAndMinMax}
-  issue: https://github.com/elastic/elasticsearch/issues/150971
 - class: org.elasticsearch.xpack.esql.inference.rerank.RerankOperatorTests
   method: testInferenceFailure
   issue: https://github.com/elastic/elasticsearch/issues/150976
@@ -677,12 +656,3 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
   method: test {csv-spec:union_types.singleIndexIpStats}
   issue: https://github.com/elastic/elasticsearch/issues/150982
-- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecForceStoredLoadingIT
-  method: test {csv-spec:subquery.subqueryInFromWithRenameMissingCounterField}
-  issue: https://github.com/elastic/elasticsearch/issues/150986
-- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecForceStoredLoadingIT
-  method: test {csv-spec:string.in3VLWithComputedNullAsValue}
-  issue: https://github.com/elastic/elasticsearch/issues/150987
-- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecForceStoredLoadingIT
-  method: test {csv-spec:dense_vector-arithmetic.mulDenseVectorWithLiteral}
-  issue: https://github.com/elastic/elasticsearch/issues/150988

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/subquery.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/subquery.csv-spec
@@ -1720,6 +1720,7 @@ subqueryInFromWithRenameMissingCounterFieldWithNullify
 required_capability: subquery_in_from_command
 required_capability: subquery_in_from_command_union_types_implicit_casting_inconsistent_after_rename
 required_capability: optional_fields_nullify_tech_preview
+request_stored: skip
 
 SET unmapped_fields="nullify"\;
 FROM k8s-downsampled, (from many_numbers)

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/subquery.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/subquery.csv-spec
@@ -1703,6 +1703,7 @@ x:integer
 subqueryInFromWithRenameMissingCounterField
 required_capability: subquery_in_from_command
 required_capability: subquery_in_from_command_union_types_implicit_casting_inconsistent_after_rename
+request_stored: skip
 
 FROM k8s-downsampled, (from many_numbers)
 | KEEP network.total_bytes_in, network.eth0.tx
@@ -1738,6 +1739,7 @@ x:long | y:aggregate_metric_double
 subqueryInFromWithRenameChainMissingCounterField
 required_capability: subquery_in_from_command
 required_capability: subquery_in_from_command_union_types_implicit_casting_inconsistent_after_rename
+request_stored: skip
 
 FROM k8s, (from many_numbers)
 | KEEP network.total_bytes_in
@@ -1756,6 +1758,7 @@ subqueryInFromWithRenameChainMissingCounterFieldWithNullify
 required_capability: subquery_in_from_command
 required_capability: subquery_in_from_command_union_types_implicit_casting_inconsistent_after_rename
 required_capability: optional_fields_nullify_tech_preview
+request_stored: skip
 
 SET unmapped_fields="nullify"\;
 FROM k8s, (from many_numbers)


### PR DESCRIPTION
closes https://github.com/elastic/elasticsearch/issues/147613
closes https://github.com/elastic/elasticsearch/issues/150943
closes https://github.com/elastic/elasticsearch/issues/150963
closes https://github.com/elastic/elasticsearch/issues/150968
closes https://github.com/elastic/elasticsearch/issues/150969
closes https://github.com/elastic/elasticsearch/issues/150970
closes https://github.com/elastic/elasticsearch/issues/150971
closes https://github.com/elastic/elasticsearch/issues/150986
closes https://github.com/elastic/elasticsearch/issues/150987
closes https://github.com/elastic/elasticsearch/issues/150988

Applies the fix suggested by @fang-xing-esql in https://github.com/elastic/elasticsearch/issues/150943#issuecomment-4642986556

Looks like we need to add `request_stored: skip` to all tests that are querying `many_numbers`.

I _think_ all the failures from EsqlSpecForceStoredLoadingIT are related to this change.
