### PR TITLE
[ESQL] Surface external read failures with typed exceptions

### DIFF
--- a/docs/changelog/151377.yaml
+++ b/docs/changelog/151377.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 151377
+summary: Surface external read failures with typed exceptions
+type: enhancement

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
@@ -37,6 +37,7 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.util.Check;
 import org.elasticsearch.xpack.esql.core.util.DateUtils;
+import org.elasticsearch.xpack.esql.datasources.ExternalFailures;
 import org.elasticsearch.xpack.esql.datasources.SourceStatisticsSerializer;
 import org.elasticsearch.xpack.esql.datasources.TextAggregatePushdownSupport;
 import org.elasticsearch.xpack.esql.datasources.cache.ColumnStatsAccumulator;
@@ -1492,7 +1493,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
                 eof = next == null;
                 return eof == false;
             } catch (IOException e) {
-                throw new RuntimeException(e);
+                throw ExternalFailures.surface(e, "Failed to read CSV record");
             }
         }
 
@@ -1663,7 +1664,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
                 }
                 return true;
             } catch (IOException e) {
-                throw new RuntimeException("Failed to read CSV batch", e);
+                throw ExternalFailures.surface(e, "Failed to read CSV batch");
             } finally {
                 long deltaTotal = totalRowCount - startTotal;
                 long deltaErrors = errorCount - startError;

--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIterator.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIterator.java
@@ -14,6 +14,7 @@ import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.util.Check;
+import org.elasticsearch.xpack.esql.datasources.ExternalFailures;
 import org.elasticsearch.xpack.esql.datasources.SourceStatisticsSerializer;
 import org.elasticsearch.xpack.esql.datasources.cache.ColumnStatsAccumulator;
 import org.elasticsearch.xpack.esql.datasources.cache.CountingInputStream;
@@ -269,7 +270,7 @@ final class NdJsonPageIterator extends BufferingPageIterator {
             }
             return true;
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw ExternalFailures.surface(e, "Failed to read NDJSON page");
         }
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalFailures.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalFailures.java
@@ -18,11 +18,17 @@ import java.util.Set;
 
 /**
  * Classifies a failure raised while reading an external data source into the exception the
- * {@code AsyncExternalSourceOperator} should surface, so that it maps to the right HTTP status.
+ * {@code AsyncExternalSourceOperator} should surface, so that it maps to the right HTTP status. The
+ * companion {@link #surface} helper is used at the worker rethrow sites inside parallel coordinators and
+ * page iterators to pre-type the failure: it wraps a raw {@link IOException} in an already-classified
+ * {@link ExternalClientException} (400) so the read boundary's {@link #classify} sees a status-typed
+ * exception. {@code surface} cannot rescue a status signal already buried under a status-neutral
+ * {@link RuntimeException} wrapper; callers must therefore pass the <em>raw</em> stored throwable, not a
+ * pre-wrapped one.
  * <p>
- * This is the single boundary where external-source reads turn into a user-visible error, and it is
- * reached only for external-source queries (the operator exists only for them), so index queries are
- * unaffected. It runs co-located with the throw, on the node that reads the external source, before
+ * {@link #classify} is the single boundary where external-source reads turn into a user-visible error,
+ * and it is reached only for external-source queries (the operator exists only for them), so index queries
+ * are unaffected. It runs co-located with the throw, on the node that reads the external source, before
  * the failure is serialized back to the coordinator — so classification relies on the concrete
  * exception type while it is still available, and only the resulting {@code status()} needs to cross
  * the wire (see {@link org.elasticsearch.xpack.esql.datasources.spi.ExternalException}). The policy:
@@ -87,7 +93,68 @@ public final class ExternalFailures {
         return new ExternalServerException(t, "Unexpected failure reading external source: {}", t.getMessage());
     }
 
+    /**
+     * Surfaces a worker-side stored failure as a typed ES|QL exception that already carries the right HTTP
+     * status, instead of a status-neutral {@link RuntimeException} wrapper. Called at the throw site inside
+     * parallel parsing coordinators and page iterators (the boundary between the worker that stored the
+     * failure and the consumer pulling from the iterator). Companion to {@link #classify}: where
+     * {@code classify} runs at the read boundary and maps a freshly raised failure to a status-typed
+     * exception, {@code surface} runs at the worker rethrow site and pins the status carried by the
+     * underlying type while preserving a context prefix ({@code fallbackMessage}, e.g.
+     * {@code "Streaming parallel parsing failed"}) so the coordinator/iterator origin stays visible in logs
+     * and the user-facing message:
+     * <ul>
+     *     <li>An {@link Error} is rethrown unchanged — a JVM/programming fault must stay fatal.</li>
+     *     <li>A {@link RuntimeException} is returned as-is. This covers status carriers
+     *     ({@link ElasticsearchException} family, {@link IllegalArgumentException}) which already pin
+     *     their own status, and any other unchecked cause raised by the worker. <strong>Note:</strong> a
+     *     bare {@link RuntimeException} that buries an {@link IOException} cause is <em>not</em> rescued
+     *     here — the wrapper has already destroyed the type signal. Callers must therefore pass the raw
+     *     stored throwable, not a pre-wrapped one.</li>
+     *     <li>An {@link IOException} or {@link UncheckedIOException} becomes an
+     *     {@link ExternalClientException} (400) — undecodable input is a client-class error, not a server
+     *     fault. The {@code fallbackMessage} prefix is kept either way, so the context survives whether
+     *     the worker raised checked or unchecked I/O.</li>
+     *     <li>Anything else (a checked, non-IO exception — typically {@link InterruptedException} stored
+     *     after a worker thread was interrupted) becomes an {@link ExternalServerException} (500): we have
+     *     no evidence it is the caller's fault, so we keep the bug visible.</li>
+     * </ul>
+     * Calling {@code surface} at the worker rethrow site lets {@code AsyncExternalSourceOperator}'s
+     * {@link #classify} compose cleanly on the result: an {@link ExternalException} returned here passes
+     * straight through {@code classify} unchanged; a non-classified {@link RuntimeException} is the only
+     * shape {@code classify} still actively re-wraps (into {@link ExternalServerException}, the same status
+     * {@code surface} would have produced for an unrecognized worker fault).
+     *
+     * @param failure the raw stored worker-side throwable; <em>not</em> a status-neutral wrapper around it
+     * @param fallbackMessage non-null context prefix (e.g. the coordinator/iterator name); included in
+     *                        every wrapped result so the throw-site origin survives classification
+     */
+    public static RuntimeException surface(Throwable failure, String fallbackMessage) {
+        if (failure instanceof Error error) {
+            throw error;
+        }
+        // UncheckedIOException is checked before the generic RuntimeException branch so its IO origin is
+        // typed as 400 with the coordinator's context prefix, instead of falling through unchanged and
+        // letting classify() re-wrap it with the boundary's generic message.
+        if (failure instanceof IOException || failure instanceof UncheckedIOException) {
+            return new ExternalClientException(failure, "{}: {}", fallbackMessage, detail(failure));
+        }
+        if (failure instanceof RuntimeException re) {
+            return re;
+        }
+        return new ExternalServerException(failure, "{}: {}", fallbackMessage, detail(failure));
+    }
+
     private static boolean isMalformedDataException(Throwable t) {
         return MALFORMED_DATA_EXCEPTIONS.contains(t.getClass().getName());
+    }
+
+    /**
+     * Best-effort short description of a failure for inclusion in a typed exception's message: the
+     * {@code getMessage()} if set, otherwise the class's simple name (so a null-message
+     * {@link InterruptedException} reads as {@code "InterruptedException"} rather than {@code "null"}).
+     */
+    private static String detail(Throwable failure) {
+        return failure.getMessage() != null ? failure.getMessage() : failure.getClass().getSimpleName();
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ParallelParsingCoordinator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ParallelParsingCoordinator.java
@@ -769,10 +769,7 @@ public final class ParallelParsingCoordinator {
         private void checkError() {
             Throwable t = firstError.get();
             if (t != null) {
-                if (t instanceof RuntimeException re) {
-                    throw re;
-                }
-                throw new RuntimeException("Parallel parsing failed", t);
+                throw ExternalFailures.surface(t, "Parallel parsing failed");
             }
         }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
@@ -927,10 +927,7 @@ public final class StreamingParallelParsingCoordinator {
         private void checkError() {
             Throwable t = firstError.get();
             if (t != null) {
-                if (t instanceof RuntimeException re) {
-                    throw re;
-                }
-                throw new RuntimeException("Streaming parallel parsing failed", t);
+                throw ExternalFailures.surface(t, "Streaming parallel parsing failed");
             }
         }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalFailuresTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalFailuresTests.java
@@ -102,4 +102,96 @@ public class ExternalFailuresTests extends ESTestCase {
             assertEquals(RestStatus.INTERNAL_SERVER_ERROR, ExceptionsHelper.status(classified));
         }
     }
+
+    public void testSurfaceRethrowsErrorUnchanged() {
+        AssertionError error = new AssertionError("boom");
+        AssertionError thrown = expectThrows(AssertionError.class, () -> ExternalFailures.surface(error, "ctx"));
+        assertSame(error, thrown);
+    }
+
+    public void testSurfaceReturnsRuntimeExceptionAsIs() {
+        // Plain RuntimeException, status carriers, and IllegalArgumentException share the same passthrough
+        // branch — they self-describe their status (or lack of one) and the worker context is not relevant.
+        RuntimeException plain = new RuntimeException("oops");
+        assertSame(plain, ExternalFailures.surface(plain, "ctx"));
+
+        var carrier = new ExternalClientException("already typed", new IOException("io"));
+        assertSame(carrier, ExternalFailures.surface(carrier, "ctx"));
+
+        var iae = new IllegalArgumentException("bad arg");
+        assertSame(iae, ExternalFailures.surface(iae, "ctx"));
+    }
+
+    public void testSurfaceWrapsIoExceptionAsExternalClient() {
+        IOException ioe = new IOException("record exceeded max_record_size");
+        RuntimeException surfaced = ExternalFailures.surface(ioe, "Streaming parallel parsing failed");
+        assertThat(surfaced, org.hamcrest.Matchers.instanceOf(ExternalClientException.class));
+        assertSame(ioe, surfaced.getCause());
+        assertEquals(RestStatus.BAD_REQUEST, ExceptionsHelper.status(surfaced));
+        assertThat(surfaced.getMessage(), org.hamcrest.Matchers.containsString("Streaming parallel parsing failed"));
+        assertThat(surfaced.getMessage(), org.hamcrest.Matchers.containsString("record exceeded max_record_size"));
+    }
+
+    public void testSurfaceWrapsUncheckedIoExceptionAsExternalClient() {
+        // UncheckedIOException is a RuntimeException — but it represents an underlying IO failure, so it must
+        // route through the IO branch (400 + context prefix), not the generic RuntimeException passthrough.
+        IOException cause = new IOException("upstream");
+        UncheckedIOException uioe = new UncheckedIOException("wrapped", cause);
+        RuntimeException surfaced = ExternalFailures.surface(uioe, "Failed to read CSV batch");
+        assertThat(surfaced, org.hamcrest.Matchers.instanceOf(ExternalClientException.class));
+        assertSame(uioe, surfaced.getCause());
+        assertEquals(RestStatus.BAD_REQUEST, ExceptionsHelper.status(surfaced));
+        assertThat(surfaced.getMessage(), org.hamcrest.Matchers.containsString("Failed to read CSV batch"));
+        assertThat(surfaced.getMessage(), org.hamcrest.Matchers.containsString("wrapped"));
+    }
+
+    public void testSurfaceDoesNotRescueIoBuriedUnderRuntimeException() {
+        // surface() cannot recover a status signal already destroyed by an intermediate RuntimeException
+        // wrapper — the documented contract is that callers pass the raw stored throwable, not a pre-wrap.
+        RuntimeException wrapper = new RuntimeException("wrapper", new IOException("inner"));
+        assertSame(wrapper, ExternalFailures.surface(wrapper, "ctx"));
+    }
+
+    public void testSurfaceComposesIdempotentlyForCheckedNonIo() {
+        // The other main coordinator path: a stored InterruptedException produces an ExternalServerException
+        // at surface(), which classify() then passes through unchanged at the read boundary.
+        InterruptedException interrupted = new InterruptedException("worker interrupted");
+        RuntimeException surfaced = ExternalFailures.surface(interrupted, "Parallel parsing failed");
+        RuntimeException classified = ExternalFailures.classify(surfaced);
+        assertSame(surfaced, classified);
+        assertEquals(RestStatus.INTERNAL_SERVER_ERROR, ExceptionsHelper.status(classified));
+    }
+
+    public void testSurfaceWrapsCheckedNonIoAsExternalServer() {
+        // Bare InterruptedException stored after a worker thread was interrupted is the canonical case here:
+        // we have no evidence of bad input, so the bug stays visible as a 500 with the context prefix.
+        InterruptedException interrupted = new InterruptedException("worker interrupted");
+        RuntimeException surfaced = ExternalFailures.surface(interrupted, "Parallel parsing failed");
+        assertThat(surfaced, org.hamcrest.Matchers.instanceOf(ExternalServerException.class));
+        assertSame(interrupted, surfaced.getCause());
+        assertEquals(RestStatus.INTERNAL_SERVER_ERROR, ExceptionsHelper.status(surfaced));
+        assertThat(surfaced.getMessage(), org.hamcrest.Matchers.containsString("Parallel parsing failed"));
+        assertThat(surfaced.getMessage(), org.hamcrest.Matchers.containsString("worker interrupted"));
+    }
+
+    public void testSurfaceFallsBackToClassNameWhenMessageIsNull() {
+        // detail() returns the class's simple name when getMessage() is null, so the formatted message reads
+        // "<prefix>: InterruptedException" rather than the unhelpful "<prefix>: null".
+        InterruptedException interrupted = new InterruptedException();
+        RuntimeException surfaced = ExternalFailures.surface(interrupted, "Parallel parsing failed");
+        assertThat(surfaced, org.hamcrest.Matchers.instanceOf(ExternalServerException.class));
+        assertThat(surfaced.getMessage(), org.hamcrest.Matchers.containsString("InterruptedException"));
+        assertThat(surfaced.getMessage(), org.hamcrest.Matchers.not(org.hamcrest.Matchers.containsString("null")));
+    }
+
+    public void testSurfaceComposesIdempotentlyWithClassify() {
+        // The expected composition at production sites: surface() runs at the worker rethrow, classify() runs
+        // at the read boundary. surface()'s typed output must pass through classify() as the same instance
+        // so the prefix and status the worker site set are preserved end-to-end.
+        IOException ioe = new IOException("truncated");
+        RuntimeException surfaced = ExternalFailures.surface(ioe, "Failed to read NDJSON page");
+        RuntimeException classified = ExternalFailures.classify(surfaced);
+        assertSame("classify must pass an already-typed surface() result through unchanged", surfaced, classified);
+        assertEquals(RestStatus.BAD_REQUEST, ExceptionsHelper.status(classified));
+    }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ParallelParsingCoordinatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ParallelParsingCoordinatorTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.datasources;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.unit.ByteSizeValue;
@@ -19,6 +20,7 @@ import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.CloseableIterator;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
@@ -30,6 +32,7 @@ import org.elasticsearch.xpack.esql.datasources.cache.ExternalStats;
 import org.elasticsearch.xpack.esql.datasources.cache.ExternalStatsCapture;
 import org.elasticsearch.xpack.esql.datasources.cache.StatsCapturingIterator;
 import org.elasticsearch.xpack.esql.datasources.spi.BufferingPageIterator;
+import org.elasticsearch.xpack.esql.datasources.spi.ExternalClientException;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.NoConfigFormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.RecordSplitter;
@@ -667,6 +670,53 @@ public class ParallelParsingCoordinatorTests extends ESTestCase {
                 "Should contain the injected error message",
                 ex.getMessage().contains("injected") || (ex.getCause() != null && ex.getCause().getMessage().contains("injected"))
             );
+        } finally {
+            exec.shutdown();
+        }
+    }
+
+    /**
+     * Pins the production wiring for elastic/esql-planning#836 on the parallel coordinator: a worker
+     * IOException surfaces as a typed {@link ExternalClientException} at the iterator's {@code hasNext()}
+     * boundary (mirroring {@code CsvFormatReader} / {@code NdJsonPageIterator}), the coordinator stores it
+     * in {@code firstError}, and {@code checkError()}'s {@code surface()} passes it through unchanged so the
+     * 400 status survives end-to-end instead of being downgraded to a generic 500 wrapper.
+     */
+    public void testParallelReadSurfacesIoFailureAsExternalClientException() throws Exception {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 100; i++) {
+            sb.append("line-").append(i).append("\n");
+        }
+        StorageObject obj = new InMemoryStorageObject(sb.toString().getBytes(StandardCharsets.UTF_8));
+        FailingFormatReader reader = new FailingFormatReader(blockFactory(), 5);
+
+        ExecutorService exec = Executors.newFixedThreadPool(4);
+        try {
+            CloseableIterator<Page> iter = ParallelParsingCoordinator.parallelRead(reader, obj, List.of("line"), 10, 4, exec);
+
+            RuntimeException ex = expectThrows(RuntimeException.class, () -> {
+                try (iter) {
+                    while (iter.hasNext()) {
+                        iter.next().releaseBlocks();
+                    }
+                }
+            });
+            assertThat(
+                "iterator-boundary IOException must surface as a typed ExternalClientException, not a generic RuntimeException",
+                ex,
+                Matchers.instanceOf(ExternalClientException.class)
+            );
+            assertEquals(
+                "ExternalClientException must classify as HTTP 400 so the read failure stops being labeled as a server fault",
+                RestStatus.BAD_REQUEST,
+                ExceptionsHelper.status(ex)
+            );
+            assertThat(
+                "the original IOException must remain reachable as the cause",
+                ex.getCause(),
+                Matchers.instanceOf(IOException.class)
+            );
+            assertThat("the injected detail must survive end-to-end", ex.getMessage(), Matchers.containsString("injected"));
         } finally {
             exec.shutdown();
         }
