### PR TITLE
Fixed text failures in DownsampleWithBasicRestIT and DownsampleRestIT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -662,18 +662,6 @@ tests:
 - class: org.elasticsearch.xpack.stateless.lucene.BlobCacheIndexInputTests
   method: testAsyncPrefetchFailureIsRecorded
   issue: https://github.com/elastic/elasticsearch/issues/151031
-- class: org.elasticsearch.xpack.downsample.DownsampleRestIT
-  method: test {p0=downsample/110_downsample_temporality/Downsample delta temporality counter}
-  issue: https://github.com/elastic/elasticsearch/issues/151046
-- class: org.elasticsearch.xpack.downsample.DownsampleRestIT
-  method: test {p0=downsample/110_downsample_temporality/Downsample mixed temporality counters}
-  issue: https://github.com/elastic/elasticsearch/issues/151047
-- class: org.elasticsearch.xpack.downsample.DownsampleWithBasicRestIT
-  method: test {p0=downsample/110_downsample_temporality/Downsample mixed temporality counters}
-  issue: https://github.com/elastic/elasticsearch/issues/151048
-- class: org.elasticsearch.xpack.downsample.DownsampleWithBasicRestIT
-  method: test {p0=downsample/110_downsample_temporality/Downsample delta temporality counter}
-  issue: https://github.com/elastic/elasticsearch/issues/151049
 - class: org.elasticsearch.xpack.ml.qa.MlYamlRestIT
   method: test {p0=ml/estimate_model_memory/Test partition field with independent influencer}
   issue: https://github.com/elastic/elasticsearch/issues/151052

--- a/x-pack/plugin/downsample/qa/rest/build.gradle
+++ b/x-pack/plugin/downsample/qa/rest/build.gradle
@@ -39,9 +39,18 @@ if (buildParams.inFipsJvm){
 }
 
 if (buildParams.snapshotBuild == false) {
+  // The index.time_series.temporality_field setting is gated behind the time_series_temporality feature flag, which is disabled in
+  // non-snapshot (release) builds, so the 110_downsample_temporality tests cannot run there. A single substring pattern leaks because
+  // the randomized runner checks the bare method name and the parameterized name separately, so we must exclude both forms for each
+  // suite class (the same handling MutedTestsBuildService applies). Remove this block once the feature flag is lifted.
   tasks.named("yamlRestTest").configure {
     filter {
-      excludeTestsMatching "*110_downsample_temporality*"
+      excludeTestsMatching "org.elasticsearch.xpack.downsample.DownsampleRestIT.test {p0=downsample/110_downsample_temporality/Downsample delta temporality counter}"
+      excludeTestsMatching "org.elasticsearch.xpack.downsample.DownsampleRestIT.test {p0=downsample/110_downsample_temporality/Downsample mixed temporality counters}"
+      excludeTestsMatching "org.elasticsearch.xpack.downsample.DownsampleRestIT.test"
+      excludeTestsMatching "org.elasticsearch.xpack.downsample.DownsampleWithBasicRestIT.test {p0=downsample/110_downsample_temporality/Downsample delta temporality counter}"
+      excludeTestsMatching "org.elasticsearch.xpack.downsample.DownsampleWithBasicRestIT.test {p0=downsample/110_downsample_temporality/Downsample mixed temporality counters}"
+      excludeTestsMatching "org.elasticsearch.xpack.downsample.DownsampleWithBasicRestIT.test"
     }
   }
 }


### PR DESCRIPTION
Excluding just "110_downsample_temporality" is insufficient when the entire test-suite runs.

Fixes:
- https://github.com/elastic/elasticsearch/issues/151049
- https://github.com/elastic/elasticsearch/issues/151048
- https://github.com/elastic/elasticsearch/issues/151047
- https://github.com/elastic/elasticsearch/issues/151046