### PR TITLE
Quote flakiness test commands

### DIFF
--- a/.buildkite/scripts/flakiness-detection/commands.test.ts
+++ b/.buildkite/scripts/flakiness-detection/commands.test.ts
@@ -151,7 +151,7 @@ describe("generateBatchCommand", () => {
       { gradleProject: ":server", kind: "test", sourceSet: "test", fqcn: "org.elasticsearch.index.IndexTests" },
     ];
     expect(generateBatchCommand(batch, DEFAULT_BATCHING_CONFIG)).toBe(
-      ".ci/scripts/run-gradle.sh -Dtests.iters=100 -Dtests.timeoutSuite=3600000! :server:test --tests org.elasticsearch.index.IndexTests",
+      ".ci/scripts/run-gradle.sh -Dtests.iters=100 '-Dtests.timeoutSuite=3600000!' :server:test --tests org.elasticsearch.index.IndexTests",
     );
   });
 
@@ -161,7 +161,7 @@ describe("generateBatchCommand", () => {
       { gradleProject: ":libs:core", kind: "test", sourceSet: "test", fqcn: "org.elasticsearch.core.BarTests" },
     ];
     expect(generateBatchCommand(batch, DEFAULT_BATCHING_CONFIG)).toBe(
-      ".ci/scripts/run-gradle.sh -Dtests.iters=100 -Dtests.timeoutSuite=3600000! :server:test --tests org.elasticsearch.index.FooTests :libs:core:test --tests org.elasticsearch.core.BarTests",
+      ".ci/scripts/run-gradle.sh -Dtests.iters=100 '-Dtests.timeoutSuite=3600000!' :server:test --tests org.elasticsearch.index.FooTests :libs:core:test --tests org.elasticsearch.core.BarTests",
     );
   });
 
@@ -171,7 +171,21 @@ describe("generateBatchCommand", () => {
       { gradleProject: ":server", kind: "test", sourceSet: "test", fqcn: "org.elasticsearch.BarTests" },
     ];
     expect(generateBatchCommand(batch, DEFAULT_BATCHING_CONFIG)).toBe(
-      ".ci/scripts/run-gradle.sh -Dtests.iters=100 -Dtests.timeoutSuite=3600000! :server:test --tests org.elasticsearch.FooTests --tests org.elasticsearch.BarTests",
+      ".ci/scripts/run-gradle.sh -Dtests.iters=100 '-Dtests.timeoutSuite=3600000!' :server:test --tests org.elasticsearch.FooTests --tests org.elasticsearch.BarTests",
+    );
+  });
+
+  test("shell-quotes Java test filters with shell metacharacters", () => {
+    const batch: ClassifiedTest[] = [
+      {
+        gradleProject: ":server",
+        kind: "test",
+        sourceSet: "test",
+        fqcn: "org.elasticsearch.index.Foo Tests'$(echo $HOME)`whoami`;|()",
+      },
+    ];
+    expect(generateBatchCommand(batch, DEFAULT_BATCHING_CONFIG)).toBe(
+      ".ci/scripts/run-gradle.sh -Dtests.iters=100 '-Dtests.timeoutSuite=3600000!' :server:test --tests 'org.elasticsearch.index.Foo Tests'\\''$(echo $HOME)`whoami`;|()'",
     );
   });
 
@@ -185,7 +199,7 @@ describe("generateBatchCommand", () => {
       },
     ];
     expect(generateBatchCommand(batch, DEFAULT_BATCHING_CONFIG)).toBe(
-      ".ci/scripts/run-gradle.sh -Dtests.iters=20 -Dtests.timeoutSuite=3600000! :server:internalClusterTest --tests org.elasticsearch.cluster.ClusterIT",
+      ".ci/scripts/run-gradle.sh -Dtests.iters=20 '-Dtests.timeoutSuite=3600000!' :server:internalClusterTest --tests org.elasticsearch.cluster.ClusterIT",
     );
   });
 
@@ -276,6 +290,20 @@ describe("generateBatchCommand", () => {
     );
   });
 
