### PR TITLE
[Test] Fix `testReindexFailsWhenSourceIndexIsClosed`

### DIFF
--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexBasicTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexBasicTests.java
@@ -11,6 +11,7 @@ package org.elasticsearch.reindex;
 
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.admin.indices.alias.Alias;
+import org.elasticsearch.action.admin.indices.close.CloseIndexResponse;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
@@ -39,6 +40,7 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.notNullValue;
 
@@ -451,10 +453,18 @@ public class ReindexBasicTests extends ReindexTestCase {
     public void testReindexFailsWhenSourceIndexIsClosed() {
         String sourceIndex = "source";
         String destIndex = "dest";
-        createIndex(sourceIndex);
+        createIndex(sourceIndex, Settings.builder().put("index.routing.rebalance.enable", "none").build());
         ensureGreen(sourceIndex);
         indexRandom(true, prepareIndex(sourceIndex).setId("1").setSource("foo", "bar"));
-        indicesAdmin().prepareClose(sourceIndex).get();
+
+        CloseIndexResponse closeResponse = indicesAdmin().prepareClose(sourceIndex).get();
+        assertThat(closeResponse.isAcknowledged(), is(true));
+        assertThat(closeResponse.getIndices(), hasSize(1));
+        assertThat(
+            "close did not actually close source: " + closeResponse.getIndices(),
+            closeResponse.getIndices().getFirst().hasFailures(),
+            is(false)
+        );
 
         Exception e = expectThrows(Exception.class, () -> {
             ReindexRequest request = new ReindexRequest();


### PR DESCRIPTION

### What
- Create the `source` index with `index.routing.rebalance.enable: none`.
- Assert the close actually closed the index (`isAcknowledged()` + no `IndexResult`
  failures) instead of ignoring the `CloseIndexResponse`.

### Why
The test closes `source`, then expects the subsequent reindex to throw
`IndexClosedException`. Intermittently (≈5% on slow FIPS / platform-support runs)
no exception is thrown.

The CI logs make the cause clear from the order of events. In all three failures
the same sequence appears:

1. `completed closing of indices []` — the close transitioned **zero** indices;
   `source` was never actually closed.
2. ~90ms later: `Cluster health ... [YELLOW] to [GREEN] ... shards started [[source][N]]`
   — a `source` shard only reached STARTED *after* the close, so it was
   INITIALIZING/RELOCATING during the close.
3. Earlier setup shows only node *joins* (a second data node joins just before the
   `source` work) and **no** node-left events.

A previously-STARTED shard (it was, since `ensureGreen` passed and indexing
succeeded) going back to INITIALIZING with no node loss is a balancer rebalance
onto the freshly-joined data node. That relocating shard fails the
verify-before-close step in `MetadataIndexStateService`, so the close silently
no-ops and `prepareClose(...).get()` returns without throwing. The index stays
open, reindex copies the doc into an auto-created `dest`, and `expectThrows` sees
no exception.

The prior fix (#148441) added `ensureGreen` *before* indexing, but the relocation
is triggered *after* indexing, so it missed the window; slow runs widen it.

### Fix rationale
- Disabling rebalancing on `source` prevents the balancer from relocating its
  shards onto the later-joining node, removing the race deterministically.
- Asserting the close result means that if anything ever defeats this again, the
  test fails loudly with the per-shard close-failure reason rather than the
  cryptic "no exception was thrown".

Closes https://github.com/elastic/elasticsearch/issues/151024