### PR TITLE
ESQL: surface external read IOExceptions as 400, not 500

### DIFF
--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
@@ -67,6 +67,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.io.UncheckedIOException;
 import java.nio.charset.Charset;
 import java.time.DateTimeException;
 import java.time.Instant;
@@ -1492,7 +1493,9 @@ public class CsvFormatReader implements SegmentableFormatReader {
                 eof = next == null;
                 return eof == false;
             } catch (IOException e) {
-                throw new RuntimeException(e);
+                // UncheckedIOException, not RuntimeException: ExternalFailures.classify keys on the
+                // surfaced type, and burying the IOException turns a malformed-input 400 into a 500.
+                throw new UncheckedIOException(e);
             }
         }
 
@@ -1663,7 +1666,9 @@ public class CsvFormatReader implements SegmentableFormatReader {
                 }
                 return true;
             } catch (IOException e) {
-                throw new RuntimeException("Failed to read CSV batch", e);
+                // UncheckedIOException, not RuntimeException: ExternalFailures.classify keys on the
+                // surfaced type, and burying the IOException turns a malformed-input 400 into a 500.
+                throw new UncheckedIOException("Failed to read CSV batch", e);
             } finally {
                 long deltaTotal = totalRowCount - startTotal;
                 long deltaErrors = errorCount - startError;

--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIterator.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIterator.java
@@ -31,6 +31,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -269,7 +270,9 @@ final class NdJsonPageIterator extends BufferingPageIterator {
             }
             return true;
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            // UncheckedIOException, not RuntimeException: ExternalFailures.classify keys on the
+            // surfaced type, and burying the IOException turns a malformed-input 400 into a 500.
+            throw new UncheckedIOException(e);
         }
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ParallelParsingCoordinator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ParallelParsingCoordinator.java
@@ -25,6 +25,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -771,6 +772,12 @@ public final class ParallelParsingCoordinator {
             if (t != null) {
                 if (t instanceof RuntimeException re) {
                     throw re;
+                }
+                if (t instanceof IOException ioe) {
+                    // Keep the IOException visible at the top of the chain: ExternalFailures.classify
+                    // keys on the surfaced type, and burying a read/parse failure under a plain
+                    // RuntimeException turns a malformed-input 400 into a server-fault 500.
+                    throw new UncheckedIOException("Parallel parsing failed", ioe);
                 }
                 throw new RuntimeException("Parallel parsing failed", t);
             }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
@@ -28,6 +28,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -929,6 +930,12 @@ public final class StreamingParallelParsingCoordinator {
             if (t != null) {
                 if (t instanceof RuntimeException re) {
                     throw re;
+                }
+                if (t instanceof IOException ioe) {
+                    // Keep the IOException visible at the top of the chain: ExternalFailures.classify
+                    // keys on the surfaced type, and burying a read/parse failure under a plain
+                    // RuntimeException turns a malformed-input 400 into a server-fault 500.
+                    throw new UncheckedIOException("Streaming parallel parsing failed", ioe);
                 }
                 throw new RuntimeException("Streaming parallel parsing failed", t);
             }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ParallelParsingCoordinatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ParallelParsingCoordinatorTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.datasources;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.unit.ByteSizeValue;
@@ -19,6 +20,7 @@ import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.CloseableIterator;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
@@ -42,6 +44,7 @@ import org.hamcrest.Matchers;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -666,6 +669,43 @@ public class ParallelParsingCoordinatorTests extends ESTestCase {
             assertTrue(
                 "Should contain the injected error message",
                 ex.getMessage().contains("injected") || (ex.getCause() != null && ex.getCause().getMessage().contains("injected"))
+            );
+        } finally {
+            exec.shutdown();
+        }
+    }
+
+    /**
+     * A parse failure is a data problem, not a server bug, so what the coordinator surfaces must
+     * classify to {@code 400}. The segment worker stores an {@link IOException} and the coordinator's
+     * error check re-throws it on the consuming thread — if that re-throw buries the
+     * {@code IOException} under a plain {@code RuntimeException}, {@link ExternalFailures#classify}
+     * can no longer see the data-error type and reports {@code 500 ExternalServerException} instead
+     * (the captured chain in elastic/esql-planning#897).
+     */
+    public void testStoredIoFailureClassifiesAsClientError() throws Exception {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 100; i++) {
+            sb.append("line-").append(i).append("\n");
+        }
+        StorageObject obj = new InMemoryStorageObject(sb.toString().getBytes(StandardCharsets.UTF_8));
+        FailingFormatReader reader = new FailingFormatReader(blockFactory(), 5);
+
+        ExecutorService exec = Executors.newFixedThreadPool(4);
+        try {
+            CloseableIterator<Page> iter = ParallelParsingCoordinator.parallelRead(reader, obj, List.of("line"), 10, 4, exec);
+            RuntimeException ex = expectThrows(RuntimeException.class, () -> {
+                try (iter) {
+                    while (iter.hasNext()) {
+                        Page page = iter.next();
+                        page.releaseBlocks();
+                    }
+                }
+            });
+            assertEquals(
+                "an unreadable record must surface as a client error, got: " + ExternalFailures.classify(ex),
+                RestStatus.BAD_REQUEST,
+                ExceptionsHelper.status(ExternalFailures.classify(ex))
             );
         } finally {
             exec.shutdown();
@@ -1576,7 +1616,10 @@ public class ParallelParsingCoordinatorTests extends ESTestCase {
                     try {
                         nextPage = readBatch();
                     } catch (IOException e) {
-                        throw new RuntimeException(e);
+                        // Mirrors the production page iterators (CsvFormatReader, NdJsonPageIterator):
+                        // an IOException crossing the Iterator boundary surfaces as UncheckedIOException
+                        // so ExternalFailures.classify still sees a data error (400), not a bug (500).
+                        throw new UncheckedIOException(e);
                     }
                     return nextPage != null;
                 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinatorTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.datasources;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
@@ -15,6 +16,7 @@ import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.CloseableIterator;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Nullability;
@@ -892,6 +894,50 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
             RuntimeException ex = expectThrows(RuntimeException.class, () -> collectLines(iterator));
             String chain = ex.toString() + (ex.getCause() != null ? " | cause: " + ex.getCause() : "");
             assertTrue("expected a bounded grow-loop failure, got: " + chain, chain.contains("record exceeded max_record_size"));
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    /**
+     * A parse failure is a data problem, not a server bug, so what the coordinator surfaces must
+     * classify to {@code 400}. The worker stores an {@link IOException} (here the record-size cap;
+     * any malformed-input read failure takes the same path) and the coordinator's error check
+     * re-throws it on the consuming thread — if that re-throw buries the {@code IOException} under a
+     * plain {@code RuntimeException}, {@link ExternalFailures#classify} can no longer see the
+     * data-error type and reports {@code 500 ExternalServerException} instead
+     * (the captured chain in elastic/esql-planning#897).
+     */
+    public void testStoredIoFailureClassifiesAsClientError() throws Exception {
+        int maxRecordBytes = 8 * 1024;
+        StringBuilder sb = new StringBuilder();
+        while (sb.length() < 64 * 1024) {
+            sb.append("some-row-of-bytes-with-a-trailing-newline-and-a-bit-of-padding\n");
+        }
+        byte[] bytes = sb.toString().getBytes(StandardCharsets.UTF_8);
+
+        ExecutorService executor = Executors.newFixedThreadPool(4);
+        try {
+            NeverBoundaryFormatReader reader = new NeverBoundaryFormatReader(64);
+            var iterator = new StreamingParallelParsingCoordinator.StreamingParallelIterator(
+                reader,
+                new ByteArrayInputStream(bytes),
+                null,
+                List.of("line"),
+                50,
+                4,
+                executor,
+                ErrorPolicy.STRICT,
+                null,
+                maxRecordBytes,
+                null
+            );
+            RuntimeException ex = expectThrows(RuntimeException.class, () -> collectLines(iterator));
+            assertEquals(
+                "an unreadable record must surface as a client error, got: " + ExternalFailures.classify(ex),
+                RestStatus.BAD_REQUEST,
+                ExceptionsHelper.status(ExternalFailures.classify(ex))
+            );
         } finally {
             executor.shutdownNow();
         }


### PR DESCRIPTION
## What this is about

A malformed record in an `EXTERNAL` text read (CSV/TSV/NDJSON) fails the query with `500 ExternalServerException`, as if Elasticsearch itself were broken. The failure is a data problem, and the contract says data problems are `400 ExternalClientException`:

```
external_server_exception: Unexpected failure reading external source: Streaming parallel parsing failed
  └ runtime_exception: Streaming parallel parsing failed
      └ i_o_exception: record exceeded max_record_size [67108864] … for format [tsv]
```

## What this PR does

The read path raises data problems as `IOException`, and `ExternalFailures.classify` keys on the surfaced type: `IOException`/`UncheckedIOException` → 400, anything unrecognized → 500. Five crossings buried the `IOException` under a plain `RuntimeException` before it reached the classifier — both parallel coordinators' `checkError`, both `CsvFormatReader` page iterators, and `NdJsonPageIterator`. We preserve it as `UncheckedIOException` at each crossing instead; the classifier already maps that to 400. No change to `classify` itself.

## Does it work?

Two new coordinator-level tests pin the contract — what the coordinator surfaces must classify to 400. Both fail on main with `expected:<BAD_REQUEST> but was:<INTERNAL_SERVER_ERROR>` and pass with this change. The coordinator, CSV, and NDJSON suites are unchanged and green.

## What's in the diff

- `StreamingParallelParsingCoordinator.checkError` / `ParallelParsingCoordinator.checkError`: a stored `IOException` re-throws as `UncheckedIOException` with the same message, instead of a plain `RuntimeException`.
- `CsvFormatReader` record + batch iterators, `NdJsonPageIterator`: the `hasNext()` boundary wraps `IOException` in `UncheckedIOException`, not `RuntimeException`.
- Tests: `testStoredIoFailureClassifiesAsClientError` in both coordinator suites; the parallel test fixture mirrors the production iterator wrap.

## What's out of scope

- Why a stray quote can grow a TSV record to the cap in the first place (the dialect/quoting question) — separate work.
- `error_mode` handling for the parallel record-cap path — the right semantics there are not a blind skip.
