### PR TITLE
Add bundled JDK 26 / 26.0.1 to 9.3.4, 9.3.5, 9.4.1 release notes

### DIFF
--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -12,9 +12,6 @@ If you are migrating from a version prior to version 9.0, you must first upgrade
 
 % ## Next version [elasticsearch-nextversion-breaking-changes]
 
-```{applies_to}
-stack: ga 9.3.5
-```
 ## 9.4.2 [elasticsearch-9.4.2-breaking-changes]
 
 There are no breaking changes associated with this release.

--- a/docs/release-notes/changelog-bundles/9.3.4.yml
+++ b/docs/release-notes/changelog-bundles/9.3.4.yml
@@ -101,6 +101,11 @@ changelogs:
     area: Reindex
     type: bug
     issues: []
+  - pr: 146167
+    summary: Update bundled JDK to Java 26
+    area: Packaging
+    type: upgrade
+    issues: []
   - pr: 146186
     summary: Omit uncomputed model stats
     area: Machine Learning

--- a/docs/release-notes/changelog-bundles/9.3.5.yml
+++ b/docs/release-notes/changelog-bundles/9.3.5.yml
@@ -126,6 +126,11 @@ changelogs:
     type: bug
     issues:
       - 147171
+  - pr: 147424
+    summary: Bump bundled JDK to Java 26.0.1
+    area: Packaging
+    type: upgrade
+    issues: []
   - pr: 147427
     summary: "Aggs: Fix auto_date_histogram/date_histogram inside a global agg"
     area: Aggregations

--- a/docs/release-notes/changelog-bundles/9.4.1.yml
+++ b/docs/release-notes/changelog-bundles/9.4.1.yml
@@ -69,10 +69,20 @@ changelogs:
     type: bug
     issues: []
     source_repo: elastic/ml-cpp
+  - pr: 146167
+    summary: Update bundled JDK to Java 26
+    area: Packaging
+    type: upgrade
+    issues: []
   - pr: 147063
     summary: "[Inference API] Fix inference initialization thread exhaustion"
     area: Inference
     type: bug
+    issues: []
+  - pr: 147424
+    summary: Bump bundled JDK to Java 26.0.1
+    area: Packaging
+    type: upgrade
     issues: []
   - pr: 147678
     summary: Fix race in `TickerScheduleTriggerEngine` by checking watcher to node allocation

--- a/docs/release-notes/deprecations.md
+++ b/docs/release-notes/deprecations.md
@@ -21,6 +21,8 @@ To give you insight into what deprecated features you’re using, {{es}}:
 ES|QL:
 * Add deprecation message for ES|QL query log [#149013](https://github.com/elastic/elasticsearch/pull/149013)
 
+
+
 ## 9.3.5 [elasticsearch-9.3.5-deprecations]
 
 There are no deprecations associated with this release.

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -122,6 +122,9 @@ Machine Learning:
 * Restrict file system access for pytorch models [#2851](https://github.com/elastic/ml-cpp/pull/2851)
 * Update the PyTorch library to version 2.7.1 [#2863](https://github.com/elastic/ml-cpp/pull/2863)
 
+Packaging:
+* Bump bundled JDK to Java 26.0.1 [#147424](https://github.com/elastic/elasticsearch/pull/147424)
+
 Search:
 * Add logging tracking to _xpack/usage [#148087](https://github.com/elastic/elasticsearch/pull/148087)
 
@@ -222,8 +225,8 @@ Machine Learning:
 * Update the PyTorch library to version 2.7.1 [#2863](https://github.com/elastic/ml-cpp/pull/2863)
 
 Packaging:
-* Update bundled JDK to Java 26 [#146167](https://github.com/elastic/elasticsearch/pull/146167)
 * Bump bundled JDK to Java 26.0.1 [#147424](https://github.com/elastic/elasticsearch/pull/147424)
+* Update bundled JDK to Java 26 [#146167](https://github.com/elastic/elasticsearch/pull/146167)
 
 Security:
 * Update elastic-apm-agent-java8 to 1.55.6 [#148271](https://github.com/elastic/elasticsearch/pull/148271)
@@ -730,7 +733,6 @@ Monitoring:
 * Add mode and codec fields to Stack Monitoring index template [#143673](https://github.com/elastic/elasticsearch/pull/143673)
 
 Packaging:
-* Bump bundled JDK to Java 26.0.1 [#147424](https://github.com/elastic/elasticsearch/pull/147424)
 * Flip cloud-ess-fips default from FIPS 140-2 to FIPS 140-3 [#140788](https://github.com/elastic/elasticsearch/pull/140788)
 
 Performance:


### PR DESCRIPTION
## Summary

Follow-up to #151616. That PR added the JDK entries directly to `index.md`, but not to the changelog bundles that `generateReleaseNotes` builds from, so the next regeneration would drop them.

This PR adds the entries to the bundles (the source of truth) and regenerates the release notes:

- JDK 26 (#146167): 9.3.4 and 9.4.1
- JDK 26.0.1 (#147424): 9.3.5 and 9.4.1

It also corrects the placement of 26.0.1. #151616 listed it under 9.4.0, but its version labels show it shipped in 9.3.5 and 9.4.1.

Relates: #151616, #146167, #147424