### PR TITLE
[9.3] [Transform] Honor cluster health wait timeout when ensuring system index shards are active (#149462)

### DIFF
--- a/docs/changelog/149462.yaml
+++ b/docs/changelog/149462.yaml
@@ -1,0 +1,6 @@
+area: Transform
+issues:
+  - 149400
+pr: 149462
+summary: Honor `ClusterHealth` timeout when waiting for transform internal index shards
+type: bug

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformMessages.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformMessages.java
@@ -22,6 +22,8 @@ public class TransformMessages {
     public static final String REST_STOP_TRANSFORM_WITHOUT_CONFIG =
         "Detected transforms with no config [{0}]. Use force to stop/delete them.";
     public static final String REST_PUT_FAILED_PERSIST_TRANSFORM_CONFIGURATION = "Failed to persist transform configuration";
+    public static final String TRANSFORM_WAIT_FOR_INDEX_SHARDS_ACTIVE_TIMEOUT =
+        "Timed out waiting for transform system index shards to become active";
     public static final String REST_PUT_TRANSFORM_FAILED_TO_DEDUCE_DEST_MAPPINGS = "Failed to deduce dest mappings";
     public static final String REST_PUT_TRANSFORM_INCONSISTENT_ID =
         "Inconsistent id; ''{0}'' specified in the body differs from ''{1}'' specified as a URL argument";

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/TransformInternalIndex.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/TransformInternalIndex.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.transform.persistence;
 
+import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.ResourceAlreadyExistsException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
@@ -27,10 +28,12 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.indices.SystemIndexDescriptor;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.core.common.notifications.AbstractAuditMessage;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import org.elasticsearch.xpack.core.transform.TransformField;
+import org.elasticsearch.xpack.core.transform.TransformMessages;
 import org.elasticsearch.xpack.core.transform.transforms.DestConfig;
 import org.elasticsearch.xpack.core.transform.transforms.SourceConfig;
 import org.elasticsearch.xpack.core.transform.transforms.TransformCheckpoint;
@@ -395,7 +398,18 @@ public final class TransformInternalIndex {
         )
             // cluster health does not wait for active shards per default
             .waitForActiveShards(ActiveShardCount.ONE);
-        ActionListener<ClusterHealthResponse> innerListener = ActionListener.wrap(r -> listener.onResponse(null), listener::onFailure);
+        ActionListener<ClusterHealthResponse> innerListener = listener.delegateFailureAndWrap((l, r) -> {
+            if (r.isTimedOut()) {
+                l.onFailure(
+                    new ElasticsearchStatusException(
+                        TransformMessages.TRANSFORM_WAIT_FOR_INDEX_SHARDS_ACTIVE_TIMEOUT,
+                        RestStatus.SERVICE_UNAVAILABLE
+                    )
+                );
+            } else {
+                l.onResponse(null);
+            }
+        });
         executeAsyncWithOrigin(
             client.threadPool().getThreadContext(),
             TRANSFORM_ORIGIN,

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/persistence/TransformInternalIndexTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/persistence/TransformInternalIndexTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.transform.persistence;
 
+import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.ResourceAlreadyExistsException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
@@ -33,8 +34,10 @@ import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.core.transform.TransformMessages;
 import org.elasticsearch.xpack.core.transform.transforms.persistence.TransformInternalIndexConstants;
 import org.junit.Before;
 
@@ -43,7 +46,10 @@ import java.io.UncheckedIOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
@@ -290,6 +296,44 @@ public class TransformInternalIndexTests extends ESTestCase {
         verifyNoMoreInteractions(adminClient);
         verify(indicesClient, times(1)).create(any(), any());
         verifyNoMoreInteractions(indicesClient);
+        verify(clusterClient, times(1)).health(any(), any());
+        verifyNoMoreInteractions(clusterClient);
+    }
+
+    public void testCreateLatestVersionedIndexIfRequired_GivenClusterHealthTimeout() {
+        // The index already exists but shards are not active; the cluster health request times out waiting for them.
+        // The listener must be failed with SERVICE_UNAVAILABLE rather than completed successfully (see #149400).
+        ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.state()).thenReturn(randomTransformClusterState(false));
+
+        ClusterAdminClient clusterClient = mock(ClusterAdminClient.class);
+        doAnswer(invocationOnMock -> {
+            @SuppressWarnings("unchecked")
+            ActionListener<ClusterHealthResponse> listener = (ActionListener<ClusterHealthResponse>) invocationOnMock.getArguments()[1];
+            ClusterHealthResponse timeoutResponse = new ClusterHealthResponse();
+            timeoutResponse.setTimedOut(true);
+            listener.onResponse(timeoutResponse);
+            return null;
+        }).when(clusterClient).health(any(), any());
+
+        AdminClient adminClient = mock(AdminClient.class);
+        when(adminClient.cluster()).thenReturn(clusterClient);
+        Client client = mock(Client.class);
+        when(client.admin()).thenReturn(adminClient);
+
+        ThreadPool threadPool = mock(ThreadPool.class);
+        when(threadPool.getThreadContext()).thenReturn(new ThreadContext(Settings.EMPTY));
+        when(client.threadPool()).thenReturn(threadPool);
+
+        AtomicReference<Exception> caughtException = new AtomicReference<>();
+        ActionListener<Void> testListener = ActionListener.wrap(aVoid -> fail("Expected failure due to timeout"), caughtException::set);
+
+        TransformInternalIndex.createLatestVersionedIndexIfRequired(clusterService, client, Settings.EMPTY, testListener);
+
+        Exception exception = caughtException.get();
+        assertThat(exception, instanceOf(ElasticsearchStatusException.class));
+        assertThat(((ElasticsearchStatusException) exception).status(), equalTo(RestStatus.SERVICE_UNAVAILABLE));
+        assertThat(exception.getMessage(), equalTo(TransformMessages.TRANSFORM_WAIT_FOR_INDEX_SHARDS_ACTIVE_TIMEOUT));
         verify(clusterClient, times(1)).health(any(), any());
         verifyNoMoreInteractions(clusterClient);
     }


### PR DESCRIPTION
Backports the following commits to 9.3:
 - [Transform] Honor cluster health wait timeout when ensuring system index shards are active (#149462)