### PR TITLE
[8.19] Fix ML DFA rolling-upgrade tests after failed tasks (#149356)

### DIFF
--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/90_ml_data_frame_analytics_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/90_ml_data_frame_analytics_crud.yml
@@ -1,3 +1,22 @@
+setup:
+  # Rolling upgrades can leave analytics tasks in a failed state when nodes restart
+  # mid-run. Force-stop clears failed tasks so subsequent tests can start/stop cleanly.
+  - do:
+      ml.stop_data_frame_analytics:
+        id: "old_cluster_outlier_detection_job"
+        force: true
+        allow_no_match: true
+  - do:
+      ml.stop_data_frame_analytics:
+        id: "old_cluster_regression_job"
+        force: true
+        allow_no_match: true
+  - do:
+      ml.stop_data_frame_analytics:
+        id: "old_cluster_classification_job"
+        force: true
+        allow_no_match: true
+
 ---
 "Get old outlier_detection job":
 
@@ -37,6 +56,7 @@
   - do:
       ml.stop_data_frame_analytics:
         id: "old_cluster_outlier_detection_job"
+        force: true
         timeout: "60s"
   - match: { stopped: true }
 
@@ -83,6 +103,7 @@
   - do:
       ml.stop_data_frame_analytics:
         id: "old_cluster_regression_job"
+        force: true
         timeout: "60s"
   - match: { stopped: true }
 
@@ -160,6 +181,7 @@
   - do:
       ml.stop_data_frame_analytics:
         id: "mixed_cluster_outlier_detection_job"
+        force: true
         timeout: "60s"
   - match: { stopped: true }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Fix ML DFA rolling-upgrade tests after failed tasks (#149356)](https://github.com/elastic/elasticsearch/pull/149356)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)