### PR TITLE
Disallow disabling doc values in columnar modes

### DIFF
--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapperTests.java
@@ -840,8 +840,6 @@ public class MatchOnlyTextFieldMapperTests extends MapperTestCase {
         assertDocValuesDedup(b -> b.field("null_value", "NULL"), true);
         // ignore_above on the keyword delegate omits long values, so the keyword copy is incomplete and the field keeps its own.
         assertDocValuesDedup(b -> b.field("ignore_above", 10), true);
-        // A keyword delegate with doc values disabled is not a copy at all, so the field keeps its own doc values.
-        assertDocValuesDedup(b -> b.field("doc_values", false), true);
     }
 
     private void assertDocValuesDedup(CheckedConsumer<XContentBuilder, IOException> keywordConfig, boolean expectsOwnDocValues)

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mapping/80_columnar_doc_values.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mapping/80_columnar_doc_values.yml
@@ -1,0 +1,85 @@
+---
+"columnar rejects doc_values disabled":
+  - requires:
+      test_runner_features: [ capabilities ]
+      capabilities:
+        - method: PUT
+          path: /{index}
+          capabilities: [ columnar_index_modes ]
+      cluster_features: [ "mapper.columnar.rejects_doc_values_disabled" ]
+      reason: "columnar mode does not allow disabling doc_values"
+
+  - do:
+      catch: /Disabling doc_values in \[columnar\] index mode is not allowed/
+      indices.create:
+        index: test_columnar_doc_values_disabled
+        body:
+          settings:
+            index.mode: columnar
+          mappings:
+            properties:
+              kwd:
+                type: keyword
+                doc_values: false
+
+---
+"logsdb_columnar rejects doc_values disabled":
+  - requires:
+      test_runner_features: [ capabilities ]
+      capabilities:
+        - method: PUT
+          path: /{index}
+          capabilities: [ columnar_index_modes ]
+      cluster_features: [ "mapper.columnar.rejects_doc_values_disabled" ]
+      reason: "logsdb_columnar mode does not allow disabling doc_values"
+
+  - do:
+      catch: /Disabling doc_values in \[logsdb_columnar\] index mode is not allowed/
+      indices.create:
+        index: test_logsdb_columnar_doc_values_disabled
+        body:
+          settings:
+            index.mode: logsdb_columnar
+          mappings:
+            properties:
+              kwd:
+                type: keyword
+                doc_values: false
+
+---
+"standard allows doc_values disabled":
+  - requires:
+      cluster_features: [ "mapper.columnar.rejects_doc_values_disabled" ]
+      reason: "verify doc_values can still be disabled in non-columnar modes"
+
+  - do:
+      indices.create:
+        index: test_standard_doc_values_disabled
+        body:
+          settings:
+            index.mode: standard
+          mappings:
+            properties:
+              kwd:
+                type: keyword
+                doc_values: false
+  - match: { acknowledged: true }
+
+---
+"logsdb allows doc_values disabled":
+  - requires:
+      cluster_features: [ "mapper.columnar.rejects_doc_values_disabled" ]
+      reason: "verify doc_values can still be disabled in non-columnar modes"
+
+  - do:
+      indices.create:
+        index: test_logsdb_doc_values_disabled
+        body:
+          settings:
+            index.mode: logsdb
+          mappings:
+            properties:
+              kwd:
+                type: keyword
+                doc_values: false
+  - match: { acknowledged: true }

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/mapper/SyntheticVersusColumnarStoredSourceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/mapper/SyntheticVersusColumnarStoredSourceIT.java
@@ -138,6 +138,8 @@ public class SyntheticVersusColumnarStoredSourceIT extends ESIntegTestCase {
                         mapping.remove(Mapper.SYNTHETIC_SOURCE_KEEP_PARAM);
                         mapping.remove("store");
                         mapping.remove("copy_to");
+                        // disabling doc_values not allowed in columnar index mode
+                        mapping.remove(FieldMapper.DocValuesParameter.PARAMETER_NAME);
                         return mapping;
                     });
                 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -1653,6 +1653,11 @@ public abstract class FieldMapper extends Mapper {
                 if (XContentMapValues.nodeBooleanValue(value, name)) {
                     setValue(new Values(true, getDefaultValue().cardinality(), getDefaultValue().multiValue()));
                 } else {
+                    if (context.getIndexSettings().getMode().isStrictColumnar()) {
+                        throw new IllegalArgumentException(
+                            "Disabling doc_values in [" + context.getIndexSettings().getMode() + "] index mode is not allowed"
+                        );
+                    }
                     setValue(Values.DISABLED);
                 }
             }

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
@@ -125,6 +125,7 @@ public class MapperFeatures implements FeatureSpecification {
         "mapper.columnar.inline_array_order_binary_doc_values"
     );
     public static final NodeFeature COLUMNAR_DROPS_DYNAMIC_FALSE_FIELDS = new NodeFeature("mapper.columnar.drops_dynamic_false_fields");