+  test("shell-quotes YAML suite tasks and per-task suite properties with shell metacharacters", () => {
+    const batch: ClassifiedTest[] = [
+      {
+        gradleProject: ":x pack:plugin:ml;|(`whoami`)",
+        kind: "yamlRestTestSuite",
+        sourceSet: "yamlRestTest",
+        suitePath: "ml/suite path'$(echo $HOME)`date`;|()",
+      },
+    ];
+    expect(generateBatchCommand(batch, DEFAULT_BATCHING_CONFIG)).toBe(
+      ".ci/scripts/repeat-rest-test.sh 10 .ci/scripts/run-gradle.sh ':x pack:plugin:ml;|(`whoami`):yamlRestTest' --rerun '-Dtests.rest.suite.:x pack:plugin:ml;|(`whoami`):yamlRestTest=ml/suite path'\\''$(echo $HOME)`date`;|()'",
+    );
+  });
+
   test("YAML REST test case targets the exact parameterized test", () => {
     const batch: ClassifiedTest[] = [
       {
@@ -287,7 +315,7 @@ describe("generateBatchCommand", () => {
       },
     ];
     expect(generateBatchCommand(batch, DEFAULT_BATCHING_CONFIG)).toBe(
-      '.ci/scripts/repeat-rest-test.sh 10 .ci/scripts/run-gradle.sh :x-pack:plugin:apm-data:yamlRestTest --tests "org.elasticsearch.xpack.apmdata.APMYamlTestSuiteIT.test {yaml=/10_apm/Test template reinstallation}" --rerun',
+      ".ci/scripts/repeat-rest-test.sh 10 .ci/scripts/run-gradle.sh :x-pack:plugin:apm-data:yamlRestTest --tests 'org.elasticsearch.xpack.apmdata.APMYamlTestSuiteIT.test {yaml=/10_apm/Test template reinstallation}' --rerun",
     );
   });
 
@@ -309,7 +337,22 @@ describe("generateBatchCommand", () => {
       },
     ];
     expect(generateBatchCommand(batch, DEFAULT_BATCHING_CONFIG)).toBe(
-      '.ci/scripts/repeat-rest-test.sh 10 .ci/scripts/run-gradle.sh :x-pack:plugin:apm-data:yamlRestTest --tests "org.elasticsearch.xpack.apmdata.APMYamlTestSuiteIT.test {yaml=/10_apm/Test template reinstallation}" --rerun :x-pack:plugin:ml:yamlRestTest --tests "org.elasticsearch.xpack.ml.MlYamlIT.test {yaml=ml/anomaly_detectors_get/basic}" --rerun',
+      ".ci/scripts/repeat-rest-test.sh 10 .ci/scripts/run-gradle.sh :x-pack:plugin:apm-data:yamlRestTest --tests 'org.elasticsearch.xpack.apmdata.APMYamlTestSuiteIT.test {yaml=/10_apm/Test template reinstallation}' --rerun :x-pack:plugin:ml:yamlRestTest --tests 'org.elasticsearch.xpack.ml.MlYamlIT.test {yaml=ml/anomaly_detectors_get/basic}' --rerun",
+    );
+  });
+
+  test("shell-quotes YAML test case descriptors with shell metacharacters", () => {
+    const batch: ClassifiedTest[] = [
+      {
+        gradleProject: ":x-pack:plugin:ml",
+        kind: "yamlRestTestCase",
+        sourceSet: "yamlRestTest",
+        fqcn: "org.elasticsearch.xpack.ml.MlYamlIT",
+        yamlTest: "test {yaml=ml/quoted 'case' $(echo $HOME) `date`;|()}",
+      },
+    ];
+    expect(generateBatchCommand(batch, DEFAULT_BATCHING_CONFIG)).toBe(
+      ".ci/scripts/repeat-rest-test.sh 10 .ci/scripts/run-gradle.sh :x-pack:plugin:ml:yamlRestTest --tests 'org.elasticsearch.xpack.ml.MlYamlIT.test {yaml=ml/quoted '\\''case'\\'' $(echo $HOME) `date`;|()}' --rerun",
     );
   });
 
@@ -318,7 +361,7 @@ describe("generateBatchCommand", () => {
       { gradleProject: ":server", kind: "test", sourceSet: "test", fqcn: "org.elasticsearch.FooTests" },
     ];
     expect(generateBatchCommand(batch, { ...DEFAULT_BATCHING_CONFIG, target: "local" })).toBe(
-      "./gradlew -Dtests.iters=100 -Dtests.timeoutSuite=3600000! :server:test --tests org.elasticsearch.FooTests",
+      "./gradlew -Dtests.iters=100 '-Dtests.timeoutSuite=3600000!' :server:test --tests org.elasticsearch.FooTests",
     );
   });
 
