### PR TITLE
Disable BCC slow upload hot threads logging

### DIFF
--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/objectstore/ObjectStoreService.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/objectstore/ObjectStoreService.java
@@ -269,7 +269,7 @@ public class ObjectStoreService extends AbstractLifecycleComponent implements Cl
      */
     public static final Setting<TimeValue> OBJECT_STORE_UPLOAD_HOT_THREADS_LOG_INTERVAL = Setting.timeSetting(
         "stateless.object_store.upload_hot_threads_log_interval",
-        TimeValue.timeValueSeconds(30L),
+        TimeValue.ZERO,
         TimeValue.ZERO,
         Setting.Property.NodeScope,
         Setting.Property.Dynamic


### PR DESCRIPTION
In most cases uploads are sitting in the generation queue and
the hot threads does not provide too much info. Only log hot threads
for the opt in cases.