### PR TITLE
Add reference docs for the ml_standard tokenizer

### DIFF
--- a/docs/reference/text-analysis/analysis-mlstandard-tokenizer.md
+++ b/docs/reference/text-analysis/analysis-mlstandard-tokenizer.md
@@ -1,0 +1,34 @@
+---
+navigation_title: "ML standard"
+mapped_pages:
+  - https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-mlstandard-tokenizer.html
+---
+
+# ML standard tokenizer [analysis-mlstandard-tokenizer]
+
+
+The `ml_standard` tokenizer tokenizes log messages and other machine-generated text for use with machine learning categorization. It is similar to the `whitespace` tokenizer, but applies additional rules that work well for log formats in English.
+
+The tokenizer keeps URLs, email addresses, Unix paths, and Windows paths as single tokens where possible. It also filters out tokens that are hexadecimal numbers or begin with a digit.
+
+
+## Example output [ml-standard-tokenizer-example-output]
+
+```console
+POST _analyze
+{
+  "tokenizer": "ml_standard",
+  "text": "Failed to bootstrap path: path = /usr/libexec/mdmclient, error = 108: Invalid path"
+}
+```
+
+The above sentence would produce the following terms:
+
+```text
+[ Failed, to, bootstrap, path, path, /usr/libexec/mdmclient, error, Invalid, path ]
+```
+
+
+## Configuration [ml-standard-tokenizer-configuration]
+
+The `ml_standard` tokenizer is not configurable.

--- a/docs/reference/text-analysis/toc.yml
+++ b/docs/reference/text-analysis/toc.yml
@@ -18,6 +18,7 @@ toc:
       - file: analysis-keyword-tokenizer.md
       - file: analysis-letter-tokenizer.md
       - file: analysis-lowercase-tokenizer.md
+      - file: analysis-mlstandard-tokenizer.md
       - file: analysis-ngram-tokenizer.md
       - file: analysis-pathhierarchy-tokenizer.md
       - file: analysis-pattern-tokenizer.md

--- a/docs/reference/text-analysis/tokenizer-reference.md
+++ b/docs/reference/text-analysis/tokenizer-reference.md
@@ -68,6 +68,9 @@ The following tokenizers are usually used with structured text like identifiers,
 [Keyword Tokenizer](/reference/text-analysis/analysis-keyword-tokenizer.md)
 :   The `keyword` tokenizer is a noop tokenizer that accepts whatever text it is given and outputs the exact same text as a single term. It can be combined with token filters like [`lowercase`](/reference/text-analysis/analysis-lowercase-tokenfilter.md) to normalise the analysed terms.
 
+[ML Standard Tokenizer](/reference/text-analysis/analysis-mlstandard-tokenizer.md)
+:   The `ml_standard` tokenizer tokenizes log messages and other machine-generated text for use with machine learning categorization. It keeps URLs, email addresses, and paths as single tokens where possible, and filters out tokens that are hexadecimal numbers or begin with a digit.
+
 [Pattern Tokenizer](/reference/text-analysis/analysis-pattern-tokenizer.md)
 :   The `pattern` tokenizer uses a regular expression to either split text into terms whenever it matches a word separator, or to capture matching text as terms.
 


### PR DESCRIPTION
Adds documentation for the `ml_standard` tokenizer, which is used to tokenize log messages and other machine-generated text for machine learning categorization. The new page is linked from the tokenizer reference and added to the text-analysis table of contents so it appears in the official docs site.

Resolves #136708

- [x] I have signed the [contributor license agreement](https://www.elastic.co/contributor-agreement).
- [x] I have followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md).
- This is a documentation-only change (no code), so the code-submission items do not apply.
- [x] The pull request targets `main`.
- [x] This is not a class submission.