### PR TITLE
ESQL: Test flattened dimensions

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/in_subquery_with_ts_source.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/in_subquery_with_ts_source.csv-spec
@@ -170,6 +170,7 @@ emp_no:integer | first_name:keyword
 ;
 
 mainFromInSubqueryTsWithWithoutAndRateInNestedInSubquery
+skip_flattened_rewrite: without_unsupported
 required_capability: where_in_subquery_without_view
 required_capability: subquery_with_ts
 required_capability: ts_command_v0
@@ -279,6 +280,7 @@ emp_no:integer | first_name:keyword
 ;
 
 mainFromInSubqueryTsWithSumOverTimeWithoutGroupingInInSubquery
+skip_flattened_rewrite: without_unsupported
 required_capability: where_in_subquery_without_view
 required_capability: subquery_with_ts
 required_capability: ts_command_v0
@@ -770,6 +772,7 @@ max_rate:double | cluster:keyword
 ;
 
 mainTsInSubqueryTsWithWithoutInMainRateInSubquery
+skip_flattened_rewrite: without_unsupported
 required_capability: where_in_subquery_without_view
 required_capability: subquery_with_ts
 required_capability: ts_command_v0
@@ -790,6 +793,7 @@ total_cost:double | _timeseries:keyword
 ;
 
 mainTsInSubqueryTsWithWithoutInMainRateInNotInSubquery
+skip_flattened_rewrite: without_unsupported
 required_capability: where_in_subquery_without_view
 required_capability: subquery_with_ts
 required_capability: ts_command_v0
@@ -811,6 +815,7 @@ total_cost:double | _timeseries:keyword
 ;
 
 mainTsInSubqueryTsWithWithoutInMainAndSubquery
+skip_flattened_rewrite: without_unsupported
 required_capability: where_in_subquery_without_view
 required_capability: subquery_with_ts
 required_capability: ts_command_v0
@@ -832,6 +837,7 @@ total_cost:double | _timeseries:keyword
 ;
 
 mainTsNotInSubqueryTsWithWithoutInMainAndNotInSubquery
+skip_flattened_rewrite: without_unsupported
 required_capability: where_in_subquery_without_view
 required_capability: subquery_with_ts
 required_capability: ts_command_v0
@@ -1117,6 +1123,7 @@ max_bytes:long | pod:keyword
 ;
 
 mainTsInSubqueryTsRateInMainWithoutInInSubquery
+skip_flattened_rewrite: without_unsupported
 required_capability: where_in_subquery_without_view
 required_capability: subquery_with_ts
 required_capability: ts_command_v0
@@ -1226,6 +1233,7 @@ max_rate:double | cluster:keyword
 ;
 
 mainTsNotInSubqueryTsWithoutInBothMainAndInSubquery
+skip_flattened_rewrite: without_unsupported
 required_capability: where_in_subquery_without_view
 required_capability: subquery_with_ts
 required_capability: ts_command_v0
@@ -1607,6 +1615,7 @@ top:double | cluster:keyword
 ;
 
 mainTsWithWithoutInSubqueryRow
+skip_flattened_rewrite: without_unsupported
 required_capability: where_in_subquery_without_view
 required_capability: subquery_with_row
 required_capability: ts_command_v0
@@ -1623,6 +1632,7 @@ total_cost:double | _timeseries:keyword
 ;
 
 mainTsWithWithoutInSubqueryFrom
+skip_flattened_rewrite: without_unsupported
 required_capability: where_in_subquery_without_view
 required_capability: ts_command_v0
 required_capability: esql_without_grouping
@@ -1643,6 +1653,7 @@ total_cost:double | _timeseries:keyword
 
 // main query row command, subquery ts command
 rowMainInSubqueryTs
+skip_flattened_rewrite: subquery_bleed
 required_capability: where_in_subquery_without_view
 required_capability: subquery_with_ts
 required_capability: ts_command_v0

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-rate.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-rate.csv-spec
@@ -448,6 +448,7 @@ rate_bytes_in:double | cluster:keyword | time_bucket:datetime
 ;
 
 sum_rate_per_region
+skip_flattened_rewrite: mv_dimension
 required_capability: ts_command_v0
 required_capability: rate_with_interpolation_v2
 required_capability: pack_dimensions_in_ts

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-without.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-without.csv-spec
@@ -3,6 +3,7 @@
 
 
 without_single_dimension
+skip_flattened_rewrite: without_unsupported
 required_capability: esql_without_grouping
 // tag::docsWithoutSingleDimension[]
 TS k8s
@@ -21,6 +22,7 @@ total_cost:double | _timeseries:keyword
 
 
 without_multiple_dimensions
+skip_flattened_rewrite: without_unsupported
 required_capability: esql_without_grouping
 // tag::docsWithoutMultipleDimensions[]
 TS k8s
