### PR TITLE
Add YAML REST tests for logsdb_columnar with passthrough objects

### DIFF
--- a/x-pack/plugin/logsdb/src/yamlRestTest/resources/rest-api-spec/test/32_columnar_logsdb_passthrough.yml
+++ b/x-pack/plugin/logsdb/src/yamlRestTest/resources/rest-api-spec/test/32_columnar_logsdb_passthrough.yml
@@ -1,0 +1,198 @@
+---
+setup:
+  - requires:
+      test_runner_features: [ capabilities, allowed_warnings ]
+      capabilities:
+        - method: PUT
+          path: /{index}
+          capabilities: [ columnar_index_modes ]
+      reason: "Support for columnar index modes required"
+
+---
+"passthrough object with static and dynamic fields":
+  - do:
+      cluster.put_component_template:
+        name: "cl-passthrough-mappings"
+        body:
+          template:
+            settings:
+              mode: "logsdb_columnar"
+            mappings:
+              properties:
+                host.name:
+                  type: keyword
+                log.level:
+                  type: keyword
+                attributes:
+                  type: passthrough
+                  dynamic: true
+                  priority: 1
+
+  - do:
+      indices.put_index_template:
+        name: "cl-passthrough-index-template"
+        body:
+          index_patterns: [ "logs-cl-passthrough-test" ]
+          priority: 1000
+          data_stream: {}
+          composed_of: [ "cl-passthrough-mappings" ]
+      allowed_warnings:
+        - "index template [cl-passthrough-index-template] has index patterns [logs-cl-passthrough-test] matching patterns from existing older templates [global] with patterns (global => [*]); this template [cl-passthrough-index-template] will take precedence during new index creation"
+
+  - do:
+      indices.create_data_stream:
+        name: "logs-cl-passthrough-test"
+  - is_true: acknowledged
+
+  - do:
+      bulk:
+        index: "logs-cl-passthrough-test"
+        refresh: true
+        body:
+          - '{"create":{}}'
+          - '{"@timestamp":"2024-01-01T00:00:00.000Z","host.name":"web-01","log.level":"INFO","attributes.service":"frontend","attributes.env":"prod"}'
+          - '{"create":{}}'
+          - '{"@timestamp":"2024-01-01T00:00:01.000Z","host.name":"web-02","log.level":"WARN","attributes.service":"backend","attributes.env":"staging"}'
+  - match: { errors: false }
+
+  - do:
+      search:
+        index: "logs-cl-passthrough-test"
+        body:
+          size: 0
+  - match: { hits.total.value: 2 }
+
+  # Dynamic passthrough sub-fields are accessible via root-level aliases
+  - do:
+      search:
+        index: "logs-cl-passthrough-test"
+        body:
+          query:
+            term:
+              env: "prod"
+  - match: { hits.total.value: 1 }
+
+  # Same field is also accessible via the full passthrough path
+  - do:
+      search:
+        index: "logs-cl-passthrough-test"
+        body:
+          query:
+            term:
+              attributes.env: "prod"
+  - match: { hits.total.value: 1 }
+
+  # Static fields work normally alongside passthrough
+  - do:
+      search:
+        index: "logs-cl-passthrough-test"
+        body:
+          query:
+            bool:
+              filter:
+                - term:
+                    log.level: "WARN"
+                - term:
+                    service: "backend"
+  - match: { hits.total.value: 1 }
+
+  # Dynamic passthrough sub-fields appear in the mapping
+  - do:
+      indices.get_data_stream:
+        name: "logs-cl-passthrough-test"
+        expand_wildcards: hidden
+  - set: { data_streams.0.indices.0.index_name: backing_index }
+
+  - do:
+      indices.get_mapping:
+        index: $backing_index
+  - match: { .$backing_index.mappings.properties.attributes.type: passthrough }
+  - match: { .$backing_index.mappings.properties.attributes.properties.service.type: keyword }
+  - match: { .$backing_index.mappings.properties.attributes.properties.env.type: keyword }
+
+---
+"two passthrough objects with priority - higher priority alias wins":
+  - do:
+      cluster.put_component_template:
+        name: "cl-passthrough-priority-mappings"
+        body:
+          template:
+            settings:
+              mode: "logsdb_columnar"
+            mappings:
+              properties:
+                host.name:
+                  type: keyword
+                attributes:
+                  type: passthrough
+                  dynamic: true
+                  priority: 1
+                resource:
+                  type: passthrough
+                  dynamic: true
+                  priority: 2
+
+  - do:
+      indices.put_index_template:
+        name: "cl-passthrough-priority-template"
+        body:
+          index_patterns: [ "logs-cl-passthrough-priority-test" ]
+          priority: 1000
+          data_stream: {}
+          composed_of: [ "cl-passthrough-priority-mappings" ]
+      allowed_warnings:
+        - "index template [cl-passthrough-priority-template] has index patterns [logs-cl-passthrough-priority-test] matching patterns from existing older templates [global] with patterns (global => [*]); this template [cl-passthrough-priority-template] will take precedence during new index creation"
+
+  - do:
+      indices.create_data_stream:
+        name: "logs-cl-passthrough-priority-test"
+  - is_true: acknowledged
+
+  # Index a document where both passthroughs have the same sub-field name "region"
+  - do:
+      bulk:
+        index: "logs-cl-passthrough-priority-test"
+        refresh: true
+        body:
+          - '{"create":{}}'
+          - '{"@timestamp":"2024-01-01T00:00:00.000Z","host.name":"node-01","attributes.region":"us-east","resource.region":"us-west"}'
+  - match: { errors: false }
+
+  # Root alias "region" resolves to resource.region (priority 2 > 1)
+  - do:
+      search:
+        index: "logs-cl-passthrough-priority-test"
+        body:
+          query:
+            term:
+              region: "us-west"
+  - match: { hits.total.value: 1 }
+
+  # Root alias "region" does not match attributes.region value
+  - do:
+      search:
+        index: "logs-cl-passthrough-priority-test"
+        body:
+          query:
+            term:
+              region: "us-east"
+  - match: { hits.total.value: 0 }
+
+  # Both concrete paths remain independently searchable
+  - do:
+      search:
+        index: "logs-cl-passthrough-priority-test"
+        body:
+          query:
+            term:
+              attributes.region: "us-east"
+  - match: { hits.total.value: 1 }
+
+  - do:
+      search:
+        index: "logs-cl-passthrough-priority-test"
+        body:
+          query:
+            term:
+              resource.region: "us-west"
+  - match: { hits.total.value: 1 }


### PR DESCRIPTION
## Summary

- Adds `32_columnar_logsdb_passthrough.yml` to the logsdb YAML REST test suite, covering `logsdb_columnar` index mode with `passthrough` object type mappings
- Test 1: a `passthrough` object with static fields (`host.name`, `log.level`) and dynamic sub-fields; verifies root-level aliases, full-path queries, and that dynamic fields appear in the backing index mapping after indexing
- Test 2: two `passthrough` objects (`attributes` priority 1, `resource` priority 2) with a conflicting sub-field name; verifies that the higher-priority passthrough's alias wins at the root level while both concrete paths remain independently queryable

## Test plan

- [ ] `./gradlew :x-pack:plugin:logsdb:yamlRestTest --tests "*.32_columnar_logsdb_passthrough*"`