### PR TITLE
[9.4] Migrate :x-pack:plugin:transform/qa:single-node-tests to test cluster junit rule (#150270)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/RestrictedBuildApiService.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/RestrictedBuildApiService.java
@@ -62,7 +62,6 @@ public abstract class RestrictedBuildApiService implements BuildService<Restrict
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:text-structure:qa:text-structure-with-security");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:transform:qa:multi-cluster-tests-with-security");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:transform:qa:multi-node-tests");
-        map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:transform:qa:single-node-tests");
         return map;
     }
 

--- a/x-pack/plugin/transform/qa/single-node-tests/build.gradle
+++ b/x-pack/plugin/transform/qa/single-node-tests/build.gradle
@@ -1,5 +1,5 @@
 
-apply plugin: 'elasticsearch.legacy-java-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 
 dependencies {
   javaRestTestImplementation(testArtifact(project(xpackModule('core'))))
@@ -7,9 +7,10 @@ dependencies {
   javaRestTestImplementation project(path: xpackModule('transform:qa:common'))
 }
 
-testClusters.configureEach {
-  testDistribution = 'DEFAULT'
-  setting 'xpack.security.enabled', 'true'
-  setting 'xpack.license.self_generated.type', 'trial'
-  user username: "x_pack_rest_user", password: "x-pack-test-password"
+tasks.named('javaRestTest') {
+  // TransformUsageIT exercises _xpack/usage, which fans out to every xpack feature's
+  // usage transport action (cluster:monitor/xpack/usage/<feature>). Only the DEFAULT
+  // distribution registers them all; with the integ-test distribution the request fails
+  // with "failed to find action [cluster:monitor/xpack/usage/<feature>]".
+  usesDefaultDistribution("TransformUsageIT exercises _xpack/usage across all xpack features")
 }

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRestTestCase.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRestTestCase.java
@@ -18,6 +18,8 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.core.transform.TransformField;
 import org.elasticsearch.xpack.core.transform.transforms.DestAlias;
@@ -25,6 +27,7 @@ import org.elasticsearch.xpack.core.transform.transforms.SettingsConfig;
 import org.elasticsearch.xpack.transform.integration.common.TransformCommonRestTestCase;
 import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.ClassRule;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -53,6 +56,23 @@ public abstract class TransformRestTestCase extends TransformCommonRestTestCase 
 
     protected static final String REVIEWS_INDEX_NAME = "reviews";
     protected static final String REVIEWS_DATE_NANO_INDEX_NAME = "reviews_nano";
+
+    // TransformUsageIT exercises _xpack/usage, which fans out to every xpack feature's
+    // usage transport action (cluster:monitor/xpack/usage/<feature>). Only the DEFAULT
+    // distribution registers them all, so we use it here rather than the integ-test
+    // distribution + an explicit .module(...) list.
+    @ClassRule
+    public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
+        .distribution(DistributionType.DEFAULT)
+        .setting("xpack.security.enabled", "true")
+        .setting("xpack.license.self_generated.type", "trial")
+        .user("x_pack_rest_user", TEST_PASSWORD)
+        .build();
+
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
+    }
 
     @Override
     protected Settings restClientSettings() {


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Migrate :x-pack:plugin:transform/qa:single-node-tests to test cluster junit rule (#150270)