### PR TITLE
[9.3] ESQL: fix nullify unmapped LOOKUP JOIN key

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -887,9 +887,13 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                         context
                     );
                 } else {
-                    // resolve the using columns against the left and the right side then assemble the new join config
-                    leftKeys = resolveUsingColumns(join.config().leftFields(), join.left().output(), "left");
-                    rightKeys = resolveUsingColumns(join.config().rightFields(), join.right().output(), "right");
+                    // resolve each side independently — skip sides that are already resolved
+                    leftKeys = Resolvables.resolved(config.leftFields())
+                        ? config.leftFields()
+                        : resolveUsingColumns(config.leftFields(), join.left().output(), "left");
+                    rightKeys = Resolvables.resolved(config.rightFields())
+                        ? config.rightFields()
+                        : resolveUsingColumns(config.rightFields(), join.right().output(), "right");
                 }
                 config = new JoinConfig(type, leftKeys, rightKeys, joinOnConditions);
                 return new LookupJoin(join.source(), join.left(), join.right(), config, join.isRemote());
@@ -1029,9 +1033,8 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                     }
                     resolved.add(resolvedField);
                 } else {
-                    throw new IllegalStateException(
-                        "Surprised to discover column [ " + col.name() + "] already resolved when resolving JOIN keys"
-                    );
+                    // Multi-key LOOKUP JOIN re-entry after ResolveUnmapped: prior-pass-resolved keys pass through.
+                    resolved.add(col);
                 }
             }
             return resolved;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/rules/ResolveUnmapped.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/rules/ResolveUnmapped.java
@@ -15,6 +15,7 @@ import org.elasticsearch.xpack.esql.analysis.AnalyzerRules;
 import org.elasticsearch.xpack.esql.analysis.UnmappedResolution;
 import org.elasticsearch.xpack.esql.core.expression.Alias;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Expressions;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
@@ -38,6 +39,7 @@ import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.Project;
 import org.elasticsearch.xpack.esql.plan.logical.Row;
 import org.elasticsearch.xpack.esql.plan.logical.UnaryPlan;
+import org.elasticsearch.xpack.esql.plan.logical.join.LookupJoin;
 import org.elasticsearch.xpack.esql.plan.logical.local.LocalRelation;
 
 import java.util.ArrayList;
@@ -47,6 +49,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Consumer;
 
 import static org.elasticsearch.xpack.esql.analysis.Analyzer.ResolveRefs.insistKeyword;
 import static org.elasticsearch.xpack.esql.core.util.CollectionUtils.combine;
