### PR TITLE
ES|QL: make the worker queue dynamic

### DIFF
--- a/docs/changelog/151103.yaml
+++ b/docs/changelog/151103.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 151103
+summary: Make the worker queue dynamic
+type: enhancement

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlPlugin.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlPlugin.java
@@ -45,6 +45,7 @@ import org.elasticsearch.compute.operator.topn.TopNOperatorStatus;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.license.XPackLicenseState;
+import org.elasticsearch.monitor.jvm.JvmInfo;
 import org.elasticsearch.plugins.ActionPlugin;
 import org.elasticsearch.plugins.ExtensiblePlugin;
 import org.elasticsearch.plugins.Plugin;
@@ -600,12 +601,14 @@ public class EsqlPlugin extends Plugin implements ActionPlugin, ExtensiblePlugin
         final int allocatedProcessors = EsExecutors.allocatedProcessors(settings);
         int configuredSize = ESQL_WORKER_THREAD_POOL_SIZE.get(settings);
         int poolSize = configuredSize > 0 ? configuredSize : ThreadPool.searchOrGetThreadPoolSize(allocatedProcessors);
+        long heapMb = JvmInfo.jvmInfo().getMem().getHeapMax().getBytes() / (1024 * 1024);
+        int queueSize = (int) Math.max((heapMb + (long) allocatedProcessors * 400) / 2, 1000);
         return List.of(
             new FixedExecutorBuilder(
                 settings,
                 ESQL_WORKER_THREAD_POOL_NAME,
                 poolSize,
-                1000,
+                queueSize,
                 ESQL_WORKER_THREAD_POOL_NAME,
                 EsExecutors.TaskTrackingConfig.DEFAULT
             )

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlPlugin.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlPlugin.java
@@ -597,12 +597,17 @@ public class EsqlPlugin extends Plugin implements ActionPlugin, ExtensiblePlugin
         );
     }
 
+    // visible for testing
+    static int workerQueueSize(long heapBytes, int allocatedProcessors) {
+        long heapMb = heapBytes / (1024 * 1024);
+        return (int) Math.max((heapMb + (long) allocatedProcessors * 400) / 2, 1000);
+    }
+
     public List<ExecutorBuilder<?>> getExecutorBuilders(Settings settings) {
         final int allocatedProcessors = EsExecutors.allocatedProcessors(settings);
         int configuredSize = ESQL_WORKER_THREAD_POOL_SIZE.get(settings);
         int poolSize = configuredSize > 0 ? configuredSize : ThreadPool.searchOrGetThreadPoolSize(allocatedProcessors);
-        long heapMb = JvmInfo.jvmInfo().getMem().getHeapMax().getBytes() / (1024 * 1024);
-        int queueSize = (int) Math.max((heapMb + (long) allocatedProcessors * 400) / 2, 1000);
+        int queueSize = workerQueueSize(JvmInfo.jvmInfo().getMem().getHeapMax().getBytes(), allocatedProcessors);
         return List.of(
             new FixedExecutorBuilder(
                 settings,

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/EsqlWorkerThreadPoolTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/EsqlWorkerThreadPoolTests.java
@@ -7,7 +7,10 @@
 
 package org.elasticsearch.xpack.esql.plugin;
 
+import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.monitor.jvm.JvmInfo;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ExecutorBuilder;
 
@@ -51,5 +54,57 @@ public class EsqlWorkerThreadPoolTests extends ESTestCase {
 
     public void testThreadPoolNameConstant() {
         assertEquals("esql_worker", ESQL_WORKER_THREAD_POOL_NAME);
+    }
+
+    // --- worker queue size formula ---
+
+    public void testWorkerQueueSizeFloor() {
+        // with no heap and a single CPU the floor of 1000 must hold
+        assertEquals(1000, EsqlPlugin.workerQueueSize(0, 1));
+    }
+
+    public void testWorkerQueueSizeFloorWithSmallValues() {
+        // 512 MB heap, 4 CPUs: (512 + 4*400)/2 = (512+1600)/2 = 1056, above floor
+        assertEquals(1056, EsqlPlugin.workerQueueSize(512L * 1024 * 1024, 4));
+    }
+
+    public void testWorkerQueueSizeScalesWithHeap() {
+        // 4 GB heap, 8 CPUs: (4096 + 8*400)/2 = (4096+3200)/2 = 3648
+        assertEquals(3648, EsqlPlugin.workerQueueSize(4L * 1024 * 1024 * 1024, 8));
+    }
+
+    public void testWorkerQueueSizeScalesWithCpus() {
+        // 0 heap, enough CPUs to exceed 1000: need (n*400)/2 > 1000 => n > 5
+        // 6 CPUs: (0 + 6*400)/2 = 1200 > 1000
+        assertEquals(1200, EsqlPlugin.workerQueueSize(0, 6));
+    }
+
+    public void testWorkerQueueSizeNeverBelowFloor() {
+        // exhaustive check: any combination of tiny heap and few CPUs must stay >= 1000
+        for (int cpus = 1; cpus <= 5; cpus++) {
+            for (long heapMb = 0; heapMb <= 1000; heapMb += 100) {
+                int size = EsqlPlugin.workerQueueSize(heapMb * 1024 * 1024, cpus);
+                assertTrue("queue size must be >= 1000, got " + size + " for " + heapMb + "MB heap, " + cpus + " CPUs", size >= 1000);
+            }
+        }
+    }
+
+    public void testGetExecutorBuildersUsesFormula() {
+        // verify the builder registered for the esql_worker pool defaults to the formula result
+        EsqlPlugin plugin = new EsqlPlugin();
+        Settings settings = Settings.EMPTY;
+        int allocatedProcessors = EsExecutors.allocatedProcessors(settings);
+        long heapBytes = JvmInfo.jvmInfo().getMem().getHeapMax().getBytes();
+        int expectedQueueSize = EsqlPlugin.workerQueueSize(heapBytes, allocatedProcessors);
+
+        List<ExecutorBuilder<?>> builders = plugin.getExecutorBuilders(settings);
+        ExecutorBuilder<?> workerBuilder = builders.get(0);
+        Setting<?> queueSizeSetting = workerBuilder.getRegisteredSettings()
+            .stream()
+            .filter(s -> s.getKey().equals(ESQL_WORKER_THREAD_POOL_NAME + ".queue_size"))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("queue_size setting not registered"));
+
+        assertEquals(expectedQueueSize, queueSizeSetting.getDefault(Settings.EMPTY));
     }
 }


### PR DESCRIPTION
The queue size is fixed (1000). With this, we make it dependent on the available memory and the number of CPUs:

```  
queueSize = max( (heap/1MB + numCPUs*400) / 2, 1000)
```