### PR TITLE
[9.4] ESQL: Fix ValuesReader assertion error (#149683)

### DIFF
--- a/docs/changelog/149683.yaml
+++ b/docs/changelog/149683.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 149683
+summary: Fix `ValuesReader` assertion error
+type: bug

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/read/ValuesReader.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/read/ValuesReader.java
@@ -153,6 +153,7 @@ public abstract class ValuesReader implements ReleasableIterator<Block[]> {
             for (CurrentWork field : current) {
                 field.columnAtATime = field.field.columnAtATime(ctx);
                 if (field.columnAtATime != null) {
+                    field.rowStride = null;
                     columnAtATime.add(field);
                 } else {
                     field.rowStride = field.field.rowStride(ctx);

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/read/ValuesSourceReaderOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/read/ValuesSourceReaderOperatorTests.java
@@ -17,15 +17,19 @@ import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.NoMergePolicy;
+import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.index.TieredMergePolicy;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.tests.mockfile.HandleLimitFS;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.IOFunction;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Randomness;
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.lucene.search.Queries;
@@ -84,6 +88,7 @@ import org.elasticsearch.index.mapper.TextFieldMapper;
 import org.elasticsearch.index.mapper.TextSearchInfo;
 import org.elasticsearch.index.mapper.TsidExtractingIdFieldMapper;
 import org.elasticsearch.index.mapper.blockloader.ConstantBytes;
+import org.elasticsearch.search.fetch.StoredFieldsSpec;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xcontent.json.JsonXContent;
@@ -1984,6 +1989,192 @@ public class ValuesSourceReaderOperatorTests extends OperatorTestCase {
         }
         assertEquals(numDocs, totalPositions);
         assertDriverContext(driverContext);
+    }
+
+    public void testManyReaderClearsRowStrideReaderWhenSwitchingToColumnAtATime() throws IOException {
+        testManyReaderClearsReaderState(FirstSegmentLoading.ROW_STRIDE);
+    }
+
+    public void testManyReaderClearsColumnAtATimeReaderWhenSwitchingToRowStride() throws IOException {
+        testManyReaderClearsReaderState(FirstSegmentLoading.COLUMN_AT_A_TIME);
+    }
+
+    private enum FirstSegmentLoading {
+        ROW_STRIDE,
+        COLUMN_AT_A_TIME
+    }
+
+    private void testManyReaderClearsReaderState(FirstSegmentLoading firstSegmentLoading) throws IOException {
+        // Create two segments so one page can cross a segment boundary.
+        try (
+            IndexWriter writer = new IndexWriter(
+                directory,
+                newIndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE).setMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH)
+            )
+        ) {
+            writer.addDocument(new Document());
+            writer.commit();
+            writer.addDocument(new Document());
+            writer.commit();
+        }
+        reader = DirectoryReader.open(directory);
+        assertThat(reader.leaves(), hasSize(2));
+
+        // Build an incoming page that points at both segments.
+        DriverContext driverContext = driverContext();
+        DocVector docVector;
+        try (DocVector.FixedBuilder builder = DocVector.newFixedBuilder(driverContext.blockFactory(), 2)) {
+            builder.append(0, 0, 0);
+            builder.append(0, 1, 0);
+            docVector = builder.build(DocVector.config());
+        }
+        assertFalse("multi-segment page", docVector.singleSegment());
+
+        // Configure a loader that changes strategy between the first and second segment.
+        ValuesSourceReaderOperator.Factory readerFactory = new ValuesSourceReaderOperator.Factory(
+            ByteSizeValue.ofGb(1),
+            List.of(
+                new ValuesSourceReaderOperator.FieldInfo(
+                    "switching_loader",
+                    ElementType.INT,
+                    false,
+                    (warningsMode, shardIdx) -> ValuesSourceReaderOperator.load(new SwitchingStrategyBlockLoader(firstSegmentLoading))
+                )
+            ),
+            new IndexedByShardIdFromSingleton<>(
+                new ValuesSourceReaderOperator.ShardContext(
+                    reader,
+                    (sourcePaths) -> SourceLoader.FROM_STORED_SOURCE,
+                    STORED_FIELDS_SEQUENTIAL_PROPORTIONS
+                )
+            ),
+            randomBoolean(),
+            0,
+            randomDoubleBetween(0.1, 10.0, true),
+            docSequenceBytesRefFieldThreshold(),
+            () -> 0L
+        );
+
+        // Run the operator through the segment switch that used to trip assertions.
+        Page inputPage = new Page(docVector.asBlock());
+        var runner = new TestDriverRunner().builder(driverContext);
+        List<Page> results = runner.input(List.of(inputPage)).run(readerFactory);
+        try {
+            assertThat(results, hasSize(1));
+            Page result = results.get(0);
+            assertThat(result.getBlockCount(), equalTo(2));
+            IntVector loaded = result.<IntBlock>getBlock(1).asVector();
+            assertThat(loaded.getPositionCount(), equalTo(2));
+            assertThat(loaded.getInt(0), equalTo(0));
+            assertThat(loaded.getInt(1), equalTo(10));
+        } finally {
+            results.forEach(Page::releaseBlocks);
+        }
+        assertDriverContext(driverContext);
+    }
+
+    /**
+     * Test loader that deliberately changes loading strategy across segments.
+     */
+    private record SwitchingStrategyBlockLoader(FirstSegmentLoading firstSegmentLoading) implements BlockLoader {
+        @Override
+        public BlockLoader.Builder builder(BlockLoader.BlockFactory factory, int expectedCount) {
+            return factory.ints(expectedCount);
+        }
+
+        @Override
+        public IOFunction<CircuitBreaker, BlockLoader.ColumnAtATimeReader> columnAtATimeReader(LeafReaderContext context) {
+            boolean firstSegment = context.ord == 0;
+            boolean columnAtATime = firstSegmentLoading == FirstSegmentLoading.COLUMN_AT_A_TIME ? firstSegment : firstSegment == false;
+            return columnAtATime ? breaker -> new SegmentColumnAtATimeReader(context.ord) : null;
+        }
+
+        @Override
+        public BlockLoader.RowStrideReader rowStrideReader(CircuitBreaker breaker, LeafReaderContext context) {
+            return new SegmentRowStrideReader(context.ord);
+        }
+
+        @Override
+        public StoredFieldsSpec rowStrideStoredFieldSpec() {
+            return StoredFieldsSpec.NO_REQUIREMENTS;
+        }
+
+        @Override
+        public boolean supportsOrdinals() {
+            return false;
+        }
+
+        @Override
+        public SortedSetDocValues ordinals(LeafReaderContext context) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String toString() {
+            return "switching_strategy";
+        }
+    }
+
+    /**
+     * Column reader that emits deterministic values for its segment.
+     */
+    private record SegmentColumnAtATimeReader(int segment) implements BlockLoader.ColumnAtATimeReader {
+        @Override
+        public BlockLoader.Block read(BlockLoader.BlockFactory factory, BlockLoader.Docs docs, int offset, boolean nullsFiltered) {
+            BlockLoader.IntBuilder builder = factory.ints(docs.count() - offset);
+            boolean success = false;
+            try {
+                for (int p = offset; p < docs.count(); p++) {
+                    builder.appendInt(value(segment, docs.get(p)));
+                }
+                success = true;
+                return builder.build();
+            } finally {
+                if (success == false) {
+                    builder.close();
+                }
+            }
+        }
+
+        @Override
+        public boolean canReuse(int startingDocID) {
+            return true;
+        }
+
+        @Override
+        public void close() {}
+
+        @Override
+        public String toString() {
+            return "segment_column_at_a_time";
+        }
+    }
+
+    /**
+     * Row-stride reader that emits deterministic values for its segment.
+     */
+    private record SegmentRowStrideReader(int segment) implements BlockLoader.RowStrideReader {
+        @Override
+        public void read(int docId, BlockLoader.StoredFields storedFields, BlockLoader.Builder builder) {
+            ((BlockLoader.IntBuilder) builder).appendInt(value(segment, docId));
+        }
+
+        @Override
+        public boolean canReuse(int startingDocID) {
+            return true;
+        }
+
+        @Override
+        public void close() {}
+
+        @Override
+        public String toString() {
+            return "segment_row_stride";
+        }
+    }
+
+    private static int value(int segment, int doc) {
+        return segment * 10 + doc;
     }
 
     public void testManyShards() throws IOException {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/read/ValuesSourceReaderOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/read/ValuesSourceReaderOperatorTests.java
@@ -2051,8 +2051,7 @@ public class ValuesSourceReaderOperatorTests extends OperatorTestCase {
             randomBoolean(),
             0,
             randomDoubleBetween(0.1, 10.0, true),
-            docSequenceBytesRefFieldThreshold(),
-            () -> 0L
+            docSequenceBytesRefFieldThreshold()
         );
 
         // Run the operator through the segment switch that used to trip assertions.

--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/RestEsqlIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/RestEsqlIT.java
@@ -19,6 +19,7 @@ import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.test.ListMatcher;
 import org.elasticsearch.test.MapMatcher;
 import org.elasticsearch.test.TestClustersThreadFilter;
@@ -66,11 +67,13 @@ import static org.elasticsearch.xpack.esql.planner.PlannerSettings.LUCENE_TOPN_L
 import static org.elasticsearch.xpack.esql.qa.rest.RestEsqlTestCase.Mode.SYNC;
 import static org.elasticsearch.xpack.esql.tools.ProfileParser.parseProfile;
 import static org.elasticsearch.xpack.esql.tools.ProfileParser.readProfileFromResponse;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.any;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.either;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -1308,6 +1311,66 @@ public class RestEsqlIT extends RestEsqlTestCase {
             greaterThanOrEqualTo(1)
         );
         assertMap(reader, matchesMap().extraOk().entry("status", matchesMap().extraOk().entry("readers_built", readersBuiltMatcher)));
+    }
+
+    public void testConditionalBlockLoaderSwitchesStrategyAcrossSegments() throws IOException {
+        assumeTrue(
+            "requires fixed ValuesReader state after conditional block loaders switch strategies across segments",
+            hasCapabilities(adminClient(), List.of(EsqlCapabilities.Cap.FIX_VALUES_READER_STALE_ROW_STRIDE_READER.capabilityName()))
+        );
+        createIndex(testIndexName(), Settings.builder().put("index.number_of_shards", "1").build(), """
+            {
+              "properties": {
+                "sort": {
+                  "type": "integer"
+                },
+                "message": {
+                  "type": "text",
+                  "fields": {
+                    "keyword": {
+                      "type": "keyword",
+                      "ignore_above": 256
+                    }
+                  }
+                }
+              }
+            }
+            """);
+
+        CheckedConsumer<Map.Entry<Integer, String>, IOException> indexMessageDoc = doc -> {
+            Request request = new Request("POST", testIndexName() + "/_doc");
+            request.addParameter("refresh", "true");
+            request.setJsonEntity(String.format(Locale.ROOT, "{\"sort\": %d, \"message\": \"%s\"}", doc.getKey(), doc.getValue()));
+            Response response = client().performRequest(request);
+            assertThat(response.getStatusLine().getStatusCode(), oneOf(200, 201));
+        };
+
+        String longMessage = "words ".repeat(256);
+        String shortMessage = "words words words";
+        indexMessageDoc.accept(Map.entry(0, longMessage));
+        indexMessageDoc.accept(Map.entry(1, shortMessage));
+
+        Map<String, Object> result = runEsql(
+            requestObjectBuilder().query(fromIndex() + " | SORT sort ASC | KEEP message")
+                .profile(true)
+                .pragmas(
+                    Settings.builder()
+                        .put(QueryPragmas.DATA_PARTITIONING.getKey(), "shard")
+                        .put(QueryPragmas.PAGE_SIZE.getKey(), 1000)
+                        .build()
+                )
+                .pragmasOk()
+        );
+
+        ListMatcher schemaMatcher = matchesList().item(Map.of("name", "message", "type", "text"));
+        ListMatcher rowsMatcher = matchesList().item(List.of(longMessage)).item(List.of(shortMessage));
+        assertResultMap(result, getResultMatcher(result).entry("profile", getProfileMatcher()), schemaMatcher, rowsMatcher);
+
+        Map<String, Object> reader = findSingleReaderProfile("node_reduce", result);
+        @SuppressWarnings("unchecked")
+        Map<String, Integer> readersBuilt = (Map<String, Integer>) ((Map<String, Object>) reader.get("status")).get("readers_built");
+        assertThat(readersBuilt, hasKey("message:column_at_a_time:Delegating[to=message.keyword, impl=BytesRefsFromOrds.Singleton]"));
+        assertThat(readersBuilt, hasKey(allOf(startsWith("message:row_stride:["), endsWith("/BlockSourceReader.Bytes]"))));
     }
 
     public void testAutoPartitioning() throws IOException {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -2144,6 +2144,12 @@ public class EsqlCapabilities {
         ENABLE_REDUCE_NODE_LATE_MATERIALIZATION,
 
         /**
+         * Fix stale row-stride reader state when a conditional block loader uses column-at-a-time loading after row-stride loading
+         * across segments.
+         */
+        FIX_VALUES_READER_STALE_ROW_STRIDE_READER,
+
+        /**
          * {@link ReplaceStatsFilteredOrNullAggWithEval} now replaces an
          * {@link org.elasticsearch.xpack.esql.expression.function.aggregate.AggregateFunction} with null value with an
          * {@link org.elasticsearch.xpack.esql.plan.logical.Eval}.


### PR DESCRIPTION
Backports the following commits to 9.4:
 - ESQL: Fix ValuesReader assertion error (#149683)