### PR TITLE
[9.3] OsProbe: Fix parsing of cgroup lines (#151095)

### DIFF
--- a/docs/changelog/151095.yaml
+++ b/docs/changelog/151095.yaml
@@ -1,0 +1,5 @@
+area: Infra/Core
+issues: []
+pr: 151095
+summary: Fix OS stats for cgroup paths containing colons
+type: bug

--- a/server/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
+++ b/server/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
@@ -322,9 +322,9 @@ public class OsProbe {
              * The virtual file /proc/self/cgroup lists the control groups that the Elasticsearch process is a member of. Each line contains
              * three colon-separated fields of the form hierarchy-ID:subsystem-list:cgroup-path. For cgroups version 1 hierarchies, the
              * subsystem-list is a comma-separated list of subsystems. The subsystem-list can be empty if the hierarchy represents a cgroups
-             * version 2 hierarchy. For cgroups version 1
+             * version 2 hierarchy. The cgroup-path field is a path and may contain additional colons.
              */
-            final String[] fields = line.split(":");
+            final String[] fields = line.split(":", 3);
             assert fields.length == 3;
             final String[] controllers = fields[1].split(",");
             for (final String controller : controllers) {
@@ -350,10 +350,10 @@ public class OsProbe {
      * The lines from {@code /proc/self/cgroup}. This file represents the control groups to which the Elasticsearch process belongs. Each
      * line in this file represents a control group hierarchy of the form
      * <p>
-     * {@code \d+:([^:,]+(?:,[^:,]+)?):(/.*)}
+     * {@code (\d+):((?:[^:,]+(?:,[^:,]+)*)?):(/.*)}
      * <p>
      * with the first field representing the hierarchy ID, the second field representing a comma-separated list of the subsystems bound to
-     * the hierarchy, and the last field representing the control group.
+     * the hierarchy, and the last field representing the control group. The control group is a path and may contain additional colons.
      *
      * @return the lines from {@code /proc/self/cgroup}
      * @throws IOException if an I/O exception occurs reading {@code /proc/self/cgroup}

--- a/server/src/test/java/org/elasticsearch/monitor/os/OsProbeTests.java
+++ b/server/src/test/java/org/elasticsearch/monitor/os/OsProbeTests.java
@@ -222,6 +222,22 @@ public class OsProbeTests extends ESTestCase {
         }
     }
 
+    public void testCgroupProbeWithColonInPath() {
+        final int cgroupsVersion = 2;
+        final String hierarchy = "user.slice/user-1000.slice/user@1000.service/app.slice/"
+            + "app-dbus\\x2d:1.2\\x2dorg.gnome.Console.slice/tmux-spawn-uuid.scope";
+
+        final OsProbe probe = new OsProbeMock(hierarchy).setAvailableCgroupsVersion(cgroupsVersion)
+            .setProcSelfCgroupLines(getProcSelfGroupLines(cgroupsVersion, hierarchy));
+
+        final OsStats.Cgroup cgroup = probe.osStats().getCgroup();
+
+        assertNotNull(cgroup);
+        assertThat(cgroup.getCpuAcctControlGroup(), equalTo("/" + hierarchy));
+        assertThat(cgroup.getCpuControlGroup(), equalTo("/" + hierarchy));
+        assertThat(cgroup.getMemoryControlGroup(), equalTo("/" + hierarchy));
+    }
+
     public void testCgroupProbeWithMissingCpuMax() {
         final int cgroupsVersion = 2;
         final var hierarchy = randomAlphaOfLength(16);


### PR DESCRIPTION
Backports the following commits to 9.3:
 - OsProbe: Fix parsing of cgroup lines (#151095)