### PR TITLE
Re-escape wildcard operators produced by the normalizer in wildcard queries

### DIFF
--- a/docs/changelog/151008.yaml
+++ b/docs/changelog/151008.yaml
@@ -1,0 +1,6 @@
+pr: 151008
+summary: Fix wildcard queries on keyword fields whose normalizer rewrites wildcard characters
+area: Mapping
+type: bug
+issues:
+ - 150699

--- a/server/src/main/java/org/elasticsearch/index/mapper/StringFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/StringFieldType.java
@@ -63,7 +63,8 @@ import static org.elasticsearch.search.SearchService.ALLOW_EXPENSIVE_QUERIES;
  */
 public abstract class StringFieldType extends TermBasedFieldType {
 
-    private static final Pattern WILDCARD_PATTERN = Pattern.compile("(\\\\.)|([?*]+)");
+    // DOTALL so an escape (\X) is recognised even when X is a line terminator, matching Lucene which escapes any code point.
+    private static final Pattern WILDCARD_PATTERN = Pattern.compile("(\\\\.)|([?*]+)", Pattern.DOTALL);
 
     public StringFieldType(String name, IndexType indexType, boolean isStored, TextSearchInfo textSearchInfo, Map<String, String> meta) {
         super(name, indexType, isStored, textSearchInfo, meta);
@@ -122,30 +123,52 @@ public abstract class StringFieldType extends TermBasedFieldType {
         if (normalizer == null) {
             return value;
         }
-        // we want to normalize everything except wildcard characters, e.g. F?o Ba* to f?o ba*, even if e.g there
-        // is a char_filter that would otherwise remove them
+        // Normalize the literal parts of the pattern but keep the ? and * operators, e.g. F?o Ba* to f?o ba*. Escapes
+        // (\X) are literal data, so we gather each contiguous literal run (across plain text and escapes) and normalize
+        // it as a whole; context-sensitive normalizers need the full run. Operators the normalizer emits are re-escaped.
         Matcher wildcardMatcher = WILDCARD_PATTERN.matcher(value);
         BytesRefBuilder sb = new BytesRefBuilder();
+        StringBuilder literal = new StringBuilder();
         int last = 0;
 
         while (wildcardMatcher.find()) {
-            if (wildcardMatcher.start() > 0) {
-                String chunk = value.substring(last, wildcardMatcher.start());
-
-                BytesRef normalized = normalizer.normalize(fieldname, chunk);
-                sb.append(normalized);
+            if (wildcardMatcher.start() > last) {
+                literal.append(value, last, wildcardMatcher.start());
             }
-            // append the matched group - without normalizing
-            sb.append(new BytesRef(wildcardMatcher.group()));
-
+            String escape = wildcardMatcher.group(1);
+            if (escape != null) {
+                // \X is an escape: the escaped character is literal data, so drop the backslash and keep X
+                literal.append(escape, 1, escape.length());
+            } else {
+                // operators: flush the accumulated literal run, then keep them verbatim
+                appendNormalizedLiteral(sb, normalizer, fieldname, literal.toString());
+                literal.setLength(0);
+                sb.append(new BytesRef(wildcardMatcher.group()));
+            }
             last = wildcardMatcher.end();
         }
         if (last < value.length()) {
-            String chunk = value.substring(last);
-            BytesRef normalized = normalizer.normalize(fieldname, chunk);
-            sb.append(normalized);
+            literal.append(value, last, value.length());
         }
+        appendNormalizedLiteral(sb, normalizer, fieldname, literal.toString());
         return sb.toBytesRef().utf8ToString();
+    }
+
+    /** Normalizes one literal run and appends it, re-escaping any {@code *}, {@code ?}, or backslash the normalizer produced. */
+    private static void appendNormalizedLiteral(BytesRefBuilder sb, Analyzer normalizer, String fieldname, String chunk) {
+        if (chunk.isEmpty()) {
+            return;
+        }
+        String normalized = normalizer.normalize(fieldname, chunk).utf8ToString();
+        StringBuilder escaped = new StringBuilder(normalized.length());
+        for (int i = 0; i < normalized.length(); i++) {
+            char c = normalized.charAt(i);
+            if (c == '*' || c == '?' || c == '\\') {
+                escaped.append('\\');
+            }
+            escaped.append(c);
+        }
+        sb.append(new BytesRef(escaped.toString()));
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldTypeTests.java
@@ -17,6 +17,7 @@ import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.Tokenizer;
 import org.apache.lucene.analysis.core.WhitespaceTokenizer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
@@ -153,6 +154,104 @@ public class KeywordFieldTypeTests extends FieldTypeTestCase {
         };
         MappedFieldType ft = new KeywordFieldType("field", new NamedAnalyzer("my_normalizer", AnalyzerScope.INDEX, normalizer));
         assertEquals(new TermQuery(new Term("field", "foo bar")), ft.termQuery("fOo BaR", MOCK_CONTEXT));
+    }
+
+    public void testNormalizeWildcardPatternReescapesOperators() {
+        // Regression test for #150699: when a normalizer (e.g. ICU NFKC) maps fullwidth forms to the ASCII wildcard
+        // operators, literal data must not become an operator, and the contents of an escape sequence must be
+        // normalized like any other literal.
+        Analyzer normalizer = new Analyzer() {
+            @Override
+            protected TokenStreamComponents createComponents(String fieldName) {
+                Tokenizer in = new WhitespaceTokenizer();
+                return new TokenStreamComponents(in, fullwidthToAsciiFilter(in));
+            }
+
+            @Override
+            protected TokenStream normalize(String fieldName, TokenStream in) {
+                return fullwidthToAsciiFilter(in);
+            }
+        };
+        NamedAnalyzer named = new NamedAnalyzer("fullwidth_nfkc", AnalyzerScope.INDEX, normalizer);
+
+        // Bug 1: an escaped fullwidth '＊' must be normalized to an escaped ASCII '*' (a literal star), not left as-is.
+        assertEquals("東京\\*大阪", StringFieldType.normalizeWildcardPattern("f", "東京\\＊大阪", named));
+        // Bug 2: a bare fullwidth '＊' must become an escaped ASCII '*' (literal), not a wildcard operator.
+        assertEquals("東京\\*大阪", StringFieldType.normalizeWildcardPattern("f", "東京＊大阪", named));
+        // Bug 2: a bare fullwidth '？' must become an escaped ASCII '?' (literal).
+        assertEquals("東京\\?大阪", StringFieldType.normalizeWildcardPattern("f", "東京？大阪", named));
+        // Real ASCII wildcard operators are preserved verbatim, including at the start and end of the pattern.
+        assertEquals("東京*大阪", StringFieldType.normalizeWildcardPattern("f", "東京*大阪", named));
+        assertEquals("foo?bar*", StringFieldType.normalizeWildcardPattern("f", "foo?bar*", named));
+        assertEquals("*大阪", StringFieldType.normalizeWildcardPattern("f", "*大阪", named));
+        assertEquals("東京*", StringFieldType.normalizeWildcardPattern("f", "東京*", named));
+        // A fullwidth backslash '＼' that normalizes to '\' must be re-escaped to a literal backslash, whether the
+        // user wrote it bare or escaped.
+        assertEquals("東京\\\\大阪", StringFieldType.normalizeWildcardPattern("f", "東京＼大阪", named));
+        assertEquals("東京\\\\大阪", StringFieldType.normalizeWildcardPattern("f", "東京\\＼大阪", named));
+        // An escape before a line terminator is still an escape (WILDCARD_PATTERN is DOTALL): "a\<LF>b" is the literal
+        // "a<LF>b", and the backslash must not be re-introduced as a literal backslash.
+        assertEquals("a\nb", StringFieldType.normalizeWildcardPattern("f", "a\\\nb", named));
+    }
+
+    private static TokenFilter fullwidthToAsciiFilter(TokenStream in) {
+        // Mimics the ICU NFKC mapping of the wildcard control characters: ＊ -> *, ？ -> ?, ＼ -> \
+        return new TokenFilter(in) {
+            private final CharTermAttribute termAtt = addAttribute(CharTermAttribute.class);
+
+            @Override
+            public boolean incrementToken() throws IOException {
+                if (input.incrementToken() == false) {
+                    return false;
+                }
+                String normalized = termAtt.toString().replace('＊', '*').replace('？', '?').replace('＼', '\\');
+                termAtt.setEmpty().append(normalized);
+                return true;
+            }
+        };
+    }
+
+    public void testNormalizeWildcardPatternNormalizesContiguousLiteralRunAcrossEscape() {
+        // Regression test for #150699: an escape sequence in the middle of a literal run must not split normalization.
+        // A context-sensitive normalizer (here a multi-character mapping "ab" -> "x") must see the whole run "ab",
+        // even when it is written as "a\b".
+        Analyzer normalizer = new Analyzer() {
+            @Override
+            protected TokenStreamComponents createComponents(String fieldName) {
+                Tokenizer in = new WhitespaceTokenizer();
+                return new TokenStreamComponents(in, mappingFilter(in));
+            }
+
+            @Override
+            protected TokenStream normalize(String fieldName, TokenStream in) {
+                return mappingFilter(in);
+            }
+        };
+        NamedAnalyzer named = new NamedAnalyzer("ab_to_x", AnalyzerScope.INDEX, normalizer);
+
+        // "a\b" is the literal "ab" in Lucene; normalizing the whole contiguous run yields "x".
+        assertEquals("x", StringFieldType.normalizeWildcardPattern("f", "a\\b", named));
+        // Adjacent escapes accumulate into the same run, so "\a\b" (also literal "ab") yields "x" too.
+        assertEquals("x", StringFieldType.normalizeWildcardPattern("f", "\\a\\b", named));
+        // A wildcard operator between the two characters keeps them in separate runs, so the mapping does not apply.
+        assertEquals("a*b", StringFieldType.normalizeWildcardPattern("f", "a*b", named));
+    }
+
+    private static TokenFilter mappingFilter(TokenStream in) {
+        // A deliberately context-sensitive normalizer: it only maps the two-character sequence "ab" to "x".
+        return new TokenFilter(in) {
+            private final CharTermAttribute termAtt = addAttribute(CharTermAttribute.class);
+
+            @Override
+            public boolean incrementToken() throws IOException {
+                if (input.incrementToken() == false) {
+                    return false;
+                }
+                String normalized = termAtt.toString().replace("ab", "x");
+                termAtt.setEmpty().append(normalized);
+                return true;
+            }
+        };
     }
 
     public void testTermsQuery() {


### PR DESCRIPTION
`wildcard` queries on a `keyword` field can return wrong results when the field uses a normalizer that rewrites the wildcard control characters `*`, `?`, or `\`. The most common trigger is ICU NFKC, which maps fullwidth forms to ASCII (`＊`→`*`, `？`→`?`, `＼`→`\`).

`normalizeWildcardPattern` normalizes the literal parts of the pattern and keeps `?`/`*` as operators, but had two defects:

- The contents of an escape `\X` were appended verbatim, so the escaped character was never normalized — `\＊` searched for a character that isn't in the index and returned 0 hits.
- A normalized literal wasn't re-escaped, so a normalizer emitting `*`/`?`/`\` turned literal data into an operator — a bare `＊` became a wildcard and over-matched.

The fix gathers each contiguous literal run (across plain text and escapes) and normalizes it as a whole, so context-sensitive normalizers (e.g. ICU NFC) see the full run, then re-escapes any `*`/`?`/`\` the normalizer produces. Operator runs are kept verbatim, and `WILDCARD_PATTERN` now uses `DOTALL` so an escape before a line terminator is still treated as an escape.

One behavior change: a trailing lone backslash (`abc\`) now normalizes to a literal backslash `\\` instead of passing through as a raw `\`; both are equivalent to Lucene.

Closes #150699
