### PR TITLE
[clickbench-auto] ESQL: TSV dialect must not apply CSV quoting — unbalanced literal quotes glue records past max_record_size

### DIFF
--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatOptions.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatOptions.java
@@ -15,7 +15,10 @@ import java.time.format.DateTimeFormatter;
  * Configurable options for CSV/TSV parsing.
  *
  * @param delimiter          field separator character (default: comma)
- * @param quoteChar          character used to quote fields (default: double-quote)
+ * @param quoteChar          character used to quote fields (default: double-quote for CSV), or
+ *                           {@link #NO_QUOTE_CHAR} to disable quoting entirely (the TSV default —
+ *                           real-world TSV has no quoting concept; embedded separators are
+ *                           backslash-escaped, and a literal {@code "} is plain data)
  * @param escapeChar         character used to escape special characters (default: backslash)
  * @param commentPrefix      prefix for comment lines to skip (default: "//")
  * @param nullValue          string representation of null in the data (default: empty string)
@@ -53,6 +56,13 @@ public record CsvFormatOptions(
         BRACKETS
     }
 
+    /**
+     * Sentinel {@link #quoteChar} value meaning "no quoting": no character opens a quoted field, so a
+     * record always ends at the first unescaped {@code \n}. This is the TSV default. Quoting can be
+     * re-enabled per query via the {@code quote} WITH option.
+     */
+    public static final char NO_QUOTE_CHAR = '\0';
+
     /** 10 MB default field size limit — generous for real-world data, prevents OOM on corrupt files. */
     static final int DEFAULT_MAX_FIELD_SIZE = 10 * 1024 * 1024;
 
@@ -73,9 +83,17 @@ public record CsvFormatOptions(
         DEFAULT_COLUMN_PREFIX
     );
 
+    /**
+     * TSV dialect: tab-delimited and <strong>unquoted</strong>. Real-world TSV (ClickBench,
+     * mysqldump, Presto/Trino, ClickHouse {@code TSV}) carries no quoting — embedded tabs/newlines
+     * are backslash-escaped and a literal {@code "} byte is field data. Applying CSV quoting here is
+     * actively harmful: an unbalanced field-start {@code "} would glue records across newlines until
+     * the scan exceeds {@code max_record_size}. Users with genuinely quoted tab-separated data can
+     * opt back in with {@code WITH {"quote": "\""}}.
+     */
     public static final CsvFormatOptions TSV = new CsvFormatOptions(
         '\t',
-        '"',
+        NO_QUOTE_CHAR,
         '\\',
         "//",
         "",
@@ -106,5 +124,16 @@ public record CsvFormatOptions(
         if (columnPrefix == null) {
             throw new IllegalArgumentException("columnPrefix must not be null");
         }
+    }
+
+    /**
+     * Whether this dialect applies quoting at all. When {@code false} ({@link #quoteChar} is
+     * {@link #NO_QUOTE_CHAR}), no character toggles quote state anywhere in the pipeline — the
+     * record-boundary scanners, the logical record reader and the Jackson tokenizer all treat
+     * {@code "} (and every other byte) as plain field data, and a record ends at the first
+     * {@code \n} unconditionally.
+     */
+    public boolean quoting() {
+        return quoteChar != NO_QUOTE_CHAR;
     }
 }

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
@@ -117,7 +117,9 @@ import java.util.regex.Pattern;
  *   <caption>CSV options</caption>
  *   <tr><th>ES/ESQL key</th><th>Default</th><th>Description</th></tr>
  *   <tr><td>{@code delimiter}</td><td>{@code ,}</td><td>Field separator character</td></tr>
- *   <tr><td>{@code quote}</td><td>{@code "}</td><td>Quoting character</td></tr>
+ *   <tr><td>{@code quote}</td><td>{@code "} (CSV); none (TSV)</td>
+ *       <td>Quoting character. The TSV dialect applies no quoting by default — a literal {@code "}
+ *           is field data; pass {@code "quote": "\""} to opt back in.</td></tr>
  *   <tr><td>{@code escape}</td><td>{@code \}</td><td>Escape character inside quoted fields</td></tr>
  *   <tr><td>{@code comment}</td><td>{@code //}</td><td>Line comment prefix</td></tr>
  *   <tr><td>{@code null_value}</td><td>(empty)</td><td>String representation of null</td></tr>
@@ -791,9 +793,11 @@ public class CsvFormatReader implements SegmentableFormatReader {
     private Iterator<List<?>> newCsvIterator(CsvLogicalRecordReader recordReader) throws IOException {
         CsvSchema csvSchema = CsvSchema.emptySchema()
             .withColumnSeparator(options.delimiter())
-            .withQuoteChar(options.quoteChar())
             .withEscapeChar(options.escapeChar())
             .withNullValue(options.nullValue());
+        // No-quoting dialect (TSV default): the Jackson tokenizer must match the record-boundary
+        // scanner and the logical record reader, so a literal " byte stays plain field data.
+        csvSchema = options.quoting() ? csvSchema.withQuoteChar(options.quoteChar()) : csvSchema.withoutQuoteChar();
         return new CsvRecordIterator(recordReader, csvSchema);
     }
 
@@ -1338,6 +1342,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
      */
     private static String[] splitHeaderCommaDelimiterBracketAware(String line, char quote, char esc) {
         final char delim = ',';
+        final boolean quoting = quote != CsvFormatOptions.NO_QUOTE_CHAR;
         List<String> entries = new ArrayList<>();
         int start = 0;
         boolean inQuotes = false;
@@ -1371,7 +1376,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
                 fieldHasNonWhitespace = false;
                 continue;
             }
-            if (c == quote && fieldHasNonWhitespace == false) {
+            if (quoting && c == quote && fieldHasNonWhitespace == false) {
                 inQuotes = true;
                 continue;
             }
@@ -1392,6 +1397,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
      */
     private static String[] splitCommaDelimiterBracketAwareFields(String line, char quote, char esc) {
         final char delim = ',';
+        final boolean quoting = quote != CsvFormatOptions.NO_QUOTE_CHAR;
         List<String> entries = new ArrayList<>();
         StringBuilder current = new StringBuilder();
         boolean inQuotes = false;
@@ -1432,7 +1438,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
                     bracketDepth--;
                 }
                 i++;
-            } else if (c == quote && (current.length() == 0 || isWhitespaceOnlyFieldPrefix(current))) {
+            } else if (quoting && c == quote && (current.length() == 0 || isWhitespaceOnlyFieldPrefix(current))) {
                 inQuotes = true;
                 quoteOpenAt = i;
                 i++;
@@ -2161,6 +2167,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
         private boolean splitAndConvertProjected(String line) {
             final char delim = ',';
             final char quote = options.quoteChar();
+            final boolean quoting = options.quoting();
             final char esc = options.escapeChar();
 
             StringBuilder current = new StringBuilder();
@@ -2219,7 +2226,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
                         bracketDepth--;
                     }
                     i++;
-                } else if (c == quote && fieldHasNonWhitespace == false) {
+                } else if (quoting && c == quote && fieldHasNonWhitespace == false) {
                     trailingFieldHasContent = true;
                     inQuotes = true;
                     quoteOpenAt = i;

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvLogicalRecordReader.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvLogicalRecordReader.java
@@ -14,11 +14,16 @@ import java.nio.charset.StandardCharsets;
 
 /**
  * Reads one logical CSV record at a time while enforcing the query's byte-sized record cap.
+ *
+ * <p>When {@code quoteChar} is {@link CsvFormatOptions#NO_QUOTE_CHAR} (the TSV dialect), quoting is
+ * disabled: no character toggles quote state and a record ends at the first {@code \n} (or
+ * {@code \r}/{@code \r\n}) unconditionally.
  */
 final class CsvLogicalRecordReader {
 
     private final Reader reader;
     private final char quoteChar;
+    private final boolean quoting;
     private final char delimiter;
     private final int maxRecordBytes;
     private final Charset charset;
@@ -33,6 +38,7 @@ final class CsvLogicalRecordReader {
         }
         this.reader = reader;
         this.quoteChar = quoteChar;
+        this.quoting = quoteChar != CsvFormatOptions.NO_QUOTE_CHAR;
         this.delimiter = delimiter;
         this.maxRecordBytes = maxRecordBytes;
         this.charset = charset;
@@ -107,7 +113,7 @@ final class CsvLogicalRecordReader {
                 fieldHasNonWhitespace = false;
                 continue;
             }
-            if (ch == quoteChar && fieldHasNonWhitespace == false) {
+            if (quoting && ch == quoteChar && fieldHasNonWhitespace == false) {
                 inQuotes = true;
                 sb.append((char) ch);
                 continue;

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvRecordSplitter.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvRecordSplitter.java
@@ -90,6 +90,10 @@ final class CsvRecordSplitter implements RecordSplitter {
      * only at field start (after an unquoted {@code delimiter} or {@code \n}, optionally past field-leading
      * whitespace); a mid-field {@code quoteChar} is a literal and does not toggle quote state.
      * <p>
+     * With quoting disabled ({@link CsvFormatOptions#quoting()} {@code false} — the TSV dialect), the scan
+     * degenerates to a pure newline scan: no byte toggles quote state, every unescaped {@code \n} is a
+     * boundary, and {@code maxRecordBytes} enforcement is unchanged.
+     * <p>
      * Best-effort/open-tail contract: the scan assumes the buffer begins at a record boundary and advances
      * {@code lastBoundary} only on a true unquoted record terminator. So a chunk the segmentator cut mid-record
      * yields no boundary inside that leading partial, and a genuinely unterminated quoted field keeps
@@ -104,6 +108,7 @@ final class CsvRecordSplitter implements RecordSplitter {
         int recordStart = offset;
         boolean inQuotes = false;
         boolean fieldHasNonWhitespace = false;
+        boolean quoting = options.quoting();
         byte quoteAsByte = (byte) options.quoteChar();
         byte delimAsByte = (byte) options.delimiter();
         for (int i = offset; i < end; i++) {
@@ -139,7 +144,7 @@ final class CsvRecordSplitter implements RecordSplitter {
                 fieldHasNonWhitespace = false;
             } else if (b == delimAsByte) {
                 fieldHasNonWhitespace = false;
-            } else if (b == quoteAsByte && fieldHasNonWhitespace == false) {
+            } else if (quoting && b == quoteAsByte && fieldHasNonWhitespace == false) {
                 inQuotes = true;
             } else if (CsvFormatReader.isAsciiCsvFieldLeadingWhitespace(b & 0xff) == false) {
                 fieldHasNonWhitespace = true;
@@ -200,6 +205,7 @@ final class CsvRecordSplitter implements RecordSplitter {
         long consumed = 0;
         boolean inQuotes = false;
         boolean fieldHasNonWhitespace = false;
+        boolean quoting = options.quoting();
         byte quoteAsByte = (byte) options.quoteChar();
         byte escAsByte = (byte) options.escapeChar();
         byte delimAsByte = (byte) options.delimiter();
@@ -257,7 +263,7 @@ final class CsvRecordSplitter implements RecordSplitter {
                 fieldHasNonWhitespace = false;
                 continue;
             }
-            if (b == quoteAsByte && fieldHasNonWhitespace == false) {
+            if (quoting && b == quoteAsByte && fieldHasNonWhitespace == false) {
                 inQuotes = true;
                 continue;
             }
@@ -301,12 +307,16 @@ final class CsvRecordSplitter implements RecordSplitter {
      * field start (optionally after field-leading whitespace); a mid-field {@code quoteChar} is a
      * literal and does not toggle quote state. Returns the byte count up to and including the first
      * record-terminating {@code \n} that is outside a quoted field, or {@code -1} at EOF.
+     * <p>
+     * With quoting disabled ({@link CsvFormatOptions#quoting()} {@code false} — the TSV dialect), the
+     * scan degenerates to a pure newline scan with unchanged {@code maxRecordBytes} enforcement.
      */
     private long findNextRecordBoundaryQuotedFieldsOnly(InputStream stream) throws IOException {
         BufferedInputStream bis = stream instanceof BufferedInputStream b ? b : new BufferedInputStream(stream);
         long consumed = 0;
         boolean inQuotes = false;
         boolean fieldHasNonWhitespace = false;
+        boolean quoting = options.quoting();
         byte quoteAsByte = (byte) options.quoteChar();
         byte delimAsByte = (byte) options.delimiter();
         while (true) {
@@ -343,7 +353,7 @@ final class CsvRecordSplitter implements RecordSplitter {
             }
             if (b == delimAsByte) {
                 fieldHasNonWhitespace = false;
-            } else if (b == quoteAsByte && fieldHasNonWhitespace == false) {
+            } else if (quoting && b == quoteAsByte && fieldHasNonWhitespace == false) {
                 inQuotes = true;
             } else if (CsvFormatReader.isAsciiCsvFieldLeadingWhitespace(ib & 0xff) == false) {
                 fieldHasNonWhitespace = true;

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
@@ -1591,14 +1591,76 @@ public class CsvFormatReaderTests extends ESTestCase {
     /**
      * A field-leading quote opens a quoted field; an embedded {@code ""} is a literal quote and a lone
      * {@code "} closes the field. Pins the doubled-quote peek (the {@code peekByte} window) in both scanners.
+     * Quoting on TSV is opt-in via {@code WITH {"quote": "\""}} — the TSV default applies no quoting.
      */
     public void testTsvDoubledQuoteInQuotedFieldIsLiteral() throws IOException {
-        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(CsvFormatOptions.TSV);
+        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory, CsvFormatOptions.TSV, "tsv", List.of(".tsv"))
+            .withConfig(Map.of("quote", "\""));
         String row1 = "\"a\"\"b\"\tc\n"; // quoted field a"b (doubled quote), then c
         byte[] buf = (row1 + "d\te\n").getBytes(StandardCharsets.UTF_8);
 
         assertEquals(row1.length(), reader.recordSplitter().findNextRecordBoundary(new BufferedInputStream(new ByteArrayInputStream(buf))));
         assertEquals(buf.length - 1, reader.recordSplitter().findLastRecordBoundary(buf, buf.length));
+    }
+
+    /** The TSV dialect is unquoted by default; CSV keeps RFC 4180 quoting. */
+    public void testTsvDialectHasNoQuotingByDefault() {
+        assertFalse(CsvFormatOptions.TSV.quoting());
+        assertEquals(CsvFormatOptions.NO_QUOTE_CHAR, CsvFormatOptions.TSV.quoteChar());
+        assertTrue(CsvFormatOptions.DEFAULT.quoting());
+    }
+
+    /**
+     * TSV end-to-end with an unbalanced field-start {@code "}: the quote is literal data, the record
+     * ends at the newline, and the row count is exact. Pre-fix, the field-start quote opened quote
+     * state, glued both rows into one record, and the {@code "} was stripped by the tokenizer.
+     */
+    public void testTsvUnbalancedFieldStartQuoteIsLiteralData() throws IOException {
+        String tsv = "id:long\tname:keyword\n1\t\"alpha\n2\tbeta\n";
+        StorageObject object = createStorageObject(tsv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(CsvFormatOptions.TSV);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(2, page.getPositionCount());
+            BytesRefBlock name = (BytesRefBlock) page.getBlock(1);
+            assertEquals(new BytesRef("\"alpha"), name.getBytesRef(0, new BytesRef()));
+            assertEquals(new BytesRef("beta"), name.getBytesRef(1, new BytesRef()));
+        }
+    }
+
+    /** The logical record reader splits unquoted TSV on every newline, embedded unbalanced quotes and all. */
+    public void testTsvRecordReaderSplitsOnNewlineWithUnbalancedQuotes() throws IOException {
+        String data = "1\t\"x\tc\n2\td\te\n";
+        try (BufferedReader br = new BufferedReader(new StringReader(data))) {
+            CsvLogicalRecordReader recordReader = new CsvLogicalRecordReader(
+                br,
+                CsvFormatOptions.TSV.quoteChar(),
+                CsvFormatOptions.TSV.delimiter(),
+                SegmentableFormatReader.DEFAULT_MAX_RECORD_BYTES,
+                CsvFormatOptions.TSV.encoding()
+            );
+            assertEquals("1\t\"x\tc", recordReader.readRecord(false));
+            assertEquals("2\td\te", recordReader.readRecord(false));
+            assertNull(recordReader.readRecord(false));
+        }
+    }
+
+    /** {@code WITH {"quote": "\""}} restores the quote-aware dialect on TSV — a quoted newline is field content. */
+    public void testTsvOptInQuoteRestoresQuoting() throws IOException {
+        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory, CsvFormatOptions.TSV, "tsv", List.of(".tsv"))
+            .withConfig(Map.of("quote", "\""));
+        String tsv = "id:long\tname:keyword\n1\t\"multi\nline\"\n";
+        StorageObject object = createStorageObject(tsv);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(1, page.getPositionCount());
+            BytesRefBlock name = (BytesRefBlock) page.getBlock(1);
+            assertEquals(new BytesRef("multi\nline"), name.getBytesRef(0, new BytesRef()));
+        }
     }
 
     /** Oracle: the boundary scanner and {@link CsvFormatReader#readCsvRecord} must agree on record count, CSV and TSV. */

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvRecordSplitterContractTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvRecordSplitterContractTests.java
@@ -46,6 +46,10 @@ public class CsvRecordSplitterContractTests extends ESTestCase {
 
         Case bracket = bracketMvc(128);
         assertEquals(13L, bracket.newSplitter().findNextRecordBoundary(new ByteArrayInputStream(bytes("[multi\nline]\n"))));
+
+        // The unquoted TSV dialect has no quoting concept: the same shape ends at the first newline.
+        Case unquoted = unquotedNewlineScan(128);
+        assertEquals(7L, unquoted.newSplitter().findNextRecordBoundary(new ByteArrayInputStream(bytes("\"multi\nline\"\n"))));
     }
 
     public void testRecordTooLargeSentinel() throws IOException {
@@ -79,11 +83,33 @@ public class CsvRecordSplitterContractTests extends ESTestCase {
     }
 
     private static Case[] cases(int maxRecordBytes) {
-        return new Case[] { quotedFieldsOnly(maxRecordBytes), bracketMvc(maxRecordBytes) };
+        return new Case[] { quotedFieldsOnly(maxRecordBytes), bracketMvc(maxRecordBytes), unquotedNewlineScan(maxRecordBytes) };
     }
 
     private static Case quotedFieldsOnly(int maxRecordBytes) {
-        return new Case("quoted-fields-only", () -> new CsvRecordSplitter(CsvFormatOptions.TSV, maxRecordBytes));
+        // Tab-delimited with quoting enabled — the WITH {"quote": "\""} opt-in shape (the TSV
+        // default is unquoted, covered by the unquoted-newline-scan case below).
+        return new Case("quoted-fields-only", () -> new CsvRecordSplitter(quotedTsv(), maxRecordBytes));
+    }
+
+    private static Case unquotedNewlineScan(int maxRecordBytes) {
+        return new Case("unquoted-newline-scan", () -> new CsvRecordSplitter(CsvFormatOptions.TSV, maxRecordBytes));
+    }
+
+    private static CsvFormatOptions quotedTsv() {
+        return new CsvFormatOptions(
+            '\t',
+            '"',
+            '\\',
+            "//",
+            "",
+            StandardCharsets.UTF_8,
+            null,
+            CsvFormatOptions.DEFAULT_MAX_FIELD_SIZE,
+            CsvFormatOptions.MultiValueSyntax.NONE,
+            true,
+            CsvFormatOptions.DEFAULT_COLUMN_PREFIX
+        );
     }
 
     private static Case bracketMvc(int maxRecordBytes) {

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvRecordSplitterMaxRecordSizeTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvRecordSplitterMaxRecordSizeTests.java
@@ -35,11 +35,28 @@ public class CsvRecordSplitterMaxRecordSizeTests extends ESTestCase {
 
     public void testQuotedFieldsOnlyReturnsRecordTooLargeForUnclosedQuote() throws IOException {
         int maxRecordBytes = 32;
-        RecordSplitter splitter = new CsvRecordSplitter(CsvFormatOptions.TSV, maxRecordBytes);
+        // Tab-delimited with quoting opted in (the TSV default is unquoted and is covered below).
+        RecordSplitter splitter = new CsvRecordSplitter(quotedTsv(), maxRecordBytes);
         byte[] bytes = bytes("\"" + "x".repeat(maxRecordBytes + 1));
 
         assertEquals(RecordSplitter.RECORD_TOO_LARGE, splitter.findNextRecordBoundary(new ByteArrayInputStream(bytes)));
         assertEquals(RecordSplitter.RECORD_TOO_LARGE, splitter.findLastRecordBoundary(bytes, bytes.length));
+    }
+
+    /**
+     * The unquoted TSV dialect must NOT let an unbalanced field-start {@code "} inflate the apparent
+     * record: every newline is a boundary, so small records with stray quotes never trip the cap.
+     * Pre-fix, the quote-aware scan glued all four rows into one pseudo-record and returned
+     * {@code RECORD_TOO_LARGE}.
+     */
+    public void testTsvUnquotedFieldStartQuoteDoesNotInflateRecord() throws IOException {
+        int maxRecordBytes = 16;
+        RecordSplitter splitter = new CsvRecordSplitter(CsvFormatOptions.TSV, maxRecordBytes);
+        String row = "\"aaaa\tb\n"; // 8 bytes, unbalanced field-start quote
+        byte[] buf = bytes(row.repeat(4));
+
+        assertEquals(row.length(), splitter.findNextRecordBoundary(new ByteArrayInputStream(buf)));
+        assertEquals(buf.length - 1, splitter.findLastRecordBoundary(buf, buf.length));
     }
 
     public void testBracketMvcReturnsRecordTooLargeForUnclosedBracket() throws IOException {
@@ -125,6 +142,23 @@ public class CsvRecordSplitterMaxRecordSizeTests extends ESTestCase {
             null,
             CsvFormatOptions.DEFAULT_MAX_FIELD_SIZE,
             CsvFormatOptions.MultiValueSyntax.BRACKETS,
+            true,
+            CsvFormatOptions.DEFAULT_COLUMN_PREFIX
+        );
+    }
+
+    /** Tab-delimited with quoting re-enabled — the shape produced by {@code WITH {"quote": "\""}} on TSV. */
+    private static CsvFormatOptions quotedTsv() {
+        return new CsvFormatOptions(
+            '\t',
+            '"',
+            '\\',
+            "//",
+            "",
+            StandardCharsets.UTF_8,
+            null,
+            CsvFormatOptions.DEFAULT_MAX_FIELD_SIZE,
+            CsvFormatOptions.MultiValueSyntax.NONE,
             true,
             CsvFormatOptions.DEFAULT_COLUMN_PREFIX
         );

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvRecordSplitterTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvRecordSplitterTests.java
@@ -50,12 +50,52 @@ public class CsvRecordSplitterTests extends ESTestCase {
     }
 
     public void testTsvDoubledQuoteInQuotedFieldIsLiteral() throws IOException {
-        RecordSplitter splitter = splitter(CsvFormatOptions.TSV);
+        // Quote-aware doubled-quote handling only applies when quoting is opted in (TSV default is unquoted).
+        RecordSplitter splitter = splitter(quotedTsv());
         String row1 = "\"a\"\"b\"\tc\n";
         byte[] buf = bytes(row1 + "d\te\n");
 
         assertEquals(row1.length(), splitter.findNextRecordBoundary(new BufferedInputStream(new ByteArrayInputStream(buf))));
         assertEquals(buf.length - 1, splitter.findLastRecordBoundary(buf, buf.length));
+    }
+
+    /**
+     * The TSV dialect applies no quoting: an unbalanced field-start {@code "} is literal data and must
+     * not glue records across newlines. Pre-fix, the quote-aware scan opened quote state on the first
+     * row's field-start quote and skipped every following newline, gluing the rest of the input into
+     * one giant pseudo-record.
+     */
+    public void testTsvFieldStartUnbalancedQuoteDoesNotGlueRecords() throws IOException {
+        RecordSplitter splitter = splitter(CsvFormatOptions.TSV);
+        String row1 = "1\t\"broken\tc\n";
+        byte[] buf = bytes(row1 + "2\t\"also broken\te\n3\tf\tg\n");
+
+        assertEquals(row1.length(), splitter.findNextRecordBoundary(new BufferedInputStream(new ByteArrayInputStream(buf))));
+        assertEquals(buf.length - 1, splitter.findLastRecordBoundary(buf, buf.length));
+
+        int records = 0;
+        BufferedInputStream in = new BufferedInputStream(new ByteArrayInputStream(buf));
+        while (splitter.findNextRecordBoundary(in) >= 0) {
+            records++;
+        }
+        assertEquals("a boundary must be found at every newline", 3, records);
+    }
+
+    /** Without the {@code quote} opt-in a quoted newline splits the record; with it, the old behavior returns. */
+    public void testTsvQuotingIsOptIn() throws IOException {
+        String data = "\"a\nb\"\tc\n";
+        byte[] buf = bytes(data);
+
+        assertEquals(
+            "unquoted TSV must end the record at the first newline",
+            "\"a\n".length(),
+            splitter(CsvFormatOptions.TSV).findNextRecordBoundary(new BufferedInputStream(new ByteArrayInputStream(buf)))
+        );
+        assertEquals(
+            "WITH {\"quote\": \"\\\"\"} must restore quote-aware scanning",
+            buf.length,
+            splitter(quotedTsv()).findNextRecordBoundary(new BufferedInputStream(new ByteArrayInputStream(buf)))
+        );
     }
 
     public void testBracketMvcNewlineDoesNotTerminateRecord() throws IOException {
@@ -91,6 +131,23 @@ public class CsvRecordSplitterTests extends ESTestCase {
             null,
             CsvFormatOptions.DEFAULT_MAX_FIELD_SIZE,
             CsvFormatOptions.MultiValueSyntax.BRACKETS,
+            true,
+            CsvFormatOptions.DEFAULT_COLUMN_PREFIX
+        );
+    }
+
+    /** Tab-delimited with quoting re-enabled — the shape produced by {@code WITH {"quote": "\""}} on TSV. */
+    private static CsvFormatOptions quotedTsv() {
+        return new CsvFormatOptions(
+            '\t',
+            '"',
+            '\\',
+            "//",
+            "",
+            StandardCharsets.UTF_8,
+            null,
+            CsvFormatOptions.DEFAULT_MAX_FIELD_SIZE,
+            CsvFormatOptions.MultiValueSyntax.NONE,
             true,
             CsvFormatOptions.DEFAULT_COLUMN_PREFIX
         );

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalTsvLiteralQuotesIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalTsvLiteralQuotesIT.java
@@ -79,6 +79,26 @@ public class ExternalTsvLiteralQuotesIT extends AbstractEsqlIntegTestCase {
         }
     }
 
+    /**
+     * Field-START unbalanced quotes on the gzip streaming-parallel path, spanning multiple chunks.
+     * Every row's middle column begins with a single literal {@code "}. Under the old quote-aware
+     * TSV dialect a field-start quote opened quote state, so rows glued pairwise (or, for an odd
+     * tail, ran past {@code max_record_size}); with the unquoted TSV dialect every newline is a
+     * record boundary, the count is exact, and the {@code "} survives as field data.
+     */
+    public void testGzipStreamOnlyFieldStartUnbalancedQuotes() throws Exception {
+        assumeTrue("requires EXTERNAL command capability", EXTERNAL_COMMAND.isEnabled());
+        assumeTrue("max_record_size / parsing_parallelism pragmas are snapshot-only", Build.current().isSnapshot());
+        int rows = 150_000;
+        Path file = writeTsv(rows, Codec.GZIP, QuoteShape.FIELD_START);
+        try {
+            assertCount(file, pragmas(4, "1mb"), rows);
+            assertFieldStartQuotePreservedAsData(file, pragmas(4, "1mb"));
+        } finally {
+            Files.deleteIfExists(file);
+        }
+    }
+
     /** Stream-only path with dense literal quotes throughout the data, default cap. */
     public void testGzipStreamOnlyDenseLiteralQuotes() throws Exception {
         assumeTrue("requires EXTERNAL command capability", EXTERNAL_COMMAND.isEnabled());
@@ -133,7 +153,9 @@ public class ExternalTsvLiteralQuotesIT extends AbstractEsqlIntegTestCase {
         /** Row 0 has one literal mid-field quote, the rest are quote-free (forces a no-boundary chunk). */
         SINGLE_LEADING,
         /** Every row has an even number of literal mid-field quotes. */
-        DENSE
+        DENSE,
+        /** Every row's middle column STARTS with a single unbalanced literal quote. */
+        FIELD_START
     }
 
     private QueryPragmas pragmas(int parsingParallelism, String maxRecordSize) {
@@ -157,6 +179,22 @@ public class ExternalTsvLiteralQuotesIT extends AbstractEsqlIntegTestCase {
         }
     }
 
+    /**
+     * The literal {@code "} must survive as field data: with {@code header_row: false} the middle
+     * column is {@code col1}, and row 7's value is exactly {@code "b7} — leading quote intact, not
+     * stripped by any quote-aware tokenizer.
+     */
+    private void assertFieldStartQuotePreservedAsData(Path file, QueryPragmas pragmas) {
+        String query = "EXTERNAL \""
+            + StoragePath.fileUri(file)
+            + "\" WITH {\"header_row\": false} | WHERE col0 == \"f0_7\" | KEEP col1 | LIMIT 1";
+        try (var response = run(syncEsqlQueryRequest(query).pragmas(pragmas), TimeValue.timeValueMinutes(2))) {
+            List<List<Object>> values = getValuesList(response);
+            assertThat(values.size(), equalTo(1));
+            assertThat(values.get(0).get(0), equalTo("\"b7"));
+        }
+    }
+
     private Path writeTsv(int rows, Codec codec, QuoteShape shape) throws Exception {
         Path file = createTempDir().resolve("quotes" + codec.ext);
         OutputStream os = Files.newOutputStream(file);
@@ -168,6 +206,7 @@ public class ExternalTsvLiteralQuotesIT extends AbstractEsqlIntegTestCase {
                 String mid = switch (shape) {
                     case SINGLE_LEADING -> i == 0 ? "a\"b" : "a" + i; // one literal quote, only on row 0
                     case DENSE -> "x\"y\"z"; // two literal quotes every row
+                    case FIELD_START -> "\"b" + i; // unbalanced field-start quote, every row
                 };
                 w.write("f0_" + i + "\t" + mid + "\tf2_" + i + "\n");
             }


### PR DESCRIPTION
> **Draft, not ready for review** — filed automatically from an ES|QL ClickBench bench run as the validated-fix anchor for a correctness finding. Likely to be folded into other in-flight work; kept as a draft so the report can link working, tested code.

## What this is about

Every ES|QL query against compressed TSV on S3 at ClickBench-100M scale fails HTTP 500:

```
record exceeded max_record_size [67108864] after scanning [66117827] bytes for format [tsv];
possible unclosed quote or bracket cell
```

TSV is the CSV reader with `CsvFormatOptions.TSV`, which keeps `quoteChar='"'`. Real-world TSV has no quoting — a literal `"` is field data, and ClickBench's web data is dense with unbalanced field-start quotes. The record-boundary scanner opens quote-state on one, skips every following newline as quoted content, and on the compressed streaming path `StreamingParallelParsingCoordinator.growUntilRecordBoundary` grows the "record" past the 64 MiB cap and fails the query. On uncompressed TSV the same glue is absorbed per-record under `error_mode=null_field` — silently merging rows instead of failing.

## What this PR does

Makes the TSV dialect genuinely unquoted, end-to-end, so the splitter and the tokenizer describe the same grammar:

- `CsvFormatOptions`: `NO_QUOTE_CHAR` sentinel + `quoting()` accessor; the `TSV` constant is unquoted. CSV unchanged.
- `CsvLogicalRecordReader.readRecord`: with quoting off, a record ends at the first `\n` unconditionally.
- `CsvRecordSplitter`: with quoting off, both boundary scanners degenerate to pure newline scans (max-record cap preserved).
- `CsvFormatReader`: Jackson `CsvSchema.withoutQuoteChar()` for data + schema inference.
- The existing `quote` WITH option re-enables quoting per query for genuinely quoted tab-separated data.

## Does it work?

Targeted unit tests green at the bench's pinned main (`cbc52676`): `CsvRecordSplitter{,Contract,MaxRecordSize}Tests` (field-start unbalanced `"` does not glue; boundary at every newline; cap preserved), `CsvFormatReaderTests` (literal quotes as data; WITH-quote opt-in), and a new `ExternalTsvLiteralQuotesIT` shape — a field-start unbalanced quote spanning more than one chunk on the gzip path, the exact live killer, previously untested.

## What's out of scope / relations

- #149351 (prefix-XOR boundary scanner) accelerates the same quote semantics for CSV, opt-in; this PR removes quoting from TSV entirely, which makes TSV's scan a plain newline scan. The two touch `CsvFormatReader` — merge-order note for whichever lands second.
- The compressed-path fatality of segmentator overflows (vs the per-record recoverable path) is untouched — a possible separate hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