@@ -63,6 +65,7 @@ total_cost:double | _timeseries:keyword
 
 
 without_with_tbucket
+skip_flattened_rewrite: without_unsupported
 required_capability: esql_without_grouping
 required_capability: tbucket
 // tag::docsWithoutWithTbucket[]
@@ -82,6 +85,7 @@ total_cost:double | _timeseries:keyword                                      | t
 
 
 without_avg
+skip_flattened_rewrite: without_unsupported
 required_capability: esql_without_grouping
 TS k8s 
 | STATS avg_cost = avg(network.cost) BY WITHOUT(pod, region) 
@@ -95,6 +99,7 @@ avg_cost:double        | _timeseries:keyword
 
 
 without_max
+skip_flattened_rewrite: without_unsupported
 required_capability: esql_without_grouping
 TS k8s 
 | STATS max_cost = max(network.cost) BY WITHOUT(pod, region) 

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/metric_temporality.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/metric_temporality.csv-spec
@@ -3,6 +3,7 @@
 //TODO: When we support temporality, the rate/increase should be the same for all series
 
 multipleAggsWithoutTBucket
+skip_flattened_rewrite: metric_temporality
 required_capability: ts_command_v0
 required_capability: tsdb_temporality_support_v8
 
@@ -23,6 +24,7 @@ prod-null       | 0.2928479               | 264.0
 
 
 rateGroupedByTemporality
+skip_flattened_rewrite: metric_temporality
 required_capability: ts_command_v0
 required_capability: tsdb_temporality_support_v8
 
@@ -43,6 +45,7 @@ null                   | 0.2928479
 
 
 multipleAggsByTBucket
+skip_flattened_rewrite: metric_temporality
 required_capability: ts_command_v0
 required_capability: tsdb_temporality_support_v8
 
@@ -72,6 +75,7 @@ bucket:datetime          | cluster:keyword | bytes_per_second:double | bytes:dou
 
 
 irateWithoutTBucket
+skip_flattened_rewrite: metric_temporality
 required_capability: ts_command_v0
 required_capability: tsdb_temporality_support_v8
 
@@ -92,6 +96,7 @@ prod-null       | 0.5786293
 
 
 irateGroupedByTemporality
+skip_flattened_rewrite: metric_temporality
 required_capability: ts_command_v0
 required_capability: tsdb_temporality_support_v8
 
@@ -112,6 +117,7 @@ null                   | 0.5786293
 
 
 irateByTBucket
+skip_flattened_rewrite: metric_temporality
 required_capability: ts_command_v0
 required_capability: tsdb_temporality_support_v8
 
@@ -141,6 +147,7 @@ bucket:datetime          | cluster:keyword | irate_bytes:double
 
 
 histogramAggsWithoutTBucket
+skip_flattened_rewrite: metric_temporality
 required_capability: ts_command_v0
 required_capability: tsdb_temporality_support_v8
 
@@ -161,6 +168,7 @@ prod-null       | 667      | 600.0      | 523.18     | 11.0      | 998.0
 
 
 histogramAggsGroupedByTemporality
+skip_flattened_rewrite: metric_temporality
 required_capability: ts_command_v0
 required_capability: tsdb_temporality_support_v8
 
@@ -181,6 +189,7 @@ null                   | 667      | 600.0      | 523.18     | 11.0      | 998.0
 
 
 histogramAggsByTBucket
+skip_flattened_rewrite: metric_temporality
 required_capability: ts_command_v0
 required_capability: tsdb_temporality_support_v8
 
@@ -210,6 +219,7 @@ bucket:datetime          | cluster:keyword | cnt:long | med:double | avg:double 
 
 
 histogramOverTimeAggsByTemporality
+skip_flattened_rewrite: metric_temporality
 required_capability: ts_command_v0
 required_capability: tsdb_temporality_support_v8
 
@@ -236,6 +246,7 @@ null                   | 523.18        | 11.0          | 998.0         | 667    
 
 
 tdigestAggsWithoutTBucket
+skip_flattened_rewrite: metric_temporality
 required_capability: ts_command_v0
 required_capability: tsdb_temporality_support_v8
 
@@ -256,6 +267,7 @@ prod-null       | 667      | 503.0..603.0  | 523.18     | 11.0      | 998.0
 
 
 tdigestAggsGroupedByTemporality
+skip_flattened_rewrite: metric_temporality
 required_capability: ts_command_v0
 required_capability: tsdb_temporality_support_v8
 
@@ -276,6 +288,7 @@ null                   | 667      | 503.0..603.0  | 523.18     | 11.0      | 998
 
 
 tdigestAggsByTBucket
+skip_flattened_rewrite: metric_temporality
 required_capability: ts_command_v0
 required_capability: tsdb_temporality_support_v8
 
