### PR TITLE
[8.19] [ML] Add extra validation in trained_model creation (#150227)

### DIFF
--- a/docs/changelog/150227.yaml
+++ b/docs/changelog/150227.yaml
@@ -1,0 +1,5 @@
+area: Machine Learning
+issues: []
+pr: 150227
+summary: Add extra validation in `trained_model` creation
+type: bug

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfig.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.core.ml.inference;
 
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionRequestValidationException;
@@ -24,6 +25,7 @@ import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.common.time.TimeUtils;
 import org.elasticsearch.xpack.core.ml.MlConfigVersion;
@@ -63,6 +65,13 @@ import static org.elasticsearch.xpack.core.ml.utils.NamedXContentObjectHelper.wr
 import static org.elasticsearch.xpack.core.ml.utils.ToXContentParams.EXCLUDE_GENERATED;
 
 public class TrainedModelConfig implements ToXContentObject, Writeable {
+
+    public static final int MAX_DESCRIPTION_LENGTH = 1_000;
+    public static final int MAX_TAGS_LENGTH = 100;
+    public static final int MAX_PREFIX_STRING_LENGTH = 1_000;
+    public static final int MAX_INPUT_FIELD_NAMES = 100;
+    public static final int MAX_DEFAULT_FIELD_MAP_ENTRIES = 100;
+    public static final int MAX_METADATA_SIZE_BYTES = (int) ByteSizeValue.ofKb(64).getBytes();
 
     public static final String NAME = "trained_model_config";
     public static final int CURRENT_DEFINITION_COMPRESSION_VERSION = 1;
@@ -951,6 +960,12 @@ public class TrainedModelConfig implements ToXContentObject, Writeable {
                     validationException
                 );
             }
+            if (tags.size() > MAX_TAGS_LENGTH) {
+                validationException = addValidationError(
+                    "[" + TAGS.getPreferredName() + "] must contain not more than " + MAX_TAGS_LENGTH + " tags.",
+                    validationException
+                );
+            }
             List<String> badTags = tags.stream()
                 .filter(tag -> (MlStrings.isValidId(tag) && MlStrings.hasValidLengthForId(tag)) == false)
                 .collect(Collectors.toList());
@@ -995,6 +1010,72 @@ public class TrainedModelConfig implements ToXContentObject, Writeable {
                 // packaged model validation
                 validationException = checkIllegalSetting(modelPackageConfig, MODEL_PACKAGE.getPreferredName(), validationException);
             }
+
+            if (prefixStrings != null) {
+                if (prefixStrings.ingestPrefix() != null && prefixStrings.ingestPrefix().length() > MAX_PREFIX_STRING_LENGTH) {
+                    validationException = addValidationError(
+                        "["
+                            + PREFIX_STRINGS.getPreferredName()
+                            + "."
+                            + TrainedModelPrefixStrings.INGEST_PREFIX.getPreferredName()
+                            + "] must be not more than "
+                            + MAX_PREFIX_STRING_LENGTH
+                            + " characters in length.",
+                        validationException
+                    );
+                }
+                if (prefixStrings.searchPrefix() != null && prefixStrings.searchPrefix().length() > MAX_PREFIX_STRING_LENGTH) {
+                    validationException = addValidationError(
+                        "["
+                            + PREFIX_STRINGS.getPreferredName()
+                            + "."
+                            + TrainedModelPrefixStrings.SEARCH_PREFIX.getPreferredName()
+                            + "] must be not more than "
+                            + MAX_PREFIX_STRING_LENGTH
+                            + " characters in length.",
+                        validationException
+                    );
+                }
+            }
+
+            if (input != null && input.getFieldNames().size() > MAX_INPUT_FIELD_NAMES) {
+                validationException = addValidationError(
+                    "["
+                        + INPUT.getPreferredName()
+                        + "."
+                        + TrainedModelInput.FIELD_NAMES.getPreferredName()
+                        + "] must contain not more than "
+                        + MAX_INPUT_FIELD_NAMES
+                        + " field names.",
+                    validationException
+                );
+            }
+
+            if (defaultFieldMap != null && defaultFieldMap.size() > MAX_DEFAULT_FIELD_MAP_ENTRIES) {
+                validationException = addValidationError(
+                    "["
+                        + DEFAULT_FIELD_MAP.getPreferredName()
+                        + "] must contain not more than "
+                        + MAX_DEFAULT_FIELD_MAP_ENTRIES
+                        + " entries.",
+                    validationException
+                );
+            }
+
+            if (metadata != null && serializationSize(metadata) > MAX_METADATA_SIZE_BYTES) {
+                validationException = addValidationError(
+                    "[" + METADATA.getPreferredName() + "] must be not more than " + MAX_METADATA_SIZE_BYTES + " bytes in size.",
+                    validationException
+                );
+            }
+
+            if (description != null && description.length() > MAX_DESCRIPTION_LENGTH) {
+                validationException = addValidationError(
+                    "[" + DESCRIPTION.getPreferredName() + "] must be not more than " + MAX_DESCRIPTION_LENGTH + " characters in length.",
+                    validationException
+                );
+            }
+
             if (validationException != null) {
                 throw validationException;
             }
@@ -1033,6 +1114,15 @@ public class TrainedModelConfig implements ToXContentObject, Writeable {
             }
 
             return this;
+        }
+
+        private static int serializationSize(Map<String, Object> map) {
+            try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
+                builder.value(map);
+                return BytesReference.bytes(builder).length();
+            } catch (IOException e) {
+                throw new ElasticsearchException("Error occurred computing serialization size", e);
+            }
         }
 
         private static ActionRequestValidationException checkIllegalSetting(

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfigTests.java
@@ -350,6 +350,128 @@ public class TrainedModelConfigTests extends AbstractBWCSerializationTestCase<Tr
         assertThat(ex.getMessage(), containsString("illegal to set [created_by] at inference model creation"));
     }
 
