### PR TITLE
Add block loader tests for multi_value=false keyword fields

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/tracking/BinaryAndCounts.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/tracking/BinaryAndCounts.java
@@ -42,10 +42,9 @@ public record BinaryAndCounts(TrackingBinaryDocValues binary, @Nullable Tracking
 
             if (skipCountsIfOne) {
                 DocValuesSkipper countsSkipper = context.reader().getDocValuesSkipper(countsFieldName);
-                if (countsSkipper == null) {
-                    throw new IllegalStateException("couldn't find skipper for counts field [" + countsFieldName + "]");
-                }
-                if (countsSkipper.maxValue() == 1) {
+                if (countsSkipper == null || countsSkipper.maxValue() == 1) {
+                    // null - means field is configured with multi-values=false
+                    // 1 - means a multi-valued field, but all documents have at most one value.
                     result = new BinaryAndCounts(binary, null);
                     return result;
                 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
@@ -19,14 +19,17 @@ import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.IndexableFieldType;
+import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.tests.analysis.MockLowerCaseFilter;
 import org.apache.lucene.tests.analysis.MockTokenizer;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexSortConfig;
@@ -41,6 +44,7 @@ import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.analysis.PreConfiguredTokenFilter;
 import org.elasticsearch.index.analysis.TokenFilterFactory;
 import org.elasticsearch.index.analysis.TokenizerFactory;
+import org.elasticsearch.index.mapper.blockloader.BlockLoaderFunctionConfig;
 import org.elasticsearch.index.termvectors.TermVectorsService;
 import org.elasticsearch.indices.analysis.AnalysisModule;
 import org.elasticsearch.plugins.AnalysisPlugin;
@@ -70,6 +74,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.nullValue;
 
 public class KeywordFieldMapperTests extends MapperTestCase {
 
@@ -1322,6 +1327,60 @@ public class KeywordFieldMapperTests extends MapperTestCase {
             e.getCause().getMessage(),
             containsString("configured with [multi_value=false] but encountered multiple values in the same document")
         );
+    }
+
+    /**
+     * Verifies that {@link org.elasticsearch.index.mapper.blockloader.docvalues.fn.ByteLengthFromBytesRefDocValuesBlockLoader}
+     * correctly reads byte lengths from a keyword field mapped with both {@code doc_values.cardinality: high} and
+     * {@code doc_values.multi_value: false}. With {@code multi_value: false} the doc-values are written as plain
+     * {@code BinaryDocValues} (no {@code .counts} companion field), so the loader takes the {@code SingleValued} code path. Three
+     * documents are indexed — two with values and one sparse — and the loader must return the correct byte lengths including {@code null}
+     * for the sparse document.
+     */
+    public void testMultiValueFalseHighCardinalityByteLengthBlockLoader() throws IOException {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        MapperService mapperService = createMapperService(
+            fieldMapping(
+                b -> b.field("type", "keyword")
+                    .startObject("doc_values")
+                    .field("cardinality", "high")
+                    .field("multi_value", false)
+                    .endObject()
+            )
+        );
+        DocumentMapper mapper = mapperService.documentMapper();
+
+        withLuceneIndex(mapperService, iw -> {
+            iw.addDocument(mapper.parse(source(b -> b.field("field", "foo"))).rootDoc());
+            iw.addDocument(mapper.parse(source(b -> {})).rootDoc());
+            iw.addDocument(mapper.parse(source(b -> b.field("field", "elasticsearch"))).rootDoc());
+            iw.forceMerge(1);
+        }, reader -> {
+            assertThat(reader.leaves(), hasSize(1));
+            LeafReaderContext ctx = reader.leaves().get(0);
+            BlockLoader blockLoader = mapperService.fieldType("field")
+                .blockLoader(new DummyBlockLoaderContext.MapperServiceBlockLoaderContext(mapperService) {
+                    @Override
+                    public MappedFieldType.FieldExtractPreference fieldExtractPreference() {
+                        return MappedFieldType.FieldExtractPreference.DOC_VALUES;
+                    }
+
+                    @Override
+                    public BlockLoaderFunctionConfig blockLoaderFunctionConfig() {
+                        return new BlockLoaderFunctionConfig.JustFunction(BlockLoaderFunctionConfig.Function.BYTE_LENGTH);
+                    }
+                });
+            var columnReaderSource = blockLoader.columnAtATimeReader(ctx);
+            assertNotNull("ByteLengthFromBytesRefDocValuesBlockLoader must support column-at-a-time reading", columnReaderSource);
+            CircuitBreaker breaker = newLimitedBreaker(ByteSizeValue.ofMb(1));
+            try (BlockLoader.ColumnAtATimeReader columnReader = columnReaderSource.apply(breaker)) {
+                TestBlock block = (TestBlock) columnReader.read(TestBlock.factory(), TestBlock.docs(0, 1, 2), 0, false);
+                assertThat(block.size(), equalTo(3));
+                assertThat(block.get(0), equalTo("foo".length()));
+                assertThat(block.get(1), nullValue());
+                assertThat(block.get(2), equalTo("elasticsearch".length()));
+            }
+        });
     }
 
     public void testFieldTypeWithSkipDocValues_LogsDbModeDisabledSetting() throws IOException {

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
@@ -2264,4 +2264,87 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
         }
         assertTrue("expected a doc values field for [field]", hasDocValuesField);
     }
+
+    /**
+     * Verifies the block loader read path for a field mapped with {@code doc_values.multi_value: false}. Enabling single-value
+     * enforcement changes the on-disk doc-values format, but it must not change what the block loader returns for single-valued
+     * documents.
+     *
+     * <p>For field types whose default mapping also supports column-at-a-time doc-values loading we assert that the two mappings produce
+     * identical blocks, including {@code null} for the sparse middle document. For field types whose default mapping uses source-based
+     * row-stride loading (e.g. {@code text}) the column-at-a-time path is only enabled by {@code multi_value: false}; in that case we
+     * only verify the structural invariant: docs 0 and 2 are non-null, doc 1 is null.
+     */
+    public void testMultiValueFalseBlockLoader() throws IOException {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        assumeTrue("supports doc_values multi_value parameter", supportsMultiValueParameter());
+
+        // getSampleValueForDocument() is deterministic for most types, so a single call is enough.
+        Object sample = getSampleValueForDocument();
+
+        MapperService mvFalse = createMapperService(fieldMapping(b -> {
+            minimalMapping(b);
+            b.startObject("doc_values").field("multi_value", false).endObject();
+        }));
+        MapperService defaults = createMapperService(fieldMapping(this::minimalMapping));
+
+        Object[] mvFalseBlock = loadThreeDocs(mvFalse, sample);
+        assumeTrue("field must support column-at-a-time doc-values loading", mvFalseBlock != null);
+        Object[] defaultBlock = loadThreeDocs(defaults, sample);
+
+        if (defaultBlock != null) {
+            // Both mappings support column-at-a-time: assert identical encoded values.
+            assertThat(mvFalseBlock[0], equalTo(defaultBlock[0]));
+            assertThat(mvFalseBlock[1], nullValue());          // sparse / unset middle document
+            assertThat(mvFalseBlock[2], equalTo(defaultBlock[2]));
+        } else {
+            // Default mapping reads from source (no doc-values); multi_value:false adds doc-values, enabling the
+            // column-at-a-time path. Verify the structural invariant: present docs are non-null, sparse is null.
+            assertNotNull(mvFalseBlock[0]);
+            assertThat(mvFalseBlock[1], nullValue());          // sparse / unset middle document
+            assertNotNull(mvFalseBlock[2]);
+        }
+    }
+
+    /**
+     * Indexes three documents — {@code [sample, &lt;empty&gt;, sample]} — force-merges to one segment, and loads the field's block via the
+     * column-at-a-time reader with {@link MappedFieldType.FieldExtractPreference#DOC_VALUES}. Returns the three loaded values, or
+     * {@code null} when the field type has no column-at-a-time reader (e.g. source-only loaders), so the caller can skip via
+     * {@code assumeTrue}.
+     */
+    private Object[] loadThreeDocs(MapperService mapperService, Object sample) throws IOException {
+        DocumentMapper mapper = mapperService.documentMapper();
+        Object[] result = new Object[3];
+        boolean[] supported = { true };
+        withLuceneIndex(mapperService, iw -> {
+            iw.addDocument(mapper.parse(source(b -> b.field("field", sample))).rootDoc());
+            iw.addDocument(mapper.parse(source(b -> {})).rootDoc());
+            iw.addDocument(mapper.parse(source(b -> b.field("field", sample))).rootDoc());
+            iw.forceMerge(1);
+        }, reader -> {
+            assertThat(reader.leaves(), hasSize(1));
+            LeafReaderContext ctx = reader.leaves().get(0);
+            BlockLoader blockLoader = mapperService.fieldType("field")
+                .blockLoader(new DummyBlockLoaderContext.MapperServiceBlockLoaderContext(mapperService) {
+                    @Override
+                    public MappedFieldType.FieldExtractPreference fieldExtractPreference() {
+                        return MappedFieldType.FieldExtractPreference.DOC_VALUES;
+                    }
+                });
+            var columnReaderSource = blockLoader.columnAtATimeReader(ctx);
+            if (columnReaderSource == null) {
+                supported[0] = false;
+                return;
+            }
+            CircuitBreaker breaker = newLimitedBreaker(ByteSizeValue.ofMb(1));
+            try (BlockLoader.ColumnAtATimeReader columnReader = columnReaderSource.apply(breaker)) {
+                TestBlock block = (TestBlock) columnReader.read(TestBlock.factory(), TestBlock.docs(0, 1, 2), 0, false);
+                assertThat(block.size(), equalTo(3));
+                result[0] = block.get(0);
+                result[1] = block.get(1);
+                result[2] = block.get(2);
+            }
+        });
+        return supported[0] ? result : null;
+    }
 }

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
@@ -2307,7 +2307,7 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
     }
 
     /**
-     * Indexes three documents — {@code [sample, &lt;empty&gt;, sample]} — force-merges to one segment, and loads the field's block via the
+     * Indexes three documents — {@code [sample, <empty>, sample]} — force-merges to one segment, and loads the field's block via the
      * column-at-a-time reader with {@link MappedFieldType.FieldExtractPreference#DOC_VALUES}. Returns the three loaded values, or
      * {@code null} when the field type has no column-at-a-time reader (e.g. source-only loaders), so the caller can skip via
      * {@code assumeTrue}.


### PR DESCRIPTION
BinaryAndCounts: handle missing .counts companion field gracefully when skipCountsIfOne=true — occurs when the binary field was written in single-valued mode (doc_values.multi_value: false) which emits plain BinaryDocValues without a separate counts field.

MapperTestCase: add testMultiValueFalseBlockLoader() to verify the block loader read path for all field types that support multi_value, using equivalence against the default-mapping block to avoid hardcoding per-type encoded values.

KeywordFieldMapperTests: add testMultiValueFalseHighCardinalityByteLengthBlockLoader() to verify ByteLengthFromBytesRefDocValuesBlockLoader with both cardinality=high and multi_value=false (SingleValued code path).