@@ -329,28 +332,61 @@ public class ResolveUnmapped extends AnalyzerRules.ParameterizedAnalyzerRule<Log
      * excluding the {@link UnresolvedPattern} and {@link UnresolvedTimestamp} subtypes.
      */
     private static LinkedHashMap<String, List<UnresolvedAttribute>> collectUnresolved(LogicalPlan plan) {
-        Set<String> childOutputNames = new HashSet<>();
-        for (LogicalPlan child : plan.children()) {
-            for (Attribute attr : child.output()) {
-                childOutputNames.add(attr.name());
-            }
-        }
         Set<String> aliasedGroupings = aliasNamesInAggregateGroupings(plan);
 
         LinkedHashMap<String, List<UnresolvedAttribute>> unresolved = new LinkedHashMap<>();
-        plan.forEachExpression(UnresolvedAttribute.class, ua -> {
+        Consumer<UnresolvedAttribute> sink = ua -> {
             if (leaveUnresolved(ua) == false
                 // The aggs will "export" the aliases as UnresolvedAttributes part of their .aggregates(); we don't need to consider those
                 // as they'll be resolved as refs once the aliased expression is resolved.
-                && aliasedGroupings.contains(ua.name()) == false
-            // Filter out unresolved attributes that exist in the children's output. These attributes are not truly unmapped;
-            // they just haven't been resolved yet by ResolveRefs (e.g. because the children only became resolved after ImplicitCasting).
-            // ResolveRefs will wire them up in the next iteration of the resolution batch.
-                && childOutputNames.contains(ua.name()) == false) {
+                && aliasedGroupings.contains(ua.name()) == false) {
                 unresolved.computeIfAbsent(ua.name(), k -> new ArrayList<>()).add(ua);
             }
-        });
+        };
+        plan.forEachDown(LogicalPlan.class, node -> collectLoadCandidates(node, sink));
         return unresolved;
+    }
+
+    /**
+     * Per-node walk: which unresolved attributes from this node's local context (its own expressions or join config)
+     * cannot be resolved against its immediate children's outputs, and so are candidates for {@code _source} loading?
+     * UAs whose names match a child's output are skipped — ResolveRefs will wire them up on the next iteration.
+     */
+    private static void collectLoadCandidates(LogicalPlan node, Consumer<UnresolvedAttribute> sink) {
+        if (node instanceof LookupJoin lj) {
+            Set<String> leftOutputNames = new HashSet<>(Expressions.names(lj.left().output()));
+            Set<String> rightOutputNames = new HashSet<>(Expressions.names(lj.right().output()));
+            // Unresolved left keys not found in the left child → load candidates.
+            for (Attribute lf : lj.config().leftFields()) {
+                if (lf instanceof UnresolvedAttribute ua && leftOutputNames.contains(ua.name()) == false) {
+                    sink.accept(ua);
+                }
+            }
+            // joinOnConditions UAs not found in either child → load candidates.
+            Expression conds = lj.config().joinOnConditions();
+            if (conds != null) {
+                conds.forEachUp(UnresolvedAttribute.class, ua -> {
+                    if (leftOutputNames.contains(ua.name()) == false && rightOutputNames.contains(ua.name()) == false) {
+                        sink.accept(ua);
+                    }
+                });
+            }
+            // Unresolved right keys are intentionally ignored — a query that references them is invalid and will fail verification.
+        } else {
+            Set<String> childOutputNames = new HashSet<>();
+            for (LogicalPlan child : node.children()) {
+                for (Attribute a : child.output()) {
+                    childOutputNames.add(a.name());
+                }
+            }
+            for (Expression expr : node.expressions()) {
+                expr.forEachUp(UnresolvedAttribute.class, ua -> {
+                    if (childOutputNames.contains(ua.name()) == false) {
+                        sink.accept(ua);
+                    }
+                });
+            }
+        }
     }
 
     private static boolean leaveUnresolved(UnresolvedAttribute attribute) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerUnmappedTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerUnmappedTests.java
@@ -2451,6 +2451,22 @@ public class AnalyzerUnmappedTests extends ESTestCase {
         assertThat(Expressions.names(plan.output()), is(List.of("COUNT(*)", "empNo", "languageCode", "does_not_exist2")));
     }
 
+    // #149569: an unmapped left join key is nullified, so the join resolves (trivial no-match) instead of
+    // failing with "Unknown column ... in left side of join".
+    public void testLookupJoinUnmappedLeftKeyNullify() {
+        var plan = analyzeStatement(setUnmappedNullify("FROM test | LOOKUP JOIN languages_lookup ON language_code"));
+        assertThat(plan.resolved(), is(true));
+    }
+
+    // #149569: a missing field inside a join-filter expression must still error (not be silently nullified) —
+    // lookup joins can't evaluate arbitrary ON expressions yet.
+    public void testLookupJoinExpressionWithMissingFieldStillErrors() {
+        verificationFailure(
+            setUnmappedNullify("FROM test | LOOKUP JOIN languages_lookup ON (language_code == languages) AND (does_not_exist == \"x\")"),
+            "Unsupported join filter expression"
+        );
+    }
+
     // same tree as above, except for the source nodes
     public void testSubquerysMixAndLookupJoinLoad() {
         assumeTrue("Requires subquery in FROM command support", EsqlCapabilities.Cap.SUBQUERY_IN_FROM_COMMAND.isEnabled());


### PR DESCRIPTION
Partial backport of #148805 to 9.3 (nullify-relevant fix only).

Under `unmapped_fields="nullify"`, a `LOOKUP JOIN` on a key unmapped in the main index but present in the lookup failed instead of nullifying the key.

Relates to #149569

Assisted by Claude