### PR TITLE
[9.4] Initializing inference indices (#145938)

### DIFF
--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/DefaultEndPointsIT.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/DefaultEndPointsIT.java
@@ -36,7 +36,7 @@ public class DefaultEndPointsIT extends InferenceBaseRestTest {
     private TestThreadPool threadPool;
 
     @Before
-    public void setupTest() throws IOException {
+    public void setupTest() throws Exception {
         threadPool = new TestThreadPool(DefaultEndPointsIT.class.getSimpleName());
 
         Request loggingSettings = new Request("PUT", "_cluster/settings");
@@ -45,6 +45,8 @@ public class DefaultEndPointsIT extends InferenceBaseRestTest {
                     "logger.org.elasticsearch.xpack.ml.packageloader" : "DEBUG"
                 }}""");
         client().performRequest(loggingSettings);
+        initInferenceIndices();
+        ensureNoInitializingShards();
     }
 
     @After

--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceBaseRestTest.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceBaseRestTest.java
@@ -11,6 +11,7 @@ import org.apache.http.util.EntityUtils;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
+import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.ResponseListener;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.SecureString;
@@ -423,6 +424,21 @@ public class InferenceBaseRestTest extends ESRestTestCase {
     @SuppressWarnings("unchecked")
     public static List<Map<String, Object>> getAllModels() throws IOException {
         return (List<Map<String, Object>>) getInternalAsMap("_inference/_all").get("endpoints");
+    }
+
+    /**
+     * Ensure that the internal inference indices shards have been initialized.
+     */
+    public static void initInferenceIndices() throws Exception {
+        assertBusy(() -> {
+            try {
+                var request = new Request("GET", "_inference/_all");
+                client().performRequest(request);
+            } catch (ResponseException e) {
+                // Translate the exception to an AssertionError so assertBusy can retry it
+                fail();
+            }
+        });
     }
 
     private static Map<String, Object> getInternalAsMap(String endpoint) throws IOException {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Initializing inference indices (#145938)](https://github.com/elastic/elasticsearch/pull/145938)

<!--- Backport version: 12.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)