### PR TITLE
Fix flaky decRef race in BytesReadRankFeatureIT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -605,9 +605,6 @@ tests:
 - class: org.elasticsearch.upgrades.MultiVersionRepositoryAccessIT
   method: testUpgradeMovesRepoToNewMetaVersion
   issue: https://github.com/elastic/elasticsearch/issues/151391
-- class: org.elasticsearch.index.store.BytesReadRankFeatureIT
-  method: testRankFeaturePhaseEmptyDocIdsStillReportsDirectoryMetrics
-  issue: https://github.com/elastic/elasticsearch/issues/151392
 - class: org.elasticsearch.xpack.stateless.cluster.coordination.TransportConsistentClusterStateReadIT
   method: testWaitsUntilTheNodeRejoinsTheClusterToReturnAValidClusterState
   issue: https://github.com/elastic/elasticsearch/issues/151402

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/store/BytesReadRankFeatureIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/store/BytesReadRankFeatureIT.java
@@ -150,13 +150,7 @@ public class BytesReadRankFeatureIT extends ESIntegTestCase {
             );
         } finally {
             if (queryResult != null) {
-                if (queryResult.hasReferences()) {
-                    queryResult.decRef();
-                }
                 searchService.freeReaderContext(queryResult.getContextId());
-            }
-            if (rankResult != null && rankResult.hasReferences()) {
-                rankResult.decRef();
             }
         }
     }


### PR DESCRIPTION
Closes: #151392

The test delivered query and rank phase results through 

SearchService.runAsync -> ActionRunnable.supplyAndDecRef -> ActionListener.respondAndRelease, 

which owns the final `decRef` once onResponse returns. The `PlainActionFuture` never incRefs, so the framework releases the last reference itself. The finally block then did a racy `hasReferences()/decRef()` on the same results: when a search thread stalled between onResponse and its own decRef, the test thread reached finally first and closed the result, so the resuming search thread double-decRef'd and tripped "invalid decRef call: already closed".
