### PR TITLE
Painless: script_aware Stream.collect(Collector) and primitive forEachRemaining

### DIFF
--- a/docs/changelog/151337.yaml
+++ b/docs/changelog/151337.yaml
@@ -1,0 +1,5 @@
+area: Infra/Scripting
+issues: []
+pr: 151337
+summary: "Painless: `script_aware` Stream.collect(Collector) and primitive `forEachRemaining`"
+type: enhancement

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/api/Augmentation.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/api/Augmentation.java
@@ -1064,102 +1064,99 @@ public class Augmentation {
     }
 
     /**
-     * Cancellation-aware wrapper around {@link PrimitiveIterator.OfInt#forEachRemaining(IntConsumer)}.
-     * Walks the receiver via {@link PrimitiveIterator.OfInt#nextInt} (no boxing) and polls
-     * {@link PainlessScript#_pollCancellation()} once per element.  Fast path delegates straight to the
-     * JDK when the script has no cancellation check installed.
+     * Cancellation-aware wrapper around {@link PrimitiveIterator.OfInt#forEachRemaining(IntConsumer)}.  Delegates
+     * to the JDK, wrapping {@code action} so it polls {@link PainlessScript#_pollCancellation()} once per element.
+     * Fast path delegates straight to the JDK when the script has no cancellation check installed.
      */
     public static void forEachRemaining(PainlessScript script, PrimitiveIterator.OfInt receiver, IntConsumer action) {
         if (script._getCancellationCheck() == null) {
             receiver.forEachRemaining(action);
             return;
         }
-        while (receiver.hasNext()) {
-            action.accept(receiver.nextInt());
+        receiver.forEachRemaining((int i) -> {
             script._pollCancellation();
-        }
+            action.accept(i);
+        });
     }
 
     /**
-     * Cancellation-aware wrapper around {@link PrimitiveIterator.OfLong#forEachRemaining(LongConsumer)}.
-     * Walks the receiver via {@link PrimitiveIterator.OfLong#nextLong} (no boxing) and polls
-     * {@link PainlessScript#_pollCancellation()} once per element.  Fast path delegates straight to the
-     * JDK when the script has no cancellation check installed.
+     * Cancellation-aware wrapper around {@link PrimitiveIterator.OfLong#forEachRemaining(LongConsumer)}.  Delegates
+     * to the JDK, wrapping {@code action} so it polls {@link PainlessScript#_pollCancellation()} once per element.
+     * Fast path delegates straight to the JDK when the script has no cancellation check installed.
      */
     public static void forEachRemaining(PainlessScript script, PrimitiveIterator.OfLong receiver, LongConsumer action) {
         if (script._getCancellationCheck() == null) {
             receiver.forEachRemaining(action);
             return;
         }
-        while (receiver.hasNext()) {
-            action.accept(receiver.nextLong());
+        receiver.forEachRemaining((long l) -> {
             script._pollCancellation();
-        }
+            action.accept(l);
+        });
     }
 
     /**
-     * Cancellation-aware wrapper around {@link PrimitiveIterator.OfDouble#forEachRemaining(DoubleConsumer)}.
-     * Walks the receiver via {@link PrimitiveIterator.OfDouble#nextDouble} (no boxing) and polls
-     * {@link PainlessScript#_pollCancellation()} once per element.  Fast path delegates straight to the
-     * JDK when the script has no cancellation check installed.
+     * Cancellation-aware wrapper around {@link PrimitiveIterator.OfDouble#forEachRemaining(DoubleConsumer)}.  Delegates
+     * to the JDK, wrapping {@code action} so it polls {@link PainlessScript#_pollCancellation()} once per element.
+     * Fast path delegates straight to the JDK when the script has no cancellation check installed.
      */
     public static void forEachRemaining(PainlessScript script, PrimitiveIterator.OfDouble receiver, DoubleConsumer action) {
         if (script._getCancellationCheck() == null) {
             receiver.forEachRemaining(action);
             return;
         }
-        while (receiver.hasNext()) {
-            action.accept(receiver.nextDouble());
+        receiver.forEachRemaining((double d) -> {
             script._pollCancellation();
-        }
+            action.accept(d);
+        });
     }
 
     /**
-     * Cancellation-aware wrapper around {@link Spliterator.OfInt#forEachRemaining(IntConsumer)}.  Drives the
-     * receiver via {@link Spliterator.OfInt#tryAdvance(IntConsumer)} so the augmentation can poll
-     * {@link PainlessScript#_pollCancellation()} between each element.  Fast path delegates straight to the
-     * JDK when the script has no cancellation check installed.
+     * Cancellation-aware wrapper around {@link Spliterator.OfInt#forEachRemaining(IntConsumer)}.  Delegates to the
+     * JDK, wrapping {@code action} so it polls {@link PainlessScript#_pollCancellation()} once per element.  Fast
+     * path delegates straight to the JDK when the script has no cancellation check installed.
      */
     public static void forEachRemaining(PainlessScript script, Spliterator.OfInt receiver, IntConsumer action) {
         if (script._getCancellationCheck() == null) {
             receiver.forEachRemaining(action);
             return;
         }
-        while (receiver.tryAdvance(action)) {
+        receiver.forEachRemaining((int i) -> {
             script._pollCancellation();
-        }
+            action.accept(i);
+        });
     }
 
     /**
-     * Cancellation-aware wrapper around {@link Spliterator.OfLong#forEachRemaining(LongConsumer)}.  Drives the
-     * receiver via {@link Spliterator.OfLong#tryAdvance(LongConsumer)} so the augmentation can poll
-     * {@link PainlessScript#_pollCancellation()} between each element.  Fast path delegates straight to the
-     * JDK when the script has no cancellation check installed.
+     * Cancellation-aware wrapper around {@link Spliterator.OfLong#forEachRemaining(LongConsumer)}.  Delegates to the
+     * JDK, wrapping {@code action} so it polls {@link PainlessScript#_pollCancellation()} once per element.  Fast
+     * path delegates straight to the JDK when the script has no cancellation check installed.
      */
     public static void forEachRemaining(PainlessScript script, Spliterator.OfLong receiver, LongConsumer action) {
         if (script._getCancellationCheck() == null) {
             receiver.forEachRemaining(action);
             return;
         }
-        while (receiver.tryAdvance(action)) {
+        receiver.forEachRemaining((long l) -> {
             script._pollCancellation();
-        }
+            action.accept(l);
+        });
     }
 
     /**
-     * Cancellation-aware wrapper around {@link Spliterator.OfDouble#forEachRemaining(DoubleConsumer)}.  Drives the
-     * receiver via {@link Spliterator.OfDouble#tryAdvance(DoubleConsumer)} so the augmentation can poll
-     * {@link PainlessScript#_pollCancellation()} between each element.  Fast path delegates straight to the
-     * JDK when the script has no cancellation check installed.
+     * Cancellation-aware wrapper around {@link Spliterator.OfDouble#forEachRemaining(DoubleConsumer)}.  Delegates to
+     * the JDK, wrapping {@code action} so it polls {@link PainlessScript#_pollCancellation()} once per element.  Fast
+     * path delegates straight to the JDK when the script has no cancellation check installed.
      */
     public static void forEachRemaining(PainlessScript script, Spliterator.OfDouble receiver, DoubleConsumer action) {
         if (script._getCancellationCheck() == null) {
             receiver.forEachRemaining(action);
             return;
         }
-        while (receiver.tryAdvance(action)) {
+        receiver.forEachRemaining((double d) -> {
             script._pollCancellation();
-        }
+            action.accept(d);
+        });
     }
 
     // stream terminal wrappers for cancellation-aware iteration
