### PR TITLE
SQL: fix CLI tests failures due to unconsumed output (#145967)

### DIFF
--- a/docs/changelog/145967.yaml
+++ b/docs/changelog/145967.yaml
@@ -1,0 +1,7 @@
+area: SQL
+issues:
+ - 143646
+ - 143645
+pr: 145967
+summary: Fix CLI tests failures due to unconsumed output
+type: bug

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -242,9 +242,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
   method: test
   issue: https://github.com/elastic/elasticsearch/issues/150569
-- class: org.elasticsearch.xpack.sql.qa.security.CliApiKeyIT
-  method: testCliConnectionWithInvalidApiKey
-  issue: https://github.com/elastic/elasticsearch/issues/150941
 - class: org.elasticsearch.test.rest.yaml.RcsCcsSearchYamlTestSuiteIT
   method: test {p0=search/400_synthetic_source/stored keyword with ignore_above}
   issue: https://github.com/elastic/elasticsearch/issues/150952

--- a/x-pack/plugin/sql/qa/server/security/src/test/java/org/elasticsearch/xpack/sql/qa/security/CliApiKeyIT.java
+++ b/x-pack/plugin/sql/qa/server/security/src/test/java/org/elasticsearch/xpack/sql/qa/security/CliApiKeyIT.java
@@ -12,7 +12,6 @@ import org.elasticsearch.xpack.sql.qa.cli.EmbeddedCli.ApiKeySecurityConfig;
 
 import static org.elasticsearch.xpack.sql.qa.security.RestSqlIT.SSL_ENABLED;
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertEquals;
 
 /**
  * Integration tests for CLI connections using API key authentication.
@@ -79,17 +78,7 @@ public class CliApiKeyIT extends SqlApiKeyTestCase {
         );
 
         try (EmbeddedCli cli = new EmbeddedCli(elasticsearchAddress(), false, apiKeyConfig)) {
-            String result = cli.command("SELECT 1");
-            StringBuilder fullError = new StringBuilder(result);
-            String line;
-            while ((line = cli.readLine()) != null && !line.isEmpty()) {
-                fullError.append(line);
-            }
-            String errorMessage = fullError.toString();
-            assertTrue(
-                "Expected authentication error but got: " + errorMessage,
-                errorMessage.contains("security_exception") || errorMessage.contains("Communication error")
-            );
+            assertThat(cli.command("SELECT 1"), containsString("Bad request"));
         }
     }
 

--- a/x-pack/plugin/sql/qa/server/security/src/test/java/org/elasticsearch/xpack/sql/qa/security/JdbcApiKeyIT.java
+++ b/x-pack/plugin/sql/qa/server/security/src/test/java/org/elasticsearch/xpack/sql/qa/security/JdbcApiKeyIT.java
@@ -85,7 +85,7 @@ public class JdbcApiKeyIT extends SqlApiKeyTestCase {
                 connection.createStatement().executeQuery("SELECT 1");
             }
         });
-        assertThat(e.getMessage(), containsString("security_exception"));
+        assertThat(e.getMessage(), containsString("unable to authenticate"));
     }
 
     public void testJdbcConnectionWithLimitedApiKey() throws Exception {

--- a/x-pack/plugin/sql/sql-client/src/main/java/org/elasticsearch/xpack/sql/client/RemoteFailure.java
+++ b/x-pack/plugin/sql/sql-client/src/main/java/org/elasticsearch/xpack/sql/client/RemoteFailure.java
@@ -253,9 +253,7 @@ public class RemoteFailure {
         if (type == null) {
             throw new IOException("expected [type] but didn't see it");
         }
-        if (remoteTrace == null) {
-            throw new IOException("expected [stack_trace] cannot but didn't see it");
-        }
+        // stack_trace is optional — authentication and other early-rejection errors may omit it
         return new RemoteFailure(type, reason, remoteTrace, headers, metadata, cause);
     }
 

--- a/x-pack/plugin/sql/sql-client/src/test/java/org/elasticsearch/xpack/sql/client/RemoteFailureTests.java
+++ b/x-pack/plugin/sql/sql-client/src/test/java/org/elasticsearch/xpack/sql/client/RemoteFailureTests.java
@@ -92,15 +92,12 @@ public class RemoteFailureTests extends ESTestCase {
             { "error": ["bogus"] }""", e.getMessage());
     }
 
-    public void testNoStack() {
-        IOException e = expectThrows(IOException.class, () -> parse("no_stack.json"));
-        assertThat(
-            e.getMessage(),
-            startsWith(
-                "Can't parse error from Elasticsearch [expected [stack_trace] cannot but "
-                    + "didn't see it] at [line 5 col 3]. Response:\n{"
-            )
-        );
+    public void testNoStack() throws IOException {
+        // stack_trace is optional — authentication errors and other early rejections may omit it
+        RemoteFailure failure = parse("no_stack.json");
+        assertEquals("illegal_argument_exception", failure.type());
+        assertEquals("[sql/query] unknown field [test], parser not found", failure.reason());
+        assertNull(failure.remoteTrace());
     }
 
     public void testNoType() {
@@ -157,12 +154,14 @@ public class RemoteFailureTests extends ESTestCase {
     }
 
     public void testTooBig() {
+        // Build a response that is too large to replay, missing the required "type" field.
+        // This exercises the "Response too large" code path in parseErrorMessage.
         StringBuilder tooBig = new StringBuilder(RemoteFailure.MAX_RAW_RESPONSE);
         tooBig.append("""
             {
               "error" : {
-                "type" : "illegal_argument_exception",
                 "reason" : "something",
+                "stack_trace" : "trace",
                 "header" : {
             """);
         int i = 0;
@@ -181,11 +180,8 @@ public class RemoteFailureTests extends ESTestCase {
             IOException.class,
             () -> RemoteFailure.parseFromResponse(new BytesArray(tooBig.toString()).streamInput())
         );
-        assertEquals(
-            "Can't parse error from Elasticsearch [expected [stack_trace] cannot but didn't see it] "
-                + "at [line 8463 col 1]. Attempted to include response but failed because [Response too large].",
-            e.getMessage()
-        );
+        assertThat(e.getMessage(), startsWith("Can't parse error from Elasticsearch [expected [type] but didn't see it]"));
+        assertThat(e.getMessage(), containsString("Attempted to include response but failed because [Response too large]."));
     }
 
     public void testFailureWithMetadata() throws IOException {


### PR DESCRIPTION
Manual backport

Fixes: https://github.com/elastic/elasticsearch/issues/150942
Fixes: https://github.com/elastic/elasticsearch/issues/150941