### PR TITLE
ESQL:DS: Migrate tests from EXTERNAL to FROM

### DIFF
--- a/x-pack/plugin/esql-datasource-csv/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/csv/CsvFormatSpecIT.java
+++ b/x-pack/plugin/esql-datasource-csv/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/csv/CsvFormatSpecIT.java
@@ -18,6 +18,7 @@ import org.elasticsearch.xpack.esql.qa.rest.AbstractExternalSourceSpecTestCase;
 import org.junit.ClassRule;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * Parameterized integration tests for standalone CSV files.
@@ -44,6 +45,14 @@ public class CsvFormatSpecIT extends AbstractExternalSourceSpecTestCase {
     @Override
     protected String getTestRestCluster() {
         return cluster.getHttpAddresses();
+    }
+
+    // Pilot the FROM <dataset> path on S3 only: the cluster's anonymous-capable S3 fixture (auth=none)
+    // backs a dataset without needing a cluster encryption key. Migrated csv-spec tests therefore run via
+    // FROM on S3 and via the rebuilt EXTERNAL query on HTTP/GCS/AZURE/LOCAL, so none are skipped.
+    @Override
+    protected Set<StorageBackend> datasetModeBackends() {
+        return Set.of(StorageBackend.S3);
     }
 
     // CSV reads only the csv-*.csv-spec files. The shared external-*.csv-spec files read the

--- a/x-pack/plugin/esql-datasource-csv/qa/src/javaRestTest/resources/csv-basic.csv-spec
+++ b/x-pack/plugin/esql-datasource-csv/qa/src/javaRestTest/resources/csv-basic.csv-spec
@@ -4,11 +4,17 @@
 // so for CSV/TSV (default none) we read the scalar twin instead. The scalar columns are identical to
 // employees, so these assertions match. Multi-value behavior is covered by csv-multivalue.csv-spec /
 // tsv-multivalue.csv-spec.
+//
+// Authored as FROM <dataset>: each test declares its source via a `dataset:` directive. On
+// dataset-capable backends (S3) the harness registers the dataset and runs the FROM query verbatim;
+// on the others it rebuilds the equivalent EXTERNAL query. employees_no_mv has no index equivalent,
+// so the dataset keeps the bare file name (no _ds suffix needed).
 
 readAllEmployeesScalar
 required_capability: external_command
+dataset: employees_no_mv: "{{employees_no_mv}}"
 
-EXTERNAL "{{employees_no_mv}}"
+FROM employees_no_mv
 | KEEP emp_no, first_name, last_name, birth_date, gender, hire_date, languages, height, salary, still_hired
 | SORT emp_no
 | LIMIT 5;
@@ -23,8 +29,9 @@ emp_no:integer | first_name:keyword | last_name:keyword | birth_date:date       
 
 filterByEmployeeNumberScalar
 required_capability: external_command
+dataset: employees_no_mv: "{{employees_no_mv}}"
 
-EXTERNAL "{{employees_no_mv}}"
+FROM employees_no_mv
 | WHERE emp_no == 10001
 | KEEP emp_no, first_name, last_name;
 
@@ -34,8 +41,9 @@ emp_no:integer | first_name:keyword | last_name:keyword
 
 aggregateCountScalar
 required_capability: external_command
+dataset: employees_no_mv: "{{employees_no_mv}}"
 
-EXTERNAL "{{employees_no_mv}}"
+FROM employees_no_mv
 | STATS count = COUNT(*);
 
 count:long
@@ -44,8 +52,9 @@ count:long
 
 aggregateByGenderScalar
 required_capability: external_command
+dataset: employees_no_mv: "{{employees_no_mv}}"
 
-EXTERNAL "{{employees_no_mv}}"
+FROM employees_no_mv
 | STATS count = COUNT(*) BY gender
 | SORT gender;
 
@@ -57,8 +66,9 @@ count:long | gender:keyword
 
 topNSortBySalaryDescScalar
 required_capability: external_command
+dataset: employees_no_mv: "{{employees_no_mv}}"
 
-EXTERNAL "{{employees_no_mv}}"
+FROM employees_no_mv
 | KEEP emp_no, first_name, salary
 | SORT salary DESC
 | LIMIT 3;

--- a/x-pack/plugin/esql-datasource-csv/qa/src/javaRestTest/resources/csv-headerless.csv-spec
+++ b/x-pack/plugin/esql-datasource-csv/qa/src/javaRestTest/resources/csv-headerless.csv-spec
@@ -6,13 +6,19 @@
 //   col1 = emp_no column     (row 0 cell = "emp_no:integer", row 1 cell = "10001", ...)
 // The schema widens to KEYWORD because col1 mixes the literal string "emp_no:integer" with
 // integer-looking values like "10001".
+//
+// Authored as FROM <dataset>: the per-query CSV options that used to live in EXTERNAL ... WITH {...}
+// now live in a `dataset:` directive. On S3 the harness registers the dataset and runs FROM verbatim;
+// on the other backends it rebuilds the equivalent EXTERNAL query. Dataset names are distinct per
+// option set so each query's settings are unambiguous.
 
 headerRowFalse
 required_capability: external_command
 required_capability: external_csv_header_row_option
 required_capability: datasource_file_readers_no_text_type
+dataset: employees_headerless: "{{employees}}" WITH {"header_row": false, "multi_value_syntax": "brackets"}
 
-EXTERNAL "{{employees}}" WITH {"header_row": false, "multi_value_syntax": "brackets"}
+FROM employees_headerless
 | KEEP col1
 | LIMIT 2
 ;
@@ -26,8 +32,9 @@ headerRowFalseWithCustomPrefix
 required_capability: external_command
 required_capability: external_csv_header_row_option
 required_capability: datasource_file_readers_no_text_type
+dataset: employees_headerless_prefixed: "{{employees}}" WITH {"header_row": false, "column_prefix": "f", "multi_value_syntax": "brackets"}
 
-EXTERNAL "{{employees}}" WITH {"header_row": false, "column_prefix": "f", "multi_value_syntax": "brackets"}
+FROM employees_headerless_prefixed
 | KEEP f1
 | LIMIT 2
 ;
@@ -52,8 +59,9 @@ required_capability: external_command
 required_capability: external_csv_header_row_option
 required_capability: external_source_read_schema
 required_capability: datasource_file_readers_no_text_type
+dataset: employees_multifile_headerless: "{{employees_multifile}}" WITH {"header_row": false, "schema_resolution": "first_file_wins"}
 
-EXTERNAL "{{employees_multifile}}" WITH {"header_row": false, "schema_resolution": "first_file_wins"}
+FROM employees_multifile_headerless
 | SORT col0 ASC
 | LIMIT 10
 ;

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/datasources/AbstractFromDatasetSubqueryRestTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/datasources/AbstractFromDatasetSubqueryRestTestCase.java
@@ -11,7 +11,6 @@ import org.elasticsearch.Build;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
-import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -34,8 +33,9 @@ import static org.hamcrest.Matchers.equalTo;
  * <ul>
  *   <li>The {@link #requireSnapshotBuild()} {@code @BeforeClass} gate matching
  *       {@code DataSourceCrudRestIT} (datasets are snapshot-only today).</li>
- *   <li>Static REST helpers for {@code PUT /_query/data_source/...}, {@code PUT /_query/dataset/...},
- *       {@code POST /_query}, and idempotent dataset/data-source cleanup.</li>
+ *   <li>Static REST helpers for {@code PUT /_query/data_source/...}, {@code PUT /_query/dataset/...}
+ *       (delegating to {@link DatasetRegistry}), {@code POST /_query}, and tolerant dataset/data-source
+ *       cleanup.</li>
  *   <li>A canonical row asserter for the {@code {emp_no, first_name}} projection every concrete
  *       suite uses.</li>
  * </ul>
@@ -60,39 +60,21 @@ public abstract class AbstractFromDatasetSubqueryRestTestCase extends ESRestTest
     /**
      * {@code PUT /_query/data_source/<name>} with {@code type} and (optional) {@code settings}.
      * Used by every backend wrapper to register an {@code s3}/{@code gcs}/{@code azure} data source
-     * pointing at the in-process fixture.
+     * pointing at the in-process fixture. Delegates to {@link DatasetRegistry} so the request-building
+     * lives in one place; this base manages its own lifecycle, so the uncached verb is used.
      */
     protected static void putDataSource(String name, String type, Map<String, Object> settings) throws IOException {
-        Request req = new Request("PUT", "/_query/data_source/" + name);
-        try (XContentBuilder b = jsonBuilder()) {
-            b.startObject().field("type", type);
-            if (settings.isEmpty() == false) {
-                b.field("settings", settings);
-            }
-            b.endObject();
-            req.setJsonEntity(Strings.toString(b));
-        }
-        Response r = client().performRequest(req);
-        assertThat(r.getStatusLine().getStatusCode(), equalTo(200));
+        DatasetRegistry.putDataSource(client(), name, type, settings);
     }
 
     /**
      * {@code PUT /_query/dataset/<name>} bound to the supplied {@code data_source} + {@code resource}
      * URI. {@code settings} may carry {@code format} or any format-specific keys the validator
-     * accepts (e.g. {@code optimized_reader} for parquet, {@code delimiter} for csv).
+     * accepts (e.g. {@code optimized_reader} for parquet, {@code delimiter} for csv). Delegates to
+     * {@link DatasetRegistry}.
      */
     protected static void putDataset(String name, String dataSource, String resource, Map<String, Object> settings) throws IOException {
-        Request req = new Request("PUT", "/_query/dataset/" + name);
-        try (XContentBuilder b = jsonBuilder()) {
-            b.startObject().field("data_source", dataSource).field("resource", resource);
-            if (settings.isEmpty() == false) {
-                b.field("settings", settings);
-            }
-            b.endObject();
-            req.setJsonEntity(Strings.toString(b));
-        }
-        Response r = client().performRequest(req);
-        assertThat(r.getStatusLine().getStatusCode(), equalTo(200));
+        DatasetRegistry.putDataset(client(), name, dataSource, resource, settings);
     }
 
     /** The benign warning ES|QL emits when a query omits an explicit {@code LIMIT}. */
@@ -124,16 +106,10 @@ public abstract class AbstractFromDatasetSubqueryRestTestCase extends ESRestTest
     /**
      * {@code DELETE <path>} that swallows 404s so {@code @AfterClass} sweeps don't fail when a
      * registration step was skipped (e.g. the test method short-circuited before the dataset was
-     * created).
+     * created). Delegates to {@link DatasetRegistry#deleteIgnoringMissing}.
      */
     protected static void deleteIgnoringMissing(String path) throws IOException {
-        try {
-            client().performRequest(new Request("DELETE", path));
-        } catch (ResponseException e) {
-            if (e.getResponse().getStatusLine().getStatusCode() != 404) {
-                throw e;
-            }
-        }
+        DatasetRegistry.deleteIgnoringMissing(client(), path);
     }
 
     /**

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/datasources/DatasetRegistry.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/datasources/DatasetRegistry.java
@@ -6,20 +6,22 @@
  */
 package org.elasticsearch.xpack.esql.datasources;
 
+import org.apache.http.util.EntityUtils;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentParserConfiguration;
+import org.elasticsearch.xcontent.json.JsonXContent;
 
 import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
 
 /**
  * Class-scoped, idempotent registry of {@code data_source}/{@code dataset} pairs for the
@@ -36,7 +38,11 @@ import static org.hamcrest.Matchers.equalTo;
  * an {@code @AfterClass} hook to drop everything this registry created and clear the caches.
  *
  * <p>The registry is deliberately static: each spec IT runs in its own Gradle JVM fork, and
- * {@link #cleanup(RestClient)} clears the caches, so sequential suites in one JVM stay isolated.
+ * {@link #cleanup(RestClient)} clears the caches, so sequential suites in one JVM stay isolated. When a
+ * suite cannot run {@link #cleanup(RestClient)} (a broken cluster, or a failure before the
+ * {@code @AfterClass} hook), it must still call {@link #clearCaches()} so a later suite in the same fork
+ * starts from an empty cache rather than skipping a needed PUT against a cluster that no longer holds the
+ * custom.
  *
  * <p>The survival invariant above is the load-bearing assumption behind the cache, so
  * {@link #cleanup(RestClient)} fails loudly if a custom this registry recorded as successfully
@@ -71,22 +77,30 @@ public final class DatasetRegistry {
 
     /**
      * Ensures a {@code dataset} named {@code name} bound to {@code dataSource} + {@code resource} with the
-     * given format {@code settings} exists, issuing {@code PUT /_query/dataset/<name>} only when the
-     * content signature differs from the cached one. The owning {@code data_source} must already exist
-     * (register it first via {@link #ensureDataSource}); the CRUD layer rejects a dataset whose parent is
-     * missing.
+     * format options in the {@code withJson} object (the {@code WITH {...}} JSON, or {@code null} for
+     * none) exists, issuing {@code PUT /_query/dataset/<name>} only when the content signature differs
+     * from the cached one. The owning {@code data_source} must already exist (register it first via
+     * {@link #ensureDataSource}); the CRUD layer rejects a dataset whose parent is missing.
+     * <p>
+     * The signature is keyed off the raw {@code withJson} so the JSON is parsed only on a cache miss, not
+     * on every spec invocation.
      */
-    public static synchronized void ensureDataset(
-        RestClient client,
-        String name,
-        String dataSource,
-        String resource,
-        Map<String, Object> settings
-    ) throws IOException {
-        String signature = dataSource + "|" + resource + "|" + settings;
+    public static synchronized void ensureDataset(RestClient client, String name, String dataSource, String resource, String withJson)
+        throws IOException {
+        String signature = dataSource + "|" + resource + "|" + withJson;
         if (signature.equals(datasets.get(name)) == false) {
-            putDataset(client, name, dataSource, resource, settings);
+            putDataset(client, name, dataSource, resource, parseSettings(withJson));
             datasets.put(name, signature);
+        }
+    }
+
+    /** Parses a {@code dataset:} directive's {@code WITH {...}} JSON into a settings map ({@code null} maps to empty). */
+    private static Map<String, Object> parseSettings(String withJson) throws IOException {
+        if (withJson == null) {
+            return Map.of();
+        }
+        try (XContentParser parser = JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, withJson)) {
+            return parser.map();
         }
     }
 
@@ -146,6 +160,17 @@ public final class DatasetRegistry {
     }
 
     /**
+     * Clears the static caches without issuing any REST calls. Call this from an {@code @AfterClass}
+     * {@code finally} so a suite that could not run {@link #cleanup(RestClient)} (broken cluster, or a
+     * failure that aborted cleanup) does not leave stale entries that would make a later suite in the same
+     * JVM fork skip a needed PUT.
+     */
+    public static synchronized void clearCaches() {
+        datasets.clear();
+        dataSources.clear();
+    }
+
+    /**
      * {@code DELETE <path>} that swallows 404s, for ad-hoc sweeps of resources whose existence is not
      * tracked by this registry (e.g. test indices, or datasets a test may or may not have created). The
      * registry's own {@link #cleanup} deliberately does <em>not</em> use this — it expects its tracked
@@ -179,7 +204,11 @@ public final class DatasetRegistry {
         }
     }
 
-    private static void assertOk(Response response, String what) {
-        assertThat(what, response.getStatusLine().getStatusCode(), equalTo(200));
+    private static void assertOk(Response response, String what) throws IOException {
+        int status = response.getStatusLine().getStatusCode();
+        if (status != 200) {
+            String body = response.getEntity() == null ? "<no body>" : EntityUtils.toString(response.getEntity());
+            throw new AssertionError(what + " returned unexpected status [" + status + "]: " + body);
+        }
     }
 }

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/datasources/DatasetRegistry.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/datasources/DatasetRegistry.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
+
+/**
+ * Class-scoped, idempotent registry of {@code data_source}/{@code dataset} pairs for the
+ * {@code FROM <dataset>} spec-test path. Datasets and data sources are {@code ProjectCustom} cluster
+ * metadata that survive the REST framework's per-class index wipe, so registration is cached by a
+ * content signature: re-registering the same {@code (name, type, settings)} is a no-op, while a
+ * changed signature re-issues the create-or-replace PUT. Call {@link #cleanup(RestClient)} from an
+ * {@code @AfterClass} hook to drop everything this registry created.
+ *
+ * <p>The registry is deliberately static: each spec IT runs in its own Gradle JVM fork, and
+ * {@link #cleanup(RestClient)} clears the caches, so sequential suites in one JVM stay isolated.
+ */
+public final class DatasetRegistry {
+
+    /** data_source name -&gt; content signature of the last successful PUT. */
+    private static final Map<String, String> dataSources = new LinkedHashMap<>();
+    /** dataset name -&gt; content signature of the last successful PUT. */
+    private static final Map<String, String> datasets = new LinkedHashMap<>();
+
+    private DatasetRegistry() {}
+
+    /**
+     * Ensures a {@code data_source} named {@code name} of the given {@code type} (e.g. {@code s3}) with
+     * {@code settings} exists, issuing {@code PUT /_query/data_source/<name>} only when the content
+     * signature differs from the cached one. Returns {@code name} for chaining into
+     * {@link #ensureDataset}.
+     */
+    public static synchronized String ensureDataSource(RestClient client, String name, String type, Map<String, Object> settings)
+        throws IOException {
+        String signature = type + "|" + settings;
+        if (signature.equals(dataSources.get(name)) == false) {
+            Request req = new Request("PUT", "/_query/data_source/" + name);
+            try (XContentBuilder b = jsonBuilder()) {
+                b.startObject().field("type", type);
+                if (settings.isEmpty() == false) {
+                    b.field("settings", settings);
+                }
+                b.endObject();
+                req.setJsonEntity(Strings.toString(b));
+            }
+            assertOk(client.performRequest(req), "PUT data_source [" + name + "]");
+            dataSources.put(name, signature);
+        }
+        return name;
+    }
+
+    /**
+     * Ensures a {@code dataset} named {@code name} bound to {@code dataSource} + {@code resource} with the
+     * given format {@code settings} exists, issuing {@code PUT /_query/dataset/<name>} only when the
+     * content signature differs from the cached one. The owning {@code data_source} must already exist
+     * (register it first via {@link #ensureDataSource}); the CRUD layer rejects a dataset whose parent is
+     * missing.
+     */
+    public static synchronized void ensureDataset(
+        RestClient client,
+        String name,
+        String dataSource,
+        String resource,
+        Map<String, Object> settings
+    ) throws IOException {
+        String signature = dataSource + "|" + resource + "|" + settings;
+        if (signature.equals(datasets.get(name))) {
+            return;
+        }
+        Request req = new Request("PUT", "/_query/dataset/" + name);
+        try (XContentBuilder b = jsonBuilder()) {
+            b.startObject().field("data_source", dataSource).field("resource", resource);
+            if (settings.isEmpty() == false) {
+                b.field("settings", settings);
+            }
+            b.endObject();
+            req.setJsonEntity(Strings.toString(b));
+        }
+        assertOk(client.performRequest(req), "PUT dataset [" + name + "]");
+        datasets.put(name, signature);
+    }
+
+    /**
+     * Deletes everything this registry created, datasets first so the data-source deletes do not 409 on
+     * a still-referenced parent, then clears the caches. Swallows 404s so a partially-set-up suite can be
+     * swept cleanly.
+     */
+    public static synchronized void cleanup(RestClient client) throws IOException {
+        for (String name : datasets.keySet()) {
+            deleteIgnoringMissing(client, "/_query/dataset/" + name);
+        }
+        datasets.clear();
+        for (String name : dataSources.keySet()) {
+            deleteIgnoringMissing(client, "/_query/data_source/" + name);
+        }
+        dataSources.clear();
+    }
+
+    private static void deleteIgnoringMissing(RestClient client, String path) throws IOException {
+        try {
+            client.performRequest(new Request("DELETE", path));
+        } catch (ResponseException e) {
+            if (e.getResponse().getStatusLine().getStatusCode() != 404) {
+                throw e;
+            }
+        }
+    }
+
+    private static void assertOk(Response response, String what) throws IOException {
+        int status = response.getStatusLine().getStatusCode();
+        if (status != 200) {
+            throw new IOException(what + " returned unexpected status [" + status + "]");
+        }
+    }
+}

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/datasources/DatasetRegistry.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/datasources/DatasetRegistry.java
@@ -18,17 +18,31 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 
 /**
  * Class-scoped, idempotent registry of {@code data_source}/{@code dataset} pairs for the
- * {@code FROM <dataset>} spec-test path. Datasets and data sources are {@code ProjectCustom} cluster
- * metadata that survive the REST framework's per-class index wipe, so registration is cached by a
- * content signature: re-registering the same {@code (name, type, settings)} is a no-op, while a
- * changed signature re-issues the create-or-replace PUT. Call {@link #cleanup(RestClient)} from an
- * {@code @AfterClass} hook to drop everything this registry created.
+ * {@code FROM <dataset>} spec-test path, plus the raw {@code PUT}/{@code DELETE} verbs shared with test
+ * bases that manage their own dataset lifecycle.
+ *
+ * <p>Datasets and data sources are {@code ProjectCustom} cluster metadata, and none of
+ * {@link org.elasticsearch.test.rest.ESRestTestCase}'s between-test cleanup steps remove them: the wipe
+ * deletes indices, data streams, views, templates, snapshots, cluster settings and ILM/CCR/shutdown
+ * metadata and issues {@code POST /_features/_reset}, but ES|QL registers no system-feature reset hook,
+ * so these customs persist for the whole JVM until explicitly deleted. Registration is therefore safely
+ * cached by a content signature: re-registering the same {@code (name, type, settings)} is a no-op,
+ * while a changed signature re-issues the create-or-replace PUT. Call {@link #cleanup(RestClient)} from
+ * an {@code @AfterClass} hook to drop everything this registry created and clear the caches.
  *
  * <p>The registry is deliberately static: each spec IT runs in its own Gradle JVM fork, and
  * {@link #cleanup(RestClient)} clears the caches, so sequential suites in one JVM stay isolated.
+ *
+ * <p>The survival invariant above is the load-bearing assumption behind the cache, so
+ * {@link #cleanup(RestClient)} fails loudly if a custom this registry recorded as successfully
+ * registered has vanished by teardown. That can only happen if the invariant breaks (e.g. a future
+ * framework change starts wiping these customs); surfacing it at teardown turns an otherwise
+ * non-obvious "FROM &lt;dataset&gt; not found" mid-suite failure into a precise signal.
  */
 public final class DatasetRegistry {
 
@@ -49,16 +63,7 @@ public final class DatasetRegistry {
         throws IOException {
         String signature = type + "|" + settings;
         if (signature.equals(dataSources.get(name)) == false) {
-            Request req = new Request("PUT", "/_query/data_source/" + name);
-            try (XContentBuilder b = jsonBuilder()) {
-                b.startObject().field("type", type);
-                if (settings.isEmpty() == false) {
-                    b.field("settings", settings);
-                }
-                b.endObject();
-                req.setJsonEntity(Strings.toString(b));
-            }
-            assertOk(client.performRequest(req), "PUT data_source [" + name + "]");
+            putDataSource(client, name, type, settings);
             dataSources.put(name, signature);
         }
         return name;
@@ -79,9 +84,38 @@ public final class DatasetRegistry {
         Map<String, Object> settings
     ) throws IOException {
         String signature = dataSource + "|" + resource + "|" + settings;
-        if (signature.equals(datasets.get(name))) {
-            return;
+        if (signature.equals(datasets.get(name)) == false) {
+            putDataset(client, name, dataSource, resource, settings);
+            datasets.put(name, signature);
         }
+    }
+
+    /**
+     * Issues an uncached {@code PUT /_query/data_source/<name>} with {@code type} and (optional)
+     * {@code settings}. Shared by {@link #ensureDataSource} and by test bases that manage their own
+     * data-source lifecycle; callers wanting create-once-per-signature semantics should use
+     * {@link #ensureDataSource} instead.
+     */
+    public static void putDataSource(RestClient client, String name, String type, Map<String, Object> settings) throws IOException {
+        Request req = new Request("PUT", "/_query/data_source/" + name);
+        try (XContentBuilder b = jsonBuilder()) {
+            b.startObject().field("type", type);
+            if (settings.isEmpty() == false) {
+                b.field("settings", settings);
+            }
+            b.endObject();
+            req.setJsonEntity(Strings.toString(b));
+        }
+        assertOk(client.performRequest(req), "PUT data_source [" + name + "]");
+    }
+
+    /**
+     * Issues an uncached {@code PUT /_query/dataset/<name>} bound to {@code dataSource} + {@code resource}
+     * with the given format {@code settings}. Shared by {@link #ensureDataset} and by test bases that
+     * manage their own dataset lifecycle; the owning {@code data_source} must already exist.
+     */
+    public static void putDataset(RestClient client, String name, String dataSource, String resource, Map<String, Object> settings)
+        throws IOException {
         Request req = new Request("PUT", "/_query/dataset/" + name);
         try (XContentBuilder b = jsonBuilder()) {
             b.startObject().field("data_source", dataSource).field("resource", resource);
@@ -92,26 +126,32 @@ public final class DatasetRegistry {
             req.setJsonEntity(Strings.toString(b));
         }
         assertOk(client.performRequest(req), "PUT dataset [" + name + "]");
-        datasets.put(name, signature);
     }
 
     /**
      * Deletes everything this registry created, datasets first so the data-source deletes do not 409 on
-     * a still-referenced parent, then clears the caches. Swallows 404s so a partially-set-up suite can be
-     * swept cleanly.
+     * a still-referenced parent, then clears the caches. Every cached entry was recorded only after a
+     * successful PUT and is expected to survive the suite (see the class Javadoc), so a missing custom
+     * here is treated as a broken survival invariant and fails teardown rather than being swallowed.
      */
     public static synchronized void cleanup(RestClient client) throws IOException {
         for (String name : datasets.keySet()) {
-            deleteIgnoringMissing(client, "/_query/dataset/" + name);
+            deleteRegistered(client, "/_query/dataset/" + name);
         }
         datasets.clear();
         for (String name : dataSources.keySet()) {
-            deleteIgnoringMissing(client, "/_query/data_source/" + name);
+            deleteRegistered(client, "/_query/data_source/" + name);
         }
         dataSources.clear();
     }
 
-    private static void deleteIgnoringMissing(RestClient client, String path) throws IOException {
+    /**
+     * {@code DELETE <path>} that swallows 404s, for ad-hoc sweeps of resources whose existence is not
+     * tracked by this registry (e.g. test indices, or datasets a test may or may not have created). The
+     * registry's own {@link #cleanup} deliberately does <em>not</em> use this — it expects its tracked
+     * customs to still exist.
+     */
+    public static void deleteIgnoringMissing(RestClient client, String path) throws IOException {
         try {
             client.performRequest(new Request("DELETE", path));
         } catch (ResponseException e) {
@@ -121,10 +161,25 @@ public final class DatasetRegistry {
         }
     }
 
-    private static void assertOk(Response response, String what) throws IOException {
-        int status = response.getStatusLine().getStatusCode();
-        if (status != 200) {
-            throw new IOException(what + " returned unexpected status [" + status + "]");
+    /** Deletes a custom this registry registered; a 404 means it vanished mid-suite — see {@link #cleanup}. */
+    private static void deleteRegistered(RestClient client, String path) throws IOException {
+        try {
+            client.performRequest(new Request("DELETE", path));
+        } catch (ResponseException e) {
+            if (e.getResponse().getStatusLine().getStatusCode() == 404) {
+                throw new AssertionError(
+                    "["
+                        + path
+                        + "] was registered by this suite but is already gone at teardown; the data_source/dataset "
+                        + "survival invariant the registry's cache relies on appears to be broken",
+                    e
+                );
+            }
+            throw e;
         }
+    }
+
+    private static void assertOk(Response response, String what) {
+        assertThat(what, response.getStatusLine().getStatusCode(), equalTo(200));
     }
 }

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/AbstractExternalSourceSpecTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/AbstractExternalSourceSpecTestCase.java
@@ -16,6 +16,7 @@ import org.elasticsearch.xpack.esql.CsvSpecReader.CsvTestCase;
 import org.elasticsearch.xpack.esql.CsvSpecReader.DatasetSource;
 import org.elasticsearch.xpack.esql.CsvTestsDataLoader;
 import org.elasticsearch.xpack.esql.SpecReader;
+import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.xpack.esql.datasources.AzureFixtureUtils;
 import org.elasticsearch.xpack.esql.datasources.AzureFixtureUtils.DataSourcesAzureHttpFixture;
 import org.elasticsearch.xpack.esql.datasources.DatasetRegistry;
@@ -48,6 +49,7 @@ import static org.elasticsearch.xpack.esql.datasources.AzureFixtureUtils.CONTAIN
 import static org.elasticsearch.xpack.esql.datasources.FixtureUtils.COMPRESSED_EXTENSIONS;
 import static org.elasticsearch.xpack.esql.datasources.S3FixtureUtils.BUCKET;
 import static org.elasticsearch.xpack.esql.datasources.S3FixtureUtils.WAREHOUSE;
+import static org.elasticsearch.xpack.esql.qa.rest.RestEsqlTestCase.hasCapabilities;
 
 /**
  * Abstract base class for external source integration tests using S3HttpFixture.
@@ -355,13 +357,15 @@ public abstract class AbstractExternalSourceSpecTestCase extends EsqlSpecTestCas
         // ClickBench templates are resolved by ClickBenchParquetSpecIT, not by this class.
         assumeFalse("ClickBench templates require ClickBenchParquetSpecIT", testCase.query.contains("{{clickbench}}"));
 
-        // Pick the Azure URI form once per test so wildcard expansion sees a single, consistent form.
-        useAzureHadoopForm = storageBackend == StorageBackend.AZURE && randomBoolean();
-
         if (testCase.datasetSources.isEmpty() == false && datasetModeBackends().contains(storageBackend)) {
             runDatasetMode();
             return;
         }
+
+        // Pick the Azure URI form once per test so wildcard expansion sees a single, consistent form.
+        // Only the EXTERNAL/rebuild path resolves Azure templates; dataset mode is S3-only, so this is
+        // scoped to the non-dataset path it actually affects.
+        useAzureHadoopForm = storageBackend == StorageBackend.AZURE && randomBoolean();
 
         // Non-dataset path: rebuild EXTERNAL from any dataset: directives, then run the existing flow.
         String query = rebuildExternalFromDatasets(testCase.query);
@@ -411,8 +415,18 @@ public abstract class AbstractExternalSourceSpecTestCase extends EsqlSpecTestCas
      * the spec's {@code FROM <name>} query verbatim — cold then warm (same warm-path rationale as the
      * EXTERNAL flow above). Each source's resource template is resolved to the backend URI exactly as the
      * EXTERNAL path resolves it.
+     * <p>
+     * Skipped (rather than failed) on a cluster that lacks {@code dataset_in_from_command}: that
+     * capability gates resolving {@code FROM <dataset>} in {@code POST /_query}, which is what this path
+     * exercises. The EXTERNAL-rebuild fallback in {@link EsqlSpecTestCase#rebuildExternalFromDatasets}
+     * stays gated only by {@code external_command}, so the two execution paths advertise their real
+     * requirements independently of the spec's static {@code required_capability} lines.
      */
     private void runDatasetMode() throws Throwable {
+        assumeTrue(
+            "FROM <dataset> requires the [dataset_in_from_command] capability",
+            hasCapabilities(client(), List.of(EsqlCapabilities.Cap.DATASET_IN_FROM_COMMAND.capabilityName()))
+        );
         String dataSourceName = ensureDataSourceForBackend();
         for (DatasetSource source : testCase.datasetSources) {
             String resource = transformTemplates(source.resource());

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/AbstractExternalSourceSpecTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/AbstractExternalSourceSpecTestCase.java
@@ -9,9 +9,6 @@ package org.elasticsearch.xpack.esql.qa.rest;
 import org.elasticsearch.Version;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
-import org.elasticsearch.xcontent.XContentParser;
-import org.elasticsearch.xcontent.XContentParserConfiguration;
-import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.esql.CsvSpecReader.CsvTestCase;
 import org.elasticsearch.xpack.esql.CsvSpecReader.DatasetSource;
 import org.elasticsearch.xpack.esql.CsvTestsDataLoader;
@@ -280,12 +277,18 @@ public abstract class AbstractExternalSourceSpecTestCase extends EsqlSpecTestCas
      * Drops every {@code data_source}/{@code dataset} registered by {@link DatasetRegistry} during the
      * suite (datasets first, so data-source deletes do not 409 on a still-referenced parent). These are
      * {@code ProjectCustom} metadata that survive the framework's index wipe, so they must be cleaned
-     * explicitly. Skipped when the test clusters are already known broken.
+     * explicitly. The cluster-side delete is skipped when the test clusters are already known broken, but
+     * the static caches are always cleared (in a {@code finally}) so a broken cluster — or a cleanup that
+     * throws partway — cannot poison a later suite sharing this JVM fork.
      */
     @AfterClass
     public static void cleanupRegisteredDatasets() throws IOException {
-        if (testClustersOk) {
-            DatasetRegistry.cleanup(adminClient());
+        try {
+            if (testClustersOk) {
+                DatasetRegistry.cleanup(adminClient());
+            }
+        } finally {
+            DatasetRegistry.clearCaches();
         }
     }
 
@@ -390,31 +393,38 @@ public abstract class AbstractExternalSourceSpecTestCase extends EsqlSpecTestCas
         }
 
         logger.debug("Transformed query for {} backend: {}", storageBackend, query);
-        doTest(query);
+        runColdThenWarm(query, isExternalQuery(query) && testCase.expectedDocumentsFound == null);
+    }
 
-        // Warm pass — exercise the cache on EVERY external spec test, for every format and codec that
-        // extends this base. The cold run above reconciled this file's statistics into the
-        // coordinator's per-file schema cache; the aggregate-metadata pushdown that serves COUNT(*) /
-        // MIN / MAX from that cache is a SECOND code path that a single run never touches. Re-running
-        // the identical query asserts the warm path against the same expected results, so a cache-only
-        // correctness bug (e.g. a COUNT(*) that only doubles on the warm read) fails deterministically
-        // here instead of surfacing flakily in CI when the randomized spec order happens to repeat a
-        // file against a shared cluster. Skipped only when the spec pins documents_found, because the
-        // warm run short-circuits to zero scanned documents and so cannot match the cold scan count.
-        // The schema cache is per-coordinator: on a single-node IT the warm run always hits it; on a
-        // multi-node IT the second run may land on another coordinator and re-scan (a coverage gap,
-        // never a wrong answer). The deterministic ExternalNdJsonMultiScanPushdownIT is the guaranteed
-        // warm-path guard regardless of routing.
-        if (isExternalQuery(query) && testCase.expectedDocumentsFound == null) {
+    /**
+     * Runs {@code query} once (cold) and, when {@code warmPass} is set, a second time (warm) against the
+     * identical expected results.
+     * <p>
+     * The warm pass exercises the cache on EVERY external/dataset spec test, for every format and codec
+     * that extends this base. The cold run reconciles the file's statistics into the coordinator's
+     * per-file schema cache; the aggregate-metadata pushdown that serves COUNT(*) / MIN / MAX from that
+     * cache is a SECOND code path that a single run never touches. Re-running the identical query asserts
+     * the warm path, so a cache-only correctness bug (e.g. a COUNT(*) that only doubles on the warm read)
+     * fails deterministically here instead of surfacing flakily in CI when the randomized spec order
+     * happens to repeat a file against a shared cluster. Callers pass {@code warmPass == false} when the
+     * spec pins {@code documents_found}, because the warm run short-circuits to zero scanned documents and
+     * so cannot match the cold scan count. The schema cache is per-coordinator: on a single-node IT the
+     * warm run always hits it; on a multi-node IT the second run may land on another coordinator and
+     * re-scan (a coverage gap, never a wrong answer). The deterministic ExternalNdJsonMultiScanPushdownIT
+     * is the guaranteed warm-path guard regardless of routing.
+     */
+    private void runColdThenWarm(String query, boolean warmPass) throws Throwable {
+        doTest(query);
+        if (warmPass) {
             doTest(query);
         }
     }
 
     /**
      * Registers the {@code data_source} (once per backend) and every declared {@code dataset}, then runs
-     * the spec's {@code FROM <name>} query verbatim — cold then warm (same warm-path rationale as the
-     * EXTERNAL flow above). Each source's resource template is resolved to the backend URI exactly as the
-     * EXTERNAL path resolves it.
+     * the spec's {@code FROM <name>} query verbatim — cold then warm via {@link #runColdThenWarm}, the
+     * same idiom the EXTERNAL flow uses. Each source's resource template is resolved to the backend URI
+     * exactly as the EXTERNAL path resolves it.
      * <p>
      * Skipped (rather than failed) on a cluster that lacks {@code dataset_in_from_command}: that
      * capability gates resolving {@code FROM <dataset>} in {@code POST /_query}, which is what this path
@@ -430,14 +440,11 @@ public abstract class AbstractExternalSourceSpecTestCase extends EsqlSpecTestCas
         String dataSourceName = ensureDataSourceForBackend();
         for (DatasetSource source : testCase.datasetSources) {
             String resource = transformTemplates(source.resource());
-            DatasetRegistry.ensureDataset(client(), source.name(), dataSourceName, resource, parseWithSettings(source.withJson()));
+            DatasetRegistry.ensureDataset(client(), source.name(), dataSourceName, resource, source.withJson());
         }
         String query = testCase.query;
         logger.debug("Dataset-mode query for {} backend: {}", storageBackend, query);
-        doTest(query);
-        if (testCase.expectedDocumentsFound == null) {
-            doTest(query);
-        }
+        runColdThenWarm(query, testCase.expectedDocumentsFound == null);
     }
 
     /** Lazily registers (and caches) the {@code data_source} pointing at the in-process fixture for the active backend. */
@@ -453,16 +460,6 @@ public abstract class AbstractExternalSourceSpecTestCase extends EsqlSpecTestCas
             // dataset mode without a registered data_source body, which is a wiring bug.
             default -> throw new IllegalStateException("Dataset mode not supported for backend [" + storageBackend + "]");
         };
-    }
-
-    /** Parses a {@code dataset:} directive's {@code WITH {...}} JSON into a settings map ({@code null} maps to empty). */
-    private static Map<String, Object> parseWithSettings(String withJson) throws IOException {
-        if (withJson == null) {
-            return Map.of();
-        }
-        try (XContentParser parser = JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, withJson)) {
-            return parser.map();
-        }
     }
 
     /**

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/AbstractExternalSourceSpecTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/AbstractExternalSourceSpecTestCase.java
@@ -9,17 +9,23 @@ package org.elasticsearch.xpack.esql.qa.rest;
 import org.elasticsearch.Version;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentParserConfiguration;
+import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.esql.CsvSpecReader.CsvTestCase;
+import org.elasticsearch.xpack.esql.CsvSpecReader.DatasetSource;
 import org.elasticsearch.xpack.esql.CsvTestsDataLoader;
 import org.elasticsearch.xpack.esql.SpecReader;
 import org.elasticsearch.xpack.esql.datasources.AzureFixtureUtils;
 import org.elasticsearch.xpack.esql.datasources.AzureFixtureUtils.DataSourcesAzureHttpFixture;
+import org.elasticsearch.xpack.esql.datasources.DatasetRegistry;
 import org.elasticsearch.xpack.esql.datasources.FixtureUtils;
 import org.elasticsearch.xpack.esql.datasources.GcsFixtureUtils;
 import org.elasticsearch.xpack.esql.datasources.GcsFixtureUtils.DataSourcesGcsHttpFixture;
 import org.elasticsearch.xpack.esql.datasources.S3FixtureUtils;
 import org.elasticsearch.xpack.esql.datasources.S3FixtureUtils.DataSourcesS3HttpFixture;
 import org.elasticsearch.xpack.esql.datasources.S3FixtureUtils.S3RequestLog;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 
@@ -29,6 +35,8 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -267,6 +275,19 @@ public abstract class AbstractExternalSourceSpecTestCase extends EsqlSpecTestCas
     }
 
     /**
+     * Drops every {@code data_source}/{@code dataset} registered by {@link DatasetRegistry} during the
+     * suite (datasets first, so data-source deletes do not 409 on a still-referenced parent). These are
+     * {@code ProjectCustom} metadata that survive the framework's index wipe, so they must be cleaned
+     * explicitly. Skipped when the test clusters are already known broken.
+     */
+    @AfterClass
+    public static void cleanupRegisteredDatasets() throws IOException {
+        if (testClustersOk) {
+            DatasetRegistry.cleanup(adminClient());
+        }
+    }
+
+    /**
      * Automatically checks for unsupported S3 operations after each test.
      */
     @org.junit.After
@@ -308,22 +329,47 @@ public abstract class AbstractExternalSourceSpecTestCase extends EsqlSpecTestCas
     }
 
     /**
+     * Backends for which migrated specs (those carrying {@code dataset:} directives) run via the native
+     * {@code FROM <dataset>} path, registering a {@code data_source}/{@code dataset} per declared source.
+     * Every other backend rebuilds the equivalent {@code EXTERNAL} query instead, so no test is skipped.
+     * Defaults to none; only suites whose cluster + fixture can back a dataset override this.
+     */
+    protected Set<StorageBackend> datasetModeBackends() {
+        return Set.of();
+    }
+
+    /**
      * Override doTest() to transform templates and inject storage-specific parameters.
+     * <p>
+     * A spec that declares {@code dataset:} sources runs one of two ways:
+     * <ul>
+     *   <li>on a {@link #datasetModeBackends()} backend, the datasets are registered and the spec's
+     *       {@code FROM <name>} query is run verbatim (see {@link #runDatasetMode()});</li>
+     *   <li>on any other backend, the equivalent {@code EXTERNAL} query is rebuilt from the directive
+     *       (see {@link #rebuildExternalFromDatasets(String)}) and run through the existing flow.</li>
+     * </ul>
+     * Specs with no {@code dataset:} directive are unaffected.
      */
     @Override
     protected void doTest() throws Throwable {
-        String query = testCase.query;
-
         // ClickBench templates are resolved by ClickBenchParquetSpecIT, not by this class.
-        assumeFalse("ClickBench templates require ClickBenchParquetSpecIT", query.contains("{{clickbench}}"));
+        assumeFalse("ClickBench templates require ClickBenchParquetSpecIT", testCase.query.contains("{{clickbench}}"));
+
+        // Pick the Azure URI form once per test so wildcard expansion sees a single, consistent form.
+        useAzureHadoopForm = storageBackend == StorageBackend.AZURE && randomBoolean();
+
+        if (testCase.datasetSources.isEmpty() == false && datasetModeBackends().contains(storageBackend)) {
+            runDatasetMode();
+            return;
+        }
+
+        // Non-dataset path: rebuild EXTERNAL from any dataset: directives, then run the existing flow.
+        String query = rebuildExternalFromDatasets(testCase.query);
 
         if (query.contains(MULTIFILE_SUFFIX) || query.contains(HIVE_SUFFIX + "}}")) {
             // HTTP does not support directory listing, so skip multi-file/Hive-partitioned glob tests
             assumeTrue("HTTP backend does not support multi-file glob patterns", storageBackend != StorageBackend.HTTP);
         }
-
-        // Pick the Azure URI form once per test so wildcard expansion sees a single, consistent form.
-        useAzureHadoopForm = storageBackend == StorageBackend.AZURE && randomBoolean();
 
         // Transform templates like {{employees}} to actual paths
         query = transformTemplates(query);
@@ -357,6 +403,51 @@ public abstract class AbstractExternalSourceSpecTestCase extends EsqlSpecTestCas
         // warm-path guard regardless of routing.
         if (isExternalQuery(query) && testCase.expectedDocumentsFound == null) {
             doTest(query);
+        }
+    }
+
+    /**
+     * Registers the {@code data_source} (once per backend) and every declared {@code dataset}, then runs
+     * the spec's {@code FROM <name>} query verbatim — cold then warm (same warm-path rationale as the
+     * EXTERNAL flow above). Each source's resource template is resolved to the backend URI exactly as the
+     * EXTERNAL path resolves it.
+     */
+    private void runDatasetMode() throws Throwable {
+        String dataSourceName = ensureDataSourceForBackend();
+        for (DatasetSource source : testCase.datasetSources) {
+            String resource = transformTemplates(source.resource());
+            DatasetRegistry.ensureDataset(client(), source.name(), dataSourceName, resource, parseWithSettings(source.withJson()));
+        }
+        String query = testCase.query;
+        logger.debug("Dataset-mode query for {} backend: {}", storageBackend, query);
+        doTest(query);
+        if (testCase.expectedDocumentsFound == null) {
+            doTest(query);
+        }
+    }
+
+    /** Lazily registers (and caches) the {@code data_source} pointing at the in-process fixture for the active backend. */
+    private String ensureDataSourceForBackend() throws IOException {
+        return switch (storageBackend) {
+            case S3 -> DatasetRegistry.ensureDataSource(
+                client(),
+                "esql_spec_s3",
+                "s3",
+                Map.of("endpoint", s3Fixture.getAddress(), "auth", "none")
+            );
+            // datasetModeBackends() currently only returns S3; reaching here means a backend opted into
+            // dataset mode without a registered data_source body, which is a wiring bug.
+            default -> throw new IllegalStateException("Dataset mode not supported for backend [" + storageBackend + "]");
+        };
+    }
+
+    /** Parses a {@code dataset:} directive's {@code WITH {...}} JSON into a settings map ({@code null} maps to empty). */
+    private static Map<String, Object> parseWithSettings(String withJson) throws IOException {
+        if (withJson == null) {
+            return Map.of();
+        }
+        try (XContentParser parser = JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, withJson)) {
+            return parser.map();
         }
     }
 

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
@@ -431,7 +431,10 @@ public abstract class EsqlSpecTestCase extends ESRestTestCase {
         DatasetSource source = sources.get(0);
         int pipe = FixtureUtils.findFirstPipeAfterExternal(query);
         String tail = pipe < 0 ? "" : " " + query.substring(pipe);
-        StringBuilder external = new StringBuilder("EXTERNAL \"").append(source.resource()).append("\"");
+        // source.resource() is decoded (quotes/escapes resolved by the parser); re-escape it back into the
+        // EXTERNAL string literal so a resource containing a backslash or quote round-trips correctly.
+        String literal = source.resource().replace("\\", "\\\\").replace("\"", "\\\"");
+        StringBuilder external = new StringBuilder("EXTERNAL \"").append(literal).append("\"");
         if (source.withJson() != null) {
             external.append(" WITH ").append(source.withJson());
         }

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
@@ -28,10 +28,12 @@ import org.elasticsearch.test.rest.TestFeatureService;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.esql.CsvAssert;
 import org.elasticsearch.xpack.esql.CsvSpecReader.CsvTestCase;
+import org.elasticsearch.xpack.esql.CsvSpecReader.DatasetSource;
 import org.elasticsearch.xpack.esql.CsvTestUtils;
 import org.elasticsearch.xpack.esql.CsvTestsDataLoader;
 import org.elasticsearch.xpack.esql.SpecReader;
 import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
+import org.elasticsearch.xpack.esql.datasources.FixtureUtils;
 import org.elasticsearch.xpack.esql.planner.PlannerSettings;
 import org.elasticsearch.xpack.esql.plugin.EsqlFeatures;
 import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
@@ -400,7 +402,41 @@ public abstract class EsqlSpecTestCase extends ESRestTestCase {
     }
 
     protected void doTest() throws Throwable {
-        doTest(testCase.query);
+        doTest(rebuildExternalFromDatasets(testCase.query));
+    }
+
+    /**
+     * Rebuild the {@code EXTERNAL "<resource>" WITH {<json>}} query equivalent to a migrated
+     * {@code FROM <name>} spec from its {@code dataset:} directive(s). This is the universal fallback used
+     * by every EXTERNAL-capable test family; {@code AbstractExternalSourceSpecTestCase} overrides the
+     * execution path to register and run the {@code FROM} form directly on dataset-capable backends.
+     *
+     * <p>Specs without a {@code dataset:} directive are returned unchanged. EXTERNAL is single-source
+     * today, so a spec declaring more than one source has no EXTERNAL equivalent and fails fast (rather
+     * than silently mis-running); the guard is removed once EXTERNAL gains multi-source support.
+     */
+    protected final String rebuildExternalFromDatasets(String query) {
+        List<DatasetSource> sources = testCase.datasetSources;
+        if (sources.isEmpty()) {
+            return query;
+        }
+        if (sources.size() > 1) {
+            throw new AssertionError(
+                "Cannot rebuild a single EXTERNAL query for ["
+                    + sources.size()
+                    + "] dataset sources; multi-source FROM <dataset> has no EXTERNAL equivalent yet: "
+                    + query
+            );
+        }
+        DatasetSource source = sources.get(0);
+        int pipe = FixtureUtils.findFirstPipeAfterExternal(query);
+        String tail = pipe < 0 ? "" : " " + query.substring(pipe);
+        StringBuilder external = new StringBuilder("EXTERNAL \"").append(source.resource()).append("\"");
+        if (source.withJson() != null) {
+            external.append(" WITH ").append(source.withJson());
+        }
+        external.append(tail);
+        return external.toString();
     }
 
     protected final void doTest(String query) throws Throwable {

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeApproximationRestTest.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeApproximationRestTest.java
@@ -52,11 +52,15 @@ public abstract class GenerativeApproximationRestTest extends EsqlSpecTestCase {
         // For simplicity, we just allow all warnings here.
         testCase.allowAllWarnings();
 
+        // Dataset-backed specs (FROM <dataset>) have no index on this cluster; rebuild their EXTERNAL equivalent
+        // first so they run as before the FROM <dataset> migration. Non-dataset specs are returned unchanged.
+        String query = rebuildExternalFromDatasets(testCase.query);
+
         // Sample a huge number of rows, so that exact results are computed.
         executeQuery("""
             SET approximation={"rows":2000000000};
             {QUERY}
-            """.replace("{QUERY}", testCase.query));
+            """.replace("{QUERY}", query));
 
         try {
             GenerativeForkRestTest.shouldSkipForkTest(testCase);
@@ -64,7 +68,7 @@ public abstract class GenerativeApproximationRestTest extends EsqlSpecTestCase {
                 SET approximation={"rows":2000000000};
                 {QUERY}
                 | FORK (WHERE true | LIMIT 300) (WHERE true) | LIMIT 300 | WHERE _fork == "fork1" | DROP _fork
-                """.replace("{QUERY}", testCase.query));
+                """.replace("{QUERY}", query));
         } catch (AssumptionViolatedException e) {
             // do nothing
         }
@@ -73,13 +77,13 @@ public abstract class GenerativeApproximationRestTest extends EsqlSpecTestCase {
             // Subqueries use FORK under the hood, hence have the same restrictions as FORK tests.
             GenerativeForkRestTest.shouldSkipForkTest(testCase);
             assumeTrue("Subqueries in approximation require inline stats capability", APPROXIMATION_INLINE_STATS_V2.isEnabled());
-            assumeTrue("Subquery must start with FROM", testCase.query.toUpperCase(Locale.ROOT).startsWith("FROM "));
+            assumeTrue("Subquery must start with FROM", query.toUpperCase(Locale.ROOT).startsWith("FROM "));
             executeQuery("""
                 SET approximation={"rows":2000000000};
                 FROM ({QUERY} | EVAL _subquery=1), ({QUERY} | EVAL _subquery=2)
                 | WHERE _subquery == 1
                 | DROP _subquery
-                """.replace("{QUERY}", testCase.query));
+                """.replace("{QUERY}", query));
         } catch (AssumptionViolatedException e) {
             // do nothing
         }

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeForkRestTest.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeForkRestTest.java
@@ -50,7 +50,9 @@ public abstract class GenerativeForkRestTest extends EsqlSpecTestCase {
     @Override
     protected void doTest() throws Throwable {
         // we add a LIMIT in one of the branches, so we prevent the filter pushdown that would end up removing one of the branches.
-        String query = testCase.query + " | FORK (WHERE true | LIMIT 300) (WHERE true) | LIMIT 300 | WHERE _fork == \"fork1\" | DROP _fork";
+        // Dataset-backed specs (FROM <dataset>) have no index on this cluster; rebuild their EXTERNAL equivalent first.
+        String query = rebuildExternalFromDatasets(testCase.query)
+            + " | FORK (WHERE true | LIMIT 300) (WHERE true) | LIMIT 300 | WHERE _fork == \"fork1\" | DROP _fork";
         doTest(query);
     }
 

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvSpecReader.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvSpecReader.java
@@ -145,23 +145,39 @@ public final class CsvSpecReader {
 
     /**
      * A single external source declared by a {@code dataset:} preamble directive of the form
-     * {@code dataset: <name>: "<resource>" [WITH {<json>}]}. It carries everything the test harness
-     * needs to either (a) register a {@code data_source}/{@code dataset} pair and run the spec's
+     * {@code dataset: <name>: "<resource>" [WITH {<json>}] [// comment]}. It carries everything the test
+     * harness needs to either (a) register a {@code data_source}/{@code dataset} pair and run the spec's
      * {@code FROM <name>} query verbatim on dataset-capable backends, or (b) rebuild the equivalent
      * {@code EXTERNAL "<resource>" WITH {<json>}} query on backends that cannot back a dataset.
      *
      * @param name      the dataset name referenced by the {@code FROM} clause
-     * @param resource  the resource URI or {@code {{template}}} placeholder (without surrounding quotes)
+     * @param resource  the decoded resource URI or {@code {{template}}} placeholder: surrounding quotes
+     *                  removed and backslash escapes resolved (e.g. {@code \"} -&gt; {@code "})
      * @param withJson  the brace-delimited JSON options object (e.g. {@code {"header_row": false}}), or
      *                  {@code null} when the directive carries no {@code WITH} clause
      */
     public record DatasetSource(String name, String resource, String withJson) {}
 
     /**
-     * Parses {@code dataset:} preamble directives. Each declares one named external source whose
-     * format options are exactly today's EXTERNAL {@code WITH} options; storage connection settings are
-     * still injected by the test harness, never written in the spec. The directive is repeatable so a
-     * single query can reference multiple datasets.
+     * Parses {@code dataset:} preamble directives of the form
+     * {@code dataset: <name>: "<resource>" [WITH {<json>}] [// comment]}. Each declares one named external
+     * source whose format options are exactly today's EXTERNAL {@code WITH} options; storage connection
+     * settings are still injected by the test harness, never written in the spec. The directive is
+     * repeatable so a single query can reference multiple datasets.
+     * <p>
+     * The resource string supports {@code \\}-escapes (so it may contain an embedded {@code "}), and a
+     * trailing {@code //} comment is permitted after the resource or after the {@code WITH} object.
+     * {@link SpecReader} only strips whole-line comments, so the inline comment is handled here; the
+     * scanners are quote/brace aware so a {@code //} inside the resource (e.g. {@code http://...}) or
+     * inside a JSON string value is never mistaken for a comment.
+     * <p>
+     * Like the other preamble directives ({@code Capability}, {@code Pragma}, {@code RequestStored}, ...),
+     * this parser deliberately runs in both the preamble and the result phase and carries no
+     * {@code state.testCase == null} guard: it accumulates into {@link ParserContext#datasetSources} (the
+     * list backing the test currently being assembled), not into {@code state.testCase}. The guard on
+     * {@code Warning}/{@code WarningRegex}/{@code IgnoreOrder} exists only because those write into
+     * {@code state.testCase.*}; adding it here would stop the directive from firing in the preamble
+     * (where {@code testCase == null}) and silently fold it into the query text.
      */
     record Dataset(ParserContext state) implements SpecReader.Parser {
         @Override
@@ -182,30 +198,111 @@ public final class CsvSpecReader {
             if (name.isEmpty() || spec.startsWith("\"") == false) {
                 throw new IllegalArgumentException("Invalid dataset directive [" + line + "]: a name and a quoted resource are required");
             }
-            int closeQuote = spec.indexOf('"', 1);
+            StringBuilder decoded = new StringBuilder();
+            int closeQuote = scanQuoted(spec, 1, decoded);
             if (closeQuote < 0) {
                 throw new IllegalArgumentException("Invalid dataset directive [" + line + "]: unterminated resource string");
             }
-            String resource = spec.substring(1, closeQuote);
+            String resource = decoded.toString();
             String remainder = spec.substring(closeQuote + 1).trim();
             String withJson = null;
-            if (remainder.isEmpty() == false) {
+            if (remainder.isEmpty() == false && isLineComment(remainder) == false) {
                 if (remainder.toLowerCase(Locale.ROOT).startsWith("with") == false) {
                     throw new IllegalArgumentException(
-                        "Invalid dataset directive [" + line + "]: expected WITH after the resource, got [" + remainder + "]"
+                        "Invalid dataset directive ["
+                            + line
+                            + "]: expected WITH or a // comment after the resource, got ["
+                            + remainder
+                            + "]"
                     );
                 }
                 String afterWith = remainder.substring("with".length()).trim();
-                if (afterWith.startsWith("{") == false || afterWith.endsWith("}") == false) {
+                if (afterWith.startsWith("{") == false) {
                     throw new IllegalArgumentException(
                         "Invalid dataset directive [" + line + "]: WITH must be followed by a JSON object, got [" + afterWith + "]"
                     );
                 }
-                withJson = afterWith;
+                int closeBrace = matchingBrace(afterWith, 0);
+                if (closeBrace < 0) {
+                    throw new IllegalArgumentException(
+                        "Invalid dataset directive [" + line + "]: unterminated WITH JSON object, got [" + afterWith + "]"
+                    );
+                }
+                withJson = afterWith.substring(0, closeBrace + 1);
+                String tail = afterWith.substring(closeBrace + 1).trim();
+                if (tail.isEmpty() == false && isLineComment(tail) == false) {
+                    throw new IllegalArgumentException(
+                        "Invalid dataset directive ["
+                            + line
+                            + "]: unexpected trailing token after WITH JSON object: ["
+                            + tail
+                            + "]; inline comments must start with //"
+                    );
+                }
             }
             state.datasetSources.add(new DatasetSource(name, resource, withJson));
             return Boolean.TRUE;
         }
+    }
+
+    /**
+     * Scans a double-quoted string starting at {@code from} (the index just past the opening quote),
+     * decoding backslash escapes ({@code \"} -&gt; {@code "}, {@code \\} -&gt; {@code \}; any other
+     * {@code \x} -&gt; {@code x}) into {@code out}. Returns the index of the closing quote, or {@code -1}
+     * if the string is unterminated. Mirrors the escape handling in
+     * {@code AbstractExternalSourceSpecTestCase.findClosingBrace}.
+     */
+    private static int scanQuoted(String s, int from, StringBuilder out) {
+        for (int i = from; i < s.length(); i++) {
+            char c = s.charAt(i);
+            if (c == '\\') {
+                if (i + 1 >= s.length()) {
+                    return -1;
+                }
+                out.append(s.charAt(i + 1));
+                i++;
+            } else if (c == '"') {
+                return i;
+            } else {
+                out.append(c);
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Returns the index of the closing brace matching the opening brace at {@code open}, skipping over
+     * quoted strings (and their backslash escapes) so braces inside JSON string values are ignored, or
+     * {@code -1} if no matching brace is found.
+     */
+    private static int matchingBrace(String s, int open) {
+        int depth = 0;
+        boolean inQuotes = false;
+        for (int i = open; i < s.length(); i++) {
+            char c = s.charAt(i);
+            if (inQuotes) {
+                if (c == '\\') {
+                    i++;
+                } else if (c == '"') {
+                    inQuotes = false;
+                }
+            } else if (c == '"') {
+                inQuotes = true;
+            } else if (c == '{') {
+                depth++;
+            } else if (c == '}') {
+                depth--;
+                if (depth == 0) {
+                    return i;
+                }
+            }
+        }
+        return -1;
+    }
+
+    /** Whether {@code s} begins a {@code //} line comment (the inline-comment marker for spec directives). */
+    private static boolean isLineComment(String s) {
+        return s.startsWith("//");
     }
 
     record RequestStored(ParserContext state) implements SpecReader.Parser {

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvSpecReader.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvSpecReader.java
@@ -22,6 +22,7 @@ public final class CsvSpecReader {
     public static SpecReader.Parser specParser() {
         var ctx = new ParserContext();
         ctx.addOptionParser(new Capability(ctx));
+        ctx.addOptionParser(new Dataset(ctx));
         ctx.addOptionParser(new Pragma(ctx));
         ctx.addOptionParser(new RequestStored(ctx));
         ctx.addOptionParser(new RequestTimeFilter(ctx));
@@ -49,6 +50,7 @@ public final class CsvSpecReader {
         private final List<String> requiredCapabilities = new ArrayList<>();
         private final List<String> requiredCapabilitiesLocalCluster = new ArrayList<>();
         private final List<String> missingCapabilitiesRemoteCluster = new ArrayList<>();
+        private final List<DatasetSource> datasetSources = new ArrayList<>();
         private final List<SpecReader.Parser> optionParsers = new ArrayList<>();
         private final Map<String, String> pragmas = new HashMap<>();
         WhenLoadsRequestedToStored requestStored = WhenLoadsRequestedToStored.IGNORE_VALUE_ORDER;
@@ -84,6 +86,7 @@ public final class CsvSpecReader {
                 testCase.requiredCapabilities = List.copyOf(requiredCapabilities);
                 testCase.requiredCapabilitiesLocalCluster = List.copyOf(requiredCapabilitiesLocalCluster);
                 testCase.missingCapabilitiesRemoteCluster = List.copyOf(missingCapabilitiesRemoteCluster);
+                testCase.datasetSources = List.copyOf(datasetSources);
                 testCase.pragmas = Map.copyOf(pragmas);
                 testCase.requestStored = requestStored;
                 testCase.requestTimeRangeGte = requestTimeRangeGte;
@@ -92,6 +95,7 @@ public final class CsvSpecReader {
                 requiredCapabilities.clear();
                 requiredCapabilitiesLocalCluster.clear();
                 missingCapabilitiesRemoteCluster.clear();
+                datasetSources.clear();
                 requestStored = WhenLoadsRequestedToStored.IGNORE_VALUE_ORDER;
                 requestTimeRangeGte = null;
                 requestTimeRangeLte = null;
@@ -136,6 +140,71 @@ public final class CsvSpecReader {
                 return Boolean.TRUE;
             }
             return null;
+        }
+    }
+
+    /**
+     * A single external source declared by a {@code dataset:} preamble directive of the form
+     * {@code dataset: <name>: "<resource>" [WITH {<json>}]}. It carries everything the test harness
+     * needs to either (a) register a {@code data_source}/{@code dataset} pair and run the spec's
+     * {@code FROM <name>} query verbatim on dataset-capable backends, or (b) rebuild the equivalent
+     * {@code EXTERNAL "<resource>" WITH {<json>}} query on backends that cannot back a dataset.
+     *
+     * @param name      the dataset name referenced by the {@code FROM} clause
+     * @param resource  the resource URI or {@code {{template}}} placeholder (without surrounding quotes)
+     * @param withJson  the brace-delimited JSON options object (e.g. {@code {"header_row": false}}), or
+     *                  {@code null} when the directive carries no {@code WITH} clause
+     */
+    public record DatasetSource(String name, String resource, String withJson) {}
+
+    /**
+     * Parses {@code dataset:} preamble directives. Each declares one named external source whose
+     * format options are exactly today's EXTERNAL {@code WITH} options; storage connection settings are
+     * still injected by the test harness, never written in the spec. The directive is repeatable so a
+     * single query can reference multiple datasets.
+     */
+    record Dataset(ParserContext state) implements SpecReader.Parser {
+        @Override
+        public Object parse(String line) {
+            String lower = line.toLowerCase(Locale.ROOT);
+            if (lower.startsWith("dataset:") == false) {
+                return null;
+            }
+            String rest = line.substring("dataset:".length()).trim();
+            int colon = rest.indexOf(':');
+            if (colon < 0) {
+                throw new IllegalArgumentException(
+                    "Invalid dataset directive [" + line + "]: expected 'dataset: <name>: \"<resource>\" [WITH {...}]'"
+                );
+            }
+            String name = rest.substring(0, colon).trim();
+            String spec = rest.substring(colon + 1).trim();
+            if (name.isEmpty() || spec.startsWith("\"") == false) {
+                throw new IllegalArgumentException("Invalid dataset directive [" + line + "]: a name and a quoted resource are required");
+            }
+            int closeQuote = spec.indexOf('"', 1);
+            if (closeQuote < 0) {
+                throw new IllegalArgumentException("Invalid dataset directive [" + line + "]: unterminated resource string");
+            }
+            String resource = spec.substring(1, closeQuote);
+            String remainder = spec.substring(closeQuote + 1).trim();
+            String withJson = null;
+            if (remainder.isEmpty() == false) {
+                if (remainder.toLowerCase(Locale.ROOT).startsWith("with") == false) {
+                    throw new IllegalArgumentException(
+                        "Invalid dataset directive [" + line + "]: expected WITH after the resource, got [" + remainder + "]"
+                    );
+                }
+                String afterWith = remainder.substring("with".length()).trim();
+                if (afterWith.startsWith("{") == false || afterWith.endsWith("}") == false) {
+                    throw new IllegalArgumentException(
+                        "Invalid dataset directive [" + line + "]: WITH must be followed by a JSON object, got [" + afterWith + "]"
+                    );
+                }
+                withJson = afterWith;
+            }
+            state.datasetSources.add(new DatasetSource(name, resource, withJson));
+            return Boolean.TRUE;
         }
     }
 
@@ -314,6 +383,13 @@ public final class CsvSpecReader {
          * (not supported for single-cluster tests)
          */
         public List<String> missingCapabilitiesRemoteCluster = List.of();
+        /**
+         * External sources declared via {@code dataset:} preamble directives, in declaration order.
+         * Empty for the vast majority of tests. When non-empty the query is expected to read these
+         * via {@code FROM <name>}; the test harness registers the datasets (dataset-capable backends)
+         * or rebuilds the equivalent {@code EXTERNAL} query (other backends).
+         */
+        public List<DatasetSource> datasetSources = List.of();
         /**
          * When set from a {@code timestamp_bounds:} line in the expected-results section, the REST request includes
          * a Query DSL range on {@code @timestamp} with these bounds (inclusive).

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/csv-multivalue.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/csv-multivalue.csv-spec
@@ -3,11 +3,18 @@
 // (web_logs). The failure path is the important case: multi-value data read with
 // multi_value_syntax: none misaligns columns — the commas inside [a,b,c] become field separators, so
 // the row has more columns than the schema and is rejected per the error policy.
+//
+// Authored as FROM <dataset>: the per-query CSV options that used to live in EXTERNAL ... WITH {...}
+// now live in `dataset:` directives. On dataset-capable backends (S3) the harness registers the
+// dataset and runs FROM verbatim; on every other backend (including the general single/mixed/multi
+// -cluster EsqlSpecTestCase families that read this shared file) it rebuilds the equivalent EXTERNAL
+// query. Dataset names are distinct per option set so each query's settings are unambiguous.
 
 csvBracketsParsesMultiValue
 required_capability: external_command
+dataset: mv_sample_brackets: "{{mv_sample}}" WITH {"multi_value_syntax": "brackets"}
 
-EXTERNAL "{{mv_sample}}" WITH {"multi_value_syntax": "brackets"}
+FROM mv_sample_brackets
 | EVAL cnt = MV_COUNT(tags)
 | KEEP id, tags, cnt
 | SORT id
@@ -20,8 +27,9 @@ id:integer | tags:keyword         | cnt:integer
 
 csvNoneOnMultiValueDataFailsColumnMismatch
 required_capability: external_command
+dataset: mv_sample_none: "{{mv_sample}}" WITH {"multi_value_syntax": "none", "error_mode": "skip_row"}
 
-EXTERNAL "{{mv_sample}}" WITH {"multi_value_syntax": "none", "error_mode": "skip_row"}
+FROM mv_sample_none
 | KEEP id, tags
 | SORT id
 ;
@@ -34,8 +42,9 @@ id:integer | tags:keyword
 
 csvScalarWithNoneParses
 required_capability: external_command
+dataset: web_logs_none: "{{web_logs}}" WITH {"multi_value_syntax": "none"}
 
-EXTERNAL "{{web_logs}}" WITH {"multi_value_syntax": "none"}
+FROM web_logs_none
 | STATS c = COUNT(*)
 ;
 
@@ -45,8 +54,9 @@ c:long
 
 csvScalarWithBracketsParsesSame
 required_capability: external_command
+dataset: web_logs_brackets: "{{web_logs}}" WITH {"multi_value_syntax": "brackets"}
 
-EXTERNAL "{{web_logs}}" WITH {"multi_value_syntax": "brackets"}
+FROM web_logs_brackets
 | STATS c = COUNT(*)
 ;
 
@@ -76,8 +86,9 @@ c:long
 
 mvExpandFromSplit
 required_capability: external_command
+dataset: employees_brackets: "{{employees}}" WITH {"multi_value_syntax": "brackets"}
 
-EXTERNAL "{{employees}}" WITH {"multi_value_syntax": "brackets"}
+FROM employees_brackets
 | MV_EXPAND job_positions
 | KEEP emp_no, first_name, job_positions
 | SORT emp_no, job_positions
@@ -96,8 +107,9 @@ emp_no:integer | first_name:keyword | job_positions:keyword
 
 mvCountFromSplit
 required_capability: external_command
+dataset: employees_brackets: "{{employees}}" WITH {"multi_value_syntax": "brackets"}
 
-EXTERNAL "{{employees}}" WITH {"multi_value_syntax": "brackets"}
+FROM employees_brackets
 | WHERE emp_no == 10001
 | EVAL cnt = MV_COUNT(job_positions)
 | KEEP emp_no, job_positions, cnt
@@ -109,8 +121,9 @@ emp_no:integer | job_positions:keyword | cnt:integer
 
 mvConcatFromSplit
 required_capability: external_command
+dataset: employees_brackets: "{{employees}}" WITH {"multi_value_syntax": "brackets"}
 
-EXTERNAL "{{employees}}" WITH {"multi_value_syntax": "brackets"}
+FROM employees_brackets
 | WHERE emp_no == 10001
 | EVAL joined = MV_CONCAT(job_positions, ", ")
 | KEEP emp_no, joined
@@ -122,8 +135,9 @@ emp_no:integer | joined:keyword
 
 mvDedupeFromSplit2
 required_capability: external_command
+dataset: employees_brackets: "{{employees}}" WITH {"multi_value_syntax": "brackets"}
 
-EXTERNAL "{{employees}}" WITH {"multi_value_syntax": "brackets"}
+FROM employees_brackets
 | WHERE emp_no == 10004
 | EVAL deduped = MV_SORT(MV_DEDUPE(salary_change))
 | KEEP emp_no, deduped, first_name
@@ -135,7 +149,9 @@ emp_no:integer | deduped:double          | first_name:keyword
 
 filterFirstRowAllColumns
 required_capability: external_command
-EXTERNAL "{{employees}}" WITH {"multi_value_syntax": "brackets"}
+dataset: employees_brackets: "{{employees}}" WITH {"multi_value_syntax": "brackets"}
+
+FROM employees_brackets
 | WHERE emp_no < 10003
 | SORT emp_no
 ;
@@ -146,8 +162,9 @@ birth_date:date          | emp_no:integer | first_name:keyword | gender:keyword 
 
 mvDedupeFromSplit
 required_capability: external_command
+dataset: employees_brackets: "{{employees}}" WITH {"multi_value_syntax": "brackets"}
 
-EXTERNAL "{{employees}}" WITH {"multi_value_syntax": "brackets"}
+FROM employees_brackets
 | WHERE emp_no == 10002
 | EVAL deduped = MV_DEDUPE(job_positions)
 | KEEP emp_no, deduped
@@ -159,8 +176,9 @@ emp_no:integer | deduped:keyword
 
 mvMinFromSplit
 required_capability: external_command
+dataset: employees_brackets: "{{employees}}" WITH {"multi_value_syntax": "brackets"}
 
-EXTERNAL "{{employees}}" WITH {"multi_value_syntax": "brackets"}
+FROM employees_brackets
 | WHERE emp_no == 10004
 | EVAL mn = MV_MIN(job_positions)
 | KEEP emp_no, mn
@@ -172,8 +190,9 @@ emp_no:integer | mn:keyword
 
 mvMaxFromSplit
 required_capability: external_command
+dataset: employees_brackets: "{{employees}}" WITH {"multi_value_syntax": "brackets"}
 
-EXTERNAL "{{employees}}" WITH {"multi_value_syntax": "brackets"}
+FROM employees_brackets
 | WHERE emp_no == 10004
 | EVAL mx = MV_MAX(job_positions)
 | KEEP emp_no, mx
@@ -185,8 +204,9 @@ emp_no:integer | mx:keyword
 
 mvAppendFromScalars
 required_capability: external_command
+dataset: employees_brackets: "{{employees}}" WITH {"multi_value_syntax": "brackets"}
 
-EXTERNAL "{{employees}}" WITH {"multi_value_syntax": "brackets"}
+FROM employees_brackets
 | WHERE emp_no == 10001
 | KEEP emp_no, job_positions
 ;
@@ -196,4 +216,3 @@ emp_no:integer | job_positions:keyword
 ;
 
 // TRANGE and TBUCKET require @timestamp; RENAME hire_date to @timestamp for these tests.
-

--- a/x-pack/plugin/esql/qa/testFixtures/src/test/java/org/elasticsearch/xpack/esql/CsvSpecReaderTests.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/test/java/org/elasticsearch/xpack/esql/CsvSpecReaderTests.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.CsvSpecReader.CsvTestCase;
+import org.elasticsearch.xpack.esql.CsvSpecReader.DatasetSource;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.nullValue;
+
+/**
+ * Unit tests for the {@code dataset:} preamble directive parsed by {@link CsvSpecReader}. The directive
+ * grammar is {@code dataset: <name>: "<resource>" [WITH {<json>}] [// comment]}; these tests pin the
+ * non-trivial bits: escape decoding in the resource, quote/brace-aware scanning (so {@code //} inside the
+ * resource or a JSON value is not a comment), trailing whitespace/comment tolerance, and the rejection of
+ * stray trailing tokens.
+ */
+public class CsvSpecReaderTests extends ESTestCase {
+
+    /**
+     * Feeds the supplied preamble directive line(s) through a fresh parser followed by a trivial
+     * {@code FROM foo} query and an empty result section, returning the assembled test case so the
+     * accumulated {@link CsvTestCase#datasetSources} can be asserted.
+     */
+    private static CsvTestCase parse(String... preamble) {
+        SpecReader.Parser parser = CsvSpecReader.specParser();
+        for (String line : preamble) {
+            parser.parse(line);
+        }
+        parser.parse("FROM foo;");
+        Object result = parser.parse(";");
+        assertThat(result, instanceOf(CsvTestCase.class));
+        return (CsvTestCase) result;
+    }
+
+    private static DatasetSource parseOne(String directive) {
+        CsvTestCase testCase = parse(directive);
+        assertThat(testCase.datasetSources, hasSize(1));
+        return testCase.datasetSources.get(0);
+    }
+
+    public void testResourceOnly() {
+        DatasetSource source = parseOne("dataset: employees: \"{{employees}}\"");
+        assertThat(source.name(), equalTo("employees"));
+        assertThat(source.resource(), equalTo("{{employees}}"));
+        assertThat(source.withJson(), nullValue());
+    }
+
+    public void testResourceWithJson() {
+        DatasetSource source = parseOne("dataset: hl: \"{{employees}}\" WITH {\"header_row\": false}");
+        assertThat(source.name(), equalTo("hl"));
+        assertThat(source.resource(), equalTo("{{employees}}"));
+        assertThat(source.withJson(), equalTo("{\"header_row\": false}"));
+    }
+
+    public void testEscapedQuoteInResourceIsDecoded() {
+        // directive text: dataset: q: "ab\"cd"
+        DatasetSource source = parseOne("dataset: q: \"ab\\\"cd\"");
+        assertThat(source.resource(), equalTo("ab\"cd"));
+        assertThat(source.withJson(), nullValue());
+    }
+
+    public void testEscapedBackslashInResourceIsDecoded() {
+        // directive text: dataset: q: "a\\b" -> resource a\b
+        DatasetSource source = parseOne("dataset: q: \"a\\\\b\"");
+        assertThat(source.resource(), equalTo("a\\b"));
+    }
+
+    public void testDoubleSlashInResourceIsNotAComment() {
+        DatasetSource source = parseOne("dataset: u: \"http://host/path\"");
+        assertThat(source.resource(), equalTo("http://host/path"));
+        assertThat(source.withJson(), nullValue());
+    }
+
+    public void testTrailingCommentAfterResource() {
+        DatasetSource source = parseOne("dataset: c: \"{{x}}\" // no WITH here");
+        assertThat(source.resource(), equalTo("{{x}}"));
+        assertThat(source.withJson(), nullValue());
+    }
+
+    public void testTrailingCommentAfterWith() {
+        DatasetSource source = parseOne("dataset: c: \"{{x}}\" WITH {\"a\": 1}   // trailing note");
+        assertThat(source.resource(), equalTo("{{x}}"));
+        assertThat(source.withJson(), equalTo("{\"a\": 1}"));
+    }
+
+    public void testDoubleSlashInsideJsonValueIsNotAComment() {
+        DatasetSource source = parseOne("dataset: c: \"{{x}}\" WITH {\"url\": \"http://h//x\"}");
+        assertThat(source.withJson(), equalTo("{\"url\": \"http://h//x\"}"));
+    }
+
+    public void testNestedBraceInJsonIsMatched() {
+        DatasetSource source = parseOne("dataset: c: \"{{x}}\" WITH {\"a\": {\"b\": 1}}");
+        assertThat(source.withJson(), equalTo("{\"a\": {\"b\": 1}}"));
+    }
+
+    public void testRepeatableDirectiveAccumulates() {
+        CsvTestCase testCase = parse("dataset: a: \"{{x}}\"", "dataset: b: \"{{y}}\" WITH {\"k\": \"v\"}");
+        assertThat(testCase.datasetSources, hasSize(2));
+        assertThat(testCase.datasetSources.get(0).name(), equalTo("a"));
+        assertThat(testCase.datasetSources.get(1).name(), equalTo("b"));
+        assertThat(testCase.datasetSources.get(1).withJson(), equalTo("{\"k\": \"v\"}"));
+    }
+
+    public void testStrayTrailingTokenRejected() {
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> CsvSpecReader.specParser().parse("dataset: c: \"{{x}}\" WITH {\"a\": 1} garbage")
+        );
+        assertThat(e.getMessage(), containsString("unexpected trailing token after WITH JSON object"));
+    }
+
+    public void testUnterminatedResourceRejected() {
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> CsvSpecReader.specParser().parse("dataset: c: \"{{x}}")
+        );
+        assertThat(e.getMessage(), containsString("unterminated resource string"));
+    }
+
+    public void testUnterminatedWithBraceRejected() {
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> CsvSpecReader.specParser().parse("dataset: c: \"{{x}}\" WITH {\"a\": 1")
+        );
+        assertThat(e.getMessage(), containsString("unterminated WITH JSON object"));
+    }
+
+    public void testNonWithNonCommentTrailerRejected() {
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> CsvSpecReader.specParser().parse("dataset: c: \"{{x}}\" bogus")
+        );
+        assertThat(e.getMessage(), containsString("expected WITH or a // comment after the resource"));
+    }
+
+    public void testMissingQuotedResourceRejected() {
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> CsvSpecReader.specParser().parse("dataset: c: bare")
+        );
+        assertThat(e.getMessage(), containsString("a name and a quoted resource are required"));
+    }
+}

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvIT.java
@@ -329,6 +329,10 @@ public class CsvIT extends ESTestCase {
             "CSV tests cannot handle EXTERNAL sources (requires QA integration tests)",
             testCase.query.trim().toUpperCase(java.util.Locale.ROOT).startsWith("EXTERNAL")
         );
+        assumeFalseLogging(
+            "CSV tests cannot handle dataset-backed FROM <dataset> sources (requires QA integration tests)",
+            testCase.datasetSources.isEmpty() == false
+        );
         assumeTrueLogging(
             "CSV tests don't support remote cluster capability requirements",
             testCase.missingCapabilitiesRemoteCluster.isEmpty()


### PR DESCRIPTION
This is a first step into migrating the existing tests from the `EXTERNAL ... WITH ...` format to the `FROM <dataset>` format.

Only a few pilot .csv-spec suits are migrated. These get a new directive, `dataset` of the form `<dataset name>: <EXTERNAL tail>`, where "EXTERNAL tail" is the content of EXTERNAL command.

The <dataset name> is a dataset configured to include the URI (like "{{foo}}" template), the WITH clause params, plus whatever the testsuite needs to inject to perform the test (like `"auth": none`).

Because of the state of things, S3 source is tested only; GCS/Azure, will need the encryption key wired and dataset allowed for. HTTP/local files not supported yet in datasets either.
