### PR TITLE
Document nori default XPN stoptag behavior for Korean prefixes

### DIFF
--- a/docs/reference/elasticsearch-plugins/analysis-nori-speech.md
+++ b/docs/reference/elasticsearch-plugins/analysis-nori-speech.md
@@ -24,6 +24,34 @@ and defaults to:
 ]
 ```
 
+::::{warning}
+The default `stoptags` include `XPN` (prefix). For Korean terms where a meaning-carrying prefix is emitted as `XPN`, the default `nori` analyzer removes the prefix. For example, `비급여` is analyzed as `급여`:
+
+```console
+GET _analyze
+{
+  "analyzer": "nori",
+  "text": "비급여"
+}
+```
+
+Which responds with:
+
+```console-result
+{
+  "tokens" : [ {
+    "token" : "급여",
+    "start_offset" : 1,
+    "end_offset" : 3,
+    "type" : "word",
+    "position" : 1
+  } ]
+}
+```
+
+To preserve the full term, add entries such as `비급여` with `user_dictionary_rules` so they are emitted as a single noun token. To preserve prefix tokens globally, define a custom `stoptags` list that omits `XPN`; this preserves prefixes such as `비` but can add prefix noise.
+::::
+
 For example:
 
 ```console


### PR DESCRIPTION
Adds a warning to the `nori_part_of_speech` token filter docs: the default `stoptags` include `XPN`, so a meaning-carrying Korean prefix emitted as `XPN` is removed by the default `nori` analyzer. For example, `비급여` (non-covered) is analyzed as `급여` (covered), so the index cannot distinguish the two.

The warning shows the `_analyze` output and two remedies: registering such terms via `user_dictionary_rules` (preserves the full term as a single noun token), or defining a custom `stoptags` list that omits `XPN` (preserves prefix tokens, with possible prefix noise).

Closes #151094.
