### PR TITLE
Fix compile errors

### DIFF
--- a/modules/lang-painless/build.gradle
+++ b/modules/lang-painless/build.gradle
@@ -57,6 +57,10 @@ restResources {
     }
 }
 
+tasks.named("compileJava").configure {
+    options.compilerArgs << '-Xlint:-overloads'
+}
+
 tasks.named("test").configure {
     // in WhenThingsGoWrongTests we intentionally generate an out of memory error, this prevents the heap from being dumped to disk
     jvmArgs '-XX:-OmitStackTraceInFastThrow', '-XX:-HeapDumpOnOutOfMemoryError'

--- a/server/src/main/java/org/elasticsearch/index/mapper/IdLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IdLoader.java
@@ -614,7 +614,7 @@ public sealed interface IdLoader permits IdLoader.TsIdLoader, IdLoader.StoredIdL
                 throws IOException {
                 try (var builder = factory.bytesRefs(docs.count() - offset)) {
                     for (int i = offset; i < docs.count(); i++) {
-                        read(docs.get(i), (BlockLoader.BytesRefBuilder) builder);
+                        read(docs.get(i), builder);
                     }
                     return builder.build();
                 }


### PR DESCRIPTION
Compile error 1 (introduced by #148249):

```
> Task :server:compileJava
Note: PluginProcessor: writing plugin descriptor for 13 Log4j Plugins to `META-INF/org/apache/logging/log4j/core/config/plugins/Log4j2Plugins.dat`.
/Users/mvg/dev/code/elasticsearch/main/server/src/main/java/org/elasticsearch/index/mapper/IdLoader.java:617: warning: [cast] redundant cast to BytesRefBuilder
                        read(docs.get(i), (BlockLoader.BytesRefBuilder) builder);
```

and overload compile errors in lang-painless. (likely introduced by #151454)
