### PR TITLE
[CI] Ensure java is present before running GradleRunner, fall back to gradlew

### DIFF
--- a/.buildkite/hooks/pre-command.bat
+++ b/.buildkite/hooks/pre-command.bat
@@ -7,10 +7,10 @@ SET JAVA_HOME=%USERPROFILE%\.java\%ES_BUILD_JAVA%
 SET JAVA16_HOME=%USERPROFILE%\.java\openjdk16
 SET PATH=%PATH%;%USERPROFILE%\.java\%ES_BUILD_JAVA%\bin
 
-SET GRADLEW=./gradlew --parallel --no-daemon --scan --build-cache --no-watch-fs -Dorg.elasticsearch.build.cache.url=https://gradle-enterprise.elastic.co/cache/
-SET GRADLEW_BAT=./gradlew.bat --parallel --no-daemon --scan --build-cache --no-watch-fs -Dorg.elasticsearch.build.cache.url=https://gradle-enterprise.elastic.co/cache/
+SET GRADLEW=./gradlew --parallel --scan --build-cache --no-watch-fs -Dorg.elasticsearch.build.cache.url=https://gradle-enterprise.elastic.co/cache/
+SET GRADLEW_BAT=./gradlew.bat --parallel --scan --build-cache --no-watch-fs -Dorg.elasticsearch.build.cache.url=https://gradle-enterprise.elastic.co/cache/
 
-(if not exist "%USERPROFILE%/.gradle" mkdir "%USERPROFILE%/.gradle") && (echo. >> "%USERPROFILE%/.gradle/gradle.properties" && echo org.gradle.daemon=false >> "%USERPROFILE%/.gradle/gradle.properties")
+@REM (if not exist "%USERPROFILE%/.gradle" mkdir "%USERPROFILE%/.gradle") && (echo. >> "%USERPROFILE%/.gradle/gradle.properties" && echo org.gradle.daemon=false >> "%USERPROFILE%/.gradle/gradle.properties")
 
 set WORKSPACE=%cd%
 set BUILD_NUMBER=%BUILDKITE_BUILD_NUMBER%

--- a/.buildkite/pipelines/pull-request/.defaults.yml
+++ b/.buildkite/pipelines/pull-request/.defaults.yml
@@ -1,4 +1,5 @@
 config:
+  allow-labels: TODO-remove-me
   skip-labels:
     - ">test-mute"
   excluded-regions:

--- a/.buildkite/pipelines/pull-request/.defaults.yml
+++ b/.buildkite/pipelines/pull-request/.defaults.yml
@@ -1,5 +1,4 @@
 config:
-  allow-labels: TODO-remove-me
   skip-labels:
     - ">test-mute"
   excluded-regions:

--- a/.buildkite/pipelines/pull-request/packaging-tests-windows-sample.yml
+++ b/.buildkite/pipelines/pull-request/packaging-tests-windows-sample.yml
@@ -2,6 +2,7 @@ config:
   skip-labels:
     - ">test-mute"
     - ":Delivery/Packaging"
+  allow-labels: "Team:Delivery"
 steps:
   - group: packaging-tests-windows-sample
     steps:
@@ -22,6 +23,35 @@ steps:
           diskType: hyperdisk-balanced
           diskSizeGb: 350
           preemptible: true
-          spotZones: 'asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c'
+          spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"
         env:
           PACKAGING_TASK: "{{matrix.PACKAGING_TASK}}"
+  - group: platform-support-windows
+    steps:
+      - label: "{{matrix.image}} / {{matrix.GRADLE_TASK}} / platform-support-windows"
+        command: |
+          .\.buildkite\scripts\run-script.ps1 bash .buildkite/scripts/windows-run-gradle.sh --continue
+        timeout_in_minutes: 420
+        matrix:
+          setup:
+            image:
+              - windows-2025
+            GRADLE_TASK:
+              - checkPart1
+        agents:
+          provider: gcp
+          image: family/elasticsearch-{{matrix.image}}
+          machineType: n4-standard-16
+          diskType: pd-ssd
+          diskSizeGb: 350
+        env:
+          GRADLE_TASK: "{{matrix.GRADLE_TASK}}"
+        retry:
+          automatic:
+            - exit_status: "-1"
+              limit: 3
+              signal_reason: none
+            - signal_reason: agent_stop
+              limit: 3
+            - exit_status: "1"
+              limit: 1