@@ -1297,26 +1294,19 @@ public class Augmentation {
      * the {@link Collector} — so this decomposes the collector and rebuilds an equivalent one whose
      * accumulator also polls {@link PainlessScript#_pollCancellation()} once per element.  Painless does
      * not expose {@link Stream#parallel()}, so the stream is always sequential: the accumulator runs once
-     * per element and the combiner is never invoked.  The rebuilt collector drops {@code IDENTITY_FINISH}
-     * (the original finisher, an identity function in that case, is applied explicitly) so the result is
-     * identical to the JDK; remaining characteristics are preserved.  Fast path delegates straight to the
-     * JDK when the script has no cancellation check installed.
+     * per element and the combiner is never invoked.  The original characteristics (including
+     * {@code IDENTITY_FINISH}) and finisher are preserved unchanged, so the result is identical to the JDK.
+     * Fast path delegates straight to the JDK when the script has no cancellation check installed.
      */
     public static <T, A, R> R collect(PainlessScript script, Stream<T> receiver, Collector<? super T, A, R> collector) {
         if (script._getCancellationCheck() == null) {
             return receiver.collect(collector);
         }
         BiConsumer<A, ? super T> accumulator = collector.accumulator();
-        List<Collector.Characteristics> characteristics = new ArrayList<>();
-        for (Collector.Characteristics characteristic : collector.characteristics()) {
-            if (characteristic != Collector.Characteristics.IDENTITY_FINISH) {
-                characteristics.add(characteristic);
-            }
-        }
         Collector<T, A, R> polling = Collector.of(collector.supplier(), (a, t) -> {
             accumulator.accept(a, t);
             script._pollCancellation();
-        }, collector.combiner(), collector.finisher(), characteristics.toArray(new Collector.Characteristics[0]));
+        }, collector.combiner(), collector.finisher(), collector.characteristics().toArray(new Collector.Characteristics[0]));
         return receiver.collect(polling);
     }
 

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/api/Augmentation.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/api/Augmentation.java
@@ -57,6 +57,7 @@ import java.util.function.ToDoubleFunction;
 import java.util.function.UnaryOperator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collector;
 import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
@@ -1188,6 +1189,35 @@ public class Augmentation {
             accumulator.accept(r, t);
             script._pollCancellation();
         }, combiner);
+    }
+
+    /**
+     * Cancellation-aware wrapper around {@link Stream#collect(Collector)}.  Unlike the other stream
+     * terminals there is no per-element argument to wrap directly — the accumulator is bundled inside
+     * the {@link Collector} — so this decomposes the collector and rebuilds an equivalent one whose
+     * accumulator also polls {@link PainlessScript#_pollCancellation()} once per element.  Painless does
+     * not expose {@link Stream#parallel()}, so the stream is always sequential: the accumulator runs once
+     * per element and the combiner is never invoked.  The rebuilt collector drops {@code IDENTITY_FINISH}
+     * (the original finisher, an identity function in that case, is applied explicitly) so the result is
+     * identical to the JDK; remaining characteristics are preserved.  Fast path delegates straight to the
+     * JDK when the script has no cancellation check installed.
+     */
+    public static <T, A, R> R collect(PainlessScript script, Stream<T> receiver, Collector<? super T, A, R> collector) {
+        if (script._getCancellationCheck() == null) {
+            return receiver.collect(collector);
+        }
+        BiConsumer<A, ? super T> accumulator = collector.accumulator();
+        List<Collector.Characteristics> characteristics = new ArrayList<>();
+        for (Collector.Characteristics characteristic : collector.characteristics()) {
+            if (characteristic != Collector.Characteristics.IDENTITY_FINISH) {
+                characteristics.add(characteristic);
+            }
+        }
+        Collector<T, A, R> polling = Collector.of(collector.supplier(), (a, t) -> {
+            accumulator.accept(a, t);
+            script._pollCancellation();
+        }, collector.combiner(), collector.finisher(), characteristics.toArray(new Collector.Characteristics[0]));
+        return receiver.collect(polling);
     }
 
     /** Cancellation-aware wrapper around {@link IntStream#forEach}. */

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/api/Augmentation.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/api/Augmentation.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
+import java.util.PrimitiveIterator;
 import java.util.Spliterator;
 import java.util.TreeMap;
 import java.util.function.BiConsumer;
