### PR TITLE
[CI] Resize some intake steps and move them to spot instances

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -160,7 +160,7 @@ if [[ "${BUILDKITE_AGENT_META_DATA_PROVIDER:-}" != *"k8s"* ]]; then
   nohup .buildkite/scripts/setup-monitoring.sh </dev/null >/dev/null 2>&1 &
 
   export GCP_PREEMPTION_WATCHDOG=true
-  # export GCP_PREEMPTION_SIMULATE_AFTER_SECONDS=1800 # Uncomment to force a fake preemption after that many seconds
+  export GCP_PREEMPTION_SIMULATE_AFTER_SECONDS=300 # Uncomment to force a fake preemption after that many seconds
 fi
 
 # Initialize the build scan and gobld annotations with empty/open <details> tags

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -160,7 +160,7 @@ if [[ "${BUILDKITE_AGENT_META_DATA_PROVIDER:-}" != *"k8s"* ]]; then
   nohup .buildkite/scripts/setup-monitoring.sh </dev/null >/dev/null 2>&1 &
 
   export GCP_PREEMPTION_WATCHDOG=true
-  export GCP_PREEMPTION_SIMULATE_AFTER_SECONDS=300 # Uncomment to force a fake preemption after that many seconds
+  # export GCP_PREEMPTION_SIMULATE_AFTER_SECONDS=300 # Uncomment to force a fake preemption after that many seconds
 fi
 
 # Initialize the build scan and gobld annotations with empty/open <details> tags

--- a/.buildkite/pipelines/intake.yml
+++ b/.buildkite/pipelines/intake.yml
@@ -6,8 +6,25 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
-      machineType: custom-32-98304
+      machineType: n4-standard-16
+      preemptible: true
+      spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"
+      diskType: hyperdisk-balanced
       buildDirectory: /dev/shm/bk
+    retry:
+      manual:
+        reason: Retry with smart test selection if desired
+        allowed: true
+        permit_on_passed: false
+      automatic:
+        - limit: 2
+          exit_status: "-1"
+          signal_reason: none
+        - limit: 3
+          exit_status: "47"
+          signal_reason: none
+        - limit: 2
+          signal_reason: agent_stop
   - wait
   - label: part1
     command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-file-fingerprints checkPart1
@@ -15,48 +32,150 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
-      machineType: n1-standard-32
+      machineType: n4-standard-16
+      preemptible: true
+      spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"
+      diskType: hyperdisk-balanced
       buildDirectory: /dev/shm/bk
+    retry:
+      manual:
+        reason: Retry with smart test selection if desired
+        allowed: true
+        permit_on_passed: false
+      automatic:
+        - limit: 2
+          exit_status: "-1"
+          signal_reason: none
+        - limit: 3
+          exit_status: "47"
+          signal_reason: none
+        - limit: 2
+          signal_reason: agent_stop
   - label: part2
     command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-file-fingerprints checkPart2
     timeout_in_minutes: 300
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
-      machineType: n1-standard-32
+      machineType: n4-standard-16
+      preemptible: true
+      spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"
+      diskType: hyperdisk-balanced
       buildDirectory: /dev/shm/bk
+    retry:
+      manual:
+        reason: Retry with smart test selection if desired
+        allowed: true
+        permit_on_passed: false
+      automatic:
+        - limit: 2
+          exit_status: "-1"
+          signal_reason: none
+        - limit: 3
+          exit_status: "47"
+          signal_reason: none
+        - limit: 2
+          signal_reason: agent_stop
   - label: part3
     command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-file-fingerprints checkPart3
     timeout_in_minutes: 300
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
-      machineType: n1-standard-32
+      machineType: n4-standard-16
+      preemptible: true
+      spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"
+      diskType: hyperdisk-balanced
       buildDirectory: /dev/shm/bk
+    retry:
+      manual:
+        reason: Retry with smart test selection if desired
+        allowed: true
+        permit_on_passed: false
+      automatic:
+        - limit: 2
+          exit_status: "-1"
+          signal_reason: none
+        - limit: 3
+          exit_status: "47"
+          signal_reason: none
+        - limit: 2
+          signal_reason: agent_stop
   - label: part4
     command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-file-fingerprints checkPart4
     timeout_in_minutes: 300
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
-      machineType: n1-standard-32
+      machineType: n4-standard-16
+      preemptible: true
+      spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"
+      diskType: hyperdisk-balanced
       buildDirectory: /dev/shm/bk
+    retry:
+      manual:
+        reason: Retry with smart test selection if desired
+        allowed: true
+        permit_on_passed: false
+      automatic:
+        - limit: 2
+          exit_status: "-1"
+          signal_reason: none
+        - limit: 3
+          exit_status: "47"
+          signal_reason: none
+        - limit: 2
+          signal_reason: agent_stop
   - label: part5
     command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-file-fingerprints checkPart5
     timeout_in_minutes: 300
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
-      machineType: n1-standard-32
+      machineType: n4-standard-16
+      preemptible: true
+      spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"
+      diskType: hyperdisk-balanced
       buildDirectory: /dev/shm/bk
+    retry:
+      manual:
+        reason: Retry with smart test selection if desired
+        allowed: true
+        permit_on_passed: false
+      automatic:
+        - limit: 2
+          exit_status: "-1"
+          signal_reason: none
+        - limit: 3
+          exit_status: "47"
+          signal_reason: none
+        - limit: 2
+          signal_reason: agent_stop
   - label: part6
     command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-file-fingerprints checkPart6
     timeout_in_minutes: 300
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
-      machineType: n1-standard-32
+      machineType: n4-standard-16
+      preemptible: true
+      spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"
+      diskType: hyperdisk-balanced
       buildDirectory: /dev/shm/bk
+    retry:
+      manual:
+        reason: Retry with smart test selection if desired
+        allowed: true
+        permit_on_passed: false
+      automatic:
+        - limit: 2
+          exit_status: "-1"
+          signal_reason: none
+        - limit: 3
+          exit_status: "47"
+          signal_reason: none
+        - limit: 2
+          signal_reason: agent_stop
 
   - group: bwc-snapshots
     steps:
@@ -69,10 +188,27 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2404
-          machineType: custom-32-98304
+          machineType: n4-standard-16
+          preemptible: true
+          spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"
+          diskType: hyperdisk-balanced
           buildDirectory: /dev/shm/bk
         env:
           BWC_VERSION: "{{matrix.BWC_VERSION}}"
+        retry:
+          manual:
+            reason: Retry with smart test selection if desired
+            allowed: true
+            permit_on_passed: false
+          automatic:
+            - limit: 2
+              exit_status: "-1"
+              signal_reason: none
+            - limit: 3
+              exit_status: "47"
+              signal_reason: none
+            - limit: 2
+              signal_reason: agent_stop
   - label: bc-upgrade
     command: ".buildkite/scripts/run-bc-upgrade-tests.sh"
   - group: lucene-compat

--- a/.buildkite/scripts/run-bc-upgrade-tests.sh
+++ b/.buildkite/scripts/run-bc-upgrade-tests.sh
@@ -72,6 +72,8 @@ steps:
           machineType: n4-standard-16
           diskType: hyperdisk-balanced
           buildDirectory: /dev/shm/bk
+          preemptible: true
+          spotZones: 'asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c'
         matrix:
           setup:
             PART: ["1", "2", "3", "4", "5", "6"]


### PR DESCRIPTION
- Resize intake job instance sizes to match pull requests
- Move intake `check` and BWC jobs to spot instances, add retries

Tested using the intake pipeline manually