### PR TITLE
ESQL: Validate pragma in CSV specs

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestUtils.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestUtils.java
@@ -14,7 +14,6 @@ import org.elasticsearch.Version;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.network.InetAddresses;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.time.DateFormatters;
 import org.elasticsearch.common.time.DateUtils;
 import org.elasticsearch.common.util.BigArrays;
@@ -102,11 +101,8 @@ import static org.elasticsearch.xpack.esql.core.util.NumericUtils.asLongUnsigned
 import static org.elasticsearch.xpack.esql.core.util.SpatialCoordinateTypes.CARTESIAN;
 import static org.elasticsearch.xpack.esql.core.util.SpatialCoordinateTypes.GEO;
 import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.stringToAggregateMetricDoubleLiteral;
-import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.in;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 
 public final class CsvTestUtils {
     private static final Logger LOGGER = LogManager.getLogger(CsvTestUtils.class);
@@ -305,14 +301,8 @@ public final class CsvTestUtils {
         );
     }
 
-    public static void checkPragma(
-        Map<String, String> pragmaSettings
-    ) {
-        assertThat(
-            "Pragma not found, spelling mistake?",
-            pragmaSettings.keySet(),
-            everyItem(in(QueryPragmas.VALID_PRAGMA_NAMES))
-        );
+    public static void checkPragma(Map<String, String> pragmaSettings) {
+        assertThat("Pragma not found, spelling mistake?", pragmaSettings.keySet(), everyItem(in(QueryPragmas.VALID_PRAGMA_NAMES)));
     }
 
     public static void assumeTrueLogging(String message, boolean condition) {

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestUtils.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestUtils.java
@@ -14,6 +14,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.network.InetAddresses;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.time.DateFormatters;
 import org.elasticsearch.common.time.DateUtils;
 import org.elasticsearch.common.util.BigArrays;
@@ -54,6 +55,7 @@ import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.xpack.esql.action.ResponseValueUtils;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.util.StringUtils;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 import org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter;
 import org.junit.AssumptionViolatedException;
 import org.supercsv.io.CsvListReader;
@@ -100,8 +102,11 @@ import static org.elasticsearch.xpack.esql.core.util.NumericUtils.asLongUnsigned
 import static org.elasticsearch.xpack.esql.core.util.SpatialCoordinateTypes.CARTESIAN;
 import static org.elasticsearch.xpack.esql.core.util.SpatialCoordinateTypes.GEO;
 import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.stringToAggregateMetricDoubleLiteral;
+import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.in;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 
 public final class CsvTestUtils {
     private static final Logger LOGGER = LogManager.getLogger(CsvTestUtils.class);
@@ -297,6 +302,16 @@ public final class CsvTestUtils {
                 Sets.difference(new HashSet<>(requiredCapabilities), enabledCapabilities.capabilities())
             ),
             enabledCapabilities.capabilities().containsAll(requiredCapabilities)
+        );
+    }
+
+    public static void checkPragma(
+        Map<String, String> pragmaSettings
+    ) {
+        assertThat(
+            "Pragma not found, spelling mistake?",
+            pragmaSettings.keySet(),
+            everyItem(in(QueryPragmas.VALID_PRAGMA_NAMES))
         );
     }
 

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/_README.md
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/_README.md
@@ -242,3 +242,23 @@ similarityScore:double | topIds:long
 ;
 ```
 
+### Query pragmas
+
+Query pragmas can also be provided with the `pragma: pragma_name=value` directive.
+In the following example, we use the `runtime_lexical_search` pragma:
+
+```csv-spec
+matchOnTextWithRow
+required_capability: match_support_runtime_text
+pragma: runtime_lexical_search=true
+
+ROW content = to_text(["This is a brown fox", "This is a brown dog", "This dog is really brown"])
+| MV_EXPAND content
+| WHERE match(content, "dog")
+| SORT content
+;
+content:text
+This dog is really brown
+This is a brown dog
+;
+```

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvIT.java
@@ -128,6 +128,7 @@ public class CsvIT extends ESTestCase {
     private static final Logger logger = LogManager.getLogger(CsvIT.class);
     private static final EsqlCapabilities ENABLED_CAPS = EsqlCapabilities.capabilities(TEST_FUNCTION_REGISTRY, false);
     private static final EsqlCapabilities ALL_CAPS = EsqlCapabilities.capabilities(TEST_FUNCTION_REGISTRY, true);
+    private static final QueryPragmas ALL_PRAGMAS = new QueryPragmas(Settings.EMPTY);
     private static final int BULK_INDEX_BATCH_SIZE = 10_000;
 
     private static InternalTestCluster cluster;
@@ -307,6 +308,7 @@ public class CsvIT extends ESTestCase {
         );
         CsvTestUtils.checkTestCapabilities(ALL_CAPS, ENABLED_CAPS, testCase.requiredCapabilities);
         CsvTestUtils.checkTestCapabilities(ALL_CAPS, ENABLED_CAPS, testCase.requiredCapabilitiesLocalCluster);
+        CsvTestUtils.checkPragma(testCase.pragmas);
 
         currentGroupName = groupName;
         // verify no prior failures

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/QueryPragmas.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/QueryPragmas.java
@@ -28,8 +28,10 @@ import org.elasticsearch.xpack.esql.datasources.spi.SourceOperatorContext;
 import org.elasticsearch.xpack.esql.planner.PlannerSettings;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.stream.Stream;
 
 /**
  * Holds the pragmas for an ESQL query. Just a wrapper of settings for now.
@@ -183,6 +185,31 @@ public final class QueryPragmas implements Writeable {
     public static final Setting<Boolean> RUNTIME_LEXICAL_SEARCH = Setting.boolSetting("runtime_lexical_search", false);
 
     public static final QueryPragmas EMPTY = new QueryPragmas(Settings.EMPTY);
+
+    public static final List<String> VALID_PRAGMA_NAMES = Stream.of(
+        EXCHANGE_BUFFER_SIZE,
+        ENRICH_MAX_WORKERS,
+        TASK_CONCURRENCY,
+        DATA_PARTITIONING,
+        PAGE_SIZE,
+        STATUS_INTERVAL,
+        MAX_CONCURRENT_NODES_PER_CLUSTER,
+        MAX_CONCURRENT_SHARDS_PER_NODE,
+        UNAVAILABLE_SHARD_RESOLUTION_ATTEMPTS,
+        NODE_LEVEL_REDUCTION,
+        FOLD_LIMIT,
+        FIELD_EXTRACT_PREFERENCE,
+        ROUNDTO_PUSHDOWN_THRESHOLD,
+        MAX_KEYWORD_SORT_FIELDS,
+        EXTERNAL_DISTRIBUTION,
+        IN_SUBQUERY_HASH_JOIN_THRESHOLD,
+        BRANCH_PARALLEL_DEGREE,
+        PARSING_PARALLELISM,
+        MAX_CONCURRENT_OPEN_SEGMENTS,
+        MAX_RECORD_SIZE,
+        FORCE_DOC_SEQUENCE,
+        RUNTIME_LEXICAL_SEARCH
+    ).map(Setting::getKey).toList();
 
     private final Settings settings;
 


### PR DESCRIPTION
Implements the suggestion from @fang-xing-esql to validate the pragma names in CSV tests: https://github.com/elastic/elasticsearch/pull/150779#pullrequestreview-4444314148

I am also adding an example in our development docs on how to use the new pragma directive.