### PR TITLE
[8.19] Add bundled JDK 26 and 26.0.1 to 8.19.15 and 8.19.16 release notes

### DIFF
--- a/docs/reference/release-notes/8.19.15.asciidoc
+++ b/docs/reference/release-notes/8.19.15.asciidoc
@@ -48,6 +48,9 @@ Authentication::
 [float]
 === Upgrades
 
+Packaging::
+* Update bundled JDK to Java 26 {es-pull}146167[#146167]
+
 Security::
 * Upgrade bouncycastle to 1.84 {es-pull}147197[#147197]
 

--- a/docs/reference/release-notes/8.19.16.asciidoc
+++ b/docs/reference/release-notes/8.19.16.asciidoc
@@ -63,6 +63,9 @@ Watcher::
 Infra/Logging::
 * Upgrade to log4j 2.26.0 {es-pull}132166[#132166] (issue: {es-issue}132035[#132035])
 
+Packaging::
+* Update bundled JDK to Java 26.0.1 {es-pull}147424[#147424]
+
 Security::
 * Update elastic-apm-agent-java8 to 1.55.6 {es-pull}148271[#148271]
 


### PR DESCRIPTION
## Summary

Adds JDK 26 (#146167) and JDK 26.0.1 (#147424) to the 8.19.15 and 8.19.16 AsciiDoc release notes. 

Relates: #151616, #151631