### PR TITLE
Enable doc values by default for text/match_only_text fields in strictly columnar mode

### DIFF
--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
@@ -125,11 +125,15 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
 
     public static final String CONTENT_TYPE = "match_only_text";
 
-    private static final FieldMapper.DocValuesParameter.Values DEFAULT_DOC_VALUES_PARAMS = new FieldMapper.DocValuesParameter.Values(
-        false,
-        FieldMapper.DocValuesParameter.Values.Cardinality.HIGH,
-        true
-    );
+    private static FieldMapper.DocValuesParameter.Values defaultDocValuesParameters(IndexMode indexMode) {
+        return new FieldMapper.DocValuesParameter.Values(
+            // Strictly columnar indices read field values from doc values, so enable doc values by default for match_only_text in that
+            // mode.
+            indexMode.isStrictColumnar(),
+            FieldMapper.DocValuesParameter.Values.Cardinality.HIGH,
+            true
+        );
+    }
 
     public static class Defaults {
         public static final FieldType FIELD_TYPE;
@@ -149,10 +153,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
     public static class Builder extends TextFamilyBuilder {
 
         private final Parameter<Map<String, String>> meta = Parameter.metaParam();
-        private final FieldMapper.DocValuesParameter docValuesParameters = FieldMapper.DocValuesParameter.ofWithCardinality(
-            DEFAULT_DOC_VALUES_PARAMS,
-            m -> ((MatchOnlyTextFieldMapper) m).docValuesParameters
-        );
+        private final FieldMapper.DocValuesParameter docValuesParameters;
 
         private final Parameter<Boolean> indexed;
 
@@ -183,6 +184,14 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
             this.storedFieldInBinaryFormat = storedFieldInBinaryFormat;
             this.usesBinaryDocValuesForFallbackFields = usesBinaryDocValuesForFallbackFields;
             this.indexMode = indexMode;
+            this.docValuesParameters = FieldMapper.DocValuesParameter.ofWithCardinality(() -> {
+                FieldMapper.DocValuesParameter.Values defaultDocValues = defaultDocValuesParameters(indexMode);
+                // In strict-columnar mode, skip the field's own doc values when a plain keyword multi-field already stores an identical
+                // copy of the raw values, so loading and synthetic source route through that delegate instead of duplicating the column.
+                boolean enabled = defaultDocValues.enabled()
+                    && multiFieldsBuilder.hasColumnarModeCompatibleKeywordDelegate(indexMode) == false;
+                return new FieldMapper.DocValuesParameter.Values(enabled, defaultDocValues.cardinality(), defaultDocValues.multiValue());
+            }, defaultDocValuesParameters(indexMode), m -> ((MatchOnlyTextFieldMapper) m).docValuesParameters);
         }
 
         public Builder(String name, MappingParserContext context) {
@@ -265,6 +274,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
             this.offsetsFieldName = FieldArrayContext.getOffsetsFieldName(
                 context,
                 indexMode.isStrictColumnar(),
+                docValuesParameters.getValue().enabled(),
                 docValuesParameters.getValue().multiValue(),
                 this
             );
@@ -338,7 +348,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
                 true,
                 false,
                 false,
-                DEFAULT_DOC_VALUES_PARAMS
+                new FieldMapper.DocValuesParameter.Values(false, FieldMapper.DocValuesParameter.Values.Cardinality.HIGH, true)
             );
         }
 

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldBlockLoaderTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldBlockLoaderTests.java
@@ -27,10 +27,10 @@ public class MatchOnlyTextFieldBlockLoaderTests extends BinaryDVBlockLoaderTestC
 
     @Override
     protected Object expected(Map<String, Object> fieldMapping, Object value, TestContext testContext) {
-        // match_only_text only enables doc values when the single-value handler forces them on, in which case the document is
-        // single-valued; doc values come back in sorted order, which for a single value is also its source order.
-        if (hasDocValues(fieldMapping, false)) {
-            return valuesInSortedOrder(value);
+        // match_only_text enables doc values either when the single-value handler forces them on or by default in strict-columnar mode
+        boolean strictColumnar = params.indexMode().isStrictColumnar();
+        if (hasDocValues(fieldMapping, strictColumnar)) {
+            return strictColumnar ? valuesInSourceOrder(value) : valuesInSortedOrder(value);
         }
 
         // Without doc values, a genuinely synthetic source reconstructs the field from a per-field fallback. Multi fields don't get that

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapperTests.java
@@ -29,6 +29,7 @@ import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
@@ -789,6 +790,97 @@ public class MatchOnlyTextFieldMapperTests extends MapperTestCase {
                 + "index versions",
             doc.rootDoc().getFields("field.counts").isEmpty()
         );
+    }
+
+    public void testDocValuesEnabledByDefaultWhenIndexModeIsColumnar() throws IOException {
+        assumeTrue("columnar index mode requires snapshot build", IndexMode.COLUMNAR_FEATURE_FLAG.isEnabled());
+        assertDocValuesEnabledByDefaultInColumnarMode(IndexMode.COLUMNAR);
+    }
+
+    public void testDocValuesEnabledByDefaultWhenIndexModeIsColumnarLogsdb() throws IOException {
+        assumeTrue("columnar index mode requires snapshot build", IndexMode.COLUMNAR_FEATURE_FLAG.isEnabled());
+        assertDocValuesEnabledByDefaultInColumnarMode(IndexMode.LOGSDB_COLUMNAR);
+    }
+
+    private void assertDocValuesEnabledByDefaultInColumnarMode(IndexMode indexMode) throws IOException {
+        var indexSettingsBuilder = getIndexSettingsBuilder().put(IndexSettings.MODE.getKey(), indexMode.getName());
+        Settings indexSettings = indexSettingsBuilder.build();
+
+        DocumentMapper mapper = createMapperService(
+            indexSettings,
+            mapping(b -> b.startObject("field").field("type", "match_only_text").endObject())
+        ).documentMapper();
+        MatchOnlyTextFieldMapper fieldMapper = (MatchOnlyTextFieldMapper) mapper.mappers().getMapper("field");
+        MatchOnlyTextFieldMapper.MatchOnlyTextFieldType fieldType = fieldMapper.fieldType();
+
+        // Strictly columnar indices read field values from doc values, so doc values are on by default even without an explicit doc_values.
+        assertTrue(fieldType.hasDocValues());
+
+        ParsedDocument doc = mapper.parse(source(b -> {
+            b.field("@timestamp", "2024-01-01T00:00:00Z");
+            b.field("field", randomAlphanumericOfLength(10));
+        }));
+        boolean hasDocValuesField = false;
+        for (IndexableField field : doc.rootDoc().getFields("field")) {
+            if (field.fieldType().docValuesType() == DocValuesType.BINARY) {
+                hasDocValuesField = true;
+            }
+        }
+        assertTrue("Should have a doc_values field in columnar mode by default", hasDocValuesField);
+    }
+
+    public void testDocValuesDedupedAgainstPlainKeywordDelegateInColumnarMode() throws IOException {
+        assumeTrue("columnar index mode requires snapshot build", IndexMode.COLUMNAR_FEATURE_FLAG.isEnabled());
+
+        // A plain keyword multi-field (dv-backed, no normalizer/ignore_above/null_value) is a complete copy of the raw values, so the field
+        // skips its own doc values (and offsets) and loads through the delegate; the keyword's doc values are the only copy that is
+        // written.
+        assertDocValuesDedup(b -> {}, false);
+        // null_value on the keyword delegate substitutes values, so the keyword copy is not byte-identical and the field keeps its own.
+        assertDocValuesDedup(b -> b.field("null_value", "NULL"), true);
+        // ignore_above on the keyword delegate omits long values, so the keyword copy is incomplete and the field keeps its own.
+        assertDocValuesDedup(b -> b.field("ignore_above", 10), true);
+        // A keyword delegate with doc values disabled is not a copy at all, so the field keeps its own doc values.
+        assertDocValuesDedup(b -> b.field("doc_values", false), true);
+    }
+
+    private void assertDocValuesDedup(CheckedConsumer<XContentBuilder, IOException> keywordConfig, boolean expectsOwnDocValues)
+        throws IOException {
+        var indexSettingsBuilder = getIndexSettingsBuilder().put(IndexSettings.MODE.getKey(), IndexMode.COLUMNAR.getName());
+        Settings indexSettings = indexSettingsBuilder.build();
+
+        DocumentMapper mapper = createMapperService(indexSettings, mapping(b -> {
+            b.startObject("field");
+            b.field("type", "match_only_text");
+            b.startObject("fields");
+            b.startObject("keyword");
+            b.field("type", "keyword");
+            keywordConfig.accept(b);
+            b.endObject();
+            b.endObject();
+            b.endObject();
+        })).documentMapper();
+
+        MatchOnlyTextFieldMapper fieldMapper = (MatchOnlyTextFieldMapper) mapper.mappers().getMapper("field");
+        assertThat(fieldMapper.fieldType().hasDocValues(), equalTo(expectsOwnDocValues));
+
+        ParsedDocument doc = mapper.parse(source(b -> {
+            b.field("@timestamp", "2024-01-01T00:00:00Z");
+            b.array("field", randomAlphanumericOfLength(8), randomAlphanumericOfLength(8));
+        }));
+
+        boolean hasOwnBinaryDocValues = false;
+        boolean hasOwnOffsets = false;
+        for (IndexableField field : doc.rootDoc().getFields()) {
+            if (field.name().equals("field") && field.fieldType().docValuesType() == DocValuesType.BINARY) {
+                hasOwnBinaryDocValues = true;
+            }
+            if (field.name().equals("field.offsets")) {
+                hasOwnOffsets = true;
+            }
+        }
+        assertThat("field's own binary doc values", hasOwnBinaryDocValues, equalTo(expectsOwnDocValues));
+        assertThat("field's own offsets sidecar", hasOwnOffsets, equalTo(expectsOwnDocValues));
     }
 
     public void testDocValuesExplicitlyDisabled() throws IOException {

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldWithKeywordSubfieldBlockLoaderTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldWithKeywordSubfieldBlockLoaderTests.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.mapper.extras;
+
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.datageneration.DocumentGenerator;
+import org.elasticsearch.datageneration.FieldType;
+import org.elasticsearch.datageneration.MappingGenerator;
+import org.elasticsearch.datageneration.Template;
+import org.elasticsearch.datageneration.datasource.MultifieldAddonHandler;
+import org.elasticsearch.index.mapper.BlockLoaderTestCase;
+import org.elasticsearch.index.mapper.BlockLoaderTestRunner;
+import org.elasticsearch.index.mapper.MapperServiceTestCase;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentType;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.elasticsearch.index.mapper.BlockLoaderTestCase.buildSpecification;
+
+/**
+ * Exercises the strict-columnar dedup path for match_only_text: a parent that carries a keyword multi-field. Whether the parent keeps its
+ * own doc values or delegates to a plain keyword copy, the loaded values come back in source order, so both branches share an expectation.
+ */
+public class MatchOnlyTextFieldWithKeywordSubfieldBlockLoaderTests extends MapperServiceTestCase {
+    private final BlockLoaderTestCase.Params params;
+    private final BlockLoaderTestRunner runner;
+
+    @ParametersFactory(argumentFormatting = "preference=%s")
+    public static List<Object[]> args() {
+        return BlockLoaderTestCase.args();
+    }
+
+    public MatchOnlyTextFieldWithKeywordSubfieldBlockLoaderTests(BlockLoaderTestCase.Params params) {
+        this.params = params;
+        this.runner = new BlockLoaderTestRunner(params).breaker(newLimitedBreaker(ByteSizeValue.ofMb(1)));
+        if (randomBoolean()) {
+            runner.allowDummyDocs();
+        }
+    }
+
+    public void testBlockLoaderOfMatchOnlyTextFieldWithKeywordSubfield() throws IOException {
+        // The dedup this exercises - skipping the field's own doc values in favour of a plain keyword delegate - only happens in
+        // strict-columnar mode. In other modes the field has no own doc values anyway, so there is nothing new to assert here.
+        assumeTrue(
+            "dedup of doc values against a keyword sub-field only applies in strict-columnar mode",
+            params.indexMode().isStrictColumnar()
+        );
+
+        var template = new Template(Map.of("parent", new Template.Leaf("parent", FieldType.MATCH_ONLY_TEXT.toString())));
+        var specification = buildSpecification(
+            List.of(new MultifieldAddonHandler(Map.of(FieldType.MATCH_ONLY_TEXT, List.of(FieldType.KEYWORD)), 1f)),
+            params.indexMode()
+        );
+
+        var mapping = new MappingGenerator(specification).generate(template);
+        runner.document(new DocumentGenerator(specification).generate(template, mapping));
+        var fieldValue = runner.mapDoc().get("parent");
+
+        // Either the field keeps its own multi-valued doc values (read via the offsets sidecar) or it delegates to a plain keyword copy
+        // with no normalizer/ignore_above/null_value transforming the values - both yield the non-null values in source order.
+        Object expected = valuesInSourceOrder(fieldValue);
+        var mappingXContent = XContentBuilder.builder(XContentType.JSON.xContent()).map(mapping.raw());
+        runner.mapperService(createMapperService(BlockLoaderTestCase.getSettingsForParams(params).build(), mappingXContent));
+        runner.fieldName("parent");
+        runner.run(expected);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Object valuesInSourceOrder(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof String s) {
+            return new BytesRef(s);
+        }
+        var resultList = ((List<String>) value).stream().filter(Objects::nonNull).map(BytesRef::new).toList();
+        if (resultList.isEmpty()) {
+            return null;
+        }
+        if (resultList.size() == 1) {
+            return resultList.get(0);
+        }
+        return resultList;
+    }
+
+    @Override
+    protected Collection<? extends Plugin> getPlugins() {
+        return List.of(new MapperExtrasPlugin());
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldArrayContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldArrayContext.java
@@ -171,7 +171,7 @@ public class FieldArrayContext {
         }
 
         // multi_value = true + columnar mode path
-        var columnarOffsetsFieldName = getOffsetsFieldName(context, isStrictColumnar, multiValue, fieldMapperBuilder);
+        var columnarOffsetsFieldName = getOffsetsFieldName(context, isStrictColumnar, hasDocValues, multiValue, fieldMapperBuilder);
         if (columnarOffsetsFieldName != null) {
             return columnarOffsetsFieldName;
         }
@@ -186,14 +186,20 @@ public class FieldArrayContext {
     public static String getOffsetsFieldName(
         MapperBuilderContext context,
         boolean isStrictColumnar,
+        boolean hasDocValues,
         boolean multiValue,
         FieldMapper.Builder fieldMapperBuilder
     ) {
         // Note, stored fields and nested docs will not be allowed in columnar mode - no need to check them explicitly
-        // Note, doc values cannot be disabled in columnar mode
+        // The offsets sidecar reconstructs array order from the field's own doc values, so it is only meaningful when those are present;
+        // a columnar text field that dedups against a plain keyword delegate disables its own doc values and records no offsets here.
         // TODO: copy_to is disabled since copy_to forces _ignored_source to be used for synthetic source, recording offsets in addition
         // to that is a big storage overhead. This will be addressed in a follow up
-        if (multiValue && isStrictColumnar && context.isSourceSynthetic() && fieldMapperBuilder.copyTo.copyToFields().isEmpty()) {
+        if (multiValue
+            && hasDocValues
+            && isStrictColumnar
+            && context.isSourceSynthetic()
+            && fieldMapperBuilder.copyTo.copyToFields().isEmpty()) {
             return context.buildFullName(offsetsFieldName(fieldMapperBuilder.leafName()));
         }
         return null;

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -638,6 +638,10 @@ public abstract class FieldMapper extends Mapper {
 
             private boolean hasSyntheticSourceCompatibleKeywordField;
 
+            // True when a keyword multi-field's doc values are a byte-identical, complete copy of the parent's raw values: no normalizer
+            // altering them, no ignore_above omitting long values, and no null_value injecting substitutes.
+            private boolean hasColumnarModeCompatibleKeywordDelegate;
+
             public Builder add(FieldMapper.Builder builder) {
                 fieldBuilders.put(builder.leafName(), builder);
 
@@ -646,9 +650,23 @@ public abstract class FieldMapper extends Mapper {
                         && (kwd.docValuesParameters().enabled || kwd.isStored())) {
                         hasSyntheticSourceCompatibleKeywordField = true;
                     }
+                    if (isColumnarModeCompatibleKeywordDelegate(kwd)) {
+                        hasColumnarModeCompatibleKeywordDelegate = true;
+                    }
                 }
 
                 return this;
+            }
+
+            // A keyword delegate is columnar-mode-compatible when its doc values losslessly mirror the parent's raw values: normalizer is
+            // absent (or skips storing the original), doc values are present, and neither ignore_above nor null_value transforms them.
+            // Normalizes, ignore_above, and null_value all transform indexed values -> original source is changed, which we don't want
+            // if we're using a keyword subfield as a delegate for parent field.
+            private static boolean isColumnarModeCompatibleKeywordDelegate(KeywordFieldMapper.Builder kwd) {
+                return (kwd.hasNormalizer() == false || kwd.isNormalizerSkipStoreOriginalValue())
+                    && kwd.docValuesParameters().enabled
+                    && kwd.hasIgnoreAbove() == false
+                    && kwd.hasNullValue() == false;
             }
 
             private void add(FieldMapper mapper) {
@@ -678,6 +696,12 @@ public abstract class FieldMapper extends Mapper {
                     if (kwd.hasNormalizer() == false && (kwd.fieldType().hasDocValues() || kwd.fieldType().isStored())) {
                         hasSyntheticSourceCompatibleKeywordField = true;
                     }
+                    if (kwd.hasNormalizer() == false
+                        && kwd.fieldType().hasDocValues()
+                        && kwd.fieldType().ignoreAbove().valuesPotentiallyIgnored() == false
+                        && kwd.fieldType().hasNullValue() == false) {
+                        hasColumnarModeCompatibleKeywordDelegate = true;
+                    }
                 }
             }
 
@@ -704,6 +728,9 @@ public abstract class FieldMapper extends Mapper {
                         && (kwd.docValuesParameters().enabled || kwd.isStored())) {
                         hasSyntheticSourceCompatibleKeywordField = true;
                     }
+                    if (isColumnarModeCompatibleKeywordDelegate(kwd)) {
+                        hasColumnarModeCompatibleKeywordDelegate = true;
+                    }
                 }
             }
 
@@ -717,6 +744,14 @@ public abstract class FieldMapper extends Mapper {
 
             public boolean hasSyntheticSourceCompatibleKeywordField() {
                 return hasSyntheticSourceCompatibleKeywordField;
+            }
+
+            /**
+             * Returns true when this field has a keyword multi-field whose doc values are a complete, byte-identical copy of the parent's
+             * raw values AND the index mode is strictly columnar, so the parent can skip its own doc values and load via the delegate.
+             */
+            public boolean hasColumnarModeCompatibleKeywordDelegate(IndexMode mode) {
+                return mode != null && mode.isStrictColumnar() && hasColumnarModeCompatibleKeywordDelegate;
             }
 
             public MultiFields build(Mapper.Builder mainFieldBuilder, MapperBuilderContext context) {
@@ -1536,8 +1571,30 @@ public abstract class FieldMapper extends Mapper {
             return new DocValuesParameter(defaultValue, initializer, true);
         }
 
+        /**
+         * Variant of {@link #ofWithCardinality(Values, Function)} that computes the default value lazily so it can depend on sibling
+         * multi-fields, which are only known after this parameter is constructed. The {@code subParameterDefaults} provides the
+         * {@code cardinality} and {@code multi_value} sub-parameter defaults, which do not vary lazily.
+         */
+        public static DocValuesParameter ofWithCardinality(
+            Supplier<Values> defaultValueSupplier,
+            Values subParameterDefaults,
+            Function<FieldMapper, Values> initializer
+        ) {
+            return new DocValuesParameter(defaultValueSupplier, subParameterDefaults, initializer, true);
+        }
+
         private DocValuesParameter(Values defaultValue, Function<FieldMapper, Values> initializer, boolean supportsCardinality) {
-            super(PARAMETER_NAME, false, () -> defaultValue, null, initializer, null, Values::toString);
+            this(() -> defaultValue, defaultValue, initializer, supportsCardinality);
+        }
+
+        private DocValuesParameter(
+            Supplier<Values> defaultValueSupplier,
+            Values subParameterDefaults,
+            Function<FieldMapper, Values> initializer,
+            boolean supportsCardinality
+        ) {
+            super(PARAMETER_NAME, false, defaultValueSupplier, null, initializer, null, Values::toString);
 
             if (supportsCardinality) {
                 cardinalityParameter = Optional.of(
@@ -1545,7 +1602,7 @@ public abstract class FieldMapper extends Mapper {
                         "cardinality",
                         false,
                         m -> initializer.apply(m).cardinality,
-                        defaultValue.cardinality,
+                        subParameterDefaults.cardinality,
                         Values.Cardinality.class
                     )
                 );
@@ -1553,7 +1610,12 @@ public abstract class FieldMapper extends Mapper {
                 cardinalityParameter = Optional.empty();
             }
 
-            multiValueParameter = Parameter.boolParam("multi_value", false, m -> initializer.apply(m).multiValue, defaultValue.multiValue);
+            multiValueParameter = Parameter.boolParam(
+                "multi_value",
+                false,
+                m -> initializer.apply(m).multiValue,
+                subParameterDefaults.multiValue
+            );
         }
 
         /**

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -352,6 +352,16 @@ public final class KeywordFieldMapper extends FieldMapper {
             return this.normalizerSkipStoreOriginalValue.getValue();
         }
 
+        // Returns true when an effective ignore_above limit applies (field-level or index-level), so the doc values omit longer values.
+        public boolean hasIgnoreAbove() {
+            return this.ignoreAbove.getValue() != Integer.MAX_VALUE;
+        }
+
+        // Returns true when a null_value is configured, so the doc values substitute it for nulls rather than mirroring the raw values.
+        public boolean hasNullValue() {
+            return this.nullValue.getValue() != null;
+        }
+
         Builder nullValue(String nullValue) {
             this.nullValue.setValue(nullValue);
             return this;
@@ -1305,6 +1315,11 @@ public final class KeywordFieldMapper extends FieldMapper {
          *  be skipped at parsing time. */
         public IgnoreAbove ignoreAbove() {
             return ignoreAbove;
+        }
+
+        // True when a null_value is configured; such a substitution mutates the doc values away from the raw indexed values.
+        public boolean hasNullValue() {
+            return nullValue != null;
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
@@ -116,6 +116,9 @@ public class MapperFeatures implements FeatureSpecification {
     static final NodeFeature KEYWORD_COLUMNAR_DEFAULT_HIGH_CARDINALITY = new NodeFeature(
         "mapper.keyword.columnar_default_high_cardinality"
     );
+    static final NodeFeature TEXT_FIELDS_ENABLE_DOC_VALUES_BY_DEFAULT_IN_COLUMNAR_MODE = new NodeFeature(
+        "mapper.text_fields.enable_doc_values_by_default_in_columnar_mode"
+    );
     static final NodeFeature COLUMNAR_MAINTAIN_ARRAY_ORDER_IP_TEXT = new NodeFeature("mapper.columnar.maintain_array_order_ip_text");
     public static final NodeFeature COLUMNAR_DROPS_DYNAMIC_FALSE_FIELDS = new NodeFeature("mapper.columnar.drops_dynamic_false_fields");
 
@@ -197,6 +200,7 @@ public class MapperFeatures implements FeatureSpecification {
             COLUMNAR_MAINTAIN_ARRAY_ORDER,
             COLUMNAR_REJECTS_RUNTIME_DYNAMIC,
             KEYWORD_COLUMNAR_DEFAULT_HIGH_CARDINALITY,
+            TEXT_FIELDS_ENABLE_DOC_VALUES_BY_DEFAULT_IN_COLUMNAR_MODE,
             COLUMNAR_MAINTAIN_ARRAY_ORDER_IP_TEXT,
             COLUMNAR_DROPS_DYNAMIC_FALSE_FIELDS,
             DOC_VALUES_MULTI_VALUE_INDEX_SETTING

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -266,7 +266,9 @@ public final class TextFieldMapper extends FieldMapper {
     private static DocValuesParameter.Values defaultDocValuesParameters(IndexSettings indexSettings) {
         boolean multiValue = DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled() == false
             || FieldMapper.DOC_VALUES_MULTI_VALUE_SETTING.get(indexSettings.getSettings());
-        return new DocValuesParameter.Values(false, DocValuesParameter.Values.Cardinality.HIGH, multiValue);
+        // Strictly columnar indices read field values from doc values, so enable doc values by default for text fields in that mode.
+        boolean enabled = indexSettings.getMode().isStrictColumnar();
+        return new DocValuesParameter.Values(enabled, DocValuesParameter.Values.Cardinality.HIGH, multiValue);
     }
 
     public static class Builder extends TextFamilyBuilder {
@@ -323,10 +325,14 @@ public final class TextFieldMapper extends FieldMapper {
         public Builder(String name, IndexSettings indexSettings, IndexAnalyzers indexAnalyzers, boolean isWithinMultiField) {
             super(name, indexSettings.getIndexVersionCreated(), isWithinMultiField);
             this.indexSettings = indexSettings;
-            this.docValuesParameters = DocValuesParameter.ofWithCardinality(
-                defaultDocValuesParameters(indexSettings),
-                m -> ((TextFieldMapper) m).docValuesParameters
-            );
+            this.docValuesParameters = DocValuesParameter.ofWithCardinality(() -> {
+                DocValuesParameter.Values defaultDocValues = defaultDocValuesParameters(indexSettings);
+                // In strict-columnar mode, skip the text field's own doc values when a plain keyword multi-field already stores an
+                // identical copy of the raw values, so loading and synthetic source route through that delegate instead of duplicating.
+                boolean enabled = defaultDocValues.enabled()
+                    && multiFieldsBuilder.hasColumnarModeCompatibleKeywordDelegate(indexSettings.getMode()) == false;
+                return new DocValuesParameter.Values(enabled, defaultDocValues.cardinality(), defaultDocValues.multiValue());
+            }, defaultDocValuesParameters(indexSettings), m -> ((TextFieldMapper) m).docValuesParameters);
             this.index = Parameter.indexParam(m -> ((TextFieldMapper) m).index, true);
             this.analyzers = new TextParams.Analyzers(
                 indexAnalyzers,
@@ -566,6 +572,7 @@ public final class TextFieldMapper extends FieldMapper {
             this.offsetsFieldName = FieldArrayContext.getOffsetsFieldName(
                 context,
                 indexSettings.getMode().isStrictColumnar(),
+                docValuesParameters.getValue().enabled(),
                 docValuesParameters.getValue().multiValue(),
                 this
             );
@@ -1357,8 +1364,8 @@ public final class TextFieldMapper extends FieldMapper {
 
         @Override
         public BlockLoader blockLoader(BlockLoaderContext blContext) {
-            // Check if we can load from a synthetic source delegate
-            if (canUseSyntheticSourceDelegateForLoading()) {
+            // Prefer the delegate only when this field has no own doc values
+            if (hasDocValues() == false && canUseSyntheticSourceDelegateForLoading()) {
                 return new DelegatingBlockLoader(syntheticSourceDelegate.get().blockLoader(blContext)) {
                     @Override
                     public String delegatingTo() {

--- a/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
@@ -57,6 +57,7 @@ import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.lucene.search.MultiPhrasePrefixQuery;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersion;
@@ -2600,6 +2601,100 @@ public class TextFieldMapperTests extends MapperTestCase {
 
         // then
         assertThat(fieldType.omitNorms(), is(true));
+    }
+
+    public void testDocValuesEnabledByDefaultWhenIndexModeIsColumnar() throws IOException {
+        assumeTrue("columnar index mode requires snapshot build", IndexMode.COLUMNAR_FEATURE_FLAG.isEnabled());
+        assertDocValuesEnabledByDefaultInColumnarMode(IndexMode.COLUMNAR);
+    }
+
+    public void testDocValuesEnabledByDefaultWhenIndexModeIsColumnarLogsdb() throws IOException {
+        assumeTrue("columnar index mode requires snapshot build", IndexMode.COLUMNAR_FEATURE_FLAG.isEnabled());
+        assertDocValuesEnabledByDefaultInColumnarMode(IndexMode.LOGSDB_COLUMNAR);
+    }
+
+    private void assertDocValuesEnabledByDefaultInColumnarMode(IndexMode indexMode) throws IOException {
+        Settings.Builder indexSettingsBuilder = getIndexSettingsBuilder();
+        indexSettingsBuilder.put(IndexSettings.MODE.getKey(), indexMode.getName());
+        Settings indexSettings = indexSettingsBuilder.build();
+
+        XContentBuilder mapping = mapping(b -> b.startObject("field").field("type", "text").endObject());
+
+        DocumentMapper mapper = createMapperService(indexSettings, mapping).documentMapper();
+        TextFieldMapper textMapper = (TextFieldMapper) mapper.mappers().getMapper("field");
+
+        // Strictly columnar indices read field values from doc values, so doc values are on by default even without an explicit doc_values.
+        assertTrue(textMapper.fieldType().hasDocValues());
+
+        var source = source(b -> {
+            b.field("@timestamp", Instant.now());
+            b.field("field", randomAlphanumericOfLength(10));
+        });
+        ParsedDocument doc = mapper.parse(source);
+        boolean hasDocValuesField = false;
+        for (IndexableField field : doc.rootDoc().getFields("field")) {
+            if (field.fieldType().docValuesType() == DocValuesType.BINARY) {
+                hasDocValuesField = true;
+            }
+        }
+        assertTrue("Should have a doc_values field in columnar mode by default", hasDocValuesField);
+    }
+
+    public void testDocValuesDedupedAgainstPlainKeywordDelegateInColumnarMode() throws IOException {
+        assumeTrue("columnar index mode requires snapshot build", IndexMode.COLUMNAR_FEATURE_FLAG.isEnabled());
+
+        // A plain keyword multi-field (dv-backed, no normalizer/ignore_above/null_value) is a complete copy of the raw values, so the text
+        // field skips its own doc values (and offsets) and loads through the delegate; the keyword's doc values are the only copy written.
+        assertTextDocValuesDedup(b -> {}, false);
+        // null_value on the keyword delegate substitutes values, so the keyword copy is not byte-identical and the text field keeps its
+        // own.
+        assertTextDocValuesDedup(b -> b.field("null_value", "NULL"), true);
+        // ignore_above on the keyword delegate omits long values, so the keyword copy is incomplete and the text field keeps its own.
+        assertTextDocValuesDedup(b -> b.field("ignore_above", 10), true);
+        // A keyword delegate with doc values disabled is not a copy at all, so the text field keeps its own doc values.
+        assertTextDocValuesDedup(b -> b.field("doc_values", false), true);
+    }
+
+    private void assertTextDocValuesDedup(CheckedConsumer<XContentBuilder, IOException> keywordConfig, boolean expectsOwnDocValues)
+        throws IOException {
+        Settings.Builder indexSettingsBuilder = getIndexSettingsBuilder();
+        indexSettingsBuilder.put(IndexSettings.MODE.getKey(), IndexMode.COLUMNAR.getName());
+        Settings indexSettings = indexSettingsBuilder.build();
+
+        XContentBuilder mapping = mapping(b -> {
+            b.startObject("field");
+            b.field("type", "text");
+            b.startObject("fields");
+            b.startObject("keyword");
+            b.field("type", "keyword");
+            keywordConfig.accept(b);
+            b.endObject();
+            b.endObject();
+            b.endObject();
+        });
+
+        DocumentMapper mapper = createMapperService(indexSettings, mapping).documentMapper();
+        TextFieldMapper textMapper = (TextFieldMapper) mapper.mappers().getMapper("field");
+        assertThat(textMapper.fieldType().hasDocValues(), equalTo(expectsOwnDocValues));
+
+        var source = source(b -> {
+            b.field("@timestamp", Instant.now());
+            b.array("field", randomAlphanumericOfLength(8), randomAlphanumericOfLength(8));
+        });
+        ParsedDocument doc = mapper.parse(source);
+
+        boolean hasOwnBinaryDocValues = false;
+        boolean hasOwnOffsets = false;
+        for (IndexableField field : doc.rootDoc().getFields()) {
+            if (field.name().equals("field") && field.fieldType().docValuesType() == DocValuesType.BINARY) {
+                hasOwnBinaryDocValues = true;
+            }
+            if (field.name().equals("field.offsets")) {
+                hasOwnOffsets = true;
+            }
+        }
+        assertThat("text field's own binary doc values", hasOwnBinaryDocValues, equalTo(expectsOwnDocValues));
+        assertThat("text field's own offsets sidecar", hasOwnOffsets, equalTo(expectsOwnDocValues));
     }
 
     public void testConditionalBlockLoader() throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/mapper/blockloader/TextFieldBlockLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/blockloader/TextFieldBlockLoaderTests.java
@@ -43,6 +43,13 @@ public class TextFieldBlockLoaderTests extends BinaryDVBlockLoaderTestCase {
         TestContext testContext,
         boolean useBinaryDocValues
     ) {
+        // In strict-columnar mode either path yields the raw values in source order: a text field that keeps its own doc values reads them
+        // back via the offsets sidecar, and one that skips them in favour of a plain keyword delegate loads that delegate's columnar doc
+        // values, which also preserve arrival order. The delegate is only skipped when it is a byte-identical copy, so they never diverge.
+        if (params.indexMode().isStrictColumnar()) {
+            return valuesInSourceOrder(value);
+        }
+
         if (fieldMapping.getOrDefault("store", false).equals(true)) {
             return valuesInSourceOrder(value);
         }

--- a/server/src/test/java/org/elasticsearch/index/mapper/blockloader/TextFieldWithKeywordSubfieldBlockLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/blockloader/TextFieldWithKeywordSubfieldBlockLoaderTests.java
@@ -29,9 +29,12 @@ import java.util.List;
 import java.util.Map;
 
 import static org.elasticsearch.index.mapper.BlockLoaderTestCase.buildSpecification;
-import static org.elasticsearch.index.mapper.BlockLoaderTestCase.hasDocValues;
 
-public class TextFieldWithParentBlockLoaderTests extends MapperServiceTestCase {
+/**
+ * Exercises the strict-columnar dedup path: a text parent that carries a keyword multi-field. When that keyword sub-field is a complete,
+ * byte-identical copy of the raw values the parent skips its own doc values and loads through the delegate; otherwise it keeps its own.
+ */
+public class TextFieldWithKeywordSubfieldBlockLoaderTests extends MapperServiceTestCase {
     private final BlockLoaderTestCase.Params params;
     private final BlockLoaderTestRunner runner;
 
@@ -40,7 +43,7 @@ public class TextFieldWithParentBlockLoaderTests extends MapperServiceTestCase {
         return BlockLoaderTestCase.args();
     }
 
-    public TextFieldWithParentBlockLoaderTests(BlockLoaderTestCase.Params params) {
+    public TextFieldWithKeywordSubfieldBlockLoaderTests(BlockLoaderTestCase.Params params) {
         this.params = params;
         this.runner = new BlockLoaderTestRunner(params).breaker(newLimitedBreaker(ByteSizeValue.ofMb(1)));
         if (randomBoolean()) {
@@ -48,12 +51,17 @@ public class TextFieldWithParentBlockLoaderTests extends MapperServiceTestCase {
         }
     }
 
-    // This is similar to BlockLoaderTestCase#testBlockLoaderOfMultiField but has customizations required to properly test the case
-    // of text multi field in a keyword field.
-    public void testBlockLoaderOfParentField() throws IOException {
-        var template = new Template(Map.of("parent", new Template.Leaf("parent", FieldType.KEYWORD.toString())));
+    public void testBlockLoaderOfTextFieldWithKeywordSubfield() throws IOException {
+        // The dedup this exercises - skipping the text field's own doc values in favour of a plain keyword delegate - only happens in
+        // strict-columnar mode. In other modes the text field has no own doc values anyway, so there is nothing new to assert here.
+        assumeTrue(
+            "dedup of text doc values against a keyword sub-field only applies in strict-columnar mode",
+            params.indexMode().isStrictColumnar()
+        );
+
+        var template = new Template(Map.of("parent", new Template.Leaf("parent", FieldType.TEXT.toString())));
         var specification = buildSpecification(
-            List.of(new MultifieldAddonHandler(Map.of(FieldType.KEYWORD, List.of(FieldType.TEXT)), 1f)),
+            List.of(new MultifieldAddonHandler(Map.of(FieldType.TEXT, List.of(FieldType.KEYWORD)), 1f)),
             params.indexMode()
         );
 
@@ -63,46 +71,25 @@ public class TextFieldWithParentBlockLoaderTests extends MapperServiceTestCase {
         runner.document(new DocumentGenerator(specification).generate(template, mapping));
         var fieldValue = runner.mapDoc().get("parent");
 
-        Object expected = expected(fieldMapping, fieldValue, new BlockLoaderTestCase.TestContext(false, true));
+        Object expected = TextFieldBlockLoaderTests.expectedValue(
+            fieldMapping,
+            fieldValue,
+            params,
+            new BlockLoaderTestCase.TestContext(false, false),
+            false
+        );
         var mappingXContent = XContentBuilder.builder(XContentType.JSON.xContent()).map(mapping.raw());
         runner.mapperService(mapperServiceForParams(mappingXContent));
-        runner.fieldName("parent.subfield_text");
+        runner.fieldName("parent");
         runner.run(expected);
     }
 
     private MapperService mapperServiceForParams(XContentBuilder mappingXContent) throws IOException {
-        // Columnar index modes preserve array order via offsets recorded on the keyword parent. The text subfield delegates its block
-        // loader to that parent, so the index must actually be built in columnar mode for the offsets to exist - otherwise the delegate
-        // falls back to sorted ordinal order and no longer matches the arrival-order expectation.
+        // Columnar index modes preserve array order via offsets recorded on the field's own doc values, so the index must actually be built
+        // in columnar mode for those offsets to exist - otherwise the source-order expectation no longer holds.
         if (params.indexMode().isColumnar()) {
             return createMapperService(BlockLoaderTestCase.getSettingsForParams(params).build(), mappingXContent);
         }
         return params.syntheticSource() ? createSytheticSourceMapperService(mappingXContent) : createMapperService(mappingXContent);
-    }
-
-    @SuppressWarnings("unchecked")
-    private Object expected(Map<String, Object> fieldMapping, Object value, BlockLoaderTestCase.TestContext testContext) {
-        assert fieldMapping.containsKey("fields");
-
-        var textFieldMapping = (Map<String, Object>) ((Map<String, Object>) fieldMapping.get("fields")).get("subfield_text");
-
-        // In strict-columnar mode the text subfield enables doc values by default, and the text loader reads its own doc values before
-        // ever delegating to the keyword parent, so the value comes from the subfield's own (source-ordered) doc values rather than the
-        // parent field's loader.
-        if (params.indexMode().isStrictColumnar()) {
-            return TextFieldBlockLoaderTests.expectedValue(textFieldMapping, value, params, testContext, false);
-        }
-
-        Object normalizer = fieldMapping.get("normalizer");
-        boolean docValues = hasDocValues(fieldMapping, true);
-        boolean store = fieldMapping.getOrDefault("store", false).equals(true);
-
-        if (normalizer == null && (docValues || store)) {
-            // we are using block loader of the parent field
-            return KeywordFieldBlockLoaderTests.expectedValue(fieldMapping, value, params, testContext);
-        }
-
-        // we are using block loader of the text field itself
-        return TextFieldBlockLoaderTests.expectedValue(textFieldMapping, value, params, testContext, false);
     }
 }

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/AllSupportedFieldsTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/AllSupportedFieldsTestCase.java
@@ -286,6 +286,10 @@ public class AllSupportedFieldsTestCase extends ESRestTestCase {
                 "Cluster has nodes that default to low-cardinality doc values in columnar index modes",
                 clusterHasFeature("mapper.keyword.columnar_default_high_cardinality")
             );
+            assumeTrue(
+                "Cluster has nodes that do not default to doc values for text fields in columnar index modes",
+                clusterHasFeature("mapper.text_fields.enable_doc_values_by_default_in_columnar_mode")
+            );
         }
         if (supportsNodeAssignment()) {
             for (Map.Entry<String, NodeInfo> e : localNodeToInfo().entrySet()) {


### PR DESCRIPTION
Note, this also introduces an optimization where text/match_only_text parent fields do not store their own doc values if they have a compatible keyword subfield - no normalizer, no ignore_above, no null_value. This reduces double storing by allowing the parent fields delegate synthetic source and block loader paths to the keyword subfield.

Note also - this behavior is only applicable to the default doc values parameters. If a user explicitly enabled doc values via a mapping configuration, then that takes priority.