### PR TITLE
Decouple BuildPlugin jar packaging test from version in archive name

### DIFF
--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/BuildPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/BuildPluginFuncTest.groovy
@@ -122,8 +122,17 @@ class BuildPluginFuncTest extends AbstractGradleFuncTest {
         def result = gradleRunner("assemble", "-x", "generateClusterFeaturesMetadata").build()
         then:
         result.task(":assemble").outcome == TaskOutcome.SUCCESS
-        file("build/distributions/hello-world.jar").exists()
-        assertValidJar(file("build/distributions/hello-world.jar"))
+
+        and: "the produced jar bundles LICENSE and NOTICE"
+        // The jar file name embeds the project version, which is set by elasticsearch.build via
+        // ElasticsearchBasePlugin#apply(project.setVersion(VersionProperties.getElasticsearch())).
+        // We deliberately don't pin the version in the assertion — the jar name is incidental;
+        // what this test actually verifies is that the LICENSE / NOTICE files are packaged.
+        def distributionsDir = file("build/distributions")
+        def producedJars = distributionsDir.listFiles({ f -> f.name.startsWith("hello-world") && f.name.endsWith(".jar") } as FileFilter) ?: []
+        assert producedJars.length == 1 :
+            "expected exactly one hello-world*.jar in ${distributionsDir}, found: ${producedJars*.name}"
+        assertValidJar(producedJars[0])
     }
 
     def "applies checks"() {


### PR DESCRIPTION
Gradle 9.x resolves Jar.archiveFileName at task execution time, which
picks up the project.version set by ElasticsearchBasePlugin via
elasticsearch.build. The hard-coded \"hello-world.jar\" assertion no
longer matches; the actual artifact is now e.g.
\"hello-world-9.5.0-SNAPSHOT.jar\".

The test's real intent is to verify LICENSE and NOTICE are packaged
inside the produced jar, not to pin the exact file name. Match the
jar via glob (hello-world*.jar) so future version changes don't
break it again.

Verified locally:
  ./gradlew :build-tools-internal:integTest \
    --tests 'org.elasticsearch.gradle.internal.BuildPluginFuncTest.packages license and notice file'
  -> BUILD SUCCESSFUL