### PR TITLE
[ESQL] Fix flaky "Unknown column" test failure

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvFlattenedKeywordIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvFlattenedKeywordIT.java
@@ -10,6 +10,8 @@ package org.elasticsearch.xpack.esql;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Booleans;
@@ -44,6 +46,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoTimeout;
 import static org.elasticsearch.xpack.esql.CsvSpecReader.specParser;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.classpathResources;
 
@@ -801,6 +804,13 @@ public class CsvFlattenedKeywordIT extends CsvIT {
                 return expected;
             }
             return new CsvTestUtils.ExpectedResults(expected.columnNames(), expected.columnTypes(), newValues);
+        }
+
+        @Override
+        public void afterIndexLoaded(CsvTestsDataLoader.TestDataset dataset, Client client) {
+            // Workaround for https://github.com/elastic/elasticsearch/issues/151369
+            // See BucketColumnMetadataIT#waitForAllTasks for additional context
+            assertNoTimeout(client.admin().cluster().prepareHealth(CsvIT.TEST_REQUEST_TIMEOUT).setWaitForEvents(Priority.LANGUID).get());
         }
 
         /**

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvIT.java
@@ -17,6 +17,7 @@ import org.elasticsearch.action.support.ActionFilter;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.analysis.common.CommonAnalysisPlugin;
+import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.metadata.View;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
@@ -179,6 +180,11 @@ public class CsvIT extends ESTestCase {
          * against the actual query output.
          */
         ExpectedResults transformExpectedResults(String testId, CsvSpecReader.CsvTestCase testCase, ExpectedResults expected);
+
+        /**
+         * Called once after the index for {@code dataset} has been fully populated.
+         */
+        default void afterIndexLoaded(CsvTestsDataLoader.TestDataset dataset, Client client) throws IOException {}
     }
 
     public static final IndexLoadStrategy IDENTITY_INDEX_LOAD_STRATEGY = new IndexLoadStrategy() {
@@ -572,6 +578,7 @@ public class CsvIT extends ESTestCase {
                     );
                 }
             }
