### PR TITLE
Painless: script_aware wrappers for native iteration methods

### DIFF
--- a/docs/changelog/151059.yaml
+++ b/docs/changelog/151059.yaml
@@ -1,0 +1,5 @@
+pr: 151059
+summary: "Painless: `script_aware` wrappers for native iteration methods"
+area: Infra/Scripting
+type: enhancement
+issues: []

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/api/Augmentation.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/api/Augmentation.java
@@ -741,23 +741,18 @@ public class Augmentation {
 
     /**
      * Cancellation-aware {@code each} on Map.  Visits every entry, polling
-     * {@link PainlessScript#_pollCancellation()} once per entry.  Delegates to
-     * {@link #each(Map, BiConsumer)} when the script has no cancellation check installed.
+     * {@link PainlessScript#_pollCancellation()} once per entry.  Fast path delegates straight to
+     * {@link Map#forEach} when the script has no cancellation check installed.
      */
     public static <K, V> Object each(PainlessScript script, Map<K, V> receiver, BiConsumer<K, V> consumer) {
         if (script._getCancellationCheck() == null) {
-            return each(receiver, consumer);
+            receiver.forEach(consumer);
+            return receiver;
         }
         for (Map.Entry<K, V> kvPair : receiver.entrySet()) {
             consumer.accept(kvPair.getKey(), kvPair.getValue());
             script._pollCancellation();
         }
-        return receiver;
-    }
-
-    /** Iterates through a Map, passing each item to the given consumer. */
-    public static <K, V> Object each(Map<K, V> receiver, BiConsumer<K, V> consumer) {
-        receiver.forEach(consumer);
         return receiver;
     }
 

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/api/Augmentation.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/api/Augmentation.java
@@ -21,10 +21,13 @@ import java.time.temporal.TemporalAccessor;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Spliterator;
 import java.util.TreeMap;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
@@ -35,6 +38,7 @@ import java.util.function.ObjIntConsumer;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.function.ToDoubleFunction;
+import java.util.function.UnaryOperator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
@@ -53,6 +57,28 @@ public class Augmentation {
     /** Exposes Matcher.group(String) as namedGroup(String), so it doesn't conflict with group(int) */
     public static String namedGroup(Matcher receiver, String name) {
         return receiver.group(name);
+    }
+
+    /**
+     * Cancellation-aware wrapper around {@link Iterable#forEach}.  Polls
+     * {@link PainlessScript#_pollCancellation()} once per element so a long iteration honours search
+     * timeouts.  Delegates to {@link #forEach(Iterable, Consumer)} when the script has no cancellation
+     * check installed.
+     */
+    public static <T> void forEach(PainlessScript script, Iterable<T> receiver, Consumer<T> consumer) {
+        if (script._getCancellationCheck() == null) {
+            forEach(receiver, consumer);
+            return;
+        }
+        for (T t : receiver) {
+            consumer.accept(t);
+            script._pollCancellation();
+        }
+    }
+
+    /** Plain delegation to {@link Iterable#forEach} used as the fast path of the script-aware overload. */
+    public static <T> void forEach(Iterable<T> receiver, Consumer<T> consumer) {
+        receiver.forEach(consumer);
     }
 
     // some groovy methods on iterable
@@ -340,6 +366,34 @@ public class Augmentation {
         return sum;
     }
 
+    /**
+     * Cancellation-aware wrapper around {@link Collection#removeIf}.  Iterates explicitly via the
+     * receiver's iterator so each {@link Predicate#test} invocation can be followed by a
+     * {@link PainlessScript#_pollCancellation()} call.  Delegates to
+     * {@link #removeIf(Collection, Predicate)} when the script has no cancellation check installed
+     * (which preserves the JDK implementation's optimisations on collections that override removeIf).
+     */
+    public static <T> boolean removeIf(PainlessScript script, Collection<T> receiver, Predicate<T> predicate) {
+        if (script._getCancellationCheck() == null) {
+            return removeIf(receiver, predicate);
+        }
+        boolean removed = false;
+        Iterator<T> iter = receiver.iterator();
+        while (iter.hasNext()) {
+            if (predicate.test(iter.next())) {
+                iter.remove();
+                removed = true;
+            }
+            script._pollCancellation();
+        }
+        return removed;
+    }
+
+    /** Plain delegation to {@link Collection#removeIf} used as the fast path of the script-aware overload. */
+    public static <T> boolean removeIf(Collection<T> receiver, Predicate<T> predicate) {
+        return receiver.removeIf(predicate);
+    }
+
     // some groovy methods on collection
     // see http://docs.groovy-lang.org/latest/html/groovy-jdk/java/util/Collection.html
 
@@ -565,6 +619,49 @@ public class Augmentation {
             }
         }
         return result;
+    }
+
+    /**
+     * Cancellation-aware wrapper around {@link Map#forEach}.  Iterates the entry set and polls
+     * {@link PainlessScript#_pollCancellation()} once per entry.  Delegates to
+     * {@link #forEach(Map, BiConsumer)} when the script has no cancellation check installed.
+     */
+    public static <K, V> void forEach(PainlessScript script, Map<K, V> receiver, BiConsumer<K, V> consumer) {
+        if (script._getCancellationCheck() == null) {
+            forEach(receiver, consumer);
+            return;
+        }
+        for (Map.Entry<K, V> entry : receiver.entrySet()) {
+            consumer.accept(entry.getKey(), entry.getValue());
+            script._pollCancellation();
+        }
+    }
+
+    /** Plain delegation to {@link Map#forEach} used as the fast path of the script-aware overload. */
+    public static <K, V> void forEach(Map<K, V> receiver, BiConsumer<K, V> consumer) {
+        receiver.forEach(consumer);
+    }
+
+    /**
+     * Cancellation-aware wrapper around {@link Map#replaceAll}.  Walks the entry set, computes each
+     * new value via {@code function}, and writes it back through {@link Map.Entry#setValue}, polling
+     * {@link PainlessScript#_pollCancellation()} once per entry.  Delegates to
+     * {@link #replaceAll(Map, BiFunction)} when the script has no cancellation check installed.
+     */
+    public static <K, V> void replaceAll(PainlessScript script, Map<K, V> receiver, BiFunction<K, V, V> function) {
+        if (script._getCancellationCheck() == null) {
+            replaceAll(receiver, function);
+            return;
+        }
+        for (Map.Entry<K, V> entry : receiver.entrySet()) {
+            entry.setValue(function.apply(entry.getKey(), entry.getValue()));
+            script._pollCancellation();
+        }
+    }
+
+    /** Plain delegation to {@link Map#replaceAll} used as the fast path of the script-aware overload. */
+    public static <K, V> void replaceAll(Map<K, V> receiver, BiFunction<K, V, V> function) {
+        receiver.replaceAll(function);
     }
 
     // some groovy methods on map
