### PR TITLE
Harden synthetic id escape prefix

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/TSDBSyntheticIdFieldsProducer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/TSDBSyntheticIdFieldsProducer.java
@@ -204,19 +204,38 @@ public class TSDBSyntheticIdFieldsProducer extends FieldsProducer {
         private static BytesRef extractTsid(BytesRef id) {
             // The synthetic id is Uid-encoded, possibly with a 0xfd escape prefix, so we need to skip that prefix
             // when extracting the tsid. See TsidExtractingIdFieldMapper#writeSyntheticId
-            final int escapeBytes = id.length > 0 && Byte.toUnsignedInt(id.bytes[id.offset]) >= Uid.BASE64_ESCAPE ? 1 : 0;
-            if (id.length > Long.BYTES + Integer.BYTES + escapeBytes) {
-                return TsidExtractingIdFieldMapper.extractTimeSeriesIdFromSyntheticId(id);
-            } else {
-                // Lookup whatever term `id` has been provided
-                return escapeBytes == 0 ? id : new BytesRef(id.bytes, id.offset + escapeBytes, id.length - escapeBytes);
+            if (id.length == 0) {
+                return id;
             }
+            final int firstByte = Byte.toUnsignedInt(id.bytes[id.offset]);
+            if (firstByte > Uid.BASE64_ESCAPE) {
+                // Synthetic terms never start with 0xFE or 0xFF — those bytes are escaped
+                // with 0xFD, so it's safe and correct to return END.
+                return null;
+            }
+            // A valid escaped synthetic _id is [0xFD, b, ...] where b >= 0xFD, because Uid#encodeBase64Id
+            // only prepends 0xFD when the decoded first byte (i.e., b) is >= 0xFD. If the second byte (b)
+            // is < 0xFD, this is not a valid escape, so we keep the 0xFD in the tsid lookup — so that the
+            // matching term will be [0xFD, 0xFD, b, ...] which is greater than [0xFD, b, ...]. We can't
+            // return END here to keep the seekCeil contract.
+            final int escapeBytes = firstByte == Uid.BASE64_ESCAPE
+                && (id.length > 1 && Byte.toUnsignedInt(id.bytes[id.offset + 1]) >= Uid.BASE64_ESCAPE) ? 1 : 0;
+            int len = id.length - escapeBytes;
+            if (len > Long.BYTES + Integer.BYTES) {
+                len -= (Long.BYTES + Integer.BYTES);
+            }
+            return new BytesRef(id.bytes, id.offset + escapeBytes, len);
         }
 
         @Override
         public SeekStatus seekCeil(BytesRef id) throws IOException {
             assert id != null;
-            int tsIdOrd = docValues.lookupTsIdTerm(extractTsid(id));
+            BytesRef tsid = extractTsid(id);
+            if (tsid == null) {
+                resetDocID(DocIdSetIterator.NO_MORE_DOCS);
+                return SeekStatus.END;
+            }
+            int tsIdOrd = docValues.lookupTsIdTerm(tsid);
             // _tsid not found
             if (tsIdOrd < 0) {
                 tsIdOrd = -tsIdOrd - 1;

--- a/server/src/main/java/org/elasticsearch/index/mapper/TsidExtractingIdFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TsidExtractingIdFieldMapper.java
@@ -224,7 +224,11 @@ public class TsidExtractingIdFieldMapper extends IdFieldMapper {
         assert id.length > Long.BYTES + Integer.BYTES;
         int len = Math.toIntExact(id.length - Long.BYTES - Integer.BYTES);
         int offset = id.offset;
-        if (Byte.toUnsignedInt(id.bytes[offset]) >= Uid.BASE64_ESCAPE) {
+        final int firstByte = Byte.toUnsignedInt(id.bytes[offset]);
+        assert firstByte <= Uid.BASE64_ESCAPE : "invalid first byte [" + id + "]";
+        if (firstByte >= Uid.BASE64_ESCAPE) {
+            assert len > 2 && Byte.toUnsignedInt(id.bytes[offset + 1]) >= Uid.BASE64_ESCAPE
+                : "invalid second byte with escaped [" + id + "]";
             offset++;
             --len;
         }

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/TSDBSyntheticIdPostingsFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/TSDBSyntheticIdPostingsFormatTests.java
@@ -77,9 +77,9 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -403,7 +403,7 @@ public class TSDBSyntheticIdPostingsFormatTests extends ESTestCase {
         });
     }
 
-    public void testSeekCeilWithShortOrEmptyTerms() throws IOException {
+    public void testSeekCeilWithInvalidEscapedTerms() throws IOException {
         runTestWithRandomDocs((writer, finalDocs) -> {
             try (var reader = DirectoryReader.open(writer)) {
                 assertThat(reader.leaves().size(), equalTo(1));
@@ -414,76 +414,67 @@ public class TSDBSyntheticIdPostingsFormatTests extends ESTestCase {
 
                 final TermsEnum syntheticIdTermsEnum = LazyFilterTermsEnum.unwrap(terms.iterator());
                 assertThat(syntheticIdTermsEnum, instanceOf(SyntheticIdTermsEnum.class));
-
-                final BytesRef firstTerm = finalDocs.firstKey();
-
-                // Test seekCeil with empty BytesRef - should position on first term
+                // terms start with 0xFD is valid if the next byte is >= 0xFD, but either case, the seekCeil should position correctly
                 {
-                    var emptyTerm = new BytesRef();
-                    assertThat(emptyTerm.compareTo(firstTerm), lessThan(0));
-                    assertThat(syntheticIdTermsEnum.seekCeil(emptyTerm), equalTo(TermsEnum.SeekStatus.NOT_FOUND));
-                    assertThat(syntheticIdTermsEnum.term(), equalTo(firstTerm));
-                }
-
-                // Test seekCeil with BytesRef shorter than minimum synthetic ID length
-                // A valid synthetic ID is at least Long.BYTES + Integer.BYTES + 1 bytes
-                {
-                    var shortTerm = new BytesRef(new byte[] { 0x00 });
-                    assertThat(shortTerm.compareTo(firstTerm), lessThan(0));
-                    assertThat(syntheticIdTermsEnum.seekCeil(shortTerm), equalTo(TermsEnum.SeekStatus.NOT_FOUND));
-                    assertThat(syntheticIdTermsEnum.term(), equalTo(firstTerm));
-                }
-
-                {
-                    // Term with exactly Long.BYTES + Integer.BYTES (12 bytes) - still too short
-                    var borderlineTerm = new BytesRef(new byte[Long.BYTES + Integer.BYTES]);
-                    assertThat(syntheticIdTermsEnum.seekCeil(borderlineTerm), equalTo(TermsEnum.SeekStatus.NOT_FOUND));
-                    assertThat(syntheticIdTermsEnum.term(), equalTo(firstTerm));
-                }
-
-                // Test seekExact with short terms - should return false
-                {
-                    assertThat(syntheticIdTermsEnum.seekExact(new BytesRef()), equalTo(false));
-                    assertThat(syntheticIdTermsEnum.seekExact(new BytesRef(new byte[] { 0x01, 0x02 })), equalTo(false));
-                }
-
-                // Test seekCeil with truncated versions of existing terms
-                {
-                    var randomDocsIds = randomNonEmptySubsetOf(finalDocs.keySet());
-                    for (var existingTerm : randomDocsIds) {
-                        // Truncate to various lengths shorter than minimum synthetic ID length
-                        var truncatedTerm = new BytesRef(
-                            existingTerm.bytes,
-                            existingTerm.offset,
-                            randomIntBetween(1, Long.BYTES + Integer.BYTES)
-                        );
-
-                        var status = syntheticIdTermsEnum.seekCeil(truncatedTerm);
-                        assertThat(status, equalTo(TermsEnum.SeekStatus.NOT_FOUND));
-
-                        // The positioned term should be >= truncated term
-                        var positionedTerm = syntheticIdTermsEnum.term();
-                        assertThat(positionedTerm.compareTo(truncatedTerm), greaterThanOrEqualTo(0));
+                    byte firstByte = (byte) 0xFD;
+                    var lookupTerm = new BytesRef(new byte[] { firstByte });
+                    var status = syntheticIdTermsEnum.seekCeil(lookupTerm);
+                    if (status == TermsEnum.SeekStatus.END) {
+                        assertNull(finalDocs.ceilingKey(lookupTerm));
+                    } else {
+                        assertThat(status, is(TermsEnum.SeekStatus.NOT_FOUND));
+                        assertThat(syntheticIdTermsEnum.term(), equalTo(finalDocs.ceilingKey(lookupTerm)));
+                        assertThat(syntheticIdTermsEnum.term(), greaterThan(lookupTerm));
                     }
-                }
-
-                // After seekCeil on a short term, verify we can iterate through all terms
-                {
-                    var emptyTerm = new BytesRef();
-                    assertThat(syntheticIdTermsEnum.seekCeil(emptyTerm), equalTo(TermsEnum.SeekStatus.NOT_FOUND));
-
-                    // Count unique terms by iterating - finalDocs.size() is the number of unique synthetic IDs
-                    int uniqueTermCount = 1; // already positioned on first
-                    BytesRef previousTerm = BytesRef.deepCopyOf(syntheticIdTermsEnum.term());
-                    BytesRef currentTerm;
-                    while ((currentTerm = syntheticIdTermsEnum.next()) != null) {
-                        // Only count when the term changes (skip duplicate docs with same synthetic ID)
-                        if (currentTerm.equals(previousTerm) == false) {
-                            uniqueTermCount++;
-                            previousTerm = BytesRef.deepCopyOf(currentTerm);
+                    for (int secondByte = 0x00; secondByte <= 0xFF; secondByte++) {
+                        lookupTerm = new BytesRef(new byte[] { firstByte, (byte) secondByte });
+                        status = syntheticIdTermsEnum.seekCeil(lookupTerm);
+                        if (status == TermsEnum.SeekStatus.END) {
+                            assertNull(finalDocs.ceilingKey(lookupTerm));
+                        } else {
+                            assertThat(status, is(TermsEnum.SeekStatus.NOT_FOUND));
+                            assertThat(syntheticIdTermsEnum.term(), equalTo(finalDocs.ceilingKey(lookupTerm)));
+                            assertThat(syntheticIdTermsEnum.term(), greaterThan(lookupTerm));
                         }
                     }
-                    assertThat(uniqueTermCount, equalTo(finalDocs.size()));
+                }
+                // all terms start with 0xFE or 0xFF are not found
+                for (int firstByte : List.of(0xFE, 0xFF)) {
+                    assertThat(syntheticIdTermsEnum.seekCeil(new BytesRef(new byte[] { (byte) firstByte })), is(TermsEnum.SeekStatus.END));
+                    for (int secondByte = 0x00; secondByte <= 0xFF; secondByte++) {
+                        assertThat(
+                            syntheticIdTermsEnum.seekCeil(new BytesRef(new byte[] { (byte) firstByte, (byte) secondByte })),
+                            is(TermsEnum.SeekStatus.END)
+                        );
+                        byte thirdByte = randomByte();
+                        assertThat(
+                            syntheticIdTermsEnum.seekCeil(new BytesRef(new byte[] { (byte) firstByte, (byte) secondByte, thirdByte })),
+                            is(TermsEnum.SeekStatus.END)
+                        );
+                    }
+                }
+                // terms start with 0x00..0xFC — these are shorter than any valid synthetic id, seekCeil should position correctly
+                for (int firstByte = 0x00; firstByte < 0xFD; firstByte++) {
+                    var lookupTerm = new BytesRef(new byte[] { (byte) firstByte });
+                    var status = syntheticIdTermsEnum.seekCeil(lookupTerm);
+                    if (status == TermsEnum.SeekStatus.END) {
+                        assertNull(finalDocs.ceilingKey(lookupTerm));
+                    } else {
+                        assertThat(status, is(TermsEnum.SeekStatus.NOT_FOUND));
+                        assertThat(syntheticIdTermsEnum.term(), equalTo(finalDocs.ceilingKey(lookupTerm)));
+                        assertThat(syntheticIdTermsEnum.term(), greaterThan(lookupTerm));
+                    }
+                    for (int secondByte = 0x00; secondByte <= 0xFF; secondByte++) {
+                        lookupTerm = new BytesRef(new byte[] { (byte) firstByte, (byte) secondByte });
+                        status = syntheticIdTermsEnum.seekCeil(lookupTerm);
+                        if (status == TermsEnum.SeekStatus.END) {
+                            assertNull(finalDocs.ceilingKey(lookupTerm));
+                        } else {
+                            assertThat(status, is(TermsEnum.SeekStatus.NOT_FOUND));
+                            assertThat(syntheticIdTermsEnum.term(), equalTo(finalDocs.ceilingKey(lookupTerm)));
+                            assertThat(syntheticIdTermsEnum.term(), greaterThan(lookupTerm));
+                        }
+                    }
                 }
             }
         });


### PR DESCRIPTION
The prefix escape fix for synthetic id in #150433 is not enough for two cases:

1. The prefix starts with `0xFE` or `0xFF` - these terms never exist and we can safely return END. Currently, `seekCeil(0xFF_00)` calls `seekCeil(0x00)` internally and the returned term is before `0xFF_00`, breaking the `seekCeil` contract and leading to an infinite loop.

2. The prefix starts with `0xFD`, but the second byte is less than `0xFD`. For example: `0xFD_00` - currently, we call `seekCeil(0x00)` internally and the found term (e.g. `0x00_01`) is less than `0xFD_00` because no escape prefix is prepended, leading the returned term to be smaller than the seeking term, breaking the seekCeil contract.

#150433 focused on valid terms; this change covers invalid terms.

Relates #145018
Relates #150433