@@ -302,6 +315,7 @@ bucket:datetime          | cluster:keyword | cnt:long | med:double    | avg:doub
 
 
 tdigestOverTimeAggsByTemporality
+skip_flattened_rewrite: metric_temporality
 required_capability: ts_command_v0
 required_capability: tsdb_temporality_support_v8
 

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/subquery_with_ts_source.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/subquery_with_ts_source.csv-spec
@@ -52,6 +52,7 @@ null                     | null         | 0.161517
 ;
 
 subqueryInFromWithTsSubqueryRateWithBucket
+skip_flattened_rewrite: subquery_bleed
 required_capability: subquery_in_from_command
 required_capability: subquery_with_ts
 required_capability: ts_command_v0
@@ -80,6 +81,7 @@ null                     | null         | 3.19            | 2024-05-10T00:20:00.
 ;
 
 subqueryInFromWithTsSubqueryMaxOverTime
+skip_flattened_rewrite: subquery_bleed
 required_capability: subquery_in_from_command
 required_capability: subquery_with_ts
 required_capability: ts_command_v0
@@ -107,6 +109,7 @@ null                     | null         | qa              | 32.75       | 2024-0
 ;
 
 subqueryInFromWithTsSubqueryMinOverTime
+skip_flattened_rewrite: subquery_bleed
 required_capability: subquery_in_from_command
 required_capability: subquery_with_ts
 required_capability: ts_command_v0
@@ -130,6 +133,7 @@ null                     | null         | prod            | 29.0        | 2024-0
 ;
 
 subqueryInFromWithTsSubqueryAvgOverTime
+skip_flattened_rewrite: subquery_bleed
 required_capability: subquery_in_from_command
 required_capability: subquery_with_ts
 required_capability: ts_command_v0
@@ -154,6 +158,7 @@ null                     | null         | qa              | 12.375          | 20
 ;
 
 subqueryInFromWithTsSubquerySumOverTime
+skip_flattened_rewrite: subquery_bleed
 required_capability: subquery_in_from_command
 required_capability: subquery_with_ts
 required_capability: ts_command_v0
@@ -176,6 +181,7 @@ null                     | null         | qa              | 67.625          | 20
 ;
 
 subqueryInFromWithTsSubqueryCountOverTime
+skip_flattened_rewrite: subquery_bleed
 required_capability: subquery_in_from_command
 required_capability: subquery_with_ts
 required_capability: ts_command_v0
@@ -198,6 +204,7 @@ null                     | null         | prod            | 3          | 2024-05
 ;
 
 subqueryInFromWithTsSubqueryLastOverTime
+skip_flattened_rewrite: subquery_bleed
 required_capability: subquery_in_from_command
 required_capability: subquery_with_ts
 required_capability: ts_command_v0
@@ -222,6 +229,7 @@ null                     | null         | staging         | 12.5            | 20
 ;
 
 subqueryInFromWithTsSubqueryFirstOverTime
+skip_flattened_rewrite: subquery_bleed
 required_capability: subquery_in_from_command
 required_capability: subquery_with_ts
 required_capability: ts_command_v0
@@ -306,6 +314,7 @@ null                     | null         | staging         | 7403
 ;
 
 subqueryInFromWithMainIndexPatternWithTsAndFromSubqueries
+skip_flattened_rewrite: subquery_bleed
 required_capability: subquery_in_from_command
 required_capability: subquery_with_ts
 required_capability: ts_command_v0
@@ -329,6 +338,7 @@ null                     | null         | qa              | 10797
 ;
 
 subqueryInFromWithMainIndexPatternWithMixedTsRowAndFromSubqueries
+skip_flattened_rewrite: subquery_bleed
 required_capability: subquery_in_from_command
 required_capability: subquery_with_ts
 required_capability: subquery_with_row
@@ -398,6 +408,7 @@ null                     | null         | qa              | 10797
 ;
 
 subqueryInFromWithTsSubqueryWithEvalInMainQuery
+skip_flattened_rewrite: subquery_bleed
 required_capability: subquery_in_from_command
 required_capability: subquery_with_ts
 required_capability: ts_command_v0
@@ -445,6 +456,7 @@ null                     | null         | qa          | 10797
 ;
 
 subqueryInFromWithTsSubqueryWithDropInSubquery
+skip_flattened_rewrite: subquery_bleed
 required_capability: subquery_in_from_command
 required_capability: subquery_with_ts
 required_capability: ts_command_v0
@@ -467,6 +479,7 @@ null                     | null         | qa              | 13.1737
 ;
 
 subqueryInFromWithTsSubqueryWithKeepInSubquery
+skip_flattened_rewrite: subquery_bleed
 required_capability: subquery_in_from_command
 required_capability: subquery_with_ts
 required_capability: ts_command_v0
@@ -489,6 +502,7 @@ null                     | null         | qa              | 13.1737
 ;
 
 subqueryInFromWithTsSubqueryDownsampled
