### PR TITLE
ESQL: auto-test FIELD_EXTRACT in more cases

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/categorize.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/categorize.csv-spec
@@ -616,6 +616,7 @@ COUNT():long | x:keyword
 ;
 
 categorize in aggs same as grouping inside function
+skip_flattened_rewrite: categorize_on_flattened_unsupported
 required_capability: categorize_v6
 
 FROM sample_data
@@ -631,6 +632,7 @@ COUNT():long | x:keyword
 ;
 
 categorize in aggs same as grouping inside function with explicit alias
+skip_flattened_rewrite: categorize_on_flattened_unsupported
 required_capability: categorize_v6
 
 FROM sample_data
@@ -678,6 +680,7 @@ count:long | category:keyword         | timestamp:datetime
 
 
 multiple groupings with categorize and limit before stats
+skip_flattened_rewrite: categorize_on_flattened_unsupported
 required_capability: categorize_multiple_groupings
 
 FROM sample_data | SORT message | LIMIT 5

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/enrich.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/enrich.csv-spec
@@ -668,6 +668,7 @@ Fyodor Dostoevsky     |1211           |null             |null          |null    
 
 
 statsAfterRemoteEnrich
+skip_flattened_rewrite: enrich_output_type_mismatch
 required_capability: enrich_load
 
 FROM sample_data
@@ -684,6 +685,7 @@ messages:long | language_name:keyword
 
 
 enrichAfterRemoteEnrich
+skip_flattened_rewrite: enrich_output_type_mismatch
 required_capability: enrich_load
 
 FROM sample_data
@@ -701,6 +703,7 @@ Connected to 10.1.0.1 | 1                     | English                     | En
 
 
 coordinatorEnrichAfterRemoteEnrich
+skip_flattened_rewrite: enrich_output_type_mismatch
 required_capability: enrich_load
 
 FROM sample_data
@@ -718,6 +721,7 @@ Connected to 10.1.0.1 | 1                     | English                     | En
 
 
 doubleRemoteEnrich
+skip_flattened_rewrite: enrich_output_type_mismatch
 required_capability: enrich_load
 
 FROM sample_data
@@ -735,6 +739,7 @@ Connected to 10.1.0.1 | 1                     | English                     | En
 
 
 enrichAfterCoordinatorEnrich
+skip_flattened_rewrite: enrich_output_type_mismatch
 required_capability: enrich_load
 
 FROM sample_data
@@ -752,6 +757,7 @@ Connected to 10.1.0.1 | 1                     | English                     | En
 
 
 doubleCoordinatorEnrich
+skip_flattened_rewrite: enrich_output_type_mismatch
 required_capability: enrich_load
 
 FROM sample_data

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/in_subquery.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/in_subquery.csv-spec
@@ -645,6 +645,7 @@ emp_no:integer | first_name:keyword | language_name:keyword
 ;
 
 enrichBeforeInSubquery
+skip_flattened_rewrite: enrich_output_type_mismatch
 required_capability: where_in_subquery_without_view
 
 FROM employees
@@ -664,6 +665,7 @@ emp_no:integer | language_name:keyword
 ;
 
 enrichInsideInSubquery
+skip_flattened_rewrite: enrich_output_type_mismatch
 required_capability: where_in_subquery_without_view
 
 FROM employees
@@ -687,6 +689,7 @@ emp_no:integer | first_name:keyword | languages:integer
 ;
 
 enrichInsideNotInSubquery
+skip_flattened_rewrite: enrich_output_type_mismatch
 required_capability: where_in_subquery_without_view
 
 FROM employees
@@ -710,6 +713,7 @@ emp_no:integer | first_name:keyword | languages:integer
 ;
 
 enrichAfterNotInSubquery
+skip_flattened_rewrite: enrich_output_type_mismatch
 required_capability: where_in_subquery_without_view
 
 FROM employees

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/inlinestats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/inlinestats.csv-spec
@@ -3247,6 +3247,7 @@ count:long
 ;
 
 multiIndexTsLongInlinestatsInline2
