### PR TITLE
Fix OTel test timings and add extra validations

### DIFF
--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/export/otelsdk/OtelSdkSettings.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/export/otelsdk/OtelSdkSettings.java
@@ -28,6 +28,66 @@ public final class OtelSdkSettings {
 
     private OtelSdkSettings() {}
 
+    /** Best-effort upper bound on time spent flushing buffered metrics or spans to the exporter. */
+    public static final Setting<TimeValue> TELEMETRY_OTEL_FLUSH_TIMEOUT = Setting.timeSetting(
+        "telemetry.otel.flush_timeout",
+        TimeValue.timeValueSeconds(10),
+        NodeScope
+    );
+
+    /** External OTel resource attributes attached to every metric and span exported by the SDK path.*/
+    public static final Setting.AffixSetting<String> TELEMETRY_OTEL_RESOURCE_ATTRIBUTES = Setting.prefixKeySetting(
+        "telemetry.otel.resource.",
+        key -> Setting.simpleString(key, NodeScope)
+    );
+
+    // --- General OTLP settings
+
+    /** Total attempts per export (initial + retries). {@code 1} disables retry. */
+    public static final Setting<Integer> TELEMETRY_OTEL_OTLP_RETRY_MAX_ATTEMPTS = Setting.intSetting(
+        "telemetry.otel.otlp.retry.max_attempts",
+        2,
+        1,
+        5,
+        NodeScope
+    );
+
+    public static final Setting<TimeValue> TELEMETRY_OTEL_OTLP_RETRY_INITIAL_BACKOFF = Setting.timeSetting(
+        "telemetry.otel.otlp.retry.initial_backoff",
+        TimeValue.timeValueSeconds(1),
+        NodeScope
+    );
+
+    public static final Setting<Double> TELEMETRY_OTEL_OTLP_RETRY_BACKOFF_MULTIPLIER = Setting.doubleSetting(
+        "telemetry.otel.otlp.retry.backoff_multiplier",
+        1.5,
+        1.0,
+        NodeScope
+    );
+
+    /**
+     * Total deadline for one OTLP send() including retries; must stay below the collection interval so a slow export
+     * does not stretch into the next cycle.
+     */
+    public static final Setting<TimeValue> TELEMETRY_OTEL_OTLP_SEND_TIMEOUT = Setting.timeSetting(
+        "telemetry.otel.otlp.send_timeout",
+        TimeValue.timeValueSeconds(5),
+        TimeValue.timeValueMillis(1),
+        TimeValue.timeValueSeconds(60),
+        new GreaterThanTimeValueValidator("telemetry.otel.otlp.send_timeout", TELEMETRY_OTEL_OTLP_RETRY_INITIAL_BACKOFF),
+        NodeScope
+    );
+
+    public static final Setting<TimeValue> TELEMETRY_OTEL_OTLP_CONNECT_TIMEOUT = Setting.timeSetting(
+        "telemetry.otel.otlp.connect_timeout",
+        TimeValue.timeValueSeconds(2),
+        TimeValue.timeValueMillis(1),
+        TimeValue.timeValueSeconds(10),
+        NodeScope
+    );
+
+    // --- Metrics
+
     public static final Setting<String> TELEMETRY_OTEL_METRICS_ENDPOINT = Setting.simpleString(
         "telemetry.otel.metrics.endpoint",
         "",
@@ -37,6 +97,7 @@ public final class OtelSdkSettings {
     public static final Setting<TimeValue> TELEMETRY_OTEL_METRICS_INTERVAL = Setting.timeSetting(
         "telemetry.otel.metrics.interval",
         TimeValue.timeValueSeconds(10),
+        new GreaterThanTimeValueValidator("telemetry.otel.metrics.interval", TELEMETRY_OTEL_OTLP_SEND_TIMEOUT),
         NodeScope
     );
 
@@ -84,47 +145,7 @@ public final class OtelSdkSettings {
         NodeScope
     );
 
-    /** Total attempts per export (initial + retries). {@code 1} disables retry. */
-    public static final Setting<Integer> TELEMETRY_OTEL_OTLP_RETRY_MAX_ATTEMPTS = Setting.intSetting(
-        "telemetry.otel.otlp.retry.max_attempts",
-        2,
-        1,
-        5,
-        NodeScope
-    );
-
-    public static final Setting<TimeValue> TELEMETRY_OTEL_OTLP_RETRY_INITIAL_BACKOFF = Setting.timeSetting(
-        "telemetry.otel.otlp.retry.initial_backoff",
-        TimeValue.timeValueSeconds(1),
-        NodeScope
-    );
-
-    public static final Setting<Double> TELEMETRY_OTEL_OTLP_RETRY_BACKOFF_MULTIPLIER = Setting.doubleSetting(
-        "telemetry.otel.otlp.retry.backoff_multiplier",
-        1.5,
-        1.0,
-        NodeScope
-    );
-
-    /**
-     * Total deadline for one OTLP send() including retries; must stay below the collection interval so a slow export
-     * does not stretch into the next cycle.
-     */
-    public static final Setting<TimeValue> TELEMETRY_OTEL_OTLP_SEND_TIMEOUT = Setting.timeSetting(
-        "telemetry.otel.otlp.send_timeout",
-        TimeValue.timeValueSeconds(5),
-        TimeValue.timeValueMillis(1),
-        TimeValue.timeValueSeconds(60),
-        NodeScope
-    );
-
-    public static final Setting<TimeValue> TELEMETRY_OTEL_OTLP_CONNECT_TIMEOUT = Setting.timeSetting(
-        "telemetry.otel.otlp.connect_timeout",
-        TimeValue.timeValueSeconds(2),
-        TimeValue.timeValueMillis(1),
-        TimeValue.timeValueSeconds(10),
-        NodeScope
-    );
+    // --- Traces
 
     /** OTLP HTTP endpoint URL where the SDK exports buffered spans. Required when the SDK trace path is active. */
     public static final Setting<String> TELEMETRY_OTEL_TRACES_ENDPOINT = Setting.simpleString(
@@ -195,18 +216,7 @@ public final class OtelSdkSettings {
         NodeScope
     );
 
-    /** Best-effort upper bound on time spent flushing buffered metrics or spans to the exporter. */
-    public static final Setting<TimeValue> TELEMETRY_OTEL_FLUSH_TIMEOUT = Setting.timeSetting(
-        "telemetry.otel.flush_timeout",
-        TimeValue.timeValueSeconds(10),
-        NodeScope
-    );
-
-    /** External OTel resource attributes attached to every metric and span exported by the SDK path.*/
-    public static final Setting.AffixSetting<String> TELEMETRY_OTEL_RESOURCE_ATTRIBUTES = Setting.prefixKeySetting(
-        "telemetry.otel.resource.",
-        key -> Setting.simpleString(key, NodeScope)
-    );
+    // --- Logs
 
     /** OTLP/gRPC endpoint URL where the SDK exports audit log records. Required when {@link #TELEMETRY_OTEL_LOGS_ENABLED} is true. */
     public static final Setting<String> TELEMETRY_OTEL_LOGS_ENDPOINT = Setting.simpleString("telemetry.otel.logs.endpoint", "", NodeScope);
@@ -235,4 +245,33 @@ public final class OtelSdkSettings {
         },
         NodeScope
     );
+
+    private static final class GreaterThanTimeValueValidator implements Setting.Validator<TimeValue> {
+
+        private final String thisSettingKey;
+        private final Setting<TimeValue> otherSetting;
+
+        private GreaterThanTimeValueValidator(String thisSettingKey, Setting<TimeValue> otherSetting) {
+            this.thisSettingKey = thisSettingKey;
+            this.otherSetting = otherSetting;
+        }
+
+        @Override
+        public void validate(TimeValue value) {}
+
+        @Override
+        public void validate(TimeValue value, Map<Setting<?>, Object> settings) {
+            var otherValue = (TimeValue) settings.get(otherSetting);
+            if (value.compareTo(otherValue) <= 0) {
+                throw new IllegalArgumentException(
+                    thisSettingKey + " (" + value + ") must be greater than " + otherSetting.getKey() + " (" + otherValue + ")"
+                );
+            }
+        }
+
+        @Override
+        public Iterator<Setting<?>> settings() {
+            return List.<Setting<?>>of(otherSetting).iterator();
+        }
+    }
 }

--- a/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/internal/export/otelsdk/OtelSdkSettingsTests.java
+++ b/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/internal/export/otelsdk/OtelSdkSettingsTests.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.telemetry.apm.internal.export.otelsdk;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.test.ESTestCase;
+
+import static org.elasticsearch.telemetry.apm.internal.export.otelsdk.OtelSdkSettings.TELEMETRY_OTEL_METRICS_INTERVAL;
+import static org.elasticsearch.telemetry.apm.internal.export.otelsdk.OtelSdkSettings.TELEMETRY_OTEL_OTLP_RETRY_INITIAL_BACKOFF;
+import static org.elasticsearch.telemetry.apm.internal.export.otelsdk.OtelSdkSettings.TELEMETRY_OTEL_OTLP_SEND_TIMEOUT;
+
+public class OtelSdkSettingsTests extends ESTestCase {
+
+    public void testSendTimeoutGreaterThanInitialBackoffIsValid() {
+        Settings settings = Settings.builder()
+            .put(TELEMETRY_OTEL_OTLP_SEND_TIMEOUT.getKey(), TimeValue.timeValueSeconds(2))
+            .put(TELEMETRY_OTEL_OTLP_RETRY_INITIAL_BACKOFF.getKey(), TimeValue.timeValueSeconds(1))
+            .build();
+        TELEMETRY_OTEL_OTLP_SEND_TIMEOUT.get(settings);
+    }
+
+    public void testSendTimeoutEqualToInitialBackoffIsRejected() {
+        Settings settings = Settings.builder()
+            .put(TELEMETRY_OTEL_OTLP_SEND_TIMEOUT.getKey(), TimeValue.timeValueSeconds(1))
+            .put(TELEMETRY_OTEL_OTLP_RETRY_INITIAL_BACKOFF.getKey(), TimeValue.timeValueSeconds(1))
+            .build();
+        expectThrows(IllegalArgumentException.class, () -> TELEMETRY_OTEL_OTLP_SEND_TIMEOUT.get(settings));
+    }
+
+    public void testSendTimeoutLessThanInitialBackoffIsRejected() {
+        Settings settings = Settings.builder()
+            .put(TELEMETRY_OTEL_OTLP_SEND_TIMEOUT.getKey(), TimeValue.timeValueMillis(500))
+            .put(TELEMETRY_OTEL_OTLP_RETRY_INITIAL_BACKOFF.getKey(), TimeValue.timeValueSeconds(1))
+            .build();
+        expectThrows(IllegalArgumentException.class, () -> TELEMETRY_OTEL_OTLP_SEND_TIMEOUT.get(settings));
+    }
+
+    public void testSendTimeoutDefaultIsRejectedWhenInitialBackoffIsHigher() {
+        // send_timeout defaults to 5s
+        Settings settings = Settings.builder()
+            .put(TELEMETRY_OTEL_OTLP_RETRY_INITIAL_BACKOFF.getKey(), TimeValue.timeValueSeconds(10))
+            .build();
+        expectThrows(IllegalArgumentException.class, () -> TELEMETRY_OTEL_OTLP_SEND_TIMEOUT.get(settings));
+    }
+
+    public void testMetricsIntervalGreaterThanSendTimeoutIsValid() {
+        Settings settings = Settings.builder()
+            .put(TELEMETRY_OTEL_METRICS_INTERVAL.getKey(), TimeValue.timeValueMillis(500))
+            .put(TELEMETRY_OTEL_OTLP_SEND_TIMEOUT.getKey(), TimeValue.timeValueMillis(300))
+            .build();
+        TELEMETRY_OTEL_METRICS_INTERVAL.get(settings);
+    }
+
+    public void testMetricsIntervalEqualToSendTimeoutIsRejected() {
+        Settings settings = Settings.builder()
+            .put(TELEMETRY_OTEL_METRICS_INTERVAL.getKey(), TimeValue.timeValueSeconds(5))
+            .put(TELEMETRY_OTEL_OTLP_SEND_TIMEOUT.getKey(), TimeValue.timeValueSeconds(5))
+            .build();
+        expectThrows(IllegalArgumentException.class, () -> TELEMETRY_OTEL_METRICS_INTERVAL.get(settings));
+    }
+
+    public void testMetricsIntervalLessThanSendTimeoutIsRejected() {
+        Settings settings = Settings.builder()
+            .put(TELEMETRY_OTEL_METRICS_INTERVAL.getKey(), TimeValue.timeValueSeconds(4))
+            .put(TELEMETRY_OTEL_OTLP_SEND_TIMEOUT.getKey(), TimeValue.timeValueSeconds(5))
+            .build();
+        expectThrows(IllegalArgumentException.class, () -> TELEMETRY_OTEL_METRICS_INTERVAL.get(settings));
+    }
+
+    public void testMetricsIntervalDefaultIsRejectedWhenSendTimeoutIsHigher() {
+        // metrics.interval defaults to 10s
+        Settings settings = Settings.builder().put(TELEMETRY_OTEL_OTLP_SEND_TIMEOUT.getKey(), TimeValue.timeValueSeconds(15)).build();
+        expectThrows(IllegalArgumentException.class, () -> TELEMETRY_OTEL_METRICS_INTERVAL.get(settings));
+    }
+
+    public void testDefaultValuesAreValid() {
+        TELEMETRY_OTEL_OTLP_SEND_TIMEOUT.get(Settings.EMPTY);
+        TELEMETRY_OTEL_METRICS_INTERVAL.get(Settings.EMPTY);
+    }
+}

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -539,9 +539,6 @@ tests:
 - class: org.elasticsearch.xpack.stateless.StatelessHollowIndexShardsIT
   method: testUnhollowOnUpdates
   issue: https://github.com/elastic/elasticsearch/issues/151100
-- class: org.elasticsearch.test.apmintegration.OTelMetricsBufferingIT
-  method: testOutageBuffersToDiskAndDrainsOnRecovery
-  issue: https://github.com/elastic/elasticsearch/issues/150387
 - class: org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.DivTests
   method: testEvaluate {TestCase=<integer>, <dense_vector>}
   issue: https://github.com/elastic/elasticsearch/issues/151114

--- a/server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -2092,6 +2092,23 @@ public class Setting<T> implements ToXContentObject {
         );
     }
 
+    public static Setting<TimeValue> timeSetting(
+        final String key,
+        final TimeValue defaultValue,
+        final TimeValue minValue,
+        final TimeValue maxValue,
+        final Validator<TimeValue> validator,
+        final Property... properties
+    ) {
+        return new Setting<>(
+            key,
+            defaultValue.getStringRep(),
+            minMaxTimeValueParser(key, minValue, maxValue, isFiltered(properties)),
+            validator,
+            properties
+        );
+    }
+
     private static Function<String, TimeValue> minTimeValueParser(final String key, final TimeValue minValue, boolean isFiltered) {
         return s -> {
             TimeValue value;

--- a/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/OTelMetricsBufferSurvivesRestartIT.java
+++ b/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/OTelMetricsBufferSurvivesRestartIT.java
@@ -24,13 +24,17 @@ public class OTelMetricsBufferSurvivesRestartIT extends AbstractTelemetryIT {
     public static ElasticsearchCluster cluster = AbstractMetricsIT.baseClusterBuilder()
         .systemProperty("telemetry.otel.metrics.enabled", "true")
         .setting("telemetry.otel.metrics.endpoint", () -> "http://" + recordingApmServer.getHttpAddress() + "/v1/metrics")
-        .setting("telemetry.otel.metrics.interval", "1s")
         .setting("telemetry.otel.metrics.disk_buffer_size", "10mb")
         .setting("telemetry.otel.metrics.buffer_ttl", "5m")
-        .setting("telemetry.otel.otlp.send_timeout", "1s")
         // Tight write/read windows so pre-existing buffered files become drainable within the test budget.
         .setting("telemetry.otel.metrics.disk_buffer_write_window", "100ms")
         .setting("telemetry.otel.metrics.disk_buffer_read_min_age", "200ms")
+        // metrics.interval must be > otlp.send_timeout so that the OTLP exporter can fully fail, and so that PeriodicMetricReader does not
+        // skip an export cycle
+        .setting("telemetry.otel.metrics.interval", "500ms")
+        .setting("telemetry.otel.otlp.send_timeout", "300ms")
+        // initial_backoff that is way smaller than otlp.send_timeout allows the exporter to fully exhaust the retries
+        .setting("telemetry.otel.otlp.retry.initial_backoff", "100ms")
         .build();
 
     @ClassRule
@@ -49,7 +53,7 @@ public class OTelMetricsBufferSurvivesRestartIT extends AbstractTelemetryIT {
     public void testPreExistingBufferFilesDrainAfterRestart() throws Exception {
         recordingApmServer.setResponseCode(503);
         client().performRequest(new Request("GET", "/_use_apm_metrics"));
-        Thread.sleep(3000);
+        Thread.sleep(1000);
 
         cluster.restart(false);
         closeClients();

--- a/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/OTelMetricsBufferingIT.java
+++ b/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/OTelMetricsBufferingIT.java
@@ -12,6 +12,7 @@ package org.elasticsearch.test.apmintegration;
 import io.opentelemetry.sdk.common.Clock;
 
 import org.elasticsearch.client.Request;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.junit.ClassRule;
 import org.junit.rules.TestRule;
@@ -32,13 +33,21 @@ public class OTelMetricsBufferingIT extends AbstractMetricsIT {
     public static ElasticsearchCluster cluster = AbstractMetricsIT.baseClusterBuilder()
         .systemProperty("telemetry.otel.metrics.enabled", "true")
         .setting("telemetry.otel.metrics.endpoint", () -> "http://" + recordingApmServer.getHttpAddress() + "/v1/metrics")
-        .setting("telemetry.otel.metrics.interval", "500ms")
         .setting("telemetry.otel.metrics.disk_buffer_size", "10mb")
         .setting("telemetry.otel.metrics.buffer_ttl", "5m")
         // Tight write/read windows so buffered files become drainable within the test budget.
         .setting("telemetry.otel.metrics.disk_buffer_write_window", "100ms")
         .setting("telemetry.otel.metrics.disk_buffer_read_min_age", "200ms")
+        // metrics.interval must be > otlp.send_timeout so that the OTLP exporter can fully fail, and so that PeriodicMetricReader does not
+        // skip an export cycle
+        .setting("telemetry.otel.metrics.interval", "500ms")
+        .setting("telemetry.otel.otlp.send_timeout", "300ms")
+        // initial_backoff that is way smaller than otlp.send_timeout allows the exporter to fully exhaust the retries
+        .setting("telemetry.otel.otlp.retry.initial_backoff", "100ms")
         .build();
+
+    // make it bigger than otlp.send_timeout to allow the OTLP exporter to fully fail, and delegate to the disk buffering exporter
+    private static final TimeValue SLEEP_BETWEEN_RUNS = TimeValue.timeValueMillis(400);
 
     // use the same clock implementation as the OTel SDK itself
     private static final Clock otelClock = Clock.getDefault();
@@ -70,7 +79,7 @@ public class OTelMetricsBufferingIT extends AbstractMetricsIT {
         for (int i = 0; i < BUFFER_BATCHES; i++) {
             client().performRequest(new Request("GET", "/_use_apm_metrics"));
             client().performRequest(new Request("GET", "/_flush_telemetry"));
-            Thread.sleep(300);
+            Thread.sleep(SLEEP_BETWEEN_RUNS.millis());
         }
 
         long outageEndEpochNanos = otelClock.now();

--- a/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/OtelMetricsIT.java
+++ b/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/OtelMetricsIT.java
@@ -39,6 +39,8 @@ public class OtelMetricsIT extends AbstractMetricsIT {
         .systemProperty("telemetry.otel.metrics.enabled", "true")
         .setting("telemetry.otel.metrics.endpoint", () -> "http://" + recordingApmServer.getHttpAddress() + "/v1/metrics")
         .setting("telemetry.otel.metrics.interval", "100ms")
+        .setting("telemetry.otel.otlp.send_timeout", "80ms")
+        .setting("telemetry.otel.otlp.retry.initial_backoff", "20ms")
         .setting("telemetry.otel.metrics.disk_buffer_size", "0b")
         // Mirrors the three labels ServerlessServerCli writes via telemetry.agent.global_labels.* on the APM-agent path,
         // bridged here to the OTel resource via the telemetry.otel.resource.* affix.

--- a/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/OtelSdkSpanProcessorMetricsIT.java
+++ b/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/OtelSdkSpanProcessorMetricsIT.java
@@ -47,6 +47,8 @@ public class OtelSdkSpanProcessorMetricsIT extends AbstractTelemetryIT {
         .setting("telemetry.otel.traces.sample_rate", "1.0")
         .setting("telemetry.otel.metrics.endpoint", () -> "http://" + recordingApmServer.getHttpAddress() + "/v1/metrics")
         .setting("telemetry.otel.metrics.interval", "100ms")
+        .setting("telemetry.otel.otlp.send_timeout", "80ms")
+        .setting("telemetry.otel.otlp.retry.initial_backoff", "20ms")
         .setting("telemetry.otel.metrics.disk_buffer_size", "0b")
         .build();
 


### PR DESCRIPTION
This PR fixes time-related settings in the tests, and also adds extra validations on the settings to avoid issues like this one in the future.

The issue behind the test failures originated from the fact that while we overrode the `metrics.interval` and the `otlp.send_timeout` settings, the `otlp.retry.initial_backoff` had a default value of 1 second: this caused the OTLP HTTP sender to sleep for a second despite the fact that we set the overall send timeout to 300ms.

The `OtelSdkSettings` now contains extra validations that ensure that `metrics.interval` > `send_timeout` > `retry.initial_backoff`. This way the OTel settings will try to prevent these sorts of timing issues.

Closes https://github.com/elastic/elasticsearch/issues/150387
