### PR TITLE
Make implementation a parameter in various ESVectorUtil benchmarks

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/quantization/ComputeNeighboursBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/quantization/ComputeNeighboursBenchmark.java
@@ -32,6 +32,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
+@Fork(value = 1, jvmArgsPrepend = { "--add-modules=jdk.incubator.vector" })
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Benchmark)
@@ -39,8 +40,6 @@ import java.util.concurrent.TimeUnit;
 @Warmup(iterations = 1, time = 1)
 // real iterations. not useful to spend tons of time here, better to fork more
 @Measurement(iterations = 3, time = 1)
-// engage some noise reduction
-@Fork(value = 1)
 public class ComputeNeighboursBenchmark {
 
     static {
@@ -79,7 +78,6 @@ public class ComputeNeighboursBenchmark {
     }
 
     @Benchmark
-    @Fork(jvmArgsPrepend = { "--add-modules=jdk.incubator.vector" })
     public void bruteForce(Blackhole bh) {
         bh.consume(NeighborHood.computeNeighborhoodsBruteForce(vectors, clusterPerNeighbour));
     }

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/quantization/PackAsBinaryBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/quantization/PackAsBinaryBenchmark.java
@@ -9,8 +9,10 @@
 package org.elasticsearch.benchmark.vector.quantization;
 
 import org.elasticsearch.benchmark.Utils;
+import org.elasticsearch.benchmark.vector.VectorImplementation;
 import org.elasticsearch.index.codec.vectors.BQVectorUtils;
-import org.elasticsearch.simdvec.ESVectorUtil;
+import org.elasticsearch.simdvec.ESVectorizationProvider;
+import org.elasticsearch.simdvec.internal.vectorization.ESVectorUtilSupport;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -28,6 +30,7 @@ import java.io.IOException;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
+@Fork(value = 1, jvmArgsPrepend = { "--add-modules=jdk.incubator.vector" })
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
@@ -35,8 +38,6 @@ import java.util.concurrent.TimeUnit;
 @Warmup(iterations = 4, time = 1)
 // real iterations. not useful to spend tons of time here, better to fork more
 @Measurement(iterations = 5, time = 1)
-// engage some noise reduction
-@Fork(value = 1)
 public class PackAsBinaryBenchmark {
 
     static {
@@ -46,12 +47,16 @@ public class PackAsBinaryBenchmark {
     @Param({ "384", "782", "1024" })
     int dims;
 
+    @Param({ "SCALAR", "PANAMA" })
+    VectorImplementation implementation;
+
     int length;
 
     int numVectors = 1000;
 
     int[][] qVectors;
     byte[] packed;
+    ESVectorUtilSupport impl;
 
     @Setup
     public void setup() throws IOException {
@@ -66,44 +71,19 @@ public class PackAsBinaryBenchmark {
                 qVector[i] = random.nextInt(2);
             }
         }
+
+        impl = switch (implementation) {
+            case SCALAR -> ESVectorizationProvider.lookup(false, false).getVectorUtilSupport();
+            case PANAMA -> ESVectorizationProvider.lookup(true, false).getVectorUtilSupport();
+            default -> throw new IllegalArgumentException(implementation.toString());
+        };
     }
 
     @Benchmark
     public void packAsBinary(Blackhole bh) {
         for (int i = 0; i < numVectors; i++) {
-            ESVectorUtil.packAsBinary(qVectors[i], packed);
+            impl.packAsBinary(qVectors[i], packed);
             bh.consume(packed);
-        }
-    }
-
-    @Benchmark
-    public void packAsBinaryLegacy(Blackhole bh) {
-        for (int i = 0; i < numVectors; i++) {
-            packAsBinaryLegacy(qVectors[i], packed);
-            bh.consume(packed);
-        }
-    }
-
-    @Benchmark
-    @Fork(jvmArgsPrepend = { "--add-modules=jdk.incubator.vector" })
-    public void packAsBinaryPanama(Blackhole bh) {
-        for (int i = 0; i < numVectors; i++) {
-            ESVectorUtil.packAsBinary(qVectors[i], packed);
-            bh.consume(packed);
-        }
-    }
-
-    private static void packAsBinaryLegacy(int[] vector, byte[] packed) {
-        for (int i = 0; i < vector.length;) {
-            byte result = 0;
-            for (int j = 7; j >= 0 && i < vector.length; j--) {
-                assert vector[i] == 0 || vector[i] == 1;
-                result |= (byte) ((vector[i] & 1) << j);
-                ++i;
-            }
-            int index = ((i + 7) / 8) - 1;
-            assert index < packed.length;
-            packed[index] = result;
         }
     }
 }

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/quantization/TransposeHalfByteBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/quantization/TransposeHalfByteBenchmark.java
@@ -9,8 +9,10 @@
 package org.elasticsearch.benchmark.vector.quantization;
 
 import org.elasticsearch.benchmark.Utils;
+import org.elasticsearch.benchmark.vector.VectorImplementation;
 import org.elasticsearch.index.codec.vectors.BQVectorUtils;
-import org.elasticsearch.simdvec.ESVectorUtil;
+import org.elasticsearch.simdvec.ESVectorizationProvider;
+import org.elasticsearch.simdvec.internal.vectorization.ESVectorUtilSupport;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -28,6 +30,7 @@ import java.io.IOException;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
+@Fork(value = 1, jvmArgsPrepend = { "--add-modules=jdk.incubator.vector" })
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
@@ -35,8 +38,6 @@ import java.util.concurrent.TimeUnit;
 @Warmup(iterations = 4, time = 1)
 // real iterations. not useful to spend tons of time here, better to fork more
 @Measurement(iterations = 5, time = 1)
-// engage some noise reduction
-@Fork(value = 1)
 public class TransposeHalfByteBenchmark {
 
     static {
@@ -46,12 +47,16 @@ public class TransposeHalfByteBenchmark {
     @Param({ "384", "782", "1024" })
     int dims;
 
+    @Param({ "SCALAR", "PANAMA" })
+    VectorImplementation implementation;
+
     int length;
 
     int numVectors = 1000;
 
     int[][] qVectors;
     byte[] packed;
+    ESVectorUtilSupport impl;
 
     @Setup
     public void setup() throws IOException {
@@ -66,52 +71,19 @@ public class TransposeHalfByteBenchmark {
                 qVector[i] = random.nextInt(16);
             }
         }
+
+        impl = switch (implementation) {
+            case SCALAR -> ESVectorizationProvider.lookup(false, false).getVectorUtilSupport();
+            case PANAMA -> ESVectorizationProvider.lookup(true, false).getVectorUtilSupport();
+            default -> throw new IllegalArgumentException(implementation.toString());
+        };
     }
 
     @Benchmark
     public void transposeHalfByte(Blackhole bh) {
         for (int i = 0; i < numVectors; i++) {
-            ESVectorUtil.transposeHalfByte(qVectors[i], packed);
+            impl.transposeHalfByte(qVectors[i], packed);
             bh.consume(packed);
-        }
-    }
-
-    @Benchmark
-    public void transposeHalfByteLegacy(Blackhole bh) {
-        for (int i = 0; i < numVectors; i++) {
-            transposeHalfByteLegacy(qVectors[i], packed);
-            bh.consume(packed);
-        }
-    }
-
-    @Benchmark
-    @Fork(jvmArgsPrepend = { "--add-modules=jdk.incubator.vector" })
-    public void transposeHalfBytePanama(Blackhole bh) {
-        for (int i = 0; i < numVectors; i++) {
-            ESVectorUtil.transposeHalfByte(qVectors[i], packed);
-            bh.consume(packed);
-        }
-    }
-
-    public static void transposeHalfByteLegacy(int[] q, byte[] quantQueryByte) {
-        for (int i = 0; i < q.length;) {
-            assert q[i] >= 0 && q[i] <= 15;
-            int lowerByte = 0;
-            int lowerMiddleByte = 0;
-            int upperMiddleByte = 0;
-            int upperByte = 0;
-            for (int j = 7; j >= 0 && i < q.length; j--) {
-                lowerByte |= (q[i] & 1) << j;
-                lowerMiddleByte |= ((q[i] >> 1) & 1) << j;
-                upperMiddleByte |= ((q[i] >> 2) & 1) << j;
-                upperByte |= ((q[i] >> 3) & 1) << j;
-                i++;
-            }
-            int index = ((i + 7) / 8) - 1;
-            quantQueryByte[index] = (byte) lowerByte;
-            quantQueryByte[index + quantQueryByte.length / 4] = (byte) lowerMiddleByte;
-            quantQueryByte[index + quantQueryByte.length / 2] = (byte) upperMiddleByte;
-            quantQueryByte[index + 3 * quantQueryByte.length / 4] = (byte) upperByte;
         }
     }
 }


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch/pull/151727

Make vector implementation a benchmark parameter to match other benchmarks