### PR TITLE
Use Elasticsearch as a Prometheus data source in Grafana (docs)

### DIFF
--- a/docs/reference/query-languages/promql.md
+++ b/docs/reference/query-languages/promql.md
@@ -31,5 +31,6 @@ When you use the Prometheus-compatible HTTP API or embed PromQL in an {{esql}} q
 
 * [HTTP API](promql/promql-http-api.md): Prometheus-compatible `/_prometheus/` endpoints for queries and discovery.
 * [Functions](promql/functions.md): PromQL function reference organized by category, including {{es}}-specific differences from Prometheus.
+* [Prometheus data source in Grafana](promql/promql-grafana.md): Use {{es}} as a Prometheus data source in Grafana for dashboards, autocomplete, and Metrics Drilldown.
 * [Limitations](promql/promql-limitations.md): How behavior differs from Prometheus, including unsupported PromQL constructs, HTTP behavior, instant-query nuances, staleness semantics, exemplars, and related topics.
 

--- a/docs/reference/query-languages/promql/promql-grafana.md
+++ b/docs/reference/query-languages/promql/promql-grafana.md
@@ -1,0 +1,190 @@
+---
+description: Use Elasticsearch as a Prometheus data source in Grafana to query metrics with PromQL, power autocomplete and Metrics Drilldown, and reuse existing dashboards.
+navigation_title: Prometheus data source in Grafana
+applies_to:
+  stack: preview 9.4, ga 9.5
+  serverless: ga
+products:
+  - id: elasticsearch
+---
+
+# Use {{es}} as a Prometheus data source in Grafana [promql-grafana]
+
+{{es}} exposes a [Prometheus-compatible HTTP API](promql-http-api.md) under the `/_prometheus/` prefix.
+Because the API follows the [Prometheus query API](https://prometheus.io/docs/prometheus/latest/querying/api/), you can point Grafana's built-in **Prometheus** data source directly at {{es}} without sidecars, adapters, or pipeline changes.
+
+Grafana then treats {{es}} like any other Prometheus backend: dashboard panels, query autocompletion, template variables, and [Metrics Drilldown](https://grafana.com/docs/grafana/latest/visualizations/simplified-exploration/metrics/) all use PromQL against metrics stored in {{es}} [time series data streams](docs-content://manage-data/data-store/data-streams/time-series-data-stream-tsds.md) (TSDS).
+
+This guide covers connecting Grafana to {{es}}. To ingest metrics from Prometheus, see [Prometheus remote write](docs-content://manage-data/data-store/data-streams/tsds-ingest-prometheus-remote-write.md).
+
+::::{important}
+Before you build dashboards, review the [PromQL limitations](promql-limitations.md).
+Behavior differs from upstream Prometheus in a few areas, and some PromQL constructs are not evaluated yet.
+Knowing these up front helps you tell an expected limitation apart from a real problem when [troubleshooting](#promql-grafana-troubleshooting).
+::::
+
+## Before you begin [promql-grafana-prerequisites]
+
+You need:
+
+- The {{es}} endpoint for your deployment.
+  On {{es-serverless}}, find it in the Elastic Cloud console under **Manage > Application endpoints, cluster and component IDs**, next to **Elasticsearch**.
+  The endpoint looks like `https://<project-id>.es.<region>.<provider>.elastic.cloud`.
+- An [API key](docs-content://deploy-manage/api-keys/elasticsearch-api-keys.md) for Grafana to query metrics.
+
+Create an API key scoped to read metrics data streams only, so a leaked Grafana key cannot be used to write data.
+In **Control security privileges**, use a role descriptor such as:
+
+```json
+{
+  "query": {
+    "indices": [
+      {
+        "names": ["metrics-*.prometheus-*"],
+        "privileges": ["read", "view_index_metadata"]
+      }
+    ]
+  }
+}
+```
+
+The `metrics-*.prometheus-*` pattern scopes the key to metrics ingested through [Prometheus remote write](docs-content://manage-data/data-store/data-streams/tsds-ingest-prometheus-remote-write.md), which is what this guide focuses on.
+Because the key can read only those data streams, Grafana queries stay limited to that Prometheus data even when they use the default `/_prometheus/` endpoint.
+
+When the key is created, copy the **Encoded** value (select the **Encoded** format if Kibana offers a format dropdown). This is the value you pass directly as `ApiKey <encoded>`; you cannot retrieve it again after closing the dialog.
+
+::::{tip}
+You can configure a separate Grafana data source per index pattern to give teams scoped access to their own metrics.
+Add an index expression after `/_prometheus/`, for example `https://<es_endpoint>/_prometheus/metrics-prod-*`.
+See [Index scoping](promql-http-api.md#promql-http-api-index-scope).
+::::
+
+## Add the data source [promql-grafana-datasource]
+
+Configure the data source through the Grafana UI or through [provisioning](https://grafana.com/docs/grafana/latest/administration/provisioning/#data-sources).
+
+### Add the data source in the UI [promql-grafana-datasource-ui]
+
+1. In Grafana, go to **Connections > Data sources > Add data source**, then choose **Prometheus**.
+2. Set the following:
+    - **Name**: `Elasticsearch`
+    - **Prometheus server URL**: `https://<es_endpoint>/_prometheus`
+    - Under **Custom HTTP Headers**, add a header:
+        - **Header**: `Authorization`
+        - **Value**: `ApiKey <query_api_key>`
+3. Click **Save & test**.
+
+Grafana confirms the connection, and autocompletion starts working in the query editor.
+The data source has more options than the ones above; for the authoritative steps and the full option reference, see the [Grafana Prometheus data source documentation](https://grafana.com/docs/grafana/latest/datasources/prometheus/configure/).
+
+::::{note}
+Grafana sends Prometheus queries with `POST` by default, which {{es}} accepts on authenticated HTTPS endpoints such as {{es-serverless}}.
+If TLS terminates before {{es}} and the node receives plain HTTP, set the data source **HTTP method** to `GET` instead.
+See [Form-encoded POST requests](promql-limitations.md#promql-limitations-form-post).
+::::
+
+### Add the data source with provisioning [promql-grafana-datasource-provisioning]
+
+To provision the data source from a file, create `provisioning/datasources/datasource.yml`, replacing `<es_endpoint>` and `<query_api_key>`:
+
+```yaml
+apiVersion: 1
+
+datasources:
+  - name: Elasticsearch
+    type: prometheus
+    access: proxy
+    url: "https://<es_endpoint>/_prometheus"
+    uid: elasticsearch-prometheus
+    isDefault: true
+    jsonData:
+      httpHeaderName1: Authorization
+    secureJsonData:
+      httpHeaderValue1: "ApiKey <query_api_key>"
+```
+
+Mount the `provisioning` directory into Grafana at `/etc/grafana/provisioning`.
+
+## Use dashboards [promql-grafana-dashboard]
+
+Existing Prometheus dashboards work against {{es}} without changes, as long as the PromQL they use is supported (see [Limitations](promql-limitations.md)).
+You can point an existing dashboard at {{es}} or build a new one on top of the data source.
+
+### Point an existing dashboard at {{es}} [promql-grafana-dashboard-switch]
+
+If a dashboard already runs against another Prometheus-compatible backend, switch its data source to {{es}} using the dashboard's [data source variable](https://grafana.com/docs/grafana/latest/dashboards/variables/add-template-variables/) dropdown (for dashboards that use one) or by editing the panels or the dashboard JSON model (for panels that reference a data source directly).
+
+### Build a new dashboard [promql-grafana-dashboard-new]
+
+1. Go to **Dashboards > New > New dashboard > Add visualization**.
+2. Select the **Elasticsearch** data source.
+3. In the query editor, write a PromQL query (for example, `sum(up)`). Autocompletion and the metric browser are backed by the {{es}} [metadata and discovery endpoints](promql-http-api.md#promql-http-api-metadata).
+4. Choose a visualization, then save the dashboard.
+
+## Troubleshooting [promql-grafana-troubleshooting]
+
+When a panel shows an error, returns no data, or renders something unexpected, the cause is in one of two layers:
+
+- The {{es}} Prometheus API (owned by Elastic).
+- The Grafana **Prometheus** data source, which translates Grafana's requests into Prometheus API calls (owned by Grafana, not Elastic).
+
+### Step 1: Read the panel error [promql-grafana-troubleshooting-read-error]
+
+Grafana shows the data source's error message directly on the panel: hover or click the warning indicator in the panel's top-left corner.
+For most errors {{es}} returns a descriptive message, and you can act on it without reproducing anything:
+
+- A message that a PromQL construct or query parameter is **not supported yet** points to a [documented limitation](promql-limitations.md). Adjust the query, or wait for the feature. No issue needed.
+- An authentication or authorization message (`401`/`403`) points to the API key. See [Common symptoms](#promql-grafana-troubleshooting-symptoms).
+- A `406 Not Acceptable` on every query points to the form-encoded `POST` requirement. See [Common symptoms](#promql-grafana-troubleshooting-symptoms).
+
+If the message is clear and matches a documented limitation, you're done.
+If it is unclear, the panel returns wrong or empty data with no error, or you suspect the data source layer, continue to Step 2.
+
+### Step 2: Inspect the request and response [promql-grafana-troubleshooting-inspect]
+
+If the panel error is unclear, or the panel returns wrong or empty data with no error, open the query inspector (panel menu > **Inspect > Query**) and run the query.
+The inspector shows both the request Grafana sent (endpoint, `query`, `start`, `end`, `step`) and the raw response from {{es}}, which usually points straight at the cause.
+
+To confirm {{es}}'s behavior independently of Grafana, replay the same request directly against the [HTTP API](promql-http-api.md).
+Replace `<es_endpoint>` and `<query_api_key>` with your values:
+
+```bash
+curl "https://<es_endpoint>/_prometheus/api/v1/query_range" \
+  -H "Authorization: ApiKey <query_api_key>" \
+  --data-urlencode 'query=up' \
+  --data-urlencode 'start=2026-06-18T09:00:00Z' \
+  --data-urlencode 'end=2026-06-18T10:00:00Z' \
+  --data-urlencode 'step=15s'
+```
+
+For metric discovery, autocompletion, or template-variable problems, check the relevant [metadata endpoint](promql-http-api.md#promql-http-api-metadata) instead (for example `/_prometheus/api/v1/labels` or `/_prometheus/api/v1/series`).
+
+### Step 3: Decide where the issue belongs [promql-grafana-troubleshooting-decide]
+
+- **{{es}} returns the expected data (in the inspector response or via curl), but the panel does not show it.**
+  The cause is in Grafana, not {{es}}, and is almost always configuration or usage rather than a bug: panel and visualization settings, template variables, the dashboard time range, or transformations.
+  Review the panel and dashboard configuration. For help, use the [Grafana documentation](https://grafana.com/docs/grafana/latest/) and [community forums](https://community.grafana.com/). Only [open a Grafana issue](https://github.com/grafana/grafana/issues) if you can confirm an actual bug in the Prometheus data source.
+- **{{es}} returns an error (`"status": "error"`) or wrong data.**
+  Before assuming an {{es}} problem, rule out a genuinely invalid query, which would fail against upstream Prometheus too.
+  Confirm the expression is valid PromQL, for example with [PromLens](https://demo.promlens.com/).
+  Then check whether the behavior is an expected difference:
+    - The expression might use a [construct that {{es}} does not evaluate yet](promql-limitations.md#promql-limitations-unsupported-constructs), such as set operators or group modifiers. These return a `4xx` with `errorType: bad_data`.
+    - The request might include a [query parameter {{es}} does not support yet](promql-limitations.md#promql-limitations-unsupported-query-params), which also fails with `4xx`.
+    - [Instant queries](promql-limitations.md#promql-limitations-instant-query) and [staleness handling](promql-limitations.md#promql-limitations-staleness) differ from upstream Prometheus.
+
+    If the query is valid and the behavior is not explained by a documented limitation, [open an {{es}} issue](https://github.com/elastic/elasticsearch/issues) with the request and the full response body.
+
+### Common symptoms [promql-grafana-troubleshooting-symptoms]
+
+| Symptom | Likely cause | What to check |
+| --- | --- | --- |
+| `406 Not Acceptable` on every query | Form-encoded `POST` is not accepted by this deployment | Set the data source **HTTP method** to `GET`, or ensure TLS terminates at {{es}}. See [Form-encoded POST requests](promql-limitations.md#promql-limitations-form-post) |
+| `401`/`403` errors | API key missing, invalid, or lacking privileges | Verify the `Authorization: ApiKey <key>` header and that the key grants `read` and `view_index_metadata` on `metrics-*.prometheus-*` |
+| Empty results, no error | No matching data in the time range or index scope | Confirm metrics exist in the queried [index scope](promql-http-api.md#promql-http-api-index-scope) and time window by reproducing the request directly |
+| `bad_data` error on a specific expression | Unsupported PromQL construct | Compare the expression against [unsupported constructs](promql-limitations.md#promql-limitations-unsupported-constructs) |
+
+## Further reading
+
+- [HTTP API](promql-http-api.md): the Prometheus-compatible endpoints Grafana calls.
+- [Limitations](promql-limitations.md): unsupported PromQL constructs and HTTP behavior.
+- [Prometheus remote write](docs-content://manage-data/data-store/data-streams/tsds-ingest-prometheus-remote-write.md): ingest metrics into {{es}}.

--- a/docs/reference/query-languages/promql/promql-grafana.md
+++ b/docs/reference/query-languages/promql/promql-grafana.md
@@ -41,7 +41,10 @@ In **Control security privileges**, use a role descriptor such as:
     "indices": [
       {
         "names": ["metrics-*.prometheus-*"],
-        "privileges": ["read", "view_index_metadata"]
+        "privileges": ["read", "view_index_metadata"],
+        "query": {
+          "terms": { "_tier": ["data_hot", "data_warm"] }
+        }
       }
     ]
   }
@@ -56,6 +59,7 @@ When the key is created, copy the **Encoded** value (select the **Encoded** form
 ::::{tip}
 You can configure a separate Grafana data source per index pattern to give teams scoped access to their own metrics.
 Add an index expression after `/_prometheus/`, for example `https://<es_endpoint>/_prometheus/metrics-prod-*`.
+Index aliases are also supported as the index expression – you need to scope the API key to the alias name rather than the underlying index pattern.
 See [Index scoping](promql-http-api.md#promql-http-api-index-scope).
 ::::
 
@@ -65,7 +69,7 @@ Configure the data source through the Grafana UI or through [provisioning](https
 
 ### Add the data source in the UI [promql-grafana-datasource-ui]
 
-1. In Grafana, go to **Connections > Data sources > Add data source**, then choose **Prometheus**.
+1. In Grafana, go to **Connections → Data sources → Add data source**, then choose **Prometheus**.
 2. Set the following:
     - **Name**: `Elasticsearch`
     - **Prometheus server URL**: `https://<es_endpoint>/_prometheus`
@@ -99,9 +103,16 @@ datasources:
     isDefault: true
     jsonData:
       httpHeaderName1: Authorization
+      # If TLS terminates before Elasticsearch (plain HTTP to the node), uncomment:
+      # httpMethod: GET
     secureJsonData:
       httpHeaderValue1: "ApiKey <query_api_key>"
 ```
+
+::::{note}
+`isDefault: true` overrides the existing default data source for all users in the Grafana instance.
+Set it to `false` if this deployment already has a default data source.
+::::
 
 Mount the `provisioning` directory into Grafana at `/etc/grafana/provisioning`.
 
@@ -116,7 +127,7 @@ If a dashboard already runs against another Prometheus-compatible backend, switc
 
 ### Build a new dashboard [promql-grafana-dashboard-new]
 
-1. Go to **Dashboards > New > New dashboard > Add visualization**.
+1. Go to **Dashboards → New → New dashboard → Add visualization**.
 2. Select the **Elasticsearch** data source.
 3. In the query editor, write a PromQL query (for example, `sum(up)`). Autocompletion and the metric browser are backed by the {{es}} [metadata and discovery endpoints](promql-http-api.md#promql-http-api-metadata).
 4. Choose a visualization, then save the dashboard.
@@ -142,7 +153,7 @@ If it is unclear, the panel returns wrong or empty data with no error, or you su
 
 ### Step 2: Inspect the request and response [promql-grafana-troubleshooting-inspect]
 
-If the panel error is unclear, or the panel returns wrong or empty data with no error, open the query inspector (panel menu > **Inspect > Query**) and run the query.
+If the panel error is unclear, or the panel returns wrong or empty data with no error, open the query inspector (panel menu → **Inspect → Query**) and run the query.
 The inspector shows both the request Grafana sent (endpoint, `query`, `start`, `end`, `step`) and the raw response from {{es}}, which usually points straight at the cause.
 
 To confirm {{es}}'s behavior independently of Grafana, replay the same request directly against the [HTTP API](promql-http-api.md).
@@ -176,12 +187,13 @@ For metric discovery, autocompletion, or template-variable problems, check the r
 
 ### Common symptoms [promql-grafana-troubleshooting-symptoms]
 
-| Symptom | Likely cause | What to check |
-| --- | --- | --- |
-| `406 Not Acceptable` on every query | Form-encoded `POST` is not accepted by this deployment | Set the data source **HTTP method** to `GET`, or ensure TLS terminates at {{es}}. See [Form-encoded POST requests](promql-limitations.md#promql-limitations-form-post) |
-| `401`/`403` errors | API key missing, invalid, or lacking privileges | Verify the `Authorization: ApiKey <key>` header and that the key grants `read` and `view_index_metadata` on `metrics-*.prometheus-*` |
-| Empty results, no error | No matching data in the time range or index scope | Confirm metrics exist in the queried [index scope](promql-http-api.md#promql-http-api-index-scope) and time window by reproducing the request directly |
-| `bad_data` error on a specific expression | Unsupported PromQL construct | Compare the expression against [unsupported constructs](promql-limitations.md#promql-limitations-unsupported-constructs) |
+| Symptom | Likely cause | What to check                                                                                                                                                                                    |
+| --- | --- |--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `406 Not Acceptable` on every query | Form-encoded `POST` is not accepted by this deployment | Upgrade to the latest deployment version; ensure TLS terminates at {{es}}. See [Form-encoded POST requests](promql-limitations.md#promql-limitations-form-post) |
+| `401`/`403` errors | API key missing, invalid, or lacking privileges | Verify the `Authorization: ApiKey <key>` header and that the key grants `read` and `view_index_metadata` on `metrics-*.prometheus-*`                                                             |
+| Empty results, no error | No matching data in the time range or index scope | Confirm metrics exist in the queried [index scope](promql-http-api.md#promql-http-api-index-scope) and time window by reproducing the request directly                                           |
+| `bad_data` error on a specific expression | Unsupported PromQL construct | Compare the expression against [unsupported constructs](promql-limitations.md#promql-limitations-unsupported-constructs)                                                                         |
+| Recurring errors related to exemplar queries | `/api/v1/query_exemplars` is not implemented | In Grafana, go to **Data sources → Elasticsearch → Exemplars** and disable all configured exemplar links                                                                                         |
 
 ## Further reading
 

--- a/docs/reference/query-languages/promql/promql-http-api.md
+++ b/docs/reference/query-languages/promql/promql-http-api.md
@@ -12,6 +12,7 @@ products:
 
 These endpoints run under the `/_prometheus/` prefix.
 They are intended for Prometheus-compatible tooling such as Grafana data sources, autocompletion, variable queries, and similar clients.
+To connect Grafana to {{es}}, see [Use {{es}} as a Prometheus data source in Grafana](promql-grafana.md).
 
 These APIs only consider metric data stored in [time series data streams](docs-content://manage-data/data-store/data-streams/time-series-data-stream-tsds.md) (TSDS).
 
@@ -241,4 +242,5 @@ Server errors (HTTP 5xx) and timeout responses reflect operational failures insi
 - [Prometheus query API](https://prometheus.io/docs/prometheus/latest/querying/api/)
 - [Prometheus remote write](docs-content://manage-data/data-store/data-streams/tsds-ingest-prometheus-remote-write.md)
 - [`PROMQL` command ({{esql}})](/reference/query-languages/esql/commands/promql.md)
+- [Use {{es}} as a Prometheus data source in Grafana](promql-grafana.md)
 - [Limitations](promql-limitations.md)

--- a/docs/reference/query-languages/promql/promql-http-api.md
+++ b/docs/reference/query-languages/promql/promql-http-api.md
@@ -24,6 +24,7 @@ Every path has two forms:
 - Explicit index expression: `/_prometheus/{index}/api/v1/<path>`
 
 The `{index}` segment is an {{es}} index expression (for example, `metrics-generic.prometheus-*`) that restricts which indices are considered in the query.
+Index aliases are also accepted; when using an alias, API key privileges must be granted on the alias name, not the underlying index names.
 This can reduce latency on clusters that contain many large time series data streams when you query a subset of indices.
 
 When you omit `{index}` in the path, qualifying indices are identified through the default index expression `metrics-*`.

--- a/docs/reference/query-languages/promql/promql-limitations.md
+++ b/docs/reference/query-languages/promql/promql-limitations.md
@@ -58,5 +58,4 @@ Metric definition help text is not surfaced yet, so the `help` field remains an 
 
 ## Exemplar queries (HTTP API) [promql-limitations-exemplars]
 
-`/api/v1/query_exemplars` is not implemented yet.
-Turn off exemplar queries in your Prometheus-compatible client for now (for example, the Grafana data source exemplars option) so it does not call that endpoint.
+`/api/v1/query_exemplars` is not implemented yet, so exemplar queries are not supported.

--- a/docs/reference/query-languages/promql/promql-limitations.md
+++ b/docs/reference/query-languages/promql/promql-limitations.md
@@ -59,3 +59,5 @@ Metric definition help text is not surfaced yet, so the `help` field remains an 
 ## Exemplar queries (HTTP API) [promql-limitations-exemplars]
 
 `/api/v1/query_exemplars` is not implemented yet, so exemplar queries are not supported.
+To avoid errors, turn off exemplar queries in your Prometheus-compatible client.
+In Grafana, go to **Data sources → Elasticsearch → Exemplars** and disable all configured exemplar links.

--- a/docs/reference/query-languages/toc.yml
+++ b/docs/reference/query-languages/toc.yml
@@ -434,6 +434,7 @@ toc:
           - file: promql/functions/math.md
           - file: promql/functions/date-time.md
           - file: promql/functions/conversion.md
+      - file: promql/promql-grafana.md
       - file: promql/promql-limitations.md
   - file: sql.md
     children:


### PR DESCRIPTION
## Summary

Adds a reference page documenting how to use {{es}} as a Prometheus data source in Grafana, since the `/_prometheus/` HTTP API is Prometheus-compatible and Grafana can point its built-in Prometheus data source straight at {{es}}.

The new page (`docs/reference/query-languages/promql/promql-grafana.md`) covers:

- **Prerequisites**: the {{es}} endpoint and an API key scoped to `metrics-*.prometheus-*` (read + `view_index_metadata`), which limits the key to metrics ingested via Prometheus remote write — the focus of this guide.
- **Adding the data source** through the Grafana UI and via provisioning, including the `Authorization: ApiKey <encoded>` custom header and the form-encoded `POST`/`GET` note.
- **Using dashboards**: re-pointing an existing dashboard at {{es}} and building a new one.
- **Troubleshooting**: a layered approach (Elasticsearch API vs. Grafana data source) to help users self-diagnose and know where to seek help, plus a common-symptoms table.

Also cross-links the new page from the PromQL overview and the HTTP API reference, and removes a stale exemplars instruction in the limitations page that referenced a non-existent Grafana option.