### PR TITLE
Define native overrides for single sub-array vector comparisons

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/ESVectorUtilByteOperationBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/ESVectorUtilByteOperationBenchmark.java
@@ -52,6 +52,7 @@ public class ESVectorUtilByteOperationBenchmark {
     @Param({ "1", "128", "207", "256", "300", "512", "702", "1024", "1536", "2048" })
     public int size;
 
+    final int offset = 1;   // so it doesn't fall back on the full-array implementations
     byte[] a;
     byte[] b;
     byte[] normalizeSource;
@@ -64,14 +65,14 @@ public class ESVectorUtilByteOperationBenchmark {
     }
 
     public void setup(Random random) {
-        a = new byte[size];
-        b = new byte[size];
-        normalizeSource = new byte[size];
-        normalizeTarget = new byte[size];
+        a = new byte[size + offset];
+        b = new byte[size + offset];
+        normalizeSource = new byte[size + offset];
+        normalizeTarget = new byte[size + offset];
         random.nextBytes(a);
         random.nextBytes(b);
         random.nextBytes(normalizeSource);
-        for (int i = 0; i < size; i++) {
+        for (int i = offset; i < size; i++) {
             if (normalizeSource[i] == 0) {
                 normalizeSource[i] = 1;
             }
@@ -85,13 +86,13 @@ public class ESVectorUtilByteOperationBenchmark {
 
     @Benchmark
     public float dotProduct() {
-        return impl.dotProduct(a, b, 0, size);
+        return impl.dotProduct(a, b, offset, size);
     }
 
     @Benchmark
     public float l2Normalize() {
-        System.arraycopy(normalizeSource, 0, normalizeTarget, 0, size);
-        impl.l2Normalize(normalizeTarget, 0, size);
+        System.arraycopy(normalizeSource, offset, normalizeTarget, offset, size);
+        impl.l2Normalize(normalizeTarget, offset, size);
         return normalizeTarget[0];
     }
 }

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/ESVectorUtilByteOperationBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/ESVectorUtilByteOperationBenchmark.java
@@ -46,7 +46,7 @@ public class ESVectorUtilByteOperationBenchmark {
         Utils.configureBenchmarkLogging();
     }
 
-    @Param({ "SCALAR", "PANAMA" })
+    @Param({ "SCALAR", "PANAMA", "NATIVE" })
     public VectorImplementation implementation;
 
     @Param({ "1", "128", "207", "256", "300", "512", "702", "1024", "1536", "2048" })
@@ -80,6 +80,7 @@ public class ESVectorUtilByteOperationBenchmark {
         impl = switch (implementation) {
             case SCALAR -> ESVectorizationProvider.lookup(false, false).getVectorUtilSupport();
             case PANAMA -> ESVectorizationProvider.lookup(true, false).getVectorUtilSupport();
+            case NATIVE -> ESVectorizationProvider.lookup(true, true).getVectorUtilSupport();
             default -> throw new IllegalArgumentException(implementation.toString());
         };
     }
@@ -87,6 +88,11 @@ public class ESVectorUtilByteOperationBenchmark {
     @Benchmark
     public float dotProduct() {
         return impl.dotProduct(a, b, offset, size);
+    }
+
+    @Benchmark
+    public float squareDistance() {
+        return impl.squareDistance(a, b, offset, size);
     }
 
     @Benchmark

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/ESVectorUtilFloatOperationBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/ESVectorUtilFloatOperationBenchmark.java
@@ -52,6 +52,7 @@ public class ESVectorUtilFloatOperationBenchmark {
     @Param({ "1", "128", "207", "256", "300", "512", "702", "1024", "1536", "2048" })
     public int size;
 
+    final int offset = 1;   // so it doesn't fall back on the full-array implementations
     float[] a;
     float[] b;
     float[] normalizeSource;
@@ -64,11 +65,11 @@ public class ESVectorUtilFloatOperationBenchmark {
     }
 
     public void setup(Random random) {
-        a = new float[size];
-        b = new float[size];
-        normalizeSource = new float[size];
-        normalizeTarget = new float[size];
-        for (int i = 0; i < size; i++) {
+        a = new float[size + offset];
+        b = new float[size + offset];
+        normalizeSource = new float[size + offset];
+        normalizeTarget = new float[size + offset];
+        for (int i = offset; i < size; i++) {
             a[i] = random.nextFloat();
             b[i] = random.nextFloat();
             normalizeSource[i] = random.nextFloat() + 0.1f;
@@ -82,13 +83,13 @@ public class ESVectorUtilFloatOperationBenchmark {
 
     @Benchmark
     public float dotProduct() {
-        return impl.dotProduct(a, b, 0, size);
+        return impl.dotProduct(a, b, offset, size);
     }
 
     @Benchmark
     public float l2Normalize() {
-        System.arraycopy(normalizeSource, 0, normalizeTarget, 0, size);
-        impl.l2Normalize(normalizeTarget, 0, size);
+        System.arraycopy(normalizeSource, offset, normalizeTarget, offset, size);
+        impl.l2Normalize(normalizeTarget, offset, size);
         return normalizeTarget[0];
     }
 }

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/ESVectorUtilFloatOperationBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/ESVectorUtilFloatOperationBenchmark.java
@@ -46,7 +46,7 @@ public class ESVectorUtilFloatOperationBenchmark {
         Utils.configureBenchmarkLogging();
     }
 
-    @Param({ "SCALAR", "PANAMA" })
+    @Param({ "SCALAR", "PANAMA", "NATIVE" })
     public VectorImplementation implementation;
 
     @Param({ "1", "128", "207", "256", "300", "512", "702", "1024", "1536", "2048" })
@@ -77,6 +77,7 @@ public class ESVectorUtilFloatOperationBenchmark {
         impl = switch (implementation) {
             case SCALAR -> ESVectorizationProvider.lookup(false, false).getVectorUtilSupport();
             case PANAMA -> ESVectorizationProvider.lookup(true, false).getVectorUtilSupport();
+            case NATIVE -> ESVectorizationProvider.lookup(true, true).getVectorUtilSupport();
             default -> throw new IllegalArgumentException(implementation.toString());
         };
     }
@@ -84,6 +85,11 @@ public class ESVectorUtilFloatOperationBenchmark {
     @Benchmark
     public float dotProduct() {
         return impl.dotProduct(a, b, offset, size);
+    }
+
+    @Benchmark
+    public float squareDistance() {
+        return impl.squareDistance(a, b, offset, size);
     }
 
     @Benchmark

--- a/benchmarks/src/test/java/org/elasticsearch/benchmark/vector/ESVectorUtilByteOperationBenchmarkTests.java
+++ b/benchmarks/src/test/java/org/elasticsearch/benchmark/vector/ESVectorUtilByteOperationBenchmarkTests.java
@@ -14,6 +14,7 @@ import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import org.elasticsearch.benchmark.vector.scorer.BenchmarkTest;
 import org.elasticsearch.test.ESTestCase;
 
+import java.util.List;
 import java.util.Random;
 
 public class ESVectorUtilByteOperationBenchmarkTests extends ESTestCase {
@@ -32,13 +33,32 @@ public class ESVectorUtilByteOperationBenchmarkTests extends ESTestCase {
         bench.setup(new Random(seed));
         float expected = bench.dotProduct();
 
-        bench = new ESVectorUtilByteOperationBenchmark();
-        bench.size = size;
-        bench.implementation = VectorImplementation.PANAMA;
-        bench.setup(new Random(seed));
-        float panama = bench.dotProduct();
+        for (var impl : List.of(VectorImplementation.PANAMA, VectorImplementation.NATIVE)) {
+            bench = new ESVectorUtilByteOperationBenchmark();
+            bench.size = size;
+            bench.implementation = impl;
+            bench.setup(new Random(seed));
+            float actual = bench.dotProduct();
+            assertEquals(expected, actual, 0f);
+        }
+    }
 
-        assertEquals(expected, panama, 0f);
+    public void testSquareDistance() {
+        long seed = randomLong();
+        var bench = new ESVectorUtilByteOperationBenchmark();
+        bench.size = size;
+        bench.implementation = VectorImplementation.SCALAR;
+        bench.setup(new Random(seed));
+        float expected = bench.squareDistance();
+
+        for (var impl : List.of(VectorImplementation.PANAMA, VectorImplementation.NATIVE)) {
+            bench = new ESVectorUtilByteOperationBenchmark();
+            bench.size = size;
+            bench.implementation = impl;
+            bench.setup(new Random(seed));
+            float actual = bench.squareDistance();
+            assertEquals(expected, actual, 0f);
+        }
     }
 
     public void testl2Normalize() {
@@ -50,13 +70,14 @@ public class ESVectorUtilByteOperationBenchmarkTests extends ESTestCase {
         bench.setup(new Random(seed));
         float expected = bench.l2Normalize();
 
-        bench = new ESVectorUtilByteOperationBenchmark();
-        bench.size = size;
-        bench.implementation = VectorImplementation.PANAMA;
-        bench.setup(new Random(seed));
-        float panama = bench.l2Normalize();
-
-        assertEquals(expected, panama, 0f);
+        for (var impl : List.of(VectorImplementation.PANAMA, VectorImplementation.NATIVE)) {
+            bench = new ESVectorUtilByteOperationBenchmark();
+            bench.size = size;
+            bench.implementation = impl;
+            bench.setup(new Random(seed));
+            float actual = bench.l2Normalize();
+            assertEquals(expected, actual, 0f);
+        }
     }
 
     @ParametersFactory

--- a/benchmarks/src/test/java/org/elasticsearch/benchmark/vector/ESVectorUtilFloatOperationBenchmarkTests.java
+++ b/benchmarks/src/test/java/org/elasticsearch/benchmark/vector/ESVectorUtilFloatOperationBenchmarkTests.java
@@ -14,6 +14,7 @@ import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import org.elasticsearch.benchmark.vector.scorer.BenchmarkTest;
 import org.elasticsearch.test.ESTestCase;
 
+import java.util.List;
 import java.util.Random;
 
 public class ESVectorUtilFloatOperationBenchmarkTests extends ESTestCase {
@@ -32,13 +33,32 @@ public class ESVectorUtilFloatOperationBenchmarkTests extends ESTestCase {
         bench.setup(new Random(seed));
         float expected = bench.dotProduct();
 
-        bench = new ESVectorUtilFloatOperationBenchmark();
-        bench.size = size;
-        bench.implementation = VectorImplementation.PANAMA;
-        bench.setup(new Random(seed));
-        float panama = bench.dotProduct();
+        for (var impl : List.of(VectorImplementation.PANAMA, VectorImplementation.NATIVE)) {
+            bench = new ESVectorUtilFloatOperationBenchmark();
+            bench.size = size;
+            bench.implementation = impl;
+            bench.setup(new Random(seed));
+            float actual = bench.dotProduct();
+            assertEquals(expected, actual, 1e-3f * size);
+        }
+    }
 
-        assertEquals(expected, panama, 1e-3f * size);
+    public void testSquareDistance() {
+        long seed = randomLong();
+        var bench = new ESVectorUtilFloatOperationBenchmark();
+        bench.size = size;
+        bench.implementation = VectorImplementation.SCALAR;
+        bench.setup(new Random(seed));
+        float expected = bench.squareDistance();
+
+        for (var impl : List.of(VectorImplementation.PANAMA, VectorImplementation.NATIVE)) {
+            bench = new ESVectorUtilFloatOperationBenchmark();
+            bench.size = size;
+            bench.implementation = impl;
+            bench.setup(new Random(seed));
+            float actual = bench.squareDistance();
+            assertEquals(expected, actual, 1e-3f * size);
+        }
     }
 
     public void testL2Normalize() {
@@ -50,13 +70,14 @@ public class ESVectorUtilFloatOperationBenchmarkTests extends ESTestCase {
         bench.setup(new Random(seed));
         float expected = bench.l2Normalize();
 
-        bench = new ESVectorUtilFloatOperationBenchmark();
-        bench.size = size;
-        bench.implementation = VectorImplementation.PANAMA;
-        bench.setup(new Random(seed));
-        float panama = bench.l2Normalize();
-
-        assertEquals(expected, panama, 1e-5f);
+        for (var impl : List.of(VectorImplementation.PANAMA, VectorImplementation.NATIVE)) {
+            bench = new ESVectorUtilFloatOperationBenchmark();
+            bench.size = size;
+            bench.implementation = impl;
+            bench.setup(new Random(seed));
+            float actual = bench.l2Normalize();
+            assertEquals(expected, actual, 1e-3f * size);
+        }
     }
 
     @ParametersFactory

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/Native22ESVectorUtilSupport.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/Native22ESVectorUtilSupport.java
@@ -33,8 +33,26 @@ public final class Native22ESVectorUtilSupport extends PanamaESVectorUtilSupport
     }
 
     @Override
+    public float dotProduct(float[] a, float[] b, int offset, int length) {
+        return Similarities.dotProductF32(
+            MemorySegment.ofArray(a).asSlice((long) offset * Float.BYTES, (long) length * Float.BYTES),
+            MemorySegment.ofArray(b).asSlice((long) offset * Float.BYTES, (long) length * Float.BYTES),
+            length
+        );
+    }
+
+    @Override
     public float squareDistance(float[] a, float[] b) {
         return Similarities.squareDistanceF32(MemorySegment.ofArray(a), MemorySegment.ofArray(b), a.length);
+    }
+
+    @Override
+    public float squareDistance(float[] a, float[] b, int offset, int length) {
+        return Similarities.squareDistanceF32(
+            MemorySegment.ofArray(a).asSlice((long) offset * Float.BYTES, (long) length * Float.BYTES),
+            MemorySegment.ofArray(b).asSlice((long) offset * Float.BYTES, (long) length * Float.BYTES),
+            length
+        );
     }
 
     @Override
@@ -48,8 +66,26 @@ public final class Native22ESVectorUtilSupport extends PanamaESVectorUtilSupport
     }
 
     @Override
+    public float dotProduct(byte[] a, byte[] b, int offset, int length) {
+        return Similarities.dotProductI8(
+            MemorySegment.ofArray(a).asSlice(offset, length),
+            MemorySegment.ofArray(b).asSlice(offset, length),
+            length
+        );
+    }
+
+    @Override
     public float squareDistance(byte[] a, byte[] b) {
         return Similarities.squareDistanceI8(MemorySegment.ofArray(a), MemorySegment.ofArray(b), a.length);
+    }
+
+    @Override
+    public float squareDistance(byte[] a, byte[] b, int offset, int length) {
+        return Similarities.squareDistanceI8(
+            MemorySegment.ofArray(a).asSlice(offset, length),
+            MemorySegment.ofArray(b).asSlice(offset, length),
+            length
+        );
     }
 
     @Override


### PR DESCRIPTION
Using memory segment slices, we can easily use existing native methods for sub-array comparisons.

These show large improvements in performance over the panama implementation - 1.5-2x faster for float, 6-12x faster for byte