+    static final NodeFeature COLUMNAR_REJECTS_DOC_VALUES_DISABLED = new NodeFeature("mapper.columnar.rejects_doc_values_disabled");
 
     @Override
     public Set<NodeFeature> getTestFeatures() {
@@ -209,7 +210,8 @@ public class MapperFeatures implements FeatureSpecification {
             COLUMNAR_INLINE_ARRAY_ORDER_BINARY_DOC_VALUES,
             COLUMNAR_DROPS_DYNAMIC_FALSE_FIELDS,
             DOC_VALUES_MULTI_VALUE_INDEX_SETTING,
-            DOC_VALUES_MULTI_VALUE_FALSE_ALIAS
+            DOC_VALUES_MULTI_VALUE_FALSE_ALIAS,
+            COLUMNAR_REJECTS_DOC_VALUES_DISABLED
         );
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocValuesParameterTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocValuesParameterTests.java
@@ -10,11 +10,54 @@
 package org.elasticsearch.index.mapper;
 
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexSettings;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
 public class DocValuesParameterTests extends MapperServiceTestCase {
+
+    // -----------------------------------------------------------------------
+    // Tests for disabling doc values
+    // -----------------------------------------------------------------------
+
+    public void testDisablingDocValuesAllowedInStandardMode() throws Exception {
+        var settings = Settings.builder().put(IndexSettings.MODE.getKey(), "standard").build();
+        MapperService mapperService = createMapperService(
+            settings,
+            fieldMapping(b -> b.field("type", "keyword").field("doc_values", false))
+        );
+        KeywordFieldMapper mapper = (KeywordFieldMapper) mapperService.documentMapper().mappers().getMapper("field");
+        assertThat(mapper.docValuesParameters(), equalTo(FieldMapper.DocValuesParameter.Values.DISABLED));
+    }
+
+    public void testDisablingDocValuesDisallowedInColumnar() throws Exception {
+        var settings = Settings.builder().put(IndexSettings.MODE.getKey(), "columnar").build();
+        var e = expectThrows(
+            MapperParsingException.class,
+            () -> createMapperService(settings, fieldMapping(b -> b.field("type", "keyword").field("doc_values", false)))
+        );
+        assertThat(e.getMessage(), containsString("Disabling doc_values in [columnar] index mode is not allowed"));
+    }
+
+    public void testDisablingDocValuesDisallowedInLogsdbColumnar() throws Exception {
+        var settings = Settings.builder().put(IndexSettings.MODE.getKey(), "logsdb_columnar").build();
+        var e = expectThrows(
+            MapperParsingException.class,
+            () -> createMapperService(settings, fieldMapping(b -> b.field("type", "keyword").field("doc_values", false)))
+        );
+        assertThat(e.getMessage(), containsString("Disabling doc_values in [logsdb_columnar] index mode is not allowed"));
+    }
+
+    public void testDisablingDocValuesAllowedInLogsdb() throws Exception {
+        var settings = Settings.builder().put(IndexSettings.MODE.getKey(), "logsdb").build();
+        MapperService mapperService = createMapperService(
+            settings,
+            fieldMapping(b -> b.field("type", "keyword").field("doc_values", false))
+        );
+        KeywordFieldMapper mapper = (KeywordFieldMapper) mapperService.documentMapper().mappers().getMapper("field");
+        assertThat(mapper.docValuesParameters(), equalTo(FieldMapper.DocValuesParameter.Values.DISABLED));
+    }
 
     // -----------------------------------------------------------------------
     // Null-fallback: omitting one sub-parameter falls back to the field-type default

--- a/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
@@ -2652,8 +2652,6 @@ public class TextFieldMapperTests extends MapperTestCase {
         assertTextDocValuesDedup(b -> b.field("null_value", "NULL"), true);
         // ignore_above on the keyword delegate omits long values, so the keyword copy is incomplete and the text field keeps its own.
         assertTextDocValuesDedup(b -> b.field("ignore_above", 10), true);
-        // A keyword delegate with doc values disabled is not a copy at all, so the text field keeps its own doc values.
-        assertTextDocValuesDedup(b -> b.field("doc_values", false), true);
     }
 
     private void assertTextDocValuesDedup(CheckedConsumer<XContentBuilder, IOException> keywordConfig, boolean expectsOwnDocValues)

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/BlockLoaderTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/BlockLoaderTestCase.java
@@ -481,6 +481,8 @@ public abstract class BlockLoaderTestCase extends MapperServiceTestCase {
                         // synthetic_source_keep and store are forbidden on strict-columnar indices
                         mapping.remove(Mapper.SYNTHETIC_SOURCE_KEEP_PARAM);
                         mapping.remove("store");
+                        // doc_values not allowed to be disabled on strict-columnar indices
+                        mapping.remove(FieldMapper.DocValuesParameter.PARAMETER_NAME);
                         return mapping;
                     });
                 }

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/NumberFieldBlockLoaderTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/NumberFieldBlockLoaderTestCase.java
@@ -11,6 +11,8 @@ package org.elasticsearch.index.mapper;
 
 import org.elasticsearch.datageneration.FieldType;
 import org.elasticsearch.datageneration.Mapping;
