### PR TITLE
Expose native libs via dedicated consumable variant

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaBasePlugin.java
@@ -142,7 +142,11 @@ public class ElasticsearchJavaBasePlugin implements Plugin<Project> {
         String nativeProject = ":libs:native:native-libraries";
         Configuration nativeConfig = project.getConfigurations().create("nativeLibs");
         nativeConfig.defaultDependencies(deps -> {
-            deps.add(project.getDependencies().project(Map.of("path", nativeProject, "configuration", "default")));
+            // Request the dedicated `nativeLibs` consumable variant explicitly. We intentionally do not
+            // rely on the `default` configuration of `:libs:native:native-libraries`: if any plugin (e.g.
+            // `elasticsearch.build`) ends up applied to that project, `default` is silently rebound to the
+            // Java runtime variant, which would corrupt `es.nativelibs.path` for every test JVM.
+            deps.add(project.getDependencies().project(Map.of("path", nativeProject, "configuration", "nativeLibs")));
         });
         // This input to the following lambda needs to be serializable. Configuration is not serializable, but FileCollection is.
         FileCollection nativeConfigFiles = nativeConfig;

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaBasePlugin.java
@@ -140,18 +140,17 @@ public class ElasticsearchJavaBasePlugin implements Plugin<Project> {
 
     private static void configureNativeLibraryPath(Project project) {
         String nativeProject = ":libs:native:native-libraries";
-        // Gradle 9.x requires explicit configuration roles: a configuration created via
-        // `configurations.create(name)` is no longer implicitly resolvable. We declare this one as
+        // Gradle 9.x requires explicit configuration roles. We declare this configuration as
         // resolvable because we feed its resolved files into `es.nativelibs.path` below via `getAsPath()`.
-        Configuration nativeConfig = project.getConfigurations().resolvable("nativeLibs", c -> {
-            c.defaultDependencies(deps -> {
-                // Request the dedicated `nativeLibs` consumable variant explicitly. We intentionally do not
-                // rely on the `default` configuration of `:libs:native:native-libraries`: if any plugin (e.g.
-                // `elasticsearch.build`) ends up applied to that project, `default` is silently rebound to the
-                // Java runtime variant, which would corrupt `es.nativelibs.path` for every test JVM.
-                deps.add(project.getDependencies().project(Map.of("path", nativeProject, "configuration", "nativeLibs")));
-            });
-        }).get();
+        // Note that `defaultDependencies(…)` is only permitted on dependency-scope configurations under
+        // 9.x role semantics, so we add the project dependency directly to this resolvable configuration
+        // instead. We intentionally request the producer's dedicated `nativeLibs` consumable variant by
+        // name rather than relying on the `default` configuration of `:libs:native:native-libraries`:
+        // if any plugin (e.g. `elasticsearch.build`) ends up applied to that project, `default` would be
+        // silently rebound to the Java runtime variant and corrupt `es.nativelibs.path` for every test JVM.
+        Configuration nativeConfig = project.getConfigurations().resolvable("nativeLibs").get();
+        project.getDependencies()
+            .add("nativeLibs", project.getDependencies().project(Map.of("path", nativeProject, "configuration", "nativeLibs")));
         // This input to the following lambda needs to be serializable. Configuration is not serializable, but FileCollection is.
         FileCollection nativeConfigFiles = nativeConfig;
 

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaBasePlugin.java
@@ -140,14 +140,18 @@ public class ElasticsearchJavaBasePlugin implements Plugin<Project> {
 
     private static void configureNativeLibraryPath(Project project) {
         String nativeProject = ":libs:native:native-libraries";
-        Configuration nativeConfig = project.getConfigurations().create("nativeLibs");
-        nativeConfig.defaultDependencies(deps -> {
-            // Request the dedicated `nativeLibs` consumable variant explicitly. We intentionally do not
-            // rely on the `default` configuration of `:libs:native:native-libraries`: if any plugin (e.g.
-            // `elasticsearch.build`) ends up applied to that project, `default` is silently rebound to the
-            // Java runtime variant, which would corrupt `es.nativelibs.path` for every test JVM.
-            deps.add(project.getDependencies().project(Map.of("path", nativeProject, "configuration", "nativeLibs")));
-        });
+        // Gradle 9.x requires explicit configuration roles: a configuration created via
+        // `configurations.create(name)` is no longer implicitly resolvable. We declare this one as
+        // resolvable because we feed its resolved files into `es.nativelibs.path` below via `getAsPath()`.
+        Configuration nativeConfig = project.getConfigurations().resolvable("nativeLibs", c -> {
+            c.defaultDependencies(deps -> {
+                // Request the dedicated `nativeLibs` consumable variant explicitly. We intentionally do not
+                // rely on the `default` configuration of `:libs:native:native-libraries`: if any plugin (e.g.
+                // `elasticsearch.build`) ends up applied to that project, `default` is silently rebound to the
+                // Java runtime variant, which would corrupt `es.nativelibs.path` for every test JVM.
+                deps.add(project.getDependencies().project(Map.of("path", nativeProject, "configuration", "nativeLibs")));
+            });
+        }).get();
         // This input to the following lambda needs to be serializable. Configuration is not serializable, but FileCollection is.
         FileCollection nativeConfigFiles = nativeConfig;
 

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaBasePlugin.java
@@ -140,17 +140,29 @@ public class ElasticsearchJavaBasePlugin implements Plugin<Project> {
 
     private static void configureNativeLibraryPath(Project project) {
         String nativeProject = ":libs:native:native-libraries";
-        // Gradle 9.x requires explicit configuration roles. We declare this configuration as
-        // resolvable because we feed its resolved files into `es.nativelibs.path` below via `getAsPath()`.
-        // Note that `defaultDependencies(…)` is only permitted on dependency-scope configurations under
-        // 9.x role semantics, so we add the project dependency directly to this resolvable configuration
-        // instead. We intentionally request the producer's dedicated `nativeLibs` consumable variant by
-        // name rather than relying on the `default` configuration of `:libs:native:native-libraries`:
-        // if any plugin (e.g. `elasticsearch.build`) ends up applied to that project, `default` would be
+        // Skip on the producer itself: that project already declares its own (consumable) `nativeLibs`
+        // configuration, and there is no test JVM in that project that needs `es.nativelibs.path`.
+        // Without this guard the names collide ("a configuration with that name already exists").
+        if (project.getPath().equals(nativeProject)) {
+            return;
+        }
+        // Gradle 9.x enforces strict configuration roles: a single configuration cannot both declare
+        // dependencies and be resolved. We therefore use a pair:
+        // - `nativeLibsDeclared` (dependency-scope) holds the declaration of the producer's variant.
+        // - `resolvedNativeLibs` (resolvable) extends it and is what we resolve files from.
+        // We intentionally request the producer's dedicated `nativeLibs` consumable variant by name
+        // rather than relying on the `default` configuration of `:libs:native:native-libraries`: if
+        // any plugin (e.g. `elasticsearch.build`) ends up applied to that project, `default` would be
         // silently rebound to the Java runtime variant and corrupt `es.nativelibs.path` for every test JVM.
-        Configuration nativeConfig = project.getConfigurations().resolvable("nativeLibs").get();
+        Configuration nativeLibsDeclared = project.getConfigurations().dependencyScope("nativeLibsDeclared").get();
+        Configuration nativeConfig = project.getConfigurations()
+            .resolvable("resolvedNativeLibs", c -> c.extendsFrom(nativeLibsDeclared))
+            .get();
         project.getDependencies()
-            .add("nativeLibs", project.getDependencies().project(Map.of("path", nativeProject, "configuration", "nativeLibs")));
+            .add(
+                nativeLibsDeclared.getName(),
+                project.getDependencies().project(Map.of("path", nativeProject, "configuration", "nativeLibs"))
+            );
         // This input to the following lambda needs to be serializable. Configuration is not serializable, but FileCollection is.
         FileCollection nativeConfigFiles = nativeConfig;
 

--- a/build-tools/src/testFixtures/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy
+++ b/build-tools/src/testFixtures/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy
@@ -74,9 +74,18 @@ abstract class AbstractGradleFuncTest extends Specification {
             "org.gradle.java.installations.fromEnv=JAVA_HOME,RUNTIME_JAVA_HOME,JAVA15_HOME,JAVA14_HOME,JAVA13_HOME,JAVA12_HOME,JAVA11_HOME,JAVA8_HOME"
 
         def nativeLibsProject = subProject(":libs:native:native-libraries")
+        // Stub mirrors the real producer: a dedicated `nativeLibs` consumable variant that
+        // carries the platform-native library directory. ElasticsearchJavaBasePlugin requests
+        // exactly this configuration via project(path:..., configuration: 'nativeLibs').
         nativeLibsProject << """
             plugins {
                 id 'base'
+            }
+            configurations {
+                nativeLibs {
+                    canBeConsumed = true
+                    canBeResolved = false
+                }
             }
         """
         def mutedTestsFile = testProjectDir.newFile("muted-tests.yml")

--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -347,7 +347,10 @@ configure(subprojects.findAll { ['archives', 'packages'].contains(it.name) }) {
     libsKeystoreCli project(path: ':distribution:tools:keystore-cli')
     libsSecurityCli project(':x-pack:plugin:security:cli')
     libsGeoIpCli project(':distribution:tools:geoip-cli')
-    libsNative project(':libs:native:native-libraries')
+    // Request the dedicated `nativeLibs` consumable variant — see libs/native/libraries/build.gradle.
+    // Do not switch this back to the `default` configuration: it is plugin-order dependent and would
+    // silently bind to the Java runtime variant if `elasticsearch.build` is ever applied to that project.
+    libsNative project(path: ':libs:native:native-libraries', configuration: 'nativeLibs')
     libsEntitlementAgent project(':libs:entitlement:agent')
     libsEntitlementBridge project(':libs:entitlement:bridge')
   }

--- a/libs/native/libraries/build.gradle
+++ b/libs/native/libraries/build.gradle
@@ -12,24 +12,29 @@ import org.elasticsearch.gradle.transform.UnzipTransform
 apply plugin: 'base'
 
 configurations {
+  // Internal configuration: declares + resolves the per-platform binary distributions pulled from
+  // the elasticsearch-native repository. Used only as input to `extractLibs`; never published.
   libs {
     attributes.attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, ArtifactTypeDefinition.DIRECTORY_TYPE)
     canBeConsumed = false
   }
-  // Dedicated consumable variant carrying the extracted platform-specific native libraries
-  // (the `extractLibs` task output directory). Consumers must request this configuration
-  // explicitly via `project(path: ':libs:native:native-libraries', configuration: 'nativeLibs')`.
-  //
-  // We deliberately do NOT publish these binaries via the `default` configuration. If another
-  // plugin (e.g. `elasticsearch.build`) ends up applied to this project, its standard Java
-  // outputs would otherwise hijack `default` and silently break native library resolution for
-  // every test JVM (es.nativelibs.path) and for the distribution packaging. Keeping a named
-  // configuration here makes the contract explicit and resilient to such cross-project changes.
-  nativeLibs {
-    canBeConsumed = true
-    canBeResolved = false
-    attributes.attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, ArtifactTypeDefinition.DIRECTORY_TYPE)
-  }
+}
+
+// Dedicated consumable variant carrying the extracted platform-specific native libraries
+// (the `extractLibs` task output directory). Consumers must request this configuration
+// explicitly via `project(path: ':libs:native:native-libraries', configuration: 'nativeLibs')`.
+//
+// We deliberately do NOT publish these binaries via the `default` configuration. If another
+// plugin (e.g. `elasticsearch.build`) ends up applied to this project, its standard Java
+// outputs would otherwise hijack `default` and silently break native library resolution for
+// every test JVM (es.nativelibs.path) and for the distribution packaging. Keeping a named
+// configuration here makes the contract explicit and resilient to such cross-project changes.
+//
+// Declared via the role-based factory because Gradle 9.x locks configuration usage at creation
+// time — toggling `canBeConsumed`/`canBeResolved` post-creation on a legacy configuration is
+// rejected with "Cannot change the allowed usage of configuration ...".
+configurations.consumable('nativeLibs') {
+  attributes.attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, ArtifactTypeDefinition.DIRECTORY_TYPE)
 }
 
 var zstdVersion = "1.5.7"

--- a/libs/native/libraries/build.gradle
+++ b/libs/native/libraries/build.gradle
@@ -16,6 +16,20 @@ configurations {
     attributes.attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, ArtifactTypeDefinition.DIRECTORY_TYPE)
     canBeConsumed = false
   }
+  // Dedicated consumable variant carrying the extracted platform-specific native libraries
+  // (the `extractLibs` task output directory). Consumers must request this configuration
+  // explicitly via `project(path: ':libs:native:native-libraries', configuration: 'nativeLibs')`.
+  //
+  // We deliberately do NOT publish these binaries via the `default` configuration. If another
+  // plugin (e.g. `elasticsearch.build`) ends up applied to this project, its standard Java
+  // outputs would otherwise hijack `default` and silently break native library resolution for
+  // every test JVM (es.nativelibs.path) and for the distribution packaging. Keeping a named
+  // configuration here makes the contract explicit and resilient to such cross-project changes.
+  nativeLibs {
+    canBeConsumed = true
+    canBeResolved = false
+    attributes.attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, ArtifactTypeDefinition.DIRECTORY_TYPE)
+  }
 }
 
 var zstdVersion = "1.5.7"
@@ -85,5 +99,5 @@ def extractLibs = tasks.register('extractLibs', Copy) {
 }
 
 artifacts {
-  'default' extractLibs
+  nativeLibs extractLibs
 }


### PR DESCRIPTION
Replace the implicit `default` configuration of :libs:native:native-libraries
with a named, plugin-independent `nativeLibs` consumable variant. Consumers
(ElasticsearchJavaBasePlugin, distribution packaging) request it by name.

This prevents `default` from being silently rebound to the Java runtime
variant when elasticsearch.build is (now or in future) applied to the
native-libraries project, which otherwise corrupts es.nativelibs.path for
every test JVM and breaks native zstd/vec resolution across the build.