### PR TITLE
Randomly use columnar index mode in a few tests in IndexingIT

### DIFF
--- a/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/AbstractRollingUpgradeTestCase.java
+++ b/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/AbstractRollingUpgradeTestCase.java
@@ -50,7 +50,8 @@ public abstract class AbstractRollingUpgradeTestCase extends ParameterizedRollin
                 }
             })
             .setting("xpack.security.enabled", "false")
-            .feature(FeatureFlag.TIME_SERIES_MODE);
+            .feature(FeatureFlag.TIME_SERIES_MODE)
+            .feature(FeatureFlag.COLUMNAR_INDEX_MODE_FEATURE_FLAG);
 
         // Avoid triggering bogus assertion when serialized parsed mappings don't match with original mappings, because _source key is
         // inconsistent. As usual, we operate under the premise that "versionless" clusters (serverless) are on the latest code and

--- a/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/IndexingIT.java
+++ b/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/IndexingIT.java
@@ -77,12 +77,13 @@ public class IndexingIT extends AbstractRollingUpgradeTestCase {
         }
 
         if (isOldCluster()) {
+            String indexMode = randomlyUseColumnarMode() ? ", \"index.mode\": \"columnar\"" : "";
             Request createTestIndex = new Request("PUT", "/test_index");
-            createTestIndex.setJsonEntity("{\"settings\": {\"index.number_of_replicas\": 0}}");
+            createTestIndex.setJsonEntity("{\"settings\": {\"index.number_of_replicas\": 0" + indexMode + "}}");
             useIgnoreMultipleMatchingTemplatesWarningsHandler(createTestIndex);
             client().performRequest(createTestIndex);
 
-            String recoverQuickly = "{\"settings\": {\"index.unassigned.node_left.delayed_timeout\": \"100ms\"}}";
+            String recoverQuickly = "{\"settings\": {\"index.unassigned.node_left.delayed_timeout\": \"100ms\"" + indexMode + "}}";
             Request createIndexWithReplicas = new Request("PUT", "/index_with_replicas");
             createIndexWithReplicas.setJsonEntity(recoverQuickly);
             useIgnoreMultipleMatchingTemplatesWarningsHandler(createIndexWithReplicas);
@@ -138,8 +139,9 @@ public class IndexingIT extends AbstractRollingUpgradeTestCase {
         bulk.setJsonEntity(b);
 
         if (isOldCluster()) {
+            String indexMode = randomlyUseColumnarMode() ? ", \"index.mode\": \"columnar\"" : "";
             Request createTestIndex = new Request("PUT", "/" + indexName);
-            createTestIndex.setJsonEntity("{\"settings\": {\"index.number_of_replicas\": 0}}");
+            createTestIndex.setJsonEntity("{\"settings\": {\"index.number_of_replicas\": 0" + indexMode + "}}");
             client().performRequest(createTestIndex);
         } else if (isMixedCluster()) {
             Request waitForGreen = new Request("GET", "/_cluster/health");
@@ -167,9 +169,11 @@ public class IndexingIT extends AbstractRollingUpgradeTestCase {
         final String indexName = "test_date_nanos";
         if (isOldCluster()) {
             Request createIndex = new Request("PUT", "/" + indexName);
-            XContentBuilder mappings = XContentBuilder.builder(XContentType.JSON.xContent())
-                .startObject()
-                .startObject("mappings")
+            XContentBuilder mappings = XContentBuilder.builder(XContentType.JSON.xContent()).startObject();
+            if (randomlyUseColumnarMode()) {
+                mappings.startObject("settings").field("index.mode", "columnar").endObject();
+            }
+            mappings.startObject("mappings")
                 .startObject("properties")
                 .startObject("date")
                 .field("type", "date")
@@ -442,6 +446,26 @@ public class IndexingIT extends AbstractRollingUpgradeTestCase {
             entityAsMap(client().performRequest(new Request("GET", "/synthetic/_doc/new"))),
             matchesMap().extraOk().entry("_source", matchesMap().entry("kwd", "new").entry("int", 21341325))
         );
+    }
+
+    /**
+     * Returns {@code true} when the cluster advertises support for {@code index.mode: columnar}.
+     * Columnar mode is gated by a feature flag first available in 9.5.0 and by a transport version
+     * that all nodes in the cluster must understand. Checking the REST capability is the
+     * authoritative and framework-recommended way to gate on this — it accounts for both.
+     */
+    private static boolean clusterSupportsColumnarMode() throws IOException {
+        return clusterHasCapability("PUT", "/{index}", List.of(), List.of("columnar_index_modes")).orElse(false);
+    }
+
+    /**
+     * Randomly decides whether a newly created index should use {@code index.mode: columnar}.
+     * Only returns {@code true} when the cluster already supports columnar mode. The mode is
+     * chosen once at index-creation time (old-cluster phase); because {@code index.mode} is
+     * {@code Final}, every mixed-cluster node must be able to read it — this gating ensures that.
+     */
+    private static boolean randomlyUseColumnarMode() throws IOException {
+        return clusterSupportsColumnarMode() && randomBoolean();
     }
 
     private void assertCount(String index, int count) throws IOException {


### PR DESCRIPTION
For tests that are mode-agnostic (testIndexing, testAutoIdWithOpTypeCreate, testDateNanosFormatUpgrade), randomly create indices with index.mode=columnar when the old cluster advertises the columnar_index_modes REST capability. Falls back to standard mode on pre-9.5.0 clusters. Enables the columnar feature flag on the rolling-upgrade test cluster so nodes >=9.5.0 receive it.