### PR TITLE
Rename BulkByScrollWireSerializingTestUtils to BulkByPaginatedSearchWireSerializingTestUtils

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/reindex/BulkByPaginatedSearchWireSerializingTestUtils.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/BulkByPaginatedSearchWireSerializingTestUtils.java
@@ -41,7 +41,7 @@ import static org.elasticsearch.index.reindex.resumeinfo.SliceStatusWireSerializ
 import static org.elasticsearch.xcontent.json.JsonXContent.jsonXContent;
 
 /**
- * Shared helpers for bulk-by-scroll wire serialization tests.
+ * Shared helpers for bulk-by-paginated-search wire serialization tests.
  */
 public final class BulkByPaginatedSearchWireSerializingTestUtils {
 
@@ -260,7 +260,7 @@ public final class BulkByPaginatedSearchWireSerializingTestUtils {
     }
 
     /**
-     * Minimal random resume info for embedding in bulk-by-scroll requests (worker or multi-slice).
+     * Minimal random resume info for embedding in bulk-by-paginated-search requests (worker or multi-slice).
      */
     public static void fillRandomBulkFields(AbstractBulkByPaginatedSearchRequest<?> request) {
         if (ESTestCase.randomBoolean()) {

--- a/server/src/test/java/org/elasticsearch/index/reindex/BulkByPaginatedSearchWireSerializingTestUtils.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/BulkByPaginatedSearchWireSerializingTestUtils.java
@@ -43,9 +43,9 @@ import static org.elasticsearch.xcontent.json.JsonXContent.jsonXContent;
 /**
  * Shared helpers for bulk-by-scroll wire serialization tests.
  */
-public final class BulkByScrollWireSerializingTestUtils {
+public final class BulkByPaginatedSearchWireSerializingTestUtils {
 
-    private BulkByScrollWireSerializingTestUtils() {}
+    private BulkByPaginatedSearchWireSerializingTestUtils() {}
 
     /**
      * Registry sufficient for {@link ReindexRequest}, {@link UpdateByQueryRequest}, {@link DeleteByQueryRequest},
@@ -349,7 +349,7 @@ public final class BulkByScrollWireSerializingTestUtils {
             case 13 -> mutatedRequest.setResumeInfo(
                 ESTestCase.randomValueOtherThan(
                     originalRequest.getResumeInfo().orElse(null),
-                    BulkByScrollWireSerializingTestUtils::randomResumeInfo
+                    BulkByPaginatedSearchWireSerializingTestUtils::randomResumeInfo
                 )
             );
             case 14 -> {

--- a/server/src/test/java/org/elasticsearch/index/reindex/DeleteByQueryRequestWireSerializingTests.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/DeleteByQueryRequestWireSerializingTests.java
@@ -19,16 +19,16 @@ import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 
-import static org.elasticsearch.index.reindex.BulkByScrollWireSerializingTestUtils.fillRandomBulkFields;
-import static org.elasticsearch.index.reindex.BulkByScrollWireSerializingTestUtils.mutateAbstractBulkByScrollRequest;
-import static org.elasticsearch.index.reindex.BulkByScrollWireSerializingTestUtils.randomResumeInfo;
+import static org.elasticsearch.index.reindex.BulkByPaginatedSearchWireSerializingTestUtils.fillRandomBulkFields;
+import static org.elasticsearch.index.reindex.BulkByPaginatedSearchWireSerializingTestUtils.mutateAbstractBulkByScrollRequest;
+import static org.elasticsearch.index.reindex.BulkByPaginatedSearchWireSerializingTestUtils.randomResumeInfo;
 
 public class DeleteByQueryRequestWireSerializingTests extends AbstractWireSerializingTestCase<
     DeleteByQueryRequestWireSerializingTests.Wrapper> {
 
     @Override
     protected NamedWriteableRegistry getNamedWriteableRegistry() {
-        return BulkByScrollWireSerializingTestUtils.bulkScrollRequestNamedWriteableRegistry();
+        return BulkByPaginatedSearchWireSerializingTestUtils.bulkScrollRequestNamedWriteableRegistry();
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/index/reindex/ReindexRequestWireSerializingTests.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/ReindexRequestWireSerializingTests.java
@@ -107,7 +107,7 @@ public class ReindexRequestWireSerializingTests extends AbstractWireSerializingT
     }
 
     /**
-     * Mutates {@code mutatedRequest} (a copy of {@code originalRequest}) along exactly one logical field: bulk-by-scroll fields,
+     * Mutates {@code mutatedRequest} (a copy of {@code originalRequest}) along exactly one logical field: bulk-by-paginated-search fields,
      * destination index, destination version, remote info, or script.
      */
     public static void mutateReindexRequest(ReindexRequest originalRequest, ReindexRequest mutatedRequest) {

--- a/server/src/test/java/org/elasticsearch/index/reindex/ReindexRequestWireSerializingTests.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/ReindexRequestWireSerializingTests.java
@@ -27,18 +27,18 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Objects;
 
-import static org.elasticsearch.index.reindex.BulkByScrollWireSerializingTestUtils.fillRandomBulkFields;
-import static org.elasticsearch.index.reindex.BulkByScrollWireSerializingTestUtils.mutateAbstractBulkByScrollRequest;
-import static org.elasticsearch.index.reindex.BulkByScrollWireSerializingTestUtils.randomRemoteInfo;
-import static org.elasticsearch.index.reindex.BulkByScrollWireSerializingTestUtils.randomResumeInfo;
-import static org.elasticsearch.index.reindex.BulkByScrollWireSerializingTestUtils.reindexRequestsEqual;
-import static org.elasticsearch.index.reindex.BulkByScrollWireSerializingTestUtils.resumeInfoOptionalContentHashCode;
+import static org.elasticsearch.index.reindex.BulkByPaginatedSearchWireSerializingTestUtils.fillRandomBulkFields;
+import static org.elasticsearch.index.reindex.BulkByPaginatedSearchWireSerializingTestUtils.mutateAbstractBulkByScrollRequest;
+import static org.elasticsearch.index.reindex.BulkByPaginatedSearchWireSerializingTestUtils.randomRemoteInfo;
+import static org.elasticsearch.index.reindex.BulkByPaginatedSearchWireSerializingTestUtils.randomResumeInfo;
+import static org.elasticsearch.index.reindex.BulkByPaginatedSearchWireSerializingTestUtils.reindexRequestsEqual;
+import static org.elasticsearch.index.reindex.BulkByPaginatedSearchWireSerializingTestUtils.resumeInfoOptionalContentHashCode;
 
 public class ReindexRequestWireSerializingTests extends AbstractWireSerializingTestCase<ReindexRequestWireSerializingTests.Wrapper> {
 
     @Override
     protected NamedWriteableRegistry getNamedWriteableRegistry() {
-        return BulkByScrollWireSerializingTestUtils.bulkScrollRequestNamedWriteableRegistry();
+        return BulkByPaginatedSearchWireSerializingTestUtils.bulkScrollRequestNamedWriteableRegistry();
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/index/reindex/RemoteInfoWireSerializingTests.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/RemoteInfoWireSerializingTests.java
@@ -23,8 +23,8 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Map;
 
-import static org.elasticsearch.index.reindex.BulkByScrollWireSerializingTestUtils.matchAllQueryBytes;
-import static org.elasticsearch.index.reindex.BulkByScrollWireSerializingTestUtils.randomRemoteInfo;
+import static org.elasticsearch.index.reindex.BulkByPaginatedSearchWireSerializingTestUtils.matchAllQueryBytes;
+import static org.elasticsearch.index.reindex.BulkByPaginatedSearchWireSerializingTestUtils.randomRemoteInfo;
 import static org.elasticsearch.xcontent.json.JsonXContent.jsonXContent;
 
 public class RemoteInfoWireSerializingTests extends AbstractWireSerializingTestCase<RemoteInfo> {
@@ -49,8 +49,8 @@ public class RemoteInfoWireSerializingTests extends AbstractWireSerializingTestC
     }
 
     /**
-     * {@link BulkByScrollWireSerializingTestUtils#randomRemoteInfo()} always uses
-     * {@link BulkByScrollWireSerializingTestUtils#matchAllQueryBytes()}; toggling with a different fixed query avoids
+     * {@link BulkByPaginatedSearchWireSerializingTestUtils#randomRemoteInfo()} always uses
+     * {@link BulkByPaginatedSearchWireSerializingTestUtils#matchAllQueryBytes()}; toggling with a different fixed query avoids
      * {@link ESTestCase#randomValueOtherThan} spinning forever when the supplier keeps returning the same bytes as the input.
      */
     private static BytesReference queryMutation(BytesReference current) {

--- a/server/src/test/java/org/elasticsearch/index/reindex/ResumeBulkByPaginatedSearchRequestWireSerializingTests.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/ResumeBulkByPaginatedSearchRequestWireSerializingTests.java
@@ -19,8 +19,8 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Objects;
 
-import static org.elasticsearch.index.reindex.BulkByScrollWireSerializingTestUtils.reindexRequestsEqual;
-import static org.elasticsearch.index.reindex.BulkByScrollWireSerializingTestUtils.resumeInfoOptionalContentHashCode;
+import static org.elasticsearch.index.reindex.BulkByPaginatedSearchWireSerializingTestUtils.reindexRequestsEqual;
+import static org.elasticsearch.index.reindex.BulkByPaginatedSearchWireSerializingTestUtils.resumeInfoOptionalContentHashCode;
 import static org.elasticsearch.index.reindex.ReindexRequestWireSerializingTests.mutateReindexRequest;
 import static org.elasticsearch.index.reindex.ReindexRequestWireSerializingTests.newRandomReindexWireInstance;
 
@@ -29,7 +29,7 @@ public class ResumeBulkByPaginatedSearchRequestWireSerializingTests extends Abst
 
     @Override
     protected NamedWriteableRegistry getNamedWriteableRegistry() {
-        return BulkByScrollWireSerializingTestUtils.bulkScrollRequestNamedWriteableRegistry();
+        return BulkByPaginatedSearchWireSerializingTestUtils.bulkScrollRequestNamedWriteableRegistry();
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/index/reindex/UpdateByQueryRequestWireSerializingTests.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/UpdateByQueryRequestWireSerializingTests.java
@@ -22,18 +22,18 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Objects;
 
-import static org.elasticsearch.index.reindex.BulkByScrollWireSerializingTestUtils.fillRandomBulkFields;
-import static org.elasticsearch.index.reindex.BulkByScrollWireSerializingTestUtils.mutateAbstractBulkByScrollRequest;
-import static org.elasticsearch.index.reindex.BulkByScrollWireSerializingTestUtils.randomResumeInfo;
-import static org.elasticsearch.index.reindex.BulkByScrollWireSerializingTestUtils.resumeInfoOptionalContentHashCode;
-import static org.elasticsearch.index.reindex.BulkByScrollWireSerializingTestUtils.updateByQueryRequestsEqual;
+import static org.elasticsearch.index.reindex.BulkByPaginatedSearchWireSerializingTestUtils.fillRandomBulkFields;
+import static org.elasticsearch.index.reindex.BulkByPaginatedSearchWireSerializingTestUtils.mutateAbstractBulkByScrollRequest;
+import static org.elasticsearch.index.reindex.BulkByPaginatedSearchWireSerializingTestUtils.randomResumeInfo;
+import static org.elasticsearch.index.reindex.BulkByPaginatedSearchWireSerializingTestUtils.resumeInfoOptionalContentHashCode;
+import static org.elasticsearch.index.reindex.BulkByPaginatedSearchWireSerializingTestUtils.updateByQueryRequestsEqual;
 
 public class UpdateByQueryRequestWireSerializingTests extends AbstractWireSerializingTestCase<
     UpdateByQueryRequestWireSerializingTests.Wrapper> {
 
     @Override
     protected NamedWriteableRegistry getNamedWriteableRegistry() {
-        return BulkByScrollWireSerializingTestUtils.bulkScrollRequestNamedWriteableRegistry();
+        return BulkByPaginatedSearchWireSerializingTestUtils.bulkScrollRequestNamedWriteableRegistry();
     }
 
     @Override


### PR DESCRIPTION
Renames `BulkByScrollWireSerializingTestUtils` to `BulkByPaginatedSearchWireSerializingTestUtils` now that reindexing uses both scroll and point-in-time search

Relates: https://github.com/elastic/elasticsearch-team/issues/2406