### PR TITLE
Normalize file seed host entries

### DIFF
--- a/docs/changelog/151003.yaml
+++ b/docs/changelog/151003.yaml
@@ -1,0 +1,5 @@
+area: Cluster Coordination
+issues: []
+pr: 151003
+summary: Normalize file-based seed host entries
+type: bug

--- a/server/src/main/java/org/elasticsearch/discovery/FileBasedSeedHostsProvider.java
+++ b/server/src/main/java/org/elasticsearch/discovery/FileBasedSeedHostsProvider.java
@@ -48,7 +48,9 @@ public class FileBasedSeedHostsProvider implements SeedHostsProvider {
     private List<String> getHostsList() {
         if (Files.exists(unicastHostsFilePath)) {
             try (Stream<String> lines = Files.lines(unicastHostsFilePath)) {
-                return lines.filter(line -> line.startsWith("#") == false) // lines starting with `#` are comments
+                return lines.map(String::strip)
+                    .filter(line -> line.isEmpty() == false)
+                    .filter(line -> line.startsWith("#") == false) // lines starting with `#` are comments
                     .toList();
             } catch (IOException e) {
                 logger.warn(() -> "failed to read file [" + unicastHostsFilePath + "]", e);

--- a/server/src/test/java/org/elasticsearch/discovery/FileBasedSeedHostsProviderTests.java
+++ b/server/src/test/java/org/elasticsearch/discovery/FileBasedSeedHostsProviderTests.java
@@ -107,6 +107,14 @@ public class FileBasedSeedHostsProviderTests extends ESTestCase {
         assertEquals(0, addresses.size());
     }
 
+    public void testHostEntriesAreTrimmed() throws Exception {
+        final List<String> hostEntries = Arrays.asList("  # comment, should be ignored", "", " 192.168.0.1:9301 ");
+        final List<TransportAddress> addresses = setupAndRunHostProvider(hostEntries);
+        assertEquals(1, addresses.size());
+        assertEquals("192.168.0.1", addresses.get(0).getAddress());
+        assertEquals(9301, addresses.get(0).getPort());
+    }
+
     public void testUnicastHostsDoesNotExist() {
         final FileBasedSeedHostsProvider fileBasedSeedHostsProvider = new FileBasedSeedHostsProvider(createTempDir().toAbsolutePath());
         SeedHostsResolver seedHostsResolver = new SeedHostsResolver("test", Settings.EMPTY, transportService, fileBasedSeedHostsProvider);


### PR DESCRIPTION
## Summary

Normalize entries read from `unicast_hosts.txt` before resolving file-based seed hosts.

Previously, `FileBasedSeedHostsProvider` passed each non-comment line from the file directly to the seed host resolver. This meant that an otherwise valid entry with leading or trailing whitespace, such as:

```text
 192.168.0.1:9301 
```

was passed through unchanged and failed during transport address parsing. The same normalization gap also meant that blank lines and indented comments were treated as host entries.

This change strips each line before filtering and resolution, then ignores empty lines and comments after normalization.

## Details

- Strip whitespace from each line read from `unicast_hosts.txt`.
- Ignore blank lines after stripping.
- Ignore comment lines after stripping, so indented comments are handled consistently.
- Add a focused test covering whitespace, blank lines, and indented comments in the file-based seed hosts provider.

## Testing

The following tests were run locally:

```bash
./gradlew :server:test --tests org.elasticsearch.discovery.FileBasedSeedHostsProviderTests.testHostEntriesAreTrimmed
./gradlew :server:test --tests org.elasticsearch.discovery.FileBasedSeedHostsProviderTests
./gradlew :server:check
```

Both passed.
