### PR TITLE
Fix flaky DockerTests test011SecurityEnabledStatus

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -380,9 +380,6 @@ tests:
 - class: org.elasticsearch.xpack.ccr.CcrSeqNoPruningIT
   method: testSeqNoPartiallyRetainedByCcrLease
   issue: https://github.com/elastic/elasticsearch/issues/150435
-- class: org.elasticsearch.packaging.test.DockerTests
-  method: test011SecurityEnabledStatus
-  issue: https://github.com/elastic/elasticsearch/issues/150438
 - class: org.elasticsearch.xpack.esql.action.FileSourceSecretDecryptionAcrossNodesIT
   method: testJoinedDataNodeDecryptsTheSecret
   issue: https://github.com/elastic/elasticsearch/issues/150440

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
@@ -157,8 +157,10 @@ public class DockerTests extends PackagingTestCase {
      */
     public void test011SecurityEnabledStatus() throws Exception {
         waitForElasticsearch(installation, "elastic", PASSWORD);
-        final int statusCode = makeRequestAsElastic("wrong_password");
-        assertThat(statusCode, equalTo(401));
+        // Authenticating the reserved `elastic` user consults the security index. Right after startup that index can briefly be
+        // unavailable, in which case the request fails with 503 (UnavailableShardsException) rather than the expected 401. Retry
+        // until the reserved realm is serving authentication decisions. See https://github.com/elastic/elasticsearch/issues/150438
+        assertBusy(() -> assertThat(makeRequestAsElastic("wrong_password"), equalTo(401)));
     }
 
     /**


### PR DESCRIPTION
## Summary

`DockerTests.test011SecurityEnabledStatus` is an intermittent failure (~3% fail rate, 17/565 executions on `main`) that has recurred for years (#131397, #124990, #118517, #116628) and only ever been muted, never fixed.

The test waits for the cluster to be healthy, then sends a request as `elastic` with a wrong password and asserts the status is `401`. Authenticating the reserved `elastic` user consults the security index. Immediately after startup that index can briefly be unavailable, in which case the reserved realm returns **503** (`UnavailableShardsException`) instead of **401**:

```
java.lang.AssertionError:
Expected: <401>
     but: was <503>
```

`ServerUtils.waitForElasticsearch` already retries early `401`s on the health endpoint for this exact security-index race, but the separate single-shot wrong-password probe in the test had no such tolerance.

## Change

- Wrap the wrong-password probe in `assertBusy(...)` so it retries until the reserved realm is serving authentication decisions and returns the expected `401`.
- Unmute the test in `muted-tests.yml`.

This is a test-harness hardening only; no production code changes.

## Test plan

- [x] `./gradlew :qa:packaging:spotlessJavaCheck :qa:packaging:compileTestJava`
- [x] CI packaging tests (Docker) on the PR branch

Closes #150438