### PR TITLE
[9.3] [CI] Ensure java is present before running GradleRunner, fall back to gradlew (#151091)

### DIFF
--- a/.buildkite/hooks/pre-command.bat
+++ b/.buildkite/hooks/pre-command.bat
@@ -6,10 +6,10 @@ FOR /F "tokens=* eol=#" %%i in ('type .ci\java-versions.properties') do set %%i
 SET JAVA_HOME=%USERPROFILE%\.java\%ES_BUILD_JAVA%
 SET JAVA16_HOME=%USERPROFILE%\.java\openjdk16
 
-SET GRADLEW=./gradlew --parallel --no-daemon --scan --build-cache --no-watch-fs -Dorg.elasticsearch.build.cache.url=https://gradle-enterprise.elastic.co/cache/
-SET GRADLEW_BAT=./gradlew.bat --parallel --no-daemon --scan --build-cache --no-watch-fs -Dorg.elasticsearch.build.cache.url=https://gradle-enterprise.elastic.co/cache/
+SET GRADLEW=./gradlew --parallel --scan --build-cache --no-watch-fs -Dorg.elasticsearch.build.cache.url=https://gradle-enterprise.elastic.co/cache/
+SET GRADLEW_BAT=./gradlew.bat --parallel --scan --build-cache --no-watch-fs -Dorg.elasticsearch.build.cache.url=https://gradle-enterprise.elastic.co/cache/
 
-(if not exist "%USERPROFILE%/.gradle" mkdir "%USERPROFILE%/.gradle") && (echo. >> "%USERPROFILE%/.gradle/gradle.properties" && echo org.gradle.daemon=false >> "%USERPROFILE%/.gradle/gradle.properties")
+@REM (if not exist "%USERPROFILE%/.gradle" mkdir "%USERPROFILE%/.gradle") && (echo. >> "%USERPROFILE%/.gradle/gradle.properties" && echo org.gradle.daemon=false >> "%USERPROFILE%/.gradle/gradle.properties")
 
 set WORKSPACE=%cd%
 set BUILD_NUMBER=%BUILDKITE_BUILD_NUMBER%

--- a/.buildkite/pipelines/pull-request/packaging-tests-windows-sample.yml
+++ b/.buildkite/pipelines/pull-request/packaging-tests-windows-sample.yml
@@ -22,6 +22,6 @@ steps:
           diskType: hyperdisk-balanced
           diskSizeGb: 350
           preemptible: true
-          spotZones: 'asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c'
+          spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"
         env:
           PACKAGING_TASK: "{{matrix.PACKAGING_TASK}}"

--- a/.buildkite/scripts/windows-run-gradle.sh
+++ b/.buildkite/scripts/windows-run-gradle.sh
@@ -2,4 +2,15 @@
 
 set -euo pipefail
 
+WORKSPACE="$(pwd)"
+export WORKSPACE
+
+export $(cat .ci/java-versions.properties | grep '=' | xargs)
+
+JAVA_HOME="$HOME/.java/$ES_BUILD_JAVA"
+export JAVA_HOME
+
+PATH="$JAVA_HOME/bin:$PATH"
+export PATH
+
 .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true ${GRADLE_PARAMS:-} $GRADLE_TASK

--- a/.ci/scripts/run-gradle.sh
+++ b/.ci/scripts/run-gradle.sh
@@ -65,5 +65,5 @@ echo "--- Running gradle tasks"
 if command -v java > /dev/null; then
   java -jar "$RUNNER_JAR" -- $GRADLEW_ARGS -S --max-workers=$MAX_WORKERS $TESTS_SEED_PARAM "$@"
 else
-  "$GRADLEW" -S --max-workers=$MAX_WORKERS $TESTS_SEED_PARAM ${EXTRA_GRADLE_ARGS:-} "$@"
+  "$GRADLEW" -S --max-workers=$MAX_WORKERS $TESTS_SEED_PARAM "$@"
 fi

--- a/.ci/scripts/run-gradle.sh
+++ b/.ci/scripts/run-gradle.sh
@@ -61,4 +61,9 @@ fi
 GRADLEW_ARGS="${GRADLEW#./gradlew }"
 
 echo "--- Running gradle tasks"
-java -jar "$RUNNER_JAR" -- $GRADLEW_ARGS -S --max-workers=$MAX_WORKERS $TESTS_SEED_PARAM "$@"
+
+if command -v java > /dev/null; then
+  java -jar "$RUNNER_JAR" -- $GRADLEW_ARGS -S --max-workers=$MAX_WORKERS $TESTS_SEED_PARAM "$@"
+else
+  "$GRADLEW" -S --max-workers=$MAX_WORKERS $TESTS_SEED_PARAM ${EXTRA_GRADLE_ARGS:-} "$@"
+fi


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[CI] Ensure java is present before running GradleRunner, fall back to gradlew (#151091)](https://github.com/elastic/elasticsearch/pull/151091)

<!--- Backport version: 12.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)