### PR TITLE
Fix SmokeTestWatcherTestSuiteIT#testMonitorClusterHealth

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -244,9 +244,6 @@ tests:
 - class: org.elasticsearch.xpack.ml.integration.ForecastIT
   method: testOverflowToDisk
   issue: https://github.com/elastic/elasticsearch/issues/148606
-- class: org.elasticsearch.smoketest.SmokeTestWatcherTestSuiteIT
-  method: testMonitorClusterHealth
-  issue: https://github.com/elastic/elasticsearch/issues/148615
 - class: org.elasticsearch.xpack.esql.qa.multi_node.GenerativeIT
   method: test {feature:UNMAPPED_FIELDS_LOAD}
   issue: https://github.com/elastic/elasticsearch/issues/148619

--- a/x-pack/plugin/watcher/src/javaRestTest/java/org/elasticsearch/smoketest/SmokeTestWatcherTestSuiteIT.java
+++ b/x-pack/plugin/watcher/src/javaRestTest/java/org/elasticsearch/smoketest/SmokeTestWatcherTestSuiteIT.java
@@ -107,8 +107,11 @@ public class SmokeTestWatcherTestSuiteIT extends WatcherRestTestCase {
             indexWatch(watchId, builder);
         }
 
-        // check watch count
-        assertWatchCount(1);
+        // check watch count — wrap in assertBusy because when the .watches index is created for the
+        // first time, the WatcherLifeCycleService detects the new shard allocation and triggers a
+        // reload (pauseExecution + async reloadInner). During the pause window the watch count is 0;
+        // it becomes 1 once reloadInner finishes loading watches from the index.
+        assertBusy(() -> assertWatchCount(1));
 
         // check watch history
         ObjectPath objectPath = getWatchHistoryEntry(watchId);


### PR DESCRIPTION
When the .watches index is created for the first time, the lifecycle service
triggers a reload (pauseExecution -> async reloadInner). The bare assertion
races the reload and occasionally sees count=0. Wrap it in assertBusy().

Closes https://github.com/elastic/elasticsearch/issues/148615