@@ -358,7 +401,7 @@ describe("generateBatchCommand", () => {
       },
     ];
     expect(generateBatchCommand(batch, DEFAULT_BATCHING_CONFIG)).toBe(
-      '.ci/scripts/repeat-rest-test.sh 10 .ci/scripts/run-gradle.sh :x-pack:plugin:ml:yamlRestTest --tests "org.elasticsearch.xpack.ml.MlYamlIT.test {yaml=ml/a}" --tests "org.elasticsearch.xpack.ml.MlYamlIT.test {yaml=ml/b}" --rerun',
+      ".ci/scripts/repeat-rest-test.sh 10 .ci/scripts/run-gradle.sh :x-pack:plugin:ml:yamlRestTest --tests 'org.elasticsearch.xpack.ml.MlYamlIT.test {yaml=ml/a}' --tests 'org.elasticsearch.xpack.ml.MlYamlIT.test {yaml=ml/b}' --rerun",
     );
   });
 });

--- a/.buildkite/scripts/flakiness-detection/commands.ts
+++ b/.buildkite/scripts/flakiness-detection/commands.ts
@@ -4,6 +4,19 @@ import type { BatchingConfig, ClassifiedTest, RunnableCommand, TestKind } from "
 
 import { KIND_KEYS, KIND_LABELS, KIND_ORDER } from "./domain.ts";
 
