### PR TITLE
Use a monotonic clock for SingleObjectCache refresh

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/SingleObjectCache.java
+++ b/server/src/main/java/org/elasticsearch/common/util/SingleObjectCache.java
@@ -10,8 +10,10 @@ package org.elasticsearch.common.util;
 
 import org.elasticsearch.core.TimeValue;
 
+import java.util.Objects;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.LongSupplier;
 
 /**
  * A very simple single object cache that allows non-blocking refresh calls
@@ -22,13 +24,20 @@ public abstract class SingleObjectCache<T> {
     private volatile T cached;
     private final Lock refreshLock = new ReentrantLock();
     private final TimeValue refreshInterval;
-    protected long lastRefreshTimestamp = 0;
+    private final LongSupplier nanoTimeSupplier;
+    protected long lastRefreshTimestamp;
 
     protected SingleObjectCache(TimeValue refreshInterval, T initialValue) {
+        this(refreshInterval, initialValue, System::nanoTime);
+    }
+
+    protected SingleObjectCache(TimeValue refreshInterval, T initialValue, LongSupplier nanoTimeSupplier) {
         if (initialValue == null) {
             throw new IllegalArgumentException("initialValue must not be null");
         }
         this.refreshInterval = refreshInterval;
+        this.nanoTimeSupplier = Objects.requireNonNull(nanoTimeSupplier);
+        this.lastRefreshTimestamp = nanoTimeSupplier.getAsLong() - refreshInterval.nanos() - 1;
         cached = initialValue;
     }
 
@@ -42,7 +51,7 @@ public abstract class SingleObjectCache<T> {
                     if (needsRefresh()) { // check again!
                         cached = refresh();
                         assert cached != null;
-                        lastRefreshTimestamp = System.currentTimeMillis();
+                        lastRefreshTimestamp = nanoTimeSupplier.getAsLong();
                     }
                 } finally {
                     refreshLock.unlock();
@@ -67,10 +76,10 @@ public abstract class SingleObjectCache<T> {
      * Returns <code>true</code> iff the cache needs to be refreshed.
      */
     protected boolean needsRefresh() {
-        if (refreshInterval.millis() == 0) {
+        if (refreshInterval.nanos() == 0) {
             return true;
         }
-        final long currentTime = System.currentTimeMillis();
-        return (currentTime - lastRefreshTimestamp) > refreshInterval.millis();
+        final long currentTimeNanos = nanoTimeSupplier.getAsLong();
+        return (currentTimeNanos - lastRefreshTimestamp) > refreshInterval.nanos();
     }
 }

--- a/server/src/test/java/org/elasticsearch/common/util/SingleObjectCacheTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/SingleObjectCacheTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.test.ESTestCase;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 public class SingleObjectCacheTests extends ESTestCase {
 
@@ -83,5 +84,24 @@ public class SingleObjectCacheTests extends ESTestCase {
         t.join();
         assertEquals(2, cache.getOrRefresh().intValue());
 
+    }
+
+    public void testRefreshesAfterMonotonicIntervalElapses() {
+        final AtomicInteger count = new AtomicInteger(0);
+        final AtomicLong nanoTime = new AtomicLong(0);
+        final TimeValue refreshInterval = TimeValue.timeValueMillis(10);
+        final SingleObjectCache<Integer> cache = new SingleObjectCache<Integer>(refreshInterval, 0, nanoTime::get) {
+
+            @Override
+            protected Integer refresh() {
+                return count.incrementAndGet();
+            }
+        };
+        assertEquals(1, cache.getOrRefresh().intValue());
+        assertEquals(1, cache.getOrRefresh().intValue());
+        nanoTime.addAndGet(refreshInterval.nanos());
+        assertEquals(1, cache.getOrRefresh().intValue());
+        nanoTime.incrementAndGet();
+        assertEquals(2, cache.getOrRefresh().intValue());
     }
 }


### PR DESCRIPTION
Switch `SingleObjectCache` to a monotonic time source so that node monitor caches (`fs`, `os`, `process`) refresh correctly after wall-clock corrections. The cache previously compared `System.currentTimeMillis()` against the last refresh timestamp; if the wall clock jumped forward and was then rolled back, `needsRefresh()` could remain false for a long time, leaving `_nodes/stats` returning stale values until the wall clock caught up or the node was restarted.

`SingleObjectCache` now uses a `LongSupplier` (defaulting to `System::nanoTime`) for both recording and comparing the last refresh timestamp, and the interval is evaluated in nanoseconds. A new test asserts that refreshes occur once a monotonic interval elapses regardless of wall-clock changes.

- [x] I have signed the [contributor license agreement](https://www.elastic.co/contributor-agreement).
- [x] I have followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md).
- [x] The pull request targets `main`.
- [x] This is not a class submission.

Resolves #147398