+skip_flattened_rewrite: inline_stats_multi_index_column_mismatch
 required_capability: inline_stats
 
 FROM sample_data, sample_data_ts_long, sample_data_ts_nanos
@@ -4632,6 +4633,7 @@ emp_idx:integer|salary:integer |sum:long       |languages:integer
 ;
 
 inlineStatsAfterEnrichAndSort
+skip_flattened_rewrite: enrich_output_type_mismatch
 required_capability: inline_stats_preceeded_by_sort
 required_capability: enrich_load
 

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/lookup-join.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/lookup-join.csv-spec
@@ -1127,6 +1127,7 @@ ignoreOrder:true
 ;
 
 lookupIPFromIndexKeepKeep
+skip_flattened_rewrite: enrich_output_type_mismatch
 required_capability: join_lookup_v12
 
 FROM sample_data
@@ -5045,6 +5046,7 @@ Connected to 10.1.0.1 | 1                     | English               | Success
 
 
 lookupJoinAfterLimitAndRemoteEnrich
+skip_flattened_rewrite: enrich_output_type_mismatch
 required_capability: join_lookup_v12
 
 FROM sample_data
@@ -5068,6 +5070,7 @@ Connected to 10.1.0.1 | English                      | null                  | U
 
 
 lookupJoinAfterTopNAndRemoteEnrich
+skip_flattened_rewrite: enrich_output_type_mismatch
 required_capability: join_lookup_v12
 
 FROM sample_data

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
@@ -965,6 +965,7 @@ c:l | gender:s | b:s
 ;
 
 countSameFieldWithEnrich
+skip_flattened_rewrite: enrich_output_type_mismatch
 required_capability: fixed_pushdown_past_project
 required_capability: enrich_load
 from employees | stats  b = count(gender), c = count(gender) by gender | enrich languages_policy on gender with b = language_name | sort c asc
@@ -977,6 +978,7 @@ c:l | gender:s | b:s
 ;
 
 countSameFieldWithEnrichLimit0
+skip_flattened_rewrite: enrich_output_type_mismatch
 required_capability: fixed_pushdown_past_project
 from employees | stats  b = count(gender), c = count(gender) by gender | enrich languages_policy on gender with b = language_name | sort c asc | limit 0
 ;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/union_types.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/union_types.csv-spec
@@ -1561,6 +1561,7 @@ FROM sample_data, sample_data_ts_long
 ;
 
 multiIndexIndirectUseOfUnionTypesInEnrich
+skip_flattened_rewrite: enrich_output_type_mismatch
 required_capability: union_types
 required_capability: enrich_load
 FROM sample_data, sample_data_ts_long

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/unmapped-load.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/unmapped-load.csv-spec
@@ -83,6 +83,7 @@ FROM partial_mapping_sample_data
 ;
 
 doesNotLoadUnmappedFieldsEnrich
+skip_flattened_rewrite: enrich_output_type_mismatch
 required_capability: optional_fields_v5
 required_capability: enrich_load
 

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/unmapped_fields.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/unmapped_fields.csv-spec
@@ -411,6 +411,7 @@ sample_data_ts_long | 42
 ;
 
 fieldIsPartiallyUnmappedMultiIndex
+skip_flattened_rewrite: insist_on_flattened_unsupported
 required_capability: index_metadata_field
 required_capability: unmapped_fields
 FROM sample_data, no_mapping_sample_data METADATA _index
@@ -437,6 +438,7 @@ sample_data            | Connected to 10.1.0.1
 ;
 
 fieldIsPartiallyUnmappedAndRenamedMultiIndex
+skip_flattened_rewrite: insist_on_flattened_unsupported
 required_capability: unmapped_fields
 FROM sample_data, no_mapping_sample_data
 | INSIST_🐔 message
@@ -463,6 +465,7 @@ Connected to 10.1.0.1
 ;
 
 fieldIsPartiallyUnmappedPartiallySourceIsDisabledMultiIndex
+skip_flattened_rewrite: insist_on_flattened_unsupported
 required_capability: index_metadata_field
 required_capability: source_field_mapping
 required_capability: unmapped_fields
