### PR TITLE
[9.4] Fix AVLTreeDigest CDF monotonicity for penultimate centroid (#151181)

### DIFF
--- a/docs/changelog/151181.yaml
+++ b/docs/changelog/151181.yaml
@@ -1,0 +1,6 @@
+area: Aggregations
+issues:
+ - 151012
+pr: 151181
+summary: Fix AVLTreeDigest CDF monotonicity for penultimate centroid
+type: bug

--- a/libs/tdigest/src/main/java/org/elasticsearch/tdigest/AVLTreeDigest.java
+++ b/libs/tdigest/src/main/java/org/elasticsearch/tdigest/AVLTreeDigest.java
@@ -279,9 +279,14 @@ public class AVLTreeDigest extends AbstractTDigest {
                 right = (b.mean() - a.mean()) / 2;
             }
 
-            // for the last element, assume right width is same as left
             if (x < a.mean() + right) {
-                return (r + a.count() * interpolate(x, a.mean() - right, a.mean() + right)) / count;
+                return (r + a.count() * interpolate(x, a.mean() - left, a.mean() + right)) / count;
+            }
+            r += a.count();
+
+            // for the last element, assume right width is same as left
+            if (x < b.mean() + right) {
+                return (r + b.count() * interpolate(x, b.mean() - right, b.mean() + right)) / count;
             }
             return 1;
         }

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -275,9 +275,6 @@ tests:
   method: "builds distribution from branches via archives extractedAssemble [bwcDistVersion: 8.2.1, bwcProject: major3, expectedAssembleTaskName:
     extractedAssemble, #2]"
   issue: https://github.com/elastic/elasticsearch/issues/150410
-- class: org.elasticsearch.tdigest.AVLTreeDigestTests
-  method: testMonotonicity
-  issue: https://github.com/elastic/elasticsearch/issues/151012
 - class: org.elasticsearch.repositories.azure.AzureBlobContainerTests
   method: testCanConfigureReadTimeout
   issue: https://github.com/elastic/elasticsearch/issues/151022


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Fix AVLTreeDigest CDF monotonicity for penultimate centroid (#151181)