@@ -1058,6 +1059,105 @@ public class Augmentation {
             return;
         }
         while (receiver.tryAdvance(consumer)) {
+            script._pollCancellation();
+        }
+    }
+
+    /**
+     * Cancellation-aware wrapper around {@link PrimitiveIterator.OfInt#forEachRemaining(IntConsumer)}.
+     * Walks the receiver via {@link PrimitiveIterator.OfInt#nextInt} (no boxing) and polls
+     * {@link PainlessScript#_pollCancellation()} once per element.  Fast path delegates straight to the
+     * JDK when the script has no cancellation check installed.
+     */
+    public static void forEachRemaining(PainlessScript script, PrimitiveIterator.OfInt receiver, IntConsumer action) {
+        if (script._getCancellationCheck() == null) {
+            receiver.forEachRemaining(action);
+            return;
+        }
+        while (receiver.hasNext()) {
+            action.accept(receiver.nextInt());
+            script._pollCancellation();
+        }
+    }
+
+    /**
+     * Cancellation-aware wrapper around {@link PrimitiveIterator.OfLong#forEachRemaining(LongConsumer)}.
+     * Walks the receiver via {@link PrimitiveIterator.OfLong#nextLong} (no boxing) and polls
+     * {@link PainlessScript#_pollCancellation()} once per element.  Fast path delegates straight to the
+     * JDK when the script has no cancellation check installed.
+     */
+    public static void forEachRemaining(PainlessScript script, PrimitiveIterator.OfLong receiver, LongConsumer action) {
+        if (script._getCancellationCheck() == null) {
+            receiver.forEachRemaining(action);
+            return;
+        }
+        while (receiver.hasNext()) {
+            action.accept(receiver.nextLong());
+            script._pollCancellation();
+        }
+    }
+
+    /**
+     * Cancellation-aware wrapper around {@link PrimitiveIterator.OfDouble#forEachRemaining(DoubleConsumer)}.
+     * Walks the receiver via {@link PrimitiveIterator.OfDouble#nextDouble} (no boxing) and polls
+     * {@link PainlessScript#_pollCancellation()} once per element.  Fast path delegates straight to the
+     * JDK when the script has no cancellation check installed.
+     */
+    public static void forEachRemaining(PainlessScript script, PrimitiveIterator.OfDouble receiver, DoubleConsumer action) {
+        if (script._getCancellationCheck() == null) {
+            receiver.forEachRemaining(action);
+            return;
+        }
+        while (receiver.hasNext()) {
+            action.accept(receiver.nextDouble());
+            script._pollCancellation();
+        }
+    }
+
+    /**
+     * Cancellation-aware wrapper around {@link Spliterator.OfInt#forEachRemaining(IntConsumer)}.  Drives the
+     * receiver via {@link Spliterator.OfInt#tryAdvance(IntConsumer)} so the augmentation can poll
+     * {@link PainlessScript#_pollCancellation()} between each element.  Fast path delegates straight to the
+     * JDK when the script has no cancellation check installed.
+     */
+    public static void forEachRemaining(PainlessScript script, Spliterator.OfInt receiver, IntConsumer action) {
+        if (script._getCancellationCheck() == null) {
+            receiver.forEachRemaining(action);
+            return;
+        }
+        while (receiver.tryAdvance(action)) {
+            script._pollCancellation();
+        }
+    }
+
+    /**
+     * Cancellation-aware wrapper around {@link Spliterator.OfLong#forEachRemaining(LongConsumer)}.  Drives the
+     * receiver via {@link Spliterator.OfLong#tryAdvance(LongConsumer)} so the augmentation can poll
+     * {@link PainlessScript#_pollCancellation()} between each element.  Fast path delegates straight to the
+     * JDK when the script has no cancellation check installed.
+     */
+    public static void forEachRemaining(PainlessScript script, Spliterator.OfLong receiver, LongConsumer action) {
+        if (script._getCancellationCheck() == null) {
+            receiver.forEachRemaining(action);
+            return;
+        }
+        while (receiver.tryAdvance(action)) {
+            script._pollCancellation();
+        }
+    }
+
+    /**
+     * Cancellation-aware wrapper around {@link Spliterator.OfDouble#forEachRemaining(DoubleConsumer)}.  Drives the
+     * receiver via {@link Spliterator.OfDouble#tryAdvance(DoubleConsumer)} so the augmentation can poll
+     * {@link PainlessScript#_pollCancellation()} between each element.  Fast path delegates straight to the
+     * JDK when the script has no cancellation check installed.
+     */
+    public static void forEachRemaining(PainlessScript script, Spliterator.OfDouble receiver, DoubleConsumer action) {
+        if (script._getCancellationCheck() == null) {
+            receiver.forEachRemaining(action);
+            return;
+        }
+        while (receiver.tryAdvance(action)) {
             script._pollCancellation();
         }
     }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/api/Augmentation.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/api/Augmentation.java
@@ -1063,100 +1063,92 @@ public class Augmentation {
         }
     }
 
