### PR TITLE
[8.19] [Inference] Fix batched deploy inference race in DefaultEndPointsIT (#149274)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -230,9 +230,6 @@ tests:
 - class: org.elasticsearch.action.search.SearchQueryThenFetchAsyncActionTests
   method: testBottomFieldSort
   issue: https://github.com/elastic/elasticsearch/issues/118214
-- class: org.elasticsearch.xpack.inference.DefaultEndPointsIT
-  method: testMultipleInferencesTriggeringDownloadAndDeploy
-  issue: https://github.com/elastic/elasticsearch/issues/117208
 - class: org.elasticsearch.repositories.blobstore.testkit.analyze.MinioRepositoryAnalysisRestIT
   issue: https://github.com/elastic/elasticsearch/issues/120672
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT

--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/DefaultEndPointsIT.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/DefaultEndPointsIT.java
@@ -23,9 +23,13 @@ import org.junit.Before;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.hamcrest.Matchers.empty;
@@ -36,6 +40,12 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.oneOf;
 
 public class DefaultEndPointsIT extends InferenceBaseRestTest {
+
+    /**
+     * Per-attempt wait for parallel async inference callbacks. Kept well below the {@link #assertBusy} budget so retries
+     * can run while the built-in model is still downloading and deploying.
+     */
+    private static final int PARALLEL_BURST_LATCH_TIMEOUT_SECONDS = 30;
 
     private TestThreadPool threadPool;
 
@@ -201,10 +211,29 @@ public class DefaultEndPointsIT extends InferenceBaseRestTest {
         );
     }
 
-    public void testMultipleInferencesTriggeringDownloadAndDeploy() throws InterruptedException, IOException {
+    public void testMultipleInferencesTriggeringDownloadAndDeploy() throws Exception {
+        var initialEndpointId = "initial-model";
+        // Creating an inference endpoint to force the backing indices to be created to reduce the likelihood of the test failing
+        // because it's trying to interact with the indices while they're being created.
+        putModel(initialEndpointId, mockCompletionServiceModelConfig(TaskType.SPARSE_EMBEDDING, "streaming_completion_test_service"));
+        // delete model so it doesn't affect other tests
+        deleteModel(initialEndpointId);
+
+        var inputs = List.of("Hello World", "Goodnight moon");
+        var queryParams = Map.of("timeout", "120s");
+        // Concurrent cold-start deploy races can return transient 503s or short-lived client errors; retry until stable.
+        assertBusy(() -> runParallelElserInferenceBurst(inputs, queryParams), 120, TimeUnit.SECONDS);
+        assertElserDeploymentStarted();
+    }
+
+    /**
+     * Fires parallel inference requests against the default ELSER endpoint and asserts that at least one succeeds without
+     * non-transient errors. Intended to be retried via {@link #assertBusy} while the built-in model is downloading and deploying.
+     */
+    private void runParallelElserInferenceBurst(List<String> inputs, Map<String, String> queryParams) throws InterruptedException {
         int numParallelRequests = 4;
         var latch = new CountDownLatch(numParallelRequests);
-        var errors = new ArrayList<Exception>();
+        var errors = Collections.synchronizedList(new ArrayList<Exception>());
         var successCount = new AtomicInteger(0);
 
         var listener = new ResponseListener() {
@@ -221,8 +250,6 @@ public class DefaultEndPointsIT extends InferenceBaseRestTest {
             }
         };
 
-        var inputs = List.of("Hello World", "Goodnight moon");
-        var queryParams = Map.of("timeout", "120s");
         for (int i = 0; i < numParallelRequests; i++) {
             var request = createInferenceRequest(
                 Strings.format("_inference/%s", ElasticsearchInternalService.DEFAULT_ELSER_ID),
@@ -233,13 +260,13 @@ public class DefaultEndPointsIT extends InferenceBaseRestTest {
             client().performRequestAsync(request, listener);
         }
 
-        latch.await();
-        // Filter out transient shard unavailability errors on .ml-inference-* indices. These can occur when
-        // multiple concurrent requests race to initialize the ML model storage index during the first deployment.
-        var significantErrors = errors.stream().filter(e -> isTransientMlInferenceIndexError(e) == false).toList();
-        assertThat("Received non-transient errors", significantErrors, empty());
+        assertTrue(
+            "Timed out waiting for parallel inference requests",
+            latch.await(PARALLEL_BURST_LATCH_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        );
+        var significantErrors = errors.stream().filter(e -> isTransientDeployRaceError(e) == false).toList();
+        assertThat("Received non-transient errors: " + significantErrors, significantErrors, empty());
         assertThat("Expected at least one inference request to succeed", successCount.get(), greaterThan(0));
-        assertElserDeploymentStarted();
     }
 
     /**
@@ -284,14 +311,50 @@ public class DefaultEndPointsIT extends InferenceBaseRestTest {
     }
 
     /**
+     * Returns true for errors that can occur while concurrent requests race to download, put, and deploy a built-in model.
+     */
+    private static boolean isTransientDeployRaceError(Exception e) {
+        return isTransientDeployRaceError(e, new HashSet<>());
+    }
+
+    private static boolean isTransientDeployRaceError(Exception e, Set<Exception> seen) {
+        if (e == null || seen.add(e) == false) {
+            return false;
+        }
+        if (isTransientMlInferenceIndexError(e)) {
+            return true;
+        }
+        // Observed in #149130 when batched inference races with a deployment that is not ready for the second input yet.
+        if (e instanceof ArrayIndexOutOfBoundsException aioob) {
+            String message = aioob.getMessage();
+            if (message != null && message.contains("out of bounds for length 0")) {
+                return true;
+            }
+        }
+        if (e.getCause() instanceof Exception cause && isTransientDeployRaceError(cause, seen)) {
+            return true;
+        }
+        for (var suppressed : e.getSuppressed()) {
+            if (suppressed instanceof Exception suppressedException && isTransientDeployRaceError(suppressedException, seen)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Returns true if the exception is a transient 503 caused by a not-yet-initialized shard on a .ml-inference-*
      * index. This happens when concurrent requests simultaneously trigger a built-in model deployment and one of
      * them searches the ML inference index while another is in the process of creating it.
      */
     private static boolean isTransientMlInferenceIndexError(Exception e) {
-        return e instanceof ResponseException re
-            && re.getResponse().getStatusLine().getStatusCode() == RestStatus.SERVICE_UNAVAILABLE.getStatus()
-            && e.getMessage().contains("no_shard_available_action_exception")
-            && e.getMessage().contains(".ml-inference-");
+        if (e instanceof ResponseException re
+            && re.getResponse().getStatusLine().getStatusCode() == RestStatus.SERVICE_UNAVAILABLE.getStatus()) {
+            String message = e.getMessage();
+            return message != null
+                && message.contains(".ml-inference-")
+                && (message.contains("no_shard_available_action_exception") || message.contains("NoShardAvailableActionException"));
+        }
+        return false;
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInferTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInferTrainedModelDeploymentAction.java
@@ -154,7 +154,17 @@ public class TransportInferTrainedModelDeploymentAction extends TransportTasksAc
             }
 
             private void sendResponse() {
-                finalListener.onResponse(new InferTrainedModelDeploymentAction.Response(results.asList()));
+                var orderedResults = new ArrayList<InferenceResults>(totalNumberOfResponses);
+                for (int i = 0; i < totalNumberOfResponses; i++) {
+                    InferenceResults result = results.get(i);
+                    if (result == null) {
+                        result = new ErrorInferenceResults(
+                            new IllegalStateException("Missing inference result for input index [" + i + "]")
+                        );
+                    }
+                    orderedResults.add(result);
+                }
+                finalListener.onResponse(new InferTrainedModelDeploymentAction.Response(orderedResults));
             }
         };
     }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Inference] Fix batched deploy inference race in DefaultEndPointsIT (#149274)](https://github.com/elastic/elasticsearch/pull/149274)

<!--- Backport version: 12.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)