### PR TITLE
Use unlimited queue in RecordingApmServer

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -506,9 +506,6 @@ tests:
 - class: org.elasticsearch.xpack.ml.qa.MlYamlRestIT
   method: test {p0=ml/data_frame_analytics_crud/Test put valid config with default outlier detection, query, and filter}
   issue: https://github.com/elastic/elasticsearch/issues/150630
-- class: org.elasticsearch.test.apmintegration.OTelMetricsBufferingIT
-  method: testOutageBuffersToDiskAndDrainsOnRecovery
-  issue: https://github.com/elastic/elasticsearch/issues/150387
 - class: org.elasticsearch.xpack.esql.qa.ndjson.NdJsonCompressedFormatSpecIT
   method: test {csv-spec:external-basic.forkTwoBranches [ndjson.bz/AZURE]}
   issue: https://github.com/elastic/elasticsearch/issues/150651

--- a/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/RecordingApmServer.java
+++ b/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/RecordingApmServer.java
@@ -35,7 +35,8 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -44,7 +45,7 @@ import java.util.function.Consumer;
 public class RecordingApmServer extends ExternalResource {
     private static final Logger logger = LogManager.getLogger(RecordingApmServer.class);
 
-    final ArrayBlockingQueue<ReceivedTelemetry> received = new ArrayBlockingQueue<>(1000);
+    private final BlockingQueue<ReceivedTelemetry> received = new LinkedBlockingQueue<>();
 
     /**
      * The "Resource" (telemetry source identity) observed by this server. The test JVM emits
@@ -157,6 +158,9 @@ public class RecordingApmServer extends ExternalResource {
                 }
             }
             exchange.sendResponseHeaders(responseCode, 0);
+        } catch (Throwable t) {
+            logger.error("Unexpected error caught when serving HTTP request", t);
+            throw t;
         }
     }
 


### PR DESCRIPTION
The limited queue with limit=1000 was dropping telemetry in longer/more intensive tests, and that resulted in assertions failing in strange ways: metrics sometimes not appearing at all.

Closes https://github.com/elastic/elasticsearch/issues/150387