### PR TITLE
Refactor doGenerateSeqNoForOperation

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -1199,7 +1199,7 @@ public class InternalEngine extends Engine {
     protected long generateSeqNoForOperationOnPrimary(final Operation operation) {
         assert operation.origin() == Operation.Origin.PRIMARY;
         assert operation.seqNo() == UNASSIGNED_SEQ_NO : "ops should not have an assigned seq no. but was: " + operation.seqNo();
-        return doGenerateSeqNoForOperation(operation);
+        return doGenerateSeqNo();
     }
 
     protected void advanceMaxSeqNoOfUpdatesOnPrimary(long seqNo) {
@@ -1211,12 +1211,11 @@ public class InternalEngine extends Engine {
     }
 
     /**
-     * Generate the sequence number for the specified operation.
+     * Generate a sequence number.
      *
-     * @param operation the operation
      * @return the sequence number
      */
-    long doGenerateSeqNoForOperation(final Operation operation) {
+    long doGenerateSeqNo() {
         return localCheckpointTracker.generateSeqNo();
     }
 

--- a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -5342,7 +5342,7 @@ public class InternalEngineTests extends EngineTestCase {
                 .build();
             noOpEngine = new InternalEngine(noopEngineConfig, IndexWriter.MAX_DOCS, supplier) {
                 @Override
-                protected long doGenerateSeqNoForOperation(Operation operation) {
+                protected long doGenerateSeqNo() {
                     throw new UnsupportedOperationException();
                 }
             };

--- a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -181,7 +181,7 @@ import java.util.function.Function;
 import java.util.function.IntSupplier;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
-import java.util.function.ToLongBiFunction;
+import java.util.function.ToLongFunction;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 
@@ -772,7 +772,7 @@ public class InternalEngineTests extends EngineTestCase {
                 store,
                 createTempDir(),
                 LocalCheckpointTracker::new,
-                (engine, operation) -> seqNos.get(counter.getAndIncrement())
+                (engine) -> seqNos.get(counter.getAndIncrement())
             );
             for (int i = 0; i < docs; i++) {
                 final String id = Integer.toString(i);
@@ -5075,13 +5075,13 @@ public class InternalEngineTests extends EngineTestCase {
      *                                number
      * @return a sequence number generator
      */
-    private ToLongBiFunction<Engine, Engine.Operation> getStallingSeqNoGenerator(
+    private ToLongFunction<Engine> getStallingSeqNoGenerator(
         final AtomicReference<CountDownLatch> latchReference,
         final CyclicBarrier barrier,
         final AtomicBoolean stall,
         final AtomicLong expectedLocalCheckpoint
     ) {
-        return (engine, operation) -> {
+        return (engine) -> {
             final long seqNo = generateNewSeqNo(engine);
             final CountDownLatch latch = latchReference.get();
             if (stall.get()) {
@@ -5816,7 +5816,7 @@ public class InternalEngineTests extends EngineTestCase {
                 null,
                 localCheckpointTrackerSupplier,
                 null,
-                (engine, operation) -> seqNoGenerator.getAndIncrement()
+                (engine) -> seqNoGenerator.getAndIncrement()
             )
         ) {
             final String id = "id";

--- a/server/src/test/java/org/elasticsearch/index/replication/IndexLevelReplicationTests.java
+++ b/server/src/test/java/org/elasticsearch/index/replication/IndexLevelReplicationTests.java
@@ -445,7 +445,7 @@ public class IndexLevelReplicationTests extends ESIndexLevelReplicationTestCase 
                 assertThat(col, hasSize(1));
                 return addDocument(col.iterator().next());
             }
-        }, null, null, config);
+        }, config);
         try (ReplicationGroup shards = new ReplicationGroup(buildIndexMetadata(0)) {
             @Override
             protected EngineFactory getEngineFactory(ShardRouting routing) {

--- a/server/src/test/java/org/elasticsearch/index/replication/RecoveryDuringReplicationTests.java
+++ b/server/src/test/java/org/elasticsearch/index/replication/RecoveryDuringReplicationTests.java
@@ -907,7 +907,7 @@ public class RecoveryDuringReplicationTests extends ESIndexLevelReplicationTestC
                     assertThat(col, hasSize(1));
                     return addDocument(col.iterator().next());
                 }
-            }, null, null, config);
+            }, config);
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/indices/recovery/RecoveryTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/RecoveryTests.java
@@ -436,7 +436,7 @@ public class RecoveryTests extends ESIndexLevelReplicationTestCase {
                             assertThat(col, hasSize(1));
                             return addDocument(col.iterator().next());
                         }
-                    }, null, null, config);
+                    }, config);
                 }
             }
         }) {

--- a/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
@@ -144,7 +144,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
-import java.util.function.ToLongBiFunction;
+import java.util.function.ToLongFunction;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.index.engine.Engine.Operation.Origin.PEER_RECOVERY;
@@ -502,7 +502,7 @@ public abstract class EngineTestCase extends ESTestCase {
         Store store,
         Path translogPath,
         BiFunction<Long, Long, LocalCheckpointTracker> localCheckpointTrackerSupplier,
-        ToLongBiFunction<Engine, Engine.Operation> seqNoForOperation
+        ToLongFunction<Engine> seqNoForOperation
     ) throws IOException {
         return createEngine(
             defaultSettings,
@@ -562,7 +562,7 @@ public abstract class EngineTestCase extends ESTestCase {
         @Nullable IndexWriterFactory indexWriterFactory,
         @Nullable BiFunction<Long, Long, LocalCheckpointTracker> localCheckpointTrackerSupplier,
         @Nullable LongSupplier globalCheckpointSupplier,
-        @Nullable ToLongBiFunction<Engine, Engine.Operation> seqNoForOperation
+        @Nullable ToLongFunction<Engine> seqNoForOperation
     ) throws IOException {
         return createEngine(
             indexSettings,
@@ -584,7 +584,7 @@ public abstract class EngineTestCase extends ESTestCase {
         MergePolicy mergePolicy,
         @Nullable IndexWriterFactory indexWriterFactory,
         @Nullable BiFunction<Long, Long, LocalCheckpointTracker> localCheckpointTrackerSupplier,
-        @Nullable ToLongBiFunction<Engine, Engine.Operation> seqNoForOperation,
+        @Nullable ToLongFunction<Engine> seqNoForOperation,
         @Nullable Sort indexSort,
         @Nullable LongSupplier globalCheckpointSupplier
     ) throws IOException {
@@ -609,7 +609,7 @@ public abstract class EngineTestCase extends ESTestCase {
     private InternalEngine createEngine(
         @Nullable IndexWriterFactory indexWriterFactory,
         @Nullable BiFunction<Long, Long, LocalCheckpointTracker> localCheckpointTrackerSupplier,
-        @Nullable ToLongBiFunction<Engine, Engine.Operation> seqNoForOperation,
+        @Nullable ToLongFunction<Engine> seqNoForOperation,
         EngineConfig config
     ) throws IOException {
         final Store store = config.getStore();
@@ -659,7 +659,7 @@ public abstract class EngineTestCase extends ESTestCase {
     private static InternalEngine createInternalEngine(
         @Nullable final IndexWriterFactory indexWriterFactory,
         @Nullable final BiFunction<Long, Long, LocalCheckpointTracker> localCheckpointTrackerSupplier,
-        @Nullable final ToLongBiFunction<Engine, Engine.Operation> seqNoForOperation,
+        @Nullable final ToLongFunction<Engine> seqNoForOperation,
         final EngineConfig config
     ) {
         if (localCheckpointTrackerSupplier == null) {
@@ -673,7 +673,7 @@ public abstract class EngineTestCase extends ESTestCase {
 
                 @Override
                 protected long doGenerateSeqNo() {
-                    return seqNoForOperation != null ? seqNoForOperation.applyAsLong(this, null) : super.doGenerateSeqNo();
+                    return seqNoForOperation != null ? seqNoForOperation.applyAsLong(this) : super.doGenerateSeqNo();
                 }
             };
         } else {
@@ -687,7 +687,7 @@ public abstract class EngineTestCase extends ESTestCase {
 
                 @Override
                 protected long doGenerateSeqNo() {
-                    return seqNoForOperation != null ? seqNoForOperation.applyAsLong(this, null) : super.doGenerateSeqNo();
+                    return seqNoForOperation != null ? seqNoForOperation.applyAsLong(this) : super.doGenerateSeqNo();
                 }
             };
         }

--- a/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
@@ -692,7 +692,6 @@ public abstract class EngineTestCase extends ESTestCase {
                 }
             };
         }
-
     }
 
     public EngineConfig config(IndexSettings indexSettings, Store store, Path translogPath, MergePolicy mergePolicy) {

--- a/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
@@ -652,10 +652,7 @@ public abstract class EngineTestCase extends ESTestCase {
         return internalEngine.getLocalCheckpointTracker().generateSeqNo();
     }
 
-    public static InternalEngine createInternalEngine(
-        @Nullable final IndexWriterFactory indexWriterFactory,
-        final EngineConfig config
-    ) {
+    public static InternalEngine createInternalEngine(@Nullable final IndexWriterFactory indexWriterFactory, final EngineConfig config) {
         return createInternalEngine(indexWriterFactory, null, null, config);
     }
 
@@ -675,10 +672,8 @@ public abstract class EngineTestCase extends ESTestCase {
                 }
 
                 @Override
-                protected long doGenerateSeqNoForOperation(final Operation operation) {
-                    return seqNoForOperation != null
-                        ? seqNoForOperation.applyAsLong(this, operation)
-                        : super.doGenerateSeqNoForOperation(operation);
+                protected long doGenerateSeqNo() {
+                    return seqNoForOperation != null ? seqNoForOperation.applyAsLong(this, null) : super.doGenerateSeqNo();
                 }
             };
         } else {
@@ -691,10 +686,8 @@ public abstract class EngineTestCase extends ESTestCase {
                 }
 
                 @Override
-                protected long doGenerateSeqNoForOperation(final Operation operation) {
-                    return seqNoForOperation != null
-                        ? seqNoForOperation.applyAsLong(this, operation)
-                        : super.doGenerateSeqNoForOperation(operation);
+                protected long doGenerateSeqNo() {
+                    return seqNoForOperation != null ? seqNoForOperation.applyAsLong(this, null) : super.doGenerateSeqNo();
                 }
             };
         }

--- a/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
@@ -607,7 +607,7 @@ public abstract class EngineTestCase extends ESTestCase {
         return createEngine(null, null, null, config);
     }
 
-    protected InternalEngine createEngine(
+    private InternalEngine createEngine(
         @Nullable IndexWriterFactory indexWriterFactory,
         @Nullable BiFunction<Long, Long, LocalCheckpointTracker> localCheckpointTrackerSupplier,
         @Nullable ToLongBiFunction<Engine, Engine.Operation> seqNoForOperation,
@@ -654,6 +654,13 @@ public abstract class EngineTestCase extends ESTestCase {
     }
 
     public static InternalEngine createInternalEngine(
+        @Nullable final IndexWriterFactory indexWriterFactory,
+        final EngineConfig config
+    ) {
+        return createInternalEngine(indexWriterFactory, null, null, config);
+    }
+
+    private static InternalEngine createInternalEngine(
         @Nullable final IndexWriterFactory indexWriterFactory,
         @Nullable final BiFunction<Long, Long, LocalCheckpointTracker> localCheckpointTrackerSupplier,
         @Nullable final ToLongBiFunction<Engine, Engine.Operation> seqNoForOperation,

--- a/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
@@ -152,7 +152,6 @@ import static org.elasticsearch.index.engine.Engine.Operation.Origin.PRIMARY;
 import static org.elasticsearch.index.engine.Engine.Operation.Origin.REPLICA;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.notNullValue;
 


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/150409, in that this refactoring will make it easier to implement the test changes that we want there in a clean manner.

Rather than `long doGenerateSeqNoForOperation(final Operation operation) ...` this refactoring gives us `long doGenerateSeqNo()`. Which is to say, drop the `operation` argument and rename the method since it's no longer 'for (an) operation'.

That's the core of the change, and then everything else is acknowledging that change throughout the rest of the code (almost entirely tests, fwiw).
