### PR TITLE
ES|QL: zero-fill sparse BUCKET rows before CHANGE_POINT to satisfy the 22-value minimum

### DIFF
--- a/docs/reference/query-languages/esql/_snippets/commands/layout/change_point.md
+++ b/docs/reference/query-languages/esql/_snippets/commands/layout/change_point.md
@@ -61,6 +61,10 @@ The possible change point types are:
 ::::{note}
 There must be at least 22 values for change point detection. Any values beyond the first 1,000 are ignored.
 
+When `ON key` matches a `STATS` grouping produced by `BUCKET` on a `datetime` or `date_nanos` field (any field name), and a time range is available from foldable `from` and `to` arguments on `BUCKET` or from an `@timestamp` range filter on the request, missing bucket keys between real buckets are always zero-filled so the value sequence is contiguous. If fewer than 22 real buckets are present and interior gap fill alone does not reach 22, additional buckets are added alternately to the left and right of the real data until 22 are reached or the timerange ends; when one side reaches the range edge, padding continues on the other side only. Real buckets are never removed. Detection is still sequence-based, not time-aware.
+
+Gap-filled buckets always use a value of `0`. That is appropriate for count-like metrics (for example `COUNT()` and `SUM()` of events) where a missing bucket means no activity. It is not correct for other aggregations such as `AVG()`, `MIN()`, and `MAX()`, where a missing bucket does not imply zero. For those metrics, gap filling is best-effort so sparse time-bucketed series can reach the 22-value minimum; interpret results with care. A future ES|QL enhancement may allow choosing the fill value, but the syntax does not expose that today.
+
 When a `BY` clause is provided, these rules apply per group. {applies_to}`stack: ga 9.5` {applies_to}`serverless: ga`
 ::::
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/ChangePointBucketFillUtils.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/ChangePointBucketFillUtils.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.operator;
+
+import org.elasticsearch.common.Rounding;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NavigableSet;
+import java.util.TreeSet;
+
+/**
+ * Utilities for computing which bucket keys to synthesize before {@link ChangePointOperator}.
+ */
+public final class ChangePointBucketFillUtils {
+
+    /**
+     * Minimum number of values required by {@link org.elasticsearch.xpack.ml.aggs.changepoint.ChangePointDetector},
+     * equal to {@code (2 * MINIMUM_BUCKETS) + 2} in that class ({@code MINIMUM_BUCKETS} is 10).
+     */
+    public static final int MINIMUM_BUCKET_COUNT = 22;
+
+    private ChangePointBucketFillUtils() {}
+
+    public static int countBucketsInRange(Rounding.Prepared rounding, long minDate, long maxDate) {
+        int count = 0;
+        long current = rounding.round(minDate);
+        while (current < maxDate) {
+            count++;
+            current = rounding.nextRoundingValue(current);
+        }
+        return count;
+    }
+
+    /**
+     * Returns the sorted bucket keys that should be present. Interior gaps between consecutive real keys
+     * are always filled. When fewer than {@link #MINIMUM_BUCKET_COUNT} real bucket keys are present and
+     * interior gap fill alone does not reach the minimum, buckets are added alternately to the left and
+     * right of the real-key cluster. When one side reaches the timerange edge, extension continues on the
+     * other side only until the minimum is reached or both sides are exhausted. Real bucket keys are
+     * never removed.
+     */
+    public static List<Long> computeFilledKeys(NavigableSet<Long> existingInRange, Rounding.Prepared rounding, long minDate, long maxDate) {
+        if (existingInRange.isEmpty()) {
+            return List.of();
+        }
+
+        TreeSet<Long> result = new TreeSet<>(existingInRange);
+
+        List<Long> sorted = new ArrayList<>(existingInRange);
+        for (int i = 0; i < sorted.size() - 1; i++) {
+            long t = sorted.get(i);
+            long next = sorted.get(i + 1);
+            while (true) {
+                t = rounding.nextRoundingValue(t);
+                if (t >= next) {
+                    break;
+                }
+                if (t >= minDate && t < maxDate) {
+                    result.add(t);
+                }
+            }
+        }
+
+        if (existingInRange.size() < MINIMUM_BUCKET_COUNT && result.size() < MINIMUM_BUCKET_COUNT) {
+            extendAroundCluster(result, rounding, minDate, maxDate);
+        }
+
+        return new ArrayList<>(result);
+    }
+
+    public static boolean needsFill(NavigableSet<Long> existingInRange, Rounding.Prepared rounding, long minDate, long maxDate) {
+        return computeFilledKeys(existingInRange, rounding, minDate, maxDate).size() != existingInRange.size();
+    }
+
+    private static void extendAroundCluster(TreeSet<Long> result, Rounding.Prepared rounding, long minDate, long maxDate) {
+        long left = result.first();
+        long right = result.last();
+        boolean preferRight = true;
+
+        while (result.size() < MINIMUM_BUCKET_COUNT) {
+            boolean extended = false;
+            if (preferRight) {
+                extended = tryExtendRight(result, rounding, maxDate, right);
+                if (extended) {
+                    right = result.last();
+                }
+            } else {
+                extended = tryExtendLeft(result, rounding, minDate, left);
+                if (extended) {
+                    left = result.first();
+                }
+            }
+
+            if (extended == false) {
+                if (preferRight) {
+                    extended = tryExtendLeft(result, rounding, minDate, left);
+                    if (extended) {
+                        left = result.first();
+                    }
+                } else {
+                    extended = tryExtendRight(result, rounding, maxDate, right);
+                    if (extended) {
+                        right = result.last();
+                    }
+                }
+            }
+
+            if (extended == false) {
+                break;
+            }
+            preferRight = preferRight == false;
+        }
+    }
+
+    private static boolean tryExtendRight(TreeSet<Long> result, Rounding.Prepared rounding, long maxDate, long right) {
+        long next = rounding.nextRoundingValue(right);
+        if (next < maxDate) {
+            result.add(next);
+            return true;
+        }
+        return false;
+    }
+
+    private static boolean tryExtendLeft(TreeSet<Long> result, Rounding.Prepared rounding, long minDate, long left) {
+        long previous = previousRoundingValue(rounding, left, minDate);
+        if (previous >= minDate && previous < left) {
+            result.add(previous);
+            return true;
+        }
+        return false;
+    }
+
+    private static long previousRoundingValue(Rounding.Prepared rounding, long key, long minDate) {
+        long t = rounding.round(minDate);
+        long previous = t;
+        while (t < key) {
+            previous = t;
+            t = rounding.nextRoundingValue(t);
+        }
+        return previous < key ? previous : Long.MIN_VALUE;
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/ChangePointFillEmptyBucketsOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/ChangePointFillEmptyBucketsOperator.java
@@ -1,0 +1,506 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.operator;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.Rounding;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.bytes.PagedBytesBuilder;
+import org.elasticsearch.common.bytes.PagedBytesCursor;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BlockUtils;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.FloatBlock;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.core.Releasables;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeSet;
+
+/**
+ * Inserts zero-valued rows for missing date bucket keys before {@link ChangePointOperator}.
+ */
+public class ChangePointFillEmptyBucketsOperator implements Operator {
+
+    public record Factory(
+        int keyChannel,
+        int valueChannel,
+        int[] groupingChannels,
+        Rounding.Prepared dateBucketRounding,
+        long minDate,
+        long maxDate
+    ) implements OperatorFactory {
+
+        @Override
+        public Operator get(DriverContext driverContext) {
+            return new ChangePointFillEmptyBucketsOperator(
+                driverContext,
+                keyChannel,
+                valueChannel,
+                groupingChannels,
+                dateBucketRounding,
+                minDate,
+                maxDate
+            );
+        }
+
+        @Override
+        public String describe() {
+            return Strings.format(
+                "ChangePointFillEmptyBucketsOperator[keyChannel=%d, valueChannel=%d, groupingChannels=%s]",
+                keyChannel,
+                valueChannel,
+                Arrays.toString(groupingChannels)
+            );
+        }
+    }
+
+    private final DriverContext driverContext;
+    private final int keyChannel;
+    private final int valueChannel;
+    private final int[] groupingChannels;
+    private final Rounding.Prepared dateBucketRounding;
+    private final long minDate;
+    private final long maxDate;
+
+    private GroupKeyEncoder encoder;
+    private PagedBytesBuilder currentGroupKeyStorage;
+    private PagedBytesCursor currentGroupKeyCursor;
+    private final Deque<Page> currentGroupPages;
+    private final Deque<Page> outputPages;
+    private boolean finished;
+
+    public ChangePointFillEmptyBucketsOperator(
+        DriverContext driverContext,
+        int keyChannel,
+        int valueChannel,
+        int[] groupingChannels,
+        Rounding.Prepared dateBucketRounding,
+        long minDate,
+        long maxDate
+    ) {
+        this.driverContext = driverContext;
+        this.keyChannel = keyChannel;
+        this.valueChannel = valueChannel;
+        this.groupingChannels = groupingChannels;
+        this.dateBucketRounding = dateBucketRounding;
+        this.minDate = minDate;
+        this.maxDate = maxDate;
+        this.currentGroupPages = new ArrayDeque<>();
+        this.outputPages = new ArrayDeque<>();
+    }
+
+    @Override
+    public boolean needsInput() {
+        return finished == false && outputPages.isEmpty();
+    }
+
+    @Override
+    public void addInput(Page page) {
+        try {
+            processPage(page);
+        } catch (Exception e) {
+            page.releaseBlocks();
+            throw e;
+        }
+    }
+
+    @Override
+    public void finish() {
+        if (finished == false) {
+            finished = true;
+            flushGroup();
+        }
+    }
+
+    @Override
+    public boolean isFinished() {
+        return finished && outputPages.isEmpty();
+    }
+
+    @Override
+    public Page getOutput() {
+        if (outputPages.isEmpty()) {
+            return null;
+        }
+        return outputPages.removeFirst();
+    }
+
+    @Override
+    public boolean canProduceMoreDataWithoutExtraInput() {
+        return outputPages.isEmpty() == false;
+    }
+
+    @Override
+    public void close() {
+        Releasables.closeExpectNoException(
+            () -> Releasables.close(currentGroupPages),
+            () -> Releasables.close(outputPages),
+            encoder,
+            currentGroupKeyStorage
+        );
+    }
+
+    @Override
+    public String toString() {
+        return "ChangePointFillEmptyBucketsOperator[keyChannel="
+            + keyChannel
+            + ", valueChannel="
+            + valueChannel
+            + ", groupingChannels="
+            + Arrays.toString(groupingChannels)
+            + "]";
+    }
+
+    private void processPage(Page page) {
+        if (page.getPositionCount() == 0) {
+            page.releaseBlocks();
+            return;
+        }
+        if (groupingChannels.length > 0 && encoder == null) {
+            initEncoderAndCurrentKeyStorage(page);
+            storeCurrentGroupKey(encoder.encode(page, 0));
+        }
+
+        if (groupingChannels.length == 0) {
+            currentGroupPages.add(page);
+            return;
+        }
+
+        int positionCount = page.getPositionCount();
+        int scanStart = 0;
+        for (int i = 0; i < positionCount; i++) {
+            PagedBytesCursor key = encoder.encode(page, i);
+            if (key.equals(currentGroupKeyCursor)) {
+                continue;
+            }
+            if (i > scanStart) {
+                currentGroupPages.add(page.slice(scanStart, i));
+            }
+            flushGroup();
+            scanStart = i;
+            storeCurrentGroupKey(key);
+        }
+
+        if (scanStart == 0) {
+            currentGroupPages.add(page);
+        } else {
+            currentGroupPages.add(page.slice(scanStart, positionCount));
+            page.releaseBlocks();
+        }
+    }
+
+    private void initEncoderAndCurrentKeyStorage(Page page) {
+        List<ElementType> elementTypes = new ArrayList<>(page.getBlockCount());
+        for (int i = 0; i < page.getBlockCount(); i++) {
+            elementTypes.add(page.getBlock(i).elementType());
+        }
+        BlockFactory blockFactory = driverContext.blockFactory();
+        PagedBytesBuilder encoderRow = new PagedBytesBuilder(
+            blockFactory.bigArrays().recycler(),
+            blockFactory.breaker(),
+            "change-point-fill-group-key-encoder",
+            64
+        );
+        encoder = new GroupKeyEncoder(groupingChannels, elementTypes, encoderRow);
+        currentGroupKeyStorage = new PagedBytesBuilder(
+            blockFactory.bigArrays().recycler(),
+            blockFactory.breaker(),
+            "change-point-fill-current-group-key",
+            64
+        );
+        currentGroupKeyCursor = new PagedBytesCursor();
+    }
+
+    private void storeCurrentGroupKey(PagedBytesCursor freshKey) {
+        currentGroupKeyStorage.clear();
+        currentGroupKeyStorage.append(freshKey);
+        currentGroupKeyStorage.view(currentGroupKeyCursor);
+    }
+
+    private void flushGroup() {
+        if (currentGroupPages.isEmpty()) {
+            return;
+        }
+
+        List<Row> rows = new ArrayList<>();
+        List<Page> bufferedPages = new ArrayList<>();
+        for (Page page : currentGroupPages) {
+            bufferedPages.add(page);
+            int positionCount = page.getPositionCount();
+            for (int i = 0; i < positionCount; i++) {
+                rows.add(new Row(((LongBlock) page.getBlock(keyChannel)).getLong(i), page, i));
+            }
+        }
+        currentGroupPages.clear();
+
+        TreeSet<Long> existingInRange = new TreeSet<>();
+        Map<Long, Row> rowsByKey = new HashMap<>();
+        for (Row row : rows) {
+            if (row.key >= minDate && row.key < maxDate) {
+                existingInRange.add(row.key);
+                rowsByKey.putIfAbsent(row.key, row);
+            }
+        }
+
+        List<Long> filledKeys = ChangePointBucketFillUtils.computeFilledKeys(existingInRange, dateBucketRounding, minDate, maxDate);
+        if (filledKeys.size() == existingInRange.size()) {
+            for (Page page : bufferedPages) {
+                outputPages.add(page);
+            }
+            return;
+        }
+
+        Row template = rows.getFirst();
+        List<Row> filledRows = new ArrayList<>(filledKeys.size());
+        for (long key : filledKeys) {
+            Row existing = rowsByKey.get(key);
+            filledRows.add(existing != null ? existing : syntheticRow(template, key));
+        }
+        for (Row row : rows) {
+            if (row.key < minDate || row.key >= maxDate) {
+                filledRows.add(row);
+            }
+        }
+        filledRows.sort(Comparator.comparingLong(Row::key));
+
+        outputPages.add(buildPage(filledRows, template));
+        for (Page page : bufferedPages) {
+            page.releaseBlocks();
+        }
+    }
+
+    private Row syntheticRow(Row template, long key) {
+        BlockFactory blockFactory = driverContext.blockFactory();
+        int blockCount = template.page.getBlockCount();
+        Block[] blocks = new Block[blockCount];
+        boolean success = false;
+        try {
+            for (int channel = 0; channel < blockCount; channel++) {
+                Block source = template.page.getBlock(channel);
+                if (channel == keyChannel) {
+                    try (LongBlock.Builder builder = blockFactory.newLongBlockBuilder(1)) {
+                        builder.appendLong(key);
+                        blocks[channel] = builder.build();
+                    }
+                } else if (channel == valueChannel) {
+                    blocks[channel] = zeroValueBlock(source.elementType(), blockFactory);
+                } else if (isGroupingChannel(channel)) {
+                    blocks[channel] = copySinglePosition(source, template.position, blockFactory);
+                } else {
+                    blocks[channel] = blockFactory.newConstantNullBlock(1);
+                }
+            }
+            Page page = new Page(blocks);
+            success = true;
+            return new Row(key, page, 0);
+        } finally {
+            if (success == false) {
+                Releasables.closeExpectNoException(blocks);
+            }
+        }
+    }
+
+    private boolean isGroupingChannel(int channel) {
+        for (int groupingChannel : groupingChannels) {
+            if (groupingChannel == channel) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private Block copySinglePosition(Block source, int position, BlockFactory blockFactory) {
+        return switch (source.elementType()) {
+            case LONG -> {
+                try (LongBlock.Builder builder = blockFactory.newLongBlockBuilder(1)) {
+                    builder.appendLong(((LongBlock) source).getLong(position));
+                    yield builder.build();
+                }
+            }
+            case DOUBLE -> {
+                try (DoubleBlock.Builder builder = blockFactory.newDoubleBlockBuilder(1)) {
+                    builder.appendDouble(((DoubleBlock) source).getDouble(position));
+                    yield builder.build();
+                }
+            }
+            case BYTES_REF -> {
+                try (BytesRefBlock.Builder builder = blockFactory.newBytesRefBlockBuilder(1)) {
+                    if (source.isNull(position)) {
+                        builder.appendNull();
+                    } else {
+                        builder.appendBytesRef(((BytesRefBlock) source).getBytesRef(position, new BytesRef()));
+                    }
+                    yield builder.build();
+                }
+            }
+            case BOOLEAN -> {
+                try (var builder = blockFactory.newBooleanBlockBuilder(1)) {
+                    builder.appendBoolean(((org.elasticsearch.compute.data.BooleanBlock) source).getBoolean(position));
+                    yield builder.build();
+                }
+            }
+            case INT -> {
+                try (IntBlock.Builder builder = blockFactory.newIntBlockBuilder(1)) {
+                    builder.appendInt(((IntBlock) source).getInt(position));
+                    yield builder.build();
+                }
+            }
+            default -> blockFactory.newConstantNullBlock(1);
+        };
+    }
+
+    private Block zeroValueBlock(ElementType elementType, BlockFactory blockFactory) {
+        return switch (elementType) {
+            case LONG -> {
+                try (LongBlock.Builder builder = blockFactory.newLongBlockBuilder(1)) {
+                    builder.appendLong(0L);
+                    yield builder.build();
+                }
+            }
+            case DOUBLE -> {
+                try (DoubleBlock.Builder builder = blockFactory.newDoubleBlockBuilder(1)) {
+                    builder.appendDouble(0d);
+                    yield builder.build();
+                }
+            }
+            case INT -> {
+                try (IntBlock.Builder builder = blockFactory.newIntBlockBuilder(1)) {
+                    builder.appendInt(0);
+                    yield builder.build();
+                }
+            }
+            case FLOAT -> {
+                try (FloatBlock.Builder builder = blockFactory.newFloatBlockBuilder(1)) {
+                    builder.appendFloat(0f);
+                    yield builder.build();
+                }
+            }
+            default -> blockFactory.newConstantNullBlock(1);
+        };
+    }
+
+    private Page buildPage(List<Row> rows, Row typeTemplate) {
+        int blockCount = rows.getFirst().page.getBlockCount();
+        BlockFactory blockFactory = driverContext.blockFactory();
+        Block[] blocks = new Block[blockCount];
+        boolean success = false;
+        try {
+            for (int channel = 0; channel < blockCount; channel++) {
+                blocks[channel] = mergeChannel(rows, channel, blockFactory, typeTemplate.page.getBlock(channel).elementType());
+            }
+            Page page = new Page(blocks);
+            success = true;
+            for (Row row : rows) {
+                if (row.page.getPositionCount() == 1) {
+                    row.page.releaseBlocks();
+                }
+            }
+            return page;
+        } finally {
+            if (success == false) {
+                Releasables.closeExpectNoException(blocks);
+            }
+        }
+    }
+
+    private Block mergeChannel(List<Row> rows, int channel, BlockFactory blockFactory, ElementType elementType) {
+        return switch (elementType) {
+            case LONG -> {
+                try (LongBlock.Builder builder = blockFactory.newLongBlockBuilder(rows.size())) {
+                    for (Row row : rows) {
+                        Block block = row.page.getBlock(channel);
+                        if (block.isNull(row.position)) {
+                            builder.appendNull();
+                        } else {
+                            builder.appendLong(((LongBlock) block).getLong(row.position));
+                        }
+                    }
+                    yield builder.build();
+                }
+            }
+            case DOUBLE -> {
+                try (DoubleBlock.Builder builder = blockFactory.newDoubleBlockBuilder(rows.size())) {
+                    for (Row row : rows) {
+                        Block block = row.page.getBlock(channel);
+                        if (block.isNull(row.position)) {
+                            builder.appendNull();
+                        } else {
+                            builder.appendDouble(((DoubleBlock) block).getDouble(row.position));
+                        }
+                    }
+                    yield builder.build();
+                }
+            }
+            case BYTES_REF -> {
+                try (BytesRefBlock.Builder builder = blockFactory.newBytesRefBlockBuilder(rows.size())) {
+                    for (Row row : rows) {
+                        Block block = row.page.getBlock(channel);
+                        if (block.isNull(row.position)) {
+                            builder.appendNull();
+                        } else {
+                            builder.appendBytesRef(((BytesRefBlock) block).getBytesRef(row.position, new BytesRef()));
+                        }
+                    }
+                    yield builder.build();
+                }
+            }
+            case BOOLEAN -> {
+                try (var builder = blockFactory.newBooleanBlockBuilder(rows.size())) {
+                    for (Row row : rows) {
+                        Block block = row.page.getBlock(channel);
+                        if (block.isNull(row.position)) {
+                            builder.appendNull();
+                        } else {
+                            builder.appendBoolean(((org.elasticsearch.compute.data.BooleanBlock) block).getBoolean(row.position));
+                        }
+                    }
+                    yield builder.build();
+                }
+            }
+            case INT -> {
+                try (IntBlock.Builder builder = blockFactory.newIntBlockBuilder(rows.size())) {
+                    for (Row row : rows) {
+                        Block block = row.page.getBlock(channel);
+                        if (block.isNull(row.position)) {
+                            builder.appendNull();
+                        } else {
+                            builder.appendInt(((IntBlock) block).getInt(row.position));
+                        }
+                    }
+                    yield builder.build();
+                }
+            }
+            default -> {
+                for (Row row : rows) {
+                    Object value = BlockUtils.toJavaObject(row.page.getBlock(channel), row.position);
+                    if (value != null) {
+                        throw new IllegalArgumentException(
+                            "Unsupported element type [" + elementType + "] in ChangePointFillEmptyBucketsOperator"
+                        );
+                    }
+                }
+                yield blockFactory.newConstantNullBlock(rows.size());
+            }
+        };
+    }
+
+    private record Row(long key, Page page, int position) {}
+}

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/ChangePointBucketFillUtilsTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/ChangePointBucketFillUtilsTests.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.operator;
+
+import org.elasticsearch.common.Rounding;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.TreeSet;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+
+public class ChangePointBucketFillUtilsTests extends ESTestCase {
+
+    public void testInteriorGapFill() {
+        Rounding.Prepared rounding = Rounding.builder(Rounding.DateTimeUnit.HOUR_OF_DAY).build().prepareForUnknown();
+        long hour0 = rounding.round(0L);
+        long hour2 = rounding.nextRoundingValue(rounding.nextRoundingValue(hour0));
+
+        TreeSet<Long> existing = new TreeSet<>(List.of(hour0, hour2));
+        List<Long> filled = ChangePointBucketFillUtils.computeFilledKeys(existing, rounding, hour0, hour2 + 1);
+
+        assertThat(filled.size(), equalTo(3));
+        assertThat(filled.get(1), equalTo(rounding.nextRoundingValue(hour0)));
+    }
+
+    public void testEdgeExtensionWhenSingleBucketAtStart() {
+        Rounding.Prepared rounding = Rounding.builder(Rounding.DateTimeUnit.HOUR_OF_DAY).build().prepareForUnknown();
+        long start = rounding.round(0L);
+        long end = start;
+        for (int i = 0; i < ChangePointBucketFillUtils.MINIMUM_BUCKET_COUNT; i++) {
+            end = rounding.nextRoundingValue(end);
+        }
+
+        TreeSet<Long> existing = new TreeSet<>(List.of(start));
+        List<Long> filled = ChangePointBucketFillUtils.computeFilledKeys(existing, rounding, start, end);
+
+        assertThat(filled.size(), equalTo(ChangePointBucketFillUtils.MINIMUM_BUCKET_COUNT));
+        assertThat(filled.getFirst(), equalTo(start));
+        long expectedLast = start;
+        for (int i = 0; i < ChangePointBucketFillUtils.MINIMUM_BUCKET_COUNT - 1; i++) {
+            expectedLast = rounding.nextRoundingValue(expectedLast);
+        }
+        assertThat(filled.getLast(), equalTo(expectedLast));
+    }
+
+    public void testEdgeExtensionWhenSingleBucketAtEnd() {
+        Rounding.Prepared rounding = Rounding.builder(Rounding.DateTimeUnit.HOUR_OF_DAY).build().prepareForUnknown();
+        long start = rounding.round(0L);
+        long end = start;
+        for (int i = 0; i < 40; i++) {
+            end = rounding.nextRoundingValue(end);
+        }
+        long lastBucket = previousRoundingValue(rounding, end, start);
+
+        TreeSet<Long> existing = new TreeSet<>(List.of(lastBucket));
+        List<Long> filled = ChangePointBucketFillUtils.computeFilledKeys(existing, rounding, start, end);
+
+        assertThat(filled.size(), equalTo(ChangePointBucketFillUtils.MINIMUM_BUCKET_COUNT));
+        assertThat(filled, hasItem(lastBucket));
+        assertThat(filled.getLast(), equalTo(lastBucket));
+        assertThat(filled, not(hasItem(start)));
+        long expectedFirst = lastBucket;
+        for (int i = 0; i < ChangePointBucketFillUtils.MINIMUM_BUCKET_COUNT - 1; i++) {
+            expectedFirst = previousRoundingValue(rounding, expectedFirst, start);
+        }
+        assertThat(filled.getFirst(), equalTo(expectedFirst));
+    }
+
+    public void testExtendOnlyOnOtherSideWhenOneEdgeReached() {
+        Rounding.Prepared rounding = Rounding.builder(Rounding.DateTimeUnit.HOUR_OF_DAY).build().prepareForUnknown();
+        long start = rounding.round(0L);
+        long end = start;
+        for (int i = 0; i < 10; i++) {
+            end = rounding.nextRoundingValue(end);
+        }
+        long lastBucket = previousRoundingValue(rounding, end, start);
+
+        TreeSet<Long> existing = new TreeSet<>(List.of(lastBucket));
+        List<Long> filled = ChangePointBucketFillUtils.computeFilledKeys(existing, rounding, start, end);
+
+        assertThat(filled.size(), equalTo(10));
+        assertThat(filled.getLast(), equalTo(lastBucket));
+        for (int i = 1; i < filled.size(); i++) {
+            assertThat(filled.get(i), equalTo(rounding.nextRoundingValue(filled.get(i - 1))));
+        }
+    }
+
+    public void testInteriorFillAllGapsWhenSparseEndpoints() {
+        Rounding.Prepared rounding = Rounding.builder(Rounding.DateTimeUnit.HOUR_OF_DAY).build().prepareForUnknown();
+        long start = rounding.round(0L);
+        long end = start;
+        for (int i = 0; i < 40; i++) {
+            end = rounding.nextRoundingValue(end);
+        }
+        long lastBucket = previousRoundingValue(rounding, end, start);
+
+        TreeSet<Long> existing = new TreeSet<>(List.of(start, lastBucket));
+        List<Long> filled = ChangePointBucketFillUtils.computeFilledKeys(existing, rounding, start, end);
+
+        assertThat(filled.size(), equalTo(40));
+        assertThat(filled.getFirst(), equalTo(start));
+        assertThat(filled.getLast(), equalTo(lastBucket));
+    }
+
+    public void testNoEdgeExtensionWhenAtLeastMinimumRealBuckets() {
+        Rounding.Prepared rounding = Rounding.builder(Rounding.DateTimeUnit.HOUR_OF_DAY).build().prepareForUnknown();
+        long start = rounding.round(0L);
+        TreeSet<Long> existing = new TreeSet<>();
+        long current = start;
+        for (int i = 0; i < ChangePointBucketFillUtils.MINIMUM_BUCKET_COUNT; i++) {
+            existing.add(current);
+            current = rounding.nextRoundingValue(current);
+        }
+        long end = current;
+
+        assertThat(ChangePointBucketFillUtils.needsFill(existing, rounding, start, end), equalTo(false));
+        assertThat(ChangePointBucketFillUtils.computeFilledKeys(existing, rounding, start, end), equalTo(new ArrayList<>(existing)));
+    }
+
+    public void testInteriorFillWhenSparseRealBucketsAtOrAboveMinimum() {
+        Rounding.Prepared rounding = Rounding.builder(Rounding.DateTimeUnit.HOUR_OF_DAY).build().prepareForUnknown();
+        long start = rounding.round(0L);
+        TreeSet<Long> existing = new TreeSet<>();
+        long current = start;
+        for (int i = 0; i < ChangePointBucketFillUtils.MINIMUM_BUCKET_COUNT; i++) {
+            existing.add(current);
+            current = rounding.nextRoundingValue(current);
+            current = rounding.nextRoundingValue(current);
+        }
+        long end = current;
+        for (int i = 0; i < 5; i++) {
+            end = rounding.nextRoundingValue(end);
+        }
+
+        List<Long> filled = ChangePointBucketFillUtils.computeFilledKeys(existing, rounding, start, end);
+
+        assertThat(ChangePointBucketFillUtils.needsFill(existing, rounding, start, end), equalTo(true));
+        assertThat(filled.size(), equalTo(ChangePointBucketFillUtils.MINIMUM_BUCKET_COUNT * 2 - 1));
+        for (int i = 1; i < filled.size(); i++) {
+            assertThat(filled.get(i), equalTo(rounding.nextRoundingValue(filled.get(i - 1))));
+        }
+    }
+
+    public void testNoFillWhenDenseAndAboveMinimum() {
+        Rounding.Prepared rounding = Rounding.builder(Rounding.DateTimeUnit.HOUR_OF_DAY).build().prepareForUnknown();
+        long start = rounding.round(0L);
+        TreeSet<Long> existing = new TreeSet<>();
+        long current = start;
+        for (int i = 0; i < 25; i++) {
+            existing.add(current);
+            current = rounding.nextRoundingValue(current);
+        }
+        long end = current;
+
+        assertThat(ChangePointBucketFillUtils.needsFill(existing, rounding, start, end), equalTo(false));
+    }
+
+    public void testCountBucketsInRange() {
+        Rounding.Prepared rounding = Rounding.builder(Rounding.DateTimeUnit.HOUR_OF_DAY).build().prepareForUnknown();
+        long start = rounding.round(0L);
+        long end = start;
+        for (int i = 0; i < 22; i++) {
+            end = rounding.nextRoundingValue(end);
+        }
+        assertThat(ChangePointBucketFillUtils.countBucketsInRange(rounding, start, end), equalTo(22));
+    }
+
+    public void testEmptyExistingReturnsEmpty() {
+        Rounding.Prepared rounding = Rounding.builder(Rounding.DateTimeUnit.HOUR_OF_DAY).build().prepareForUnknown();
+        long start = rounding.round(0L);
+        long end = start;
+        for (int i = 0; i < 22; i++) {
+            end = rounding.nextRoundingValue(end);
+        }
+        assertThat(ChangePointBucketFillUtils.computeFilledKeys(new TreeSet<>(), rounding, start, end).size(), equalTo(0));
+    }
+
+    private static long previousRoundingValue(Rounding.Prepared rounding, long key, long minDate) {
+        long t = rounding.round(minDate);
+        long previous = t;
+        while (t < key) {
+            previous = t;
+            t = rounding.nextRoundingValue(t);
+        }
+        return previous;
+    }
+}

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/ChangePointFillEmptyBucketsOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/ChangePointFillEmptyBucketsOperatorTests.java
@@ -1,0 +1,360 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.operator;
+
+import org.elasticsearch.common.Rounding;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.test.TestBlockFactory;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class ChangePointFillEmptyBucketsOperatorTests extends ESTestCase {
+
+    private static final Rounding.Prepared HOUR_ROUNDING = Rounding.builder(Rounding.DateTimeUnit.HOUR_OF_DAY).build().prepareForUnknown();
+
+    private DriverContext driverContext() {
+        BlockFactory blockFactory = TestBlockFactory.getNonBreakingInstance();
+        return new DriverContext(BigArrays.NON_RECYCLING_INSTANCE, blockFactory, null);
+    }
+
+    public void testFillsInteriorGap() {
+        DriverContext ctx = driverContext();
+        BlockFactory blockFactory = ctx.blockFactory();
+        long hour0 = HOUR_ROUNDING.round(0L);
+        long hour2 = HOUR_ROUNDING.nextRoundingValue(HOUR_ROUNDING.nextRoundingValue(hour0));
+        long maxDate = HOUR_ROUNDING.nextRoundingValue(hour2);
+
+        try (
+            LongBlock.Builder keyBuilder = blockFactory.newLongBlockBuilder(2);
+            DoubleBlock.Builder valueBuilder = blockFactory.newDoubleBlockBuilder(2)
+        ) {
+            keyBuilder.appendLong(hour0);
+            keyBuilder.appendLong(hour2);
+            valueBuilder.appendDouble(50d);
+            valueBuilder.appendDouble(50d);
+            Page input = new Page(keyBuilder.build(), valueBuilder.build());
+
+            try (
+                ChangePointFillEmptyBucketsOperator op = new ChangePointFillEmptyBucketsOperator(
+                    ctx,
+                    0,
+                    1,
+                    new int[0],
+                    HOUR_ROUNDING,
+                    hour0,
+                    maxDate
+                )
+            ) {
+                op.addInput(input);
+                op.finish();
+                Page output = op.getOutput();
+                assertNotNull(output);
+                assertThat(output.getPositionCount(), equalTo(3));
+                LongBlock keys = (LongBlock) output.getBlock(0);
+                DoubleBlock values = (DoubleBlock) output.getBlock(1);
+                assertThat(keys.getLong(1), equalTo(HOUR_ROUNDING.nextRoundingValue(hour0)));
+                assertThat(values.getDouble(1), equalTo(0d));
+            }
+        }
+    }
+
+    public void testEdgeExtensionWhenSingleBucketAtEnd() {
+        DriverContext ctx = driverContext();
+        BlockFactory blockFactory = ctx.blockFactory();
+        long start = HOUR_ROUNDING.round(0L);
+        long end = start;
+        for (int i = 0; i < 40; i++) {
+            end = HOUR_ROUNDING.nextRoundingValue(end);
+        }
+        long lastBucket = previousRoundingValue(HOUR_ROUNDING, end, start);
+
+        try (
+            LongBlock.Builder keyBuilder = blockFactory.newLongBlockBuilder(1);
+            LongBlock.Builder valueBuilder = blockFactory.newLongBlockBuilder(1)
+        ) {
+            keyBuilder.appendLong(lastBucket);
+            valueBuilder.appendLong(99L);
+            Page input = new Page(keyBuilder.build(), valueBuilder.build());
+
+            try (
+                ChangePointFillEmptyBucketsOperator op = new ChangePointFillEmptyBucketsOperator(
+                    ctx,
+                    0,
+                    1,
+                    new int[0],
+                    HOUR_ROUNDING,
+                    start,
+                    end
+                )
+            ) {
+                op.addInput(input);
+                op.finish();
+                Page output = op.getOutput();
+                assertNotNull(output);
+                assertThat(output.getPositionCount(), equalTo(ChangePointBucketFillUtils.MINIMUM_BUCKET_COUNT));
+                LongBlock keys = (LongBlock) output.getBlock(0);
+                LongBlock values = (LongBlock) output.getBlock(1);
+                assertThat(keys.getLong(output.getPositionCount() - 1), equalTo(lastBucket));
+                assertThat(values.getLong(output.getPositionCount() - 1), equalTo(99L));
+                assertThat(values.getLong(0), equalTo(0L));
+            }
+        }
+    }
+
+    public void testInteriorFillWhenSparseRealBucketsAtOrAboveMinimum() {
+        DriverContext ctx = driverContext();
+        BlockFactory blockFactory = ctx.blockFactory();
+        long start = HOUR_ROUNDING.round(0L);
+        List<Long> sparseHours = new ArrayList<>();
+        long current = start;
+        for (int i = 0; i < ChangePointBucketFillUtils.MINIMUM_BUCKET_COUNT; i++) {
+            sparseHours.add(current);
+            current = HOUR_ROUNDING.nextRoundingValue(current);
+            current = HOUR_ROUNDING.nextRoundingValue(current);
+        }
+        long end = current;
+        for (int i = 0; i < 5; i++) {
+            end = HOUR_ROUNDING.nextRoundingValue(end);
+        }
+
+        try (
+            LongBlock.Builder keyBuilder = blockFactory.newLongBlockBuilder(sparseHours.size());
+            DoubleBlock.Builder valueBuilder = blockFactory.newDoubleBlockBuilder(sparseHours.size())
+        ) {
+            for (long hour : sparseHours) {
+                keyBuilder.appendLong(hour);
+                valueBuilder.appendDouble(5d);
+            }
+            Page input = new Page(keyBuilder.build(), valueBuilder.build());
+
+            try (
+                ChangePointFillEmptyBucketsOperator op = new ChangePointFillEmptyBucketsOperator(
+                    ctx,
+                    0,
+                    1,
+                    new int[0],
+                    HOUR_ROUNDING,
+                    start,
+                    end
+                )
+            ) {
+                op.addInput(input);
+                op.finish();
+                Page output = op.getOutput();
+                assertNotNull(output);
+                assertThat(output.getPositionCount(), equalTo(ChangePointBucketFillUtils.MINIMUM_BUCKET_COUNT * 2 - 1));
+                DoubleBlock values = (DoubleBlock) output.getBlock(1);
+                for (int i = 0; i < output.getPositionCount(); i++) {
+                    if (sparseHours.contains(((LongBlock) output.getBlock(0)).getLong(i))) {
+                        assertThat(values.getDouble(i), equalTo(5d));
+                    } else {
+                        assertThat(values.getDouble(i), equalTo(0d));
+                    }
+                }
+            }
+        }
+    }
+
+    public void testFillsInteriorGapPerGroup() {
+        DriverContext ctx = driverContext();
+        BlockFactory blockFactory = ctx.blockFactory();
+        long hour0 = HOUR_ROUNDING.round(0L);
+        long hour2 = HOUR_ROUNDING.nextRoundingValue(HOUR_ROUNDING.nextRoundingValue(hour0));
+        long maxDate = HOUR_ROUNDING.nextRoundingValue(hour2);
+
+        try (
+            LongBlock.Builder keyBuilder = blockFactory.newLongBlockBuilder(4);
+            DoubleBlock.Builder valueBuilder = blockFactory.newDoubleBlockBuilder(4);
+            LongBlock.Builder groupBuilder = blockFactory.newLongBlockBuilder(4)
+        ) {
+            keyBuilder.appendLong(hour0);
+            valueBuilder.appendDouble(10d);
+            groupBuilder.appendLong(1L);
+
+            keyBuilder.appendLong(hour2);
+            valueBuilder.appendDouble(20d);
+            groupBuilder.appendLong(1L);
+
+            keyBuilder.appendLong(hour0);
+            valueBuilder.appendDouble(30d);
+            groupBuilder.appendLong(2L);
+
+            keyBuilder.appendLong(hour2);
+            valueBuilder.appendDouble(40d);
+            groupBuilder.appendLong(2L);
+
+            Page input = new Page(keyBuilder.build(), valueBuilder.build(), groupBuilder.build());
+
+            try (
+                ChangePointFillEmptyBucketsOperator op = new ChangePointFillEmptyBucketsOperator(
+                    ctx,
+                    0,
+                    1,
+                    new int[] { 2 },
+                    HOUR_ROUNDING,
+                    hour0,
+                    maxDate
+                )
+            ) {
+                op.addInput(input);
+                op.finish();
+
+                Page groupOne = op.getOutput();
+                assertNotNull(groupOne);
+                assertThat(groupOne.getPositionCount(), equalTo(3));
+                LongBlock groupOneGroups = (LongBlock) groupOne.getBlock(2);
+                DoubleBlock groupOneValues = (DoubleBlock) groupOne.getBlock(1);
+                assertThat(groupOneGroups.getLong(0), equalTo(1L));
+                assertThat(groupOneValues.getDouble(1), equalTo(0d));
+
+                Page groupTwo = op.getOutput();
+                assertNotNull(groupTwo);
+                assertThat(groupTwo.getPositionCount(), equalTo(3));
+                LongBlock groupTwoGroups = (LongBlock) groupTwo.getBlock(2);
+                DoubleBlock groupTwoValues = (DoubleBlock) groupTwo.getBlock(1);
+                assertThat(groupTwoGroups.getLong(0), equalTo(2L));
+                assertThat(groupTwoValues.getDouble(1), equalTo(0d));
+                assertNull(op.getOutput());
+            }
+        }
+    }
+
+    public void testPassThroughWhenNoGapsAndEnoughValues() {
+        DriverContext ctx = driverContext();
+        BlockFactory blockFactory = ctx.blockFactory();
+        long hour0 = HOUR_ROUNDING.round(0L);
+        List<Long> hours = new ArrayList<>();
+        long current = hour0;
+        for (int i = 0; i < 25; i++) {
+            hours.add(current);
+            current = HOUR_ROUNDING.nextRoundingValue(current);
+        }
+        long maxDate = current;
+
+        try (
+            LongBlock.Builder keyBuilder = blockFactory.newLongBlockBuilder(hours.size());
+            DoubleBlock.Builder valueBuilder = blockFactory.newDoubleBlockBuilder(hours.size())
+        ) {
+            for (long hour : hours) {
+                keyBuilder.appendLong(hour);
+                valueBuilder.appendDouble(1d);
+            }
+            Page input = new Page(keyBuilder.build(), valueBuilder.build());
+
+            try (
+                ChangePointFillEmptyBucketsOperator op = new ChangePointFillEmptyBucketsOperator(
+                    ctx,
+                    0,
+                    1,
+                    new int[0],
+                    HOUR_ROUNDING,
+                    hour0,
+                    maxDate
+                )
+            ) {
+                op.addInput(input);
+                op.finish();
+                Page output = op.getOutput();
+                assertNotNull(output);
+                assertThat(output.getPositionCount(), equalTo(input.getPositionCount()));
+                input.releaseBlocks();
+            }
+        }
+    }
+
+    public void testPreservesOutOfRangeRowsAfterFill() {
+        DriverContext ctx = driverContext();
+        BlockFactory blockFactory = ctx.blockFactory();
+        long hour0 = HOUR_ROUNDING.round(0L);
+        long hour2 = HOUR_ROUNDING.nextRoundingValue(HOUR_ROUNDING.nextRoundingValue(hour0));
+        long hour5 = HOUR_ROUNDING.nextRoundingValue(HOUR_ROUNDING.nextRoundingValue(HOUR_ROUNDING.nextRoundingValue(hour2)));
+        long maxDate = HOUR_ROUNDING.nextRoundingValue(hour2);
+
+        try (
+            LongBlock.Builder keyBuilder = blockFactory.newLongBlockBuilder(3);
+            DoubleBlock.Builder valueBuilder = blockFactory.newDoubleBlockBuilder(3)
+        ) {
+            keyBuilder.appendLong(hour0);
+            valueBuilder.appendDouble(10d);
+            keyBuilder.appendLong(hour2);
+            valueBuilder.appendDouble(20d);
+            keyBuilder.appendLong(hour5);
+            valueBuilder.appendDouble(30d);
+            Page input = new Page(keyBuilder.build(), valueBuilder.build());
+
+            try (
+                ChangePointFillEmptyBucketsOperator op = new ChangePointFillEmptyBucketsOperator(
+                    ctx,
+                    0,
+                    1,
+                    new int[0],
+                    HOUR_ROUNDING,
+                    hour0,
+                    maxDate
+                )
+            ) {
+                op.addInput(input);
+                op.finish();
+                Page output = op.getOutput();
+                assertNotNull(output);
+                assertThat(output.getPositionCount(), equalTo(4));
+                LongBlock keys = (LongBlock) output.getBlock(0);
+                DoubleBlock values = (DoubleBlock) output.getBlock(1);
+                assertThat(keys.getLong(0), equalTo(hour0));
+                assertThat(keys.getLong(1), equalTo(HOUR_ROUNDING.nextRoundingValue(hour0)));
+                assertThat(values.getDouble(1), equalTo(0d));
+                assertThat(keys.getLong(2), equalTo(hour2));
+                assertThat(keys.getLong(3), equalTo(hour5));
+                assertThat(values.getDouble(3), equalTo(30d));
+            }
+        }
+    }
+
+    public void testNoOutputWhenNoInput() {
+        DriverContext ctx = driverContext();
+        long hour0 = HOUR_ROUNDING.round(0L);
+        long maxDate = hour0;
+        for (int i = 0; i < 22; i++) {
+            maxDate = HOUR_ROUNDING.nextRoundingValue(maxDate);
+        }
+
+        try (
+            ChangePointFillEmptyBucketsOperator op = new ChangePointFillEmptyBucketsOperator(
+                ctx,
+                0,
+                1,
+                new int[0],
+                HOUR_ROUNDING,
+                hour0,
+                maxDate
+            )
+        ) {
+            op.finish();
+            assertNull(op.getOutput());
+            assertTrue(op.isFinished());
+        }
+    }
+
+    private static long previousRoundingValue(Rounding.Prepared rounding, long key, long minDate) {
+        long t = rounding.round(minDate);
+        long previous = t;
+        while (t < key) {
+            previous = t;
+            t = rounding.nextRoundingValue(t);
+        }
+        return previous;
+    }
+}

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/change_point.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/change_point.csv-spec
@@ -1534,3 +1534,112 @@ k:integer | grp:keyword | type:keyword
 13        | a           | step_change
 13        | b           | step_change
 ;
+
+
+sparse buckets filled from filter
+required_capability: change_point
+request_time_filter: 2024-05-10T00:00:00.000Z,2024-05-10T00:22:00.000Z
+
+FROM k8s
+  | WHERE DATE_TRUNC(1 minute, @timestamp) IN (
+      "2024-05-10T00:00:00.000Z", "2024-05-10T00:05:00.000Z", "2024-05-10T00:10:00.000Z",
+      "2024-05-10T00:15:00.000Z", "2024-05-10T00:20:00.000Z"
+    )
+  | STATS count=COUNT() BY @timestamp=BUCKET(@timestamp, 1 MINUTE)
+  | CHANGE_POINT count ON @timestamp AS type, pvalue
+  | STATS bucket_count=COUNT(*)
+;
+
+bucket_count:long
+22
+;
+
+
+interior gap zero fill preserves dip sequence
+required_capability: change_point
+request_time_filter: 2024-05-10T00:00:00.000Z,2024-05-10T00:03:00.000Z
+
+FROM k8s
+  | WHERE @timestamp IN ("2024-05-10T00:00:00.000Z", "2024-05-10T00:02:00.000Z")
+  | STATS count=COUNT(*) BY @timestamp=BUCKET(@timestamp, 1 MINUTE)
+  | EVAL count=50
+  | CHANGE_POINT count ON @timestamp AS type, pvalue
+  | WHERE type == "dip"
+  | KEEP @timestamp, count, type
+;
+
+@timestamp:datetime      | count:long | type:keyword
+2024-05-10T00:01:00.000Z | 50         | dip
+;
+
+
+single sparse bucket padded backward
+required_capability: change_point
+request_time_filter: 2024-05-10T00:00:00.000Z,2024-05-10T01:00:00.000Z
+
+FROM k8s
+  | WHERE DATE_TRUNC(1 minute, @timestamp) IN ("2024-05-10T00:20:00.000Z")
+  | STATS count=COUNT() BY @timestamp=BUCKET(@timestamp, 1 MINUTE)
+  | CHANGE_POINT count ON @timestamp AS type, pvalue
+  | STATS bucket_count=COUNT(*)
+;
+
+bucket_count:long
+22
+;
+
+
+single sparse bucket keeps real row
+required_capability: change_point
+request_time_filter: 2024-05-10T00:00:00.000Z,2024-05-10T01:00:00.000Z
+
+FROM k8s
+  | WHERE DATE_TRUNC(1 minute, @timestamp) IN ("2024-05-10T00:20:00.000Z")
+  | STATS count=COUNT() BY @timestamp=BUCKET(@timestamp, 1 MINUTE)
+  | CHANGE_POINT count ON @timestamp AS type, pvalue
+  | WHERE @timestamp == "2024-05-10T00:20:00.000Z"
+  | KEEP @timestamp, count
+;
+
+@timestamp:datetime      | count:long
+2024-05-10T00:20:00.000Z | 10
+;
+
+
+interior gap adds zero bucket row
+required_capability: change_point
+request_time_filter: 2024-05-10T00:00:00.000Z,2024-05-10T00:30:00.000Z
+
+FROM k8s
+  | WHERE DATE_TRUNC(1 minute, @timestamp) IN (
+      "2024-05-10T00:00:00.000Z", "2024-05-10T00:02:00.000Z"
+    )
+  | STATS count=COUNT() BY @timestamp=BUCKET(@timestamp, 1 MINUTE)
+  | CHANGE_POINT count ON @timestamp AS type, pvalue
+  | WHERE @timestamp == "2024-05-10T00:01:00.000Z"
+  | KEEP @timestamp, count
+;
+
+@timestamp:datetime      | count:long
+2024-05-10T00:01:00.000Z | 0
+;
+
+
+sparse buckets filled per group
+required_capability: change_point
+request_time_filter: 2024-05-10T00:00:00.000Z,2024-05-10T00:22:00.000Z
+
+FROM k8s
+  | WHERE DATE_TRUNC(1 minute, @timestamp) IN (
+      "2024-05-10T00:00:00.000Z", "2024-05-10T00:05:00.000Z", "2024-05-10T00:10:00.000Z",
+      "2024-05-10T00:15:00.000Z", "2024-05-10T00:20:00.000Z"
+    )
+  | STATS count=COUNT() BY @timestamp=BUCKET(@timestamp, 1 MINUTE), cluster
+  | CHANGE_POINT count ON @timestamp BY cluster
+  | STATS bucket_count=COUNT(*) BY cluster
+  | STATS bad_groups=COUNT(*) WHERE bucket_count != 22
+;
+
+bad_groups:long
+0
+;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/ChangePointBucketSpecExtractor.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/ChangePointBucketSpecExtractor.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.optimizer;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.Rounding;
+import org.elasticsearch.xpack.esql.core.expression.Alias;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.AttributeMap;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.FoldContext;
+import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
+import org.elasticsearch.xpack.esql.core.querydsl.QueryDslTimestampBoundsExtractor.TimestampBounds;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.Foldables;
+import org.elasticsearch.xpack.esql.expression.function.grouping.Bucket;
+import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
+import org.elasticsearch.xpack.esql.plan.logical.ChangePoint;
+import org.elasticsearch.xpack.esql.plan.logical.Eval;
+import org.elasticsearch.xpack.esql.plan.logical.Limit;
+import org.elasticsearch.xpack.esql.plan.logical.LimitBy;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.plan.logical.OrderBy;
+import org.elasticsearch.xpack.esql.plan.logical.Project;
+import org.elasticsearch.xpack.esql.plan.logical.TopN;
+import org.elasticsearch.xpack.esql.plan.logical.UnaryPlan;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.elasticsearch.common.logging.HeaderWarning.addWarning;
+import static org.elasticsearch.compute.operator.ChangePointBucketFillUtils.MINIMUM_BUCKET_COUNT;
+import static org.elasticsearch.compute.operator.ChangePointBucketFillUtils.countBucketsInRange;
+import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.dateTimeToLong;
+
+/**
+ * Extracts {@link Bucket} metadata from a {@link ChangePoint} plan for sparse-bucket gap filling.
+ */
+public final class ChangePointBucketSpecExtractor {
+
+    public record ChangePointBucketFillSpec(
+        Rounding.Prepared rounding,
+        long minDate,
+        long maxDate,
+        Attribute key,
+        Attribute value,
+        List<Expression> groupings
+    ) {}
+
+    private ChangePointBucketSpecExtractor() {}
+
+    public static Optional<ChangePointBucketFillSpec> extract(ChangePoint changePoint, LogicalOptimizerContext context) {
+        LogicalPlan plan = changePoint.child();
+        if (plan instanceof Limit limit) {
+            plan = limit.child();
+        } else if (plan instanceof LimitBy limitBy) {
+            plan = limitBy.child();
+        } else {
+            return Optional.empty();
+        }
+        if (plan instanceof OrderBy orderBy) {
+            return extractFromStatsSubtree(
+                changePoint.source(),
+                orderBy.child(),
+                changePoint.key(),
+                changePoint.value(),
+                changePoint.groupings(),
+                context
+            );
+        }
+        if (plan instanceof TopN topN) {
+            return extractFromStatsSubtree(
+                changePoint.source(),
+                topN.child(),
+                changePoint.key(),
+                changePoint.value(),
+                changePoint.groupings(),
+                context
+            );
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<ChangePointBucketFillSpec> extractFromStatsSubtree(
+        Source source,
+        LogicalPlan plan,
+        Attribute key,
+        Attribute value,
+        List<Expression> groupings,
+        LogicalOptimizerContext context
+    ) {
+        AttributeMap.Builder<Expression> evalExprs = AttributeMap.builder();
+        Aggregate aggregate = findAggregate(plan, evalExprs);
+        if (aggregate == null) {
+            return Optional.empty();
+        }
+
+        Bucket bucket = findBucketForKey(aggregate, key, evalExprs.build());
+        if (bucket == null) {
+            return Optional.empty();
+        }
+
+        DataType fieldType = bucket.field().dataType();
+        if (fieldType != DataType.DATETIME && fieldType != DataType.DATE_NANOS) {
+            return Optional.empty();
+        }
+
+        Optional<long[]> timerange = resolveTimerange(bucket, context);
+        if (timerange.isEmpty()) {
+            return Optional.empty();
+        }
+
+        long minDate = timerange.get()[0];
+        long maxDate = timerange.get()[1];
+        Rounding.Prepared rounding = bucket.getDateRounding(context.foldCtx(), minDate, maxDate);
+
+        int possibleBuckets = countBucketsInRange(rounding, minDate, maxDate);
+        if (possibleBuckets < MINIMUM_BUCKET_COUNT) {
+            addWarning(
+                "Line {}:{}: CHANGE_POINT bucket zero-fill skipped; the requested time range and bucket interval allow only [{}] buckets "
+                    + "but at least [{}] are required",
+                source.source().getLineNumber(),
+                source.source().getColumnNumber(),
+                possibleBuckets,
+                MINIMUM_BUCKET_COUNT
+            );
+            return Optional.empty();
+        }
+
+        return Optional.of(new ChangePointBucketFillSpec(rounding, minDate, maxDate, key, value, groupings));
+    }
+
+    private static Aggregate findAggregate(LogicalPlan plan, AttributeMap.Builder<Expression> evalExprs) {
+        if (plan instanceof Eval eval) {
+            collectEvalAliases(eval, evalExprs);
+            return findAggregate(eval.child(), evalExprs);
+        }
+        if (plan instanceof Aggregate aggregate) {
+            collectEvalExprsFromChild(aggregate.child(), evalExprs);
+            return aggregate;
+        }
+        if (plan instanceof UnaryPlan unary) {
+            return findAggregate(unary.child(), evalExprs);
+        }
+        return null;
+    }
+
+    private static void collectEvalExprsFromChild(LogicalPlan plan, AttributeMap.Builder<Expression> evalExprs) {
+        if (plan instanceof Eval eval) {
+            collectEvalAliases(eval, evalExprs);
+            collectEvalExprsFromChild(eval.child(), evalExprs);
+        } else if (plan instanceof Project project) {
+            collectEvalExprsFromChild(project.child(), evalExprs);
+        } else if (plan instanceof UnaryPlan unary) {
+            collectEvalExprsFromChild(unary.child(), evalExprs);
+        }
+    }
+
+    private static void collectEvalAliases(Eval eval, AttributeMap.Builder<Expression> evalExprs) {
+        for (NamedExpression field : eval.fields()) {
+            if (field instanceof Alias alias) {
+                evalExprs.put(alias.toAttribute(), alias.child());
+            }
+        }
+    }
+
+    private static Bucket findBucketForKey(Aggregate aggregate, Attribute key, AttributeMap<Expression> evalExprs) {
+        for (Expression grouping : aggregate.groupings()) {
+            Attribute groupingAttr = null;
+            Expression bucketExpr = null;
+            if (grouping instanceof Attribute attribute) {
+                groupingAttr = attribute;
+                bucketExpr = evalExprs.get(attribute);
+            } else if (grouping instanceof Alias alias) {
+                groupingAttr = alias.toAttribute();
+                bucketExpr = evalExprs.get(groupingAttr);
+                if (bucketExpr == null) {
+                    bucketExpr = alias.child();
+                }
+            }
+            if (groupingAttr == null || key.name().equals(groupingAttr.name()) == false) {
+                continue;
+            }
+            if (bucketExpr instanceof Bucket bucket) {
+                return bucket;
+            }
+        }
+        for (var entry : evalExprs.entrySet()) {
+            if (key.name().equals(entry.getKey().name()) && entry.getValue() instanceof Bucket bucket) {
+                return bucket;
+            }
+        }
+        return null;
+    }
+
+    private static Optional<long[]> resolveTimerange(Bucket bucket, LogicalOptimizerContext context) {
+        FoldContext foldCtx = context.foldCtx();
+        if (bucket.from() != null && bucket.to() != null && bucket.from().foldable() && bucket.to().foldable()) {
+            return Optional.of(new long[] { foldToLong(foldCtx, bucket.from()), foldToLong(foldCtx, bucket.to()) });
+        }
+        TimestampBounds bounds = context.timestampBounds();
+        if (bounds != null) {
+            return Optional.of(new long[] { bounds.start().toEpochMilli(), bounds.end().toEpochMilli() });
+        }
+        return Optional.empty();
+    }
+
+    private static long foldToLong(FoldContext ctx, Expression e) {
+        Object value = Foldables.valueOf(ctx, e);
+        return DataType.isDateTime(e.dataType()) ? ((Number) value).longValue() : dateTimeToLong(((BytesRef) value).utf8ToString());
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalOptimizerContext.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalOptimizerContext.java
@@ -8,7 +8,9 @@
 package org.elasticsearch.xpack.esql.optimizer;
 
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xpack.esql.core.expression.FoldContext;
+import org.elasticsearch.xpack.esql.core.querydsl.QueryDslTimestampBoundsExtractor.TimestampBounds;
 import org.elasticsearch.xpack.esql.session.Configuration;
 
 import java.util.Objects;
@@ -17,11 +19,23 @@ public class LogicalOptimizerContext {
     private final Configuration configuration;
     private final FoldContext foldCtx;
     private final TransportVersion minimumVersion;
+    @Nullable
+    private final TimestampBounds timestampBounds;
 
     public LogicalOptimizerContext(Configuration configuration, FoldContext foldCtx, TransportVersion minimumVersion) {
+        this(configuration, foldCtx, minimumVersion, null);
+    }
+
+    public LogicalOptimizerContext(
+        Configuration configuration,
+        FoldContext foldCtx,
+        TransportVersion minimumVersion,
+        @Nullable TimestampBounds timestampBounds
+    ) {
         this.configuration = configuration;
         this.foldCtx = foldCtx;
         this.minimumVersion = minimumVersion;
+        this.timestampBounds = timestampBounds;
     }
 
     public Configuration configuration() {
@@ -36,6 +50,11 @@ public class LogicalOptimizerContext {
         return minimumVersion;
     }
 
+    @Nullable
+    public TimestampBounds timestampBounds() {
+        return timestampBounds;
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (obj == this) return true;
@@ -43,12 +62,13 @@ public class LogicalOptimizerContext {
         var that = (LogicalOptimizerContext) obj;
         return this.configuration.equals(that.configuration)
             && this.foldCtx.equals(that.foldCtx)
-            && Objects.equals(this.minimumVersion, that.minimumVersion);
+            && Objects.equals(this.minimumVersion, that.minimumVersion)
+            && Objects.equals(this.timestampBounds, that.timestampBounds);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(configuration, foldCtx, minimumVersion);
+        return Objects.hash(configuration, foldCtx, minimumVersion, timestampBounds);
     }
 
     @Override
@@ -59,6 +79,8 @@ public class LogicalOptimizerContext {
             + foldCtx
             + ", minimumVersion="
             + minimumVersion
+            + ", timestampBounds="
+            + timestampBounds
             + ']';
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizer.java
@@ -65,6 +65,7 @@ import org.elasticsearch.xpack.esql.optimizer.rules.logical.ReorderLimitProjectA
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.ReplaceAggregateAggExpressionWithEval;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.ReplaceAggregateNestedExpressionWithEval;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.ReplaceAliasingEvalWithProject;
+import org.elasticsearch.xpack.esql.optimizer.rules.logical.ReplaceChangePointBucketFill;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.ReplaceChangePointByExpressionWithEval;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.ReplaceLimitAndSortAsTopN;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.ReplaceLimitByExpressionWithEval;
@@ -182,6 +183,7 @@ public class LogicalPlanOptimizer extends ParameterizedRuleExecutor<LogicalPlan,
             new ReplaceTrivialTypeConversions(),
             new ReplaceAliasingEvalWithProject(),
             new SkipQueryOnEmptyMappings(),
+            new ReplaceChangePointBucketFill(),
             new SubstituteSurrogateExpressions(),
             new SubstituteTransportVersionAwareExpressions(),
             // check for a trivial conversion introduced by a surrogate

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceChangePointBucketFill.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceChangePointBucketFill.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.optimizer.rules.logical;
+
+import org.elasticsearch.xpack.esql.optimizer.ChangePointBucketSpecExtractor;
+import org.elasticsearch.xpack.esql.optimizer.ChangePointBucketSpecExtractor.ChangePointBucketFillSpec;
+import org.elasticsearch.xpack.esql.optimizer.LogicalOptimizerContext;
+import org.elasticsearch.xpack.esql.plan.logical.ChangePoint;
+import org.elasticsearch.xpack.esql.plan.logical.ChangePointFillEmptyBuckets;
+import org.elasticsearch.xpack.esql.plan.logical.Limit;
+import org.elasticsearch.xpack.esql.plan.logical.LimitBy;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.plan.logical.OrderBy;
+import org.elasticsearch.xpack.esql.plan.logical.TopN;
+
+import java.util.Optional;
+
+/**
+ * Inserts {@link ChangePointFillEmptyBuckets} before {@link ChangePoint} when the sort key traces to a
+ * literal date {@code BUCKET} grouping and a timerange is available.
+ */
+public final class ReplaceChangePointBucketFill extends OptimizerRules.ParameterizedOptimizerRule<ChangePoint, LogicalOptimizerContext> {
+
+    public ReplaceChangePointBucketFill() {
+        super(OptimizerRules.TransformDirection.UP);
+    }
+
+    @Override
+    protected LogicalPlan rule(ChangePoint changePoint, LogicalOptimizerContext context) {
+        Optional<ChangePointBucketFillSpec> spec = ChangePointBucketSpecExtractor.extract(changePoint, context);
+        if (spec.isEmpty()) {
+            return changePoint;
+        }
+
+        LogicalPlan child = changePoint.child();
+        LogicalPlan fillChild;
+        if (child instanceof Limit limit && limit.child() instanceof OrderBy ob) {
+            fillChild = ob;
+        } else if (child instanceof LimitBy limitBy && limitBy.child() instanceof OrderBy ob) {
+            fillChild = ob;
+        } else if (child instanceof TopN topN) {
+            fillChild = topN;
+        } else {
+            return changePoint;
+        }
+
+        ChangePointBucketFillSpec fillSpec = spec.get();
+        ChangePointFillEmptyBuckets fill = new ChangePointFillEmptyBuckets(
+            changePoint.source(),
+            fillChild,
+            fillSpec.value(),
+            fillSpec.key(),
+            fillSpec.groupings(),
+            fillSpec.rounding(),
+            fillSpec.minDate(),
+            fillSpec.maxDate()
+        );
+
+        LogicalPlan newChild;
+        if (child instanceof Limit limit) {
+            newChild = new Limit(limit.source(), limit.limit(), fill, limit.duplicated(), limit.local());
+        } else if (child instanceof LimitBy limitBy) {
+            newChild = new LimitBy(limitBy.source(), limitBy.limitPerGroup(), fill, limitBy.groupings());
+        } else {
+            newChild = fill;
+        }
+
+        return new ChangePoint(
+            changePoint.source(),
+            newChild,
+            changePoint.value(),
+            changePoint.key(),
+            changePoint.targetType(),
+            changePoint.targetPvalue(),
+            changePoint.groupings()
+        );
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceLimitAndSortAsTopN.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceLimitAndSortAsTopN.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.optimizer.rules.logical;
 
+import org.elasticsearch.xpack.esql.plan.logical.ChangePointFillEmptyBuckets;
 import org.elasticsearch.xpack.esql.plan.logical.Limit;
 import org.elasticsearch.xpack.esql.plan.logical.LimitBy;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
@@ -23,10 +24,32 @@ public final class ReplaceLimitAndSortAsTopN extends OptimizerRules.OptimizerRul
         if (plan instanceof Limit limit) {
             if (plan.child() instanceof OrderBy o) {
                 p = new TopN(o.source(), o.child(), o.order(), limit.limit(), false);
+            } else if (plan.child() instanceof ChangePointFillEmptyBuckets fill && fill.child() instanceof OrderBy o) {
+                p = new ChangePointFillEmptyBuckets(
+                    fill.source(),
+                    new TopN(o.source(), o.child(), o.order(), limit.limit(), false),
+                    fill.value(),
+                    fill.key(),
+                    fill.groupings(),
+                    fill.dateBucketRounding(),
+                    fill.minDate(),
+                    fill.maxDate()
+                );
             }
         } else if (plan instanceof LimitBy limitBy) {
             if (plan.child() instanceof OrderBy o) {
                 p = new TopNBy(o.source(), o.child(), o.order(), limitBy.limitPerGroup(), limitBy.groupings());
+            } else if (plan.child() instanceof ChangePointFillEmptyBuckets fill && fill.child() instanceof OrderBy o) {
+                p = new ChangePointFillEmptyBuckets(
+                    fill.source(),
+                    new TopNBy(o.source(), o.child(), o.order(), limitBy.limitPerGroup(), limitBy.groupings()),
+                    fill.value(),
+                    fill.key(),
+                    fill.groupings(),
+                    fill.dateBucketRounding(),
+                    fill.minDate(),
+                    fill.maxDate()
+                );
             }
         }
         return p;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/ChangePointFillEmptyBuckets.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/ChangePointFillEmptyBuckets.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.logical;
+
+import org.elasticsearch.common.Rounding;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Fills missing date bucket rows with zero values before {@link ChangePoint}.
+ */
+public class ChangePointFillEmptyBuckets extends UnaryPlan {
+
+    private final Attribute value;
+    private final Attribute key;
+    private final List<Expression> groupings;
+    private final Rounding.Prepared dateBucketRounding;
+    private final long minDate;
+    private final long maxDate;
+
+    public ChangePointFillEmptyBuckets(
+        Source source,
+        LogicalPlan child,
+        Attribute value,
+        Attribute key,
+        List<Expression> groupings,
+        Rounding.Prepared dateBucketRounding,
+        long minDate,
+        long maxDate
+    ) {
+        super(source, child);
+        this.value = value;
+        this.key = key;
+        this.groupings = groupings;
+        this.dateBucketRounding = dateBucketRounding;
+        this.minDate = minDate;
+        this.maxDate = maxDate;
+    }
+
+    public Attribute value() {
+        return value;
+    }
+
+    public Attribute key() {
+        return key;
+    }
+
+    public List<Expression> groupings() {
+        return groupings;
+    }
+
+    public Rounding.Prepared dateBucketRounding() {
+        return dateBucketRounding;
+    }
+
+    public long minDate() {
+        return minDate;
+    }
+
+    public long maxDate() {
+        return maxDate;
+    }
+
+    @Override
+    public List<Attribute> output() {
+        return child().output();
+    }
+
+    @Override
+    public UnaryPlan replaceChild(LogicalPlan newChild) {
+        return new ChangePointFillEmptyBuckets(source(), newChild, value, key, groupings, dateBucketRounding, minDate, maxDate);
+    }
+
+    @Override
+    public boolean expressionsResolved() {
+        return value.resolved() && key.resolved();
+    }
+
+    @Override
+    protected NodeInfo<? extends LogicalPlan> info() {
+        return NodeInfo.create(
+            this,
+            ChangePointFillEmptyBuckets::new,
+            child(),
+            value,
+            key,
+            groupings,
+            dateBucketRounding,
+            minDate,
+            maxDate
+        );
+    }
+
+    @Override
+    public String getWriteableName() {
+        throw new UnsupportedOperationException("not serialized");
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        throw new UnsupportedOperationException("not serialized");
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/ChangePointFillEmptyBucketsExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/ChangePointFillEmptyBucketsExec.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.physical;
+
+import org.elasticsearch.common.Rounding;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Physical plan for zero-filling missing date bucket rows before {@link ChangePointExec}.
+ */
+public class ChangePointFillEmptyBucketsExec extends UnaryExec {
+
+    private final Attribute value;
+    private final Attribute key;
+    private final List<Expression> groupings;
+    private final Rounding.Prepared dateBucketRounding;
+    private final long minDate;
+    private final long maxDate;
+
+    public ChangePointFillEmptyBucketsExec(
+        Source source,
+        PhysicalPlan child,
+        Attribute value,
+        Attribute key,
+        List<Expression> groupings,
+        Rounding.Prepared dateBucketRounding,
+        long minDate,
+        long maxDate
+    ) {
+        super(source, child);
+        this.value = value;
+        this.key = key;
+        this.groupings = groupings;
+        this.dateBucketRounding = dateBucketRounding;
+        this.minDate = minDate;
+        this.maxDate = maxDate;
+    }
+
+    public Attribute value() {
+        return value;
+    }
+
+    public Attribute key() {
+        return key;
+    }
+
+    public List<Expression> groupings() {
+        return groupings;
+    }
+
+    public Rounding.Prepared dateBucketRounding() {
+        return dateBucketRounding;
+    }
+
+    public long minDate() {
+        return minDate;
+    }
+
+    public long maxDate() {
+        return maxDate;
+    }
+
+    @Override
+    public List<Attribute> output() {
+        return child().output();
+    }
+
+    @Override
+    public UnaryExec replaceChild(PhysicalPlan newChild) {
+        return new ChangePointFillEmptyBucketsExec(source(), newChild, value, key, groupings, dateBucketRounding, minDate, maxDate);
+    }
+
+    @Override
+    protected NodeInfo<? extends PhysicalPlan> info() {
+        return NodeInfo.create(
+            this,
+            ChangePointFillEmptyBucketsExec::new,
+            child(),
+            value,
+            key,
+            groupings,
+            dateBucketRounding,
+            minDate,
+            maxDate
+        );
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        throw new UnsupportedOperationException("not serialized");
+    }
+
+    @Override
+    public String getWriteableName() {
+        throw new UnsupportedOperationException("not serialized");
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -31,6 +31,7 @@ import org.elasticsearch.compute.lucene.IndexedByShardId;
 import org.elasticsearch.compute.lucene.query.DataPartitioning;
 import org.elasticsearch.compute.lucene.query.LuceneOperator;
 import org.elasticsearch.compute.lucene.query.TimeSeriesSourceOperator;
+import org.elasticsearch.compute.operator.ChangePointFillEmptyBucketsOperator;
 import org.elasticsearch.compute.operator.ChangePointOperator;
 import org.elasticsearch.compute.operator.ColumnExtractOperator;
 import org.elasticsearch.compute.operator.ColumnLoadOperator;
@@ -144,6 +145,7 @@ import org.elasticsearch.xpack.esql.plan.logical.EsRelation;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
 import org.elasticsearch.xpack.esql.plan.physical.ChangePointExec;
+import org.elasticsearch.xpack.esql.plan.physical.ChangePointFillEmptyBucketsExec;
 import org.elasticsearch.xpack.esql.plan.physical.CompoundOutputEvalExec;
 import org.elasticsearch.xpack.esql.plan.physical.DissectExec;
 import org.elasticsearch.xpack.esql.plan.physical.EnrichExec;
@@ -361,6 +363,8 @@ public class LocalExecutionPlanner {
             return planTimeSeriesCollapse(tsCollapse, context);
         } else if (node instanceof RerankExec rerank) {
             return planRerank(rerank, context);
+        } else if (node instanceof ChangePointFillEmptyBucketsExec fill) {
+            return planChangePointFillEmptyBuckets(fill, context);
         } else if (node instanceof ChangePointExec changePoint) {
             return planChangePoint(changePoint, context);
         } else if (node instanceof CompletionExec completion) {
@@ -1839,6 +1843,28 @@ public class LocalExecutionPlanner {
                 collapse.start(),
                 collapse.end(),
                 collapse.stepMillis()
+            ),
+            layout
+        );
+    }
+
+    private PhysicalOperation planChangePointFillEmptyBuckets(ChangePointFillEmptyBucketsExec fill, LocalExecutionPlannerContext context) {
+        PhysicalOperation source = plan(fill.child(), context);
+        Layout layout = source.layout;
+        int keyChannel = layout.get(fill.key().id()).channel();
+        int valueChannel = layout.get(fill.value().id()).channel();
+        List<Integer> groupingChannels = fill.groupings()
+            .stream()
+            .map(g -> getAttributeChannel(g, layout, "CHANGE_POINT BY expression must be an attribute"))
+            .toList();
+        return source.with(
+            new ChangePointFillEmptyBucketsOperator.Factory(
+                keyChannel,
+                valueChannel,
+                groupingChannels.stream().mapToInt(Integer::intValue).toArray(),
+                fill.dateBucketRounding(),
+                fill.minDate(),
+                fill.maxDate()
             ),
             layout
         );

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/mapper/MapperUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/mapper/MapperUtils.java
@@ -13,6 +13,7 @@ import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.MetadataAttribute;
 import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
 import org.elasticsearch.xpack.esql.plan.logical.ChangePoint;
+import org.elasticsearch.xpack.esql.plan.logical.ChangePointFillEmptyBuckets;
 import org.elasticsearch.xpack.esql.plan.logical.Dissect;
 import org.elasticsearch.xpack.esql.plan.logical.Enrich;
 import org.elasticsearch.xpack.esql.plan.logical.Eval;
@@ -40,6 +41,7 @@ import org.elasticsearch.xpack.esql.plan.logical.local.LocalRelation;
 import org.elasticsearch.xpack.esql.plan.logical.show.ShowInfo;
 import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
 import org.elasticsearch.xpack.esql.plan.physical.ChangePointExec;
+import org.elasticsearch.xpack.esql.plan.physical.ChangePointFillEmptyBucketsExec;
 import org.elasticsearch.xpack.esql.plan.physical.DissectExec;
 import org.elasticsearch.xpack.esql.plan.physical.EnrichExec;
 import org.elasticsearch.xpack.esql.plan.physical.EvalExec;
@@ -162,6 +164,19 @@ public class MapperUtils {
                 collapse.start(),
                 collapse.end(),
                 collapse.stepMillis()
+            );
+        }
+
+        if (p instanceof ChangePointFillEmptyBuckets fill) {
+            return new ChangePointFillEmptyBucketsExec(
+                fill.source(),
+                child,
+                fill.value(),
+                fill.key(),
+                fill.groupings(),
+                fill.dateBucketRounding(),
+                fill.minDate(),
+                fill.maxDate()
             );
         }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
@@ -438,8 +438,12 @@ public class EsqlSession {
                     var logicalPlanPreOptimizer = new LogicalPlanPreOptimizer(
                         new LogicalPreOptimizerContext(foldContext, inferenceService, minimumVersion)
                     );
+                    TimestampBounds timestampBoundsForOptimizer = QueryDslTimestampBoundsExtractor.extractTimestampBounds(
+                        request.filter(),
+                        finalConfiguration::absoluteStartedTimeInMillis
+                    );
                     var logicalPlanOptimizer = new LogicalPlanOptimizer(
-                        new LogicalOptimizerContext(finalConfiguration, foldContext, minimumVersion)
+                        new LogicalOptimizerContext(finalConfiguration, foldContext, minimumVersion, timestampBoundsForOptimizer)
                     );
 
                     var columnMetadata = new Holder<Map<NameId, Map<String, Object>>>();

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/approximation/ApproximationSupportTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/approximation/ApproximationSupportTests.java
@@ -62,6 +62,7 @@ import org.elasticsearch.xpack.esql.expression.function.aggregate.Top;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Values;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.VarianceOverTime;
 import org.elasticsearch.xpack.esql.plan.logical.BinaryPlan;
+import org.elasticsearch.xpack.esql.plan.logical.ChangePointFillEmptyBuckets;
 import org.elasticsearch.xpack.esql.plan.logical.CompoundOutputEval;
 import org.elasticsearch.xpack.esql.plan.logical.Dedup;
 import org.elasticsearch.xpack.esql.plan.logical.Drop;
@@ -198,6 +199,7 @@ public class ApproximationSupportTests extends ESTestCase {
         Rename.class,
         ResolvingProject.class,
         SemiJoin.class,
+        ChangePointFillEmptyBuckets.class,
         SparklineGenerateEmptyBuckets.class,
         UnresolvedExternalRelation.class,
         UnresolvedRelation.class,

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/ChangePointBucketSpecExtractorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/ChangePointBucketSpecExtractorTests.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.optimizer;
+
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.EsqlTestUtils;
+import org.elasticsearch.xpack.esql.core.expression.FoldContext;
+import org.elasticsearch.xpack.esql.core.querydsl.QueryDslTimestampBoundsExtractor.TimestampBounds;
+import org.elasticsearch.xpack.esql.optimizer.AbstractLogicalPlanOptimizerTests.TestSubstitutionOnlyOptimizer;
+import org.elasticsearch.xpack.esql.optimizer.rules.logical.ReplaceChangePointBucketFill;
+import org.elasticsearch.xpack.esql.optimizer.rules.logical.SubstituteSurrogatePlans;
+import org.elasticsearch.xpack.esql.plan.logical.ChangePoint;
+import org.elasticsearch.xpack.esql.plan.logical.ChangePointFillEmptyBuckets;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class ChangePointBucketSpecExtractorTests extends ESTestCase {
+
+    public void testExtractAfterSurrogateSubstitution() {
+        LogicalPlan afterSurrogate = afterSurrogateSubstitution();
+        ChangePoint changePoint = findChangePoint(afterSurrogate);
+        assertThat(changePoint, notNullValue());
+        assertThat(changePoint.child().getClass().getSimpleName(), is("Limit"));
+
+        Optional<ChangePointBucketSpecExtractor.ChangePointBucketFillSpec> spec = ChangePointBucketSpecExtractor.extract(
+            changePoint,
+            context(bounds())
+        );
+        assertTrue("expected spec, plan:\n" + afterSurrogate, spec.isPresent());
+        assertWarnings("No limit defined, adding default limit of [1000]");
+    }
+
+    public void testFillInsertedAfterSurrogateOnly() {
+        LogicalPlan plan = new ReplaceChangePointBucketFill().apply(afterSurrogateSubstitution(), context(bounds()));
+
+        List<LogicalPlan> fills = new ArrayList<>();
+        plan.forEachDown(ChangePointFillEmptyBuckets.class, fills::add);
+        assertFalse("expected fill after surrogate only, plan:\n" + plan, fills.isEmpty());
+        assertWarnings("No limit defined, adding default limit of [1000]");
+    }
+
+    public void testFillInsertedAfterSubstitutionsBatch() {
+        LogicalPlan plan = new TestSubstitutionOnlyOptimizer(context(bounds())) {
+            LogicalPlan run(LogicalPlan analyzed) {
+                return execute(analyzed);
+            }
+        }.run(analyzedPlan());
+
+        List<LogicalPlan> fills = new ArrayList<>();
+        plan.forEachDown(ChangePointFillEmptyBuckets.class, fills::add);
+        assertFalse("expected fill after substitutions batch, plan:\n" + plan, fills.isEmpty());
+        assertWarnings("No limit defined, adding default limit of [1000]");
+    }
+
+    private static LogicalPlan analyzedPlan() {
+        return EsqlTestUtils.analyzer().addK8s().query("""
+            FROM k8s
+            | STATS c = COUNT() BY @timestamp = BUCKET(@timestamp, 1 MINUTE)
+            | CHANGE_POINT c ON @timestamp
+            """);
+    }
+
+    private static LogicalPlan afterSurrogateSubstitution() {
+        return new SubstituteSurrogatePlans().apply(analyzedPlan());
+    }
+
+    private static TimestampBounds bounds() {
+        return new TimestampBounds(Instant.parse("2024-05-10T00:00:00.000Z"), Instant.parse("2024-05-10T01:00:00.000Z"));
+    }
+
+    private static LogicalOptimizerContext context(TimestampBounds bounds) {
+        return new LogicalOptimizerContext(EsqlTestUtils.TEST_CFG, FoldContext.small(), TransportVersion.current(), bounds);
+    }
+
+    private static ChangePoint findChangePoint(LogicalPlan plan) {
+        List<ChangePoint> changePoints = new ArrayList<>();
+        plan.forEachDown(ChangePoint.class, changePoints::add);
+        assertThat(changePoints.size(), is(1));
+        return changePoints.getFirst();
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/LogicalOptimizerContextTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/LogicalOptimizerContextTests.java
@@ -14,9 +14,12 @@ import org.elasticsearch.xpack.esql.ConfigurationTestUtils;
 import org.elasticsearch.xpack.esql.EsqlTestUtils;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.FoldContext;
+import org.elasticsearch.xpack.esql.core.querydsl.QueryDslTimestampBoundsExtractor.TimestampBounds;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.optimizer.LogicalOptimizerContext;
 import org.elasticsearch.xpack.esql.session.Configuration;
+
+import java.time.Instant;
 
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.randomMinimumVersion;
 import static org.hamcrest.Matchers.equalTo;
@@ -34,7 +37,9 @@ public class LogicalOptimizerContextTests extends ESTestCase {
         assertThat(
             ctx.toString(),
             equalTo(
-                "LogicalOptimizerContext[configuration=" + EsqlTestUtils.TEST_CFG + ", foldCtx=FoldContext[3/102], minimumVersion=9075000]"
+                "LogicalOptimizerContext[configuration="
+                    + EsqlTestUtils.TEST_CFG
+                    + ", foldCtx=FoldContext[3/102], minimumVersion=9075000, timestampBounds=null]"
             )
         );
     }
@@ -48,19 +53,29 @@ public class LogicalOptimizerContextTests extends ESTestCase {
     }
 
     private LogicalOptimizerContext copy(LogicalOptimizerContext c) {
-        return new LogicalOptimizerContext(c.configuration(), c.foldCtx(), c.minimumVersion());
+        return new LogicalOptimizerContext(c.configuration(), c.foldCtx(), c.minimumVersion(), c.timestampBounds());
     }
 
     private LogicalOptimizerContext mutate(LogicalOptimizerContext c) {
         Configuration configuration = c.configuration();
         FoldContext foldCtx = c.foldCtx();
         TransportVersion minVersion = c.minimumVersion();
-        switch (randomIntBetween(0, 2)) {
+        TimestampBounds timestampBounds = c.timestampBounds();
+        switch (randomIntBetween(0, 3)) {
             case 0 -> configuration = randomValueOtherThan(configuration, ConfigurationTestUtils::randomConfiguration);
             case 1 -> foldCtx = randomValueOtherThan(foldCtx, this::randomFoldContext);
             case 2 -> minVersion = randomValueOtherThan(minVersion, EsqlTestUtils::randomMinimumVersion);
+            case 3 -> timestampBounds = randomValueOtherThan(timestampBounds, this::randomTimestampBounds);
         }
-        return new LogicalOptimizerContext(configuration, foldCtx, minVersion);
+        return new LogicalOptimizerContext(configuration, foldCtx, minVersion, timestampBounds);
+    }
+
+    private TimestampBounds randomTimestampBounds() {
+        if (randomBoolean()) {
+            return null;
+        }
+        Instant start = Instant.ofEpochMilli(randomLongBetween(0, 1_000_000_000_000L));
+        return new TimestampBounds(start, start.plusSeconds(randomLongBetween(1, 3600)));
     }
 
     private FoldContext randomFoldContext() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceChangePointBucketFillTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceChangePointBucketFillTests.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.optimizer.rules.logical;
+
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.EsqlTestUtils;
+import org.elasticsearch.xpack.esql.core.expression.FoldContext;
+import org.elasticsearch.xpack.esql.core.querydsl.QueryDslTimestampBoundsExtractor.TimestampBounds;
+import org.elasticsearch.xpack.esql.optimizer.LogicalOptimizerContext;
+import org.elasticsearch.xpack.esql.optimizer.LogicalPlanOptimizer;
+import org.elasticsearch.xpack.esql.plan.logical.ChangePointFillEmptyBuckets;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.plan.logical.TopN;
+import org.elasticsearch.xpack.esql.plan.logical.TopNBy;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class ReplaceChangePointBucketFillTests extends ESTestCase {
+
+    public void testInsertsFillForBucketWithTimestampBounds() {
+        TimestampBounds bounds = bounds();
+        LogicalPlan plan = analyzedPlan(bounds);
+        LogicalPlan optimized = optimize(plan, bounds);
+
+        List<LogicalPlan> fills = new ArrayList<>();
+        optimized.forEachDown(ChangePointFillEmptyBuckets.class, fills::add);
+        if (fills.isEmpty()) {
+            fail("expected ChangePointFillEmptyBuckets in plan:\n" + optimized);
+        }
+        assertThat(fills.size(), equalTo(1));
+        assertTrue(((ChangePointFillEmptyBuckets) fills.getFirst()).child() instanceof TopN);
+        assertWarnings("No limit defined, adding default limit of [1000]");
+    }
+
+    public void testInsertsFillWithTopNByForGroupedBucket() {
+        TimestampBounds bounds = bounds();
+        LogicalPlan plan = EsqlTestUtils.analyzer().addK8s().timestampBounds(bounds).query("""
+            FROM k8s
+            | STATS c = COUNT() BY @timestamp = BUCKET(@timestamp, 1 MINUTE), cluster
+            | CHANGE_POINT c ON @timestamp BY cluster
+            """);
+        LogicalPlan optimized = optimize(plan, bounds);
+
+        List<LogicalPlan> fills = new ArrayList<>();
+        optimized.forEachDown(ChangePointFillEmptyBuckets.class, fills::add);
+        if (fills.isEmpty()) {
+            fail("expected ChangePointFillEmptyBuckets in plan:\n" + optimized);
+        }
+        assertThat(fills.size(), equalTo(1));
+        assertTrue(((ChangePointFillEmptyBuckets) fills.getFirst()).child() instanceof TopNBy);
+        assertWarnings("No limit defined, adding default limit of [1000]");
+    }
+
+    public void testSkipsTBucket() {
+        TimestampBounds bounds = bounds();
+        LogicalPlan plan = EsqlTestUtils.analyzer().addK8s().timestampBounds(bounds).query("""
+            FROM k8s
+            | STATS c = COUNT() BY @timestamp = TBUCKET(60)
+            | CHANGE_POINT c ON @timestamp
+            """);
+
+        LogicalPlan optimized = optimize(plan, bounds);
+        List<LogicalPlan> fills = new ArrayList<>();
+        optimized.forEachDown(ChangePointFillEmptyBuckets.class, fills::add);
+        assertTrue(fills.isEmpty());
+        assertWarnings("No limit defined, adding default limit of [1000]");
+    }
+
+    public void testWarnsAndSkipsFillWhenTimerangeTooShort() {
+        TimestampBounds bounds = new TimestampBounds(Instant.parse("2024-05-10T00:00:00.000Z"), Instant.parse("2024-05-10T00:15:00.000Z"));
+        LogicalPlan plan = analyzedPlan(bounds);
+
+        LogicalPlan optimized = optimize(plan, bounds);
+        List<LogicalPlan> fills = new ArrayList<>();
+        optimized.forEachDown(ChangePointFillEmptyBuckets.class, fills::add);
+        assertTrue(fills.isEmpty());
+        assertWarnings(
+            "No limit defined, adding default limit of [1000]",
+            "Line 3:3: CHANGE_POINT bucket zero-fill skipped; the requested time range and bucket interval allow only [15] buckets but at least [22] are required"
+        );
+    }
+
+    private static LogicalPlan analyzedPlan(TimestampBounds bounds) {
+        return EsqlTestUtils.analyzer().addK8s().timestampBounds(bounds).query("""
+            FROM k8s
+            | STATS c = COUNT() BY @timestamp = BUCKET(@timestamp, 1 MINUTE)
+            | CHANGE_POINT c ON @timestamp
+            """);
+    }
+
+    private static TimestampBounds bounds() {
+        return new TimestampBounds(Instant.parse("2024-05-10T00:00:00.000Z"), Instant.parse("2024-05-10T01:00:00.000Z"));
+    }
+
+    private static LogicalPlan optimize(LogicalPlan plan, TimestampBounds bounds) {
+        LogicalOptimizerContext context = new LogicalOptimizerContext(
+            EsqlTestUtils.TEST_CFG,
+            FoldContext.small(),
+            TransportVersion.current(),
+            bounds
+        );
+        return new LogicalPlanOptimizer(context).optimize(plan);
+    }
+}


### PR DESCRIPTION
> **Context for reviewers:** I'm a Kibana contributor. I used Cursor to produce this change from a behaviour spec I wrote, and I've tested it locally. I'm opening this as a **discussion driver** to unblock a Kibana use case, not as a finished proposal.

## Summary

`CHANGE_POINT` needs at least **22 values** in the ordered sequence passed to the detector. Take this example query:

```esql
FROM ...
| STATS metric = COUNT() BY @timestamp = BUCKET(@timestamp, 1 hour)
| CHANGE_POINT metric ON @timestamp
```

When the underlying data is sparse — few buckets actually contain events — the aggregated table may have far fewer than 22 rows. `CHANGE_POINT` then fails or returns null, even though the user selected a time range where many more buckets *could* exist.

This change adds an optimizer-driven bucket gap-fill step that runs immediately before `CHANGE_POINT` when the query matches a narrow, well-defined pattern. Missing bucket keys are synthesised as rows with value `0`, so the detector receives a contiguous time-bucket sequence and can run.

### Query flow (before vs after)

```mermaid
flowchart TD
    subgraph before["Today (no fill)"]
        A1[FROM + filters] --> B1[STATS with BUCKET on datetime]
        B1 --> C1[CHANGE_POINT]
        C1 --> D1["Fails or null if &lt; 22 real buckets"]
    end

    subgraph after["With this change"]
        A2[FROM + filters] --> B2[STATS with BUCKET on datetime]
        B2 --> O{Optimizer: pattern matches?}
        O -->|No| C2[CHANGE_POINT unchanged]
        O -->|Yes| F[Fill missing bucket rows with 0]
        F --> C3[CHANGE_POINT]
        C3 --> D2["Runs on contiguous sequence up to 22+ buckets"]
    end
```

The fill step is inserted only when all of the following hold:

- `CHANGE_POINT … ON key` refers to a `STATS` grouping produced by `BUCKET` on a `datetime` / `date_nanos` field
- A time range is known, either from foldable `from`/`to` on `BUCKET`, or from an `@timestamp` range on the request filter
- The range and bucket interval could theoretically contain at least 22 buckets (otherwise fill is skipped with a warning)

When a `BY` clause is present, gap filling runs **per group**.

### How the 22-bucket minimum is reached

The underlying ML detector requires 22 values. This change does not lower that bar; it tries to **construct** a valid sequence when the query shape allows it.

| Step | Rule |
|------|------|
| **1. Interior gaps** | Between any two consecutive real bucket keys, every missing bucket in the time range is always inserted with value `0`. |
| **2. Edge padding** | If fewer than 22 buckets remain after step 1, additional buckets are added **alternately** to the left and right of the cluster of real data. |
| **3. Range boundary** | When one side hits the start or end of the known time range, padding continues on the other side only. |
| **4. Hard limit** | Real buckets are never removed. Padding stops at 22 buckets or when the range is exhausted — whichever comes first. |
| **5. Can't help** | If the requested range and interval can fit fewer than 22 buckets total, gap fill is **not** applied; a header warning is emitted and behaviour falls back to today. |

**Fill value:** synthesised buckets always use `0`. That matches count-like metrics (`COUNT()`, `SUM()` of events) where a missing bucket means no activity. For `AVG()`, `MIN()`, `MAX()`, etc., this is best-effort only — results should be interpreted with care. The syntax does not expose a configurable fill value today (noted in docs as a possible future enhancement).

Detection itself remains **sequence-based, not time-aware** — we are shaping the input table, not changing the detector algorithm.

### High level code changes

- Logical optimizer rule + spec extractor to recognise the `STATS` / `BUCKET` / `CHANGE_POINT` pattern
- New logical/physical plan node and compute operator to insert zero-valued rows
- Threading of request `@timestamp` bounds into the logical optimizer (for range resolution when `BUCKET` has no explicit `from`/`to`)
- Docs update for `CHANGE_POINT`
- Unit tests (fill algorithm, operator, optimizer) and CSV specs for sparse-bucket scenarios

---

## Related

https://github.com/elastic/elasticsearch/issues/111483 (this change instead narrows the filling to only when `CHANGE_POINT` is used)