### PR TITLE
Rename BulkIndexByScrollResponseTests to BulkIndexByPaginatedSearchResponseTests

### DIFF
--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/BulkIndexByPaginatedSearchResponseTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/BulkIndexByPaginatedSearchResponseTests.java
@@ -28,7 +28,7 @@ import static java.util.Collections.emptyList;
 import static org.elasticsearch.core.TimeValue.timeValueMillis;
 import static org.hamcrest.Matchers.equalTo;
 
-public class BulkIndexByScrollResponseTests extends ESTestCase {
+public class BulkIndexByPaginatedSearchResponseTests extends ESTestCase {
     public void testMergeConstructor() {
         int mergeCount = between(2, 10);
         List<BulkByPaginatedSearchResponse> responses = new ArrayList<>(mergeCount);


### PR DESCRIPTION


Now that reindexing uses both scroll and point-in-time search, all scroll exclusive references need to be removed. This is step 10 of https://github.com/elastic/elasticsearch-team/issues/2406.

Relates: https://github.com/elastic/elasticsearch-team/issues/2406

