### PR TITLE
[ML] Fix missing assumeTrue guards on CPS migration tests in DatafeedManagerTests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -626,18 +626,6 @@ tests:
 - class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
   method: test {yaml=scroll/10_basic/Basic scroll}
   issue: https://github.com/elastic/elasticsearch/issues/151698
-- class: org.elasticsearch.xpack.ml.datafeed.DatafeedManagerTests
-  method: testUpdateDatafeedFirstTimeMigrationShouldHonourExplicitProjectRoutingInUpdate
-  issue: https://github.com/elastic/elasticsearch/issues/151699
-- class: org.elasticsearch.xpack.ml.datafeed.DatafeedManagerTests
-  method: testUpdateDatafeedFirstTimeMigrationShouldDefaultProjectRoutingToOrigin
-  issue: https://github.com/elastic/elasticsearch/issues/151700
-- class: org.elasticsearch.xpack.ml.datafeed.DatafeedManagerTests
-  method: testUpdateDatafeedAlreadyMigratedShouldNotDefaultRoutingOnRekey
-  issue: https://github.com/elastic/elasticsearch/issues/151701
-- class: org.elasticsearch.xpack.ml.datafeed.DatafeedManagerTests
-  method: testUpdateDatafeedFirstTimeMigrationShouldNotOverrideExistingProjectRouting
-  issue: https://github.com/elastic/elasticsearch/issues/151702
 - class: org.elasticsearch.xpack.esql.CsvIT
   method: test {csv-spec:string.mvAppendNull}
   issue: https://github.com/elastic/elasticsearch/issues/151707

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedManagerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedManagerTests.java
@@ -1471,6 +1471,7 @@ public class DatafeedManagerTests extends ESTestCase {
 
     @SuppressWarnings("unchecked")
     public void testUpdateDatafeedFirstTimeMigrationShouldDefaultProjectRoutingToOrigin() {
+        assumeTrue("feature under test must be enabled", DatafeedConfig.DATAFEED_CROSS_PROJECT.isEnabled());
         Settings settings = Settings.builder().put("serverless.cross_project.enabled", true).put("xpack.security.enabled", false).build();
 
         DatafeedConfigProvider datafeedConfigProvider = mock(DatafeedConfigProvider.class);
@@ -1508,6 +1509,7 @@ public class DatafeedManagerTests extends ESTestCase {
 
     @SuppressWarnings("unchecked")
     public void testUpdateDatafeedFirstTimeMigrationShouldNotOverrideExistingProjectRouting() {
+        assumeTrue("feature under test must be enabled", DatafeedConfig.DATAFEED_CROSS_PROJECT.isEnabled());
         Settings settings = Settings.builder().put("serverless.cross_project.enabled", true).put("xpack.security.enabled", false).build();
 
         DatafeedConfigProvider datafeedConfigProvider = mock(DatafeedConfigProvider.class);
@@ -1552,6 +1554,7 @@ public class DatafeedManagerTests extends ESTestCase {
 
     @SuppressWarnings("unchecked")
     public void testUpdateDatafeedFirstTimeMigrationShouldHonourExplicitProjectRoutingInUpdate() {
+        assumeTrue("feature under test must be enabled", DatafeedConfig.DATAFEED_CROSS_PROJECT.isEnabled());
         Settings settings = Settings.builder().put("serverless.cross_project.enabled", true).put("xpack.security.enabled", false).build();
 
         DatafeedConfigProvider datafeedConfigProvider = mock(DatafeedConfigProvider.class);
@@ -1596,6 +1599,7 @@ public class DatafeedManagerTests extends ESTestCase {
 
     @SuppressWarnings("unchecked")
     public void testUpdateDatafeedAlreadyMigratedShouldNotDefaultRoutingOnRekey() {
+        assumeTrue("feature under test must be enabled", DatafeedConfig.DATAFEED_CROSS_PROJECT.isEnabled());
         Settings settings = Settings.builder().put("serverless.cross_project.enabled", true).put("xpack.security.enabled", false).build();
 
         DatafeedConfigProvider datafeedConfigProvider = mock(DatafeedConfigProvider.class);


### PR DESCRIPTION
## Summary

Adds the missing `assumeTrue(DatafeedConfig.DATAFEED_CROSS_PROJECT.isEnabled())` guard to the four CPS migration unit tests added in #146651. Without it, release builds (`-Dbuild.snapshot=false`) disable the feature flag, the migration path never runs, and `capturedUpdate` stays null.

Closes #151699
Closes #151700
Closes #151701
Closes #151702