### PR TITLE
[9.4] Truncate error for ILM's step_info instead of string (#150413)

### DIFF
--- a/docs/changelog/150413.yaml
+++ b/docs/changelog/150413.yaml
@@ -1,0 +1,5 @@
+area: ILM
+issues: []
+pr: 150413
+summary: Truncate error for ILM's `step_info` instead of string
+type: bug

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/LifecycleExecutionState.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/LifecycleExecutionState.java
@@ -359,7 +359,7 @@ public record LifecycleExecutionState(
         }
 
         public Builder setStepInfo(String stepInfo) {
-            this.stepInfo = potentiallyTruncateLongJsonWithExplanation(stepInfo);
+            this.stepInfo = stepInfo;
             return this;
         }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/LifecycleExecutionStateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/LifecycleExecutionStateTests.java
@@ -29,14 +29,16 @@ public class LifecycleExecutionStateTests extends ESTestCase {
         assertEquals(customMetadata, parsed.asMap());
     }
 
-    public void testTruncatingStepInfo() {
+    public void testManuallyTruncatingStepInfo() {
         Map<String, String> custom = createCustomMetadata();
         LifecycleExecutionState state = LifecycleExecutionState.fromCustomMetadata(custom);
         assertThat(custom.get("step_info"), equalTo(state.stepInfo()));
         String longStepInfo = "{\"key\": \""
             + randomAlphanumericOfLength(LifecycleExecutionState.MAXIMUM_STEP_INFO_STRING_LENGTH + 100)
             + "\"}";
-        LifecycleExecutionState newState = LifecycleExecutionState.builder(state).setStepInfo(longStepInfo).build();
+        LifecycleExecutionState newState = LifecycleExecutionState.builder(state)
+            .setStepInfo(LifecycleExecutionState.potentiallyTruncateLongJsonWithExplanation(longStepInfo))
+            .build();
         assertThat(newState.stepInfo(), hasLength(LifecycleExecutionState.MAXIMUM_STEP_INFO_STRING_LENGTH));
         assertThat(newState.stepInfo(), endsWith("... (~111 chars truncated)\"}"));
     }

--- a/x-pack/plugin/ilm/src/javaRestTest/java/org/elasticsearch/xpack/ilm/ExplainLifecycleIT.java
+++ b/x-pack/plugin/ilm/src/javaRestTest/java/org/elasticsearch/xpack/ilm/ExplainLifecycleIT.java
@@ -13,7 +13,6 @@ import org.apache.http.util.EntityUtils;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
-import org.elasticsearch.cluster.metadata.LifecycleExecutionState;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
@@ -356,7 +355,9 @@ public class ExplainLifecycleIT extends IlmESRestTestCase {
 
         final String indexBase = "my-logs";
         final String indexName = indexBase + "-" + randomAlphaOfLength(5).toLowerCase(Locale.ROOT);
-        final String longMissingAliasName = randomAlphanumericOfLength(LifecycleExecutionState.MAXIMUM_STEP_INFO_STRING_LENGTH);
+        final String longMissingAliasName = randomAlphanumericOfLength(
+            10 + IndexLifecycleTransition.MAXIMUM_STEP_INFO_ERROR_MESSAGE_LENGTH
+        );
 
         final Request templateRequest = new Request("PUT", "_index_template/template_" + policyName);
         final String templateBody = Strings.format("""
@@ -379,8 +380,8 @@ public class ExplainLifecycleIT extends IlmESRestTestCase {
         assertOK(client().performRequest(indexRequest));
 
         final String expectedReason = Strings.format(
-            "index.lifecycle.rollover_alias [%s... (~122 chars truncated)",
-            longMissingAliasName.substring(0, longMissingAliasName.length() - 107)
+            "index.lifecycle.rollover_alias [%s... (~83 chars truncated)",
+            longMissingAliasName.substring(0, longMissingAliasName.length() - 67)
         );
         final Map<String, Object> expectedStepInfo = Map.of("type", "illegal_argument_exception", "reason", expectedReason);
         assertBusy(() -> {

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleTransition.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleTransition.java
@@ -17,6 +17,7 @@ import org.elasticsearch.cluster.metadata.LifecycleExecutionState;
 import org.elasticsearch.cluster.metadata.ProjectMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.xcontent.ToXContentObject;
@@ -34,6 +35,7 @@ import org.elasticsearch.xpack.core.ilm.RolloverAction;
 import org.elasticsearch.xpack.core.ilm.Step;
 import org.elasticsearch.xpack.core.ilm.TerminalPolicyStep;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -54,6 +56,11 @@ import static org.elasticsearch.xcontent.ToXContent.EMPTY_PARAMS;
  * performed by methods in this class.
  */
 public final class IndexLifecycleTransition {
+    // Maximum size of an error's "message" field when converting an exception to JSON for a step_info
+    public static int MAXIMUM_STEP_INFO_ERROR_MESSAGE_LENGTH = 256;
+    // Maximum number of suppressed exceptions to keep when converting an exception to JSON for a step_info
+    public static int MAXIMUM_STEP_INFO_SUPPRESSED_EXCEPTIONS = 2;
+
     private static final Logger logger = LogManager.getLogger(IndexLifecycleTransition.class);
 
     /**
@@ -181,7 +188,11 @@ public final class IndexLifecycleTransition {
         LifecycleExecutionState.Builder failedState = LifecycleExecutionState.builder(nextStepState);
         failedState.setFailedStep(currentStep.name());
         failedState.setStepInfo(Strings.toString(((builder, params) -> {
-            ElasticsearchException.generateThrowableXContent(builder, EMPTY_PARAMS, cause);
+            ElasticsearchException.generateThrowableXContent(
+                builder,
+                EMPTY_PARAMS,
+                maybeTruncateException(cause, MAXIMUM_STEP_INFO_SUPPRESSED_EXCEPTIONS)
+            );
             return builder;
         })));
         Step failedStep = stepLookupFunction.apply(idxMeta, currentStep);
@@ -202,6 +213,79 @@ public final class IndexLifecycleTransition {
         }
 
         return project.withLifecycleState(idxMeta.getIndex(), failedState.build());
+    }
+
+    /**
+     * Take an exception that we're about to stick into the step_info for a policy, and recursively
+     * truncate the messages of the exceptions, the causes, and the suppressed exceptions. These
+     * messages are truncated to be no longer than {@link #MAXIMUM_STEP_INFO_ERROR_MESSAGE_LENGTH}.
+     * If there are multiple suppressed exceptions, only {@link #MAXIMUM_STEP_INFO_SUPPRESSED_EXCEPTIONS}
+     * are kept. This returns potentially a different exception type than what was passed in,
+     * however, the exception that is return has an overridden name so that we preserve the name
+     * when it is converted to JSON.
+     *
+     * @param maxCauses the maximum depth to recurse into causes. Once it reaches 0 then further causes are discarded.
+     */
+    public static @Nullable Throwable maybeTruncateException(@Nullable Throwable error, int maxCauses) {
+        if (error == null) {
+            return null;
+        }
+        // Short circuit if we've hit the max number of clauses, ignoring everything except for the name and message of this cause
+        if (maxCauses <= 0) {
+            return new ElasticsearchException(truncateWithExplanation(error.getMessage())) {
+                @Override
+                protected String getExceptionName() {
+                    // Override to use original exception name
+                    return getExceptionName(error);
+                }
+            };
+        }
+        // We don't know what kind of error we've seen, but we still need to be able to truncate it,
+        // so convert it to an ElasticsearchException that "pretends" to have the same name as the
+        // original exception (the class isn't used in the stringification, so nothing is lost).
+        ElasticsearchException newError = new ElasticsearchException(
+            truncateWithExplanation(error.getMessage()),
+            maybeTruncateException(error.getCause(), maxCauses - 1)
+        ) {
+            @Override
+            protected String getExceptionName() {
+                // Override to use original exception name. We discard the type,
+                // but that's okay, because the name is what is used when converting it to JSON.
+                return getExceptionName(error);
+            }
+        };
+        // Truncate and limit the suppressed exceptions
+        Arrays.stream(error.getSuppressed()).limit(MAXIMUM_STEP_INFO_SUPPRESSED_EXCEPTIONS).forEach(suppressed -> {
+            Throwable newSuppressed = maybeTruncateException(suppressed, maxCauses - 1);
+            if (newSuppressed != null) {
+                newError.addSuppressed(newSuppressed);
+            }
+        });
+        // If it's an ElasticsearchException, try to truncate any long metadata
+        if (error instanceof ElasticsearchException ee) {
+            for (String key : ee.getMetadataKeys()) {
+                if (ee.getMetadata(key) != null) {
+                    newError.addMetadata(key, ee.getMetadata(key).stream().map(IndexLifecycleTransition::truncateWithExplanation).toList());
+                }
+            }
+        }
+        return newError;
+    }
+
+    /**
+     * Truncate a string to {@link #MAXIMUM_STEP_INFO_ERROR_MESSAGE_LENGTH},
+     * appending "... (~N chars truncated)" to the end if truncation happens.
+     */
+    private static String truncateWithExplanation(String input) {
+        if (input == null || input.length() <= MAXIMUM_STEP_INFO_ERROR_MESSAGE_LENGTH) {
+            return input;
+        }
+        final int roughNumberOfCharsTruncated = input.length() - MAXIMUM_STEP_INFO_ERROR_MESSAGE_LENGTH;
+        final String truncationExplanation = "... (~" + roughNumberOfCharsTruncated + " chars truncated)";
+        final String truncated = Strings.cleanTruncate(input, MAXIMUM_STEP_INFO_ERROR_MESSAGE_LENGTH - truncationExplanation.length())
+            + truncationExplanation;
+        assert truncated.length() <= MAXIMUM_STEP_INFO_ERROR_MESSAGE_LENGTH : "truncation didn't work";
+        return truncated;
     }
 
     /**

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/SetStepInfoUpdateTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/SetStepInfoUpdateTask.java
@@ -98,7 +98,11 @@ public class SetStepInfoUpdateTask extends IndexLifecycleClusterStateUpdateTask 
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.startObject();
-            ElasticsearchException.generateThrowableXContent(builder, params, exception);
+            ElasticsearchException.generateThrowableXContent(
+                builder,
+                params,
+                IndexLifecycleTransition.maybeTruncateException(exception, IndexLifecycleTransition.MAXIMUM_STEP_INFO_SUPPRESSED_EXCEPTIONS)
+            );
             builder.endObject();
             return builder;
         }

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleTransitionTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleTransitionTests.java
@@ -8,16 +8,19 @@
 package org.elasticsearch.xpack.ilm;
 
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.LifecycleExecutionState;
 import org.elasticsearch.cluster.metadata.ProjectMetadata;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.client.NoOpClient;
+import org.elasticsearch.xcontent.ObjectPath;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -58,9 +61,11 @@ import static org.elasticsearch.xpack.ilm.IndexLifecycleTransition.moveStateToNe
 import static org.elasticsearch.xpack.ilm.LifecyclePolicyTestsUtils.newTestLifecyclePolicy;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.startsWith;
 
 public class IndexLifecycleTransitionTests extends ESTestCase {
 
@@ -315,6 +320,102 @@ public class IndexLifecycleTransitionTests extends ESTestCase {
         );
         assertProjectOnErrorStep(project, index, currentStep, newProject, now, """
             {"type":"illegal_argument_exception","reason":"non elasticsearch-exception\"""");
+    }
+
+    public void testMoveIndexToErrorStepWithGiganticError() throws IOException {
+        String indexName = "my_index";
+        Step.StepKey currentStep = new Step.StepKey("current_phase", "current_action", "current_step");
+        Step.StepKey nextStepKey = new Step.StepKey("next_phase", "next_action", "next_step");
+        long now = randomNonNegativeLong();
+        ElasticsearchException cause = new ResourceNotFoundException(
+            "this is an error with a long list of suppressed errors "
+                + randomAlphaOfLengthBetween(1, IndexLifecycleTransition.MAXIMUM_STEP_INFO_ERROR_MESSAGE_LENGTH * 2),
+            new IllegalArgumentException(
+                "other cause " + randomAlphaOfLengthBetween(1, IndexLifecycleTransition.MAXIMUM_STEP_INFO_ERROR_MESSAGE_LENGTH * 2),
+                new ElasticsearchException(
+                    "this message will be truncated " + randomAlphaOfLength(IndexLifecycleTransition.MAXIMUM_STEP_INFO_ERROR_MESSAGE_LENGTH)
+                )
+            )
+        );
+        cause.addMetadata(
+            "es.mykey",
+            "long metadata " + randomAlphaOfLength(IndexLifecycleTransition.MAXIMUM_STEP_INFO_ERROR_MESSAGE_LENGTH)
+        );
+        // We add 10 suppressed exceptions, and only 3 will remain in the step_info
+        for (int i = 0; i < 10; i++) {
+            cause.addSuppressed(
+                new ElasticsearchException(
+                    "this is a long suppressed error #"
+                        + i
+                        + " "
+                        + randomAlphaOfLengthBetween(1, IndexLifecycleTransition.MAXIMUM_STEP_INFO_ERROR_MESSAGE_LENGTH * 2)
+                )
+            );
+        }
+
+        LifecycleExecutionState.Builder lifecycleState = LifecycleExecutionState.builder();
+        lifecycleState.setPhase(currentStep.phase());
+        lifecycleState.setAction(currentStep.action());
+        lifecycleState.setStep(currentStep.name());
+        ProjectMetadata project = buildProject(indexName, Settings.builder(), lifecycleState.build(), List.of());
+        Index index = project.index(indexName).getIndex();
+
+        ProjectMetadata newProject = IndexLifecycleTransition.moveIndexToErrorStep(
+            index,
+            project,
+            cause,
+            () -> now,
+            (idxMeta, stepKey) -> new MockStep(stepKey, nextStepKey)
+        );
+        assertNotSame(project, newProject);
+        IndexMetadata newIndexMetadata = newProject.getIndexSafe(index);
+        assertNotSame(project.index(index), newIndexMetadata);
+        LifecycleExecutionState newLifecycleState = newProject.index(index).getLifecycleExecutionState();
+        LifecycleExecutionState oldLifecycleState = project.index(index).getLifecycleExecutionState();
+        assertNotSame(oldLifecycleState, newLifecycleState);
+        assertEquals(currentStep.phase(), newLifecycleState.phase());
+        assertEquals(currentStep.action(), newLifecycleState.action());
+        assertEquals(ErrorStep.NAME, newLifecycleState.step());
+        assertEquals(currentStep.name(), newLifecycleState.failedStep());
+        assertEquals(oldLifecycleState.phaseTime(), newLifecycleState.phaseTime());
+        assertEquals(oldLifecycleState.actionTime(), newLifecycleState.actionTime());
+        assertEquals(now, newLifecycleState.stepTime().longValue());
+
+        // We want to validate that the step info is valid JSON, so we check to make sure that it
+        // has been truncated at least (it always should be based on the test exception above),
+        // and that it can be parsed into an object.
+        String errorStepInfo = newLifecycleState.stepInfo();
+        logger.info("--> step_info: {}", errorStepInfo);
+
+        // We should always have at least one thing truncated
+        assertThat(errorStepInfo, containsString("chars truncated"));
+        Map<String, Object> error = XContentHelper.convertToMap(JsonXContent.jsonXContent, errorStepInfo, randomBoolean());
+
+        // Validate that we've limited the number of suppresed exceptions to 3 maximum
+        Object suppressed = error.get("suppressed");
+        assertNotNull(suppressed);
+        assertThat(suppressed, instanceOf(List.class));
+        if (suppressed instanceof List<?> suppressedList) {
+            assertThat(suppressedList.size(), equalTo(IndexLifecycleTransition.MAXIMUM_STEP_INFO_SUPPRESSED_EXCEPTIONS));
+        }
+
+        // We iterate through causes, so the root cause should be truncated as well
+        Object reason = ObjectPath.eval("caused_by.reason", error.get("caused_by"));
+        if (reason instanceof String r) {
+            assertThat(r, containsString("this message will be truncated"));
+            assertThat(r, containsString("... (~31 chars truncated)"));
+        } else {
+            fail("expected reason to be a string but it was not");
+        }
+        Object meta = error.get("mykey");
+        if (meta instanceof String m) {
+            assertThat(m, startsWith("long metadata "));
+            assertThat(m, containsString("... (~14 chars truncated"));
+        } else {
+            fail("expected metadata to be a string but it was not");
+        }
+        // Validate that the type passthrough works
+        assertThat(error.get("type"), equalTo("resource_not_found_exception"));
     }
 
     public void testAddStepInfoToProject() throws IOException {

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/SetStepInfoUpdateTaskTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/SetStepInfoUpdateTaskTests.java
@@ -8,12 +8,14 @@
 package org.elasticsearch.xpack.ilm;
 
 import org.apache.logging.log4j.Level;
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ProjectState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.LifecycleExecutionState;
 import org.elasticsearch.cluster.metadata.ProjectMetadata;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
@@ -31,6 +33,7 @@ import org.elasticsearch.xpack.core.ilm.Step.StepKey;
 import org.junit.Before;
 
 import static org.elasticsearch.cluster.metadata.LifecycleExecutionState.ILM_CUSTOM_METADATA_KEY;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
@@ -130,6 +133,16 @@ public class SetStepInfoUpdateTaskTests extends ESTestCase {
             task.onFailure(new RuntimeException("test exception"));
             mockLog.assertAllExpectationsMatched();
         }
+    }
+
+    public void testExceptionWrapperTruncates() {
+        SetStepInfoUpdateTask.ExceptionWrapper wrapper = new SetStepInfoUpdateTask.ExceptionWrapper(
+            new ElasticsearchException(
+                "this is a long message " + randomAlphaOfLength(IndexLifecycleTransition.MAXIMUM_STEP_INFO_ERROR_MESSAGE_LENGTH)
+            )
+        );
+
+        assertThat(Strings.toString(wrapper), containsString("... (~23 chars truncated)"));
     }
 
     private void setStatePolicy(String policyValue) {


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Truncate error for ILM's step_info instead of string (#150413)