### PR TITLE
[9.3] Allow slack in SnapshotMetricsIT histogram duration bounds (#145170)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/repositories/SnapshotMetricsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/repositories/SnapshotMetricsIT.java
@@ -146,13 +146,6 @@ public class SnapshotMetricsIT extends AbstractSnapshotIntegTestCase {
         assertDoubleHistogramMetrics(SnapshotMetrics.SNAPSHOT_SHARDS_DURATION, hasSize(numShards));
         assertDoubleHistogramMetrics(SnapshotMetrics.SNAPSHOT_SHARDS_DURATION, everyItem(lessThan(maxHistogramDurationSeconds)));
 
-        // Sanity check shard queue time observations
-        assertDoubleHistogramMetrics(SnapshotMetrics.SNAPSHOT_SHARDS_QUEUE_TIME, hasSize(numShards));
-        assertDoubleHistogramMetrics(
-            SnapshotMetrics.SNAPSHOT_SHARDS_QUEUE_TIME,
-            everyItem(allOf(greaterThanOrEqualTo(0.0), lessThan(maxHistogramDurationSeconds)))
-        );
-
         // Sanity check snapshot observations
         assertDoubleHistogramMetrics(SnapshotMetrics.SNAPSHOT_DURATION, hasSize(1));
         assertDoubleHistogramMetrics(SnapshotMetrics.SNAPSHOT_DURATION, everyItem(lessThan(maxHistogramDurationSeconds)));

--- a/server/src/internalClusterTest/java/org/elasticsearch/repositories/SnapshotMetricsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/repositories/SnapshotMetricsIT.java
@@ -60,6 +60,13 @@ import static org.hamcrest.Matchers.not;
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST)
 public class SnapshotMetricsIT extends AbstractSnapshotIntegTestCase {
 
+    /**
+     * OpenTelemetry double histograms may report bucket values rounded slightly above the wall-clock
+     * interval measured here with {@link TimeValue#secondsFrac()}, causing strict {@code lessThan}
+     * comparisons to flake (e.g. 0.108 vs 0.107915...).
+     */
+    private static final double DOUBLE_HISTOGRAM_DURATION_UPPER_BOUND_SLACK_SEC = 1e-4;
+
     private static final String REQUIRE_NODE_NAME_SETTING = IndexMetadata.INDEX_ROUTING_REQUIRE_GROUP_PREFIX + "._name";
 
     @Override
@@ -125,6 +132,7 @@ public class SnapshotMetricsIT extends AbstractSnapshotIntegTestCase {
         // wait for snapshot to finish to test the other metrics
         safeGet(snapshotFuture);
         final TimeValue snapshotElapsedTime = TimeValue.timeValueNanos(System.nanoTime() - beforeCreateSnapshotNanos);
+        final double maxHistogramDurationSeconds = snapshotElapsedTime.secondsFrac() + DOUBLE_HISTOGRAM_DURATION_UPPER_BOUND_SLACK_SEC;
         collectMetrics();
 
         // sanity check blobs, bytes and throttling metrics
@@ -136,11 +144,18 @@ public class SnapshotMetricsIT extends AbstractSnapshotIntegTestCase {
 
         // Sanity check shard duration observations
         assertDoubleHistogramMetrics(SnapshotMetrics.SNAPSHOT_SHARDS_DURATION, hasSize(numShards));
-        assertDoubleHistogramMetrics(SnapshotMetrics.SNAPSHOT_SHARDS_DURATION, everyItem(lessThan(snapshotElapsedTime.secondsFrac())));
+        assertDoubleHistogramMetrics(SnapshotMetrics.SNAPSHOT_SHARDS_DURATION, everyItem(lessThan(maxHistogramDurationSeconds)));
+
+        // Sanity check shard queue time observations
+        assertDoubleHistogramMetrics(SnapshotMetrics.SNAPSHOT_SHARDS_QUEUE_TIME, hasSize(numShards));
+        assertDoubleHistogramMetrics(
+            SnapshotMetrics.SNAPSHOT_SHARDS_QUEUE_TIME,
+            everyItem(allOf(greaterThanOrEqualTo(0.0), lessThan(maxHistogramDurationSeconds)))
+        );
 
         // Sanity check snapshot observations
         assertDoubleHistogramMetrics(SnapshotMetrics.SNAPSHOT_DURATION, hasSize(1));
-        assertDoubleHistogramMetrics(SnapshotMetrics.SNAPSHOT_DURATION, everyItem(lessThan(snapshotElapsedTime.secondsFrac())));
+        assertDoubleHistogramMetrics(SnapshotMetrics.SNAPSHOT_DURATION, everyItem(lessThan(maxHistogramDurationSeconds)));
 
         // Work out the maximum amount of concurrency per node
         final ThreadPool tp = internalCluster().getDataNodeInstance(ThreadPool.class);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Allow slack in SnapshotMetricsIT histogram duration bounds (#145170)](https://github.com/elastic/elasticsearch/pull/145170)

<!--- Backport version: 12.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)