@@ -490,6 +493,7 @@ partial_mapping_sample_data           | 2024-10-23T13:55:01.543Z | Connected to 
 ;
 
 partialMappingStats
+skip_flattened_rewrite: partial_mapping_field_extract_conflict
 required_capability: index_metadata_field
 required_capability: source_field_mapping
 required_capability: unmapped_fields
@@ -509,6 +513,7 @@ max(@timestamp):date     | count(*):long | message:keyword
 ;
 
 partialMappingCoalesce
+skip_flattened_rewrite: partial_mapping_field_extract_conflict
 required_capability: index_metadata_field
 required_capability: source_field_mapping
 required_capability: unmapped_fields
@@ -538,6 +543,7 @@ FROM partial_mapping_sample_data,partial_mapping_excluded_source_sample_data MET
 ;
 
 partialMappingUnionTypes
+skip_flattened_rewrite: partial_mapping_field_extract_conflict
 required_capability: index_metadata_field
 required_capability: source_field_mapping
 required_capability: unmapped_fields
@@ -566,6 +572,7 @@ FROM partial_mapping_sample_data,partial_mapping_excluded_source_sample_data MET
 ;
 
 partialMappingStatsAfterCast
+skip_flattened_rewrite: partial_mapping_field_extract_conflict
 required_capability: index_metadata_field
 required_capability: source_field_mapping
 required_capability: unmapped_fields

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/views.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/views.csv-spec
@@ -337,6 +337,7 @@ HOD            | Al Ḩudaydah  | POINT (42.951100 14.802200) | Yemen           
 ;
 
 airportsLookupJoinViewAirports
+skip_flattened_rewrite: lookup_join_in_view_flattened_source
 required_capability: join_lookup_v12
 required_capability: lookup_join_on_boolean_expression
 required_capability: views_with_branching
@@ -353,6 +354,7 @@ LUH            | Ludhiāna     | POINT (75.850000 30.910000) | India           |
 ;
 
 airportsLookupJoinViewAirportsStats
+skip_flattened_rewrite: lookup_join_in_view_flattened_source
 required_capability: join_lookup_v12
 required_capability: lookup_join_on_boolean_expression
 required_capability: views_with_branching
@@ -375,6 +377,7 @@ count:long | duplications:long
 ;
 
 airportsLookupJoinViewAirportsStatsValues
+skip_flattened_rewrite: lookup_join_in_view_flattened_source
 required_capability: join_lookup_v12
 required_capability: lookup_join_on_boolean_expression
 required_capability: views_with_branching

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvFlattenedKeywordIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvFlattenedKeywordIT.java
@@ -739,7 +739,7 @@ public class CsvFlattenedKeywordIT extends CsvIT {
                         + "the unmodified spec already covers this behavior"
                 );
             }
-            // Check 1: LOOKUP JOIN source-side type mismatch.
+            // LOOKUP JOIN phase 1 - source-side type mismatch.
             // If a LOOKUP JOIN field is keyword-protected in the target (KEYWORD) but
             // converted to flattened in a FROM-source dataset, executing the join would
             // raise a type-incompatibility error. Detect and skip now so the test does
@@ -786,7 +786,7 @@ public class CsvFlattenedKeywordIT extends CsvIT {
                     }
                 }
             }