--- a/.buildkite/pipelines/pull-request/packaging-tests-windows-sample.yml
+++ b/.buildkite/pipelines/pull-request/packaging-tests-windows-sample.yml
@@ -41,7 +41,7 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-{{matrix.image}}
-          machineType: n4-standard-16
+          machineType: n1-standard-16
           diskType: pd-ssd
           diskSizeGb: 350
         env:

--- a/.buildkite/pipelines/pull-request/packaging-tests-windows-sample.yml
+++ b/.buildkite/pipelines/pull-request/packaging-tests-windows-sample.yml
@@ -2,7 +2,6 @@ config:
   skip-labels:
     - ">test-mute"
     - ":Delivery/Packaging"
-  allow-labels: "Team:Delivery"
 steps:
   - group: packaging-tests-windows-sample
     steps:
@@ -26,32 +25,3 @@ steps:
           spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"
         env:
           PACKAGING_TASK: "{{matrix.PACKAGING_TASK}}"
-  - group: platform-support-windows
-    steps:
-      - label: "{{matrix.image}} / {{matrix.GRADLE_TASK}} / platform-support-windows"
-        command: |
-          .\.buildkite\scripts\run-script.ps1 bash .buildkite/scripts/windows-run-gradle.sh --continue
-        timeout_in_minutes: 420
-        matrix:
-          setup:
-            image:
-              - windows-2025
-            GRADLE_TASK:
-              - checkPart1
-        agents:
-          provider: gcp
-          image: family/elasticsearch-{{matrix.image}}
-          machineType: n1-standard-16
-          diskType: pd-ssd
-          diskSizeGb: 350
-        env:
-          GRADLE_TASK: "{{matrix.GRADLE_TASK}}"
-        retry:
-          automatic:
-            - exit_status: "-1"
-              limit: 3
-              signal_reason: none
-            - signal_reason: agent_stop
-              limit: 3
-            - exit_status: "1"
-              limit: 1

--- a/.buildkite/scripts/windows-run-gradle.sh
+++ b/.buildkite/scripts/windows-run-gradle.sh
@@ -2,4 +2,15 @@
 
 set -euo pipefail
 
+WORKSPACE="$(pwd)"
+export WORKSPACE
+
+export $(cat .ci/java-versions.properties | grep '=' | xargs)
+
+JAVA_HOME="$HOME/.java/$ES_BUILD_JAVA"
+export JAVA_HOME
+
+PATH="$JAVA_HOME/bin:$PATH"
+export PATH
+
 .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true ${GRADLE_PARAMS:-} $GRADLE_TASK

--- a/.ci/scripts/run-gradle.sh
+++ b/.ci/scripts/run-gradle.sh
@@ -61,4 +61,14 @@ fi
 GRADLEW_ARGS="${GRADLEW#./gradlew }"
 
 echo "--- Running gradle tasks"
-java -jar "$RUNNER_JAR" -- $GRADLEW_ARGS -S --max-workers=$MAX_WORKERS $TESTS_SEED_PARAM ${EXTRA_GRADLE_ARGS:-} "$@"
+if ! command -v java > /dev/null; then
+  if [[ "${JAVA_HOME:-}" ]]; then
+    export PATH="$JAVA_HOME/bin:$PATH"
+  fi
+fi
+
+if command -v java > /dev/null; then
+  java -jar "$RUNNER_JAR" -- $GRADLEW_ARGS -S --max-workers=$MAX_WORKERS $TESTS_SEED_PARAM ${EXTRA_GRADLE_ARGS:-} "$@"
+else
+  "$GRADLEW" -S --max-workers=$MAX_WORKERS $TESTS_SEED_PARAM ${EXTRA_GRADLE_ARGS:-} "$@"
+fi

--- a/.ci/scripts/run-gradle.sh
+++ b/.ci/scripts/run-gradle.sh
@@ -67,6 +67,14 @@ if ! command -v java > /dev/null; then
   fi
 fi
 
