### PR TITLE
Correct the search thread pool queue_size formula in 9.x

### DIFF
--- a/docs/reference/elasticsearch/configuration-reference/thread-pool-settings.md
+++ b/docs/reference/elasticsearch/configuration-reference/thread-pool-settings.md
@@ -18,7 +18,11 @@ There are several thread pools, but the important ones include:
 $$$search-threadpool$$$
 
 `search`
-:   For count/search operations at the shard level. Used also by fetch and other search related operations  Thread pool type is `fixed` with a size of `int((`[`# of allocated processors`](#node.processors)` * 3) / 2) + 1`, and queue_size of `1000`.
+:   For count/search operations at the shard level. Used also by fetch and other search related operations  Thread pool type is `fixed` with a size of `int((`[`# of allocated processors`](#node.processors)` * 3) / 2) + 1`, and queue_size of `1000 * (int((`[`# of allocated processors`](#node.processors)` * 3) / 2) + 1)`.
+
+    :::{note}
+    In {{stack}} 8.x and earlier, the default queue_size was 1000.
+    :::
 
 $$$search-throttled$$$`search_throttled`
 :   For count/search/suggest/get operations on `search_throttled indices`. Thread pool type is `fixed` with a size of `1`, and queue_size of `100`.


### PR DESCRIPTION
Updates the `thread-pool-settings.md` reference to reflect the change introduced in [#116578](https://github.com/elastic/elasticsearch/pull/116578), where the default `queue_size` for the `search` thread pool was changed from a fixed `1000` to `1000 * pool_size`. The previous wording incorrectly implied a static queue depth regardless of node size, which has caused confusion in capacity planning. A short note is also added to call out the 8.x behavior for operators migrating from older versions.

Resolves #149782

- [x] I have signed the [contributor license agreement](https://www.elastic.co/contributor-agreement).
- [x] I have followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md).
- This is a documentation-only change (no code), so the code-submission items do not apply.
- [x] The pull request targets `main`.
- [x] This is not a class submission.