### PR TITLE
Make an expensive views test faster by reducing index count

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/views.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/views.csv-spec
@@ -673,7 +673,10 @@ required_capability: views_false_circular_reference_fix
 
 // Reproduces https://github.com/elastic/elasticsearch/issues/146208
 // FROM *,-employees* should not trigger a false circular view reference error.
-FROM *,-employees*, -view*row*, -view_k8s_*
+// Use airports as a concrete non-employee index to keep total > 0, then use the employees* wildcard
+// to match all employee views and data. The -employees* exclusion removes them all, which is the
+// exact pattern that triggered the false circular-reference bug in issue #146208.
+FROM airports, employees*, -employees*
 | STATS total = COUNT(*)
 | EVAL at_least_one = total > 0
 | KEEP at_least_one
@@ -690,7 +693,11 @@ required_capability: views_false_circular_reference_fix
 
 // Reproduces https://github.com/elastic/elasticsearch/issues/146208
 // FROM *,-employees_extra,-employees_all should not trigger a false circular view reference error.
-FROM *,-employees_extra,-employees_all, -view*row*, -view_k8s_*, -employees_in_subquery*
+// Use airports as a concrete non-employee index, then use employees* wildcard to include all employee
+// views while excluding only employees_extra, employees_all, and employees_in_subquery*.
+// This verifies that partial wildcard exclusion of employees does not trigger a false circular
+// reference for the remaining employee views (employees_rehired, employees_not_rehired).
+FROM airports, employees*, -employees_extra, -employees_all, -employees_in_subquery*
 | STATS total = COUNT(*)
 | EVAL at_least_one = total > 0
 | KEEP at_least_one


### PR DESCRIPTION
The test ran in 23s before, now down to 600ms (in CsvIT)