### PR TITLE
Fixed failing test DocValuesCodecDuelTests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -251,9 +251,6 @@ tests:
 - class: org.elasticsearch.xpack.ml.integration.MlDistributedFailureIT
   method: testFullClusterRestart
   issue: https://github.com/elastic/elasticsearch/issues/150960
-- class: org.elasticsearch.index.codec.tsdb.DocValuesCodecDuelTests
-  method: testDuel
-  issue: https://github.com/elastic/elasticsearch/issues/150972
 - class: org.elasticsearch.gradle.internal.test.rest.LegacyYamlRestTestPluginFuncTest
   method: plugin projects are wired into test cluster setup
   issue: https://github.com/elastic/elasticsearch/issues/148014

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/DocValuesCodecDuelTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/DocValuesCodecDuelTests.java
@@ -60,7 +60,7 @@ public class DocValuesCodecDuelTests extends ESTestCase {
 
                 final DocValuesFormat docValuesFormat = randomBoolean()
                     ? new ES819Version3TSDBDocValuesFormat(
-                        ESTestCase.randomIntBetween(1, 4096),
+                        ESTestCase.randomIntBetween(2, 4096),
                         ESTestCase.randomIntBetween(1, 512),
                         random().nextBoolean(),
                         ES819TSDBDocValuesFormatTests.randomBinaryCompressionMode(),


### PR DESCRIPTION
In `DocValuesCodecDuelTests`, `skipIndexIntervalSize` was randomized as `randomIntBetween(1, 4096)`, but `ES819TSDBDocValuesFormat`'s constructor rejects any value < 2. The seed happened to roll a 1.

Fixes https://github.com/elastic/elasticsearch/issues/150972