### PR TITLE
Mute ESVectorUtilTests#testLogSumExpNQT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -1,4 +1,7 @@
 tests:
+- class: org.elasticsearch.simdvec.ESVectorUtilTests
+  method: testLogSumExpNQT
+  issue: https://github.com/elastic/elasticsearch/issues/151487
 - class: org.elasticsearch.packaging.test.PackagesSecurityAutoConfigurationTests
   method: test20SecurityNotAutoConfiguredOnReInstallation
   issue: https://github.com/elastic/elasticsearch/issues/112635


### PR DESCRIPTION
Mutes `org.elasticsearch.simdvec.ESVectorUtilTests#testLogSumExpNQT` which is failing intermittently on FIPS runners due to floating-point precision in SIMD log-sum-exp computation.

Relates #151487