### PR TITLE
Add SELinux :z label to Docker volume mounts in NativeImageBuildTask

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/docker/NativeImageBuildTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/docker/NativeImageBuildTask.java
@@ -180,14 +180,14 @@ public abstract class NativeImageBuildTask extends DefaultTask {
                     path = path.replace("\\", "/");
                 }
                 args.add("-v");
-                args.add(path + ":/cp/" + i + ":ro");
+                args.add(path + ":/cp/" + i + ":ro,z");
             }
             args.add("-v");
             String outPath = outputDir.getAbsolutePath();
             if (File.separatorChar == '\\') {
                 outPath = outPath.replace("\\", "/");
             }
-            args.add(outPath + ":/output");
+            args.add(outPath + ":/output:z");
             args.add("--platform");
             args.add(platform);
             args.add(imageTag);


### PR DESCRIPTION
On SELinux-enforcing hosts (Fedora, RHEL) the container process is denied access to host-mounted paths unless the volume is relabeled. The :z suffix applies a shared SELinux context, which is a no-op on non-SELinux systems.