### PR TITLE
Enable Renovate Dependency Dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,8 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>elastic/renovate-config:base",
-    "github>elastic/renovate-config:ci-agent-images",
-    ":disableDependencyDashboard"
+    "github>elastic/renovate-config:ci-agent-images"
   ],
   "schedule": [
     "after 1pm on tuesday"


### PR DESCRIPTION
Drop `:disableDependencyDashboard` from `renovate.json` so Renovate (re-)creates the Dependency Dashboard issue on this repo.

## Why

The Dependency Dashboard provides:

- a **manual "run Renovate now" trigger** for out-of-band runs. Per the internal Renovate cookbook, ticking the checkbox at the bottom of the dashboard issue is the supported mechanism to force an immediate evaluation when waiting for the next scheduled run is not desired.
- **visibility** into pending, rate-limited, and errored updates that would otherwise be invisible without trawling Renovate logs.

The internal getting-started docs also recommend enabling it.

## Context

Investigation into why no Renovate PR was raised for Gradle wrapper `9.6.0-rc-2` (available since June 11). A local dry run of the current `renovate.json` against `renovate@39.107.0` (the production version per the Renovate FAQ) shows the update is correctly surfaced — both branches `renovate/gradle-wrapper-9.5.x` (9.5.1 patch) and `renovate/gradle-wrapper-9.6.x` (9.6.0-rc-2 minor) are generated. So the config itself is fine; the next step is to confirm end-to-end behavior on the platform side, for which the dashboard's "run now" button is the right tool.