### PR TITLE
Treat STOPPED as not running in ObjectStoreService.

### DIFF
--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/objectstore/ObjectStoreService.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/objectstore/ObjectStoreService.java
@@ -646,8 +646,7 @@ public class ObjectStoreService extends AbstractLifecycleComponent implements Cl
     }
 
     private boolean isRunning() {
-        final Lifecycle.State state = lifecycleState();
-        return state != Lifecycle.State.INITIALIZED && state != Lifecycle.State.STOPPED && state != Lifecycle.State.CLOSED;
+        return lifecycleState() == Lifecycle.State.STARTED;
     }
 
     private void ensureRunning() {

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/objectstore/ObjectStoreService.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/objectstore/ObjectStoreService.java
@@ -647,7 +647,7 @@ public class ObjectStoreService extends AbstractLifecycleComponent implements Cl
 
     private boolean isRunning() {
         final Lifecycle.State state = lifecycleState();
-        return state != Lifecycle.State.INITIALIZED && state != Lifecycle.State.CLOSED;
+        return state != Lifecycle.State.INITIALIZED && state != Lifecycle.State.STOPPED && state != Lifecycle.State.CLOSED;
     }
 
     private void ensureRunning() {

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/objectstore/ObjectStoreServiceTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/objectstore/ObjectStoreServiceTests.java
@@ -214,6 +214,26 @@ public class ObjectStoreServiceTests extends ESTestCase {
         }
     }
 
+    /**
+     * The service passes briefly through {@link Lifecycle.State#STOPPED} on its way to {@code CLOSED}. Enqueueing an upload during that
+     * window must be treated the same as enqueueing after close: the liveness check considers the service not running and notifies the
+     * listener rather than letting the upload proceed against a service that is shutting down.
+     */
+    public void testEnqueueWhileStoppedNotifiesListener() throws IOException {
+        try (var testHarness = new FakeStatelessNode(this::newEnvironment, this::newNodeEnvironment, xContentRegistry())) {
+            final var objectStoreService = testHarness.objectStoreService;
+
+            objectStoreService.stop();
+            assertThat(objectStoreService.lifecycleState(), equalTo(Lifecycle.State.STOPPED));
+
+            final var future = new PlainActionFuture<Void>();
+            objectStoreService.uploadTranslogFile("translog-1", new BytesArray(new byte[] { 1, 2, 3 }), future);
+
+            final var e = expectThrows(IllegalStateException.class, future::actionGet);
+            assertThat(e.getMessage(), startsWith("Object store service is not running"));
+        }
+    }
+
     public void testStartingShardRetrievesSegmentsFromOneCommit() throws IOException {
         final var mergesEnabled = randomBoolean();
         final var indexWriterConfig = mergesEnabled


### PR DESCRIPTION
Object store service passes briefly through `STOPPED` before `CLOSED`, but isRunning() only excluded `INITIALIZED` and `CLOSED` — so work could be enqueued against a shutting-down service. This adds `STOPPED` to the check, closing that race (found while debugging the flaky StatelessReshardDisruptionIT, #150708).
