### PR TITLE
Reindex: account Apache HC response buffer against REQUEST circuit breaker

### DIFF
--- a/docs/changelog/150000.yaml
+++ b/docs/changelog/150000.yaml
@@ -1,0 +1,5 @@
+area: Reindex
+issues: []
+pr: 150000
+summary: Account Apache HC response buffer bytes against the REQUEST circuit breaker in reindex-from-remote
+type: bug

--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/ReindexFromRemoteCircuitBreakerIT.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/ReindexFromRemoteCircuitBreakerIT.java
@@ -68,10 +68,13 @@ public class ReindexFromRemoteCircuitBreakerIT extends ESSingleNodeTestCase {
         return Settings.builder()
             .put(super.nodeSettings())
             .put(TransportReindexAction.REMOTE_CLUSTER_WHITELIST.getKey(), "*:*")
-            // Sized above the version-lookup (~600 B) and open-PIT (~700 B) responses — both are
-            // immediately released — but below the first remote search response (≈ 100 KiB for
-            // 5 × 20 KiB random-alpha docs after JSON encoding) so the breaker trips when the
-            // RemoteParseContext flushes its accumulated bytes at the end of parsing.
+            // Sized above the version-lookup (~600 B) and open-PIT (~700 B) responses so those
+            // non-chunked requests pass their buffer-level reservations, but below the total
+            // per-hit bytes for this test (~5 × 20 KiB = 100 KiB) so RemoteParseContext trips on
+            // the final flushRemaining call with the reindex_remote_response label.
+            // ES search responses use chunked transfer encoding (no Content-Length), so the
+            // buffer-level accounting in BreakerAwareHeapBufferedAsyncResponseConsumer is skipped
+            // for them; the parse-context accounting is the relevant guard here.
             .put(HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_LIMIT_SETTING.getKey(), "5kb")
             .build();
     }