+which java
+echo "$JAVA_HOME"
+echo "$PATH"
+
+echo java -jar "$RUNNER_JAR" -- $GRADLEW_ARGS -S --max-workers=$MAX_WORKERS $TESTS_SEED_PARAM ${EXTRA_GRADLE_ARGS:-} "$@"
+
+set -x
+
 if command -v java > /dev/null; then
   java -jar "$RUNNER_JAR" -- $GRADLEW_ARGS -S --max-workers=$MAX_WORKERS $TESTS_SEED_PARAM ${EXTRA_GRADLE_ARGS:-} "$@"
 else

--- a/.ci/scripts/run-gradle.sh
+++ b/.ci/scripts/run-gradle.sh
@@ -62,6 +62,14 @@ GRADLEW_ARGS="${GRADLEW#./gradlew }"
 
 echo "--- Running gradle tasks"
 
+set -x
+
+echo "PATH=$PATH"
+echo "JAVA_HOME=$JAVA_HOME"
+which java
+
+java -jar "$RUNNER_JAR" -- help || true
+
 if command -v java > /dev/null; then
   java -jar "$RUNNER_JAR" -- $GRADLEW_ARGS -S --max-workers=$MAX_WORKERS $TESTS_SEED_PARAM ${EXTRA_GRADLE_ARGS:-} "$@"
 else

--- a/.ci/scripts/run-gradle.sh
+++ b/.ci/scripts/run-gradle.sh
@@ -62,9 +62,12 @@ GRADLEW_ARGS="${GRADLEW#./gradlew }"
 
 echo "--- Running gradle tasks"
 if ! command -v java > /dev/null; then
-  if [[ "${JAVA_HOME:-}" ]]; then
-    export PATH="$JAVA_HOME/bin:$PATH"
+  if [[ "${ES_BUILD_JAVA:-}" == "" ]]; then
+    export $(cat .ci/java-versions.properties | grep '=' | xargs)
   fi
+
+  PATH="$HOME/.java/$ES_BUILD_JAVA/bin:$PATH"
+  export PATH
 fi
 
 which java

--- a/.ci/scripts/run-gradle.sh
+++ b/.ci/scripts/run-gradle.sh
@@ -61,22 +61,6 @@ fi
 GRADLEW_ARGS="${GRADLEW#./gradlew }"
 
 echo "--- Running gradle tasks"
-if ! command -v java > /dev/null; then
-  if [[ "${ES_BUILD_JAVA:-}" == "" ]]; then
-    export $(cat .ci/java-versions.properties | grep '=' | xargs)
-  fi
-
-  PATH="$HOME/.java/$ES_BUILD_JAVA/bin:$PATH"
-  export PATH
-fi
-
-which java
-echo "$JAVA_HOME"
-echo "$PATH"
-
-echo java -jar "$RUNNER_JAR" -- $GRADLEW_ARGS -S --max-workers=$MAX_WORKERS $TESTS_SEED_PARAM ${EXTRA_GRADLE_ARGS:-} "$@"
-
-set -x
 
 if command -v java > /dev/null; then
   java -jar "$RUNNER_JAR" -- $GRADLEW_ARGS -S --max-workers=$MAX_WORKERS $TESTS_SEED_PARAM ${EXTRA_GRADLE_ARGS:-} "$@"

--- a/.ci/scripts/run-gradle.sh
+++ b/.ci/scripts/run-gradle.sh
@@ -62,14 +62,6 @@ GRADLEW_ARGS="${GRADLEW#./gradlew }"
 
 echo "--- Running gradle tasks"
 
-set -x
-
-echo "PATH=$PATH"
-echo "JAVA_HOME=$JAVA_HOME"
-which java
-
-java -jar "$RUNNER_JAR" -- help || true
-
 if command -v java > /dev/null; then
   java -jar "$RUNNER_JAR" -- $GRADLEW_ARGS -S --max-workers=$MAX_WORKERS $TESTS_SEED_PARAM ${EXTRA_GRADLE_ARGS:-} "$@"
 else


### PR DESCRIPTION
Fix up some env vars on Windows, and get rid of `--no-daemon`, which is causing issues with GradleRunner (and other things).