### PR TITLE
ES|QL: resolve surrogates before rewrapWithCast in union type field resolution

### DIFF
--- a/docs/changelog/151633.yaml
+++ b/docs/changelog/151633.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 151475
+pr: 151633
+summary: Resolve surrogates before `rewrapWithCast` in union type field resolution
+type: bug

--- a/docs/changelog/151633.yaml
+++ b/docs/changelog/151633.yaml
@@ -2,5 +2,5 @@ area: ES|QL
 issues:
  - 151475
 pr: 151633
-summary: Resolve surrogates before `rewrapWithCast` in union type field resolution
+summary: Resolve surrogates in union type field resolution before plan serialization
 type: bug

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -2663,7 +2663,10 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                         if (((UnionTypeEsField) fa.field()).getUnmappedConversionExpression() != null) {
                             throw new IllegalStateException("Unexpected potentially unmapped expression for [" + fa.fieldName() + "]");
                         }
-                        return createIfDoesNotAlreadyExist(fa, unionTypeEsField.rewrapWithCast(convertExpression), unionFieldAttributes);
+                        // Resolve surrogates immediately, since expressions stored in (Compact)MultiTypeEsField are serialized
+                        // to data nodes, and SurrogateExpressions cannot be serialized.
+                        Expression resolvedConvertExpression = SubstituteSurrogateExpressions.rule(convertExpression);
+                        return createIfDoesNotAlreadyExist(fa, unionTypeEsField.rewrapWithCast(resolvedConvertExpression), unionFieldAttributes);
                     }
                 } else if (convert.field() instanceof AbstractConvertFunction subConvert) {
                     return convertExpression.replaceChildren(

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -2666,7 +2666,11 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                         // Resolve surrogates immediately, since expressions stored in (Compact)MultiTypeEsField are serialized
                         // to data nodes, and SurrogateExpressions cannot be serialized.
                         Expression resolvedConvertExpression = SubstituteSurrogateExpressions.rule(convertExpression);
-                        return createIfDoesNotAlreadyExist(fa, unionTypeEsField.rewrapWithCast(resolvedConvertExpression), unionFieldAttributes);
+                        return createIfDoesNotAlreadyExist(
+                            fa,
+                            unionTypeEsField.rewrapWithCast(resolvedConvertExpression),
+                            unionFieldAttributes
+                        );
                     }
                 } else if (convert.field() instanceof AbstractConvertFunction subConvert) {
                     return convertExpression.replaceChildren(

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -2663,7 +2663,7 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                         if (((UnionTypeEsField) fa.field()).getUnmappedConversionExpression() != null) {
                             throw new IllegalStateException("Unexpected potentially unmapped expression for [" + fa.fieldName() + "]");
                         }
-                        // Resolve surrogates immediately, since expressions stored in (Compact)MultiTypeEsField are serialized
+                        // Resolve surrogates immediately, since expressions stored in UnionTypeEsField are serialized
                         // to data nodes, and SurrogateExpressions cannot be serialized.
                         Expression resolvedConvertExpression = SubstituteSurrogateExpressions.rule(convertExpression);
                         return createIfDoesNotAlreadyExist(


### PR DESCRIPTION
## Summary

Fixes #151475

- When an explicit cast (e.g. `TO_LONG`) is applied to a field already implicitly converted to a `UnionTypeEsField` by `DateMillisToNanosInEsRelation`, the analyzer reaches the `rewrapWithCast()` path in `resolveConvertFunction`.
- This path passed the raw surrogate expression (`ToLongSurrogate`) directly to `rewrapWithCast()`.
- That map is serialized to data nodes, causing `UnsupportedOperationException: not serialized` when `getWriteableName()` is called on the unresolved surrogate.

The fix is to apply `SubstituteSurrogateExpressions.rule()` to the convert expression before passing it to `rewrapWithCast()`, consistent with what `typeSpecificConvert()` already does for the same reason.

## Test plan

`./gradlew ":x-pack:plugin:esql:internalClusterTest" --tests "org.elasticsearch.xpack.esql.action.ManyShardsIT.testMultiTypes" -Dtests.seed=8C2C9194B6E380ED` passes.
