### PR TITLE
feat(mapper): reject runtime fields in columnar modes

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mapping/60_columnar_runtime_fields.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mapping/60_columnar_runtime_fields.yml
@@ -1,0 +1,175 @@
+setup:
+  - requires:
+      test_runner_features: [ capabilities ]
+      capabilities:
+        - method: PUT
+          path: /{index}
+          capabilities: [ columnar_index_modes ]
+      reason: "columnar index modes required"
+
+---
+
+"columnar rejects runtime fields in create index mapping":
+  - do:
+      catch: bad_request
+      indices.create:
+        index: test_columnar_runtime
+        body:
+          settings:
+            index.mode: columnar
+          mappings:
+            properties:
+              kwd:
+                type: keyword
+            runtime:
+              runtime_kwd:
+                type: keyword
+  - match: { status: 400 }
+  - match: { error.type: "illegal_argument_exception" }
+  - match: { error.reason: "mapping-level runtime fields are not allowed in index using [columnar] index mode" }
+
+---
+
+"columnar rejects runtime fields in put mapping":
+  - do:
+      indices.create:
+        index: test_columnar_put_runtime
+        body:
+          settings:
+            index.mode: columnar
+          mappings:
+            properties:
+              kwd:
+                type: keyword
+
+  - do:
+      catch: bad_request
+      indices.put_mapping:
+        index: test_columnar_put_runtime
+        body:
+          runtime:
+            runtime_kwd:
+              type: keyword
+  - match: { status: 400 }
+  - match: { error.type: "illegal_argument_exception" }
+  - match: { error.reason: "mapping-level runtime fields are not allowed in index using [columnar] index mode" }
+
+---
+
+"columnar accepts query-time runtime mappings":
+  - do:
+      indices.create:
+        index: test_columnar_query_runtime
+        body:
+          settings:
+            index.mode: columnar
+          mappings:
+            properties:
+              kwd:
+                type: keyword
+
+  - do:
+      index:
+        index: test_columnar_query_runtime
+        id: "1"
+        refresh: true
+        body:
+          kwd: foo
+
+  - do:
+      search:
+        index: test_columnar_query_runtime
+        body:
+          runtime_mappings:
+            runtime_upper:
+              type: keyword
+              script:
+                source: "emit(doc['kwd'].value.toUpperCase())"
+          fields: [ runtime_upper ]
+          _source: false
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0.fields.runtime_upper: [ "FOO" ] }
+
+---
+
+"logsdb_columnar rejects runtime fields in create index mapping":
+  - do:
+      catch: bad_request
+      indices.create:
+        index: test_logsdb_columnar_runtime
+        body:
+          settings:
+            index.mode: logsdb_columnar
+          mappings:
+            properties:
+              kwd:
+                type: keyword
+            runtime:
+              runtime_kwd:
+                type: keyword
+  - match: { status: 400 }
+  - match: { error.type: "illegal_argument_exception" }
+  - match: { error.reason: "mapping-level runtime fields are not allowed in index using [logsdb_columnar] index mode" }
+
+---
+
+"logsdb_columnar rejects runtime fields in put mapping":
+  - do:
+      indices.create:
+        index: test_logsdb_columnar_put_runtime
+        body:
+          settings:
+            index.mode: logsdb_columnar
+          mappings:
+            properties:
+              kwd:
+                type: keyword
+
+  - do:
+      catch: bad_request
+      indices.put_mapping:
+        index: test_logsdb_columnar_put_runtime
+        body:
+          runtime:
+            runtime_kwd:
+              type: keyword
+  - match: { status: 400 }
+  - match: { error.type: "illegal_argument_exception" }
+  - match: { error.reason: "mapping-level runtime fields are not allowed in index using [logsdb_columnar] index mode" }
+
+---
+
+"logsdb_columnar accepts query-time runtime mappings":
+  - do:
+      indices.create:
+        index: test_logsdb_columnar_query_runtime
+        body:
+          settings:
+            index.mode: logsdb_columnar
+          mappings:
+            properties:
+              kwd:
+                type: keyword
+
+  - do:
+      index:
+        index: test_logsdb_columnar_query_runtime
+        id: "1"
+        refresh: true
+        body:
+          "@timestamp": "2024-01-01T00:00:00Z"
+          kwd: foo
+
+  - do:
+      search:
+        index: test_logsdb_columnar_query_runtime
+        body:
+          runtime_mappings:
+            runtime_upper:
+              type: keyword
+              script:
+                source: "emit(doc['kwd'].value.toUpperCase())"
+          fields: [ runtime_upper ]
+          _source: false
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0.fields.runtime_upper: [ "FOO" ] }

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/mapper/ColumnarRuntimeFieldsValidationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/mapper/ColumnarRuntimeFieldsValidationIT.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexMode;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.xcontent.XContentType;
+import org.junit.Before;
+
+import java.util.Random;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.hamcrest.Matchers.containsString;
+
+public class ColumnarRuntimeFieldsValidationIT extends ESIntegTestCase {
+
+    private static final String MAPPING_WITH_RUNTIME_FIELD = """
+        {
+          "properties": {
+            "kwd": { "type": "keyword" }
+          },
+          "runtime": {
+            "runtime_kwd": { "type": "keyword" }
+          }
+        }
+        """;
+
+    private static final String MAPPING_WITHOUT_RUNTIME_FIELD = """
+        {
+          "properties": {
+            "kwd": { "type": "keyword" }
+          }
+        }
+        """;
+
+    private static final String RUNTIME_FIELD_PUT_MAPPING_BODY = """
+        {
+          "runtime": {
+            "runtime_kwd": { "type": "keyword" }
+          }
+        }
+        """;
+
+    @Before
+    public void checkFeatureFlag() {
+        assumeTrue("columnar index modes require snapshot build", IndexMode.COLUMNAR_FEATURE_FLAG.isEnabled());
+    }
+
+    @Override
+    protected Settings.Builder setRandomIndexSettings(Random random, Settings.Builder builder) {
+        // Columnar mode requires DOC_VALUES_ONLY for seq_no; remove the randomly-chosen value so
+        // it doesn't conflict with the index-mode default (disable_sequence_numbers=true).
+        return super.setRandomIndexSettings(random, builder).remove(IndexSettings.SEQ_NO_INDEX_OPTIONS_SETTING.getKey());
+    }
+
+    public void testColumnarCreateIndexRejectsRuntimeField() {
+        assertCreateIndexRejected(IndexMode.COLUMNAR, "test_columnar_create_runtime");
+    }
+
+    public void testColumnarPutMappingRejectsRuntimeField() {
+        assertPutMappingRejected(IndexMode.COLUMNAR, "test_columnar_put_runtime");
+    }
+
+    public void testLogsdbColumnarCreateIndexRejectsRuntimeField() {
+        assertCreateIndexRejected(IndexMode.LOGSDB_COLUMNAR, "test_logsdb_columnar_create_runtime");
+    }
+
+    public void testLogsdbColumnarPutMappingRejectsRuntimeField() {
+        assertPutMappingRejected(IndexMode.LOGSDB_COLUMNAR, "test_logsdb_columnar_put_runtime");
+    }
+
+    private void assertCreateIndexRejected(IndexMode mode, String index) {
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> prepareCreate(index).setSettings(modeSettings(mode)).setMapping(MAPPING_WITH_RUNTIME_FIELD).get()
+        );
+        assertThat(e.getMessage(), containsString("mapping-level runtime fields are not allowed in index using [" + mode + "] index mode"));
+    }
+
+    private void assertPutMappingRejected(IndexMode mode, String index) {
+        assertAcked(prepareCreate(index).setSettings(modeSettings(mode)).setMapping(MAPPING_WITHOUT_RUNTIME_FIELD));
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> indicesAdmin().preparePutMapping(index).setSource(RUNTIME_FIELD_PUT_MAPPING_BODY, XContentType.JSON).get()
+        );
+        assertThat(e.getMessage(), containsString("mapping-level runtime fields are not allowed in index using [" + mode + "] index mode"));
+    }
+
+    private static Settings modeSettings(IndexMode mode) {
+        return Settings.builder().put(IndexSettings.MODE.getKey(), mode.getName()).build();
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/IndexMode.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexMode.java
@@ -471,7 +471,9 @@ public enum IndexMode {
         }
 
         @Override
-        public void validateMapping(MappingLookup lookup, Settings settings) {}
+        public void validateMapping(MappingLookup lookup, Settings settings) {
+            validateNoMappingRuntimeFields(lookup, this);
+        }
 
         @Override
         public void validateAlias(String indexRouting, String searchRouting) {
@@ -569,7 +571,9 @@ public enum IndexMode {
         }
 
         @Override
-        public void validateMapping(MappingLookup lookup, Settings settings) {}
+        public void validateMapping(MappingLookup lookup, Settings settings) {
+            validateNoMappingRuntimeFields(lookup, this);
+        }
 
         @Override
         public void validateAlias(String indexRouting, String searchRouting) {
@@ -739,6 +743,17 @@ public enum IndexMode {
 
     protected static String tsdbMode() {
         return "[" + IndexSettings.MODE.getKey() + "=time_series]";
+    }
+
+    /**
+     * Rejects mappings that declare runtime fields at the root of the document mapping.
+     */
+    private static void validateNoMappingRuntimeFields(MappingLookup lookup, IndexMode mode) {
+        // TODO Consider including the names of the offending runtime fields in this error message
+        // so users can locate the index or component template that introduced them.
+        if (lookup.getMapping().getRoot().runtimeFields().isEmpty() == false) {
+            throw new IllegalArgumentException("mapping-level runtime fields are not allowed in index using [" + mode + "] index mode");
+        }
     }
 
     private static CompressedXContent createDefaultMapping(CheckedConsumer<XContentBuilder, IOException> fieldsCustomizer)

--- a/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
@@ -271,7 +271,7 @@ public class RootObjectMapper extends ObjectMapper {
         return dynamicTemplates.value();
     }
 
-    Collection<RuntimeField> runtimeFields() {
+    public Collection<RuntimeField> runtimeFields() {
         return runtimeFields.values();
     }
 

--- a/server/src/test/java/org/elasticsearch/index/ColumnarMappingRuntimeFieldsValidationTests.java
+++ b/server/src/test/java/org/elasticsearch/index/ColumnarMappingRuntimeFieldsValidationTests.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.mapper.MapperServiceTestCase;
+
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.containsString;
+
+public class ColumnarMappingRuntimeFieldsValidationTests extends MapperServiceTestCase {
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        assumeTrue("columnar index modes require snapshot build", IndexMode.COLUMNAR_FEATURE_FLAG.isEnabled());
+    }
+
+    public void testColumnarRejectsSingleRootRuntimeField() {
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> createMapperService(
+                columnarSettings(IndexMode.COLUMNAR),
+                runtimeMapping(b -> b.startObject("runtime_keyword").field("type", "keyword").endObject())
+            )
+        );
+        assertRuntimeFieldRejected(e, IndexMode.COLUMNAR);
+    }
+
+    public void testColumnarRejectsMultipleRootRuntimeFields() {
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> createMapperService(columnarSettings(IndexMode.COLUMNAR), runtimeMapping(b -> {
+                b.startObject("runtime_keyword").field("type", "keyword").endObject();
+                b.startObject("runtime_long").field("type", "long").endObject();
+            }))
+        );
+        assertRuntimeFieldRejected(e, IndexMode.COLUMNAR);
+    }
+
+    public void testColumnarAcceptsMappingWithoutRuntimeFields() throws IOException {
+        createMapperService(columnarSettings(IndexMode.COLUMNAR), mapping(b -> {
+            b.startObject("name").field("type", "keyword").endObject();
+            b.startObject("count").field("type", "long").endObject();
+        }));
+    }
+
+    public void testLogsdbColumnarRejectsSingleRootRuntimeField() {
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> createMapperService(
+                columnarSettings(IndexMode.LOGSDB_COLUMNAR),
+                runtimeMapping(b -> b.startObject("runtime_keyword").field("type", "keyword").endObject())
+            )
+        );
+        assertRuntimeFieldRejected(e, IndexMode.LOGSDB_COLUMNAR);
+    }
+
+    public void testLogsdbColumnarRejectsMultipleRootRuntimeFields() {
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> createMapperService(columnarSettings(IndexMode.LOGSDB_COLUMNAR), runtimeMapping(b -> {
+                b.startObject("runtime_keyword").field("type", "keyword").endObject();
+                b.startObject("runtime_long").field("type", "long").endObject();
+            }))
+        );
+        assertRuntimeFieldRejected(e, IndexMode.LOGSDB_COLUMNAR);
+    }
+
+    public void testLogsdbColumnarAcceptsMappingWithoutRuntimeFields() throws IOException {
+        createMapperService(columnarSettings(IndexMode.LOGSDB_COLUMNAR), mapping(b -> {
+            b.startObject("name").field("type", "keyword").endObject();
+            b.startObject("count").field("type", "long").endObject();
+        }));
+    }
+
+    private static Settings columnarSettings(IndexMode mode) {
+        return Settings.builder().put(IndexSettings.MODE.getKey(), mode.getName()).build();
+    }
+
+    private static void assertRuntimeFieldRejected(IllegalArgumentException e, IndexMode mode) {
+        assertThat(e.getMessage(), containsString("mapping-level runtime fields are not allowed in index using [" + mode + "] index mode"));
+    }
+}

