### PR TITLE
[9.3] Fix testConfiguredReservedRolesAfterClosingAndOpeningIndex (#147710) | Fix testConfiguredReservedRolesAfterClosingAndOpeningIndex (#148285) | Fix QueryableReservedRolesIT close-during-recovery race (#148496)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -39,9 +39,6 @@ tests:
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=transform/transforms_unattended/Test unattended put and start}
   issue: https://github.com/elastic/elasticsearch/issues/120019
-- class: org.elasticsearch.xpack.security.QueryableReservedRolesIT
-  method: testConfiguredReservedRolesAfterClosingAndOpeningIndex
-  issue: https://github.com/elastic/elasticsearch/issues/120127
 - class: org.elasticsearch.xpack.ccr.FollowIndexSecurityIT
   method: testCleanShardFollowTaskAfterDeleteFollower
   issue: https://github.com/elastic/elasticsearch/issues/120339

--- a/x-pack/plugin/security/qa/security-basic/src/javaRestTest/java/org/elasticsearch/xpack/security/QueryableReservedRolesIT.java
+++ b/x-pack/plugin/security/qa/security-basic/src/javaRestTest/java/org/elasticsearch/xpack/security/QueryableReservedRolesIT.java
@@ -48,6 +48,7 @@ import static org.elasticsearch.xpack.security.QueryRoleIT.assertQuery;
 import static org.elasticsearch.xpack.security.QueryRoleIT.waitForMigrationCompletion;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.iterableWithSize;
 import static org.hamcrest.Matchers.not;
