### PR TITLE
Change assertBusy to awaitClusterState

### DIFF
--- a/modules/reindex-management/src/internalClusterTest/java/org/elasticsearch/reindex/management/ReindexRelocationIT.java
+++ b/modules/reindex-management/src/internalClusterTest/java/org/elasticsearch/reindex/management/ReindexRelocationIT.java
@@ -680,7 +680,7 @@ public class ReindexRelocationIT extends ESIntegTestCase {
 
         // Wait for .tasks and replica to be created before stopping nodeB, otherwise the replica
         // on nodeA is stale and can't be promoted to primary when nodeB leaves
-        assertBusy(() -> assertTrue(indexExists(TaskResultsService.TASK_INDEX)), 30, TimeUnit.SECONDS);
+        awaitClusterState(state -> state.metadata().getProject().hasIndex(TaskResultsService.TASK_INDEX));
         ensureGreen(TaskResultsService.TASK_INDEX);
 
         internalCluster().stopNode(nodeName);

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexFailureTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexFailureTests.java
@@ -104,7 +104,7 @@ public class ReindexFailureTests extends ReindexTestCase {
                  * so we *try* and wait for the delete to be fully
                  * complete here.
                  */
-                assertBusy(() -> assertFalse(indexExists("source")));
+                awaitClusterState(state -> state.metadata().getProject().hasIndex("source") == false);
             } catch (ExecutionException e) {
                 logger.info("Triggered a reindex failure on the {} attempt: {}", attempt, e.getMessage());
                 assertThat(


### PR DESCRIPTION
`awaitBusy` busy-polls on the test thread. It is more performative to subscribe a cluster state listener using `awaitClusterState`
