### PR TITLE
Fix/bbq flat bfloat16 nested search visibility

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/42_knn_search_bbq_flat_bfloat16.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/42_knn_search_bbq_flat_bfloat16.yml
@@ -427,6 +427,12 @@ setup:
         index: bbq_flat_nested
         max_num_segments: 1
 
+  # In stateless, a single-segment force-merge is a no-op, so no commit propagates
+  # to the search shard; refresh waits for the latest commit to avoid a race.
+  - do:
+      indices.refresh:
+        index: bbq_flat_nested
+
   - do:
       search:
         index: bbq_flat_nested

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/42_knn_search_bbq_flat_bfloat16.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/42_knn_search_bbq_flat_bfloat16.yml
@@ -427,8 +427,6 @@ setup:
         index: bbq_flat_nested
         max_num_segments: 1
 
-  # In stateless, a single-segment force-merge is a no-op, so no commit propagates
-  # to the search shard; refresh waits for the latest commit to avoid a race.
   - do:
       indices.refresh:
         index: bbq_flat_nested


### PR DESCRIPTION
In stateless, a single-segment force-merge is a no-op, so no new
commit propagates to the search shard. The nested queries test could
then race against stale search shard state. Add an explicit refresh
after the force-merge so the search waits for the latest commit.