### PR TITLE
ES|QL Rewrite MV_COUNT(VALUES(x)) to COUNT_DISTINCT

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats_count_distinct.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats_count_distinct.csv-spec
@@ -311,3 +311,58 @@ COUNT_DISTINCT(case1):long | COUNT_DISTINCT(case2):long | ts_month:datetime
 0                           | 0                           | 2024-01-01T00:00:00.000Z
 0                           | 3                           | 2024-02-01T00:00:00.000Z
 ;
+
+mvCountOfValuesRewrittenToCountDistinct
+required_capability: mv_count_values_as_count_distinct
+// MV_COUNT(VALUES(x)) is routed to the approximate COUNT_DISTINCT, but stays an integer (not long)
+from employees | stats c = mv_count(values(languages));
+
+c:integer
+5
+;
+
+mvCountOfValuesAllNullGroupStaysNull
+required_capability: mv_count_values_as_count_distinct
+// VALUES is null (never an empty multivalue) for an all-null group, so MV_COUNT(VALUES(x)) is null, not 0
+from employees | where languages is null | stats c = mv_count(values(languages));
+
+c:integer
+null
+;
+
+mvCountOfValuesByGroup
+required_capability: mv_count_values_as_count_distinct
+from employees | stats c = mv_count(values(languages)) by gender | sort gender;
+
+c:integer | gender:keyword
+5         | F
+5         | M
+4         | null
+;
+
+mvCountOfValuesStillEmittedKeepsExactPath
+required_capability: mv_count_values_as_count_distinct
+// VALUES is also emitted, so the materialization is needed regardless and MV_COUNT keeps the exact path
+from employees | stats vals = values(languages), c = mv_count(values(languages)) | eval sorted = mv_sort(vals) | keep c, sorted;
+
+c:integer | sorted:integer
+5         | [1, 2, 3, 4, 5]
+;
+
+mvCountOfValuesWithFilter
+required_capability: mv_count_values_as_count_distinct
+// the per-aggregate filter must be carried onto the rewritten COUNT_DISTINCT
+from employees | stats c = mv_count(values(languages)) where gender == "M";
+
+c:integer
+5
+;
+
+mvCountOfValuesFilteredToEmptyStaysNull
+required_capability: mv_count_values_as_count_distinct
+// when the filter removes every row the group has no values, so the result must be null (not 0)
+from employees | stats c = mv_count(values(languages)) where gender == "Z";
+
+c:integer
+null
+;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -3059,6 +3059,12 @@ public class EsqlCapabilities {
          */
         APPROXIMATION_FIX_MV_FUNCTIONS,
 
+        /**
+         * Rewrite {@code MV_COUNT(VALUES(x))} to the approximate, HyperLogLog++ backed {@code COUNT_DISTINCT}
+         * aggregator, avoiding the full per-group materialization that {@code VALUES} performs.
+         */
+        MV_COUNT_VALUES_AS_COUNT_DISTINCT,
+
         // Last capability should still have a comma for fewer merge conflicts when adding new ones :)
         // This comment prevents the semicolon from being on the previous capability when Spotless formats the file.
         ;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountDistinct.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountDistinct.java
@@ -78,6 +78,15 @@ public class CountDistinct extends AggregateFunction implements OptionalArgument
     private static final int DEFAULT_PRECISION = 3000;
     private final Expression precision;
 
+    /**
+     * Whether {@code COUNT_DISTINCT} can aggregate the given type. Used by planner rules that route
+     * other aggregations to {@code COUNT_DISTINCT}; {@code VALUES}, for instance, supports more types
+     * (such as {@code unsigned_long} and the spatial types) than {@code COUNT_DISTINCT} does.
+     */
+    public static boolean isSupportedType(DataType type) {
+        return SUPPLIERS.containsKey(type);
+    }
+
     @FunctionInfo(
         returnType = "long",
         briefSummary = "Returns the approximate number of distinct values.",

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizer.java
@@ -68,6 +68,7 @@ import org.elasticsearch.xpack.esql.optimizer.rules.logical.ReplaceAliasingEvalW
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.ReplaceChangePointByExpressionWithEval;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.ReplaceLimitAndSortAsTopN;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.ReplaceLimitByExpressionWithEval;
+import org.elasticsearch.xpack.esql.optimizer.rules.logical.ReplaceMvCountOfValuesWithCountDistinct;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.ReplaceOrderByExpressionWithEval;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.ReplaceRegexMatch;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.ReplaceRowAsLocalRelation;
@@ -164,6 +165,9 @@ public class LogicalPlanOptimizer extends ParameterizedRuleExecutor<LogicalPlan,
             // Must run before ReplaceAggregateNestedExpressionWithEval, which extracts
             // SUM(field + c) into a pre-agg EVAL and hides the pattern from this rule.
             new RewriteSumOfExpressionPlusConstant(),
+            // Recognize MV_COUNT(VALUES(x)) before the Replace*WithEval rules decompose it, so the
+            // produced CASE(COUNT_DISTINCT(x) == 0, ...) scalar-over-aggregate is extracted and deduplicated by them.
+            new ReplaceMvCountOfValuesWithCountDistinct(),
             // first extract nested expressions inside aggs
             new ReplaceAggregateNestedExpressionWithEval(),
             // then extract nested aggs top-level

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceMvCountOfValuesWithCountDistinct.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceMvCountOfValuesWithCountDistinct.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.optimizer.rules.logical;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.CountDistinct;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.Values;
+import org.elasticsearch.xpack.esql.expression.function.scalar.conditional.Case;
+import org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToInteger;
+import org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvCount;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Equals;
+import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Rewrites {@code MV_COUNT(VALUES(x))} into the approximate, HyperLogLog++ backed
+ * {@link CountDistinct} aggregator. Without this rule {@code VALUES(x)} materializes every
+ * contributing value per group before {@code MV_COUNT} counts them, which is {@code O(rows)} in
+ * memory; {@code COUNT_DISTINCT} keeps a fixed-size sketch per group instead.
+ *
+ * <p>The rewrite preserves the observable semantics of {@code MV_COUNT(VALUES(x))} except for
+ * exactness:
+ * <ul>
+ *     <li>the result type stays {@code integer} (wrapped in {@link ToInteger});</li>
+ *     <li>a group with no non-null values still yields {@code null}: {@code VALUES} returns
+ *     {@code null} (never an empty multivalue) for such a group, so {@code MV_COUNT} returns
+ *     {@code null}, whereas {@code COUNT_DISTINCT} returns {@code 0}. Mapping {@code 0 -> null} is
+ *     the exact inverse since {@code MV_COUNT(VALUES(x))} can never be {@code 0}.</li>
+ * </ul>
+ * The replacement expression is {@code CASE(COUNT_DISTINCT(x) == 0, null, TO_INTEGER(COUNT_DISTINCT(x)))}.
+ * The two {@code COUNT_DISTINCT(x)} references share a canonical form, so the downstream
+ * {@link ReplaceAggregateAggExpressionWithEval} extracts a single aggregator plus a follow-up
+ * {@code EVAL}.
+ *
+ * <p>The rule only fires when the {@code VALUES} result is consumed exclusively by {@code MV_COUNT}.
+ * If the same {@code VALUES(x)} is also emitted or used elsewhere the materialization is needed
+ * regardless, so rewriting would only add the sketch cost without removing the accumulation.
+ * It is also restricted to types supported by {@code COUNT_DISTINCT} and to non-windowed aggregates.
+ */
+public final class ReplaceMvCountOfValuesWithCountDistinct extends OptimizerRules.OptimizerRule<Aggregate> {
+
+    public ReplaceMvCountOfValuesWithCountDistinct() {
+        super(OptimizerRules.TransformDirection.UP);
+    }
+
+    @Override
+    protected LogicalPlan rule(Aggregate aggregate) {
+        Set<Expression> rewritableValues = rewritableValues(aggregate);
+        if (rewritableValues.isEmpty()) {
+            return aggregate;
+        }
+
+        boolean[] changed = { false };
+        List<NamedExpression> newAggregates = new ArrayList<>(aggregate.aggregates().size());
+        for (NamedExpression agg : aggregate.aggregates()) {
+            NamedExpression rewritten = (NamedExpression) agg.transformDown(MvCount.class, mvCount -> {
+                if (mvCount.field() instanceof Values values && rewritableValues.contains(values.canonical())) {
+                    changed[0] = true;
+                    return toCountDistinct(values);
+                }
+                return mvCount;
+            });
+            newAggregates.add(rewritten);
+        }
+
+        return changed[0] ? aggregate.with(aggregate.child(), aggregate.groupings(), newAggregates) : aggregate;
+    }
+
+    /**
+     * Returns the canonical forms of the {@link Values} aggregates that are safe to rewrite: those
+     * supported by {@link CountDistinct}, non-windowed, and consumed exclusively as the direct
+     * argument of an {@link MvCount}.
+     */
+    private static Set<Expression> rewritableValues(Aggregate aggregate) {
+        Map<Expression, Integer> totalUses = new HashMap<>();
+        Map<Expression, Integer> mvCountUses = new HashMap<>();
+        for (NamedExpression agg : aggregate.aggregates()) {
+            agg.forEachDown(Values.class, values -> totalUses.merge(values.canonical(), 1, Integer::sum));
+            agg.forEachDown(MvCount.class, mvCount -> {
+                if (mvCount.field() instanceof Values values) {
+                    mvCountUses.merge(values.canonical(), 1, Integer::sum);
+                }
+            });
+        }
+
+        Set<Expression> rewritable = new HashSet<>();
+        for (Map.Entry<Expression, Integer> entry : totalUses.entrySet()) {
+            Values values = (Values) entry.getKey();
+            // every use is wrapped directly by MV_COUNT
+            if (entry.getValue().equals(mvCountUses.get(entry.getKey()))
+                && values.hasWindow() == false
+                && CountDistinct.isSupportedType(values.field().dataType())) {
+                rewritable.add(entry.getKey());
+            }
+        }
+        return rewritable;
+    }
+
+    private static Expression toCountDistinct(Values values) {
+        Source source = values.source();
+        // precision left null so COUNT_DISTINCT uses its default threshold
+        CountDistinct countDistinct = new CountDistinct(source, values.field(), values.filter(), values.window(), null);
+        Equals isEmpty = new Equals(source, countDistinct, new Literal(source, 0L, DataType.LONG));
+        Literal nullInteger = new Literal(source, null, DataType.INTEGER);
+        ToInteger count = new ToInteger(source, countDistinct);
+        return new Case(source, isEmpty, List.of(nullInteger, count));
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceMvCountOfValuesWithCountDistinctGoldenTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceMvCountOfValuesWithCountDistinctGoldenTests.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.optimizer.rules.logical;
+
+import org.elasticsearch.xpack.esql.optimizer.GoldenTestCase;
+
+import java.util.EnumSet;
+
+/**
+ * Golden tests for {@link ReplaceMvCountOfValuesWithCountDistinct}. The {@code ANALYSIS} stage captures the
+ * pre-rewrite plan ({@code MV_COUNT(VALUES(x))}) and {@code LOGICAL_OPTIMIZATION} captures the result, so the
+ * expected files show the full rewrite: a single {@code COUNT_DISTINCT} aggregate plus the
+ * {@code CASE(... == 0, null, TO_INTEGER(...))} eval that preserves the {@code integer} type and the null-on-empty
+ * group semantics.
+ */
+public class ReplaceMvCountOfValuesWithCountDistinctGoldenTests extends GoldenTestCase {
+
+    private static final EnumSet<Stage> STAGES = EnumSet.of(Stage.ANALYSIS, Stage.LOGICAL_OPTIMIZATION);
+
+    public void testRewrite() {
+        runGoldenTest("""
+            FROM employees
+            | STATS c = MV_COUNT(VALUES(salary))
+            """, STAGES);
+    }
+
+    public void testRewriteWithGrouping() {
+        runGoldenTest("""
+            FROM employees
+            | STATS c = MV_COUNT(VALUES(salary)) BY gender
+            """, STAGES);
+    }
+
+    public void testRewriteKeywordField() {
+        runGoldenTest("""
+            FROM employees
+            | STATS c = MV_COUNT(VALUES(gender))
+            """, STAGES);
+    }
+
+    public void testDuplicatesDeduplicatedToSingleCountDistinct() {
+        runGoldenTest("""
+            FROM employees
+            | STATS a = MV_COUNT(VALUES(salary)), b = MV_COUNT(VALUES(salary))
+            """, STAGES);
+    }
+
+    public void testMixedWithOtherAggregates() {
+        runGoldenTest("""
+            FROM employees
+            | STATS c = MV_COUNT(VALUES(salary)), m = MAX(salary), n = COUNT(*) BY gender
+            """, STAGES);
+    }
+
+    public void testFilterCarriedOntoCountDistinct() {
+        runGoldenTest("""
+            FROM employees
+            | STATS c = MV_COUNT(VALUES(salary)) WHERE gender == "M"
+            """, STAGES);
+    }
+
+    public void testInlineStats() {
+        runGoldenTest("""
+            FROM employees
+            | INLINE STATS c = MV_COUNT(VALUES(salary))
+            """, STAGES);
+    }
+
+    // VALUES is also emitted, so its materialization is needed regardless: MV_COUNT keeps the exact path.
+    public void testValuesEmittedElsewhereNotRewritten() {
+        runGoldenTest("""
+            FROM employees
+            | STATS v = VALUES(salary), c = MV_COUNT(VALUES(salary))
+            """, STAGES);
+    }
+
+    // COUNT_DISTINCT does not support geo_point, so the exact VALUES path is preserved.
+    public void testUnsupportedTypeNotRewritten() {
+        runGoldenTest("""
+            FROM airports
+            | STATS c = MV_COUNT(VALUES(location))
+            """, STAGES);
+    }
+
+    // MV_COUNT over a non-VALUES aggregate must be left untouched.
+    public void testMvCountNotOverValuesUntouched() {
+        runGoldenTest("""
+            FROM employees
+            | STATS c = MV_COUNT(TOP(salary, 3, "asc"))
+            """, STAGES);
+    }
+}

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testDuplicatesDeduplicatedToSingleCountDistinct/analysis.expected
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testDuplicatesDeduplicatedToSingleCountDistinct/analysis.expected
@@ -1,0 +1,3 @@
+Limit[1000[INTEGER],false,false]
+\_Aggregate[[],[MVCOUNT(VALUES(salary{f}#0,true[BOOLEAN],PT0S[TIME_DURATION])) AS a#1, MVCOUNT(VALUES(salary{f}#0,true[BOOLEAN],PT0S[TIME_DURATION])) AS b#2]]
+  \_EsRelation[employees][avg_worked_seconds{f}#3, birth_date{f}#4, emp_no{f}#5, first_name{f}#6, gender{f}#7, height{f}#8, height.float{f}#9, height.half_float{f}#10, height.scaled_float{f}#11, hire_date{f}#12, is_rehired{f}#13, job_positions{f}#14, languages{f}#15, languages.byte{f}#16, languages.long{f}#17, languages.short{f}#18, last_name{f}#19, salary{f}#0, salary_change{f}#20, salary_change.int{f}#21, salary_change.keyword{f}#22, salary_change.long{f}#23, still_hired{f}#24]

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testDuplicatesDeduplicatedToSingleCountDistinct/logical_optimization.expected
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testDuplicatesDeduplicatedToSingleCountDistinct/logical_optimization.expected
@@ -1,0 +1,5 @@
+Project[[a{r}#0, b{r}#1]]
+\_Eval[[CASE($$COUNTDISTINCT$VALUES(salary)$0{r$}#2 == 0[LONG],null[INTEGER],TOINTEGER($$COUNTDISTINCT$VALUES(salary)$0{r$}#2)) AS a#0, CASE($$COUNTDISTINCT$VALUES(salary)$0{r$}#2 == 0[LONG],null[INTEGER],TOINTEGER($$COUNTDISTINCT$VALUES(salary)$0{r$}#2)) AS b#1]]
+  \_Limit[1000[INTEGER],false,false]
+    \_Aggregate[[],[COUNTDISTINCT(salary{f}#3,true[BOOLEAN],PT0S[TIME_DURATION]) AS $$COUNTDISTINCT$VALUES(salary)$0#2]]
+      \_EsRelation[employees][avg_worked_seconds{f}#4, birth_date{f}#5, emp_no{f}#6, first_name{f}#7, gender{f}#8, height{f}#9, height.float{f}#10, height.half_float{f}#11, height.scaled_float{f}#12, hire_date{f}#13, is_rehired{f}#14, job_positions{f}#15, languages{f}#16, languages.byte{f}#17, languages.long{f}#18, languages.short{f}#19, last_name{f}#20, salary{f}#3, salary_change{f}#21, salary_change.int{f}#22, salary_change.keyword{f}#23, salary_change.long{f}#24, still_hired{f}#25]

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testDuplicatesDeduplicatedToSingleCountDistinct/query.esql
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testDuplicatesDeduplicatedToSingleCountDistinct/query.esql
@@ -1,0 +1,2 @@
+FROM employees
+| STATS a = MV_COUNT(VALUES(salary)), b = MV_COUNT(VALUES(salary))

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testFilterCarriedOntoCountDistinct/analysis.expected
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testFilterCarriedOntoCountDistinct/analysis.expected
@@ -1,0 +1,3 @@
+Limit[1000[INTEGER],false,false]
+\_Aggregate[[],[FilteredExpression[MVCOUNT(VALUES(salary{f}#0,true[BOOLEAN],PT0S[TIME_DURATION])),gender{f}#1 == M[KEYWORD]] AS c#2]]
+  \_EsRelation[employees][avg_worked_seconds{f}#3, birth_date{f}#4, emp_no{f}#5, first_name{f}#6, gender{f}#1, height{f}#7, height.float{f}#8, height.half_float{f}#9, height.scaled_float{f}#10, hire_date{f}#11, is_rehired{f}#12, job_positions{f}#13, languages{f}#14, languages.byte{f}#15, languages.long{f}#16, languages.short{f}#17, last_name{f}#18, salary{f}#0, salary_change{f}#19, salary_change.int{f}#20, salary_change.keyword{f}#21, salary_change.long{f}#22, still_hired{f}#23]

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testFilterCarriedOntoCountDistinct/logical_optimization.expected
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testFilterCarriedOntoCountDistinct/logical_optimization.expected
@@ -1,0 +1,6 @@
+Project[[c{r}#0]]
+\_Eval[[CASE($$COUNTDISTINCT$VALUES(salary)$0{r$}#1 == 0[LONG],null[INTEGER],TOINTEGER($$COUNTDISTINCT$VALUES(salary)$0{r$}#1)) AS c#0]]
+  \_Limit[1000[INTEGER],false,false]
+    \_Aggregate[[],[COUNTDISTINCT(salary{f}#2,true[BOOLEAN],PT0S[TIME_DURATION]) AS $$COUNTDISTINCT$VALUES(salary)$0#1]]
+      \_Filter[gender{f}#3 == M[KEYWORD]]
+        \_EsRelation[employees][avg_worked_seconds{f}#4, birth_date{f}#5, emp_no{f}#6, first_name{f}#7, gender{f}#3, height{f}#8, height.float{f}#9, height.half_float{f}#10, height.scaled_float{f}#11, hire_date{f}#12, is_rehired{f}#13, job_positions{f}#14, languages{f}#15, languages.byte{f}#16, languages.long{f}#17, languages.short{f}#18, last_name{f}#19, salary{f}#2, salary_change{f}#20, salary_change.int{f}#21, salary_change.keyword{f}#22, salary_change.long{f}#23, still_hired{f}#24]

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testFilterCarriedOntoCountDistinct/query.esql
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testFilterCarriedOntoCountDistinct/query.esql
@@ -1,0 +1,2 @@
+FROM employees
+| STATS c = MV_COUNT(VALUES(salary)) WHERE gender == "M"

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testInlineStats/analysis.expected
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testInlineStats/analysis.expected
@@ -1,0 +1,4 @@
+Limit[1000[INTEGER],false,false]
+\_InlineStats[]
+  \_Aggregate[[],[MVCOUNT(VALUES(salary{f}#0,true[BOOLEAN],PT0S[TIME_DURATION])) AS c#1]]
+    \_EsRelation[employees][avg_worked_seconds{f}#2, birth_date{f}#3, emp_no{f}#4, first_name{f}#5, gender{f}#6, height{f}#7, height.float{f}#8, height.half_float{f}#9, height.scaled_float{f}#10, hire_date{f}#11, is_rehired{f}#12, job_positions{f}#13, languages{f}#14, languages.byte{f}#15, languages.long{f}#16, languages.short{f}#17, last_name{f}#18, salary{f}#0, salary_change{f}#19, salary_change.int{f}#20, salary_change.keyword{f}#21, salary_change.long{f}#22, still_hired{f}#23]

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testInlineStats/logical_optimization.expected
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testInlineStats/logical_optimization.expected
@@ -1,0 +1,7 @@
+Limit[1000[INTEGER],false,false]
+\_InlineJoin[LEFT,[],[]]
+  |_EsRelation[employees][avg_worked_seconds{f}#0, birth_date{f}#1, emp_no{f}#2, first_name{f}#3, gender{f}#4, height{f}#5, height.float{f}#6, height.half_float{f}#7, height.scaled_float{f}#8, hire_date{f}#9, is_rehired{f}#10, job_positions{f}#11, languages{f}#12, languages.byte{f}#13, languages.long{f}#14, languages.short{f}#15, last_name{f}#16, salary{f}#17, salary_change{f}#18, salary_change.int{f}#19, salary_change.keyword{f}#20, salary_change.long{f}#21, still_hired{f}#22]
+  \_Project[[c{r}#23]]
+    \_Eval[[CASE($$COUNTDISTINCT$VALUES(salary)$0{r$}#24 == 0[LONG],null[INTEGER],TOINTEGER($$COUNTDISTINCT$VALUES(salary)$0{r$}#24)) AS c#23]]
+      \_Aggregate[[],[COUNTDISTINCT(salary{f}#17,true[BOOLEAN],PT0S[TIME_DURATION]) AS $$COUNTDISTINCT$VALUES(salary)$0#24]]
+        \_StubRelation[[avg_worked_seconds{f}#0, birth_date{f}#1, emp_no{f}#2, first_name{f}#3, gender{f}#4, height{f}#5, height.float{f}#6, height.half_float{f}#7, height.scaled_float{f}#8, hire_date{f}#9, is_rehired{f}#10, job_positions{f}#11, languages{f}#12, languages.byte{f}#13, languages.long{f}#14, languages.short{f}#15, last_name{f}#16, salary{f}#17, salary_change{f}#18, salary_change.int{f}#19, salary_change.keyword{f}#20, salary_change.long{f}#21, still_hired{f}#22]]

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testInlineStats/query.esql
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testInlineStats/query.esql
@@ -1,0 +1,2 @@
+FROM employees
+| INLINE STATS c = MV_COUNT(VALUES(salary))

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testMixedWithOtherAggregates/analysis.expected
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testMixedWithOtherAggregates/analysis.expected
@@ -1,0 +1,3 @@
+Limit[1000[INTEGER],false,false]
+\_Aggregate[[gender{f}#0],[MVCOUNT(VALUES(salary{f}#1,true[BOOLEAN],PT0S[TIME_DURATION])) AS c#2, MAX(salary{f}#1,true[BOOLEAN],PT0S[TIME_DURATION]) AS m#3, COUNT(*[KEYWORD],true[BOOLEAN],PT0S[TIME_DURATION]) AS n#4, gender{f}#0]]
+  \_EsRelation[employees][avg_worked_seconds{f}#5, birth_date{f}#6, emp_no{f}#7, first_name{f}#8, gender{f}#0, height{f}#9, height.float{f}#10, height.half_float{f}#11, height.scaled_float{f}#12, hire_date{f}#13, is_rehired{f}#14, job_positions{f}#15, languages{f}#16, languages.byte{f}#17, languages.long{f}#18, languages.short{f}#19, last_name{f}#20, salary{f}#1, salary_change{f}#21, salary_change.int{f}#22, salary_change.keyword{f}#23, salary_change.long{f}#24, still_hired{f}#25]

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testMixedWithOtherAggregates/logical_optimization.expected
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testMixedWithOtherAggregates/logical_optimization.expected
@@ -1,0 +1,5 @@
+Project[[c{r}#0, m{r}#1, n{r}#2, gender{f}#3]]
+\_Eval[[CASE($$COUNTDISTINCT$VALUES(salary)$0{r$}#4 == 0[LONG],null[INTEGER],TOINTEGER($$COUNTDISTINCT$VALUES(salary)$0{r$}#4)) AS c#0]]
+  \_Limit[1000[INTEGER],false,false]
+    \_Aggregate[[gender{f}#3],[COUNTDISTINCT(salary{f}#5,true[BOOLEAN],PT0S[TIME_DURATION]) AS $$COUNTDISTINCT$VALUES(salary)$0#4, MAX(salary{f}#5,true[BOOLEAN],PT0S[TIME_DURATION]) AS m#1, COUNT(*[KEYWORD],true[BOOLEAN],PT0S[TIME_DURATION]) AS n#2, gender{f}#3]]
+      \_EsRelation[employees][avg_worked_seconds{f}#6, birth_date{f}#7, emp_no{f}#8, first_name{f}#9, gender{f}#3, height{f}#10, height.float{f}#11, height.half_float{f}#12, height.scaled_float{f}#13, hire_date{f}#14, is_rehired{f}#15, job_positions{f}#16, languages{f}#17, languages.byte{f}#18, languages.long{f}#19, languages.short{f}#20, last_name{f}#21, salary{f}#5, salary_change{f}#22, salary_change.int{f}#23, salary_change.keyword{f}#24, salary_change.long{f}#25, still_hired{f}#26]

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testMixedWithOtherAggregates/query.esql
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testMixedWithOtherAggregates/query.esql
@@ -1,0 +1,2 @@
+FROM employees
+| STATS c = MV_COUNT(VALUES(salary)), m = MAX(salary), n = COUNT(*) BY gender

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testMvCountNotOverValuesUntouched/analysis.expected
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testMvCountNotOverValuesUntouched/analysis.expected
@@ -1,0 +1,3 @@
+Limit[1000[INTEGER],false,false]
+\_Aggregate[[],[MVCOUNT(TOP(salary{f}#0,true[BOOLEAN],PT0S[TIME_DURATION],3[INTEGER],asc[KEYWORD])) AS c#1]]
+  \_EsRelation[employees][avg_worked_seconds{f}#2, birth_date{f}#3, emp_no{f}#4, first_name{f}#5, gender{f}#6, height{f}#7, height.float{f}#8, height.half_float{f}#9, height.scaled_float{f}#10, hire_date{f}#11, is_rehired{f}#12, job_positions{f}#13, languages{f}#14, languages.byte{f}#15, languages.long{f}#16, languages.short{f}#17, last_name{f}#18, salary{f}#0, salary_change{f}#19, salary_change.int{f}#20, salary_change.keyword{f}#21, salary_change.long{f}#22, still_hired{f}#23]

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testMvCountNotOverValuesUntouched/logical_optimization.expected
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testMvCountNotOverValuesUntouched/logical_optimization.expected
@@ -1,0 +1,5 @@
+Project[[c{r}#0]]
+\_Eval[[MVCOUNT($$TOP$MV_COUNT(TOP(sa>$0{r$}#1) AS c#0]]
+  \_Limit[1000[INTEGER],false,false]
+    \_Aggregate[[],[TOP(salary{f}#2,true[BOOLEAN],PT0S[TIME_DURATION],3[INTEGER],asc[KEYWORD]) AS $$TOP$MV_COUNT(TOP(sa>$0#1]]
+      \_EsRelation[employees][avg_worked_seconds{f}#3, birth_date{f}#4, emp_no{f}#5, first_name{f}#6, gender{f}#7, height{f}#8, height.float{f}#9, height.half_float{f}#10, height.scaled_float{f}#11, hire_date{f}#12, is_rehired{f}#13, job_positions{f}#14, languages{f}#15, languages.byte{f}#16, languages.long{f}#17, languages.short{f}#18, last_name{f}#19, salary{f}#2, salary_change{f}#20, salary_change.int{f}#21, salary_change.keyword{f}#22, salary_change.long{f}#23, still_hired{f}#24]

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testMvCountNotOverValuesUntouched/query.esql
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testMvCountNotOverValuesUntouched/query.esql
@@ -1,0 +1,2 @@
+FROM employees
+| STATS c = MV_COUNT(TOP(salary, 3, "asc"))

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testRewrite/analysis.expected
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testRewrite/analysis.expected
@@ -1,0 +1,3 @@
+Limit[1000[INTEGER],false,false]
+\_Aggregate[[],[MVCOUNT(VALUES(salary{f}#0,true[BOOLEAN],PT0S[TIME_DURATION])) AS c#1]]
+  \_EsRelation[employees][avg_worked_seconds{f}#2, birth_date{f}#3, emp_no{f}#4, first_name{f}#5, gender{f}#6, height{f}#7, height.float{f}#8, height.half_float{f}#9, height.scaled_float{f}#10, hire_date{f}#11, is_rehired{f}#12, job_positions{f}#13, languages{f}#14, languages.byte{f}#15, languages.long{f}#16, languages.short{f}#17, last_name{f}#18, salary{f}#0, salary_change{f}#19, salary_change.int{f}#20, salary_change.keyword{f}#21, salary_change.long{f}#22, still_hired{f}#23]

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testRewrite/logical_optimization.expected
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testRewrite/logical_optimization.expected
@@ -1,0 +1,5 @@
+Project[[c{r}#0]]
+\_Eval[[CASE($$COUNTDISTINCT$VALUES(salary)$0{r$}#1 == 0[LONG],null[INTEGER],TOINTEGER($$COUNTDISTINCT$VALUES(salary)$0{r$}#1)) AS c#0]]
+  \_Limit[1000[INTEGER],false,false]
+    \_Aggregate[[],[COUNTDISTINCT(salary{f}#2,true[BOOLEAN],PT0S[TIME_DURATION]) AS $$COUNTDISTINCT$VALUES(salary)$0#1]]
+      \_EsRelation[employees][avg_worked_seconds{f}#3, birth_date{f}#4, emp_no{f}#5, first_name{f}#6, gender{f}#7, height{f}#8, height.float{f}#9, height.half_float{f}#10, height.scaled_float{f}#11, hire_date{f}#12, is_rehired{f}#13, job_positions{f}#14, languages{f}#15, languages.byte{f}#16, languages.long{f}#17, languages.short{f}#18, last_name{f}#19, salary{f}#2, salary_change{f}#20, salary_change.int{f}#21, salary_change.keyword{f}#22, salary_change.long{f}#23, still_hired{f}#24]

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testRewrite/query.esql
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testRewrite/query.esql
@@ -1,0 +1,2 @@
+FROM employees
+| STATS c = MV_COUNT(VALUES(salary))

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testRewriteKeywordField/analysis.expected
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testRewriteKeywordField/analysis.expected
@@ -1,0 +1,3 @@
+Limit[1000[INTEGER],false,false]
+\_Aggregate[[],[MVCOUNT(VALUES(gender{f}#0,true[BOOLEAN],PT0S[TIME_DURATION])) AS c#1]]
+  \_EsRelation[employees][avg_worked_seconds{f}#2, birth_date{f}#3, emp_no{f}#4, first_name{f}#5, gender{f}#0, height{f}#6, height.float{f}#7, height.half_float{f}#8, height.scaled_float{f}#9, hire_date{f}#10, is_rehired{f}#11, job_positions{f}#12, languages{f}#13, languages.byte{f}#14, languages.long{f}#15, languages.short{f}#16, last_name{f}#17, salary{f}#18, salary_change{f}#19, salary_change.int{f}#20, salary_change.keyword{f}#21, salary_change.long{f}#22, still_hired{f}#23]

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testRewriteKeywordField/logical_optimization.expected
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testRewriteKeywordField/logical_optimization.expected
@@ -1,0 +1,5 @@
+Project[[c{r}#0]]
+\_Eval[[CASE($$COUNTDISTINCT$VALUES(gender)$0{r$}#1 == 0[LONG],null[INTEGER],TOINTEGER($$COUNTDISTINCT$VALUES(gender)$0{r$}#1)) AS c#0]]
+  \_Limit[1000[INTEGER],false,false]
+    \_Aggregate[[],[COUNTDISTINCT(gender{f}#2,true[BOOLEAN],PT0S[TIME_DURATION]) AS $$COUNTDISTINCT$VALUES(gender)$0#1]]
+      \_EsRelation[employees][avg_worked_seconds{f}#3, birth_date{f}#4, emp_no{f}#5, first_name{f}#6, gender{f}#2, height{f}#7, height.float{f}#8, height.half_float{f}#9, height.scaled_float{f}#10, hire_date{f}#11, is_rehired{f}#12, job_positions{f}#13, languages{f}#14, languages.byte{f}#15, languages.long{f}#16, languages.short{f}#17, last_name{f}#18, salary{f}#19, salary_change{f}#20, salary_change.int{f}#21, salary_change.keyword{f}#22, salary_change.long{f}#23, still_hired{f}#24]

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testRewriteKeywordField/query.esql
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testRewriteKeywordField/query.esql
@@ -1,0 +1,2 @@
+FROM employees
+| STATS c = MV_COUNT(VALUES(gender))

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testRewriteWithGrouping/analysis.expected
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testRewriteWithGrouping/analysis.expected
@@ -1,0 +1,3 @@
+Limit[1000[INTEGER],false,false]
+\_Aggregate[[gender{f}#0],[MVCOUNT(VALUES(salary{f}#1,true[BOOLEAN],PT0S[TIME_DURATION])) AS c#2, gender{f}#0]]
+  \_EsRelation[employees][avg_worked_seconds{f}#3, birth_date{f}#4, emp_no{f}#5, first_name{f}#6, gender{f}#0, height{f}#7, height.float{f}#8, height.half_float{f}#9, height.scaled_float{f}#10, hire_date{f}#11, is_rehired{f}#12, job_positions{f}#13, languages{f}#14, languages.byte{f}#15, languages.long{f}#16, languages.short{f}#17, last_name{f}#18, salary{f}#1, salary_change{f}#19, salary_change.int{f}#20, salary_change.keyword{f}#21, salary_change.long{f}#22, still_hired{f}#23]

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testRewriteWithGrouping/logical_optimization.expected
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testRewriteWithGrouping/logical_optimization.expected
@@ -1,0 +1,5 @@
+Project[[c{r}#0, gender{f}#1]]
+\_Eval[[CASE($$COUNTDISTINCT$VALUES(salary)$0{r$}#2 == 0[LONG],null[INTEGER],TOINTEGER($$COUNTDISTINCT$VALUES(salary)$0{r$}#2)) AS c#0]]
+  \_Limit[1000[INTEGER],false,false]
+    \_Aggregate[[gender{f}#1],[COUNTDISTINCT(salary{f}#3,true[BOOLEAN],PT0S[TIME_DURATION]) AS $$COUNTDISTINCT$VALUES(salary)$0#2, gender{f}#1]]
+      \_EsRelation[employees][avg_worked_seconds{f}#4, birth_date{f}#5, emp_no{f}#6, first_name{f}#7, gender{f}#1, height{f}#8, height.float{f}#9, height.half_float{f}#10, height.scaled_float{f}#11, hire_date{f}#12, is_rehired{f}#13, job_positions{f}#14, languages{f}#15, languages.byte{f}#16, languages.long{f}#17, languages.short{f}#18, last_name{f}#19, salary{f}#3, salary_change{f}#20, salary_change.int{f}#21, salary_change.keyword{f}#22, salary_change.long{f}#23, still_hired{f}#24]

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testRewriteWithGrouping/query.esql
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testRewriteWithGrouping/query.esql
@@ -1,0 +1,2 @@
+FROM employees
+| STATS c = MV_COUNT(VALUES(salary)) BY gender

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testUnsupportedTypeNotRewritten/analysis.expected
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testUnsupportedTypeNotRewritten/analysis.expected
@@ -1,0 +1,3 @@
+Limit[1000[INTEGER],false,false]
+\_Aggregate[[],[MVCOUNT(VALUES(location{f}#0,true[BOOLEAN],PT0S[TIME_DURATION])) AS c#1]]
+  \_EsRelation[airports][abbrev{f}#2, city{f}#3, city_location{f}#4, country{f}#5, location{f}#0, name{f}#6, scalerank{f}#7, type{f}#8]

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testUnsupportedTypeNotRewritten/logical_optimization.expected
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testUnsupportedTypeNotRewritten/logical_optimization.expected
@@ -1,0 +1,5 @@
+Project[[c{r}#0]]
+\_Eval[[MVCOUNT($$VALUES$MV_COUNT(VALUES>$0{r$}#1) AS c#0]]
+  \_Limit[1000[INTEGER],false,false]
+    \_Aggregate[[],[VALUES(location{f}#2,true[BOOLEAN],PT0S[TIME_DURATION]) AS $$VALUES$MV_COUNT(VALUES>$0#1]]
+      \_EsRelation[airports][abbrev{f}#3, city{f}#4, city_location{f}#5, country{f}#6, location{f}#2, name{f}#7, scalerank{f}#8, type{f}#9]

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testUnsupportedTypeNotRewritten/query.esql
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testUnsupportedTypeNotRewritten/query.esql
@@ -1,0 +1,2 @@
+FROM airports
+| STATS c = MV_COUNT(VALUES(location))

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testValuesEmittedElsewhereNotRewritten/analysis.expected
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testValuesEmittedElsewhereNotRewritten/analysis.expected
@@ -1,0 +1,3 @@
+Limit[1000[INTEGER],false,false]
+\_Aggregate[[],[VALUES(salary{f}#0,true[BOOLEAN],PT0S[TIME_DURATION]) AS v#1, MVCOUNT(VALUES(salary{f}#0,true[BOOLEAN],PT0S[TIME_DURATION])) AS c#2]]
+  \_EsRelation[employees][avg_worked_seconds{f}#3, birth_date{f}#4, emp_no{f}#5, first_name{f}#6, gender{f}#7, height{f}#8, height.float{f}#9, height.half_float{f}#10, height.scaled_float{f}#11, hire_date{f}#12, is_rehired{f}#13, job_positions{f}#14, languages{f}#15, languages.byte{f}#16, languages.long{f}#17, languages.short{f}#18, last_name{f}#19, salary{f}#0, salary_change{f}#20, salary_change.int{f}#21, salary_change.keyword{f}#22, salary_change.long{f}#23, still_hired{f}#24]

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testValuesEmittedElsewhereNotRewritten/logical_optimization.expected
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testValuesEmittedElsewhereNotRewritten/logical_optimization.expected
@@ -1,0 +1,5 @@
+Project[[v{r}#0, c{r}#1]]
+\_Eval[[MVCOUNT(v{r}#0) AS c#1]]
+  \_Limit[1000[INTEGER],false,false]
+    \_Aggregate[[],[VALUES(salary{f}#2,true[BOOLEAN],PT0S[TIME_DURATION]) AS v#0]]
+      \_EsRelation[employees][avg_worked_seconds{f}#3, birth_date{f}#4, emp_no{f}#5, first_name{f}#6, gender{f}#7, height{f}#8, height.float{f}#9, height.half_float{f}#10, height.scaled_float{f}#11, hire_date{f}#12, is_rehired{f}#13, job_positions{f}#14, languages{f}#15, languages.byte{f}#16, languages.long{f}#17, languages.short{f}#18, last_name{f}#19, salary{f}#2, salary_change{f}#20, salary_change.int{f}#21, salary_change.keyword{f}#22, salary_change.long{f}#23, still_hired{f}#24]

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testValuesEmittedElsewhereNotRewritten/query.esql
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/logical/golden_tests/ReplaceMvCountOfValuesWithCountDistinctGoldenTests/testValuesEmittedElsewhereNotRewritten/query.esql
@@ -1,0 +1,2 @@
+FROM employees
+| STATS v = VALUES(salary), c = MV_COUNT(VALUES(salary))


### PR DESCRIPTION
# Rewrite MV_COUNT(VALUES(x)) to COUNT_DISTINCT

Closes elastic/esql-planning#799.

`MV_COUNT(VALUES(x))` is a distinct count computed the expensive way: `VALUES`
materializes every distinct value per group (O(distinct) memory) only for
`MV_COUNT` to count and discard them. This adds a logical-optimizer rule that
rewrites it to the HyperLogLog++-backed `COUNT_DISTINCT`, dropping the
materialization.

## Details
- New `ReplaceMvCountOfValuesWithCountDistinct` rule, run in `substitutions()`.
- Rewrites only when `VALUES(x)` is consumed exclusively by `MV_COUNT`, the type
  is supported by `COUNT_DISTINCT`, and the aggregate is non-windowed.
- Full fidelity: output stays `integer` and all-null/empty groups stay `null`,
  via `CASE(COUNT_DISTINCT(x) == 0, null, TO_INTEGER(COUNT_DISTINCT(x)))`; any
  per-aggregate filter is carried onto `COUNT_DISTINCT`.
- Gated by capability `mv_count_values_as_count_distinct` (default on).
- Trade-off: this makes the result **approximate** on supported types.

## Tests
Golden tests (plan snapshots) + capability-gated CSV spec tests.
