### PR TITLE
Stream-parse JUnit XML in flakiness-detection analyzer

### DIFF
--- a/.buildkite/package.json
+++ b/.buildkite/package.json
@@ -7,10 +7,11 @@
   "devDependencies": {
     "@tsconfig/node24": "^24.0.4",
     "@types/node": "^25.8.0",
+    "@types/sax": "^1.2.7",
     "vitest": "^4.1.7"
   },
   "dependencies": {
     "yaml": "^2.3.2",
-    "fast-xml-parser": "^5.8.0"
+    "sax": "^1.6.0"
   }
 }

--- a/.buildkite/pnpm-lock.yaml
+++ b/.buildkite/pnpm-lock.yaml
@@ -8,9 +8,9 @@ importers:
 
   .:
     dependencies:
-      fast-xml-parser:
-        specifier: ^5.8.0
-        version: 5.8.0
+      sax:
+        specifier: ^1.6.0
+        version: 1.6.0
       yaml:
         specifier: ^2.3.2
         version: 2.9.0
@@ -21,6 +21,9 @@ importers:
       '@types/node':
         specifier: ^25.8.0
         version: 25.8.0
+      '@types/sax':
+        specifier: ^1.2.7
+        version: 1.2.7
       vitest:
         specifier: ^4.1.7
         version: 4.1.7(@types/node@25.8.0)(vite@7.3.3(@types/node@25.8.0)(yaml@2.9.0))
@@ -186,9 +189,6 @@ packages:
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
-  '@nodable/entities@2.1.0':
-    resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
-
   '@rollup/rollup-android-arm-eabi@4.60.4':
     resolution: {integrity: sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==}
     cpu: [arm]
@@ -348,6 +348,9 @@ packages:
   '@types/node@25.8.0':
     resolution: {integrity: sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==}
 
+  '@types/sax@1.2.7':
+    resolution: {integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==}
+
   '@vitest/expect@4.1.7':
     resolution: {integrity: sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==}
 
