### PR TITLE
Fix ES94BloomFilterDocValuesFormatTests test failure

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -593,9 +593,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.action.ExternalNdJsonMultiScanPushdownIT
   method: testMultiScanColdDoesNotDoubleCountWarmCountStar
   issue: https://github.com/elastic/elasticsearch/issues/150837
-- class: org.elasticsearch.index.codec.bloomfilter.ES94BloomFilterDocValuesFormatTests
-  method: testMergedBloomFilterUsesMaxSize
-  issue: https://github.com/elastic/elasticsearch/issues/150843
 - class: org.elasticsearch.xpack.esql.qa.ndjson.NdJsonFormatSpecIT
   method: test {csv-spec:external-basic.forkTwoBranches [AZURE]}
   issue: https://github.com/elastic/elasticsearch/issues/150844

--- a/server/src/test/java/org/elasticsearch/index/codec/bloomfilter/ES94BloomFilterDocValuesFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/bloomfilter/ES94BloomFilterDocValuesFormatTests.java
@@ -23,6 +23,7 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.LogMergePolicy;
 import org.apache.lucene.index.StandardDirectoryReader;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.tests.codecs.asserting.AssertingCodec;
@@ -214,7 +215,9 @@ public class ES94BloomFilterDocValuesFormatTests extends ESTestCase {
                     return (flushCount.getAndIncrement() % 2 == 0) ? smallSize : largeSize;
                 }
             }));
-            conf.setMergePolicy(newLogMergePolicy());
+            LogMergePolicy mergePolicy = newLogMergePolicy();
+            mergePolicy.setMergeFactor(1000);
+            conf.setMergePolicy(mergePolicy);
             conf.setMaxBufferedDocs(10);
             conf.setUseCompoundFile(false);
             try (IndexWriter writer = new IndexWriter(directory, conf)) {


### PR DESCRIPTION
Fixes #150843

## What

The test `testMergedBloomFilterUsesMaxSize` asserted that after writing docs there would be multiple index segments before calling `forceMerge(1)`, but with seed `AEA9DB71835F47C1` the assertion failed because `directoryReader.leaves().size()` was 1 instead of `> 1`.


## Root cause

`newLogMergePolicy()` in `LuceneTestCase` randomises `mergeFactor` between 2 and 9. With a small `mergeFactor` (e.g. 2) and `atLeast(50)` returning a doc count whose resulting flush count is an exact power of the merge factor (e.g. 8 flushes → 8 level-0 segments that collapse to 4 → 2 → 1), all segments are automatically merged away before the precondition assertion runs. The fix pins the merge factor to 1000 in `testMergedBloomFilterUsesMaxSize` so that automatic merging cannot occur during the initial indexing phase, guaranteeing the multiple-segment precondition is met regardless of the random seed.

Verified against base `321be9a86702ae310b60228c2cf5579c5ddeecbd`: the named test passes (Goal 1) and the project's test task is green (Goal 2).
This PR also removes the test's `muted-tests.yml` entry, so CI will run it again.
