### PR TITLE
ESQL: support date_nanos in BUCKET bounds, fix OffsetRounding.fixedRoundingPoints

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/Rounding.java
+++ b/server/src/main/java/org/elasticsearch/common/Rounding.java
@@ -405,6 +405,7 @@ public abstract class Rounding implements Writeable {
          * @return the original {@link Rounding} that created this instance.
          */
         Rounding getUnprepared();
+
     }
 
     /**
@@ -615,6 +616,7 @@ public abstract class Rounding implements Writeable {
             public Rounding getUnprepared() {
                 return new ToUpperRounding(delegate.getUnprepared());
             }
+
         }
 
         private final Rounding next;
@@ -723,6 +725,7 @@ public abstract class Rounding implements Writeable {
         public long[] fixedRoundingPoints() {
             return null;
         }
+
     }
 
     static class TimeUnitRounding extends Rounding {
@@ -1737,8 +1740,15 @@ public abstract class Rounding implements Writeable {
 
         @Override
         public long[] fixedRoundingPoints() {
-            // TODO we can likely translate here
-            return null;
+            long[] pts = delegatePrepared.fixedRoundingPoints();
+            if (pts == null) {
+                return null;
+            }
+            long[] shifted = new long[pts.length];
+            for (int i = 0; i < pts.length; i++) {
+                shifted[i] = pts[i] + offset;
+            }
+            return shifted;
         }
 
         @Override
@@ -1746,6 +1756,7 @@ public abstract class Rounding implements Writeable {
             Rounding unprepared = delegatePrepared.getUnprepared();
             return new OffsetRounding(unprepared, offset);
         }
+
     }
 
     public static Rounding read(StreamInput in) throws IOException {

--- a/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToDouble.java
+++ b/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToDouble.java
@@ -10,6 +10,8 @@ package org.elasticsearch.xpack.esql.expression.function.scalar.math;
 // begin generated imports
 import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.ann.Fixed;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.xpack.esql.core.tree.Source;
 
 import java.util.Arrays;
 // end generated imports
@@ -23,8 +25,11 @@ import java.util.Arrays;
  * This class is generated. Edit {@code X-RoundTo.java.st} instead.
  */
 class RoundToDouble {
-    static final RoundTo.Build BUILD = (source, field, points) -> {
-        double[] f = points.stream().mapToDouble(p -> p.doubleValue()).toArray();
+    interface Build {
+        ExpressionEvaluator.Factory build(Source source, ExpressionEvaluator.Factory field, double[] points);
+    }
+
+    static final Build BUILD = (source, field, f) -> {
         return switch (f.length) {
             // TODO should be a consistent way to do the 0 version - is CASE(MV_COUNT(f) == 1, f[0])
             case 1 -> new RoundToDouble1Evaluator.Factory(source, field, f[0]);

--- a/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToInt.java
+++ b/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToInt.java
@@ -10,6 +10,8 @@ package org.elasticsearch.xpack.esql.expression.function.scalar.math;
 // begin generated imports
 import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.ann.Fixed;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.xpack.esql.core.tree.Source;
 
 import java.util.Arrays;
 // end generated imports
@@ -23,8 +25,11 @@ import java.util.Arrays;
  * This class is generated. Edit {@code X-RoundTo.java.st} instead.
  */
 class RoundToInt {
-    static final RoundTo.Build BUILD = (source, field, points) -> {
-        int[] f = points.stream().mapToInt(p -> p.intValue()).toArray();
+    interface Build {
+        ExpressionEvaluator.Factory build(Source source, ExpressionEvaluator.Factory field, int[] points);
+    }
+
+    static final Build BUILD = (source, field, f) -> {
         return switch (f.length) {
             // TODO should be a consistent way to do the 0 version - is CASE(MV_COUNT(f) == 1, f[0])
             case 1 -> new RoundToInt1Evaluator.Factory(source, field, f[0]);

--- a/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLong.java
+++ b/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLong.java
@@ -10,6 +10,8 @@ package org.elasticsearch.xpack.esql.expression.function.scalar.math;
 // begin generated imports
 import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.ann.Fixed;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.xpack.esql.core.tree.Source;
 
 import java.util.Arrays;
 // end generated imports
@@ -23,8 +25,11 @@ import java.util.Arrays;
  * This class is generated. Edit {@code X-RoundTo.java.st} instead.
  */
 class RoundToLong {
-    static final RoundTo.Build BUILD = (source, field, points) -> {
-        long[] f = points.stream().mapToLong(p -> p.longValue()).toArray();
+    interface Build {
+        ExpressionEvaluator.Factory build(Source source, ExpressionEvaluator.Factory field, long[] points);
+    }
+
+    static final Build BUILD = (source, field, f) -> {
         return switch (f.length) {
             // TODO should be a consistent way to do the 0 version - is CASE(MV_COUNT(f) == 1, f[0])
             case 1 -> new RoundToLong1Evaluator.Factory(source, field, f[0]);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/grouping/Bucket.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/grouping/Bucket.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.Rounding.RoundingConvention;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.time.DateUtils;
 import org.elasticsearch.compute.expression.ExpressionEvaluator;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
@@ -539,7 +540,15 @@ public class Bucket extends GroupingFunction.EvaluatableGroupingFunction
     }
 
     public static TypeResolution isStringOrDate(Expression e, String operationName, TypeResolutions.ParamOrdinal paramOrd) {
-        return isType(e, exp -> DataType.isString(exp) || DataType.isDateTime(exp), operationName, paramOrd, "datetime", "string");
+        return isType(
+            e,
+            exp -> DataType.isString(exp) || DataType.isMillisOrNanos(exp),
+            operationName,
+            paramOrd,
+            "datetime",
+            "date_nanos",
+            "string"
+        );
     }
 
     @Override
@@ -553,7 +562,13 @@ public class Bucket extends GroupingFunction.EvaluatableGroupingFunction
 
     private long foldToLong(FoldContext ctx, Expression e) {
         Object value = Foldables.valueOf(ctx, e);
-        return DataType.isDateTime(e.dataType()) ? ((Number) value).longValue() : dateTimeToLong(((BytesRef) value).utf8ToString());
+        if (DataType.isDateTime(e.dataType())) {
+            return ((Number) value).longValue();
+        }
+        if (e.dataType() == DataType.DATE_NANOS) {
+            return DateUtils.toMilliSeconds(((Number) value).longValue());
+        }
+        return dateTimeToLong(((BytesRef) value).utf8ToString());
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundTo.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundTo.java
@@ -35,10 +35,8 @@ import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
 import org.elasticsearch.xpack.esql.stats.SearchStats;
 
 import java.io.IOException;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
 
 import static org.elasticsearch.common.logging.LoggerMessageFormat.format;
 import static org.elasticsearch.xpack.esql.action.EsqlCapabilities.Cap.ROUND_TO_BLOCK_LOADER;
@@ -127,7 +125,7 @@ public class RoundTo extends EsqlScalarFunction implements BlockLoaderExpression
         }
 
         DataType dataType = dataType();
-        if (dataType == null || SIGNATURES.containsKey(dataType) == false) {
+        if ((dataType == LONG || dataType == DATETIME || dataType == DATE_NANOS || dataType == INTEGER || dataType == DOUBLE) == false) {
             return new TypeResolution(format(null, "all arguments must be numeric, date, or data_nanos"));
         }
 
@@ -185,51 +183,42 @@ public class RoundTo extends EsqlScalarFunction implements BlockLoaderExpression
     @Override
     public ExpressionEvaluator.Factory toEvaluator(ToEvaluator toEvaluator) {
         DataType dataType = dataType();
-        Build build = SIGNATURES.get(dataType);
-        if (build == null) {
-            throw new IllegalStateException("unsupported type");
+        ExpressionEvaluator.Factory fieldEval = Cast.cast(source(), field().dataType(), dataType, toEvaluator.apply(field()));
+        if (dataType == LONG || dataType == DATETIME || dataType == DATE_NANOS) {
+            long[] cc = new long[points.size()];
+            for (int i = 0; i < points.size(); i++) {
+                var p = (Number) Foldables.valueOf(toEvaluator.foldCtx(), points.get(i));
+                if (p == null) {
+                    return null;
+                }
+                cc[i] = DataTypeConverter.safeToLong(p);
+            }
+            Arrays.sort(cc);
+            return RoundToLong.BUILD.build(source(), fieldEval, cc);
+        } else if (dataType == INTEGER) {
+            int[] cc = new int[points.size()];
+            for (int i = 0; i < points.size(); i++) {
+                var p = (Number) Foldables.valueOf(toEvaluator.foldCtx(), points.get(i));
+                if (p == null) {
+                    return null;
+                }
+                cc[i] = p.intValue();
+            }
+            Arrays.sort(cc);
+            return RoundToInt.BUILD.build(source(), fieldEval, cc);
+        } else if (dataType == DOUBLE) {
+            double[] cc = new double[points.size()];
+            for (int i = 0; i < points.size(); i++) {
+                var p = (Number) Foldables.valueOf(toEvaluator.foldCtx(), points.get(i));
+                if (p == null) {
+                    return null;
+                }
+                cc[i] = p.doubleValue();
+            }
+            Arrays.sort(cc);
+            return RoundToDouble.BUILD.build(source(), fieldEval, cc);
         }
-
-        ExpressionEvaluator.Factory field = toEvaluator.apply(field());
-        field = Cast.cast(source(), field().dataType(), dataType, field);
-        List<Object> points = Iterators.toList(Iterators.map(points().iterator(), p -> Foldables.valueOf(toEvaluator.foldCtx(), p)));
-        List<Number> sortedPoints = sortedRoundingPoints(points, dataType); // provide sorted points to the evaluator
-        return build.build(source(), field, sortedPoints);
-    }
-
-    interface Build {
-        ExpressionEvaluator.Factory build(Source source, ExpressionEvaluator.Factory field, List<Number> points);
-    }
-
-    private static final Map<DataType, Build> SIGNATURES = Map.ofEntries(
-        Map.entry(DATETIME, RoundToLong.BUILD),
-        Map.entry(DATE_NANOS, RoundToLong.BUILD),
-        Map.entry(INTEGER, RoundToInt.BUILD),
-        Map.entry(LONG, RoundToLong.BUILD),
-        Map.entry(DOUBLE, RoundToDouble.BUILD)
-    );
-
-    public static List<Number> sortedRoundingPoints(List<Object> points, DataType dataType) {
-        List<Number> pointsTobeSorted = points.stream().filter(Objects::nonNull).map(p -> (Number) p).toList();
-
-        return switch (dataType) {
-            case INTEGER -> pointsTobeSorted.stream()
-                .mapToInt(Number::intValue)
-                .sorted()
-                .boxed()
-                .collect(java.util.stream.Collectors.toList());
-            case DOUBLE -> pointsTobeSorted.stream()
-                .mapToDouble(Number::doubleValue)
-                .sorted()
-                .boxed()
-                .collect(java.util.stream.Collectors.toList());
-            case LONG, DATETIME, DATE_NANOS -> pointsTobeSorted.stream()
-                .mapToLong(DataTypeConverter::safeToLong)
-                .sorted()
-                .boxed()
-                .collect(java.util.stream.Collectors.toList());
-            default -> throw new IllegalArgumentException("Unsupported data type: " + dataType);
-        };
+        throw new IllegalStateException("unsupported type: " + dataType);
     }
 
     @Override
@@ -242,29 +231,17 @@ public class RoundTo extends EsqlScalarFunction implements BlockLoaderExpression
             if (dt != LONG && dt != DATETIME && dt != DATE_NANOS) {
                 return null;
             }
-            long[] sortedPoints = sortedLongPoints();
-            if (sortedPoints == null) {
-                return null;
+            long[] pts = new long[points.size()];
+            for (int i = 0; i < points.size(); i++) {
+                if (points.get(i) instanceof Literal lit) {
+                    pts[i] = DataTypeConverter.safeToLong((Number) lit.value());
+                } else {
+                    return null;
+                }
             }
-            return new PushedBlockLoaderExpression(f, new BlockLoaderFunctionConfig.RoundToLongs(sortedPoints));
+            Arrays.sort(pts);
+            return new PushedBlockLoaderExpression(f, new BlockLoaderFunctionConfig.RoundToLongs(pts));
         }
         return null;
-    }
-
-    private long[] sortedLongPoints() {
-        List<Object> values = new ArrayList<>(points.size());
-        for (Expression p : points) {
-            if (p instanceof Literal lit) {
-                values.add(lit.value());
-            } else {
-                return null;
-            }
-        }
-        List<Number> sorted = sortedRoundingPoints(values, dataType());
-        long[] result = new long[sorted.size()];
-        for (int i = 0; i < sorted.size(); i++) {
-            result[i] = sorted.get(i).longValue();
-        }
-        return result;
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/X-RoundTo.java.st
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/X-RoundTo.java.st
@@ -10,6 +10,8 @@ package org.elasticsearch.xpack.esql.expression.function.scalar.math;
 // begin generated imports
 import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.ann.Fixed;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.xpack.esql.core.tree.Source;
 
 import java.util.Arrays;
 // end generated imports
@@ -23,8 +25,11 @@ import java.util.Arrays;
  * This class is generated. Edit {@code X-RoundTo.java.st} instead.
  */
 class RoundTo$Type$ {
-    static final RoundTo.Build BUILD = (source, field, points) -> {
-        $type$[] f = points.stream().mapTo$Type$(p -> p.$type$Value()).toArray();
+    interface Build {
+        ExpressionEvaluator.Factory build(Source source, ExpressionEvaluator.Factory field, $type$[] points);
+    }
+
+    static final Build BUILD = (source, field, f) -> {
         return switch (f.length) {
             // TODO should be a consistent way to do the 0 version - is CASE(MV_COUNT(f) == 1, f[0])
             case 1 -> new RoundTo$Type$1Evaluator.Factory(source, field, f[0]);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/ReplaceRoundToWithQueryAndTags.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/ReplaceRoundToWithQueryAndTags.java
@@ -48,6 +48,7 @@ import org.elasticsearch.xpack.esql.stats.SearchStats;
 
 import java.time.ZoneId;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
@@ -446,7 +447,7 @@ public class ReplaceRoundToWithQueryAndTags extends PhysicalOptimizerRules.Param
     }
 
     private static List<Number> resolveRoundingPoints(List<Expression> roundingPoints, DataType dataType) {
-        List<Object> points = new ArrayList<>(roundingPoints.size());
+        List<Number> points = new ArrayList<>(roundingPoints.size());
         for (Expression e : roundingPoints) {
             if (e instanceof Literal l && l.value() instanceof Number n) {
                 switch (dataType) {
@@ -458,7 +459,13 @@ public class ReplaceRoundToWithQueryAndTags extends PhysicalOptimizerRules.Param
                 }
             }
         }
-        return RoundTo.sortedRoundingPoints(points, dataType);
+        switch (dataType) {
+            case INTEGER -> points.sort(Comparator.comparingInt(Number::intValue));
+            case LONG, DATETIME, DATE_NANOS -> points.sort(Comparator.comparingLong(Number::longValue));
+            case DOUBLE -> points.sort(Comparator.comparingDouble(Number::doubleValue));
+            default -> throw new IllegalArgumentException("Unsupported data type: " + dataType);
+        }
+        return points;
     }
 
     private static Expression createRangeExpression(

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
@@ -697,7 +697,7 @@ public class VerifierTests extends ESTestCase {
         defaultAnalyzer().error(
             "from test | stats max(emp_no) by bucket(hire_date, 5, 1 day, 1 month)",
             containsString(
-                "third argument of [bucket(hire_date, 5, 1 day, 1 month)] must be [datetime or string], "
+                "third argument of [bucket(hire_date, 5, 1 day, 1 month)] must be [datetime, date_nanos or string], "
                     + "found value [1 day] type [date_period]"
             )
         );
@@ -705,7 +705,7 @@ public class VerifierTests extends ESTestCase {
         defaultAnalyzer().error(
             "from test | stats max(emp_no) by bucket(hire_date, 5, \"2000-01-01\", 1 month)",
             containsString(
-                "fourth argument of [bucket(hire_date, 5, \"2000-01-01\", 1 month)] must be [datetime or string], "
+                "fourth argument of [bucket(hire_date, 5, \"2000-01-01\", 1 month)] must be [datetime, date_nanos or string], "
                     + "found value [1 month] type [date_period]"
             )
         );


### PR DESCRIPTION
Prerequisite for #150649.

Two small fixes:

1. `Bucket.isStringOrDate` now accepts `date_nanos` in addition to `datetime` and `string`, so TSTEP/TBUCKET work with date_nanos timestamp fields.
2. `Bucket.foldToLong` handles `DATE_NANOS` by converting nanoseconds to milliseconds via `DateUtils.toMilliSeconds`.
3. `OffsetRounding.Prepared.fixedRoundingPoints()` now shifts the delegate's rounding points by the offset, enabling `ReplaceDateTruncBucketWithRoundTo` to work correctly when a timezone offset is applied.