### PR TITLE
[9.4] Enable Renovate Dependency Dashboard (#151396)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,8 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>elastic/renovate-config:base",
-    "github>elastic/renovate-config:ci-agent-images",
-    ":disableDependencyDashboard"
+    "github>elastic/renovate-config:ci-agent-images"
   ],
   "schedule": [
     "after 1pm on tuesday"


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Enable Renovate Dependency Dashboard (#151396)