### PR TITLE
[9.4] Fix OTLP histogram conversion for single-count histograms without bucket boundaries (#151411)

### DIFF
--- a/docs/changelog/151411.yaml
+++ b/docs/changelog/151411.yaml
@@ -1,0 +1,5 @@
+area: TSDB
+issues: []
+pr: 151411
+summary: Fix OTLP histogram handling for single-count histograms without bucket boundaries
+type: bug

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/datapoint/ExponentialHistogramConverter.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/datapoint/ExponentialHistogramConverter.java
@@ -122,7 +122,7 @@ public class ExponentialHistogramConverter {
 
         int size = dataPoint.getBucketCountsCount();
 
-        if (size > 0) {
+        if (size > 0 && dataPoint.getExplicitBoundsCount() > 0) {
             bucketsScratch.clear();
 
             boolean minHandled = false;

--- a/x-pack/plugin/otel-data/src/test/java/org/elasticsearch/xpack/oteldata/otlp/datapoint/HistogramToExponentialHistogramConverterTests.java
+++ b/x-pack/plugin/otel-data/src/test/java/org/elasticsearch/xpack/oteldata/otlp/datapoint/HistogramToExponentialHistogramConverterTests.java
@@ -339,6 +339,36 @@ public class HistogramToExponentialHistogramConverterTests extends ESTestCase {
                     null,
                     -0.42,
                     0.5
+                ) },
+            new Object[] {
+                "single count no bounds with sum",
+                (Supplier<TestCase>) () -> new TestCase(
+                    HistogramDataPoint.newBuilder().addBucketCounts(10L).setCount(10L).setSum(100.0).build(),
+                    List.of(),
+                    List.of(),
+                    null,
+                    null,
+                    null
+                ) },
+            new Object[] {
+                "single count no bounds without sum",
+                (Supplier<TestCase>) () -> new TestCase(
+                    HistogramDataPoint.newBuilder().addBucketCounts(5L).setCount(5L).build(),
+                    List.of(),
+                    List.of(),
+                    null,
+                    null,
+                    null
+                ) },
+            new Object[] {
+                "single count no bounds with zero count",
+                (Supplier<TestCase>) () -> new TestCase(
+                    HistogramDataPoint.newBuilder().addBucketCounts(0L).setCount(0L).build(),
+                    List.of(),
+                    List.of(),
+                    null,
+                    null,
+                    null
                 ) }
         );
 

--- a/x-pack/plugin/otel-data/src/test/java/org/elasticsearch/xpack/oteldata/otlp/datapoint/HistogramToTDigestConverterTests.java
+++ b/x-pack/plugin/otel-data/src/test/java/org/elasticsearch/xpack/oteldata/otlp/datapoint/HistogramToTDigestConverterTests.java
@@ -124,6 +124,36 @@ public class HistogramToTDigestConverterTests extends ESTestCase {
                     .build(),
                 List.of(5L, 10L, 15L, 20L),
                 List.of(0.5, 3.0, 12.5, 20.0),
+                true },
+            new Object[] {
+                "no explicit bounds with count and sum",
+                HistogramDataPoint.newBuilder().setCount(10L).setSum(100.0).build(),
+                List.of(),
+                List.of(),
+                true },
+            new Object[] {
+                "no explicit bounds with single bucket count",
+                HistogramDataPoint.newBuilder().addBucketCounts(10L).setCount(10L).setSum(100.0).build(),
+                List.of(),
+                List.of(),
+                false },
+            new Object[] {
+                "no explicit bounds with single bucket count without sum",
+                HistogramDataPoint.newBuilder().addBucketCounts(5L).setCount(5L).build(),
+                List.of(),
+                List.of(),
+                false },
+            new Object[] {
+                "no explicit bounds with single zero bucket count",
+                HistogramDataPoint.newBuilder().addBucketCounts(0L).setCount(0L).build(),
+                List.of(),
+                List.of(),
+                false },
+            new Object[] {
+                "no explicit bounds with zero count",
+                HistogramDataPoint.newBuilder().setCount(0L).setSum(0.0).build(),
+                List.of(),
+                List.of(),
                 true }
         );
     }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Fix OTLP histogram conversion for single-count histograms without bucket boundaries (#151411)](https://github.com/elastic/elasticsearch/pull/151411)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)