### PR TITLE
Backport #142335 to 8.19: Pass through includeSourceInError

### DIFF
--- a/docs/changelog/142335.yaml
+++ b/docs/changelog/142335.yaml
@@ -1,0 +1,5 @@
+area: Infra/Core
+issues: []
+pr: 142335
+summary: Pass through `includeSourceInError`
+type: bug

--- a/server/src/internalClusterTest/java/org/elasticsearch/rest/action/document/RestBulkActionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/rest/action/document/RestBulkActionIT.java
@@ -73,4 +73,33 @@ public class RestBulkActionIT extends ESIntegTestCase {
             )
         );
     }
+
+    public void testBulkIndexWithSourceOnErrorDisabledWithPipeline() throws Exception {
+        var source = "{\"field\": NaN}";
+        var sourceEscaped = "{\\\"field\\\": NaN}";
+        var pipeline = randomAlphaOfLength(12);
+
+        var putPipelineRequest = new Request("PUT", "/_ingest/pipeline/" + pipeline);
+        putPipelineRequest.setJsonEntity("{\"processors\":[]}");
+        getRestClient().performRequest(putPipelineRequest);
+
+        var request = new Request("PUT", "/test_index/_bulk");
+        request.addParameter("pipeline", pipeline);
+        request.setJsonEntity(Strings.format("{\"index\":{\"_id\":\"1\"}}\n%s\n", source));
+
+        Response response = getRestClient().performRequest(request);
+        String responseContent = Streams.copyToString(new InputStreamReader(response.getEntity().getContent(), UTF_8));
+        assertThat(responseContent, containsString(sourceEscaped));
+
+        request.addParameter(RestUtils.INCLUDE_SOURCE_ON_ERROR_PARAMETER, "false");
+
+        response = getRestClient().performRequest(request);
+        responseContent = Streams.copyToString(new InputStreamReader(response.getEntity().getContent(), UTF_8));
+        assertThat(
+            responseContent,
+            both(not(containsString(sourceEscaped))).and(
+                containsString("REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled)")
+            )
+        );
+    }
 }

--- a/server/src/main/java/org/elasticsearch/action/index/IndexRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/index/IndexRequest.java
@@ -423,7 +423,8 @@ public class IndexRequest extends ReplicatedWriteRequest<IndexRequest> implement
     }
 
     public Map<String, Object> sourceAsMap(XContentParserDecorator parserDecorator) {
-        return XContentHelper.convertToMap(source, false, contentType, parserDecorator).v2();
+        var parserConfiguration = XContentParserConfiguration.EMPTY.withIncludeSourceOnError(includeSourceOnError);
+        return XContentHelper.parseToType(XContentParser::map, source, contentType, parserConfiguration, parserDecorator).v2();
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/index/IndexRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/index/IndexRequest.java
@@ -42,6 +42,8 @@ import org.elasticsearch.ingest.IngestService;
 import org.elasticsearch.plugins.internal.XContentParserDecorator;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
@@ -416,7 +418,8 @@ public class IndexRequest extends ReplicatedWriteRequest<IndexRequest> implement
     }
 
     public Map<String, Object> sourceAsMap() {
-        return XContentHelper.convertToMap(source, false, contentType).v2();
+        var parserConfiguration = XContentParserConfiguration.EMPTY.withIncludeSourceOnError(includeSourceOnError);
+        return XContentHelper.parseToType(XContentParser::map, source, contentType, parserConfiguration).v2();
     }
 
     public Map<String, Object> sourceAsMap(XContentParserDecorator parserDecorator) {


### PR DESCRIPTION
Backport of #142335 to branch 8.19.

Resolved conflicts:
- `RestBulkActionIT.java`: added only the new `testBulkIndexWithSourceOnErrorDisabledWithPipeline` test; omitted main-only Slice tests.
- `IndexRequest.java`: 8.19 has no `IndexSource` class, so implemented `includeSourceOnError` passthrough directly using `XContentParserConfiguration.withIncludeSourceOnError` + `XContentHelper.parseToType`.
- `ShardBulkInferenceActionFilter.java`: kept HEAD (calls `indexRequest.sourceAsMap()`, which now passes through `includeSourceOnError` internally).
- `IndexSource.java`: kept deleted (does not exist in 8.19).