### PR TITLE
[Slices] Add support for multiple slices in DenseVectorFieldMapper

### DIFF
--- a/server/src/main/java/module-info.java
+++ b/server/src/main/java/module-info.java
@@ -57,7 +57,6 @@ module org.elasticsearch.server {
     requires org.apache.lucene.queryparser;
     requires org.apache.lucene.sandbox;
     requires org.apache.lucene.suggest;
-    requires org.jspecify;
 
     exports org.elasticsearch;
     exports org.elasticsearch.action;

--- a/server/src/main/java/module-info.java
+++ b/server/src/main/java/module-info.java
@@ -57,6 +57,7 @@ module org.elasticsearch.server {
     requires org.apache.lucene.queryparser;
     requires org.apache.lucene.sandbox;
     requires org.apache.lucene.suggest;
+    requires org.jspecify;
 
     exports org.elasticsearch;
     exports org.elasticsearch.action;

--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
@@ -39,6 +39,7 @@ import org.apache.lucene.util.BitUtil;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.logging.DeprecationCategory;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
@@ -109,6 +110,7 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParser.Token;
 import org.elasticsearch.xcontent.XContentString;
+import org.jspecify.annotations.NonNull;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -119,6 +121,7 @@ import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.HexFormat;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -3387,8 +3390,8 @@ public class DenseVectorFieldMapper extends FieldMapper {
                     mappingOversample,
                     queryOversample
                 );
-                final String singleSliceRouting = extractSingleSliceRouting(sliceRouting, sliceEnabled);
-                if (singleSliceRouting != null) {
+                final BytesRef[] sliceIds = extractSliceRouting(sliceRouting, sliceEnabled);
+                if (sliceIds != null) {
                     knnQuery = parentFilter != null
                         ? new DiversifyingChildrenIVFKnnFloatSlicedVectorQuery(
                             name(),
@@ -3400,7 +3403,7 @@ public class DenseVectorFieldMapper extends FieldMapper {
                             visitRatio,
                             ivfQueryConfigResolver,
                             RoutingFieldMapper.NAME,
-                            new BytesRef(singleSliceRouting)
+                            sliceIds
                         )
                         : new IVFKnnFloatSlicedVectorQuery(
                             name(),
@@ -3411,7 +3414,7 @@ public class DenseVectorFieldMapper extends FieldMapper {
                             visitRatio,
                             ivfQueryConfigResolver,
                             RoutingFieldMapper.NAME,
-                            new BytesRef(singleSliceRouting)
+                            sliceIds
                         );
                 } else {
                     knnQuery = parentFilter != null
@@ -3454,7 +3457,7 @@ public class DenseVectorFieldMapper extends FieldMapper {
         }
 
         @Nullable
-        private static String extractSingleSliceRouting(@Nullable String sliceRouting, boolean sliceEnabled) {
+        private static BytesRef[] extractSliceRouting(@Nullable String sliceRouting, boolean sliceEnabled) {
             if (sliceRouting == null) {
                 if (sliceEnabled) {
                     throw new IllegalArgumentException(
@@ -3463,21 +3466,33 @@ public class DenseVectorFieldMapper extends FieldMapper {
                 }
                 return null;
             }
-            final String trimmed = sliceRouting.trim();
-            if (trimmed.isEmpty()) {
+            String[] sliceValues = Strings.splitStringByCommaToArray(sliceRouting.trim());
+            if (sliceValues.length == 0) {
                 throw new IllegalArgumentException("[" + SliceIndexing.PARAM_NAME + "] cannot be blank for KNN queries");
             }
-            if (SliceIndexing.SLICE_ALL.equals(trimmed)) {
+            final LinkedHashSet<String> uniqueSliceValues = new LinkedHashSet<>();
+            for (String sliceValue : sliceValues) {
+                uniqueSliceValues.add(validateSliceValue(sliceValue));
+            }
+            final BytesRef[] sliceIds = new BytesRef[uniqueSliceValues.size()];
+            int i = 0;
+            for (String sliceValue : uniqueSliceValues) {
+                sliceIds[i++] = new BytesRef(sliceValue);
+            }
+            return sliceIds;
+        }
+
+        private static String validateSliceValue(String sliceValue) {
+            final String value = sliceValue.trim();
+            if (value.isEmpty()) {
+                throw new IllegalArgumentException("[" + SliceIndexing.PARAM_NAME + "] cannot be blank for KNN queries");
+            }
+            if (SliceIndexing.SLICE_ALL.equals(value)) {
                 throw new IllegalArgumentException(
                     "[" + SliceIndexing.PARAM_NAME + "] value [" + SliceIndexing.SLICE_ALL + "] is not supported for KNN"
                 );
             }
-            if (trimmed.indexOf(',') >= 0) {
-                throw new IllegalArgumentException(
-                    "[" + SliceIndexing.PARAM_NAME + "] must be a single value for KNN queries, but received [" + trimmed + "]"
-                );
-            }
-            return trimmed;
+            return value;
         }
 
         public VectorSimilarity getSimilarity() {

--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
@@ -110,7 +110,6 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParser.Token;
 import org.elasticsearch.xcontent.XContentString;
-import org.jspecify.annotations.NonNull;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;

--- a/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldTypeTests.java
@@ -1044,26 +1044,47 @@ public class DenseVectorFieldTypeTests extends FieldTypeTestCase {
         assertThat(exception.getMessage(), containsString("[_slice] value [_all] is not supported for KNN"));
     }
 
-    public void testBBQIVFRejectsMultiValueSliceForKnn() {
+    public void testBBQIVFUsesSlicedQueryForMultiSliceRouting() {
         BitSetProducer parentFilter = random().nextBoolean() ? null : context -> null;
         DenseVectorFieldType fieldType = createBBQIVFFloatFieldType();
-        IllegalArgumentException exception = expectThrows(
-            IllegalArgumentException.class,
-            () -> fieldType.createKnnQuery(
-                VectorData.fromFloats(testQueryVector(64)),
-                5,
-                10,
-                10f,
-                null,
-                null,
-                null,
-                parentFilter,
-                randomFrom(DenseVectorFieldMapper.FilterHeuristic.values()),
-                randomBoolean(),
-                "s1,s2"
-            )
+        Query query = fieldType.createKnnQuery(
+            VectorData.fromFloats(testQueryVector(64)),
+            5,
+            10,
+            10f,
+            null,
+            null,
+            null,
+            parentFilter,
+            randomFrom(DenseVectorFieldMapper.FilterHeuristic.values()),
+            randomBoolean(),
+            "s1,s2"
         );
-        assertThat(exception.getMessage(), containsString("[_slice] must be a single value for KNN queries"));
+        if (parentFilter == null) {
+            assertThat(query, instanceOf(IVFKnnFloatVectorQuery.class));
+        } else {
+            assertThat(query, instanceOf(DiversifyingChildrenIVFKnnFloatSlicedVectorQuery.class));
+        }
+        assertThat(query.toString("ignored"), containsString("_routing=[s1,s2]"));
+    }
+
+    public void testBBQIVFDeduplicatesMultiSliceRoutingForKnn() {
+        BitSetProducer parentFilter = random().nextBoolean() ? null : context -> null;
+        DenseVectorFieldType fieldType = createBBQIVFFloatFieldType();
+        Query query = fieldType.createKnnQuery(
+            VectorData.fromFloats(testQueryVector(64)),
+            5,
+            10,
+            10f,
+            null,
+            null,
+            null,
+            parentFilter,
+            randomFrom(DenseVectorFieldMapper.FilterHeuristic.values()),
+            randomBoolean(),
+            "s1,s1,s2"
+        );
+        assertThat(query.toString("ignored"), containsString("_routing=[s1,s2]"));
     }
 
     private static DenseVectorFieldType createBBQIVFFloatFieldType() {

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/47_knn_search_bbq_disk_slice.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/47_knn_search_bbq_disk_slice.yml
@@ -91,6 +91,45 @@ setup:
   - match: { hits.hits.0._id: "2" }
   - match: { hits.hits.1._id: "4" }
 ---
+"KNN search with multiple _slice values searches across the requested slices":
+  - do:
+      search:
+        index: bbq_disk_slice
+        _slice: s1,s2
+        body:
+          knn:
+            field: vector
+            query_vector: [0.707107, 0.707107, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+            k: 4
+            num_candidates: 10
+
+  - match: { hits.total.value: 4 }
+  - length: { hits.hits: 4 }
+  - match: { hits.hits.0._id: "1" }
+  - match: { hits.hits.1._id: "2" }
+  - match: { hits.hits.2._id: "3" }
+  - match: { hits.hits.3._id: "4" }
+
+---
+"KNN search with multiple _slice values and duplicatessearches across the requested slices":
+  - do:
+      search:
+        index: bbq_disk_slice
+        _slice: s1,s2,s1,s2
+        body:
+          knn:
+            field: vector
+            query_vector: [0.707107, 0.707107, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+            k: 4
+            num_candidates: 10
+
+  - match: { hits.total.value: 4 }
+  - length: { hits.hits: 4 }
+  - match: { hits.hits.0._id: "1" }
+  - match: { hits.hits.1._id: "2" }
+  - match: { hits.hits.2._id: "3" }
+  - match: { hits.hits.3._id: "4" }
+---
 "Search without _slice is rejected on slice-enabled index":
   - do:
       catch: /\[_slice\] is required when \[index.slice.enabled\] is true for search request/


### PR DESCRIPTION
Support for querying multiple slices was added in https://github.com/elastic/elasticsearch/pull/150903. This PR adds this capability to the mapper so it is fully supported by Elasticsearch. 