### PR TITLE
Fix BlobStoreSyncDirectoryTests.testCloseCancelsOnGoingUploads

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -626,9 +626,6 @@ tests:
 - class: org.elasticsearch.xpack.stateless.StatelessMergePreWarmingIT
   method: testMergePreWarmingFailureDoesNotFailTheEngine
   issue: https://github.com/elastic/elasticsearch/issues/151618
-- class: org.elasticsearch.xpack.stateless.cluster.coordination.BlobStoreSyncDirectoryTests
-  method: testCloseCancelsOnGoingUploads
-  issue: https://github.com/elastic/elasticsearch/issues/151622
 - class: org.elasticsearch.gradle.internal.precommit.PomValidationPrecommitPluginFuncTest
   method: detects missing POM elements and reports structured problems
   issue: https://github.com/elastic/elasticsearch/issues/151636

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/cluster/coordination/BlobStoreSyncDirectoryTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/cluster/coordination/BlobStoreSyncDirectoryTests.java
@@ -278,18 +278,12 @@ public class BlobStoreSyncDirectoryTests extends ESTestCase {
                         long blobSize,
                         boolean failIfAlreadyExists
                     ) throws IOException {
+                        uploadedFiles.add(blobName);
                         super.writeBlob(purpose, blobName, inputStream, blobSize, failIfAlreadyExists);
                     }
                 };
             }
-        };
-            var dir = new BlobStoreSyncDirectory(
-                new ByteBuffersDirectory(),
-                () -> statelessNode.objectStoreService.getClusterStateBlobContainerForTerm(1),
-                statelessNode.threadPool.executor(ThreadPool.Names.SNAPSHOT)
-            );
-            var indexWriter = new IndexWriter(dir, getIndexWriterConfig())
-        ) {
+        }) {
             var threadPool = statelessNode.threadPool;
             var snapshotExecutor = (EsThreadPoolExecutor) threadPool.executor(ThreadPool.Names.SNAPSHOT);
             var maxPoolSize = snapshotExecutor.getMaximumPoolSize();
@@ -306,22 +300,43 @@ public class BlobStoreSyncDirectoryTests extends ESTestCase {
                 });
             }
 
-            indexRandomDocuments(indexWriter, randomIntBetween(100, 200));
-            var commitFuture = threadPool.executor(ThreadPool.Names.GENERIC).submit(() -> {
+            var bytesDirectory = new ByteBuffersDirectory();
+            var filesToUpload = createRandomFiles(bytesDirectory, randomIntBetween(10, 100));
+            var dir = new BlobStoreSyncDirectory(
+                bytesDirectory,
+                () -> statelessNode.objectStoreService.getClusterStateBlobContainerForTerm(1),
+                snapshotExecutor
+            );
+
+            var genericExecutor = threadPool.executor(ThreadPool.Names.GENERIC);
+            var syncFuture = genericExecutor.submit(() -> {
                 try {
-                    indexWriter.commit();
+                    dir.sync(filesToUpload);
                 } catch (IOException e) {
                     throw new RuntimeException(e);
                 }
             });
-
             dir.close();
-
             blockExecutionLatch.countDown();
 
-            expectThrows(Exception.class, commitFuture::get);
+            try {
+                syncFuture.get();
+            } catch (Exception ignored) {}
+
             assertThat(uploadedFiles, is(empty()));
         }
+    }
+
+    private static List<String> createRandomFiles(ByteBuffersDirectory directory, int numberOfDocs) throws IOException {
+        List<String> files = new ArrayList<>();
+        for (int i = 0; i < numberOfDocs; i++) {
+            final var fileName = "segments_" + i;
+            try (var out = directory.createOutput(fileName, IOContext.DEFAULT)) {
+                out.writeString(randomAlphaOfLengthBetween(10, 100));
+                files.add(fileName);
+            }
+        }
+        return files;
     }
 
     private void indexRandomDocuments(IndexWriter indexWriter, int numberOfDocsSecondCommit) throws IOException {

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/cluster/coordination/BlobStoreSyncDirectoryTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/cluster/coordination/BlobStoreSyncDirectoryTests.java
@@ -321,7 +321,9 @@ public class BlobStoreSyncDirectoryTests extends ESTestCase {
 
             try {
                 syncFuture.get();
-            } catch (Exception ignored) {}
+            } catch (Exception ignored) {
+                fail("we don't expect any exception to be thrown during sync");
+            }
 
             assertThat(uploadedFiles, is(empty()));
         }

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/cluster/coordination/BlobStoreSyncDirectoryTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/cluster/coordination/BlobStoreSyncDirectoryTests.java
@@ -319,12 +319,7 @@ public class BlobStoreSyncDirectoryTests extends ESTestCase {
             dir.close();
             blockExecutionLatch.countDown();
 
-            try {
-                syncFuture.get();
-            } catch (Exception ignored) {
-                fail("we don't expect any exception to be thrown during sync");
-            }
-
+            assertThrows(Exception.class, syncFuture::get);
             assertThat(uploadedFiles, is(empty()));
         }
     }


### PR DESCRIPTION
### Context
In the test case, we were closing the underlying Lucene directory directly. The IndexWriter created in `try-with-resources` block was trying to clean up itself (during the auto-close) and expected the underlying directory to be open (since the rollback function was getting non-empty list of files). Usually, the `dir.close()` happened before the files were added (a race) so in most cases the was a noop, that's why the issue was not caught.

This issue could be easily reproduced by adding a latch that would ensure that files are added to the upload queue before the `dir` is closed.

### Solution

The `IndexWriter` was a redundant mechanism store some content in the Lucene directory. I replaced that with direct calls to the `BlobStoreSyncDirectory`.

### Out of scope

Other methods in the same class follow the same pattern. The refactoring is out of scope of this PR.

Closes: #151622 