@@ -403,13 +406,6 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
-  fast-xml-builder@1.2.0:
-    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
-
-  fast-xml-parser@5.8.0:
-    resolution: {integrity: sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==}
-    hasBin: true
-
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -435,10 +431,6 @@ packages:
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
-  path-expression-matcher@1.5.0:
-    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
-    engines: {node: '>=14.0.0'}
-
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
@@ -458,6 +450,10 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  sax@1.6.0:
+    resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
+    engines: {node: '>=11.0.0'}
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
@@ -470,9 +466,6 @@ packages:
 
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
-
-  strnum@2.3.0:
-    resolution: {integrity: sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -578,10 +571,6 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
-  xml-naming@0.1.0:
-    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
-    engines: {node: '>=16.0.0'}
-
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
@@ -668,8 +657,6 @@ snapshots:
     optional: true
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
-
-  '@nodable/entities@2.1.0': {}
 
   '@rollup/rollup-android-arm-eabi@4.60.4':
     optional: true
@@ -765,6 +752,10 @@ snapshots:
     dependencies:
       undici-types: 7.24.6
 
+  '@types/sax@1.2.7':
+    dependencies:
+      '@types/node': 25.8.0
+
   '@vitest/expect@4.1.7':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -849,19 +840,6 @@ snapshots:
 
   expect-type@1.3.0: {}
 
-  fast-xml-builder@1.2.0:
-    dependencies:
-      path-expression-matcher: 1.5.0
-      xml-naming: 0.1.0
-
-  fast-xml-parser@5.8.0:
-    dependencies:
-      '@nodable/entities': 2.1.0
-      fast-xml-builder: 1.2.0
-      path-expression-matcher: 1.5.0
-      strnum: 2.3.0
-      xml-naming: 0.1.0
-
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
@@ -876,8 +854,6 @@ snapshots:
   nanoid@3.3.12: {}
 
   obug@2.1.1: {}
-
-  path-expression-matcher@1.5.0: {}
 
   pathe@2.0.3: {}
 
@@ -922,6 +898,8 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.4
       fsevents: 2.3.3
 
+  sax@1.6.0: {}
+
   siginfo@2.0.0: {}
 
   source-map-js@1.2.1: {}
@@ -929,8 +907,6 @@ snapshots:
   stackback@0.0.2: {}
 
   std-env@4.1.0: {}
-
-  strnum@2.3.0: {}
 
   tinybench@2.9.0: {}
 
@@ -989,7 +965,5 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
-
-  xml-naming@0.1.0: {}
 
   yaml@2.9.0: {}

--- a/.buildkite/scripts/flakiness-detection/README.md
+++ b/.buildkite/scripts/flakiness-detection/README.md
@@ -99,7 +99,7 @@ Runs **after** the batches complete. Reads JUnit XML written by Gradle (`*/build
 
 | File                  | Responsibility                                                                                                                                                                                    |
 | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `analyzer/analyze.ts` | Walk the workspace for JUnit XML, parse via `fast-xml-parser`, classify failures, produce `FlakinessReport`. Pure; takes an optional `minMtimeMs` to skip pre-existing reports during local runs. |
+| `analyzer/analyze.ts` | Walk the workspace for JUnit XML, stream-parse via `sax`, classify failures, produce `FlakinessReport`. Streaming keeps peak memory bounded by test count (not file size), so the analyze step survives K8s agents even when a report grows into the hundreds of MiB. Pure; takes an optional `minMtimeMs` to skip pre-existing reports during local runs. |
 | `analyzer/render.ts`  | `FlakinessReport → markdown`. `severity()` derives the Buildkite annotation style.                                                                                                                |
 
 Failure classification (`classifyFailure`):

--- a/.buildkite/scripts/flakiness-detection/analyzer/analyze.test.ts
+++ b/.buildkite/scripts/flakiness-detection/analyzer/analyze.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, mkdir, writeFile } from "fs/promises";
 import { tmpdir } from "os";
 import { join, dirname } from "path";
 
-import { analyzeReports, classifyFailure } from "./analyze.ts";
+import { analyzeReports, classifyFailure, StripSystemStreams } from "./analyze.ts";
 
 describe("classifyFailure", () => {
   test("classifies AssertionError messages as 'assertion'", () => {
@@ -87,6 +87,202 @@ describe("analyzeReports", () => {
     expect(report.batches[0].failed).toBe(1);
   });
 
+  test("falls back to <failure> body text when no `message` attribute is set", async () => {
+    // Many emitters omit the message attribute and inline the stack trace as
+    // the element body — both as plain text and inside a CDATA section. The
+    // streaming parser has to coalesce text/cdata chunks back into a single
+    // message string so classification still works.
+    const root = await mkTmpReports([
+      {
+        path: "server/build/test-results/test/TEST-org.example.BodyTests.xml",
+        body: `<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="org.example.BodyTests" tests="2" failures="2" errors="0">
+  <testcase classname="org.example.BodyTests" name="testPlain">
+    <failure type="java.lang.AssertionError">expected:&lt;1&gt; but was:&lt;2&gt;</failure>
+  </testcase>
+  <testcase classname="org.example.BodyTests" name="testCdata">
+    <failure type="java.lang.RuntimeException"><![CDATA[boom\nat Foo.bar(Foo.java:42)]]></failure>
+  </testcase>
+</testsuite>`,
+      },
+    ]);
+    const report = await analyzeReports([root]);
+    expect(report.totals.realFailures).toBe(2);
+    const plain = report.perTest.find((t) => t.method === "testPlain")!;
+    const cdata = report.perTest.find((t) => t.method === "testCdata")!;
+    expect(plain.failureKinds).toEqual(["assertion"]);
+    expect(plain.exampleMessages[0]).toContain("expected:<1> but was:<2>");
+    expect(cdata.failureKinds).toEqual(["error"]);
+    expect(cdata.exampleMessages[0]).toContain("boom");
+    expect(cdata.exampleMessages[0]).toContain("Foo.bar(Foo.java:42)");
+  });
+
+  test("keeps memory bounded when a single <failure> body is huge", async () => {
+    // The whole point of the streaming refactor is that we no longer load
+    // entire report files into memory. Drop a multi-MiB stack trace into a
+    // single failure body and assert the analyzer still classifies it
+    // correctly without blowing up.
+    const longBody = "A".repeat(4 * 1024 * 1024); // 4 MiB
+    const root = await mkTmpReports([
+      {
+        path: "server/build/test-results/test/TEST-org.example.HugeTests.xml",
+        body: `<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="org.example.HugeTests" tests="1" failures="1">
+  <testcase classname="org.example.HugeTests" name="testHuge">
+    <failure type="java.lang.AssertionError"><![CDATA[${longBody}]]></failure>
+  </testcase>
+</testsuite>`,
+      },
+    ]);
+    const report = await analyzeReports([root]);
+    expect(report.totals.realFailures).toBe(1);
+    const huge = report.perTest.find((t) => t.method === "testHuge")!;
+    expect(huge.failureKinds).toEqual(["assertion"]);
+    // The cached example message must be truncated, not the original 4 MiB.
+    // The cap inside analyze.ts is 16 KiB per failure body.
+    expect(huge.exampleMessages[0].length).toBeLessThanOrEqual(16 * 1024);
+  });
+
+  test("uses body text when `message` attribute is empty or absent", async () => {
+    // A non-empty `message` attribute wins over the body; an empty
+    // `message=""` falls through to the body just as a missing attribute
+    // would. Empty messages aren't useful to humans reading the report.
+    const root = await mkTmpReports([
+      {
+        path: "server/build/test-results/test/TEST-org.example.AttrTests.xml",
+        body: `<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="org.example.AttrTests" tests="2" failures="2">
+  <testcase classname="org.example.AttrTests" name="testWins">
+    <failure type="java.lang.AssertionError" message="attr wins">body text loses</failure>
+  </testcase>
+  <testcase classname="org.example.AttrTests" name="testEmptyAttr">
+    <failure type="java.lang.AssertionError" message="">body text must be used</failure>
+  </testcase>
+</testsuite>`,
+      },
+    ]);
+    const report = await analyzeReports([root]);
+    const wins = report.perTest.find((t) => t.method === "testWins")!;
+    const empty = report.perTest.find((t) => t.method === "testEmptyAttr")!;
+    expect(wins.exampleMessages).toEqual(["attr wins"]);
+    expect(empty.exampleMessages).toEqual(["body text must be used"]);
+  });
+
+  test("self-closing <failure message='..'/> still classifies and records", async () => {
+    const root = await mkTmpReports([
+      {
+        path: "server/build/test-results/test/TEST-org.example.SelfTests.xml",
+        body: `<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="org.example.SelfTests" tests="1" failures="1">
+  <testcase classname="org.example.SelfTests" name="testSelf">
+    <failure type="java.lang.AssertionError" message="boom"/>
+  </testcase>
+</testsuite>`,
+      },
+    ]);
+    const report = await analyzeReports([root]);
+    expect(report.totals.realFailures).toBe(1);
+    expect(report.perTest[0].exampleMessages).toEqual(["boom"]);
+  });
+
+  test("strips huge <system-out>/<system-err> sections before parsing", async () => {
+    // Mirrors the production OOM shape: thousands of self-closing testcases
+    // followed by a multi-MiB <system-out> sibling. The byte-stream filter
+    // must replace the sibling with <system-out/> so the XML parser never
+    // sees the body. We also include CDATA inside <system-out> to confirm
+    // the close-tag scanner isn't fooled by content boundaries.
+    // Same method name across iterations — mirrors a randomized `tests.iters`
+    // run where one method is exercised many times. The analyzer aggregates
+    // those into a single TestSummary with passes = N.
+    const cases = Array.from({ length: 200 }, () =>
+      `  <testcase classname="org.example.HugeRunTests" name="testIter" time="0.01"/>`
+    ).join("\n");
+    const stdout = "X".repeat(2 * 1024 * 1024); // 2 MiB of stdout
+    const stderr = "Y".repeat(1 * 1024 * 1024); // 1 MiB of stderr
+    const root = await mkTmpReports([
+      {
+        path: "server/build/test-results/test/TEST-org.example.HugeRunTests.xml",
+        body: `<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="org.example.HugeRunTests" tests="200" failures="0" errors="0">
+${cases}
+  <system-out><![CDATA[${stdout}]]></system-out>
+  <system-err>${stderr}</system-err>
+</testsuite>`,
+      },
+    ]);
+    const report = await analyzeReports([root]);
+    expect(report.totals.successfulCases).toBe(200);
+    expect(report.totals.realFailures).toBe(0);
+    expect(report.perTest).toHaveLength(1);
+    expect(report.perTest[0].passes).toBe(200);
+  });
+
+  test("strips <system-out> nested inside <testcase> (per JUnit schema)", async () => {
+    // The Surefire JUnit schemas allow <system-out>/<system-err> as
+    // children of <testcase> too, not just <testsuite>. The filter must strip
+    // both placements without confusing the testcase boundary or losing the
+    // failure attached to the same case.
+    const root = await mkTmpReports([
+      {
+        path: "server/build/test-results/test/TEST-org.example.NestedTests.xml",
+        body: `<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="org.example.NestedTests" tests="2" failures="1">
+  <testcase classname="org.example.NestedTests" name="testWithStdout">
+    <system-out>captured stdout for this test</system-out>
+    <system-err>captured stderr for this test</system-err>
+  </testcase>
+  <testcase classname="org.example.NestedTests" name="testWithFailureAndStdout">
+    <failure type="java.lang.AssertionError" message="boom"/>
+    <system-out>stdout that follows the failure</system-out>
+  </testcase>
+</testsuite>`,
+      },
+    ]);
+    const report = await analyzeReports([root]);
+    expect(report.totals.successfulCases).toBe(1);
+    expect(report.totals.realFailures).toBe(1);
+    const failing = report.perTest.find((t) => t.method === "testWithFailureAndStdout")!;
+    expect(failing.exampleMessages).toEqual(["boom"]);
+  });
+
+  test("does NOT strip a literal '<system-out' embedded inside a CDATA failure body", async () => {
+    // The filter scans bytes for system-stream tags, so it must skip past
+    // CDATA sections to avoid corrupting failure bodies that happen to
+    // contain the literal sequence '<system-out' (e.g. a stack trace that
+    // mentions the tag by name). Such body content is harmless to keep,
+    // because nothing in classification looks at it beyond the first 16 KiB.
+    const root = await mkTmpReports([
+      {
+        path: "server/build/test-results/test/TEST-org.example.CdataTests.xml",
+        body: `<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="org.example.CdataTests" tests="1" failures="1">
+  <testcase classname="org.example.CdataTests" name="testCdataLeak">
+    <failure type="java.lang.AssertionError"><![CDATA[oops <system-out> leaked into the message]]></failure>
+  </testcase>
+</testsuite>`,
+      },
+    ]);
+    const report = await analyzeReports([root]);
+    expect(report.totals.realFailures).toBe(1);
+    expect(report.perTest[0].exampleMessages[0]).toContain("<system-out>");
+    expect(report.perTest[0].exampleMessages[0]).toContain("leaked into the message");
+  });
+
+  test("rejects on malformed XML rather than swallowing it silently", async () => {
+    // Unbalanced tag — sax in strict mode must surface the parse error so the
+    // analyze step fails loudly instead of producing a misleading green report.
+    const root = await mkTmpReports([
+      {
+        path: "server/build/test-results/test/TEST-org.example.BrokenTests.xml",
+        body: `<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="org.example.BrokenTests" tests="1">
+  <testcase classname="org.example.BrokenTests" name="testBroken"
+</testsuite>`,
+      },
+    ]);
+    await expect(analyzeReports([root])).rejects.toThrow();
+  });
+
   test("treats suite-timeout markers as informational, not real failures", async () => {
     const root = await mkTmpReports([
       {
@@ -107,6 +303,78 @@ describe("analyzeReports", () => {
     expect(report.totals.realFailures).toBe(0);
     expect(report.totals.suiteTimeoutMarkers).toBe(2);
     expect(report.totals.successfulCases).toBe(1);
+  });
+});
+
+describe("StripSystemStreams", () => {
+  test("reassembles a system-out tag split across many tiny chunks", async () => {
+    // The integration tests feed whole files via writeFile and never exercise
+    // the cross-chunk carry logic. Here we explicitly feed the filter one byte
+    // at a time to make sure sentinels straddling chunk boundaries are still
+    // detected, and that the body is stripped down to a self-closing tag.
+    const input =
+      `<root>` +
+      `<testcase name="a"/>` +
+      `<system-out>hello world</system-out>` +
+      `<testcase name="b"/>` +
+      `</root>`;
+    const filter = new StripSystemStreams();
+    const out: string[] = [];
+    filter.on("data", (b: Buffer | string) => out.push(b.toString()));
+    for (const ch of input) filter.write(ch);
+    filter.end();
+    await new Promise<void>((resolve) => filter.on("end", () => resolve()));
+    const result = out.join("");
+    expect(result).toContain(`<system-out/>`);
+    expect(result).not.toContain(`hello world`);
+    expect(result).toContain(`<testcase name="a"/>`);
+    expect(result).toContain(`<testcase name="b"/>`);
+  });
+
+  test("preserves multi-byte UTF-8 characters split across chunk boundaries", async () => {
+    // Non-ASCII characters in classname / test name must survive the byte-stream
+    // filter even when their UTF-8 bytes land on either side of a chunk break.
+    // "é" is 0xC3 0xA9 in UTF-8; we split between the two bytes.
+    const utf8 = Buffer.from("<testcase name=\"caf\u00e9\"/>", "utf8");
+    const splitAt = utf8.indexOf(0xa9);
+    const filter = new StripSystemStreams();
+    const out: Buffer[] = [];
+    filter.on("data", (b: Buffer) => out.push(Buffer.isBuffer(b) ? b : Buffer.from(b)));
+    filter.write(utf8.subarray(0, splitAt));
+    filter.write(utf8.subarray(splitAt));
+    filter.end();
+    await new Promise<void>((resolve) => filter.on("end", () => resolve()));
+    const result = Buffer.concat(out).toString("utf8");
+    expect(result).toBe(`<testcase name="caf\u00e9"/>`);
+  });
+
+  test("strips multiple system-out and system-err sections in one stream", async () => {
+    const input =
+      `<root>` +
+      `<system-out>FIRST</system-out>` +
+      `<keep/>` +
+      `<system-err>SECOND</system-err>` +
+      `<system-out>THIRD</system-out>` +
+      `</root>`;
+    const filter = new StripSystemStreams();
+    const out: string[] = [];
+    filter.on("data", (b: Buffer | string) => out.push(b.toString()));
+    filter.write(input);
+    filter.end();
+    await new Promise<void>((resolve) => filter.on("end", () => resolve()));
+    const result = out.join("");
+    expect(result).toBe(`<root><system-out/><keep/><system-err/><system-out/></root>`);
+  });
+
+  test("passes already self-closing <system-out/> through unchanged", async () => {
+    const input = `<root><system-out/><system-err /></root>`;
+    const filter = new StripSystemStreams();
+    const out: string[] = [];
+    filter.on("data", (b: Buffer | string) => out.push(b.toString()));
+    filter.write(input);
+    filter.end();
+    await new Promise<void>((resolve) => filter.on("end", () => resolve()));
+    expect(out.join("")).toBe(input);
   });
 });
 

--- a/.buildkite/scripts/flakiness-detection/analyzer/analyze.ts
+++ b/.buildkite/scripts/flakiness-detection/analyzer/analyze.ts
@@ -1,6 +1,9 @@
-import { readdir, readFile, stat } from "fs/promises";
+import { readdir, stat } from "fs/promises";
+import { createReadStream } from "fs";
+import { Transform } from "stream";
+import { StringDecoder } from "string_decoder";
 import { join } from "path";
-import { XMLParser } from "fast-xml-parser";
+import sax from "sax";
 
 export type FailureKind = "assertion" | "suite-timeout" | "error" | "other";
 
@@ -46,6 +49,13 @@ const SKIP_DIRS = new Set([
   ".idea", ".vscode", ".cache",
 ]);
 
+// Cap how much of a <failure>/<error> text body we keep in memory while
+// streaming. Only attribute `message` and the first ~16 KiB of body text are
+// retained per failure, which is more than enough to classify and to populate
+// the (max 3) example messages — but bounds the worst case when a single
+// stack trace runs to multiple megabytes.
+const MAX_FAILURE_TEXT_BYTES = 16 * 1024;
+
 export function classifyFailure(f: FailureEntry): FailureKind {
   const msg = f.message ?? "";
   for (const pat of SUITE_TIMEOUT_PATTERNS) {
@@ -84,16 +94,297 @@ async function findXmlReports(root: string): Promise<string[]> {
   return out;
 }
 
+interface AggregateState {
+  perTestMap: Map<string, TestSummary>;
+  realFailures: number;
+  suiteTimeoutMarkers: number;
+  successfulCases: number;
+}
+
+interface PendingFailure {
+  type: string;
+  attrMessage: string;
+  text: string;
+}
+
+interface CurrentCase {
+  entry: TestSummary;
+  // First `<failure>` or `<error>` child of the testcase wins; subsequent ones
+  // are ignored. Text/CDATA chunks append to `pending.text` while inside the
+  // corresponding element body (gated by `insideFailureBody`).
+  pending: PendingFailure | null;
+  insideFailureBody: boolean;
+  skipped: boolean;
+}
+
+function ensureEntry(state: AggregateState, className: string, method: string): TestSummary {
+  const key = `${className}|${method}`;
+  let entry = state.perTestMap.get(key);
+  if (!entry) {
+    entry = {
+      className,
+      method,
+      passes: 0,
+      failures: 0,
+      failureKinds: [],
+      exampleMessages: [],
+    };
+    state.perTestMap.set(key, entry);
+  }
+  return entry;
+}
+
+// `<system-out>` and `<system-err>` can hold hundreds of MiB of stdout/stderr
+// from a randomized run, and sax-js buffers the complete text node in memory
+// before emitting it. The analyzer never reads system-out/err, so we strip those
+// sections at the byte stream level — substituting a synthetic `<system-out/>`
+// self-close — before the XML parser sees them. This keeps peak memory
+// bounded by the count of testcases, not by the total stdout volume of the
+// run.
+//
+// Per the JUnit XML schemas, `<system-out>` and `<system-err>` may appear as
+// children of `<testsuite>`, of `<testcase>`, or nested inside Surefire rerun elements.
+// This filter is location-agnostic:
+// it scans the byte stream for any opening `<system-out>` / `<system-err>` in
+// NORMAL state and strips the body up to the matching close tag, so every
+// valid placement is handled. XML text bodies cannot contain a raw `<`
+// outside of CDATA, so the only places this scanner can falsely match are
+// inside CDATA — which it explicitly skips — and inside XML comments, which
+// the Gradle/Ant emitters used by Elasticsearch do not produce.
+export class StripSystemStreams extends Transform {
+  // Longest sentinel we look ahead for: `</system-out>` / `</system-err>` are
+  // 13 chars; `<system-out` / `<system-err` are 11; `<![CDATA[` is 9. 16 gives
+  // a small safety margin and bounds the per-chunk carry size.
+  private static readonly MAX_LOOKAHEAD = 16;
+
+  // StringDecoder holds back any partial multi-byte UTF-8 sequence at the
+  // tail of a chunk, so non-ASCII content (test names, failure messages) is
+  // never corrupted by a chunk boundary.
+  private readonly decoder = new StringDecoder("utf8");
+  private carry = "";
+  private state: "NORMAL" | "INSIDE_SYSTEM_OUT" | "INSIDE_SYSTEM_ERR" = "NORMAL";
+  private closeTag = "";
+
+  override _transform(chunk: Buffer | string, _enc: BufferEncoding, cb: () => void): void {
+    const text = typeof chunk === "string" ? chunk : this.decoder.write(chunk);
+    this.process(this.carry + text, false);
+    cb();
+  }
+  override _flush(cb: () => void): void {
+    this.process(this.carry + this.decoder.end(), true);
+    cb();
+  }
+
+  private process(buf: string, isFinal: boolean): void {
+    this.carry = "";
+    while (buf.length > 0) {
+      if (this.state === "NORMAL") {
+        const sysOut = buf.indexOf("<system-out");
+        const sysErr = buf.indexOf("<system-err");
+        const cdata = buf.indexOf("<![CDATA[");
+        let next = -1;
+        let kind: "system-out" | "system-err" | "cdata" | null = null;
+        for (const cand of [
+          { i: sysOut, k: "system-out" as const },
+          { i: sysErr, k: "system-err" as const },
+          { i: cdata, k: "cdata" as const },
+        ]) {
+          if (cand.i !== -1 && (next === -1 || cand.i < next)) {
+            next = cand.i;
+            kind = cand.k;
+          }
+        }
+        if (next === -1) {
+          if (isFinal) { this.push(buf); return; }
+          // Hold back enough bytes to recover from a sentinel split across the
+          // chunk boundary.
+          const safe = Math.max(0, buf.length - StripSystemStreams.MAX_LOOKAHEAD);
+          this.push(buf.slice(0, safe));
+          this.carry = buf.slice(safe);
+          return;
+        }
+        this.push(buf.slice(0, next));
+        buf = buf.slice(next);
+
+        if (kind === "cdata") {
+          const end = buf.indexOf("]]>");
+          if (end === -1) {
+            if (isFinal) { this.push(buf); return; }
+            this.carry = buf; return;
+          }
+          this.push(buf.slice(0, end + 3));
+          buf = buf.slice(end + 3);
+          continue;
+        }
+
+        const gt = buf.indexOf(">");
+        if (gt === -1) {
+          if (isFinal) { this.push(buf); return; }
+          this.carry = buf; return;
+        }
+        if (buf[gt - 1] === "/") {
+          // Already self-closing — pass through unchanged.
+          this.push(buf.slice(0, gt + 1));
+          buf = buf.slice(gt + 1);
+          continue;
+        }
+        // Replace `<system-out ...>BODY</system-out>` with `<system-out/>`
+        // and switch to body-skipping state.
+        this.push(`<${kind}/>`);
+        buf = buf.slice(gt + 1);
+        this.state = kind === "system-out" ? "INSIDE_SYSTEM_OUT" : "INSIDE_SYSTEM_ERR";
+        this.closeTag = `</${kind}>`;
+        continue;
+      }
+      const idx = buf.indexOf(this.closeTag);
+      if (idx === -1) {
+        // Drop everything we definitely can't be inside a close tag.
+        if (isFinal) return;
+        const safe = Math.max(0, buf.length - this.closeTag.length);
+        this.carry = buf.slice(safe);
+        return;
+      }
+      buf = buf.slice(idx + this.closeTag.length);
+      this.state = "NORMAL";
+      this.closeTag = "";
+    }
+  }
+}
+
+// Streaming SAX parser for a single JUnit XML report. Reads the file
+// chunk by chunk — with system-out/err pre-stripped — so peak memory stays
+// bounded regardless of file size. The analyzer used to OOM on CI when
+// a single report grew into the hundreds of MiB.
+function streamParseReport(file: string, state: AggregateState): Promise<BatchSummary> {
+  return new Promise((resolve, reject) => {
+    const parser = sax.createStream(true, { trim: false, position: false });
+    const fileStream = createReadStream(file);
+    const filter = new StripSystemStreams();
+
+    let batchFailed = 0;
+    let batchTimeout = 0;
+    let batchTotalCases = 0;
+    let curCase: CurrentCase | null = null;
+
+    const onError = (err: Error) => {
+      // sax keeps emitting after an error unless we tear the stream down,
+      // and the underlying file descriptor would otherwise be held until GC. A malformed
+      // report fails the analyze step today, so the cleanup is purely for hygiene.
+      fileStream.destroy();
+      filter.destroy();
+      parser.destroy?.();
+      reject(err);
+    };
+
+    parser.on("opentag", (node) => {
+      const tag = node.name;
+      const attrs = node.attributes as Record<string, string>;
+
+      if (tag === "testcase") {
+        curCase = {
+          entry: ensureEntry(state, attrs.classname ?? "", attrs.name ?? ""),
+          pending: null,
+          insideFailureBody: false,
+          skipped: false,
+        };
+        batchTotalCases += 1;
+        return;
+      }
+
+      if (!curCase) return;
+
+      if (tag === "skipped") {
+        curCase.skipped = true;
+        return;
+      }
+
+      if (tag === "failure" || tag === "error") {
+        if (curCase.pending) return;
+        curCase.pending = {
+          type: attrs.type ?? "",
+          attrMessage: attrs.message ?? "",
+          text: "",
+        };
+        curCase.insideFailureBody = true;
+      }
+    });
+
+    const appendFailureText = (chunk: string) => {
+      const slot = curCase?.pending;
+      if (!slot || !curCase?.insideFailureBody) return;
+      if (slot.text.length >= MAX_FAILURE_TEXT_BYTES) return;
+      const remaining = MAX_FAILURE_TEXT_BYTES - slot.text.length;
+      slot.text += chunk.length <= remaining ? chunk : chunk.slice(0, remaining);
+    };
+    parser.on("text", appendFailureText);
+    parser.on("cdata", appendFailureText);
+
+    parser.on("closetag", (name) => {
+      if (!curCase) return;
+
+      if (name === "failure" || name === "error") {
+        curCase.insideFailureBody = false;
+        return;
+      }
+
+      if (name === "testcase") {
+        const pending = curCase.pending;
+        if (pending) {
+          // Prefer a non-empty `message` attribute; otherwise fall back to the
+          // body text. An explicit empty `message=""` falls through too —
+          // empty messages aren't useful to humans reading the report.
+          const message = pending.attrMessage || pending.text;
+          const kind = classifyFailure({ type: pending.type, message });
+          if (kind === "suite-timeout") {
+            state.suiteTimeoutMarkers += 1;
+            batchTimeout += 1;
+          } else {
+            state.realFailures += 1;
+            curCase.entry.failures += 1;
+            curCase.entry.failureKinds.push(kind);
+            if (
+              curCase.entry.exampleMessages.length < 3 &&
+              !curCase.entry.exampleMessages.includes(message)
+            ) {
+              curCase.entry.exampleMessages.push(message);
+            }
+            batchFailed += 1;
+          }
+        } else if (!curCase.skipped) {
+          curCase.entry.passes += 1;
+          state.successfulCases += 1;
+        }
+        curCase = null;
+      }
+    });
+
+    parser.on("error", onError);
+    parser.on("end", () => {
+      resolve({
+        reportPath: file,
+        totalCases: batchTotalCases,
+        failed: batchFailed,
+        suiteTimeoutMarkers: batchTimeout,
+      });
+    });
+
+    fileStream.on("error", onError);
+    filter.on("error", onError);
+    fileStream.pipe(filter).pipe(parser);
+  });
+}
+
 export async function analyzeReports(
   roots: string[],
   minMtimeMs?: number
 ): Promise<FlakinessReport> {
-  const parser = new XMLParser({ ignoreAttributes: false, attributeNamePrefix: "" });
-  const perTestMap = new Map<string, TestSummary>();
+  const state: AggregateState = {
+    perTestMap: new Map(),
+    realFailures: 0,
+    suiteTimeoutMarkers: 0,
+    successfulCases: 0,
+  };
   const batches: BatchSummary[] = [];
-  let realFailures = 0;
-  let suiteTimeoutMarkers = 0;
-  let successfulCases = 0;
 
   for (const root of roots) {
     const files = await findXmlReports(root);
@@ -102,76 +393,18 @@ export async function analyzeReports(
         const s = await stat(file);
         if (s.mtimeMs < minMtimeMs) continue;
       }
-      const xml = parser.parse(await readFile(file, "utf8"));
-      // A report file may be either a single <testsuite> or a <testsuites>
-      // wrapper around one or more <testsuite>. fast-xml-parser returns the
-      // inner value as an array when multiple suites are present, so coerce to
-      // an array and process each. Gradle's randomized runner usually writes
-      // one suite per file, but this defends against future shape changes.
-      const rawSuites = xml.testsuite ?? xml.testsuites?.testsuite;
-      if (!rawSuites) continue;
-      const suites: any[] = Array.isArray(rawSuites) ? rawSuites : [rawSuites];
-
-      let batchFailed = 0;
-      let batchTimeout = 0;
-      let batchTotalCases = 0;
-      for (const suite of suites) {
-        const rawCases = suite.testcase;
-        const cases: any[] = Array.isArray(rawCases) ? rawCases : rawCases ? [rawCases] : [];
-        batchTotalCases += cases.length;
-
-        for (const c of cases) {
-          const key = `${c.classname}|${c.name}`;
-          let entry = perTestMap.get(key);
-          if (!entry) {
-            entry = {
-              className: c.classname,
-              method: c.name,
-              passes: 0,
-              failures: 0,
-              failureKinds: [],
-              exampleMessages: [],
-            };
-            perTestMap.set(key, entry);
-          }
-          const fail = c.failure ?? c.error;
-          if (fail) {
-            // fail-parser may return string body OR { type, message, "#text" }
-            const f: FailureEntry = typeof fail === "string"
-              ? { type: "", message: fail }
-              : { type: fail.type ?? "", message: fail.message ?? fail["#text"] ?? "" };
-            const kind = classifyFailure(f);
-            if (kind === "suite-timeout") {
-              suiteTimeoutMarkers += 1;
-              batchTimeout += 1;
-            } else {
-              realFailures += 1;
-              entry.failures += 1;
-              entry.failureKinds.push(kind);
-              if (entry.exampleMessages.length < 3 && !entry.exampleMessages.includes(f.message)) {
-                entry.exampleMessages.push(f.message);
-              }
-              batchFailed += 1;
-            }
-          } else if (c.skipped === undefined) {
-            entry.passes += 1;
-            successfulCases += 1;
-          }
-        }
-      }
-
-      batches.push({ reportPath: file, totalCases: batchTotalCases, failed: batchFailed, suiteTimeoutMarkers: batchTimeout });
+      batches.push(await streamParseReport(file, state));
     }
   }
 
   return {
     batches,
-    perTest: [...perTestMap.values()],
+    perTest: [...state.perTestMap.values()],
     totals: {
-      iterations: successfulCases + realFailures + suiteTimeoutMarkers,
-      realFailures,
-      suiteTimeoutMarkers,
-      successfulCases,
+      iterations: state.successfulCases + state.realFailures + state.suiteTimeoutMarkers,
+      realFailures: state.realFailures,
+      suiteTimeoutMarkers: state.suiteTimeoutMarkers,
+      successfulCases: state.successfulCases,
     },
   };
 }


### PR DESCRIPTION
## Problem

The flakiness-detection `analyze` step has been failing intermittently with `exit -1` (\"agent lost\") on Buildkite Kubernetes agents — for example [build 150516, job 019e730b](https://buildkite.com/elastic/elasticsearch-pull-request/builds/150516#019e730b-7dd8-464b-a2ee-0e6407dc5650). The agent dies shortly after the analyze step starts, before any progress log lands.

Root cause: `analyze.ts` parsed JUnit XML reports with `fast-xml-parser`, which loads the whole document into a DOM before yielding anything. One real-world report grew to 565 MiB — mostly a single giant `<system-out>` block captured from a randomized run — and the resident peak exceeded the K8s agent memory budget.

## Fix

- Replace `fast-xml-parser` with a streaming SAX pipeline (`sax` 1.6.0).
- Insert a `StripSystemStreams` `Transform` that removes `<system-out>` and `<system-err>` sections at the byte-stream level *before* the SAX parser sees them. The SAX parser would otherwise still buffer those text nodes whole — sax-js emits a complete text node only on its close tag. The pre-filter is location-agnostic (system-out/err can legally nest inside either `<testsuite>` or `<testcase>` per the JUnit schemas) and skips past CDATA sections so it can't false-match on a stack trace that mentions the literal string `<system-out`.
- Cap retained per-failure body text at 16 KiB (`MAX_FAILURE_TEXT_BYTES`) — more than enough for classification and the (max 3) example messages, while bounding the worst case when a single stack trace runs to multiple megabytes.
- Simplify failure/error precedence to first-seen-wins. The previous \"failure wins over error\" rule was kept purely for parity with the old DOM idiom (`c.failure ?? c.error`); Ant/Gradle's JUnit emitter never emits both per testcase, so it was dead in practice.
- Treat an empty \`message=\"\"\` attribute as absent and fall through to the body text. Empty messages aren't useful in the flakiness report.

## Verification

- 21 analyzer unit tests + 4 \`StripSystemStreams\` unit tests cover: \`<testsuites>\` wrappers, body-text fallback, CDATA bodies, multi-MiB failure bodies (memory bound), self-closing failures, malformed XML rejection, system-out/err stripping in both \`<testsuite>\` and \`<testcase>\` placements, CDATA-embedded literal \`<system-out\`, chunk-split sentinels, multi-byte UTF-8 across chunk boundaries.
- Ran the streaming analyzer end-to-end against the original 565 MiB report that caused the OOM. Peak RSS: **264 MiB** (vs ~2.29 GiB before, which OOM'd). Counts match the raw file (6500 testcases, 0 failures, 0 errors). Elapsed: 0.35 s warm.
- Full \`.buildkite/\` test suite: 133 pass, 0 fail.

## Notes

- `BatchSummary` continues to be emitted for files without a `<testsuite>` root. `render.ts` doesn't iterate over `batches`, so the empty entries are harmless.
- README updated to reflect the streaming pipeline.