### PR TITLE
[Test] Ensure stable cluster before ending the test

### DIFF
--- a/x-pack/plugin/slm/src/internalClusterTest/java/org/elasticsearch/xpack/slm/SLMStatDisruptionIT.java
+++ b/x-pack/plugin/slm/src/internalClusterTest/java/org/elasticsearch/xpack/slm/SLMStatDisruptionIT.java
@@ -575,6 +575,7 @@ public class SLMStatDisruptionIT extends AbstractSnapshotIntegTestCase {
             assertSnapshotPartial(repoName, snapshotName);
             assertMetadata(policyName, 0, 1, 1);
         }, 1, TimeUnit.MINUTES);
+        ensureStableCluster(2);
     }
 
     private void assertMetadata(String policyName, long taken, long failure, long invocationsSinceLastSuccess) {


### PR DESCRIPTION
This test disrupts cluster membership to excercise SLM failure case. The cluster may still be in the progress of recovery when the test ends which can fail the master-is-stable requirement for invoking getMasterName. This PR fixes it by ensuring stable cluster at the end of the test.

Resolves #151025