+skip_flattened_rewrite: subquery_bleed
 required_capability: subquery_in_from_command
 required_capability: subquery_with_ts
 required_capability: ts_command_v0
@@ -527,6 +541,7 @@ cnt:long
 ;
 
 subqueryInFromWithTsSubqueryWithFilterInSubqueryAndMainQuery
+skip_flattened_rewrite: subquery_bleed
 required_capability: subquery_in_from_command
 required_capability: subquery_with_ts
 required_capability: ts_command_v0
@@ -587,6 +602,7 @@ null                     | null         | 790.423509
 ;
 
 subqueryInFromWithTsSubqueryWithWhereOnPodInSubquery
+skip_flattened_rewrite: subquery_bleed
 required_capability: subquery_in_from_command
 required_capability: subquery_with_ts
 required_capability: ts_command_v0
@@ -612,6 +628,7 @@ null                     | null         | two         | false                   
 ;
 
 subqueryInFromWithTsSubqueryAndInlineStatsInSubquery
+skip_flattened_rewrite: subquery_bleed
 required_capability: subquery_in_from_command
 required_capability: subquery_with_ts
 required_capability: ts_command_v0
@@ -695,6 +712,7 @@ FROM
 // Mirrors castCounterDouble from k8s-counter.csv-spec - explicitly casts the
 // counter_double to double inside the TS subquery, then aggregates per (cluster, pod).
 subqueryInFromWithTsSubqueryCastCounterDouble
+skip_flattened_rewrite: subquery_bleed
 required_capability: subquery_in_from_command
 required_capability: subquery_with_ts
 required_capability: ts_command_v0
@@ -729,6 +747,7 @@ null                     | null         | 63.875            | qa              | 
 // Mirrors AggregateMetricDoubleStatsAfterBinaryOperator - filters an
 // aggregate_metric_double field with a binary operator and then aggregates.
 subqueryInFromWithTsSubqueryAndStatsAfterFilter
+skip_flattened_rewrite: subquery_bleed
 required_capability: subquery_in_from_command
 required_capability: subquery_with_ts
 required_capability: ts_command_v0
@@ -755,6 +774,7 @@ null                     | null         | two         | 540.0         | 1251.0
 // Mirrors AggregateMetricDoubleInlineFilterInStats - uses an inline WHERE
 // filter inside STATS over an aggregate_metric_double field.
 subqueryInFromWithTsSubqueryAmdInlineFilterInStats
+skip_flattened_rewrite: subquery_bleed
 required_capability: subquery_in_from_command
 required_capability: subquery_with_ts
 required_capability: ts_command_v0
@@ -782,6 +802,7 @@ null                     | null         | staging         | 539.0               
 // subquery exercising implicit casting between aggregate_metric_double and
 // double via *_over_time functions.
 subqueryInFromWithTsSubqueryAmdImplicitCastingAndStats
+skip_flattened_rewrite: subquery_bleed
 required_capability: subquery_in_from_command
 required_capability: subquery_with_ts
 required_capability: ts_command_v0
@@ -843,6 +864,7 @@ null           | 2023-10-23T13:33:34.937Z | 172.21.0.5   | null            | nul
 // METADATA _index is declared inside the TS subquery AND on the outer FROM,
 // so sample_data rows also carry the correct _index in the unioned result.
 subqueryInFromWithTsSubqueryAndMetadataIndexInBoth
+skip_flattened_rewrite: subquery_bleed
 required_capability: subquery_in_from_command
 required_capability: subquery_with_ts
 required_capability: ts_command_v0
@@ -921,6 +943,7 @@ null                     | null         | 790.423509      | 972
 
 // Mirrors percentile_over_time - exercises PERCENTILE_OVER_TIME with TBUCKET.
 subqueryInFromWithTsSubqueryPercentileOverTime
+skip_flattened_rewrite: subquery_bleed
 required_capability: subquery_in_from_command
 required_capability: subquery_with_ts
 required_capability: ts_command_v0
@@ -948,6 +971,7 @@ null                     | null         | prod            | 12.375          | 12
 // Mirrors absent_over_time - counterpart to the present_over_time pattern
 // already covered earlier in this file.
 subqueryInFromWithTsSubqueryAbsentOverTime
+skip_flattened_rewrite: subquery_bleed
 required_capability: subquery_in_from_command
 required_capability: subquery_with_ts
 required_capability: ts_command_v0
@@ -1002,6 +1026,7 @@ null                     | null         | 2024-05-10T00:02:00.000Z | 3.625     |
 
 // Mirrors derivative_of_gauge_metric - exercises DERIV inside a TS subquery.
 subqueryInFromWithTsSubqueryDeriv
