### PR TITLE
[8.19] Add missing release notes for bundled JDK 26 and 26.0.1 upgrades (#151616)

### DIFF
--- a/docs/changelog/146167.yaml
+++ b/docs/changelog/146167.yaml
@@ -1,0 +1,5 @@
+pr: 146167
+summary: Update bundled JDK to Java 26
+area: Packaging
+type: upgrade
+issues: []


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Add missing release notes for bundled JDK 26 and 26.0.1 upgrades (#151616)](https://github.com/elastic/elasticsearch/pull/151616)

<!--- Backport version: 12.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)