### PR TITLE
Revert mute for CoreWithSecurityClientYamlTestSuiteIT extended stats test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -360,9 +360,6 @@ tests:
 - class: org.elasticsearch.packaging.test.WindowsServiceTests
   method: test16InstallSpecialCharactersInJdkPath
   issue: https://github.com/elastic/elasticsearch/issues/151142
-- class: org.elasticsearch.xpack.security.CoreWithSecurityClientYamlTestSuiteIT
-  method: test {yaml=tsdb/120_counter_fields/extended stats}
-  issue: https://github.com/elastic/elasticsearch/issues/151158
 
 # Examples:
 #


### PR DESCRIPTION
## Summary
- Reverts ead46ca5eb23fd1a6d8d7e24e22ff8c987fc2425, which muted `CoreWithSecurityClientYamlTestSuiteIT test {yaml=tsdb/120_counter_fields/extended stats}` for #151158
- Test failure due to suite timeout, unrelated to the particular test.

## Test plan
- [ ] CI passes on 9.3 without the mute entry in `muted-tests.yml`

Closes #151158


Made with [Cursor](https://cursor.com)