### PR TITLE
Mark PromQL as GA in serverless and 9.5

### DIFF
--- a/docs/reference/query-languages/esql/_snippets/commands/layout/promql.md
+++ b/docs/reference/query-languages/esql/_snippets/commands/layout/promql.md
@@ -1,13 +1,13 @@
 ```yaml {applies_to}
-serverless: preview
-stack: preview 9.4
+serverless: ga
+stack: preview 9.4, ga 9.5
 ```
 
 The `PROMQL` source command queries [time series indices](docs-content://manage-data/data-store/data-streams/time-series-data-stream-tsds.md) using [**Prometheus Query Language (PromQL)**](https://prometheus.io/docs/prometheus/latest/querying/basics/).
 Like [`TS`](/reference/query-languages/esql/commands/ts.md), it enables time series aggregation functions, but accepts PromQL syntax instead of ES|QL.
 
 ::::{note}
-In 9.4, `PROMQL` command is available as a preview feature. Current limitations include:
+Current limitations include:
 
 - Group modifiers such as `on(chip) group_left(chip_name)` are not supported.
 - Set operators such as `or`, `and`, and `unless` are not supported.

--- a/docs/reference/query-languages/esql/_snippets/lists/source-commands.md
+++ b/docs/reference/query-languages/esql/_snippets/lists/source-commands.md
@@ -1,5 +1,5 @@
 - [`FROM`](/reference/query-languages/esql/commands/from.md)
-- [`PROMQL`](/reference/query-languages/esql/commands/promql.md) {applies_to}`stack: preview 9.4` {applies_to}`serverless: preview`
+- [`PROMQL`](/reference/query-languages/esql/commands/promql.md) {applies_to}`stack: preview 9.4` {applies_to}`stack: ga 9.5`
 - [`ROW`](/reference/query-languages/esql/commands/row.md)
 - [`SHOW`](/reference/query-languages/esql/commands/show.md)
 - [`TS`](/reference/query-languages/esql/commands/ts.md) {applies_to}`stack: preview 9.2` {applies_to}`serverless: preview`

--- a/docs/reference/query-languages/promql.md
+++ b/docs/reference/query-languages/promql.md
@@ -2,8 +2,8 @@
 description: Query metrics in Elasticsearch time series data streams with PromQL through the ES|QL runtime and a Prometheus-compatible HTTP API.
 navigation_title: PromQL
 applies_to:
-  stack: preview 9.4.0
-  serverless: preview
+  stack: preview 9.4, ga 9.5
+  serverless: ga
 products:
   - id: elasticsearch
 ---
@@ -12,11 +12,6 @@ products:
 
 The [Prometheus Query Language (PromQL)](https://prometheus.io/docs/prometheus/latest/querying/basics/) is a functional query language to select and aggregate metrics.
 
-
-::::{warning}
-This functionality is in technical preview and might be changed or removed in a future release.
-Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
-::::
 
 ## What is PromQL in {{es}}? [promql-what]
 

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/abs.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/abs.json
@@ -20,6 +20,6 @@
   "examples" : [
     "abs(rate(http_requests_total[5m]))"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/abs.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/abs.json
@@ -20,6 +20,5 @@
   "examples" : [
     "abs(rate(http_requests_total[5m]))"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/absent_over_time.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/absent_over_time.json
@@ -20,6 +20,5 @@
   "examples" : [
     "absent_over_time(nonexistent_metric[5m])"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/absent_over_time.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/absent_over_time.json
@@ -20,6 +20,6 @@
   "examples" : [
     "absent_over_time(nonexistent_metric[5m])"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/acos.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/acos.json
@@ -20,6 +20,5 @@
   "examples" : [
     "acos(some_metric)"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/acos.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/acos.json
@@ -20,6 +20,6 @@
   "examples" : [
     "acos(some_metric)"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/acosh.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/acosh.json
@@ -20,6 +20,6 @@
   "examples" : [
     "acosh(some_metric)"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/acosh.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/acosh.json
@@ -20,6 +20,5 @@
   "examples" : [
     "acosh(some_metric)"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/asin.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/asin.json
@@ -20,6 +20,5 @@
   "examples" : [
     "asin(some_metric)"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/asin.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/asin.json
@@ -20,6 +20,6 @@
   "examples" : [
     "asin(some_metric)"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/asinh.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/asinh.json
@@ -20,6 +20,5 @@
   "examples" : [
     "asinh(some_metric)"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/asinh.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/asinh.json
@@ -20,6 +20,6 @@
   "examples" : [
     "asinh(some_metric)"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/atan.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/atan.json
@@ -20,6 +20,5 @@
   "examples" : [
     "atan(some_metric)"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/atan.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/atan.json
@@ -20,6 +20,6 @@
   "examples" : [
     "atan(some_metric)"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/atanh.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/atanh.json
@@ -20,6 +20,6 @@
   "examples" : [
     "atanh(some_metric)"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/atanh.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/atanh.json
@@ -20,6 +20,5 @@
   "examples" : [
     "atanh(some_metric)"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/avg.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/avg.json
@@ -20,6 +20,5 @@
   "examples" : [
     "avg(http_requests_total)"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/avg.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/avg.json
@@ -20,6 +20,6 @@
   "examples" : [
     "avg(http_requests_total)"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/avg_over_time.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/avg_over_time.json
@@ -20,6 +20,6 @@
   "examples" : [
     "avg_over_time(http_requests_total[5m])"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/avg_over_time.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/avg_over_time.json
@@ -20,6 +20,5 @@
   "examples" : [
     "avg_over_time(http_requests_total[5m])"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/ceil.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/ceil.json
@@ -20,6 +20,6 @@
   "examples" : [
     "ceil(rate(http_requests_total[5m]))"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/ceil.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/ceil.json
@@ -20,6 +20,5 @@
   "examples" : [
     "ceil(rate(http_requests_total[5m]))"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/clamp.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/clamp.json
@@ -32,6 +32,6 @@
   "examples" : [
     "clamp(http_requests_total, 0, 100)"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/clamp.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/clamp.json
@@ -32,6 +32,5 @@
   "examples" : [
     "clamp(http_requests_total, 0, 100)"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/clamp_max.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/clamp_max.json
@@ -26,6 +26,5 @@
   "examples" : [
     "clamp_max(http_requests_total, 100)"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/clamp_max.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/clamp_max.json
@@ -26,6 +26,6 @@
   "examples" : [
     "clamp_max(http_requests_total, 100)"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/clamp_min.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/clamp_min.json
@@ -26,6 +26,5 @@
   "examples" : [
     "clamp_min(http_requests_total, 0)"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/clamp_min.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/clamp_min.json
@@ -26,6 +26,6 @@
   "examples" : [
     "clamp_min(http_requests_total, 0)"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/cos.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/cos.json
@@ -20,6 +20,5 @@
   "examples" : [
     "cos(some_metric)"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/cos.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/cos.json
@@ -20,6 +20,6 @@
   "examples" : [
     "cos(some_metric)"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/cosh.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/cosh.json
@@ -20,6 +20,6 @@
   "examples" : [
     "cosh(some_metric)"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/cosh.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/cosh.json
@@ -20,6 +20,5 @@
   "examples" : [
     "cosh(some_metric)"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/count.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/count.json
@@ -20,6 +20,5 @@
   "examples" : [
     "count(http_requests_total)"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/count.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/count.json
@@ -20,6 +20,6 @@
   "examples" : [
     "count(http_requests_total)"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/count_over_time.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/count_over_time.json
@@ -20,6 +20,5 @@
   "examples" : [
     "count_over_time(http_requests_total[5m])"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/count_over_time.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/count_over_time.json
@@ -20,6 +20,6 @@
   "examples" : [
     "count_over_time(http_requests_total[5m])"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/day_of_month.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/day_of_month.json
@@ -20,6 +20,6 @@
   "examples" : [
     "day_of_month()"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/day_of_month.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/day_of_month.json
@@ -20,6 +20,5 @@
   "examples" : [
     "day_of_month()"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/day_of_week.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/day_of_week.json
@@ -20,6 +20,6 @@
   "examples" : [
     "day_of_week()"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/day_of_week.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/day_of_week.json
@@ -20,6 +20,5 @@
   "examples" : [
     "day_of_week()"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/day_of_year.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/day_of_year.json
@@ -20,6 +20,6 @@
   "examples" : [
     "day_of_year()"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/day_of_year.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/day_of_year.json
@@ -20,6 +20,5 @@
   "examples" : [
     "day_of_year()"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/days_in_month.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/days_in_month.json
@@ -20,6 +20,6 @@
   "examples" : [
     "days_in_month()"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/days_in_month.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/days_in_month.json
@@ -20,6 +20,5 @@
   "examples" : [
     "days_in_month()"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/deg.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/deg.json
@@ -20,6 +20,5 @@
   "examples" : [
     "deg(some_metric)"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/deg.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/deg.json
@@ -20,6 +20,6 @@
   "examples" : [
     "deg(some_metric)"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/delta.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/delta.json
@@ -20,6 +20,5 @@
   "examples" : [
     "delta(cpu_temp_celsius[2h])"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/delta.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/delta.json
@@ -20,6 +20,6 @@
   "examples" : [
     "delta(cpu_temp_celsius[2h])"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/deriv.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/deriv.json
@@ -20,6 +20,5 @@
   "examples" : [
     "deriv(node_memory_free_bytes[5m])"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/deriv.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/deriv.json
@@ -20,6 +20,6 @@
   "examples" : [
     "deriv(node_memory_free_bytes[5m])"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/exp.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/exp.json
@@ -20,6 +20,5 @@
   "examples" : [
     "exp(rate(http_requests_total[5m]))"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/exp.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/exp.json
@@ -20,6 +20,6 @@
   "examples" : [
     "exp(rate(http_requests_total[5m]))"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/first_over_time.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/first_over_time.json
@@ -20,6 +20,5 @@
   "examples" : [
     "first_over_time(http_requests_total[1h])"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/first_over_time.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/first_over_time.json
@@ -20,6 +20,6 @@
   "examples" : [
     "first_over_time(http_requests_total[1h])"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/floor.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/floor.json
@@ -20,6 +20,5 @@
   "examples" : [
     "floor(rate(http_requests_total[5m]))"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/floor.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/floor.json
@@ -20,6 +20,6 @@
   "examples" : [
     "floor(rate(http_requests_total[5m]))"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/histogram_quantile.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/histogram_quantile.json
@@ -26,6 +26,6 @@
   "examples" : [
     "histogram_quantile(0.9, rate(http_request_duration_seconds_bucket[5m]))"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/histogram_quantile.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/histogram_quantile.json
@@ -26,6 +26,5 @@
   "examples" : [
     "histogram_quantile(0.9, rate(http_request_duration_seconds_bucket[5m]))"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/hour.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/hour.json
@@ -20,6 +20,6 @@
   "examples" : [
     "hour()"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/hour.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/hour.json
@@ -20,6 +20,5 @@
   "examples" : [
     "hour()"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/idelta.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/idelta.json
@@ -20,6 +20,5 @@
   "examples" : [
     "idelta(cpu_temp_celsius[5m])"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/idelta.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/idelta.json
@@ -20,6 +20,6 @@
   "examples" : [
     "idelta(cpu_temp_celsius[5m])"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/increase.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/increase.json
@@ -20,6 +20,5 @@
   "examples" : [
     "increase(http_requests_total[5m])"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/increase.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/increase.json
@@ -20,6 +20,6 @@
   "examples" : [
     "increase(http_requests_total[5m])"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/irate.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/irate.json
@@ -20,6 +20,6 @@
   "examples" : [
     "irate(http_requests_total[5m])"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/irate.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/irate.json
@@ -20,6 +20,5 @@
   "examples" : [
     "irate(http_requests_total[5m])"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/last_over_time.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/last_over_time.json
@@ -20,6 +20,5 @@
   "examples" : [
     "last_over_time(http_requests_total[1h])"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/last_over_time.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/last_over_time.json
@@ -20,6 +20,6 @@
   "examples" : [
     "last_over_time(http_requests_total[1h])"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/ln.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/ln.json
@@ -20,6 +20,6 @@
   "examples" : [
     "ln(memory_usage_bytes)"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/ln.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/ln.json
@@ -20,6 +20,5 @@
   "examples" : [
     "ln(memory_usage_bytes)"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/log10.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/log10.json
@@ -20,6 +20,6 @@
   "examples" : [
     "log10(http_requests_total)"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/log10.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/log10.json
@@ -20,6 +20,5 @@
   "examples" : [
     "log10(http_requests_total)"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/log2.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/log2.json
@@ -20,6 +20,5 @@
   "examples" : [
     "log2(memory_usage_bytes)"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/log2.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/log2.json
@@ -20,6 +20,6 @@
   "examples" : [
     "log2(memory_usage_bytes)"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/max.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/max.json
@@ -20,6 +20,6 @@
   "examples" : [
     "max(http_requests_total)"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/max.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/max.json
@@ -20,6 +20,5 @@
   "examples" : [
     "max(http_requests_total)"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/max_over_time.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/max_over_time.json
@@ -20,6 +20,6 @@
   "examples" : [
     "max_over_time(http_requests_total[5m])"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/max_over_time.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/max_over_time.json
@@ -20,6 +20,5 @@
   "examples" : [
     "max_over_time(http_requests_total[5m])"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/min.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/min.json
@@ -20,6 +20,6 @@
   "examples" : [
     "min(http_requests_total)"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/min.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/min.json
@@ -20,6 +20,5 @@
   "examples" : [
     "min(http_requests_total)"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/min_over_time.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/min_over_time.json
@@ -20,6 +20,6 @@
   "examples" : [
     "min_over_time(http_requests_total[5m])"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/min_over_time.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/min_over_time.json
@@ -20,6 +20,5 @@
   "examples" : [
     "min_over_time(http_requests_total[5m])"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/minute.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/minute.json
@@ -20,6 +20,6 @@
   "examples" : [
     "minute()"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/minute.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/minute.json
@@ -20,6 +20,5 @@
   "examples" : [
     "minute()"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/month.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/month.json
@@ -20,6 +20,5 @@
   "examples" : [
     "month()"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/month.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/month.json
@@ -20,6 +20,6 @@
   "examples" : [
     "month()"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/pi.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/pi.json
@@ -13,6 +13,6 @@
   "examples" : [
     "pi()"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/pi.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/pi.json
@@ -13,6 +13,5 @@
   "examples" : [
     "pi()"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/present_over_time.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/present_over_time.json
@@ -20,6 +20,6 @@
   "examples" : [
     "present_over_time(http_requests_total[5m])"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/present_over_time.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/present_over_time.json
@@ -20,6 +20,5 @@
   "examples" : [
     "present_over_time(http_requests_total[5m])"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/quantile.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/quantile.json
@@ -26,6 +26,6 @@
   "examples" : [
     "quantile(0.9, http_request_duration_seconds)"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/quantile.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/quantile.json
@@ -26,6 +26,5 @@
   "examples" : [
     "quantile(0.9, http_request_duration_seconds)"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/quantile_over_time.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/quantile_over_time.json
@@ -26,6 +26,6 @@
   "examples" : [
     "quantile_over_time(0.5, http_requests_total[1h])"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/quantile_over_time.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/quantile_over_time.json
@@ -26,6 +26,5 @@
   "examples" : [
     "quantile_over_time(0.5, http_requests_total[1h])"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/rad.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/rad.json
@@ -20,6 +20,6 @@
   "examples" : [
     "rad(some_metric)"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/rad.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/rad.json
@@ -20,6 +20,5 @@
   "examples" : [
     "rad(some_metric)"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/rate.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/rate.json
@@ -20,6 +20,5 @@
   "examples" : [
     "rate(http_requests_total[5m])"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/rate.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/rate.json
@@ -20,6 +20,6 @@
   "examples" : [
     "rate(http_requests_total[5m])"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/round.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/round.json
@@ -26,6 +26,5 @@
   "examples" : [
     "round(rate(http_requests_total[5m]))"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/round.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/round.json
@@ -26,6 +26,6 @@
   "examples" : [
     "round(rate(http_requests_total[5m]))"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/scalar.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/scalar.json
@@ -20,6 +20,6 @@
   "examples" : [
     "scalar(sum(http_requests_total))"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/scalar.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/scalar.json
@@ -20,6 +20,5 @@
   "examples" : [
     "scalar(sum(http_requests_total))"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/sgn.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/sgn.json
@@ -20,6 +20,5 @@
   "examples" : [
     "sgn(delta(queue_depth[5m]))"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/sgn.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/sgn.json
@@ -20,6 +20,6 @@
   "examples" : [
     "sgn(delta(queue_depth[5m]))"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/sin.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/sin.json
@@ -20,6 +20,5 @@
   "examples" : [
     "sin(some_metric)"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/sin.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/sin.json
@@ -20,6 +20,6 @@
   "examples" : [
     "sin(some_metric)"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/sinh.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/sinh.json
@@ -20,6 +20,6 @@
   "examples" : [
     "sinh(some_metric)"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/sinh.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/sinh.json
@@ -20,6 +20,5 @@
   "examples" : [
     "sinh(some_metric)"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/sqrt.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/sqrt.json
@@ -20,6 +20,6 @@
   "examples" : [
     "sqrt(http_requests_total)"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/sqrt.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/sqrt.json
@@ -20,6 +20,5 @@
   "examples" : [
     "sqrt(http_requests_total)"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/stddev.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/stddev.json
@@ -20,6 +20,5 @@
   "examples" : [
     "stddev(http_requests_total)"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/stddev.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/stddev.json
@@ -20,6 +20,6 @@
   "examples" : [
     "stddev(http_requests_total)"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/stddev_over_time.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/stddev_over_time.json
@@ -20,6 +20,6 @@
   "examples" : [
     "stddev_over_time(http_requests_total[5m])"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/stddev_over_time.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/stddev_over_time.json
@@ -20,6 +20,5 @@
   "examples" : [
     "stddev_over_time(http_requests_total[5m])"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/stdvar.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/stdvar.json
@@ -20,6 +20,5 @@
   "examples" : [
     "stdvar(http_requests_total)"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/stdvar.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/stdvar.json
@@ -20,6 +20,6 @@
   "examples" : [
     "stdvar(http_requests_total)"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/stdvar_over_time.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/stdvar_over_time.json
@@ -20,6 +20,5 @@
   "examples" : [
     "stdvar_over_time(http_requests_total[5m])"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/stdvar_over_time.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/stdvar_over_time.json
@@ -20,6 +20,6 @@
   "examples" : [
     "stdvar_over_time(http_requests_total[5m])"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/sum.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/sum.json
@@ -20,6 +20,5 @@
   "examples" : [
     "sum(http_requests_total)"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/sum.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/sum.json
@@ -20,6 +20,6 @@
   "examples" : [
     "sum(http_requests_total)"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/sum_over_time.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/sum_over_time.json
@@ -20,6 +20,6 @@
   "examples" : [
     "sum_over_time(http_requests_total[5m])"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/sum_over_time.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/sum_over_time.json
@@ -20,6 +20,5 @@
   "examples" : [
     "sum_over_time(http_requests_total[5m])"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/tan.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/tan.json
@@ -20,6 +20,6 @@
   "examples" : [
     "tan(some_metric)"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/tan.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/tan.json
@@ -20,6 +20,5 @@
   "examples" : [
     "tan(some_metric)"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/tanh.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/tanh.json
@@ -20,6 +20,6 @@
   "examples" : [
     "tanh(some_metric)"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/tanh.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/tanh.json
@@ -20,6 +20,5 @@
   "examples" : [
     "tanh(some_metric)"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/time.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/time.json
@@ -13,6 +13,6 @@
   "examples" : [
     "time()"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/time.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/time.json
@@ -13,6 +13,5 @@
   "examples" : [
     "time()"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/vector.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/vector.json
@@ -20,6 +20,6 @@
   "examples" : [
     "vector(1)"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/vector.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/vector.json
@@ -20,6 +20,5 @@
   "examples" : [
     "vector(1)"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/year.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/year.json
@@ -20,6 +20,5 @@
   "examples" : [
     "year()"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/year.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/functions/year.json
@@ -20,6 +20,6 @@
   "examples" : [
     "year()"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/add.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/add.json
@@ -81,6 +81,5 @@
   "examples" : [
     "requests_total + requests_errors"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/add.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/add.json
@@ -81,6 +81,6 @@
   "examples" : [
     "requests_total + requests_errors"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/and.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/and.json
@@ -27,6 +27,6 @@
   "examples" : [
     "vector1 and vector2"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/and.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/and.json
@@ -27,6 +27,5 @@
   "examples" : [
     "vector1 and vector2"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/div.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/div.json
@@ -81,6 +81,5 @@
   "examples" : [
     "requests_errors / requests_total"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/div.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/div.json
@@ -81,6 +81,6 @@
   "examples" : [
     "requests_errors / requests_total"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/eq.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/eq.json
@@ -81,6 +81,5 @@
   "examples" : [
     "requests_total == 256"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/eq.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/eq.json
@@ -81,6 +81,6 @@
   "examples" : [
     "requests_total == 256"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/gt.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/gt.json
@@ -81,6 +81,5 @@
   "examples" : [
     "requests_total > 256"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/gt.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/gt.json
@@ -81,6 +81,6 @@
   "examples" : [
     "requests_total > 256"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/gte.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/gte.json
@@ -81,6 +81,6 @@
   "examples" : [
     "requests_total >= 256"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/gte.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/gte.json
@@ -81,6 +81,5 @@
   "examples" : [
     "requests_total >= 256"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/label_eq.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/label_eq.json
@@ -27,6 +27,6 @@
   "examples" : [
     "requests_total{method=\"GET\"}"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/label_eq.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/label_eq.json
@@ -27,6 +27,5 @@
   "examples" : [
     "requests_total{method=\"GET\"}"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/label_neq.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/label_neq.json
@@ -27,6 +27,5 @@
   "examples" : [
     "requests_total{method!=\"DELETE\"}"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/label_neq.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/label_neq.json
@@ -27,6 +27,6 @@
   "examples" : [
     "requests_total{method!=\"DELETE\"}"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/label_nre.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/label_nre.json
@@ -27,6 +27,5 @@
   "examples" : [
     "requests_total{method!~\"DELETE|PUT\"}"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/label_nre.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/label_nre.json
@@ -27,6 +27,6 @@
   "examples" : [
     "requests_total{method!~\"DELETE|PUT\"}"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/label_re.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/label_re.json
@@ -27,6 +27,5 @@
   "examples" : [
     "requests_total{method=~\"GET|POST\"}"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/label_re.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/label_re.json
@@ -27,6 +27,6 @@
   "examples" : [
     "requests_total{method=~\"GET|POST\"}"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/lt.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/lt.json
@@ -81,6 +81,6 @@
   "examples" : [
     "requests_total < 256"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/lt.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/lt.json
@@ -81,6 +81,5 @@
   "examples" : [
     "requests_total < 256"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/lte.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/lte.json
@@ -81,6 +81,5 @@
   "examples" : [
     "requests_total <= 256"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/lte.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/lte.json
@@ -81,6 +81,6 @@
   "examples" : [
     "requests_total <= 256"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/mod.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/mod.json
@@ -81,6 +81,6 @@
   "examples" : [
     "metric % 10"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/mod.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/mod.json
@@ -81,6 +81,5 @@
   "examples" : [
     "metric % 10"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/mul.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/mul.json
@@ -81,6 +81,5 @@
   "examples" : [
     "100 * rate(requests_total[5m])"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/mul.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/mul.json
@@ -81,6 +81,6 @@
   "examples" : [
     "100 * rate(requests_total[5m])"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/neg.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/neg.json
@@ -33,6 +33,6 @@
   "examples" : [
     "-requests_total"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/neg.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/neg.json
@@ -33,6 +33,5 @@
   "examples" : [
     "-requests_total"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/neq.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/neq.json
@@ -81,6 +81,5 @@
   "examples" : [
     "requests_error != 0"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/neq.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/neq.json
@@ -81,6 +81,6 @@
   "examples" : [
     "requests_error != 0"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/or.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/or.json
@@ -27,6 +27,6 @@
   "examples" : [
     "vector1 or vector2"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/or.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/or.json
@@ -27,6 +27,5 @@
   "examples" : [
     "vector1 or vector2"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/pow.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/pow.json
@@ -81,6 +81,5 @@
   "examples" : [
     "metric ^ 2"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/pow.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/pow.json
@@ -81,6 +81,6 @@
   "examples" : [
     "metric ^ 2"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/sub.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/sub.json
@@ -81,6 +81,6 @@
   "examples" : [
     "requests_total - requests_errors"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/sub.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/sub.json
@@ -81,6 +81,5 @@
   "examples" : [
     "requests_total - requests_errors"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/unless.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/unless.json
@@ -27,6 +27,5 @@
   "examples" : [
     "vector1 unless vector2"
   ],
-  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/unless.json
+++ b/docs/reference/query-languages/promql/kibana/generated/x-pack-esql/definition/operators/unless.json
@@ -27,6 +27,6 @@
   "examples" : [
     "vector1 unless vector2"
   ],
-  "preview" : true,
+  "preview" : false,
   "snapshot_only" : false
 }

--- a/docs/reference/query-languages/promql/promql-http-api.md
+++ b/docs/reference/query-languages/promql/promql-http-api.md
@@ -2,18 +2,13 @@
 description: Prometheus-compatible HTTP endpoints for PromQL queries and metric discovery against time series data in Elasticsearch.
 navigation_title: HTTP API
 applies_to:
-  stack: preview 9.4.0
-  serverless: preview
+  stack: preview 9.4, ga 9.5
+  serverless: ga
 products:
   - id: elasticsearch
 ---
 
 # PromQL HTTP API [promql-http-api]
-
-::::{warning}
-This functionality is in technical preview and might be changed or removed in a future release.
-Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
-::::
 
 These endpoints run under the `/_prometheus/` prefix.
 They are intended for Prometheus-compatible tooling such as Grafana data sources, autocompletion, variable queries, and similar clients.
@@ -130,7 +125,7 @@ At least one `match[]` parameter is required.
 
 ### Metric metadata [promql-http-api-metadata-endpoint]
 
-{applies_to}`stack: preview 9.5.0` {applies_to}`serverless: preview`
+{applies_to}`stack: preview 9.5` {applies_to}`stack: ga 9.5`
 
 `GET /_prometheus/api/v1/metadata`\
 `GET /_prometheus/{index}/api/v1/metadata`
@@ -152,7 +147,7 @@ The `metadata` route does not support `match[]`, `start`, or `end`.
 
 ### Build information [promql-http-api-buildinfo]
 
-{applies_to}`stack: preview 9.5.0` {applies_to}`serverless: preview`
+{applies_to}`stack: preview 9.5` {applies_to}`stack: ga 9.5`
 
 `GET /_prometheus/api/v1/status/buildinfo`\
 `GET /_prometheus/{index}/api/v1/status/buildinfo`

--- a/docs/reference/query-languages/promql/promql-limitations.md
+++ b/docs/reference/query-languages/promql/promql-limitations.md
@@ -2,8 +2,8 @@
 description: Execution and HTTP constraints for PromQL in Elasticsearch, including unsupported constructs and instant-query behavior.
 navigation_title: Limitations
 applies_to:
-  stack: preview 9.4.0
-  serverless: preview
+  stack: preview 9.4, ga 9.5
+  serverless: ga
 products:
   - id: elasticsearch
 ---
@@ -13,11 +13,6 @@ products:
 PromQL reads metrics stored in [time series data streams](docs-content://manage-data/data-store/data-streams/time-series-data-stream-tsds.md) (TSDS).
 The following constraints apply to execution in {{es}}, including the [Prometheus-compatible HTTP API](promql-http-api.md) and the {{esql}} [`PROMQL`](/reference/query-languages/esql/commands/promql.md) source command, unless stated otherwise.
 They describe behavioral differences and unsupported areas compared with upstream Prometheus.
-
-::::{warning}
-This functionality is in technical preview and might be changed or removed in a future release.
-Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
-::::
 
 ## Form-encoded POST requests (HTTP API) [promql-limitations-form-post]
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/promql/function/PromqlDocsSupport.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/promql/function/PromqlDocsSupport.java
@@ -275,7 +275,6 @@ public final class PromqlDocsSupport {
             builder.endArray();
 
             builder.array("examples", examples.toArray(String[]::new));
-            builder.field("preview", false);
             builder.field("snapshot_only", false);
             builder.endObject();
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/promql/function/PromqlDocsSupport.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/promql/function/PromqlDocsSupport.java
@@ -275,7 +275,7 @@ public final class PromqlDocsSupport {
             builder.endArray();
 
             builder.array("examples", examples.toArray(String[]::new));
-            builder.field("preview", true);
+            builder.field("preview", false);
             builder.field("snapshot_only", false);
             builder.endObject();
 


### PR DESCRIPTION
## Summary
- Update PromQL reference docs and ES|QL `PROMQL` command metadata to mark the feature as GA on serverless and from stack 9.5, keeping cumulative `stack: preview 9.4` tags where applicable.
- Remove technical preview warnings from the PromQL documentation pages.
- Set `preview: false` in `PromqlDocsSupport` and regenerate the PromQL Kibana definition JSON files.