### PR TITLE
[ESQL] ESQL: restore CSV/TSV/NDJSON read perf after cap enforcement

### DIFF
--- a/docs/changelog/151393.yaml
+++ b/docs/changelog/151393.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 151393
+summary: Restore CSV/TSV/NDJSON read perf after cap enforcement
+type: bug

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
@@ -776,25 +776,36 @@ public class CsvFormatReader implements SegmentableFormatReader {
         }
     }
 
-    private Iterator<List<?>> newCsvIterator(Reader reader) throws IOException {
-        return newCsvIterator(
-            new CsvLogicalRecordReader(
-                reader,
-                options.quoteChar(),
-                options.delimiter(),
-                SegmentableFormatReader.DEFAULT_MAX_RECORD_BYTES,
-                options.encoding()
-            )
-        );
+    /**
+     * Per-record iterator used for schema reading, sampling, and bootstrap paths where each record is
+     * materialized into a {@link String} before Jackson parses it. Cost is bounded by
+     * {@link #schemaSampleSize} on inference paths; the bulk read loop swaps over to
+     * {@link #newJacksonBulkIterator} after schema resolution so the per-row hot path stays on
+     * Jackson's direct bulk char-buffer tokenization.
+     */
+    private Iterator<List<?>> newCsvIterator(CsvLogicalRecordReader recordReader) throws IOException {
+        return new CsvRecordIterator(recordReader, newCsvSchema());
     }
 
-    private Iterator<List<?>> newCsvIterator(CsvLogicalRecordReader recordReader) throws IOException {
-        CsvSchema csvSchema = CsvSchema.emptySchema()
+    /**
+     * Bulk-path iterator: hands the raw {@link Reader} straight to Jackson's {@link CsvParser} so the
+     * per-row hot loop tokenizes characters in Jackson's internal char buffer instead of re-materializing
+     * each logical record into a {@link StringBuilder} for a follow-up Jackson parse. The byte-level
+     * {@code max_record_size} cap is enforced upstream by {@link CsvRecordCappingInputStream}, so this
+     * path no longer needs the per-char accounting that {@link CsvLogicalRecordReader#readRecord} added.
+     * Used after schema resolution / sampling, where every subsequent record flows through this iterator.
+     */
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    private Iterator<List<?>> newJacksonBulkIterator(Reader reader) throws IOException {
+        return (Iterator) sharedCsvMapper.readerFor(List.class).with(newCsvSchema()).readValues(reader);
+    }
+
+    private CsvSchema newCsvSchema() {
+        return CsvSchema.emptySchema()
             .withColumnSeparator(options.delimiter())
             .withQuoteChar(options.quoteChar())
             .withEscapeChar(options.escapeChar())
             .withNullValue(options.nullValue());
-        return new CsvRecordIterator(recordReader, csvSchema);
     }
 
     /**
@@ -990,7 +1001,15 @@ public class CsvFormatReader implements SegmentableFormatReader {
         // length() throws UnsupportedOperationException. The byte count flows through {@link
         // ExternalStats} as sizeInBytes when the file lacks a publishable length.
         CountingInputStream stream = new CountingInputStream(rawStream);
-        BufferedReader reader = new BufferedReader(new InputStreamReader(stream, options.encoding()), READER_BUFFER_SIZE);
+        // Scope the byte-level cap wrap to the Jackson bulk path. Bracket-aware parsing relies on
+        // CsvLogicalRecordReader.addBytes for a recoverable per-record cap; wrapping the underlying
+        // stream would let the cap fire mid-{@link BufferedReader#fill}, leaving the reader at an
+        // undefined offset and turning a per-row recovery into a stream-fatal abort. When bracket
+        // mode is enabled the data path goes through CsvLogicalRecordReader and never reaches the
+        // Jackson bulk iterator, so the wrap brings no defense-in-depth there either.
+        boolean useBracketAware = options.multiValueSyntax() == CsvFormatOptions.MultiValueSyntax.BRACKETS && options.delimiter() == ',';
+        InputStream capped = useBracketAware ? stream : new CsvRecordCappingInputStream(stream, context.maxRecordBytes());
+        BufferedReader reader = new BufferedReader(new InputStreamReader(capped, options.encoding()), READER_BUFFER_SIZE);
         CsvLogicalRecordReader recordReader = new CsvLogicalRecordReader(
             reader,
             options.quoteChar(),
@@ -1042,7 +1061,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
                 recordReader.readRecord(
                     options.multiValueSyntax() == CsvFormatOptions.MultiValueSyntax.BRACKETS && options.delimiter() == ','
                 );
-            } catch (CsvLogicalRecordReader.CsvRecordTooLargeException e) {
+            } catch (CsvRecordTooLargeException e) {
                 if (effective.isStrict()) {
                     throw e;
                 }
@@ -1812,7 +1831,10 @@ public class CsvFormatReader implements SegmentableFormatReader {
 
                 boolean useBracketAwareParsing = bracketMultiValues && options.delimiter() == ',';
                 if (useBracketAwareParsing == false && csvIterator == null) {
-                    csvIterator = newCsvIterator(recordReader);
+                    // Hot data path: Jackson reads directly from the BufferedReader and tokenizes records in its
+                    // own bulk char buffer. The per-record byte cap is enforced upstream by the wrapping
+                    // CsvRecordCappingInputStream, so we don't need CsvLogicalRecordReader's per-char loop here.
+                    csvIterator = newJacksonBulkIterator(reader);
                 }
             }
             boolean useFusedBracketPath = csvIterator == null && bracketMultiValues && options.delimiter() == ',';
@@ -1888,7 +1910,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
         private String readBracketAwareRecord() throws IOException {
             try {
                 return recordReader.readRecord(true);
-            } catch (CsvLogicalRecordReader.CsvRecordTooLargeException e) {
+            } catch (CsvRecordTooLargeException e) {
                 totalRowCount++;
                 onRowError(e.getMessage(), e, EMPTY_ROW, true);
                 return "";
@@ -1930,6 +1952,10 @@ public class CsvFormatReader implements SegmentableFormatReader {
                 blockFactory.breaker(),
                 errorPolicy
             );
+            // Drop the per-record sampling iterator so the bulk Jackson path can pick up where the
+            // sample left off. Without this reset, inferred-schema reads stay on the slow per-record
+            // CsvLogicalRecordReader path for the remainder of the file.
+            csvIterator = null;
             if (sample.rows().isEmpty()) {
                 blockFactory.breaker().addWithoutBreaking(-sample.reservedBytes());
                 return null;
@@ -1948,6 +1974,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
                 blockFactory.breaker(),
                 errorPolicy
             );
+            csvIterator = null;
             if (sample.rows().isEmpty()) {
                 blockFactory.breaker().addWithoutBreaking(-sample.reservedBytes());
                 return null;

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvLogicalRecordReader.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvLogicalRecordReader.java
@@ -151,10 +151,4 @@ final class CsvLogicalRecordReader {
         }
         return 3;
     }
-
-    static final class CsvRecordTooLargeException extends IOException {
-        CsvRecordTooLargeException(int maxRecordBytes) {
-            super("CSV record exceeded max_record_size [" + maxRecordBytes + "]");
-        }
-    }
 }

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvRecordCappingInputStream.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvRecordCappingInputStream.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.csv;
+
+import org.elasticsearch.xpack.esql.datasources.spi.RecordCappingInputStream;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * CSV/TSV byte-cap wrapper. Quote-unaware (an embedded {@code '\n'} or {@code '\r'} inside a quoted
+ * field resets the counter prematurely), so the cap is a defense-in-depth bound rather than an
+ * exact per-record check; the splitter applies the authoritative quote-aware check at split
+ * discovery, and Jackson's {@code StreamReadConstraints.maxStringLength} bounds individual fields.
+ *
+ * <p>Wrapped only on the non-bracket-aware data path; the bracket-aware path uses
+ * {@link CsvLogicalRecordReader}'s char-decoded {@code addBytes} cap, which is exact and supports
+ * row-level recovery under lenient error policies.
+ *
+ * <p>Under lenient error policies on the wrapped non-bracket-aware path, a thrown
+ * {@link CsvRecordTooLargeException} surfaces as a stream-fatal abort because the underlying
+ * stream position is undefined after the trip; the cause chain still carries the original
+ * {@code "max_record_size [N]"} message.
+ *
+ * @see RecordCappingInputStream for the shared CRLF / cap state machine.
+ */
+final class CsvRecordCappingInputStream extends RecordCappingInputStream {
+
+    private final int maxRecordBytes;
+
+    CsvRecordCappingInputStream(InputStream in, int maxRecordBytes) {
+        super(in, maxRecordBytes);
+        this.maxRecordBytes = maxRecordBytes;
+    }
+
+    @Override
+    protected IOException recordTooLarge() {
+        return new CsvRecordTooLargeException(maxRecordBytes);
+    }
+}

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvRecordTooLargeException.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvRecordTooLargeException.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.csv;
+
+import java.io.IOException;
+
+/**
+ * Raised when a CSV/TSV record exceeds the configured {@code max_record_size} byte budget. Thrown
+ * either by {@link CsvRecordCappingInputStream} (the hot data path, raw-byte and quote-unaware) or
+ * by {@link CsvLogicalRecordReader} (legacy bracket-aware path, char-decoded byte estimate).
+ */
+final class CsvRecordTooLargeException extends IOException {
+    CsvRecordTooLargeException(int maxRecordBytes) {
+        super("CSV record exceeded max_record_size [" + maxRecordBytes + "]");
+    }
+}

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
@@ -6298,4 +6298,161 @@ public class CsvFormatReaderTests extends ESTestCase {
             Matchers.lessThan((long) bytes.length / 2)
         );
     }
+
+    /**
+     * Regression for https://github.com/elastic/esql-planning/issues/894: the Jackson hot data path enforces
+     * {@code max_record_size} via the upstream {@link CsvRecordCappingInputStream}. An oversized record
+     * trips the cap during the {@link java.io.BufferedReader} bulk fill (potentially before any individual
+     * row has been emitted), the {@link CsvRecordTooLargeException} propagates as an {@link IOException},
+     * and the outer {@code CsvBatchIterator.hasNext()} wraps it in a {@link RuntimeException} whose cause
+     * chain carries the original {@code "max_record_size [N]"} message.
+     */
+    public void testJacksonBulkPathPropagatesMaxRecordSizeError() {
+        int maxRecordBytes = 32;
+        String csv = "id:long,text:keyword\n1,ok\n100," + "x".repeat(maxRecordBytes) + "\n";
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+
+        FormatReadContext context = FormatReadContext.builder()
+            .batchSize(10)
+            .errorPolicy(ErrorPolicy.STRICT)
+            .maxRecordBytes(maxRecordBytes)
+            .build();
+
+        RuntimeException ex = expectThrows(RuntimeException.class, () -> {
+            try (CloseableIterator<Page> iterator = reader.read(object, context)) {
+                while (iterator.hasNext()) {
+                    Page page = iterator.next();
+                    page.releaseBlocks();
+                }
+            }
+        });
+        Throwable rootCause = ex;
+        while (rootCause.getCause() != null && rootCause.getCause() != rootCause) {
+            rootCause = rootCause.getCause();
+        }
+        assertTrue("expected a CsvRecordTooLargeException in the cause chain, got: " + ex, rootCause instanceof CsvRecordTooLargeException);
+        assertThat(rootCause.getMessage(), Matchers.containsString("max_record_size [" + maxRecordBytes + "]"));
+    }
+
+    /**
+     * Lenient policy still aborts the read once an oversized record trips the byte cap because the underlying
+     * {@link CsvRecordCappingInputStream} cannot resume after a thrown {@link IOException}; the destructive
+     * stream wrapper exists precisely to keep the byte-accounting monotonic with the parser's consumption.
+     * This is a deliberate tradeoff documented on
+     * {@link org.elasticsearch.xpack.esql.datasource.csv.CsvRecordCappingInputStream}: cap-too-large becomes
+     * stream-fatal on the Jackson bulk path. The bracket-aware path retains row-level recovery via
+     * {@link org.elasticsearch.xpack.esql.datasource.csv.CsvLogicalRecordReader}'s char-decoded accounting.
+     */
+    public void testJacksonBulkPathAbortsOnCapTooLargeEvenUnderLenientPolicy() {
+        int maxRecordBytes = 32;
+        String csv = "id:long,text:keyword\n1,ok\n100," + "x".repeat(maxRecordBytes) + "\n";
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+
+        FormatReadContext context = FormatReadContext.builder()
+            .batchSize(10)
+            .errorPolicy(ErrorPolicy.LENIENT)
+            .maxRecordBytes(maxRecordBytes)
+            .build();
+
+        RuntimeException ex = expectThrows(RuntimeException.class, () -> {
+            try (CloseableIterator<Page> iterator = reader.read(object, context)) {
+                while (iterator.hasNext()) {
+                    iterator.next().releaseBlocks();
+                }
+            }
+        });
+        Throwable rootCause = ex;
+        while (rootCause.getCause() != null && rootCause.getCause() != rootCause) {
+            rootCause = rootCause.getCause();
+        }
+        assertTrue(
+            "lenient policy must still abort with the cap exception in the cause chain, got: " + ex,
+            rootCause instanceof CsvRecordTooLargeException
+        );
+        assertThat(rootCause.getMessage(), Matchers.containsString("max_record_size [" + maxRecordBytes + "]"));
+    }
+
+    /**
+     * Regression for the inferred-schema bulk-path engagement (issue #894 review feedback): when the schema is
+     * inferred at read time, the per-record sampling iterator must be torn down after sampling so the data path
+     * picks up the Jackson bulk iterator. Without this, post-sample reads stay on the slow per-record
+     * {@code CsvLogicalRecordReader} loop and the headline perf fix never engages for ad-hoc CSVs.
+     *
+     * <p>Behavioral assertion: the cap-stream wrap (active on non-bracket-aware reads) trips the cap as a
+     * stream-fatal abort once an oversized data row is reached past the sampling window — which is only
+     * possible if the bulk path is engaged after sampling. If the iterator stayed on
+     * {@code CsvRecordIterator}, the cap would surface per-row and the read would either skip (lenient) or
+     * fail with a different exception shape — neither matching the strict-mode contract asserted below.
+     */
+    public void testInferredSchemaSwitchesToJacksonBulkPathAfterSampling() {
+        int maxRecordBytes = 64;
+        StringBuilder csv = new StringBuilder("id,name\n");
+        // A handful of small rows to feed schema inference, well below the cap.
+        for (int i = 0; i < 10; i++) {
+            csv.append(i).append(",row").append(i).append('\n');
+        }
+        // Oversized data row past the sampling prefix; only the Jackson-bulk-path cap stream sees this byte
+        // span. Adding the row terminator makes the record length exceed maxRecordBytes.
+        csv.append("99,").append("x".repeat(maxRecordBytes)).append('\n');
+        StorageObject object = createStorageObject(csv.toString());
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+
+        FormatReadContext context = FormatReadContext.builder()
+            .batchSize(10)
+            .errorPolicy(ErrorPolicy.STRICT)
+            .maxRecordBytes(maxRecordBytes)
+            .build();
+
+        RuntimeException ex = expectThrows(RuntimeException.class, () -> {
+            try (CloseableIterator<Page> iterator = reader.read(object, context)) {
+                while (iterator.hasNext()) {
+                    iterator.next().releaseBlocks();
+                }
+            }
+        });
+        Throwable rootCause = ex;
+        while (rootCause.getCause() != null && rootCause.getCause() != rootCause) {
+            rootCause = rootCause.getCause();
+        }
+        assertTrue(
+            "inferred-schema reads must reach the cap-stream-protected bulk path after sampling, got: " + ex,
+            rootCause instanceof CsvRecordTooLargeException
+        );
+        assertThat(rootCause.getMessage(), Matchers.containsString("max_record_size [" + maxRecordBytes + "]"));
+    }
+
+    /**
+     * Regression for the bracket-aware row-recovery contract (issue #894 review feedback): when bracket-multi-value
+     * parsing is enabled the cap-stream wrap is suppressed in {@link CsvFormatReader#read} so the cap stays an
+     * exact, recoverable per-record check inside {@link CsvLogicalRecordReader#addBytes}. Under lenient policy an
+     * oversized row must be skipped and the surrounding rows must still parse, rather than the cap-stream-wrapped
+     * destructive abort that the non-bracket-aware path exhibits.
+     */
+    public void testBracketAwareLenientSkipsOversizedRecordAndKeepsReading() throws IOException {
+        int maxRecordBytes = 32;
+        StringBuilder csv = new StringBuilder("id:long,tags:keyword\n");
+        csv.append("1,[a,b]\n");
+        csv.append("2,[").append("x".repeat(maxRecordBytes)).append("]\n");
+        csv.append("3,[c,d]\n");
+        StorageObject object = createStorageObject(csv.toString());
+        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(Map.of("multi_value_syntax", "brackets"));
+
+        FormatReadContext context = FormatReadContext.builder()
+            .batchSize(10)
+            .errorPolicy(ErrorPolicy.LENIENT)
+            .maxRecordBytes(maxRecordBytes)
+            .build();
+
+        long total = 0;
+        try (CloseableIterator<Page> iterator = reader.read(object, context)) {
+            while (iterator.hasNext()) {
+                Page page = iterator.next();
+                total += page.getPositionCount();
+                page.releaseBlocks();
+            }
+        }
+        assertEquals("bracket-aware lenient must drop the oversized row and keep the surrounding rows", 2L, total);
+    }
 }

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvRecordCappingInputStreamTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvRecordCappingInputStreamTests.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.csv;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+public class CsvRecordCappingInputStreamTests extends ESTestCase {
+
+    public void testConstructorRejectsNonPositiveMaxRecordBytes() {
+        IllegalArgumentException ex = expectThrows(
+            IllegalArgumentException.class,
+            () -> new CsvRecordCappingInputStream(new ByteArrayInputStream(new byte[0]), 0)
+        );
+        assertEquals("maxRecordBytes must be positive, got: 0", ex.getMessage());
+    }
+
+    public void testLfTerminatedRecordAtExactLimitPasses() throws IOException {
+        // Splitter rule: boundary - recordStart + 1 > max. A record of `max - 1` content bytes plus the LF
+        // terminator is `max` bytes total, which must pass.
+        int max = 8;
+        byte[] bytes = bytes("x".repeat(max - 1) + "\n");
+        assertReadsAll(bytes, max);
+    }
+
+    public void testLfTerminatedRecordOneByteOverLimitThrows() throws IOException {
+        int max = 8;
+        byte[] bytes = bytes("x".repeat(max) + "\n");
+        assertCapThrows(bytes, max);
+    }
+
+    public void testLoneCrTerminatedRecordOneByteOverLimitThrows() throws IOException {
+        int max = 8;
+        byte[] bytes = bytes("x".repeat(max) + "\rnext");
+        assertCapThrows(bytes, max);
+    }
+
+    public void testCrLfRecordCountsLfTowardSameRecord() throws IOException {
+        // "x"*max + "\r\n" has byte length max+2; the LF still belongs to the terminated record so the
+        // cap must trip on the LF, matching CsvRecordSplitter.recordExceedsLimit + CsvLogicalRecordReader.
+        int max = 8;
+        byte[] bytes = bytes("x".repeat(max) + "\r\n");
+        assertCapThrows(bytes, max);
+    }
+
+    public void testCrLfAtExactLimitPasses() throws IOException {
+        // max == content + \r + \n. "x"*(max-2) + "\r\n" is exactly max bytes total.
+        int max = 8;
+        byte[] bytes = bytes("x".repeat(max - 2) + "\r\n");
+        assertReadsAll(bytes, max);
+    }
+
+    public void testCounterResetsAfterTerminator() throws IOException {
+        int max = 4;
+        byte[] bytes = bytes("ab\ncd\nef\n");
+        try (InputStream in = wrap(bytes, max)) {
+            assertArrayEquals(bytes, in.readAllBytes());
+        }
+    }
+
+    public void testCrossBufferCrLfDoesNotDoubleCount() throws IOException {
+        // Record "xxxx\r\n" is 6 bytes total; with max=6 the record fits exactly. The cross-buffer split puts
+        // the '\r' at the tail of one read and the '\n' at the head of the next, so the LF must count toward
+        // the same already-terminated-by-CR record without re-counting beyond the cap.
+        int max = 6;
+        byte[] bytes = bytes("xxxx\r\nyyy");
+        try (TwoByteReadStream src = new TwoByteReadStream(bytes); InputStream in = new CsvRecordCappingInputStream(src, max)) {
+            assertArrayEquals(bytes, in.readAllBytes());
+        }
+    }
+
+    public void testCrossBufferLoneCrResetsBeforeNextRecord() throws IOException {
+        // Records "aaa\r" (4 bytes) and "bbbb" (4 bytes, EOF-terminated) both fit at max=4. The '\r' lands at
+        // the tail of a 2-byte read so the next read's first byte ('b') must start a fresh record.
+        int max = 4;
+        byte[] bytes = bytes("aaa\rbbbb");
+        try (TwoByteReadStream src = new TwoByteReadStream(bytes); InputStream in = new CsvRecordCappingInputStream(src, max)) {
+            assertArrayEquals(bytes, in.readAllBytes());
+        }
+    }
+
+    public void testEofWithoutTerminatorRespectsCap() throws IOException {
+        int max = 4;
+        byte[] safe = bytes("x".repeat(max));
+        try (InputStream in = wrap(safe, max)) {
+            assertArrayEquals(safe, in.readAllBytes());
+        }
+        byte[] tooLarge = bytes("x".repeat(max + 1));
+        IOException ex = expectThrows(IOException.class, () -> {
+            try (InputStream in = wrap(tooLarge, max)) {
+                in.readAllBytes();
+            }
+        });
+        assertThat(ex.getMessage(), org.hamcrest.Matchers.containsString("max_record_size [" + max + "]"));
+    }
+
+    public void testSingleByteReadEnforcesSameCap() throws IOException {
+        int max = 4;
+        byte[] bytes = bytes("x".repeat(max + 1) + "\n");
+        try (InputStream in = wrap(bytes, max)) {
+            IOException ex = expectThrows(IOException.class, () -> {
+                while (in.read() != -1) {
+                    // drain byte-by-byte to exercise the single-byte read path
+                }
+            });
+            assertThat(ex.getMessage(), org.hamcrest.Matchers.containsString("max_record_size [" + max + "]"));
+        }
+    }
+
+    public void testEmptyRecordsBetweenTerminatorsResetCleanly() throws IOException {
+        int max = 4;
+        byte[] bytes = bytes("ab\n\n\ncd\n");
+        try (InputStream in = wrap(bytes, max)) {
+            assertArrayEquals(bytes, in.readAllBytes());
+        }
+    }
+
+    public void testMarkResetDisabled() throws IOException {
+        try (InputStream in = wrap(bytes("abc"), 8)) {
+            assertFalse(in.markSupported());
+            in.mark(100); // no-op
+            IOException ex = expectThrows(IOException.class, in::reset);
+            assertThat(ex.getMessage(), org.hamcrest.Matchers.containsString("not supported"));
+        }
+    }
+
+    private static byte[] bytes(String value) {
+        return value.getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static CsvRecordCappingInputStream wrap(byte[] data, int maxRecordBytes) {
+        return new CsvRecordCappingInputStream(new ByteArrayInputStream(data), maxRecordBytes);
+    }
+
+    private static void assertReadsAll(byte[] bytes, int maxRecordBytes) throws IOException {
+        try (InputStream in = wrap(bytes, maxRecordBytes)) {
+            assertArrayEquals(bytes, in.readAllBytes());
+        }
+    }
+
+    private static void assertCapThrows(byte[] bytes, int maxRecordBytes) {
+        IOException ex = expectThrows(IOException.class, () -> {
+            try (InputStream in = wrap(bytes, maxRecordBytes)) {
+                in.readAllBytes();
+            }
+        });
+        assertThat(ex.getMessage(), org.hamcrest.Matchers.containsString("max_record_size [" + maxRecordBytes + "]"));
+    }
+
+    /** Returns no more than two bytes per {@code read(byte[], off, len)} so cross-buffer carry paths get exercised. */
+    private static final class TwoByteReadStream extends InputStream {
+        private final byte[] data;
+        private int pos;
+
+        TwoByteReadStream(byte[] data) {
+            this.data = data;
+        }
+
+        @Override
+        public int read() {
+            return pos < data.length ? (data[pos++] & 0xff) : -1;
+        }
+
+        @Override
+        public int read(byte[] buf, int off, int len) {
+            if (pos >= data.length) {
+                return -1;
+            }
+            int n = Math.min(2, Math.min(len, data.length - pos));
+            System.arraycopy(data, pos, buf, off, n);
+            pos += n;
+            return n;
+        }
+    }
+}

--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIterator.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIterator.java
@@ -121,11 +121,25 @@ final class NdJsonPageIterator extends BufferingPageIterator {
         }
         this.rowLimit = rowLimit;
         if (canUseByteArrayFastPath(object)) {
+            // Strict policy: wrap with the byte-cap stream so an oversized line trips during the single
+            // readAllBytes() pull — no second walk over the buffer like the previous enforceMaxRecordBytes
+            // pre-scan. Lenient policy: that wrap can't preserve the row-drop contract (an IOException
+            // mid-bulk-read leaves the underlying stream at an undefined offset), so we keep the
+            // post-read filtering pass — bounded to the byte-array fast path's ≤16 MiB segments — to
+            // drop oversized lines while leaving the rest of the file intact. Splitter-side enforcement
+            // (NdJsonRecordSplitter.findLastRecordBoundary at split discovery time) still covers parallel
+            // chunks; this branch protects whole-file and byte-range macro-split reads that bypass splitting.
             byte[] data;
-            try (InputStream toClose = inputStream) {
-                data = toClose.readAllBytes();
+            if (errorPolicy.isStrict()) {
+                try (InputStream toClose = new NdJsonRecordCappingInputStream(inputStream, recordSplitter)) {
+                    data = toClose.readAllBytes();
+                }
+            } else {
+                try (InputStream toClose = inputStream) {
+                    data = toClose.readAllBytes();
+                }
+                data = filterOversizedRecords(data, recordSplitter);
             }
-            data = enforceMaxRecordBytes(data, errorPolicy, recordSplitter);
             this.byteCounter = null;
             this.byteArrayBytesRead = data.length;
             this.pageDecoder = new NdJsonPageDecoder(
@@ -159,8 +173,16 @@ final class NdJsonPageIterator extends BufferingPageIterator {
         }
     }
 
-    private static byte[] enforceMaxRecordBytes(byte[] data, ErrorPolicy errorPolicy, NdJsonRecordSplitter recordSplitter)
-        throws IOException {
+    /**
+     * Lenient-mode byte-array post-filter: walks the freshly buffered segment once and drops every
+     * record whose terminator-inclusive byte count exceeds {@code maxRecordBytes}, leaving the rest
+     * of the file intact for downstream parsing. This preserves the pre-existing skip-row contract
+     * for oversized NDJSON lines while still avoiding a redundant pre-scan on the strict path
+     * (which goes through {@link NdJsonRecordCappingInputStream}). Bounded by the byte-array fast
+     * path's segment cap, so the extra walk is a single bounded pass rather than open-ended work.
+     */
+    private static byte[] filterOversizedRecords(byte[] data, NdJsonRecordSplitter recordSplitter) {
+        int max = recordSplitter.maxRecordBytes();
         ByteArrayOutputStream filtered = null;
         int recordStart = 0;
         for (int i = 0; i < data.length; i++) {
@@ -170,12 +192,12 @@ final class NdJsonPageIterator extends BufferingPageIterator {
                 if (b == '\r' && i + 1 < data.length && data[i + 1] == '\n') {
                     boundary = ++i;
                 }
-                filtered = copyOrSkipRecord(data, recordStart, boundary + 1, filtered, errorPolicy, recordSplitter);
+                filtered = copyOrSkipRecord(data, recordStart, boundary + 1, max, filtered);
                 recordStart = boundary + 1;
             }
         }
         if (recordStart < data.length) {
-            filtered = copyOrSkipRecord(data, recordStart, data.length, filtered, errorPolicy, recordSplitter);
+            filtered = copyOrSkipRecord(data, recordStart, data.length, max, filtered);
         }
         return filtered == null ? data : filtered.toByteArray();
     }
@@ -184,16 +206,13 @@ final class NdJsonPageIterator extends BufferingPageIterator {
         byte[] data,
         int recordStart,
         int recordEnd,
-        ByteArrayOutputStream filtered,
-        ErrorPolicy errorPolicy,
-        NdJsonRecordSplitter recordSplitter
-    ) throws IOException {
+        int maxRecordBytes,
+        ByteArrayOutputStream filtered
+    ) {
         int recordBytes = recordEnd - recordStart;
-        if (recordBytes > recordSplitter.maxRecordBytes()) {
-            if (errorPolicy.isStrict()) {
-                throw recordSplitter.recordTooLargeException();
-            }
+        if (recordBytes > maxRecordBytes) {
             if (filtered == null) {
+                // First skip materializes the kept-prefix once; subsequent records are appended as we go.
                 filtered = new ByteArrayOutputStream(data.length);
                 filtered.write(data, 0, recordStart);
             }

--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonRecordCappingInputStream.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonRecordCappingInputStream.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.ndjson;
+
+import org.elasticsearch.xpack.esql.datasources.spi.RecordCappingInputStream;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Objects;
+
+/**
+ * NDJSON byte-cap wrapper. Unlike CSV, NDJSON records cannot embed unescaped {@code '\n'} or
+ * {@code '\r'}: the JSON grammar requires those control characters to be escaped within string
+ * values, so every raw {@code '\n'} or {@code '\r'} byte is unambiguously a record terminator and
+ * the cap is precise per line.
+ *
+ * <p>Wrapped only under strict error policy by {@link NdJsonPageIterator}; the lenient path uses a
+ * post-read filter pass to preserve the historical drop-and-continue behavior for oversized lines
+ * (a thrown {@link IOException} from this stream is unrecoverable and would turn the row drop into
+ * a stream-fatal abort).
+ *
+ * @see RecordCappingInputStream for the shared CRLF / cap state machine.
+ */
+final class NdJsonRecordCappingInputStream extends RecordCappingInputStream {
+
+    private final NdJsonRecordSplitter recordSplitter;
+
+    NdJsonRecordCappingInputStream(InputStream in, NdJsonRecordSplitter recordSplitter) {
+        super(in, Objects.requireNonNull(recordSplitter, "recordSplitter").maxRecordBytes());
+        this.recordSplitter = recordSplitter;
+    }
+
+    @Override
+    protected IOException recordTooLarge() {
+        return recordSplitter.recordTooLargeException();
+    }
+}

--- a/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIteratorTests.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIteratorTests.java
@@ -2163,4 +2163,67 @@ public class NdJsonPageIteratorTests extends ESTestCase {
             Matchers.equalTo((long) rows)
         );
     }
+
+    /**
+     * Regression for https://github.com/elastic/esql-planning/issues/894: on the byte-array fast path the
+     * cap is now enforced by {@link NdJsonRecordCappingInputStream} during the single {@code readAllBytes}
+     * pull instead of by a separate pre-scan. Under {@link ErrorPolicy#STRICT} an oversized record must
+     * still surface a {@code max_record_size [N]} error rather than parse silently.
+     */
+    public void testByteArrayFastPathStrictModeEnforcesMaxRecordBytes() {
+        int maxRecordBytes = 16;
+        StringBuilder ndjson = new StringBuilder().append("{\"id\":1}\n");
+        ndjson.append("{\"id\":2,\"text\":\"").append("x".repeat(maxRecordBytes)).append("\"}\n");
+        byte[] data = ndjson.toString().getBytes(StandardCharsets.UTF_8);
+
+        var reader = new NdJsonFormatReader(null, blockFactory);
+        var object = new BytesStorageObject("file:///cap.ndjson", data);
+        FormatReadContext context = FormatReadContext.builder()
+            .batchSize(10)
+            .errorPolicy(ErrorPolicy.STRICT)
+            .maxRecordBytes(maxRecordBytes)
+            .build();
+
+        IOException ex = expectThrows(IOException.class, () -> {
+            try (var iterator = reader.read(object, context)) {
+                while (iterator.hasNext()) {
+                    iterator.next().releaseBlocks();
+                }
+            }
+        });
+        Throwable rootCause = ex;
+        while (rootCause.getCause() != null && rootCause.getCause() != rootCause) {
+            rootCause = rootCause.getCause();
+        }
+        assertThat(rootCause.getMessage(), Matchers.containsString("max_record_size [" + maxRecordBytes + "]"));
+    }
+
+    /**
+     * Companion lenient-mode contract: oversized records on the byte-array fast path must be dropped (not
+     * surfaced) so the user-visible {@code max_record_size} contract from PR #150240 is preserved. The pre-read
+     * filter pass (replacing the legacy {@code enforceMaxRecordBytes}) walks the buffered segment once and
+     * skips lines whose terminator-inclusive byte count exceeds the cap, leaving the surrounding rows intact.
+     */
+    public void testByteArrayFastPathLenientModeDropsOversizedRecord() throws IOException {
+        int maxRecordBytes = 16;
+        StringBuilder ndjson = new StringBuilder().append("{\"id\":1}\n");
+        ndjson.append("{\"id\":2,\"text\":\"").append("x".repeat(maxRecordBytes)).append("\"}\n");
+        ndjson.append("{\"id\":3}\n");
+        byte[] data = ndjson.toString().getBytes(StandardCharsets.UTF_8);
+
+        var reader = new NdJsonFormatReader(null, blockFactory);
+        var object = new BytesStorageObject("file:///cap-lenient.ndjson", data);
+        ErrorPolicy lenient = new ErrorPolicy(ErrorPolicy.Mode.SKIP_ROW, Long.MAX_VALUE, 1.0, false);
+        FormatReadContext context = FormatReadContext.builder().batchSize(10).errorPolicy(lenient).maxRecordBytes(maxRecordBytes).build();
+
+        long total = 0;
+        try (var iterator = reader.read(object, context)) {
+            while (iterator.hasNext()) {
+                var page = iterator.next();
+                total += page.getPositionCount();
+                page.releaseBlocks();
+            }
+        }
+        assertThat("lenient must drop the oversized record and keep the surrounding rows", total, Matchers.equalTo(2L));
+    }
 }

--- a/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonRecordCappingInputStreamTests.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonRecordCappingInputStreamTests.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.ndjson;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+public class NdJsonRecordCappingInputStreamTests extends ESTestCase {
+
+    public void testLfTerminatedRecordAtExactLimitPasses() throws IOException {
+        int max = 8;
+        byte[] bytes = bytes("x".repeat(max - 1) + "\n");
+        assertReadsAll(bytes, max);
+    }
+
+    public void testLfTerminatedRecordOneByteOverLimitThrows() throws IOException {
+        int max = 8;
+        byte[] bytes = bytes("x".repeat(max) + "\n");
+        assertCapThrows(bytes, max);
+    }
+
+    public void testLoneCrTerminatedRecordOneByteOverLimitThrows() throws IOException {
+        int max = 8;
+        byte[] bytes = bytes("x".repeat(max) + "\rnext");
+        assertCapThrows(bytes, max);
+    }
+
+    public void testCrLfRecordCountsLfTowardSameRecord() throws IOException {
+        int max = 8;
+        byte[] bytes = bytes("x".repeat(max) + "\r\n");
+        assertCapThrows(bytes, max);
+    }
+
+    public void testCrLfAtExactLimitPasses() throws IOException {
+        int max = 8;
+        byte[] bytes = bytes("x".repeat(max - 2) + "\r\n");
+        assertReadsAll(bytes, max);
+    }
+
+    public void testCounterResetsAfterTerminator() throws IOException {
+        int max = 4;
+        byte[] bytes = bytes("ab\ncd\nef\n");
+        try (InputStream in = wrap(bytes, max)) {
+            assertArrayEquals(bytes, in.readAllBytes());
+        }
+    }
+
+    public void testCrossBufferCrLfDoesNotDoubleCount() throws IOException {
+        // Record "xxxx\r\n" is 6 bytes total; with max=6 it fits exactly. The cross-buffer split puts the
+        // '\r' at the tail of one read and the '\n' at the head of the next, exercising the pendingCr carry.
+        int max = 6;
+        byte[] bytes = bytes("xxxx\r\nyyy");
+        try (
+            TwoByteReadStream src = new TwoByteReadStream(bytes);
+            InputStream in = new NdJsonRecordCappingInputStream(src, new NdJsonRecordSplitter(max))
+        ) {
+            assertArrayEquals(bytes, in.readAllBytes());
+        }
+    }
+
+    public void testCrossBufferLoneCrResetsBeforeNextRecord() throws IOException {
+        // Records "aaa\r" (4 bytes) and "bbbb" (4 bytes, EOF-terminated) both fit at max=4.
+        int max = 4;
+        byte[] bytes = bytes("aaa\rbbbb");
+        try (
+            TwoByteReadStream src = new TwoByteReadStream(bytes);
+            InputStream in = new NdJsonRecordCappingInputStream(src, new NdJsonRecordSplitter(max))
+        ) {
+            assertArrayEquals(bytes, in.readAllBytes());
+        }
+    }
+
+    public void testEofWithoutTerminatorRespectsCap() throws IOException {
+        int max = 4;
+        byte[] safe = bytes("x".repeat(max));
+        try (InputStream in = wrap(safe, max)) {
+            assertArrayEquals(safe, in.readAllBytes());
+        }
+        byte[] tooLarge = bytes("x".repeat(max + 1));
+        IOException ex = expectThrows(IOException.class, () -> {
+            try (InputStream in = wrap(tooLarge, max)) {
+                in.readAllBytes();
+            }
+        });
+        assertThat(ex.getMessage(), org.hamcrest.Matchers.containsString("max_record_size [" + max + "]"));
+    }
+
+    public void testSingleByteReadEnforcesSameCap() throws IOException {
+        int max = 4;
+        byte[] bytes = bytes("x".repeat(max + 1) + "\n");
+        try (InputStream in = wrap(bytes, max)) {
+            IOException ex = expectThrows(IOException.class, () -> {
+                while (in.read() != -1) {
+                    // drain byte-by-byte
+                }
+            });
+            assertThat(ex.getMessage(), org.hamcrest.Matchers.containsString("max_record_size [" + max + "]"));
+        }
+    }
+
+    public void testMarkResetDisabled() throws IOException {
+        try (InputStream in = wrap(bytes("abc"), 8)) {
+            assertFalse(in.markSupported());
+            in.mark(100); // no-op
+            IOException ex = expectThrows(IOException.class, in::reset);
+            assertThat(ex.getMessage(), org.hamcrest.Matchers.containsString("not supported"));
+        }
+    }
+
+    public void testNullSplitterFailsAtConstructionBoundary() {
+        NullPointerException ex = expectThrows(
+            NullPointerException.class,
+            () -> new NdJsonRecordCappingInputStream(new ByteArrayInputStream(bytes("x")), null)
+        );
+        assertThat(ex.getMessage(), org.hamcrest.Matchers.containsString("recordSplitter"));
+    }
+
+    private static byte[] bytes(String value) {
+        return value.getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static NdJsonRecordCappingInputStream wrap(byte[] data, int maxRecordBytes) {
+        return new NdJsonRecordCappingInputStream(new ByteArrayInputStream(data), new NdJsonRecordSplitter(maxRecordBytes));
+    }
+
+    private static void assertReadsAll(byte[] bytes, int maxRecordBytes) throws IOException {
+        try (InputStream in = wrap(bytes, maxRecordBytes)) {
+            assertArrayEquals(bytes, in.readAllBytes());
+        }
+    }
+
+    private static void assertCapThrows(byte[] bytes, int maxRecordBytes) {
+        IOException ex = expectThrows(IOException.class, () -> {
+            try (InputStream in = wrap(bytes, maxRecordBytes)) {
+                in.readAllBytes();
+            }
+        });
+        assertThat(ex.getMessage(), org.hamcrest.Matchers.containsString("max_record_size [" + maxRecordBytes + "]"));
+    }
+
+    /** Returns at most two bytes per {@code read(byte[], off, len)} so cross-buffer carry paths get exercised. */
+    private static final class TwoByteReadStream extends InputStream {
+        private final byte[] data;
+        private int pos;
+
+        TwoByteReadStream(byte[] data) {
+            this.data = data;
+        }
+
+        @Override
+        public int read() {
+            return pos < data.length ? (data[pos++] & 0xff) : -1;
+        }
+
+        @Override
+        public int read(byte[] buf, int off, int len) {
+            if (pos >= data.length) {
+                return -1;
+            }
+            int n = Math.min(2, Math.min(len, data.length - pos));
+            System.arraycopy(data, pos, buf, off, n);
+            pos += n;
+            return n;
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/RecordCappingInputStream.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/RecordCappingInputStream.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.spi;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Stream wrapper that enforces the {@code max_record_size} byte cap on every record without
+ * decoding characters or visiting bytes outside the bulk-read fast path. The byte counter starts at
+ * zero, accumulates every byte (including line terminators), and resets when an unquoted record
+ * terminator is observed: {@code '\n'}, {@code '\r'}, or {@code '\r\n'}. The cap matches the
+ * terminator-inclusive byte length used by record splitters so an oversized record fails at every
+ * layer with the same threshold.
+ *
+ * <p>Format-specific subclasses provide the {@link #recordTooLarge() exception factory}; the rest
+ * of the state machine — single-byte / bulk read accounting, CRLF spanning across reads, mark/reset
+ * lockout — is shared. This keeps the CSV and NDJSON cap streams from drifting in lockstep when one
+ * gets a CRLF or boundary-handling fix.
+ *
+ * <p>The hot path is {@link #read(byte[], int, int)}: it delegates a single bulk read to the
+ * underlying stream and then sweeps the freshly populated region in one tight loop. {@link #read()}
+ * is wired to the same accounting but is not on the throughput-critical path (the downstream parser
+ * buffers in bulk).
+ *
+ * <p>{@code mark}/{@code reset} are disabled to keep the byte counter monotonic with the bytes the
+ * downstream parser consumes; a rewind would skew the cap relative to the actual record boundaries.
+ *
+ * <p><b>Semantics under lenient error policies:</b> a thrown {@link IOException} from a bulk read
+ * leaves the underlying stream in an undefined position (the parser may have buffered partial bytes
+ * ahead of the trip), so the wrapper cannot resume after a cap failure. Callers that need row-level
+ * recovery under lenient policy must keep this wrapper out of those paths.
+ */
+public abstract class RecordCappingInputStream extends FilterInputStream {
+
+    private final int maxRecordBytes;
+    /** Bytes accumulated since the last terminator. Reset to zero on {@code \n} / lone {@code \r} / {@code \r\n}. */
+    private long bytesSinceLastTerminator;
+    /** True iff the previous byte (across reads) was a {@code \r}; a leading {@code \n} on the next read pairs with it as CRLF. */
+    private boolean pendingCr;
+
+    protected RecordCappingInputStream(InputStream in, int maxRecordBytes) {
+        super(in);
+        if (maxRecordBytes <= 0) {
+            throw new IllegalArgumentException("maxRecordBytes must be positive, got: " + maxRecordBytes);
+        }
+        this.maxRecordBytes = maxRecordBytes;
+    }
+
+    /**
+     * Format-specific exception thrown when a record exceeds the byte cap. Subclasses should return
+     * an exception with the same {@code "record exceeded max_record_size [N]"} message shape used by
+     * the matching record splitter so log lines stay consistent across enforcement points.
+     */
+    protected abstract IOException recordTooLarge();
+
+    @Override
+    public final int read() throws IOException {
+        int b = in.read();
+        if (b < 0) {
+            return b;
+        }
+        if (pendingCr) {
+            pendingCr = false;
+            if (b == '\n') {
+                // CRLF: the LF closes the same record that the prior CR opened the terminator for. Count it toward
+                // that record, check the cap once more, then reset so the next byte starts a fresh run.
+                bytesSinceLastTerminator++;
+                if (bytesSinceLastTerminator > maxRecordBytes) {
+                    throw recordTooLarge();
+                }
+                bytesSinceLastTerminator = 0;
+                return b;
+            }
+            // Lone CR: the prior CR was itself the terminator. Reset now so the current byte starts a fresh record.
+            bytesSinceLastTerminator = 0;
+        }
+        bytesSinceLastTerminator++;
+        if (bytesSinceLastTerminator > maxRecordBytes) {
+            throw recordTooLarge();
+        }
+        if (b == '\n') {
+            // LF terminator of a non-CR-prefixed record: reset immediately.
+            bytesSinceLastTerminator = 0;
+        } else if (b == '\r') {
+            // Defer the reset until the next read disambiguates lone CR vs CRLF; the count is already cap-validated.
+            pendingCr = true;
+        }
+        return b;
+    }
+
+    @Override
+    public final int read(byte[] buf, int off, int len) throws IOException {
+        int n = in.read(buf, off, len);
+        if (n <= 0) {
+            return n;
+        }
+        scanRegion(buf, off, n);
+        return n;
+    }
+
+    @Override
+    public final boolean markSupported() {
+        return false;
+    }
+
+    @Override
+    public final synchronized void mark(int readLimit) {
+        // Intentional no-op: see class-level Javadoc on monotonic counter invariant.
+    }
+
+    @Override
+    public final synchronized void reset() throws IOException {
+        throw new IOException("mark/reset not supported on " + getClass().getSimpleName());
+    }
+
+    private void scanRegion(byte[] buf, int off, int len) throws IOException {
+        int end = off + len;
+        long runningBytes = bytesSinceLastTerminator;
+        int i = off;
+        if (pendingCr) {
+            pendingCr = false;
+            if (buf[i] == '\n') {
+                // CRLF spanning two reads: count the LF toward the same record before resetting (matches the
+                // splitter byte-extent rule, which counts both CR and LF toward the terminated record).
+                runningBytes++;
+                if (runningBytes > maxRecordBytes) {
+                    bytesSinceLastTerminator = runningBytes;
+                    throw recordTooLarge();
+                }
+                runningBytes = 0;
+                i++;
+            } else {
+                // Lone CR carried across reads: the prior CR was itself the terminator. Reset before counting the
+                // current byte as the first byte of the new record below.
+                runningBytes = 0;
+            }
+        }
+        for (; i < end; i++) {
+            byte b = buf[i];
+            runningBytes++;
+            if (runningBytes > maxRecordBytes) {
+                // Mirror the splitter's recordExceedsLimit check: include the terminator byte in the cap test so
+                // the failure threshold matches the splitter and the legacy logical-record reader to the byte.
+                bytesSinceLastTerminator = runningBytes;
+                throw recordTooLarge();
+            }
+            if (b == '\n') {
+                runningBytes = 0;
+                continue;
+            }
+            if (b == '\r') {
+                if (i + 1 < end) {
+                    if (buf[i + 1] == '\n') {
+                        runningBytes++;
+                        if (runningBytes > maxRecordBytes) {
+                            bytesSinceLastTerminator = runningBytes;
+                            throw recordTooLarge();
+                        }
+                        i++;
+                    }
+                    runningBytes = 0;
+                } else {
+                    // CR is the last byte of this read; defer the reset to the next call which will see either an LF
+                    // (CRLF) or a non-LF (lone CR) and account for it accordingly.
+                    pendingCr = true;
+                }
+            }
+        }
+        bytesSinceLastTerminator = runningBytes;
+    }
+}


### PR DESCRIPTION
PR #150240 added max_record_size enforcement that regressed
external text reads. CSV/TSV went 1.8x-4.7x slower because
CsvLogicalRecordReader.readRecord read each character into a
StringBuilder while counting bytes per char and the resulting
String was then re-tokenized by Jackson on the hot path. NDJSON
went ~1.1x slower because NdJsonPageIterator.enforceMaxRecordBytes
walked every byte once before NdJsonPageDecoder walked them again.

The bulk CSV path now hands the BufferedReader straight to a
Jackson MappingIterator so each record is tokenized once in
Jackson's char buffer. NDJSON drops the pre-scan. Cap enforcement
moves to thin Csv/NdJson RecordCappingInputStream wrappers that
sweep the bulk read region in a single tight loop, count
terminator bytes the same way the splitters do, and throw the
shared CsvRecordTooLargeException on cap exceedance. NDJSON wraps
only under strict policy to preserve the previous lenient
drop-and-continue semantics.

CsvLogicalRecordReader remains on the low-traffic paths (schema
read, bracket-aware MVC, bootstrap, sampling) so the legacy
per-char cap stays available where row-level recovery matters.
CsvRecordTooLargeException is lifted out of the legacy reader
into a top-level class so both layers throw the same type.

Adds unit coverage for the new cap streams (LF, CRLF, lone CR,
cross-buffer carry, EOF, mark/reset) plus end-to-end CSV and
NDJSON tests that lock the strict abort and lenient-skip contracts.

Fixes https://github.com/elastic/esql-planning/issues/894

Developed with AI-assisted tooling