### PR TITLE
[9.4] Fix GPU SQ format name to match CPU equivalent (#149512)

### DIFF
--- a/docs/changelog/149512.yaml
+++ b/docs/changelog/149512.yaml
@@ -1,0 +1,6 @@
+area: Vector Search
+issues:
+ - 148975
+pr: 149512
+summary: Fix GPU SQ format name to match CPU equivalent
+type: bug

--- a/libs/gpu-codec/src/main/java/org/elasticsearch/gpu/codec/ES92GpuHnswSQVectorsFormat.java
+++ b/libs/gpu-codec/src/main/java/org/elasticsearch/gpu/codec/ES92GpuHnswSQVectorsFormat.java
@@ -31,7 +31,7 @@ import static org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper.MAX_
  * HNSW graph is built on GPU, while scalar quantization and search is performed on CPU.
  */
 public class ES92GpuHnswSQVectorsFormat extends KnnVectorsFormat {
-    public static final String NAME = "Lucene99HnswVectorsFormat";
+    public static final String NAME = "ES814HnswScalarQuantizedVectorsFormat";
     static final int MAXIMUM_MAX_CONN = 512;
     static final int MAXIMUM_BEAM_WIDTH = 3200;
     private final int maxConn;
@@ -52,6 +52,10 @@ public class ES92GpuHnswSQVectorsFormat extends KnnVectorsFormat {
             7,
             false
         );
+    }
+
+    public ES92GpuHnswSQVectorsFormat(int maxConn, int beamWidth) {
+        this(CuVSResourceManager::pooling, CuVSGPUSupport.instance().getTotalGpuMemory(), maxConn, beamWidth, null, 7, false);
     }
 
     public ES92GpuHnswSQVectorsFormat(

--- a/libs/gpu-codec/src/main/java/org/elasticsearch/gpu/codec/ES92GpuHnswVectorsFormat.java
+++ b/libs/gpu-codec/src/main/java/org/elasticsearch/gpu/codec/ES92GpuHnswVectorsFormat.java
@@ -60,6 +60,10 @@ public class ES92GpuHnswVectorsFormat extends KnnVectorsFormat {
         this(CuVSResourceManager::pooling, CuVSGPUSupport.instance().getTotalGpuMemory(), DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH);
     }
 
+    public ES92GpuHnswVectorsFormat(int maxConn, int beamWidth) {
+        this(CuVSResourceManager::pooling, CuVSGPUSupport.instance().getTotalGpuMemory(), maxConn, beamWidth);
+    }
+
     public ES92GpuHnswVectorsFormat(long totalDeviceMemory, int maxConn, int beamWidth) {
         this(CuVSResourceManager::pooling, totalDeviceMemory, maxConn, beamWidth);
     }

--- a/libs/gpu-codec/src/test/java/org/elasticsearch/gpu/codec/GpuFormatNameCompatibilityTests.java
+++ b/libs/gpu-codec/src/test/java/org/elasticsearch/gpu/codec/GpuFormatNameCompatibilityTests.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.gpu.codec;
+
+import org.apache.lucene.codecs.KnnVectorsFormat;
+import org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.KnnFloatVectorField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.util.TestUtil;
+import org.elasticsearch.common.logging.LogConfigurator;
+import org.elasticsearch.gpu.CuVSGPUSupport;
+import org.elasticsearch.index.codec.vectors.ES814HnswScalarQuantizedVectorsFormat;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.ESTestCase.WithoutEntitlements;
+import org.junit.BeforeClass;
+
+import java.io.IOException;
+
+/**
+ * Verifies that GPU HNSW format names match their CPU equivalents, so that
+ * Lucene's {@link PerFieldKnnVectorsFormat} resolves the correct reader at
+ * search time via {@link KnnVectorsFormat#forName(String)}.
+ */
+@WithoutEntitlements
+public class GpuFormatNameCompatibilityTests extends ESTestCase {
+
+    static {
+        LogConfigurator.configureESLogging();
+    }
+
+    static boolean gpuSupported;
+
+    @BeforeClass
+    public static void beforeClass() {
+        gpuSupported = CuVSGPUSupport.instance().isSupported();
+    }
+
+    public void testGpuFloatFormatName() {
+        assertEquals("Lucene99HnswVectorsFormat", ES92GpuHnswVectorsFormat.NAME);
+    }
+
+    public void testGpuSQFormatNameMatchesCpuSQ() {
+        assertEquals("ES814HnswScalarQuantizedVectorsFormat", ES92GpuHnswSQVectorsFormat.NAME);
+        assertEquals(ES814HnswScalarQuantizedVectorsFormat.NAME, ES92GpuHnswSQVectorsFormat.NAME);
+    }
+
+    // -- the remainder of the tests require a GPU to be present
+
+    public void testGpuFloatFormatNameFromFormat() {
+        assumeTrue("cuvs not supported", gpuSupported);
+        assertEquals("Lucene99HnswVectorsFormat", (new ES92GpuHnswVectorsFormat()).getName());
+    }
+
+    public void testGpuSQFormatNameMatchesCpuSQFromFormat() {
+        assumeTrue("cuvs not supported", gpuSupported);
+        assertEquals("ES814HnswScalarQuantizedVectorsFormat", (new ES92GpuHnswSQVectorsFormat()).getName());
+    }
+
+    public void testForNameResolvesCpuSQFormat() {
+        assumeTrue("cuvs not supported", gpuSupported);
+        var resolved = KnnVectorsFormat.forName(ES92GpuHnswSQVectorsFormat.NAME);
+        assertNotNull(resolved);
+        assertEquals("ES814HnswScalarQuantizedVectorsFormat", resolved.getName());
+    }
+
+    public void testFloatFieldInfoFormatNameAfterIndexing() throws IOException {
+        assumeTrue("cuvs not supported", gpuSupported);
+        doTestFieldInfoFormatName(new ES92GpuHnswVectorsFormat(), "Lucene99HnswVectorsFormat");
+    }
+
+    public void testSQFieldInfoFormatNameAfterIndexing() throws IOException {
+        assumeTrue("cuvs not supported", gpuSupported);
+        doTestFieldInfoFormatName(new ES92GpuHnswSQVectorsFormat(), "ES814HnswScalarQuantizedVectorsFormat");
+    }
+
+    private void doTestFieldInfoFormatName(KnnVectorsFormat gpuFormat, String expectedFormatName) throws IOException {
+        try (Directory dir = newDirectory()) {
+            IndexWriterConfig iwc = new IndexWriterConfig();
+            iwc.setCodec(TestUtil.alwaysKnnVectorsFormat(gpuFormat));
+            try (IndexWriter writer = new IndexWriter(dir, iwc)) {
+                Document doc = new Document();
+                doc.add(new KnnFloatVectorField("vector", new float[] { 1.0f, 2.0f, 3.0f }, VectorSimilarityFunction.DOT_PRODUCT));
+                writer.addDocument(doc);
+            }
+            try (DirectoryReader reader = DirectoryReader.open(dir)) {
+                for (LeafReaderContext leaf : reader.leaves()) {
+                    FieldInfo fi = leaf.reader().getFieldInfos().fieldInfo("vector");
+                    assertNotNull(fi);
+                    String storedFormatName = fi.getAttribute(PerFieldKnnVectorsFormat.PER_FIELD_FORMAT_KEY);
+                    assertEquals(
+                        "Format name written to FieldInfo must match CPU equivalent for correct SPI resolution",
+                        expectedFormatName,
+                        storedFormatName
+                    );
+                }
+            }
+        }
+    }
+}

--- a/qa/vector/src/main/java/org/elasticsearch/test/knn/KnnIndexTester.java
+++ b/qa/vector/src/main/java/org/elasticsearch/test/knn/KnnIndexTester.java
@@ -240,13 +240,20 @@ public class KnnIndexTester {
                     flatVectorThreshold
                 );
             }
-            case GPU_HNSW -> switch (quantizeBits) {
-                case null -> new ES92GpuHnswVectorsFormat();
-                case 7 -> new ES92GpuHnswSQVectorsFormat();
-                default -> throw new IllegalArgumentException(
-                    "GPU HNSW index type only supports 7 bits quantization, but got: " + quantizeBits
+            case GPU_HNSW -> {
+                int graphDegree = ES92GpuHnswVectorsFormat.cagraGraphDegree(args.hnswM());
+                int intermediateGraphDegree = ES92GpuHnswVectorsFormat.cagraIntermediateGraphDegree(
+                    args.hnswM(),
+                    args.hnswEfConstruction()
                 );
-            };
+                yield switch (quantizeBits) {
+                    case null -> new ES92GpuHnswVectorsFormat(graphDegree, intermediateGraphDegree);
+                    case 7 -> new ES92GpuHnswSQVectorsFormat(graphDegree, intermediateGraphDegree);
+                    default -> throw new IllegalArgumentException(
+                        "GPU HNSW index type only supports 7 bits quantization, but got: " + quantizeBits
+                    );
+                };
+            }
             case HNSW -> switch (quantizeBits) {
                 case null -> new ES93HnswVectorsFormat(
                     args.hnswM(),
@@ -283,7 +290,7 @@ public class KnnIndexTester {
             };
         };
 
-        logger.info("Using format {}", format.getName());
+        logger.info("Using format {} (via {})", format.getName(), format.getClass().getName());
 
         return new Lucene104Codec() {
             @Override

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/ES814HnswScalarQuantizedVectorsFormat.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/ES814HnswScalarQuantizedVectorsFormat.java
@@ -24,7 +24,7 @@ import static org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat.DEFAUL
 
 public class ES814HnswScalarQuantizedVectorsFormat extends AbstractHnswVectorsFormat {
 
-    static final String NAME = "ES814HnswScalarQuantizedVectorsFormat";
+    public static final String NAME = "ES814HnswScalarQuantizedVectorsFormat";
 
     /** The format for storing, reading, merging vectors on disk */
     final FlatVectorsFormat flatVectorsFormat;

--- a/x-pack/plugin/gpu/src/internalClusterTest/java/org/elasticsearch/xpack/gpu/BaseGPUIndexTestCase.java
+++ b/x-pack/plugin/gpu/src/internalClusterTest/java/org/elasticsearch/xpack/gpu/BaseGPUIndexTestCase.java
@@ -178,8 +178,9 @@ public abstract class BaseGPUIndexTestCase extends ESIntegTestCase {
         float[] queryVector = randomFloatVector(dims, similarity);
         int k = 10;
         int numCandidates = k * 5;
+        int minMatches = "int8_hnsw".equals(type) ? k - 4 : k - 3;
 
-        // Test 1: Approximate KNN search - expect at least k-3 out of k matches
+        // Test 1: Approximate KNN search - expect at least minMatches out of k matches
         var searchResponse1 = prepareSearch(indexName1).setSize(k)
             .setFetchSource(false)
             .addFetchField("my_keyword")
@@ -195,7 +196,7 @@ public abstract class BaseGPUIndexTestCase extends ESIntegTestCase {
         try {
             SearchHit[] hits1 = searchResponse1.getHits().getHits();
             SearchHit[] hits2 = searchResponse2.getHits().getHits();
-            assertAtLeastNOutOfKMatches(hits1, hits2, k - 3, k);
+            assertAtLeastNOutOfKMatches(hits1, hits2, minMatches, k);
         } finally {
             searchResponse1.decRef();
             searchResponse2.decRef();
@@ -228,7 +229,7 @@ public abstract class BaseGPUIndexTestCase extends ESIntegTestCase {
         assertNoFailures(indicesAdmin().prepareForceMerge(indexName2).get());
         ensureGreen();
 
-        // Test 3: Approximate KNN search - expect at least k-3 out of k matches
+        // Test 3: Approximate KNN search after force merge - expect at least minMatches out of k matches
         var searchResponse3 = prepareSearch(indexName1).setSize(k)
             .setFetchSource(false)
             .addFetchField("my_keyword")
@@ -244,7 +245,7 @@ public abstract class BaseGPUIndexTestCase extends ESIntegTestCase {
         try {
             SearchHit[] hits3 = searchResponse3.getHits().getHits();
             SearchHit[] hits4 = searchResponse4.getHits().getHits();
-            assertAtLeastNOutOfKMatches(hits3, hits4, k - 3, k);
+            assertAtLeastNOutOfKMatches(hits3, hits4, minMatches, k);
         } finally {
             searchResponse3.decRef();
             searchResponse4.decRef();
@@ -504,7 +505,7 @@ public abstract class BaseGPUIndexTestCase extends ESIntegTestCase {
                 String.format(Locale.ROOT, "Score mismatch for document ID %s at position %d", hits1[i].getId(), i),
                 hits1[i].getScore(),
                 hits2[i].getScore(),
-                0.0001f
+                5e-3f
             );
         }
     }

--- a/x-pack/plugin/gpu/src/test/java/org/elasticsearch/xpack/gpu/GPUDenseVectorFieldMapperTests.java
+++ b/x-pack/plugin/gpu/src/test/java/org/elasticsearch/xpack/gpu/GPUDenseVectorFieldMapperTests.java
@@ -27,6 +27,7 @@ import java.util.Collection;
 import java.util.Collections;
 
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.startsWith;
 
 public class GPUDenseVectorFieldMapperTests extends DenseVectorFieldMapperTests {
 
@@ -61,9 +62,9 @@ public class GPUDenseVectorFieldMapperTests extends DenseVectorFieldMapperTests 
     public void testKnnQuantizedHNSWVectorsFormat() throws IOException {
         // TOD improve the test with custom parameters
         KnnVectorsFormat knnVectorsFormat = getKnnVectorsFormat("int8_hnsw");
-        String expectedStr = "Lucene99HnswVectorsFormat(name=Lucene99HnswVectorsFormat, "
+        String expectedStr = "ES814HnswScalarQuantizedVectorsFormat(name=ES814HnswScalarQuantizedVectorsFormat, "
             + "maxConn=12, beamWidth=22, flatVectorFormat=ES814ScalarQuantizedVectorsFormat";
-        assertTrue(knnVectorsFormat.toString().startsWith(expectedStr));
+        assertThat(knnVectorsFormat.toString(), startsWith(expectedStr));
     }
 
     @Override

--- a/x-pack/plugin/gpu/src/yamlRestTest/resources/rest-api-spec/test/gpu/supported/20_int8_hnsw.yml
+++ b/x-pack/plugin/gpu/src/yamlRestTest/resources/rest-api-spec/test/gpu/supported/20_int8_hnsw.yml
@@ -1,4 +1,8 @@
 ---
+# Uses well-separated vectors (matching the CPU int8_hnsw test in 41_knn_search_byte_quantized.yml)
+# to avoid quantization noise swapping result orderings on small datasets.
+# Single shard avoids tiny per-shard segments where CAGRA graph parameters get
+# clamped to near-trivial values.
 "Test GPU vector operations":
 
   - requires:
@@ -11,15 +15,15 @@
         body:
           mappings:
             properties:
-              embedding:
+              vector:
                 type: dense_vector
-                dims: 24
+                dims: 5
                 similarity: l2_norm
                 index_options:
                   type: int8_hnsw
           settings:
-            index.number_of_shards: 2
-            index.refresh_interval: -1 # disable automatic refresh to ensure documents are indexed together
+            index.number_of_shards: 1
+            index.refresh_interval: -1
   - match: { error: null }
 
   - do:
@@ -29,118 +33,87 @@
         body:
           - index:
               _id: "1"
-          - text: "First document"
-            embedding: [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]
+          - vector: [230.0, 300.33, -34.8988, 15.555, -200.0]
           - index:
               _id: "2"
-          - text: "Second document"
-            embedding: [0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2]
+          - vector: [-0.5, 100.0, -13, 14.8, -156.0]
           - index:
               _id: "3"
-          - text: "Third document"
-            embedding: [0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3]
-          - index:
-              _id: "4"
-          - text: "Fourth document"
-            embedding: [0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4]
-          - index:
-              _id: "5"
-          - text: "Fifth document"
-            embedding: [0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]
-          - index:
-              _id: "6"
-          - text: "Sixth document"
-            embedding: [0.6, 0.6, 0.6, 0.6, 0.6, 0.6, 0.6, 0.6, 0.6, 0.6, 0.6, 0.6, 0.6, 0.6, 0.6, 0.6, 0.6, 0.6, 0.6, 0.6, 0.6, 0.6, 0.6, 0.6]
-          - index:
-              _id: "7"
-          - text: "Seventh document"
-            embedding: [0.7, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7]
-          - index:
-              _id : "8"
-          - text: "Eighth document"
-            embedding: [0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8]
-          - index:
-              _id: "9"
-          - text: "Ninth document"
-            embedding: [0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9]
-          - index:
-              _id: "10"
-          - text: "Tenth document"
-            embedding: [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+          - vector: [0.5, 111.3, -13.0, 14.8, -156.0]
   - match: { errors: false }
 
+  # Search before force merge
   - do:
       search:
         index: my_vectors
         body:
           knn:
-            field: embedding
-            query_vector: [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+            field: vector
+            query_vector: [-0.5, 90.0, -10, 14.8, -156.0]
             k: 2
-  - match: { hits.hits.0._id: "10" }
-  - match: { hits.hits.1._id: "9" }
-
-  - do:
-      bulk:
-        index: my_vectors
-        refresh: true
-        body:
-          - delete:
-              _id: "1"
-          - delete:
-              _id: "10"
-  - match: { errors: false }
-
-  - do:
-      indices.forcemerge:
-        index: my_vectors
-        max_num_segments: 1
-
-  - do:
-      search:
-        index: my_vectors
-        body:
-          knn:
-            field: embedding
-            query_vector: [ 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0 ]
-            k: 2
-  - match: { hits.hits.0._id: "9" }
-  - match: { hits.hits.1._id: "8" }
-
-
-  - do:
-      bulk:
-        index: my_vectors
-        refresh: true
-        body:
-          - index:
-              _id: "2"
-          - text: "Second document"
-            embedding: [ 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0 ]
-
-  - do:
-      indices.forcemerge:
-        index: my_vectors
-        max_num_segments: 1
-
-  - do:
-      search:
-        index: my_vectors
-        body:
-          knn:
-            field: embedding
-            query_vector: [ 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0 ]
-            k: 2
+            num_candidates: 3
   - match: { hits.hits.0._id: "2" }
-  - match: { hits.hits.1._id: "9" }
+  - match: { hits.hits.1._id: "3" }
+
+  # Delete a doc and force merge
+  - do:
+      delete:
+        index: my_vectors
+        id: "1"
+        refresh: true
+  - match: { result: "deleted" }
+
+  - do:
+      indices.forcemerge:
+        index: my_vectors
+        max_num_segments: 1
 
   - do:
       search:
         index: my_vectors
         body:
           knn:
-            field: embedding
-            query_vector: [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]
+            field: vector
+            query_vector: [-0.5, 90.0, -10, 14.8, -156.0]
             k: 2
+            num_candidates: 3
+  - match: { hits.hits.0._id: "2" }
+  - match: { hits.hits.1._id: "3" }
+
+  # Re-index doc 3 with a vector close to doc 1's original, then force merge
+  - do:
+      index:
+        index: my_vectors
+        id: "3"
+        refresh: true
+        body:
+          vector: [230.0, 300.33, -34.8988, 15.555, -200.0]
+
+  - do:
+      indices.forcemerge:
+        index: my_vectors
+        max_num_segments: 1
+
+  - do:
+      search:
+        index: my_vectors
+        body:
+          knn:
+            field: vector
+            query_vector: [230.0, 300.33, -34.8988, 15.555, -200.0]
+            k: 2
+            num_candidates: 3
   - match: { hits.hits.0._id: "3" }
-  - match: { hits.hits.1._id: "4" }
+  - match: { hits.hits.1._id: "2" }
+
+  - do:
+      search:
+        index: my_vectors
+        body:
+          knn:
+            field: vector
+            query_vector: [-0.5, 90.0, -10, 14.8, -156.0]
+            k: 2
+            num_candidates: 3
+  - match: { hits.hits.0._id: "2" }
+  - match: { hits.hits.1._id: "3" }


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Fix GPU SQ format name to match CPU equivalent (#149512)