### PR TITLE
[8.19] Migrate :x-pack:plugin:eql:qa:correctness:javaRestTest to Junit test cluster (#149249)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/RestrictedBuildApiService.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/RestrictedBuildApiService.java
@@ -52,7 +52,6 @@ public abstract class RestrictedBuildApiService implements BuildService<Restrict
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:qa:third-party:slack");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:ent-search:qa:rest");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:eql:qa:ccs-rolling-upgrade");
-        map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:eql:qa:correctness");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:eql:qa:mixed-node");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:ml:qa:basic-multi-node");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:ml:qa:disabled");

--- a/x-pack/plugin/eql/qa/correctness/README.md
+++ b/x-pack/plugin/eql/qa/correctness/README.md
@@ -66,13 +66,6 @@ or
 ./gradlew ':x-pack:plugin:eql:qa:correctness:javaRestTest' --tests "org.elasticsearch.xpack.eql.EsEQLCorrectnessIT.test {<queryNo>}" -Dtests.eql_correctness_debug=true
 ```
 
-#### Preserve data across node restarts
-If you'd like to preserve the restored index and avoid the network download and delay of restoring them on every run of the node,
-you can set the `eql.test.preserve.data` system property, e.g.:
-```shell script
-./gradlew :x-pack:plugin:eql:qa:correctness:javaRestTest -Deql.test.preserve.data=true
-```
-
 ### Run an ES node manually and run the tests against it
 
 If one wants to run an ES node manually (most probably to be able to debug the server), needs to run the following:

--- a/x-pack/plugin/eql/qa/correctness/build.gradle
+++ b/x-pack/plugin/eql/qa/correctness/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'elasticsearch.java'
-apply plugin: 'elasticsearch.legacy-java-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 apply plugin: 'elasticsearch.internal-testclusters'
 
 import org.elasticsearch.gradle.testclusters.RunTask
@@ -10,6 +10,9 @@ dependencies {
   javaRestTestImplementation(testArtifact(project(xpackModule('core'))))
   javaRestTestImplementation project(xpackModule('ql:test-fixtures'))
   javaRestTestImplementation 'io.ous:jtoml:2.0.0'
+  clusterModules project(':x-pack:plugin:eql')
+  clusterModules project(':x-pack:plugin:security')
+  clusterModules project(':modules:repository-gcs')
 }
 
 File serviceAccountFile = providers.environmentVariable('eql_test_credentials_file')
@@ -21,27 +24,32 @@ Boolean preserveData = providers.systemProperty('eql.test.preserve.data')
   .map { s -> Boolean.parseBoolean(s) }
   .getOrElse(false)
 
-testClusters.configureEach {
-    if (serviceAccountFile) {
-      keystore 'gcs.client.eql_test.credentials_file', serviceAccountFile
-    }
-    if (preserveData) {
-      preserveDataDir = true
-    }
-    testDistribution = 'DEFAULT'
-    setting 'xpack.license.self_generated.type', 'basic'
-    jvmArgs '-Xms4g', '-Xmx4g'
-    setting 'xpack.security.enabled', 'true'
-    user username: 'admin', password: 'admin-password', role: 'superuser'
+// Gradle test-cluster wiring retained only for the `runEqlCorrectnessNode` RunTask;
+// the `javaRestTest` cluster is provisioned via a JUnit @ClassRule in EsEQLCorrectnessIT.
+def runTaskCluster = testClusters.register('runTask') {
+  testDistribution = 'DEFAULT'
+  setting 'xpack.license.self_generated.type', 'basic'
+  setting 'xpack.security.enabled', 'true'
+  user username: 'admin', password: 'admin-password', role: 'superuser'
+  if (serviceAccountFile) {
+    keystore 'gcs.client.eql_test.credentials_file', serviceAccountFile
+  }
+  if (preserveData) {
+    preserveDataDir = true
+  }
+  jvmArgs '-Xms8g', '-Xmx8g'
 }
 
-def runTaskCluster = testClusters.register('runTask') {
-    jvmArgs '-Xms8g', '-Xmx8g'
-}
+boolean inFipsJvm = buildParams.inFipsJvm
 
 tasks.named('javaRestTest').configure {
-  onlyIf("FIPS mode disabled and service accoutn file available") {
-      serviceAccountFile && buildParams.inFipsJvm == false
+  onlyIf("FIPS mode disabled and service account file available") {
+      serviceAccountFile && inFipsJvm == false
+  }
+  if (serviceAccountFile) {
+    // Bridge the configuration-time `eql_test_credentials_file` env var (or `eql.test.credentials.file` sysprop)
+    // through to the test JVM as a system property; the @ClassRule in EsEQLCorrectnessIT reads it from there.
+    systemProperty 'eql.test.credentials.file', serviceAccountFile.absolutePath
   }
 
   testLogging {

--- a/x-pack/plugin/eql/qa/correctness/src/javaRestTest/java/org/elasticsearch/xpack/eql/EsEQLCorrectnessIT.java
+++ b/x-pack/plugin/eql/qa/correctness/src/javaRestTest/java/org/elasticsearch/xpack/eql/EsEQLCorrectnessIT.java
@@ -23,6 +23,9 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.local.LocalClusterSpecBuilder;
+import org.elasticsearch.test.cluster.util.resource.Resource;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.test.rest.ObjectPath;
@@ -32,9 +35,11 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -49,6 +54,35 @@ public class EsEQLCorrectnessIT extends ESRestTestCase {
 
     private static final String PARAM_FORMATTING = "%1$s";
     private static final String QUERIES_FILENAME = "queries.toml";
+
+    @ClassRule
+    public static ElasticsearchCluster cluster = buildCluster();
+
+    private static ElasticsearchCluster buildCluster() {
+        LocalClusterSpecBuilder<ElasticsearchCluster> builder = ElasticsearchCluster.local()
+            .module("x-pack-eql")
+            .module("x-pack-security")
+            .module("repository-gcs")
+            .setting("xpack.license.self_generated.type", "basic")
+            .setting("xpack.security.enabled", "true")
+            .jvmArg("-Xmx4g")
+            .user("admin", "admin-password", "superuser", false);
+
+        String credentialsFile = System.getProperty("eql.test.credentials.file");
+        if (credentialsFile == null) {
+            credentialsFile = System.getenv("eql_test_credentials_file");
+        }
+        if (credentialsFile != null) {
+            final Path credentialsPath = Path.of(credentialsFile);
+            builder.keystore("gcs.client.eql_test.credentials_file", Resource.fromFile(credentialsPath));
+        }
+        return builder.build();
+    }
+
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
+    }
 
     private static Properties CFG;
     private static RequestOptions COMMON_REQUEST_OPTIONS;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Migrate :x-pack:plugin:eql:qa:correctness:javaRestTest to Junit test cluster (#149249)](https://github.com/elastic/elasticsearch/pull/149249)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)