### PR TITLE
Use Locale.ENGLISH in Painless day-of-week display-name examples

### DIFF
--- a/docs/reference/elasticsearch/index-settings/mapping-limit.md
+++ b/docs/reference/elasticsearch/index-settings/mapping-limit.md
@@ -122,7 +122,7 @@ Runtime fields also count towards the limit:
       "day_of_week": {
         "type": "keyword",
         "script": {
-          "source": "emit(doc['timestamp'].value.dayOfWeekEnum.getDisplayName(TextStyle.FULL, Locale.ROOT))"
+          "source": "emit(doc['timestamp'].value.dayOfWeekEnum.getDisplayName(TextStyle.FULL, Locale.ENGLISH))"
         }
       }
     }

--- a/docs/reference/scripting-languages/painless/painless-runtime-fields-context.md
+++ b/docs/reference/scripting-languages/painless/painless-runtime-fields-context.md
@@ -110,7 +110,7 @@ PUT kibana_sample_data_ecommerce/_mapping
     "full_day_name": {
       "type": "keyword",
       "script": {
-        "source": """emit(doc['order_date'].value.dayOfWeekEnum.getDisplayName(TextStyle.FULL, Locale.ROOT));
+        "source": """emit(doc['order_date'].value.dayOfWeekEnum.getDisplayName(TextStyle.FULL, Locale.ENGLISH));
         """
       }
     }
@@ -156,31 +156,31 @@ Response:
       "sum_other_doc_count": 0,
       "buckets": [
         {
-          "key": "Thu",
+          "key": "Thursday",
           "doc_count": 775
         },
         {
-          "key": "Fri",
+          "key": "Friday",
           "doc_count": 770
         },
         {
-          "key": "Sat",
+          "key": "Saturday",
           "doc_count": 736
         },
         {
-          "key": "Sun",
+          "key": "Sunday",
           "doc_count": 614
         },
         {
-          "key": "Tue",
+          "key": "Tuesday",
           "doc_count": 609
         },
         {
-          "key": "Wed",
+          "key": "Wednesday",
           "doc_count": 592
         },
         {
-          "key": "Mon",
+          "key": "Monday",
           "doc_count": 579
         }
       ]

--- a/docs/reference/scripting-languages/painless/use-painless-scripts-in-runtime-fields.md
+++ b/docs/reference/scripting-languages/painless/use-painless-scripts-in-runtime-fields.md
@@ -38,7 +38,7 @@ PUT my-index/
         "script": {
           "source":
           """emit(doc['@timestamp'].value.dayOfWeekEnum
-          .getDisplayName(TextStyle.FULL, Locale.ROOT))"""
+          .getDisplayName(TextStyle.FULL, Locale.ENGLISH))"""
         }
       }
     },
@@ -67,7 +67,7 @@ GET my-index/_search
       "script": {
         "source":
         """emit(doc['@timestamp'].value.dayOfWeekEnum
-        .getDisplayName(TextStyle.FULL, Locale.ROOT))"""
+        .getDisplayName(TextStyle.FULL, Locale.ENGLISH))"""
       }
     }
   },


### PR DESCRIPTION
Replaces `Locale.ROOT` with `Locale.ENGLISH` in the Painless runtime fields examples that call `dayOfWeekEnum.getDisplayName(TextStyle.FULL, ...)`. With `Locale.ROOT`, `getDisplayName` returns the short standalone form (e.g. `Mon`, `Tue`), which is not what the surrounding examples expect. Switching to `Locale.ENGLISH` makes the documentation return the full day name (`Monday`, `Tuesday`, ...), matching the rest of the example output and the existing usages in `painless-api-examples.md` and `search-aggregations-bucket-composite-aggregation.md`.

Also updates the corresponding example response in `painless-runtime-fields-context.md` so that the aggregation bucket keys (`Thu`, `Fri`, ...) are shown as the full names (`Thursday`, `Friday`, ...), consistent with the corrected script.

Files changed:

- `docs/reference/elasticsearch/index-settings/mapping-limit.md`
- `docs/reference/scripting-languages/painless/painless-runtime-fields-context.md`
- `docs/reference/scripting-languages/painless/use-painless-scripts-in-runtime-fields.md`

Resolves #149497

- [x] I have signed the [contributor license agreement](https://www.elastic.co/contributor-agreement).
- [x] I have followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md).
- This is a documentation-only change (no code), so building with `gradle check` and the OS/architecture support matrix do not apply.
- [x] The pull request targets `main`.
- [x] This is not a class submission.