### PR TITLE
Fix testCommitsOfScrollAreDeletedAfterIndexIsClosedAndOpened

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -611,9 +611,6 @@ tests:
 - class: org.elasticsearch.xpack.logsdb.LogsdbRestIT
   method: testEsqlRuntimeFields
   issue: https://github.com/elastic/elasticsearch/issues/151547
-- class: org.elasticsearch.xpack.stateless.commits.StatelessFileDeletionIT
-  method: testCommitsOfScrollAreDeletedAfterIndexIsClosedAndOpened
-  issue: https://github.com/elastic/elasticsearch/issues/151558
 - class: org.elasticsearch.xpack.esql.qa.multi_node.GenerativeIT
   method: test {feature:BASELINE}
   issue: https://github.com/elastic/elasticsearch/issues/149746

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/commits/StatelessFileDeletionIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/commits/StatelessFileDeletionIT.java
@@ -924,8 +924,13 @@ public class StatelessFileDeletionIT extends AbstractStatelessPluginIntegTestCas
             var blobsAfterReleasingScroll = listBlobsWithAbsolutePath(shardCommitsContainer);
             assertThat(Sets.intersection(blobsUsedForScroll, blobsAfterReleasingScroll), empty());
         });
-        // responses from newCommitNotification must be received
-        assertThat(countNewCommitNotifications.get(), greaterThan(newCommitNotificationsBeforeReleasingScroll));
+
+        // For most cases we expect at least one additional newCommitNotification response after releasing the scroll.
+        // Except for the close/open case, where notifications induced by the forced flush (in
+        // TransportVerifyShardBeforeCloseAction.executeShardOperation) may race with the search shard closing and may not be counted.
+        if (testCase != TestSearchScrollCase.COMMITS_OF_SCROLL_DELETED_AFTER_INDEX_CLOSED_AND_OPENED) {
+            assertThat(countNewCommitNotifications.get(), greaterThan(newCommitNotificationsBeforeReleasingScroll));
+        }
 
         if (testCase == TestSearchScrollCase.COMMITS_DROPPED_AFTER_SCROLL_CLOSES_AND_INDEXING_INACTIVITY) {
             // The last notification response should no longer contain blobs used for scroll


### PR DESCRIPTION
Test was mistakenly assuming close's forced flush's new commit notifications may be successfully processed in time by the closing search shard.

Closes #151558
