### PR TITLE
[9.4] [ES|QL] fix sample csv test (#151190)

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/sample.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/sample.csv-spec
@@ -29,7 +29,7 @@ x:integer
 ;
 
 
-adjust stats for sampling
+with stats
 required_capability: sample_v3
 
 FROM employees
@@ -38,7 +38,7 @@ FROM employees
 ;
 
 count:long | avg_emp_no:double | sum_emp_no:long
-5..95      | 10010.0..10090.0  | 100100..908100
+5..95      | 10010.0..10090.0  | 50500..958550
 ;
 
 


### PR DESCRIPTION
Backports the following commits to 9.4:
 - [ES|QL] fix sample csv test (#151190)