### PR TITLE
[9.3] [Inference API] Fix flaky test #117208 (#146390)

### DIFF
--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/CreateFromDeploymentIT.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/CreateFromDeploymentIT.java
@@ -424,8 +424,4 @@ public class CreateFromDeploymentIT extends InferenceBaseRestTest {
         client().performRequest(request);
     }
 
-    protected Map<String, Object> getTrainedModelStats(String modelId) throws IOException {
-        Request request = new Request("GET", "/_ml/trained_models/" + modelId + "/_stats");
-        return entityAsMap(client().performRequest(request));
-    }
 }

--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/DefaultEndPointsIT.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/DefaultEndPointsIT.java
@@ -9,9 +9,12 @@ package org.elasticsearch.xpack.inference;
 
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
+import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.ResponseListener;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.core.inference.results.SparseEmbeddingResults;
@@ -25,8 +28,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.oneOf;
@@ -208,10 +213,12 @@ public class DefaultEndPointsIT extends InferenceBaseRestTest {
         int numParallelRequests = 4;
         var latch = new CountDownLatch(numParallelRequests);
         var errors = new ArrayList<Exception>();
+        var successCount = new AtomicInteger(0);
 
         var listener = new ResponseListener() {
             @Override
             public void onSuccess(Response response) {
+                successCount.incrementAndGet();
                 latch.countDown();
             }
 
@@ -235,6 +242,64 @@ public class DefaultEndPointsIT extends InferenceBaseRestTest {
         }
 
         latch.await();
-        assertThat(errors.toString(), errors, empty());
+        // Filter out transient shard unavailability errors on .ml-inference-* indices. These can occur when
+        // multiple concurrent requests race to initialize the ML model storage index during the first deployment.
+        var significantErrors = errors.stream().filter(e -> isTransientMlInferenceIndexError(e) == false).toList();
+        assertThat("Received non-transient errors", significantErrors, empty());
+        assertThat("Expected at least one inference request to succeed", successCount.get(), greaterThan(0));
+        assertElserDeploymentStarted();
+    }
+
+    /**
+     * Asserts that the ELSER deployment is in a started or fully-allocated state by querying
+     * {@code _ml/trained_models/<model_id>/_stats}. Called after inference requests complete to
+     * confirm the deployment is healthy and ready to serve requests.
+     *
+     * The response json of getTrainedModelStats is:
+     * {
+     *   "count": 2,
+     *   "trained_model_stats": [
+     *     {
+     *       "model_id": ".elser_model_2_linux-x86_64",
+     *       "... other fields ...",
+     *       "deployment_stats": {
+     *         "... other fields ...",
+     *         "state": "started",
+     *         "allocation_status": {
+     *           "allocation_count": 1,
+     *           "target_allocation_count": 1,
+     *           "state": "fully_allocated"
+     *         },
+     *         "... other fields ...",
+     *       }
+     *     },
+     *     "... other trained model stats ...",
+     *   ]
+     * }
+     */
+    @SuppressWarnings("unchecked")
+    private void assertElserDeploymentStarted() throws IOException {
+        var elserConfig = getModel(ElasticsearchInternalService.DEFAULT_ELSER_ID);
+        var serviceSettings = (Map<String, Object>) elserConfig.get("service_settings");
+        var mlModelId = (String) serviceSettings.get("model_id");
+
+        var statsResponse = getTrainedModelStats(mlModelId);
+        var trainedModelStats = (List<Map<String, Object>>) statsResponse.get("trained_model_stats");
+        assertFalse(statsResponse.toString(), trainedModelStats.isEmpty());
+
+        var state = (String) XContentMapValues.extractValue("deployment_stats.allocation_status.state", trainedModelStats.get(0));
+        assertThat(statsResponse.toString(), state, is(oneOf("started", "fully_allocated")));
+    }
+
+    /**
+     * Returns true if the exception is a transient 503 caused by a not-yet-initialized shard on a .ml-inference-*
+     * index. This happens when concurrent requests simultaneously trigger a built-in model deployment and one of
+     * them searches the ML inference index while another is in the process of creating it.
+     */
+    private static boolean isTransientMlInferenceIndexError(Exception e) {
+        return e instanceof ResponseException re
+            && re.getResponse().getStatusLine().getStatusCode() == RestStatus.SERVICE_UNAVAILABLE.getStatus()
+            && e.getMessage().contains("no_shard_available_action_exception")
+            && e.getMessage().contains(".ml-inference-");
     }
 }

--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceBaseRestTest.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceBaseRestTest.java
@@ -434,6 +434,11 @@ public class InferenceBaseRestTest extends ESRestTestCase {
         return entityAsMap(response);
     }
 
+    protected static Map<String, Object> getTrainedModelStats(String modelId) throws IOException {
+        var request = new Request("GET", "/_ml/trained_models/" + modelId + "/_stats");
+        return entityAsMap(client().performRequest(request));
+    }
+
     protected Map<String, Object> infer(String modelId, List<String> input) throws IOException {
         var endpoint = Strings.format("_inference/%s", modelId);
         return inferInternal(endpoint, input, null, Map.of());


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Inference API] Fix flaky test #117208 (#146390)](https://github.com/elastic/elasticsearch/pull/146390)

<!--- Backport version: 12.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)