### PR TITLE
ESQL: More tests for URL_ENCODE and URL_ENCODE_COMPONENT

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
@@ -3017,6 +3017,22 @@ u:keyword
 ["hello+elastic%21", "a%2Bb-c%25d", "", ".-_~", "%21%23%24%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D", "%F0%9F%94%A5%F0%9F%92%A7"]
 ;
 
+url_encode tests with text field table reads
+required_capability: url_encode
+
+FROM books
+| EVAL author_encoded = URL_ENCODE(author),
+        title_encoded = URL_ENCODE(title)
+| KEEP book_no, author_encoded, title_encoded
+| SORT book_no
+| WHERE book_no IN ("1211", "1463")
+;
+
+book_no:keyword | author_encoded:keyword | title_encoded:keyword
+1211            | Fyodor+Dostoevsky      | The+brothers+Karamazov
+1463            | J.+R.+R.+Tolkien       | Realms+of+Tolkien%3A+Images+of+Middle-earth
+;
+
 url_decode sample for docs
 required_capability: url_decode
 
@@ -3128,6 +3144,19 @@ ROW a = "+!\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcd
 
 a:keyword                                                                                                                                                   | b:keyword | c:keyword
 "%2B%21%22%23%24%25%26%27%28%29%2A%2B%2C-.%2F0123456789%3A%3B%3C%3D%3E%3F%40ABCDEFGHIJKLMNOPQRSTUVWXYZ%5B%5C%5D%5E_%60abcdefghijklmnopqrstuvwxyz%7B%7C%7D~" | ".-_~"    |❗🐶🐱
+;
+
+url_encode_component tests with keyword field table reads
+required_capability: url_encode_component
+
+FROM sample_data
+| WHERE message == "Connected to 10.1.0.1"
+| EVAL encoded = URL_ENCODE_COMPONENT(message)
+| KEEP encoded
+;
+
+encoded:keyword
+Connected%20to%2010.1.0.1
 ;
 
 url_encode_component tests with table reads


### PR DESCRIPTION
Adds a test for `URL_ENCODE_COMPONENT` that takes a `keyword` input from the index so `CsvFlattenedKeywordIT` can chew on it. Adds another test for `URL_ENCODE` that takes  a `text` as input just because I noticed it was missing.