### PR TITLE
Add missing release notes for bundled JDK 26 and 26.0.1 upgrades

### DIFF
--- a/docs/changelog/146167.yaml
+++ b/docs/changelog/146167.yaml
@@ -1,0 +1,5 @@
+pr: 146167
+summary: Update bundled JDK to Java 26
+area: Packaging
+type: upgrade
+issues: []

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -221,6 +221,10 @@ Machine Learning:
 * Restrict file system access for pytorch models [#2851](https://github.com/elastic/ml-cpp/pull/2851)
 * Update the PyTorch library to version 2.7.1 [#2863](https://github.com/elastic/ml-cpp/pull/2863)
 
+Packaging:
+* Update bundled JDK to Java 26 [#146167](https://github.com/elastic/elasticsearch/pull/146167)
+* Bump bundled JDK to Java 26.0.1 [#147424](https://github.com/elastic/elasticsearch/pull/147424)
+
 Security:
 * Update elastic-apm-agent-java8 to 1.55.6 [#148271](https://github.com/elastic/elasticsearch/pull/148271)
 
@@ -726,6 +730,7 @@ Monitoring:
 * Add mode and codec fields to Stack Monitoring index template [#143673](https://github.com/elastic/elasticsearch/pull/143673)
 
 Packaging:
+* Bump bundled JDK to Java 26.0.1 [#147424](https://github.com/elastic/elasticsearch/pull/147424)
 * Flip cloud-ess-fips default from FIPS 140-2 to FIPS 140-3 [#140788](https://github.com/elastic/elasticsearch/pull/140788)
 
 Performance:
@@ -1085,6 +1090,9 @@ Aggregations:
 
 ES|QL:
 * Skip time series field type merge for non-TS agg queries [#143262](https://github.com/elastic/elasticsearch/pull/143262)
+
+Packaging:
+* Update bundled JDK to Java 26 [#146167](https://github.com/elastic/elasticsearch/pull/146167)
 
 
 ### Fixes [elasticsearch-9.3.4-fixes]


### PR DESCRIPTION
## Summary

Two bundled JDK upgrades shipped without changelog entries or release note mentions:

- **JDK 26** (#146167) — shipped in 9.3.4, 9.4.1, 8.19.15
- **JDK 26.0.1** (#147424) — shipped in 9.3.5, 9.4.1, 8.19.16

Every prior JDK bump (24, 24.0.2, 25.0.1, 25.0.2) included a `docs/changelog` yaml and appeared in the release notes under Packaging.

This PR adds:
1. The missing `docs/changelog/146167.yaml` entry for the JDK 26 upgrade
2. Release note entries in `docs/release-notes/index.md` for 9.3.4, 9.3.5, and 9.4.1

Relates: #146167, #147424