### PR TITLE
[9.4] [Test] Fix `testReindexFailsWhenSourceIndexIsClosed` (#151673)

### DIFF
--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexBasicTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexBasicTests.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.reindex;
 
 import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.action.admin.indices.close.CloseIndexResponse;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexSettings;
@@ -34,6 +35,7 @@ import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.notNullValue;
 
@@ -248,9 +250,18 @@ public class ReindexBasicTests extends ReindexTestCase {
     public void testReindexFailsWhenSourceIndexIsClosed() {
         String sourceIndex = "source";
         String destIndex = "dest";
-        createIndex(sourceIndex);
+        createIndex(sourceIndex, Settings.builder().put("index.routing.rebalance.enable", "none").build());
+        ensureGreen(sourceIndex);
         indexRandom(true, prepareIndex(sourceIndex).setId("1").setSource("foo", "bar"));
-        indicesAdmin().prepareClose(sourceIndex).get();
+
+        CloseIndexResponse closeResponse = indicesAdmin().prepareClose(sourceIndex).get();
+        assertThat(closeResponse.isAcknowledged(), is(true));
+        assertThat(closeResponse.getIndices(), hasSize(1));
+        assertThat(
+            "close did not actually close source: " + closeResponse.getIndices(),
+            closeResponse.getIndices().getFirst().hasFailures(),
+            is(false)
+        );
 
         Exception e = expectThrows(Exception.class, () -> {
             ReindexRequest request = new ReindexRequest();

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -248,9 +248,6 @@ tests:
 - class: org.elasticsearch.cluster.routing.allocation.decider.WriteLoadConstraintDeciderIT
   method: testMaxQueueLatencyMetricIsPublished
   issue: https://github.com/elastic/elasticsearch/issues/146283
-- class: org.elasticsearch.reindex.ReindexBasicTests
-  method: testReindexFailsWhenSourceIndexIsClosed
-  issue: https://github.com/elastic/elasticsearch/issues/151024
 - class: org.elasticsearch.index.codec.tsdb.TSDBSyntheticIdPostingsFormatTests
   method: testSeek
   issue: https://github.com/elastic/elasticsearch/issues/150912


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Test] Fix `testReindexFailsWhenSourceIndexIsClosed` (#151673)](https://github.com/elastic/elasticsearch/pull/151673)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)