### PR TITLE
[Inference API] Fix failing test 151603

### DIFF
--- a/x-pack/plugin/inference/qa/oauth2/build.gradle
+++ b/x-pack/plugin/inference/qa/oauth2/build.gradle
@@ -23,4 +23,9 @@ dependencies {
 
 tasks.named("javaRestTest").configure {
   usesDefaultDistribution("OpenAI OAuth2 end-to-end tests")
+  // no.nav.security:mock-oauth2-server pulls in the non-FIPS BouncyCastle (bcpkix-jdk18on) as a
+  // runtime dependency, which collides with the FIPS BouncyCastle (bcpkix-fips) that the build
+  // adds to every test classpath in FIPS mode (jar hell). The mock server is not FIPS-compatible
+  // and the OAuth2 wiring under test is independent of the security provider, so skip on FIPS JVMs.
+  onlyIf("OAuth2 mock server is not FIPS compatible") { buildParams.inFipsJvm == false }
 }


### PR DESCRIPTION
Fixes #151603 #151604

## Problem

The `x-pack/plugin/inference/qa/oauth2` module (added in #150132) declares
`no.nav.security:mock-oauth2-server:2.2.1`, which transitively depends on
`org.bouncycastle:bcpkix-jdk18on:1.81` (non-FIPS BouncyCastle) as a runtime
dependency. In FIPS test runs, `elasticsearch.fips.gradle` appends the FIPS
BouncyCastle jar (`bcpkix-fips:2.0.7`) to every `Test` task's classpath. Both
jars define `org.bouncycastle.cert.AttributeCertificateHolder`, causing a
deterministic jar-hell failure in `BootstrapForTesting.<clinit>` before any
test method executes.

## Fix

Skip the `javaRestTest` task when running under a FIPS JVM
(`buildParams.inFipsJvm`). The `mock-oauth2-server` library is not
FIPS-compatible, and the OAuth2 protocol wiring under test is independent of
the security provider, so the coverage loss is negligible. This follows the
same pattern used in `qa/ccs-rolling-upgrade-remote-cluster/build.gradle` and
`x-pack/qa/rolling-upgrade-basic/build.gradle`.