### PR TITLE
ESQL: Prep for roundup fast path

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/EvalBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/EvalBenchmark.java
@@ -502,7 +502,7 @@ public class EvalBenchmark {
                 checkToUpperExpected(this, actual, true);
             }
         },
-        TSTEP_5("tstep(5)") {
+        TSTEP_5_EQUAL("tstep(5)") {
             @Override
             ExpressionEvaluator evaluator() {
                 return tStepEvaluator(5);
@@ -513,7 +513,7 @@ public class EvalBenchmark {
                 checkTimeGroupingExpected(this, actual);
             }
         },
-        TBUCKET_5("tbucket(5)") {
+        TBUCKET_5_EQUAL("tbucket(5)") {
             @Override
             ExpressionEvaluator evaluator() {
                 return tBucketEvaluator(5);
@@ -524,7 +524,7 @@ public class EvalBenchmark {
                 checkTimeGroupingExpected(this, actual);
             }
         },
-        TSTEP_7("tstep(7)") {
+        TSTEP_7_EQUAL("tstep(7)") {
             @Override
             ExpressionEvaluator evaluator() {
                 return tStepEvaluator(7);
@@ -535,7 +535,7 @@ public class EvalBenchmark {
                 checkTimeGroupingExpected(this, actual);
             }
         },
-        TSTEP_99("tstep(99)") {
+        TSTEP_99_EQUAL("tstep(99)") {
             @Override
             ExpressionEvaluator evaluator() {
                 return tStepEvaluator(99);
@@ -546,7 +546,7 @@ public class EvalBenchmark {
                 checkTimeGroupingExpected(this, actual);
             }
         },
-        TBUCKET_99("tbucket(99)") {
+        TBUCKET_99_EQUAL("tbucket(99)") {
             @Override
             ExpressionEvaluator evaluator() {
                 return tBucketEvaluator(99);
@@ -557,7 +557,7 @@ public class EvalBenchmark {
                 checkTimeGroupingExpected(this, actual);
             }
         },
-        TSTEP_64("tstep(64)") {
+        TSTEP_64_EQUAL("tstep(64)") {
             @Override
             ExpressionEvaluator evaluator() {
                 return tStepEvaluator(64);
@@ -568,7 +568,7 @@ public class EvalBenchmark {
                 checkTimeGroupingExpected(this, actual);
             }
         },
-        TBUCKET_64("tbucket(64)") {
+        TBUCKET_64_EQUAL("tbucket(64)") {
             @Override
             ExpressionEvaluator evaluator() {
                 return tBucketEvaluator(64);
@@ -579,7 +579,7 @@ public class EvalBenchmark {
                 checkTimeGroupingExpected(this, actual);
             }
         },
-        TSTEP_1024("tstep(1024)") {
+        TSTEP_1024_EQUAL("tstep(1024)") {
             @Override
             ExpressionEvaluator evaluator() {
                 return tStepEvaluator(1024);
@@ -590,7 +590,7 @@ public class EvalBenchmark {
                 checkTimeGroupingExpected(this, actual);
             }
         },
-        TBUCKET_1024("tbucket(1024)") {
+        TBUCKET_1024_EQUAL("tbucket(1024)") {
             @Override
             ExpressionEvaluator evaluator() {
                 return tBucketEvaluator(1024);
@@ -601,7 +601,7 @@ public class EvalBenchmark {
                 checkTimeGroupingExpected(this, actual);
             }
         },
-        TBUCKET_7("tbucket(7)") {
+        TBUCKET_7_EQUAL("tbucket(7)") {
             @Override
             ExpressionEvaluator evaluator() {
                 return tBucketEvaluator(7);
@@ -612,7 +612,7 @@ public class EvalBenchmark {
                 checkTimeGroupingExpected(this, actual);
             }
         },
-        TBUCKET_5_UF("tbucket_uf(5)") {
+        TBUCKET_5_NONEQUAL("tbucket_nonequal(5)") {
             @Override
             ExpressionEvaluator evaluator() {
                 return nonUniformBucketEvaluator(5);
@@ -623,7 +623,7 @@ public class EvalBenchmark {
                 checkTimeGroupingExpected(this, actual);
             }
         },
-        TBUCKET_7_UF("tbucket_uf(7)") {
+        TBUCKET_7_NONEQUAL("tbucket_nonequal(7)") {
             @Override
             ExpressionEvaluator evaluator() {
                 return nonUniformBucketEvaluator(7);
@@ -634,7 +634,7 @@ public class EvalBenchmark {
                 checkTimeGroupingExpected(this, actual);
             }
         },
-        TBUCKET_99_UF("tbucket_uf(99)") {
+        TBUCKET_99_NONEQUAL("tbucket_nonequal(99)") {
             @Override
             ExpressionEvaluator evaluator() {
                 return nonUniformBucketEvaluator(99);
@@ -645,7 +645,7 @@ public class EvalBenchmark {
                 checkTimeGroupingExpected(this, actual);
             }
         },
-        TBUCKET_1024_UF("tbucket_uf(1024)") {
+        TBUCKET_1024_NONEQUAL("tbucket_nonequal(1024)") {
             @Override
             ExpressionEvaluator evaluator() {
                 return nonUniformBucketEvaluator(1024);
@@ -1499,8 +1499,9 @@ public class EvalBenchmark {
 
     private static Page page(Operation operation) {
         return switch (operation) {
-            case TSTEP_5, TSTEP_7, TBUCKET_5, TSTEP_99, TBUCKET_99, TSTEP_64, TBUCKET_64, TSTEP_1024, TBUCKET_1024, TBUCKET_7, TBUCKET_5_UF,
-                TBUCKET_7_UF, TBUCKET_99_UF, TBUCKET_1024_UF -> bucketPage();
+            case TSTEP_5_EQUAL, TSTEP_7_EQUAL, TBUCKET_5_EQUAL, TSTEP_99_EQUAL, TBUCKET_99_EQUAL, TSTEP_64_EQUAL, TBUCKET_64_EQUAL,
+                TSTEP_1024_EQUAL, TBUCKET_1024_EQUAL, TBUCKET_7_EQUAL, TBUCKET_5_NONEQUAL, TBUCKET_7_NONEQUAL, TBUCKET_99_NONEQUAL,
+                TBUCKET_1024_NONEQUAL -> bucketPage();
             case ABS, ADD, DATE_TRUNC, EQUAL_TO_CONST, MOD_LONG_CONST_60, DIV_LONG_CONST_60, ROUND_TO_4_VIA_CASE, ROUND_TO_2, ROUND_TO_3,
                 ROUND_TO_4 -> {
                 var builder = blockFactory.newLongBlockBuilder(BLOCK_LENGTH);

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/EvalBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/EvalBenchmark.java
@@ -86,10 +86,12 @@ import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
 
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneOffset;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
@@ -500,10 +502,10 @@ public class EvalBenchmark {
                 checkToUpperExpected(this, actual, true);
             }
         },
-        TSTEP_10("tstep(10)") {
+        TSTEP_5("tstep(5)") {
             @Override
             ExpressionEvaluator evaluator() {
-                return tStepEvaluator(10);
+                return tStepEvaluator(5);
             }
 
             @Override
@@ -511,10 +513,21 @@ public class EvalBenchmark {
                 checkTimeGroupingExpected(this, actual);
             }
         },
-        TBUCKET_10("tbucket(10)") {
+        TBUCKET_5("tbucket(5)") {
             @Override
             ExpressionEvaluator evaluator() {
-                return tBucketEvaluator(10);
+                return tBucketEvaluator(5);
+            }
+
+            @Override
+            void checkExpected(Page actual) {
+                checkTimeGroupingExpected(this, actual);
+            }
+        },
+        TSTEP_7("tstep(7)") {
+            @Override
+            ExpressionEvaluator evaluator() {
+                return tStepEvaluator(7);
             }
 
             @Override
@@ -537,6 +550,105 @@ public class EvalBenchmark {
             @Override
             ExpressionEvaluator evaluator() {
                 return tBucketEvaluator(99);
+            }
+
+            @Override
+            void checkExpected(Page actual) {
+                checkTimeGroupingExpected(this, actual);
+            }
+        },
+        TSTEP_64("tstep(64)") {
+            @Override
+            ExpressionEvaluator evaluator() {
+                return tStepEvaluator(64);
+            }
+
+            @Override
+            void checkExpected(Page actual) {
+                checkTimeGroupingExpected(this, actual);
+            }
+        },
+        TBUCKET_64("tbucket(64)") {
+            @Override
+            ExpressionEvaluator evaluator() {
+                return tBucketEvaluator(64);
+            }
+
+            @Override
+            void checkExpected(Page actual) {
+                checkTimeGroupingExpected(this, actual);
+            }
+        },
+        TSTEP_1024("tstep(1024)") {
+            @Override
+            ExpressionEvaluator evaluator() {
+                return tStepEvaluator(1024);
+            }
+
+            @Override
+            void checkExpected(Page actual) {
+                checkTimeGroupingExpected(this, actual);
+            }
+        },
+        TBUCKET_1024("tbucket(1024)") {
+            @Override
+            ExpressionEvaluator evaluator() {
+                return tBucketEvaluator(1024);
+            }
+
+            @Override
+            void checkExpected(Page actual) {
+                checkTimeGroupingExpected(this, actual);
+            }
+        },
+        TBUCKET_7("tbucket(7)") {
+            @Override
+            ExpressionEvaluator evaluator() {
+                return tBucketEvaluator(7);
+            }
+
+            @Override
+            void checkExpected(Page actual) {
+                checkTimeGroupingExpected(this, actual);
+            }
+        },
+        TBUCKET_5_UF("tbucket_uf(5)") {
+            @Override
+            ExpressionEvaluator evaluator() {
+                return nonUniformBucketEvaluator(5);
+            }
+
+            @Override
+            void checkExpected(Page actual) {
+                checkTimeGroupingExpected(this, actual);
+            }
+        },
+        TBUCKET_7_UF("tbucket_uf(7)") {
+            @Override
+            ExpressionEvaluator evaluator() {
+                return nonUniformBucketEvaluator(7);
+            }
+
+            @Override
+            void checkExpected(Page actual) {
+                checkTimeGroupingExpected(this, actual);
+            }
+        },
+        TBUCKET_99_UF("tbucket_uf(99)") {
+            @Override
+            ExpressionEvaluator evaluator() {
+                return nonUniformBucketEvaluator(99);
+            }
+
+            @Override
+            void checkExpected(Page actual) {
+                checkTimeGroupingExpected(this, actual);
+            }
+        },
+        TBUCKET_1024_UF("tbucket_uf(1024)") {
+            @Override
+            ExpressionEvaluator evaluator() {
+                return nonUniformBucketEvaluator(1024);
             }
 
             @Override
@@ -944,6 +1056,27 @@ public class EvalBenchmark {
             configuration()
         ).surrogate();
         return EvalMapper.toEvaluator(FOLD_CONTEXT, rewriteWithRule(surrogate, ts), layout(ts)).get(driverContext);
+    }
+
+    private static ExpressionEvaluator nonUniformBucketEvaluator(int bucketCount) {
+        FieldAttribute ts = timestampField();
+        return EvalMapper.toEvaluator(FOLD_CONTEXT, nonUniformRoundTo(ts, bucketCount), layout(ts)).get(driverContext);
+    }
+
+    /**
+     * Creates a RoundTo with quadratically-spaced points — guaranteed non-uniform so neither branch
+     * uses the fixed-interval fast path.
+     */
+    private static RoundTo nonUniformRoundTo(FieldAttribute ts, int bucketCount) {
+        long range = TBUCKET_RANGE_END_MILLIS - TBUCKET_RANGE_START_MILLIS;
+        List<Expression> literals = new ArrayList<>(bucketCount + 1);
+        for (int i = 0; i <= bucketCount; i++) {
+            // Quadratic distribution: denser near start, sparser near end
+            double fraction = (double) i * i / ((double) bucketCount * bucketCount);
+            long t = TBUCKET_RANGE_START_MILLIS + (long) (fraction * range);
+            literals.add(new Literal(Source.EMPTY, t, DataType.DATETIME));
+        }
+        return new RoundTo(Source.EMPTY, ts, literals);
     }
 
     private static Expression rewriteWithRule(Expression expression, FieldAttribute ts) {
@@ -1366,7 +1499,8 @@ public class EvalBenchmark {
 
     private static Page page(Operation operation) {
         return switch (operation) {
-            case TSTEP_10, TBUCKET_10, TSTEP_99, TBUCKET_99 -> bucketPage();
+            case TSTEP_5, TSTEP_7, TBUCKET_5, TSTEP_99, TBUCKET_99, TSTEP_64, TBUCKET_64, TSTEP_1024, TBUCKET_1024, TBUCKET_7, TBUCKET_5_UF,
+                TBUCKET_7_UF, TBUCKET_99_UF, TBUCKET_1024_UF -> bucketPage();
             case ABS, ADD, DATE_TRUNC, EQUAL_TO_CONST, MOD_LONG_CONST_60, DIV_LONG_CONST_60, ROUND_TO_4_VIA_CASE, ROUND_TO_2, ROUND_TO_3,
                 ROUND_TO_4 -> {
                 var builder = blockFactory.newLongBlockBuilder(BLOCK_LENGTH);
@@ -1523,10 +1657,11 @@ public class EvalBenchmark {
         long span = TBUCKET_RANGE_END_MILLIS - TBUCKET_RANGE_START_MILLIS;
         var builder = blockFactory.newLongBlockBuilder(BLOCK_LENGTH);
         for (int i = 0; i < BLOCK_LENGTH; i++) {
+            // These evaluators are built from bounded range metadata, so benchmark rows should model that same range filter.
             long value = switch (i & 3) {
                 case 0 -> TBUCKET_RANGE_START_MILLIS + (((long) i * 31) % span);
-                case 1 -> TBUCKET_RANGE_START_MILLIS - (((long) i * 17) % span);
-                case 2 -> TBUCKET_RANGE_END_MILLIS + (((long) i * 23) % span);
+                case 1 -> TBUCKET_RANGE_START_MILLIS + (((long) i * 17) % span);
+                case 2 -> TBUCKET_RANGE_END_MILLIS - (((long) i * 23) % span);
                 case 3 -> TBUCKET_RANGE_START_MILLIS + (((long) i * 61) % span);
                 default -> throw new IllegalStateException("unreachable");
             };
@@ -1557,11 +1692,11 @@ public class EvalBenchmark {
 
     @Benchmark
     @OperationsPerInvocation(1024 * BLOCK_LENGTH)
-    public void run() {
-        run(operation);
+    public void run(Blackhole bh) {
+        bh.consume(run(operation));
     }
 
-    private static void run(Operation operation) {
+    private static Object run(Operation operation) {
         try (var operator = operator(operation)) {
             Page page = page(operation);
             Page output = null;
@@ -1571,6 +1706,8 @@ public class EvalBenchmark {
             }
             // We only check the last one
             checkExpected(operation, output);
+
+            return output;
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/common/Rounding.java
+++ b/server/src/main/java/org/elasticsearch/common/Rounding.java
@@ -405,6 +405,7 @@ public abstract class Rounding implements Writeable {
          * @return the original {@link Rounding} that created this instance.
          */
         Rounding getUnprepared();
+
     }
 
     /**
@@ -615,6 +616,7 @@ public abstract class Rounding implements Writeable {
             public Rounding getUnprepared() {
                 return new ToUpperRounding(delegate.getUnprepared());
             }
+
         }
 
         private final Rounding next;
@@ -723,6 +725,7 @@ public abstract class Rounding implements Writeable {
         public long[] fixedRoundingPoints() {
             return null;
         }
+
     }
 
     static class TimeUnitRounding extends Rounding {
@@ -1737,8 +1740,15 @@ public abstract class Rounding implements Writeable {
 
         @Override
         public long[] fixedRoundingPoints() {
-            // TODO we can likely translate here
-            return null;
+            long[] pts = delegatePrepared.fixedRoundingPoints();
+            if (pts == null) {
+                return null;
+            }
+            long[] shifted = new long[pts.length];
+            for (int i = 0; i < pts.length; i++) {
+                shifted[i] = pts[i] + offset;
+            }
+            return shifted;
         }
 
         @Override
@@ -1746,6 +1756,7 @@ public abstract class Rounding implements Writeable {
             Rounding unprepared = delegatePrepared.getUnprepared();
             return new OffsetRounding(unprepared, offset);
         }
+
     }
 
     public static Rounding read(StreamInput in) throws IOException {

--- a/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToDouble.java
+++ b/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToDouble.java
@@ -10,6 +10,8 @@ package org.elasticsearch.xpack.esql.expression.function.scalar.math;
 // begin generated imports
 import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.ann.Fixed;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.xpack.esql.core.tree.Source;
 
 import java.util.Arrays;
 // end generated imports
@@ -23,8 +25,11 @@ import java.util.Arrays;
  * This class is generated. Edit {@code X-RoundTo.java.st} instead.
  */
 class RoundToDouble {
-    static final RoundTo.Build BUILD = (source, field, points) -> {
-        double[] f = points.stream().mapToDouble(p -> p.doubleValue()).toArray();
+    interface Build {
+        ExpressionEvaluator.Factory build(Source source, ExpressionEvaluator.Factory field, double[] points);
+    }
+
+    static final Build BUILD = (source, field, f) -> {
         return switch (f.length) {
             // TODO should be a consistent way to do the 0 version - is CASE(MV_COUNT(f) == 1, f[0])
             case 1 -> new RoundToDouble1Evaluator.Factory(source, field, f[0]);

--- a/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToInt.java
+++ b/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToInt.java
@@ -10,6 +10,8 @@ package org.elasticsearch.xpack.esql.expression.function.scalar.math;
 // begin generated imports
 import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.ann.Fixed;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.xpack.esql.core.tree.Source;
 
 import java.util.Arrays;
 // end generated imports
@@ -23,8 +25,11 @@ import java.util.Arrays;
  * This class is generated. Edit {@code X-RoundTo.java.st} instead.
  */
 class RoundToInt {
-    static final RoundTo.Build BUILD = (source, field, points) -> {
-        int[] f = points.stream().mapToInt(p -> p.intValue()).toArray();
+    interface Build {
+        ExpressionEvaluator.Factory build(Source source, ExpressionEvaluator.Factory field, int[] points);
+    }
+
+    static final Build BUILD = (source, field, f) -> {
         return switch (f.length) {
             // TODO should be a consistent way to do the 0 version - is CASE(MV_COUNT(f) == 1, f[0])
             case 1 -> new RoundToInt1Evaluator.Factory(source, field, f[0]);

--- a/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLong.java
+++ b/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLong.java
@@ -10,6 +10,8 @@ package org.elasticsearch.xpack.esql.expression.function.scalar.math;
 // begin generated imports
 import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.ann.Fixed;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.xpack.esql.core.tree.Source;
 
 import java.util.Arrays;
 // end generated imports
@@ -23,8 +25,11 @@ import java.util.Arrays;
  * This class is generated. Edit {@code X-RoundTo.java.st} instead.
  */
 class RoundToLong {
-    static final RoundTo.Build BUILD = (source, field, points) -> {
-        long[] f = points.stream().mapToLong(p -> p.longValue()).toArray();
+    interface Build {
+        ExpressionEvaluator.Factory build(Source source, ExpressionEvaluator.Factory field, long[] points);
+    }
+
+    static final Build BUILD = (source, field, f) -> {
         return switch (f.length) {
             // TODO should be a consistent way to do the 0 version - is CASE(MV_COUNT(f) == 1, f[0])
             case 1 -> new RoundToLong1Evaluator.Factory(source, field, f[0]);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/grouping/Bucket.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/grouping/Bucket.java
@@ -301,7 +301,7 @@ public class Bucket extends GroupingFunction.EvaluatableGroupingFunction
         ) Expression to,
         Configuration configuration
     ) {
-        this(source, field, buckets, from, to, configuration, 0L, DOWN);
+        this(source, field, buckets, from, to, configuration, 0L, null);
     }
 
     public Bucket(
@@ -321,7 +321,7 @@ public class Bucket extends GroupingFunction.EvaluatableGroupingFunction
         this.to = to;
         this.configuration = configuration;
         this.offset = offset;
-        this.roundingConvention = roundingConvention;
+        this.roundingConvention = roundingConvention != null ? roundingConvention : DOWN;
     }
 
     private Bucket(StreamInput in) throws IOException {
@@ -335,7 +335,7 @@ public class Bucket extends GroupingFunction.EvaluatableGroupingFunction
             in.getTransportVersion().supports(ESQL_BUCKET_OFFSET) ? in.readZLong() : 0L,
             in.getTransportVersion().supports(ESQL_SUPPORT_EXPLICIT_BUCKET_ROUNDING_CONFIGURATION)
                 ? in.readEnum(RoundingConvention.class)
-                : DOWN
+                : null
         );
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/grouping/Bucket.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/grouping/Bucket.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.Rounding.RoundingConvention;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.time.DateUtils;
 import org.elasticsearch.compute.expression.ExpressionEvaluator;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
@@ -539,7 +540,15 @@ public class Bucket extends GroupingFunction.EvaluatableGroupingFunction
     }
 
     public static TypeResolution isStringOrDate(Expression e, String operationName, TypeResolutions.ParamOrdinal paramOrd) {
-        return isType(e, exp -> DataType.isString(exp) || DataType.isDateTime(exp), operationName, paramOrd, "datetime", "string");
+        return isType(
+            e,
+            exp -> DataType.isString(exp) || DataType.isMillisOrNanos(exp),
+            operationName,
+            paramOrd,
+            "datetime",
+            "date_nanos",
+            "string"
+        );
     }
 
     @Override
@@ -553,7 +562,13 @@ public class Bucket extends GroupingFunction.EvaluatableGroupingFunction
 
     private long foldToLong(FoldContext ctx, Expression e) {
         Object value = Foldables.valueOf(ctx, e);
-        return DataType.isDateTime(e.dataType()) ? ((Number) value).longValue() : dateTimeToLong(((BytesRef) value).utf8ToString());
+        if (DataType.isDateTime(e.dataType())) {
+            return ((Number) value).longValue();
+        }
+        if (e.dataType() == DataType.DATE_NANOS) {
+            return DateUtils.toMilliSeconds(((Number) value).longValue());
+        }
+        return dateTimeToLong(((BytesRef) value).utf8ToString());
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundTo.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundTo.java
@@ -35,10 +35,8 @@ import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
 import org.elasticsearch.xpack.esql.stats.SearchStats;
 
 import java.io.IOException;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
 
 import static org.elasticsearch.common.logging.LoggerMessageFormat.format;
 import static org.elasticsearch.xpack.esql.action.EsqlCapabilities.Cap.ROUND_TO_BLOCK_LOADER;
@@ -127,7 +125,7 @@ public class RoundTo extends EsqlScalarFunction implements BlockLoaderExpression
         }
 
         DataType dataType = dataType();
-        if (dataType == null || SIGNATURES.containsKey(dataType) == false) {
+        if ((dataType == LONG || dataType == DATETIME || dataType == DATE_NANOS || dataType == INTEGER || dataType == DOUBLE) == false) {
             return new TypeResolution(format(null, "all arguments must be numeric, date, or data_nanos"));
         }
 
@@ -185,51 +183,42 @@ public class RoundTo extends EsqlScalarFunction implements BlockLoaderExpression
     @Override
     public ExpressionEvaluator.Factory toEvaluator(ToEvaluator toEvaluator) {
         DataType dataType = dataType();
-        Build build = SIGNATURES.get(dataType);
-        if (build == null) {
-            throw new IllegalStateException("unsupported type");
+        ExpressionEvaluator.Factory fieldEval = Cast.cast(source(), field().dataType(), dataType, toEvaluator.apply(field()));
+        if (dataType == LONG || dataType == DATETIME || dataType == DATE_NANOS) {
+            long[] cc = new long[points.size()];
+            for (int i = 0; i < points.size(); i++) {
+                var p = (Number) Foldables.valueOf(toEvaluator.foldCtx(), points.get(i));
+                if (p == null) {
+                    return null;
+                }
+                cc[i] = DataTypeConverter.safeToLong(p);
+            }
+            Arrays.sort(cc);
+            return RoundToLong.BUILD.build(source(), fieldEval, cc);
+        } else if (dataType == INTEGER) {
+            int[] cc = new int[points.size()];
+            for (int i = 0; i < points.size(); i++) {
+                var p = (Number) Foldables.valueOf(toEvaluator.foldCtx(), points.get(i));
+                if (p == null) {
+                    return null;
+                }
+                cc[i] = p.intValue();
+            }
+            Arrays.sort(cc);
+            return RoundToInt.BUILD.build(source(), fieldEval, cc);
+        } else if (dataType == DOUBLE) {
+            double[] cc = new double[points.size()];
+            for (int i = 0; i < points.size(); i++) {
+                var p = (Number) Foldables.valueOf(toEvaluator.foldCtx(), points.get(i));
+                if (p == null) {
+                    return null;
+                }
+                cc[i] = p.doubleValue();
+            }
+            Arrays.sort(cc);
+            return RoundToDouble.BUILD.build(source(), fieldEval, cc);
         }
-
-        ExpressionEvaluator.Factory field = toEvaluator.apply(field());
-        field = Cast.cast(source(), field().dataType(), dataType, field);
-        List<Object> points = Iterators.toList(Iterators.map(points().iterator(), p -> Foldables.valueOf(toEvaluator.foldCtx(), p)));
-        List<Number> sortedPoints = sortedRoundingPoints(points, dataType); // provide sorted points to the evaluator
-        return build.build(source(), field, sortedPoints);
-    }
-
-    interface Build {
-        ExpressionEvaluator.Factory build(Source source, ExpressionEvaluator.Factory field, List<Number> points);
-    }
-
-    private static final Map<DataType, Build> SIGNATURES = Map.ofEntries(
-        Map.entry(DATETIME, RoundToLong.BUILD),
-        Map.entry(DATE_NANOS, RoundToLong.BUILD),
-        Map.entry(INTEGER, RoundToInt.BUILD),
-        Map.entry(LONG, RoundToLong.BUILD),
-        Map.entry(DOUBLE, RoundToDouble.BUILD)
-    );
-
-    public static List<Number> sortedRoundingPoints(List<Object> points, DataType dataType) {
-        List<Number> pointsTobeSorted = points.stream().filter(Objects::nonNull).map(p -> (Number) p).toList();
-
-        return switch (dataType) {
-            case INTEGER -> pointsTobeSorted.stream()
-                .mapToInt(Number::intValue)
-                .sorted()
-                .boxed()
-                .collect(java.util.stream.Collectors.toList());
-            case DOUBLE -> pointsTobeSorted.stream()
-                .mapToDouble(Number::doubleValue)
-                .sorted()
-                .boxed()
-                .collect(java.util.stream.Collectors.toList());
-            case LONG, DATETIME, DATE_NANOS -> pointsTobeSorted.stream()
-                .mapToLong(DataTypeConverter::safeToLong)
-                .sorted()
-                .boxed()
-                .collect(java.util.stream.Collectors.toList());
-            default -> throw new IllegalArgumentException("Unsupported data type: " + dataType);
-        };
+        throw new IllegalStateException("unsupported type: " + dataType);
     }
 
     @Override
@@ -242,29 +231,17 @@ public class RoundTo extends EsqlScalarFunction implements BlockLoaderExpression
             if (dt != LONG && dt != DATETIME && dt != DATE_NANOS) {
                 return null;
             }
-            long[] sortedPoints = sortedLongPoints();
-            if (sortedPoints == null) {
-                return null;
+            long[] pts = new long[points.size()];
+            for (int i = 0; i < points.size(); i++) {
+                if (points.get(i) instanceof Literal lit) {
+                    pts[i] = DataTypeConverter.safeToLong((Number) lit.value());
+                } else {
+                    return null;
+                }
             }
-            return new PushedBlockLoaderExpression(f, new BlockLoaderFunctionConfig.RoundToLongs(sortedPoints));
+            Arrays.sort(pts);
+            return new PushedBlockLoaderExpression(f, new BlockLoaderFunctionConfig.RoundToLongs(pts));
         }
         return null;
-    }
-
-    private long[] sortedLongPoints() {
-        List<Object> values = new ArrayList<>(points.size());
-        for (Expression p : points) {
-            if (p instanceof Literal lit) {
-                values.add(lit.value());
-            } else {
-                return null;
-            }
-        }
-        List<Number> sorted = sortedRoundingPoints(values, dataType());
-        long[] result = new long[sorted.size()];
-        for (int i = 0; i < sorted.size(); i++) {
-            result[i] = sorted.get(i).longValue();
-        }
-        return result;
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundTo.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundTo.java
@@ -189,7 +189,7 @@ public class RoundTo extends EsqlScalarFunction implements BlockLoaderExpression
             for (int i = 0; i < points.size(); i++) {
                 var p = (Number) Foldables.valueOf(toEvaluator.foldCtx(), points.get(i));
                 if (p == null) {
-                    return null;
+                    throw new IllegalStateException("unexpected null for rounding point");
                 }
                 cc[i] = DataTypeConverter.safeToLong(p);
             }
@@ -200,7 +200,7 @@ public class RoundTo extends EsqlScalarFunction implements BlockLoaderExpression
             for (int i = 0; i < points.size(); i++) {
                 var p = (Number) Foldables.valueOf(toEvaluator.foldCtx(), points.get(i));
                 if (p == null) {
-                    return null;
+                    throw new IllegalStateException("unexpected null for rounding point");
                 }
                 cc[i] = p.intValue();
             }
@@ -211,7 +211,7 @@ public class RoundTo extends EsqlScalarFunction implements BlockLoaderExpression
             for (int i = 0; i < points.size(); i++) {
                 var p = (Number) Foldables.valueOf(toEvaluator.foldCtx(), points.get(i));
                 if (p == null) {
-                    return null;
+                    throw new IllegalStateException("unexpected null for rounding point");
                 }
                 cc[i] = p.doubleValue();
             }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/X-RoundTo.java.st
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/X-RoundTo.java.st
@@ -10,6 +10,8 @@ package org.elasticsearch.xpack.esql.expression.function.scalar.math;
 // begin generated imports
 import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.ann.Fixed;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.xpack.esql.core.tree.Source;
 
 import java.util.Arrays;
 // end generated imports
@@ -23,8 +25,11 @@ import java.util.Arrays;
  * This class is generated. Edit {@code X-RoundTo.java.st} instead.
  */
 class RoundTo$Type$ {
-    static final RoundTo.Build BUILD = (source, field, points) -> {
-        $type$[] f = points.stream().mapTo$Type$(p -> p.$type$Value()).toArray();
+    interface Build {
+        ExpressionEvaluator.Factory build(Source source, ExpressionEvaluator.Factory field, $type$[] points);
+    }
+
+    static final Build BUILD = (source, field, f) -> {
         return switch (f.length) {
             // TODO should be a consistent way to do the 0 version - is CASE(MV_COUNT(f) == 1, f[0])
             case 1 -> new RoundTo$Type$1Evaluator.Factory(source, field, f[0]);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/ReplaceRoundToWithQueryAndTags.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/ReplaceRoundToWithQueryAndTags.java
@@ -48,6 +48,7 @@ import org.elasticsearch.xpack.esql.stats.SearchStats;
 
 import java.time.ZoneId;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
@@ -446,7 +447,7 @@ public class ReplaceRoundToWithQueryAndTags extends PhysicalOptimizerRules.Param
     }
 
     private static List<Number> resolveRoundingPoints(List<Expression> roundingPoints, DataType dataType) {
-        List<Object> points = new ArrayList<>(roundingPoints.size());
+        List<Number> points = new ArrayList<>(roundingPoints.size());
         for (Expression e : roundingPoints) {
             if (e instanceof Literal l && l.value() instanceof Number n) {
                 switch (dataType) {
@@ -458,7 +459,13 @@ public class ReplaceRoundToWithQueryAndTags extends PhysicalOptimizerRules.Param
                 }
             }
         }
-        return RoundTo.sortedRoundingPoints(points, dataType);
+        switch (dataType) {
+            case INTEGER -> points.sort(Comparator.comparingInt(Number::intValue));
+            case LONG, DATETIME, DATE_NANOS -> points.sort(Comparator.comparingLong(Number::longValue));
+            case DOUBLE -> points.sort(Comparator.comparingDouble(Number::doubleValue));
+            default -> throw new IllegalArgumentException("Unsupported data type: " + dataType);
+        }
+        return points;
     }
 
     private static Expression createRangeExpression(

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
@@ -697,7 +697,7 @@ public class VerifierTests extends ESTestCase {
         defaultAnalyzer().error(
             "from test | stats max(emp_no) by bucket(hire_date, 5, 1 day, 1 month)",
             containsString(
-                "third argument of [bucket(hire_date, 5, 1 day, 1 month)] must be [datetime or string], "
+                "third argument of [bucket(hire_date, 5, 1 day, 1 month)] must be [datetime, date_nanos or string], "
                     + "found value [1 day] type [date_period]"
             )
         );
@@ -705,7 +705,7 @@ public class VerifierTests extends ESTestCase {
         defaultAnalyzer().error(
             "from test | stats max(emp_no) by bucket(hire_date, 5, \"2000-01-01\", 1 month)",
             containsString(
-                "fourth argument of [bucket(hire_date, 5, \"2000-01-01\", 1 month)] must be [datetime or string], "
+                "fourth argument of [bucket(hire_date, 5, \"2000-01-01\", 1 month)] must be [datetime, date_nanos or string], "
                     + "found value [1 month] type [date_period]"
             )
         );


### PR DESCRIPTION
Prerequisite for follow-up PR.

Quick refactoring: 

- `Bucket.isStringOrDate` now accepts `date_nanos` in addition to `datetime` and `string`.
- `Bucket.foldToLong` converts `date_nanos` nanoseconds to milliseconds via `DateUtils.toMilliSeconds`.
- `OffsetRounding.Prepared.fixedRoundingPoints()` shifts delegate rounding points by the offset.
- `RoundTo.Build` interface and `toEvaluator` refactored to use primitive arrays instead of boxed `List<Number`.
