### PR TITLE
Document Outlook connector fixes in known issues

### DIFF
--- a/docs/reference/search-connectors/es-connectors-known-issues.md
+++ b/docs/reference/search-connectors/es-connectors-known-issues.md
@@ -159,6 +159,24 @@ The connector service has the following known issues:
     **Fix**: [elastic/connectors#4059](https://github.com/elastic/connectors/pull/4059), shipped in 8.19.17, 9.3.6, 9.4.3, and 9.5.0.
 
 
+* **Outlook connector fails to sync on non-English Exchange servers**
+
+    The connector resolved default folders by English display names (`Contacts`, `Archive`). On localized on-prem Exchange servers these names differ, raising `ErrorFolderNotFound` and aborting the sync.
+
+    **Affected versions**: 8.11.0–8.19.16, 9.0.0–9.3.5, and 9.4.0–9.4.2. Non-English on-prem Exchange servers only.
+
+    **Fix**: [elastic/connectors#4065](https://github.com/elastic/connectors/pull/4065), shipped in 8.19.17, 9.3.6, 9.4.3, and 9.5.0. Folders are now resolved by locale-agnostic distinguished folder IDs; the Archive leaf folder still has no distinguished ID in Exchange and is skipped on localized servers when absent.
+
+
+* **Outlook connector fails when Active Directory users lack a mail attribute**
+
+    On on-prem Exchange, the connector passed the raw LDAP `mail` attribute into `exchangelib.Account`. When the attribute is missing, `ldap3` returns `[]`, causing `ValueError: primary_smtp_address [] is not an email address` and aborting the sync.
+
+    **Affected versions**: 8.11.0–8.19.16, 9.0.0–9.3.5, and 9.4.0–9.4.2. On-prem Exchange with Active Directory only.
+
+    **Fix**: [elastic/connectors#4078](https://github.com/elastic/connectors/pull/4078), shipped in 8.19.17, 9.3.6, 9.4.3, and 9.5.0.
+
+
 ## Individual connector known issues [es-connectors-known-issues-specific]
 
 Individual connectors may have additional known issues. Refer to [each connector’s reference documentation](/reference/search-connectors/index.md) for connector-specific known issues.


### PR DESCRIPTION
## Summary

- Document two recently fixed Outlook connector bugs in `es-connectors-known-issues.md`
- Localized Exchange folder resolution crash ([elastic/connectors#4065](https://github.com/elastic/connectors/pull/4065))
- Active Directory users without a `mail` attribute crash ([elastic/connectors#4078](https://github.com/elastic/connectors/pull/4078))
- Both fixes shipped in 8.19.17, 9.3.6, 9.4.3, and 9.5.0

## Test plan

- [x] Verified affected version ranges against connector release history
- [ ] `docs-builder` (from repo root)

Made with [Cursor](https://cursor.com)