### PR TITLE
Mute CsvFlattenedKeywordIT (#151452)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -626,6 +626,8 @@ tests:
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=search.vectors/40_knn_search/Vector rescoring has no effect for non-quantized vectors and provides same results as non-rescored knn}
   issue: https://github.com/elastic/elasticsearch/issues/151418
+- class: org.elasticsearch.xpack.esql.CsvFlattenedKeywordIT
+  issue: https://github.com/elastic/elasticsearch/issues/151452
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=search.vectors/42_knn_search_flat/Vector rescoring has no effect for non-quantized vectors and provides same results as non-rescored knn}
   issue: https://github.com/elastic/elasticsearch/issues/151453


### PR DESCRIPTION
## Summary

Mutes `org.elasticsearch.xpack.esql.CsvFlattenedKeywordIT` while [#151452](https://github.com/elastic/elasticsearch/issues/151452) is being investigated.

**Root cause:** `CsvFlattenedKeywordIT` is a snapshot-only variant that re-runs the csv-spec corpus with every `keyword` field rewritten to `flattened`. 8 `views.csv-spec` tests fail intermittently because stored view bodies contain `language_name IN ("English", "French")` — the variant converts `language_name` to `flattened` in the index but does not rewrite the view body's `IN` expression with `field_extract(...)`, causing:

```
VerificationException: 1st argument of [language_name IN (...)] must be [flattened],
  found value ["English"] type [keyword]
```

These tests are failing:

  - inSubqueryReferencingConjunctionView
  - inSubqueryReferencingConjunctionViewAlternateView
  - inSubqueryReferencingNestedInSubqueryView
  - inSubqueryReferencingNestedInSubqueryViewAlternateView
  - inNestedAndDisjunctionNotInConjunctionViews
  - inNestedAndDisjunctionNotInConjunctionViewsAlternateView
  - threeInSubqueriesIntersectNestedConjunctionDisjunctionViews
  - threeInSubqueriesIntersectNestedConjunctionDisjunctionViewsAlternateView