### PR TITLE
Updating simulated exception thrown in RRF and linear retriever IT tests  to avoid shutting down the shard

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -524,9 +524,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.analysis.AnalyzerUnmappedGoldenTests
   method: testTypeConflictTimeseriesDoubleUnmappedWithCast
   issue: https://github.com/elastic/elasticsearch/issues/150672
-- class: org.elasticsearch.xpack.rank.rrf.RRFRetrieverBuilderNestedDocsIT
-  method: testRRFRetrieverPartialSearchErrorsTrue
-  issue: https://github.com/elastic/elasticsearch/issues/150673
 - class: org.elasticsearch.xpack.remotecluster.CrossClusterEsqlRCS1EnrichUnavailableRemotesIT
   method: testEsqlEnrichWithSkipUnavailable
   issue: https://github.com/elastic/elasticsearch/issues/150686

--- a/x-pack/plugin/rank-rrf/src/internalClusterTest/java/org/elasticsearch/xpack/rank/ShardFailingQueryBuilder.java
+++ b/x-pack/plugin/rank-rrf/src/internalClusterTest/java/org/elasticsearch/xpack/rank/ShardFailingQueryBuilder.java
@@ -7,9 +7,7 @@
 
 package org.elasticsearch.xpack.rank;
 
-import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.store.DataInput;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;

--- a/x-pack/plugin/rank-rrf/src/internalClusterTest/java/org/elasticsearch/xpack/rank/ShardFailingQueryBuilder.java
+++ b/x-pack/plugin/rank-rrf/src/internalClusterTest/java/org/elasticsearch/xpack/rank/ShardFailingQueryBuilder.java
@@ -58,7 +58,7 @@ public class ShardFailingQueryBuilder extends LeafQueryBuilder<ShardFailingQuery
     @Override
     protected Query doToQuery(SearchExecutionContext context) throws IOException {
         if (context.getShardId() % 2 == 0) {
-            throw new CorruptIndexException("simulated failure", (DataInput) null);
+            throw new IllegalArgumentException("simulated failure");
         } else {
             return Queries.ALL_DOCS_INSTANCE;
         }


### PR DESCRIPTION
Debugged this with the help of Claude and I think that the following makes some sense (at least, it's worth the effort to try) 

The exception thrown in the linked issue is when the test is cleaning up its resources (not related to actual prod code). When we throw the `CorruptIndexException`, this in turn causes the `org.elasticsearch.search.SearchService#processFailure` to identify it as such, and fail the shard's engine through `Engine#failEngine`. 

In the specific scenario, there seems to be a race condition between two threads sharing the same exception object:

  1. Search thread: `processFailure` calls `failShard(exc)`, which posts the shard failure notification to the generic thread pool (async, via `FailedShardHandler` at `IndicesClusterStateService:1275`). It then returns,
  and `org.elasticsearch.search.SearchService#wrapListenerForErrorHandling` mutates the exception in-place by calling `setStackTrace(EMPTY_STACK_TRACE_ARRAY)` on it and all its causes.
  2. Generic thread: picks up the shard failure task and calls `localShardFailed`, which serializes the exception for transport to the master. By this point, the search thread may or may not have already cleared the stack traces.

The master stores this exception by reference in the cluster state. When it publishes the state to other nodes, the exception is serialized at publication time, but the master's in-memory reference continues to point to the (now-mutated) object. 

So:
* Master's in-memory state: `UnassignedInfo.details()` calls `ExceptionsHelper.stackTrace(failure)` on the mutated exception → no stack trace frames
* Other nodes' state: deserialized from the publication that happened before the mutation → full stack trace frames

The post-test `ensureClusterStateConsistency()` check compares XContent maps from master vs. local nodes, sees the unassigned_info/details mismatch, and fails. The failure can be reproduced by setting `        Thread.sleep(100);`  right before   clearing up the stack trace through `setStackTrace(EMPTY_STACK_TRACE_ARRAY)`. E.g.:

```
ExceptionsHelper.unwrapCausesAndSuppressed(e, err -> {
                    try {
                        Thread.sleep(100);
                    } catch (InterruptedException ex) {
                        throw new RuntimeException(ex);
                    }
                    err.setStackTrace(EMPTY_STACK_TRACE_ARRAY);
                    return false;
                });
```

We can simply change the exception type (as we don't need to strictly check a `CorruptIndexException` )  and throw an `IAE` instaed.

Closes https://github.com/elastic/elasticsearch/issues/150673