### PR TITLE
[8.19] [TEST] Drain cluster state after ML feature reset before waitForPendingTasks in x-pack REST tests #147237

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -1052,7 +1052,7 @@ public abstract class ESRestTestCase extends ESTestCase {
         deleteAllNodeShutdownMetadata();
     }
 
-    private void waitForClusterUpdates() throws Exception {
+    public void waitForClusterUpdates() throws Exception {
         logger.info("Waiting for all cluster updates up to this moment to be processed");
 
         try {

--- a/wiki/sessions/2026-06-18-0b11f42a.md
+++ b/wiki/sessions/2026-06-18-0b11f42a.md
@@ -1,0 +1,4 @@
+# Session Journal 2026-06-18
+
+**Session:** `0b11f42a-f738-4f4d-a97a-ff8bf78c90c0`
+

--- a/wiki/sessions/2026-06-18-0b11f42a.md
+++ b/wiki/sessions/2026-06-18-0b11f42a.md
@@ -1,4 +1,0 @@
-# Session Journal 2026-06-18
-
-**Session:** `0b11f42a-f738-4f4d-a97a-ff8bf78c90c0`
-

--- a/x-pack/plugin/src/test/java/org/elasticsearch/xpack/test/rest/AbstractXPackRestTest.java
+++ b/x-pack/plugin/src/test/java/org/elasticsearch/xpack/test/rest/AbstractXPackRestTest.java
@@ -136,6 +136,10 @@ public abstract class AbstractXPackRestTest extends ESClientYamlSuiteTestCase {
     private void clearMlState() throws Exception {
         if (isMachineLearningTest()) {
             new MlRestTestStateCleaner(logger, adminClient()).resetFeatures();
+            // _features/_reset can enqueue async cluster-state updates (e.g. inference
+            // endpoint cache invalidation via ClearInferenceEndpointCacheAction). Drain
+            // them here so the subsequent waitForPendingTasks does not race with them.
+            waitForClusterUpdates();
         }
     }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[TEST] Drain cluster state after ML feature reset before waitForPendingTasks in x-pack REST tests #147237](https://github.com/elastic/elasticsearch/pull/147237)

<!--- Backport version: 12.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)