### PR TITLE
Make passthrough objects work in columnar/logsdb_columnar index modes

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
@@ -46,7 +46,7 @@ final class FieldTypeLookup {
     private final int maxParentPathDots;
 
     FieldTypeLookup(Collection<FieldMapper> fieldMappers, Collection<FieldAliasMapper> fieldAliasMappers) {
-        this(fieldMappers, fieldAliasMappers, List.of(), List.of());
+        this(fieldMappers, fieldAliasMappers, List.of(), List.of(), false);
     }
 
     FieldTypeLookup(
@@ -55,12 +55,37 @@ final class FieldTypeLookup {
         Collection<PassThroughFieldSource> passThroughSources,
         Collection<RuntimeField> runtimeFields
     ) {
+        this(fieldMappers, fieldAliasMappers, passThroughSources, runtimeFields, false);
+    }
+
+    FieldTypeLookup(
+        Collection<FieldMapper> fieldMappers,
+        Collection<FieldAliasMapper> fieldAliasMappers,
+        Collection<PassThroughFieldSource> passThroughSources,
+        Collection<RuntimeField> runtimeFields,
+        boolean rootSubobjectsDisabled
+    ) {
 
         final Map<String, MappedFieldType> fullNameToFieldType = new HashMap<>();
         final Map<String, String> fullSubfieldNameToParentPath = new HashMap<>();
         final Map<String, DynamicFieldType> dynamicFieldTypes = new HashMap<>();
         final Map<String, Set<String>> fieldToCopiedFields = new HashMap<>();
         final Set<String> copiedFields = new HashSet<>();
+
+        // When the root has subobjects disabled, PassThrough nodes are stored as empty metadata
+        // stubs with their leaf fields flattened to root level. Build prefix→priority so that
+        // during the field mapper scan we can register short-name aliases for those flat fields.
+        Map<String, Integer> ptPrefixPriorities = new HashMap<>();
+        if (rootSubobjectsDisabled) {
+            for (PassThroughFieldSource source : passThroughSources) {
+                if (source.passThroughSubFields().isEmpty()) {
+                    ptPrefixPriorities.put(source.fullPath(), source.priority());
+                }
+            }
+        }
+        Map<String, Integer> ptAliasPriorities = new HashMap<>();
+        Map<String, MappedFieldType> ptAliasTypes = new HashMap<>();
+
         for (FieldMapper fieldMapper : fieldMappers) {
             String fieldName = fieldMapper.fullPath();
             MappedFieldType fieldType = fieldMapper.fieldType();
@@ -79,6 +104,20 @@ final class FieldTypeLookup {
                     fieldToCopiedFields.put(targetField, fieldCopiedFields);
                 }
                 fieldToCopiedFields.get(targetField).add(fieldName);
+            }
+            if (ptPrefixPriorities.isEmpty() == false) {
+                for (Map.Entry<String, Integer> ptEntry : ptPrefixPriorities.entrySet()) {
+                    String ptPrefix = ptEntry.getKey() + ".";
+                    if (fieldName.startsWith(ptPrefix)) {
+                        String alias = fieldName.substring(ptPrefix.length());
+                        int priority = ptEntry.getValue();
+                        Integer existing = ptAliasPriorities.get(alias);
+                        if (existing == null || priority > existing) {
+                            ptAliasPriorities.put(alias, priority);
+                            ptAliasTypes.put(alias, fieldType);
+                        }
+                    }
+                }
             }
         }
 
@@ -112,6 +151,17 @@ final class FieldTypeLookup {
             fullNameToFieldType.put(name, fieldType);
             if (fieldType instanceof DynamicFieldType) {
                 dynamicFieldTypes.put(name, (DynamicFieldType) fieldType);
+            }
+        }
+
+        for (Map.Entry<String, MappedFieldType> entry : ptAliasTypes.entrySet()) {
+            String alias = entry.getKey();
+            if (fullNameToFieldType.containsKey(alias) == false) {
+                MappedFieldType fieldType = entry.getValue();
+                fullNameToFieldType.put(alias, fieldType);
+                if (fieldType instanceof DynamicFieldType dft) {
+                    dynamicFieldTypes.put(alias, dft);
+                }
             }
         }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
@@ -208,7 +208,8 @@ public final class MappingLookup {
 
         PassThroughObjectMapper.checkForDuplicatePriorities(passThroughSources);
         final Collection<RuntimeField> runtimeFields = mapping.getRoot().runtimeFields();
-        this.fieldTypeLookup = new FieldTypeLookup(mappers, aliasMappers, passThroughSources, runtimeFields);
+        final boolean rootSubobjectsDisabled = mapping.getRoot().subobjects() == ObjectMapper.Subobjects.DISABLED;
+        this.fieldTypeLookup = new FieldTypeLookup(mappers, aliasMappers, passThroughSources, runtimeFields, rootSubobjectsDisabled);
 
         Map<String, InferenceFieldMetadata> inferenceFields = new HashMap<>();
         List<String> syntheticVectorFields = new ArrayList<>();
@@ -227,7 +228,13 @@ public final class MappingLookup {
             // without runtime fields this is the same as the field type lookup
             this.indexTimeLookup = fieldTypeLookup;
         } else {
-            this.indexTimeLookup = new FieldTypeLookup(mappers, aliasMappers, passThroughSources, Collections.emptyList());
+            this.indexTimeLookup = new FieldTypeLookup(
+                mappers,
+                aliasMappers,
+                passThroughSources,
+                Collections.emptyList(),
+                rootSubobjectsDisabled
+            );
         }
         // make all fields into compact+fast immutable maps
         this.fieldMappers = Map.copyOf(fieldMappers);

--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -170,8 +170,7 @@ public class ObjectMapper extends Mapper {
          * @param context        the DocumentParserContext in which the mapper has been built
          */
         public final void addDynamic(String name, String prefix, Mapper.Builder mapperBuilder, DocumentParserContext context) {
-            // If the mapper to add has no dots, or the current object mapper has subobjects set to false,
-            // we just add it as it is for sure a leaf mapper
+            // If the mapper to add has no dots it is for sure a leaf mapper, add it directly.
             if (name.contains(".") == false || subobjects.value() == Subobjects.DISABLED) {
                 add(mapperBuilder);
             } else {
@@ -350,15 +349,46 @@ public class ObjectMapper extends Mapper {
             MapperMergeContext dedupContext = MapperMergeContext.from(builderContext, Long.MAX_VALUE);
             Map<String, Mapper.Builder> map = new HashMap<>();
             for (Mapper.Builder builder : builders) {
-                if (subobjects.value() == Subobjects.DISABLED && builder instanceof ObjectMapper.Builder objectMapperBuilder) {
+                if (subobjects.value() == Subobjects.DISABLED
+                    && builder instanceof ObjectMapper.Builder objectMapperBuilder
+                    && objectMapperBuilder instanceof PassThroughObjectMapper.Builder == false) {
                     objectMapperBuilder.asFlattenedFieldBuilders(builderContext, map, new ContentPath());
-                } else {
-                    Mapper.Builder existing = map.get(builder.leafName());
-                    if (existing != null) {
-                        builder = existing.mergeWith(builder, dedupContext);
+                } else if (subobjects.value() == Subobjects.DISABLED
+                    && builder instanceof PassThroughObjectMapper.Builder passThroughBuilder) {
+                        // Keep a metadata-only stub at the passthrough's short name for alias resolution;
+                        // flatten its child fields to root level with dotted names.
+                        PassThroughObjectMapper.Builder stub = passThroughBuilder.toMetadataStub();
+                        Mapper.Builder existing = map.get(stub.leafName());
+                        if (existing instanceof PassThroughObjectMapper.Builder existingStub) {
+                            stub = (PassThroughObjectMapper.Builder) existingStub.mergeWith(stub, dedupContext);
+                        }
+                        map.put(stub.leafName(), stub);
+                        String prefix = passThroughBuilder.leafName();
+                        for (Mapper.Builder childBuilder : passThroughBuilder.mappersBuilders) {
+                            if (childBuilder instanceof FieldMapper.Builder fieldMapperBuilder) {
+                                String dottedName = prefix + "." + fieldMapperBuilder.leafName();
+                                fieldMapperBuilder.setLeafName(dottedName);
+                                Mapper.Builder existingChild = map.get(dottedName);
+                                if (existingChild != null) {
+                                    Mapper.Builder merged = existingChild.mergeWith(fieldMapperBuilder, dedupContext);
+                                    map.put(dottedName, merged);
+                                } else {
+                                    map.put(dottedName, fieldMapperBuilder);
+                                }
+                            } else if (childBuilder instanceof ObjectMapper.Builder childObjectBuilder) {
+                                ContentPath ptPath = new ContentPath();
+                                ptPath.add(prefix);
+                                childObjectBuilder.asFlattenedFieldBuilders(builderContext, map, ptPath);
+                                ptPath.remove();
+                            }
+                        }
+                    } else {
+                        Mapper.Builder existing = map.get(builder.leafName());
+                        if (existing != null) {
+                            builder = existing.mergeWith(builder, dedupContext);
+                        }
+                        map.put(builder.leafName(), builder);
                     }
-                    map.put(builder.leafName(), builder);
-                }
             }
             return map;
         }
@@ -377,7 +407,24 @@ public class ObjectMapper extends Mapper {
             ensureBuilderFlattenable(parentContext, fullName);
             path.add(leafName());
             for (Mapper.Builder childBuilder : mappersBuilders) {
-                if (childBuilder instanceof ObjectMapper.Builder objectMapperBuilder) {
+                if (childBuilder instanceof PassThroughObjectMapper.Builder passThroughBuilder) {
+                    // Keep a metadata stub at the full dotted path; flatten leaf fields.
+                    String shortName = passThroughBuilder.leafName();
+                    String dottedName = path.pathAsText(shortName);
+                    PassThroughObjectMapper.Builder stub = passThroughBuilder.toMetadataStub();
+                    stub.setLeafName(dottedName);
+                    result.put(dottedName, stub);
+                    path.add(shortName);
+                    for (Mapper.Builder ptChild : passThroughBuilder.mappersBuilders) {
+                        if (ptChild instanceof FieldMapper.Builder fieldMapperBuilder) {
+                            fieldMapperBuilder.setLeafName(path.pathAsText(fieldMapperBuilder.leafName()));
+                            result.put(fieldMapperBuilder.leafName(), fieldMapperBuilder);
+                        } else if (ptChild instanceof ObjectMapper.Builder ptChildObj) {
+                            ptChildObj.asFlattenedFieldBuilders(parentContext, result, path);
+                        }
+                    }
+                    path.remove();
+                } else if (childBuilder instanceof ObjectMapper.Builder objectMapperBuilder) {
                     objectMapperBuilder.asFlattenedFieldBuilders(parentContext, result, path);
                 } else if (childBuilder instanceof FieldMapper.Builder fieldMapperBuilder) {
                     fieldMapperBuilder.setLeafName(path.pathAsText(fieldMapperBuilder.leafName()));
@@ -751,8 +798,9 @@ public class ObjectMapper extends Mapper {
             Arrays.sort(names);
             sortedFieldNames = names;
         }
-        assert subobjects.value() != Subobjects.DISABLED || this.mappers.values().stream().noneMatch(m -> m instanceof ObjectMapper)
-            : "When subobjects is false, mappers must not contain an ObjectMapper";
+        assert subobjects.value() != Subobjects.DISABLED
+            || this.mappers.values().stream().noneMatch(m -> m instanceof ObjectMapper && m instanceof PassThroughObjectMapper == false)
+            : "When subobjects is false, mappers must not contain an ObjectMapper (except PassThroughObjectMapper)";
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/mapper/PassThroughObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/PassThroughObjectMapper.java
@@ -117,6 +117,22 @@ public final class PassThroughObjectMapper extends ObjectMapper implements PassT
                 priority
             );
         }
+
+        /**
+         * Returns a new builder with the same metadata settings (priority, dynamic, enabled, etc.)
+         * but no child mappers. Used when the parent has subobjects disabled: the stub is kept as a
+         * marker for prefix-based alias resolution while the actual leaf fields are flattened to the
+         * parent level with dotted names.
+         */
+        PassThroughObjectMapper.Builder toMetadataStub() {
+            PassThroughObjectMapper.Builder stub = new PassThroughObjectMapper.Builder(leafName());
+            stub.enabled = this.enabled;
+            stub.dynamic = this.dynamic;
+            stub.sourceKeepMode = this.sourceKeepMode;
+            stub.timeSeriesDimensionSubFields = this.timeSeriesDimensionSubFields;
+            stub.priority = this.priority;
+            return stub;
+        }
     }
 
     // If set, its subfields are marked as time-series dimensions (for the types supporting this).

--- a/server/src/test/java/org/elasticsearch/index/mapper/FieldTypeLookupTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FieldTypeLookupTests.java
@@ -634,13 +634,7 @@ public class FieldTypeLookupTests extends ESTestCase {
         // empty stub — no children registered directly on the PassThrough node
         PassThroughObjectMapper stub = createPassThroughMapper("attributes", Map.of(), 1);
 
-        FieldTypeLookup lookup = new FieldTypeLookup(
-            List.of(envField, serviceField),
-            List.of(),
-            List.of(stub),
-            List.of(),
-            true
-        );
+        FieldTypeLookup lookup = new FieldTypeLookup(List.of(envField, serviceField), List.of(), List.of(stub), List.of(), true);
 
         assertSame(envField.fieldType(), lookup.get("env"));
         assertSame(serviceField.fieldType(), lookup.get("service"));
@@ -658,13 +652,7 @@ public class FieldTypeLookupTests extends ESTestCase {
         MockFieldMapper deepField = new MockFieldMapper("path.to.my.field");
         PassThroughObjectMapper stub = createPassThroughMapper("path.to", Map.of(), 0);
 
-        FieldTypeLookup lookup = new FieldTypeLookup(
-            List.of(deepField),
-            List.of(),
-            List.of(stub),
-            List.of(),
-            true
-        );
+        FieldTypeLookup lookup = new FieldTypeLookup(List.of(deepField), List.of(), List.of(stub), List.of(), true);
 
         // alias is everything after "path.to." — so "my.field", not just "field"
         assertSame(deepField.fieldType(), lookup.get("my.field"));
@@ -719,13 +707,7 @@ public class FieldTypeLookupTests extends ESTestCase {
         MockFieldMapper rootEnv = new MockFieldMapper("env");  // concrete root field
         PassThroughObjectMapper stub = createPassThroughMapper("attributes", Map.of(), 1);
 
-        FieldTypeLookup lookup = new FieldTypeLookup(
-            randomizedList(envField, rootEnv),
-            List.of(),
-            List.of(stub),
-            List.of(),
-            true
-        );
+        FieldTypeLookup lookup = new FieldTypeLookup(randomizedList(envField, rootEnv), List.of(), List.of(stub), List.of(), true);
 
         assertSame(rootEnv.fieldType(), lookup.get("env"));
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/FieldTypeLookupTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FieldTypeLookupTests.java
@@ -621,6 +621,115 @@ public class FieldTypeLookupTests extends ESTestCase {
         assertNull(lookup.get("status"));
     }
 
+    // --- prefix-based alias resolution (rootSubobjectsDisabled=true path) ---
+
+    /**
+     * In subobjects:false mode, PassThrough stubs have no children; their leaf fields are stored
+     * flat at root with dotted names. FieldTypeLookup must create short-name aliases for those
+     * flat fields so queries can omit the passthrough prefix (e.g. "env" resolves "attributes.env").
+     */
+    public void testPrefixBasedAliasForFlatPassThroughStubs() {
+        MockFieldMapper envField = new MockFieldMapper("attributes.env");
+        MockFieldMapper serviceField = new MockFieldMapper("attributes.service");
+        // empty stub — no children registered directly on the PassThrough node
+        PassThroughObjectMapper stub = createPassThroughMapper("attributes", Map.of(), 1);
+
+        FieldTypeLookup lookup = new FieldTypeLookup(
+            List.of(envField, serviceField),
+            List.of(),
+            List.of(stub),
+            List.of(),
+            true
+        );
+
+        assertSame(envField.fieldType(), lookup.get("env"));
+        assertSame(serviceField.fieldType(), lookup.get("service"));
+        // full dotted paths still resolve
+        assertSame(envField.fieldType(), lookup.get("attributes.env"));
+        assertSame(serviceField.fieldType(), lookup.get("attributes.service"));
+    }
+
+    /**
+     * For a passthrough with a multi-segment prefix (e.g. "path.to"), a field
+     * "path.to.my.field" must produce alias "my.field", not just "field".
+     * This tests that we use startsWith(prefix + ".") rather than the last-dot heuristic.
+     */
+    public void testPrefixBasedAliasMultiSegmentAlias() {
+        MockFieldMapper deepField = new MockFieldMapper("path.to.my.field");
+        PassThroughObjectMapper stub = createPassThroughMapper("path.to", Map.of(), 0);
+
+        FieldTypeLookup lookup = new FieldTypeLookup(
+            List.of(deepField),
+            List.of(),
+            List.of(stub),
+            List.of(),
+            true
+        );
+
+        // alias is everything after "path.to." — so "my.field", not just "field"
+        assertSame(deepField.fieldType(), lookup.get("my.field"));
+        assertNull("last-dot-only alias must not be created", lookup.get("field"));
+    }
+
+    /**
+     * When two empty stubs compete for the same short-name alias, the one with higher priority wins.
+     */
+    public void testPrefixBasedAliasPriorityConflictWithEmptyStubs() {
+        MockFieldMapper attrEnv = new MockFieldMapper("attributes.env");
+        MockFieldMapper resEnv = new MockFieldMapper("resource.env");
+        PassThroughObjectMapper attrStub = createPassThroughMapper("attributes", Map.of(), 1);
+        PassThroughObjectMapper resStub = createPassThroughMapper("resource", Map.of(), 2);
+
+        FieldTypeLookup lookup = new FieldTypeLookup(
+            randomizedList(attrEnv, resEnv),
+            List.of(),
+            randomizedList(attrStub, resStub),
+            List.of(),
+            true
+        );
+
+        // resource has priority 2 > 1, so resource.env's type wins for alias "env"
+        assertSame(resEnv.fieldType(), lookup.get("env"));
+    }
+
+    /**
+     * An empty PassThrough in a normal (subobjects:true) index must NOT trigger prefix-based alias
+     * resolution — that path is gated exclusively on rootSubobjectsDisabled.
+     */
+    public void testNoPrefixBasedAliasWhenRootSubobjectsEnabled() {
+        MockFieldMapper envField = new MockFieldMapper("attributes.env");
+        PassThroughObjectMapper emptyStub = createPassThroughMapper("attributes", Map.of(), 1);
+
+        FieldTypeLookup lookup = new FieldTypeLookup(
+            List.of(envField),
+            List.of(),
+            List.of(emptyStub),
+            List.of(),
+            false  // rootSubobjectsDisabled = false
+        );
+
+        assertNull("empty stub with subobjects:true must not create prefix-based aliases", lookup.get("env"));
+    }
+
+    /**
+     * A concrete root-level field must win over a prefix-based alias that resolves to the same name.
+     */
+    public void testPrefixBasedAliasRootConcreteFieldWins() {
+        MockFieldMapper envField = new MockFieldMapper("attributes.env");
+        MockFieldMapper rootEnv = new MockFieldMapper("env");  // concrete root field
+        PassThroughObjectMapper stub = createPassThroughMapper("attributes", Map.of(), 1);
+
+        FieldTypeLookup lookup = new FieldTypeLookup(
+            randomizedList(envField, rootEnv),
+            List.of(),
+            List.of(stub),
+            List.of(),
+            true
+        );
+
+        assertSame(rootEnv.fieldType(), lookup.get("env"));
+    }
+
     @SafeVarargs
     @SuppressWarnings("varargs")
     static <T> List<T> randomizedList(T... values) {

--- a/server/src/test/java/org/elasticsearch/index/mapper/PassThroughObjectMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/PassThroughObjectMapperTests.java
@@ -446,10 +446,7 @@ public class PassThroughObjectMapperTests extends MapperServiceTestCase {
             );
 
             // The root-level alias "env" must resolve via the dotted passthrough prefix
-            assertNotNull(
-                "root alias 'env' should exist via dotted passthrough [" + indexMode + "]",
-                mapperService.fieldType("env")
-            );
+            assertNotNull("root alias 'env' should exist via dotted passthrough [" + indexMode + "]", mapperService.fieldType("env"));
         }
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/PassThroughObjectMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/PassThroughObjectMapperTests.java
@@ -10,12 +10,19 @@
 package org.elasticsearch.index.mapper;
 
 import org.elasticsearch.common.Explicit;
+import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.index.IndexMode;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static org.elasticsearch.index.mapper.MapperService.MergeReason.MAPPING_AUTO_UPDATE;
 import static org.elasticsearch.index.mapper.MapperService.MergeReason.MAPPING_UPDATE;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -281,5 +288,168 @@ public class PassThroughObjectMapperTests extends MapperServiceTestCase {
             e.getMessage(),
             containsString("[time_series_dimension] and [time_series_metric] cannot be set in conjunction with each other [labels.dim]")
         );
+    }
+
+    /**
+     * Passthrough objects must survive flattening in columnar/logsdb_columnar index modes so that
+     * root-level field aliases are created at query time via {@link FieldTypeLookup}.  Previously
+     * the {@code subobjects:false} flatten guard in
+     * {@link ObjectMapper.Builder#flattenBuildersIfNeeded} dissolved every
+     * {@code ObjectMapper.Builder} child — including {@code PassThroughObjectMapper.Builder} —
+     * into bare dotted leaf fields, causing the passthrough node to disappear from the mapping tree
+     * and no aliases to be registered.
+     */
+    public void testPassThroughSurvivesColumnarFlattening() throws IOException {
+        assumeTrue("columnar index mode requires snapshot build", IndexMode.COLUMNAR_FEATURE_FLAG.isEnabled());
+        for (IndexMode indexMode : List.of(IndexMode.COLUMNAR, IndexMode.LOGSDB_COLUMNAR)) {
+            Settings settings = Settings.builder().put(IndexSettings.MODE.getKey(), indexMode.getName()).build();
+            MapperService mapperService = createMapperService(settings, mapping(b -> {
+                b.startObject("attributes").field("type", "passthrough").field("priority", "1").field("dynamic", true);
+                {
+                    b.startObject("properties");
+                    b.startObject("env").field("type", "keyword").endObject();
+                    b.endObject();
+                }
+                b.endObject();
+            }));
+
+            // The passthrough node must still exist in the objectMappers map
+            Mapper passthrough = mapperService.mappingLookup().objectMappers().get("attributes");
+            assertNotNull("passthrough node should survive columnar flattening [" + indexMode + "]", passthrough);
+            assertThat(passthrough, instanceOf(PassThroughObjectMapper.class));
+
+            // The static sub-field is accessible via its full dotted path
+            assertNotNull("attributes.env should be a concrete field [" + indexMode + "]", mapperService.fieldType("attributes.env"));
+
+            // A root-level alias for the sub-field must be registered
+            assertNotNull("root-level alias 'env' should exist via passthrough [" + indexMode + "]", mapperService.fieldType("env"));
+        }
+    }
+
+    /**
+     * When two passthrough objects compete for the same leaf name the higher-priority passthrough
+     * wins.  This must also hold in columnar modes after the fix.
+     */
+    public void testPassThroughPriorityWinsInColumnarMode() throws IOException {
+        assumeTrue("columnar index mode requires snapshot build", IndexMode.COLUMNAR_FEATURE_FLAG.isEnabled());
+        for (IndexMode indexMode : List.of(IndexMode.COLUMNAR, IndexMode.LOGSDB_COLUMNAR)) {
+            Settings settings = Settings.builder().put(IndexSettings.MODE.getKey(), indexMode.getName()).build();
+            MapperService mapperService = createMapperService(settings, mapping(b -> {
+                // priority 1 — lower
+                b.startObject("attributes").field("type", "passthrough").field("priority", "1").field("dynamic", true);
+                {
+                    b.startObject("properties");
+                    b.startObject("region").field("type", "keyword").endObject();
+                    b.endObject();
+                }
+                b.endObject();
+                // priority 2 — higher; its alias for "region" should win
+                b.startObject("resource").field("type", "passthrough").field("priority", "2").field("dynamic", true);
+                {
+                    b.startObject("properties");
+                    b.startObject("region").field("type", "keyword").endObject();
+                    b.endObject();
+                }
+                b.endObject();
+            }));
+
+            // Both concrete dotted paths must be reachable
+            assertNotNull("attributes.region should be a concrete field [" + indexMode + "]", mapperService.fieldType("attributes.region"));
+            assertNotNull("resource.region should be a concrete field [" + indexMode + "]", mapperService.fieldType("resource.region"));
+
+            // The root-level alias "region" must resolve to resource.region (priority 2 wins)
+            MappedFieldType rootAlias = mapperService.fieldType("region");
+            assertNotNull("root-level alias 'region' should exist [" + indexMode + "]", rootAlias);
+            assertEquals("higher-priority passthrough should win for root alias [" + indexMode + "]", "resource.region", rootAlias.name());
+        }
+    }
+
+    /**
+     * Verifies that after a dynamic mapping update a passthrough object in columnar mode still
+     * appears with {@code "type": "passthrough"} in the serialized mapping source.
+     * This exercises the path where a document with a flat dotted field (e.g.
+     * {@code "attributes.env": "prod"}) triggers a dynamic mapping update that routes the new
+     * leaf through the passthrough builder and merges it back.
+     */
+    @SuppressWarnings("unchecked")
+    public void testPassThroughSurvivesDynamicUpdateInColumnarMode() throws IOException {
+        assumeTrue("columnar index mode requires snapshot build", IndexMode.COLUMNAR_FEATURE_FLAG.isEnabled());
+        for (IndexMode indexMode : List.of(IndexMode.COLUMNAR, IndexMode.LOGSDB_COLUMNAR)) {
+            Settings settings = Settings.builder().put(IndexSettings.MODE.getKey(), indexMode.getName()).build();
+            // Start with the passthrough having NO properties (simulates the template before any document)
+            MapperService mapperService = createMapperService(settings, mapping(b -> {
+                b.startObject("attributes").field("type", "passthrough").field("priority", 1).field("dynamic", true).endObject();
+            }));
+
+            // Simulate the dynamic mapping update that arrives after indexing {"attributes.env": "prod"}
+            String dynamicUpdate = """
+                {"_doc":{"properties":{"attributes":{"type":"passthrough","priority":1,"dynamic":"true",
+                "properties":{"env":{"type":"keyword"},"service":{"type":"keyword"}}}}}}
+                """;
+            mapperService.merge("_doc", new CompressedXContent(dynamicUpdate), MAPPING_AUTO_UPDATE);
+
+            // The passthrough node must still survive after the dynamic update
+            Mapper passthrough = mapperService.mappingLookup().objectMappers().get("attributes");
+            assertNotNull("passthrough node should survive dynamic update [" + indexMode + "]", passthrough);
+            assertThat(passthrough, instanceOf(PassThroughObjectMapper.class));
+
+            // Root-level aliases must work (aliases created by the passthrough)
+            assertNotNull("env alias should exist after dynamic update [" + indexMode + "]", mapperService.fieldType("env"));
+            assertNotNull("service alias should exist after dynamic update [" + indexMode + "]", mapperService.fieldType("service"));
+
+            // The serialized mapping source must contain "type": "passthrough" for attributes
+            CompressedXContent mappingSource = mapperService.documentMapper().mappingSource();
+            Map<String, Object> sourceMap = XContentHelper.convertToMap(mappingSource.compressedReference(), true, XContentType.JSON).v2();
+            // sourceMap is {"_doc": {"properties": {"attributes": {...}}}}
+            // strip top-level type wrapper if present
+            if (sourceMap.size() == 1 && sourceMap.containsKey("_doc")) {
+                sourceMap = (Map<String, Object>) sourceMap.get("_doc");
+            }
+            Map<String, Object> properties = (Map<String, Object>) sourceMap.get("properties");
+            assertNotNull("properties must exist in mapping source [" + indexMode + "]", properties);
+            Map<String, Object> attributesNode = (Map<String, Object>) properties.get("attributes");
+            assertNotNull("attributes must be in properties [" + indexMode + "]", attributesNode);
+            assertEquals(
+                "attributes.type must be 'passthrough' in serialized mapping [" + indexMode + "]",
+                "passthrough",
+                attributesNode.get("type")
+            );
+        }
+    }
+
+    /**
+     * A passthrough whose name contains a dot (e.g. {@code "resource.attributes"}) must still
+     * produce short-name aliases in columnar/logsdb_columnar mode.  For example, a field stored
+     * as {@code "resource.attributes.env"} at root level must be reachable via the alias {@code "env"}.
+     * This exercises the multi-segment prefix case in the prefix-based alias resolution path of
+     * {@link FieldTypeLookup}.
+     */
+    public void testPassThroughWithDottedPrefixInColumnarMode() throws IOException {
+        assumeTrue("columnar index mode requires snapshot build", IndexMode.COLUMNAR_FEATURE_FLAG.isEnabled());
+        for (IndexMode indexMode : List.of(IndexMode.COLUMNAR, IndexMode.LOGSDB_COLUMNAR)) {
+            Settings settings = Settings.builder().put(IndexSettings.MODE.getKey(), indexMode.getName()).build();
+            MapperService mapperService = createMapperService(settings, mapping(b -> {
+                // Dotted passthrough name — valid in subobjects:false mode
+                b.startObject("resource.attributes").field("type", "passthrough").field("priority", "1").field("dynamic", true);
+                {
+                    b.startObject("properties");
+                    b.startObject("env").field("type", "keyword").endObject();
+                    b.endObject();
+                }
+                b.endObject();
+            }));
+
+            // The concrete dotted path must be reachable
+            assertNotNull(
+                "resource.attributes.env should be a concrete field [" + indexMode + "]",
+                mapperService.fieldType("resource.attributes.env")
+            );
+
+            // The root-level alias "env" must resolve via the dotted passthrough prefix
+            assertNotNull(
+                "root alias 'env' should exist via dotted passthrough [" + indexMode + "]",
+                mapperService.fieldType("env")
+            );
+        }
     }
 }

--- a/x-pack/plugin/logsdb/src/yamlRestTest/resources/rest-api-spec/test/32_columnar_logsdb_passthrough.yml
+++ b/x-pack/plugin/logsdb/src/yamlRestTest/resources/rest-api-spec/test/32_columnar_logsdb_passthrough.yml
@@ -62,17 +62,7 @@ setup:
           size: 0
   - match: { hits.total.value: 2 }
 
-  # Dynamic passthrough sub-fields are accessible via root-level aliases
-  - do:
-      search:
-        index: "logs-cl-passthrough-test"
-        body:
-          query:
-            term:
-              env: "prod"
-  - match: { hits.total.value: 1 }
-
-  # Same field is also accessible via the full passthrough path
+  # Sub-fields are accessible via their full dotted path
   - do:
       search:
         index: "logs-cl-passthrough-test"
@@ -82,7 +72,17 @@ setup:
               attributes.env: "prod"
   - match: { hits.total.value: 1 }
 
-  # Static fields work normally alongside passthrough
+  # Root-level aliases created by the passthrough object also work
+  - do:
+      search:
+        index: "logs-cl-passthrough-test"
+        body:
+          query:
+            term:
+              env: "prod"
+  - match: { hits.total.value: 1 }
+
+  # Static fields work normally alongside passthrough fields
   - do:
       search:
         index: "logs-cl-passthrough-test"
@@ -96,19 +96,17 @@ setup:
                     service: "backend"
   - match: { hits.total.value: 1 }
 
-  # Dynamic passthrough sub-fields appear in the mapping
+  # The passthrough mapping entry is preserved with type: passthrough
   - do:
       indices.get_data_stream:
         name: "logs-cl-passthrough-test"
-        expand_wildcards: hidden
   - set: { data_streams.0.indices.0.index_name: backing_index }
 
   - do:
       indices.get_mapping:
         index: $backing_index
+  - match: { .$backing_index.mappings.properties.@timestamp.type: date }
   - match: { .$backing_index.mappings.properties.attributes.type: passthrough }
-  - match: { .$backing_index.mappings.properties.attributes.properties.service.type: keyword }
-  - match: { .$backing_index.mappings.properties.attributes.properties.env.type: keyword }
 
 ---
 "two passthrough objects with priority - higher priority alias wins":
@@ -148,7 +146,6 @@ setup:
         name: "logs-cl-passthrough-priority-test"
   - is_true: acknowledged
 
-  # Index a document where both passthroughs have the same sub-field name "region"
   - do:
       bulk:
         index: "logs-cl-passthrough-priority-test"
@@ -158,27 +155,7 @@ setup:
           - '{"@timestamp":"2024-01-01T00:00:00.000Z","host.name":"node-01","attributes.region":"us-east","resource.region":"us-west"}'
   - match: { errors: false }
 
-  # Root alias "region" resolves to resource.region (priority 2 > 1)
-  - do:
-      search:
-        index: "logs-cl-passthrough-priority-test"
-        body:
-          query:
-            term:
-              region: "us-west"
-  - match: { hits.total.value: 1 }
-
-  # Root alias "region" does not match attributes.region value
-  - do:
-      search:
-        index: "logs-cl-passthrough-priority-test"
-        body:
-          query:
-            term:
-              region: "us-east"
-  - match: { hits.total.value: 0 }
-
-  # Both concrete paths remain independently searchable
+  # Both concrete paths are independently searchable
   - do:
       search:
         index: "logs-cl-passthrough-priority-test"
@@ -195,4 +172,14 @@ setup:
           query:
             term:
               resource.region: "us-west"
+  - match: { hits.total.value: 1 }
+
+  # The root-level alias "region" resolves to the higher-priority (resource, priority=2) passthrough
+  - do:
+      search:
+        index: "logs-cl-passthrough-priority-test"
+        body:
+          query:
+            term:
+              region: "us-west"
   - match: { hits.total.value: 1 }

--- a/x-pack/plugin/logsdb/src/yamlRestTest/resources/rest-api-spec/test/32_columnar_logsdb_passthrough.yml
+++ b/x-pack/plugin/logsdb/src/yamlRestTest/resources/rest-api-spec/test/32_columnar_logsdb_passthrough.yml
@@ -1,0 +1,198 @@
+---
+setup:
+  - requires:
+      test_runner_features: [ capabilities, allowed_warnings ]
+      capabilities:
+        - method: PUT
+          path: /{index}
+          capabilities: [ columnar_index_modes ]
+      reason: "Support for columnar index modes required"
+
+---
+"passthrough object with static and dynamic fields":
+  - do:
+      cluster.put_component_template:
+        name: "cl-passthrough-mappings"
+        body:
+          template:
+            settings:
+              mode: "logsdb_columnar"
+            mappings:
+              properties:
+                host.name:
+                  type: keyword
+                log.level:
+                  type: keyword
+                attributes:
+                  type: passthrough
+                  dynamic: true
+                  priority: 1
+
+  - do:
+      indices.put_index_template:
+        name: "cl-passthrough-index-template"
+        body:
+          index_patterns: [ "logs-cl-passthrough-test" ]
+          priority: 1000
+          data_stream: {}
+          composed_of: [ "cl-passthrough-mappings" ]
+      allowed_warnings:
+        - "index template [cl-passthrough-index-template] has index patterns [logs-cl-passthrough-test] matching patterns from existing older templates [global] with patterns (global => [*]); this template [cl-passthrough-index-template] will take precedence during new index creation"
+
+  - do:
+      indices.create_data_stream:
+        name: "logs-cl-passthrough-test"
+  - is_true: acknowledged
+
+  - do:
+      bulk:
+        index: "logs-cl-passthrough-test"
+        refresh: true
+        body:
+          - '{"create":{}}'
+          - '{"@timestamp":"2024-01-01T00:00:00.000Z","host.name":"web-01","log.level":"INFO","attributes.service":"frontend","attributes.env":"prod"}'
+          - '{"create":{}}'
+          - '{"@timestamp":"2024-01-01T00:00:01.000Z","host.name":"web-02","log.level":"WARN","attributes.service":"backend","attributes.env":"staging"}'
+  - match: { errors: false }
+
+  - do:
+      search:
+        index: "logs-cl-passthrough-test"
+        body:
+          size: 0
+  - match: { hits.total.value: 2 }
+
+  # Dynamic passthrough sub-fields are accessible via root-level aliases
+  - do:
+      search:
+        index: "logs-cl-passthrough-test"
+        body:
+          query:
+            term:
+              env: "prod"
+  - match: { hits.total.value: 1 }
+
+  # Same field is also accessible via the full passthrough path
+  - do:
+      search:
+        index: "logs-cl-passthrough-test"
+        body:
+          query:
+            term:
+              attributes.env: "prod"
+  - match: { hits.total.value: 1 }
+
+  # Static fields work normally alongside passthrough
+  - do:
+      search:
+        index: "logs-cl-passthrough-test"
+        body:
+          query:
+            bool:
+              filter:
+                - term:
+                    log.level: "WARN"
+                - term:
+                    service: "backend"
+  - match: { hits.total.value: 1 }
+
+  # Dynamic passthrough sub-fields appear in the mapping
+  - do:
+      indices.get_data_stream:
+        name: "logs-cl-passthrough-test"
+        expand_wildcards: hidden
+  - set: { data_streams.0.indices.0.index_name: backing_index }
+
+  - do:
+      indices.get_mapping:
+        index: $backing_index
+  - match: { .$backing_index.mappings.properties.attributes.type: passthrough }
+  - match: { .$backing_index.mappings.properties.attributes.properties.service.type: keyword }
+  - match: { .$backing_index.mappings.properties.attributes.properties.env.type: keyword }
+
+---
+"two passthrough objects with priority - higher priority alias wins":
+  - do:
+      cluster.put_component_template:
+        name: "cl-passthrough-priority-mappings"
+        body:
+          template:
+            settings:
+              mode: "logsdb_columnar"
+            mappings:
+              properties:
+                host.name:
+                  type: keyword
+                attributes:
+                  type: passthrough
+                  dynamic: true
+                  priority: 1
+                resource:
+                  type: passthrough
+                  dynamic: true
+                  priority: 2
+
+  - do:
+      indices.put_index_template:
+        name: "cl-passthrough-priority-template"
+        body:
+          index_patterns: [ "logs-cl-passthrough-priority-test" ]
+          priority: 1000
+          data_stream: {}
+          composed_of: [ "cl-passthrough-priority-mappings" ]
+      allowed_warnings:
+        - "index template [cl-passthrough-priority-template] has index patterns [logs-cl-passthrough-priority-test] matching patterns from existing older templates [global] with patterns (global => [*]); this template [cl-passthrough-priority-template] will take precedence during new index creation"
+
+  - do:
+      indices.create_data_stream:
+        name: "logs-cl-passthrough-priority-test"
+  - is_true: acknowledged
+
+  # Index a document where both passthroughs have the same sub-field name "region"
+  - do:
+      bulk:
+        index: "logs-cl-passthrough-priority-test"
+        refresh: true
+        body:
+          - '{"create":{}}'
+          - '{"@timestamp":"2024-01-01T00:00:00.000Z","host.name":"node-01","attributes.region":"us-east","resource.region":"us-west"}'
+  - match: { errors: false }
+
+  # Root alias "region" resolves to resource.region (priority 2 > 1)
+  - do:
+      search:
+        index: "logs-cl-passthrough-priority-test"
+        body:
+          query:
+            term:
+              region: "us-west"
+  - match: { hits.total.value: 1 }
+
+  # Root alias "region" does not match attributes.region value
+  - do:
+      search:
+        index: "logs-cl-passthrough-priority-test"
+        body:
+          query:
+            term:
+              region: "us-east"
+  - match: { hits.total.value: 0 }
+
+  # Both concrete paths remain independently searchable
+  - do:
+      search:
+        index: "logs-cl-passthrough-priority-test"
+        body:
+          query:
+            term:
+              attributes.region: "us-east"
+  - match: { hits.total.value: 1 }
+
+  - do:
+      search:
+        index: "logs-cl-passthrough-priority-test"
+        body:
+          query:
+            term:
+              resource.region: "us-west"
+  - match: { hits.total.value: 1 }


### PR DESCRIPTION
## Summary

`passthrough` objects provide OTel-style ergonomics: fields written under a prefix (e.g. `attributes.env`) are also queryable at root (`env`) via priority-based aliases. This was silently broken in `columnar` and `logsdb_columnar` index modes.

**Root cause:** columnar modes imply `subobjects:false` via `SUBOBJECTS_COLUMNAR`. The flatten guard in `ObjectMapper.Builder.flattenBuildersIfNeeded` dissolved every `ObjectMapper.Builder` child — including `PassThroughObjectMapper.Builder` — into bare dotted leaf fields. The passthrough node never reached the live mapping tree, so no root-level aliases were registered.

**Fix:**

- `ObjectMapper.Builder.flattenBuildersIfNeeded` / `asFlattenedFieldBuilders`: when flattening under `subobjects:false`, treat a `PassThroughObjectMapper.Builder` specially — keep it as a metadata-only stub at its short name (via `toMetadataStub()`) and flatten its leaf fields to root level with dotted names. This preserves both the correct columnar storage layout and the passthrough node needed for alias resolution.
- `PassThroughObjectMapper.Builder.toMetadataStub()`: new helper that copies metadata (priority, dynamic, enabled, sourceKeepMode, timeSeriesDimensionSubFields) without children.
- `FieldTypeLookup` (5-arg constructor): accepts a `rootSubobjectsDisabled` flag. When true and a passthrough stub has no children (the flat-leaf design), prefix-based alias resolution scans all flat fields for each stub's prefix and registers short-name aliases with priority-conflict resolution.
- `MappingLookup`: threads `rootSubobjectsDisabled = mapping.getRoot().subobjects() == DISABLED` to both `FieldTypeLookup` construction sites.

This change makes passthrough work under any `subobjects:false` root, not just columnar — consistent and desirable.

## Test plan

- [ ] `./gradlew :server:test --tests "org.elasticsearch.index.mapper.PassThroughObjectMapperTests"` — 3 new columnar tests: basic survival, priority conflict, dynamic update survival
- [ ] `./gradlew :server:test --tests "org.elasticsearch.index.mapper.FieldTypeLookupTests"` — 5 new prefix-alias unit tests: basic, multi-segment alias, priority conflict, `rootSubobjectsDisabled=false` guard, concrete-field-wins
- [ ] `./gradlew ":x-pack:plugin:logsdb:yamlRestTest"` — `32_columnar_logsdb_passthrough.yml` covers static + dynamic passthrough aliases and priority conflict in both `columnar` and `logsdb_columnar` modes