### PR TITLE
[8.19] Fix flaky WatcherYamlRestIT test

### DIFF
--- a/x-pack/plugin/watcher/src/yamlRestTest/resources/rest-api-spec/test/mustache/10_webhook.yml
+++ b/x-pack/plugin/watcher/src/yamlRestTest/resources/rest-api-spec/test/mustache/10_webhook.yml
@@ -20,7 +20,8 @@
         body:
           pipeline:
             description: _description
-            processors: [ grok: { field: host, patterns : ["\\[?%{IPORHOST:hostname}\\]?:%{NUMBER:port:int}"]} ]
+            processors: [ grok: { field: host, patterns: [ "(?:\\[(?<hostname>[^\\]]+)\\]|(?<hostname>%{IPORHOST})):(?<port>\\d+)" ] },
+                          convert: { field: port, type: integer } ]
           docs: [ { _index: index, _id: id, _source: { host: $host } } ]
   - set: { docs.0.doc._source.hostname: hostname }
   - set: { docs.0.doc._source.port: port }
@@ -28,6 +29,7 @@
   - do:
       watcher.put_watch:
         id: "test_watch"
+        active: false
         body:
           trigger:
             schedule:


### PR DESCRIPTION
Avoid concurrent execution of the same watch via schedule and API

Backporting: #145671 

Closes: #151004 