@@ -1576,7 +1626,10 @@ public class ParallelParsingCoordinatorTests extends ESTestCase {
                     try {
                         nextPage = readBatch();
                     } catch (IOException e) {
-                        throw new RuntimeException(e);
+                        // Mirror the production iterators (CsvFormatReader, NdJsonPageIterator), which surface
+                        // a raw IOException as a typed ExternalClientException at the hasNext() boundary so the
+                        // 400 status survives into the coordinator's firstError.
+                        throw ExternalFailures.surface(e, "Failed to read injected test page");
                     }
                     return nextPage != null;
                 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinatorTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.datasources;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
@@ -15,6 +16,7 @@ import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.CloseableIterator;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Nullability;
@@ -26,6 +28,7 @@ import org.elasticsearch.xpack.esql.datasources.cache.ExternalStats;
 import org.elasticsearch.xpack.esql.datasources.cache.ExternalStatsCapture;
 import org.elasticsearch.xpack.esql.datasources.cache.StatsCapturingIterator;
 import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
+import org.elasticsearch.xpack.esql.datasources.spi.ExternalClientException;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.NoConfigFormatReader;
@@ -317,6 +320,54 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
                 "Expected injected failure message but got: " + ex.getMessage(),
                 ex.getMessage().contains("injected") || (ex.getCause() != null && ex.getCause().getMessage().contains("injected"))
             );
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    /**
+     * Pins the typed-failure contract from elastic/esql-planning#836 on the streaming coordinator: a raw
+     * {@link IOException} thrown by a worker (here, {@code FailingFormatReader.read}) is stored in
+     * {@code firstError} and surfaced by {@code checkError()}'s {@code surface()} as a typed
+     * {@link ExternalClientException} (HTTP 400) — including the coordinator's "Streaming parallel parsing
+     * failed" prefix — rather than a status-neutral {@link RuntimeException} that would later be
+     * misclassified as 500. The injected "injected failure" mirrors the path real failures take (e.g. a
+     * record exceeding {@code max_record_size}).
+     */
+    public void testParserIoFailureSurfacesAsExternalClientException() throws Exception {
+        String content = buildContent(100);
+        InputStream stream = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+
+        ExecutorService executor = Executors.newFixedThreadPool(4);
+        try {
+            FailingFormatReader reader = new FailingFormatReader(5, 1024);
+            RuntimeException ex = expectThrows(
+                RuntimeException.class,
+                () -> collectLines(
+                    StreamingParallelParsingCoordinator.parallelRead(reader, stream, List.of("line"), 50, 4, executor, ErrorPolicy.STRICT)
+                )
+            );
+            assertThat(
+                "stored IOException must surface as a typed ExternalClientException, not a generic RuntimeException",
+                ex,
+                Matchers.instanceOf(ExternalClientException.class)
+            );
+            assertEquals(
+                "ExternalClientException must classify as HTTP 400 so the read failure stops being labeled as a server fault",
+                RestStatus.BAD_REQUEST,
+                ExceptionsHelper.status(ex)
+            );
+            assertThat(
+                "the original IOException must remain reachable as the cause",
+                ex.getCause(),
+                Matchers.instanceOf(IOException.class)
+            );
+            assertThat(
+                "the coordinator's context prefix must survive in the surfaced message",
+                ex.getMessage(),
+                Matchers.containsString("Streaming parallel parsing failed")
+            );
+            assertThat("the injected detail must survive end-to-end", ex.getMessage(), Matchers.containsString("injected"));
         } finally {
             executor.shutdownNow();
         }


### PR DESCRIPTION
Replace the status-neutral `RuntimeException` wrapper at five worker
rethrow sites in the external-source read path with a typed ES|QL
exception that already carries the right HTTP status. Adds a
`ExternalFailures.surface(failure, fallbackMessage)` helper:

  - `Error` is rethrown unchanged.
  - `IOException`/`UncheckedIOException` becomes `ExternalClientException`
    (400) with the call-site context prefix preserved.
  - `RuntimeException` is returned as-is so status carriers
    (`ElasticsearchException` family, `IllegalArgumentException`) keep
    their own 400/429/503.
  - Other checked exceptions (e.g. `InterruptedException`) become
    `ExternalServerException` (500) with the prefix preserved.

Wired into the two parallel parsing coordinators' `checkError` and the
three page-iterator `hasNext` sites in `CsvFormatReader` and
`NdJsonPageIterator`. The result composes idempotently with
`ExternalFailures.classify` at the read boundary, so the 400 survives
end-to-end instead of being misclassified as a 500.

Developed with AI-assisted tooling