### PR TITLE
Fix capitalization in plugin titles

### DIFF
--- a/docs/reference/elasticsearch-plugins/cloud-aws-best-practices.md
+++ b/docs/reference/elasticsearch-plugins/cloud-aws-best-practices.md
@@ -3,7 +3,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/plugins/current/cloud-aws-best-practices.html
 ---
 
-# Best Practices in AWS [cloud-aws-best-practices]
+# Best practices in AWS [cloud-aws-best-practices]
 
 This section contains some other information about designing and managing an {{es}} cluster on your own AWS infrastructure. If you would prefer to avoid these operational details then you may be interested in a hosted {{es}} installation available on AWS-based infrastructure from [https://www.elastic.co/cloud](https://www.elastic.co/cloud).
 

--- a/docs/reference/elasticsearch-plugins/discovery-azure-classic-long.md
+++ b/docs/reference/elasticsearch-plugins/discovery-azure-classic-long.md
@@ -3,7 +3,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/plugins/current/discovery-azure-classic-long.html
 ---
 
-# Setup process for Azure Discovery [discovery-azure-classic-long]
+# Setup process for Azure discovery [discovery-azure-classic-long]
 
 We will expose here one strategy which is to hide our Elasticsearch cluster from outside.
 
@@ -179,7 +179,7 @@ ssh azure-elasticsearch-cluster.cloudapp.net
 Once connected,  [install {{es}}](docs-content://deploy-manage/deploy/self-managed/installing-elasticsearch.md).
 
 
-## Install Elasticsearch cloud azure plugin [discovery-azure-classic-long-plugin]
+## Install Elasticsearch cloud Azure plugin [discovery-azure-classic-long-plugin]
 
 ```sh
 # Install the plugin

--- a/docs/reference/elasticsearch-plugins/discovery-azure-classic-usage.md
+++ b/docs/reference/elasticsearch-plugins/discovery-azure-classic-usage.md
@@ -3,7 +3,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/plugins/current/discovery-azure-classic-usage.html
 ---
 
-# Azure Virtual Machine discovery [discovery-azure-classic-usage]
+# Azure virtual machine discovery [discovery-azure-classic-usage]
 
 Azure VM discovery allows to use the Azure APIs to perform automatic discovery. Here is a simple sample configuration:
 
@@ -34,7 +34,7 @@ You can use [core network host settings](/reference/elasticsearch/configuration-
 ::::
 
 
-## How to start (short story) [discovery-azure-classic-short]
+## How to start [discovery-azure-classic-short]
 
 * Create Azure instances
 * Install Elasticsearch

--- a/docs/reference/elasticsearch-plugins/discovery-azure-classic.md
+++ b/docs/reference/elasticsearch-plugins/discovery-azure-classic.md
@@ -3,9 +3,9 @@ mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/plugins/current/discovery-azure-classic.html
 ---
 
-# Azure Classic discovery plugin [discovery-azure-classic]
+# Azure classic discovery plugin [discovery-azure-classic]
 
-The Azure Classic Discovery plugin uses the Azure Classic API to identify the addresses of seed hosts.
+The Azure classic discovery plugin uses the Azure classic API to identify the addresses of seed hosts.
 
 ::::{admonition} Deprecated in 5.0.0.
 :class: warning

--- a/docs/reference/elasticsearch-plugins/discovery-ec2.md
+++ b/docs/reference/elasticsearch-plugins/discovery-ec2.md
@@ -3,7 +3,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/plugins/current/discovery-ec2.html
 ---
 
-# EC2 Discovery plugin [discovery-ec2]
+# EC2 discovery plugin [discovery-ec2]
 
 The EC2 discovery plugin provides a list of seed addresses to the [discovery process](docs-content://deploy-manage/distributed-architecture/discovery-cluster-formation/discovery-hosts-providers.md) by querying the [AWS API](https://github.com/aws/aws-sdk-java) for a list of EC2 instances matching certain criteria determined by the [plugin settings](/reference/elasticsearch-plugins/discovery-ec2-usage.md).
 

--- a/docs/reference/elasticsearch-plugins/discovery-gce-network-host.md
+++ b/docs/reference/elasticsearch-plugins/discovery-gce-network-host.md
@@ -3,7 +3,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/plugins/current/discovery-gce-network-host.html
 ---
 
-# GCE Network Host [discovery-gce-network-host]
+# GCE network host [discovery-gce-network-host]
 
 When the `discovery-gce` plugin is installed, the following are also allowed as valid network host settings:
 
@@ -24,11 +24,11 @@ network.host: _gce:hostname_
 network.host: _gce_
 ```
 
-## How to start (short story) [discovery-gce-usage-short]
+## How to start [discovery-gce-usage-short]
 
-* Create Google Compute Engine instance (with compute rw permissions)
+* Create a Google Compute Engine instance (with compute rw permissions)
 * Install Elasticsearch
-* Install Google Compute Engine Cloud plugin
+* Install the Google Compute Engine cloud plugin
 * Modify `elasticsearch.yml` file
 * Start Elasticsearch
 

--- a/docs/reference/elasticsearch-plugins/discovery-gce-usage-long.md
+++ b/docs/reference/elasticsearch-plugins/discovery-gce-usage-long.md
@@ -3,7 +3,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/plugins/current/discovery-gce-usage-long.html
 ---
 
-# Setting up GCE Discovery [discovery-gce-usage-long]
+# Setting up GCE discovery [discovery-gce-usage-long]
 
 ## Prerequisites [discovery-gce-usage-long-prerequisites]
 
@@ -73,7 +73,7 @@ Failing to set this will result in unauthorized messages when starting Elasticse
 Once connected,  [install {{es}}](docs-content://deploy-manage/deploy/self-managed/installing-elasticsearch.md).
 
 
-## Install Elasticsearch discovery gce plugin [discovery-gce-usage-long-install-plugin]
+## Install the Elasticsearch discovery GCE plugin [discovery-gce-usage-long-install-plugin]
 
 Install the plugin:
 

--- a/docs/reference/elasticsearch-plugins/discovery-gce-usage-tips.md
+++ b/docs/reference/elasticsearch-plugins/discovery-gce-usage-tips.md
@@ -3,7 +3,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/plugins/current/discovery-gce-usage-tips.html
 ---
 
-# GCE Tips [discovery-gce-usage-tips]
+# GCE tips [discovery-gce-usage-tips]
 
 ## Store project id locally [discovery-gce-usage-tips-projectid]
 
@@ -14,7 +14,7 @@ gcloud config set project es-cloud
 ```
 
 
-## Machine Permissions [discovery-gce-usage-tips-permissions]
+## Machine permissions [discovery-gce-usage-tips-permissions]
 
 If you have created a machine without the correct permissions, you will see `403 unauthorized` error messages. To change machine permission on an existing instance, first stop the instance then Edit. Scroll down to `Access Scopes` to change permission. The other way to alter these permissions is to delete the instance (NOT THE DISK). Then create another with the correct permissions.
 

--- a/docs/reference/elasticsearch-plugins/discovery-gce-usage.md
+++ b/docs/reference/elasticsearch-plugins/discovery-gce-usage.md
@@ -3,9 +3,9 @@ mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/plugins/current/discovery-gce-usage.html
 ---
 
-# GCE Virtual Machine discovery [discovery-gce-usage]
+# GCE virtual machine discovery [discovery-gce-usage]
 
-Google Compute Engine VM discovery allows to use the google APIs to perform automatic discovery of seed hosts. Here is a simple sample configuration:
+Google Compute Engine (GCE) VM discovery allows to use the google APIs to perform automatic discovery of seed hosts. Here is a simple sample configuration:
 
 ```yaml
 cloud:


### PR DESCRIPTION
Relates to the [#423](https://github.com/elastic/docs-projects/issues/423) docs migration tasks and cleans up some unnecessary title cases.

