### PR TITLE
[8.19] Filter _source field names by code point (#151146)

### DIFF
--- a/docs/changelog/151146.yaml
+++ b/docs/changelog/151146.yaml
@@ -1,0 +1,5 @@
+area: Infra/Core
+issues: []
+pr: 151146
+summary: Filter `_source` field names by code point
+type: bug

--- a/server/src/main/java/org/elasticsearch/common/xcontent/support/XContentMapValues.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/support/XContentMapValues.java
@@ -308,8 +308,11 @@ public class XContentMapValues {
     }
 
     private static int step(CharacterRunAutomaton automaton, String key, int state) {
-        for (int i = 0; state != -1 && i < key.length(); ++i) {
-            state = automaton.step(state, key.charAt(i));
+        // Step by code point, not UTF-16 char: the automaton is built over code points (see CharacterRunAutomaton#run).
+        for (int i = 0; state != -1 && i < key.length();) {
+            final int cp = key.codePointAt(i);
+            state = automaton.step(state, cp);
+            i += Character.charCount(cp);
         }
         return state;
     }

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/UnmappedFieldFetcher.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/UnmappedFieldFetcher.java
@@ -181,8 +181,11 @@ public class UnmappedFieldFetcher {
     }
 
     private static int step(CharacterRunAutomaton automaton, String key, int state) {
-        for (int i = 0; state != -1 && i < key.length(); ++i) {
-            state = automaton.step(state, key.charAt(i));
+        // Step by code point, not UTF-16 char: the automaton is built over code points (see CharacterRunAutomaton#run).
+        for (int i = 0; state != -1 && i < key.length();) {
+            final int cp = key.codePointAt(i);
+            state = automaton.step(state, cp);
+            i += Character.charCount(cp);
         }
         return state;
     }

--- a/server/src/main/java/org/elasticsearch/search/lookup/SourceFilter.java
+++ b/server/src/main/java/org/elasticsearch/search/lookup/SourceFilter.java
@@ -101,8 +101,11 @@ public final class SourceFilter {
     }
 
     private static int step(CharacterRunAutomaton automaton, String key, int state) {
-        for (int i = 0; state != -1 && i < key.length(); ++i) {
-            state = automaton.step(state, key.charAt(i));
+        // Step by code point, not UTF-16 char: the automaton is built over code points (see CharacterRunAutomaton#run).
+        for (int i = 0; state != -1 && i < key.length();) {
+            final int cp = key.codePointAt(i);
+            state = automaton.step(state, cp);
+            i += Character.charCount(cp);
         }
         return state;
     }

--- a/server/src/test/java/org/elasticsearch/common/xcontent/support/XContentMapValuesTests.java
+++ b/server/src/test/java/org/elasticsearch/common/xcontent/support/XContentMapValuesTests.java
@@ -580,6 +580,21 @@ public class XContentMapValuesTests extends AbstractFilteringTestCase {
         assertEquals(Collections.singletonMap("指数", 3), XContentMapValues.filter(map, new String[0], new String[] { "搜索" }));
     }
 
+    public void testNonBmpCharactersInPaths() {
+        // Unlike the BMP CJK chars in testSupplementaryCharactersInPaths above, these are above U+FFFF (surrogate pairs).
+        final String x = "\uD835\uDD4F"; // U+1D54F MATHEMATICAL DOUBLE-STRUCK CAPITAL X
+        final String y = "\uD835\uDD50"; // U+1D550 MATHEMATICAL DOUBLE-STRUCK CAPITAL Y
+
+        Map<String, Object> map = new HashMap<>();
+        map.put(x, 2);
+        map.put(y, 3);
+
+        // include: only the requested non-BMP field is retained
+        assertEquals(Map.of(x, 2), XContentMapValues.filter(map, new String[] { x }, new String[0]));
+        // exclude: the excluded non-BMP field is dropped, the other is retained
+        assertEquals(Map.of(y, 3), XContentMapValues.filter(map, new String[0], new String[] { x }));
+    }
+
     /**
      * Tests that we can extract paths which share a prefix with other paths.
      * See {@link AbstractFilteringTestCase#testFilterSharedPrefixes()}

--- a/server/src/test/java/org/elasticsearch/search/fetch/subphase/FieldFetcherTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/subphase/FieldFetcherTests.java
@@ -1414,6 +1414,27 @@ public class FieldFetcherTests extends MapperServiceTestCase {
         assertThat(fields.get("unmapped_object.b").getValue(), equalTo("bar"));
     }
 
+    public void testUnmappedFieldsWildcardWithNonBmpName() throws IOException {
+        MapperService mapperService = createMapperService();
+
+        // name contains U+1D54F (a surrogate pair), so the wildcard pattern's literal portion must match by code point
+        final String objName = "unmapped_\uD835\uDD4F";
+
+        XContentBuilder source = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject(objName)
+            .field("a", "foo")
+            .field("b", "bar")
+            .endObject()
+            .endObject();
+
+        Map<String, DocumentField> fields = fetchFields(mapperService, source, fieldAndFormatList(objName + ".*", null, true));
+        assertThat(fields.size(), equalTo(2));
+        assertThat(fields.keySet(), containsInAnyOrder(objName + ".a", objName + ".b"));
+        assertThat(fields.get(objName + ".a").getValue(), equalTo("foo"));
+        assertThat(fields.get(objName + ".b").getValue(), equalTo("bar"));
+    }
+
     public void testLastFormatWins() throws IOException {
         MapperService mapperService = createMapperService();
 

--- a/server/src/test/java/org/elasticsearch/search/lookup/SourceFilterTests.java
+++ b/server/src/test/java/org/elasticsearch/search/lookup/SourceFilterTests.java
@@ -156,4 +156,25 @@ public class SourceFilterTests extends ESTestCase {
         Source filteredBytes = fromBytes.filter(new SourceFilter(new String[] { "myObject" }, new String[] { "myObject.myField" }));
         assertEquals(filteredBytes.source(), Map.of("myObject", Map.of("other", "otherValue")));
     }
+
+    public void testNonBmpFieldNames() {
+        final String x = "\uD835\uDD4F"; // U+1D54F MATHEMATICAL DOUBLE-STRUCK CAPITAL X (a surrogate pair)
+        final String y = "\uD835\uDD50"; // U+1D550 MATHEMATICAL DOUBLE-STRUCK CAPITAL Y
+
+        // map filter path: include keeps only the requested supplementary-character field
+        Source included = Source.fromMap(Map.of(x, 1, y, 2), XContentType.JSON)
+            .filter(new SourceFilter(new String[] { x }, new String[] {}));
+        assertEquals(Map.of(x, 1), included.source());
+
+        // map filter path: exclude drops the excluded supplementary-character field
+        Source excluded = Source.fromMap(Map.of(x, 1, y, 2), XContentType.JSON)
+            .filter(new SourceFilter(new String[] {}, new String[] { x }));
+        assertEquals(Map.of(y, 2), excluded.source());
+
+        // path-level checks used by synthetic source / field selection (drive SourceFilter#step directly)
+        assertTrue(new SourceFilter(new String[] { x }, null).isExplicitlyIncluded(x));
+        assertFalse(new SourceFilter(new String[] { x }, null).isExplicitlyIncluded(y));
+        assertTrue(new SourceFilter(null, new String[] { x }).isPathFiltered(x, false));
+        assertFalse(new SourceFilter(null, new String[] { x }).isPathFiltered(y, false));
+    }
 }

--- a/server/src/test/java/org/elasticsearch/search/lookup/SourceFilterTests.java
+++ b/server/src/test/java/org/elasticsearch/search/lookup/SourceFilterTests.java
@@ -172,8 +172,6 @@ public class SourceFilterTests extends ESTestCase {
         assertEquals(Map.of(y, 2), excluded.source());
 
         // path-level checks used by synthetic source / field selection (drive SourceFilter#step directly)
-        assertTrue(new SourceFilter(new String[] { x }, null).isExplicitlyIncluded(x));
-        assertFalse(new SourceFilter(new String[] { x }, null).isExplicitlyIncluded(y));
         assertTrue(new SourceFilter(null, new String[] { x }).isPathFiltered(x, false));
         assertFalse(new SourceFilter(null, new String[] { x }).isPathFiltered(y, false));
     }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Filter _source field names by code point (#151146)](https://github.com/elastic/elasticsearch/pull/151146)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)