### PR TITLE
[9.3] [CI] Fix example-plugins after move to GradleRunner (#151010)

### DIFF
--- a/.ci/scripts/run-gradle.sh
+++ b/.ci/scripts/run-gradle.sh
@@ -42,10 +42,12 @@ fi
 
 set -e
 
-RUNNER_JAR="build-tools/gradle-runner/build/libs/gradle-runner.jar"
+RUNNER_JAR="$WORKSPACE/build-tools/gradle-runner/build/libs/gradle-runner.jar"
 if [[ ! -f "$RUNNER_JAR" ]]; then
   echo "--- Building gradle-runner"
+  cd "$WORKSPACE"
   ./gradlew --no-scan --no-daemon --console=plain :build-tools:gradle-runner:jar
+  cd -
 fi
 
 # Pass TESTS_SEED as Java system property if available


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[CI] Fix example-plugins after move to GradleRunner (#151010)](https://github.com/elastic/elasticsearch/pull/151010)

<!--- Backport version: 12.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)