### PR TITLE
[9.4] reduce memory footprint of approximation CSV tests (#151644)

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/approximation.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/approximation.csv-spec
@@ -383,18 +383,18 @@ request_stored: skip
 SET approximation={"rows":100000}\;
 FROM many_numbers
     | MV_EXPAND mv
-    | STATS avg=avg(mv), median=median(mv), one=3/(1+SUM(2.0*mv)/SUM(mv)) BY mv
+    | STATS avg=avg(mv), one=3/(1+SUM(2.0*mv)/SUM(mv)) BY mv
     | SORT mv DESC
     | LIMIT 5
 ;
 
 
-avg:double               | median:double | one:double | mv:integer | _approximation_confidence_interval(avg):double      | _approximation_certified(avg):boolean | _approximation_confidence_interval(median):double | _approximation_certified(median):boolean | _approximation_confidence_interval(one):double | _approximation_certified(one):boolean
-1999.999999..2000.000001 | 2000          | 1          | 2000       | [1999.999999..2000.000001,1999.999999..2000.000001] | {any}                                 | [2000,2000]                                       | {any}                                    | [1,1]                                          | {any}
-1998.999999..1999.000001 | 1999          | 1          | 1999       | [1998.999999..1999.000001,1998.999999..1999.000001] | {any}                                 | [1999,1999]                                       | {any}                                    | [1,1]                                          | {any}
-1997.999999..1998.000001 | 1998          | 1          | 1998       | [1997.999999..1998.000001,1997.999999..1998.000001] | {any}                                 | [1998,1998]                                       | {any}                                    | [1,1]                                          | {any}
-1996.999999..1997.000001 | 1997          | 1          | 1997       | [1996.999999..1997.000001,1996.999999..1997.000001] | {any}                                 | [1997,1997]                                       | {any}                                    | [1,1]                                          | {any}
-1995.999999..1996.000001 | 1996          | 1          | 1996       | [1995.999999..1996.000001,1995.999999..1996.000001] | {any}                                 | [1996,1996]                                       | {any}                                    | [1,1]                                          | {any}
+avg:double               | one:double | mv:integer | _approximation_confidence_interval(avg):double      | _approximation_certified(avg):boolean | _approximation_confidence_interval(one):double | _approximation_certified(one):boolean
+1999.999999..2000.000001 | 1          | 2000       | [1999.999999..2000.000001,1999.999999..2000.000001] | {any}                                 | [1,1]                                          | {any}
+1998.999999..1999.000001 | 1          | 1999       | [1998.999999..1999.000001,1998.999999..1999.000001] | {any}                                 | [1,1]                                          | {any}
+1997.999999..1998.000001 | 1          | 1998       | [1997.999999..1998.000001,1997.999999..1998.000001] | {any}                                 | [1,1]                                          | {any}
+1996.999999..1997.000001 | 1          | 1997       | [1996.999999..1997.000001,1996.999999..1997.000001] | {any}                                 | [1,1]                                          | {any}
+1995.999999..1996.000001 | 1          | 1996       | [1995.999999..1996.000001,1995.999999..1996.000001] | {any}                                 | [1,1]                                          | {any}
 ;
 
 


### PR DESCRIPTION
backport of #151644