### PR TITLE
[9.4] ES|QL: resolve surrogates before rewrapWithCast in union type field resolution (#151633)

### DIFF
--- a/docs/changelog/151633.yaml
+++ b/docs/changelog/151633.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 151475
+pr: 151633
+summary: Resolve surrogates in union type field resolution before plan serialization
+type: bug

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -2493,6 +2493,9 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                             AbstractConvertFunction originalConversionFunction = (AbstractConvertFunction) entry.getValue();
                             Expression originalField = originalConversionFunction.field();
                             Expression newConvertFunction = convertExpression.replaceChildren(Collections.singletonList(originalField));
+                            // Resolve surrogates immediately, since expressions stored in UnionTypeEsField are serialized
+                            // to data nodes, and SurrogateExpressions cannot be serialized.
+                            newConvertFunction = SubstituteSurrogateExpressions.rule(newConvertFunction);
                             indexToConversionExpressions.put(indexName, newConvertFunction);
                         }
                         // The only code that creates MultiTypeEsField with synthetic=false (reaching this branch) is


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [ES|QL: resolve surrogates before rewrapWithCast in union type field resolution (#151633)](https://github.com/elastic/elasticsearch/pull/151633)

<!--- Backport version: 12.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)