### PR TITLE
Document CATEGORIZE output_format values

### DIFF
--- a/docs/reference/query-languages/esql/_snippets/generated/x-pack-esql/functions/functionNamedParams/categorize.md
+++ b/docs/reference/query-languages/esql/_snippets/generated/x-pack-esql/functions/functionNamedParams/categorize.md
@@ -6,7 +6,7 @@
 :   (keyword) Analyzer used to convert the field into tokens for text categorization.
 
 `output_format`
-:   (keyword) The output format of the categories. Defaults to regex.
+:   (keyword) The output format of the categories. Supported formats are `regex`, which outputs a regular expression matching the category, and `tokens`, which outputs a human-readable representation of the category. Defaults to `regex`.
 
 `similarity_threshold`
 :   (integer) The minimum percentage of token weight that must match for text to be added to the category bucket. Must be between 1 and 100. The larger the value the narrower the categories. Larger values will increase memory usage and create narrower categories. Defaults to 70.

--- a/docs/reference/query-languages/esql/_snippets/generated/x-pack-esql/functions/functionNamedParams/categorize.md
+++ b/docs/reference/query-languages/esql/_snippets/generated/x-pack-esql/functions/functionNamedParams/categorize.md
@@ -6,7 +6,7 @@
 :   (keyword) Analyzer used to convert the field into tokens for text categorization.
 
 `output_format`
-:   (keyword) The output format of the categories. Supported formats are `regex`, which outputs a regular expression matching the category, and `tokens`, which outputs a human-readable representation of the category. Defaults to `regex`.
+:   (keyword) The output format of the categories. Supported formats are `regex`, which outputs a regular expression matching the category, and `tokens`, which outputs a more human-readable space-separated list of the matching tokens of the category. Defaults to `regex`.
 
 `similarity_threshold`
 :   (integer) The minimum percentage of token weight that must match for text to be added to the category bucket. Must be between 1 and 100. The larger the value the narrower the categories. Larger values will increase memory usage and create narrower categories. Defaults to 70.

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/grouping/Categorize.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/grouping/Categorize.java
@@ -140,7 +140,10 @@ public class Categorize extends GroupingFunction.NonEvaluatableGroupingFunction 
                     name = OUTPUT_FORMAT,
                     type = "keyword",
                     valueHint = { "regex", "tokens" },
-                    description = "The output format of the categories. Defaults to regex."
+                    description = "The output format of the categories. "
+                        + "Supported formats are `regex`, which outputs a regular expression matching the category, "
+                        + "and `tokens`, which outputs a human-readable representation of the category. "
+                        + "Defaults to `regex`."
                 ),
                 @MapParam.MapParamEntry(
                     name = SIMILARITY_THRESHOLD,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/grouping/Categorize.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/grouping/Categorize.java
@@ -142,7 +142,7 @@ public class Categorize extends GroupingFunction.NonEvaluatableGroupingFunction 
                     valueHint = { "regex", "tokens" },
                     description = "The output format of the categories. "
                         + "Supported formats are `regex`, which outputs a regular expression matching the category, "
-                        + "and `tokens`, which outputs a human-readable representation of the category. "
+                        + "and `tokens`, which outputs a more human-readable space-separated list of the matching tokens of the category. "
                         + "Defaults to `regex`."
                 ),
                 @MapParam.MapParamEntry(


### PR DESCRIPTION
## Summary
- Updated the `output_format` parameter description for the CATEGORIZE function to document both supported formats: `regex` and `tokens`
- `regex` outputs a regular expression matching the category
- `tokens` outputs a human-readable representation of the category
- Previously the docs only mentioned the default (`regex`) without listing possible values

## Test plan
- [x] Ran `CategorizeTests` to regenerate docs snippets
- [x] Verified generated `categorize.md` reflects the updated description

🤖 Generated with [Claude Code](https://claude.com/claude-code)