### PR TITLE
ES|QL: Skip QueryBuilderResolver#rewrite when runtime match is used

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/capabilities/RewriteableAware.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/capabilities/RewriteableAware.java
@@ -28,4 +28,10 @@ public interface RewriteableAware extends TranslationAware {
      */
     Expression replaceQueryBuilder(QueryBuilder queryBuilder);
 
+    /**
+     * @return true if the `QueryBuilder` needs to be rewritten, false otherwise.
+     * If no rewrite is required, this instance will be skipped during the rewrite phase in
+     * {@link org.elasticsearch.xpack.esql.expression.function.fulltext.QueryBuilderResolver#resolveQueryBuilders}.
+     */
+    boolean requiresQueryBuilderRewrite();
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/FullTextFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/FullTextFunction.java
@@ -625,6 +625,11 @@ public abstract class FullTextFunction extends Function
         };
     }
 
+    @Override
+    public boolean requiresQueryBuilderRewrite() {
+        return false == isRuntimeSearch();
+    }
+
     /**
      * Check if the full-text function exists only in the current node (not in child nodes)
      */

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/QueryBuilderResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/QueryBuilderResolver.java
@@ -43,7 +43,7 @@ public final class QueryBuilderResolver {
         var hasRewriteableAwareFunctions = plan.anyMatch(p -> {
             Holder<Boolean> hasRewriteable = new Holder<>(false);
             p.forEachExpression(expr -> {
-                if (expr instanceof RewriteableAware) {
+                if (expr instanceof RewriteableAware rewriteableAware && rewriteableAware.requiresQueryBuilderRewrite()) {
                     hasRewriteable.set(true);
                 }
             });
@@ -97,12 +97,8 @@ public final class QueryBuilderResolver {
             Holder<IOException> exceptionHolder = new Holder<>();
             Holder<Boolean> updated = new Holder<>(false);
             LogicalPlan newPlan = plan.transformExpressionsDown(Expression.class, expr -> {
-                if (expr instanceof FullTextFunction ftf && ftf.isRuntimeSearch()) {
-                    return expr;
-                }
-
                 Expression finalExpression = expr;
-                if (expr instanceof RewriteableAware rewriteableAware) {
+                if (expr instanceof RewriteableAware rewriteableAware && rewriteableAware.requiresQueryBuilderRewrite()) {
                     QueryBuilder builder = rewriteableAware.queryBuilder(), initial = builder;
                     builder = builder == null
                         ? rewriteableAware.asQuery(LucenePushdownPredicates.DEFAULT, TranslatorHandler.TRANSLATOR_HANDLER).toQueryBuilder()


### PR DESCRIPTION
In the case where match runs on runtime expressions, we can skip the query builder rewrite that happens on the coordinator (during `PreMapper`).
We already do this, we don't generate a query builder for match in this case:

https://github.com/elastic/elasticsearch/blob/a3cde96e6434a399d3472b547c77dfc2830ba593/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/QueryBuilderResolver.java#L100-L102

 However we still go through initializing `QueryBuilderResolver.FunctionsRewritable` and calling `#rewrite`.
 We could short circuit this altogether if we have this check in `QueryBuilderResolver#resolveQueryBuilders`.
 Also instead of relying on `isRuntimeSearch` which is a method of `FullTextFunction`, we extend `RewritableAware` to make this check more generic.