@@ -914,6 +1011,77 @@ public class Augmentation {
                 .put(kvPair.getKey(), kvPair.getValue());
         }
         return map;
+    }
+
+    // native wrappers for cancellation-aware iteration
+
+    /**
+     * Cancellation-aware wrapper around {@link List#replaceAll}.  Uses a {@link ListIterator} so each
+     * {@link UnaryOperator#apply} call can be followed by a {@link PainlessScript#_pollCancellation()}
+     * call.  Delegates to {@link #replaceAll(List, UnaryOperator)} when the script has no
+     * cancellation check installed (which preserves the JDK implementation's optimisations on lists
+     * that override replaceAll).
+     */
+    public static <T> void replaceAll(PainlessScript script, List<T> receiver, UnaryOperator<T> operator) {
+        if (script._getCancellationCheck() == null) {
+            replaceAll(receiver, operator);
+            return;
+        }
+        ListIterator<T> iter = receiver.listIterator();
+        while (iter.hasNext()) {
+            iter.set(operator.apply(iter.next()));
+            script._pollCancellation();
+        }
+    }
+
+    /** Plain delegation to {@link List#replaceAll} used as the fast path of the script-aware overload. */
+    public static <T> void replaceAll(List<T> receiver, UnaryOperator<T> operator) {
+        receiver.replaceAll(operator);
+    }
+
+    /**
+     * Cancellation-aware wrapper around {@link Iterator#forEachRemaining}.  Walks the receiver via
+     * {@link Iterator#hasNext}/{@link Iterator#next} and polls {@link PainlessScript#_pollCancellation()}
+     * once per element.  Delegates to {@link #forEachRemaining(Iterator, Consumer)} when the script
+     * has no cancellation check installed.
+     */
+    public static <T> void forEachRemaining(PainlessScript script, Iterator<T> receiver, Consumer<T> consumer) {
+        if (script._getCancellationCheck() == null) {
+            forEachRemaining(receiver, consumer);
+            return;
+        }
+        while (receiver.hasNext()) {
+            consumer.accept(receiver.next());
+            script._pollCancellation();
+        }
+    }
+
+    /** Plain delegation to {@link Iterator#forEachRemaining} used as the fast path of the script-aware overload. */
+    public static <T> void forEachRemaining(Iterator<T> receiver, Consumer<T> consumer) {
+        receiver.forEachRemaining(consumer);
+    }
+
+    /**
+     * Cancellation-aware wrapper around {@link Spliterator#forEachRemaining}.  Drives the receiver
+     * via {@link Spliterator#tryAdvance} so the augmentation can poll
+     * {@link PainlessScript#_pollCancellation()} between each element rather than letting the
+     * spliterator's bulk traversal run uninterrupted.  Delegates to
+     * {@link #forEachRemaining(Spliterator, Consumer)} when the script has no cancellation check
+     * installed.
+     */
+    public static <T> void forEachRemaining(PainlessScript script, Spliterator<T> receiver, Consumer<T> consumer) {
+        if (script._getCancellationCheck() == null) {
+            forEachRemaining(receiver, consumer);
+            return;
+        }
+        while (receiver.tryAdvance(consumer)) {
+            script._pollCancellation();
+        }
+    }
+
+    /** Plain delegation to {@link Spliterator#forEachRemaining} used as the fast path of the script-aware overload. */
+    public static <T> void forEachRemaining(Spliterator<T> receiver, Consumer<T> consumer) {
+        receiver.forEachRemaining(consumer);
     }
 
     // CharSequence augmentation

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/api/Augmentation.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/api/Augmentation.java
@@ -62,23 +62,18 @@ public class Augmentation {
     /**
      * Cancellation-aware wrapper around {@link Iterable#forEach}.  Polls
      * {@link PainlessScript#_pollCancellation()} once per element so a long iteration honours search
-     * timeouts.  Delegates to {@link #forEach(Iterable, Consumer)} when the script has no cancellation
-     * check installed.
+     * timeouts.  Fast path delegates straight to the JDK when the script has no cancellation check
+     * installed.
      */
     public static <T> void forEach(PainlessScript script, Iterable<T> receiver, Consumer<T> consumer) {
         if (script._getCancellationCheck() == null) {
-            forEach(receiver, consumer);
+            receiver.forEach(consumer);
             return;
         }
         for (T t : receiver) {
             consumer.accept(t);
             script._pollCancellation();
         }
-    }
-
-    /** Plain delegation to {@link Iterable#forEach} used as the fast path of the script-aware overload. */
-    public static <T> void forEach(Iterable<T> receiver, Consumer<T> consumer) {
-        receiver.forEach(consumer);
     }
 
     // some groovy methods on iterable
@@ -369,13 +364,13 @@ public class Augmentation {
     /**
      * Cancellation-aware wrapper around {@link Collection#removeIf}.  Iterates explicitly via the
      * receiver's iterator so each {@link Predicate#test} invocation can be followed by a
-     * {@link PainlessScript#_pollCancellation()} call.  Delegates to
-     * {@link #removeIf(Collection, Predicate)} when the script has no cancellation check installed
-     * (which preserves the JDK implementation's optimisations on collections that override removeIf).
+     * {@link PainlessScript#_pollCancellation()} call.  Fast path delegates straight to the JDK when
+     * the script has no cancellation check installed (preserving optimisations on collections that
+     * override removeIf, e.g. {@code ArrayList}).
      */
     public static <T> boolean removeIf(PainlessScript script, Collection<T> receiver, Predicate<T> predicate) {
         if (script._getCancellationCheck() == null) {
-            return removeIf(receiver, predicate);
+            return receiver.removeIf(predicate);
         }
         boolean removed = false;
         Iterator<T> iter = receiver.iterator();
@@ -387,11 +382,6 @@ public class Augmentation {
             script._pollCancellation();
         }
         return removed;
-    }
-
-    /** Plain delegation to {@link Collection#removeIf} used as the fast path of the script-aware overload. */
-    public static <T> boolean removeIf(Collection<T> receiver, Predicate<T> predicate) {
-        return receiver.removeIf(predicate);
     }
 
     // some groovy methods on collection
@@ -623,12 +613,12 @@ public class Augmentation {
 
     /**
      * Cancellation-aware wrapper around {@link Map#forEach}.  Iterates the entry set and polls
-     * {@link PainlessScript#_pollCancellation()} once per entry.  Delegates to
-     * {@link #forEach(Map, BiConsumer)} when the script has no cancellation check installed.
+     * {@link PainlessScript#_pollCancellation()} once per entry.  Fast path delegates straight to the
+     * JDK when the script has no cancellation check installed.
      */
     public static <K, V> void forEach(PainlessScript script, Map<K, V> receiver, BiConsumer<K, V> consumer) {
         if (script._getCancellationCheck() == null) {
-            forEach(receiver, consumer);
+            receiver.forEach(consumer);
             return;
         }
         for (Map.Entry<K, V> entry : receiver.entrySet()) {
@@ -637,31 +627,21 @@ public class Augmentation {
         }
     }
 
-    /** Plain delegation to {@link Map#forEach} used as the fast path of the script-aware overload. */
-    public static <K, V> void forEach(Map<K, V> receiver, BiConsumer<K, V> consumer) {
-        receiver.forEach(consumer);
-    }
-
     /**
      * Cancellation-aware wrapper around {@link Map#replaceAll}.  Walks the entry set, computes each
      * new value via {@code function}, and writes it back through {@link Map.Entry#setValue}, polling
-     * {@link PainlessScript#_pollCancellation()} once per entry.  Delegates to
-     * {@link #replaceAll(Map, BiFunction)} when the script has no cancellation check installed.
+     * {@link PainlessScript#_pollCancellation()} once per entry.  Fast path delegates straight to the
+     * JDK when the script has no cancellation check installed.
      */
     public static <K, V> void replaceAll(PainlessScript script, Map<K, V> receiver, BiFunction<K, V, V> function) {
         if (script._getCancellationCheck() == null) {
-            replaceAll(receiver, function);
+            receiver.replaceAll(function);
             return;
         }
         for (Map.Entry<K, V> entry : receiver.entrySet()) {
             entry.setValue(function.apply(entry.getKey(), entry.getValue()));
             script._pollCancellation();
         }
-    }
-
-    /** Plain delegation to {@link Map#replaceAll} used as the fast path of the script-aware overload. */
-    public static <K, V> void replaceAll(Map<K, V> receiver, BiFunction<K, V, V> function) {
-        receiver.replaceAll(function);
     }
 
     // some groovy methods on map
@@ -1018,13 +998,12 @@ public class Augmentation {
     /**
      * Cancellation-aware wrapper around {@link List#replaceAll}.  Uses a {@link ListIterator} so each
      * {@link UnaryOperator#apply} call can be followed by a {@link PainlessScript#_pollCancellation()}
-     * call.  Delegates to {@link #replaceAll(List, UnaryOperator)} when the script has no
-     * cancellation check installed (which preserves the JDK implementation's optimisations on lists
-     * that override replaceAll).
+     * call.  Fast path delegates straight to the JDK when the script has no cancellation check
+     * installed (preserving optimisations on lists that override replaceAll, e.g. {@code ArrayList}).
      */
     public static <T> void replaceAll(PainlessScript script, List<T> receiver, UnaryOperator<T> operator) {
         if (script._getCancellationCheck() == null) {
-            replaceAll(receiver, operator);
+            receiver.replaceAll(operator);
             return;
         }
         ListIterator<T> iter = receiver.listIterator();
@@ -1034,20 +1013,15 @@ public class Augmentation {
         }
     }
 
-    /** Plain delegation to {@link List#replaceAll} used as the fast path of the script-aware overload. */
-    public static <T> void replaceAll(List<T> receiver, UnaryOperator<T> operator) {
-        receiver.replaceAll(operator);
-    }
-
     /**
      * Cancellation-aware wrapper around {@link Iterator#forEachRemaining}.  Walks the receiver via
      * {@link Iterator#hasNext}/{@link Iterator#next} and polls {@link PainlessScript#_pollCancellation()}
-     * once per element.  Delegates to {@link #forEachRemaining(Iterator, Consumer)} when the script
-     * has no cancellation check installed.
+     * once per element.  Fast path delegates straight to the JDK when the script has no cancellation
+     * check installed.
      */
     public static <T> void forEachRemaining(PainlessScript script, Iterator<T> receiver, Consumer<T> consumer) {
         if (script._getCancellationCheck() == null) {
-            forEachRemaining(receiver, consumer);
+            receiver.forEachRemaining(consumer);
             return;
         }
         while (receiver.hasNext()) {
@@ -1056,32 +1030,21 @@ public class Augmentation {
         }
     }
 
-    /** Plain delegation to {@link Iterator#forEachRemaining} used as the fast path of the script-aware overload. */
-    public static <T> void forEachRemaining(Iterator<T> receiver, Consumer<T> consumer) {
-        receiver.forEachRemaining(consumer);
-    }
-
     /**
      * Cancellation-aware wrapper around {@link Spliterator#forEachRemaining}.  Drives the receiver
      * via {@link Spliterator#tryAdvance} so the augmentation can poll
      * {@link PainlessScript#_pollCancellation()} between each element rather than letting the
-     * spliterator's bulk traversal run uninterrupted.  Delegates to
-     * {@link #forEachRemaining(Spliterator, Consumer)} when the script has no cancellation check
-     * installed.
+     * spliterator's bulk traversal run uninterrupted.  Fast path delegates straight to the JDK when
+     * the script has no cancellation check installed.
      */
     public static <T> void forEachRemaining(PainlessScript script, Spliterator<T> receiver, Consumer<T> consumer) {
         if (script._getCancellationCheck() == null) {
-            forEachRemaining(receiver, consumer);
+            receiver.forEachRemaining(consumer);
             return;
         }
         while (receiver.tryAdvance(consumer)) {
             script._pollCancellation();
         }
-    }
-
-    /** Plain delegation to {@link Spliterator#forEachRemaining} used as the fast path of the script-aware overload. */
-    public static <T> void forEachRemaining(Spliterator<T> receiver, Consumer<T> consumer) {
-        receiver.forEachRemaining(consumer);
     }
 
     // CharSequence augmentation

--- a/modules/lang-painless/src/main/resources/org/elasticsearch/painless/java.lang.txt
+++ b/modules/lang-painless/src/main/resources/org/elasticsearch/painless/java.lang.txt
@@ -39,7 +39,7 @@ class java.lang.Comparable {
 }
 
 class java.lang.Iterable {
-  void forEach(Consumer)
+  void org.elasticsearch.painless.api.Augmentation forEach(Consumer) @script_aware
   Iterator iterator()
   Spliterator spliterator()
   # some adaptations of groovy wmethods

--- a/modules/lang-painless/src/main/resources/org/elasticsearch/painless/java.util.txt
+++ b/modules/lang-painless/src/main/resources/org/elasticsearch/painless/java.util.txt
@@ -22,7 +22,7 @@ class java.util.Collection {
   boolean containsAll(Collection)
   boolean isEmpty()
   boolean removeAll(Collection)
-  boolean removeIf(Predicate)
+  boolean org.elasticsearch.painless.api.Augmentation removeIf(Predicate) @script_aware
   boolean retainAll(Collection)
   int size()
   Spliterator spliterator()
@@ -94,7 +94,7 @@ class java.util.Formattable {
 }
 
 class java.util.Iterator {
-  void forEachRemaining(Consumer)
+  void org.elasticsearch.painless.api.Augmentation forEachRemaining(Consumer) @script_aware
   boolean hasNext()
   def next()
   void remove()
@@ -111,7 +111,7 @@ class java.util.List {
   ListIterator listIterator()
   ListIterator listIterator(int)
   def remove(int)
-  void replaceAll(UnaryOperator)
+  void org.elasticsearch.painless.api.Augmentation replaceAll(UnaryOperator) @script_aware
   def set(int,def)
   int org.elasticsearch.painless.api.Augmentation getLength()
   void sort(Comparator)
@@ -137,7 +137,7 @@ class java.util.Map {
   boolean containsValue(def)
   Set entrySet()
   boolean equals(Object)
-  void forEach(BiConsumer)
+  void org.elasticsearch.painless.api.Augmentation forEach(BiConsumer) @script_aware
   def get(def)
   def getOrDefault(def,def)
   boolean isEmpty()
@@ -150,7 +150,7 @@ class java.util.Map {
   boolean remove(def,def)
   def replace(def,def)
   boolean replace(def,def,def)
-  void replaceAll(BiFunction)
+  void org.elasticsearch.painless.api.Augmentation replaceAll(BiFunction) @script_aware
   int size()
   Collection values()
   Object org.elasticsearch.painless.api.Augmentation getByPath(String)
@@ -250,7 +250,7 @@ class java.util.Spliterator {
   int SUBSIZED
   int characteristics()
   long estimateSize()
-  void forEachRemaining(Consumer)
+  void org.elasticsearch.painless.api.Augmentation forEachRemaining(Consumer) @script_aware
   Comparator getComparator()
   long getExactSizeIfKnown()
   boolean hasCharacteristics(int)

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/AugmentationCancellationTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/AugmentationCancellationTests.java
@@ -839,4 +839,64 @@ public class AugmentationCancellationTests extends ScriptTestCase {
         // No runnable set — _getCancellationCheck() returns null; fast paths must not throw.
         script.execute();
     }
+
+    // --- Native methods routed through @script_aware Augmentation wrappers ---
+
+    /** {@code Iterable.forEach} visits every element and must poll. */
+    public void testIterableForEachAugmentationFiresCancelRunnable() {
+        assertFires(compileFillThen("", "big.forEach(x -> x.toString());"), "cancelled-iterable-foreach");
+    }
+
+    /** {@code Collection.removeIf} with an always-false predicate scans the whole collection and must poll. */
+    public void testCollectionRemoveIfAugmentationFiresCancelRunnable() {
+        assertFires(compileFillThen("", "big.removeIf(x -> false);"), "cancelled-removeif");
+    }
+
+    /** {@code Iterator.forEachRemaining} on a fresh iterator visits every element and must poll. */
+    public void testIteratorForEachRemainingAugmentationFiresCancelRunnable() {
+        assertFires(compileFillThen("", "big.iterator().forEachRemaining(x -> x.toString());"), "cancelled-iterator-foreachremaining");
+    }
+
+    /** {@code List.replaceAll} with an identity operator scans the whole list and must poll. */
+    public void testListReplaceAllAugmentationFiresCancelRunnable() {
+        assertFires(compileFillThen("", "big.replaceAll(x -> x);"), "cancelled-list-replaceall");
+    }
+
+    /** {@code Map.forEach} visits every entry and must poll. */
+    public void testMapForEachAugmentationFiresCancelRunnable() {
+        assertFires(compileFillMapThen("", "big.forEach((k, v) -> v.toString());"), "cancelled-map-foreach");
+    }
+
+    /** {@code Map.replaceAll} with an identity function scans the whole map and must poll. */
+    public void testMapReplaceAllAugmentationFiresCancelRunnable() {
+        assertFires(compileFillMapThen("", "big.replaceAll((k, v) -> v);"), "cancelled-map-replaceall");
+    }
+
+    /** {@code Spliterator.forEachRemaining} on a fresh spliterator visits every element and must poll. */
+    public void testSpliteratorForEachRemainingAugmentationFiresCancelRunnable() {
+        assertFires(
+            compileFillThen("", "big.spliterator().forEachRemaining(x -> x.toString());"),
+            "cancelled-spliterator-foreachremaining"
+        );
+    }
+
+    /**
+     * Each new native-wrapper script-aware augmentation must take the no-poll fast path when the
+     * script has no cancellation check installed.  Exercises all seven native wrappers (Iterable,
+     * Collection, Iterator, List, Map x2, Spliterator) in one script execution.
+     */
+    public void testNativeWrapperAugmentationsNoRunnable() {
+        ScriptedMetricAggContexts.InitScript script = compileFillThen(
+            "Map newMap() { Map m = new HashMap(); m.put(1, 1); return m; }",
+            "big.forEach(x -> x.toString()); "
+                + "big.removeIf(x -> false); "
+                + "big.iterator().forEachRemaining(x -> x.toString()); "
+                + "big.replaceAll(x -> x); "
+                + "Map m = newMap(); m.forEach((k, v) -> v.toString()); "
+                + "Map m2 = newMap(); m2.replaceAll((k, v) -> v); "
+                + "big.spliterator().forEachRemaining(x -> x.toString());"
+        );
+        // No runnable set — _getCancellationCheck() returns null; fast paths must not throw.
+        script.execute();
+    }
 }

--- a/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/95_script_cancellation.yml
+++ b/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/95_script_cancellation.yml
@@ -2377,6 +2377,44 @@
   - is_true: timed_out
 
 ---
+"Search timeout aborts a long-running removeIf augmentation loop":
+  - do:
+      indices.create:
+        index: test_removeif_augmentation_timeout
+        body:
+          settings:
+            number_of_shards: 1
+  - do:
+      index:
+        index: test_removeif_augmentation_timeout
+        id: d1
+        body: {"val": 1}
+  - do:
+      indices.refresh: {}
+
+  # The @script_aware Collection.removeIf drives the iteration itself. An outer each() over a list
+  # invokes a nested removeIf with an always-false predicate so the inner list size is preserved;
+  # the cancellation poll inside removeIf must fire so the 100 ms timeout cancels even though the
+  # script body has no loop.
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: test_removeif_augmentation_timeout
+        timeout: 100ms
+        body:
+          query:
+            script:
+              script:
+                source: |
+                  List a = new ArrayList();
+                  for (int i = 0; i < 50000; i++) { a.add(i); }
+                  List b = new ArrayList();
+                  for (int i = 0; i < 50000; i++) { b.add(i); }
+                  a.each(x -> b.removeIf(y -> false));
+                  return true;
+  - is_true: timed_out
+
+---
 "Search timeout aborts a long-running String.replace augmentation loop":
   - do:
       indices.create:


### PR DESCRIPTION
Follow-up to #151016. Converts seven native JDK iteration methods that were previously routed straight to the JDK into `@script_aware` Augmentation wrappers, so iteration driven through these Java standard methods honours search timeouts the same way the Groovy-style augmentations do.

Each new overload polls `PainlessScript._pollCancellation()` once per element, and delegates to the existing non-`@script_aware` method when `_getCancellationCheck()` is null so non-cancellation contexts pay zero overhead.

| Class | Method |
|---|---|
| `java.lang.Iterable` | `forEach(Consumer)` |
| `java.util.Collection` | `removeIf(Predicate)` |
| `java.util.Iterator` | `forEachRemaining(Consumer)` |
| `java.util.List` | `replaceAll(UnaryOperator)` |
| `java.util.Map` | `forEach(BiConsumer)` |
| `java.util.Map` | `replaceAll(BiFunction)` |
| `java.util.Spliterator` | `forEachRemaining(Consumer)` |

Native return types are preserved (`void` / `boolean`) so there is no API change visible to scripts.

For methods on collections that override the native (e.g. `ArrayList.removeIf`), the fast path delegates straight to the JDK so optimised implementations are preserved when no cancellation check is installed.