+skip_flattened_rewrite: subquery_bleed
 required_capability: subquery_in_from_command
 required_capability: subquery_with_ts
 required_capability: ts_command_v0
@@ -1031,6 +1056,7 @@ null                     | null         | three       | 0.101674         | 2024-
 // Mirrors oneRateIncreaseWithBucketAndClusterThenFilter - exercises INCREASE
 // alongside RATE inside a TS subquery.
 subqueryInFromWithTsSubqueryRateAndIncrease
+skip_flattened_rewrite: subquery_bleed
 required_capability: subquery_in_from_command
 required_capability: subquery_with_ts
 required_capability: ts_command_v0
@@ -1060,6 +1086,7 @@ null                     | null         | prod            | 64.5       | 2287.44
 // Mirrors GroupingOnScalarFunction - groups by a scalar function (to_upper(pod))
 // inside a TS subquery.
 subqueryInFromWithTsSubqueryStatsByScalarFunction
+skip_flattened_rewrite: subquery_bleed
 required_capability: subquery_in_from_command
 required_capability: subquery_with_ts
 required_capability: ts_command_v0
@@ -1085,6 +1112,7 @@ null                     | null         | TWO         | 12.375   | 2024-05-10T00
 // Mirrors windowSmallerThanBucket - exercises MAX_OVER_TIME with an explicit
 // look-back window smaller than the bucket size.
 subqueryInFromWithTsSubqueryMaxOverTimeWithWindow
+skip_flattened_rewrite: subquery_bleed
 required_capability: subquery_in_from_command
 required_capability: subquery_with_ts
 required_capability: ts_command_v0
@@ -1120,6 +1148,7 @@ null                     | null         | prod            | one         | 9.375 
 // Mirrors storedSourceTimeseriesGroupByAllImplicitly - exercises the
 // stored-source TSDB variant as the TS subquery source.
 subqueryInFromWithTsSubqueryStoredSource
+skip_flattened_rewrite: subquery_bleed
 required_capability: subquery_in_from_command
 required_capability: subquery_with_ts
 required_capability: ts_command_v0
@@ -1146,6 +1175,7 @@ null                     | null         | prod            | three       | 8.375
 // output column and is not addressable in subsequent EVAL/KEEP/outer query
 // stages, so the union surfaces only avg_cost from the subquery.
 subqueryInFromWithTsSubqueryWithoutGrouping
+skip_flattened_rewrite: subquery_bleed
 required_capability: subquery_in_from_command
 required_capability: subquery_with_ts
 required_capability: ts_command_v0
@@ -1169,6 +1199,7 @@ null                     | null         | 8.833333        | "{""cluster"":""qa""
 
 // Mirrors irate_of_long_grouping - exercises IRATE inside a TS subquery.
 subqueryInFromWithTsSubqueryIrate
+skip_flattened_rewrite: subquery_bleed
 required_capability: subquery_in_from_command
 required_capability: subquery_with_ts
 required_capability: ts_command_v0
@@ -1271,6 +1302,7 @@ null                     | null         | 2024-05-10T00:02:00.000Z | 3487       
 // Mirrors count_distinct_over_time_of_long - exercises COUNT_DISTINCT_OVER_TIME
 // in a TS subquery.
 subqueryInFromWithTsSubqueryCountDistinctOverTime
+skip_flattened_rewrite: subquery_bleed
 required_capability: subquery_in_from_command
 required_capability: subquery_with_ts
 required_capability: ts_command_v0

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvFlattenedKeywordIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvFlattenedKeywordIT.java
@@ -10,9 +10,16 @@ package org.elasticsearch.xpack.esql;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Booleans;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentFactory;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentParserConfiguration;
+import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.junit.AfterClass;
 import org.junit.AssumptionViolatedException;
@@ -632,6 +639,33 @@ public class CsvFlattenedKeywordIT extends CsvIT {
         }
 
         @Override
