### PR TITLE
ESQL: Support scalar() over nested aggregations in PromQL binary ops

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-promql-nested.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-promql-nested.csv-spec
@@ -255,3 +255,54 @@ PROMQL index=k8s step=1h result=(avg(ceil(sum by (cluster) (network.cost))));
 result:double      | step:datetime
 20.666666666666668 | 2024-05-10T01:00:00.000Z
 ;
+
+// Tests for scalar() and other single-depth aggregates combined with nested
+// cross-series aggregations in binary operators.
+
+nested_sum_div_count_of_nested_count
+required_capability: promql_command_v0
+required_capability: fix_promql_time_bucket_v2
+required_capability: promql_nested_aggregates
+required_capability: promql_scalar_over_nested_aggregate
+// sum (depth 1) / count(sum by (cluster) ...) (depth 2)
+PROMQL index=k8s step=1h result=(sum(network.bytes_in) / count(sum by (cluster) (network.bytes_in)));
+
+result:double          | step:datetime
+1617.3333333333333     | 2024-05-10T01:00:00.000Z
+;
+
+nested_max_div_count_of_nested_sum
+required_capability: promql_command_v0
+required_capability: fix_promql_time_bucket_v2
+required_capability: promql_nested_aggregates
+required_capability: promql_scalar_over_nested_aggregate
+// max (depth 1) / count(sum by (cluster) ...) (depth 2)
+PROMQL index=k8s step=1h result=(max(network.cost) / count(sum by (cluster) (network.cost)));
+
+result:double          | step:datetime
+3.625                  | 2024-05-10T01:00:00.000Z
+;
+
+nested_count_of_nested_count_mul_scalar_100
+required_capability: promql_command_v0
+required_capability: fix_promql_time_bucket_v2
+required_capability: promql_nested_aggregates
+required_capability: promql_scalar_over_nested_aggregate
+// count(count by (pod) ...) (depth 2) * 100 (scalar literal)
+PROMQL index=k8s step=1h result=(count(count by (pod) (network.cost)) * 100);
+
+result:double          | step:datetime
+300.0                  | 2024-05-10T01:00:00.000Z
+;
+
+nested_min_plus_count_of_nested_sum
+required_capability: promql_command_v0
+required_capability: fix_promql_time_bucket_v2
+required_capability: promql_nested_aggregates
+required_capability: promql_scalar_over_nested_aggregate
+// min (depth 1) + count(sum by (cluster) ...) (depth 2)
+PROMQL index=k8s step=1h result=(min(network.cost) + count(sum by (cluster) (network.cost)));
+
+result:double          | step:datetime
+3.0                    | 2024-05-10T01:00:00.000Z
+;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -3163,6 +3163,12 @@ public class EsqlCapabilities {
          */
         PROMQL_HISTOGRAM_QUANTILE_IMPLICIT_LE,
 
+        /**
+         * Support for PromQL {@code scalar()} and other single-depth aggregates combined with nested
+         * cross-series aggregations in binary operators (e.g. {@code scalar(x) * 100 / count(count by (pod) (y))}).
+         */
+        PROMQL_SCALAR_OVER_NESTED_AGGREGATE,
+
         // Last capability should still have a comma for fewer merge conflicts when adding new ones :)
         // This comment prevents the semicolon from being on the previous capability when Spotless formats the file.
         ;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/promql/TranslatePromqlToEsqlPlan.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/promql/TranslatePromqlToEsqlPlan.java
@@ -26,9 +26,13 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.expression.Order;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.AggregateFunction;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.Count;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.LastOverTime;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.Max;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.Min;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.PromqlHistogramQuantile;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Scalar;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.Sum;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.TimeSeriesAggregateFunction;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Values;
 import org.elasticsearch.xpack.esql.expression.function.grouping.TStep;
@@ -762,7 +766,13 @@ public final class TranslatePromqlToEsqlPlan extends AnalyzerRules.Parameterized
         // Both aggregated -> fold into one; otherwise take the aggregated side's plan.
         LogicalPlan resultPlan;
         if (leftAgg && rightAgg) {
-            resultPlan = foldBinaryOperatorAggregate(leftResult, rightResult);
+            int leftDepth = aggregateDepth(leftResult.plan());
+            int rightDepth = aggregateDepth(rightResult.plan());
+            if (leftDepth != rightDepth) {
+                resultPlan = foldMixedDepthBinaryOperatorAggregate(leftResult, rightResult);
+            } else {
+                resultPlan = foldBinaryOperatorAggregate(leftResult, rightResult);
+            }
         } else if (leftAgg) {
             resultPlan = leftResult.plan();
         } else {
@@ -838,6 +848,234 @@ public final class TranslatePromqlToEsqlPlan extends AnalyzerRules.Parameterized
         var rightEvals = right.plan().collect(Eval.class);
         for (Eval eval : rightEvals.reversed()) {
             result = new Eval(eval.source(), result, eval.fields());
+        }
+        return result;
+    }
+
+    /**
+     * Counts the number of nested aggregate levels in a plan (walking through UnaryPlan wrappers).
+     */
+    private static int aggregateDepth(LogicalPlan plan) {
+        int depth = 0;
+        LogicalPlan current = plan;
+        while (current != null) {
+            if (current instanceof Aggregate) {
+                depth++;
+            }
+            current = (current instanceof UnaryPlan up) ? up.child() : null;
+        }
+        return depth;
+    }
+
+    /**
+     * Merges a binary operator where the two sides have different aggregate nesting depths.
+     * The simpler side's aggregate expressions are decomposed and injected into the deeper side's
+     * plan: per-series parts go into the innermost {@link TimeSeriesAggregate}, and cross-series
+     * aggregate parts go into the first outer {@link Aggregate}.
+     */
+    private static LogicalPlan foldMixedDepthBinaryOperatorAggregate(TranslationResult left, TranslationResult right) {
+        int leftDepth = aggregateDepth(left.plan());
+        int rightDepth = aggregateDepth(right.plan());
+
+        TranslationResult simpler = leftDepth <= rightDepth ? left : right;
+        TranslationResult deeper = leftDepth > rightDepth ? left : right;
+
+        var names = new TemporaryNameGenerator.Monotonic();
+
+        // Get the simpler side's single aggregate and its value expressions
+        Aggregate simplerAgg = findInnermostAggregate(simpler.plan());
+        @SuppressWarnings("unchecked")
+        List<NamedExpression> filteredSimplerAggs = (List<NamedExpression>) (List<?>) withFilter(
+            simplerAgg.aggregates(),
+            simpler.pendingFilter()
+        );
+
+        // Decompose each aggregate expression from the simpler side into inner (per-series for the
+        // merged innermost TSA) and outer (cross-series for the deeper side's first outer Aggregate).
+        var innerAdditions = new ArrayList<NamedExpression>();
+        var outerAdditions = new ArrayList<NamedExpression>();
+
+        for (NamedExpression ne : filteredSimplerAggs) {
+            if (ne instanceof Alias alias && alias.child() instanceof AggregateFunction aggFunc) {
+                if (isPartiallyDecomposable(aggFunc)) {
+                    // Decomposable (Sum, Count, Max, Min): keep in inner TSA, re-aggregate at outer.
+                    Alias innerAlias = new Alias(alias.source(), names.next(alias.name()), aggFunc);
+                    innerAdditions.add(innerAlias);
+
+                    AggregateFunction reAgg = createReAggregation(aggFunc.source(), aggFunc, innerAlias.toAttribute());
+                    outerAdditions.add(new Alias(alias.source(), alias.name(), reAgg, alias.id()));
+                } else {
+                    // Non-decomposable (Scalar, etc.): wrap inner field in Values, full agg at outer.
+                    Expression innerField = aggFunc.field();
+                    Values valuesInner = new Values(aggFunc.source(), innerField, aggFunc.filter(), aggFunc.window());
+                    Alias innerAlias = new Alias(alias.source(), names.next(alias.name()), valuesInner);
+                    innerAdditions.add(innerAlias);
+
+                    AggregateFunction outerFunc = (AggregateFunction) aggFunc.replaceChildren(
+                        rebuildAggChildren(aggFunc, innerAlias.toAttribute())
+                    );
+                    outerAdditions.add(new Alias(alias.source(), alias.name(), outerFunc, alias.id()));
+                }
+            }
+            // Grouping keys (step, _timeseries, etc.) are already present in the deeper plan.
+        }
+
+        // Inject into the deeper plan by walking the aggregate chain.
+        // Level 0 (innermost): add innerAdditions to the TimeSeriesAggregate.
+        // Level 1 (first outer Aggregate): add outerAdditions.
+        // Levels 2+ (higher Aggregates): add passthrough (Values) for each outer addition.
+        LogicalPlan result = injectIntoAggregateChain(deeper.plan(), innerAdditions, outerAdditions, names);
+
+        // Replay any Evals from the simpler side on top.
+        var simplerEvals = simpler.plan().collect(Eval.class);
+        for (Eval eval : simplerEvals.reversed()) {
+            result = new Eval(eval.source(), result, eval.fields());
+        }
+        return result;
+    }
+
+    private static boolean isPartiallyDecomposable(AggregateFunction aggFunc) {
+        return aggFunc instanceof Sum || aggFunc instanceof Count || aggFunc instanceof Max || aggFunc instanceof Min;
+    }
+
+    /**
+     * Creates a re-aggregation function that correctly combines partial results from a wider grouping.
+     * Sum of partial sums = total sum; Sum of partial counts = total count; Max of maxes = total max; etc.
+     */
+    private static AggregateFunction createReAggregation(Source source, AggregateFunction original, Expression ref) {
+        if (original instanceof Sum) return new Sum(source, ref);
+        if (original instanceof Count) return new Sum(source, ref);
+        if (original instanceof Max) return new Max(source, ref);
+        if (original instanceof Min) return new Min(source, ref);
+        throw new QlIllegalArgumentException("Cannot create re-aggregation for {}", original.getClass().getSimpleName());
+    }
+
+    /**
+     * Rebuilds the children list for an {@link AggregateFunction}, replacing the field with a new reference
+     * while keeping filter and window at their defaults (the filter was already applied at the inner level).
+     */
+    private static List<Expression> rebuildAggChildren(AggregateFunction aggFunc, Expression newField) {
+        var children = new ArrayList<>(aggFunc.children());
+        children.set(0, newField);
+        children.set(1, Literal.TRUE);
+        return children;
+    }
+
+    /**
+     * Walks the deeper plan's aggregate chain and injects expressions at the correct levels.
+     */
+    private static LogicalPlan injectIntoAggregateChain(
+        LogicalPlan plan,
+        List<NamedExpression> innerAdditions,
+        List<NamedExpression> outerAdditions,
+        TemporaryNameGenerator.Monotonic names
+    ) {
+        // Collect the aggregate chain bottom-up: [innermost, ..., outermost]
+        var aggChain = new ArrayList<Aggregate>();
+        var wrappers = new ArrayList<LogicalPlan>();
+        collectAggregateChain(plan, aggChain, wrappers);
+
+        if (aggChain.size() < 2) {
+            throw new QlIllegalArgumentException("Expected at least 2 aggregate levels in the deeper plan");
+        }
+
+        // Level 0: innermost TSA — inject inner expressions
+        Aggregate innermost = aggChain.getFirst();
+        var newInnerAggs = new ArrayList<NamedExpression>(innermost.aggregates());
+        newInnerAggs.addAll(innerAdditions);
+        LogicalPlan rebuilt = rebuildAggregate(innermost, innermost.child(), newInnerAggs);
+
+        // Level 1+: non-TSA Aggregates — inject additions before trailing grouping keys.
+        // The aggregates() list appends grouping keys at the end; validation skips the last
+        // groupings().size() elements, so new expressions must go before that tail.
+        for (int i = 1; i < aggChain.size(); i++) {
+            Aggregate level = aggChain.get(i);
+            int groupingCount = level.groupings().size();
+            int aggEnd = level.aggregates().size() - groupingCount;
+            var computedAggs = new ArrayList<NamedExpression>(level.aggregates().subList(0, aggEnd));
+            var trailingGroupings = level.aggregates().subList(aggEnd, level.aggregates().size());
+
+            if (i == 1) {
+                computedAggs.addAll(outerAdditions);
+            } else {
+                for (NamedExpression oe : outerAdditions) {
+                    Attribute ref = oe.toAttribute();
+                    computedAggs.add(new Alias(ref.source(), names.next(ref.name()), new Values(ref.source(), ref), oe.id()));
+                }
+            }
+
+            var renamedAggs = new ArrayList<NamedExpression>(computedAggs.stream().map(e -> {
+                Expression inner = e;
+                if (e instanceof Alias a) {
+                    inner = a.child();
+                }
+                return (NamedExpression) new Alias(e.source(), names.next(e.name()), inner, e.id());
+            }).toList());
+            renamedAggs.addAll(trailingGroupings);
+            rebuilt = rebuildAggregate(level, rebuilt, renamedAggs);
+        }
+
+        // Re-wrap with non-aggregate nodes (Evals, Projects, etc.) that were above aggregates
+        for (LogicalPlan wrapper : wrappers) {
+            if (wrapper instanceof Eval eval) {
+                rebuilt = new Eval(eval.source(), rebuilt, eval.fields());
+            } else if (wrapper instanceof Project project) {
+                rebuilt = new Project(project.source(), rebuilt, project.projections());
+            } else if (wrapper instanceof Filter filter) {
+                rebuilt = new Filter(filter.source(), rebuilt, filter.condition());
+            }
+        }
+
+        return rebuilt;
+    }
+
+    /**
+     * Collects the aggregate chain from a plan, walking through UnaryPlan wrappers.
+     * Aggregates are collected bottom-up (innermost first).
+     * Non-aggregate wrappers above the outermost aggregate are collected separately.
+     */
+    private static void collectAggregateChain(LogicalPlan plan, List<Aggregate> aggChain, List<LogicalPlan> wrappers) {
+        boolean seenAggregate = false;
+        LogicalPlan current = plan;
+        var preAggWrappers = new ArrayList<LogicalPlan>();
+        while (current != null) {
+            if (current instanceof Aggregate agg) {
+                seenAggregate = true;
+                aggChain.add(agg);
+            } else if (current instanceof UnaryPlan && seenAggregate == false) {
+                preAggWrappers.add(current);
+            }
+            current = (current instanceof UnaryPlan up) ? up.child() : null;
+        }
+        // Reverse aggChain so innermost is first
+        java.util.Collections.reverse(aggChain);
+        // wrappers are those above the outermost aggregate, in top-down order
+        wrappers.addAll(preAggWrappers);
+    }
+
+    private static LogicalPlan rebuildAggregate(Aggregate original, LogicalPlan newChild, List<NamedExpression> newAggs) {
+        if (original instanceof TimeSeriesAggregate tsa) {
+            return new TimeSeriesAggregate(
+                tsa.source(),
+                newChild,
+                tsa.groupings(),
+                newAggs,
+                tsa.timeBucket(),
+                tsa.timestamp(),
+                tsa.origin()
+            );
+        }
+        return original.with(newChild, original.groupings(), newAggs);
+    }
+
+    private static Aggregate findInnermostAggregate(LogicalPlan plan) {
+        Aggregate result = null;
+        LogicalPlan current = plan;
+        while (current != null) {
+            if (current instanceof Aggregate agg) {
+                result = agg;
+            }
+            current = (current instanceof UnaryPlan up) ? up.child() : null;
         }
         return result;
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/PromqlCommand.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/PromqlCommand.java
@@ -505,14 +505,6 @@ public class PromqlCommand extends UnaryPlan implements TelemetryAware, Timestam
                     if (usesWithoutGrouping(binaryOperator.left()) || usesWithoutGrouping(binaryOperator.right())) {
                         failures.add(fail(lp, "binary expressions with WITHOUT are not supported at this time [{}]", lp.sourceText()));
                     }
-                    if (hasSourceBackedExpression(binaryOperator.left())
-                        && hasSourceBackedExpression(binaryOperator.right())
-                        && (usesNestedAcrossSeriesAggregation(binaryOperator.left())
-                            || usesNestedAcrossSeriesAggregation(binaryOperator.right()))) {
-                        failures.add(
-                            fail(lp, "binary expressions with nested aggregations are not supported at this time [{}]", lp.sourceText())
-                        );
-                    }
                 }
                 case PlaceholderRelation placeholderRelation -> {
                     // ok
@@ -569,14 +561,6 @@ public class PromqlCommand extends UnaryPlan implements TelemetryAware, Timestam
             collectTopLevelUnionChain(setOp.left(), chain);
             collectTopLevelUnionChain(setOp.right(), chain);
         }
-    }
-
-    private static boolean hasSourceBackedExpression(LogicalPlan plan) {
-        return plan.anyMatch(p -> p instanceof Selector && (p instanceof LiteralSelector) == false);
-    }
-
-    private static boolean usesNestedAcrossSeriesAggregation(LogicalPlan plan) {
-        return plan.anyMatch(p -> p instanceof AcrossSeriesAggregate agg && agg.child().anyMatch(AcrossSeriesAggregate.class::isInstance));
     }
 
     private static boolean usesWithoutGrouping(LogicalPlan plan) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlPlanBinaryOperatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlPlanBinaryOperatorTests.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.esql.optimizer.promql;
 