+const SAFE_SHELL_ARG = /^[A-Za-z0-9_./:=,+@%-]+$/;
+
+function shellQuote(arg: string): string {
+  if (arg.length > 0 && SAFE_SHELL_ARG.test(arg)) {
+    return arg;
+  }
+  return `'${arg.replace(/'/g, "'\\''")}'`;
+}
+
+function joinShellArgs(args: string[]): string {
+  return args.map(shellQuote).join(" ");
+}
+
 export function dedupeTests(tests: ClassifiedTest[]): ClassifiedTest[] {
   const seen = new Set<string>();
   const result: ClassifiedTest[] = [];
@@ -84,10 +97,10 @@ export function deduplicateYamlRunners(tests: ClassifiedTest[]): ClassifiedTest[
 function tasksWithFilters(
   batch: ClassifiedTest[],
   taskName: string,
-  toFilter: (t: ClassifiedTest) => string,
+  toFilter: (t: ClassifiedTest) => string[],
   perTaskSuffix?: string,
-): string {
-  const byTask = new Map<string, string[]>();
+): string[] {
+  const byTask = new Map<string, string[][]>();
   for (const t of batch) {
     const task = `${t.gradleProject}:${taskName}`;
     const filters = byTask.get(task);
@@ -98,8 +111,7 @@ function tasksWithFilters(
     }
   }
   return [...byTask.entries()]
-    .map(([task, filters]) => [task, ...filters, ...(perTaskSuffix ? [perTaskSuffix] : [])].join(" "))
-    .join(" ");
+    .flatMap(([task, filters]) => [task, ...filters.flat(), ...(perTaskSuffix ? [perTaskSuffix] : [])]);
 }
 
 export function generateBatchCommand(batch: ClassifiedTest[], cfg: BatchingConfig): string {
@@ -111,19 +123,30 @@ export function generateBatchCommand(batch: ClassifiedTest[], cfg: BatchingConfi
 
   switch (kind) {
     case "test": {
-      const tasks = tasksWithFilters(batch, "test", (t) => `--tests ${t.fqcn}`);
-      return `${gradle} -Dtests.iters=${cfg.itersByKind.test} -Dtests.timeoutSuite=${cfg.suiteTimeoutMs}! ${tasks}`;
+      const tasks = tasksWithFilters(batch, "test", (t) => ["--tests", t.fqcn!]);
+      return joinShellArgs([gradle, `-Dtests.iters=${cfg.itersByKind.test}`, `-Dtests.timeoutSuite=${cfg.suiteTimeoutMs}!`, ...tasks]);
     }
     case "internalClusterTest": {
-      const tasks = tasksWithFilters(batch, "internalClusterTest", (t) => `--tests ${t.fqcn}`);
-      return `${gradle} -Dtests.iters=${cfg.itersByKind.internalClusterTest} -Dtests.timeoutSuite=${cfg.suiteTimeoutMs}! ${tasks}`;
+      const tasks = tasksWithFilters(batch, "internalClusterTest", (t) => ["--tests", t.fqcn!]);
+      return joinShellArgs([
+        gradle,
+        `-Dtests.iters=${cfg.itersByKind.internalClusterTest}`,
+        `-Dtests.timeoutSuite=${cfg.suiteTimeoutMs}!`,
+        ...tasks,
+      ]);
     }
     case "javaRestTest": {
-      const tasks = tasksWithFilters(batch, "javaRestTest", (t) => `--tests ${t.fqcn}`, "--rerun");
-      return `.ci/scripts/repeat-rest-test.sh ${cfg.restIters} ${gradle} ${tasks}`;
+      const tasks = tasksWithFilters(batch, "javaRestTest", (t) => ["--tests", t.fqcn!], "--rerun");
+      return joinShellArgs([".ci/scripts/repeat-rest-test.sh", String(cfg.restIters), gradle, ...tasks]);
     }
     case "yamlRestTestRunner": {
-      return `.ci/scripts/repeat-rest-test.sh ${cfg.restIters} ${gradle} ${batch[0].gradleProject}:yamlRestTest --rerun`;
+      return joinShellArgs([
+        ".ci/scripts/repeat-rest-test.sh",
+        String(cfg.restIters),
+        gradle,
+        `${batch[0].gradleProject}:yamlRestTest`,
+        "--rerun",
+      ]);
     }
     case "yamlRestTestSuite": {
       // `tests.rest.suite` is a JVM system property, not a Gradle task option,
@@ -141,18 +164,17 @@ export function generateBatchCommand(batch: ClassifiedTest[], cfg: BatchingConfi
           byTask.set(task, [t.suitePath!]);
         }
       }
-      const tasks = [...byTask.keys()].map((task) => `${task} --rerun`).join(" ");
+      const tasks = [...byTask.keys()].flatMap((task) => [task, "--rerun"]);
       const suiteProps = [...byTask.entries()]
-        .map(([task, paths]) => `-Dtests.rest.suite.${task}=${paths.join(",")}`)
-        .join(" ");
-      return `.ci/scripts/repeat-rest-test.sh ${cfg.restIters} ${gradle} ${tasks} ${suiteProps}`;
+        .map(([task, paths]) => `-Dtests.rest.suite.${task}=${paths.join(",")}`);
+      return joinShellArgs([".ci/scripts/repeat-rest-test.sh", String(cfg.restIters), gradle, ...tasks, ...suiteProps]);
     }
     case "yamlRestTestCase": {
       // Each parameterized case is addressed by the full `<FQCN>.test {yaml=...}`
       // form, so multiple cases can be batched into one gradle invocation and
       // share agent and cluster setup.
-      const tasks = tasksWithFilters(batch, "yamlRestTest", (t) => `--tests "${t.fqcn}.${t.yamlTest}"`, "--rerun");
-      return `.ci/scripts/repeat-rest-test.sh ${cfg.restIters} ${gradle} ${tasks}`;
+      const tasks = tasksWithFilters(batch, "yamlRestTest", (t) => ["--tests", `${t.fqcn}.${t.yamlTest}`], "--rerun");
+      return joinShellArgs([".ci/scripts/repeat-rest-test.sh", String(cfg.restIters), gradle, ...tasks]);
     }
   }
 }

--- a/.buildkite/scripts/flakiness-detection/runners/buildkite.test.ts
+++ b/.buildkite/scripts/flakiness-detection/runners/buildkite.test.ts
@@ -34,7 +34,7 @@ describe("toBuildkitePipeline end-to-end", () => {
     expect(step.parallelism).toBeUndefined();
     expect(step.env).toBeUndefined();
     expect(step.command).toContain(
-      ".ci/scripts/run-gradle.sh -Dtests.iters=100 -Dtests.timeoutSuite=3600000! :server:test --tests org.elasticsearch.index.IndexTests"
+      ".ci/scripts/run-gradle.sh -Dtests.iters=100 '-Dtests.timeoutSuite=3600000!' :server:test --tests org.elasticsearch.index.IndexTests"
     );
     expect(step.command).toContain("exit 0");
     // Inner timeout fires 2m before outer timeout_in_minutes so the wrapper


### PR DESCRIPTION
## Summary
- quote generated flakiness detection command arguments with POSIX single-quote escaping
- build Gradle task/filter commands as argv tokens before joining them into shell strings
- add regression coverage for shell metacharacters in Java filters, YAML suite properties, and YAML test case descriptors

## Testing
- pnpm vitest run scripts/flakiness-detection/commands.test.ts
- pnpm test