+            indexLoadStrategy.afterIndexLoaded(dataset, cluster.client());
         }
     };
 

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/expression/function/grouping/BucketColumnMetadataIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/expression/function/grouping/BucketColumnMetadataIT.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.expression.function.grouping;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.View;
+import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
@@ -26,11 +27,21 @@ import java.util.Map;
 import java.util.Objects;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoTimeout;
 import static org.elasticsearch.xpack.esql.action.EsqlQueryRequest.syncEsqlQueryRequest;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
 
 public class BucketColumnMetadataIT extends AbstractEsqlIntegTestCase {
+
+    private void waitForAllTasks() {
+        // Fix for flaky test reported in https://github.com/elastic/elasticsearch/issues/150849
+        // Remove once the root cause is fixed: https://github.com/elastic/elasticsearch/issues/151369
+        // See also https://github.com/elastic/elasticsearch/issues/151371
+        //
+        // When removing this, also remove it from CvFlattenedKeywordIT.KeywordToFlattenedStrategy.afterIndexLoaded()
+        assertNoTimeout(clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForEvents(Priority.LANGUID).get());
+    }
 
     @Before
     public void requireBucketMetadataCapability() {
@@ -44,6 +55,8 @@ public class BucketColumnMetadataIT extends AbstractEsqlIntegTestCase {
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
             .get();
 
+        waitForAllTasks();
+
         try (var response = run(syncEsqlQueryRequest("""
             FROM dates | STATS date=VALUES(date) BY bucket=BUCKET(date, 20, "1985-01-01T00:00:00Z", "1986-01-01T00:00:00Z")
             """))) {
@@ -56,6 +69,8 @@ public class BucketColumnMetadataIT extends AbstractEsqlIntegTestCase {
             .setSource("date", "1985-07-09T00:00:00.000Z")
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
             .get();
+
+        waitForAllTasks();
 
         try (var response = run(syncEsqlQueryRequest("""
             FROM dates | STATS date=VALUES(date) BY BUCKET(date, 20, "1985-01-01T00:00:00Z", "1986-01-01T00:00:00Z")
@@ -73,6 +88,8 @@ public class BucketColumnMetadataIT extends AbstractEsqlIntegTestCase {
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
             .get();
 
+        waitForAllTasks();
+
         try (var response = run(syncEsqlQueryRequest("""
             FROM dates
             | STATS date=VALUES(date) BY bucket=BUCKET(date, 20, "1985-01-01T00:00:00Z", "1986-01-01T00:00:00Z")
@@ -87,6 +104,8 @@ public class BucketColumnMetadataIT extends AbstractEsqlIntegTestCase {
             .setSource("date", "1985-07-09T00:00:00.000Z")
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
             .get();
+
+        waitForAllTasks();
 
         try (var response = run(syncEsqlQueryRequest("""
             FROM dates
@@ -103,6 +122,8 @@ public class BucketColumnMetadataIT extends AbstractEsqlIntegTestCase {
             .setSource("date", "1985-07-09T00:00:00.000Z")
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
             .get();
+
+        waitForAllTasks();
 
         try (var response = run(syncEsqlQueryRequest("""
             FROM dates
@@ -129,6 +150,8 @@ public class BucketColumnMetadataIT extends AbstractEsqlIntegTestCase {
             .add(client().prepareIndex("numbers").setSource("number", 100))
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
             .get();
+
+        waitForAllTasks();
 
         try (var response = run(syncEsqlQueryRequest("""
             FROM
@@ -163,6 +186,8 @@ public class BucketColumnMetadataIT extends AbstractEsqlIntegTestCase {
             .add(client().prepareIndex("numbers").setSource("number", 100))
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
             .get();
+
+        waitForAllTasks();
 
         assertAcked(
             client().execute(
@@ -201,6 +226,8 @@ public class BucketColumnMetadataIT extends AbstractEsqlIntegTestCase {
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
             .get();
 
+        waitForAllTasks();
+
         // dropping bucket in subsequent aggregation
         try (var response = run(syncEsqlQueryRequest("""
             FROM test
@@ -236,6 +263,8 @@ public class BucketColumnMetadataIT extends AbstractEsqlIntegTestCase {
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
             .get();
 
+        waitForAllTasks();
+
         try (var response = run(syncEsqlQueryRequest("""
             FROM test
             | STATS count() BY
@@ -252,6 +281,8 @@ public class BucketColumnMetadataIT extends AbstractEsqlIntegTestCase {
             .setSource("number", 1, "date", "1985-07-09T00:00:00.000Z")
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
             .get();
+
+        waitForAllTasks();
 
         try (var response = run(syncEsqlQueryRequest("""
             FROM test
@@ -275,6 +306,8 @@ public class BucketColumnMetadataIT extends AbstractEsqlIntegTestCase {
 
     public void testBucketColumnMetadataRetainedAfterLookupJoin() {
         client().prepareIndex("events").setSource("value", 150).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
+
+        waitForAllTasks();
 
         assertAcked(
             client().admin()
@@ -305,6 +338,8 @@ public class BucketColumnMetadataIT extends AbstractEsqlIntegTestCase {
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
             .get();
 
+        waitForAllTasks();
+
         try (var response = run(syncEsqlQueryRequest("""
             FROM dates
             | FORK ( STATS c=COUNT(*) BY bucket=BUCKET(date, 1 month) )
@@ -321,6 +356,8 @@ public class BucketColumnMetadataIT extends AbstractEsqlIntegTestCase {
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
             .get();
 
+        waitForAllTasks();
+
         try (var response = run(syncEsqlQueryRequest("""
             FROM dates
             | INLINE STATS c=COUNT(*) BY bucket=BUCKET(date, 20, "1985-01-01T00:00:00Z", "1986-01-01T00:00:00Z")
@@ -334,6 +371,8 @@ public class BucketColumnMetadataIT extends AbstractEsqlIntegTestCase {
             .setSource("date", "1985-07-09T00:00:00.000Z")
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
             .get();
+
+        waitForAllTasks();
 
         try (var response = run(syncEsqlQueryRequest("""
             FROM dates
@@ -351,6 +390,8 @@ public class BucketColumnMetadataIT extends AbstractEsqlIntegTestCase {
             .setSource("number", 1, "date", "1985-07-09T00:00:00.000Z")
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
             .get();
+
+        waitForAllTasks();
 
         try (var response = run(syncEsqlQueryRequest("""
             FROM test
@@ -384,6 +425,8 @@ public class BucketColumnMetadataIT extends AbstractEsqlIntegTestCase {
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
             .get();
 
+        waitForAllTasks();
+
         try (var response = run(syncEsqlQueryRequest("TS ts-index | STATS max(metric) BY tb = TBUCKET(1 hour)"))) {
             assertThat(findColumn(response, "tb").meta(), equalTo(Map.of("bucket", Map.of("interval", 1L, "unit", "hour"))));
         }
@@ -397,6 +440,8 @@ public class BucketColumnMetadataIT extends AbstractEsqlIntegTestCase {
             .setSource("date", "1985-07-09T00:00:00.000Z")
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
             .get();
+
+        waitForAllTasks();
 
         Map<String, Object> expected = Map.of("bucket", Map.of("interval", 1L, "unit", "day"));
         try (var response = run(syncEsqlQueryRequest("""
@@ -417,6 +462,8 @@ public class BucketColumnMetadataIT extends AbstractEsqlIntegTestCase {
         // BUCKET(field, 0, 0, 0) is accepted by the analyzer but fails at evaluation (NaN/divide-by-zero).
         // Such impossible bucket definitions must not surface any metadata.
         client().prepareIndex("numbers").setSource("number", 1).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
+
+        waitForAllTasks();
 
         try (var response = run(syncEsqlQueryRequest("""
             FROM numbers
@@ -446,6 +493,8 @@ public class BucketColumnMetadataIT extends AbstractEsqlIntegTestCase {
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
             .get();
 
+        waitForAllTasks();
+
         try (var response = run(syncEsqlQueryRequest("""
             FROM dates
             | STATS c=COUNT(*) BY b = BUCKET(date, 0, "1985-01-01T00:00:00Z", "1986-01-01T00:00:00Z")
@@ -459,6 +508,8 @@ public class BucketColumnMetadataIT extends AbstractEsqlIntegTestCase {
             .setSource("date", "1985-07-09T00:00:00.000Z")
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
             .get();
+
+        waitForAllTasks();
 
         try (var response = run(syncEsqlQueryRequest("""
             FROM dates
@@ -475,6 +526,8 @@ public class BucketColumnMetadataIT extends AbstractEsqlIntegTestCase {
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
             .get();
 
+        waitForAllTasks();
+
         try (var response = run(syncEsqlQueryRequest("""
             FROM date_nanos_idx
             | STATS c=COUNT(*) BY b = BUCKET(date, 0, "1985-01-01T00:00:00Z", "1986-01-01T00:00:00Z")
@@ -489,6 +542,8 @@ public class BucketColumnMetadataIT extends AbstractEsqlIntegTestCase {
             .setSource("date", "1985-07-09T00:00:00.000Z")
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
             .get();
+
+        waitForAllTasks();
 
         try (var response = run(syncEsqlQueryRequest("""
             FROM date_nanos_idx
@@ -517,6 +572,8 @@ public class BucketColumnMetadataIT extends AbstractEsqlIntegTestCase {
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
             .get();
 
+        waitForAllTasks();
+
         try (var response = run(syncEsqlQueryRequest("""
             FROM dates
             | STATS c=COUNT(*) BY bucket=BUCKET(date, null)
@@ -543,6 +600,8 @@ public class BucketColumnMetadataIT extends AbstractEsqlIntegTestCase {
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
             .get();
 
+        waitForAllTasks();
+
         try (var response = run(syncEsqlQueryRequest("""
             FROM dates
             | STATS c=COUNT(*) BY bucket=BUCKET(date, null, "1985-01-01T00:00:00Z", "1986-01-01T00:00:00Z")
@@ -557,6 +616,8 @@ public class BucketColumnMetadataIT extends AbstractEsqlIntegTestCase {
             .setSource("date", "1985-07-09T00:00:00.000Z")
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
             .get();
+
+        waitForAllTasks();
 
         try (var response = run(syncEsqlQueryRequest("""
             FROM dates
@@ -573,6 +634,8 @@ public class BucketColumnMetadataIT extends AbstractEsqlIntegTestCase {
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
             .get();
 
+        waitForAllTasks();
+
         try (var response = run(syncEsqlQueryRequest("""
             FROM dates
             | STATS c=COUNT(*) BY bucket=BUCKET(date, 20, "1985-01-01T00:00:00Z", null)
@@ -587,6 +650,8 @@ public class BucketColumnMetadataIT extends AbstractEsqlIntegTestCase {
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
             .get();
 
+        waitForAllTasks();
+
         try (var response = run(syncEsqlQueryRequest("""
             FROM dates
             | STATS c=COUNT(*) BY b = BUCKET(date + 1 HOUR, 1 YEAR) - 1 HOUR
@@ -597,6 +662,8 @@ public class BucketColumnMetadataIT extends AbstractEsqlIntegTestCase {
 
     public void testBucketWrappedInRoundHasNoMetadata() {
         client().prepareIndex("test").setSource("value", 150).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
+
+        waitForAllTasks();
 
         try (var response = run(syncEsqlQueryRequest("""
             FROM test
@@ -609,6 +676,8 @@ public class BucketColumnMetadataIT extends AbstractEsqlIntegTestCase {
     public void testBucketInsideAggregateHasNoMetadata() {
         client().prepareIndex("test").setSource("value", 150).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
 
+        waitForAllTasks();
+
         try (var response = run(syncEsqlQueryRequest("""
             FROM test
             | STATS avg_b = AVG(BUCKET(value, 100.0)) BY bucket = BUCKET(value, 100.0)
@@ -620,6 +689,8 @@ public class BucketColumnMetadataIT extends AbstractEsqlIntegTestCase {
 
     public void testBucketColumnCastHasNoMetadata() {
         client().prepareIndex("test").setSource("value", 150).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
+
+        waitForAllTasks();
 
         try (var response = run(syncEsqlQueryRequest("""
             FROM test
@@ -637,6 +708,8 @@ public class BucketColumnMetadataIT extends AbstractEsqlIntegTestCase {
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
             .get();
 
+        waitForAllTasks();
+
         try (var response = run(syncEsqlQueryRequest("""
             FROM dates
             | STATS c=COUNT(*) BY bucket = BUCKET(date + 1 HOUR, 1 YEAR)
@@ -647,6 +720,8 @@ public class BucketColumnMetadataIT extends AbstractEsqlIntegTestCase {
 
     public void testBucketWithFoldableBucketsArg() {
         client().prepareIndex("test").setSource("value", 150).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
+
+        waitForAllTasks();
 
         try (var response = run(syncEsqlQueryRequest("""
             FROM test


### PR DESCRIPTION
 ## Problem                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                         
`BucketColumnMetadataIT` and `CsvFlattenedKeywordIT` were intermittently failing with "Unknown column" errors. The root cause is a race between index creation (which triggers cluster state updates) and query execution: ES|QL resolves field capabilities before the  cluster state propagated to all nodes has fully settled, so a field that exists in the mapping is transiently invisible to the field-capabilities layer.                                                                                                               

- Fixes https://github.com/elastic/elasticsearch/issues/150849
- Root cause: https://github.com/elastic/elasticsearch/issues/151369
- Related: https://github.com/elastic/elasticsearch/issues/151371

## Fix                                                                                                                                                                                                                                                  
Wait for all `LANGUID`-priority cluster events to drain before running any query. This is the lowest cluster priority, so `waitForEvents(LANGUID)` only returns once every higher-priority event (including the index-creation cluster state update) has been processed by every node.

This is a temporary mitigation that can be remove once the root cause has been fixed.                                                                                                                                            
