### PR TITLE
Add regression tests for partially unmapped small numeric fields (#151525)

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
@@ -103,6 +103,9 @@ public class CsvTestsDataLoader {
             .withDynamic("false")
             .noSubfields(),
         new TestDataset("all_types", "mapping-all-types.json", "all-types.csv"),
+        new TestDataset("all_types", "mapping-all-types.json", "all-types.csv").withIndex("all_types_no_short")
+            .withTypeMapping(removeFields("short"))
+            .withDynamic("false"),
         new TestDataset("hosts"),
         new TestDataset("apps"),
         new TestDataset("apps").withIndex("apps_short").withTypeMapping(Map.of("id", "short")),

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/unmapped-load.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/unmapped-load.csv-spec
@@ -17,6 +17,27 @@ id:integer | name:keyword
 11         | kkkkk
 ;
 
+// Reproducer for #151525: explicit cast on a partially unmapped small numeric field must not CCE.
+// all_types maps `short` as short; all_types_no_short has `short` unmapped but with values in _source.
+// With unmapped_fields=load the field is a two-legged PUNK; short::integer must work on both legs.
+partiallyUnmappedSmallNumericFieldExplicitCast
+required_capability: optional_fields_v5
+
+SET unmapped_fields="load"\;
+FROM all_types, all_types_no_short
+| EVAL short_int = short::integer
+| STATS count = COUNT(*) BY integer, short_int
+| SORT integer ASC
+;
+
+count:long | integer:integer | short_int:integer
+2          | 1               | 10
+2          | 2               | 20
+2          | 3               | 30
+2          | 4               | 40
+2          | 5               | 50
+;
+
 
 // These ones verify we don't do anything extra when unmapped_fields is not set to "load"
 doesNotLoadUnmappedFieldsSort

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerUnmappedTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerUnmappedTests.java
@@ -14,16 +14,19 @@ import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.xpack.esql.TestAnalyzer;
 import org.elasticsearch.xpack.esql.VerificationException;
 import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Expressions;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.FoldContext;
 import org.elasticsearch.xpack.esql.core.expression.MetadataAttribute;
 import org.elasticsearch.xpack.esql.core.expression.UnresolvedTimestamp;
+import org.elasticsearch.xpack.esql.core.type.CompactMultiTypeEsField;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.type.EsField;
 import org.elasticsearch.xpack.esql.core.type.InvalidMappedField;
 import org.elasticsearch.xpack.esql.core.type.PotentiallyUnmappedKeywordEsField;
 import org.elasticsearch.xpack.esql.core.type.UnsupportedEsField;
+import org.elasticsearch.xpack.esql.expression.function.scalar.convert.AbstractConvertFunction;
 import org.elasticsearch.xpack.esql.index.EsIndex;
 import org.elasticsearch.xpack.esql.index.IndexResolution;
 import org.elasticsearch.xpack.esql.plan.IndexPattern;
@@ -931,15 +934,21 @@ public class AnalyzerUnmappedTests extends AnalyzerUnmappedTestBase {
         }
     }
 
-    public void testWrapPartiallyUnmappedFieldWidensSmallNumerics() {
+    /**
+     * Regression test for #151525: {@link IndexResolver#wrapPartiallyUnmappedField} must preserve
+     * the original type name for small numeric fields (short, byte, float, half_float, scaled_float).
+     * The physical layer looks up conversion expressions by the shard-reported type (e.g. "short"),
+     * so the type stored in the {@link InvalidMappedField} must match, not the widened type.
+     */
+    public void testWrapPartiallyUnmappedFieldPreservesSmallNumericTypes() {
         Set<String> mappedIndices = Set.of("idx_mapped");
         for (DataType smallNumeric : List.of(DataType.SHORT, DataType.BYTE, DataType.FLOAT, DataType.HALF_FLOAT, DataType.SCALED_FLOAT)) {
             EsField field = new EsField("f", smallNumeric, emptyMap(), true, EsField.TimeSeriesFieldType.NONE);
             InvalidMappedField wrapped = (InvalidMappedField) IndexResolver.wrapPartiallyUnmappedField(field, "f", "f", mappedIndices);
             assertThat(
-                "Partially-unmapped " + smallNumeric + " field should be stored under its widened type name",
+                "Partially-unmapped " + smallNumeric + " field should be stored under its original (non-widened) type name",
                 wrapped.getTypesToIndices(),
-                equalTo(Map.of(smallNumeric.widenSmallNumeric().typeName(), mappedIndices))
+                equalTo(Map.of(smallNumeric.typeName(), mappedIndices))
             );
         }
     }
@@ -1497,6 +1506,89 @@ public class AnalyzerUnmappedTests extends AnalyzerUnmappedTestBase {
 
     private static EsField doubleField(String name) {
         return new EsField(name, DataType.DOUBLE, emptyMap(), true, EsField.TimeSeriesFieldType.NONE);
+    }
+
+    private static EsField smallNumericField(String name, DataType dt) {
+        return new EsField(name, dt, emptyMap(), true, EsField.TimeSeriesFieldType.NONE);
+    }
+
+    private static final List<DataType> SMALL_NUMERIC_TYPES = List.of(
+        DataType.SHORT,
+        DataType.BYTE,
+        DataType.FLOAT,
+        DataType.HALF_FLOAT,
+        DataType.SCALED_FLOAT
+    );
+
+    /**
+     * Regression test for #151525. Via an explicit cast in the query (e.g. {@code to_integer(f)}),
+     * which goes through {@code ResolveUnionTypes}, the resulting {@link CompactMultiTypeEsField}
+     * must key the conversion expression by the <em>original</em> (pre-widening) type — e.g.
+     * {@code SHORT}, not {@code INTEGER} — so that the physical layer, which looks up by the actual
+     * mapped type reported by the shard, finds the correct expression.
+     */
+    public void testTwoLeggedPunkSmallNumericExplicitCastUsesOriginalTypeAsKey() {
+        assumeTrue("Requires OPTIONAL_FIELDS_V5", EsqlCapabilities.Cap.OPTIONAL_FIELDS_V5.isEnabled());
+
+        for (DataType dt : SMALL_NUMERIC_TYPES) {
+            DataType widened = dt.widenSmallNumeric();
+            String castFn = widened == DataType.INTEGER ? "to_integer" : "to_double";
+            EsIndex esIndex = partialIndex(
+                Map.of(
+                    "sort_field",
+                    new EsField("sort_field", DataType.INTEGER, emptyMap(), true, EsField.TimeSeriesFieldType.NONE),
+                    "f",
+                    smallNumericField("f", dt)
+                ),
+                Set.of("f")
+            );
+            LogicalPlan plan = analyzer().minimumTransportVersion(CompactMultiTypeEsField.CompactMultiTypeEsField)
+                .addIndex(esIndex)
+                .statement(setUnmappedLoad("FROM idx* | EVAL x = " + castFn + "(f) | SORT sort_field"));
+
+            CompactMultiTypeEsField compact = findCompactField(plan, "f");
+            assertNotNull("No CompactMultiTypeEsField found for 'f' with type " + dt + " (explicit cast)", compact);
+            assertThat("Widened data type for " + dt + " (explicit cast)", compact.getDataType(), is(widened));
+            assertThat(
+                "typeToConversionExpressions for explicitly-cast partially-unmapped " + dt + " must use the original type as key",
+                compact.getTypeToConversionExpressions().keySet(),
+                equalTo(Set.of(dt))
+            );
+            Expression expr = compact.getTypeToConversionExpressions().get(dt);
+            assertThat(
+                "Conversion for " + dt + " (explicit cast) must be a convert function",
+                expr,
+                instanceOf(AbstractConvertFunction.class)
+            );
+            assertThat(
+                "Inner field of the convert function for " + dt + " (explicit cast) must keep the original type",
+                ((AbstractConvertFunction) expr).field().dataType(),
+                is(dt)
+            );
+            Expression unmapped = compact.getUnmappedConversionExpression();
+            assertNotNull("unmappedConversionExpression must be non-null for partially-unmapped " + dt + " (explicit cast)", unmapped);
+            assertThat(
+                "unmappedConversionExpression (explicit cast) must be a convert function",
+                unmapped,
+                instanceOf(AbstractConvertFunction.class)
+            );
+            assertThat(
+                "unmappedConversionExpression (explicit cast) inner field must be KEYWORD",
+                ((AbstractConvertFunction) unmapped).field().dataType(),
+                is(DataType.KEYWORD)
+            );
+        }
+    }
+
+    private static CompactMultiTypeEsField findCompactField(LogicalPlan plan, String name) {
+        CompactMultiTypeEsField[] found = { null };
+        plan.forEachExpressionDown(FieldAttribute.class, fa -> {
+            // Use field name, not attribute name: ResolveUnionTypes renames attributes to $name$converted_to$type
+            if (fa.field().getName().equals(name) && fa.field() instanceof CompactMultiTypeEsField c) {
+                found[0] = c;
+            }
+        });
+        return found[0];
     }
 
     /**


### PR DESCRIPTION
## Summary

Regression tests for https://github.com/elastic/elasticsearch/issues/151525, where an explicit cast on a partially-unmapped small numeric field (e.g. `short::integer` with `unmapped_fields=load`) causes a `ClassCastException` at query execution time.

The root cause is in `IndexResolver.wrapPartiallyUnmappedField`, which widens small numeric types (SHORT→INTEGER, BYTE→INTEGER, FLOAT→DOUBLE, etc.) when building the `InvalidMappedField`/`CompactInvalidMappedField`. This means the `CompactMultiTypeEsField` produced by the analyzer stores its conversion expression under `INTEGER` instead of `SHORT`. The physical layer looks up by the actual shard-reported type (`"short"` → `SHORT`) and finds nothing, then falls through to the unmapped keyword path — causing the CCE.

These tests are **expected to fail** until the `IndexResolver` bug is fixed. They are included now to establish the contract before the fix:

- **`testWrapPartiallyUnmappedFieldPreservesSmallNumericTypes`** (`AnalyzerUnmappedTests`): unit test asserting that `wrapPartiallyUnmappedField` stores the original (non-widened) type name in the resulting `InvalidMappedField`.
- **`testTwoLeggedPunkSmallNumericExplicitCastUsesOriginalTypeAsKey`** (`AnalyzerUnmappedTests`): unit test asserting that the `CompactMultiTypeEsField` produced by `ResolveUnionTypes` keys its conversion expression by the original type (`SHORT`, not `INTEGER`) and has a non-null `unmappedConversionExpression` for the keyword leg.
- **`partiallyUnmappedSmallNumericFieldExplicitCast`** (`unmapped-load.csv-spec`): CSV integration test using the new `all_types_no_short` dataset (all_types data, `short` field unmapped, `dynamic: false`) to reproduce the exact CCE scenario from the issue.

## Test plan

- [ ] Confirm all three tests fail on this branch before the fix
- [ ] Confirm all three tests pass after the `IndexResolver` fix is applied
- [ ] Run `partiallyUnmappedSmallNumericFieldExplicitCast` in a loop (`-Dtests.iters=10`) to check for flakiness

🤖 Generated with [Claude Code](https://claude.com/claude-code)