+    // Wrap a primitive consumer so it polls _pollCancellation() once per element before delegating, or return it
+    // unchanged when no cancellation check is installed so the caller still takes the JDK fast path. Overloaded
+    // per primitive consumer type rather than one generic Consumer wrapper, which would box every element.
+
+    private static IntConsumer wrap(PainlessScript script, IntConsumer action) {
+        if (script._getCancellationCheck() == null) {
+            return action;
+        }
+        return i -> {
+            script._pollCancellation();
+            action.accept(i);
+        };
+    }
+
+    private static LongConsumer wrap(PainlessScript script, LongConsumer action) {
+        if (script._getCancellationCheck() == null) {
+            return action;
+        }
+        return l -> {
+            script._pollCancellation();
+            action.accept(l);
+        };
+    }
+
+    private static DoubleConsumer wrap(PainlessScript script, DoubleConsumer action) {
+        if (script._getCancellationCheck() == null) {
+            return action;
+        }
+        return d -> {
+            script._pollCancellation();
+            action.accept(d);
+        };
+    }
+
     /**
-     * Cancellation-aware wrapper around {@link PrimitiveIterator.OfInt#forEachRemaining(IntConsumer)}.  Delegates
-     * to the JDK, wrapping {@code action} so it polls {@link PainlessScript#_pollCancellation()} once per element.
-     * Fast path delegates straight to the JDK when the script has no cancellation check installed.
+     * Cancellation-aware wrapper around {@link PrimitiveIterator.OfInt#forEachRemaining(IntConsumer)}.  Polls
+     * {@link PainlessScript#_pollCancellation()} once per element via the wrapped {@link IntConsumer}; takes the
+     * JDK fast path unchanged when no cancellation check is installed.
      */
     public static void forEachRemaining(PainlessScript script, PrimitiveIterator.OfInt receiver, IntConsumer action) {
-        if (script._getCancellationCheck() == null) {
-            receiver.forEachRemaining(action);
-            return;
-        }
-        receiver.forEachRemaining((int i) -> {
-            script._pollCancellation();
-            action.accept(i);
-        });
+        receiver.forEachRemaining(wrap(script, action));
     }
 
     /**
-     * Cancellation-aware wrapper around {@link PrimitiveIterator.OfLong#forEachRemaining(LongConsumer)}.  Delegates
-     * to the JDK, wrapping {@code action} so it polls {@link PainlessScript#_pollCancellation()} once per element.
-     * Fast path delegates straight to the JDK when the script has no cancellation check installed.
+     * Cancellation-aware wrapper around {@link PrimitiveIterator.OfLong#forEachRemaining(LongConsumer)}.  Polls
+     * {@link PainlessScript#_pollCancellation()} once per element via the wrapped {@link LongConsumer}; takes the
+     * JDK fast path unchanged when no cancellation check is installed.
      */
     public static void forEachRemaining(PainlessScript script, PrimitiveIterator.OfLong receiver, LongConsumer action) {
-        if (script._getCancellationCheck() == null) {
-            receiver.forEachRemaining(action);
-            return;
-        }
-        receiver.forEachRemaining((long l) -> {
-            script._pollCancellation();
-            action.accept(l);
-        });
+        receiver.forEachRemaining(wrap(script, action));
     }
 
     /**
-     * Cancellation-aware wrapper around {@link PrimitiveIterator.OfDouble#forEachRemaining(DoubleConsumer)}.  Delegates
-     * to the JDK, wrapping {@code action} so it polls {@link PainlessScript#_pollCancellation()} once per element.
-     * Fast path delegates straight to the JDK when the script has no cancellation check installed.
+     * Cancellation-aware wrapper around {@link PrimitiveIterator.OfDouble#forEachRemaining(DoubleConsumer)}.  Polls
+     * {@link PainlessScript#_pollCancellation()} once per element via the wrapped {@link DoubleConsumer}; takes the
+     * JDK fast path unchanged when no cancellation check is installed.
      */
     public static void forEachRemaining(PainlessScript script, PrimitiveIterator.OfDouble receiver, DoubleConsumer action) {
-        if (script._getCancellationCheck() == null) {
-            receiver.forEachRemaining(action);
-            return;
-        }
-        receiver.forEachRemaining((double d) -> {
-            script._pollCancellation();
-            action.accept(d);
-        });
+        receiver.forEachRemaining(wrap(script, action));
     }
 
     /**
-     * Cancellation-aware wrapper around {@link Spliterator.OfInt#forEachRemaining(IntConsumer)}.  Delegates to the
-     * JDK, wrapping {@code action} so it polls {@link PainlessScript#_pollCancellation()} once per element.  Fast
-     * path delegates straight to the JDK when the script has no cancellation check installed.
+     * Cancellation-aware wrapper around {@link Spliterator.OfInt#forEachRemaining(IntConsumer)}.  Polls
+     * {@link PainlessScript#_pollCancellation()} once per element via the wrapped {@link IntConsumer}; takes the
+     * JDK fast path unchanged when no cancellation check is installed.
      */
     public static void forEachRemaining(PainlessScript script, Spliterator.OfInt receiver, IntConsumer action) {
-        if (script._getCancellationCheck() == null) {
-            receiver.forEachRemaining(action);
-            return;
-        }
-        receiver.forEachRemaining((int i) -> {
-            script._pollCancellation();
-            action.accept(i);
-        });
+        receiver.forEachRemaining(wrap(script, action));
     }
 
     /**
-     * Cancellation-aware wrapper around {@link Spliterator.OfLong#forEachRemaining(LongConsumer)}.  Delegates to the
-     * JDK, wrapping {@code action} so it polls {@link PainlessScript#_pollCancellation()} once per element.  Fast
-     * path delegates straight to the JDK when the script has no cancellation check installed.
+     * Cancellation-aware wrapper around {@link Spliterator.OfLong#forEachRemaining(LongConsumer)}.  Polls
+     * {@link PainlessScript#_pollCancellation()} once per element via the wrapped {@link LongConsumer}; takes the
+     * JDK fast path unchanged when no cancellation check is installed.
      */
     public static void forEachRemaining(PainlessScript script, Spliterator.OfLong receiver, LongConsumer action) {
-        if (script._getCancellationCheck() == null) {
-            receiver.forEachRemaining(action);
-            return;
-        }
-        receiver.forEachRemaining((long l) -> {
-            script._pollCancellation();
-            action.accept(l);
-        });
+        receiver.forEachRemaining(wrap(script, action));
     }
 
     /**
-     * Cancellation-aware wrapper around {@link Spliterator.OfDouble#forEachRemaining(DoubleConsumer)}.  Delegates to
-     * the JDK, wrapping {@code action} so it polls {@link PainlessScript#_pollCancellation()} once per element.  Fast
-     * path delegates straight to the JDK when the script has no cancellation check installed.
+     * Cancellation-aware wrapper around {@link Spliterator.OfDouble#forEachRemaining(DoubleConsumer)}.  Polls
+     * {@link PainlessScript#_pollCancellation()} once per element via the wrapped {@link DoubleConsumer}; takes the
+     * JDK fast path unchanged when no cancellation check is installed.
      */
     public static void forEachRemaining(PainlessScript script, Spliterator.OfDouble receiver, DoubleConsumer action) {
-        if (script._getCancellationCheck() == null) {
-            receiver.forEachRemaining(action);
-            return;
-        }
-        receiver.forEachRemaining((double d) -> {
-            script._pollCancellation();
-            action.accept(d);
-        });
+        receiver.forEachRemaining(wrap(script, action));
     }
 
     // stream terminal wrappers for cancellation-aware iteration

