### PR TITLE
Exponential histogram doc values return DocIdSetIterator.NO_MORE_DOCS when empty.

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -149,9 +149,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.spatial.SpatialPushDownGeoShapeIT
   method: testQuantizedXY
   issue: https://github.com/elastic/elasticsearch/issues/150782
-- class: org.elasticsearch.xpack.analytics.mapper.ExponentialHistogramFieldMapperTests
-  method: testExponentialHistogramValuesReader
-  issue: https://github.com/elastic/elasticsearch/issues/150795
 
 # Examples:
 #

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/ExponentialHistogramFieldMapper.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/ExponentialHistogramFieldMapper.java
@@ -833,6 +833,9 @@ public class ExponentialHistogramFieldMapper extends FieldMapper {
             valueSums = leafReader.getNumericDocValues(valuesSumSubFieldName(fullPath));
             valueMinima = leafReader.getNumericDocValues(valuesMinSubFieldName(fullPath));
             valueMaxima = leafReader.getNumericDocValues(valuesMaxSubFieldName(fullPath));
+            if (valueCounts == null) {
+                currentDocId = DocIdSetIterator.NO_MORE_DOCS;
+            }
             docIdSetIterator = new DocIdSetIterator() {
 
                 @Override
@@ -876,8 +879,8 @@ public class ExponentialHistogramFieldMapper extends FieldMapper {
 
         @Override
         public ExponentialHistogram histogramValue() throws IOException {
-            if (currentDocId == -1) {
-                throw new IllegalStateException("No histogram present for current document");
+            if (currentDocId == -1 || currentDocId == DocIdSetIterator.NO_MORE_DOCS) {
+                throw new IllegalStateException("No histogram present for current document id");
             }
             boolean histoPresent = histoDocValues.advanceExact(currentDocId);
             boolean zeroThresholdPresent = zeroThresholds.advanceExact(currentDocId);
@@ -917,8 +920,8 @@ public class ExponentialHistogramFieldMapper extends FieldMapper {
 
         @Override
         public double sumValue() throws IOException {
-            if (currentDocId == -1) {
-                throw new IllegalStateException("No histogram present for current document");
+            if (currentDocId == -1 || currentDocId == DocIdSetIterator.NO_MORE_DOCS) {
+                throw new IllegalStateException("No histogram present for current document id");
             }
             if (valueSums == null || valueSums.advanceExact(currentDocId) == false) {
                 // empty histogram, must have sum of 0.0
@@ -929,8 +932,8 @@ public class ExponentialHistogramFieldMapper extends FieldMapper {
 
         @Override
         public double minValue() throws IOException {
-            if (currentDocId == -1) {
-                throw new IllegalStateException("No histogram present for current document");
+            if (currentDocId == -1 || currentDocId == DocIdSetIterator.NO_MORE_DOCS) {
+                throw new IllegalStateException("No histogram present for current document id");
             }
             if (valueMinima == null || valueMinima.advanceExact(currentDocId) == false) {
                 // empty histogram
@@ -941,8 +944,8 @@ public class ExponentialHistogramFieldMapper extends FieldMapper {
 
         @Override
         public double maxValue() throws IOException {
-            if (currentDocId == -1) {
-                throw new IllegalStateException("No histogram present for current document");
+            if (currentDocId == -1 || currentDocId == DocIdSetIterator.NO_MORE_DOCS) {
+                throw new IllegalStateException("No histogram present for current document id");
             }
             if (valueMaxima == null || valueMaxima.advanceExact(currentDocId) == false) {
                 // empty histogram


### PR DESCRIPTION
This PR changes the behaviour of the empty doc values for exponential histograms. When it detects that `valueCount` is `null` instead of keeping the `currentDocId` to the value it was initialised `-1`, it sets it to `DocIdSetIterator.NO_MORE_DOCS` to signal that there are no more values.

Fixes test failure #150795