@@ -81,8 +84,9 @@ public class ReindexFromRemoteCircuitBreakerIT extends ESSingleNodeTestCase {
 
         // Single node: shard and coordinator are co-located, so the search response travels via
         // DirectResponseChannel (in-memory, no RecyclerBytesStreamOutput serialization). The 5 KiB
-        // REQUEST limit is therefore not tripped by shard serialization, only by our remote-response
-        // accounting in RemoteParseContext.
+        // REQUEST limit is not tripped by shard serialization. ES search responses use chunked
+        // transfer encoding so the buffer-level reservation is skipped; only the per-hit
+        // RemoteParseContext accounting (reindex_remote_response label) trips the breaker.
         assertAcked(
             indicesAdmin().prepareCreate("source").setSettings(Settings.builder().put("number_of_shards", 1).put("number_of_replicas", 0))
         );

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/remote/BreakerAwareConsumerFactory.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/remote/BreakerAwareConsumerFactory.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.reindex.remote;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.nio.protocol.HttpAsyncResponseConsumer;
+import org.elasticsearch.client.HttpAsyncResponseConsumerFactory;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+
+import java.util.Objects;
+
+/**
+ * {@link HttpAsyncResponseConsumerFactory} for reindex-from-remote that produces a
+ * {@link BreakerAwareHeapBufferedAsyncResponseConsumer} per request attempt. Apache HC calls
+ * {@link #createHttpAsyncResponseConsumer()} once per attempt (including retries), so each
+ * attempt independently reserves and releases its buffer bytes against the REQUEST circuit breaker.
+ */
+final class BreakerAwareConsumerFactory implements HttpAsyncResponseConsumerFactory {
+
+    /** Matches the upstream default in {@code HttpAsyncResponseConsumerFactory.DEFAULT_BUFFER_LIMIT}. */
+    static final int DEFAULT_BUFFER_LIMIT_BYTES = 100 * 1024 * 1024;
+
+    private final CircuitBreaker breaker;
+    private final int bufferLimitBytes;
+
+    BreakerAwareConsumerFactory(CircuitBreaker breaker) {
+        this(breaker, DEFAULT_BUFFER_LIMIT_BYTES);
+    }
+
+    /** Package-private for tests to supply a smaller buffer limit. */
+    BreakerAwareConsumerFactory(CircuitBreaker breaker, int bufferLimitBytes) {
+        this.breaker = Objects.requireNonNull(breaker, "breaker");
+        if (bufferLimitBytes <= 0) {
+            throw new IllegalArgumentException("bufferLimitBytes must be > 0, was " + bufferLimitBytes);
+        }
+        this.bufferLimitBytes = bufferLimitBytes;
+    }
+
+    @Override
+    public HttpAsyncResponseConsumer<HttpResponse> createHttpAsyncResponseConsumer() {
+        return new BreakerAwareHeapBufferedAsyncResponseConsumer(breaker, bufferLimitBytes);
+    }
+}

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/remote/BreakerAwareHeapBufferedAsyncResponseConsumer.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/remote/BreakerAwareHeapBufferedAsyncResponseConsumer.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.reindex.remote;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.entity.ContentType;
+import org.elasticsearch.client.HeapBufferedAsyncResponseConsumer;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * A {@link HeapBufferedAsyncResponseConsumer} that registers the raw HTTP response buffer against
+ * the {@link CircuitBreaker#REQUEST} circuit breaker for the lifetime of the buffer allocation.
+ *
+ * <p>Apache HC's default consumer buffers the entire response body in heap before the application
+ * can read it. Without accounting, multiple concurrent reindex-from-remote operations can each
+ * hold up to {@code bufferLimitBytes} of raw response data simultaneously, exhausting heap before
+ * any circuit breaker trips. This class fixes that gap by reserving bytes against the REQUEST
+ * breaker in {@link #onEntityEnclosed} and releasing them in {@link #releaseResources} (which
+ * Apache HC calls unconditionally on request completion, regardless of success or failure).
+ *
+ * <p>When the response uses chunked transfer encoding ({@code Content-Length} is unknown),
+ * no buffer-level reservation is made. The per-hit {@link RemoteParseContext} accounting
+ * that runs during parsing provides protection in that case.
+ *
+ * <p>This accounting is independent of the per-hit {@link RemoteParseContext} accounting: both
+ * are charged to the same REQUEST breaker but at different lifecycle points (buffer allocation vs.
+ * incremental parse). When the response has a known {@code Content-Length}, both reservations are
+ * held simultaneously at peak — the buffer bytes while the response body is being parsed, and the
+ * hit bytes for as long as the batch is live.
+ */
+final class BreakerAwareHeapBufferedAsyncResponseConsumer extends HeapBufferedAsyncResponseConsumer {
+
+    /** Label used when charging the REQUEST circuit breaker for the raw HTTP response buffer. */
+    static final String REMOTE_RESPONSE_BUFFER_BREAKER_LABEL = "reindex_remote_response_buffer";
+
+    private final CircuitBreaker breaker;
+    private final int bufferLimitBytes;
+    // Bytes currently reserved against the breaker; reset to 0 after release.
+    // Apache HC invokes onEntityEnclosed and releaseResources on the same I/O reactor thread
+    // for a given request, so no explicit synchronization is needed.
+    private long reservedBytes;
+
+    BreakerAwareHeapBufferedAsyncResponseConsumer(CircuitBreaker breaker, int bufferLimitBytes) {
+        super(bufferLimitBytes);
+        this.breaker = Objects.requireNonNull(breaker, "breaker");
+        this.bufferLimitBytes = bufferLimitBytes;
+    }
+
+    @Override
+    protected void onEntityEnclosed(HttpEntity entity, ContentType contentType) throws IOException {
+        long contentLength = entity.getContentLength();
+        if (contentLength > bufferLimitBytes) {
+            // Let super throw ContentTooLongException; nothing reserved yet.
+            super.onEntityEnclosed(entity, contentType);
+            return; // unreachable — super always throws when contentLength > bufferLimitBytes
+        }
+        if (contentLength <= 0) {
+            // Chunked transfer encoding: Content-Length is unknown. Reserving the full buffer cap
+            // (100MB) as a worst case would break concurrent operations that each have a response
+            // in flight but whose actual response is much smaller. Skip buffer-level accounting for
+            // chunked responses; the per-hit RemoteParseContext accounting provides protection.
+            super.onEntityEnclosed(entity, contentType);
+            return;
+        }
+        try {
+            breaker.addEstimateBytesAndMaybeBreak(contentLength, REMOTE_RESPONSE_BUFFER_BREAKER_LABEL);
+        } catch (CircuitBreakingException cbe) {
+            // Apache HC routes IOException from onEntityEnclosed to ResponseListener.onFailure.
+            throw new IOException(cbe);
+        }
+        reservedBytes = contentLength;
+        try {
+            super.onEntityEnclosed(entity, contentType);
+        } catch (IOException | RuntimeException e) {
+            // super failed after we reserved; refund now so releaseResources is idempotent.
+            breaker.addWithoutBreaking(-reservedBytes);
+            reservedBytes = 0;
+            throw e;
+        }
+    }
+
+    @Override
+    protected void releaseResources() {
+        try {
+            if (reservedBytes > 0) {
+                breaker.addWithoutBreaking(-reservedBytes);
+                reservedBytes = 0;
+            }
+        } finally {
+            super.releaseResources();
+        }
+    }
+
+    /** Visible for testing. */
+    long currentReservation() {
+        return reservedBytes;
+    }
+}

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/remote/RemoteReindexingUtils.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/remote/RemoteReindexingUtils.java
@@ -215,6 +215,12 @@ public class RemoteReindexingUtils {
         CircuitBreaker breaker,
         long memoryAccountingThresholdBytes
     ) {
+        // Account the raw HTTP response buffer against the REQUEST breaker for the buffer's
+        // lifetime (allocation in onEntityEnclosed → release in releaseResources). This is
+        // independent of the per-hit RemoteParseContext accounting that runs during parsing.
+        request.setOptions(
+            request.getOptions().toBuilder().setHttpAsyncResponseConsumerFactory(new BreakerAwareConsumerFactory(breaker)).build()
+        );
         // Preserve the thread context so headers survive after the call
         Supplier<ThreadContext.StoredContext> contextSupplier = threadPool.getThreadContext().newRestorableContext(true);
         try {
@@ -307,6 +313,11 @@ public class RemoteReindexingUtils {
                                 listener.onRejection(e);
                                 return;
                             }
+                        } else if (e.getCause() instanceof CircuitBreakingException cbe) {
+                            // BreakerAwareHeapBufferedAsyncResponseConsumer wraps CircuitBreakingException
+                            // in an IOException so that Apache HC can route it here via onFailure.
+                            listener.onFailure(cbe);
+                            return;
                         } else if (e instanceof ContentTooLongException) {
                             e = new IllegalArgumentException(
                                 "Remote responded with a chunk that was too large. Use a smaller batch size.",

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/remote/BreakerAwareConsumerFactoryTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/remote/BreakerAwareConsumerFactoryTests.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.reindex.remote;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.nio.protocol.HttpAsyncResponseConsumer;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.test.ESTestCase;
+
+import static org.elasticsearch.reindex.remote.BreakerAwareConsumerFactory.DEFAULT_BUFFER_LIMIT_BYTES;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.sameInstance;
+
+public class BreakerAwareConsumerFactoryTests extends ESTestCase {
+
+    /** Each call to createHttpAsyncResponseConsumer() returns a distinct instance so retries are independent. */
+    public void testCreateReturnsNewConsumerEachCall() {
+        BreakerAwareConsumerFactory factory = new BreakerAwareConsumerFactory(new NoopCircuitBreaker(CircuitBreaker.REQUEST));
+        HttpAsyncResponseConsumer<HttpResponse> first = factory.createHttpAsyncResponseConsumer();
+        HttpAsyncResponseConsumer<HttpResponse> second = factory.createHttpAsyncResponseConsumer();
+        assertThat("each call produces a new consumer", first, not(sameInstance(second)));
+    }
+
+    /** The created consumer is a BreakerAwareHeapBufferedAsyncResponseConsumer. */
+    public void testCreateReturnsBreakerAwareConsumer() {
+        BreakerAwareConsumerFactory factory = new BreakerAwareConsumerFactory(new NoopCircuitBreaker(CircuitBreaker.REQUEST));
+        assertThat(factory.createHttpAsyncResponseConsumer(), instanceOf(BreakerAwareHeapBufferedAsyncResponseConsumer.class));
+    }
+
+    /** The default buffer limit matches the upstream HttpAsyncResponseConsumerFactory default (100 MiB). */
+    public void testDefaultBufferLimitMatchesUpstream() {
+        assertThat(DEFAULT_BUFFER_LIMIT_BYTES, equalTo(100 * 1024 * 1024));
+        BreakerAwareConsumerFactory factory = new BreakerAwareConsumerFactory(new NoopCircuitBreaker(CircuitBreaker.REQUEST));
+        BreakerAwareHeapBufferedAsyncResponseConsumer consumer = (BreakerAwareHeapBufferedAsyncResponseConsumer) factory
+            .createHttpAsyncResponseConsumer();
+        assertThat(consumer.getBufferLimit(), equalTo(DEFAULT_BUFFER_LIMIT_BYTES));
+    }
+
+    /** A custom buffer limit is plumbed through to the created consumer. */
+    public void testCustomBufferLimitIsUsed() {
+        int customLimit = 1024;
+        BreakerAwareConsumerFactory factory = new BreakerAwareConsumerFactory(new NoopCircuitBreaker(CircuitBreaker.REQUEST), customLimit);
+        BreakerAwareHeapBufferedAsyncResponseConsumer consumer = (BreakerAwareHeapBufferedAsyncResponseConsumer) factory
+            .createHttpAsyncResponseConsumer();
+        assertThat(consumer.getBufferLimit(), equalTo(customLimit));
+    }
+
+    /** Constructor rejects non-positive bufferLimitBytes and a null breaker. */
+    public void testConstructorValidation() {
+        NoopCircuitBreaker breaker = new NoopCircuitBreaker(CircuitBreaker.REQUEST);
+        expectThrows(IllegalArgumentException.class, () -> new BreakerAwareConsumerFactory(breaker, 0));
+        expectThrows(IllegalArgumentException.class, () -> new BreakerAwareConsumerFactory(breaker, -1));
+        expectThrows(NullPointerException.class, () -> new BreakerAwareConsumerFactory(null));
+        expectThrows(NullPointerException.class, () -> new BreakerAwareConsumerFactory(null, 1024));
+    }
+}

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/remote/BreakerAwareHeapBufferedAsyncResponseConsumerTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/remote/BreakerAwareHeapBufferedAsyncResponseConsumerTests.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.reindex.remote;
+
+import org.apache.http.ContentTooLongException;
+import org.apache.http.ProtocolVersion;
+import org.apache.http.StatusLine;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.message.BasicHttpResponse;
+import org.apache.http.message.BasicStatusLine;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.elasticsearch.reindex.remote.BreakerAwareHeapBufferedAsyncResponseConsumer.REMOTE_RESPONSE_BUFFER_BREAKER_LABEL;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+
+/**
+ * Unit tests for {@link BreakerAwareHeapBufferedAsyncResponseConsumer}.
+ *
+ * <p>Uses {@link TrackingBreaker} (the same helper used by {@link RemoteParseContextTests}) to
+ * observe breaker interactions without spinning up a full cluster.
+ */
+public class BreakerAwareHeapBufferedAsyncResponseConsumerTests extends ESTestCase {
+
+    /**
+     * Minimal fake breaker: tracks net registered bytes and optionally trips when a limit is exceeded.
+     * Identical in structure to the one in RemoteParseContextTests.
+     */
+    static class TrackingBreaker extends NoopCircuitBreaker {
+        private final AtomicLong net = new AtomicLong();
+        private final long limit;
+
+        TrackingBreaker() {
+            this(Long.MAX_VALUE);
+        }
+
+        TrackingBreaker(long limit) {
+            super(CircuitBreaker.REQUEST);
+            this.limit = limit;
+        }
+
+        @Override
+        public void addEstimateBytesAndMaybeBreak(long bytes, String label) {
+            long projected = net.get() + bytes;
+            if (projected > limit) {
+                throw new CircuitBreakingException(
+                    "[" + label + "] tracking breaker tripped",
+                    bytes,
+                    limit,
+                    CircuitBreaker.Durability.TRANSIENT
+                );
+            }
+            net.addAndGet(bytes);
+        }
+
+        @Override
+        public void addWithoutBreaking(long bytes) {
+            net.addAndGet(bytes);
+        }
+
+        @Override
+        public long getUsed() {
+            return net.get();
+        }
+    }
+
+    /** Convenience: create a 200-OK BasicHttpResponse with an entity whose Content-Length is {@code len}. */
+    private static BasicHttpResponse responseWithContentLength(long len) {
+        ProtocolVersion protocolVersion = new ProtocolVersion("HTTP", 1, 1);
+        StatusLine statusLine = new BasicStatusLine(protocolVersion, 200, "OK");
+        BasicHttpResponse response = new BasicHttpResponse(statusLine);
+        response.setEntity(new StringEntity("", ContentType.APPLICATION_JSON) {
+            @Override
+            public long getContentLength() {
+                return len;
+            }
+        });
+        return response;
+    }
+
+    /** Known Content-Length → the exact byte count is reserved. */
+    public void testReservesContentLengthOnEnclosed() throws Exception {
+        TrackingBreaker breaker = new TrackingBreaker();
+        int bufferLimit = 100 * 1024 * 1024;
+        BreakerAwareHeapBufferedAsyncResponseConsumer consumer = new BreakerAwareHeapBufferedAsyncResponseConsumer(breaker, bufferLimit);
+
+        long contentLength = randomLongBetween(1, bufferLimit);
+        consumer.responseReceived(responseWithContentLength(contentLength));
+
+        assertThat("exact content-length reserved", breaker.getUsed(), equalTo(contentLength));
+        assertThat(consumer.currentReservation(), equalTo(contentLength));
+    }
+
+    /**
+     * Unknown Content-Length (chunked transfer encoding, Content-Length: -1) → no buffer-level
+     * reservation. Per-hit {@code RemoteParseContext} accounting provides protection instead.
+     */
+    public void testNoReservationWhenContentLengthUnknown() throws Exception {
+        TrackingBreaker breaker = new TrackingBreaker();
+        int bufferLimit = 1024;
+        BreakerAwareHeapBufferedAsyncResponseConsumer consumer = new BreakerAwareHeapBufferedAsyncResponseConsumer(breaker, bufferLimit);
+
+        consumer.responseReceived(responseWithContentLength(-1));
+
+        assertThat("no reservation for chunked response", breaker.getUsed(), equalTo(0L));
+        assertThat(consumer.currentReservation(), equalTo(0L));
+    }
+
+    /** Zero Content-Length → treated the same as unknown length: no reservation. */
+    public void testNoReservationWhenContentLengthZero() throws Exception {
+        TrackingBreaker breaker = new TrackingBreaker();
+        int bufferLimit = 512;
+        BreakerAwareHeapBufferedAsyncResponseConsumer consumer = new BreakerAwareHeapBufferedAsyncResponseConsumer(breaker, bufferLimit);
+
+        consumer.responseReceived(responseWithContentLength(0));
+
+        assertThat("no reservation when content-length is 0", breaker.getUsed(), equalTo(0L));
+        assertThat(consumer.currentReservation(), equalTo(0L));
+    }
+
+    /** When the breaker limit is too small, onEntityEnclosed propagates a CBE via IOException. */
+    public void testTripsBreakerWhenReservationExceedsLimit() {
+        int bufferLimit = 1024;
+        TrackingBreaker breaker = new TrackingBreaker(512L); // less than bufferLimit
+        BreakerAwareHeapBufferedAsyncResponseConsumer consumer = new BreakerAwareHeapBufferedAsyncResponseConsumer(breaker, bufferLimit);
+
+        // Content-Length = 1024 > 512 limit → breaker trips
+        IOException thrown = expectThrows(IOException.class, () -> consumer.responseReceived(responseWithContentLength(1024)));
+        assertThat("IOException wraps CircuitBreakingException", thrown.getCause(), instanceOf(CircuitBreakingException.class));
+        assertThat(thrown.getCause().getMessage(), containsString(REMOTE_RESPONSE_BUFFER_BREAKER_LABEL));
+        assertThat("no bytes leaked to breaker on trip", breaker.getUsed(), equalTo(0L));
+        assertThat("reservation field cleared", consumer.currentReservation(), equalTo(0L));
+    }
+
+    /** close() releases bytes reserved in onEntityEnclosed. */
+    public void testCloseRefundsBreaker() throws Exception {
+        TrackingBreaker breaker = new TrackingBreaker();
+        int bufferLimit = 100 * 1024;
+        BreakerAwareHeapBufferedAsyncResponseConsumer consumer = new BreakerAwareHeapBufferedAsyncResponseConsumer(breaker, bufferLimit);
+
+        consumer.responseReceived(responseWithContentLength(bufferLimit));
+        assertThat(breaker.getUsed(), equalTo((long) bufferLimit));
+
+        consumer.close();
+        assertThat("close() must refund the buffer reservation", breaker.getUsed(), equalTo(0L));
+        assertThat(consumer.currentReservation(), equalTo(0L));
+    }
+
+    /** close() is idempotent via AbstractAsyncResponseConsumer — the second call is a no-op. */
+    public void testCloseIsIdempotent() throws Exception {
+        TrackingBreaker breaker = new TrackingBreaker();
+        int bufferLimit = 4096;
+        BreakerAwareHeapBufferedAsyncResponseConsumer consumer = new BreakerAwareHeapBufferedAsyncResponseConsumer(breaker, bufferLimit);
+
+        consumer.responseReceived(responseWithContentLength(bufferLimit));
+        consumer.close();
+        consumer.close(); // second close must not double-refund
+        assertThat("no double-refund on second close", breaker.getUsed(), equalTo(0L));
+    }
+
+    /** Content-Length > buffer cap triggers ContentTooLongException before any reservation. */
+    public void testContentTooLongPropagatesWithoutReservation() {
+        TrackingBreaker breaker = new TrackingBreaker();
+        int bufferLimit = 1024;
+        BreakerAwareHeapBufferedAsyncResponseConsumer consumer = new BreakerAwareHeapBufferedAsyncResponseConsumer(breaker, bufferLimit);
+
+        // Content-Length exceeds the buffer cap — super throws ContentTooLongException, nothing reserved.
+        expectThrows(ContentTooLongException.class, () -> consumer.responseReceived(responseWithContentLength(bufferLimit + 1)));
+        assertThat("no bytes reserved when ContentTooLongException is thrown", breaker.getUsed(), equalTo(0L));
+    }
+
+    /** A NoopCircuitBreaker passes without tripping, and currentReservation tracks bytes correctly. */
+    public void testNoopBreakerDoesNotTrip() throws Exception {
+        CircuitBreaker noop = new NoopCircuitBreaker(CircuitBreaker.REQUEST);
+        int bufferLimit = 100 * 1024;
+        BreakerAwareHeapBufferedAsyncResponseConsumer consumer = new BreakerAwareHeapBufferedAsyncResponseConsumer(noop, bufferLimit);
+
+        consumer.responseReceived(responseWithContentLength(bufferLimit));
+        // NoopCircuitBreaker always reports 0 used
+        assertThat(noop.getUsed(), equalTo(0L));
+        assertThat("reservation field still set", consumer.currentReservation(), equalTo((long) bufferLimit));
+        consumer.close();
+        assertThat(consumer.currentReservation(), equalTo(0L));
+    }
+
+    /** Constructor rejects non-positive bufferLimitBytes and a null breaker. */
+    public void testConstructorValidation() {
+        TrackingBreaker breaker = new TrackingBreaker();
+        expectThrows(IllegalArgumentException.class, () -> new BreakerAwareHeapBufferedAsyncResponseConsumer(breaker, 0));
+        expectThrows(IllegalArgumentException.class, () -> new BreakerAwareHeapBufferedAsyncResponseConsumer(breaker, -1));
+        expectThrows(NullPointerException.class, () -> new BreakerAwareHeapBufferedAsyncResponseConsumer(null, 1024));
+    }
+}

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/remote/RemotePitPaginatedHitSourceTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/remote/RemotePitPaginatedHitSourceTests.java
@@ -27,7 +27,6 @@ import org.apache.http.nio.protocol.HttpAsyncRequestProducer;
 import org.apache.http.nio.protocol.HttpAsyncResponseConsumer;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.search.SearchRequest;
-import org.elasticsearch.client.HeapBufferedAsyncResponseConsumer;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.common.BackoffPolicy;
 import org.elasticsearch.common.ParsingException;
@@ -511,7 +510,8 @@ public class RemotePitPaginatedHitSourceTests extends ESTestCase {
                 any(FutureCallback.class)
             )
         ).then((Answer<Future<HttpResponse>>) invocationOnMock -> {
-            HeapBufferedAsyncResponseConsumer consumer = (HeapBufferedAsyncResponseConsumer) invocationOnMock.getArguments()[1];
+            BreakerAwareHeapBufferedAsyncResponseConsumer consumer = (BreakerAwareHeapBufferedAsyncResponseConsumer) invocationOnMock
+                .getArguments()[1];
             FutureCallback callback = (FutureCallback) invocationOnMock.getArguments()[3];
             assertEquals(ByteSizeValue.of(100, ByteSizeUnit.MB).bytesAsInt(), consumer.getBufferLimit());
             callback.failed(tooLong);

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/remote/RemoteScrollablePaginatedHitSourceTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/remote/RemoteScrollablePaginatedHitSourceTests.java
@@ -27,7 +27,6 @@ import org.apache.http.nio.protocol.HttpAsyncRequestProducer;
 import org.apache.http.nio.protocol.HttpAsyncResponseConsumer;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.search.SearchRequest;
-import org.elasticsearch.client.HeapBufferedAsyncResponseConsumer;
 import org.elasticsearch.client.ResponseListener;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.common.BackoffPolicy;
@@ -385,7 +384,8 @@ public class RemoteScrollablePaginatedHitSourceTests extends ESTestCase {
         ).then(new Answer<Future<HttpResponse>>() {
             @Override
             public Future<HttpResponse> answer(InvocationOnMock invocationOnMock) {
-                HeapBufferedAsyncResponseConsumer consumer = (HeapBufferedAsyncResponseConsumer) invocationOnMock.getArguments()[1];
+                BreakerAwareHeapBufferedAsyncResponseConsumer consumer = (BreakerAwareHeapBufferedAsyncResponseConsumer) invocationOnMock
+                    .getArguments()[1];
                 FutureCallback callback = (FutureCallback) invocationOnMock.getArguments()[3];
                 assertEquals(ByteSizeValue.of(100, ByteSizeUnit.MB).bytesAsInt(), consumer.getBufferLimit());
                 callback.failed(tooLong);


### PR DESCRIPTION
## Summary

- Adds `BreakerAwareHeapBufferedAsyncResponseConsumer`, a `HeapBufferedAsyncResponseConsumer` subclass that reserves `Content-Length` bytes against `CircuitBreaker.REQUEST` in `onEntityEnclosed` and releases them unconditionally in `releaseResources`. The reservation label is `reindex_remote_response_buffer` (distinct from the existing `reindex_remote_response` parse-context label).
- Adds `BreakerAwareConsumerFactory` implementing `HttpAsyncResponseConsumerFactory`; creates one consumer per request attempt so retries reserve/release independently.
- Wires the factory into `RemoteReindexingUtils.execute()` so every outbound request (version lookup, PIT open/close, search batches) uses it. Also unwraps `CircuitBreakingException` from the `IOException` wrapper Apache HC imposes on `onEntityEnclosed` failures.
- Chunked responses (`Content-Length <= 0`) skip buffer-level accounting — ES serves all search responses with chunked transfer encoding, so the per-hit `RemoteParseContext` accounting (PR #149389) remains the guard for those.

## Background

Closes the final OOM gap in reindex-from-remote after #148656 (BulkRequest accounting) and #149389 (parsed-hit accounting). We've seen heap dumps showing Apache HC `SimpleInputBuffer` / `ContentBufferEntity` allocations consuming up to 67% of heap. With multiple concurrent remote reindexes each holding up to 100 MB of buffered response data, heap is exhausted before any circuit breaker trips.

## Test plan

- `BreakerAwareHeapBufferedAsyncResponseConsumerTests` — unit tests covering: known Content-Length reserved exactly; chunked/zero Content-Length skips reservation; breaker trip wrapped as IOException; `releaseResources` refunds; idempotent second release; Content-Length > cap triggers `ContentTooLongException` without reservation; constructor validation.
- `BreakerAwareConsumerFactoryTests` — factory creates distinct instances per call, default and custom limits plumbed correctly, constructor validation.
- `RemoteScrollablePaginatedHitSourceTests` / `RemotePitPaginatedHitSourceTests` — updated cast assertions.
- `ReindexFromRemoteCircuitBreakerIT` — reverted to 5 kb limit (search responses are chunked so buffer accounting is skipped; parse-context trip at `reindex_remote_response` label is the target).
- `ReindexFromRemoteCircuitBreakerReleaseIT` — unchanged; verifies per-batch release across a corpus larger than the breaker limit.
