### PR TITLE
Fix reindex throttle timing

### DIFF
--- a/docs/changelog/151208.yaml
+++ b/docs/changelog/151208.yaml
@@ -1,0 +1,6 @@
+area: Reindex
+issues:
+ - 150875
+pr: 151208
+summary: Account for elapsed bulk processing time when throttling reindex requests
+type: bug

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractAsyncBulkByPaginatedSearchAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractAsyncBulkByPaginatedSearchAction.java
@@ -73,7 +73,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
@@ -136,14 +135,6 @@ public abstract class AbstractAsyncBulkByPaginatedSearchAction<
      * (before the ref is restored when {@code maxDocs} leaves a partial batch).
      */
     private final AtomicBoolean requestFinishing = new AtomicBoolean(false);
-    /**
-     * Keeps track of the total number of bulk operations performed
-     * from a single paginated search response. It is possible that
-     * multiple bulk requests are performed from a single paginated search
-     * response, meaning that we have to take into account the total
-     * in order to compute a correct search context keep-alive time.
-     */
-    private final AtomicInteger totalBatchSizeInSinglePaginatedSearchResponse = new AtomicInteger();
     /**
      * The remaining throttle delay calculated when the previous page finished. It is consumed by the next paginated search response so
      * time spent waiting for that response neither shortens the delay nor causes it to be calculated twice.
@@ -760,8 +751,6 @@ public abstract class AbstractAsyncBulkByPaginatedSearchAction<
             finishHim(null);
             return;
         }
-        this.totalBatchSizeInSinglePaginatedSearchResponse.addAndGet(batchSize);
-
         if (asyncResponse.hasRemainingHits()) {
             // NB this means the next bulk task will be traced as a child of the current one, but it should really be a sibling
             onPaginatedSearchResponse(worker.throttleDelay(thisBatchStartTimeNS, System.nanoTime(), batchSize), asyncResponse);
@@ -832,8 +821,7 @@ public abstract class AbstractAsyncBulkByPaginatedSearchAction<
             // if we can't relocate, continue. we could still finish gracefully, or eventually meet the conditions for relocation.
         }
 
-        int totalBatchSize = totalBatchSizeInSinglePaginatedSearchResponse.getAndSet(0);
-        ThrottleDelay throttleDelay = worker.throttleDelay(thisBatchStartTimeNS, System.nanoTime(), totalBatchSize);
+        ThrottleDelay throttleDelay = worker.throttleDelay(thisBatchStartTimeNS, System.nanoTime(), batchSize);
         pendingThrottleDelay.set(throttleDelay);
         asyncResponse.done(throttleDelay.delay());
     }

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractAsyncBulkByPaginatedSearchAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractAsyncBulkByPaginatedSearchAction.java
@@ -47,6 +47,7 @@ import org.elasticsearch.index.reindex.PaginatedSearchFailure;
 import org.elasticsearch.index.reindex.ResumeInfo;
 import org.elasticsearch.index.reindex.ResumeInfo.WorkerResumeInfo;
 import org.elasticsearch.index.reindex.WorkerBulkByPaginatedSearchTaskState;
+import org.elasticsearch.index.reindex.WorkerBulkByPaginatedSearchTaskState.ThrottleDelay;
 import org.elasticsearch.reindex.remote.RemotePitPaginatedHitSource;
 import org.elasticsearch.reindex.remote.RemoteScrollablePaginatedHitSource;
 import org.elasticsearch.rest.RestStatus;
@@ -124,7 +125,6 @@ public abstract class AbstractAsyncBulkByPaginatedSearchAction<
      * {@link RequestWrapper} completely.
      */
     private final BiFunction<RequestWrapper<?>, PaginatedHitSource.Hit, RequestWrapper<?>> scriptApplier;
-    private int lastBatchSize;
     /**
      * The current paginated search response being processed. Set atomically so that either {@link #prepareBulkRequest} or
      * {@link #finishHim(Exception, List, List, boolean)} can claim exclusive ownership of the remaining hits and release them exactly once.
@@ -144,6 +144,11 @@ public abstract class AbstractAsyncBulkByPaginatedSearchAction<
      * in order to compute a correct search context keep-alive time.
      */
     private final AtomicInteger totalBatchSizeInSinglePaginatedSearchResponse = new AtomicInteger();
+    /**
+     * The remaining throttle delay calculated when the previous page finished. It is consumed by the next paginated search response so
+     * time spent waiting for that response neither shortens the delay nor causes it to be calculated twice.
+     */
+    private final AtomicReference<ThrottleDelay> pendingThrottleDelay = new AtomicReference<>(ThrottleDelay.ZERO);
     /**
      * Minimum time a relocated task must run before it can be relocated again.
      * Prevents quick back-to-back relocations that could cause issues with tasks endpoints,
@@ -516,19 +521,15 @@ public abstract class AbstractAsyncBulkByPaginatedSearchAction<
     }
 
     void onPaginatedSearchResponse(PaginatedSearchConsumableHitsResponse asyncResponse) {
-        // TODO - https://github.com/elastic/elasticsearch/issues/150875
-        // lastBatchStartTime is essentially unused (see WorkerBulkByPaginatedSearchTaskState.throttleWaitTime).
-        // Leaving it for now, since it seems like a bug?
-        onPaginatedSearchResponse(System.nanoTime(), this.lastBatchSize, asyncResponse);
+        onPaginatedSearchResponse(pendingThrottleDelay.getAndSet(ThrottleDelay.ZERO), asyncResponse);
     }
 
     /**
      * Process a paginated search response.
-     * @param lastBatchStartTimeNS the time when the last batch started. Used to calculate the throttling delay.
-     * @param lastBatchSizeToUse the size of the last batch. Used to calculate the throttling delay.
+     * @param throttleDelay the remaining delay calculated when the preceding bulk batch completed
      * @param asyncResponse the response to process from {@link PaginatedHitSource}
      */
-    void onPaginatedSearchResponse(long lastBatchStartTimeNS, int lastBatchSizeToUse, PaginatedSearchConsumableHitsResponse asyncResponse) {
+    void onPaginatedSearchResponse(ThrottleDelay throttleDelay, PaginatedSearchConsumableHitsResponse asyncResponse) {
         currentPaginatedSearchResponse.set(asyncResponse);
         PaginatedHitSource.Response response = asyncResponse.response();
         logger.debug("[{}]: got paginated search response with [{}] hits", task.getId(), asyncResponse.remainingHits());
@@ -568,7 +569,7 @@ public abstract class AbstractAsyncBulkByPaginatedSearchAction<
             }
         };
         prepareBulkRequestRunnable = (AbstractRunnable) threadPool.getThreadContext().preserveContext(prepareBulkRequestRunnable);
