### PR TITLE
Fix testVirtualBatchedCompoundCommitChunksPressure

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -355,9 +355,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.heap_attack.HeapAttackIT
   method: testGroupOnManyLongs
   issue: https://github.com/elastic/elasticsearch/issues/150104
-- class: org.elasticsearch.xpack.stateless.commits.VirtualBatchedCompoundCommitsIT
-  method: testVirtualBatchedCompoundCommitChunksPressure
-  issue: https://github.com/elastic/elasticsearch/issues/150123
 - class: org.elasticsearch.simdvec.internal.vectorization.MSBitToBitESNextOSQVectorsScorerTests
   method: testSymmetric1BitDotProductMatchesNativeWhenSupported
   issue: https://github.com/elastic/elasticsearch/issues/150155

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/commits/VirtualBatchedCompoundCommitsIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/commits/VirtualBatchedCompoundCommitsIT.java
@@ -1129,7 +1129,7 @@ public class VirtualBatchedCompoundCommitsIT extends AbstractStatelessPluginInte
         ensureSearchable(indexName);
     }
 
-    public void testVirtualBatchedCompoundCommitChunksPressure() {
+    public void testVirtualBatchedCompoundCommitChunksPressure() throws Exception {
         // The test admits a first refresh that requests a 1-page chunk, and halts it mid-way before returning the chunk response.
         // Then, a second refresh comes in, that requests another 1-page chunk. It is rejected two times in a row, and the third retry
         // attempt is halted mid-way before processing the chunk request (and thus is not yet counted by the pressure). Then, we complete
@@ -1262,12 +1262,12 @@ public class VirtualBatchedCompoundCommitsIT extends AbstractStatelessPluginInte
         logger.info("--> continuing sending chunk for the first refresh");
         chunk1ToSendResponse.countDown();
         assertNoFailures(safeGet(refresh1));
-        assertThat(vbccChunksPressure.getCurrentChunksBytes(), equalTo(0L));
+        assertBusy(() -> assertThat(vbccChunksPressure.getCurrentChunksBytes(), equalTo(0L)));
 
         logger.info("--> continuing processing chunk for the second refresh");
         chunk2ToProcess.countDown();
         assertNoFailures(safeGet(refresh2));
-        assertThat(vbccChunksPressure.getCurrentChunksBytes(), equalTo(0L));
+        assertBusy(() -> assertThat(vbccChunksPressure.getCurrentChunksBytes(), equalTo(0L)));
 
         // Confirm that the pressure metrics were correctly set
         final int pages = pagesRead.get();


### PR DESCRIPTION
Need to busy wait as the pressure decrement is async vs the response being sent over the wire from the transport layer. So in rare cases, the refresh can complete before the pressure is adjusted.

Closes #150123