### PR TITLE
Fix RandomizedTimeSeriesIT test failure

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -602,9 +602,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.core.anonymizer.AnonymizationContextTests
   method: testNullClusterUuidDoesNotNpe
   issue: https://github.com/elastic/elasticsearch/issues/150887
-- class: org.elasticsearch.xpack.esql.action.RandomizedTimeSeriesIT
-  method: testRateGroupBySubset
-  issue: https://github.com/elastic/elasticsearch/issues/150867
 - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
   method: test {csv-spec:topN.topNLongRangeWildcardSort}
   issue: https://github.com/elastic/elasticsearch/issues/150874

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/RandomizedTimeSeriesIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/RandomizedTimeSeriesIT.java
@@ -634,7 +634,7 @@ public class RandomizedTimeSeriesIT extends AbstractEsqlIntegTestCase {
         var dimensions = ESTestCase.randomSubsetOf(dataGenerationHelper.attributesForMetrics);
         var dimensionsStr = dimensions.isEmpty()
             ? ""
-            : ", " + dimensions.stream().map(d -> "attributes." + d).collect(Collectors.joining(", "));
+            : ", " + dimensions.stream().map(d -> "attributes.`" + d + "`").collect(Collectors.joining(", "));
         var query = String.format(Locale.ROOT, """
             TS %s
             | STATS count(<DELTAGG>(metrics.<METRIC>)),
@@ -747,7 +747,7 @@ public class RandomizedTimeSeriesIT extends AbstractEsqlIntegTestCase {
         var dimensions = ESTestCase.randomSubsetOf(dataGenerationHelper.attributesForMetrics);
         var dimensionsStr = dimensions.isEmpty()
             ? ""
-            : ", " + dimensions.stream().map(d -> "attributes." + d).collect(Collectors.joining(", "));
+            : ", " + dimensions.stream().map(d -> "attributes.`" + d + "`").collect(Collectors.joining(", "));
         var metricName = ESTestCase.randomFrom(List.of("gaugel_hdd.bytes.used", "gauged_cpu.percent"));
         var selectedAggs = ESTestCase.randomSubsetOf(2, Agg.values());
         var aggExpression = String.format(
@@ -819,7 +819,7 @@ public class RandomizedTimeSeriesIT extends AbstractEsqlIntegTestCase {
      */
     public void testGroupBySubset() {
         var dimensions = ESTestCase.randomNonEmptySubsetOf(dataGenerationHelper.attributesForMetrics);
-        var dimensionsStr = dimensions.stream().map(d -> "attributes." + d).collect(Collectors.joining(", "));
+        var dimensionsStr = dimensions.stream().map(d -> "attributes.`" + d + "`").collect(Collectors.joining(", "));
         var query = String.format(Locale.ROOT, """
             TS %s
             | STATS


### PR DESCRIPTION
Fixes #150867

## What

The ES|QL integration test `RandomizedTimeSeriesIT.testRateGroupBySubset` failed: the `STATS ... BY` query it builds at random could not be parsed, raising `ParsingException: no viable alternative at input 'attributes.AND'`.

## Root cause

The test composed grouping keys as unescaped `attributes.<name>`, where `<name>` is a randomly generated dimension name. Because the ES|QL lexer is case-insensitive, a generated name that collides with a reserved keyword (here `AND`) is tokenized as that keyword rather than as an identifier, so the unquoted field reference is a syntax error. The fix wraps the attribute-name segment in backticks in all three query builders, which is the standard ES|QL way to use a keyword as an identifier.

Verified against base `321be9a86702ae310b60228c2cf5579c5ddeecbd`: the named test passes (Goal 1) and the project's test task is green (Goal 2).
This PR also removes the test's `muted-tests.yml` entry, so CI will run it again.
