### PR TITLE
Basic implementation of PinnedWindowEvictionPolicy

### DIFF
--- a/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/SharedBlobCacheServiceTestUtils.java
+++ b/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/SharedBlobCacheServiceTestUtils.java
@@ -33,4 +33,18 @@ public final class SharedBlobCacheServiceTestUtils {
     ) {
         cacheService.get(cacheKey, fileLength, region);
     }
+
+    /**
+     * Ensures a cache region is present for the given key, file length, region index, and timestamp by calling
+     * {@link SharedBlobCacheService#get(SharedBlobCacheService.KeyBase, long, int, long)}.
+     */
+    public static <K extends SharedBlobCacheService.KeyBase> void cacheRegion(
+        SharedBlobCacheService<K> cacheService,
+        K cacheKey,
+        long fileLength,
+        int region,
+        long timestampMillis
+    ) {
+        cacheService.get(cacheKey, fileLength, region, timestampMillis);
+    }
 }

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/cache/PinnedWindowEvictionPolicy.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/cache/PinnedWindowEvictionPolicy.java
@@ -9,17 +9,24 @@ package org.elasticsearch.xpack.stateless.cache;
 
 import org.elasticsearch.blobcache.shared.CacheRegion;
 import org.elasticsearch.blobcache.shared.EvictionPolicy;
+import org.elasticsearch.blobcache.shared.SharedBlobCacheService;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.xpack.stateless.lucene.FileCacheKey;
 
 import java.util.Objects;
 
 /**
- * Eviction policy that does not evict data within a configurable pinned window.
+ * Eviction policy that does not evict locally allocated cache regions whose content timestamp
+ * falls within a configurable pinned window.
  * <p>
- * TODO: Complete pinned-window eviction behavior in a follow-up PR. Until then, all regions are evictable.
+ * Regions for locally allocated shards with {@link SharedBlobCacheService#UNKNOWN_TIMESTAMP} are
+ * also protected from eviction until a content timestamp is available. This avoids evicting data
+ * whose age relative to the pinned window cannot yet be determined.
  */
 public class PinnedWindowEvictionPolicy implements EvictionPolicy<FileCacheKey> {
 
@@ -34,22 +41,66 @@ public class PinnedWindowEvictionPolicy implements EvictionPolicy<FileCacheKey> 
         Setting.Property.NodeScope
     );
 
-    private volatile TimeValue pinnedWindowDuration;
+    @Nullable
+    private final ClusterService clusterService;
+
+    private volatile TimeValue pinnedWindowDuration = PINNED_WINDOW_DURATION_SETTING.getDefault(Settings.EMPTY);
 
     public PinnedWindowEvictionPolicy(ClusterService clusterService) {
-        Objects.requireNonNull(clusterService);
+        this.clusterService = Objects.requireNonNull(clusterService);
         clusterService.getClusterSettings()
             .initializeAndWatchIfRegistered(PINNED_WINDOW_DURATION_SETTING, value -> this.pinnedWindowDuration = value);
+    }
+
+    /**
+     * For test subclasses that override {@link #isShardLocallyAllocated} and optionally {@link #currentTimeMillis()}.
+     */
+    protected PinnedWindowEvictionPolicy(TimeValue pinnedWindowDuration) {
+        this.clusterService = null;
+        this.pinnedWindowDuration = pinnedWindowDuration;
     }
 
     public TimeValue getPinnedWindowDuration() {
         return pinnedWindowDuration;
     }
 
