### PR TITLE
Fix two bugs in SparseFileTracker introduced by #150118

### DIFF
--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/common/SparseFileTracker.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/common/SparseFileTracker.java
@@ -176,7 +176,7 @@ public class SparseFileTracker {
             );
         }
 
-        if (subRange.end() <= complete) {
+        if (range.isEmpty() || subRange.end() <= complete) {
             listener.onResponse(null);
             return Optional.empty();
         }
@@ -586,7 +586,10 @@ public class SparseFileTracker {
             } else if (mergeWithNext) {
                 assert nextRange.isPending() == false : nextRange;
                 assert gapRange.end == nextRange.start : gapRange + " vs " + nextRange;
+                // Remove before mutating the sort key, then re-insert at the new position.
+                ranges.remove(nextRange);
                 nextRange.start = gapRange.start;
+                ranges.add(nextRange);
                 maybeUpdateCompletePointer(nextRange);
             } else {
                 maybeUpdateCompletePointer(gapRange);


### PR DESCRIPTION
## Summary

Fixes two separate bugs in `SparseFileTracker` introduced by #150118, both reproducing as `AssertionError: N >= N` in `testThreadSafety`.

### Bug 1 — empty-range crash in `determineStartingRangeAndSplit`

`waitForRange()` called with an empty `ByteRange` (start == end, which the test can produce via `randomLongBetween(rangeStart, fileLength)`) would proceed to `determineStartingRangeAndSplit`. That method performs two consecutive `splitRange()` calls when the earlier range overlaps the request boundary. The second call tries to split the upper half at `range.end()`, but when the range is empty `range.end() == range.start() == upper.start`, violating the `existing.start < splitPoint` assertion.

**Fix:** Return immediately from `waitForRange()` when the requested range is empty — the listener fires with no gaps, which is the correct semantics (nothing to wait for).

### Bug 2 — TreeSet key mutation in `onGapSuccess` `mergeWithNext` branch

When a completed gap had an adjacent **complete** range to its right, `onGapSuccess` merged them by assigning `nextRange.start = gapRange.start` while `nextRange` was still held inside the `TreeSet`. Because the comparator key (`Range.start`) changed without a remove/re-insert cycle, the tree's internal red-black ordering was corrupted. Subsequent `lower()`, `ceiling()`, and `higher()` calls could navigate to wrong nodes.

**Fix:** Remove `nextRange` before mutating its `start`, then re-insert with the new key value.

## Reproduction

Both bugs trigger `AssertionError: N >= N` at `SparseFileTracker.splitRange:340` in `testThreadSafety`. Reproduced locally at ~0.9% failure rate; 300 consecutive iterations pass after the fix.

```
./gradlew :x-pack:plugin:blob-cache:test \
  --tests org.elasticsearch.blobcache.common.SparseFileTrackerTests.testThreadSafety \
  -Dtests.seed=FE4C4E9080C24F69 -Dtests.locale=en-KY -Dtests.timezone=Asia/Amman
```

## Test plan

- [x] Original failing seed `FE4C4E9080C24F69` passes
- [x] 300 randomised iterations pass

Closes #151599