### PR TITLE
Backport #142335 to 9.3: Pass through includeSourceInError

### DIFF
--- a/docs/changelog/142335.yaml
+++ b/docs/changelog/142335.yaml
@@ -1,0 +1,5 @@
+area: Infra/Core
+issues: []
+pr: 142335
+summary: Pass through `includeSourceInError`
+type: bug

--- a/server/src/internalClusterTest/java/org/elasticsearch/rest/action/document/RestBulkActionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/rest/action/document/RestBulkActionIT.java
@@ -73,4 +73,33 @@ public class RestBulkActionIT extends ESIntegTestCase {
             )
         );
     }
+
+    public void testBulkIndexWithSourceOnErrorDisabledWithPipeline() throws Exception {
+        var source = "{\"field\": NaN}";
+        var sourceEscaped = "{\\\"field\\\": NaN}";
+        var pipeline = randomAlphaOfLength(12);
+
+        var putPipelineRequest = new Request("PUT", "/_ingest/pipeline/" + pipeline);
+        putPipelineRequest.setJsonEntity("{\"processors\":[]}");
+        getRestClient().performRequest(putPipelineRequest);
+
+        var request = new Request("PUT", "/test_index/_bulk");
+        request.addParameter("pipeline", pipeline);
+        request.setJsonEntity(Strings.format("{\"index\":{\"_id\":\"1\"}}\n%s\n", source));
+
+        Response response = getRestClient().performRequest(request);
+        String responseContent = Streams.copyToString(new InputStreamReader(response.getEntity().getContent(), UTF_8));
+        assertThat(responseContent, containsString(sourceEscaped));
+
+        request.addParameter(RestUtils.INCLUDE_SOURCE_ON_ERROR_PARAMETER, "false");
+
+        response = getRestClient().performRequest(request);
+        responseContent = Streams.copyToString(new InputStreamReader(response.getEntity().getContent(), UTF_8));
+        assertThat(
+            responseContent,
+            both(not(containsString(sourceEscaped))).and(
+                containsString("REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled)")
+            )
+        );
+    }
 }

--- a/server/src/main/java/org/elasticsearch/action/index/IndexRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/index/IndexRequest.java
@@ -435,7 +435,7 @@ public class IndexRequest extends ReplicatedWriteRequest<IndexRequest> implement
     }
 
     public Map<String, Object> sourceAsMap() {
-        return indexSource.sourceAsMap();
+        return indexSource.sourceAsMap(includeSourceOnError);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/index/IndexSource.java
+++ b/server/src/main/java/org/elasticsearch/action/index/IndexSource.java
@@ -21,6 +21,8 @@ import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
@@ -97,9 +99,10 @@ public class IndexSource implements Writeable, Releasable {
         contentType = null;
     }
 
-    public Map<String, Object> sourceAsMap() {
+    public Map<String, Object> sourceAsMap(boolean includeSourceOnError) {
         assert isClosed == false;
-        return XContentHelper.convertToMap(source, false, contentType).v2();
+        var parserConfiguration = XContentParserConfiguration.EMPTY.withIncludeSourceOnError(includeSourceOnError);
+        return XContentHelper.parseToType(XContentParser::map, source, contentType, parserConfiguration).v2();
     }
 
     /**

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/filter/ShardBulkInferenceActionFilter.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/filter/ShardBulkInferenceActionFilter.java
@@ -744,7 +744,7 @@ public class ShardBulkInferenceActionFilter implements MappedActionFilter {
             int originalSourceSize = indexSource.byteLength();
             BytesReference originalSource = indexSource.bytes();
             if (useLegacyFormat) {
-                var newDocMap = indexSource.sourceAsMap();
+                var newDocMap = indexSource.sourceAsMap(indexRequest.getIncludeSourceOnError());
                 for (var entry : inferenceFieldsMap.entrySet()) {
                     XContentMapValues.insertValue(entry.getKey(), newDocMap, entry.getValue());
                 }


### PR DESCRIPTION
Backport of #142335 to branch 9.3.

Resolved conflict in `RestBulkActionIT.java`: the new `testBulkIndexWithSourceOnErrorDisabledWithPipeline` test was inserted between tests that exist in `main` but not in `9.3` (the Slice tests). Resolved by adding only the new test without the main-only Slice tests.