### PR TITLE
Optionally always sign S3 requests

### DIFF
--- a/docs/changelog/151196.yaml
+++ b/docs/changelog/151196.yaml
@@ -1,0 +1,5 @@
+area: Snapshot/Restore
+issues: []
+pr: 151196
+summary: Optionally always sign S3 requests
+type: enhancement

--- a/docs/reference/snapshot-restore/repository-s3.asciidoc
+++ b/docs/reference/snapshot-restore/repository-s3.asciidoc
@@ -206,6 +206,19 @@ pattern then you should set this setting to `true` when upgrading.
     https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/AmazonS3Builder.html#disableChunkedEncoding--[AWS
     Java SDK documentation] for details. Defaults to `false`.
 
+`always_sign_requests`::
+
+    {es} usually uses HTTPS to protect the integrity of all network traffic to a
+    S3 repository, but if you access your repository using plain HTTP it will
+    protect the integrity of request payloads using a separate signature
+    mechanism. If `always_sign_requests` is set to `true`, {es} will use this
+    additional signature mechanism even for requests sent over HTTPS which do
+    not need it. Defaults to `false`.
+
+NOTE: The `always_sign_requests` setting is not supported by versions `9.0`,
+`9.1`, `9.2`, `9.3` or `9.4`. If you configure this setting, do not upgrade to
+any of these versions.
+
 [[repository-s3-repository]]
 ==== Repository settings
 

