### PR TITLE
Change estimation of the HNSW graph size in IndexDiskUsageAnalyzerTests#testKnnVectors

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -74,9 +74,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
   method: test {csv-spec:spatial_shapes.convertFromStringParseError}
   issue: https://github.com/elastic/elasticsearch/issues/144672
-- class: org.elasticsearch.action.admin.indices.diskusage.IndexDiskUsageAnalyzerTests
-  method: testKnnVectors
-  issue: https://github.com/elastic/elasticsearch/issues/145377
 - class: org.elasticsearch.xpack.esql.CsvIT
   method: test {csv-spec:spatial_shapes.convertFromStringParseError}
   issue: https://github.com/elastic/elasticsearch/issues/145655

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/diskusage/IndexDiskUsageAnalyzerTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/diskusage/IndexDiskUsageAnalyzerTests.java
@@ -282,7 +282,7 @@ public class IndexDiskUsageAnalyzerTests extends ESTestCase {
             long dataBytes = elementType == DenseVectorFieldMapper.ElementType.FLOAT
                 ? ((long) numDocs * dimension * Float.BYTES)
                 : ((long) numDocs * dimension);
-            long indexBytesEstimate = (long) numDocs * (Lucene99HnswVectorsFormat.DEFAULT_MAX_CONN / 4); // rough size of HNSW graph
+            long indexBytesEstimate = (long) numDocs * (Lucene99HnswVectorsFormat.DEFAULT_MAX_CONN / 5); // rough size of HNSW graph
             assertThat("numDocs=" + numDocs + ";dimension=" + dimension, stats.total().getKnnVectorsBytes(), greaterThan(dataBytes));
             long connectionOverhead = stats.total().getKnnVectorsBytes() - dataBytes;
             assertThat("numDocs=" + numDocs, connectionOverhead, greaterThan(indexBytesEstimate));


### PR DESCRIPTION
There is a CI failure that is due to an overestimation of that value.  must say I found the test weird in what is testing as it expects that the estimation should be lower to the real value on disk, and it is not clear the maths behind the estimation. 

fixes https://github.com/elastic/elasticsearch/issues/145377