### PR TITLE
[8.19] [ML] Fix test InferenceIT#testInferClassificationModel (#144919)

### DIFF
--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/InferenceIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/InferenceIT.java
@@ -49,6 +49,7 @@ public class InferenceIT extends ESRestTestCase {
     @After
     public void cleanUpData() throws Exception {
         new MlRestTestStateCleaner(logger, adminClient()).resetFeatures();
+        waitForPendingTasks(adminClient());
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[ML] Fix test InferenceIT#testInferClassificationModel (#144919)](https://github.com/elastic/elasticsearch/pull/144919)

<!--- Backport version: 12.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)