### PR TITLE
Notify upload listener when object store service is shutting down.

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -458,9 +458,6 @@ tests:
 - class: org.elasticsearch.indices.memory.breaker.HierarchyCircuitBreakerTelemetryIT
   method: testCircuitBreakerTripCountMetric
   issue: https://github.com/elastic/elasticsearch/issues/150700
-- class: org.elasticsearch.xpack.stateless.reshard.StatelessReshardDisruptionIT
-  method: testReshardWithDisruption
-  issue: https://github.com/elastic/elasticsearch/issues/150708
 - class: org.elasticsearch.xpack.esql.analysis.AnalyzerUnmappedGoldenTests
   method: testTypeConflictTimeseriesLongUnmappedWithCast
   issue: https://github.com/elastic/elasticsearch/issues/150722

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/objectstore/ObjectStoreService.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/objectstore/ObjectStoreService.java
@@ -645,10 +645,14 @@ public class ObjectStoreService extends AbstractLifecycleComponent implements Cl
         }
     }
 
-    private void ensureRunning() {
+    private boolean isRunning() {
         final Lifecycle.State state = lifecycleState();
-        if (state == Lifecycle.State.INITIALIZED || state == Lifecycle.State.CLOSED) {
-            throw new IllegalStateException("Object store service is not running [" + state + ']');
+        return state != Lifecycle.State.INITIALIZED && state != Lifecycle.State.CLOSED;
+    }
+
+    private void ensureRunning() {
+        if (isRunning() == false) {
+            throw new IllegalStateException("Object store service is not running [" + lifecycleState() + ']');
         }
     }
 
@@ -741,7 +745,9 @@ public class ObjectStoreService extends AbstractLifecycleComponent implements Cl
                 }
             }
         } catch (Exception e) {
-            assert false : "enqueue task failed: " + e;
+            // Enqueueing can fail once the service is shutting down while uploads are still in flight: notify the listener so callers
+            // release the references they hold (e.g. commit refs) rather than leaking them.
+            assert isRunning() == false : "enqueue task failed while object store service is running: " + e;
             listener.onFailure(e);
         }
     }

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/objectstore/ObjectStoreServiceTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/objectstore/ObjectStoreServiceTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.blobcache.BlobCacheUtils;
 import org.elasticsearch.blobcache.shared.SharedBlobCacheService;
 import org.elasticsearch.blobcache.shared.SharedBytes;
@@ -191,6 +192,26 @@ public class ObjectStoreServiceTests extends ESTestCase {
         assertThat(settings.get(bucketName), equalTo(bucket));
         assertThat(settings.get("client"), equalTo(client));
         assertThat(settings.get("base_path"), equalTo(basePath));
+    }
+
+    /**
+     * When the object store service is closed while an upload is still in flight, enqueueing the upload must notify its listener
+     * rather than throwing, so the caller can release the references it holds (e.g. commit refs) instead of leaking them.
+     */
+    public void testEnqueueAfterCloseNotifiesListener() throws IOException {
+        try (var testHarness = new FakeStatelessNode(this::newEnvironment, this::newNodeEnvironment, xContentRegistry())) {
+            final var objectStoreService = testHarness.objectStoreService;
+
+            objectStoreService.close();
+            assertThat(objectStoreService.lifecycleState(), equalTo(Lifecycle.State.CLOSED));
+
+            final var future = new PlainActionFuture<Void>();
+            objectStoreService.uploadTranslogFile("translog-1", new BytesArray(new byte[] { 1, 2, 3 }), future);
+
+            // The listener must be failed (not stranded by a thrown error) so the caller can release its references.
+            final var e = expectThrows(IllegalStateException.class, future::actionGet);
+            assertThat(e.getMessage(), startsWith("Object store service is not running"));
+        }
     }
 
     public void testStartingShardRetrievesSegmentsFromOneCommit() throws IOException {


### PR DESCRIPTION
`StatelessReshardDisruptionIT.testReshardWithDisruption ` failed at `Node.awaitClose(Node.java:635)` with `Some shards are still open after the threadpool terminated`. When an index node is stopped mid-upload, `enqueueTask's` `assert false` threw an `AssertionError` that escaped RetryableAction and skipped `listener.onFailure()`, leaking the commit reference and leaving the shard open at close. Always notify the listener and only assert when the service is still running.

Closes #150708