### PR TITLE
[9.4] ES|QL: better check for view support in CSV tests (#151055)

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
@@ -750,18 +750,35 @@ public class CsvTestsDataLoader {
     }
 
     private static boolean clusterHasViewSupport(RestClient client) throws IOException {
-        Request request = new Request("GET", "/_query/view");
+        // Use the _capabilities endpoint so we check ALL nodes, not just the coordinator.
+        // Views CRUD operations are master-node transport actions; if any node (e.g. an older data
+        // node acting as master) doesn't know the action, it will crash with an AssertionError.
+        Request capRequest = new Request("GET", "_capabilities");
+        capRequest.addParameter("method", "POST");
+        capRequest.addParameter("path", "/_query");
+        capRequest.addParameter("capabilities", "views_crud_as_index_actions");
         try {
-            Response ignored = client.performRequest(request);
-        } catch (ResponseException e) {
-            int code = e.getResponse().getStatusLine().getStatusCode();
-            // Different versions of Elasticsearch return different codes when views are not supported
-            if (code == 410 || code == 400 || code == 500 || code == 405) {
-                return false;
+            Response response = client.performRequest(capRequest);
+            try (var content = response.getEntity().getContent()) {
+                Map<String, Object> map = XContentHelper.convertToMap(XContentType.JSON.xContent(), content, false);
+                if (!Boolean.TRUE.equals(map.get("supported"))) {
+                    return false;
+                }
             }
-            throw e;
+        } catch (ResponseException e) {
+            return false;
         }
-        return true;
+        // The _capabilities check above confirms all nodes know the view transport actions (safe for
+        // BWC mixed-cluster tests). Now verify the view CRUD REST endpoints are actually reachable:
+        // in serverless mode, RestPutViewAction has no @ServerlessScope annotation, so those routes
+        // return 410 Gone — but _capabilities does not check the serverless scope and would still
+        // report "supported: true". A direct GET confirms real accessibility.
+        try {
+            client.performRequest(new Request("GET", "/_query/view"));
+            return true;
+        } catch (ResponseException e) {
+            return false;
+        }
     }
 
     private static void deleteView(RestClient client, String viewName) throws IOException {


### PR DESCRIPTION
Backports the following commits to 9.4:
 - ES|QL: better check for view support in CSV tests (#151055)