### PR TITLE
Handle overflow in rate for int counters

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/RateIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/RateIntGroupingAggregatorFunction.java
@@ -630,8 +630,8 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
             if (top.lastTimestamp() > secondNextTimestamp) {
                 for (int p = top.start; p < top.end; p++) {
                     var val = values.get(p);
-                    if (val > prevValue) {
-                        state.resets += val;
+                    if (Integer.compareUnsigned(val, prevValue) > 0) {
+                        state.resets += Integer.toUnsignedLong(val);
                     }
                     prevValue = val;
                 }
@@ -641,8 +641,8 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
                 continue;
             }
             var val = values.get(top.next());
-            if (val > prevValue) {
-                state.resets += val;
+            if (Integer.compareUnsigned(val, prevValue) > 0) {
+                state.resets += Integer.toUnsignedLong(val);
             }
             prevValue = val;
             if (top.exhausted()) {
@@ -658,8 +658,8 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
         top = flushQueue.top();
         for (int p = top.start; p < top.end; p++) {
             var val = values.get(p);
-            if (val > prevValue) {
-                state.resets += val;
+            if (Integer.compareUnsigned(val, prevValue) > 0) {
+                state.resets += Integer.toUnsignedLong(val);
             }
             prevValue = val;
         }
@@ -865,7 +865,7 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
         public void appendDeltaValue(long timestamp, int value) {
             assert intervals.length == 0 : "cannot append delta data when intervals already exist";
             samples++;
-            resets += value;
+            resets += Integer.toUnsignedLong(value);
             deltaLastTs = Math.max(deltaLastTs, timestamp);
             if (timestamp < deltaFirstTs) {
                 deltaFirstTs = timestamp;
@@ -881,8 +881,8 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
                 for (int i = 1; i < intervals.length; i++) {
                     int next = intervals[i - 1]; // reversed
                     int prev = intervals[i];
-                    if (intervalBuffer.lastValue(prev) > intervalBuffer.firstValue(next)) {
-                        resets += intervalBuffer.lastValue(prev);
+                    if (Integer.compareUnsigned(intervalBuffer.lastValue(prev), intervalBuffer.firstValue(next)) > 0) {
+                        resets += Integer.toUnsignedLong(intervalBuffer.lastValue(prev));
                     }
                 }
             }
@@ -957,8 +957,8 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
         }
         final long firstTS = state.firstTs();
         final long lastTS = state.lastTs();
-        double firstValue = state.firstValue();
-        double lastValue = state.lastValue() + state.resets;
+        double firstValue = Integer.toUnsignedLong(state.firstValue());
+        double lastValue = Integer.toUnsignedLong(state.lastValue()) + state.resets;
         if (isRateOverTime) {
             return (lastValue - firstValue) * dateFactor / (lastTS - firstTS);
         } else {
@@ -989,7 +989,7 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
         if (previousState == null || previousState.samples == 0) {
             if (state.samples == 1) {
                 firstTsSec = state.firstTs() / dateFactor;
-                firstValue = state.firstValue();
+                firstValue = Integer.toUnsignedLong(state.firstValue());
             } else {
                 firstValue = extrapolateToBoundary(state, tbucketStart, tbucketEnd, dateFactor, true);
             }
@@ -1002,7 +1002,7 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
         if (nextState == null || nextState.samples == 0) {
             if (state.samples == 1) {
                 lastTsSec = state.lastTs() / dateFactor;
-                lastValue = state.lastValue() + state.resets;
+                lastValue = Integer.toUnsignedLong(state.lastValue()) + state.resets;
             } else {
                 lastValue = extrapolateToBoundary(state, tbucketStart, tbucketEnd, dateFactor, false);
             }
@@ -1052,9 +1052,9 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
         boolean isLowerBoundary
     ) {
         final double startTs = state.firstTs() / dateFactor;
-        final double startValue = state.firstValue();
+        final double startValue = Integer.toUnsignedLong(state.firstValue());
         final double endTs = state.lastTs() / dateFactor;
-        final double endValue = state.lastValue() + state.resets;
+        final double endValue = Integer.toUnsignedLong(state.lastValue()) + state.resets;
         final double sampleTsSec = endTs - startTs;
         final double averageSampleInterval = sampleTsSec / state.samples;
         final double slope = (endValue - startValue) / sampleTsSec;
@@ -1098,9 +1098,9 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
         double dateFactor,
         boolean isLowerBoundary
     ) {
-        final double startValue = lowerState.lastValue();
+        final double startValue = Integer.toUnsignedLong(lowerState.lastValue());
         final double startTs = lowerState.lastTs() / dateFactor;
-        final double endValue = upperState.firstValue();
+        final double endValue = Integer.toUnsignedLong(upperState.firstValue());
         final double endTs = upperState.firstTs() / dateFactor;
         assert startTs < endTs : "expected startTs < endTs, got " + startTs + " < " + endTs;
         final double delta = deltaBetweenStates(lowerState, upperState, dateFactor);
@@ -1118,8 +1118,8 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
     }
 
     private double deltaBetweenStates(ReducedState lowerState, ReducedState upperState, double dateFactor) {
-        final double startValue = lowerState.lastValue();
-        final double endValue = upperState.firstValue();
+        final double startValue = Integer.toUnsignedLong(lowerState.lastValue());
+        final double endValue = Integer.toUnsignedLong(upperState.firstValue());
 
         // If the end value is smaller than the start value, a counter reset occurred.
         // In this case, the delta is considered equal to the end value.

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/RateIntGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/RateIntGroupingAggregatorFunctionTests.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.aggregation;
+
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.test.ComputeTestCase;
+import org.elasticsearch.compute.test.TestWarningsSource;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.greaterThan;
+
+public class RateIntGroupingAggregatorFunctionTests extends ComputeTestCase {
+
+    private DriverContext driverContext() {
+        BlockFactory blockFactory = blockFactory();
+        return new DriverContext(blockFactory.bigArrays(), blockFactory, null);
+    }
+
+    /**
+     * Verifies that RATE() on a {@code counter_integer} field produces a positive, correct result
+     * when the counter wraps past {@code Integer.MAX_VALUE}.
+     *
+     * <p>A byte counter growing at 100 MB/s crosses the signed 32-bit boundary every ~21 seconds.
+     * The values stored in the index are signed Java {@code int}s, so after the wrap the stored
+     * values are negative. Without unsigned interpretation the rate aggregator mis-classifies the
+     * wrap as a counter-reset-to-zero, producing a negative (or wildly wrong) rate.</p>
+     *
+     * <p>The correct interpretation is Counter32 / unsigned-32-bit: the wrap at 2^32 is a
+     * continuation of the monotonically-increasing counter, not a reset.</p>
+     */
+    public void testWrappingIntCounterRate() {
+        // Counter incrementing by 100_000_000 bytes per second.
+        // Logical unsigned-32-bit values: 2_100_000_000 2_200_000_000 2_300_000_000 ...
+        // Stored as signed int (truncated): 2_100_000_000 -2_094_967_296 -1_994_967_296 ...
+        // (2_200_000_000 > Integer.MAX_VALUE=2_147_483_647, so it wraps to a negative signed int)
+        final long increment = 100_000_000L;  // bytes/s
+        final int numSamples = 5;
+        int[] counterValues = new int[numSamples];
+        long[] timestampsMs = new long[numSamples];
+
+        long logicalValue = 2_100_000_000L;
+        for (int i = 0; i < numSamples; i++) {
+            counterValues[i] = (int) logicalValue;  // truncate to signed 32-bit
+            timestampsMs[i] = (i + 1) * 1000L;     // 1000 ms, 2000 ms, 3000 ms, 4000 ms, 5000 ms
+            logicalValue += increment;
+        }
+
+        // Sanity check: after the first increment the stored value should be negative (the wrap happened)
+        assertTrue("test setup: counterValues[1] must be negative to exercise the wrapping path", counterValues[1] < 0);
+
+        DriverContext driverContext = driverContext();
+        BlockFactory blockFactory = driverContext.blockFactory();
+
+        // The aggregator expects data in descending timestamp order (newest first), as produced by TSDS.
+        var valuesBuilder = blockFactory.newIntBlockBuilder(numSamples);
+        var timestampsBuilder = blockFactory.newLongBlockBuilder(numSamples);
+        for (int i = numSamples - 1; i >= 0; i--) {
+            valuesBuilder.appendInt(counterValues[i]);
+            timestampsBuilder.appendLong(timestampsMs[i]);
+        }
+
+        // Page layout: [groupId, values, timestamps, temporality, sliceIndex, futureMaxTimestamps]
+        // Channels for the aggregator: values=1, timestamps=2, temporality=3, sliceIndex=4, futureMaxTs=5
+        Page page = new Page(
+            blockFactory.newConstantIntBlockWith(0, numSamples),
+            valuesBuilder.build(),
+            timestampsBuilder.build(),
+            blockFactory.newConstantNullBlock(numSamples),   // null → CUMULATIVE
+            blockFactory.newConstantIntBlockWith(0, numSamples),
+            blockFactory.newConstantLongBlockWith(Long.MAX_VALUE, numSamples)
+        );
+
+        var aggregator = new RateIntGroupingAggregatorFunction.FunctionSupplier(true, false, TestWarningsSource.INSTANCE)
+            .groupingAggregator(driverContext, List.of(1, 2, 3, 4, 5));
+        try {
+            var addInput = aggregator.prepareProcessRawInputPage(null, page);
+            try (var groupIds = blockFactory.newConstantIntBlockWith(0, numSamples).asVector()) {
+                addInput.add(0, groupIds);
+            }
+            addInput.close();
+            page.releaseBlocks();
+
+            // Evaluate: group 0 selected; use the non-time-series context (computeRateWithoutExtrapolate path)
+            try (var selected = blockFactory.newConstantIntBlockWith(0, 1).asVector()) {
+                var ctx = new GroupingAggregatorEvaluationContext(driverContext);
+                var prepared = aggregator.prepareEvaluateFinal(selected, ctx);
+                Block[] result = new Block[1];
+                prepared.evaluate(result, 0, selected);
+                try (DoubleBlock rates = (DoubleBlock) result[0]) {
+                    assertFalse("rate should not be null for a counter that wraps", rates.isNull(0));
+                    double rate = rates.getDouble(0);
+                    // A rate on a counter can never be negative.
+                    // Without the unsigned fix, the rate is approximately -448_741_824 (negative).
+                    assertThat("rate must be positive for a monotonically-increasing wrapping counter", rate, greaterThan(0.0));
+                    // The counter increases by exactly `increment` bytes per second across all 4 seconds.
+                    assertThat("rate should equal the per-second counter increment", rate, closeTo(increment, 1.0));
+                }
+            }
+        } finally {
+            aggregator.close();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- `RATE()` on `counter_integer` fields was producing **negative rates** and **±Pb/s spikes** on real-world dashboards. A byte counter growing at hundreds of Gb/s crosses `Integer.MAX_VALUE` (~2.1 GB) within seconds, wrapping the stored signed `int` to a large negative value.
- The reset-detection logic in `RateIntGroupingAggregatorFunction` compared values as **signed**, so it misidentified the wrap as a counter-reset-to-zero. The resulting wrong delta (up to ~4.3e9 bytes negative) was divided by small within-bucket Δt in the boundary interpolation path, amplifying into Pb/s spikes.
- Fix: interpret `counter_integer` values as **unsigned 32-bit** (Counter32, matching OpenMetrics/Prometheus/SNMP) at every arithmetic site. A 2³² wrap is a continuation of the monotonically-increasing counter, handled correctly by the existing reset-compensation logic under unsigned comparison.

## Changes

- **`RateIntGroupingAggregatorFunction.java`** — 10 sites changed across 5 methods: reset comparisons use `Integer.compareUnsigned`, accumulations use `Integer.toUnsignedLong`. Storage (`IntBuffer`) and intermediate wire format (`IntBlock`) are unchanged — no transport-version bump needed.
- **`RateIntGroupingAggregatorFunctionTests.java`** (new) — regression test feeding a 5-sample wrapping counter (logical values 2.1e9→2.5e9 unsigned, stored as mixed-sign `int`s) and asserting the rate is exactly 100,000,000 bytes/s positive (without the fix: −448,741,824).

## Test plan

- [x] New unit test `testWrappingIntCounterRate` passes
- [x] `RateDoubleGroupingAggregatorFunctionTests` (existing) unaffected
- [x] `spotlessJavaCheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)