### PR TITLE
[9.3] Fix flaky AbstractSearchAsyncActionTests.testMaybeReEncode (#148213)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -346,9 +346,6 @@ tests:
 - class: org.elasticsearch.repositories.gcs.GoogleCloudStorageBlobContainerRetriesTests
   method: testReadBlobWithPrematureConnectionClose
   issue: https://github.com/elastic/elasticsearch/issues/151476
-- class: org.elasticsearch.action.search.AbstractSearchAsyncActionTests
-  method: testMaybeReEncode
-  issue: https://github.com/elastic/elasticsearch/issues/151704
 - class: org.elasticsearch.xpack.esql.parser.LookupJoinParserTests
   method: testInvalidJoinPatternsExpressionJoin
   issue: https://github.com/elastic/elasticsearch/issues/151705

--- a/server/src/test/java/org/elasticsearch/action/search/AbstractSearchAsyncActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/AbstractSearchAsyncActionTests.java
@@ -330,10 +330,12 @@ public class AbstractSearchAsyncActionTests extends ESTestCase {
             // case 2, some results are from different nodes but have same context Ids
             ArrayList<SearchPhaseResult> results = new ArrayList<>();
             Set<ShardId> shardsWithSwappedNodes = new HashSet<>();
+            // pick at least one shard that must swap, so the re-encoded id is guaranteed to differ from the original
+            ShardId mustSwap = randomFrom(originalShardIdMap.keySet());
             for (ShardId shardId : originalShardIdMap.keySet()) {
                 SearchContextIdForNode searchContextIdForNode = originalShardIdMap.get(shardId);
                 // only swap node for ids there have a non-null node id, i.e. those that didn't fail when opening a PIT
-                if (randomBoolean() && searchContextIdForNode.getNode() != null) {
+                if ((shardId.equals(mustSwap) || randomBoolean()) && searchContextIdForNode.getNode() != null) {
                     // swap to a different node
                     PhaseResult otherNode = new PhaseResult(searchContextIdForNode.getSearchContextId()).withShardTarget(
                         new SearchShardTarget("otherNode", shardId, searchContextIdForNode.getClusterAlias())


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Fix flaky AbstractSearchAsyncActionTests.testMaybeReEncode (#148213)](https://github.com/elastic/elasticsearch/pull/148213)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

Closes #151704