-        worker.delayPrepareBulkRequest(threadPool, lastBatchStartTimeNS, lastBatchSizeToUse, prepareBulkRequestRunnable);
+        worker.delayPrepareBulkRequest(threadPool, throttleDelay, prepareBulkRequestRunnable);
     }
 
     /**
@@ -759,12 +760,11 @@ public abstract class AbstractAsyncBulkByPaginatedSearchAction<
             finishHim(null);
             return;
         }
-        this.lastBatchSize = batchSize;
         this.totalBatchSizeInSinglePaginatedSearchResponse.addAndGet(batchSize);
 
         if (asyncResponse.hasRemainingHits()) {
             // NB this means the next bulk task will be traced as a child of the current one, but it should really be a sibling
-            onPaginatedSearchResponse(thisBatchStartTimeNS, batchSize, asyncResponse);
+            onPaginatedSearchResponse(worker.throttleDelay(thisBatchStartTimeNS, System.nanoTime(), batchSize), asyncResponse);
             return;
         }
         if (task.isRelocationRequested()) {
@@ -833,7 +833,9 @@ public abstract class AbstractAsyncBulkByPaginatedSearchAction<
         }
 
         int totalBatchSize = totalBatchSizeInSinglePaginatedSearchResponse.getAndSet(0);
-        asyncResponse.done(worker.throttleWaitTime(thisBatchStartTimeNS, System.nanoTime(), totalBatchSize));
+        ThrottleDelay throttleDelay = worker.throttleDelay(thisBatchStartTimeNS, System.nanoTime(), totalBatchSize);
+        pendingThrottleDelay.set(throttleDelay);
+        asyncResponse.done(throttleDelay.delay());
     }
 
     /**

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractAsyncBulkByPaginatedSearchAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractAsyncBulkByPaginatedSearchAction.java
@@ -764,7 +764,7 @@ public abstract class AbstractAsyncBulkByPaginatedSearchAction<
 
         if (asyncResponse.hasRemainingHits()) {
             // NB this means the next bulk task will be traced as a child of the current one, but it should really be a sibling
-            onPaginatedSearchResponse(asyncResponse);
+            onPaginatedSearchResponse(thisBatchStartTimeNS, batchSize, asyncResponse);
             return;
         }
         if (task.isRelocationRequested()) {

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractBaseReindexRestHandler.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractBaseReindexRestHandler.java
@@ -171,7 +171,7 @@ public abstract class AbstractBaseReindexRestHandler<
         if (requestsPerSecond == -1) {
             return Float.POSITIVE_INFINITY;
         }
-        if (requestsPerSecond <= 0) {
+        if (requestsPerSecond <= 0 || Float.isNaN(requestsPerSecond)) {
             // We validate here and in the setters because the setters use "Float.POSITIVE_INFINITY" instead of -1
             throw new IllegalArgumentException("[requests_per_second] must be a float greater than 0. Use -1 to disable throttling.");
         }

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/AsyncBulkByPaginatedSearchActionTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/AsyncBulkByPaginatedSearchActionTests.java
@@ -69,6 +69,7 @@ import org.elasticsearch.index.reindex.BulkByPaginatedSearchTask;
 import org.elasticsearch.index.reindex.PaginatedSearchFailure;
 import org.elasticsearch.index.reindex.ResumeInfo;
 import org.elasticsearch.index.reindex.WorkerBulkByPaginatedSearchTaskState;
+import org.elasticsearch.index.reindex.WorkerBulkByPaginatedSearchTaskState.ThrottleDelay;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.reindex.PaginatedHitSource.Hit;
 import org.elasticsearch.rest.RestStatus;
@@ -271,8 +272,7 @@ public class AsyncBulkByPaginatedSearchActionTests extends ESTestCase {
             action.setScroll(scrollId());
         }
         action.onPaginatedSearchResponse(
-            lastBatchTime,
-            lastBatchSize,
+            worker.throttleDelay(lastBatchTime, System.nanoTime(), lastBatchSize),
             new AbstractAsyncBulkByPaginatedSearchAction.PaginatedSearchConsumableHitsResponse(new PaginatedHitSource.AsyncResponse() {
                 @Override
                 public PaginatedHitSource.Response response() {
@@ -762,8 +762,7 @@ public class AsyncBulkByPaginatedSearchActionTests extends ESTestCase {
             action.setScroll(scrollId());
         }
         action.onPaginatedSearchResponse(
-            System.nanoTime(),
-            0,
+            ThrottleDelay.ZERO,
             new AbstractAsyncBulkByPaginatedSearchAction.PaginatedSearchConsumableHitsResponse(new PaginatedHitSource.AsyncResponse() {
                 @Override
                 public PaginatedHitSource.Response response() {
@@ -1047,8 +1046,8 @@ public class AsyncBulkByPaginatedSearchActionTests extends ESTestCase {
             scrollId(),
             null
         );
-        AbstractAsyncBulkByPaginatedSearchAction.ScrollConsumableHitsResponse asyncResponse =
-            new AbstractAsyncBulkByPaginatedSearchAction.ScrollConsumableHitsResponse(new PaginatedHitSource.AsyncResponse() {
+        AbstractAsyncBulkByPaginatedSearchAction.PaginatedSearchConsumableHitsResponse asyncResponse =
+            new AbstractAsyncBulkByPaginatedSearchAction.PaginatedSearchConsumableHitsResponse(new PaginatedHitSource.AsyncResponse() {
                 @Override
                 public PaginatedHitSource.Response response() {
                     return scrollResponse;
@@ -1062,6 +1061,77 @@ public class AsyncBulkByPaginatedSearchActionTests extends ESTestCase {
         action.notifyDone(thisBatchStartTimeNS, asyncResponse, 60);
 
         assertThat(capturedDelay.get().nanos(), equalTo(0L));
+    }
+
+    public void testPaginatedSearchWaitDoesNotChangePendingThrottleDelay() {
+        AtomicReference<TimeValue> capturedScheduledDelay = new AtomicReference<>();
+        setupClient(new TestThreadPool(getTestName()) {
+            @Override
+            public ScheduledCancellable schedule(Runnable command, TimeValue delay, Executor executor) {
+                capturedScheduledDelay.set(delay);
+                return new ScheduledCancellable() {
+                    @Override
+                    public long getDelay(TimeUnit unit) {
+                        return unit.convert(delay.nanos(), TimeUnit.NANOSECONDS);
+                    }
+
+                    @Override
+                    public int compareTo(Delayed o) {
+                        return 0;
+                    }
+
+                    @Override
+                    public boolean cancel() {
+                        return true;
+                    }
+
+                    @Override
+                    public boolean isCancelled() {
+                        return false;
+                    }
+                };
+            }
+        });
+
+        worker.rethrottle(1f);
+        DummyAsyncBulkByPaginatedSearchAction action = new DummyAsyncBulkByPaginatedSearchAction();
+        AtomicReference<TimeValue> capturedKeepAlive = new AtomicReference<>();
+        var completedResponse = new AbstractAsyncBulkByPaginatedSearchAction.PaginatedSearchConsumableHitsResponse(
+            new PaginatedHitSource.AsyncResponse() {
+                @Override
+                public PaginatedHitSource.Response response() {
+                    return createPaginatedResponse(false, false, emptyList(), 0, emptyList(), scrollId(), null);
+                }
+
+                @Override
+                public void done(TimeValue extraKeepAlive) {
+                    capturedKeepAlive.set(extraKeepAlive);
+                }
+            }
+        );
+
+        action.notifyDone(System.nanoTime() - TimeUnit.SECONDS.toNanos(5), completedResponse, 10);
+
+        assertThat(capturedKeepAlive.get().nanos(), greaterThan(0L));
+        assertThat(capturedKeepAlive.get().nanos(), lessThanOrEqualTo(TimeUnit.SECONDS.toNanos(10)));
+
+        var nextResponse = new AbstractAsyncBulkByPaginatedSearchAction.PaginatedSearchConsumableHitsResponse(
+            new PaginatedHitSource.AsyncResponse() {
+                @Override
+                public PaginatedHitSource.Response response() {
+                    return createPaginatedResponse(false, false, emptyList(), 0, emptyList(), scrollId(), null);
+                }
+
+                @Override
+                public void done(TimeValue extraKeepAlive) {
+                    fail("the next response should only be scheduled in this test");
+                }
+            }
+        );
+
+        action.onPaginatedSearchResponse(nextResponse);
+
+        assertThat(capturedScheduledDelay.get(), equalTo(capturedKeepAlive.get()));
     }
 
     /**
@@ -1128,6 +1198,10 @@ public class AsyncBulkByPaginatedSearchActionTests extends ESTestCase {
             capturedCommand.get().run();
 
             assertNotNull("PIT next search should use SearchRequest", client.lastSearch.get());
+            assertThat(
+                client.lastSearch.get().request.source().pointInTimeBuilder().getKeepAlive().seconds(),
+                either(equalTo(399L)).or(equalTo(400L))
+            );
 
             if (randomBoolean()) {
                 client.lastSearch.get().listener.onResponse(searchResponse);
@@ -2113,13 +2187,10 @@ public class AsyncBulkByPaginatedSearchActionTests extends ESTestCase {
         final DummyAsyncBulkByPaginatedSearchAction action = new DummyAsyncBulkByPaginatedSearchAction() {
             @Override
             void onPaginatedSearchResponse(
-                final long lastBatchStartTimeNS,
-                final int lastBatchSizeToUse,
+                final ThrottleDelay throttleDelay,
                 final AbstractAsyncBulkByPaginatedSearchAction.PaginatedSearchConsumableHitsResponse asyncResponse
             ) {
                 onPaginatedSearchResponseCalled.set(true);
-                assertThat("should preserve bulk start time for remaining hits", lastBatchStartTimeNS, equalTo(expectedBatchStartTimeNS));
-                assertThat("should preserve bulk batch size for remaining hits", lastBatchSizeToUse, equalTo(expectedBatchSize));
                 // don't call super - continues ingesting and listener might complete before assertions
             }
         };
@@ -2145,7 +2216,11 @@ public class AsyncBulkByPaginatedSearchActionTests extends ESTestCase {
 
         action.notifyDone(expectedBatchStartTimeNS, asyncResponse, expectedBatchSize);
 
-        assertThat("should continue consuming remaining hits via onPaginatedSearchResponse", onPaginatedSearchResponseCalled.get(), equalTo(true));
+        assertThat(
+            "should continue consuming remaining hits via onPaginatedSearchResponse",
+            onPaginatedSearchResponseCalled.get(),
+            equalTo(true)
+        );
         assertThat("listener should not be done - relocation should not happen while hits remain", listener.isDone(), equalTo(false));
     }
 
@@ -2165,13 +2240,10 @@ public class AsyncBulkByPaginatedSearchActionTests extends ESTestCase {
         final DummyAsyncBulkByPaginatedSearchAction action = new DummyAsyncBulkByPaginatedSearchAction() {
             @Override
             void onPaginatedSearchResponse(
-                final long lastBatchStartTimeNS,
-                final int lastBatchSizeToUse,
+                final ThrottleDelay throttleDelay,
                 final AbstractAsyncBulkByPaginatedSearchAction.PaginatedSearchConsumableHitsResponse asyncResponse
             ) {
                 onPaginatedSearchResponseCalled.set(true);
-                assertThat("should preserve bulk start time for remaining hits", lastBatchStartTimeNS, equalTo(expectedBatchStartTimeNS));
-                assertThat("should preserve bulk batch size for remaining hits", lastBatchSizeToUse, equalTo(expectedBatchSize));
                 // don't call super - continues ingesting and listener might complete before assertions
             }
         };
@@ -2197,7 +2269,11 @@ public class AsyncBulkByPaginatedSearchActionTests extends ESTestCase {
 
         action.notifyDone(expectedBatchStartTimeNS, asyncResponse, expectedBatchSize);
 
-        assertThat("should continue consuming remaining hits via onPaginatedSearchResponse", onPaginatedSearchResponseCalled.get(), equalTo(true));
+        assertThat(
+            "should continue consuming remaining hits via onPaginatedSearchResponse",
+            onPaginatedSearchResponseCalled.get(),
+            equalTo(true)
+        );
         assertThat("listener should not be done - relocation should not happen while hits remain", listener.isDone(), equalTo(false));
     }
 

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/AsyncBulkByPaginatedSearchActionTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/AsyncBulkByPaginatedSearchActionTests.java
@@ -984,9 +984,8 @@ public class AsyncBulkByPaginatedSearchActionTests extends ESTestCase {
             // So the next request is going to have to wait an extra 100 seconds or so (base was 10 seconds, so 110ish)
             assertThat(client.lastScroll.get().request.scroll().seconds(), either(equalTo(110L)).or(equalTo(109L)));
 
-            // Now we can simulate a response and check the delay that we used for the task.
-            // Tolerate ±1 second: throttleWaitTime uses System.nanoTime() in the subtraction, so a small timing
-            // gap between nowNS and System.nanoTime() can change the delay by up to a second.
+            // The action path samples System.nanoTime() when scheduling the delay, so the elapsed time between starting the
+            // batch and receiving this response can floor the seconds value by one.
             if (randomBoolean()) {
                 client.lastScroll.get().listener.onResponse(searchResponse);
                 assertThat(capturedDelay.get().seconds(), either(equalTo(99L)).or(equalTo(100L)));
@@ -1086,111 +1085,6 @@ public class AsyncBulkByPaginatedSearchActionTests extends ESTestCase {
         } finally {
             searchResponse.decRef();
         }
-    }
-
-    public void testScrollThrottleDelaySubtractsElapsedBulkProcessingTime() {
-        assertThrottleDelaySubtractsElapsedBulkProcessingTime(false);
-    }
-
-    public void testPITThrottleDelaySubtractsElapsedBulkProcessingTime() {
-        assertThrottleDelaySubtractsElapsedBulkProcessingTime(true);
-    }
-
-    public void testScrollResponseWaitDoesNotShortenThrottleDelay() {
-        assertPaginatedResponseWaitDoesNotShortenThrottleDelay(false);
-    }
-
-    public void testPITResponseWaitDoesNotShortenThrottleDelay() {
-        assertPaginatedResponseWaitDoesNotShortenThrottleDelay(true);
-    }
-
-    private void assertThrottleDelaySubtractsElapsedBulkProcessingTime(boolean usePit) {
-        configurePitOrScroll(usePit);
-        AtomicReference<TimeValue> capturedDelay = new AtomicReference<>();
-        setupClient(capturingDelayThreadPool(capturedDelay));
-
-        DummyAsyncBulkByScrollAction action = new DummyAsyncBulkByScrollAction();
-        worker.rethrottle(1f);
-
-        long lastBatchStartTimeNS = System.nanoTime() - TimeUnit.SECONDS.toNanos(10);
-        simulatePaginatedResponse(action, lastBatchStartTimeNS, 60, newPaginatedResponse(usePit, 1), usePit);
-
-        assertThat(capturedDelay.get().seconds(), either(equalTo(49L)).or(equalTo(50L)));
-    }
-
-    private void assertPaginatedResponseWaitDoesNotShortenThrottleDelay(boolean usePit) {
-        configurePitOrScroll(usePit);
-        AtomicReference<TimeValue> capturedDelay = new AtomicReference<>();
-        setupClient(capturingDelayThreadPool(capturedDelay));
-
-        DummyAsyncBulkByScrollAction action = new DummyAsyncBulkByScrollAction();
-        worker.rethrottle(1f);
-
-        action.notifyDone(System.nanoTime() - TimeUnit.MINUTES.toNanos(10), newConsumableHitsResponse(usePit, 0), 60);
-        action.onScrollResponse(newConsumableHitsResponse(usePit, 1));
-
-        assertThat(capturedDelay.get().seconds(), either(equalTo(59L)).or(equalTo(60L)));
-    }
-
-    private TestThreadPool capturingDelayThreadPool(AtomicReference<TimeValue> capturedDelay) {
-        return new TestThreadPool(getTestName()) {
-            @Override
-            public ScheduledCancellable schedule(Runnable command, TimeValue delay, Executor executor) {
-                capturedDelay.set(delay);
-                return new ScheduledCancellable() {
-                    @Override
-                    public long getDelay(TimeUnit unit) {
-                        return unit.convert(delay.nanos(), TimeUnit.NANOSECONDS);
-                    }
-
-                    @Override
-                    public int compareTo(Delayed o) {
-                        return 0;
-                    }
-
-                    @Override
-                    public boolean cancel() {
-                        return true;
-                    }
-
-                    @Override
-                    public boolean isCancelled() {
-                        return false;
-                    }
-                };
-            }
-        };
-    }
-
-    private PaginatedHitSource.Response newPaginatedResponse(boolean usePit, int numberOfHits) {
-        List<PaginatedHitSource.BasicHit> hits = IntStream.range(0, numberOfHits)
-            .mapToObj(i -> new PaginatedHitSource.BasicHit("index", "id-" + i, -1))
-            .toList();
-        return createPaginatedResponse(
-            usePit,
-            false,
-            emptyList(),
-            numberOfHits,
-            hits,
-            usePit ? null : scrollId(),
-            usePit ? new Object[] { "search_after" } : null
-        );
-    }
-
-    private AbstractAsyncBulkByPaginatedSearchAction.ScrollConsumableHitsResponse newConsumableHitsResponse(
-        boolean usePit,
-        int numberOfHits
-    ) {
-        PaginatedHitSource.Response response = newPaginatedResponse(usePit, numberOfHits);
-        return new AbstractAsyncBulkByPaginatedSearchAction.ScrollConsumableHitsResponse(new PaginatedHitSource.AsyncResponse() {
-            @Override
-            public PaginatedHitSource.Response response() {
-                return response;
-            }
-
-            @Override
-            public void done(TimeValue extraKeepAlive) {}
-        });
     }
 
     /**

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/AsyncBulkByPaginatedSearchActionTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/AsyncBulkByPaginatedSearchActionTests.java
@@ -1006,6 +1006,64 @@ public class AsyncBulkByPaginatedSearchActionTests extends ESTestCase {
         }
     }
 
+    public void testRemainingHitsKeepBulkStartTimeAsThrottleBaseline() {
+        AtomicReference<TimeValue> capturedDelay = new AtomicReference<>();
+        setupClient(new TestThreadPool(getTestName()) {
+            @Override
+            public ScheduledCancellable schedule(Runnable command, TimeValue delay, Executor executor) {
+                capturedDelay.set(delay);
+                return new ScheduledCancellable() {
+                    @Override
+                    public long getDelay(TimeUnit unit) {
+                        return unit.convert(delay.nanos(), TimeUnit.NANOSECONDS);
+                    }
+
+                    @Override
+                    public int compareTo(Delayed o) {
+                        return 0;
+                    }
+
+                    @Override
+                    public boolean cancel() {
+                        return true;
+                    }
+
+                    @Override
+                    public boolean isCancelled() {
+                        return false;
+                    }
+                };
+            }
+        });
+
+        worker.rethrottle(1f);
+        DummyAsyncBulkByPaginatedSearchAction action = new DummyAsyncBulkByPaginatedSearchAction();
+        PaginatedHitSource.Response scrollResponse = createPaginatedResponse(
+            false,
+            false,
+            emptyList(),
+            1,
+            singletonList(new PaginatedHitSource.BasicHit("index", "id", -1)),
+            scrollId(),
+            null
+        );
+        AbstractAsyncBulkByPaginatedSearchAction.ScrollConsumableHitsResponse asyncResponse =
+            new AbstractAsyncBulkByPaginatedSearchAction.ScrollConsumableHitsResponse(new PaginatedHitSource.AsyncResponse() {
+                @Override
+                public PaginatedHitSource.Response response() {
+                    return scrollResponse;
+                }
+
+                @Override
+                public void done(TimeValue extraKeepAlive) {}
+            });
+
+        long thisBatchStartTimeNS = System.nanoTime() - TimeUnit.MINUTES.toNanos(2);
+        action.notifyDone(thisBatchStartTimeNS, asyncResponse, 60);
+
+        assertThat(capturedDelay.get().nanos(), equalTo(0L));
+    }
+
     /**
      * Verifies that the delay scheduled between PIT search batches is correctly calculated from the throttle rate.
      * The initial delay should be zero; subsequent delays should reflect the throttling (e.g. ~100s at 1f, ~10s at 10f).
@@ -2049,13 +2107,19 @@ public class AsyncBulkByPaginatedSearchActionTests extends ESTestCase {
         worker.setNodeToRelocateToSupplier(() -> Optional.of("target-node"));
 
         final String expectedScrollId = scrollId();
-        final AtomicBoolean onScrollResponseCalled = new AtomicBoolean();
+        final long expectedBatchStartTimeNS = System.nanoTime();
+        final int expectedBatchSize = 2;
+        final AtomicBoolean onPaginatedSearchResponseCalled = new AtomicBoolean();
         final DummyAsyncBulkByPaginatedSearchAction action = new DummyAsyncBulkByPaginatedSearchAction() {
             @Override
             void onPaginatedSearchResponse(
+                final long lastBatchStartTimeNS,
+                final int lastBatchSizeToUse,
                 final AbstractAsyncBulkByPaginatedSearchAction.PaginatedSearchConsumableHitsResponse asyncResponse
             ) {
-                onScrollResponseCalled.set(true);
+                onPaginatedSearchResponseCalled.set(true);
+                assertThat("should preserve bulk start time for remaining hits", lastBatchStartTimeNS, equalTo(expectedBatchStartTimeNS));
+                assertThat("should preserve bulk batch size for remaining hits", lastBatchSizeToUse, equalTo(expectedBatchSize));
                 // don't call super - continues ingesting and listener might complete before assertions
             }
         };
@@ -2079,9 +2143,9 @@ public class AsyncBulkByPaginatedSearchActionTests extends ESTestCase {
             }
         );
 
-        action.notifyDone(System.nanoTime(), asyncResponse, 0);
+        action.notifyDone(expectedBatchStartTimeNS, asyncResponse, expectedBatchSize);
 
-        assertThat("should continue consuming remaining hits via onPaginatedSearchResponse", onScrollResponseCalled.get(), equalTo(true));
+        assertThat("should continue consuming remaining hits via onPaginatedSearchResponse", onPaginatedSearchResponseCalled.get(), equalTo(true));
         assertThat("listener should not be done - relocation should not happen while hits remain", listener.isDone(), equalTo(false));
     }
 
@@ -2095,13 +2159,19 @@ public class AsyncBulkByPaginatedSearchActionTests extends ESTestCase {
         worker.setNodeToRelocateToSupplier(() -> Optional.of("target-node"));
 
         final Object[] expectedSearchAfter = new Object[] { "search_after" };
-        final AtomicBoolean onScrollResponseCalled = new AtomicBoolean();
+        final long expectedBatchStartTimeNS = System.nanoTime();
+        final int expectedBatchSize = 2;
+        final AtomicBoolean onPaginatedSearchResponseCalled = new AtomicBoolean();
         final DummyAsyncBulkByPaginatedSearchAction action = new DummyAsyncBulkByPaginatedSearchAction() {
             @Override
             void onPaginatedSearchResponse(
+                final long lastBatchStartTimeNS,
+                final int lastBatchSizeToUse,
                 final AbstractAsyncBulkByPaginatedSearchAction.PaginatedSearchConsumableHitsResponse asyncResponse
             ) {
-                onScrollResponseCalled.set(true);
+                onPaginatedSearchResponseCalled.set(true);
+                assertThat("should preserve bulk start time for remaining hits", lastBatchStartTimeNS, equalTo(expectedBatchStartTimeNS));
+                assertThat("should preserve bulk batch size for remaining hits", lastBatchSizeToUse, equalTo(expectedBatchSize));
                 // don't call super - continues ingesting and listener might complete before assertions
             }
         };
@@ -2125,9 +2195,9 @@ public class AsyncBulkByPaginatedSearchActionTests extends ESTestCase {
             }
         );
 
-        action.notifyDone(System.nanoTime(), asyncResponse, 0);
+        action.notifyDone(expectedBatchStartTimeNS, asyncResponse, expectedBatchSize);
 
-        assertThat("should continue consuming remaining hits via onPaginatedSearchResponse", onScrollResponseCalled.get(), equalTo(true));
+        assertThat("should continue consuming remaining hits via onPaginatedSearchResponse", onPaginatedSearchResponseCalled.get(), equalTo(true));
         assertThat("listener should not be done - relocation should not happen while hits remain", listener.isDone(), equalTo(false));
     }
 

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/AsyncBulkByPaginatedSearchActionTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/AsyncBulkByPaginatedSearchActionTests.java
@@ -1088,6 +1088,111 @@ public class AsyncBulkByPaginatedSearchActionTests extends ESTestCase {
         }
     }
 
+    public void testScrollThrottleDelaySubtractsElapsedBulkProcessingTime() {
+        assertThrottleDelaySubtractsElapsedBulkProcessingTime(false);
+    }
+
+    public void testPITThrottleDelaySubtractsElapsedBulkProcessingTime() {
+        assertThrottleDelaySubtractsElapsedBulkProcessingTime(true);
+    }
+
+    public void testScrollResponseWaitDoesNotShortenThrottleDelay() {
+        assertPaginatedResponseWaitDoesNotShortenThrottleDelay(false);
+    }
+
+    public void testPITResponseWaitDoesNotShortenThrottleDelay() {
+        assertPaginatedResponseWaitDoesNotShortenThrottleDelay(true);
+    }
+
+    private void assertThrottleDelaySubtractsElapsedBulkProcessingTime(boolean usePit) {
+        configurePitOrScroll(usePit);
+        AtomicReference<TimeValue> capturedDelay = new AtomicReference<>();
+        setupClient(capturingDelayThreadPool(capturedDelay));
+
+        DummyAsyncBulkByScrollAction action = new DummyAsyncBulkByScrollAction();
+        worker.rethrottle(1f);
+
+        long lastBatchStartTimeNS = System.nanoTime() - TimeUnit.SECONDS.toNanos(10);
+        simulatePaginatedResponse(action, lastBatchStartTimeNS, 60, newPaginatedResponse(usePit, 1), usePit);
+
+        assertThat(capturedDelay.get().seconds(), either(equalTo(49L)).or(equalTo(50L)));
+    }
+
+    private void assertPaginatedResponseWaitDoesNotShortenThrottleDelay(boolean usePit) {
+        configurePitOrScroll(usePit);
+        AtomicReference<TimeValue> capturedDelay = new AtomicReference<>();
+        setupClient(capturingDelayThreadPool(capturedDelay));
+
+        DummyAsyncBulkByScrollAction action = new DummyAsyncBulkByScrollAction();
+        worker.rethrottle(1f);
+
+        action.notifyDone(System.nanoTime() - TimeUnit.MINUTES.toNanos(10), newConsumableHitsResponse(usePit, 0), 60);
+        action.onScrollResponse(newConsumableHitsResponse(usePit, 1));
+
+        assertThat(capturedDelay.get().seconds(), either(equalTo(59L)).or(equalTo(60L)));
+    }
+
+    private TestThreadPool capturingDelayThreadPool(AtomicReference<TimeValue> capturedDelay) {
+        return new TestThreadPool(getTestName()) {
+            @Override
+            public ScheduledCancellable schedule(Runnable command, TimeValue delay, Executor executor) {
+                capturedDelay.set(delay);
+                return new ScheduledCancellable() {
+                    @Override
+                    public long getDelay(TimeUnit unit) {
+                        return unit.convert(delay.nanos(), TimeUnit.NANOSECONDS);
+                    }
+
+                    @Override
+                    public int compareTo(Delayed o) {
+                        return 0;
+                    }
+
+                    @Override
+                    public boolean cancel() {
+                        return true;
+                    }
+
+                    @Override
+                    public boolean isCancelled() {
+                        return false;
+                    }
+                };
+            }
+        };
+    }
+
+    private PaginatedHitSource.Response newPaginatedResponse(boolean usePit, int numberOfHits) {
+        List<PaginatedHitSource.BasicHit> hits = IntStream.range(0, numberOfHits)
+            .mapToObj(i -> new PaginatedHitSource.BasicHit("index", "id-" + i, -1))
+            .toList();
+        return createPaginatedResponse(
+            usePit,
+            false,
+            emptyList(),
+            numberOfHits,
+            hits,
+            usePit ? null : scrollId(),
+            usePit ? new Object[] { "search_after" } : null
+        );
+    }
+
+    private AbstractAsyncBulkByPaginatedSearchAction.ScrollConsumableHitsResponse newConsumableHitsResponse(
+        boolean usePit,
+        int numberOfHits
+    ) {
+        PaginatedHitSource.Response response = newPaginatedResponse(usePit, numberOfHits);
+        return new AbstractAsyncBulkByPaginatedSearchAction.ScrollConsumableHitsResponse(new PaginatedHitSource.AsyncResponse() {
+            @Override
+            public PaginatedHitSource.Response response() {
+                return response;
+            }
+
+            @Override
+            public void done(TimeValue extraKeepAlive) {}
+        });
+    }
+
     /**
      * Execute a bulk retry test case. The total number of failures is random and the number of retries attempted is set to
      * testRequest.getMaxRetries and controlled by the failWithRejection parameter.

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/AsyncBulkByPaginatedSearchActionTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/AsyncBulkByPaginatedSearchActionTests.java
@@ -947,7 +947,8 @@ public class AsyncBulkByPaginatedSearchActionTests extends ESTestCase {
         });
 
         // Set the base for the scroll to wait - this is added to the figure we calculate below
-        testRequest.getSearchRequest().scroll(timeValueSeconds(10));
+        TimeValue scrollBase = timeValueSeconds(10);
+        testRequest.getSearchRequest().scroll(scrollBase);
 
         DummyAsyncBulkByPaginatedSearchAction action = new DummyAsyncBulkByPaginatedSearchAction() {
             @Override
@@ -980,20 +981,20 @@ public class AsyncBulkByPaginatedSearchActionTests extends ESTestCase {
             assertEquals(0, capturedDelay.get().seconds());
             capturedCommand.get().run();
 
-            // So the next request is going to have to wait an extra 100 seconds or so (base was 10 seconds, so 110ish)
-            assertThat(client.lastScroll.get().request.scroll().seconds(), either(equalTo(110L)).or(equalTo(109L)));
+            TimeValue composedScroll = client.lastScroll.get().request.scroll();
+            TimeValue keepAliveExtension = TimeValue.timeValueNanos(composedScroll.nanos() - scrollBase.nanos());
+            assertThat(keepAliveExtension.seconds(), either(equalTo(99L)).or(equalTo(100L)));
+            assertThat(composedScroll, equalTo(TimeValue.timeValueNanos(scrollBase.nanos() + keepAliveExtension.nanos())));
 
-            // The action path samples System.nanoTime() when scheduling the delay, so the elapsed time between starting the
-            // batch and receiving this response can floor the seconds value by one.
             if (randomBoolean()) {
                 client.lastScroll.get().listener.onResponse(searchResponse);
-                assertThat(capturedDelay.get().seconds(), either(equalTo(99L)).or(equalTo(100L)));
+                assertThat(capturedDelay.get(), equalTo(keepAliveExtension));
             } else {
                 // Let's rethrottle between the starting the scroll and getting the response
                 worker.rethrottle(10f);
                 client.lastScroll.get().listener.onResponse(searchResponse);
-                // The delay uses the new throttle: 100 hits at 10 req/sec = 10 seconds
-                assertThat(capturedDelay.get().seconds(), either(equalTo(9L)).or(equalTo(10L)));
+                long expectedDelayNanos = Math.round(keepAliveExtension.nanos() * 1.0d / 10.0d);
+                assertThat(capturedDelay.get(), equalTo(TimeValue.timeValueNanos(expectedDelayNanos)));
             }
 
             // Running the command ought to increment the delay counter on the task.
@@ -1134,6 +1135,48 @@ public class AsyncBulkByPaginatedSearchActionTests extends ESTestCase {
         assertThat(capturedScheduledDelay.get(), equalTo(capturedKeepAlive.get()));
     }
 
+    public void testPageThrottleUsesTheCurrentBulkSizeAfterIntermediateBulkDelay() {
+        worker.rethrottle(1f);
+        AtomicReference<TimeValue> capturedIntermediateDelay = new AtomicReference<>();
+        AtomicReference<TimeValue> capturedKeepAlive = new AtomicReference<>();
+        DummyAsyncBulkByPaginatedSearchAction action = new DummyAsyncBulkByPaginatedSearchAction() {
+            @Override
+            void onPaginatedSearchResponse(
+                ThrottleDelay throttleDelay,
+                AbstractAsyncBulkByPaginatedSearchAction.PaginatedSearchConsumableHitsResponse asyncResponse
+            ) {
+                capturedIntermediateDelay.set(throttleDelay.delay());
+            }
+        };
+        List<Hit> hits = List.of(
+            new PaginatedHitSource.BasicHit("index", "first", -1),
+            new PaginatedHitSource.BasicHit("index", "second", -1)
+        );
+        AbstractAsyncBulkByPaginatedSearchAction.PaginatedSearchConsumableHitsResponse asyncResponse =
+            new AbstractAsyncBulkByPaginatedSearchAction.PaginatedSearchConsumableHitsResponse(new PaginatedHitSource.AsyncResponse() {
+                @Override
+                public PaginatedHitSource.Response response() {
+                    return createPaginatedResponse(false, false, emptyList(), hits.size(), hits, scrollId(), null);
+                }
+
+                @Override
+                public void done(TimeValue extraKeepAlive) {
+                    capturedKeepAlive.set(extraKeepAlive);
+                }
+            });
+
+        asyncResponse.consumeHits(1);
+        action.notifyDone(System.nanoTime(), asyncResponse, 50);
+        assertThat(capturedIntermediateDelay.get().nanos(), greaterThan(TimeUnit.SECONDS.toNanos(49)));
+        assertThat(capturedIntermediateDelay.get().nanos(), lessThanOrEqualTo(TimeUnit.SECONDS.toNanos(50)));
+
+        asyncResponse.consumeHits(1);
+        action.notifyDone(System.nanoTime(), asyncResponse, 50);
+
+        assertThat(capturedKeepAlive.get().nanos(), greaterThan(TimeUnit.SECONDS.toNanos(49)));
+        assertThat(capturedKeepAlive.get().nanos(), lessThanOrEqualTo(TimeUnit.SECONDS.toNanos(50)));
+    }
+
     /**
      * Verifies that the delay scheduled between PIT search batches is correctly calculated from the throttle rate.
      * The initial delay should be zero; subsequent delays should reflect the throttling (e.g. ~100s at 1f, ~10s at 10f).
@@ -1198,18 +1241,20 @@ public class AsyncBulkByPaginatedSearchActionTests extends ESTestCase {
             capturedCommand.get().run();
 
             assertNotNull("PIT next search should use SearchRequest", client.lastSearch.get());
-            assertThat(
-                client.lastSearch.get().request.source().pointInTimeBuilder().getKeepAlive().seconds(),
-                either(equalTo(399L)).or(equalTo(400L))
-            );
+            TimeValue pitBase = TimeValue.timeValueMinutes(5);
+            TimeValue composedKeepAlive = client.lastSearch.get().request.source().pointInTimeBuilder().getKeepAlive();
+            TimeValue keepAliveExtension = TimeValue.timeValueNanos(composedKeepAlive.nanos() - pitBase.nanos());
+            assertThat(keepAliveExtension.seconds(), either(equalTo(99L)).or(equalTo(100L)));
+            assertThat(composedKeepAlive, equalTo(TimeValue.timeValueNanos(pitBase.nanos() + keepAliveExtension.nanos())));
 
             if (randomBoolean()) {
                 client.lastSearch.get().listener.onResponse(searchResponse);
-                assertThat(capturedDelay.get().seconds(), either(equalTo(99L)).or(equalTo(100L)));
+                assertThat(capturedDelay.get(), equalTo(keepAliveExtension));
             } else {
                 worker.rethrottle(10f);
                 client.lastSearch.get().listener.onResponse(searchResponse);
-                assertThat(capturedDelay.get().seconds(), either(equalTo(9L)).or(equalTo(10L)));
+                long expectedDelayNanos = Math.round(keepAliveExtension.nanos() * 1.0d / 10.0d);
+                assertThat(capturedDelay.get(), equalTo(TimeValue.timeValueNanos(expectedDelayNanos)));
             }
 
             capturedCommand.get().run();

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/RestReindexActionTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/RestReindexActionTests.java
@@ -73,6 +73,16 @@ public class RestReindexActionTests extends RestActionTestCase {
         assertEquals("10m", request.getScrollTime().toString());
     }
 
+    public void testRequestsPerSecondRejectsNaN() {
+        FakeRestRequest restRequest = new FakeRestRequest.Builder(xContentRegistry()).withParams(singletonMap("requests_per_second", "NaN"))
+            .build();
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> AbstractBaseReindexRestHandler.parseRequestsPerSecond(restRequest)
+        );
+        assertThat(exception.getMessage(), equalTo("[requests_per_second] must be a float greater than 0. Use -1 to disable throttling."));
+    }
+
     public void testDestSliceParsedWhenFeatureFlagEnabled() throws IOException {
         assumeTrue("slice indexing feature flag must be enabled", SliceIndexing.SLICE_FEATURE_FLAG.isEnabled());
         ReindexRequest request = action.buildRequest(buildRequestWithBody("""

--- a/server/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByPaginatedSearchRequest.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByPaginatedSearchRequest.java
@@ -382,7 +382,7 @@ public abstract class AbstractBulkByPaginatedSearchRequest<Self extends Abstract
      * keep-alive to make sure that it contains any time that we might wait.
      */
     public Self setRequestsPerSecond(float requestsPerSecond) {
-        if (requestsPerSecond <= 0) {
+        if (requestsPerSecond <= 0 || Float.isNaN(requestsPerSecond)) {
             throw new IllegalArgumentException(
                 "[requests_per_second] must be greater than 0. Use Float.POSITIVE_INFINITY to disable throttling."
             );

--- a/server/src/main/java/org/elasticsearch/index/reindex/WorkerBulkByPaginatedSearchTaskState.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/WorkerBulkByPaginatedSearchTaskState.java
@@ -247,7 +247,7 @@ public class WorkerBulkByPaginatedSearchTaskState implements SuccessfullyProcess
      * does not reduce the next throttle delay.
      */
     public TimeValue throttleWaitTime(long lastBatchStartTimeNS, long nowNS, int lastBatchSize) {
-        long targetBatchTime = (long) perfectlyThrottledBatchTime(lastBatchSize);
+        long targetBatchTime = round((double) perfectlyThrottledBatchTime(lastBatchSize));
         long elapsedBatchTime = max(0, nowNS - lastBatchStartTimeNS);
         long waitTime = min(MAX_THROTTLE_WAIT_TIME.nanos(), max(0, targetBatchTime - elapsedBatchTime));
         return timeValueNanos(waitTime);

--- a/server/src/main/java/org/elasticsearch/index/reindex/WorkerBulkByPaginatedSearchTaskState.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/WorkerBulkByPaginatedSearchTaskState.java
@@ -241,8 +241,9 @@ public class WorkerBulkByPaginatedSearchTaskState implements SuccessfullyProcess
     }
 
     public TimeValue throttleWaitTime(long lastBatchStartTimeNS, long nowNS, int lastBatchSize) {
-        long earliestNextBatchStartTime = nowNS + (long) perfectlyThrottledBatchTime(lastBatchSize);
-        long waitTime = min(MAX_THROTTLE_WAIT_TIME.nanos(), max(0, earliestNextBatchStartTime - System.nanoTime()));
+        long targetBatchTime = (long) perfectlyThrottledBatchTime(lastBatchSize);
+        long elapsedBatchTime = max(0, nowNS - lastBatchStartTimeNS);
+        long waitTime = min(MAX_THROTTLE_WAIT_TIME.nanos(), max(0, targetBatchTime - elapsedBatchTime));
         return timeValueNanos(waitTime);
     }
 

--- a/server/src/main/java/org/elasticsearch/index/reindex/WorkerBulkByPaginatedSearchTaskState.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/WorkerBulkByPaginatedSearchTaskState.java
@@ -240,6 +240,12 @@ public class WorkerBulkByPaginatedSearchTaskState implements SuccessfullyProcess
         }
     }
 
+    /**
+     * Calculates the remaining throttle wait for the previous bulk batch. The target batch time is based on the batch size
+     * and the current requests-per-second limit, then reduced by the elapsed time since the batch started. Callers that wait
+     * for a new scroll or PIT response should pass the response arrival time as the baseline so that search response wait time
+     * does not reduce the next throttle delay.
+     */
     public TimeValue throttleWaitTime(long lastBatchStartTimeNS, long nowNS, int lastBatchSize) {
         long targetBatchTime = (long) perfectlyThrottledBatchTime(lastBatchSize);
         long elapsedBatchTime = max(0, nowNS - lastBatchStartTimeNS);

--- a/server/src/main/java/org/elasticsearch/index/reindex/WorkerBulkByPaginatedSearchTaskState.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/WorkerBulkByPaginatedSearchTaskState.java
@@ -39,6 +39,29 @@ import static org.elasticsearch.core.TimeValue.timeValueNanos;
  */
 public class WorkerBulkByPaginatedSearchTaskState implements SuccessfullyProcessed {
 
+    /**
+     * A throttle delay paired with the rate that was used to calculate it. Keeping both values allows a delay that was calculated before
+     * a paginated search request to be shortened safely if the task is rethrottled while waiting for the response.
+     */
+    public record ThrottleDelay(TimeValue delay, float requestsPerSecond) {
+        public static final ThrottleDelay ZERO = new ThrottleDelay(TimeValue.ZERO, Float.POSITIVE_INFINITY);
+
+        public ThrottleDelay {
+            Objects.requireNonNull(delay);
+            if (requestsPerSecond <= 0 || Float.isNaN(requestsPerSecond)) {
+                throw new IllegalArgumentException("requests per second must be more than 0 but was [" + requestsPerSecond + "]");
+            }
+        }
+
+        private ThrottleDelay rethrottle(float newRequestsPerSecond) {
+            if (newRequestsPerSecond <= requestsPerSecond) {
+                return this;
+            }
+            long adjustedDelayNanos = round((double) delay.nanos() * requestsPerSecond / newRequestsPerSecond);
+            return new ThrottleDelay(timeValueNanos(adjustedDelayNanos), newRequestsPerSecond);
+        }
+    }
+
     private static final Logger logger = LogManager.getLogger(WorkerBulkByPaginatedSearchTaskState.class);
 
     /**
@@ -226,13 +249,32 @@ public class WorkerBulkByPaginatedSearchTaskState implements SuccessfullyProcess
         int lastBatchSize,
         AbstractRunnable prepareBulkRequestRunnable
     ) {
+        delayPrepareBulkRequest(
+            threadPool,
+            throttleDelay(lastBatchStartTimeNS, System.nanoTime(), lastBatchSize),
+            prepareBulkRequestRunnable
+        );
+    }
+
+    /**
+     * Schedule {@code prepareBulkRequestRunnable} using a delay calculated before a paginated search request. A faster rethrottle that
+     * happened while waiting for the response shortens the delay. A slower rethrottle takes effect on the next batch so the current search
+     * context is never kept alive for less time than the delay scheduled here.
+     */
+    public void delayPrepareBulkRequest(ThreadPool threadPool, ThrottleDelay throttleDelay, AbstractRunnable prepareBulkRequestRunnable) {
         // Synchronize so we are less likely to schedule the same request twice.
         synchronized (delayedPrepareBulkRequestReference) {
-            TimeValue delay = throttleWaitTime(lastBatchStartTimeNS, System.nanoTime(), lastBatchSize);
+            ThrottleDelay adjustedThrottleDelay = throttleDelay.rethrottle(getRequestsPerSecond());
+            TimeValue delay = adjustedThrottleDelay.delay();
             logger.debug("[{}]: preparing bulk request for [{}]", task.getId(), delay);
             try {
                 delayedPrepareBulkRequestReference.set(
-                    new DelayedPrepareBulkRequest(threadPool, getRequestsPerSecond(), delay, new RunOnce(prepareBulkRequestRunnable))
+                    new DelayedPrepareBulkRequest(
+                        threadPool,
+                        adjustedThrottleDelay.requestsPerSecond(),
+                        delay,
+                        new RunOnce(prepareBulkRequestRunnable)
+                    )
                 );
             } catch (EsRejectedExecutionException e) {
                 prepareBulkRequestRunnable.onRejection(e);
@@ -241,22 +283,32 @@ public class WorkerBulkByPaginatedSearchTaskState implements SuccessfullyProcess
     }
 
     /**
-     * Calculates the remaining throttle wait for the previous bulk batch. The target batch time is based on the batch size
-     * and the current requests-per-second limit, then reduced by the elapsed time since the batch started. Callers that wait
-     * for a new scroll or PIT response should pass the response arrival time as the baseline so that search response wait time
-     * does not reduce the next throttle delay.
+     * Calculates the remaining throttle wait for the previous bulk batch. The target batch time is based on the batch size and the current
+     * requests-per-second limit, then reduced by the elapsed time since the batch started.
      */
     public TimeValue throttleWaitTime(long lastBatchStartTimeNS, long nowNS, int lastBatchSize) {
-        long targetBatchTime = round((double) perfectlyThrottledBatchTime(lastBatchSize));
+        return throttleDelay(lastBatchStartTimeNS, nowNS, lastBatchSize).delay();
+    }
+
+    /**
+     * Calculates the remaining throttle wait and captures the rate used for the calculation.
+     */
+    public ThrottleDelay throttleDelay(long lastBatchStartTimeNS, long nowNS, int lastBatchSize) {
+        float requestsPerSecond = getRequestsPerSecond();
+        long targetBatchTime = round((double) perfectlyThrottledBatchTime(lastBatchSize, requestsPerSecond));
         long elapsedBatchTime = max(0, nowNS - lastBatchStartTimeNS);
         long waitTime = min(MAX_THROTTLE_WAIT_TIME.nanos(), max(0, targetBatchTime - elapsedBatchTime));
-        return timeValueNanos(waitTime);
+        return new ThrottleDelay(timeValueNanos(waitTime), requestsPerSecond);
     }
 
     /**
      * How many nanoseconds should a batch of lastBatchSize have taken if it were perfectly throttled? Package private for testing.
      */
     float perfectlyThrottledBatchTime(int lastBatchSize) {
+        return perfectlyThrottledBatchTime(lastBatchSize, getRequestsPerSecond());
+    }
+
+    private static float perfectlyThrottledBatchTime(int lastBatchSize, float requestsPerSecond) {
         if (requestsPerSecond == Float.POSITIVE_INFINITY) {
             return 0;
         }

--- a/server/src/main/java/org/elasticsearch/index/reindex/WorkerBulkByPaginatedSearchTaskState.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/WorkerBulkByPaginatedSearchTaskState.java
@@ -295,7 +295,7 @@ public class WorkerBulkByPaginatedSearchTaskState implements SuccessfullyProcess
      */
     public ThrottleDelay throttleDelay(long lastBatchStartTimeNS, long nowNS, int lastBatchSize) {
         float requestsPerSecond = getRequestsPerSecond();
-        long targetBatchTime = round((double) perfectlyThrottledBatchTime(lastBatchSize, requestsPerSecond));
+        long targetBatchTime = round(perfectlyThrottledBatchTime(lastBatchSize, requestsPerSecond));
         long elapsedBatchTime = max(0, nowNS - lastBatchStartTimeNS);
         long waitTime = min(MAX_THROTTLE_WAIT_TIME.nanos(), max(0, targetBatchTime - elapsedBatchTime));
         return new ThrottleDelay(timeValueNanos(waitTime), requestsPerSecond);
@@ -304,24 +304,24 @@ public class WorkerBulkByPaginatedSearchTaskState implements SuccessfullyProcess
     /**
      * How many nanoseconds should a batch of lastBatchSize have taken if it were perfectly throttled? Package private for testing.
      */
-    float perfectlyThrottledBatchTime(int lastBatchSize) {
+    double perfectlyThrottledBatchTime(int lastBatchSize) {
         return perfectlyThrottledBatchTime(lastBatchSize, getRequestsPerSecond());
     }
 
-    private static float perfectlyThrottledBatchTime(int lastBatchSize, float requestsPerSecond) {
+    private static double perfectlyThrottledBatchTime(int lastBatchSize, float requestsPerSecond) {
         if (requestsPerSecond == Float.POSITIVE_INFINITY) {
             return 0;
         }
         // requests
         // ------------------- == seconds
         // request per seconds
-        float targetBatchTimeInSeconds = lastBatchSize / requestsPerSecond;
+        double targetBatchTimeInSeconds = lastBatchSize / (double) requestsPerSecond;
         // nanoseconds per seconds * seconds == nanoseconds
         return TimeUnit.SECONDS.toNanos(1) * targetBatchTimeInSeconds;
     }
 
     private void setRequestsPerSecond(float requestsPerSecond) {
-        if (requestsPerSecond <= 0) {
+        if (requestsPerSecond <= 0 || Float.isNaN(requestsPerSecond)) {
             throw new IllegalArgumentException("requests per second must be more than 0 but was [" + requestsPerSecond + "]");
         }
         this.requestsPerSecond = requestsPerSecond;
@@ -414,7 +414,7 @@ public class WorkerBulkByPaginatedSearchTaskState implements SuccessfullyProcess
              * is given a runOnce boolean to prevent that. */
             TimeValue newDelay = newDelay(remainingDelay, newRequestsPerSecond);
             logger.debug("[{}]: rescheduling for [{}] in the future", task.getId(), newDelay);
-            return new DelayedPrepareBulkRequest(threadPool, requestsPerSecond, newDelay, command);
+            return new DelayedPrepareBulkRequest(threadPool, newRequestsPerSecond, newDelay, command);
         }
 
         /**
@@ -424,7 +424,7 @@ public class WorkerBulkByPaginatedSearchTaskState implements SuccessfullyProcess
             if (remainingDelay < 0) {
                 return timeValueNanos(0);
             }
-            return timeValueNanos(round(remainingDelay * requestsPerSecond / newRequestsPerSecond));
+            return timeValueNanos(round((double) remainingDelay * requestsPerSecond / newRequestsPerSecond));
         }
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/reindex/AbstractBulkByPaginatedSearchRequestTestCase.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/AbstractBulkByPaginatedSearchRequestTestCase.java
@@ -95,6 +95,15 @@ public abstract class AbstractBulkByPaginatedSearchRequestTestCase<R extends Abs
         extraForSliceAssertions(original, forSliced);
     }
 
+    public void testRequestsPerSecondRejectsNaN() {
+        R request = newRequest();
+        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> request.setRequestsPerSecond(Float.NaN));
+        assertThat(
+            exception.getMessage(),
+            equalTo("[requests_per_second] must be greater than 0. Use Float.POSITIVE_INFINITY to disable throttling.")
+        );
+    }
+
     public void testForSlice_maxDocsSumsCorrectly() {
         R original = newRequest();
         int originalMaxDocs = between(0, Integer.MAX_VALUE);

--- a/server/src/test/java/org/elasticsearch/index/reindex/WorkerBulkByPaginatedSearchTaskStateTests.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/WorkerBulkByPaginatedSearchTaskStateTests.java
@@ -302,6 +302,15 @@ public class WorkerBulkByPaginatedSearchTaskStateTests extends ESTestCase {
         assertThat(workerState.throttleWaitTime(lastBatchStartTimeNS, nowNS, 3).nanos(), equalTo(TimeUnit.SECONDS.toNanos(5)));
     }
 
+    public void testThrottleWaitTimeRoundsFractionalNanoseconds() {
+        workerState.rethrottle(2_000_000_000f);
+
+        long lastBatchStartTimeNS = System.nanoTime();
+        long nowNS = lastBatchStartTimeNS;
+
+        assertThat(workerState.throttleWaitTime(lastBatchStartTimeNS, nowNS, 1).nanos(), equalTo(1L));
+    }
+
     public void testThrottleWaitTimeUsesLatestRethrottleRate() {
         workerState.rethrottle(1f);
         workerState.rethrottle(2f);

--- a/server/src/test/java/org/elasticsearch/index/reindex/WorkerBulkByPaginatedSearchTaskStateTests.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/WorkerBulkByPaginatedSearchTaskStateTests.java
@@ -248,6 +248,94 @@ public class WorkerBulkByPaginatedSearchTaskStateTests extends ESTestCase {
         }
     }
 
+    public void testThrottleWaitTimeAccountsForElapsedTimeSinceLastBatchStart() {
+        workerState.rethrottle(1f);
+
+        long lastBatchStartTimeNS = System.nanoTime();
+        long nowNS = lastBatchStartTimeNS + TimeUnit.SECONDS.toNanos(5);
+
+        assertThat(workerState.throttleWaitTime(lastBatchStartTimeNS, nowNS, 10).nanos(), equalTo(TimeUnit.SECONDS.toNanos(5)));
+    }
+
+    public void testThrottleWaitTimeIsZeroWhenElapsedTimeExceedsTargetBatchTime() {
+        workerState.rethrottle(1f);
+
+        long nowNS = System.nanoTime();
+        long lastBatchStartTimeNS = nowNS - TimeUnit.SECONDS.toNanos(30);
+
+        assertThat(workerState.throttleWaitTime(lastBatchStartTimeNS, nowNS, 10).nanos(), equalTo(0L));
+    }
+
+    public void testThrottleWaitTimeDoesNotTreatEarlierNowAsElapsedTime() {
+        workerState.rethrottle(1f);
+
+        long lastBatchStartTimeNS = System.nanoTime();
+        long nowNS = lastBatchStartTimeNS - TimeUnit.SECONDS.toNanos(5);
+
+        assertThat(workerState.throttleWaitTime(lastBatchStartTimeNS, nowNS, 10).nanos(), equalTo(TimeUnit.SECONDS.toNanos(10)));
+    }
+
+    public void testThrottleWaitTimeIsZeroWhenThrottlingIsDisabled() {
+        workerState.rethrottle(Float.POSITIVE_INFINITY);
+
+        long nowNS = System.nanoTime();
+        long lastBatchStartTimeNS = nowNS - TimeUnit.SECONDS.toNanos(30);
+
+        assertThat(workerState.throttleWaitTime(lastBatchStartTimeNS, nowNS, randomIntBetween(1, 1000)).nanos(), equalTo(0L));
+    }
+
+    public void testThrottleWaitTimeIsZeroForEmptyBatch() {
+        workerState.rethrottle(1f);
+
+        long lastBatchStartTimeNS = System.nanoTime();
+        long nowNS = lastBatchStartTimeNS;
+
+        assertThat(workerState.throttleWaitTime(lastBatchStartTimeNS, nowNS, 0).nanos(), equalTo(0L));
+    }
+
+    public void testThrottleWaitTimeUsesFractionalRequestRate() {
+        workerState.rethrottle(0.5f);
+
+        long lastBatchStartTimeNS = System.nanoTime();
+        long nowNS = lastBatchStartTimeNS + TimeUnit.SECONDS.toNanos(1);
+
+        assertThat(workerState.throttleWaitTime(lastBatchStartTimeNS, nowNS, 3).nanos(), equalTo(TimeUnit.SECONDS.toNanos(5)));
+    }
+
+    public void testThrottleWaitTimeUsesLatestRethrottleRate() {
+        workerState.rethrottle(1f);
+        workerState.rethrottle(2f);
+
+        long lastBatchStartTimeNS = System.nanoTime();
+        long nowNS = lastBatchStartTimeNS + TimeUnit.SECONDS.toNanos(2);
+
+        assertThat(workerState.throttleWaitTime(lastBatchStartTimeNS, nowNS, 10).nanos(), equalTo(TimeUnit.SECONDS.toNanos(3)));
+    }
+
+    public void testThrottleWaitTimeCapsLongRemainingDelayAtMaximumThrottleWait() {
+        workerState.rethrottle(1f);
+
+        long lastBatchStartTimeNS = System.nanoTime();
+        long nowNS = lastBatchStartTimeNS;
+
+        assertThat(
+            workerState.throttleWaitTime(lastBatchStartTimeNS, nowNS, (int) TimeUnit.HOURS.toSeconds(2)).nanos(),
+            equalTo(TimeUnit.HOURS.toNanos(1))
+        );
+    }
+
+    public void testThrottleWaitTimeCapsRemainingDelayAfterElapsedTimeAtMaximumThrottleWait() {
+        workerState.rethrottle(1f);
+
+        long lastBatchStartTimeNS = System.nanoTime();
+        long nowNS = lastBatchStartTimeNS + TimeUnit.MINUTES.toNanos(30);
+
+        assertThat(
+            workerState.throttleWaitTime(lastBatchStartTimeNS, nowNS, (int) TimeUnit.HOURS.toSeconds(2)).nanos(),
+            equalTo(TimeUnit.HOURS.toNanos(1))
+        );
+    }
+
     public void testRethrottleWithRelocationGuardNonSliced() {
         final float rps = randomFloatBetween(0.1f, 1000f, true);
         workerState.rethrottleWithRelocationGuard(rps);

--- a/server/src/test/java/org/elasticsearch/index/reindex/WorkerBulkByPaginatedSearchTaskStateTests.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/WorkerBulkByPaginatedSearchTaskStateTests.java
@@ -360,6 +360,67 @@ public class WorkerBulkByPaginatedSearchTaskStateTests extends ESTestCase {
         assertThat(scheduleAfterRethrottle(throttleDelay, 1f), equalTo(timeValueSeconds(1)));
     }
 
+    public void testRepeatedFasterRethrottlesUseTheLatestScheduledRate() throws IOException {
+        workerState.rethrottle(1f);
+        AtomicReference<TimeValue> capturedDelay = new AtomicReference<>();
+        ThreadPool threadPool = new TestThreadPool(getTestName()) {
+            @Override
+            public ScheduledCancellable schedule(Runnable command, TimeValue delay, Executor executor) {
+                capturedDelay.set(delay);
+                return new ScheduledCancellable() {
+                    @Override
+                    public long getDelay(TimeUnit unit) {
+                        return unit.convert(delay.nanos(), TimeUnit.NANOSECONDS);
+                    }
+
+                    @Override
+                    public int compareTo(Delayed o) {
+                        return 0;
+                    }
+
+                    @Override
+                    public boolean cancel() {
+                        return true;
+                    }
+
+                    @Override
+                    public boolean isCancelled() {
+                        return false;
+                    }
+                };
+            }
+        };
+        try {
+            workerState.delayPrepareBulkRequest(
+                threadPool,
+                new WorkerBulkByPaginatedSearchTaskState.ThrottleDelay(timeValueSeconds(100), 1f),
+                new AbstractRunnable() {
+                    @Override
+                    protected void doRun() {}
+
+                    @Override
+                    public void onFailure(Exception e) {
+                        fail(e);
+                    }
+                }
+            );
+            assertThat(capturedDelay.get(), equalTo(timeValueSeconds(100)));
+
+            workerState.rethrottle(2f);
+            assertThat(capturedDelay.get(), equalTo(timeValueSeconds(50)));
+
+            workerState.rethrottle(4f);
+            assertThat(capturedDelay.get(), equalTo(timeValueSeconds(25)));
+        } finally {
+            threadPool.shutdown();
+        }
+    }
+
+    public void testRethrottleRejectsNaN() {
+        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> workerState.rethrottle(Float.NaN));
+        assertThat(exception.getMessage(), equalTo("requests per second must be more than 0 but was [NaN]"));
+    }
+
     private TimeValue scheduleAfterRethrottle(WorkerBulkByPaginatedSearchTaskState.ThrottleDelay throttleDelay, float requestsPerSecond)
         throws IOException {
         AtomicReference<TimeValue> capturedDelay = new AtomicReference<>();
@@ -528,13 +589,10 @@ public class WorkerBulkByPaginatedSearchTaskStateTests extends ESTestCase {
 
     public void testPerfectlyThrottledBatchTime() {
         workerState.rethrottle(Float.POSITIVE_INFINITY);
-        assertThat((double) workerState.perfectlyThrottledBatchTime(randomInt()), closeTo(0f, 0f));
+        assertThat(workerState.perfectlyThrottledBatchTime(randomInt()), closeTo(0f, 0f));
 
         int total = between(0, 1000000);
         workerState.rethrottle(1);
-        assertThat(
-            (double) workerState.perfectlyThrottledBatchTime(total),
-            closeTo(TimeUnit.SECONDS.toNanos(total), TimeUnit.SECONDS.toNanos(1))
-        );
+        assertThat(workerState.perfectlyThrottledBatchTime(total), closeTo(TimeUnit.SECONDS.toNanos(total), TimeUnit.SECONDS.toNanos(1)));
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/reindex/WorkerBulkByPaginatedSearchTaskStateTests.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/WorkerBulkByPaginatedSearchTaskStateTests.java
@@ -32,6 +32,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.elasticsearch.core.TimeValue.timeValueMillis;
 import static org.elasticsearch.core.TimeValue.timeValueSeconds;
@@ -343,6 +344,67 @@ public class WorkerBulkByPaginatedSearchTaskStateTests extends ESTestCase {
             workerState.throttleWaitTime(lastBatchStartTimeNS, nowNS, (int) TimeUnit.HOURS.toSeconds(2)).nanos(),
             equalTo(TimeUnit.HOURS.toNanos(1))
         );
+    }
+
+    public void testPendingThrottleDelayIsShortenedByFasterRethrottle() throws IOException {
+        workerState.rethrottle(1f);
+        var throttleDelay = new WorkerBulkByPaginatedSearchTaskState.ThrottleDelay(timeValueSeconds(100), 1f);
+
+        assertThat(scheduleAfterRethrottle(throttleDelay, 10f), equalTo(timeValueSeconds(10)));
+    }
+
+    public void testPendingThrottleDelayIsNotLengthenedBySlowerRethrottle() throws IOException {
+        workerState.rethrottle(10f);
+        var throttleDelay = workerState.throttleDelay(0, 0, 10);
+
+        assertThat(scheduleAfterRethrottle(throttleDelay, 1f), equalTo(timeValueSeconds(1)));
+    }
+
+    private TimeValue scheduleAfterRethrottle(WorkerBulkByPaginatedSearchTaskState.ThrottleDelay throttleDelay, float requestsPerSecond)
+        throws IOException {
+        AtomicReference<TimeValue> capturedDelay = new AtomicReference<>();
+        ThreadPool threadPool = new TestThreadPool(getTestName()) {
+            @Override
+            public ScheduledCancellable schedule(Runnable command, TimeValue delay, Executor executor) {
+                capturedDelay.set(delay);
+                return new ScheduledCancellable() {
+                    @Override
+                    public long getDelay(TimeUnit unit) {
+                        return unit.convert(delay.nanos(), TimeUnit.NANOSECONDS);
+                    }
+
+                    @Override
+                    public int compareTo(Delayed o) {
+                        return 0;
+                    }
+
+                    @Override
+                    public boolean cancel() {
+                        return true;
+                    }
+
+                    @Override
+                    public boolean isCancelled() {
+                        return false;
+                    }
+                };
+            }
+        };
+        try {
+            workerState.rethrottle(requestsPerSecond);
+            workerState.delayPrepareBulkRequest(threadPool, throttleDelay, new AbstractRunnable() {
+                @Override
+                protected void doRun() {}
+
+                @Override
+                public void onFailure(Exception e) {
+                    fail(e);
+                }
+            });
+            return capturedDelay.get();
+        } finally {
+            threadPool.shutdown();
+        }
     }
 
     public void testRethrottleWithRelocationGuardNonSliced() {


### PR DESCRIPTION
Fix reindex throttling so elapsed bulk processing time is accounted for when calculating the next throttle wait, while keeping scroll/PIT response time out of the throttle baseline.

The remaining throttle delay is now calculated once when a bulk page completes and reused for both the scroll/PIT keep-alive extension and the scheduled continuation. A faster rethrottle can shorten an already-pending delay, while a slower rethrottle does not extend it beyond the keep-alive already sent to the server.

Regression coverage includes scroll and PIT keep-alives, faster and slower pending rethrottles, and long delays that previously exposed float overflow in the rethrottle calculation.

Testing:
- `./gradlew :server:spotlessJavaCheck :modules:reindex:spotlessJavaCheck`
- `./gradlew :server:test --tests org.elasticsearch.index.reindex.WorkerBulkByPaginatedSearchTaskStateTests`
- `./gradlew :modules:reindex:test --tests org.elasticsearch.index.reindex.AsyncBulkByPaginatedSearchActionTests`
- `./gradlew :server:test --tests org.elasticsearch.index.reindex.WorkerBulkByPaginatedSearchTaskStateTests.testThrottleWaitTimeAccountsForElapsedTimeSinceLastBatchStart -Dtests.iters=10000`

closes: https://github.com/elastic/elasticsearch/issues/150875
