### PR TITLE
[CI] Fix example-plugins by patching java path

### DIFF
--- a/.buildkite/pipelines/pull-request/example-plugins.yml
+++ b/.buildkite/pipelines/pull-request/example-plugins.yml
@@ -4,6 +4,8 @@ config:
     - build-tools/.*
     - build-tools-internal/.*
     - plugins/examples/.*
+    - \.buildkite/pipelines/pull-request/example-plugins\.yml
+    - \.ci/scripts/example-plugins\.sh
 steps:
   - label: example-plugins
     command: |-

--- a/.ci/scripts/example-plugins.sh
+++ b/.ci/scripts/example-plugins.sh
@@ -19,5 +19,8 @@ resolve_java_home() {
 
 cd $WORKSPACE/plugins/examples
 
-JAVA_HOME=$(resolve_java_home) \
-  $WORKSPACE/.ci/scripts/run-gradle.sh $@
+JAVA_HOME=$(resolve_java_home)
+export JAVA_HOME
+export PATH="$JAVA_HOME/bin:$PATH"
+
+"$WORKSPACE/.ci/scripts/run-gradle.sh" "$@"


### PR DESCRIPTION
The #150528 changed the JDK launch path which caused the `example-plugins.sh`'s `JAVA_HOME` redirect to no longer be honored because the new launch path resolves java via `PATH` (not `JAVA_HOME`).