### PR TITLE
Fix OTLP histogram conversion for single-count histograms without bucket boundaries

### DIFF
--- a/docs/changelog/151411.yaml
+++ b/docs/changelog/151411.yaml
@@ -1,0 +1,6 @@
+area: TSDB
+issues: []
+pr: 151411
+summary: Fix OTLP histogram conversion for single-count histograms without bucket
+  boundaries
+type: bug

--- a/docs/changelog/151411.yaml
+++ b/docs/changelog/151411.yaml
@@ -1,6 +1,5 @@
 area: TSDB
 issues: []
 pr: 151411
-summary: Fix OTLP histogram conversion for single-count histograms without bucket
-  boundaries
+summary: Fix OTLP histogram handling for single-count histograms without bucket boundaries
 type: bug

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/datapoint/ExponentialHistogramConverter.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/datapoint/ExponentialHistogramConverter.java
@@ -125,7 +125,7 @@ public class ExponentialHistogramConverter {
 
         int size = dataPoint.getBucketCountsCount();
 
-        if (size > 0) {
+        if (size > 0 && dataPoint.getExplicitBoundsCount() > 0) {
             bucketsScratch.clear();
 
             boolean minHandled = false;

--- a/x-pack/plugin/otel-data/src/test/java/org/elasticsearch/xpack/oteldata/otlp/datapoint/HistogramToExponentialHistogramConverterTests.java
+++ b/x-pack/plugin/otel-data/src/test/java/org/elasticsearch/xpack/oteldata/otlp/datapoint/HistogramToExponentialHistogramConverterTests.java
@@ -451,6 +451,50 @@ public class HistogramToExponentialHistogramConverterTests extends ESTestCase {
                     200.0,
                     1.0,
                     15.0
+                ) },
+            new Object[] {
+                "delta/single count no bounds with sum",
+                (Supplier<TestCase>) () -> new TestCase(
+                    HistogramDataPoint.newBuilder().addBucketCounts(10L).setCount(10L).setSum(100.0).build(),
+                    AggregationTemporality.AGGREGATION_TEMPORALITY_DELTA,
+                    List.of(10L),
+                    List.of(10.0),
+                    100.0,
+                    null,
+                    null
+                ) },
+            new Object[] {
+                "delta/single count no bounds without sum",
+                (Supplier<TestCase>) () -> new TestCase(
+                    HistogramDataPoint.newBuilder().addBucketCounts(5L).setCount(5L).build(),
+                    AggregationTemporality.AGGREGATION_TEMPORALITY_DELTA,
+                    List.of(5L),
+                    List.of(0.0),
+                    null,
+                    null,
+                    null
+                ) },
+            new Object[] {
+                "cumulative/single count no bounds with sum",
+                (Supplier<TestCase>) () -> new TestCase(
+                    HistogramDataPoint.newBuilder().addBucketCounts(7L).setCount(7L).setSum(70.0).build(),
+                    AggregationTemporality.AGGREGATION_TEMPORALITY_CUMULATIVE,
+                    List.of(7L),
+                    List.of(0.0),
+                    70.0,
+                    null,
+                    null
+                ) },
+            new Object[] {
+                "delta/single count no bounds with zero count",
+                (Supplier<TestCase>) () -> new TestCase(
+                    HistogramDataPoint.newBuilder().addBucketCounts(0L).setCount(0L).build(),
+                    AggregationTemporality.AGGREGATION_TEMPORALITY_DELTA,
+                    List.of(),
+                    List.of(),
+                    null,
+                    null,
+                    null
                 ) }
         );
 

--- a/x-pack/plugin/otel-data/src/test/java/org/elasticsearch/xpack/oteldata/otlp/datapoint/HistogramToTDigestConverterTests.java
+++ b/x-pack/plugin/otel-data/src/test/java/org/elasticsearch/xpack/oteldata/otlp/datapoint/HistogramToTDigestConverterTests.java
@@ -138,6 +138,18 @@ public class HistogramToTDigestConverterTests extends ESTestCase {
                 List.of(10.0),
                 true },
             new Object[] {
+                "no explicit bounds with single bucket count without sum",
+                HistogramDataPoint.newBuilder().addBucketCounts(5L).setCount(5L).build(),
+                List.of(5L),
+                List.of(0.0),
+                true },
+            new Object[] {
+                "no explicit bounds with single zero bucket count",
+                HistogramDataPoint.newBuilder().addBucketCounts(0L).setCount(0L).build(),
+                List.of(),
+                List.of(),
+                true },
+            new Object[] {
                 "no explicit bounds with zero count",
                 HistogramDataPoint.newBuilder().setCount(0L).setSum(0.0).build(),
                 List.of(),


### PR DESCRIPTION
## Summary

In OpenTelemetry, explicit bucket histograms can have no bucket boundaries with a single count in the `bucketCounts` array, representing a single `(-Inf, +Inf)` bucket. The OTLP endpoint's `ExponentialHistogramConverter` did not handle this case correctly — it entered the bucket iteration loop (because `getBucketCountsCount() > 0`) and called `getCentroid()`, which tried to access non-existent explicit bounds, causing an `IndexOutOfBoundsException`.

- Fix `ExponentialHistogramConverter` to also check `getExplicitBoundsCount() > 0` before iterating buckets
- Add test cases for single-count histograms without bounds to both `HistogramToExponentialHistogramConverterTests` and `HistogramToTDigestConverterTests`

## Test plan

- [x] New test cases in `HistogramToExponentialHistogramConverterTests` reproduce the failure without the fix and pass with the fix
- [x] New test cases in `HistogramToTDigestConverterTests` confirm the TDigest path already handled this correctly