### PR TITLE
Use close to in some YAML knn test to avoid floating point errors

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -617,12 +617,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
   method: test {p0=esql/160_union_types/load four indices with single conversion function TO_IP}
   issue: https://github.com/elastic/elasticsearch/issues/151413
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=search.vectors/40_knn_search/Vector rescoring has no effect for non-quantized vectors and provides same results as non-rescored knn}
-  issue: https://github.com/elastic/elasticsearch/issues/151418
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=search.vectors/42_knn_search_flat/Vector rescoring has no effect for non-quantized vectors and provides same results as non-rescored knn}
-  issue: https://github.com/elastic/elasticsearch/issues/151453
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
   method: test {feature:SUBQUERIES}
   issue: https://github.com/elastic/elasticsearch/issues/149681

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/40_knn_search.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/40_knn_search.yml
@@ -558,7 +558,7 @@ setup:
 "Vector rescoring has no effect for non-quantized vectors and provides same results as non-rescored knn":
   - requires:
       reason: 'Quantized vector rescoring is required'
-      test_runner_features: [capabilities]
+      test_runner_features: [capabilities, close_to]
       capabilities:
         - method: GET
           path: /_search
@@ -606,9 +606,9 @@ setup:
 
   # Compare scores as hit IDs may change depending on how things are distributed
   - match: { hits.total: 3 }
-  - match: { hits.hits.0._score: $knn_score0 }
-  - match: { hits.hits.1._score: $knn_score1 }
-  - match: { hits.hits.2._score: $knn_score2 }
+  - close_to: { hits.hits.0._score: { value: $knn_score0, error: 0.000001 }}
+  - close_to: { hits.hits.1._score: { value: $knn_score1, error: 0.000001 }}
+  - close_to: { hits.hits.2._score: { value: $knn_score2, error: 0.000001 }}
 
 ---
 "Dimensions are dynamically set":

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/42_knn_search_flat.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/42_knn_search_flat.yml
@@ -260,7 +260,7 @@ setup:
 "Vector rescoring has no effect for non-quantized vectors and provides same results as non-rescored knn":
   - requires:
       reason: 'Quantized vector rescoring is required'
-      test_runner_features: [capabilities]
+      test_runner_features: [capabilities, close_to]
       capabilities:
         - method: GET
           path: /_search
@@ -308,9 +308,9 @@ setup:
 
   # Compare scores as hit IDs may change depending on how things are distributed
   - match: { hits.total: 3 }
-  - match: { hits.hits.0._score: $knn_score0 }
-  - match: { hits.hits.1._score: $knn_score1 }
-  - match: { hits.hits.2._score: $knn_score2 }
+  - close_to: { hits.hits.0._score: { value: $knn_score0, error: 0.000001 }}
+  - close_to: { hits.hits.1._score: { value: $knn_score1, error: 0.000001 }}
+  - close_to: { hits.hits.2._score: { value: $knn_score2, error: 0.000001 }}
 ---
 "Test bad parameters":
   - do:


### PR DESCRIPTION
fixes https://github.com/elastic/elasticsearch/issues/151418
fixes https://github.com/elastic/elasticsearch/issues/151453