### PR TITLE
ESQL: Tests for IP function with casts

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
@@ -104,6 +104,7 @@ public class CsvTestsDataLoader {
             .noSubfields(),
         new TestDataset("all_types", "mapping-all-types.json", "all-types.csv"),
         new TestDataset("hosts"),
+        new TestDataset("hosts").withIndex("hosts_ip_is_kwd").withTypeMapping(Map.of("ip0", "keyword", "ip1", "keyword")),
         new TestDataset("apps"),
         new TestDataset("apps").withIndex("apps_short").withTypeMapping(Map.of("id", "short")),
         new TestDataset("languages"),

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/grok.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/grok.csv-spec
@@ -322,7 +322,7 @@ required_capability: union_types
 required_capability: join_lookup_v12
 required_capability: keep_regex_extract_attributes
 
-from multivalue_points,heights,histogram*,host*,messa*
+from multivalue_points,heights,histogram*,host*,-hosts_ip_is_kwd,messa*
 | eval  `card` = true, PbehoQUqKSF = "VLGjhcgNkQiEVyCLo", DsxMWtGL = true, qSxTIvUorMim = true, `location` = 8593178066470220111, type = -446161601, FSkGQkgmS = false 
 | eval  PbehoQUqKSF = 753987034, HLNMQfQj = true, `within` = true, `id` = "JDKKkYwhhh", lk = null, aecuvjTkgZza = 510616700, aDAMpuVtNX = null, qCopgNZPt = "AjhJUtZefqKdJYH", BxHHlFoA = "isBrmhKLc"
 | rename message as message 

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/inlinestats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/inlinestats.csv-spec
@@ -4296,7 +4296,7 @@ skip_flattened_rewrite: match_family_rejects_field_extract
 required_capability: inline_stats_double_release_fix
 required_capability: join_lookup_v12
 
-from date*,decades,dense*,distances,*,-addresses_*
+from date*,decades,dense*,distances,*,-addresses_*,-hosts_ip_is_kwd
 | rename scalerank as other2
 | rename author.keyword as name_str
 | rename intersects as is_active_bool

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/ip.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/ip.csv-spec
@@ -191,6 +191,16 @@ card:keyword   |host:keyword   |ip0:ip         |ip1:ip
 eth1           |beta           |127.0.0.1      |127.0.0.2
 ;
 
+cidrMatchFromKeyword
+
+FROM hosts_ip_is_kwd | WHERE CIDR_MATCH(ip1::IP, "127.0.0.2/32") | KEEP card, host, ip0, ip1;
+warningRegex:evaluation of \[CIDR_MATCH\(.*::IP, \\\"127.0.0.2/32\\\"\)\] failed, treating result as null. Only first 20 failures recorded.
+warningRegex:java.lang.IllegalArgumentException: single-value function encountered multi-value
+
+card:keyword | host:keyword | ip0:keyword | ip1:keyword
+eth1         | beta         | 127.0.0.1   | 127.0.0.2
+;
+
 cidrMatchNullField
 
 from hosts | where cidr_match(ip0, "127.0.0.2/32") is null | keep card, host, ip0, ip1;
@@ -714,6 +724,20 @@ eth0         | 127.0.0.1 | 127.0.0.0
 eth1         | ::1       | ::0
 ;
 
+ipPrefixFromKeyword
+required_capability: fn_ip_prefix
+
+FROM hosts_ip_is_kwd
+| WHERE host == "alpha"
+| SORT card
+| EVAL prefix = IP_PREFIX(ip0::IP, 24, 120)
+| KEEP card, ip0, prefix;
+
+card:keyword | ip0:keyword | prefix:ip
+eth0         | 127.0.0.1   | 127.0.0.0
+eth1         | ::1         | ::0
+;
+
 ipPrefixLengthFromExpression
 required_capability: fn_ip_prefix
 row ip4 = to_ip("1.2.3.4"), ip6 = to_ip("fe80::cae2:65ff:fece:feb9"), bits_per_byte = 8
@@ -810,6 +834,26 @@ fe80::cae2:65ff:fece:feb9 | 127.0.0.3                 | inbound
 127.0.0.1                 | 127.0.0.1                 | internal
 127.0.0.1                 | 127.0.0.2                 | internal
 127.0.0.1                 | 128.0.0.1                 | outbound
+;
+
+networkDirectionFromKeyword
+required_capability: network_direction
+
+FROM hosts_ip_is_kwd
+| WHERE MV_COUNT(ip0) == 1 AND MV_COUNT(ip1) == 1
+| EVAL direction = NETWORK_DIRECTION(ip0::IP, ip1::IP, ["loopback"])
+| KEEP ip0, ip1, direction
+;
+ignoreOrder:true
+
+ip0:keyword                | ip1:keyword               | direction:keyword
+fe80::cae2:65ff:fece:feb9  | fe81::cae2:65ff:fece:feb9 | external
+fe80::cae2:65ff:fece:feb9  | 127.0.0.3                 | inbound
+::1                        | ::1                       | internal
+127.0.0.1                  | ::1                       | internal
+127.0.0.1                  | 127.0.0.1                 | internal
+127.0.0.1                  | 127.0.0.2                 | internal
+127.0.0.1                  | 128.0.0.1                 | outbound
 ;
 
 networkDirectionFromRow


### PR DESCRIPTION
Add csv-spec tests for CIDR_MATCH, IP_PREFIX, and NETWORK_DIRECTION with
keyword-to-IP casting.
