### PR TITLE
test: fix DatafeedConfigTests mutation branches in release mode

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfigTests.java
@@ -1063,22 +1063,30 @@ public class DatafeedConfigTests extends AbstractBWCSerializationTestCase<Datafe
                 if (instance.getProjectRouting() == null && DatafeedConfig.DATAFEED_CROSS_PROJECT.isEnabled()) {
                     builder.setProjectRouting("_alias:" + randomAlphaOfLengthBetween(1, 10) + "-*");
                 } else {
-                    builder.setProjectRouting(null);
+                    if (instance.getProjectRouting() == null) {
+                        mutateCloudInternalCredential(builder, instance);
+                    } else {
+                        builder.setProjectRouting(null);
+                    }
                 }
                 break;
             case 14:
-                if (instance.getCloudInternalCredential() == null) {
-                    builder.setCloudInternalCredential(
-                        new PersistedCloudCredential(randomAlphaOfLength(10), new SecureString(randomAlphaOfLength(20).toCharArray()))
-                    );
-                } else {
-                    builder.setCloudInternalCredential(null);
-                }
+                mutateCloudInternalCredential(builder, instance);
                 break;
             default:
                 throw new AssertionError("Illegal randomisation branch");
         }
         return builder.build();
+    }
+
+    private static void mutateCloudInternalCredential(DatafeedConfig.Builder builder, DatafeedConfig instance) {
+        if (instance.getCloudInternalCredential() == null) {
+            builder.setCloudInternalCredential(
+                new PersistedCloudCredential(randomAlphaOfLength(10), new SecureString(randomAlphaOfLength(20).toCharArray()))
+            );
+        } else {
+            builder.setCloudInternalCredential(null);
+        }
     }
 
     @Override


### PR DESCRIPTION
The `DatafeedConfigTests.testEqualsAndHashcode` mutation test was producing instances that compared equal to the original when run in release mode (`-Dbuild.snapshot=false`), because two of the randomisation branches could leave the mutated builder in the same state as the original. Branch 14 has been refactored into a shared helper, and branch 13 (project routing) now falls back to the cloud-internal-credential mutation when the project routing is already null in release mode so that the builder is always changed.

Resolves #150565

- I have signed the [contributor license agreement](https://www.elastic.co/contributor-agreement).
- I have followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md).
- The pull request targets `main`.
- This is not a class submission.