### PR TITLE
[9.4] [Test] Ensure stable cluster before ending the test (#151056)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -290,9 +290,6 @@ tests:
 - class: org.elasticsearch.reindex.ReindexBasicTests
   method: testReindexFailsWhenSourceIndexIsClosed
   issue: https://github.com/elastic/elasticsearch/issues/151024
-- class: org.elasticsearch.xpack.slm.SLMStatDisruptionIT
-  method: testFailedSnapshotSubmitStats
-  issue: https://github.com/elastic/elasticsearch/issues/151025
 
 # Examples:
 #

--- a/x-pack/plugin/slm/src/internalClusterTest/java/org/elasticsearch/xpack/slm/SLMStatDisruptionIT.java
+++ b/x-pack/plugin/slm/src/internalClusterTest/java/org/elasticsearch/xpack/slm/SLMStatDisruptionIT.java
@@ -575,6 +575,7 @@ public class SLMStatDisruptionIT extends AbstractSnapshotIntegTestCase {
             assertSnapshotPartial(repoName, snapshotName);
             assertMetadata(policyName, 0, 1, 1);
         }, 1, TimeUnit.MINUTES);
+        ensureStableCluster(2);
     }
 
     private void assertMetadata(String policyName, long taken, long failure, long invocationsSinceLastSuccess) {


### PR DESCRIPTION
Backports the following commits to 9.4:
 - [Test] Ensure stable cluster before ending the test (#151056)