+    public void testValidateMetadataSizeExceedsLimit() {
+        String value = "a".repeat(TrainedModelConfig.MAX_METADATA_SIZE_BYTES);
+        Map<String, Object> oversizedMetadata = Map.of("key1", value);
+        ActionRequestValidationException ex = expectThrows(
+            ActionRequestValidationException.class,
+            () -> TrainedModelConfig.builder()
+                .setParsedDefinition(TrainedModelDefinitionTests.createRandomBuilder())
+                .setModelId("test-model")
+                .setMetadata(oversizedMetadata)
+                .validate()
+        );
+        assertThat(
+            ex.getMessage(),
+            containsString("[metadata] must be not more than " + TrainedModelConfig.MAX_METADATA_SIZE_BYTES + " bytes in size.")
+        );
+    }
+
+    public void testValidateDescriptionExceedsMaxLength() {
+        String description = "a".repeat(TrainedModelConfig.MAX_DESCRIPTION_LENGTH + 1);
+        ActionRequestValidationException ex = expectThrows(
+            ActionRequestValidationException.class,
+            () -> TrainedModelConfig.builder()
+                .setParsedDefinition(TrainedModelDefinitionTests.createRandomBuilder())
+                .setModelId("test-model")
+                .setDescription(description)
+                .validate()
+        );
+        assertThat(
+            ex.getMessage(),
+            containsString("[description] must be not more than " + TrainedModelConfig.MAX_DESCRIPTION_LENGTH + " characters in length.")
+        );
+    }
+
+    public void testValidateTagsExceedMaxCount() {
+        List<String> tags = IntStream.range(0, TrainedModelConfig.MAX_TAGS_LENGTH + 1)
+            .mapToObj(i -> "tag" + i)
+            .collect(Collectors.toList());
+        ActionRequestValidationException ex = expectThrows(
+            ActionRequestValidationException.class,
+            () -> TrainedModelConfig.builder()
+                .setParsedDefinition(TrainedModelDefinitionTests.createRandomBuilder())
+                .setModelId("test-model")
+                .setTags(tags)
+                .validate()
+        );
+        assertThat(ex.getMessage(), containsString("[tags] must contain not more than " + TrainedModelConfig.MAX_TAGS_LENGTH + " tags."));
+    }
+
+    public void testValidateIngestPrefixExceedsMaxLength() {
+        String longPrefix = "a".repeat(TrainedModelConfig.MAX_PREFIX_STRING_LENGTH + 1);
+        ActionRequestValidationException ex = expectThrows(
+            ActionRequestValidationException.class,
+            () -> TrainedModelConfig.builder()
+                .setParsedDefinition(TrainedModelDefinitionTests.createRandomBuilder())
+                .setModelId("test-model")
+                .setPrefixStrings(new TrainedModelPrefixStrings(longPrefix, null))
+                .validate()
+        );
+        assertThat(
+            ex.getMessage(),
+            containsString(
+                "[prefix_strings.ingest] must be not more than " + TrainedModelConfig.MAX_PREFIX_STRING_LENGTH + " characters in length."
+            )
+        );
+    }
+
+    public void testValidateSearchPrefixExceedsMaxLength() {
+        String longPrefix = "a".repeat(TrainedModelConfig.MAX_PREFIX_STRING_LENGTH + 1);
+        ActionRequestValidationException ex = expectThrows(
+            ActionRequestValidationException.class,
+            () -> TrainedModelConfig.builder()
+                .setParsedDefinition(TrainedModelDefinitionTests.createRandomBuilder())
+                .setModelId("test-model")
+                .setPrefixStrings(new TrainedModelPrefixStrings(null, longPrefix))
+                .validate()
+        );
+        assertThat(
+            ex.getMessage(),
+            containsString(
+                "[prefix_strings.search] must be not more than " + TrainedModelConfig.MAX_PREFIX_STRING_LENGTH + " characters in length."
+            )
+        );
+    }
+
+    public void testValidateInputFieldNamesExceedMaxCount() {
+        List<String> fieldNames = IntStream.range(0, TrainedModelConfig.MAX_INPUT_FIELD_NAMES + 1)
+            .mapToObj(i -> "field" + i)
+            .collect(Collectors.toList());
+        ActionRequestValidationException ex = expectThrows(
+            ActionRequestValidationException.class,
+            () -> TrainedModelConfig.builder()
+                .setParsedDefinition(TrainedModelDefinitionTests.createRandomBuilder())
+                .setModelId("test-model")
+                .setInput(new TrainedModelInput(fieldNames))
+                .validate()
+        );
+        assertThat(
+            ex.getMessage(),
+            containsString("[input.field_names] must contain not more than " + TrainedModelConfig.MAX_INPUT_FIELD_NAMES + " field names.")
+        );
+    }
+
+    public void testValidateDefaultFieldMapExceedsMaxEntries() {
+        Map<String, String> largeMap = IntStream.range(0, TrainedModelConfig.MAX_DEFAULT_FIELD_MAP_ENTRIES + 1)
+            .boxed()
+            .collect(Collectors.toMap(i -> "key" + i, i -> "value" + i));
+        ActionRequestValidationException ex = expectThrows(
+            ActionRequestValidationException.class,
+            () -> TrainedModelConfig.builder()
+                .setParsedDefinition(TrainedModelDefinitionTests.createRandomBuilder())
+                .setModelId("test-model")
+                .setDefaultFieldMap(largeMap)
+                .validate()
+        );
+        assertThat(
+            ex.getMessage(),
+            containsString(
+                "[default_field_map] must contain not more than " + TrainedModelConfig.MAX_DEFAULT_FIELD_MAP_ENTRIES + " entries."
+            )
+        );
+    }
+
     public void testSerializationWithLazyDefinition() throws IOException {
         xContentTester(this::createParser, () -> {
             try {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[ML] Add extra validation in trained_model creation (#150227)](https://github.com/elastic/elasticsearch/pull/150227)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)