+import org.elasticsearch.index.IndexMode;
+import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.xcontent.XContentFactory;
 
 import java.io.IOException;
@@ -203,6 +205,10 @@ public abstract class NumberFieldBlockLoaderTestCase<T extends Number> extends B
         Object expected = expected(mapping.lookup().get("field"), value, new TestContext(false, false));
 
         var settings = getSettingsForParams();
+        assumeFalse(
+            "Cannot set doc_values to false on columnar modes",
+            IndexMode.fromString(settings.get(IndexSettings.MODE.getKey())).isStrictColumnar()
+        );
         runner.mapperService(createMapperService(settings.build(), XContentFactory.jsonBuilder().map(mapping.raw())));
         runner.run(expected);
     }

--- a/x-pack/plugin/core/template-resources/src/main/resources/ecs@mappings.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/ecs@mappings.json
@@ -27,8 +27,7 @@
           "ecs_non_indexed_keyword": {
             "mapping": {
               "type": "keyword",
-              "index": false,
-              "doc_values": false
+              "index": false
             },
             "path_match": [
               "*event.original",
@@ -40,8 +39,7 @@
           "ecs_non_indexed_long": {
             "mapping": {
               "type": "long",
-              "index": false,
-              "doc_values": false
+              "index": false
             },
             "path_match": [
               "*.x509.public_key_exponent"

--- a/x-pack/plugin/logsdb/src/yamlRestTest/resources/rest-api-spec/test/31_columnar_logsdb_default_mapping.yml
+++ b/x-pack/plugin/logsdb/src/yamlRestTest/resources/rest-api-spec/test/31_columnar_logsdb_default_mapping.yml
@@ -737,7 +737,17 @@ create logsdb_columnar data stream with custom sorting and missing host.name fie
 
 ---
 create logsdb_columnar data stream with custom sorting and host.name field without doc values:
+  - requires:
+      test_runner_features: [ capabilities ]
+      capabilities:
+        - method: PUT
+          path: /{index}
+          capabilities: [ columnar_index_modes ]
+      cluster_features: [ "mapper.columnar.rejects_doc_values_disabled" ]
+      reason: "logsdb_columnar mode does not allow disabling doc_values"
+
   - do:
+      catch: bad_request
       indices.put_index_template:
         name: cl-logs-template
         body:
@@ -761,15 +771,9 @@ create logsdb_columnar data stream with custom sorting and host.name field witho
           data_stream: { }
       allowed_warnings:
         - "index template [cl-logs-template] has index patterns [logs-cl-http-dev] matching patterns from existing older templates [global] with patterns (global => [*]); this template [cl-logs-template] will take precedence during new index creation"
-  - is_true: acknowledged
-
-  - do:
-      catch: bad_request
-      indices.create_data_stream:
-        name: logs-cl-http-dev
 
   - match: { error.type: "illegal_argument_exception" }
-  - match: { error.reason: "docvalues not found for index sort field:[host.name]" }
+  - match: { error.reason: "composable template [cl-logs-template] template after composition is invalid" }
 
 ---
 create logsdb_columnar data stream with incompatible ignore_above on host.name:

--- a/x-pack/plugin/logsdb/src/yamlRestTest/resources/rest-api-spec/test/50_esql_synthetic_source_disabled_fields.yml
+++ b/x-pack/plugin/logsdb/src/yamlRestTest/resources/rest-api-spec/test/50_esql_synthetic_source_disabled_fields.yml
@@ -11,6 +11,8 @@ setup:
           priority: 1000
           data_stream: {}
           template:
+            settings:
+              mode: "logsdb"
             mappings:
               properties:
                 "@timestamp":
@@ -222,6 +224,8 @@ teardown:
           priority: 1001
           data_stream: {}
           template:
+            settings:
+              mode: "logsdb"
             mappings:
               properties:
                 "@timestamp":

--- a/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/StackTemplateRegistry.java
+++ b/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/StackTemplateRegistry.java
@@ -33,11 +33,11 @@ public class StackTemplateRegistry extends IndexTemplateRegistry {
 
     // The stack template registry version. This number must be incremented when we make changes
     // to built-in templates.
-    public static final int REGISTRY_VERSION = 21;
+    public static final int REGISTRY_VERSION = 22;
 
     // The computed checksum of all templates and components that are registered in this registry.
     // This is used by a test to ensure that REGISTRY_VERSION is updated when any of the components change.
-    static final String COMPUTED_CHECKSUM = "d67e2442";
+    static final String COMPUTED_CHECKSUM = "ab03ef84";
 
     public static final String TEMPLATE_VERSION_VARIABLE = "xpack.stack.template.version";
     public static final Setting<Boolean> STACK_TEMPLATES_ENABLED = Setting.boolSetting(

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/commits/IndexCommitTimestampFieldRangeTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/commits/IndexCommitTimestampFieldRangeTests.java
@@ -386,16 +386,20 @@ public class IndexCommitTimestampFieldRangeTests extends MapperServiceTestCase {
                     b.startObject("@timestamp").field("type", "date_nanos").field("format", "epoch_millis");
                     if (strictColumnar) {
                         b.field("index", true);
+                    } else {
+                        b.field("doc_values", randomBoolean());
                     }
-                    b.field("doc_values", randomBoolean()).field("store", allowStore).endObject();
+                    b.field("store", allowStore).endObject();
                 }), indexMode);
             } else {
                 return createDocumentMapper(mapping(b -> {
                     b.startObject("@timestamp").field("type", "date").field("format", "epoch_millis");
                     if (strictColumnar) {
                         b.field("index", true);
+                    } else {
+                        b.field("doc_values", randomBoolean());
                     }
-                    b.field("doc_values", randomBoolean()).field("store", allowStore).endObject();
+                    b.field("store", allowStore).endObject();
                 }), indexMode);
             }
         } else if (indexMode == IndexMode.TIME_SERIES) {


### PR DESCRIPTION
This commit adds a check to make sure the user does not try to disable doc values for any field when in columnar modes (standard `columnar` as well as `logsdb_columnar`)
