### PR TITLE
[Slices] Don't run Yaml test in release builds

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -641,9 +641,6 @@ tests:
 - class: org.elasticsearch.xpack.ml.datafeed.DatafeedManagerTests
   method: testUpdateDatafeedFirstTimeMigrationShouldNotOverrideExistingProjectRouting
   issue: https://github.com/elastic/elasticsearch/issues/151702
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {yaml=search.vectors/47_knn_search_bbq_disk_slice/KNN search with a different _slice returns that slice's nearest neighbor}
-  issue: https://github.com/elastic/elasticsearch/issues/151703
 - class: org.elasticsearch.xpack.esql.CsvIT
   method: test {csv-spec:string.mvAppendNull}
   issue: https://github.com/elastic/elasticsearch/issues/151707

--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -55,12 +55,13 @@ if (buildParams.snapshotBuild == false) {
   // Since there is no infrastructure in place (anytime soon) to generate licenses using the production
   // private key, these tests are blacklisted in non-snapshot test runs
   restTestBlacklist.addAll(['xpack/15_basic/*', 'license/20_put_license/*', 'license/30_enterprise_license/*'])
-
   // TODO: Remove the following when the following features are released. These tests include new privileges only available under feature flags
   //  which require snapshot builds:
   // * Data Stream Lifecycle. manage_data_stream_lifecycle privilege is only available with dlm_feature_flag_enabled set
   // We disable these tests for snapshot builds to maintain release build coverage.
   restTestBlacklist.add('privileges/11_builtin/Test get builtin privileges')
+  // Requires ESNext codec which is not available in release test. This should be removed once the production codec supports slices.
+  restTestBlacklist.add('search.vectors/47_knn_search_bbq_disk_slice/*')
 }
 
 tasks.withType(StandaloneRestIntegTestTask).configureEach {


### PR DESCRIPTION
This suite requires a codec that is currently only available in snapshot builds so this disable those tests.

fixes https://github.com/elastic/elasticsearch/issues/151703