### PR TITLE
Fix Snyk dependency graph building

### DIFF
--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/snyk/SnykDependencyMonitoringGradlePluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/snyk/SnykDependencyMonitoringGradlePluginFuncTest.groovy
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.gradle.internal.snyk
 
+import groovy.json.JsonSlurper
 import org.elasticsearch.gradle.fixtures.AbstractGradleInternalPluginFuncTest
 import org.gradle.api.Plugin
 import org.gradle.testkit.runner.TaskOutcome
@@ -177,6 +178,61 @@ class SnykDependencyMonitoringGradlePluginFuncTest extends AbstractGradleInterna
         version        | expectedLifecycle
         '1.0-SNAPSHOT' | 'development'
         '1.0'          | 'production'
+    }
+
+    def "snyk dependency graph deduplicates diamond dependencies and stays reachable"() {
+        given:
+        buildFile << """
+            apply plugin:'java'
+            version = "1.0"
+
+            repositories { mavenCentral() }
+
+            dependencies {
+                implementation 'org.apache.lucene:lucene-monitor:9.2.0'
+                implementation 'org.apache.lucene:lucene-grouping:9.2.0'
+                implementation 'org.apache.lucene:lucene-core:9.2.0'
+            }
+
+            tasks.named('generateSnykDependencyGraph').configure {
+                remoteUrl = "http://acme.org"
+            }
+        """
+
+        when:
+        def result = gradleRunner("generateSnykDependencyGraph").build()
+        def json = new JsonSlurper().parse(file("build/snyk/dependencies.json"))
+        def graph = json.depGraphJSON.graph
+        def nodes = graph.nodes
+        def nodesById = nodes.collectEntries { [it.nodeId, it] }
+
+        then:
+        result.task(":generateSnykDependencyGraph").outcome == TaskOutcome.SUCCESS
+
+        and: "lucene-core is deduplicated"
+        nodes.count { it.nodeId == "org.apache.lucene:lucene-core@9.2.0" } == 1
+
+        and: "lucene-core is referenced from multiple parents"
+        def coreParents = nodes.findAll { n ->
+            n.deps?.any { it.nodeId == "org.apache.lucene:lucene-core@9.2.0" }
+        }*.nodeId
+        coreParents.size() >= 2
+
+        and: "every node is reachable from root-node (mirrors Snyk server-side validation)"
+        def visited = [] as Set
+        def stack = [graph.rootNodeId]
+        while (stack) {
+            def cur = stack.pop()
+            if (visited.add(cur)) {
+                def n = nodesById[cur]
+                assert n != null : "deps reference unknown node ${cur}"
+                n.deps?.each { stack.push(it.nodeId) }
+            }
+        }
+        visited == nodes*.nodeId.toSet()
+
+        and: "every nodeId has a matching pkg entry"
+        json.depGraphJSON.pkgs*.id.toSet() == nodes*.pkgId.toSet()
     }
 
     @Unroll

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/snyk/SnykDependencyGraphBuilder.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/snyk/SnykDependencyGraphBuilder.java
@@ -12,12 +12,14 @@ package org.elasticsearch.gradle.internal.snyk;
 import org.elasticsearch.gradle.internal.snyk.SnykDependencyGraph.SnykDependencyNode;
 import org.gradle.api.artifacts.ResolvedDependency;
 
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.Map;
 import java.util.Set;
 
 public class SnykDependencyGraphBuilder {
 
-    private Set<SnykDependencyNode> nodes = new LinkedHashSet<>();
+    private Map<String, SnykDependencyNode> nodes = new LinkedHashMap<>();
     private Set<SnykDependencyGraph.SnykDependencyPkg> pkgs = new LinkedHashSet<>();
 
     private SnykDependencyNode currentNode;
@@ -29,13 +31,16 @@ public class SnykDependencyGraphBuilder {
 
     public SnykDependencyNode addNode(String nodeId, String pkgIdPrefix, String version) {
         String pkgId = pkgIdPrefix + "@" + version;
-        SnykDependencyNode node = new SnykDependencyNode(nodeId, pkgId);
-        SnykDependencyGraph.SnykDependencyPkg pkg = new SnykDependencyGraph.SnykDependencyPkg(pkgId);
-        nodes.add(node);
+        pkgs.add(new SnykDependencyGraph.SnykDependencyPkg(pkgId));
         if (currentNode != null) {
             currentNode.addDep(pkgId);
         }
-        pkgs.add(pkg);
+        SnykDependencyNode existing = nodes.get(nodeId);
+        if (existing != null) {
+            return existing;
+        }
+        SnykDependencyNode node = new SnykDependencyNode(nodeId, pkgId);
+        nodes.put(nodeId, node);
         return node;
     }
 
@@ -55,7 +60,7 @@ public class SnykDependencyGraphBuilder {
     }
 
     public SnykDependencyGraph build() {
-        return new SnykDependencyGraph(gradleVersion, nodes, pkgs);
+        return new SnykDependencyGraph(gradleVersion, new LinkedHashSet<>(nodes.values()), pkgs);
     }
 
     public void walkGraph(String rootPkgId, String version, Set<ResolvedDependency> deps) {


### PR DESCRIPTION
The `SnykDependencyGraphBuilder.addNode` always allocated a fresh `SnykDependencyNode` and returned it, even when the same `(group:name@version)` had already been added. `LinkedHashSet.add` deduplicated it via `equals`, so the orphan never reached the graph, but its reference was still used as `currentNode` during recursion into the duplicate's `dep.getChildren()`. Every `currentNode.addDep(...)` write from that subtree landed on the discarded orphan instead of the canonical in-graph node.

The packages were present in the produced `dependencies.json`'s `nodes` array but unreachable from `root-node` via `deps` edges. This caused upload to Snyk to fail with error `not all graph nodes are reachable from root`.

The fix is to track all nodes and on duplicate return the **existing** node instead of constructing and returning a new orphaned node.