+    /**
+     * Returns {@code true} if the shard is assigned to the local node, including as a relocation target.
+     */
+    protected boolean isShardLocallyAllocated(ShardId shardId) {
+        assert clusterService != null;
+        final var state = clusterService.state();
+        final String localNodeId = state.nodes().getLocalNodeId();
+        if (localNodeId == null) {
+            return false;
+        }
+        final var routingNode = state.getRoutingNodes().node(localNodeId);
+        return routingNode != null && routingNode.getByShardId(shardId) != null;
+    }
+
+    protected long currentTimeMillis() {
+        return System.currentTimeMillis();
+    }
+
+    /**
+     * Returns {@code true} if {@code timestampMillis} is within the pinned window relative to {@link #currentTimeMillis()},
+     * inclusive of the window boundary.
+     */
+    protected boolean isWithinPinnedWindow(long timestampMillis) {
+        return currentTimeMillis() - timestampMillis <= pinnedWindowDuration.getMillis();
+    }
+
     @Override
     public boolean canEvict(CacheRegion<FileCacheKey> region, CacheRegion<FileCacheKey> incoming) {
-        // TODO: Respect pinned window duration for valid shards.
-        return true;
+        if (isShardLocallyAllocated(region.key().shardId()) == false) {
+            return true;
+        }
+        final long timestampMillis = region.timestampMillis();
+        // Protect locally allocated regions until their content age can be evaluated.
+        if (timestampMillis == SharedBlobCacheService.UNKNOWN_TIMESTAMP) {
+            return false;
+        }
+        return isWithinPinnedWindow(timestampMillis) == false;
     }
 
     @Override

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/cache/PinnedWindowEvictionPolicyTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/cache/PinnedWindowEvictionPolicyTests.java
@@ -7,25 +7,78 @@
 
 package org.elasticsearch.xpack.stateless.cache;
 
+import org.elasticsearch.blobcache.BlobCacheMetrics;
 import org.elasticsearch.blobcache.shared.CacheRegion;
+import org.elasticsearch.blobcache.shared.SharedBlobCacheService;
+import org.elasticsearch.blobcache.shared.SharedBlobCacheServiceTestUtils;
+import org.elasticsearch.blobcache.shared.SharedBytes;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.ProjectId;
+import org.elasticsearch.cluster.metadata.ProjectMetadata;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.routing.IndexRoutingTable;
+import org.elasticsearch.cluster.routing.RoutingTable;
+import org.elasticsearch.cluster.routing.ShardRoutingState;
+import org.elasticsearch.cluster.routing.TestShardRouting;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.concurrent.DeterministicTaskQueue;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.env.NodeEnvironment;
+import org.elasticsearch.env.TestEnvironment;
+import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.store.ThreadLocalDirectoryMetricHolder;
 import org.elasticsearch.test.ClusterServiceUtils;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.stateless.allocation.StatelessShardRoutingRoleStrategy;
+import org.elasticsearch.xpack.stateless.lucene.BlobStoreCacheDirectoryMetrics;
 import org.elasticsearch.xpack.stateless.lucene.FileCacheKey;
 
+import java.io.IOException;
 import java.util.Set;
 
 import static org.elasticsearch.blobcache.shared.SharedBlobCacheService.UNKNOWN_TIMESTAMP;
