### PR TITLE
Rename AsyncBulkByScrollActionTests

### DIFF
--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/AsyncBulkByPaginatedSearchActionTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/AsyncBulkByPaginatedSearchActionTests.java
@@ -1180,13 +1180,20 @@ public class AsyncBulkByPaginatedSearchActionTests extends ESTestCase {
 
     public void testCancelBeforeSendBulkRequest() throws Exception {
         cancelTaskCase(
-            (DummyAsyncBulkByPaginatedSearchAction action) -> action.sendBulkRequest(new BulkRequest(), NO_OP_RELEASE_BATCH_HITS, Assert::fail)
+            (DummyAsyncBulkByPaginatedSearchAction action) -> action.sendBulkRequest(
+                new BulkRequest(),
+                NO_OP_RELEASE_BATCH_HITS,
+                Assert::fail
+            )
         );
     }
 
     public void testCancelBeforeOnBulkResponse() throws Exception {
         cancelTaskCase(
-            (DummyAsyncBulkByPaginatedSearchAction action) -> action.onBulkResponse(new BulkResponse(new BulkItemResponse[0], 0), Assert::fail)
+            (DummyAsyncBulkByPaginatedSearchAction action) -> action.onBulkResponse(
+                new BulkResponse(new BulkItemResponse[0], 0),
+                Assert::fail
+            )
         );
     }
 

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/AsyncBulkByPaginatedSearchActionTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/AsyncBulkByPaginatedSearchActionTests.java
@@ -142,7 +142,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class AsyncBulkByScrollActionTests extends ESTestCase {
+public class AsyncBulkByPaginatedSearchActionTests extends ESTestCase {
     private MyMockClient client;
     private DummyAbstractBulkByPaginatedSearchRequest testRequest;
     private PlainActionFuture<BulkByPaginatedSearchResponse> listener;
@@ -259,7 +259,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
      * Simulates a paginated response by setting scroll or search_after state and firing onScrollResponse.
      */
     private void simulatePaginatedResponse(
-        DummyAsyncBulkByScrollAction action,
+        DummyAsyncBulkByPaginatedSearchAction action,
         long lastBatchTime,
         int lastBatchSize,
         PaginatedHitSource.Response response,
@@ -294,7 +294,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
     public void testStartRetriesOnRejectionAndSucceeds() throws Exception {
         configurePitOrScroll();
         client.searchesToReject = randomIntBetween(0, testRequest.getMaxRetries() - 1);
-        DummyAsyncBulkByScrollAction action = new DummyActionWithoutBackoff();
+        DummyAsyncBulkByPaginatedSearchAction action = new DummyActionWithoutBackoff();
         action.start();
         assertBusy(() -> assertEquals(client.searchesToReject + 1, client.searchAttempts.get()));
         if (listener.isDone()) {
@@ -311,7 +311,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
     public void testStartRetriesOnRejectionButFailsOnTooManyRejections() throws Exception {
         configurePitOrScroll();
         client.searchesToReject = testRequest.getMaxRetries() + randomIntBetween(1, 100);
-        DummyAsyncBulkByScrollAction action = new DummyActionWithoutBackoff();
+        DummyAsyncBulkByPaginatedSearchAction action = new DummyActionWithoutBackoff();
         action.start();
         assertBusy(() -> assertEquals(testRequest.getMaxRetries() + 1, client.searchAttempts.get()));
         ExecutionException e = expectThrows(ExecutionException.class, () -> listener.get());
@@ -443,7 +443,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         assertEquals(0, testTask.getStatus().getTotal());
         long total = randomIntBetween(0, Integer.MAX_VALUE);
         PaginatedHitSource.Response response = createPaginatedResponse(usePit, false, emptyList(), total, emptyList(), null, null);
-        simulatePaginatedResponse(new DummyAsyncBulkByScrollAction(), 0, 0, response, usePit);
+        simulatePaginatedResponse(new DummyAsyncBulkByPaginatedSearchAction(), 0, 0, response, usePit);
         assertEquals(total, testTask.getStatus().getTotal());
     }
 
@@ -453,7 +453,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
     public void testBuildResponseIncludesPitIdWhenUsingPit() throws Exception {
         configurePitOrScroll(true);
         PaginatedHitSource.Response response = createPaginatedResponse(true, false, emptyList(), 0, emptyList(), null, null);
-        simulatePaginatedResponse(new DummyAsyncBulkByScrollAction(), System.nanoTime(), 0, response, true);
+        simulatePaginatedResponse(new DummyAsyncBulkByPaginatedSearchAction(), System.nanoTime(), 0, response, true);
         BulkByPaginatedSearchResponse bulkResponse = listener.get();
         assertTrue("PIT response should include pitId", bulkResponse.getPitId().isPresent());
         assertThat(bulkResponse.getPitId().get(), equalTo(TEST_PIT_ID));
@@ -468,7 +468,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         for (int batches = 1; batches < maxBatches; batches++) {
             Hit hit = new PaginatedHitSource.BasicHit("index", "id", 0);
             PaginatedHitSource.Response response = createPaginatedResponse(usePit, false, emptyList(), 1, singletonList(hit), null, null);
-            DummyAsyncBulkByScrollAction action = new DummyAsyncBulkByScrollAction();
+            DummyAsyncBulkByPaginatedSearchAction action = new DummyAsyncBulkByPaginatedSearchAction();
             simulatePaginatedResponse(action, System.nanoTime(), 0, response, usePit);
 
             final int expectedBatches = batches;
@@ -485,7 +485,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         long updated = 0;
         long deleted = 0;
 
-        var action = new DummyAsyncBulkByScrollAction();
+        var action = new DummyAsyncBulkByPaginatedSearchAction();
         action.setScroll(scrollId());
 
         for (int batches = 0; batches < maxBatches; batches++) {
@@ -542,8 +542,8 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         testRequest.getSearchRequest().source().size(100);
 
         // when receiving bulk response
-        var responses = randomArray(0, maxDocs, BulkItemResponse[]::new, AsyncBulkByScrollActionTests::createBulkResponse);
-        new DummyAsyncBulkByScrollAction().onBulkResponse(new BulkResponse(responses, 0), () -> fail("should not be called"));
+        var responses = randomArray(0, maxDocs, BulkItemResponse[]::new, AsyncBulkByPaginatedSearchActionTests::createBulkResponse);
+        new DummyAsyncBulkByPaginatedSearchAction().onBulkResponse(new BulkResponse(responses, 0), () -> fail("should not be called"));
 
         // then should refresh and finish
         assertThat(listener.isDone(), equalTo(true));
@@ -558,8 +558,8 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         testRequest.getSearchRequest().source().size(100);
 
         // when receiving bulk response with max docs
-        var responses = randomArray(size, size, BulkItemResponse[]::new, AsyncBulkByScrollActionTests::createBulkResponse);
-        new DummyAsyncBulkByScrollAction().onBulkResponse(new BulkResponse(responses, 0), () -> fail("should not be called"));
+        var responses = randomArray(size, size, BulkItemResponse[]::new, AsyncBulkByPaginatedSearchActionTests::createBulkResponse);
+        new DummyAsyncBulkByPaginatedSearchAction().onBulkResponse(new BulkResponse(responses, 0), () -> fail("should not be called"));
 
         // then should refresh and finish
         assertThat(listener.isDone(), equalTo(true));
@@ -604,7 +604,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
             }
         });
         PaginatedHitSource.Response response = createPaginatedResponse(usePit, false, emptyList(), 0, emptyList(), null, null);
-        simulatePaginatedResponse(new DummyAsyncBulkByScrollAction(), System.nanoTime(), 10, response, usePit);
+        simulatePaginatedResponse(new DummyAsyncBulkByPaginatedSearchAction(), System.nanoTime(), 10, response, usePit);
         ExecutionException e = expectThrows(ExecutionException.class, () -> listener.get());
         assertThat(e.getCause(), instanceOf(EsRejectedExecutionException.class));
         assertThat(e.getCause(), hasToString(containsString("test")));
@@ -632,7 +632,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
             null,
             null
         );
-        simulatePaginatedResponse(new DummyAsyncBulkByScrollAction(), System.nanoTime(), 0, scrollResponse, usePit);
+        simulatePaginatedResponse(new DummyAsyncBulkByPaginatedSearchAction(), System.nanoTime(), 0, scrollResponse, usePit);
         BulkByPaginatedSearchResponse response = listener.get();
         assertThat(response.getBulkFailures(), empty());
         assertThat(response.getSearchFailures(), contains(shardFailure));
@@ -649,7 +649,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
     public void testSearchTimeoutsAbortRequest() throws Exception {
         boolean usePit = configurePitOrScroll();
         PaginatedHitSource.Response scrollResponse = createPaginatedResponse(usePit, true, emptyList(), 0, emptyList(), null, null);
-        simulatePaginatedResponse(new DummyAsyncBulkByScrollAction(), System.nanoTime(), 0, scrollResponse, usePit);
+        simulatePaginatedResponse(new DummyAsyncBulkByPaginatedSearchAction(), System.nanoTime(), 0, scrollResponse, usePit);
         BulkByPaginatedSearchResponse response = listener.get();
         assertThat(response.getBulkFailures(), empty());
         assertThat(response.getSearchFailures(), empty());
@@ -680,7 +680,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
             }
         };
 
-        DummyAsyncBulkByScrollAction action = new DummyAsyncBulkByScrollAction(
+        DummyAsyncBulkByPaginatedSearchAction action = new DummyAsyncBulkByPaginatedSearchAction(
             testTask,
             TimeValue.ZERO,
             trippingBreaker,
@@ -729,7 +729,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
             }
         };
 
-        DummyAsyncBulkByScrollAction action = new DummyAsyncBulkByScrollAction(
+        DummyAsyncBulkByPaginatedSearchAction action = new DummyAsyncBulkByPaginatedSearchAction(
             testTask,
             TimeValue.ZERO,
             trackingBreaker,
@@ -848,7 +848,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
      */
     public void testBulkFailuresAbortRequest() throws Exception {
         Failure failure = new Failure("index", "id", new RuntimeException("test"));
-        DummyAsyncBulkByScrollAction action = new DummyAsyncBulkByScrollAction();
+        DummyAsyncBulkByPaginatedSearchAction action = new DummyAsyncBulkByPaginatedSearchAction();
         BulkResponse bulkResponse = new BulkResponse(
             new BulkItemResponse[] { BulkItemResponse.failure(0, DocWriteRequest.OpType.CREATE, failure) },
             randomLong()
@@ -865,7 +865,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
      */
     public void testBuildRequestThrowsException() throws Exception {
         boolean usePit = configurePitOrScroll();
-        DummyAsyncBulkByScrollAction action = new DummyAsyncBulkByScrollAction() {
+        DummyAsyncBulkByPaginatedSearchAction action = new DummyAsyncBulkByPaginatedSearchAction() {
             @Override
             protected AbstractAsyncBulkByPaginatedSearchAction.RequestWrapper<?> buildRequest(Hit doc) {
                 throw new RuntimeException("surprise");
@@ -943,7 +943,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         // Set the base for the scroll to wait - this is added to the figure we calculate below
         testRequest.getSearchRequest().scroll(timeValueSeconds(10));
 
-        DummyAsyncBulkByScrollAction action = new DummyAsyncBulkByScrollAction() {
+        DummyAsyncBulkByPaginatedSearchAction action = new DummyAsyncBulkByPaginatedSearchAction() {
             @Override
             protected RequestWrapper<?> buildRequest(Hit doc) {
                 return wrap(new IndexRequest().index("test"));
@@ -1040,7 +1040,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
             }
         });
 
-        DummyAsyncBulkByScrollAction action = new DummyAsyncBulkByScrollAction() {
+        DummyAsyncBulkByPaginatedSearchAction action = new DummyAsyncBulkByPaginatedSearchAction() {
             @Override
             protected RequestWrapper<?> buildRequest(Hit doc) {
                 return wrap(new IndexRequest().index("test"));
@@ -1091,7 +1091,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         testRequest.setMaxRetries(totalFailures - (failWithRejection ? 1 : 0));
 
         client.bulksToReject = client.bulksAttempts.get() + totalFailures;
-        DummyAsyncBulkByScrollAction action = new DummyActionWithoutBackoff();
+        DummyAsyncBulkByPaginatedSearchAction action = new DummyActionWithoutBackoff();
         action.setScroll(scrollId());
         BulkRequest request = new BulkRequest();
         for (int i = 0; i < size + 1; i++) {
@@ -1113,7 +1113,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
      * The default retry time matches what we say it is in the javadoc for the request.
      */
     public void testDefaultRetryTimes() {
-        Iterator<TimeValue> policy = new DummyAsyncBulkByScrollAction().buildBackoffPolicy().iterator();
+        Iterator<TimeValue> policy = new DummyAsyncBulkByPaginatedSearchAction().buildBackoffPolicy().iterator();
         long millis = 0;
         while (policy.hasNext()) {
             millis += policy.next().millis();
@@ -1146,7 +1146,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         if (refresh != null) {
             testRequest.setRefresh(refresh);
         }
-        DummyAsyncBulkByScrollAction action = new DummyAsyncBulkByScrollAction();
+        DummyAsyncBulkByPaginatedSearchAction action = new DummyAsyncBulkByPaginatedSearchAction();
         if (addDestinationIndexes) {
             action.addDestinationIndices(singleton("foo"));
         }
@@ -1159,12 +1159,12 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
     }
 
     public void testCancelBeforeInitialSearch() throws Exception {
-        cancelTaskCase((DummyAsyncBulkByScrollAction action) -> action.start());
+        cancelTaskCase((DummyAsyncBulkByPaginatedSearchAction action) -> action.start());
     }
 
     public void testCancelBeforeScrollResponse() throws Exception {
         boolean usePit = configurePitOrScroll();
-        cancelTaskCase(usePit, (DummyAsyncBulkByScrollAction action) -> {
+        cancelTaskCase(usePit, (DummyAsyncBulkByPaginatedSearchAction action) -> {
             PaginatedHitSource.Response response = createPaginatedResponse(
                 usePit,
                 false,
@@ -1180,25 +1180,25 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
 
     public void testCancelBeforeSendBulkRequest() throws Exception {
         cancelTaskCase(
-            (DummyAsyncBulkByScrollAction action) -> action.sendBulkRequest(new BulkRequest(), NO_OP_RELEASE_BATCH_HITS, Assert::fail)
+            (DummyAsyncBulkByPaginatedSearchAction action) -> action.sendBulkRequest(new BulkRequest(), NO_OP_RELEASE_BATCH_HITS, Assert::fail)
         );
     }
 
     public void testCancelBeforeOnBulkResponse() throws Exception {
         cancelTaskCase(
-            (DummyAsyncBulkByScrollAction action) -> action.onBulkResponse(new BulkResponse(new BulkItemResponse[0], 0), Assert::fail)
+            (DummyAsyncBulkByPaginatedSearchAction action) -> action.onBulkResponse(new BulkResponse(new BulkItemResponse[0], 0), Assert::fail)
         );
     }
 
     public void testCancelBeforeStartNextScroll() throws Exception {
         long now = System.nanoTime();
-        cancelTaskCase((DummyAsyncBulkByScrollAction action) -> action.notifyDone(now, null, 0));
+        cancelTaskCase((DummyAsyncBulkByPaginatedSearchAction action) -> action.notifyDone(now, null, 0));
     }
 
     public void testCancelBeforeRefreshAndFinish() throws Exception {
         // Refresh or not doesn't matter - we don't try to refresh.
         testRequest.setRefresh(usually());
-        cancelTaskCase((DummyAsyncBulkByScrollAction action) -> action.refreshAndFinish(emptyList(), emptyList(), false));
+        cancelTaskCase((DummyAsyncBulkByPaginatedSearchAction action) -> action.refreshAndFinish(emptyList(), emptyList(), false));
         assertNull("No refresh was attempted", client.lastRefreshRequest.get());
     }
 
@@ -1231,7 +1231,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         });
 
         boolean usePit = configurePitOrScroll();
-        DummyAsyncBulkByScrollAction action = new DummyAsyncBulkByScrollAction();
+        DummyAsyncBulkByPaginatedSearchAction action = new DummyAsyncBulkByPaginatedSearchAction();
         boolean hasPaginationState = usually();
         if (hasPaginationState) {
             if (usePit) {
@@ -1251,12 +1251,12 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         }
     }
 
-    private void cancelTaskCase(Consumer<DummyAsyncBulkByScrollAction> testMe) throws Exception {
+    private void cancelTaskCase(Consumer<DummyAsyncBulkByPaginatedSearchAction> testMe) throws Exception {
         cancelTaskCase(configurePitOrScroll(), testMe);
     }
 
-    private void cancelTaskCase(boolean usePit, Consumer<DummyAsyncBulkByScrollAction> testMe) throws Exception {
-        DummyAsyncBulkByScrollAction action = new DummyAsyncBulkByScrollAction();
+    private void cancelTaskCase(boolean usePit, Consumer<DummyAsyncBulkByPaginatedSearchAction> testMe) throws Exception {
+        DummyAsyncBulkByPaginatedSearchAction action = new DummyAsyncBulkByPaginatedSearchAction();
         boolean hasPaginationState = usually();
         if (hasPaginationState) {
             if (usePit) {
@@ -1355,7 +1355,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         CountDownLatch firstConsumeReturnedFromSuper = new CountDownLatch(1);
         CountDownLatch resumePrepareAfterFinishHim = new CountDownLatch(1);
         AtomicInteger sendBulkInvocations = new AtomicInteger();
-        AbstractAsyncBulkByPaginatedSearchAction.ScrollConsumableHitsResponse consumable = new ScrollConsumableHitsResponseGate(
+        AbstractAsyncBulkByPaginatedSearchAction.ScrollConsumableHitsResponse consumable = new PaginatedSearchConsumableHitsResponseGate(
             new PaginatedHitSource.AsyncResponse() {
                 @Override
                 public PaginatedHitSource.Response response() {
@@ -1369,7 +1369,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
             resumePrepareAfterFinishHim
         );
 
-        DummyAsyncBulkByScrollAction action = new DummyAsyncBulkByScrollAction() {
+        DummyAsyncBulkByPaginatedSearchAction action = new DummyAsyncBulkByPaginatedSearchAction() {
             @Override
             protected AbstractAsyncBulkByPaginatedSearchAction.RequestWrapper<?> buildRequest(Hit doc) {
                 return AbstractAsyncBulkByPaginatedSearchAction.wrap(new IndexRequest().index("test").id(doc.getId()));
@@ -1405,7 +1405,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
 
     public void testCopyRoutingPropagatesSliceRoutingProvenanceToWriteRequests() {
         assumeTrue("slice indexing feature flag must be enabled", SliceIndexing.SLICE_FEATURE_FLAG.isEnabled());
-        DummyAsyncBulkByScrollAction action = new DummyAsyncBulkByScrollAction();
+        DummyAsyncBulkByPaginatedSearchAction action = new DummyAsyncBulkByPaginatedSearchAction();
         testRequest.getSearchRequest().searchSlice("slice-1");
 
         IndexRequest indexRequest = new IndexRequest().index("test").id("1");
@@ -1459,7 +1459,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
                 @Override
                 public void done(TimeValue extraKeepAlive) {}
             });
-        DummyAsyncBulkByScrollAction action = new DummyAsyncBulkByScrollAction();
+        DummyAsyncBulkByPaginatedSearchAction action = new DummyAsyncBulkByPaginatedSearchAction();
         action.setScroll(scrollId());
         action.setCurrentScrollResponseForTests(consumable);
 
@@ -1744,7 +1744,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
     public void testBuildScrollableResultSourceReturnsPitHitSource() {
         configurePitOrScroll(true);
         final AtomicReference<PaginatedHitSource> capturedSource = new AtomicReference<>();
-        new DummyAsyncBulkByScrollAction() {
+        new DummyAsyncBulkByPaginatedSearchAction() {
             @Override
             protected PaginatedHitSource buildScrollableResultSource(BackoffPolicy backoffPolicy, SearchRequest searchRequest) {
                 PaginatedHitSource result = super.buildScrollableResultSource(backoffPolicy, searchRequest);
@@ -1761,7 +1761,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
     public void testBuildScrollableResultSourceReturnsScrollHitSource() {
         configurePitOrScroll(false);
         final AtomicReference<PaginatedHitSource> capturedSource = new AtomicReference<>();
-        new DummyAsyncBulkByScrollAction() {
+        new DummyAsyncBulkByPaginatedSearchAction() {
             @Override
             protected PaginatedHitSource buildScrollableResultSource(BackoffPolicy backoffPolicy, SearchRequest searchRequest) {
                 PaginatedHitSource result = super.buildScrollableResultSource(backoffPolicy, searchRequest);
@@ -1783,7 +1783,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
 
         final String expectedScrollId = scrollId();
         final AtomicBoolean cleanedUp = new AtomicBoolean();
-        final DummyAsyncBulkByScrollAction action = new DummyAsyncBulkByScrollAction() {
+        final DummyAsyncBulkByPaginatedSearchAction action = new DummyAsyncBulkByPaginatedSearchAction() {
             @Override
             protected PaginatedHitSource buildScrollableResultSource(BackoffPolicy backoffPolicy, SearchRequest searchRequest) {
                 return new ClientScrollablePaginatedHitSource(
@@ -1847,7 +1847,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
 
         final Object[] expectedSearchAfter = new Object[] { "search_after" };
         final AtomicBoolean cleanedUp = new AtomicBoolean();
-        final DummyAsyncBulkByScrollAction action = new DummyAsyncBulkByScrollAction() {
+        final DummyAsyncBulkByPaginatedSearchAction action = new DummyAsyncBulkByPaginatedSearchAction() {
             @Override
             protected PaginatedHitSource buildScrollableResultSource(BackoffPolicy backoffPolicy, SearchRequest searchRequest) {
                 return new ClientPitPaginatedHitSource(
@@ -1910,7 +1910,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         worker.setNodeToRelocateToSupplier(Optional::empty);
 
         final String expectedScrollId = scrollId();
-        final DummyAsyncBulkByScrollAction action = new DummyAsyncBulkByScrollAction();
+        final DummyAsyncBulkByPaginatedSearchAction action = new DummyAsyncBulkByPaginatedSearchAction();
         action.setScroll(expectedScrollId);
 
         final AtomicBoolean doneCalled = new AtomicBoolean();
@@ -1942,7 +1942,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         worker.setNodeToRelocateToSupplier(Optional::empty);
 
         final Object[] expectedSearchAfter = new Object[] { "search_after" };
-        final DummyAsyncBulkByScrollAction action = new DummyAsyncBulkByScrollAction();
+        final DummyAsyncBulkByPaginatedSearchAction action = new DummyAsyncBulkByPaginatedSearchAction();
         action.setSearchAfterValues(expectedSearchAfter);
 
         final AtomicBoolean doneCalled = new AtomicBoolean();
@@ -1973,7 +1973,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         worker.setNodeToRelocateToSupplier(() -> Optional.of("target-node"));
 
         final String expectedScrollId = scrollId();
-        final DummyAsyncBulkByScrollAction action = new DummyAsyncBulkByScrollAction();
+        final DummyAsyncBulkByPaginatedSearchAction action = new DummyAsyncBulkByPaginatedSearchAction();
         action.setScroll(expectedScrollId);
 
         final AtomicBoolean doneCalled = new AtomicBoolean();
@@ -2004,7 +2004,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         worker.setNodeToRelocateToSupplier(() -> Optional.of("target-node"));
 
         final Object[] expectedSearchAfter = new Object[] { "search_after" };
-        final DummyAsyncBulkByScrollAction action = new DummyAsyncBulkByScrollAction();
+        final DummyAsyncBulkByPaginatedSearchAction action = new DummyAsyncBulkByPaginatedSearchAction();
         action.setSearchAfterValues(expectedSearchAfter);
 
         final AtomicBoolean doneCalled = new AtomicBoolean();
@@ -2037,7 +2037,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
 
         final String expectedScrollId = scrollId();
         final AtomicBoolean onScrollResponseCalled = new AtomicBoolean();
-        final DummyAsyncBulkByScrollAction action = new DummyAsyncBulkByScrollAction() {
+        final DummyAsyncBulkByPaginatedSearchAction action = new DummyAsyncBulkByPaginatedSearchAction() {
             @Override
             void onScrollResponse(final AbstractAsyncBulkByPaginatedSearchAction.ScrollConsumableHitsResponse asyncResponse) {
                 onScrollResponseCalled.set(true);
@@ -2081,7 +2081,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
 
         final Object[] expectedSearchAfter = new Object[] { "search_after" };
         final AtomicBoolean onScrollResponseCalled = new AtomicBoolean();
-        final DummyAsyncBulkByScrollAction action = new DummyAsyncBulkByScrollAction() {
+        final DummyAsyncBulkByPaginatedSearchAction action = new DummyAsyncBulkByPaginatedSearchAction() {
             @Override
             void onScrollResponse(final AbstractAsyncBulkByPaginatedSearchAction.ScrollConsumableHitsResponse asyncResponse) {
                 onScrollResponseCalled.set(true);
@@ -2123,7 +2123,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         testTask.requestRelocation();
         worker.setNodeToRelocateToSupplier(() -> Optional.of("target-node"));
 
-        final DummyAsyncBulkByScrollAction action = new DummyAsyncBulkByScrollAction();
+        final DummyAsyncBulkByPaginatedSearchAction action = new DummyAsyncBulkByPaginatedSearchAction();
         final var asyncResponse = new AbstractAsyncBulkByPaginatedSearchAction.ScrollConsumableHitsResponse(
             new PaginatedHitSource.AsyncResponse() {
                 @Override
@@ -2180,7 +2180,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         testTask.requestRelocation();
         worker.setNodeToRelocateToSupplier(() -> Optional.of("target-node"));
 
-        final DummyAsyncBulkByScrollAction action = new DummyAsyncBulkByScrollAction(TimeValue.timeValueHours(1));
+        final DummyAsyncBulkByPaginatedSearchAction action = new DummyAsyncBulkByPaginatedSearchAction(TimeValue.timeValueHours(1));
 
         final AtomicBoolean doneCalled = new AtomicBoolean();
         final var asyncResponse = new AbstractAsyncBulkByPaginatedSearchAction.ScrollConsumableHitsResponse(
@@ -2223,7 +2223,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         when(task.getStatus()).thenReturn(status);
 
         final String expectedScrollId = scrollId();
-        final DummyAsyncBulkByScrollAction action = new DummyAsyncBulkByScrollAction(task, TimeValue.ZERO);
+        final DummyAsyncBulkByPaginatedSearchAction action = new DummyAsyncBulkByPaginatedSearchAction(task, TimeValue.ZERO);
         action.setScroll(expectedScrollId);
 
         final var asyncResponse = new AbstractAsyncBulkByPaginatedSearchAction.ScrollConsumableHitsResponse(
@@ -2253,7 +2253,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
 
         final String expectedScrollId = scrollId();
         // Large cooldown, but task is not relocated so it should not apply
-        final DummyAsyncBulkByScrollAction action = new DummyAsyncBulkByScrollAction(TimeValue.timeValueHours(1));
+        final DummyAsyncBulkByPaginatedSearchAction action = new DummyAsyncBulkByPaginatedSearchAction(TimeValue.timeValueHours(1));
         action.setScroll(expectedScrollId);
 
         final var asyncResponse = new AbstractAsyncBulkByPaginatedSearchAction.ScrollConsumableHitsResponse(
@@ -2276,23 +2276,23 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         assertTrue(response.getTaskResumeInfo().isPresent());
     }
 
-    private class DummyAsyncBulkByScrollAction extends AbstractAsyncBulkByPaginatedSearchAction<
+    private class DummyAsyncBulkByPaginatedSearchAction extends AbstractAsyncBulkByPaginatedSearchAction<
         DummyAbstractBulkByPaginatedSearchRequest,
-        DummyTransportAsyncBulkByScrollAction> {
+        DummyTransportAsyncBulkByPaginatedSearchAction> {
 
-        DummyAsyncBulkByScrollAction() {
+        DummyAsyncBulkByPaginatedSearchAction() {
             this(testTask, TimeValue.ZERO);
         }
 
-        DummyAsyncBulkByScrollAction(TimeValue timeout) {
+        DummyAsyncBulkByPaginatedSearchAction(TimeValue timeout) {
             this(testTask, timeout);
         }
 
-        DummyAsyncBulkByScrollAction(BulkByPaginatedSearchTask task, TimeValue maxTaskShutdownGracePeriod) {
+        DummyAsyncBulkByPaginatedSearchAction(BulkByPaginatedSearchTask task, TimeValue maxTaskShutdownGracePeriod) {
             this(task, maxTaskShutdownGracePeriod, new NoopCircuitBreaker("test"), "test_bulk_batch");
         }
 
-        DummyAsyncBulkByScrollAction(
+        DummyAsyncBulkByPaginatedSearchAction(
             BulkByPaginatedSearchTask task,
             TimeValue maxTaskShutdownGracePeriod,
             CircuitBreaker circuitBreaker,
@@ -2303,7 +2303,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
                 randomBoolean(),
                 randomBoolean(),
                 randomBoolean(),
-                AsyncBulkByScrollActionTests.this.logger,
+                AsyncBulkByPaginatedSearchActionTests.this.logger,
                 new ParentTaskAssigningClient(client, localNode, testTask),
                 client.threadPool(),
                 testRequest,
@@ -2327,9 +2327,9 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
     }
 
     /**
-     * An extension to {@linkplain DummyAsyncBulkByScrollAction} that uses a 0 delaying backoff policy.
+     * An extension to {@linkplain DummyAsyncBulkByPaginatedSearchAction} that uses a 0 delaying backoff policy.
      */
-    private class DummyActionWithoutBackoff extends DummyAsyncBulkByScrollAction {
+    private class DummyActionWithoutBackoff extends DummyAsyncBulkByPaginatedSearchAction {
         @Override
         BackoffPolicy buildBackoffPolicy() {
             return buildTestBackoffPolicy();
@@ -2341,11 +2341,11 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         return constantBackoff(timeValueMillis(0), testRequest.getMaxRetries());
     }
 
-    private static class DummyTransportAsyncBulkByScrollAction extends TransportAction<
+    private static class DummyTransportAsyncBulkByPaginatedSearchAction extends TransportAction<
         DummyAbstractBulkByPaginatedSearchRequest,
         BulkByPaginatedSearchResponse> {
 
-        protected DummyTransportAsyncBulkByScrollAction(String actionName, ActionFilters actionFilters, TaskManager taskManager) {
+        protected DummyTransportAsyncBulkByPaginatedSearchAction(String actionName, ActionFilters actionFilters, TaskManager taskManager) {
             super(actionName, actionFilters, taskManager, EsExecutors.DIRECT_EXECUTOR_SERVICE);
         }
 
@@ -2585,12 +2585,12 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
      * so {@link AbstractAsyncBulkByPaginatedSearchAction#currentScrollResponse} stays {@code null} across {@code finishHim}'s
      * {@code getAndSet} when {@code maxDocs} leaves a partial scroll batch.
      */
-    private static final class ScrollConsumableHitsResponseGate extends
+    private static final class PaginatedSearchConsumableHitsResponseGate extends
         AbstractAsyncBulkByPaginatedSearchAction.ScrollConsumableHitsResponse {
         private final CountDownLatch firstConsumeReturnedFromSuper;
         private final CountDownLatch resumePrepareAfterFinishHim;
 
-        ScrollConsumableHitsResponseGate(
+        PaginatedSearchConsumableHitsResponseGate(
             PaginatedHitSource.AsyncResponse asyncResponse,
             CountDownLatch firstConsumeReturnedFromSuper,
             CountDownLatch resumePrepareAfterFinishHim

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/CancelTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/CancelTests.java
@@ -51,7 +51,7 @@ import static org.hamcrest.Matchers.hasSize;
 
 /**
  * Test that you can actually cancel a reindex/update-by-query/delete-by-query request and all the plumbing works. Doesn't test all of the
- * different cancellation places - that is the responsibility of AsyncBulkByScrollActionTests which have more precise control to
+ * different cancellation places - that is the responsibility of AsyncBulkByPaginatedSearchActionTests which have more precise control to
  * simulate failures but does not exercise important portion of the stack like transport and task management.
  */
 public class CancelTests extends ReindexTestCase {

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexCircuitBreakerTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexCircuitBreakerTests.java
@@ -34,7 +34,7 @@ import static org.hamcrest.Matchers.notNullValue;
  * bulk request that would have pushed the node toward OOM.
  *
  * <p>The reservation/release lifecycle of the hooks themselves is covered by unit tests in
- * {@code AsyncBulkByScrollActionTests}; this class verifies the production wiring (CircuitBreakerService →
+ * {@code AsyncBulkByPaginatedSearchActionTests}; this class verifies the production wiring (CircuitBreakerService →
  * Reindexer → AsyncIndexBySearchAction) actually fires against a real breaker.
  */
 public class ReindexCircuitBreakerTests extends ESSingleNodeTestCase {


### PR DESCRIPTION
Renames `AsyncBulkByScrollActionTests` to `AsyncBulkByPaginatedSearchActionTests ` now that reindexing uses both scroll and point-in-time search

Relates: https://github.com/elastic/elasticsearch-team/issues/2406