### PR TITLE
[8.19] Catch-and-rethrow TooComplexToDeterminizeException within ESQL (#137024)

### DIFF
--- a/docs/changelog/137024.yaml
+++ b/docs/changelog/137024.yaml
@@ -1,0 +1,5 @@
+pr: 137024
+summary: Catch-and-rethrow `TooComplexToDeterminizeException` within ESQL
+area: ES|QL
+type: bug
+issues: []

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/predicate/regex/AbstractStringPattern.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/predicate/regex/AbstractStringPattern.java
@@ -11,12 +11,21 @@ import org.apache.lucene.util.IntsRef;
 import org.apache.lucene.util.UnicodeUtil;
 import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.Operations;
+import org.apache.lucene.util.automaton.TooComplexToDeterminizeException;
 
 public abstract class AbstractStringPattern implements StringPattern {
 
     private Automaton automaton;
 
-    public abstract Automaton createAutomaton(boolean ignoreCase);
+    public final Automaton createAutomaton(boolean ignoreCase) {
+        try {
+            return doCreateAutomaton(ignoreCase);
+        } catch (TooComplexToDeterminizeException e) {
+            throw new IllegalArgumentException("Pattern was too complex to determinize", e);
+        }
+    }
+
+    protected abstract Automaton doCreateAutomaton(boolean ignoreCase);
 
     private Automaton automaton() {
         if (automaton == null) {

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/predicate/regex/RLikePattern.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/predicate/regex/RLikePattern.java
@@ -21,7 +21,7 @@ public class RLikePattern extends AbstractStringPattern {
     }
 
     @Override
-    public Automaton createAutomaton(boolean ignoreCase) {
+    protected Automaton doCreateAutomaton(boolean ignoreCase) {
         int matchFlags = ignoreCase ? RegExp.ASCII_CASE_INSENSITIVE : 0;
         return Operations.determinize(
             new RegExp(regexpPattern, RegExp.ALL, matchFlags).toAutomaton(),

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/predicate/regex/WildcardPattern.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/predicate/regex/WildcardPattern.java
@@ -54,7 +54,7 @@ public class WildcardPattern extends AbstractStringPattern implements Writeable 
     }
 
     @Override
-    public Automaton createAutomaton(boolean ignoreCase) {
+    protected Automaton doCreateAutomaton(boolean ignoreCase) {
         return ignoreCase
             ? Operations.determinize(
                 new RegExp(luceneWildcardToRegExp(wildcard), RegExp.ALL, RegExp.ASCII_CASE_INSENSITIVE).toAutomaton(),

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/predicate/regex/WildcardPatternList.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/predicate/regex/WildcardPatternList.java
@@ -51,7 +51,7 @@ public class WildcardPatternList extends AbstractStringPattern implements Writea
      * We create a single automaton that is the union of all individual automata to improve performance
      */
     @Override
-    public Automaton createAutomaton(boolean ignoreCase) {
+    protected Automaton doCreateAutomaton(boolean ignoreCase) {
         List<Automaton> automatonList = patternList.stream().map(x -> x.createAutomaton(ignoreCase)).toList();
         Automaton result = Operations.union(automatonList);
         return Operations.determinize(result, Operations.DEFAULT_DETERMINIZE_WORK_LIMIT);

--- a/x-pack/plugin/esql-core/src/test/java/org/elasticsearch/xpack/esql/core/expression/predicate/regex/StringPatternTests.java
+++ b/x-pack/plugin/esql-core/src/test/java/org/elasticsearch/xpack/esql/core/expression/predicate/regex/StringPatternTests.java
@@ -86,4 +86,12 @@ public class StringPatternTests extends ESTestCase {
         assertTrue(rlikeExactMatch("abc"));
         assertTrue(rlikeExactMatch("12345"));
     }
+
+    public void testTooComplexPattern() {
+        var e = expectThrows(IllegalArgumentException.class, () -> rlike("(a|b)*a(a|b){13}").createAutomaton(false));
+        assertEquals("Pattern was too complex to determinize", e.getMessage());
+
+        e = expectThrows(IllegalArgumentException.class, () -> like("*a?????????????").createAutomaton(false));
+        assertEquals("Pattern was too complex to determinize", e.getMessage());
+    }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -1127,6 +1127,11 @@ public class EsqlCapabilities {
         FIX_INDEX_LIKE_QUESTION_MARK_WILDCARD,
 
         /**
+         * Catch-and-rethrow determinization complexity errors as 400s rather than 500s
+         */
+        HANDLE_DETERMINIZATION_COMPLEXITY,
+
+        /**
          * Create new block when filtering OrdinalBytesRefBlock
          */
         FIX_FILTER_ORDINALS,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/AutomataMatch.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/AutomataMatch.java
@@ -11,6 +11,7 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.ByteRunAutomaton;
 import org.apache.lucene.util.automaton.Operations;
+import org.apache.lucene.util.automaton.TooComplexToDeterminizeException;
 import org.apache.lucene.util.automaton.Transition;
 import org.apache.lucene.util.automaton.UTF32ToUTF8;
 import org.elasticsearch.compute.ann.Evaluator;
@@ -36,7 +37,13 @@ public class AutomataMatch {
          * ByteRunAutomaton has a way to convert utf32 to utf8, but if we used it
          * we couldn't get a nice toDot - so we call UTF32ToUTF8 ourselves.
          */
-        Automaton automaton = Operations.determinize(new UTF32ToUTF8().convert(utf32Automaton), Operations.DEFAULT_DETERMINIZE_WORK_LIMIT);
+        Automaton automaton;
+        try {
+            automaton = Operations.determinize(new UTF32ToUTF8().convert(utf32Automaton), Operations.DEFAULT_DETERMINIZE_WORK_LIMIT);
+        } catch (TooComplexToDeterminizeException e) {
+            throw new IllegalArgumentException("Pattern was too complex to determinize", e);
+        }
+
         ByteRunAutomaton run = new ByteRunAutomaton(automaton, true, Operations.DEFAULT_DETERMINIZE_WORK_LIMIT);
         return new AutomataMatchEvaluator.Factory(source, field, run, toDot(automaton));
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/ExpressionBuilder.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/ExpressionBuilder.java
@@ -15,6 +15,7 @@ import org.apache.lucene.util.automaton.Automata;
 import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.CharacterRunAutomaton;
 import org.apache.lucene.util.automaton.Operations;
+import org.apache.lucene.util.automaton.TooComplexToDeterminizeException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.regex.Regex;
@@ -455,12 +456,16 @@ public abstract class ExpressionBuilder extends IdentifierBuilder {
                 list.add(o instanceof Automaton a ? a : Automata.makeString(o.toString()));
             }
             // use the fast run variant
-            result = new UnresolvedNamePattern(
-                src,
-                new CharacterRunAutomaton(Operations.concatenate(list)),
-                patternString.toString(),
-                nameString.toString()
-            );
+            try {
+                result = new UnresolvedNamePattern(
+                    src,
+                    new CharacterRunAutomaton(Operations.concatenate(list)),
+                    patternString.toString(),
+                    nameString.toString()
+                );
+            } catch (TooComplexToDeterminizeException e) {
+                throw new ParsingException("Pattern was too complex to determinize", e);
+            }
         } else {
             result = new UnresolvedAttribute(src, Strings.collectionToDelimitedString(objects, ""));
         }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/StatementParserTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/StatementParserTests.java
@@ -1315,6 +1315,13 @@ public class StatementParserTests extends AbstractStatementParserTests {
         );
     }
 
+    public void testIdentifierPatternTooComplex() {
+        // It is incredibly unlikely that we will see this limit hit in practice
+        // The repetition value 2450 was a ballpark estimate and validated experimentally
+        String explodingWildcard = "a*".repeat(2450);
+        expectError("FROM a | KEEP " + explodingWildcard, "Pattern was too complex to determinize");
+    }
+
     public void testEnrich() {
         assertEquals(
             new Enrich(

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/80_text.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/80_text.yml
@@ -620,3 +620,32 @@ setup:
       esql.query:
         body:
           query: 'FROM test | EVAL tag = name::text | KEEP name'
+---
+"like with overly complex pattern":
+  - requires:
+        capabilities:
+          - method: POST
+            path: /_query
+            parameters: [ method, path, parameters, capabilities ]
+            capabilities: [ handle_determinization_complexity ]
+        reason: "determinization errors not yet rethrown"
+  - do:
+      catch: /Pattern was too complex to determinize/
+      esql.query:
+        body:
+          query: 'FROM test | WHERE job LIKE "*a?????????????"'
+
+---
+"rlike with overly complex pattern":
+  - requires:
+      capabilities:
+        - method: POST
+          path: /_query
+          parameters: [ method, path, parameters, capabilities ]
+          capabilities: [ handle_determinization_complexity ]
+      reason: "determinization errors not yet rethrown"
+  - do:
+      catch: /Pattern was too complex to determinize/
+      esql.query:
+        body:
+          query: 'FROM test | WHERE job RLIKE "(a|b)*a(a|b){13}"'


### PR DESCRIPTION
Manual backport of https://github.com/elastic/elasticsearch/pull/137024