### PR TITLE
Switch by implementation rather than operation on ESVectorUtil benchmarks

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/ESVectorUtilByteOperationBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/ESVectorUtilByteOperationBenchmark.java
@@ -11,6 +11,8 @@ package org.elasticsearch.benchmark.vector;
 
 import org.elasticsearch.benchmark.Utils;
 import org.elasticsearch.simdvec.ESVectorUtil;
+import org.elasticsearch.simdvec.ESVectorizationProvider;
+import org.elasticsearch.simdvec.internal.vectorization.ESVectorUtilSupport;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -24,6 +26,7 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 
+import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
@@ -31,37 +34,36 @@ import java.util.concurrent.TimeUnit;
  * Benchmarks for {@link ESVectorUtil} byte range operations ({@code dotProduct} with length and
  * {@code l2Normalize}) comparing the default scalar implementation against the Panama SIMD path.
  */
+@Fork(value = 1, jvmArgsPrepend = { "--add-modules=jdk.incubator.vector" })
 @Warmup(iterations = 4, time = 1)
 @Measurement(iterations = 5, time = 1)
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 @State(Scope.Thread)
-@Fork(value = 1)
 public class ESVectorUtilByteOperationBenchmark {
 
     static {
         Utils.configureBenchmarkLogging();
     }
 
-    public enum Operation {
-        DOT_PRODUCT,
-        L2_NORMALIZE
-    }
+    @Param({ "SCALAR", "PANAMA" })
+    public VectorImplementation implementation;
 
     @Param({ "1", "128", "207", "256", "300", "512", "702", "1024", "1536", "2048" })
     public int size;
-
-    @Param
-    public Operation operation;
 
     byte[] a;
     byte[] b;
     byte[] normalizeSource;
     byte[] normalizeTarget;
+    ESVectorUtilSupport impl;
 
     @Setup(Level.Trial)
     public void setup() {
-        ThreadLocalRandom random = ThreadLocalRandom.current();
+        setup(ThreadLocalRandom.current());
+    }
+
+    public void setup(Random random) {
         a = new byte[size];
         b = new byte[size];
         normalizeSource = new byte[size];
@@ -74,55 +76,22 @@ public class ESVectorUtilByteOperationBenchmark {
                 normalizeSource[i] = 1;
             }
         }
-    }
-
-    @Benchmark
-    public float scalar() {
-        return switch (operation) {
-            case DOT_PRODUCT -> scalarDotProduct(a, b, 0, size);
-            case L2_NORMALIZE -> {
-                System.arraycopy(normalizeSource, 0, normalizeTarget, 0, size);
-                scalarL2Normalize(normalizeTarget, 0, size);
-                yield normalizeTarget[0];
-            }
+        impl = switch (implementation) {
+            case SCALAR -> ESVectorizationProvider.lookup(false, false).getVectorUtilSupport();
+            case PANAMA -> ESVectorizationProvider.lookup(true, false).getVectorUtilSupport();
+            default -> throw new IllegalArgumentException(implementation.toString());
         };
     }
 
     @Benchmark
-    @Fork(jvmArgsPrepend = { "--add-modules=jdk.incubator.vector" })
-    public float panamaSimd() {
-        return switch (operation) {
-            case DOT_PRODUCT -> ESVectorUtil.dotProduct(a, b, size);
-            case L2_NORMALIZE -> {
-                System.arraycopy(normalizeSource, 0, normalizeTarget, 0, size);
-                ESVectorUtil.l2Normalize(normalizeTarget, size);
-                yield normalizeTarget[0];
-            }
-        };
+    public float dotProduct() {
+        return impl.dotProduct(a, b, 0, size);
     }
 
-    static float scalarDotProduct(byte[] a, byte[] b, int offset, int length) {
-        int sum = 0;
-        int end = offset + length;
-        for (int i = offset; i < end; i++) {
-            sum += a[i] * b[i];
-        }
-        return sum;
-    }
-
-    static void scalarL2Normalize(byte[] v, int offset, int length) {
-        double normSq = 0;
-        int end = offset + length;
-        for (int j = offset; j < end; j++) {
-            double t = v[j];
-            normSq += t * t;
-        }
-        if (normSq == 0) {
-            return;
-        }
-        double invNorm = 1.0 / Math.sqrt(normSq);
-        for (int j = offset; j < end; j++) {
-            v[j] = (byte) (v[j] * invNorm);
-        }
+    @Benchmark
+    public float l2Normalize() {
+        System.arraycopy(normalizeSource, 0, normalizeTarget, 0, size);
+        impl.l2Normalize(normalizeTarget, 0, size);
+        return normalizeTarget[0];
     }
 }

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/ESVectorUtilFloatOperationBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/ESVectorUtilFloatOperationBenchmark.java
@@ -11,6 +11,8 @@ package org.elasticsearch.benchmark.vector;
 
 import org.elasticsearch.benchmark.Utils;
 import org.elasticsearch.simdvec.ESVectorUtil;
+import org.elasticsearch.simdvec.ESVectorizationProvider;
+import org.elasticsearch.simdvec.internal.vectorization.ESVectorUtilSupport;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -24,44 +26,44 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 
+import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Benchmarks for {@link ESVectorUtil} float range operations ({@code dotProduct} with length and
+ * Benchmarks for {@link ESVectorUtil} float range operations ({@code dotProduct} and
  * {@code l2Normalize}) comparing the default scalar implementation against the Panama SIMD path.
  */
+@Fork(value = 1, jvmArgsPrepend = { "--add-modules=jdk.incubator.vector" })
 @Warmup(iterations = 4, time = 1)
 @Measurement(iterations = 5, time = 1)
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 @State(Scope.Thread)
-@Fork(value = 1)
 public class ESVectorUtilFloatOperationBenchmark {
 
     static {
         Utils.configureBenchmarkLogging();
     }
 
-    public enum Operation {
-        DOT_PRODUCT,
-        L2_NORMALIZE
-    }
+    @Param({ "SCALAR", "PANAMA" })
+    public VectorImplementation implementation;
 
     @Param({ "1", "128", "207", "256", "300", "512", "702", "1024", "1536", "2048" })
     public int size;
-
-    @Param
-    public Operation operation;
 
     float[] a;
     float[] b;
     float[] normalizeSource;
     float[] normalizeTarget;
+    ESVectorUtilSupport impl;
 
     @Setup(Level.Trial)
     public void setup() {
-        ThreadLocalRandom random = ThreadLocalRandom.current();
+        setup(ThreadLocalRandom.current());
+    }
+
+    public void setup(Random random) {
         a = new float[size];
         b = new float[size];
         normalizeSource = new float[size];
@@ -71,55 +73,22 @@ public class ESVectorUtilFloatOperationBenchmark {
             b[i] = random.nextFloat();
             normalizeSource[i] = random.nextFloat() + 0.1f;
         }
-    }
-
-    @Benchmark
-    public float scalar() {
-        return switch (operation) {
-            case DOT_PRODUCT -> scalarDotProduct(a, b, 0, size);
-            case L2_NORMALIZE -> {
-                System.arraycopy(normalizeSource, 0, normalizeTarget, 0, size);
-                scalarL2Normalize(normalizeTarget, 0, size);
-                yield normalizeTarget[0];
-            }
+        impl = switch (implementation) {
+            case SCALAR -> ESVectorizationProvider.lookup(false, false).getVectorUtilSupport();
+            case PANAMA -> ESVectorizationProvider.lookup(true, false).getVectorUtilSupport();
+            default -> throw new IllegalArgumentException(implementation.toString());
         };
     }
 
     @Benchmark
-    @Fork(jvmArgsPrepend = { "--add-modules=jdk.incubator.vector" })
-    public float panamaSimd() {
-        return switch (operation) {
-            case DOT_PRODUCT -> ESVectorUtil.dotProduct(a, b, size);
-            case L2_NORMALIZE -> {
-                System.arraycopy(normalizeSource, 0, normalizeTarget, 0, size);
-                ESVectorUtil.l2Normalize(normalizeTarget, size);
-                yield normalizeTarget[0];
-            }
-        };
+    public float dotProduct() {
+        return impl.dotProduct(a, b, 0, size);
     }
 
-    static float scalarDotProduct(float[] a, float[] b, int offset, int length) {
-        float sum = 0f;
-        int end = offset + length;
-        for (int i = offset; i < end; i++) {
-            sum = Math.fma(a[i], b[i], sum);
-        }
-        return sum;
-    }
-
-    static void scalarL2Normalize(float[] v, int offset, int length) {
-        double normSq = 0;
-        int end = offset + length;
-        for (int j = offset; j < end; j++) {
-            double t = v[j];
-            normSq += t * t;
-        }
-        if (normSq == 0) {
-            return;
-        }
-        double invNorm = 1.0 / Math.sqrt(normSq);
-        for (int j = offset; j < end; j++) {
-            v[j] = (float) (v[j] * invNorm);
-        }
+    @Benchmark
+    public float l2Normalize() {
+        System.arraycopy(normalizeSource, 0, normalizeTarget, 0, size);
+        impl.l2Normalize(normalizeTarget, 0, size);
+        return normalizeTarget[0];
     }
 }

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/VectorImplementation.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/VectorImplementation.java
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-package org.elasticsearch.benchmark.vector.scorer;
+package org.elasticsearch.benchmark.vector;
 
 public enum VectorImplementation {
     SCALAR,

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerBFloat16BulkBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerBFloat16BulkBenchmark.java
@@ -14,6 +14,7 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.util.VectorUtil;
 import org.apache.lucene.util.hnsw.UpdateableRandomVectorScorer;
+import org.elasticsearch.benchmark.vector.VectorImplementation;
 import org.elasticsearch.index.codec.vectors.BFloat16;
 import org.elasticsearch.simdvec.VectorScorerFactory;
 import org.elasticsearch.simdvec.VectorSimilarityType;

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerFloat32BulkBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerFloat32BulkBenchmark.java
@@ -14,6 +14,7 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.util.VectorUtil;
 import org.apache.lucene.util.hnsw.UpdateableRandomVectorScorer;
+import org.elasticsearch.benchmark.vector.VectorImplementation;
 import org.elasticsearch.simdvec.VectorScorerFactory;
 import org.elasticsearch.simdvec.VectorSimilarityType;
 import org.openjdk.jmh.annotations.Param;

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerInt4BulkBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerInt4BulkBenchmark.java
@@ -14,6 +14,7 @@ import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.util.quantization.OptimizedScalarQuantizer;
+import org.elasticsearch.benchmark.vector.VectorImplementation;
 import org.elasticsearch.simdvec.VectorSimilarityType;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Setup;

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerInt7uBulkBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerInt7uBulkBenchmark.java
@@ -13,6 +13,7 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.util.hnsw.UpdateableRandomVectorScorer;
 import org.apache.lucene.util.quantization.QuantizedByteVectorValues;
+import org.elasticsearch.benchmark.vector.VectorImplementation;
 import org.elasticsearch.simdvec.VectorScorerFactory;
 import org.elasticsearch.simdvec.VectorSimilarityType;
 import org.openjdk.jmh.annotations.Param;

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerInt8BulkBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerInt8BulkBenchmark.java
@@ -14,6 +14,7 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.util.VectorUtil;
 import org.apache.lucene.util.hnsw.UpdateableRandomVectorScorer;
+import org.elasticsearch.benchmark.vector.VectorImplementation;
 import org.elasticsearch.nativeaccess.jdk.ScalarOperations;
 import org.elasticsearch.simdvec.VectorScorerFactory;
 import org.elasticsearch.simdvec.VectorSimilarityType;

--- a/benchmarks/src/test/java/org/elasticsearch/benchmark/vector/ESVectorUtilByteOperationBenchmarkTests.java
+++ b/benchmarks/src/test/java/org/elasticsearch/benchmark/vector/ESVectorUtilByteOperationBenchmarkTests.java
@@ -11,67 +11,56 @@ package org.elasticsearch.benchmark.vector;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
-import org.elasticsearch.benchmark.vector.ESVectorUtilByteOperationBenchmark.Operation;
-import org.elasticsearch.simdvec.ESVectorUtil;
+import org.elasticsearch.benchmark.vector.scorer.BenchmarkTest;
 import org.elasticsearch.test.ESTestCase;
+
+import java.util.Random;
 
 public class ESVectorUtilByteOperationBenchmarkTests extends ESTestCase {
 
-    private final Operation operation;
     private final int size;
 
-    public ESVectorUtilByteOperationBenchmarkTests(Operation operation, int size) {
-        this.operation = operation;
+    public ESVectorUtilByteOperationBenchmarkTests(int size) {
         this.size = size;
     }
 
-    public void testBenchmarkRuns() {
+    public void testDotProduct() {
+        long seed = randomLong();
         var bench = new ESVectorUtilByteOperationBenchmark();
-        bench.operation = operation;
         bench.size = size;
-        bench.setup();
-        assertFalse(Float.isNaN(bench.scalar()));
-        assertFalse(Float.isNaN(bench.panamaSimd()));
+        bench.implementation = VectorImplementation.SCALAR;
+        bench.setup(new Random(seed));
+        float expected = bench.dotProduct();
+
+        bench = new ESVectorUtilByteOperationBenchmark();
+        bench.size = size;
+        bench.implementation = VectorImplementation.PANAMA;
+        bench.setup(new Random(seed));
+        float panama = bench.dotProduct();
+
+        assertEquals(expected, panama, 0f);
     }
 
-    public void testPanamaMatchesScalar() {
-        assumeTrue("jdk.incubator.vector module required", Runtime.version().feature() >= 21);
-        assumeTrue("jdk.incubator.vector module required", ModuleLayer.boot().findModule("jdk.incubator.vector").isPresent());
+    public void testl2Normalize() {
+        long seed = randomLong();
 
         var bench = new ESVectorUtilByteOperationBenchmark();
-        bench.operation = operation;
         bench.size = size;
-        bench.setup();
+        bench.implementation = VectorImplementation.SCALAR;
+        bench.setup(new Random(seed));
+        float expected = bench.l2Normalize();
 
-        switch (operation) {
-            case DOT_PRODUCT -> assertEquals(
-                ESVectorUtilByteOperationBenchmark.scalarDotProduct(bench.a, bench.b, 0, size),
-                ESVectorUtil.dotProduct(bench.a, bench.b, size),
-                0f
-            );
-            case L2_NORMALIZE -> {
-                byte[] expected = bench.normalizeSource.clone();
-                byte[] actual = bench.normalizeSource.clone();
-                ESVectorUtilByteOperationBenchmark.scalarL2Normalize(expected, 0, size);
-                ESVectorUtil.l2Normalize(actual, size);
-                assertArrayEquals(expected, actual);
-            }
-        }
+        bench = new ESVectorUtilByteOperationBenchmark();
+        bench.size = size;
+        bench.implementation = VectorImplementation.PANAMA;
+        bench.setup(new Random(seed));
+        float panama = bench.l2Normalize();
+
+        assertEquals(expected, panama, 0f);
     }
 
     @ParametersFactory
     public static Iterable<Object[]> parametersFactory() throws NoSuchFieldException {
-        var operationField = ESVectorUtilByteOperationBenchmark.class.getField("operation");
-        var sizeField = ESVectorUtilByteOperationBenchmark.class.getField("size");
-        Operation[] operations = (Operation[]) operationField.getType().getEnumConstants();
-        String[] sizes = sizeField.getAnnotation(org.openjdk.jmh.annotations.Param.class).value();
-        Object[][] params = new Object[operations.length * sizes.length][];
-        int i = 0;
-        for (Operation operation : operations) {
-            for (String size : sizes) {
-                params[i++] = new Object[] { operation, Integer.parseInt(size) };
-            }
-        }
-        return java.util.Arrays.asList(params);
+        return BenchmarkTest.generateParameters(ESVectorUtilByteOperationBenchmark.class.getField("size"));
     }
 }

--- a/benchmarks/src/test/java/org/elasticsearch/benchmark/vector/ESVectorUtilFloatOperationBenchmarkTests.java
+++ b/benchmarks/src/test/java/org/elasticsearch/benchmark/vector/ESVectorUtilFloatOperationBenchmarkTests.java
@@ -11,67 +11,56 @@ package org.elasticsearch.benchmark.vector;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
-import org.elasticsearch.benchmark.vector.ESVectorUtilFloatOperationBenchmark.Operation;
-import org.elasticsearch.simdvec.ESVectorUtil;
+import org.elasticsearch.benchmark.vector.scorer.BenchmarkTest;
 import org.elasticsearch.test.ESTestCase;
+
+import java.util.Random;
 
 public class ESVectorUtilFloatOperationBenchmarkTests extends ESTestCase {
 
-    private final Operation operation;
     private final int size;
 
-    public ESVectorUtilFloatOperationBenchmarkTests(Operation operation, int size) {
-        this.operation = operation;
+    public ESVectorUtilFloatOperationBenchmarkTests(int size) {
         this.size = size;
     }
 
-    public void testBenchmarkRuns() {
+    public void testDotProduct() {
+        long seed = randomLong();
         var bench = new ESVectorUtilFloatOperationBenchmark();
-        bench.operation = operation;
         bench.size = size;
-        bench.setup();
-        assertFalse(Float.isNaN(bench.scalar()));
-        assertFalse(Float.isNaN(bench.panamaSimd()));
+        bench.implementation = VectorImplementation.SCALAR;
+        bench.setup(new Random(seed));
+        float expected = bench.dotProduct();
+
+        bench = new ESVectorUtilFloatOperationBenchmark();
+        bench.size = size;
+        bench.implementation = VectorImplementation.PANAMA;
+        bench.setup(new Random(seed));
+        float panama = bench.dotProduct();
+
+        assertEquals(expected, panama, 1e-3f * size);
     }
 
-    public void testPanamaMatchesScalar() {
-        assumeTrue("jdk.incubator.vector module required", Runtime.version().feature() >= 21);
-        assumeTrue("jdk.incubator.vector module required", ModuleLayer.boot().findModule("jdk.incubator.vector").isPresent());
+    public void testL2Normalize() {
+        long seed = randomLong();
 
         var bench = new ESVectorUtilFloatOperationBenchmark();
-        bench.operation = operation;
         bench.size = size;
-        bench.setup();
+        bench.implementation = VectorImplementation.SCALAR;
+        bench.setup(new Random(seed));
+        float expected = bench.l2Normalize();
 
-        switch (operation) {
-            case DOT_PRODUCT -> assertEquals(
-                ESVectorUtilFloatOperationBenchmark.scalarDotProduct(bench.a, bench.b, 0, size),
-                ESVectorUtil.dotProduct(bench.a, bench.b, size),
-                1e-3f * size
-            );
-            case L2_NORMALIZE -> {
-                float[] expected = bench.normalizeSource.clone();
-                float[] actual = bench.normalizeSource.clone();
-                ESVectorUtilFloatOperationBenchmark.scalarL2Normalize(expected, 0, size);
-                ESVectorUtil.l2Normalize(actual, size);
-                assertArrayEquals(expected, actual, 1e-5f);
-            }
-        }
+        bench = new ESVectorUtilFloatOperationBenchmark();
+        bench.size = size;
+        bench.implementation = VectorImplementation.PANAMA;
+        bench.setup(new Random(seed));
+        float panama = bench.l2Normalize();
+
+        assertEquals(expected, panama, 1e-5f);
     }
 
     @ParametersFactory
     public static Iterable<Object[]> parametersFactory() throws NoSuchFieldException {
-        var operationField = ESVectorUtilFloatOperationBenchmark.class.getField("operation");
-        var sizeField = ESVectorUtilFloatOperationBenchmark.class.getField("size");
-        Operation[] operations = (Operation[]) operationField.getType().getEnumConstants();
-        String[] sizes = sizeField.getAnnotation(org.openjdk.jmh.annotations.Param.class).value();
-        Object[][] params = new Object[operations.length * sizes.length][];
-        int i = 0;
-        for (Operation operation : operations) {
-            for (String size : sizes) {
-                params[i++] = new Object[] { operation, Integer.parseInt(size) };
-            }
-        }
-        return java.util.Arrays.asList(params);
+        return BenchmarkTest.generateParameters(ESVectorUtilFloatOperationBenchmark.class.getField("size"));
     }
 }

--- a/benchmarks/src/test/java/org/elasticsearch/benchmark/vector/scorer/BenchmarkTest.java
+++ b/benchmarks/src/test/java/org/elasticsearch/benchmark/vector/scorer/BenchmarkTest.java
@@ -11,6 +11,7 @@ package org.elasticsearch.benchmark.vector.scorer;
 
 import org.apache.lucene.util.Constants;
 import org.apache.lucene.util.IOFunction;
+import org.elasticsearch.benchmark.vector.VectorImplementation;
 import org.elasticsearch.common.CheckedBiFunction;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.BeforeClass;
@@ -31,7 +32,7 @@ import static org.elasticsearch.simdvec.internal.vectorization.JdkFeatures.SUPPO
 public class BenchmarkTest extends ESTestCase {
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    protected static Iterable<Object[]> generateParameters(Field... paramsFields) {
+    public static Iterable<Object[]> generateParameters(Field... paramsFields) {
         List<Object[]> params = Arrays.stream(paramsFields).map(f -> {
             String[] values = f.getAnnotation(Param.class).value();
             return Arrays.copyOf(values, values.length, Object[].class);

--- a/benchmarks/src/test/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerBFloat16BulkBenchmarkTests.java
+++ b/benchmarks/src/test/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerBFloat16BulkBenchmarkTests.java
@@ -11,6 +11,7 @@ package org.elasticsearch.benchmark.vector.scorer;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
+import org.elasticsearch.benchmark.vector.VectorImplementation;
 import org.elasticsearch.simdvec.VectorSimilarityType;
 
 public class VectorScorerBFloat16BulkBenchmarkTests extends BenchmarkTest {

--- a/benchmarks/src/test/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerFloat32BulkBenchmarkTests.java
+++ b/benchmarks/src/test/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerFloat32BulkBenchmarkTests.java
@@ -11,6 +11,7 @@ package org.elasticsearch.benchmark.vector.scorer;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
+import org.elasticsearch.benchmark.vector.VectorImplementation;
 import org.elasticsearch.simdvec.VectorSimilarityType;
 
 public class VectorScorerFloat32BulkBenchmarkTests extends BenchmarkTest {

--- a/benchmarks/src/test/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerInt4BulkBenchmarkTests.java
+++ b/benchmarks/src/test/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerInt4BulkBenchmarkTests.java
@@ -11,6 +11,7 @@ package org.elasticsearch.benchmark.vector.scorer;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
+import org.elasticsearch.benchmark.vector.VectorImplementation;
 import org.elasticsearch.simdvec.VectorSimilarityType;
 import org.junit.BeforeClass;
 

--- a/benchmarks/src/test/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerInt7uBulkBenchmarkTests.java
+++ b/benchmarks/src/test/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerInt7uBulkBenchmarkTests.java
@@ -11,6 +11,7 @@ package org.elasticsearch.benchmark.vector.scorer;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
+import org.elasticsearch.benchmark.vector.VectorImplementation;
 import org.elasticsearch.simdvec.VectorSimilarityType;
 
 import java.util.List;

--- a/benchmarks/src/test/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerInt8BulkBenchmarkTests.java
+++ b/benchmarks/src/test/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerInt8BulkBenchmarkTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.benchmark.vector.scorer;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
+import org.elasticsearch.benchmark.vector.VectorImplementation;
 import org.elasticsearch.simdvec.VectorSimilarityType;
 
 public class VectorScorerInt8BulkBenchmarkTests extends BenchmarkTest {

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/DefaultESVectorizationProvider.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/DefaultESVectorizationProvider.java
@@ -14,7 +14,7 @@ import org.elasticsearch.simdvec.internal.vectorization.ESVectorUtilSupport;
 
 final class DefaultESVectorizationProvider extends ESVectorizationProvider {
     @Override
-    ESVectorUtilSupport getVectorUtilSupport() {
+    public ESVectorUtilSupport getVectorUtilSupport() {
         return new DefaultESVectorUtilSupport();
     }
 

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/ESVectorizationProvider.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/ESVectorizationProvider.java
@@ -34,7 +34,7 @@ public abstract class ESVectorizationProvider {
 
     ESVectorizationProvider() {}
 
-    abstract ESVectorUtilSupport getVectorUtilSupport();
+    public abstract ESVectorUtilSupport getVectorUtilSupport();
 
     public abstract VectorScorerFactory getVectorScorerFactory();
 

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/Native22ESVectorizationProvider.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/Native22ESVectorizationProvider.java
@@ -14,7 +14,7 @@ import org.elasticsearch.simdvec.internal.vectorization.Native22ESVectorUtilSupp
 
 final class Native22ESVectorizationProvider extends ESVectorizationProvider {
     @Override
-    ESVectorUtilSupport getVectorUtilSupport() {
+    public ESVectorUtilSupport getVectorUtilSupport() {
         return new Native22ESVectorUtilSupport();
     }
 

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/Panama21ESVectorizationProvider.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/Panama21ESVectorizationProvider.java
@@ -14,7 +14,7 @@ import org.elasticsearch.simdvec.internal.vectorization.PanamaESVectorUtilSuppor
 
 final class Panama21ESVectorizationProvider extends ESVectorizationProvider {
     @Override
-    ESVectorUtilSupport getVectorUtilSupport() {
+    public ESVectorUtilSupport getVectorUtilSupport() {
         return new PanamaESVectorUtilSupport();
     }
 

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/Panama22ESVectorizationProvider.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/Panama22ESVectorizationProvider.java
@@ -14,7 +14,7 @@ import org.elasticsearch.simdvec.internal.vectorization.PanamaESVectorUtilSuppor
 
 final class Panama22ESVectorizationProvider extends ESVectorizationProvider {
     @Override
-    ESVectorUtilSupport getVectorUtilSupport() {
+    public ESVectorUtilSupport getVectorUtilSupport() {
         return new PanamaESVectorUtilSupport();
     }
 


### PR DESCRIPTION
To match with the other benchmarks, switch on implementation rather than operation for some ESVectorUtil benchmarks and tests. This means we can use the existing scalar implementation in `DefaultESVectorUtil` rather than redefining it, and simplifies the test code.