### PR TITLE
[8.19] Catch StackOverflowError in deeply nested RLIKE patterns (#150238)

### DIFF
--- a/docs/changelog/150238.yaml
+++ b/docs/changelog/150238.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 149838
+pr: 150238
+summary: Catch `StackOverflowError` in deeply nested RLIKE patterns
+type: bug

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/predicate/regex/AbstractStringPattern.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/predicate/regex/AbstractStringPattern.java
@@ -22,6 +22,8 @@ public abstract class AbstractStringPattern implements StringPattern {
             return doCreateAutomaton(ignoreCase);
         } catch (TooComplexToDeterminizeException e) {
             throw new IllegalArgumentException("Pattern was too complex to determinize", e);
+        } catch (StackOverflowError e) {
+            throw new IllegalArgumentException("Pattern nesting is too deep to evaluate", e);
         }
     }
 

--- a/x-pack/plugin/esql-core/src/test/java/org/elasticsearch/xpack/esql/core/expression/predicate/regex/StringPatternTests.java
+++ b/x-pack/plugin/esql-core/src/test/java/org/elasticsearch/xpack/esql/core/expression/predicate/regex/StringPatternTests.java
@@ -94,4 +94,12 @@ public class StringPatternTests extends ESTestCase {
         e = expectThrows(IllegalArgumentException.class, () -> like("*a?????????????").createAutomaton(false));
         assertEquals("Pattern was too complex to determinize", e.getMessage());
     }
+
+    public void testDeeplyNestedRLikePattern() {
+        // A deeply nested regex pattern (thousands of nested parentheses) previously caused a
+        // StackOverflowError in Lucene's RegExp.findLeaves(), surfacing as a 500 instead of a 400.
+        String deepPattern = "(".repeat(5000) + "a" + ")".repeat(5000);
+        var e = expectThrows(IllegalArgumentException.class, () -> rlike(deepPattern).createAutomaton(false));
+        assertEquals("Pattern nesting is too deep to evaluate", e.getMessage());
+    }
 }


### PR DESCRIPTION
Manual backport of https://github.com/elastic/elasticsearch/pull/150238/changes