### PR TITLE
Fix randomness in ReindexSearchContextFailuresIT

### DIFF
--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/ReindexSearchContextFailuresIT.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/ReindexSearchContextFailuresIT.java
@@ -91,7 +91,7 @@ public class ReindexSearchContextFailuresIT extends ESIntegTestCase {
         );
 
         String source = randomAlphanumericOfLength(12).toLowerCase(Locale.ROOT);
-        String dest = randomAlphanumericOfLength(12).toLowerCase(Locale.ROOT);
+        String dest = randomValueOtherThan(source, () -> randomAlphanumericOfLength(12).toLowerCase(Locale.ROOT));
         assertAcked(prepareCreate(source));
         assertAcked(prepareCreate(dest));
         indexRandom(
@@ -136,7 +136,7 @@ public class ReindexSearchContextFailuresIT extends ESIntegTestCase {
         );
 
         String source = randomAlphanumericOfLength(12).toLowerCase(Locale.ROOT);
-        String dest = randomAlphanumericOfLength(12).toLowerCase(Locale.ROOT);
+        String dest = randomValueOtherThan(source, () -> randomAlphanumericOfLength(12).toLowerCase(Locale.ROOT));
         assertAcked(prepareCreate(source));
         assertAcked(prepareCreate(dest));
         indexRandom(


### PR DESCRIPTION
Fixes a (low likelihood) possible test failure where the source and destination index names clash