+        public Settings transformSettings(CsvTestsDataLoader.TestDataset dataset, Settings settings) {
+            // Update dimensions in the routing path to their transformed path
+            List<String> routingPaths = settings.getAsList("index.routing_path");
+            if (routingPaths.isEmpty()) {
+                return settings;
+            }
+            Set<String> convertedPaths = keywordPathsByDatasetIndexName.getOrDefault(dataset.indexName(), Set.of());
+            if (convertedPaths.isEmpty()) {
+                return settings;
+            }
+            boolean changed = false;
+            List<String> rewritten = new ArrayList<>(routingPaths.size());
+            for (String path : routingPaths) {
+                if (convertedPaths.contains(path)) {
+                    rewritten.add(path + "." + KeywordToFlattenedTransformer.WRAPPER_SUBKEY);
+                    changed = true;
+                } else {
+                    rewritten.add(path);
+                }
+            }
+            if (changed == false) {
+                return settings;
+            }
+            return Settings.builder().put(settings).putList("index.routing_path", rewritten).build();
+        }
+
+        @Override
         public String transformDocument(CsvTestsDataLoader.TestDataset dataset, String originalDocumentJson) throws IOException {
             Set<String> paths = keywordPathsByDatasetIndexName.getOrDefault(dataset.indexName(), Set.of());
             return KeywordToFlattenedTransformer.wrapKeywordValuesAsFlattened(originalDocumentJson, paths);
@@ -639,6 +673,18 @@ public class CsvFlattenedKeywordIT extends CsvIT {
 
         @Override
         public String transformQuery(String testId, CsvSpecReader.CsvTestCase testCase) {
+            // Tests requiring ts_info_command or metrics_info_command expose TSDB dimension names
+            // directly in query output (e.g. _timeseries, _tsid). After the keyword→flattened
+            // rewrite those names change from "cluster" to "cluster.v", so the expected results
+            // no longer match. Skip the whole variant for these tests rather than updating every
+            // expected result to the sub-key form.
+            for (String cap : testCase.requiredCapabilities) {
+                if (cap.equals("ts_info_command") || cap.equals("metrics_info_command")) {
+                    throw new StacklessAssumptionViolatedException(
+                        "skipping: test requires " + cap + " which exposes raw TSDB dimension names in output"
+                    );
+                }
+            }
             // A {@code skip_flattened_rewrite:} preamble line marks a test whose failure under
             // this variant is a known limitation of field_extract() or of an upstream
             // grammar/engine constraint. Running the rewrite would only reproduce the
@@ -712,6 +758,94 @@ public class CsvFlattenedKeywordIT extends CsvIT {
                 logger.info("keyword→flattened: rewritten query:\n{}", result.rewrittenQuery());
             }
             return result.rewrittenQuery();
+        }
+
+        /**
+         * Rewrites the expected {@code _timeseries} column values so they reflect the
+         * dimension-key rename that TSDB applies after the keyword&rarr;flattened conversion.
+         */
+        @Override
+        public CsvTestUtils.ExpectedResults transformExpectedResults(
+            String testId,
+            CsvSpecReader.CsvTestCase testCase,
+            CsvTestUtils.ExpectedResults expected
+        ) {
+            int tsIdx = expected.columnNames().indexOf("_timeseries");
+            if (tsIdx < 0) {
+                return expected;
+            }
+            Set<String> convertedPaths = resolveKeywordPathsForQuery(testCase.query);
+            if (convertedPaths.isEmpty()) {
+                return expected;
+            }
+            boolean anyChanged = false;
+            List<List<Object>> newValues = new ArrayList<>(expected.values().size());
+            for (List<Object> row : expected.values()) {
+                Object tsValue = row.get(tsIdx);
+                if (tsValue == null) {
+                    newValues.add(row);
+                    continue;
+                }
+                String tsJson = tsValue.toString();
+                String rewritten = rewriteTimeseriesJson(tsJson, convertedPaths);
+                if (rewritten.equals(tsJson)) {
+                    newValues.add(row);
+                } else {
+                    List<Object> newRow = new ArrayList<>(row);
+                    newRow.set(tsIdx, rewritten);
+                    newValues.add(newRow);
+                    anyChanged = true;
+                }
+            }
+            if (anyChanged == false) {
+                return expected;
+            }
+            return new CsvTestUtils.ExpectedResults(expected.columnNames(), expected.columnTypes(), newValues);
+        }
+
+        /**
+         * Parses {@code json} as a JSON object, and for every key that appears in
+         * {@code convertedPaths} wraps the value {@code V} as
+         * {@code {"v": V}} (where {@code "v"} is
+         * {@link KeywordToFlattenedTransformer#WRAPPER_SUBKEY}), then re-serialises the result.
+         * This reflects the TSDB dimension representation change: a keyword dimension
+         * {@code host:"host-a"} becomes a flattened dimension
+         * {@code host:{"v":"host-a"}} after the keyword&rarr;flattened conversion.
+         * Returns the original {@code json} string unchanged if parsing fails or no key is found
+         * in {@code convertedPaths}.
+         */
+        private static String rewriteTimeseriesJson(String json, Set<String> convertedPaths) {
+            try (
+                XContentParser parser = XContentType.JSON.xContent().createParser(XContentParserConfiguration.EMPTY, json);
+                XContentBuilder builder = XContentFactory.jsonBuilder()
+            ) {
+                if (parser.nextToken() != XContentParser.Token.START_OBJECT) {
+                    return json;
+                }
+                boolean changed = false;
+                builder.startObject();
+                while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+                    String fieldName = parser.currentName();
+                    parser.nextToken(); // advance to value token
+                    if (convertedPaths.contains(fieldName)) {
+                        builder.startObject(fieldName);
+                        builder.field(KeywordToFlattenedTransformer.WRAPPER_SUBKEY);
+                        builder.copyCurrentStructure(parser);
+                        builder.endObject();
+                        changed = true;
+                    } else {
+                        builder.field(fieldName);
+                        builder.copyCurrentStructure(parser);
+                    }
+                }
+                builder.endObject();
+                if (changed == false) {
+                    return json;
+                }
+                return Strings.toString(builder);
+            } catch (IOException e) {
+                return json;
+            }
         }
 
         /**

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvIT.java
@@ -147,6 +147,11 @@ public class CsvIT extends ESTestCase {
         String transformMapping(CsvTestsDataLoader.TestDataset dataset, String originalMapping) throws IOException;
 
         /**
+         * Returns the index settings to use when creating the index for {@code dataset}.
+         */
+        Settings transformSettings(CsvTestsDataLoader.TestDataset dataset, Settings settings);
+
+        /**
          * Returns the document source JSON to bulk-index for {@code dataset}. Called once per CSV row.
          */
         String transformDocument(CsvTestsDataLoader.TestDataset dataset, String originalDocumentJson) throws IOException;
@@ -167,12 +172,23 @@ public class CsvIT extends ESTestCase {
          * appears in the query and so re-running the spec would only re-test the unmodified behavior.
          */
         String transformQuery(String testId, CsvSpecReader.CsvTestCase testCase);
+
+        /**
+         * Transforms the expected results loaded from the csv-spec entry before they are compared
+         * against the actual query output.
+         */
+        ExpectedResults transformExpectedResults(String testId, CsvSpecReader.CsvTestCase testCase, ExpectedResults expected);
     }
 
     public static final IndexLoadStrategy IDENTITY_INDEX_LOAD_STRATEGY = new IndexLoadStrategy() {
         @Override
         public String transformMapping(CsvTestsDataLoader.TestDataset dataset, String originalMapping) {
             return originalMapping;
+        }
+
+        @Override
+        public Settings transformSettings(CsvTestsDataLoader.TestDataset dataset, Settings settings) {
+            return settings;
         }
 
         @Override
@@ -183,6 +199,11 @@ public class CsvIT extends ESTestCase {
         @Override
         public String transformQuery(String testId, CsvSpecReader.CsvTestCase testCase) {
             return testCase.query;
+        }
+
+        @Override
+        public ExpectedResults transformExpectedResults(String testId, CsvSpecReader.CsvTestCase testCase, ExpectedResults expected) {
+            return expected;
         }
     };
 
@@ -335,7 +356,11 @@ public class CsvIT extends ESTestCase {
         // Using a longer timeout here as test infrastructure might populate data lazily while request is in progress.
         try (var response = listener.actionGet(5, TimeUnit.MINUTES)) {
             assertFalse("response must not be partial: " + response.getExecutionInfo(), response.isPartial());
-            ExpectedResults expected = loadCsvSpecValues(testCase.expectedResults);
+            ExpectedResults expected = indexLoadStrategy.transformExpectedResults(
+                groupName + "." + testName,
+                testCase,
+                loadCsvSpecValues(testCase.expectedResults)
+            );
             ActualResults actual = new ActualResults(
                 response.zoneId(),
                 response.columns().stream().map(ColumnInfoImpl::name).toList(),
@@ -521,14 +546,8 @@ public class CsvIT extends ESTestCase {
                 inference.maybeLoad(inferenceId, INFERENCE_CONFIGS.get(inferenceId));
             }
             String mapping = indexLoadStrategy.transformMapping(dataset, CsvTestsDataLoader.readMappingFile(dataset));
-            assertAcked(
-                cluster.client()
-                    .admin()
-                    .indices()
-                    .prepareCreate(dataset.indexName())
-                    .setMapping(mapping)
-                    .setSettings(dataset.loadSettings())
-            );
+            Settings settings = indexLoadStrategy.transformSettings(dataset, dataset.loadSettings());
+            assertAcked(cluster.client().admin().indices().prepareCreate(dataset.indexName()).setMapping(mapping).setSettings(settings));
             if (dataset.dataFileName() != null) {
                 var bulk = cluster.client().prepareBulk().setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
                 for (var document : CsvTestsDataLoader.readCsvDocuments(dataset.streamData(), dataset.allowSubFields())) {

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/KeywordToFlattenedTransformer.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/KeywordToFlattenedTransformer.java
@@ -50,12 +50,6 @@ import java.util.Set;
  * are rewritten elsewhere in the pipeline. The denylist is exposed via
  * {@link #PARAMS_INCOMPATIBLE_WITH_FLATTENED}.
  * <ul>
- *   <li>{@code time_series_dimension} &mdash; a TSDB dimension marker that exists on
- *       {@code keyword} but not on {@code flattened} (the flattened equivalent is the
- *       {@code time_series_dimensions} plural list with sub-paths, which is incompatible with the
- *       wrapping convention used here). Without this exclusion, every TSDB dataset's index
- *       creation fails with
- *       {@code unknown parameter [time_series_dimension] on mapper [...] of type [flattened]}.</li>
  *   <li>{@code time_series_metric} &mdash; a TSDB metric marker. Defensive: in practice only set
  *       on numeric fields, but a stray entry on a keyword would also fail mapper parsing.</li>
  *   <li>{@code fields} &mdash; multi-field declarations. The sub-fields under {@code fields}
@@ -72,6 +66,15 @@ import java.util.Set;
  * Anything else that flattened still rejects can be added to the denylist; the failure mode is
  * always the same {@code MapperParsingException} at index creation time, so new entries are easy
  * to locate from the test failure log.
+ *
+ * <h2>TSDB dimension keyword fields</h2>
+ * {@code keyword} fields that declare {@code time_series_dimension: true} are handled specially
+ * rather than being left as {@code keyword}: they are converted to {@code flattened} with
+ * {@code time_series_dimensions: ["v"]}. This makes the dimension value reachable via
+ * {@code field_extract(field, "v")} just like any other converted field. Callers that also create
+ * the index must update {@code index.routing_path} accordingly &mdash; bare paths such as
+ * {@code "pod"} must become {@code "pod.v"} &mdash; because TSDB resolves routing through the
+ * flattened sub-key, not the parent field name.
  *
  * <h2>Caller-supplied path exclusions</h2>
  * The overload {@link #transformMapping(String, Set)} accepts a set of dotted field paths that the
@@ -93,13 +96,7 @@ public final class KeywordToFlattenedTransformer {
      * keyword&rarr;flattened rewrite unsafe. Encountering any of these causes the field to be
      * left untouched. See class-level Javadoc for the per-parameter rationale.
      */
-    public static final Set<String> PARAMS_INCOMPATIBLE_WITH_FLATTENED = Set.of(
-        "time_series_dimension",
-        "time_series_metric",
-        "fields",
-        "copy_to",
-        "script"
-    );
+    public static final Set<String> PARAMS_INCOMPATIBLE_WITH_FLATTENED = Set.of("time_series_metric", "fields", "copy_to", "script");
 
     private static final String KEYWORD_TYPE = "keyword";
     private static final String FLATTENED_TYPE = "flattened";
@@ -296,14 +293,24 @@ public final class KeywordToFlattenedTransformer {
 
             JsonNode typeNode = fieldObj.get("type");
             if (typeNode != null && typeNode.isTextual() && KEYWORD_TYPE.equals(typeNode.asText())) {
-                String incompatibleParam = findIncompatibleParameter(fieldObj);
-                if (incompatibleParam != null) {
-                    skipped.add(new SkippedField(fullPath, SkipReason.INCOMPATIBLE_PARAMETER, incompatibleParam));
-                } else if (excludedPaths.contains(fullPath)) {
+                if (excludedPaths.contains(fullPath)) {
                     skipped.add(new SkippedField(fullPath, SkipReason.CALLER_EXCLUDED_PATH, null));
-                } else {
+                } else if (fieldObj.has("time_series_dimension")) {
+                    // TSDB dimension: convert to flattened with the wrapper sub-key as the dimension.
+                    // The caller must also rewrite index.routing_path entries for this field from
+                    // "field" to "field.v" so TSDB resolves routing through the flattened sub-key.
                     fieldObj.put("type", FLATTENED_TYPE);
+                    fieldObj.remove("time_series_dimension");
+                    fieldObj.putArray("time_series_dimensions").add(WRAPPER_SUBKEY);
                     paths.add(fullPath);
+                } else {
+                    String incompatibleParam = findIncompatibleParameter(fieldObj);
+                    if (incompatibleParam != null) {
+                        skipped.add(new SkippedField(fullPath, SkipReason.INCOMPATIBLE_PARAMETER, incompatibleParam));
+                    } else {
+                        fieldObj.put("type", FLATTENED_TYPE);
+                        paths.add(fullPath);
+                    }
                 }
             }
             JsonNode nested = fieldObj.path("properties");


### PR DESCRIPTION
Updates the csv-spec test transformer for `flattened` fields to support `time_series_dimension`s. This lets us automatically run 486 more tests, about 63 of which fail. I fixed a few, and will track the rest for later.

This takes index configs like:
```
{
  "mappings": { "properties": {
    "cluster": { "type": "keyword", "time_series_dimension": true }
  }},
  "settings": { "index.routing_path": ["cluster"] }
}
```

and transforms them into:
```
{
  "mappings": { "properties": {
    "cluster": { "type": "flattened", "time_series_dimensions": ["v"] }
  }},
  "settings": { "index.routing_path": ["cluster.v"] }
}
```

and then runs the tests.
