### PR TITLE
[CI] Fix example-plugins NPE on JDK 17

### DIFF
--- a/.buildkite/pipelines/pull-request/example-plugins.yml
+++ b/.buildkite/pipelines/pull-request/example-plugins.yml
@@ -4,6 +4,8 @@ config:
     - build-tools/.*
     - build-tools-internal/.*
     - plugins/examples/.*
+    - \.buildkite/pipelines/pull-request/example-plugins\.yml
+    - \.ci/scripts/example-plugins\.sh
 steps:
   - label: example-plugins
     command: |-

--- a/.buildkite/pipelines/pull-request/example-plugins.yml
+++ b/.buildkite/pipelines/pull-request/example-plugins.yml
@@ -9,7 +9,7 @@ config:
 steps:
   - label: example-plugins
     command: |-
-      ./.ci/scripts/example-plugins.sh -Dorg.gradle.jvmargs=-Xmx8g -Dtests.jvm.argline=-XX:-UseContainerSupport build --include-build $$WORKSPACE
+      ./.ci/scripts/example-plugins.sh -Dorg.gradle.jvmargs="-Xmx8g -XX:-UseContainerSupport" build --include-build $$WORKSPACE
     timeout_in_minutes: 300
     agents:
       provider: gcp

--- a/.buildkite/pipelines/pull-request/example-plugins.yml
+++ b/.buildkite/pipelines/pull-request/example-plugins.yml
@@ -7,7 +7,7 @@ config:
 steps:
   - label: example-plugins
     command: |-
-      ./.ci/scripts/example-plugins.sh -Dorg.gradle.jvmargs=-Xmx8g build --include-build $$WORKSPACE
+      ./.ci/scripts/example-plugins.sh -Dorg.gradle.jvmargs=-Xmx8g -Dtests.jvm.argline=-XX:-UseContainerSupport build --include-build $$WORKSPACE
     timeout_in_minutes: 300
     agents:
       provider: gcp


### PR DESCRIPTION
The build trips [JDK-8281571](https://bugs.openjdk.org/browse/JDK-8281571)  NPE in `CgroupV2Subsystem` when the JVM probes container CPU/memory limits on a cgroup-v2 host.

```
java.lang.NullPointerException: Cannot invoke "jdk.internal.platform.CgroupInfo.getMountPoint()" because "anyController" is null	
```

The workaround is to pass `-XX:-UseContainerSupport` which disables container resource probing and avoid hitting the JDK bug.

Note: The proper fix is updating the agents' JDK installs to 17.0.7 or later to avoid NPE bug.