+import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_INDEX_UUID;
+import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_VERSION_CREATED;
+import static org.elasticsearch.node.Node.NODE_NAME_SETTING;
 import static org.elasticsearch.xpack.stateless.cache.PinnedWindowEvictionPolicy.PINNED_WINDOW_DURATION_SETTING;
 import static org.hamcrest.Matchers.equalTo;
 
 public class PinnedWindowEvictionPolicyTests extends ESTestCase {
+
+    private static final String LOCAL_NODE_ID = "node";
+    private static final String UNKNOWN_TIMESTAMP_FILE_PREFIX = "unknown-file-";
+    private static final String OUTSIDE_WINDOW_FILE_PREFIX = "outside-window-file-";
+
+    private static final class TestPinnedWindowEvictionPolicy extends PinnedWindowEvictionPolicy {
+        private final Set<ShardId> locallyAllocatedShards;
+        private final long fixedCurrentTimeMillis;
+
+        TestPinnedWindowEvictionPolicy(Set<ShardId> locallyAllocatedShards, long fixedCurrentTimeMillis, long pinnedWindowDurationMillis) {
+            super(TimeValue.timeValueMillis(pinnedWindowDurationMillis));
+            this.locallyAllocatedShards = locallyAllocatedShards;
+            this.fixedCurrentTimeMillis = fixedCurrentTimeMillis;
+        }
+
+        @Override
+        protected boolean isShardLocallyAllocated(ShardId shardId) {
+            return locallyAllocatedShards.contains(shardId);
+        }
+
+        @Override
+        protected long currentTimeMillis() {
+            return fixedCurrentTimeMillis;
+        }
+    }
 
     public void testDurationBelowMinimumRejected() {
         Settings settings = Settings.builder().put(PINNED_WINDOW_DURATION_SETTING.getKey(), "10ms").build();
@@ -46,28 +99,267 @@ public class PinnedWindowEvictionPolicyTests extends ESTestCase {
         }
     }
 
-    public void testCanEvictAlwaysReturnsTrue() {
+    public void testCannotEvictLocallyAllocatedRegionWithinPinnedWindow() {
+        final long now = randomLongBetween(TimeValue.timeValueDays(365).millis(), TimeValue.timeValueDays(365 * 50).millis());
+        final long pinnedWindowDurationMillis = TimeValue.timeValueDays(1).millis();
+        final ShardId shardId = new ShardId("index", randomUUID(), 0);
+        final long timestampMillis = now - randomLongBetween(0, pinnedWindowDurationMillis - 1);
+        final var policy = new TestPinnedWindowEvictionPolicy(Set.of(shardId), now, pinnedWindowDurationMillis);
+
+        assertFalse(policy.canEvict(region(shardId, timestampMillis), region(shardId, timestampMillis + 1)));
+    }
+
+    /**
+     * Locally allocated regions without a content timestamp must remain protected until their age
+     * relative to the pinned window can be evaluated.
+     */
+    public void testCannotEvictLocallyAllocatedRegionWithUnknownTimestamp() {
+        final long now = randomLongBetween(1, Long.MAX_VALUE);
+        final ShardId shardId = new ShardId("index", randomUUID(), 0);
+        final var policy = new TestPinnedWindowEvictionPolicy(Set.of(shardId), now, TimeValue.timeValueDays(1).millis());
+
+        assertFalse(policy.canEvict(region(shardId, UNKNOWN_TIMESTAMP), region(shardId, now)));
+    }
+
+    public void testCanEvictLocallyAllocatedRegionOutsidePinnedWindow() {
+        final long now = randomLongBetween(TimeValue.timeValueDays(365).millis(), TimeValue.timeValueDays(365 * 50).millis());
+        final long pinnedWindowDurationMillis = TimeValue.timeValueDays(1).millis();
+        final ShardId shardId = new ShardId("index", randomUUID(), 0);
+        final long timestampMillis = now - pinnedWindowDurationMillis - randomLongBetween(1, TimeValue.timeValueDays(30).millis());
+        final var policy = new TestPinnedWindowEvictionPolicy(Set.of(shardId), now, pinnedWindowDurationMillis);
+
+        assertTrue(policy.canEvict(region(shardId, timestampMillis), region(shardId, now)));
+    }
+
+    public void testCanEvictWhenShardNotLocallyAllocated() {
+        final long now = randomLongBetween(TimeValue.timeValueDays(365).millis(), TimeValue.timeValueDays(365 * 50).millis());
+        final long pinnedWindowDurationMillis = TimeValue.timeValueDays(1).millis();
+        final ShardId localShard = new ShardId("local", randomUUID(), 0);
+        final ShardId remoteShard = new ShardId("remote", randomUUID(), 0);
+        final long timestampMillis = now - randomLongBetween(0, pinnedWindowDurationMillis - 1);
+        final var policy = new TestPinnedWindowEvictionPolicy(Set.of(localShard), now, pinnedWindowDurationMillis);
+
+        assertTrue(policy.canEvict(region(remoteShard, timestampMillis), region(localShard, timestampMillis)));
+    }
+
+    public void testPinnedWindowBoundaryIsInclusive() {
+        final long pinnedWindowDurationMillis = TimeValue.timeValueDays(1).millis();
+        final long now = pinnedWindowDurationMillis + randomLongBetween(1, Long.MAX_VALUE / 2);
+        final ShardId shardId = new ShardId("index", randomUUID(), 0);
+        final var policy = new TestPinnedWindowEvictionPolicy(Set.of(shardId), now, pinnedWindowDurationMillis);
+
+        assertFalse(policy.canEvict(region(shardId, now - pinnedWindowDurationMillis), region(shardId, now)));
+        assertTrue(policy.canEvict(region(shardId, now - pinnedWindowDurationMillis - 1), region(shardId, now)));
+    }
+
+    public void testShrinkingPinnedWindowMakesRegionEvictable() {
         final DeterministicTaskQueue taskQueue = new DeterministicTaskQueue();
-        final ClusterSettings clusterSettings = createClusterSettings(Settings.EMPTY);
+        final ClusterSettings clusterSettings = createClusterSettings(
+            Settings.builder().put(PINNED_WINDOW_DURATION_SETTING.getKey(), "1d").build()
+        );
+        final ShardId shardId = new ShardId("index", randomUUID(), 0);
+        final long now = System.currentTimeMillis();
+        final long timestampMillis = now - TimeValue.timeValueHours(12).millis();
         try (var clusterService = ClusterServiceUtils.createClusterService(taskQueue.getThreadPool(), clusterSettings)) {
+            ClusterServiceUtils.setState(
+                clusterService,
+                clusterStateWithShardOnLocalNode(
+                    shardId,
+                    indexMetadata(shardId.getIndexName(), shardId.getIndex().getUUID()),
+                    ShardRoutingState.STARTED
+                )
+            );
             final var policy = new PinnedWindowEvictionPolicy(clusterService);
-            final ShardId shardId = new ShardId("index", randomUUID(), 0);
-            final CacheRegion<FileCacheKey> region = region(shardId, 1L, "file-a");
-            final CacheRegion<FileCacheKey> incoming = region(shardId, 1L, "file-b");
+            final CacheRegion<FileCacheKey> region = region(shardId, timestampMillis);
+            final CacheRegion<FileCacheKey> incoming = region(shardId, now);
+
+            assertFalse(policy.canEvict(region, incoming));
+
+            clusterSettings.applySettings(Settings.builder().put(PINNED_WINDOW_DURATION_SETTING.getKey(), "6h").build());
             assertTrue(policy.canEvict(region, incoming));
         }
     }
 
-    private static CacheRegion<FileCacheKey> region(ShardId shardId, long primaryTerm, String file) {
+    public void testCannotEvictRegionForStartedShardOnLocalNodeWithinPinnedWindow() {
+        assertProtectedForLocalShardRoutingState(ShardRoutingState.STARTED);
+    }
+
+    public void testCannotEvictRegionForRelocationTargetShardOnLocalNodeWithinPinnedWindow() {
+        assertProtectedForLocalShardRoutingState(ShardRoutingState.INITIALIZING);
+    }
+
+    public void testCannotEvictRegionForRelocatingShardOnLocalNodeWithinPinnedWindow() {
+        assertProtectedForLocalShardRoutingState(ShardRoutingState.RELOCATING);
+    }
+
+    /**
+     * Fills the cache with a random mix of unknown-timestamp and outside-window regions, then inserts
+     * inside-window regions and verifies that only outside-window regions are evicted to make room.
+     */
+    public void testPinnedWindowEvictionPolicyEvictsOutsideWindowDataInCache() throws IOException {
+        final int numRegions = randomIntBetween(4, 100);
+        final int unknownTimestampRegionCount = randomIntBetween(0, numRegions - 1);
+        final int outsideWindowRegionCount = numRegions - unknownTimestampRegionCount;
+        final long regionSizeInBytes = cacheRegionSizeInBytes(100);
+        final TimeValue pinnedWindowDuration = TimeValue.timeValueDays(1);
+        final long now = System.currentTimeMillis();
+        final long outsideWindowTimestamp = now - pinnedWindowDuration.millis() - randomLongBetween(1, TimeValue.timeValueDays(1).millis());
+        final long insideWindowTimestamp = now - randomLongBetween(0, pinnedWindowDuration.millis() - 1);
+
+        final String oldIndexName = "old-index";
+        final String newIndexName = "new-index";
+        final IndexMetadata oldIndex = indexMetadata(oldIndexName, randomUUID());
+        final IndexMetadata newIndex = indexMetadata(newIndexName, randomUUID());
+
+        Settings settings = pinnedWindowCacheTestSettings(numRegions, regionSizeInBytes, pinnedWindowDuration);
+
+        final ShardId oldShard = new ShardId(oldIndex.getIndex(), 0);
+        final ShardId newShard = new ShardId(newIndex.getIndex(), 0);
+
+        final DeterministicTaskQueue taskQueue = new DeterministicTaskQueue();
+        try (
+            ClusterService clusterService = ClusterServiceUtils.createClusterService(
+                taskQueue.getThreadPool(),
+                createClusterSettings(settings)
+            );
+            NodeEnvironment environment = new NodeEnvironment(settings, TestEnvironment.newEnvironment(settings));
+            StatelessSharedBlobCacheService cacheService = new StatelessSharedBlobCacheService(
+                environment,
+                settings,
+                taskQueue.getThreadPool(),
+                BlobCacheMetrics.NOOP,
+                clusterService,
+                new ThreadLocalDirectoryMetricHolder<>(BlobStoreCacheDirectoryMetrics::new)
+            )
+        ) {
+            ClusterServiceUtils.setState(clusterService, clusterStateWithStartedShardsOnLocalNode(oldIndex, newIndex));
+            assertEquals(numRegions, SharedBlobCacheServiceTestUtils.freeRegionCount(cacheService));
+
+            for (int i = 0; i < unknownTimestampRegionCount; i++) {
+                populateCacheRegion(cacheService, oldShard, UNKNOWN_TIMESTAMP_FILE_PREFIX + i, regionSizeInBytes, null);
+            }
+            for (int i = 0; i < outsideWindowRegionCount; i++) {
+                populateCacheRegion(cacheService, oldShard, OUTSIDE_WINDOW_FILE_PREFIX + i, regionSizeInBytes, outsideWindowTimestamp);
+            }
+            assertEquals(0, SharedBlobCacheServiceTestUtils.freeRegionCount(cacheService));
+            assertThat(
+                countCachedRegionsWithFilePrefix(cacheService, oldShard, UNKNOWN_TIMESTAMP_FILE_PREFIX),
+                equalTo((long) unknownTimestampRegionCount)
+            );
+            assertThat(
+                countCachedRegionsWithFilePrefix(cacheService, oldShard, OUTSIDE_WINDOW_FILE_PREFIX),
+                equalTo((long) outsideWindowRegionCount)
+            );
+
+            final int oldIndexReinsertions = randomIntBetween(1, outsideWindowRegionCount);
+            for (int i = 0; i < oldIndexReinsertions; i++) {
+                populateCacheRegion(
+                    cacheService,
+                    oldShard,
+                    OUTSIDE_WINDOW_FILE_PREFIX + randomIntBetween(0, outsideWindowRegionCount - 1),
+                    regionSizeInBytes,
+                    outsideWindowTimestamp
+                );
+            }
+
+            final int newEntries = randomIntBetween(1, outsideWindowRegionCount);
+            for (int i = 0; i < newEntries; i++) {
+                populateCacheRegion(cacheService, newShard, "new-file-" + i, regionSizeInBytes, insideWindowTimestamp);
+            }
+
+            assertThat(
+                countCachedRegionsWithFilePrefix(cacheService, oldShard, UNKNOWN_TIMESTAMP_FILE_PREFIX),
+                equalTo((long) unknownTimestampRegionCount)
+            );
+            assertThat(
+                countCachedRegionsWithFilePrefix(cacheService, oldShard, OUTSIDE_WINDOW_FILE_PREFIX),
+                equalTo((long) (outsideWindowRegionCount - newEntries))
+            );
+            assertThat(cacheService.countCachedRegions(key -> key.shardId().equals(newShard)), equalTo((long) newEntries));
+            assertThat(cacheService.countCachedRegions(key -> true), equalTo((long) numRegions));
+        }
+    }
+
+    private void assertProtectedForLocalShardRoutingState(ShardRoutingState routingState) {
+        final DeterministicTaskQueue taskQueue = new DeterministicTaskQueue();
+        final ClusterSettings clusterSettings = createClusterSettings(
+            Settings.builder().put(PINNED_WINDOW_DURATION_SETTING.getKey(), "1d").build()
+        );
+        final ShardId shardId = new ShardId("index", randomUUID(), 0);
+        final long now = System.currentTimeMillis();
+        final long timestampMillis = now - randomLongBetween(0, TimeValue.timeValueHours(12).millis());
+        try (var clusterService = ClusterServiceUtils.createClusterService(taskQueue.getThreadPool(), clusterSettings)) {
+            ClusterServiceUtils.setState(
+                clusterService,
+                clusterStateWithShardOnLocalNode(shardId, indexMetadata(shardId.getIndexName(), shardId.getIndex().getUUID()), routingState)
+            );
+            final var policy = new PinnedWindowEvictionPolicy(clusterService);
+            final CacheRegion<FileCacheKey> region = region(shardId, timestampMillis);
+            final CacheRegion<FileCacheKey> incoming = region(shardId, now);
+
+            assertFalse(policy.canEvict(region, incoming));
+        }
+    }
+
+    private static IndexMetadata indexMetadata(String indexName, String indexUuid) {
+        return IndexMetadata.builder(indexName)
+            .settings(Settings.builder().put(SETTING_VERSION_CREATED, IndexVersion.current()).put(SETTING_INDEX_UUID, indexUuid))
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .build();
+    }
+
+    private static ClusterState clusterStateWithShardOnLocalNode(
+        ShardId shardId,
+        IndexMetadata indexMetadata,
+        ShardRoutingState routingState
+    ) {
+        final var shardRouting = switch (routingState) {
+            case INITIALIZING, RELOCATING -> TestShardRouting.newShardRouting(shardId, LOCAL_NODE_ID, "other-node", true, routingState);
+            case STARTED -> TestShardRouting.newShardRouting(shardId, LOCAL_NODE_ID, true, routingState);
+            case UNASSIGNED -> throw new IllegalArgumentException("unsupported routing state [" + routingState + "]");
+        };
+        final IndexRoutingTable indexRoutingTable = IndexRoutingTable.builder(shardId.getIndex()).addShard(shardRouting).build();
+        final RoutingTable routingTable = RoutingTable.builder(new StatelessShardRoutingRoleStrategy()).add(indexRoutingTable).build();
+        final DiscoveryNode localNode = DiscoveryNodeUtils.create("node", LOCAL_NODE_ID);
+        final DiscoveryNode otherNode = DiscoveryNodeUtils.create("other-node", "other-node");
+        return ClusterState.builder(ClusterName.DEFAULT)
+            .nodes(DiscoveryNodes.builder().add(localNode).add(otherNode).localNodeId(LOCAL_NODE_ID).masterNodeId(LOCAL_NODE_ID))
+            .putProjectMetadata(ProjectMetadata.builder(ProjectId.DEFAULT).put(indexMetadata, false).build())
+            .putRoutingTable(ProjectId.DEFAULT, routingTable)
+            .build();
+    }
+
+    private static ClusterState clusterStateWithStartedShardsOnLocalNode(IndexMetadata... indices) {
+        final RoutingTable.Builder routingTableBuilder = RoutingTable.builder(new StatelessShardRoutingRoleStrategy());
+        final ProjectMetadata.Builder projectMetadataBuilder = ProjectMetadata.builder(ProjectId.DEFAULT);
+        for (IndexMetadata index : indices) {
+            final ShardId shardId = new ShardId(index.getIndex(), 0);
+            routingTableBuilder.add(
+                IndexRoutingTable.builder(shardId.getIndex())
+                    .addShard(TestShardRouting.newShardRouting(shardId, LOCAL_NODE_ID, true, ShardRoutingState.STARTED))
+                    .build()
+            );
+            projectMetadataBuilder.put(index, false);
+        }
+        final DiscoveryNode localNode = DiscoveryNodeUtils.create("node", LOCAL_NODE_ID);
+        return ClusterState.builder(ClusterName.DEFAULT)
+            .nodes(DiscoveryNodes.builder().add(localNode).localNodeId(LOCAL_NODE_ID).masterNodeId(LOCAL_NODE_ID))
+            .putProjectMetadata(projectMetadataBuilder.build())
+            .putRoutingTable(ProjectId.DEFAULT, routingTableBuilder.build())
+            .build();
+    }
+
+    private static CacheRegion<FileCacheKey> region(ShardId shardId, long timestampMillis) {
         return new CacheRegion<>() {
             @Override
             public FileCacheKey key() {
-                return new FileCacheKey(shardId, primaryTerm, file);
+                return new FileCacheKey(shardId, 1L, "file");
             }
 
             @Override
             public long timestampMillis() {
-                return UNKNOWN_TIMESTAMP;
+                return timestampMillis;
             }
         };
     }
@@ -76,5 +368,52 @@ public class PinnedWindowEvictionPolicyTests extends ESTestCase {
         Set<Setting<?>> clusterSettings = Sets.newHashSet(ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
         clusterSettings.add(PINNED_WINDOW_DURATION_SETTING);
         return new ClusterSettings(settings, clusterSettings);
+    }
+
+    private static long cacheRegionSizeInBytes(long numPages) {
+        return numPages * SharedBytes.PAGE_SIZE;
+    }
+
+    private Settings pinnedWindowCacheTestSettings(int numRegions, long regionSizeInBytes, TimeValue pinnedWindowDuration) {
+        return Settings.builder()
+            .put(NODE_NAME_SETTING.getKey(), "node")
+            .put(
+                SharedBlobCacheService.SHARED_CACHE_SIZE_SETTING.getKey(),
+                ByteSizeValue.ofBytes(cacheRegionSizeInBytes(numRegions * 100L))
+            )
+            .put(SharedBlobCacheService.SHARED_CACHE_REGION_SIZE_SETTING.getKey(), ByteSizeValue.ofBytes(regionSizeInBytes))
+            .put(SharedBlobCacheService.SHARED_CACHE_INITIAL_DECAYS_SETTING.getKey(), 0)
+            .put(StatelessSharedBlobCacheService.STATELESS_CACHE_BOOST_PREFERENCE_ENABLED_SETTING.getKey(), true)
+            .put(
+                StatelessSharedBlobCacheService.STATELESS_CACHE_BOOST_PREFERENCE_EVICTION_POLICY_SETTING.getKey(),
+                StatelessCacheEvictionPolicyType.PINNED_WINDOW
+            )
+            .put(PINNED_WINDOW_DURATION_SETTING.getKey(), pinnedWindowDuration)
+            .put("path.home", createTempDir())
+            .build();
+    }
+
+    private void populateCacheRegion(
+        StatelessSharedBlobCacheService cacheService,
+        ShardId shardId,
+        String fileName,
+        long regionSizeInBytes,
+        Long timestampMillis
+    ) {
+        var key = new FileCacheKey(shardId, 1L, fileName);
+        long fileLength = randomLongBetween(1, regionSizeInBytes - 1L);
+        if (timestampMillis == null) {
+            SharedBlobCacheServiceTestUtils.cacheRegion(cacheService, key, fileLength, 0);
+        } else {
+            SharedBlobCacheServiceTestUtils.cacheRegion(cacheService, key, fileLength, 0, timestampMillis);
+        }
+    }
+
+    private static long countCachedRegionsWithFilePrefix(
+        StatelessSharedBlobCacheService cacheService,
+        ShardId shardId,
+        String fileNamePrefix
+    ) {
+        return cacheService.countCachedRegions(key -> key.shardId().equals(shardId) && key.fileName().startsWith(fileNamePrefix));
     }
 }


### PR DESCRIPTION
Does not evict cache regions that belong to local shards, and whose timestamps are unknown or fall within the configurable pinned window.
