### PR TITLE
9.3 - Override topDocs in adaptive HNSW early exit (and test fix)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -339,9 +339,6 @@ tests:
 - class: org.elasticsearch.gradle.internal.transport.TransportVersionGenerationFuncTest
   method: name can be found from staged definition
   issue: https://github.com/elastic/elasticsearch/issues/150299
-- class: org.elasticsearch.search.vectors.AdaptiveHnswQueueSaturationCollectorTests
-  method: testEarlyExitRelation
-  issue: https://github.com/elastic/elasticsearch/issues/150470
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
   method: test
   issue: https://github.com/elastic/elasticsearch/issues/150569

--- a/server/src/main/java/org/elasticsearch/search/vectors/AdaptiveHnswQueueSaturationCollector.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/AdaptiveHnswQueueSaturationCollector.java
@@ -56,7 +56,7 @@ public class AdaptiveHnswQueueSaturationCollector extends HnswQueueSaturationCol
         float thresholdLooseness,
         float patienceScaling
     ) {
-        super(delegate, 1.0, 0);
+        super(delegate, 0, 0);
         this.discoveryRateSmoothing = discoveryRateSmoothing;
         this.thresholdLooseness = thresholdLooseness;
         this.patienceScaling = patienceScaling;

--- a/server/src/main/java/org/elasticsearch/search/vectors/AdaptiveHnswQueueSaturationCollector.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/AdaptiveHnswQueueSaturationCollector.java
@@ -11,6 +11,8 @@ package org.elasticsearch.search.vectors;
 
 import org.apache.lucene.search.HnswQueueSaturationCollector;
 import org.apache.lucene.search.KnnCollector;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TotalHits;
 
 /**
  * A {@link KnnCollector.Decorator} extending {@link HnswQueueSaturationCollector}
@@ -54,7 +56,7 @@ public class AdaptiveHnswQueueSaturationCollector extends HnswQueueSaturationCol
         float thresholdLooseness,
         float patienceScaling
     ) {
-        super(delegate, 0, 0);
+        super(delegate, 1.0, 0);
         this.discoveryRateSmoothing = discoveryRateSmoothing;
         this.thresholdLooseness = thresholdLooseness;
         this.patienceScaling = patienceScaling;
@@ -67,6 +69,16 @@ public class AdaptiveHnswQueueSaturationCollector extends HnswQueueSaturationCol
     @Override
     public boolean earlyTerminated() {
         return patienceFinished || super.earlyTerminated();
+    }
+
+    @Override
+    public TopDocs topDocs() {
+        if (patienceFinished && super.earlyTerminated() == false) {
+            TopDocs delegateDocs = super.topDocs();
+            TotalHits totalHits = new TotalHits(delegateDocs.totalHits.value(), TotalHits.Relation.EQUAL_TO);
+            return new TopDocs(totalHits, delegateDocs.scoreDocs);
+        }
+        return super.topDocs();
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/vectors/AdaptiveHnswQueueSaturationCollectorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/vectors/AdaptiveHnswQueueSaturationCollectorTests.java
@@ -82,8 +82,8 @@ public class AdaptiveHnswQueueSaturationCollectorTests extends LuceneTestCase {
             if (delegate.earlyTerminated()) {
                 TopDocs topDocs = queueSaturationCollector.topDocs();
                 assertEquals(TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO, topDocs.totalHits.relation());
-            }
-            if (queueSaturationCollector.earlyTerminated()) {
+                break;
+            } else if (queueSaturationCollector.earlyTerminated()) {
                 TopDocs topDocs = queueSaturationCollector.topDocs();
                 assertEquals(TotalHits.Relation.EQUAL_TO, topDocs.totalHits.relation());
                 break;


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch/issues/150470 and backports https://github.com/elastic/elasticsearch/pull/151379 to 9.3 branch