### PR TITLE
Standardize on setting names for DLM tiers poll periods

### DIFF
--- a/docs/reference/elasticsearch/configuration-reference/data-stream-lifecycle-settings.md
+++ b/docs/reference/elasticsearch/configuration-reference/data-stream-lifecycle-settings.md
@@ -61,7 +61,7 @@ The following settings control the behavior of the frozen tier transition, which
 
 $$$dlm-frozen-transition-poll-interval$$$
 
-`dlm.frozen_transition.poll_interval`
+`dlm.frozen.transition.poll_interval`
 :   ([Static](docs-content://deploy-manage/stack-settings.md#static-cluster-setting), [time unit value](/reference/elasticsearch/rest-apis/api-conventions.md#time-units)) How often the master node checks for data stream backing indices that are ready to be converted to the frozen tier. Must be at least `1m`. Defaults to `5m`.
 
 $$$dlm-frozen-transition-max-concurrency$$$
@@ -76,7 +76,7 @@ $$$dlm-frozen-transition-max-queue-size$$$
 
 $$$dlm-frozen-cleanup-poll-interval$$$
 
-`dlm.frozen_cleanup.poll_interval`
+`dlm.frozen.cleanup.poll_interval`
 :   ([Static](docs-content://deploy-manage/stack-settings.md#static-cluster-setting), [time unit value](/reference/elasticsearch/rest-apis/api-conventions.md#time-units)) How often the master node scans for and deletes orphaned artifacts (clone indices and snapshots) left behind by interrupted frozen conversions. Must be at least `1h`. Defaults to `1d`.
 
 ## Index level settings [_index_level_settings]

--- a/x-pack/plugin/dlm-frozen-transition/src/main/java/org/elasticsearch/xpack/dlm/frozen/DLMFrozenCleanupService.java
+++ b/x-pack/plugin/dlm-frozen-transition/src/main/java/org/elasticsearch/xpack/dlm/frozen/DLMFrozenCleanupService.java
@@ -44,7 +44,7 @@ import static org.elasticsearch.logging.LogManager.getLogger;
 class DLMFrozenCleanupService extends AbstractDLMPeriodicMasterOnlyService {
 
     static final Setting<TimeValue> POLL_INTERVAL_SETTING = Setting.timeSetting(
-        "dlm.frozen_cleanup.poll_interval",
+        "dlm.frozen.cleanup.poll_interval",
         TimeValue.timeValueDays(1),
         TimeValue.timeValueHours(1),
         Setting.Property.NodeScope

--- a/x-pack/plugin/dlm-frozen-transition/src/main/java/org/elasticsearch/xpack/dlm/frozen/DLMFrozenTransitionService.java
+++ b/x-pack/plugin/dlm-frozen-transition/src/main/java/org/elasticsearch/xpack/dlm/frozen/DLMFrozenTransitionService.java
@@ -35,7 +35,7 @@ import static org.elasticsearch.logging.LogManager.getLogger;
 class DLMFrozenTransitionService extends AbstractDLMPeriodicMasterOnlyService {
 
     static final Setting<TimeValue> POLL_INTERVAL_SETTING = Setting.timeSetting(
-        "dlm.frozen_transition.poll_interval",
+        "dlm.frozen.transition.poll_interval",
         TimeValue.timeValueMinutes(5),
         TimeValue.timeValueSeconds(1),
         Setting.Property.NodeScope


### PR DESCRIPTION
Make all the settings names for DLM frozen tier consistent in code and docs