### PR TITLE
[8.19] [ML] Fix flaky BWC rolling-upgrade ML DFA tests: increase stop_data_frame_analytics timeout (#144926)

### DIFF
--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/90_ml_data_frame_analytics_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/90_ml_data_frame_analytics_crud.yml
@@ -57,7 +57,7 @@ setup:
       ml.stop_data_frame_analytics:
         id: "old_cluster_outlier_detection_job"
         force: true
-        timeout: "60s"
+        timeout: "3m"
   - match: { stopped: true }
 
   - do:
@@ -104,7 +104,7 @@ setup:
       ml.stop_data_frame_analytics:
         id: "old_cluster_regression_job"
         force: true
-        timeout: "60s"
+        timeout: "3m"
   - match: { stopped: true }
 
   - do:
@@ -182,7 +182,7 @@ setup:
       ml.stop_data_frame_analytics:
         id: "mixed_cluster_outlier_detection_job"
         force: true
-        timeout: "60s"
+        timeout: "3m"
   - match: { stopped: true }
 
   - do:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[ML] Fix flaky BWC rolling-upgrade ML DFA tests: increase stop_data_frame_analytics timeout (#144926)](https://github.com/elastic/elasticsearch/pull/144926)

<!--- Backport version: 12.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)