### PR TITLE
[9.4] Ids Query: Throw IllegalArgumentException (#151234)

### DIFF
--- a/docs/changelog/151234.yaml
+++ b/docs/changelog/151234.yaml
@@ -1,0 +1,6 @@
+area: Search
+issues:
+ - 150305
+pr: 151234
+summary: "Ids Query: Throw `IllegalArgumentException`"
+type: bug

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/630_ids_query.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/630_ids_query.yml
@@ -40,3 +40,44 @@ setup:
   - match: { error.root_cause.0.type: "query_shard_exception" }
   - match: { error.root_cause.0.reason: "failed to create query: Too many ids specified, allowed max result window is [2]" }
 
+---
+"ids query in aggregation filter returns error above max result window":
+  - requires:
+      cluster_features: ["ids_query_limit_max_ids"]
+      reason: "Ensure a limited number if ids can be supplied to ids query"
+
+  - do:
+      catch: bad_request
+      search:
+        body:
+          size: 0
+          aggs:
+            too_many_ids:
+              filter:
+                ids:
+                  values: [1, 2, 3]
+  - match: { status: 400 }
+  - match: { error.root_cause.0.type: "illegal_argument_exception" }
+  - match: { error.root_cause.0.reason: "Too many ids specified, allowed max result window is [2]" }
+
+---
+"ids query in highlight_query returns error above max result window":
+  - requires:
+      cluster_features: ["ids_query_limit_max_ids"]
+      reason: "Ensure a limited number if ids can be supplied to ids query"
+
+  - do:
+      catch: bad_request
+      search:
+        body:
+          query:
+            match_all: {}
+          highlight:
+            highlight_query:
+              ids:
+                values: [1, 2, 3]
+            fields:
+              key: {}
+  - match: { status: 400 }
+  - match: { error.root_cause.0.type: "illegal_argument_exception" }
+  - match: { error.root_cause.0.reason: "Too many ids specified, allowed max result window is [2]" }

--- a/server/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
@@ -126,7 +126,7 @@ public class IdsQueryBuilder extends LeafQueryBuilder<IdsQueryBuilder> {
     @Override
     protected Query doToQuery(SearchExecutionContext context) throws IOException {
         if (ids.size() > context.indexSettings.getMaxResultWindow()) {
-            throw new IllegalStateException(
+            throw new IllegalArgumentException(
                 "Too many ids specified, allowed max result window is [" + context.indexSettings.getMaxResultWindow() + "]"
             );
         }

--- a/server/src/test/java/org/elasticsearch/index/query/IdsQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/IdsQueryBuilderTests.java
@@ -101,7 +101,7 @@ public class IdsQueryBuilderTests extends AbstractQueryTestCase<IdsQueryBuilder>
             SearchExecutionContextHelper.SHARD_SEARCH_STATS
         );
 
-        IllegalStateException e = assertThrows(IllegalStateException.class, () -> builder.doToQuery(searchExecutionContext));
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> builder.doToQuery(searchExecutionContext));
         assertThat(e.getMessage(), equalTo("Too many ids specified, allowed max result window is [2]"));
     }
 


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Ids Query: Throw IllegalArgumentException (#151234)