--- a/modules/lang-painless/src/main/resources/org/elasticsearch/painless/java.util.stream.txt
+++ b/modules/lang-painless/src/main/resources/org/elasticsearch/painless/java.util.stream.txt
@@ -176,7 +176,7 @@ class java.util.stream.Stream {
   boolean org.elasticsearch.painless.api.Augmentation allMatch(Predicate) @script_aware
   boolean org.elasticsearch.painless.api.Augmentation anyMatch(Predicate) @script_aware
   Stream.Builder builder()
-  def collect(Collector)
+  def org.elasticsearch.painless.api.Augmentation collect(Collector) @script_aware
   def org.elasticsearch.painless.api.Augmentation collect(Supplier,BiConsumer,BiConsumer) @script_aware
   Stream concat(Stream,Stream)
   long count()

--- a/modules/lang-painless/src/main/resources/org/elasticsearch/painless/java.util.txt
+++ b/modules/lang-painless/src/main/resources/org/elasticsearch/painless/java.util.txt
@@ -225,16 +225,19 @@ class java.util.PrimitiveIterator {
 }
 
 class java.util.PrimitiveIterator$OfDouble {
+  void org.elasticsearch.painless.api.Augmentation forEachRemaining(DoubleConsumer) @script_aware
   Double next()
   double nextDouble()
 }
 
 class java.util.PrimitiveIterator$OfInt {
+  void org.elasticsearch.painless.api.Augmentation forEachRemaining(IntConsumer) @script_aware
   Integer next()
   int nextInt()
 }
 
 class java.util.PrimitiveIterator$OfLong {
+  void org.elasticsearch.painless.api.Augmentation forEachRemaining(LongConsumer) @script_aware
   Long next()
   long nextLong()
 }
@@ -265,14 +268,17 @@ class java.util.Spliterator$OfPrimitive {
 }
 
 class java.util.Spliterator$OfDouble {
+  void org.elasticsearch.painless.api.Augmentation forEachRemaining(DoubleConsumer) @script_aware
   Spliterator.OfDouble trySplit()
 }
 
 class java.util.Spliterator$OfInt {
+  void org.elasticsearch.painless.api.Augmentation forEachRemaining(IntConsumer) @script_aware
   Spliterator.OfInt trySplit()
 }
 
 class java.util.Spliterator$OfLong {
+  void org.elasticsearch.painless.api.Augmentation forEachRemaining(LongConsumer) @script_aware
   Spliterator.OfLong trySplit()
 }
 

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/AugmentationCancellationTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/AugmentationCancellationTests.java
@@ -1006,6 +1006,19 @@ public class AugmentationCancellationTests extends ScriptTestCase {
         );
     }
 
+    /** {@code Stream.collect(Collector)} drives the whole stream through the collector's accumulator and must poll. */
+    public void testStreamCollectCollectorAugmentationFiresCancelRunnable() {
+        assertFires(compileFillThen("", "big.stream().collect(Collectors.toList());"), "cancelled-stream-collect-collector");
+    }
+
+    /**
+     * {@code Stream.collect(Collector)} with a finishing collector ({@code counting()} is not
+     * {@code IDENTITY_FINISH}) still polls — the rebuilt collector applies the original finisher.
+     */
+    public void testStreamCollectFinishingCollectorAugmentationFiresCancelRunnable() {
+        assertFires(compileFillThen("", "big.stream().collect(Collectors.counting());"), "cancelled-stream-collect-counting");
+    }
+
     // --- IntStream terminal-op script-aware augmentations: per-method fires tests ---
 
     /** {@code IntStream.forEach} drives the pipeline and must poll. */
@@ -1167,6 +1180,8 @@ public class AugmentationCancellationTests extends ScriptTestCase {
                 + "big.stream().reduce(0, (a, b) -> a); "
                 + "big.stream().reduce(0, (a, b) -> a, (a, b) -> a); "
                 + "big.stream().collect(() -> new ArrayList(), (l, x) -> l.add(x), (a, b) -> a.addAll(b)); "
+                + "big.stream().collect(Collectors.toList()); "
+                + "big.stream().collect(Collectors.counting()); "
                 + "big.stream().mapToInt(x -> x).forEach(x -> x); "
                 + "big.stream().mapToInt(x -> x).allMatch(x -> true); "
                 + "big.stream().mapToInt(x -> x).reduce((a, b) -> a); "
@@ -1437,5 +1452,35 @@ public class AugmentationCancellationTests extends ScriptTestCase {
             params
         );
         assertEquals("thE qUIck brOwn fOx", out);
+    }
+
+    /**
+     * The polling branch rebuilds the collector, so pin that its output matches the JDK across an
+     * {@code IDENTITY_FINISH} collector ({@code toList}), a finishing collector ({@code counting}), and a
+     * finishing collector with a non-trivial finisher ({@code joining}).  Receiver is a statically typed
+     * {@code Stream}, so this exercises the static augmentation dispatch path.
+     */
+    public void testStreamCollectCollectorWithCheckInstalledMatchesExpectedOutput() {
+        Map<String, Object> params = new HashMap<>();
+        params.put("items", List.of("a", "b", "c"));
+        assertEquals(
+            List.of("a", "b", "c"),
+            execSourceWithCheckInstalled("List l = params['items']; state['r'] = l.stream().collect(Collectors.toList());", params)
+        );
+        assertEquals(
+            3L,
+            execSourceWithCheckInstalled("List l = params['items']; state['r'] = l.stream().collect(Collectors.counting());", params)
+        );
+        assertEquals(
+            "a,b,c",
+            execSourceWithCheckInstalled("List l = params['items']; state['r'] = l.stream().collect(Collectors.joining(','));", params)
+        );
+    }
+
+    /** A {@code def}-typed stream receiver dispatches the collector wrapper through {@code Def.lookupMethod}; pin its output. */
+    public void testStreamCollectCollectorDefReceiverMatchesExpectedOutput() {
+        Map<String, Object> params = new HashMap<>();
+        params.put("items", List.of("a", "b", "c"));
+        assertEquals(List.of("a", "b", "c"), execWithCheckInstalled("params['items'].stream().collect(Collectors.toList())", params));
     }
 }

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/AugmentationCancellationTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/AugmentationCancellationTests.java
@@ -936,10 +936,59 @@ public class AugmentationCancellationTests extends ScriptTestCase {
         );
     }
 
