### PR TITLE
Access-key-based S3 content-integrity tests

### DIFF
--- a/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/AbstractRepositoryS3RestTestCase.java
+++ b/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/AbstractRepositoryS3RestTestCase.java
@@ -59,7 +59,9 @@ public abstract class AbstractRepositoryS3RestTestCase extends ESRestTestCase {
                                 .put("client", clientName())
                                 .put("canned_acl", "private")
                                 .put("storage_class", "standard")
-                                .put("disable_chunked_encoding", randomBoolean())
+                                .put(
+                                    randomFrom(Settings.EMPTY, Settings.builder().put("disable_chunked_encoding", randomBoolean()).build())
+                                )
                                 .put(
                                     randomFrom(
                                         Settings.EMPTY,

--- a/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3ContentIntegrityRestIT.java
+++ b/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3ContentIntegrityRestIT.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.repositories.s3;
 
+import fixture.aws.AwsCredentialsUtils;
 import fixture.aws.DynamicRegionSupplier;
 import fixture.s3.S3HttpFixture;
 import fixture.s3.S3HttpHandler;
@@ -36,7 +37,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
 
-import static fixture.aws.AwsCredentialsUtils.fixedAccessKey;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.matchesPattern;
@@ -56,38 +56,6 @@ public class RepositoryS3ContentIntegrityRestIT extends AbstractRepositoryS3Rest
 
     private static final TestTrustStore trustStore = new TestTrustStore(testTlsCertificate::getPemCertificateStream);
 
-    private static final class ContentIntegrityS3HttpFixture extends S3HttpFixture {
-        ContentIntegrityS3HttpFixture(TestTlsCertificate tlsCertificate) {
-            super(true, tlsCertificate, BUCKET, BASE_PATH, fixedAccessKey(ACCESS_KEY, regionSupplier, "s3"));
-        }
-
-        @SuppressForbidden(reason = "implementing HTTP server for test fixture")
-        @Override
-        protected HttpHandler createHandler() {
-            final var delegate = asInstanceOf(S3HttpHandler.class, super.createHandler());
-            return exchange -> {
-                final var request = delegate.parseRequest(exchange);
-                if ((request.isUploadPartRequest() || request.isPutObjectRequest())
-                    && Optional.ofNullable(exchange.getRequestHeaders().get(S3HttpHandler.COPY_SOURCE_HEADER))
-                        .orElse(List.of())
-                        .isEmpty()) {
-                    assertThat(
-                        exchange.getRequestHeaders().getFirst(S3HttpHandler.CONTENT_SHA256_HEADER),
-                        anyOf(
-                            matchesPattern(S3HttpHandler.SHA256_PATTERN),
-                            equalTo(TestConfig.fromPath(request.path()).getExpectedContentSha256Header())
-                        )
-                    );
-                }
-                delegate.handle(exchange);
-            };
-        }
-    }
-
-    private static final S3HttpFixture httpS3Fixture = new ContentIntegrityS3HttpFixture(null);
-
-    private static final S3HttpFixture httpsS3Fixture = new ContentIntegrityS3HttpFixture(testTlsCertificate);
-
     private static final List<TestConfig> TEST_CONFIGS;
 
     static {
@@ -99,6 +67,52 @@ public class RepositoryS3ContentIntegrityRestIT extends AbstractRepositoryS3Rest
         }
         TEST_CONFIGS = List.copyOf(testConfigs);
     }
+
+    private static final class ContentIntegrityS3HttpFixture extends S3HttpFixture {
+        ContentIntegrityS3HttpFixture(TestTlsCertificate tlsCertificate) {
+            super(
+                true,
+                tlsCertificate,
+                BUCKET,
+                BASE_PATH,
+                (authorizationHeader, sessionTokenHeader) -> authorizationHeader != null
+                    && TEST_CONFIGS.stream()
+                        .anyMatch(
+                            testConfig -> AwsCredentialsUtils.isValidAwsV4SignedAuthorizationHeader(
+                                testConfig.getAccessKey(),
+                                regionSupplier.get(),
+                                "s3",
+                                authorizationHeader
+                            )
+                        )
+            );
+        }
+
+        @SuppressForbidden(reason = "implementing HTTP server for test fixture")
+        @Override
+        protected HttpHandler createHandler() {
+            final var delegate = asInstanceOf(S3HttpHandler.class, super.createHandler());
+            return exchange -> {
+                final var request = delegate.parseRequest(exchange);
+                final var testConfig = TestConfig.fromAuthorizationHeader(exchange.getRequestHeaders().getFirst("Authorization"));
+                final var contentSha256Header = exchange.getRequestHeaders().getFirst(S3HttpHandler.CONTENT_SHA256_HEADER);
+                if ((request.isUploadPartRequest() || request.isPutObjectRequest())
+                    && Optional.ofNullable(exchange.getRequestHeaders().get(S3HttpHandler.COPY_SOURCE_HEADER))
+                        .orElse(List.of())
+                        .isEmpty()) {
+                    assertThat(
+                        contentSha256Header,
+                        anyOf(matchesPattern(S3HttpHandler.SHA256_PATTERN), equalTo(testConfig.getExpectedUploadContentSha256Header()))
+                    );
+                }
+                delegate.handle(exchange);
+            };
+        }
+    }
+
+    private static final S3HttpFixture httpS3Fixture = new ContentIntegrityS3HttpFixture(null);
+
+    private static final S3HttpFixture httpsS3Fixture = new ContentIntegrityS3HttpFixture(testTlsCertificate);
 
     public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
         .module("repository-s3")
@@ -152,8 +166,6 @@ public class RepositoryS3ContentIntegrityRestIT extends AbstractRepositoryS3Rest
 
     /// Test suite is parametric in this config.
     public static final class TestConfig {
-        private static final String DISABLE_CHUNKED_ENCODING = "disable_chunked_encoding";
-
         private final boolean https;
         private final boolean chunkedEncoding;
 
@@ -169,19 +181,19 @@ public class RepositoryS3ContentIntegrityRestIT extends AbstractRepositoryS3Rest
 
         Settings getRepositorySettings() {
             final var builder = Settings.builder();
-            if (chunkedEncoding) {
-                if (randomBoolean()) {
-                    builder.put(DISABLE_CHUNKED_ENCODING, false);
-                } else {
-                    builder.putNull(DISABLE_CHUNKED_ENCODING);
-                }
-            } else {
-                builder.put(DISABLE_CHUNKED_ENCODING, true);
-            }
+            addBooleanSettingDefaultFalse(builder, "disable_chunked_encoding", chunkedEncoding == false);
             return builder.build();
         }
 
-        String getExpectedContentSha256Header() {
+        private void addBooleanSettingDefaultFalse(Settings.Builder builder, String key, boolean value) {
+            if (value == false && randomBoolean()) {
+                builder.putNull(key);
+            } else {
+                builder.put(key, value);
+            }
+        }
+
+        String getExpectedUploadContentSha256Header() {
             return https
                 ? (chunkedEncoding ? "STREAMING-UNSIGNED-PAYLOAD-TRAILER" : "UNSIGNED-PAYLOAD")
                 : (chunkedEncoding ? "STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER" : "STREAMING-AWS4-HMAC-SHA256-PAYLOAD");
@@ -189,7 +201,7 @@ public class RepositoryS3ContentIntegrityRestIT extends AbstractRepositoryS3Rest
 
         void applyClientSettings(LocalClusterSpecBuilder<?> builder) {
             final String client = getClientName();
-            builder.keystore("s3.client." + client + ".access_key", ACCESS_KEY);
+            builder.keystore("s3.client." + client + ".access_key", getAccessKey());
             builder.keystore("s3.client." + client + ".secret_key", SECRET_KEY);
             builder.setting("s3.client." + client + ".endpoint", getS3Fixture()::getAddress);
             builder.setting("s3.client." + client + ".path_style_access", () -> "true", n -> https || randomBoolean());
@@ -207,13 +219,19 @@ public class RepositoryS3ContentIntegrityRestIT extends AbstractRepositoryS3Rest
             return BASE_PATH + "/" + (https ? "https" : "http") + "_chunked_encoding_" + chunkedEncoding;
         }
 
-        static TestConfig fromPath(String path) {
-            for (final var testConfig : TEST_CONFIGS) {
-                if (path.contains(testConfig.getRepositoryBasePath())) {
-                    return testConfig;
+        String getAccessKey() {
+            return ACCESS_KEY + "-" + (https ? "https" : "http") + "-" + chunkedEncoding;
+        }
+
+        static TestConfig fromAuthorizationHeader(String authorizationHeader) {
+            if (authorizationHeader != null) {
+                for (final var testConfig : TEST_CONFIGS) {
+                    if (authorizationHeader.contains(testConfig.getAccessKey())) {
+                        return testConfig;
+                    }
                 }
             }
-            throw new AssertionError("no case matches request URI [" + path + "]");
+            throw new AssertionError("no case matches authorization header [" + authorizationHeader + "]");
         }
     }
 }


### PR DESCRIPTION
Today these tests rely on extracting the test config from the request
URL path, but some requests do not include the full base path in the URL
path: e.g. multi-object deletes are a `POST` to the bucket root. That's
ok for now but in a future iteration we will want to assert things about
these base-path-free requests.

This commit adjusts the tests to give each test config its own access
key, allowing us to determine the appropriate config from the
`Authorization` header instead.

It also adjusts some randomization around the `disable_chunked_encoding`
setting in preparation for future generalizations too.

Backport of #151185 to `8.19`