@@ -286,6 +287,10 @@ public class QueryableReservedRolesIT extends ESRestTestCase {
     }
 
     private void closeSecurityIndex() throws Exception {
+        // Wait for green: closing while shards are still recovering races with TransportVerifyShardBeforeCloseAction
+        // and silently no-ops — the API returns HTTP 200 with acknowledged=false and state stays OPEN.
+        ensureGreen(adminClient(), INTERNAL_SECURITY_MAIN_INDEX_7);
+
         Request request = new Request("POST", "/" + TestRestrictedIndices.INTERNAL_SECURITY_MAIN_INDEX_7 + "/_close");
         request.setOptions(
             expectWarnings(
@@ -295,15 +300,10 @@ public class QueryableReservedRolesIT extends ESRestTestCase {
         );
         Response response = adminClient().performRequest(request);
         assertOK(response);
-        // The close API can return acknowledged with the close-block applied but before IndexMetadata.state has
-        // been flipped to CLOSE.
-        assertBusy(() -> {
-            final Request stateRequest = new Request("GET", "_cluster/state/metadata/" + INTERNAL_SECURITY_MAIN_INDEX_7);
-            final Response stateResponse = adminClient().performRequest(stateRequest);
-            assertOK(stateResponse);
-            final String indexState = ObjectPath.createFromResponse(stateResponse).evaluate("metadata.indices.\\.security-7.state");
-            assertThat(indexState, equalTo("close"));
-        }, 30, TimeUnit.SECONDS);
+
+        final Map<String, Object> closeResponse = responseAsMap(response);
+        assertThat(closeResponse, hasEntry("acknowledged", true));
+        assertThat(closeResponse, hasEntry("shards_acknowledged", true));
     }
 
     private void openSecurityIndex() throws Exception {

--- a/x-pack/plugin/security/qa/security-basic/src/javaRestTest/java/org/elasticsearch/xpack/security/QueryableReservedRolesIT.java
+++ b/x-pack/plugin/security/qa/security-basic/src/javaRestTest/java/org/elasticsearch/xpack/security/QueryableReservedRolesIT.java
@@ -295,6 +295,15 @@ public class QueryableReservedRolesIT extends ESRestTestCase {
         );
         Response response = adminClient().performRequest(request);
         assertOK(response);
+        // The close API can return acknowledged with the close-block applied but before IndexMetadata.state has
+        // been flipped to CLOSE.
+        assertBusy(() -> {
+            final Request stateRequest = new Request("GET", "_cluster/state/metadata/" + INTERNAL_SECURITY_MAIN_INDEX_7);
+            final Response stateResponse = adminClient().performRequest(stateRequest);
+            assertOK(stateResponse);
+            final String indexState = ObjectPath.createFromResponse(stateResponse).evaluate("metadata.indices.\\.security-7.state");
+            assertThat(indexState, equalTo("close"));
+        }, 30, TimeUnit.SECONDS);
     }
 
     private void openSecurityIndex() throws Exception {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/QueryableBuiltInRolesSynchronizer.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/QueryableBuiltInRolesSynchronizer.java
@@ -22,6 +22,7 @@ import org.elasticsearch.cluster.NotMasterException;
 import org.elasticsearch.cluster.SimpleBatchedExecutor;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.metadata.MetadataIndexStateService;
 import org.elasticsearch.cluster.metadata.ProjectMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.cluster.service.MasterServiceTaskQueue;
@@ -487,7 +488,24 @@ public final class QueryableBuiltInRolesSynchronizer implements ClusterStateList
 
     private boolean isSecurityIndexClosed(final ClusterState state) {
         final IndexMetadata indexMetadata = resolveSecurityIndexMetadata(state.metadata());
-        return indexMetadata != null && indexMetadata.getState() == IndexMetadata.State.CLOSE;
+        return indexMetadata != null && isClosedOrClosing(state, indexMetadata);
+    }
+
+    /**
+     * Returns true if the given index is closed or is in the process of being closed. The close API installs
+     * {@link MetadataIndexStateService#INDEX_CLOSED_BLOCK} before flipping {@link IndexMetadata#getState()} to
+     * {@link IndexMetadata.State#CLOSE}, so checking the state field alone misses the in-progress window.
+     */
+    private static boolean isClosedOrClosing(final ClusterState state, final IndexMetadata indexMetadata) {
+        if (indexMetadata.getState() == IndexMetadata.State.CLOSE) {
+            return true;
+        }
+        return state.blocks()
+            .hasIndexBlockWithId(
+                state.metadata().projectFor(indexMetadata.getIndex()).id(),
+                indexMetadata.getIndex().getName(),
+                MetadataIndexStateService.INDEX_CLOSED_BLOCK_ID
+            );
     }
 
     /**
@@ -504,12 +522,13 @@ public final class QueryableBuiltInRolesSynchronizer implements ClusterStateList
         final Map<String, String> newRolesDigests,
         final ActionListener<Void> listener
     ) {
-        final IndexMetadata securityIndexMetadata = resolveSecurityIndexMetadata(clusterService.state().metadata());
+        final ClusterState currentState = clusterService.state();
+        final IndexMetadata securityIndexMetadata = resolveSecurityIndexMetadata(currentState.metadata());
         if (securityIndexMetadata == null) {
             listener.onFailure(new IndexNotFoundException(SECURITY_MAIN_ALIAS));
             return;
         }
-        if (securityIndexMetadata.getState() == IndexMetadata.State.CLOSE) {
+        if (isClosedOrClosing(currentState, securityIndexMetadata)) {
             listener.onFailure(new IndexClosedException(securityIndexMetadata.getIndex()));
             return;
         }
@@ -580,11 +599,9 @@ public final class QueryableBuiltInRolesSynchronizer implements ClusterStateList
             if (indexMetadata == null) {
                 throw new IndexNotFoundException(concreteSecurityIndexName);
             }
-            if (indexMetadata.getState() == IndexMetadata.State.CLOSE) {
-                // Index was closed between when the sync started and when this task runs. Do not update the
-                // synced-roles digest in metadata, since the actual role documents could not have been
-                // updated/deleted in a closed index. IndexClosedException is treated as an expected failure
-                // and does not count toward failedSyncAttempts.
+            if (isClosedOrClosing(state, indexMetadata)) {
+                // Bail if the index closed (or began closing) since the sync started. IndexClosedException is
+                // in isExpectedFailure, so this does not count against failedSyncAttempts.
                 throw new IndexClosedException(indexMetadata.getIndex());
             }
             Map<String, String> existingRoleDigests = indexMetadata.getCustomData(METADATA_QUERYABLE_BUILT_IN_ROLES_DIGEST_KEY);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/QueryableBuiltInRolesSynchronizer.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/QueryableBuiltInRolesSynchronizer.java
@@ -509,6 +509,10 @@ public final class QueryableBuiltInRolesSynchronizer implements ClusterStateList
             listener.onFailure(new IndexNotFoundException(SECURITY_MAIN_ALIAS));
             return;
         }
+        if (securityIndexMetadata.getState() == IndexMetadata.State.CLOSE) {
+            listener.onFailure(new IndexClosedException(securityIndexMetadata.getIndex()));
+            return;
+        }
         final Index concreteSecurityIndex = securityIndexMetadata.getIndex();
         markRolesAsSyncedTaskQueue.submitTask(
             "mark built-in roles as synced task",
@@ -575,6 +579,13 @@ public final class QueryableBuiltInRolesSynchronizer implements ClusterStateList
             IndexMetadata indexMetadata = project.index(concreteSecurityIndexName);
             if (indexMetadata == null) {
                 throw new IndexNotFoundException(concreteSecurityIndexName);
+            }
+            if (indexMetadata.getState() == IndexMetadata.State.CLOSE) {
+                // Index was closed between when the sync started and when this task runs. Do not update the
+                // synced-roles digest in metadata, since the actual role documents could not have been
+                // updated/deleted in a closed index. IndexClosedException is treated as an expected failure
+                // and does not count toward failedSyncAttempts.
+                throw new IndexClosedException(indexMetadata.getIndex());
             }
             Map<String, String> existingRoleDigests = indexMetadata.getCustomData(METADATA_QUERYABLE_BUILT_IN_ROLES_DIGEST_KEY);
             if (Objects.equals(expectedRoleDigests, existingRoleDigests)) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/support/QueryableBuiltInRolesSynchronizerTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/support/QueryableBuiltInRolesSynchronizerTests.java
@@ -36,6 +36,7 @@ import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.FixForMultiProject;
 import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.index.IndexVersions;
+import org.elasticsearch.indices.IndexClosedException;
 import org.elasticsearch.indices.SystemIndexDescriptor;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.VersionUtils;
@@ -396,6 +397,24 @@ public class QueryableBuiltInRolesSynchronizerTests extends ESTestCase {
         verify(clusterState, times(4)).nodes();
         verify(featureService, times(1)).clusterHasFeature(eq(clusterState), eq(QUERYABLE_BUILT_IN_ROLES_FEATURE));
         verifyNoMoreInteractions(nativeRolesStore, featureService, taskQueue, reservedRolesProvider, threadPool, clusterService);
+    }
+
+    public void testMarkRolesAsSyncedTaskRejectsClosedIndex() {
+        // Guard against a race where the security index becomes closed between when a sync started against an
+        // open index and when the resulting MarkRolesAsSyncedTask runs on the master service queue. The task
+        // must not write a new digest to the metadata of a closed index, since the role documents themselves
+        // could not have been updated.
+        final ClusterState clusterState = markShardsAvailable(createClusterStateWithClosedSecurityIndex()).nodes(localNodeMaster())
+            .blocks(emptyClusterBlocks())
+            .build();
+        final Map<String, String> newRoleDigests = Map.of("superuser", "digest-1", "viewer", "digest-2");
+        final MarkRolesAsSyncedTask task = new MarkRolesAsSyncedTask(
+            ActionListener.noop(),
+            TestRestrictedIndices.INTERNAL_SECURITY_MAIN_INDEX_7,
+            null,
+            newRoleDigests
+        );
+        expectThrows(IndexClosedException.class, () -> task.execute(clusterState));
     }
 
     public void testUnexpectedSyncFailures() {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/support/QueryableBuiltInRolesSynchronizerTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/support/QueryableBuiltInRolesSynchronizerTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.metadata.MetadataIndexStateService;
 import org.elasticsearch.cluster.metadata.ProjectId;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
@@ -406,6 +407,29 @@ public class QueryableBuiltInRolesSynchronizerTests extends ESTestCase {
         // could not have been updated.
         final ClusterState clusterState = markShardsAvailable(createClusterStateWithClosedSecurityIndex()).nodes(localNodeMaster())
             .blocks(emptyClusterBlocks())
+            .build();
+        final Map<String, String> newRoleDigests = Map.of("superuser", "digest-1", "viewer", "digest-2");
+        final MarkRolesAsSyncedTask task = new MarkRolesAsSyncedTask(
+            ActionListener.noop(),
+            TestRestrictedIndices.INTERNAL_SECURITY_MAIN_INDEX_7,
+            null,
+            newRoleDigests
+        );
+        expectThrows(IndexClosedException.class, () -> task.execute(clusterState));
+    }
+
+    public void testMarkRolesAsSyncedTaskRejectsClosingInProgressIndex() {
+        // INDEX_CLOSED_BLOCK is added before IndexMetadata.state flips to CLOSE; the task must reject
+        // both, not just state == CLOSE.
+        final ClusterBlocks closingInProgressBlocks = ClusterBlocks.builder()
+            .addIndexBlock(
+                ProjectId.DEFAULT,
+                TestRestrictedIndices.INTERNAL_SECURITY_MAIN_INDEX_7,
+                MetadataIndexStateService.INDEX_CLOSED_BLOCK
+            )
+            .build();
+        final ClusterState clusterState = markShardsAvailable(createClusterStateWithOpenSecurityIndex()).nodes(localNodeMaster())
+            .blocks(closingInProgressBlocks)
             .build();
         final Map<String, String> newRoleDigests = Map.of("superuser", "digest-1", "viewer", "digest-2");
         final MarkRolesAsSyncedTask task = new MarkRolesAsSyncedTask(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Fix testConfiguredReservedRolesAfterClosingAndOpeningIndex (#147710)](https://github.com/elastic/elasticsearch/pull/147710)
 - [Fix testConfiguredReservedRolesAfterClosingAndOpeningIndex (#148285)](https://github.com/elastic/elasticsearch/pull/148285)
 - [Fix QueryableReservedRolesIT close-during-recovery race (#148496)](https://github.com/elastic/elasticsearch/pull/148496)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)