-            // Check 2: cross-dataset type conflict.
+            // Lookup join phase 2 - cross-dataset type conflict.
             // If a field is converted to flattened in one FROM-source dataset but is a
             // different, non-keyword type in another FROM-source dataset, executing the
             // query either raises a VerificationException or produces wrong results because

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvFlattenedKeywordIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvFlattenedKeywordIT.java
@@ -274,13 +274,13 @@ public class CsvFlattenedKeywordIT extends CsvIT {
      *             {@code RuntimeException: Resource loading failure}. Excluding the match field
      *             at the source keeps the policy load deterministic.</li>
      *         <li>For every {@code LOOKUP JOIN ... ON &lt;field&gt;} clause in any csv-spec test
-     *             query, the join attribute is added to every dataset that participates in the
-     *             query (the lookup target itself plus every {@code FROM}/{@code TS} source).
-     *             Both sides of the join must remain {@code keyword}: if only one side were
-     *             converted to {@code flattened} the analyzer would reject the join with
-     *             {@code KEYWORD vs FLATTENED} type-mismatch, and even with both sides flattened
-     *             the engine refuses
-     *             {@code JOIN with right field [...] of type [FLATTENED] is not supported}.</li>
+     *             query, the join attribute is added to the <em>lookup target index only</em>.
+     *             The target must remain {@code keyword} because the engine refuses
+     *             {@code JOIN with right field [...] of type [FLATTENED] is not supported}.
+     *             {@code FROM}-source datasets are no longer excluded here: the cross-dataset
+     *             intersection in {@link #resolveKeywordPathsForQuery} already removes the join
+     *             key from the rewrite scope for any query that references the lookup target,
+     *             so converting the source side to {@code flattened} is safe.</li>
      *       </ol>
      *   </li>
      *   <li>{@code keywordPathsByDatasetIndexName} &mdash; the keyword paths that
@@ -313,11 +313,12 @@ public class CsvFlattenedKeywordIT extends CsvIT {
          *       field as keyword so the policy reindex into {@code .enrich-*} succeeds, and</li>
          *   <li>{@code LOOKUP JOIN ... ON ...} attributes (per
          *       {@link #computeLookupJoinFieldExclusions}) &mdash; keeps the join key as keyword
-         *       on every dataset that participates in any csv-spec {@code LOOKUP JOIN}, on
-         *       <em>both</em> sides of the join, so neither the
-         *       {@code KEYWORD vs FLATTENED} type-mismatch error nor the
-         *       {@code JOIN with right field of type [FLATTENED] is not supported} error fires
-         *       on any csv-spec query that uses the join.</li>
+         *       on the <em>lookup target index only</em>, preventing the
+         *       {@code JOIN with right field of type [FLATTENED] is not supported} error.
+         *       {@code FROM}-source datasets are excluded from this set; the cross-dataset
+         *       intersection in {@link #resolveKeywordPathsForQuery} already removes the join
+         *       key from the rewrite scope for those queries, so no explicit exclusion is
+         *       needed on the source side.</li>
          * </ul>
          */
         private final Map<String, Set<String>> protectedKeywordPathsByDatasetIndexName;
@@ -497,9 +498,11 @@ public class CsvFlattenedKeywordIT extends CsvIT {
          * {@code (sourceIndex, field)} pair is emitted only once even if many queries mention it,
          * so the logger does not double-count multi-use fields.
          *
-         * @param sourceIndex the dataset whose mapping will keep {@code field} as {@code keyword}
-         *                    (either the lookup-target or a {@code FROM} side of any csv-spec
-         *                    query that uses {@code field} as a {@code LOOKUP JOIN} key)
+         * @param sourceIndex the lookup-target dataset whose mapping will keep {@code field} as
+         *                    {@code keyword}; {@code FROM}-source datasets are no longer included
+         *                    here because the cross-dataset intersection in
+         *                    {@link #resolveKeywordPathsForQuery} already prevents the join key
+         *                    from entering the rewrite scope for queries that reference this target
          * @param field       the dotted field path that must remain {@code keyword} in
          *                    {@code sourceIndex}
          * @param target      the lookup-target index where {@code field} is the join key &mdash;
@@ -523,14 +526,12 @@ public class CsvFlattenedKeywordIT extends CsvIT {
          * {@code LOOKUP JOIN &lt;target&gt; ON &lt;body&gt;} clause via
          * {@link EsqlQueryDatasetResolver#extractLookupJoinTargets}, and returns both
          * <ol>
-         *   <li>a by-source-index map that adds each join attribute to <em>every</em> dataset the
-         *       query touches (the lookup target itself plus every {@code FROM}/{@code TS} index
-         *       resolved by {@link EsqlQueryDatasetResolver#resolveDatasetsForQuery}). Both sides
-         *       must be kept as {@code keyword}: if only the right side were converted to
-         *       {@code flattened} the analyzer would reject the join with
-         *       {@code JOIN left field [...] of type [KEYWORD] is incompatible with right field
-         *       [...] of type [FLATTENED]}, and even if both sides were flattened the engine
-         *       refuses {@code JOIN with right field [...] of type [FLATTENED] is not supported}.</li>
+         *   <li>a by-source-index map that adds each join attribute to the <em>lookup target
+         *       index only</em>. The target must stay {@code keyword} because the engine refuses
+         *       {@code JOIN with right field [...] of type [FLATTENED] is not supported}.
+         *       {@code FROM}-source datasets are excluded: the cross-dataset intersection in
+         *       {@link #resolveKeywordPathsForQuery} already removes the join key from the
+         *       rewrite scope for any query that references the lookup target.</li>
          *   <li>a per-{@code (sourceIndex, field, target)} list deduplicated to one entry per
          *       triple, used by the startup logger to surface every exclusion the variant
          *       installed.</li>
@@ -552,22 +553,19 @@ public class CsvFlattenedKeywordIT extends CsvIT {
                 if (targets.isEmpty()) {
                     continue;
                 }
-                Set<CsvTestsDataLoader.TestDataset> participants = EsqlQueryDatasetResolver.resolveDatasetsForQuery(
-                    query,
-                    CsvTestsDataLoader.CSV_DATASET
-                );
                 for (Map.Entry<String, Set<String>> targetEntry : targets.entrySet()) {
                     String targetIndex = targetEntry.getKey();
                     Set<String> fields = targetEntry.getValue();
+                    CsvTestsDataLoader.TestDataset targetDataset = CsvTestsDataLoader.CSV_DATASET.get(targetIndex);
+                    if (targetDataset == null) {
+                        continue;
+                    }
                     for (String field : fields) {
-                        for (CsvTestsDataLoader.TestDataset participant : participants) {
-                            String participantIndex = participant.indexName();
-                            exclusionsByIndex.computeIfAbsent(participantIndex, k -> new HashSet<>()).add(field);
-                            uniqueExclusions.putIfAbsent(
-                                participantIndex + "\0" + field + "\0" + targetIndex,
-                                new LookupJoinFieldExclusion(participantIndex, field, targetIndex)
-                            );
-                        }
+                        exclusionsByIndex.computeIfAbsent(targetDataset.indexName(), k -> new HashSet<>()).add(field);
+                        uniqueExclusions.putIfAbsent(
+                            targetDataset.indexName() + "\0" + field + "\0" + targetIndex,
+                            new LookupJoinFieldExclusion(targetDataset.indexName(), field, targetIndex)
+                        );
                     }
                 }
             }
@@ -740,6 +738,102 @@ public class CsvFlattenedKeywordIT extends CsvIT {
                         + "where ES|QL accepts only a bare attribute and field_extract cannot be substituted; "
                         + "the unmodified spec already covers this behavior"
                 );
+            }
+            // Check 1: LOOKUP JOIN source-side type mismatch.
+            // If a LOOKUP JOIN field is keyword-protected in the target (KEYWORD) but
+            // converted to flattened in a FROM-source dataset, executing the join would
+            // raise a type-incompatibility error. Detect and skip now so the test does
+            // not launch a query that will fail for a structural reason unrelated to
+            // field_extract coverage.
+            Map<String, Set<String>> lookupJoinTargets = EsqlQueryDatasetResolver.extractLookupJoinTargets(originalQuery);
+            Set<CsvTestsDataLoader.TestDataset> allQueryDatasets = EsqlQueryDatasetResolver.resolveDatasetsForQuery(
+                originalQuery,
+                CsvTestsDataLoader.CSV_DATASET
+            );
+            if (lookupJoinTargets.isEmpty() == false) {
+                for (Map.Entry<String, Set<String>> targetEntry : lookupJoinTargets.entrySet()) {
+                    String targetIndex = targetEntry.getKey();
+                    Set<String> joinFields = targetEntry.getValue();
+                    Set<String> protectedInTarget = protectedKeywordPathsByDatasetIndexName.getOrDefault(targetIndex, Set.of());
+                    for (String field : joinFields) {
+                        if (protectedInTarget.contains(field) == false) {
+                            continue;
+                        }
+                        for (CsvTestsDataLoader.TestDataset ds : allQueryDatasets) {
+                            if (lookupJoinTargets.containsKey(ds.indexName())) {
+                                continue;
+                            }
+                            if (keywordPathsByDatasetIndexName.getOrDefault(ds.indexName(), Set.of()).contains(field)) {
+                                SILENCED_COUNTS_BY_REASON.computeIfAbsent("lookup_join_source_flattened", k -> new AtomicInteger())
+                                    .incrementAndGet();
+                                logger.info(
+                                    "keyword→flattened: skipping; JOIN field [{}] FLATTENED in source [{}] but KEYWORD in target [{}]",
+                                    field,
+                                    ds.indexName(),
+                                    targetIndex
+                                );
+                                throw new StacklessAssumptionViolatedException(
+                                    "skipping: LOOKUP JOIN field ["
+                                        + field
+                                        + "] is FLATTENED in FROM-source ["
+                                        + ds.indexName()
+                                        + "] but KEYWORD in target ["
+                                        + targetIndex
+                                        + "]"
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+            // Check 2: cross-dataset type conflict.
+            // If a field is converted to flattened in one FROM-source dataset but is a
+            // different, non-keyword type in another FROM-source dataset, executing the
+            // query either raises a VerificationException or produces wrong results because
+            // scalar functions on an unwrapped flattened field return null. Detect and skip
+            // now to avoid spurious failures unrelated to field_extract coverage.
+            {
+                List<CsvTestsDataLoader.TestDataset> sourceDatasets = new ArrayList<>();
+                for (CsvTestsDataLoader.TestDataset d : allQueryDatasets) {
+                    if (lookupJoinTargets.containsKey(d.indexName()) == false) {
+                        sourceDatasets.add(d);
+                    }
+                }
+                for (int i = 0; i < sourceDatasets.size(); i++) {
+                    CsvTestsDataLoader.TestDataset d1 = sourceDatasets.get(i);
+                    Set<String> flattenedInD1 = keywordPathsByDatasetIndexName.getOrDefault(d1.indexName(), Set.of());
+                    if (flattenedInD1.isEmpty()) {
+                        continue;
+                    }
+                    for (int j = 0; j < sourceDatasets.size(); j++) {
+                        if (i == j) {
+                            continue;
+                        }
+                        CsvTestsDataLoader.TestDataset d2 = sourceDatasets.get(j);
+                        Set<String> nonKeywordInD2 = nonKeywordPathsByDatasetIndexName.getOrDefault(d2.indexName(), Set.of());
+                        for (String field : flattenedInD1) {
+                            if (nonKeywordInD2.contains(field)) {
+                                SILENCED_COUNTS_BY_REASON.computeIfAbsent("cross_index_type_conflict", k -> new AtomicInteger())
+                                    .incrementAndGet();
+                                logger.info(
+                                    "keyword→flattened: skipping; field [{}] FLATTENED in [{}] but non-keyword type in [{}]",
+                                    field,
+                                    d1.indexName(),
+                                    d2.indexName()
+                                );
+                                throw new StacklessAssumptionViolatedException(
+                                    "skipping: field ["
+                                        + field
+                                        + "] is FLATTENED in ["
+                                        + d1.indexName()
+                                        + "] but a different non-keyword type in ["
+                                        + d2.indexName()
+                                        + "]"
+                                );
+                            }
+                        }
+                    }
+                }
             }
             // The short "launched" marker is emitted unconditionally so that every launched test has a single,
             // grep-able log line tying the test method (from the JUnit thread context) to the set of fields


### PR DESCRIPTION
We disable the auto FIELD_EXTRACT tests for fields from lookup join. Previously, we'd find all of the field brought in by a lookup join and any reference to them is ignored. But! If there isn't a LOOKUP JOIN in the test at all, that doesn't make sense! That's just a field name collision. 

```
Before: 1999
 After: 2127

  The two new silencing categories are:
* cross_index_type_conflict (40)
* lookup_join_source_flattened (26)
```