### PR TITLE
Unmute CcrSeqNoPruningIT#testSeqNoPartiallyRetainedByCcrLease

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -374,9 +374,6 @@ tests:
   method: "builds distribution from branches via archives extractedAssemble [bwcDistVersion: 8.2.1, bwcProject: major3, expectedAssembleTaskName:
     extractedAssemble, #2]"
   issue: https://github.com/elastic/elasticsearch/issues/150410
-- class: org.elasticsearch.xpack.ccr.CcrSeqNoPruningIT
-  method: testSeqNoPartiallyRetainedByCcrLease
-  issue: https://github.com/elastic/elasticsearch/issues/150435
 - class: org.elasticsearch.xpack.esql.action.FileSourceSecretDecryptionAcrossNodesIT
   method: testJoinedDataNodeDecryptsTheSecret
   issue: https://github.com/elastic/elasticsearch/issues/150440


### PR DESCRIPTION
Closes #150435

The symptoms are the same ones that 5fc3a60763866d7878b36f4026896572c06052e9 fixed (a background merge kicking in and making the force-merge a no-op) and reverting that change reproduces the issue consistently. Running the test in a loop in a VM alongside stress-ng didn't reproduce it in 200 runs.