### PR TITLE
Unmute RcsCcsSearchYamlTestSuiteIT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -239,9 +239,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
   method: test
   issue: https://github.com/elastic/elasticsearch/issues/150569
-- class: org.elasticsearch.test.rest.yaml.RcsCcsSearchYamlTestSuiteIT
-  method: test {p0=search/400_synthetic_source/stored keyword with ignore_above}
-  issue: https://github.com/elastic/elasticsearch/issues/150952
 - class: org.elasticsearch.search.query.VectorIT
   method: testFilteredQueryStrategy
   issue: https://github.com/elastic/elasticsearch/issues/150955


### PR DESCRIPTION
This test has been muted after one suite timeout but it's not reproducible. It is being unmuted as it's unlikely there is a persistent bug within the test.

Closes https://github.com/elastic/elasticsearch/issues/150952