--- a/x-pack/qa/runtime-fields/build.gradle
+++ b/x-pack/qa/runtime-fields/build.gradle
@@ -106,6 +106,8 @@ subprojects {
           'aggregations/composite_sorted/*',
           // timeseries dimensions can't be runtime fields
           'aggregations/time_series/*',
+          // columnar index modes reject mapping-level runtime fields
+          'search/400_columnar_default_field/*',
           // The error messages are different
           'search/330_fetch_fields/error includes field name',
           'search/330_fetch_fields/error includes glob pattern',


### PR DESCRIPTION
## TL;DR

Reject mapping-level runtime fields in indices using `columnar` or `logsdb_columnar` index modes. The validation runs during mapping parsing and throws an `IllegalArgumentException` that the REST layer translates to a 400 Bad Request. Query-time runtime fields supplied via `runtime_mappings` on a search request are unaffected because they never traverse index mapping validation. Closes elastic/logs-program#124.

## Summary

The `columnar` and `logsdb_columnar` index modes do not support mapping-level runtime fields declared under the root `runtime` block of an index mapping. This PR enforces that boundary at mapping-validation time so that creating or updating an index in a columnar mode with a `runtime` block fails fast with a 400.

The validation hook is `IndexMode#validateMapping`, called from `DocumentMapper` whenever a mapping is built. For both `COLUMNAR` and `LOGSDB_COLUMNAR`, the override calls a shared helper `validateNoMappingRuntimeFields` that reads `lookup.getMapping().getRoot().runtimeFields()` and throws when the collection is non-empty. To enable that call from outside the `org.elasticsearch.index.mapper` package, `RootObjectMapper#runtimeFields()` is widened from package-private to public, with no behavioural impact for existing callers.

Query-time runtime fields are unaffected: they arrive via `SearchSourceBuilder#runtimeMappings` on the search request and are merged in at query-parse time, so the path that this PR guards is never invoked for them. The yaml suite exercises both branches in the same file to make the boundary explicit.

A `TODO` in `validateNoMappingRuntimeFields` records a follow-up: surface the names of the offending runtime fields in the error so users can locate the index or component template that introduced them. Templates are merged before mapping validation runs, so the offending field can come from a component template the user did not author directly.

## Changes

- `IndexMode.java`: adds the private `validateNoMappingRuntimeFields(MappingLookup, IndexMode)` helper and wires it into `COLUMNAR#validateMapping` and `LOGSDB_COLUMNAR#validateMapping`.
- `RootObjectMapper.java`: widens `runtimeFields()` from package-private to public so the helper above can call it from `org.elasticsearch.index`.
- `ColumnarMappingRuntimeFieldsValidationTests.java`: new unit suite for both columnar modes.
- `ColumnarRuntimeFieldsValidationIT.java`: new integration suite covering rejection on `indices.create` and `indices.put_mapping` for both modes. Overrides `setRandomIndexSettings` to drop the random `index.seq_no.index_options`, mirroring `SyntheticVersusColumnarStoredSourceIT`.
- `60_columnar_runtime_fields.yml`: new yaml suite covering rejection on create and put_mapping, plus the positive case where query-time `runtime_mappings` are accepted.
- `build.gradle`: blacklists `search/400_columnar_default_field/*` in the `core-with-mapped` runtime-fields variant, mirroring `aggregations/time_series/*`. That variant rewrites every yaml test to inject mapping-level runtime fields, which the validation above now rejects.

## Testing

```
./gradlew :server:spotlessApply :server:compileJava :server:compileTestJava :server:compileInternalClusterTestJava
./gradlew :server:test --tests "*ColumnarMappingRuntimeFieldsValidationTests"
./gradlew :server:internalClusterTest --tests "*ColumnarRuntimeFieldsValidationIT"
./gradlew :rest-api-spec:yamlRestTest --tests "org.elasticsearch.test.rest.ClientYamlTestSuiteIT.test {yaml=mapping/60_columnar_runtime_fields/*}"
```

