### PR TITLE
ES|QL: fix stats.MultiStatsAfterFalseFilter_ByLiteralValue

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
@@ -3501,6 +3501,8 @@ from employees
 ;
 
 multiStatsAfterFalseFilter_ByLiteralValue
+required_capability: fix_stats_by_foldable_expression_2
+
 from employees
 | where false
 | stats c = count(*), s = avg(salary)


### PR DESCRIPTION
Adding a capability to skip the test against 8.13, that doesn't support grouping by literals

Fixes: https://github.com/elastic/elasticsearch/issues/151063