### PR TITLE
Add x-content round-trip tests for update-by-query and delete-by-query

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByPaginatedSearchRequest.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByPaginatedSearchRequest.java
@@ -15,14 +15,21 @@ import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.action.support.replication.ReplicationRequest;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.transport.RemoteClusterAware;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentFactory;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentParserConfiguration;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -30,6 +37,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 import static org.elasticsearch.core.TimeValue.timeValueMillis;
@@ -169,6 +178,34 @@ public abstract class AbstractBulkByPaginatedSearchRequest<Self extends Abstract
             searchRequest.source(new SearchSourceBuilder());
             searchRequest.source().size(DEFAULT_SCROLL_SIZE);
         }
+    }
+
+    static <Request extends AbstractBulkByPaginatedSearchRequest<Request>> Request parseXContent(
+        Request request,
+        XContentParser parser,
+        Predicate<NodeFeature> clusterSupportsFeature,
+        Map<String, Consumer<Object>> bodyConsumers
+    ) throws IOException {
+        Map<String, Object> body = parser.map();
+        for (Map.Entry<String, Consumer<Object>> consumer : bodyConsumers.entrySet()) {
+            Object value = body.remove(consumer.getKey());
+            if (value != null) {
+                consumer.getValue().accept(value);
+            }
+        }
+        XContentBuilder builder = XContentFactory.contentBuilder(parser.contentType());
+        builder.map(body);
+        try (
+            XContentParser innerParser = XContentHelper.createParserNotCompressed(
+                XContentParserConfiguration.EMPTY.withRegistry(parser.getXContentRegistry())
+                    .withDeprecationHandler(parser.getDeprecationHandler()),
+                BytesReference.bytes(builder),
+                parser.contentType()
+            )
+        ) {
+            request.getSearchRequest().source().parseXContent(request.getSearchRequest(), innerParser, false, clusterSupportsFeature);
+        }
+        return request;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/reindex/DeleteByQueryRequest.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/DeleteByQueryRequest.java
@@ -14,12 +14,18 @@ import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
@@ -181,7 +187,22 @@ public class DeleteByQueryRequest extends AbstractBulkByPaginatedSearchRequest<D
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
         getSearchRequest().source().innerToXContent(builder, params);
+        if (getMaxDocs() != MAX_DOCS_ALL_MATCHES) {
+            builder.field("max_docs", getMaxDocs());
+        }
+        if (isAbortOnVersionConflict() == false) {
+            builder.field("conflicts", "proceed");
+        }
         builder.endObject();
         return builder;
+    }
+
+    public static DeleteByQueryRequest fromXContent(XContentParser parser, Predicate<NodeFeature> clusterSupportsFeature)
+        throws IOException {
+        DeleteByQueryRequest deleteByQueryRequest = new DeleteByQueryRequest();
+        Map<String, Consumer<Object>> consumers = new HashMap<>();
+        consumers.put("conflicts", o -> deleteByQueryRequest.setConflicts((String) o));
+        consumers.put("max_docs", s -> ReindexRequest.setMaxDocsValidateIdentical(deleteByQueryRequest, ((Number) s).intValue()));
+        return parseXContent(deleteByQueryRequest, parser, clusterSupportsFeature, consumers);
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/reindex/UpdateByQueryRequest.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/UpdateByQueryRequest.java
@@ -14,12 +14,19 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.script.Script;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 /**
  * Request to update some documents. That means you can't change their type, id, index, or anything like that. This implements
@@ -182,7 +189,23 @@ public class UpdateByQueryRequest extends AbstractBulkIndexByPaginatedSearchRequ
             getScript().toXContent(builder, params);
         }
         getSearchRequest().source().innerToXContent(builder, params);
+        if (getMaxDocs() != MAX_DOCS_ALL_MATCHES) {
+            builder.field("max_docs", getMaxDocs());
+        }
+        if (isAbortOnVersionConflict() == false) {
+            builder.field("conflicts", "proceed");
+        }
         builder.endObject();
         return builder;
+    }
+
+    public static UpdateByQueryRequest fromXContent(XContentParser parser, Predicate<NodeFeature> clusterSupportsFeature)
+        throws IOException {
+        UpdateByQueryRequest updateByQueryRequest = new UpdateByQueryRequest();
+        Map<String, Consumer<Object>> consumers = new HashMap<>();
+        consumers.put("conflicts", o -> updateByQueryRequest.setConflicts((String) o));
+        consumers.put("script", o -> updateByQueryRequest.setScript(Script.parse(o)));
+        consumers.put("max_docs", s -> ReindexRequest.setMaxDocsValidateIdentical(updateByQueryRequest, ((Number) s).intValue()));
+        return parseXContent(updateByQueryRequest, parser, clusterSupportsFeature, consumers);
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/reindex/DeleteByQueryRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/DeleteByQueryRequestTests.java
@@ -12,10 +12,16 @@ package org.elasticsearch.index.reindex;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.Predicates;
 import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.query.TermQueryBuilder;
+import org.elasticsearch.search.SearchModule;
+import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
+import java.util.Collections;
 
 import static org.apache.lucene.tests.util.TestUtil.randomSimpleString;
 import static org.hamcrest.Matchers.containsString;
@@ -24,6 +30,13 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
 public class DeleteByQueryRequestTests extends AbstractBulkByPaginatedSearchRequestTestCase<DeleteByQueryRequest> {
+
+    @Override
+    protected NamedXContentRegistry xContentRegistry() {
+        SearchModule searchModule = new SearchModule(Settings.EMPTY, Collections.emptyList());
+        return new NamedXContentRegistry(searchModule.getNamedXContents());
+    }
+
     public void testDeleteteByQueryRequestImplementsIndicesRequestReplaceable() {
         int numIndices = between(1, 100);
         String[] indices = new String[numIndices];
@@ -109,19 +122,25 @@ public class DeleteByQueryRequestTests extends AbstractBulkByPaginatedSearchRequ
         );
     }
 
-    // TODO: Implement standard to/from x-content parsing tests
-
     @Override
     protected DeleteByQueryRequest createTestInstance() {
-        return newRequest();
+        DeleteByQueryRequest deleteByQueryRequest = new DeleteByQueryRequest();
+        if (randomBoolean()) {
+            deleteByQueryRequest.setMaxDocs(randomIntBetween(1, 1000));
+        }
+        if (randomBoolean()) {
+            deleteByQueryRequest.setAbortOnVersionConflict(false);
+        }
+        if (randomBoolean()) {
+            deleteByQueryRequest.setBatchSize(randomIntBetween(1, 1000));
+        }
+        deleteByQueryRequest.setQuery(new TermQueryBuilder("foo", "fooval"));
+        return deleteByQueryRequest;
     }
 
     @Override
     protected DeleteByQueryRequest doParseInstance(XContentParser parser) throws IOException {
-        XContentParser.Token token;
-        while ((token = parser.nextToken()) != null) {
-        }
-        return newRequest();
+        return DeleteByQueryRequest.fromXContent(parser, Predicates.never());
     }
 
     @Override
@@ -130,5 +149,10 @@ public class DeleteByQueryRequestTests extends AbstractBulkByPaginatedSearchRequ
     }
 
     @Override
-    protected void assertEqualInstances(DeleteByQueryRequest expectedInstance, DeleteByQueryRequest newInstance) {}
+    protected void assertEqualInstances(DeleteByQueryRequest expectedInstance, DeleteByQueryRequest newInstance) {
+        assertNotSame(newInstance, expectedInstance);
+        assertEquals(expectedInstance.getSearchRequest(), newInstance.getSearchRequest());
+        assertEquals(expectedInstance.getMaxDocs(), newInstance.getMaxDocs());
+        assertEquals(expectedInstance.isAbortOnVersionConflict(), newInstance.isAbortOnVersionConflict());
+    }
 }

--- a/server/src/test/java/org/elasticsearch/index/reindex/UpdateByQueryRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/UpdateByQueryRequestTests.java
@@ -12,10 +12,16 @@ package org.elasticsearch.index.reindex;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.Predicates;
 import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.query.TermQueryBuilder;
+import org.elasticsearch.search.SearchModule;
+import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
+import java.util.Collections;
 
 import static org.apache.lucene.tests.util.TestUtil.randomSimpleString;
 import static org.hamcrest.Matchers.containsString;
@@ -24,6 +30,13 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
 public class UpdateByQueryRequestTests extends AbstractBulkByPaginatedSearchRequestTestCase<UpdateByQueryRequest> {
+
+    @Override
+    protected NamedXContentRegistry xContentRegistry() {
+        SearchModule searchModule = new SearchModule(Settings.EMPTY, Collections.emptyList());
+        return new NamedXContentRegistry(searchModule.getNamedXContents());
+    }
+
     public void testUpdateByQueryRequestImplementsIndicesRequestReplaceable() {
         int numIndices = between(1, 100);
         String[] indices = new String[numIndices];
@@ -93,19 +106,30 @@ public class UpdateByQueryRequestTests extends AbstractBulkByPaginatedSearchRequ
         assertEquals(original.getPipeline(), forSliced.getPipeline());
     }
 
-    // TODO: Implement standard to/from x-content parsing tests
-
     @Override
     protected UpdateByQueryRequest createTestInstance() {
-        return newRequest();
+        UpdateByQueryRequest updateByQueryRequest = new UpdateByQueryRequest();
+        if (randomBoolean()) {
+            updateByQueryRequest.setScript(mockScript(randomAlphaOfLength(5)));
+        }
+        if (randomBoolean()) {
+            updateByQueryRequest.setMaxDocs(randomIntBetween(1, 1000));
+        }
+        if (randomBoolean()) {
+            updateByQueryRequest.setAbortOnVersionConflict(false);
+        }
+        if (randomBoolean()) {
+            updateByQueryRequest.setBatchSize(randomIntBetween(1, 1000));
+        }
+        if (randomBoolean()) {
+            updateByQueryRequest.setQuery(new TermQueryBuilder("foo", "fooval"));
+        }
+        return updateByQueryRequest;
     }
 
     @Override
     protected UpdateByQueryRequest doParseInstance(XContentParser parser) throws IOException {
-        XContentParser.Token token;
-        while ((token = parser.nextToken()) != null) {
-        }
-        return newRequest();
+        return UpdateByQueryRequest.fromXContent(parser, Predicates.never());
     }
 
     @Override
@@ -114,5 +138,11 @@ public class UpdateByQueryRequestTests extends AbstractBulkByPaginatedSearchRequ
     }
 
     @Override
-    protected void assertEqualInstances(UpdateByQueryRequest expectedInstance, UpdateByQueryRequest newInstance) {}
+    protected void assertEqualInstances(UpdateByQueryRequest expectedInstance, UpdateByQueryRequest newInstance) {
+        assertNotSame(newInstance, expectedInstance);
+        assertEquals(expectedInstance.getSearchRequest(), newInstance.getSearchRequest());
+        assertEquals(expectedInstance.getMaxDocs(), newInstance.getMaxDocs());
+        assertEquals(expectedInstance.isAbortOnVersionConflict(), newInstance.isAbortOnVersionConflict());
+        assertEquals(expectedInstance.getScript(), newInstance.getScript());
+    }
 }


### PR DESCRIPTION
Adds `AbstractXContentTestCase` round-trip testing for `UpdateByQueryRequest` and `DeleteByQueryRequest`, alongside the already-tested `ReindexRequest`. A shared `parseXContent` helper in `AbstractBulkByPaginatedSearchRequest` applies request-specific top-level fields (`conflicts`, `max_docs`, and `script` for update) and then delegates the remaining body to `SearchSourceBuilder`. `toXContent` was extended on both requests to emit `max_docs` and `conflicts` so that serialization is symmetric with parsing, and the test instances now exercise the full state space.

Resolves #43456

- [x] I have signed the [contributor license agreement](https://www.elastic.co/contributor-agreement).
- [x] I have followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md).
- [x] The pull request targets `main`.
- [x] This is not a class submission.