--- a/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/AbstractRepositoryS3RestTestCase.java
+++ b/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/AbstractRepositoryS3RestTestCase.java
@@ -62,6 +62,7 @@ public abstract class AbstractRepositoryS3RestTestCase extends ESRestTestCase {
                                 .put(
                                     randomFrom(Settings.EMPTY, Settings.builder().put("disable_chunked_encoding", randomBoolean()).build())
                                 )
+                                .put(randomFrom(Settings.EMPTY, Settings.builder().put("always_sign_requests", randomBoolean()).build()))
                                 .put(
                                     randomFrom(
                                         Settings.EMPTY,

--- a/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3ContentIntegrityRestIT.java
+++ b/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3ContentIntegrityRestIT.java
@@ -37,9 +37,12 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
 
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.matchesPattern;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 
 @ThreadLeakFilters(filters = { TestContainersThreadFilter.class })
 public class RepositoryS3ContentIntegrityRestIT extends AbstractRepositoryS3RestTestCase {
@@ -62,7 +65,9 @@ public class RepositoryS3ContentIntegrityRestIT extends AbstractRepositoryS3Rest
         final var testConfigs = new ArrayList<TestConfig>();
         for (final boolean https : new boolean[] { false, true }) {
             for (final boolean chunkedEncoding : new boolean[] { false, true }) {
-                testConfigs.add(new TestConfig(https, chunkedEncoding));
+                for (final boolean alwaysSignRequests : new boolean[] { false, true }) {
+                    testConfigs.add(new TestConfig(https, chunkedEncoding, alwaysSignRequests));
+                }
             }
         }
         TEST_CONFIGS = List.copyOf(testConfigs);
@@ -103,6 +108,27 @@ public class RepositoryS3ContentIntegrityRestIT extends AbstractRepositoryS3Rest
                     assertThat(
                         contentSha256Header,
                         anyOf(matchesPattern(S3HttpHandler.SHA256_PATTERN), equalTo(testConfig.getExpectedUploadContentSha256Header()))
+                    );
+                }
+                if (testConfig.alwaysSignRequests) {
+                    assertThat(
+                        contentSha256Header,
+                        allOf(
+                            anyOf(
+                                // We either have a SHA256 hash of the body, covered by the request signature, ...
+                                matchesPattern(S3HttpHandler.SHA256_PATTERN),
+                                // ... or there's a properly-signed footer
+                                equalTo("STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER")
+                            ),
+
+                            // Redundant check given the above condition but this is the thing that the S3 docs tell users to forbid:
+                            // https://docs.aws.amazon.com/AmazonS3/latest/developerguide/bucket-policy-s3-sigv4-conditions.html
+                            not("UNSIGNED-PAYLOAD"),
+
+                            // Other possibilities that can also imply an unsigned body, even if not excluded by the suggested condition:
+                            not(nullValue()),
+                            not("STREAMING-UNSIGNED-PAYLOAD-TRAILER")
+                        )
                     );
                 }
                 delegate.handle(exchange);
@@ -168,20 +194,28 @@ public class RepositoryS3ContentIntegrityRestIT extends AbstractRepositoryS3Rest
     public static final class TestConfig {
         private final boolean https;
         private final boolean chunkedEncoding;
+        private final boolean alwaysSignRequests;
 
-        TestConfig(boolean https, boolean chunkedEncoding) {
+        TestConfig(boolean https, boolean chunkedEncoding, boolean alwaysSignRequests) {
             this.https = https;
             this.chunkedEncoding = chunkedEncoding;
+            this.alwaysSignRequests = alwaysSignRequests;
         }
 
         @Override
         public String toString() {
-            return Strings.format("{scheme=%s,chunkedEncoding=%s}", https ? "https" : "http", chunkedEncoding);
+            return Strings.format(
+                "{scheme=%s,chunkedEncoding=%s,alwaysSignRequests=%s}",
+                https ? "https" : "http",
+                chunkedEncoding,
+                alwaysSignRequests
+            );
         }
 
         Settings getRepositorySettings() {
             final var builder = Settings.builder();
             addBooleanSettingDefaultFalse(builder, "disable_chunked_encoding", chunkedEncoding == false);
+            addBooleanSettingDefaultFalse(builder, "always_sign_requests", alwaysSignRequests);
             return builder.build();
         }
 
@@ -194,7 +228,7 @@ public class RepositoryS3ContentIntegrityRestIT extends AbstractRepositoryS3Rest
         }
 
         String getExpectedUploadContentSha256Header() {
-            return https
+            return (https && alwaysSignRequests == false)
                 ? (chunkedEncoding ? "STREAMING-UNSIGNED-PAYLOAD-TRAILER" : "UNSIGNED-PAYLOAD")
                 : (chunkedEncoding ? "STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER" : "STREAMING-AWS4-HMAC-SHA256-PAYLOAD");
         }
@@ -212,15 +246,26 @@ public class RepositoryS3ContentIntegrityRestIT extends AbstractRepositoryS3Rest
         }
 
         String getClientName() {
-            return "content_integrity_client_" + (https ? "https" : "http") + "_chunked_encoding_" + chunkedEncoding;
+            return "content_integrity_client_"
+                + (https ? "https" : "http")
+                + "_chunked_encoding_"
+                + chunkedEncoding
+                + "_always_sign_requests_"
+                + alwaysSignRequests;
         }
 
         String getRepositoryBasePath() {
-            return BASE_PATH + "/" + (https ? "https" : "http") + "_chunked_encoding_" + chunkedEncoding;
+            return BASE_PATH
+                + "/"
+                + (https ? "https" : "http")
+                + "_chunked_encoding_"
+                + chunkedEncoding
+                + "_always_sign_requests_"
+                + alwaysSignRequests;
         }
 
         String getAccessKey() {
-            return ACCESS_KEY + "-" + (https ? "https" : "http") + "-" + chunkedEncoding;
+            return ACCESS_KEY + "-" + (https ? "https" : "http") + "-" + chunkedEncoding + "-" + alwaysSignRequests;
         }
 
         static TestConfig fromAuthorizationHeader(String authorizationHeader) {

--- a/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3ClientSettings.java
+++ b/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3ClientSettings.java
@@ -189,6 +189,13 @@ final class S3ClientSettings {
         key -> Setting.boolSetting(key, false, Property.NodeScope)
     );
 
+    /** Whether to include the request body in the V4 signature even when unnecessary because HTTPS is in use. */
+    static final Setting.AffixSetting<Boolean> ALWAYS_SIGN_REQUESTS = Setting.affixKeySetting(
+        PREFIX,
+        "always_sign_requests",
+        key -> Setting.boolSetting(key, false, Property.NodeScope)
+    );
+
     /** Credentials to authenticate with s3. */
     final AwsCredentials credentials;
 
@@ -236,6 +243,9 @@ final class S3ClientSettings {
     /** Region to use for signing requests or empty string to use default. */
     final String region;
 
+    /** Whether to include the request body in the V4 signature even when unnecessary because HTTPS is in use. */
+    final boolean alwaysSignRequests;
+
     private S3ClientSettings(
         AwsCredentials credentials,
         HttpScheme protocol,
@@ -251,7 +261,8 @@ final class S3ClientSettings {
         boolean pathStyleAccess,
         boolean disableChunkedEncoding,
         boolean addPurposeCustomQueryParameter,
-        String region
+        String region,
+        boolean alwaysSignRequests
     ) {
         this.credentials = credentials;
         this.protocol = protocol;
@@ -268,6 +279,7 @@ final class S3ClientSettings {
         this.disableChunkedEncoding = disableChunkedEncoding;
         this.addPurposeCustomQueryParameter = addPurposeCustomQueryParameter;
         this.region = region;
+        this.alwaysSignRequests = alwaysSignRequests;
     }
 
     /**
@@ -311,6 +323,7 @@ final class S3ClientSettings {
             newCredentials = credentials;
         }
         final String newRegion = getRepoSettingOrDefault(REGION, normalizedSettings, region);
+        final boolean newAlwaysSignRequests = getRepoSettingOrDefault(ALWAYS_SIGN_REQUESTS, normalizedSettings, alwaysSignRequests);
         if (Objects.equals(protocol, newProtocol)
             && Objects.equals(endpoint, newEndpoint)
             && Objects.equals(proxyHost, newProxyHost)
@@ -323,7 +336,8 @@ final class S3ClientSettings {
             && newPathStyleAccess == pathStyleAccess
             && newDisableChunkedEncoding == disableChunkedEncoding
             && newAddPurposeCustomQueryParameter == addPurposeCustomQueryParameter
-            && Objects.equals(region, newRegion)) {
+            && Objects.equals(region, newRegion)
+            && newAlwaysSignRequests == alwaysSignRequests) {
             return this;
         }
         return new S3ClientSettings(
@@ -341,7 +355,8 @@ final class S3ClientSettings {
             newPathStyleAccess,
             newDisableChunkedEncoding,
             newAddPurposeCustomQueryParameter,
-            newRegion
+            newRegion,
+            newAlwaysSignRequests
         );
     }
 
@@ -449,7 +464,8 @@ final class S3ClientSettings {
                 getConfigValue(settings, clientName, USE_PATH_STYLE_ACCESS),
                 getConfigValue(settings, clientName, DISABLE_CHUNKED_ENCODING),
                 getConfigValue(settings, clientName, ADD_PURPOSE_CUSTOM_QUERY_PARAMETER),
-                getConfigValue(settings, clientName, REGION)
+                getConfigValue(settings, clientName, REGION),
+                getConfigValue(settings, clientName, ALWAYS_SIGN_REQUESTS)
             );
         }
     }
@@ -476,7 +492,8 @@ final class S3ClientSettings {
             && Objects.equals(proxyPassword, that.proxyPassword)
             && Objects.equals(disableChunkedEncoding, that.disableChunkedEncoding)
             && Objects.equals(addPurposeCustomQueryParameter, that.addPurposeCustomQueryParameter)
-            && Objects.equals(region, that.region);
+            && Objects.equals(region, that.region)
+            && alwaysSignRequests == that.alwaysSignRequests;
     }
 
     @Override
@@ -495,7 +512,8 @@ final class S3ClientSettings {
             maxConnections,
             disableChunkedEncoding,
             addPurposeCustomQueryParameter,
-            region
+            region,
+            alwaysSignRequests
         );
     }
 

--- a/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3RepositoryPlugin.java
+++ b/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3RepositoryPlugin.java
@@ -124,7 +124,8 @@ public class S3RepositoryPlugin extends Plugin implements RepositoryPlugin, Relo
             S3Service.REPOSITORY_S3_CAS_TTL_SETTING,
             S3Service.REPOSITORY_S3_CAS_ANTI_CONTENTION_DELAY_SETTING,
             S3Repository.ACCESS_KEY_SETTING,
-            S3Repository.SECRET_KEY_SETTING
+            S3Repository.SECRET_KEY_SETTING,
+            S3ClientSettings.ALWAYS_SIGN_REQUESTS
         );
     }
 

--- a/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Service.java
+++ b/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Service.java
@@ -26,6 +26,7 @@ import software.amazon.awssdk.identity.spi.ResolveIdentityRequest;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
+import software.amazon.awssdk.services.s3.internal.plugins.S3OverrideAuthSchemePropertiesPlugin;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.auth.StsWebIdentityTokenFileCredentialsProvider;
 import software.amazon.awssdk.utils.SdkAutoCloseable;
@@ -268,6 +269,10 @@ class S3Service extends AbstractLifecycleComponent {
                 );
             }
             s3clientBuilder.endpointOverride(URI.create(endpoint));
+        }
+
+        if (clientSettings.alwaysSignRequests) {
+            s3clientBuilder.addPlugin(S3OverrideAuthSchemePropertiesPlugin.builder().payloadSigningEnabled(true).build());
         }
 
         return s3clientBuilder;

--- a/modules/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3ClientSettingsTests.java
+++ b/modules/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3ClientSettingsTests.java
@@ -46,6 +46,7 @@ public class S3ClientSettingsTests extends ESTestCase {
         assertThat(defaultSettings.readTimeoutMillis, is(Math.toIntExact(S3ClientSettings.Defaults.READ_TIMEOUT.millis())));
         assertThat(defaultSettings.maxConnections, is(S3ClientSettings.Defaults.MAX_CONNECTIONS));
         assertThat(defaultSettings.maxRetries, is(S3ClientSettings.Defaults.RETRY_COUNT));
+        assertFalse(defaultSettings.alwaysSignRequests);
     }
 
     public void testDefaultClientSettingsCanBeSet() {


### PR DESCRIPTION
Introduces an option to use the `STREAMING-AWS4-HMAC-SHA256-PAYLOAD`
body signature scheme even on requests sent over HTTPS that do not need
it.

Backport of #151196 to `8.19`