### PR TITLE
Rename BulkIndexByScrollResponseContentListener to BulkIndexByPaginatedSearchResponseContentListener

### DIFF
--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractBaseReindexRestHandler.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractBaseReindexRestHandler.java
@@ -53,7 +53,11 @@ public abstract class AbstractBaseReindexRestHandler<
             params.put(BulkByPaginatedSearchTask.Status.INCLUDE_CREATED, Boolean.toString(includeCreated));
             params.put(BulkByPaginatedSearchTask.Status.INCLUDE_UPDATED, Boolean.toString(includeUpdated));
 
-            return channel -> client.executeLocally(action, internal, new BulkIndexByPaginatedSearchResponseContentListener(channel, params));
+            return channel -> client.executeLocally(
+                action,
+                internal,
+                new BulkIndexByPaginatedSearchResponseContentListener(channel, params)
+            );
         } else {
             internal.setShouldStoreResult(true);
         }

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractBaseReindexRestHandler.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractBaseReindexRestHandler.java
@@ -53,7 +53,7 @@ public abstract class AbstractBaseReindexRestHandler<
             params.put(BulkByPaginatedSearchTask.Status.INCLUDE_CREATED, Boolean.toString(includeCreated));
             params.put(BulkByPaginatedSearchTask.Status.INCLUDE_UPDATED, Boolean.toString(includeUpdated));
 
-            return channel -> client.executeLocally(action, internal, new BulkIndexByScrollResponseContentListener(channel, params));
+            return channel -> client.executeLocally(action, internal, new BulkIndexByPaginatedSearchResponseContentListener(channel, params));
         } else {
             internal.setShouldStoreResult(true);
         }

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/BulkIndexByPaginatedSearchResponseContentListener.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/BulkIndexByPaginatedSearchResponseContentListener.java
@@ -24,11 +24,11 @@ import java.util.Map;
 /**
  * RestBuilderListener that returns higher than 200 status if there are any failures and allows to set XContent.Params.
  */
-public class BulkIndexByScrollResponseContentListener extends RestBuilderListener<BulkByPaginatedSearchResponse> {
+public class BulkIndexByPaginatedSearchResponseContentListener extends RestBuilderListener<BulkByPaginatedSearchResponse> {
 
     private final Map<String, String> params;
 
-    public BulkIndexByScrollResponseContentListener(RestChannel channel, Map<String, String> params) {
+    public BulkIndexByPaginatedSearchResponseContentListener(RestChannel channel, Map<String, String> params) {
         super(channel);
         this.params = params;
     }


### PR DESCRIPTION

Now that reindexing uses both scroll and point-in-time search, all scroll exclusive references need to be removed. This is step 10 of https://github.com/elastic/elasticsearch-team/issues/2406.

Relates: https://github.com/elastic/elasticsearch-team/issues/2406

