### PR TITLE
test(logsdb): skip runtime field tests when logsdb_columnar is active

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -620,12 +620,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
   method: test {csv-spec:date_nanos.implicit casting to nanos, date plus time to millis, equality test}
   issue: https://github.com/elastic/elasticsearch/issues/151536
-- class: org.elasticsearch.xpack.logsdb.LogsdbRestIT
-  method: testSyntheticSourceRuntimeFieldQueries
-  issue: https://github.com/elastic/elasticsearch/issues/151546
-- class: org.elasticsearch.xpack.logsdb.LogsdbRestIT
-  method: testEsqlRuntimeFields
-  issue: https://github.com/elastic/elasticsearch/issues/151547
 - class: org.elasticsearch.xpack.stateless.commits.StatelessFileDeletionIT
   method: testCommitsOfScrollAreDeletedAfterIndexIsClosedAndOpened
   issue: https://github.com/elastic/elasticsearch/issues/151558

--- a/x-pack/plugin/logsdb/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/LogsdbRestIT.java
+++ b/x-pack/plugin/logsdb/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/LogsdbRestIT.java
@@ -167,6 +167,7 @@ public class LogsdbRestIT extends ESRestTestCase {
     }
 
     public void testEsqlRuntimeFields() throws IOException {
+        assumeFalse("mapping-level runtime fields are not allowed in logsdb_columnar mode", columnarEnabled);
         String dataStreamName = "logs-test-esql-runtime-foo";
         var templateRequest = new Request("PUT", "/_index_template/logs-test-esql-runtime-template");
         templateRequest.setJsonEntity("""
@@ -469,6 +470,7 @@ public class LogsdbRestIT extends ESRestTestCase {
     }
 
     public void testSyntheticSourceRuntimeFieldQueries() throws IOException {
+        assumeFalse("mapping-level runtime fields are not allowed in logsdb_columnar mode", columnarEnabled);
         String dataStreamName = "logs-test-esql-synthetic-foo";
         var templateRequest = new Request("PUT", "/_index_template/logs-test-esql-synthetic-template");
         templateRequest.setJsonEntity("""


### PR DESCRIPTION
## TL;DR

`LogsdbRestIT#testEsqlRuntimeFields` and `LogsdbRestIT#testSyntheticSourceRuntimeFieldQueries` register `logs-*` data-stream templates that declare mapping-level runtime fields. When the class rule sets `cluster.logsdb_columnar.enabled=true`, `logs-*` resolves to `logsdb_columnar`, which rejects mapping-level runtime fields after #151494. Add `assumeFalse(columnarEnabled, ...)` to both tests and remove their entries from `muted-tests.yml`. Fixes #151546, fixes #151547.

## Changes

- `LogsdbRestIT.java`: adds `assumeFalse(columnarEnabled, ...)` at the top of `testEsqlRuntimeFields` and `testSyntheticSourceRuntimeFieldQueries`.
- `muted-tests.yml`: removes the entries for `testEsqlRuntimeFields` (#151547) and `testSyntheticSourceRuntimeFieldQueries` (#151546).

## Test scenarios

| Test | Scenario |
| ---- | -------- |
| `testEsqlRuntimeFields` | Skips when `columnarEnabled=true`; runs and passes on logsdb when `columnarEnabled=false`. |
| `testSyntheticSourceRuntimeFieldQueries` | Skips when `columnarEnabled=true`; runs and passes on logsdb when `columnarEnabled=false`. |

## Testing

```
# testEsqlRuntimeFields, columnarEnabled=false: test runs and passes
./gradlew :x-pack:plugin:logsdb:javaRestTest --tests "org.elasticsearch.xpack.logsdb.LogsdbRestIT.testEsqlRuntimeFields" -Dtests.seed=DEADBEEF

# testEsqlRuntimeFields, columnarEnabled=true: test skipped via assumeFalse
./gradlew :x-pack:plugin:logsdb:javaRestTest --tests "org.elasticsearch.xpack.logsdb.LogsdbRestIT.testEsqlRuntimeFields" -Dtests.seed=ABCDEF01

# testSyntheticSourceRuntimeFieldQueries, columnarEnabled=false: test runs and passes
./gradlew :x-pack:plugin:logsdb:javaRestTest --tests "org.elasticsearch.xpack.logsdb.LogsdbRestIT.testSyntheticSourceRuntimeFieldQueries" -Dtests.seed=DEADBEEF

# testSyntheticSourceRuntimeFieldQueries, columnarEnabled=true: test skipped via assumeFalse
./gradlew :x-pack:plugin:logsdb:javaRestTest --tests "org.elasticsearch.xpack.logsdb.LogsdbRestIT.testSyntheticSourceRuntimeFieldQueries" -Dtests.seed=ABCDEF01
```