+    /** {@code PrimitiveIterator.OfInt.forEachRemaining} visits every element and must poll. */
+    public void testIntPrimitiveIteratorForEachRemainingAugmentationFiresCancelRunnable() {
+        assertFires(
+            compileFillThen("", "big.stream().mapToInt(x -> x).iterator().forEachRemaining(x -> x);"),
+            "cancelled-int-primitiveiterator-foreachremaining"
+        );
+    }
+
+    /** {@code PrimitiveIterator.OfLong.forEachRemaining} visits every element and must poll. */
+    public void testLongPrimitiveIteratorForEachRemainingAugmentationFiresCancelRunnable() {
+        assertFires(
+            compileFillThen("", "big.stream().mapToLong(x -> x).iterator().forEachRemaining(x -> x);"),
+            "cancelled-long-primitiveiterator-foreachremaining"
+        );
+    }
+
+    /** {@code PrimitiveIterator.OfDouble.forEachRemaining} visits every element and must poll. */
+    public void testDoublePrimitiveIteratorForEachRemainingAugmentationFiresCancelRunnable() {
+        assertFires(
+            compileFillThen("", "big.stream().mapToDouble(x -> x).iterator().forEachRemaining(x -> x);"),
+            "cancelled-double-primitiveiterator-foreachremaining"
+        );
+    }
+
+    /** {@code Spliterator.OfInt.forEachRemaining} visits every element and must poll. */
+    public void testIntSpliteratorForEachRemainingAugmentationFiresCancelRunnable() {
+        assertFires(
+            compileFillThen("", "big.stream().mapToInt(x -> x).spliterator().forEachRemaining(x -> x);"),
+            "cancelled-int-spliterator-foreachremaining"
+        );
+    }
+
+    /** {@code Spliterator.OfLong.forEachRemaining} visits every element and must poll. */
+    public void testLongSpliteratorForEachRemainingAugmentationFiresCancelRunnable() {
+        assertFires(
+            compileFillThen("", "big.stream().mapToLong(x -> x).spliterator().forEachRemaining(x -> x);"),
+            "cancelled-long-spliterator-foreachremaining"
+        );
+    }
+
+    /** {@code Spliterator.OfDouble.forEachRemaining} visits every element and must poll. */
+    public void testDoubleSpliteratorForEachRemainingAugmentationFiresCancelRunnable() {
+        assertFires(
+            compileFillThen("", "big.stream().mapToDouble(x -> x).spliterator().forEachRemaining(x -> x);"),
+            "cancelled-double-spliterator-foreachremaining"
+        );
+    }
+
     /**
      * Each new native-wrapper script-aware augmentation must take the no-poll fast path when the
-     * script has no cancellation check installed.  Exercises all seven native wrappers (Iterable,
-     * Collection, Iterator, List, Map x2, Spliterator) in one script execution.
+     * script has no cancellation check installed.  Exercises all native wrappers (Iterable,
+     * Collection, Iterator, List, Map x2, Spliterator, and the six primitive iterator/spliterator
+     * variants) in one script execution.
      */
     public void testNativeWrapperAugmentationsNoRunnable() {
         ScriptedMetricAggContexts.InitScript script = compileFillThen(
@@ -950,7 +999,13 @@ public class AugmentationCancellationTests extends ScriptTestCase {
                 + "big.replaceAll(x -> x); "
                 + "Map m = newMap(); m.forEach((k, v) -> v.toString()); "
                 + "Map m2 = newMap(); m2.replaceAll((k, v) -> v); "
-                + "big.spliterator().forEachRemaining(x -> x.toString());"
+                + "big.spliterator().forEachRemaining(x -> x.toString()); "
+                + "big.stream().mapToInt(x -> x).iterator().forEachRemaining(x -> x); "
+                + "big.stream().mapToLong(x -> x).iterator().forEachRemaining(x -> x); "
+                + "big.stream().mapToDouble(x -> x).iterator().forEachRemaining(x -> x); "
+                + "big.stream().mapToInt(x -> x).spliterator().forEachRemaining(x -> x); "
+                + "big.stream().mapToLong(x -> x).spliterator().forEachRemaining(x -> x); "
+                + "big.stream().mapToDouble(x -> x).spliterator().forEachRemaining(x -> x);"
         );
         // No runnable set — _getCancellationCheck() returns null; fast paths must not throw.
         script.execute();

--- a/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/95_script_cancellation.yml
+++ b/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/95_script_cancellation.yml
@@ -2594,3 +2594,38 @@
                   return true;
   - is_true: timed_out
 
+---
+"Search timeout aborts a long-running Stream collect(Collector) augmentation loop":
+  - do:
+      indices.create:
+        index: test_stream_collect_collector_augmentation_timeout
+        body:
+          settings:
+            number_of_shards: 1
+  - do:
+      index:
+        index: test_stream_collect_collector_augmentation_timeout
+        id: d1
+        body: {"val": 1}
+  - do:
+      indices.refresh: {}
+
+  # The @script_aware Stream.collect(Collector) rebuilds the collector so its accumulator polls once
+  # per element.  Build a 50k list once, then run stream().collect(Collectors.toList()) inside an outer
+  # for loop ~1000 times so the per-element polling adds up past the 100 ms budget.
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: test_stream_collect_collector_augmentation_timeout
+        timeout: 100ms
+        body:
+          query:
+            script:
+              script:
+                source: |
+                  List a = new ArrayList();
+                  for (int i = 0; i < 50000; i++) { a.add(i); }
+                  for (int j = 0; j < 1000; j++) { a.stream().collect(Collectors.toList()); }
+                  return true;
+  - is_true: timed_out
+

--- a/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/95_script_cancellation.yml
+++ b/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/95_script_cancellation.yml
@@ -2629,3 +2629,205 @@
                   return true;
   - is_true: timed_out
 
+---
+"Search timeout aborts a long-running PrimitiveIterator.OfInt forEachRemaining augmentation loop":
+  - do:
+      indices.create:
+        index: test_int_primitiveiterator_foreachremaining_augmentation_timeout
+        body:
+          settings:
+            number_of_shards: 1
+  - do:
+      index:
+        index: test_int_primitiveiterator_foreachremaining_augmentation_timeout
+        id: d1
+        body: {"val": 1}
+  - do:
+      indices.refresh: {}
+
+  # The @script_aware PrimitiveIterator.OfInt.forEachRemaining walks the iterator polling once per
+  # element.  Build a 50k list once, then drive a fresh int iterator ~1000 times so the per-element
+  # polling adds up past the 100 ms budget.
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: test_int_primitiveiterator_foreachremaining_augmentation_timeout
+        timeout: 100ms
+        body:
+          query:
+            script:
+              script:
+                source: |
+                  List a = new ArrayList();
+                  for (int i = 0; i < 50000; i++) { a.add(i); }
+                  for (int j = 0; j < 1000; j++) { a.stream().mapToInt(y -> y).iterator().forEachRemaining(z -> z); }
+                  return true;
+  - is_true: timed_out
+
+---
+"Search timeout aborts a long-running PrimitiveIterator.OfLong forEachRemaining augmentation loop":
+  - do:
+      indices.create:
+        index: test_long_primitiveiterator_foreachremaining_augmentation_timeout
+        body:
+          settings:
+            number_of_shards: 1
+  - do:
+      index:
+        index: test_long_primitiveiterator_foreachremaining_augmentation_timeout
+        id: d1
+        body: {"val": 1}
+  - do:
+      indices.refresh: {}
+
+  # As above for the long-valued iterator: PrimitiveIterator.OfLong.forEachRemaining polls per element.
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: test_long_primitiveiterator_foreachremaining_augmentation_timeout
+        timeout: 100ms
+        body:
+          query:
+            script:
+              script:
+                source: |
+                  List a = new ArrayList();
+                  for (int i = 0; i < 50000; i++) { a.add(i); }
+                  for (int j = 0; j < 1000; j++) { a.stream().mapToLong(y -> y).iterator().forEachRemaining(z -> z); }
+                  return true;
+  - is_true: timed_out
+
+---
+"Search timeout aborts a long-running PrimitiveIterator.OfDouble forEachRemaining augmentation loop":
+  - do:
+      indices.create:
+        index: test_double_primitiveiterator_foreachremaining_augmentation_timeout
+        body:
+          settings:
+            number_of_shards: 1
+  - do:
+      index:
+        index: test_double_primitiveiterator_foreachremaining_augmentation_timeout
+        id: d1
+        body: {"val": 1}
+  - do:
+      indices.refresh: {}
+
+  # As above for the double-valued iterator: PrimitiveIterator.OfDouble.forEachRemaining polls per element.
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: test_double_primitiveiterator_foreachremaining_augmentation_timeout
+        timeout: 100ms
+        body:
+          query:
+            script:
+              script:
+                source: |
+                  List a = new ArrayList();
+                  for (int i = 0; i < 50000; i++) { a.add(i); }
+                  for (int j = 0; j < 1000; j++) { a.stream().mapToDouble(y -> y).iterator().forEachRemaining(z -> z); }
+                  return true;
+  - is_true: timed_out
+
+---
+"Search timeout aborts a long-running Spliterator.OfInt forEachRemaining augmentation loop":
+  - do:
+      indices.create:
+        index: test_int_spliterator_foreachremaining_augmentation_timeout
+        body:
+          settings:
+            number_of_shards: 1
+  - do:
+      index:
+        index: test_int_spliterator_foreachremaining_augmentation_timeout
+        id: d1
+        body: {"val": 1}
+  - do:
+      indices.refresh: {}
+
+  # The @script_aware Spliterator.OfInt.forEachRemaining drives the spliterator via tryAdvance, polling
+  # once per element.  Build a 50k list once, then drive a fresh int spliterator ~1000 times so the
+  # per-element polling adds up past the 100 ms budget.
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: test_int_spliterator_foreachremaining_augmentation_timeout
+        timeout: 100ms
+        body:
+          query:
+            script:
+              script:
+                source: |
+                  List a = new ArrayList();
+                  for (int i = 0; i < 50000; i++) { a.add(i); }
+                  for (int j = 0; j < 1000; j++) { a.stream().mapToInt(y -> y).spliterator().forEachRemaining(z -> z); }
+                  return true;
+  - is_true: timed_out
+
+---
+"Search timeout aborts a long-running Spliterator.OfLong forEachRemaining augmentation loop":
+  - do:
+      indices.create:
+        index: test_long_spliterator_foreachremaining_augmentation_timeout
+        body:
+          settings:
+            number_of_shards: 1
+  - do:
+      index:
+        index: test_long_spliterator_foreachremaining_augmentation_timeout
+        id: d1
+        body: {"val": 1}
+  - do:
+      indices.refresh: {}
+
+  # As above for the long-valued spliterator: Spliterator.OfLong.forEachRemaining polls per element.
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: test_long_spliterator_foreachremaining_augmentation_timeout
+        timeout: 100ms
+        body:
+          query:
+            script:
+              script:
+                source: |
+                  List a = new ArrayList();
+                  for (int i = 0; i < 50000; i++) { a.add(i); }
+                  for (int j = 0; j < 1000; j++) { a.stream().mapToLong(y -> y).spliterator().forEachRemaining(z -> z); }
+                  return true;
+  - is_true: timed_out
+
+---
+"Search timeout aborts a long-running Spliterator.OfDouble forEachRemaining augmentation loop":
+  - do:
+      indices.create:
+        index: test_double_spliterator_foreachremaining_augmentation_timeout
+        body:
+          settings:
+            number_of_shards: 1
+  - do:
+      index:
+        index: test_double_spliterator_foreachremaining_augmentation_timeout
+        id: d1
+        body: {"val": 1}
+  - do:
+      indices.refresh: {}
+
+  # As above for the double-valued spliterator: Spliterator.OfDouble.forEachRemaining polls per element.
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: test_double_spliterator_foreachremaining_augmentation_timeout
+        timeout: 100ms
+        body:
+          query:
+            script:
+              script:
+                source: |
+                  List a = new ArrayList();
+                  for (int i = 0; i < 50000; i++) { a.add(i); }
+                  for (int j = 0; j < 1000; j++) { a.stream().mapToDouble(y -> y).spliterator().forEachRemaining(z -> z); }
+                  return true;
+  - is_true: timed_out
+

--- a/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/95_script_cancellation.yml
+++ b/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/95_script_cancellation.yml
@@ -2645,9 +2645,10 @@
   - do:
       indices.refresh: {}
 
-  # The @script_aware PrimitiveIterator.OfInt.forEachRemaining walks the iterator polling once per
-  # element.  Build a 50k list once, then drive a fresh int iterator ~1000 times so the per-element
-  # polling adds up past the 100 ms budget.
+  # The @script_aware PrimitiveIterator.OfInt.forEachRemaining polls once per element.  Build a 50k
+  # list once, then drive a fresh int iterator in a loop with a high bound so the trivial-body
+  # iteration cannot complete before the 100 ms budget regardless of machine speed; the loop aborts
+  # as soon as the timeout fires, so the bound only provides headroom.
   - do:
       search:
         rest_total_hits_as_int: true
@@ -2660,7 +2661,7 @@
                 source: |
                   List a = new ArrayList();
                   for (int i = 0; i < 50000; i++) { a.add(i); }
-                  for (int j = 0; j < 1000; j++) { a.stream().mapToInt(y -> y).iterator().forEachRemaining(z -> z); }
+                  for (int j = 0; j < 999999; j++) { a.stream().mapToInt(y -> y).iterator().forEachRemaining(z -> z); }
                   return true;
   - is_true: timed_out
 
@@ -2693,7 +2694,7 @@
                 source: |
                   List a = new ArrayList();
                   for (int i = 0; i < 50000; i++) { a.add(i); }
-                  for (int j = 0; j < 1000; j++) { a.stream().mapToLong(y -> y).iterator().forEachRemaining(z -> z); }
+                  for (int j = 0; j < 999999; j++) { a.stream().mapToLong(y -> y).iterator().forEachRemaining(z -> z); }
                   return true;
   - is_true: timed_out
 
@@ -2726,7 +2727,7 @@
                 source: |
                   List a = new ArrayList();
                   for (int i = 0; i < 50000; i++) { a.add(i); }
-                  for (int j = 0; j < 1000; j++) { a.stream().mapToDouble(y -> y).iterator().forEachRemaining(z -> z); }
+                  for (int j = 0; j < 999999; j++) { a.stream().mapToDouble(y -> y).iterator().forEachRemaining(z -> z); }
                   return true;
   - is_true: timed_out
 
@@ -2761,7 +2762,7 @@
                 source: |
                   List a = new ArrayList();
                   for (int i = 0; i < 50000; i++) { a.add(i); }
-                  for (int j = 0; j < 1000; j++) { a.stream().mapToInt(y -> y).spliterator().forEachRemaining(z -> z); }
+                  for (int j = 0; j < 999999; j++) { a.stream().mapToInt(y -> y).spliterator().forEachRemaining(z -> z); }
                   return true;
   - is_true: timed_out
 
@@ -2794,7 +2795,7 @@
                 source: |
                   List a = new ArrayList();
                   for (int i = 0; i < 50000; i++) { a.add(i); }
-                  for (int j = 0; j < 1000; j++) { a.stream().mapToLong(y -> y).spliterator().forEachRemaining(z -> z); }
+                  for (int j = 0; j < 999999; j++) { a.stream().mapToLong(y -> y).spliterator().forEachRemaining(z -> z); }
                   return true;
   - is_true: timed_out
 
@@ -2827,7 +2828,7 @@
                 source: |
                   List a = new ArrayList();
                   for (int i = 0; i < 50000; i++) { a.add(i); }
-                  for (int j = 0; j < 1000; j++) { a.stream().mapToDouble(y -> y).spliterator().forEachRemaining(z -> z); }
+                  for (int j = 0; j < 999999; j++) { a.stream().mapToDouble(y -> y).spliterator().forEachRemaining(z -> z); }
                   return true;
   - is_true: timed_out
 


### PR DESCRIPTION
Makes `Stream.collect(Collector)` `@script_aware`. This closes the gap where a pipeline ending in `.collect(Collectors.toList())` over a large/expensive stream had no poll point and could escape the search timeout, even though `forEach`/`reduce`/the 3-arg `collect` were already covered.

Adds `@script_aware` wrappers for `forEachRemaining` on the primitive `PrimitiveIterator` and `Spliterator` subtypes (`OfInt`, `OfLong`, `OfDouble`).