### PR TITLE
Enforce non-null fields in StatusInfo.

### DIFF
--- a/server/src/main/java/org/elasticsearch/monitor/StatusInfo.java
+++ b/server/src/main/java/org/elasticsearch/monitor/StatusInfo.java
@@ -14,12 +14,18 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 
 import java.io.IOException;
+import java.util.Objects;
 
 /**
  * Class that represents the Health status for a node as determined by {@link NodeHealthService} and provides additional
  * info explaining the reasons
  */
 public record StatusInfo(Status status, String info) implements Writeable {
+
+    public StatusInfo {
+        Objects.requireNonNull(status, "Expected a non null status");
+        Objects.requireNonNull(info, "Expected a non null info");
+    }
 
     public StatusInfo(StreamInput in) throws IOException {
         this(readStatus(in), in.readString());
@@ -45,7 +51,7 @@ public record StatusInfo(Status status, String info) implements Writeable {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeString(status == null ? null : status.name());
+        out.writeString(status.name());
         out.writeString(info);
     }
 

--- a/server/src/test/java/org/elasticsearch/monitor/StatusInfoWireSerializingTests.java
+++ b/server/src/test/java/org/elasticsearch/monitor/StatusInfoWireSerializingTests.java
@@ -31,4 +31,17 @@ public class StatusInfoWireSerializingTests extends AbstractWireSerializingTestC
         // Since StatusInfo is a record, we don't need to check for equality
         return null;
     }
+
+    public void testNullStatusIsRejected() {
+        NullPointerException e = expectThrows(NullPointerException.class, () -> new StatusInfo(null, randomAlphaOfLengthBetween(0, 200)));
+        assertEquals("Expected a non null status", e.getMessage());
+    }
+
+    public void testNullInfoIsRejected() {
+        NullPointerException e = expectThrows(
+            NullPointerException.class,
+            () -> new StatusInfo(randomFrom(StatusInfo.Status.values()), null)
+        );
+        assertEquals("Expected a non null info", e.getMessage());
+    }
 }


### PR DESCRIPTION
The misleading `status == null ? null : status.name()` in `StatusInfo#writeTo` threw an opaque NPE during serialization rather than actually handling `null`. This PR validates `status` and `info` as non-null in the compact constructor so construction fails fast with a clear message, simplifies `writeTo` accordingly, and adds tests.
