### PR TITLE
ESQL:DS: Introduce a type-normalizing comparator

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FilterEvaluationOrderEstimator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FilterEvaluationOrderEstimator.java
@@ -136,7 +136,6 @@ public final class FilterEvaluationOrderEstimator {
         return 0.5;
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     static double estimateSelectivity(Expression expr, SplitStats stats, long rowCount) {
         if (expr instanceof Equals eq) {
             String col = columnName(eq.left());
@@ -213,7 +212,6 @@ public final class FilterEvaluationOrderEstimator {
 
     // -- selectivity estimators --
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     private static double estimateEqualitySelectivity(String colName, Object value, SplitStats stats) {
         Object min = stats.columnMin(colName);
         Object max = stats.columnMax(colName);
@@ -225,13 +223,16 @@ public final class FilterEvaluationOrderEstimator {
             return UNKNOWN_SELECTIVITY;
         }
         if (rangeWidth <= 0) {
-            if (min instanceof Comparable minC && value instanceof Comparable valC) {
-                return minC.compareTo(valC) == 0 ? 1.0 : 0.0;
+            int cmp = StatValueComparator.compare(min, value);
+            if (cmp == StatValueComparator.INCOMPARABLE) {
+                return UNKNOWN_SELECTIVITY;
             }
-            return UNKNOWN_SELECTIVITY;
+            return cmp == 0 ? 1.0 : 0.0;
         }
-        if (min instanceof Comparable minC && max instanceof Comparable maxC && value instanceof Comparable valC) {
-            if (minC.compareTo(valC) > 0 || maxC.compareTo(valC) < 0) {
+        int minCmp = StatValueComparator.compare(min, value);
+        int maxCmp = StatValueComparator.compare(max, value);
+        if (minCmp != StatValueComparator.INCOMPARABLE && maxCmp != StatValueComparator.INCOMPARABLE) {
+            if (minCmp > 0 || maxCmp < 0) {
                 return 0.0;
             }
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StatValueComparator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StatValueComparator.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.apache.lucene.util.BytesRef;
+
+/**
+ * Type-normalizing comparator for column-statistic values (min/max) against query literals.
+ * <p>
+ * Source plugins box an INT column's min/max with whatever Java width their reader exposes
+ * (ORC's {@code IntegerColumnStatistics.getMinimum()} returns {@code long}, so the value
+ * autoboxes to {@link Long}; parquet-mr returns {@code int}, so it boxes to {@link Integer}).
+ * The ES|QL parser, meanwhile, fits small integer literals to {@link Integer}. A raw
+ * {@code Comparable.compareTo} between two different boxed numeric types throws
+ * {@link ClassCastException} (e.g. {@code Long.compareTo(Integer)}), so the planner must
+ * normalize types before comparing rather than relying on each source plugin to box stats
+ * in a planner-expected width.
+ */
+public final class StatValueComparator {
+
+    /**
+     * Returned by {@link #compare(Object, Object)} when the two values cannot be meaningfully
+     * compared (null operand, or differing non-numeric runtime types). Callers must treat this
+     * as "unknown" and fall back to a conservative decision rather than acting on the value.
+     */
+    public static final int INCOMPARABLE = Integer.MIN_VALUE;
+
+    private StatValueComparator() {}
+
+    /**
+     * Compares two stat/literal values, returning negative, zero, or positive as with
+     * {@link Comparable#compareTo}, or {@link #INCOMPARABLE} when the values are not comparable
+     * (type mismatch or null). Uses exact long comparison for integral types to avoid double
+     * precision loss, and widens to double for mixed integral/floating comparisons.
+     */
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public static int compare(Object a, Object b) {
+        if (a == null || b == null) {
+            return INCOMPARABLE;
+        }
+        if (a instanceof BytesRef br) {
+            a = br.utf8ToString();
+        }
+        if (b instanceof BytesRef br) {
+            b = br.utf8ToString();
+        }
+        if (a instanceof Number na && b instanceof Number nb) {
+            if (isIntegral(na) && isIntegral(nb)) {
+                return Long.compare(na.longValue(), nb.longValue());
+            }
+            return Double.compare(na.doubleValue(), nb.doubleValue());
+        }
+        if (a instanceof Comparable ca && a.getClass() == b.getClass()) {
+            return ca.compareTo(b);
+        }
+        return INCOMPARABLE;
+    }
+
+    private static boolean isIntegral(Number n) {
+        return n instanceof Long || n instanceof Integer || n instanceof Short || n instanceof Byte;
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushCountQueryAndTagsToSource.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushCountQueryAndTagsToSource.java
@@ -20,6 +20,7 @@ import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.util.DateUtils;
+import org.elasticsearch.xpack.esql.datasources.StatValueComparator;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.AggregateFunction;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Count;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.CountApproximate;
@@ -154,7 +155,11 @@ public class PushCountQueryAndTagsToSource extends PhysicalOptimizerRules.Optimi
      */
     private static Optional<EsQueryExec.QueryBuilderAndTags> trySimplifyRange(EsQueryExec.QueryBuilderAndTags qbt) {
         if (qbt.query() instanceof RangeQueryBuilder rqb && rqb.from() != null && rqb.to() != null) {
-            int comparison = compare(rqb.from(), rqb.to());
+            int comparison = StatValueComparator.compare(rqb.from(), rqb.to());
+            if (comparison == StatValueComparator.INCOMPARABLE) {
+                // Bounds aren't comparable (e.g. mismatched boxed types); leave the range untouched.
+                return Optional.of(qbt);
+            }
             if (comparison > 0) {
                 // from > to, can remove the query entry.
                 return Optional.empty();
@@ -210,8 +215,11 @@ public class PushCountQueryAndTagsToSource extends PhysicalOptimizerRules.Optimi
         }
 
         RangeQueryBuilder merged = new RangeQueryBuilder(range1.fieldName());
-        setTighterBound(merged, range1.from(), range2.from(), range1.includeLower(), range2.includeLower(), BoundType.FROM);
-        setTighterBound(merged, range1.to(), range2.to(), range1.includeUpper(), range2.includeUpper(), BoundType.TO);
+        if (setTighterBound(merged, range1.from(), range2.from(), range1.includeLower(), range2.includeLower(), BoundType.FROM) == false
+            || setTighterBound(merged, range1.to(), range2.to(), range1.includeUpper(), range2.includeUpper(), BoundType.TO) == false) {
+            // A pair of bounds isn't comparable; don't risk producing a wrong merged range.
+            return Optional.empty();
+        }
 
         String timeZone = range1.timeZone();
         if (timeZone != null) {
@@ -249,8 +257,9 @@ public class PushCountQueryAndTagsToSource extends PhysicalOptimizerRules.Optimi
         TO
     }
 
-    // Given two bounds, sets the tighter one on the range.
-    private static void setTighterBound(
+    // Given two bounds, sets the tighter one on the range. Returns false when the two bounds cannot be
+    // compared (e.g. mismatched boxed types), signalling that the merge must be abandoned.
+    private static boolean setTighterBound(
         RangeQueryBuilder range,
         Object bound1,
         Object bound2,
@@ -265,10 +274,13 @@ public class PushCountQueryAndTagsToSource extends PhysicalOptimizerRules.Optimi
             if (bound2 != null) {
                 setRange(range, bound2, include2, boundType);
             }
-            return;
+            return true;
         }
 
-        int compare = compare(bound1, bound2);
+        int compare = StatValueComparator.compare(bound1, bound2);
+        if (compare == StatValueComparator.INCOMPARABLE) {
+            return false;
+        }
         boolean useFirst = switch (boundType) {
             case FROM -> compare > 0;
             case TO -> compare < 0;
@@ -280,11 +292,7 @@ public class PushCountQueryAndTagsToSource extends PhysicalOptimizerRules.Optimi
         }
 
         setRange(range, value, include, boundType);
-    }
-
-    @SuppressWarnings("unchecked")
-    private static int compare(Object o1, Object o2) {
-        return ((Comparable<Object>) o1).compareTo(o2);
+        return true;
     }
 
     private static void setRange(RangeQueryBuilder range, Object val, boolean include, BoundType boundType) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/SplitFilterClassifier.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/SplitFilterClassifier.java
@@ -7,10 +7,10 @@
 
 package org.elasticsearch.xpack.esql.optimizer.rules.physical.local;
 
-import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.datasources.StatValueComparator;
 import org.elasticsearch.xpack.esql.datasources.spi.SplitStats;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.And;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.Not;
@@ -515,33 +515,11 @@ final class SplitFilterClassifier {
 
     /**
      * Compares two values, returning negative, zero, or positive as with {@link Comparable#compareTo}.
-     * Returns {@link Integer#MIN_VALUE} when the values are not comparable (type mismatch or null).
-     * Uses exact long comparison for integral types to avoid double precision loss.
+     * Returns {@link StatValueComparator#INCOMPARABLE} ({@link Integer#MIN_VALUE}) when the values are
+     * not comparable (type mismatch or null). Delegates to the shared {@link StatValueComparator} so all
+     * stats-driven planner comparisons normalize boxed numeric types identically.
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     static int compareValues(Object a, Object b) {
-        if (a == null || b == null) {
-            return Integer.MIN_VALUE;
-        }
-        if (a instanceof BytesRef br) {
-            a = br.utf8ToString();
-        }
-        if (b instanceof BytesRef br) {
-            b = br.utf8ToString();
-        }
-        if (a instanceof Number na && b instanceof Number nb) {
-            if (isIntegral(na) && isIntegral(nb)) {
-                return Long.compare(na.longValue(), nb.longValue());
-            }
-            return Double.compare(na.doubleValue(), nb.doubleValue());
-        }
-        if (a instanceof Comparable ca && a.getClass() == b.getClass()) {
-            return ca.compareTo(b);
-        }
-        return Integer.MIN_VALUE;
-    }
-
-    private static boolean isIntegral(Number n) {
-        return n instanceof Long || n instanceof Integer || n instanceof Short || n instanceof Byte;
+        return StatValueComparator.compare(a, b);
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/FilterEvaluationOrderEstimatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/FilterEvaluationOrderEstimatorTests.java
@@ -75,6 +75,42 @@ public class FilterEvaluationOrderEstimatorTests extends ESTestCase {
         assertSame(statusFilter, result.get(1));
     }
 
+    /**
+     * Regression for the ORC ClassCastException: an INT column whose min/max stats box as {@link Long}
+     * (as ORC's {@code IntegerColumnStatistics} does) compared against an {@link Integer} query literal
+     * must not throw at planning time and must still produce sensible ordering.
+     */
+    public void testEqualitySelectivity_longStatsIntegerLiteral_noClassCast() {
+        SplitStats.Builder builder = new SplitStats.Builder();
+        builder.rowCount(10000);
+        builder.addColumn("counter", 0L, 1L, 100L, 5_000L);
+        builder.addColumn("other", 0L, 1L, 1_000_000L, 50_000L);
+        SplitStats stats = builder.build();
+
+        Expression counterFilter = eq("counter", 62);
+        Expression otherFilter = eq("other", 500);
+
+        List<Expression> result = FilterEvaluationOrderEstimator.orderByEstimatedCost(List.of(counterFilter, otherFilter), stats);
+        assertSame(otherFilter, result.get(0));
+        assertSame(counterFilter, result.get(1));
+    }
+
+    /** Symmetric case: {@link Integer} stats compared against a {@link Long} literal must also not throw. */
+    public void testEqualitySelectivity_integerStatsLongLiteral_noClassCast() {
+        SplitStats.Builder builder = new SplitStats.Builder();
+        builder.rowCount(10000);
+        builder.addColumn("counter", 0L, 1, 100, 5_000L);
+        builder.addColumn("other", 0L, 1, 1_000_000, 50_000L);
+        SplitStats stats = builder.build();
+
+        Expression counterFilter = eqLong("counter", 62L);
+        Expression otherFilter = eqLong("other", 500L);
+
+        List<Expression> result = FilterEvaluationOrderEstimator.orderByEstimatedCost(List.of(counterFilter, otherFilter), stats);
+        assertSame(otherFilter, result.get(0));
+        assertSame(counterFilter, result.get(1));
+    }
+
     public void testNullSelectivity_highNullRatioFirst() {
         SplitStats.Builder builder = new SplitStats.Builder();
         builder.rowCount(10000);
@@ -274,6 +310,10 @@ public class FilterEvaluationOrderEstimatorTests extends ESTestCase {
 
     private static Expression eq(String field, int value) {
         return new Equals(SRC, fieldAttr(field), intLiteral(value), null);
+    }
+
+    private static Expression eqLong(String field, long value) {
+        return new Equals(SRC, fieldAttr(field), new Literal(SRC, value, DataType.LONG), null);
     }
 
     private static SplitStats metadata(long rowCount, String col, long nullCount, int min, int max, long sizeBytes) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StatValueComparatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StatValueComparatorTests.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.test.ESTestCase;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThan;
+
+public class StatValueComparatorTests extends ESTestCase {
+
+    public void testLongVsInteger() {
+        assertThat(StatValueComparator.compare(62L, 62), equalTo(0));
+        assertThat(StatValueComparator.compare(100L, 62), greaterThan(0));
+        assertThat(StatValueComparator.compare(10L, 62), lessThan(0));
+    }
+
+    public void testIntegerVsLong() {
+        assertThat(StatValueComparator.compare(62, 62L), equalTo(0));
+        assertThat(StatValueComparator.compare(100, 62L), greaterThan(0));
+        assertThat(StatValueComparator.compare(10, 62L), lessThan(0));
+    }
+
+    public void testIntegralVsFloating() {
+        assertThat(StatValueComparator.compare(2, 2.5d), lessThan(0));
+        assertThat(StatValueComparator.compare(3L, 2.5d), greaterThan(0));
+        assertThat(StatValueComparator.compare(2.0d, 2), equalTo(0));
+    }
+
+    public void testBytesRefVsString() {
+        assertThat(StatValueComparator.compare(new BytesRef("abc"), "abc"), equalTo(0));
+        assertThat(StatValueComparator.compare(new BytesRef("abd"), "abc"), greaterThan(0));
+        assertThat(StatValueComparator.compare("abc", new BytesRef("abd")), lessThan(0));
+    }
+
+    public void testNullIsIncomparable() {
+        assertThat(StatValueComparator.compare(null, 1), equalTo(StatValueComparator.INCOMPARABLE));
+        assertThat(StatValueComparator.compare(1, null), equalTo(StatValueComparator.INCOMPARABLE));
+        assertThat(StatValueComparator.compare(null, null), equalTo(StatValueComparator.INCOMPARABLE));
+    }
+
+    public void testIncompatibleTypesAreIncomparable() {
+        assertThat(StatValueComparator.compare("abc", 1), equalTo(StatValueComparator.INCOMPARABLE));
+        assertThat(StatValueComparator.compare(new BytesRef("abc"), 1), equalTo(StatValueComparator.INCOMPARABLE));
+    }
+}


### PR DESCRIPTION
This adds a type-normalizing comparator for column-statistic values (min/max) against query literal. This prevents ClassCastException occuring, (such as in FilterEvaluationOrderEstimator).

Closes https://github.com/elastic/esql-planning/issues/690