### PR TITLE
[9.3] ES|QL: resolve surrogates before rewrapWithCast in union type field resolution (#151633)

### DIFF
--- a/docs/changelog/151633.yaml
+++ b/docs/changelog/151633.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 151475
+pr: 151633
+summary: Resolve surrogates in union type field resolution before plan serialization
+type: bug

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -340,9 +340,6 @@ tests:
 - class: org.elasticsearch.packaging.test.WindowsServiceTests
   method: test16InstallSpecialCharactersInJdkPath
   issue: https://github.com/elastic/elasticsearch/issues/151142
-- class: org.elasticsearch.xpack.esql.action.ManyShardsIT
-  method: testMultiTypes
-  issue: https://github.com/elastic/elasticsearch/issues/151475
 - class: org.elasticsearch.repositories.gcs.GoogleCloudStorageBlobContainerRetriesTests
   method: testReadBlobWithPrematureConnectionClose
   issue: https://github.com/elastic/elasticsearch/issues/151476

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -2144,6 +2144,9 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                             AbstractConvertFunction originalConversionFunction = (AbstractConvertFunction) entry.getValue();
                             Expression originalField = originalConversionFunction.field();
                             Expression newConvertFunction = convertExpression.replaceChildren(Collections.singletonList(originalField));
+                            // Resolve surrogates immediately, since expressions stored in UnionTypeEsField are serialized
+                            // to data nodes, and SurrogateExpressions cannot be serialized.
+                            newConvertFunction = SubstituteSurrogateExpressions.rule(newConvertFunction);
                             indexToConversionExpressions.put(indexName, newConvertFunction);
                         }
                         MultiTypeEsField multiTypeEsField = new MultiTypeEsField(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [ES|QL: resolve surrogates before rewrapWithCast in union type field resolution (#151633)](https://github.com/elastic/elasticsearch/pull/151633)

<!--- Backport version: 12.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)