-import org.elasticsearch.xpack.esql.VerificationException;
 import org.elasticsearch.xpack.esql.core.expression.Alias;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
@@ -43,7 +42,6 @@ import java.util.List;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.as;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
@@ -390,14 +388,38 @@ public class PromqlPlanBinaryOperatorTests extends AbstractPromqlPlanOptimizerTe
         assertThat(aggregate.aggregates().stream().filter(e -> e.anyMatch(Max.class::isInstance)).count(), equalTo(1L));
     }
 
-    public void testBinaryScalarAndNestedAggregationFailsCleanly() {
-        VerificationException e = assertThrows(
-            VerificationException.class,
-            () -> planPromql(
-                "PROMQL index=k8s step=1m result=(scalar(network.bytes_in) * 100 / count(count by (pod) (network.total_bytes_in)))"
-            )
+    public void testBinaryScalarAndNestedAggregation() {
+        var plan = planPromql(
+            "PROMQL index=k8s step=1m result=(scalar(network.bytes_in) * 100 / count(count by (pod) (network.total_bytes_in)))"
         );
-        assertThat(e.getMessage(), containsString("binary expressions with nested aggregations are not supported at this time"));
+        assertThat(plan.output().stream().map(Attribute::name).toList(), equalTo(List.of("result", "step")));
+
+        var allAggs = plan.collect(Aggregate.class);
+        assertThat("plan should contain aggregate nodes for nested aggregation", allAggs.isEmpty(), equalTo(false));
+
+        var tsAggs = plan.collect(TimeSeriesAggregate.class);
+        assertThat("should have at least one TimeSeriesAggregate", tsAggs.isEmpty(), equalTo(false));
+
+        var outerAggs = allAggs.stream().filter(a -> a instanceof TimeSeriesAggregate == false).toList();
+        assertThat("nested aggregation should produce at least one outer Aggregate", outerAggs.isEmpty(), equalTo(false));
+    }
+
+    public void testBinaryDecomposableSumAndNestedAggregation() {
+        var plan = planPromql("PROMQL index=k8s step=1m result=(sum(network.bytes_in) / count(count by (pod) (network.total_bytes_in)))");
+        assertThat(plan.output().stream().map(Attribute::name).toList(), equalTo(List.of("result", "step")));
+
+        var allAggs = plan.collect(Aggregate.class);
+        assertThat("plan should contain aggregate nodes", allAggs.isEmpty(), equalTo(false));
+
+        var outerAggs = allAggs.stream().filter(a -> a instanceof TimeSeriesAggregate == false).toList();
+        assertThat("nested aggregation produces at least one outer Aggregate", outerAggs.isEmpty(), equalTo(false));
+
+        // Sum is decomposable: somewhere in the aggregate chain a Sum re-aggregation should exist
+        assertThat(
+            "aggregate chain should contain a Sum re-aggregation",
+            outerAggs.stream().anyMatch(agg -> agg.aggregates().stream().anyMatch(e -> e.anyMatch(Sum.class::isInstance))),
+            equalTo(true)
+        );
     }
 
     public void testNestedBinaryAggregationsWithScalar() {

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/40_tsdb.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/40_tsdb.yml
@@ -1598,3 +1598,63 @@ TS command spurious grouping when non-dimension flattened keys vary:
   - match: {values.1.0: 5.4}
   - match: {values.1.1: "host-b"}
   - match: {values.1.2: {build.tag: "v2.0", region: "eu-west-1"}}
+
+---
+PromQL mixed-depth binary op with nested aggregation:
+  - requires:
+      test_runner_features: [ capabilities ]
+      capabilities:
+        - method: POST
+          path: /_query
+          parameters: []
+          capabilities: [ promql_command_v0, fix_promql_time_bucket_v2, promql_nested_aggregates, promql_scalar_over_nested_aggregate ]
+      reason: "PromQL scalar over nested aggregate support"
+  - do:
+      indices.create:
+        index: test_promql_nested_binop
+        body:
+          settings:
+            index:
+              mode: time_series
+              routing_path: [ host ]
+              time_series:
+                start_time: 2024-01-01T00:00:00Z
+                end_time: 2024-01-02T00:00:00Z
+          mappings:
+            properties:
+              "@timestamp":
+                type: date
+              host:
+                type: keyword
+                time_series_dimension: true
+              region:
+                type: keyword
+                time_series_dimension: true
+              cpu:
+                type: double
+                time_series_metric: gauge
+  - do:
+      bulk:
+        refresh: true
+        index: test_promql_nested_binop
+        body:
+          - '{"index": {}}'
+          - '{"@timestamp": "2024-01-01T01:00:00Z", "host": "a", "region": "us", "cpu": 10.0}'
+          - '{"index": {}}'
+          - '{"@timestamp": "2024-01-01T01:00:00Z", "host": "b", "region": "us", "cpu": 20.0}'
+          - '{"index": {}}'
+          - '{"@timestamp": "2024-01-01T01:00:00Z", "host": "c", "region": "eu", "cpu": 30.0}'
+          - '{"index": {}}'
+          - '{"@timestamp": "2024-01-01T01:00:00Z", "host": "d", "region": "eu", "cpu": 40.0}'
+  - is_false: errors
+  # sum(cpu) = 100; count(sum by (region) (cpu)) = 2; result = 100/2 = 50
+  - do:
+      esql.query:
+        body:
+          query: 'PROMQL index=test_promql_nested_binop step=1h result=(sum(cpu) / count(sum by (region) (cpu)))'
+  - match: {columns.0.name: "result"}
+  - match: {columns.0.type: "double"}
+  - match: {columns.1.name: "step"}
+  - match: {columns.1.type: "date"}
+  - length: {values: 1}
+  - match: {values.0.0: 50.0}


### PR DESCRIPTION
### What

Adds support for `scalar()` (and other single-depth aggregates) combined with nested cross-series aggregations in PromQL binary operators, e.g. `scalar(x) * 100 / count(count by (pod) (y))`.

### Why

Previously the verifier rejected these expressions with _"binary expressions with nested aggregations are not supported"_ because `foldBinaryOperatorAggregate` assumed both operands have equal aggregate depth. This blocked real-world Grafana dashboards that mix `scalar()` with nested `count`/`sum` patterns.

### How

- Introduce `foldMixedDepthBinaryOperatorAggregate` in `TranslatePromqlToEsqlPlan` that decomposes the shallower side and injects its parts into the deeper plan's aggregate chain.
- Decomposable aggregates (`Sum`, `Count`, `Max`, `Min`) are partially computed in the inner `TimeSeriesAggregate` and re-aggregated at the outer level.
- Non-decomposable aggregates (`Scalar`, etc.) use `Values` passthrough at the inner level.
- Remove the verifier guard that blocked nested aggregations in binary ops.

Made with [Cursor](https://cursor.com)