### PR TITLE
ESQL: unmute nullify subquery-in-FROM tests

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/unmapped-nullify.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/unmapped-nullify.csv-spec
@@ -536,13 +536,12 @@ COUNT(*):long
 100
 ;
 
-# TODO. FROMx: this fails in parsing with just FROM even if -Ignore'd(!), in bwc tests only(!)
-subqueryNoMainIndex-Ignore
+subqueryNoMainIndex
 required_capability: optional_fields_nullify_tech_preview
 required_capability: subquery_in_from_command
 
 SET unmapped_fields="nullify"\;
-FROMx
+FROM
     (FROM employees
      | EVAL emp_no_plus = emp_no_foo::LONG + 1
      | WHERE emp_no < 10003)
@@ -555,7 +554,7 @@ emp_no:integer | emp_no_foo:null | emp_no_plus:long
 10002          | null            | null
 ;
 
-subqueryInFromWithStatsInMainQuery-Ignore
+subqueryInFromWithStatsInMainQuery
 required_capability: optional_fields_nullify_tech_preview
 required_capability: subquery_in_from_command
 


### PR DESCRIPTION
These tests were muted with a FROMx typo and -Ignore because mixed-cluster bwc didn't check the old node's capabilities, so an old coordinator parse-failed on subquery syntax. That gate now exists and these tests require subquery_in_from_command, so the workaround is obsolete.

Closes #143744

Assisted by Claude