### PR TITLE
[ES|QL] Support keyword/text in TOP(field,...,outputField)

### DIFF
--- a/docs/changelog/151767.yaml
+++ b/docs/changelog/151767.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 151751
+pr: 151767
+summary: "Support keyword/text in TOP(field,...,outputField)"
+type: feature

--- a/docs/reference/query-languages/esql/_snippets/generated/x-pack-esql/functions/types/top.md
+++ b/docs/reference/query-languages/esql/_snippets/generated/x-pack-esql/functions/types/top.md
@@ -9,31 +9,51 @@
 | date | integer | keyword | date | date |
 | date | integer | keyword | double | double |
 | date | integer | keyword | integer | integer |
+| date | integer | keyword | keyword | keyword |
 | date | integer | keyword | long | long |
+| date | integer | keyword | text | keyword |
 | date | integer | keyword | | date |
 | date | integer | | | date |
 | double | integer | keyword | date | date |
 | double | integer | keyword | double | double |
 | double | integer | keyword | integer | integer |
+| double | integer | keyword | keyword | keyword |
 | double | integer | keyword | long | long |
+| double | integer | keyword | text | keyword |
 | double | integer | keyword | | double |
 | double | integer | | | double |
 | integer | integer | keyword | date | date |
 | integer | integer | keyword | double | double |
 | integer | integer | keyword | integer | integer |
+| integer | integer | keyword | keyword | keyword |
 | integer | integer | keyword | long | long |
+| integer | integer | keyword | text | keyword |
 | integer | integer | keyword | | integer |
 | integer | integer | | | integer |
 | ip | integer | keyword | | ip |
 | ip | integer | | | ip |
+| keyword | integer | keyword | date | date |
+| keyword | integer | keyword | double | double |
+| keyword | integer | keyword | integer | integer |
+| keyword | integer | keyword | keyword | keyword |
+| keyword | integer | keyword | long | long |
+| keyword | integer | keyword | text | keyword |
 | keyword | integer | keyword | | keyword |
 | keyword | integer | | | keyword |
 | long | integer | keyword | date | date |
 | long | integer | keyword | double | double |
 | long | integer | keyword | integer | integer |
+| long | integer | keyword | keyword | keyword |
 | long | integer | keyword | long | long |
+| long | integer | keyword | text | keyword |
 | long | integer | keyword | | long |
 | long | integer | | | long |
+| text | integer | keyword | date | date |
+| text | integer | keyword | double | double |
+| text | integer | keyword | integer | integer |
+| text | integer | keyword | keyword | keyword |
+| text | integer | keyword | long | long |
+| text | integer | keyword | text | keyword |
 | text | integer | keyword | | keyword |
 | text | integer | | | keyword |
 

--- a/docs/reference/query-languages/esql/kibana/generated/x-pack-esql/definition/functions/top.json
+++ b/docs/reference/query-languages/esql/kibana/generated/x-pack-esql/definition/functions/top.json
@@ -200,6 +200,36 @@
         },
         {
           "name" : "outputField",
+          "type" : "keyword",
+          "optional" : true,
+          "description" : "The extra field that, if present, will be the output of the TOP call instead of `field`."
+        }
+      ],
+      "variadic" : false,
+      "returnType" : "keyword"
+    },
+    {
+      "params" : [
+        {
+          "name" : "field",
+          "type" : "date",
+          "optional" : false,
+          "description" : "The field to collect the top values for."
+        },
+        {
+          "name" : "limit",
+          "type" : "integer",
+          "optional" : false,
+          "description" : "The maximum number of values to collect."
+        },
+        {
+          "name" : "order",
+          "type" : "keyword",
+          "optional" : true,
+          "description" : "The order to calculate the top values. Either `asc` or `desc`, and defaults to `asc` if omitted."
+        },
+        {
+          "name" : "outputField",
           "type" : "long",
           "optional" : true,
           "description" : "The extra field that, if present, will be the output of the TOP call instead of `field`."
@@ -207,6 +237,36 @@
       ],
       "variadic" : false,
       "returnType" : "long"
+    },
+    {
+      "params" : [
+        {
+          "name" : "field",
+          "type" : "date",
+          "optional" : false,
+          "description" : "The field to collect the top values for."
+        },
+        {
+          "name" : "limit",
+          "type" : "integer",
+          "optional" : false,
+          "description" : "The maximum number of values to collect."
+        },
+        {
+          "name" : "order",
+          "type" : "keyword",
+          "optional" : true,
+          "description" : "The order to calculate the top values. Either `asc` or `desc`, and defaults to `asc` if omitted."
+        },
+        {
+          "name" : "outputField",
+          "type" : "text",
+          "optional" : true,
+          "description" : "The extra field that, if present, will be the output of the TOP call instead of `field`."
+        }
+      ],
+      "variadic" : false,
+      "returnType" : "keyword"
     },
     {
       "params" : [
@@ -362,6 +422,36 @@
         },
         {
           "name" : "outputField",
+          "type" : "keyword",
+          "optional" : true,
+          "description" : "The extra field that, if present, will be the output of the TOP call instead of `field`."
+        }
+      ],
+      "variadic" : false,
+      "returnType" : "keyword"
+    },
+    {
+      "params" : [
+        {
+          "name" : "field",
+          "type" : "double",
+          "optional" : false,
+          "description" : "The field to collect the top values for."
+        },
+        {
+          "name" : "limit",
+          "type" : "integer",
+          "optional" : false,
+          "description" : "The maximum number of values to collect."
+        },
+        {
+          "name" : "order",
+          "type" : "keyword",
+          "optional" : true,
+          "description" : "The order to calculate the top values. Either `asc` or `desc`, and defaults to `asc` if omitted."
+        },
+        {
+          "name" : "outputField",
           "type" : "long",
           "optional" : true,
           "description" : "The extra field that, if present, will be the output of the TOP call instead of `field`."
@@ -369,6 +459,36 @@
       ],
       "variadic" : false,
       "returnType" : "long"
+    },
+    {
+      "params" : [
+        {
+          "name" : "field",
+          "type" : "double",
+          "optional" : false,
+          "description" : "The field to collect the top values for."
+        },
+        {
+          "name" : "limit",
+          "type" : "integer",
+          "optional" : false,
+          "description" : "The maximum number of values to collect."
+        },
+        {
+          "name" : "order",
+          "type" : "keyword",
+          "optional" : true,
+          "description" : "The order to calculate the top values. Either `asc` or `desc`, and defaults to `asc` if omitted."
+        },
+        {
+          "name" : "outputField",
+          "type" : "text",
+          "optional" : true,
+          "description" : "The extra field that, if present, will be the output of the TOP call instead of `field`."
+        }
+      ],
+      "variadic" : false,
+      "returnType" : "keyword"
     },
     {
       "params" : [
@@ -524,6 +644,36 @@
         },
         {
           "name" : "outputField",
+          "type" : "keyword",
+          "optional" : true,
+          "description" : "The extra field that, if present, will be the output of the TOP call instead of `field`."
+        }
+      ],
+      "variadic" : false,
+      "returnType" : "keyword"
+    },
+    {
+      "params" : [
+        {
+          "name" : "field",
+          "type" : "integer",
+          "optional" : false,
+          "description" : "The field to collect the top values for."
+        },
+        {
+          "name" : "limit",
+          "type" : "integer",
+          "optional" : false,
+          "description" : "The maximum number of values to collect."
+        },
+        {
+          "name" : "order",
+          "type" : "keyword",
+          "optional" : true,
+          "description" : "The order to calculate the top values. Either `asc` or `desc`, and defaults to `asc` if omitted."
+        },
+        {
+          "name" : "outputField",
           "type" : "long",
           "optional" : true,
           "description" : "The extra field that, if present, will be the output of the TOP call instead of `field`."
@@ -531,6 +681,36 @@
       ],
       "variadic" : false,
       "returnType" : "long"
+    },
+    {
+      "params" : [
+        {
+          "name" : "field",
+          "type" : "integer",
+          "optional" : false,
+          "description" : "The field to collect the top values for."
+        },
+        {
+          "name" : "limit",
+          "type" : "integer",
+          "optional" : false,
+          "description" : "The maximum number of values to collect."
+        },
+        {
+          "name" : "order",
+          "type" : "keyword",
+          "optional" : true,
+          "description" : "The order to calculate the top values. Either `asc` or `desc`, and defaults to `asc` if omitted."
+        },
+        {
+          "name" : "outputField",
+          "type" : "text",
+          "optional" : true,
+          "description" : "The extra field that, if present, will be the output of the TOP call instead of `field`."
+        }
+      ],
+      "variadic" : false,
+      "returnType" : "keyword"
     },
     {
       "params" : [
@@ -620,6 +800,186 @@
       "params" : [
         {
           "name" : "field",
+          "type" : "keyword",
+          "optional" : false,
+          "description" : "The field to collect the top values for."
+        },
+        {
+          "name" : "limit",
+          "type" : "integer",
+          "optional" : false,
+          "description" : "The maximum number of values to collect."
+        },
+        {
+          "name" : "order",
+          "type" : "keyword",
+          "optional" : true,
+          "description" : "The order to calculate the top values. Either `asc` or `desc`, and defaults to `asc` if omitted."
+        },
+        {
+          "name" : "outputField",
+          "type" : "date",
+          "optional" : true,
+          "description" : "The extra field that, if present, will be the output of the TOP call instead of `field`."
+        }
+      ],
+      "variadic" : false,
+      "returnType" : "date"
+    },
+    {
+      "params" : [
+        {
+          "name" : "field",
+          "type" : "keyword",
+          "optional" : false,
+          "description" : "The field to collect the top values for."
+        },
+        {
+          "name" : "limit",
+          "type" : "integer",
+          "optional" : false,
+          "description" : "The maximum number of values to collect."
+        },
+        {
+          "name" : "order",
+          "type" : "keyword",
+          "optional" : true,
+          "description" : "The order to calculate the top values. Either `asc` or `desc`, and defaults to `asc` if omitted."
+        },
+        {
+          "name" : "outputField",
+          "type" : "double",
+          "optional" : true,
+          "description" : "The extra field that, if present, will be the output of the TOP call instead of `field`."
+        }
+      ],
+      "variadic" : false,
+      "returnType" : "double"
+    },
+    {
+      "params" : [
+        {
+          "name" : "field",
+          "type" : "keyword",
+          "optional" : false,
+          "description" : "The field to collect the top values for."
+        },
+        {
+          "name" : "limit",
+          "type" : "integer",
+          "optional" : false,
+          "description" : "The maximum number of values to collect."
+        },
+        {
+          "name" : "order",
+          "type" : "keyword",
+          "optional" : true,
+          "description" : "The order to calculate the top values. Either `asc` or `desc`, and defaults to `asc` if omitted."
+        },
+        {
+          "name" : "outputField",
+          "type" : "integer",
+          "optional" : true,
+          "description" : "The extra field that, if present, will be the output of the TOP call instead of `field`."
+        }
+      ],
+      "variadic" : false,
+      "returnType" : "integer"
+    },
+    {
+      "params" : [
+        {
+          "name" : "field",
+          "type" : "keyword",
+          "optional" : false,
+          "description" : "The field to collect the top values for."
+        },
+        {
+          "name" : "limit",
+          "type" : "integer",
+          "optional" : false,
+          "description" : "The maximum number of values to collect."
+        },
+        {
+          "name" : "order",
+          "type" : "keyword",
+          "optional" : true,
+          "description" : "The order to calculate the top values. Either `asc` or `desc`, and defaults to `asc` if omitted."
+        },
+        {
+          "name" : "outputField",
+          "type" : "keyword",
+          "optional" : true,
+          "description" : "The extra field that, if present, will be the output of the TOP call instead of `field`."
+        }
+      ],
+      "variadic" : false,
+      "returnType" : "keyword"
+    },
+    {
+      "params" : [
+        {
+          "name" : "field",
+          "type" : "keyword",
+          "optional" : false,
+          "description" : "The field to collect the top values for."
+        },
+        {
+          "name" : "limit",
+          "type" : "integer",
+          "optional" : false,
+          "description" : "The maximum number of values to collect."
+        },
+        {
+          "name" : "order",
+          "type" : "keyword",
+          "optional" : true,
+          "description" : "The order to calculate the top values. Either `asc` or `desc`, and defaults to `asc` if omitted."
+        },
+        {
+          "name" : "outputField",
+          "type" : "long",
+          "optional" : true,
+          "description" : "The extra field that, if present, will be the output of the TOP call instead of `field`."
+        }
+      ],
+      "variadic" : false,
+      "returnType" : "long"
+    },
+    {
+      "params" : [
+        {
+          "name" : "field",
+          "type" : "keyword",
+          "optional" : false,
+          "description" : "The field to collect the top values for."
+        },
+        {
+          "name" : "limit",
+          "type" : "integer",
+          "optional" : false,
+          "description" : "The maximum number of values to collect."
+        },
+        {
+          "name" : "order",
+          "type" : "keyword",
+          "optional" : true,
+          "description" : "The order to calculate the top values. Either `asc` or `desc`, and defaults to `asc` if omitted."
+        },
+        {
+          "name" : "outputField",
+          "type" : "text",
+          "optional" : true,
+          "description" : "The extra field that, if present, will be the output of the TOP call instead of `field`."
+        }
+      ],
+      "variadic" : false,
+      "returnType" : "keyword"
+    },
+    {
+      "params" : [
+        {
+          "name" : "field",
           "type" : "long",
           "optional" : false,
           "description" : "The field to collect the top values for."
@@ -770,6 +1130,36 @@
         },
         {
           "name" : "outputField",
+          "type" : "keyword",
+          "optional" : true,
+          "description" : "The extra field that, if present, will be the output of the TOP call instead of `field`."
+        }
+      ],
+      "variadic" : false,
+      "returnType" : "keyword"
+    },
+    {
+      "params" : [
+        {
+          "name" : "field",
+          "type" : "long",
+          "optional" : false,
+          "description" : "The field to collect the top values for."
+        },
+        {
+          "name" : "limit",
+          "type" : "integer",
+          "optional" : false,
+          "description" : "The maximum number of values to collect."
+        },
+        {
+          "name" : "order",
+          "type" : "keyword",
+          "optional" : true,
+          "description" : "The order to calculate the top values. Either `asc` or `desc`, and defaults to `asc` if omitted."
+        },
+        {
+          "name" : "outputField",
           "type" : "long",
           "optional" : true,
           "description" : "The extra field that, if present, will be the output of the TOP call instead of `field`."
@@ -777,6 +1167,36 @@
       ],
       "variadic" : false,
       "returnType" : "long"
+    },
+    {
+      "params" : [
+        {
+          "name" : "field",
+          "type" : "long",
+          "optional" : false,
+          "description" : "The field to collect the top values for."
+        },
+        {
+          "name" : "limit",
+          "type" : "integer",
+          "optional" : false,
+          "description" : "The maximum number of values to collect."
+        },
+        {
+          "name" : "order",
+          "type" : "keyword",
+          "optional" : true,
+          "description" : "The order to calculate the top values. Either `asc` or `desc`, and defaults to `asc` if omitted."
+        },
+        {
+          "name" : "outputField",
+          "type" : "text",
+          "optional" : true,
+          "description" : "The extra field that, if present, will be the output of the TOP call instead of `field`."
+        }
+      ],
+      "variadic" : false,
+      "returnType" : "keyword"
     },
     {
       "params" : [
@@ -815,6 +1235,186 @@
           "type" : "keyword",
           "optional" : true,
           "description" : "The order to calculate the top values. Either `asc` or `desc`, and defaults to `asc` if omitted."
+        }
+      ],
+      "variadic" : false,
+      "returnType" : "keyword"
+    },
+    {
+      "params" : [
+        {
+          "name" : "field",
+          "type" : "text",
+          "optional" : false,
+          "description" : "The field to collect the top values for."
+        },
+        {
+          "name" : "limit",
+          "type" : "integer",
+          "optional" : false,
+          "description" : "The maximum number of values to collect."
+        },
+        {
+          "name" : "order",
+          "type" : "keyword",
+          "optional" : true,
+          "description" : "The order to calculate the top values. Either `asc` or `desc`, and defaults to `asc` if omitted."
+        },
+        {
+          "name" : "outputField",
+          "type" : "date",
+          "optional" : true,
+          "description" : "The extra field that, if present, will be the output of the TOP call instead of `field`."
+        }
+      ],
+      "variadic" : false,
+      "returnType" : "date"
+    },
+    {
+      "params" : [
+        {
+          "name" : "field",
+          "type" : "text",
+          "optional" : false,
+          "description" : "The field to collect the top values for."
+        },
+        {
+          "name" : "limit",
+          "type" : "integer",
+          "optional" : false,
+          "description" : "The maximum number of values to collect."
+        },
+        {
+          "name" : "order",
+          "type" : "keyword",
+          "optional" : true,
+          "description" : "The order to calculate the top values. Either `asc` or `desc`, and defaults to `asc` if omitted."
+        },
+        {
+          "name" : "outputField",
+          "type" : "double",
+          "optional" : true,
+          "description" : "The extra field that, if present, will be the output of the TOP call instead of `field`."
+        }
+      ],
+      "variadic" : false,
+      "returnType" : "double"
+    },
+    {
+      "params" : [
+        {
+          "name" : "field",
+          "type" : "text",
+          "optional" : false,
+          "description" : "The field to collect the top values for."
+        },
+        {
+          "name" : "limit",
+          "type" : "integer",
+          "optional" : false,
+          "description" : "The maximum number of values to collect."
+        },
+        {
+          "name" : "order",
+          "type" : "keyword",
+          "optional" : true,
+          "description" : "The order to calculate the top values. Either `asc` or `desc`, and defaults to `asc` if omitted."
+        },
+        {
+          "name" : "outputField",
+          "type" : "integer",
+          "optional" : true,
+          "description" : "The extra field that, if present, will be the output of the TOP call instead of `field`."
+        }
+      ],
+      "variadic" : false,
+      "returnType" : "integer"
+    },
+    {
+      "params" : [
+        {
+          "name" : "field",
+          "type" : "text",
+          "optional" : false,
+          "description" : "The field to collect the top values for."
+        },
+        {
+          "name" : "limit",
+          "type" : "integer",
+          "optional" : false,
+          "description" : "The maximum number of values to collect."
+        },
+        {
+          "name" : "order",
+          "type" : "keyword",
+          "optional" : true,
+          "description" : "The order to calculate the top values. Either `asc` or `desc`, and defaults to `asc` if omitted."
+        },
+        {
+          "name" : "outputField",
+          "type" : "keyword",
+          "optional" : true,
+          "description" : "The extra field that, if present, will be the output of the TOP call instead of `field`."
+        }
+      ],
+      "variadic" : false,
+      "returnType" : "keyword"
+    },
+    {
+      "params" : [
+        {
+          "name" : "field",
+          "type" : "text",
+          "optional" : false,
+          "description" : "The field to collect the top values for."
+        },
+        {
+          "name" : "limit",
+          "type" : "integer",
+          "optional" : false,
+          "description" : "The maximum number of values to collect."
+        },
+        {
+          "name" : "order",
+          "type" : "keyword",
+          "optional" : true,
+          "description" : "The order to calculate the top values. Either `asc` or `desc`, and defaults to `asc` if omitted."
+        },
+        {
+          "name" : "outputField",
+          "type" : "long",
+          "optional" : true,
+          "description" : "The extra field that, if present, will be the output of the TOP call instead of `field`."
+        }
+      ],
+      "variadic" : false,
+      "returnType" : "long"
+    },
+    {
+      "params" : [
+        {
+          "name" : "field",
+          "type" : "text",
+          "optional" : false,
+          "description" : "The field to collect the top values for."
+        },
+        {
+          "name" : "limit",
+          "type" : "integer",
+          "optional" : false,
+          "description" : "The maximum number of values to collect."
+        },
+        {
+          "name" : "order",
+          "type" : "keyword",
+          "optional" : true,
+          "description" : "The order to calculate the top values. Either `asc` or `desc`, and defaults to `asc` if omitted."
+        },
+        {
+          "name" : "outputField",
+          "type" : "text",
+          "optional" : true,
+          "description" : "The extra field that, if present, will be the output of the TOP call instead of `field`."
         }
       ],
       "variadic" : false,

--- a/x-pack/plugin/esql/compute/build.gradle
+++ b/x-pack/plugin/esql/compute/build.gradle
@@ -1162,7 +1162,7 @@ tasks.named('stringTemplates').configure {
   }
 
   File bucketedSortInputFile = new File("${projectDir}/src/main/java/org/elasticsearch/compute/data/sort/X-BucketedSort.java.st")
-  [intProperties, longProperties, floatProperties, doubleProperties].forEach { props ->
+  [intProperties, longProperties, floatProperties, doubleProperties, bytesRefProperties].forEach { props ->
     {
       template {
         it.properties = propWithoutExtra(props, "Extra")

--- a/x-pack/plugin/esql/compute/build.gradle
+++ b/x-pack/plugin/esql/compute/build.gradle
@@ -1011,9 +1011,9 @@ tasks.named('stringTemplates').configure {
     }
   }
   // TOP when the sort field and the output field can be *different* fields
-  [intProperties, longProperties, floatProperties, doubleProperties].forEach { props1 ->
+  [intProperties, longProperties, floatProperties, doubleProperties, bytesRefProperties].forEach { props1 ->
     {
-      [intProperties, longProperties, floatProperties, doubleProperties].forEach { props2 ->
+      [intProperties, longProperties, floatProperties, doubleProperties, bytesRefProperties].forEach { props2 ->
         {
           template {
             it.properties = propWithExtra(props1, props2, "OutputField")
@@ -1172,9 +1172,9 @@ tasks.named('stringTemplates').configure {
     }
   }
   // TOP when the sort field and the output field can be *different* fields
-  [intProperties, longProperties, floatProperties, doubleProperties].forEach { props1 ->
+  [intProperties, longProperties, floatProperties, doubleProperties, bytesRefProperties].forEach { props1 ->
     {
-      [intProperties, longProperties, floatProperties, doubleProperties].forEach { props2 ->
+      [intProperties, longProperties, floatProperties, doubleProperties, bytesRefProperties].forEach { props2 ->
         {
           template {
             it.properties = propWithExtra(props1, props2, "Extra")

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/SampleBooleanAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/SampleBooleanAggregator.java
@@ -127,7 +127,7 @@ class SampleBooleanAggregator {
 
         private GroupingState(BigArrays bigArrays, int limit) {
             CircuitBreaker breaker = bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST);
-            this.sort = new BytesRefBucketedSort(breaker, "sample", bigArrays, SortOrder.ASC, limit);
+            this.sort = new BytesRefBucketedSort(bigArrays, SortOrder.ASC, limit);
             boolean success = false;
             try {
                 this.bytesRefBuilder = new BreakingBytesRefBuilder(breaker, "sample");

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/SampleBytesRefAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/SampleBytesRefAggregator.java
@@ -127,7 +127,7 @@ class SampleBytesRefAggregator {
 
         private GroupingState(BigArrays bigArrays, int limit) {
             CircuitBreaker breaker = bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST);
-            this.sort = new BytesRefBucketedSort(breaker, "sample", bigArrays, SortOrder.ASC, limit);
+            this.sort = new BytesRefBucketedSort(bigArrays, SortOrder.ASC, limit);
             boolean success = false;
             try {
                 this.bytesRefBuilder = new BreakingBytesRefBuilder(breaker, "sample");

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/SampleDoubleAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/SampleDoubleAggregator.java
@@ -127,7 +127,7 @@ class SampleDoubleAggregator {
 
         private GroupingState(BigArrays bigArrays, int limit) {
             CircuitBreaker breaker = bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST);
-            this.sort = new BytesRefBucketedSort(breaker, "sample", bigArrays, SortOrder.ASC, limit);
+            this.sort = new BytesRefBucketedSort(bigArrays, SortOrder.ASC, limit);
             boolean success = false;
             try {
                 this.bytesRefBuilder = new BreakingBytesRefBuilder(breaker, "sample");

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/SampleIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/SampleIntAggregator.java
@@ -127,7 +127,7 @@ class SampleIntAggregator {
 
         private GroupingState(BigArrays bigArrays, int limit) {
             CircuitBreaker breaker = bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST);
-            this.sort = new BytesRefBucketedSort(breaker, "sample", bigArrays, SortOrder.ASC, limit);
+            this.sort = new BytesRefBucketedSort(bigArrays, SortOrder.ASC, limit);
             boolean success = false;
             try {
                 this.bytesRefBuilder = new BreakingBytesRefBuilder(breaker, "sample");

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/SampleLongAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/SampleLongAggregator.java
@@ -127,7 +127,7 @@ class SampleLongAggregator {
 
         private GroupingState(BigArrays bigArrays, int limit) {
             CircuitBreaker breaker = bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST);
-            this.sort = new BytesRefBucketedSort(breaker, "sample", bigArrays, SortOrder.ASC, limit);
+            this.sort = new BytesRefBucketedSort(bigArrays, SortOrder.ASC, limit);
             boolean success = false;
             try {
                 this.bytesRefBuilder = new BreakingBytesRefBuilder(breaker, "sample");

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopBooleanAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopBooleanAggregator.java
@@ -9,7 +9,6 @@ package org.elasticsearch.compute.aggregation;
 
 // begin generated imports
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopBooleanAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopBooleanAggregator.java
@@ -60,7 +60,13 @@ class TopBooleanAggregator {
         state.add(groupId, v);
     }
 
-    public static void combineIntermediate(GroupingState state, int groupId, BooleanBlock values, int position) {
+    public static void combineIntermediate(
+        // comment to make spotless happy about line breaks
+        GroupingState state,
+        int groupId,
+        BooleanBlock values,
+        int position
+    ) {
         int start = values.getFirstValueIndex(position);
         int end = start + values.getValueCount(position);
         for (int i = start; i < end; i++) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopBytesRefAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopBytesRefAggregator.java
@@ -9,7 +9,6 @@ package org.elasticsearch.compute.aggregation;
 
 // begin generated imports
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
@@ -79,9 +78,7 @@ class TopBytesRefAggregator {
         private final BytesRefBucketedSort sort;
 
         private GroupingState(BigArrays bigArrays, int limit, boolean ascending) {
-            // TODO pass the breaker in from the DriverContext
-            CircuitBreaker breaker = bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST);
-            this.sort = new BytesRefBucketedSort(breaker, "top", bigArrays, ascending ? SortOrder.ASC : SortOrder.DESC, limit);
+            this.sort = new BytesRefBucketedSort(bigArrays, ascending ? SortOrder.ASC : SortOrder.DESC, limit);
         }
 
         public void add(int groupId, BytesRef value) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopBytesRefAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopBytesRefAggregator.java
@@ -61,7 +61,13 @@ class TopBytesRefAggregator {
         state.add(groupId, v);
     }
 
-    public static void combineIntermediate(GroupingState state, int groupId, BytesRefBlock values, int position) {
+    public static void combineIntermediate(
+        // comment to make spotless happy about line breaks
+        GroupingState state,
+        int groupId,
+        BytesRefBlock values,
+        int position
+    ) {
         int start = values.getFirstValueIndex(position);
         int end = start + values.getValueCount(position);
         var scratch = new BytesRef();

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopBytesRefBytesRefAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopBytesRefBytesRefAggregator.java
@@ -63,7 +63,14 @@ class TopBytesRefBytesRefAggregator {
         state.add(groupId, v, outputValue);
     }
 
-    public static void combineIntermediate(GroupingState state, int groupId, BytesRefBlock values, BytesRefBlock outputValues, int position) {
+    public static void combineIntermediate(
+        // comment to make spotless happy about line breaks
+        GroupingState state,
+        int groupId,
+        BytesRefBlock values,
+        BytesRefBlock outputValues,
+        int position
+    ) {
         int start = values.getFirstValueIndex(position);
         int end = start + values.getValueCount(position);
         var outputScratch = new BytesRef();

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopBytesRefBytesRefAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopBytesRefBytesRefAggregator.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.aggregation;
+
+// begin generated imports
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.ann.Aggregator;
+import org.elasticsearch.compute.ann.GroupingAggregator;
+import org.elasticsearch.compute.ann.IntermediateState;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.sort.BytesRefBytesRefBucketedSort;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.search.sort.SortOrder;
+// end generated imports
+
+/**
+ * Aggregates the top N field values for BytesRef.
+ * <p>
+ *     This class is generated. Edit `X-TopAggregator.java.st` to edit this file.
+ * </p>
+ */
+@Aggregator({ @IntermediateState(name = "top", type = "BYTES_REF_BLOCK"), @IntermediateState(name = "output", type = "BYTES_REF_BLOCK") })
+@GroupingAggregator
+class TopBytesRefBytesRefAggregator {
+    public static SingleState initSingle(BigArrays bigArrays, int limit, boolean ascending) {
+        return new SingleState(bigArrays, limit, ascending);
+    }
+
+    public static void combine(SingleState state, BytesRef v, BytesRef outputValue) {
+        state.add(v, outputValue);
+    }
+
+    public static void combineIntermediate(SingleState state, BytesRefBlock values, BytesRefBlock outputValues) {
+        int start = values.getFirstValueIndex(0);
+        int end = start + values.getValueCount(0);
+        var outputScratch = new BytesRef();
+        var scratch = new BytesRef();
+        for (int i = start; i < end; i++) {
+            combine(state, values.getBytesRef(i, scratch), outputValues.getBytesRef(i, outputScratch));
+        }
+    }
+
+    public static Block evaluateFinal(SingleState state, DriverContext driverContext) {
+        return state.toBlock(driverContext.blockFactory());
+    }
+
+    public static GroupingState initGrouping(BigArrays bigArrays, int limit, boolean ascending) {
+        return new GroupingState(bigArrays, limit, ascending);
+    }
+
+    public static void combine(GroupingState state, int groupId, BytesRef v, BytesRef outputValue) {
+        state.add(groupId, v, outputValue);
+    }
+
+    public static void combineIntermediate(GroupingState state, int groupId, BytesRefBlock values, BytesRefBlock outputValues, int position) {
+        int start = values.getFirstValueIndex(position);
+        int end = start + values.getValueCount(position);
+        var outputScratch = new BytesRef();
+        var scratch = new BytesRef();
+        for (int i = start; i < end; i++) {
+            combine(state, groupId, values.getBytesRef(i, scratch), outputValues.getBytesRef(i, outputScratch));
+        }
+    }
+
+    public static Block evaluateFinal(GroupingState state, IntVector selected, GroupingAggregatorEvaluationContext ctx) {
+        return state.toBlock(ctx.blockFactory(), selected);
+    }
+
+    public static class GroupingState implements GroupingAggregatorState {
+        private final BytesRefBytesRefBucketedSort sort;
+
+        private GroupingState(BigArrays bigArrays, int limit, boolean ascending) {
+            this.sort = new BytesRefBytesRefBucketedSort(bigArrays, ascending ? SortOrder.ASC : SortOrder.DESC, limit);
+        }
+
+        public void add(int groupId, BytesRef value, BytesRef outputValue) {
+            sort.collect(value, outputValue, groupId);
+        }
+
+        public void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
+            sort.toBlocks(driverContext.blockFactory(), blocks, offset, selected);
+        }
+
+        Block toBlock(BlockFactory blockFactory, IntVector selected) {
+            Block[] blocks = new Block[2];
+            sort.toBlocks(blockFactory, blocks, 0, selected);
+            Releasables.close(blocks[0]);
+            return blocks[1];
+        }
+
+        @Override
+        public void enableGroupIdTracking(SeenGroupIds seen) {
+            // we figure out seen values from nulls on the values block
+        }
+
+        @Override
+        public void close() {
+            Releasables.closeExpectNoException(sort);
+        }
+    }
+
+    public static class SingleState implements AggregatorState {
+        private final GroupingState internalState;
+
+        private SingleState(BigArrays bigArrays, int limit, boolean ascending) {
+            this.internalState = new GroupingState(bigArrays, limit, ascending);
+        }
+
+        public void add(BytesRef value, BytesRef outputValue) {
+            internalState.add(0, value, outputValue);
+        }
+
+        @Override
+        public void toIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+            try (var intValues = driverContext.blockFactory().newConstantIntVector(0, 1)) {
+                internalState.toIntermediate(blocks, offset, intValues, driverContext);
+            }
+        }
+
+        Block toBlock(BlockFactory blockFactory) {
+            try (var intValues = blockFactory.newConstantIntVector(0, 1)) {
+                return internalState.toBlock(blockFactory, intValues);
+            }
+        }
+
+        @Override
+        public void close() {
+            Releasables.closeExpectNoException(internalState);
+        }
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopBytesRefBytesRefAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopBytesRefBytesRefAggregator.java
@@ -9,7 +9,6 @@ package org.elasticsearch.compute.aggregation;
 
 // begin generated imports
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopBytesRefDoubleAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopBytesRefDoubleAggregator.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.aggregation;
+
+// begin generated imports
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.ann.Aggregator;
+import org.elasticsearch.compute.ann.GroupingAggregator;
+import org.elasticsearch.compute.ann.IntermediateState;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.sort.BytesRefDoubleBucketedSort;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.search.sort.SortOrder;
+// end generated imports
+
+/**
+ * Aggregates the top N field values for BytesRef.
+ * <p>
+ *     This class is generated. Edit `X-TopAggregator.java.st` to edit this file.
+ * </p>
+ */
+@Aggregator({ @IntermediateState(name = "top", type = "BYTES_REF_BLOCK"), @IntermediateState(name = "output", type = "DOUBLE_BLOCK") })
+@GroupingAggregator
+class TopBytesRefDoubleAggregator {
+    public static SingleState initSingle(BigArrays bigArrays, int limit, boolean ascending) {
+        return new SingleState(bigArrays, limit, ascending);
+    }
+
+    public static void combine(SingleState state, BytesRef v, double outputValue) {
+        state.add(v, outputValue);
+    }
+
+    public static void combineIntermediate(SingleState state, BytesRefBlock values, DoubleBlock outputValues) {
+        int start = values.getFirstValueIndex(0);
+        int end = start + values.getValueCount(0);
+        var scratch = new BytesRef();
+        for (int i = start; i < end; i++) {
+            combine(state, values.getBytesRef(i, scratch), outputValues.getDouble(i));
+        }
+    }
+
+    public static Block evaluateFinal(SingleState state, DriverContext driverContext) {
+        return state.toBlock(driverContext.blockFactory());
+    }
+
+    public static GroupingState initGrouping(BigArrays bigArrays, int limit, boolean ascending) {
+        return new GroupingState(bigArrays, limit, ascending);
+    }
+
+    public static void combine(GroupingState state, int groupId, BytesRef v, double outputValue) {
+        state.add(groupId, v, outputValue);
+    }
+
+    public static void combineIntermediate(GroupingState state, int groupId, BytesRefBlock values, DoubleBlock outputValues, int position) {
+        int start = values.getFirstValueIndex(position);
+        int end = start + values.getValueCount(position);
+        var scratch = new BytesRef();
+        for (int i = start; i < end; i++) {
+            combine(state, groupId, values.getBytesRef(i, scratch), outputValues.getDouble(i));
+        }
+    }
+
+    public static Block evaluateFinal(GroupingState state, IntVector selected, GroupingAggregatorEvaluationContext ctx) {
+        return state.toBlock(ctx.blockFactory(), selected);
+    }
+
+    public static class GroupingState implements GroupingAggregatorState {
+        private final BytesRefDoubleBucketedSort sort;
+
+        private GroupingState(BigArrays bigArrays, int limit, boolean ascending) {
+            this.sort = new BytesRefDoubleBucketedSort(bigArrays, ascending ? SortOrder.ASC : SortOrder.DESC, limit);
+        }
+
+        public void add(int groupId, BytesRef value, double outputValue) {
+            sort.collect(value, outputValue, groupId);
+        }
+
+        public void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
+            sort.toBlocks(driverContext.blockFactory(), blocks, offset, selected);
+        }
+
+        Block toBlock(BlockFactory blockFactory, IntVector selected) {
+            Block[] blocks = new Block[2];
+            sort.toBlocks(blockFactory, blocks, 0, selected);
+            Releasables.close(blocks[0]);
+            return blocks[1];
+        }
+
+        @Override
+        public void enableGroupIdTracking(SeenGroupIds seen) {
+            // we figure out seen values from nulls on the values block
+        }
+
+        @Override
+        public void close() {
+            Releasables.closeExpectNoException(sort);
+        }
+    }
+
+    public static class SingleState implements AggregatorState {
+        private final GroupingState internalState;
+
+        private SingleState(BigArrays bigArrays, int limit, boolean ascending) {
+            this.internalState = new GroupingState(bigArrays, limit, ascending);
+        }
+
+        public void add(BytesRef value, double outputValue) {
+            internalState.add(0, value, outputValue);
+        }
+
+        @Override
+        public void toIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+            try (var intValues = driverContext.blockFactory().newConstantIntVector(0, 1)) {
+                internalState.toIntermediate(blocks, offset, intValues, driverContext);
+            }
+        }
+
+        Block toBlock(BlockFactory blockFactory) {
+            try (var intValues = blockFactory.newConstantIntVector(0, 1)) {
+                return internalState.toBlock(blockFactory, intValues);
+            }
+        }
+
+        @Override
+        public void close() {
+            Releasables.closeExpectNoException(internalState);
+        }
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopBytesRefDoubleAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopBytesRefDoubleAggregator.java
@@ -62,7 +62,14 @@ class TopBytesRefDoubleAggregator {
         state.add(groupId, v, outputValue);
     }
 
-    public static void combineIntermediate(GroupingState state, int groupId, BytesRefBlock values, DoubleBlock outputValues, int position) {
+    public static void combineIntermediate(
+        // comment to make spotless happy about line breaks
+        GroupingState state,
+        int groupId,
+        BytesRefBlock values,
+        DoubleBlock outputValues,
+        int position
+    ) {
         int start = values.getFirstValueIndex(position);
         int end = start + values.getValueCount(position);
         var scratch = new BytesRef();

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopBytesRefDoubleAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopBytesRefDoubleAggregator.java
@@ -9,7 +9,6 @@ package org.elasticsearch.compute.aggregation;
 
 // begin generated imports
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopBytesRefFloatAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopBytesRefFloatAggregator.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.aggregation;
+
+// begin generated imports
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.ann.Aggregator;
+import org.elasticsearch.compute.ann.GroupingAggregator;
+import org.elasticsearch.compute.ann.IntermediateState;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.FloatBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.sort.BytesRefFloatBucketedSort;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.search.sort.SortOrder;
+// end generated imports
+
+/**
+ * Aggregates the top N field values for BytesRef.
+ * <p>
+ *     This class is generated. Edit `X-TopAggregator.java.st` to edit this file.
+ * </p>
+ */
+@Aggregator({ @IntermediateState(name = "top", type = "BYTES_REF_BLOCK"), @IntermediateState(name = "output", type = "FLOAT_BLOCK") })
+@GroupingAggregator
+class TopBytesRefFloatAggregator {
+    public static SingleState initSingle(BigArrays bigArrays, int limit, boolean ascending) {
+        return new SingleState(bigArrays, limit, ascending);
+    }
+
+    public static void combine(SingleState state, BytesRef v, float outputValue) {
+        state.add(v, outputValue);
+    }
+
+    public static void combineIntermediate(SingleState state, BytesRefBlock values, FloatBlock outputValues) {
+        int start = values.getFirstValueIndex(0);
+        int end = start + values.getValueCount(0);
+        var scratch = new BytesRef();
+        for (int i = start; i < end; i++) {
+            combine(state, values.getBytesRef(i, scratch), outputValues.getFloat(i));
+        }
+    }
+
+    public static Block evaluateFinal(SingleState state, DriverContext driverContext) {
+        return state.toBlock(driverContext.blockFactory());
+    }
+
+    public static GroupingState initGrouping(BigArrays bigArrays, int limit, boolean ascending) {
+        return new GroupingState(bigArrays, limit, ascending);
+    }
+
+    public static void combine(GroupingState state, int groupId, BytesRef v, float outputValue) {
+        state.add(groupId, v, outputValue);
+    }
+
+    public static void combineIntermediate(GroupingState state, int groupId, BytesRefBlock values, FloatBlock outputValues, int position) {
+        int start = values.getFirstValueIndex(position);
+        int end = start + values.getValueCount(position);
+        var scratch = new BytesRef();
+        for (int i = start; i < end; i++) {
+            combine(state, groupId, values.getBytesRef(i, scratch), outputValues.getFloat(i));
+        }
+    }
+
+    public static Block evaluateFinal(GroupingState state, IntVector selected, GroupingAggregatorEvaluationContext ctx) {
+        return state.toBlock(ctx.blockFactory(), selected);
+    }
+
+    public static class GroupingState implements GroupingAggregatorState {
+        private final BytesRefFloatBucketedSort sort;
+
+        private GroupingState(BigArrays bigArrays, int limit, boolean ascending) {
+            this.sort = new BytesRefFloatBucketedSort(bigArrays, ascending ? SortOrder.ASC : SortOrder.DESC, limit);
+        }
+
+        public void add(int groupId, BytesRef value, float outputValue) {
+            sort.collect(value, outputValue, groupId);
+        }
+
+        public void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
+            sort.toBlocks(driverContext.blockFactory(), blocks, offset, selected);
+        }
+
+        Block toBlock(BlockFactory blockFactory, IntVector selected) {
+            Block[] blocks = new Block[2];
+            sort.toBlocks(blockFactory, blocks, 0, selected);
+            Releasables.close(blocks[0]);
+            return blocks[1];
+        }
+
+        @Override
+        public void enableGroupIdTracking(SeenGroupIds seen) {
+            // we figure out seen values from nulls on the values block
+        }
+
+        @Override
+        public void close() {
+            Releasables.closeExpectNoException(sort);
+        }
+    }
+
+    public static class SingleState implements AggregatorState {
+        private final GroupingState internalState;
+
+        private SingleState(BigArrays bigArrays, int limit, boolean ascending) {
+            this.internalState = new GroupingState(bigArrays, limit, ascending);
+        }
+
+        public void add(BytesRef value, float outputValue) {
+            internalState.add(0, value, outputValue);
+        }
+
+        @Override
+        public void toIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+            try (var intValues = driverContext.blockFactory().newConstantIntVector(0, 1)) {
+                internalState.toIntermediate(blocks, offset, intValues, driverContext);
+            }
+        }
+
+        Block toBlock(BlockFactory blockFactory) {
+            try (var intValues = blockFactory.newConstantIntVector(0, 1)) {
+                return internalState.toBlock(blockFactory, intValues);
+            }
+        }
+
+        @Override
+        public void close() {
+            Releasables.closeExpectNoException(internalState);
+        }
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopBytesRefFloatAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopBytesRefFloatAggregator.java
@@ -62,7 +62,14 @@ class TopBytesRefFloatAggregator {
         state.add(groupId, v, outputValue);
     }
 
-    public static void combineIntermediate(GroupingState state, int groupId, BytesRefBlock values, FloatBlock outputValues, int position) {
+    public static void combineIntermediate(
+        // comment to make spotless happy about line breaks
+        GroupingState state,
+        int groupId,
+        BytesRefBlock values,
+        FloatBlock outputValues,
+        int position
+    ) {
         int start = values.getFirstValueIndex(position);
         int end = start + values.getValueCount(position);
         var scratch = new BytesRef();

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopBytesRefFloatAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopBytesRefFloatAggregator.java
@@ -9,7 +9,6 @@ package org.elasticsearch.compute.aggregation;
 
 // begin generated imports
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopBytesRefIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopBytesRefIntAggregator.java
@@ -62,7 +62,14 @@ class TopBytesRefIntAggregator {
         state.add(groupId, v, outputValue);
     }
 
-    public static void combineIntermediate(GroupingState state, int groupId, BytesRefBlock values, IntBlock outputValues, int position) {
+    public static void combineIntermediate(
+        // comment to make spotless happy about line breaks
+        GroupingState state,
+        int groupId,
+        BytesRefBlock values,
+        IntBlock outputValues,
+        int position
+    ) {
         int start = values.getFirstValueIndex(position);
         int end = start + values.getValueCount(position);
         var scratch = new BytesRef();

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopBytesRefIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopBytesRefIntAggregator.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.aggregation;
+
+// begin generated imports
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.ann.Aggregator;
+import org.elasticsearch.compute.ann.GroupingAggregator;
+import org.elasticsearch.compute.ann.IntermediateState;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.sort.BytesRefIntBucketedSort;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.search.sort.SortOrder;
+// end generated imports
+
+/**
+ * Aggregates the top N field values for BytesRef.
+ * <p>
+ *     This class is generated. Edit `X-TopAggregator.java.st` to edit this file.
+ * </p>
+ */
+@Aggregator({ @IntermediateState(name = "top", type = "BYTES_REF_BLOCK"), @IntermediateState(name = "output", type = "INT_BLOCK") })
+@GroupingAggregator
+class TopBytesRefIntAggregator {
+    public static SingleState initSingle(BigArrays bigArrays, int limit, boolean ascending) {
+        return new SingleState(bigArrays, limit, ascending);
+    }
+
+    public static void combine(SingleState state, BytesRef v, int outputValue) {
+        state.add(v, outputValue);
+    }
+
+    public static void combineIntermediate(SingleState state, BytesRefBlock values, IntBlock outputValues) {
+        int start = values.getFirstValueIndex(0);
+        int end = start + values.getValueCount(0);
+        var scratch = new BytesRef();
+        for (int i = start; i < end; i++) {
+            combine(state, values.getBytesRef(i, scratch), outputValues.getInt(i));
+        }
+    }
+
+    public static Block evaluateFinal(SingleState state, DriverContext driverContext) {
+        return state.toBlock(driverContext.blockFactory());
+    }
+
+    public static GroupingState initGrouping(BigArrays bigArrays, int limit, boolean ascending) {
+        return new GroupingState(bigArrays, limit, ascending);
+    }
+
+    public static void combine(GroupingState state, int groupId, BytesRef v, int outputValue) {
+        state.add(groupId, v, outputValue);
+    }
+
+    public static void combineIntermediate(GroupingState state, int groupId, BytesRefBlock values, IntBlock outputValues, int position) {
+        int start = values.getFirstValueIndex(position);
+        int end = start + values.getValueCount(position);
+        var scratch = new BytesRef();
+        for (int i = start; i < end; i++) {
+            combine(state, groupId, values.getBytesRef(i, scratch), outputValues.getInt(i));
+        }
+    }
+
+    public static Block evaluateFinal(GroupingState state, IntVector selected, GroupingAggregatorEvaluationContext ctx) {
+        return state.toBlock(ctx.blockFactory(), selected);
+    }
+
+    public static class GroupingState implements GroupingAggregatorState {
+        private final BytesRefIntBucketedSort sort;
+
+        private GroupingState(BigArrays bigArrays, int limit, boolean ascending) {
+            this.sort = new BytesRefIntBucketedSort(bigArrays, ascending ? SortOrder.ASC : SortOrder.DESC, limit);
+        }
+
+        public void add(int groupId, BytesRef value, int outputValue) {
+            sort.collect(value, outputValue, groupId);
+        }
+
+        public void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
+            sort.toBlocks(driverContext.blockFactory(), blocks, offset, selected);
+        }
+
+        Block toBlock(BlockFactory blockFactory, IntVector selected) {
+            Block[] blocks = new Block[2];
+            sort.toBlocks(blockFactory, blocks, 0, selected);
+            Releasables.close(blocks[0]);
+            return blocks[1];
+        }
+
+        @Override
+        public void enableGroupIdTracking(SeenGroupIds seen) {
+            // we figure out seen values from nulls on the values block
+        }
+
+        @Override
+        public void close() {
+            Releasables.closeExpectNoException(sort);
+        }
+    }
+
+    public static class SingleState implements AggregatorState {
+        private final GroupingState internalState;
+
+        private SingleState(BigArrays bigArrays, int limit, boolean ascending) {
+            this.internalState = new GroupingState(bigArrays, limit, ascending);
+        }
+
+        public void add(BytesRef value, int outputValue) {
+            internalState.add(0, value, outputValue);
+        }
+
+        @Override
+        public void toIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+            try (var intValues = driverContext.blockFactory().newConstantIntVector(0, 1)) {
+                internalState.toIntermediate(blocks, offset, intValues, driverContext);
+            }
+        }
+
+        Block toBlock(BlockFactory blockFactory) {
+            try (var intValues = blockFactory.newConstantIntVector(0, 1)) {
+                return internalState.toBlock(blockFactory, intValues);
+            }
+        }
+
+        @Override
+        public void close() {
+            Releasables.closeExpectNoException(internalState);
+        }
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopBytesRefIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopBytesRefIntAggregator.java
@@ -9,7 +9,6 @@ package org.elasticsearch.compute.aggregation;
 
 // begin generated imports
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopBytesRefLongAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopBytesRefLongAggregator.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.aggregation;
+
+// begin generated imports
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.ann.Aggregator;
+import org.elasticsearch.compute.ann.GroupingAggregator;
+import org.elasticsearch.compute.ann.IntermediateState;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.sort.BytesRefLongBucketedSort;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.search.sort.SortOrder;
+// end generated imports
+
+/**
+ * Aggregates the top N field values for BytesRef.
+ * <p>
+ *     This class is generated. Edit `X-TopAggregator.java.st` to edit this file.
+ * </p>
+ */
+@Aggregator({ @IntermediateState(name = "top", type = "BYTES_REF_BLOCK"), @IntermediateState(name = "output", type = "LONG_BLOCK") })
+@GroupingAggregator
+class TopBytesRefLongAggregator {
+    public static SingleState initSingle(BigArrays bigArrays, int limit, boolean ascending) {
+        return new SingleState(bigArrays, limit, ascending);
+    }
+
+    public static void combine(SingleState state, BytesRef v, long outputValue) {
+        state.add(v, outputValue);
+    }
+
+    public static void combineIntermediate(SingleState state, BytesRefBlock values, LongBlock outputValues) {
+        int start = values.getFirstValueIndex(0);
+        int end = start + values.getValueCount(0);
+        var scratch = new BytesRef();
+        for (int i = start; i < end; i++) {
+            combine(state, values.getBytesRef(i, scratch), outputValues.getLong(i));
+        }
+    }
+
+    public static Block evaluateFinal(SingleState state, DriverContext driverContext) {
+        return state.toBlock(driverContext.blockFactory());
+    }
+
+    public static GroupingState initGrouping(BigArrays bigArrays, int limit, boolean ascending) {
+        return new GroupingState(bigArrays, limit, ascending);
+    }
+
+    public static void combine(GroupingState state, int groupId, BytesRef v, long outputValue) {
+        state.add(groupId, v, outputValue);
+    }
+
+    public static void combineIntermediate(GroupingState state, int groupId, BytesRefBlock values, LongBlock outputValues, int position) {
+        int start = values.getFirstValueIndex(position);
+        int end = start + values.getValueCount(position);
+        var scratch = new BytesRef();
+        for (int i = start; i < end; i++) {
+            combine(state, groupId, values.getBytesRef(i, scratch), outputValues.getLong(i));
+        }
+    }
+
+    public static Block evaluateFinal(GroupingState state, IntVector selected, GroupingAggregatorEvaluationContext ctx) {
+        return state.toBlock(ctx.blockFactory(), selected);
+    }
+
+    public static class GroupingState implements GroupingAggregatorState {
+        private final BytesRefLongBucketedSort sort;
+
+        private GroupingState(BigArrays bigArrays, int limit, boolean ascending) {
+            this.sort = new BytesRefLongBucketedSort(bigArrays, ascending ? SortOrder.ASC : SortOrder.DESC, limit);
+        }
+
+        public void add(int groupId, BytesRef value, long outputValue) {
+            sort.collect(value, outputValue, groupId);
+        }
+
+        public void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
+            sort.toBlocks(driverContext.blockFactory(), blocks, offset, selected);
+        }
+
+        Block toBlock(BlockFactory blockFactory, IntVector selected) {
+            Block[] blocks = new Block[2];
+            sort.toBlocks(blockFactory, blocks, 0, selected);
+            Releasables.close(blocks[0]);
+            return blocks[1];
+        }
+
+        @Override
+        public void enableGroupIdTracking(SeenGroupIds seen) {
+            // we figure out seen values from nulls on the values block
+        }
+
+        @Override
+        public void close() {
+            Releasables.closeExpectNoException(sort);
+        }
+    }
+
+    public static class SingleState implements AggregatorState {
+        private final GroupingState internalState;
+
+        private SingleState(BigArrays bigArrays, int limit, boolean ascending) {
+            this.internalState = new GroupingState(bigArrays, limit, ascending);
+        }
+
+        public void add(BytesRef value, long outputValue) {
+            internalState.add(0, value, outputValue);
+        }
+
+        @Override
+        public void toIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+            try (var intValues = driverContext.blockFactory().newConstantIntVector(0, 1)) {
+                internalState.toIntermediate(blocks, offset, intValues, driverContext);
+            }
+        }
+
+        Block toBlock(BlockFactory blockFactory) {
+            try (var intValues = blockFactory.newConstantIntVector(0, 1)) {
+                return internalState.toBlock(blockFactory, intValues);
+            }
+        }
+
+        @Override
+        public void close() {
+            Releasables.closeExpectNoException(internalState);
+        }
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopBytesRefLongAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopBytesRefLongAggregator.java
@@ -62,7 +62,14 @@ class TopBytesRefLongAggregator {
         state.add(groupId, v, outputValue);
     }
 
-    public static void combineIntermediate(GroupingState state, int groupId, BytesRefBlock values, LongBlock outputValues, int position) {
+    public static void combineIntermediate(
+        // comment to make spotless happy about line breaks
+        GroupingState state,
+        int groupId,
+        BytesRefBlock values,
+        LongBlock outputValues,
+        int position
+    ) {
         int start = values.getFirstValueIndex(position);
         int end = start + values.getValueCount(position);
         var scratch = new BytesRef();

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopBytesRefLongAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopBytesRefLongAggregator.java
@@ -9,7 +9,6 @@ package org.elasticsearch.compute.aggregation;
 
 // begin generated imports
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopDoubleAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopDoubleAggregator.java
@@ -60,7 +60,13 @@ class TopDoubleAggregator {
         state.add(groupId, v);
     }
 
-    public static void combineIntermediate(GroupingState state, int groupId, DoubleBlock values, int position) {
+    public static void combineIntermediate(
+        // comment to make spotless happy about line breaks
+        GroupingState state,
+        int groupId,
+        DoubleBlock values,
+        int position
+    ) {
         int start = values.getFirstValueIndex(position);
         int end = start + values.getValueCount(position);
         for (int i = start; i < end; i++) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopDoubleAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopDoubleAggregator.java
@@ -9,7 +9,6 @@ package org.elasticsearch.compute.aggregation;
 
 // begin generated imports
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopDoubleBytesRefAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopDoubleBytesRefAggregator.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.aggregation;
+
+// begin generated imports
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.ann.Aggregator;
+import org.elasticsearch.compute.ann.GroupingAggregator;
+import org.elasticsearch.compute.ann.IntermediateState;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.sort.DoubleBytesRefBucketedSort;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.search.sort.SortOrder;
+// end generated imports
+
+/**
+ * Aggregates the top N field values for double.
+ * <p>
+ *     This class is generated. Edit `X-TopAggregator.java.st` to edit this file.
+ * </p>
+ */
+@Aggregator({ @IntermediateState(name = "top", type = "DOUBLE_BLOCK"), @IntermediateState(name = "output", type = "BYTES_REF_BLOCK") })
+@GroupingAggregator
+class TopDoubleBytesRefAggregator {
+    public static SingleState initSingle(BigArrays bigArrays, int limit, boolean ascending) {
+        return new SingleState(bigArrays, limit, ascending);
+    }
+
+    public static void combine(SingleState state, double v, BytesRef outputValue) {
+        state.add(v, outputValue);
+    }
+
+    public static void combineIntermediate(SingleState state, DoubleBlock values, BytesRefBlock outputValues) {
+        int start = values.getFirstValueIndex(0);
+        int end = start + values.getValueCount(0);
+        var outputScratch = new BytesRef();
+        for (int i = start; i < end; i++) {
+            combine(state, values.getDouble(i), outputValues.getBytesRef(i, outputScratch));
+        }
+    }
+
+    public static Block evaluateFinal(SingleState state, DriverContext driverContext) {
+        return state.toBlock(driverContext.blockFactory());
+    }
+
+    public static GroupingState initGrouping(BigArrays bigArrays, int limit, boolean ascending) {
+        return new GroupingState(bigArrays, limit, ascending);
+    }
+
+    public static void combine(GroupingState state, int groupId, double v, BytesRef outputValue) {
+        state.add(groupId, v, outputValue);
+    }
+
+    public static void combineIntermediate(GroupingState state, int groupId, DoubleBlock values, BytesRefBlock outputValues, int position) {
+        int start = values.getFirstValueIndex(position);
+        int end = start + values.getValueCount(position);
+        var outputScratch = new BytesRef();
+        for (int i = start; i < end; i++) {
+            combine(state, groupId, values.getDouble(i), outputValues.getBytesRef(i, outputScratch));
+        }
+    }
+
+    public static Block evaluateFinal(GroupingState state, IntVector selected, GroupingAggregatorEvaluationContext ctx) {
+        return state.toBlock(ctx.blockFactory(), selected);
+    }
+
+    public static class GroupingState implements GroupingAggregatorState {
+        private final DoubleBytesRefBucketedSort sort;
+
+        private GroupingState(BigArrays bigArrays, int limit, boolean ascending) {
+            this.sort = new DoubleBytesRefBucketedSort(bigArrays, ascending ? SortOrder.ASC : SortOrder.DESC, limit);
+        }
+
+        public void add(int groupId, double value, BytesRef outputValue) {
+            sort.collect(value, outputValue, groupId);
+        }
+
+        public void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
+            sort.toBlocks(driverContext.blockFactory(), blocks, offset, selected);
+        }
+
+        Block toBlock(BlockFactory blockFactory, IntVector selected) {
+            Block[] blocks = new Block[2];
+            sort.toBlocks(blockFactory, blocks, 0, selected);
+            Releasables.close(blocks[0]);
+            return blocks[1];
+        }
+
+        @Override
+        public void enableGroupIdTracking(SeenGroupIds seen) {
+            // we figure out seen values from nulls on the values block
+        }
+
+        @Override
+        public void close() {
+            Releasables.closeExpectNoException(sort);
+        }
+    }
+
+    public static class SingleState implements AggregatorState {
+        private final GroupingState internalState;
+
+        private SingleState(BigArrays bigArrays, int limit, boolean ascending) {
+            this.internalState = new GroupingState(bigArrays, limit, ascending);
+        }
+
+        public void add(double value, BytesRef outputValue) {
+            internalState.add(0, value, outputValue);
+        }
+
+        @Override
+        public void toIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+            try (var intValues = driverContext.blockFactory().newConstantIntVector(0, 1)) {
+                internalState.toIntermediate(blocks, offset, intValues, driverContext);
+            }
+        }
+
+        Block toBlock(BlockFactory blockFactory) {
+            try (var intValues = blockFactory.newConstantIntVector(0, 1)) {
+                return internalState.toBlock(blockFactory, intValues);
+            }
+        }
+
+        @Override
+        public void close() {
+            Releasables.closeExpectNoException(internalState);
+        }
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopDoubleBytesRefAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopDoubleBytesRefAggregator.java
@@ -62,7 +62,14 @@ class TopDoubleBytesRefAggregator {
         state.add(groupId, v, outputValue);
     }
 
-    public static void combineIntermediate(GroupingState state, int groupId, DoubleBlock values, BytesRefBlock outputValues, int position) {
+    public static void combineIntermediate(
+        // comment to make spotless happy about line breaks
+        GroupingState state,
+        int groupId,
+        DoubleBlock values,
+        BytesRefBlock outputValues,
+        int position
+    ) {
         int start = values.getFirstValueIndex(position);
         int end = start + values.getValueCount(position);
         var outputScratch = new BytesRef();

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopDoubleBytesRefAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopDoubleBytesRefAggregator.java
@@ -9,7 +9,6 @@ package org.elasticsearch.compute.aggregation;
 
 // begin generated imports
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopDoubleDoubleAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopDoubleDoubleAggregator.java
@@ -61,7 +61,14 @@ class TopDoubleDoubleAggregator {
         state.add(groupId, v, outputValue);
     }
 
-    public static void combineIntermediate(GroupingState state, int groupId, DoubleBlock values, DoubleBlock outputValues, int position) {
+    public static void combineIntermediate(
+        // comment to make spotless happy about line breaks
+        GroupingState state,
+        int groupId,
+        DoubleBlock values,
+        DoubleBlock outputValues,
+        int position
+    ) {
         int start = values.getFirstValueIndex(position);
         int end = start + values.getValueCount(position);
         for (int i = start; i < end; i++) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopDoubleDoubleAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopDoubleDoubleAggregator.java
@@ -9,7 +9,6 @@ package org.elasticsearch.compute.aggregation;
 
 // begin generated imports
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopDoubleFloatAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopDoubleFloatAggregator.java
@@ -61,7 +61,14 @@ class TopDoubleFloatAggregator {
         state.add(groupId, v, outputValue);
     }
 
-    public static void combineIntermediate(GroupingState state, int groupId, DoubleBlock values, FloatBlock outputValues, int position) {
+    public static void combineIntermediate(
+        // comment to make spotless happy about line breaks
+        GroupingState state,
+        int groupId,
+        DoubleBlock values,
+        FloatBlock outputValues,
+        int position
+    ) {
         int start = values.getFirstValueIndex(position);
         int end = start + values.getValueCount(position);
         for (int i = start; i < end; i++) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopDoubleFloatAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopDoubleFloatAggregator.java
@@ -9,7 +9,6 @@ package org.elasticsearch.compute.aggregation;
 
 // begin generated imports
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopDoubleIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopDoubleIntAggregator.java
@@ -61,7 +61,14 @@ class TopDoubleIntAggregator {
         state.add(groupId, v, outputValue);
     }
 
-    public static void combineIntermediate(GroupingState state, int groupId, DoubleBlock values, IntBlock outputValues, int position) {
+    public static void combineIntermediate(
+        // comment to make spotless happy about line breaks
+        GroupingState state,
+        int groupId,
+        DoubleBlock values,
+        IntBlock outputValues,
+        int position
+    ) {
         int start = values.getFirstValueIndex(position);
         int end = start + values.getValueCount(position);
         for (int i = start; i < end; i++) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopDoubleIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopDoubleIntAggregator.java
@@ -9,7 +9,6 @@ package org.elasticsearch.compute.aggregation;
 
 // begin generated imports
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopDoubleLongAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopDoubleLongAggregator.java
@@ -61,7 +61,14 @@ class TopDoubleLongAggregator {
         state.add(groupId, v, outputValue);
     }
 
-    public static void combineIntermediate(GroupingState state, int groupId, DoubleBlock values, LongBlock outputValues, int position) {
+    public static void combineIntermediate(
+        // comment to make spotless happy about line breaks
+        GroupingState state,
+        int groupId,
+        DoubleBlock values,
+        LongBlock outputValues,
+        int position
+    ) {
         int start = values.getFirstValueIndex(position);
         int end = start + values.getValueCount(position);
         for (int i = start; i < end; i++) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopDoubleLongAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopDoubleLongAggregator.java
@@ -9,7 +9,6 @@ package org.elasticsearch.compute.aggregation;
 
 // begin generated imports
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopFloatAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopFloatAggregator.java
@@ -60,7 +60,13 @@ class TopFloatAggregator {
         state.add(groupId, v);
     }
 
-    public static void combineIntermediate(GroupingState state, int groupId, FloatBlock values, int position) {
+    public static void combineIntermediate(
+        // comment to make spotless happy about line breaks
+        GroupingState state,
+        int groupId,
+        FloatBlock values,
+        int position
+    ) {
         int start = values.getFirstValueIndex(position);
         int end = start + values.getValueCount(position);
         for (int i = start; i < end; i++) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopFloatAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopFloatAggregator.java
@@ -9,7 +9,6 @@ package org.elasticsearch.compute.aggregation;
 
 // begin generated imports
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopFloatBytesRefAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopFloatBytesRefAggregator.java
@@ -62,7 +62,14 @@ class TopFloatBytesRefAggregator {
         state.add(groupId, v, outputValue);
     }
 
-    public static void combineIntermediate(GroupingState state, int groupId, FloatBlock values, BytesRefBlock outputValues, int position) {
+    public static void combineIntermediate(
+        // comment to make spotless happy about line breaks
+        GroupingState state,
+        int groupId,
+        FloatBlock values,
+        BytesRefBlock outputValues,
+        int position
+    ) {
         int start = values.getFirstValueIndex(position);
         int end = start + values.getValueCount(position);
         var outputScratch = new BytesRef();

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopFloatBytesRefAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopFloatBytesRefAggregator.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.aggregation;
+
+// begin generated imports
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.ann.Aggregator;
+import org.elasticsearch.compute.ann.GroupingAggregator;
+import org.elasticsearch.compute.ann.IntermediateState;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.FloatBlock;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.sort.FloatBytesRefBucketedSort;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.search.sort.SortOrder;
+// end generated imports
+
+/**
+ * Aggregates the top N field values for float.
+ * <p>
+ *     This class is generated. Edit `X-TopAggregator.java.st` to edit this file.
+ * </p>
+ */
+@Aggregator({ @IntermediateState(name = "top", type = "FLOAT_BLOCK"), @IntermediateState(name = "output", type = "BYTES_REF_BLOCK") })
+@GroupingAggregator
+class TopFloatBytesRefAggregator {
+    public static SingleState initSingle(BigArrays bigArrays, int limit, boolean ascending) {
+        return new SingleState(bigArrays, limit, ascending);
+    }
+
+    public static void combine(SingleState state, float v, BytesRef outputValue) {
+        state.add(v, outputValue);
+    }
+
+    public static void combineIntermediate(SingleState state, FloatBlock values, BytesRefBlock outputValues) {
+        int start = values.getFirstValueIndex(0);
+        int end = start + values.getValueCount(0);
+        var outputScratch = new BytesRef();
+        for (int i = start; i < end; i++) {
+            combine(state, values.getFloat(i), outputValues.getBytesRef(i, outputScratch));
+        }
+    }
+
+    public static Block evaluateFinal(SingleState state, DriverContext driverContext) {
+        return state.toBlock(driverContext.blockFactory());
+    }
+
+    public static GroupingState initGrouping(BigArrays bigArrays, int limit, boolean ascending) {
+        return new GroupingState(bigArrays, limit, ascending);
+    }
+
+    public static void combine(GroupingState state, int groupId, float v, BytesRef outputValue) {
+        state.add(groupId, v, outputValue);
+    }
+
+    public static void combineIntermediate(GroupingState state, int groupId, FloatBlock values, BytesRefBlock outputValues, int position) {
+        int start = values.getFirstValueIndex(position);
+        int end = start + values.getValueCount(position);
+        var outputScratch = new BytesRef();
+        for (int i = start; i < end; i++) {
+            combine(state, groupId, values.getFloat(i), outputValues.getBytesRef(i, outputScratch));
+        }
+    }
+
+    public static Block evaluateFinal(GroupingState state, IntVector selected, GroupingAggregatorEvaluationContext ctx) {
+        return state.toBlock(ctx.blockFactory(), selected);
+    }
+
+    public static class GroupingState implements GroupingAggregatorState {
+        private final FloatBytesRefBucketedSort sort;
+
+        private GroupingState(BigArrays bigArrays, int limit, boolean ascending) {
+            this.sort = new FloatBytesRefBucketedSort(bigArrays, ascending ? SortOrder.ASC : SortOrder.DESC, limit);
+        }
+
+        public void add(int groupId, float value, BytesRef outputValue) {
+            sort.collect(value, outputValue, groupId);
+        }
+
+        public void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
+            sort.toBlocks(driverContext.blockFactory(), blocks, offset, selected);
+        }
+
+        Block toBlock(BlockFactory blockFactory, IntVector selected) {
+            Block[] blocks = new Block[2];
+            sort.toBlocks(blockFactory, blocks, 0, selected);
+            Releasables.close(blocks[0]);
+            return blocks[1];
+        }
+
+        @Override
+        public void enableGroupIdTracking(SeenGroupIds seen) {
+            // we figure out seen values from nulls on the values block
+        }
+
+        @Override
+        public void close() {
+            Releasables.closeExpectNoException(sort);
+        }
+    }
+
+    public static class SingleState implements AggregatorState {
+        private final GroupingState internalState;
+
+        private SingleState(BigArrays bigArrays, int limit, boolean ascending) {
+            this.internalState = new GroupingState(bigArrays, limit, ascending);
+        }
+
+        public void add(float value, BytesRef outputValue) {
+            internalState.add(0, value, outputValue);
+        }
+
+        @Override
+        public void toIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+            try (var intValues = driverContext.blockFactory().newConstantIntVector(0, 1)) {
+                internalState.toIntermediate(blocks, offset, intValues, driverContext);
+            }
+        }
+
+        Block toBlock(BlockFactory blockFactory) {
+            try (var intValues = blockFactory.newConstantIntVector(0, 1)) {
+                return internalState.toBlock(blockFactory, intValues);
+            }
+        }
+
+        @Override
+        public void close() {
+            Releasables.closeExpectNoException(internalState);
+        }
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopFloatBytesRefAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopFloatBytesRefAggregator.java
@@ -9,7 +9,6 @@ package org.elasticsearch.compute.aggregation;
 
 // begin generated imports
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopFloatDoubleAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopFloatDoubleAggregator.java
@@ -61,7 +61,14 @@ class TopFloatDoubleAggregator {
         state.add(groupId, v, outputValue);
     }
 
-    public static void combineIntermediate(GroupingState state, int groupId, FloatBlock values, DoubleBlock outputValues, int position) {
+    public static void combineIntermediate(
+        // comment to make spotless happy about line breaks
+        GroupingState state,
+        int groupId,
+        FloatBlock values,
+        DoubleBlock outputValues,
+        int position
+    ) {
         int start = values.getFirstValueIndex(position);
         int end = start + values.getValueCount(position);
         for (int i = start; i < end; i++) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopFloatDoubleAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopFloatDoubleAggregator.java
@@ -9,7 +9,6 @@ package org.elasticsearch.compute.aggregation;
 
 // begin generated imports
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopFloatFloatAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopFloatFloatAggregator.java
@@ -61,7 +61,14 @@ class TopFloatFloatAggregator {
         state.add(groupId, v, outputValue);
     }
 
-    public static void combineIntermediate(GroupingState state, int groupId, FloatBlock values, FloatBlock outputValues, int position) {
+    public static void combineIntermediate(
+        // comment to make spotless happy about line breaks
+        GroupingState state,
+        int groupId,
+        FloatBlock values,
+        FloatBlock outputValues,
+        int position
+    ) {
         int start = values.getFirstValueIndex(position);
         int end = start + values.getValueCount(position);
         for (int i = start; i < end; i++) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopFloatFloatAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopFloatFloatAggregator.java
@@ -9,7 +9,6 @@ package org.elasticsearch.compute.aggregation;
 
 // begin generated imports
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopFloatIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopFloatIntAggregator.java
@@ -61,7 +61,14 @@ class TopFloatIntAggregator {
         state.add(groupId, v, outputValue);
     }
 
-    public static void combineIntermediate(GroupingState state, int groupId, FloatBlock values, IntBlock outputValues, int position) {
+    public static void combineIntermediate(
+        // comment to make spotless happy about line breaks
+        GroupingState state,
+        int groupId,
+        FloatBlock values,
+        IntBlock outputValues,
+        int position
+    ) {
         int start = values.getFirstValueIndex(position);
         int end = start + values.getValueCount(position);
         for (int i = start; i < end; i++) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopFloatIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopFloatIntAggregator.java
@@ -9,7 +9,6 @@ package org.elasticsearch.compute.aggregation;
 
 // begin generated imports
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopFloatLongAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopFloatLongAggregator.java
@@ -61,7 +61,14 @@ class TopFloatLongAggregator {
         state.add(groupId, v, outputValue);
     }
 
-    public static void combineIntermediate(GroupingState state, int groupId, FloatBlock values, LongBlock outputValues, int position) {
+    public static void combineIntermediate(
+        // comment to make spotless happy about line breaks
+        GroupingState state,
+        int groupId,
+        FloatBlock values,
+        LongBlock outputValues,
+        int position
+    ) {
         int start = values.getFirstValueIndex(position);
         int end = start + values.getValueCount(position);
         for (int i = start; i < end; i++) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopFloatLongAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopFloatLongAggregator.java
@@ -9,7 +9,6 @@ package org.elasticsearch.compute.aggregation;
 
 // begin generated imports
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopIntAggregator.java
@@ -60,7 +60,13 @@ class TopIntAggregator {
         state.add(groupId, v);
     }
 
-    public static void combineIntermediate(GroupingState state, int groupId, IntBlock values, int position) {
+    public static void combineIntermediate(
+        // comment to make spotless happy about line breaks
+        GroupingState state,
+        int groupId,
+        IntBlock values,
+        int position
+    ) {
         int start = values.getFirstValueIndex(position);
         int end = start + values.getValueCount(position);
         for (int i = start; i < end; i++) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopIntAggregator.java
@@ -9,7 +9,6 @@ package org.elasticsearch.compute.aggregation;
 
 // begin generated imports
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopIntBytesRefAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopIntBytesRefAggregator.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.aggregation;
+
+// begin generated imports
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.ann.Aggregator;
+import org.elasticsearch.compute.ann.GroupingAggregator;
+import org.elasticsearch.compute.ann.IntermediateState;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.sort.IntBytesRefBucketedSort;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.search.sort.SortOrder;
+// end generated imports
+
+/**
+ * Aggregates the top N field values for int.
+ * <p>
+ *     This class is generated. Edit `X-TopAggregator.java.st` to edit this file.
+ * </p>
+ */
+@Aggregator({ @IntermediateState(name = "top", type = "INT_BLOCK"), @IntermediateState(name = "output", type = "BYTES_REF_BLOCK") })
+@GroupingAggregator
+class TopIntBytesRefAggregator {
+    public static SingleState initSingle(BigArrays bigArrays, int limit, boolean ascending) {
+        return new SingleState(bigArrays, limit, ascending);
+    }
+
+    public static void combine(SingleState state, int v, BytesRef outputValue) {
+        state.add(v, outputValue);
+    }
+
+    public static void combineIntermediate(SingleState state, IntBlock values, BytesRefBlock outputValues) {
+        int start = values.getFirstValueIndex(0);
+        int end = start + values.getValueCount(0);
+        var outputScratch = new BytesRef();
+        for (int i = start; i < end; i++) {
+            combine(state, values.getInt(i), outputValues.getBytesRef(i, outputScratch));
+        }
+    }
+
+    public static Block evaluateFinal(SingleState state, DriverContext driverContext) {
+        return state.toBlock(driverContext.blockFactory());
+    }
+
+    public static GroupingState initGrouping(BigArrays bigArrays, int limit, boolean ascending) {
+        return new GroupingState(bigArrays, limit, ascending);
+    }
+
+    public static void combine(GroupingState state, int groupId, int v, BytesRef outputValue) {
+        state.add(groupId, v, outputValue);
+    }
+
+    public static void combineIntermediate(GroupingState state, int groupId, IntBlock values, BytesRefBlock outputValues, int position) {
+        int start = values.getFirstValueIndex(position);
+        int end = start + values.getValueCount(position);
+        var outputScratch = new BytesRef();
+        for (int i = start; i < end; i++) {
+            combine(state, groupId, values.getInt(i), outputValues.getBytesRef(i, outputScratch));
+        }
+    }
+
+    public static Block evaluateFinal(GroupingState state, IntVector selected, GroupingAggregatorEvaluationContext ctx) {
+        return state.toBlock(ctx.blockFactory(), selected);
+    }
+
+    public static class GroupingState implements GroupingAggregatorState {
+        private final IntBytesRefBucketedSort sort;
+
+        private GroupingState(BigArrays bigArrays, int limit, boolean ascending) {
+            this.sort = new IntBytesRefBucketedSort(bigArrays, ascending ? SortOrder.ASC : SortOrder.DESC, limit);
+        }
+
+        public void add(int groupId, int value, BytesRef outputValue) {
+            sort.collect(value, outputValue, groupId);
+        }
+
+        public void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
+            sort.toBlocks(driverContext.blockFactory(), blocks, offset, selected);
+        }
+
+        Block toBlock(BlockFactory blockFactory, IntVector selected) {
+            Block[] blocks = new Block[2];
+            sort.toBlocks(blockFactory, blocks, 0, selected);
+            Releasables.close(blocks[0]);
+            return blocks[1];
+        }
+
+        @Override
+        public void enableGroupIdTracking(SeenGroupIds seen) {
+            // we figure out seen values from nulls on the values block
+        }
+
+        @Override
+        public void close() {
+            Releasables.closeExpectNoException(sort);
+        }
+    }
+
+    public static class SingleState implements AggregatorState {
+        private final GroupingState internalState;
+
+        private SingleState(BigArrays bigArrays, int limit, boolean ascending) {
+            this.internalState = new GroupingState(bigArrays, limit, ascending);
+        }
+
+        public void add(int value, BytesRef outputValue) {
+            internalState.add(0, value, outputValue);
+        }
+
+        @Override
+        public void toIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+            try (var intValues = driverContext.blockFactory().newConstantIntVector(0, 1)) {
+                internalState.toIntermediate(blocks, offset, intValues, driverContext);
+            }
+        }
+
+        Block toBlock(BlockFactory blockFactory) {
+            try (var intValues = blockFactory.newConstantIntVector(0, 1)) {
+                return internalState.toBlock(blockFactory, intValues);
+            }
+        }
+
+        @Override
+        public void close() {
+            Releasables.closeExpectNoException(internalState);
+        }
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopIntBytesRefAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopIntBytesRefAggregator.java
@@ -62,7 +62,14 @@ class TopIntBytesRefAggregator {
         state.add(groupId, v, outputValue);
     }
 
-    public static void combineIntermediate(GroupingState state, int groupId, IntBlock values, BytesRefBlock outputValues, int position) {
+    public static void combineIntermediate(
+        // comment to make spotless happy about line breaks
+        GroupingState state,
+        int groupId,
+        IntBlock values,
+        BytesRefBlock outputValues,
+        int position
+    ) {
         int start = values.getFirstValueIndex(position);
         int end = start + values.getValueCount(position);
         var outputScratch = new BytesRef();

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopIntBytesRefAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopIntBytesRefAggregator.java
@@ -9,7 +9,6 @@ package org.elasticsearch.compute.aggregation;
 
 // begin generated imports
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopIntDoubleAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopIntDoubleAggregator.java
@@ -61,7 +61,14 @@ class TopIntDoubleAggregator {
         state.add(groupId, v, outputValue);
     }
 
-    public static void combineIntermediate(GroupingState state, int groupId, IntBlock values, DoubleBlock outputValues, int position) {
+    public static void combineIntermediate(
+        // comment to make spotless happy about line breaks
+        GroupingState state,
+        int groupId,
+        IntBlock values,
+        DoubleBlock outputValues,
+        int position
+    ) {
         int start = values.getFirstValueIndex(position);
         int end = start + values.getValueCount(position);
         for (int i = start; i < end; i++) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopIntDoubleAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopIntDoubleAggregator.java
@@ -9,7 +9,6 @@ package org.elasticsearch.compute.aggregation;
 
 // begin generated imports
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopIntFloatAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopIntFloatAggregator.java
@@ -61,7 +61,14 @@ class TopIntFloatAggregator {
         state.add(groupId, v, outputValue);
     }
 
-    public static void combineIntermediate(GroupingState state, int groupId, IntBlock values, FloatBlock outputValues, int position) {
+    public static void combineIntermediate(
+        // comment to make spotless happy about line breaks
+        GroupingState state,
+        int groupId,
+        IntBlock values,
+        FloatBlock outputValues,
+        int position
+    ) {
         int start = values.getFirstValueIndex(position);
         int end = start + values.getValueCount(position);
         for (int i = start; i < end; i++) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopIntFloatAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopIntFloatAggregator.java
@@ -9,7 +9,6 @@ package org.elasticsearch.compute.aggregation;
 
 // begin generated imports
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopIntIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopIntIntAggregator.java
@@ -61,7 +61,14 @@ class TopIntIntAggregator {
         state.add(groupId, v, outputValue);
     }
 
-    public static void combineIntermediate(GroupingState state, int groupId, IntBlock values, IntBlock outputValues, int position) {
+    public static void combineIntermediate(
+        // comment to make spotless happy about line breaks
+        GroupingState state,
+        int groupId,
+        IntBlock values,
+        IntBlock outputValues,
+        int position
+    ) {
         int start = values.getFirstValueIndex(position);
         int end = start + values.getValueCount(position);
         for (int i = start; i < end; i++) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopIntIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopIntIntAggregator.java
@@ -9,7 +9,6 @@ package org.elasticsearch.compute.aggregation;
 
 // begin generated imports
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopIntLongAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopIntLongAggregator.java
@@ -61,7 +61,14 @@ class TopIntLongAggregator {
         state.add(groupId, v, outputValue);
     }
 
-    public static void combineIntermediate(GroupingState state, int groupId, IntBlock values, LongBlock outputValues, int position) {
+    public static void combineIntermediate(
+        // comment to make spotless happy about line breaks
+        GroupingState state,
+        int groupId,
+        IntBlock values,
+        LongBlock outputValues,
+        int position
+    ) {
         int start = values.getFirstValueIndex(position);
         int end = start + values.getValueCount(position);
         for (int i = start; i < end; i++) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopIntLongAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopIntLongAggregator.java
@@ -9,7 +9,6 @@ package org.elasticsearch.compute.aggregation;
 
 // begin generated imports
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopIpAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopIpAggregator.java
@@ -61,7 +61,13 @@ class TopIpAggregator {
         state.add(groupId, v);
     }
 
-    public static void combineIntermediate(GroupingState state, int groupId, BytesRefBlock values, int position) {
+    public static void combineIntermediate(
+        // comment to make spotless happy about line breaks
+        GroupingState state,
+        int groupId,
+        BytesRefBlock values,
+        int position
+    ) {
         int start = values.getFirstValueIndex(position);
         int end = start + values.getValueCount(position);
         var scratch = new BytesRef();

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopIpAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopIpAggregator.java
@@ -9,7 +9,6 @@ package org.elasticsearch.compute.aggregation;
 
 // begin generated imports
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopLongAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopLongAggregator.java
@@ -60,7 +60,13 @@ class TopLongAggregator {
         state.add(groupId, v);
     }
 
-    public static void combineIntermediate(GroupingState state, int groupId, LongBlock values, int position) {
+    public static void combineIntermediate(
+        // comment to make spotless happy about line breaks
+        GroupingState state,
+        int groupId,
+        LongBlock values,
+        int position
+    ) {
         int start = values.getFirstValueIndex(position);
         int end = start + values.getValueCount(position);
         for (int i = start; i < end; i++) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopLongAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopLongAggregator.java
@@ -9,7 +9,6 @@ package org.elasticsearch.compute.aggregation;
 
 // begin generated imports
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopLongBytesRefAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopLongBytesRefAggregator.java
@@ -62,7 +62,14 @@ class TopLongBytesRefAggregator {
         state.add(groupId, v, outputValue);
     }
 
-    public static void combineIntermediate(GroupingState state, int groupId, LongBlock values, BytesRefBlock outputValues, int position) {
+    public static void combineIntermediate(
+        // comment to make spotless happy about line breaks
+        GroupingState state,
+        int groupId,
+        LongBlock values,
+        BytesRefBlock outputValues,
+        int position
+    ) {
         int start = values.getFirstValueIndex(position);
         int end = start + values.getValueCount(position);
         var outputScratch = new BytesRef();

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopLongBytesRefAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopLongBytesRefAggregator.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.aggregation;
+
+// begin generated imports
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.ann.Aggregator;
+import org.elasticsearch.compute.ann.GroupingAggregator;
+import org.elasticsearch.compute.ann.IntermediateState;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.sort.LongBytesRefBucketedSort;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.search.sort.SortOrder;
+// end generated imports
+
+/**
+ * Aggregates the top N field values for long.
+ * <p>
+ *     This class is generated. Edit `X-TopAggregator.java.st` to edit this file.
+ * </p>
+ */
+@Aggregator({ @IntermediateState(name = "top", type = "LONG_BLOCK"), @IntermediateState(name = "output", type = "BYTES_REF_BLOCK") })
+@GroupingAggregator
+class TopLongBytesRefAggregator {
+    public static SingleState initSingle(BigArrays bigArrays, int limit, boolean ascending) {
+        return new SingleState(bigArrays, limit, ascending);
+    }
+
+    public static void combine(SingleState state, long v, BytesRef outputValue) {
+        state.add(v, outputValue);
+    }
+
+    public static void combineIntermediate(SingleState state, LongBlock values, BytesRefBlock outputValues) {
+        int start = values.getFirstValueIndex(0);
+        int end = start + values.getValueCount(0);
+        var outputScratch = new BytesRef();
+        for (int i = start; i < end; i++) {
+            combine(state, values.getLong(i), outputValues.getBytesRef(i, outputScratch));
+        }
+    }
+
+    public static Block evaluateFinal(SingleState state, DriverContext driverContext) {
+        return state.toBlock(driverContext.blockFactory());
+    }
+
+    public static GroupingState initGrouping(BigArrays bigArrays, int limit, boolean ascending) {
+        return new GroupingState(bigArrays, limit, ascending);
+    }
+
+    public static void combine(GroupingState state, int groupId, long v, BytesRef outputValue) {
+        state.add(groupId, v, outputValue);
+    }
+
+    public static void combineIntermediate(GroupingState state, int groupId, LongBlock values, BytesRefBlock outputValues, int position) {
+        int start = values.getFirstValueIndex(position);
+        int end = start + values.getValueCount(position);
+        var outputScratch = new BytesRef();
+        for (int i = start; i < end; i++) {
+            combine(state, groupId, values.getLong(i), outputValues.getBytesRef(i, outputScratch));
+        }
+    }
+
+    public static Block evaluateFinal(GroupingState state, IntVector selected, GroupingAggregatorEvaluationContext ctx) {
+        return state.toBlock(ctx.blockFactory(), selected);
+    }
+
+    public static class GroupingState implements GroupingAggregatorState {
+        private final LongBytesRefBucketedSort sort;
+
+        private GroupingState(BigArrays bigArrays, int limit, boolean ascending) {
+            this.sort = new LongBytesRefBucketedSort(bigArrays, ascending ? SortOrder.ASC : SortOrder.DESC, limit);
+        }
+
+        public void add(int groupId, long value, BytesRef outputValue) {
+            sort.collect(value, outputValue, groupId);
+        }
+
+        public void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
+            sort.toBlocks(driverContext.blockFactory(), blocks, offset, selected);
+        }
+
+        Block toBlock(BlockFactory blockFactory, IntVector selected) {
+            Block[] blocks = new Block[2];
+            sort.toBlocks(blockFactory, blocks, 0, selected);
+            Releasables.close(blocks[0]);
+            return blocks[1];
+        }
+
+        @Override
+        public void enableGroupIdTracking(SeenGroupIds seen) {
+            // we figure out seen values from nulls on the values block
+        }
+
+        @Override
+        public void close() {
+            Releasables.closeExpectNoException(sort);
+        }
+    }
+
+    public static class SingleState implements AggregatorState {
+        private final GroupingState internalState;
+
+        private SingleState(BigArrays bigArrays, int limit, boolean ascending) {
+            this.internalState = new GroupingState(bigArrays, limit, ascending);
+        }
+
+        public void add(long value, BytesRef outputValue) {
+            internalState.add(0, value, outputValue);
+        }
+
+        @Override
+        public void toIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+            try (var intValues = driverContext.blockFactory().newConstantIntVector(0, 1)) {
+                internalState.toIntermediate(blocks, offset, intValues, driverContext);
+            }
+        }
+
+        Block toBlock(BlockFactory blockFactory) {
+            try (var intValues = blockFactory.newConstantIntVector(0, 1)) {
+                return internalState.toBlock(blockFactory, intValues);
+            }
+        }
+
+        @Override
+        public void close() {
+            Releasables.closeExpectNoException(internalState);
+        }
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopLongBytesRefAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopLongBytesRefAggregator.java
@@ -9,7 +9,6 @@ package org.elasticsearch.compute.aggregation;
 
 // begin generated imports
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopLongDoubleAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopLongDoubleAggregator.java
@@ -61,7 +61,14 @@ class TopLongDoubleAggregator {
         state.add(groupId, v, outputValue);
     }
 
-    public static void combineIntermediate(GroupingState state, int groupId, LongBlock values, DoubleBlock outputValues, int position) {
+    public static void combineIntermediate(
+        // comment to make spotless happy about line breaks
+        GroupingState state,
+        int groupId,
+        LongBlock values,
+        DoubleBlock outputValues,
+        int position
+    ) {
         int start = values.getFirstValueIndex(position);
         int end = start + values.getValueCount(position);
         for (int i = start; i < end; i++) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopLongDoubleAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopLongDoubleAggregator.java
@@ -9,7 +9,6 @@ package org.elasticsearch.compute.aggregation;
 
 // begin generated imports
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopLongFloatAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopLongFloatAggregator.java
@@ -61,7 +61,14 @@ class TopLongFloatAggregator {
         state.add(groupId, v, outputValue);
     }
 
-    public static void combineIntermediate(GroupingState state, int groupId, LongBlock values, FloatBlock outputValues, int position) {
+    public static void combineIntermediate(
+        // comment to make spotless happy about line breaks
+        GroupingState state,
+        int groupId,
+        LongBlock values,
+        FloatBlock outputValues,
+        int position
+    ) {
         int start = values.getFirstValueIndex(position);
         int end = start + values.getValueCount(position);
         for (int i = start; i < end; i++) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopLongFloatAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopLongFloatAggregator.java
@@ -9,7 +9,6 @@ package org.elasticsearch.compute.aggregation;
 
 // begin generated imports
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopLongIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopLongIntAggregator.java
@@ -61,7 +61,14 @@ class TopLongIntAggregator {
         state.add(groupId, v, outputValue);
     }
 
-    public static void combineIntermediate(GroupingState state, int groupId, LongBlock values, IntBlock outputValues, int position) {
+    public static void combineIntermediate(
+        // comment to make spotless happy about line breaks
+        GroupingState state,
+        int groupId,
+        LongBlock values,
+        IntBlock outputValues,
+        int position
+    ) {
         int start = values.getFirstValueIndex(position);
         int end = start + values.getValueCount(position);
         for (int i = start; i < end; i++) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopLongIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopLongIntAggregator.java
@@ -9,7 +9,6 @@ package org.elasticsearch.compute.aggregation;
 
 // begin generated imports
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopLongLongAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopLongLongAggregator.java
@@ -61,7 +61,14 @@ class TopLongLongAggregator {
         state.add(groupId, v, outputValue);
     }
 
-    public static void combineIntermediate(GroupingState state, int groupId, LongBlock values, LongBlock outputValues, int position) {
+    public static void combineIntermediate(
+        // comment to make spotless happy about line breaks
+        GroupingState state,
+        int groupId,
+        LongBlock values,
+        LongBlock outputValues,
+        int position
+    ) {
         int start = values.getFirstValueIndex(position);
         int end = start + values.getValueCount(position);
         for (int i = start; i < end; i++) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopLongLongAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopLongLongAggregator.java
@@ -9,7 +9,6 @@ package org.elasticsearch.compute.aggregation;
 
 // begin generated imports
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/BytesRefBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/BytesRefBucketedSort.java
@@ -175,7 +175,10 @@ public class BytesRefBucketedSort implements Releasable {
             return blockFactory.newConstantNullBlock(selected.getPositionCount());
         }
 
-        try (var builder = blockFactory.newBytesRefBlockBuilder(selected.getPositionCount())) {
+        try (
+            // comment to make spotless happy about line breaks
+            var builder = blockFactory.newBytesRefBlockBuilder(selected.getPositionCount())
+        ) {
             for (int s = 0; s < selected.getPositionCount(); s++) {
                 int bucket = selected.getInt(s);
 
@@ -304,6 +307,7 @@ public class BytesRefBucketedSort implements Releasable {
         assert oldMax % bucketSize == 0;
 
         long newSize = BigArrays.overSize(
+            // comment to make spotless happy about line breaks
             ((long) bucket + 1) * bucketSize,
             PageCacheRecycler.OBJECT_PAGE_SIZE,
             org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_REF

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/BytesRefBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/BytesRefBucketedSort.java
@@ -7,58 +7,59 @@
 
 package org.elasticsearch.compute.data.sort;
 
+// begin generated imports
 import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.common.util.ByteUtils;
+import org.elasticsearch.common.util.BitArray;
 import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
-import org.elasticsearch.core.Assertions;
+import org.elasticsearch.common.util.ByteUtils;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
+import org.elasticsearch.core.Tuple;
 import org.elasticsearch.search.sort.BucketedSort;
 import org.elasticsearch.search.sort.SortOrder;
 
 import java.util.stream.IntStream;
-import java.util.stream.LongStream;
+// end generated imports
 
 /**
- * Aggregates the top N variable length {@link BytesRef} values per bucket.
+ * Aggregates the top N {@code BytesRef} values per bucket.
  * See {@link BucketedSort} for more information.
- * <p>
- *     This is substantially different from {@link IpBucketedSort} because
- *     this has to handle variable length byte strings. To do that it allocates
- *     a heap of {@link BreakingBytesRefBuilder}s.
- * </p>
+ * This class is generated. Edit @{code X-BucketedSort.java.st} instead of this file.
  */
 public class BytesRefBucketedSort implements Releasable {
-    private final BucketedSortCommon common;
-    private final CircuitBreaker breaker;
-    private final String label;
 
+    private final BigArrays bigArrays;
+    private final CircuitBreaker breaker;
+    private final SortOrder order;
+    private final int bucketSize;
+    /**
+     * {@code true} if the bucket is in heap mode, {@code false} if
+     * it is still gathering.
+     */
+    private final BitArray heapMode;
     /**
      * An array containing all the values on all buckets. The structure is as follows:
      * <p>
-     *     For each bucket, there are {@link BucketedSortCommon#bucketSize} elements, based
-     *     on the bucket id (0, 1, 2...). Then, for each bucket, it can be in 2 states:
+     *     For each bucket, there are bucketSize elements, based on the bucket id (0, 1, 2...).
+     *     Then, for each bucket, it can be in 2 states:
      * </p>
      * <ul>
      *     <li>
-     *         Gather mode: All buckets start in gather mode, and remain here while they have
-     *         less than bucketSize elements. In gather mode, the elements are stored in the
-     *         array from the highest index to the lowest index. The lowest index contains
-     *         the offset to the next slot to be filled.
+     *         Gather mode: All buckets start in gather mode, and remain here while they have less than bucketSize elements.
+     *         In gather mode, the elements are stored in the array from the highest index to the lowest index.
+     *         The lowest index contains the offset to the next slot to be filled.
      *         <p>
      *             This allows us to insert elements in O(1) time.
      *         </p>
      *         <p>
-     *             When the bucketSize-th element is collected, the bucket transitions to heap
-     *             mode, by heapifying its contents.
+     *             When the bucketSize-th element is collected, the bucket transitions to heap mode, by heapifying its contents.
      *         </p>
      *     </li>
      *     <li>
@@ -72,10 +73,13 @@ public class BytesRefBucketedSort implements Releasable {
      */
     private ObjectArray<BreakingBytesRefBuilder> values;
 
-    public BytesRefBucketedSort(CircuitBreaker breaker, String label, BigArrays bigArrays, SortOrder order, int bucketSize) {
-        this.breaker = breaker;
-        this.label = label;
-        common = new BucketedSortCommon(bigArrays, order, bucketSize);
+    public BytesRefBucketedSort(BigArrays bigArrays, SortOrder order, int bucketSize) {
+        this.bigArrays = bigArrays;
+        this.breaker = bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST);
+        this.order = order;
+        this.bucketSize = bucketSize;
+        heapMode = new BitArray(0, bigArrays);
+
         boolean success = false;
         try {
             values = bigArrays.newObjectArray(0);
@@ -87,29 +91,6 @@ public class BytesRefBucketedSort implements Releasable {
         }
     }
 
-    private void checkInvariant(int bucket) {
-        if (Assertions.ENABLED == false) {
-            return;
-        }
-        long rootIndex = common.rootIndex(bucket);
-        long requiredSize = common.endIndex(rootIndex);
-        if (values.size() < requiredSize) {
-            throw new AssertionError("values too short " + values.size() + " < " + requiredSize);
-        }
-        if (values.get(rootIndex) == null) {
-            throw new AssertionError("new gather offset can't be null");
-        }
-        if (common.inHeapMode(bucket) == false) {
-            common.assertValidNextOffset(getNextGatherOffset(rootIndex));
-        } else {
-            for (long l = rootIndex; l < common.endIndex(rootIndex); l++) {
-                if (values.get(rootIndex) == null) {
-                    throw new AssertionError("values missing in heap mode");
-                }
-            }
-        }
-    }
-
     /**
      * Collects a {@code value} into a {@code bucket}.
      * <p>
@@ -117,48 +98,71 @@ public class BytesRefBucketedSort implements Releasable {
      * </p>
      */
     public void collect(BytesRef value, int bucket) {
-        long rootIndex = common.rootIndex(bucket);
-        if (common.inHeapMode(bucket)) {
-            if (betterThan(value, values.get(rootIndex).bytesRefView())) {
+        long rootIndex = (long) bucket * bucketSize;
+        if (inHeapMode(bucket)) {
+            if (betterThan(value, bytesAt(rootIndex))) {
                 clearedBytesAt(rootIndex).append(value);
-                downHeap(rootIndex, 0, common.bucketSize);
+                downHeap(rootIndex, 0, bucketSize);
             }
-            checkInvariant(bucket);
             return;
         }
         // Gathering mode
-        long requiredSize = common.endIndex(rootIndex);
+        long requiredSize = rootIndex + bucketSize;
         if (values.size() < requiredSize) {
             grow(bucket);
         }
         int next = getNextGatherOffset(rootIndex);
-        common.assertValidNextOffset(next);
+        assert 0 <= next && next < bucketSize
+            : "Expected next to be in the range of valid buckets [0 <= " + next + " < " + bucketSize + "]";
         long index = next + rootIndex;
         clearedBytesAt(index).append(value);
         if (next == 0) {
-            common.enableHeapMode(bucket);
-            heapify(rootIndex, common.bucketSize);
+            heapMode.set(bucket);
+            heapify(rootIndex, bucketSize);
         } else {
-            ByteUtils.writeIntLE(next - 1, values.get(rootIndex).bytes(), 0);
+            setNextGatherOffset(rootIndex, next - 1);
         }
-        checkInvariant(bucket);
+    }
+
+    /**
+     * The order of the sort.
+     */
+    public SortOrder getOrder() {
+        return order;
+    }
+
+    /**
+     * The number of values to store per bucket.
+     */
+    public int getBucketSize() {
+        return bucketSize;
+    }
+
+    /**
+     * Get the first and last indexes (inclusive, exclusive) of the values for a bucket.
+     * Returns [0, 0] if the bucket has never been collected.
+     */
+    private Tuple<Long, Long> getBucketValuesIndexes(int bucket) {
+        long rootIndex = (long) bucket * bucketSize;
+        if (rootIndex >= values.size()) {
+            // We've never seen this bucket.
+            return Tuple.tuple(0L, 0L);
+        }
+        long start = inHeapMode(bucket) ? rootIndex : (rootIndex + getNextGatherOffset(rootIndex) + 1);
+        long end = rootIndex + bucketSize;
+        return Tuple.tuple(start, end);
     }
 
     /**
      * Merge the values from {@code other}'s {@code otherGroupId} into {@code groupId}.
      */
-    public void merge(int bucket, BytesRefBucketedSort other, int otherBucket) {
-        long otherRootIndex = other.common.rootIndex(otherBucket);
-        if (otherRootIndex >= other.values.size()) {
-            // The value was never collected.
-            return;
-        }
-        other.checkInvariant(otherBucket);
-        long otherStart = other.startIndex(otherBucket, otherRootIndex);
-        long otherEnd = other.common.endIndex(otherRootIndex);
+    public void merge(int groupId, BytesRefBucketedSort other, int otherGroupId) {
+        var otherBounds = other.getBucketValuesIndexes(otherGroupId);
+
         // TODO: This can be improved for heapified buckets by making use of the heap structures
-        for (long i = otherStart; i < otherEnd; i++) {
-            collect(other.values.get(i).bytesRefView(), bucket);
+        for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
+            BreakingBytesRefBuilder otherValue = other.values.get(i);
+            collect(otherValue == null ? new BytesRef() : otherValue.bytesRefView(), groupId);
         }
     }
 
@@ -167,33 +171,17 @@ public class BytesRefBucketedSort implements Releasable {
      */
     public Block toBlock(BlockFactory blockFactory, IntVector selected) {
         // Check if the selected groups are all empty, to avoid allocating extra memory
-        if (IntStream.range(0, selected.getPositionCount()).map(selected::getInt).noneMatch(bucket -> {
-            long rootIndex = common.rootIndex(bucket);
-            if (rootIndex >= values.size()) {
-                // Never collected
-                return false;
-            }
-            long start = startIndex(bucket, rootIndex);
-            long end = common.endIndex(rootIndex);
-            long size = end - start;
-            return size > 0;
-        })) {
+        if (allSelectedGroupsAreEmpty(selected)) {
             return blockFactory.newConstantNullBlock(selected.getPositionCount());
         }
 
         try (var builder = blockFactory.newBytesRefBlockBuilder(selected.getPositionCount())) {
             for (int s = 0; s < selected.getPositionCount(); s++) {
                 int bucket = selected.getInt(s);
-                long rootIndex = common.rootIndex(bucket);
-                if (rootIndex >= values.size()) {
-                    // Never collected
-                    builder.appendNull();
-                    continue;
-                }
 
-                long start = startIndex(bucket, rootIndex);
-                long end = common.endIndex(rootIndex);
-                long size = end - start;
+                var bounds = getBucketValuesIndexes(bucket);
+                var rootIndex = bounds.v1();
+                var size = bounds.v2() - bounds.v1();
 
                 if (size == 0) {
                     builder.appendNull();
@@ -201,27 +189,19 @@ public class BytesRefBucketedSort implements Releasable {
                 }
 
                 if (size == 1) {
-                    try (BreakingBytesRefBuilder bytes = values.get(start)) {
-                        builder.appendBytesRef(bytes.bytesRefView());
-                    } finally {
-                        values.set(start, null);
-                    }
+                    appendValue(builder, rootIndex);
                     continue;
                 }
 
                 // If we are in the gathering mode, we need to heapify before sorting.
-                if (common.inHeapMode(bucket) == false) {
-                    heapify(start, (int) size);
+                if (inHeapMode(bucket) == false) {
+                    heapify(rootIndex, (int) size);
                 }
-                heapSort(start, (int) size);
+                heapSort(rootIndex, (int) size);
 
                 builder.beginPositionEntry();
                 for (int i = 0; i < size; i++) {
-                    try (BreakingBytesRefBuilder bytes = values.get(start + i)) {
-                        builder.appendBytesRef(bytes.bytesRefView());
-                    } finally {
-                        values.set(start + i, null);
-                    }
+                    appendValue(builder, rootIndex + i);
                 }
                 builder.endPositionEntry();
             }
@@ -229,24 +209,70 @@ public class BytesRefBucketedSort implements Releasable {
         }
     }
 
-    private long startIndex(int bucket, long rootIndex) {
-        if (common.inHeapMode(bucket)) {
-            return rootIndex;
+    private void appendValue(org.elasticsearch.compute.data.BytesRefBlock.Builder builder, long index) {
+        BreakingBytesRefBuilder bytes = values.get(index);
+        if (bytes == null) {
+            builder.appendNull();
+            return;
         }
-        return rootIndex + getNextGatherOffset(rootIndex) + 1;
+        try {
+            builder.appendBytesRef(bytes.bytesRefView());
+        } finally {
+            values.set(index, null);
+            Releasables.closeExpectNoException(bytes);
+        }
+    }
+
+    private BreakingBytesRefBuilder clearedBytesAt(long index) {
+        BreakingBytesRefBuilder bytes = values.get(index);
+        if (bytes == null) {
+            bytes = new BreakingBytesRefBuilder(breaker, "top");
+            values.set(index, bytes);
+        } else {
+            bytes.clear();
+        }
+        return bytes;
+    }
+
+    private BytesRef bytesAt(long index) {
+        BreakingBytesRefBuilder bytes = values.get(index);
+        return bytes == null ? new BytesRef() : bytes.bytesRefView();
+    }
+
+    /**
+     * Checks if the selected groups are all empty.
+     */
+    private boolean allSelectedGroupsAreEmpty(IntVector selected) {
+        return IntStream.range(0, selected.getPositionCount()).map(selected::getInt).noneMatch(bucket -> {
+            var bounds = this.getBucketValuesIndexes(bucket);
+            var size = bounds.v2() - bounds.v1();
+            return size > 0;
+        });
+    }
+
+    /**
+     * Is this bucket a min heap {@code true} or in gathering mode {@code false}?
+     */
+    private boolean inHeapMode(int bucket) {
+        return heapMode.get(bucket);
     }
 
     /**
      * Get the next index that should be "gathered" for a bucket rooted
      * at {@code rootIndex}.
-     * <p>
-     *     Using the first 4 bytes of the element to store the next gather offset.
-     * </p>
      */
     private int getNextGatherOffset(long rootIndex) {
         BreakingBytesRefBuilder bytes = values.get(rootIndex);
-        assert bytes.length() == Integer.BYTES;
+        assert bytes != null && bytes.length() == Integer.BYTES;
         return ByteUtils.readIntLE(bytes.bytes(), 0);
+    }
+
+    /**
+     * Set the next index that should be "gathered" for a bucket rooted
+     * at {@code rootIndex}.
+     */
+    private void setNextGatherOffset(long rootIndex, int offset) {
+        ByteUtils.writeIntLE(offset, values.get(rootIndex).bytes(), 0);
     }
 
     /**
@@ -255,14 +281,15 @@ public class BytesRefBucketedSort implements Releasable {
      * {@link SortOrder#ASC} and "higher" for {@link SortOrder#DESC}.
      */
     private boolean betterThan(BytesRef lhs, BytesRef rhs) {
-        return common.order.reverseMul() * lhs.compareTo(rhs) < 0;
+        int res = lhs.compareTo(rhs);
+        return getOrder().reverseMul() * res < 0;
     }
 
     /**
      * Swap the data at two indices.
      */
     private void swap(long lhs, long rhs) {
-        BreakingBytesRefBuilder tmp = values.get(lhs);
+        var tmp = values.get(lhs);
         values.set(lhs, values.get(rhs));
         values.set(rhs, tmp);
     }
@@ -274,16 +301,16 @@ public class BytesRefBucketedSort implements Releasable {
      */
     private void grow(int bucket) {
         long oldMax = values.size();
-        assert oldMax % common.bucketSize == 0;
+        assert oldMax % bucketSize == 0;
 
         long newSize = BigArrays.overSize(
-            ((long) bucket + 1) * common.bucketSize,
+            ((long) bucket + 1) * bucketSize,
             PageCacheRecycler.OBJECT_PAGE_SIZE,
-            RamUsageEstimator.NUM_BYTES_OBJECT_REF
+            org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_REF
         );
         // Round up to the next full bucket.
-        newSize = (newSize + common.bucketSize - 1) / common.bucketSize;
-        values = common.bigArrays.resize(values, newSize * common.bucketSize);
+        newSize = (newSize + bucketSize - 1) / bucketSize;
+        values = bigArrays.resize(values, newSize * bucketSize);
         // Set the next gather offsets for all newly allocated buckets.
         fillGatherOffsets(oldMax);
     }
@@ -292,19 +319,18 @@ public class BytesRefBucketedSort implements Releasable {
      * Maintain the "next gather offsets" for newly allocated buckets.
      */
     private void fillGatherOffsets(long startingAt) {
-        assert startingAt % common.bucketSize == 0;
-        int nextOffset = common.bucketSize - 1;
-        for (long bucketRoot = startingAt; bucketRoot < values.size(); bucketRoot += common.bucketSize) {
+        assert startingAt % bucketSize == 0;
+        int nextOffset = getBucketSize() - 1;
+        for (long bucketRoot = startingAt; bucketRoot < values.size(); bucketRoot += getBucketSize()) {
             BreakingBytesRefBuilder bytes = values.get(bucketRoot);
             if (bytes != null) {
                 continue;
             }
-            bytes = new BreakingBytesRefBuilder(breaker, label);
+            bytes = new BreakingBytesRefBuilder(breaker, "top");
             values.set(bucketRoot, bytes);
             bytes.grow(Integer.BYTES);
             bytes.setLength(Integer.BYTES);
             ByteUtils.writeIntLE(nextOffset, bytes.bytes(), 0);
-            checkInvariant(Math.toIntExact(bucketRoot / common.bucketSize));
         }
     }
 
@@ -375,13 +401,13 @@ public class BytesRefBucketedSort implements Releasable {
             int leftChild = parent * 2 + 1;
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
-                if (betterThan(values.get(worstIndex).bytesRefView(), values.get(leftIndex).bytesRefView())) {
+                if (betterThan(bytesAt(worstIndex), bytesAt(leftIndex))) {
                     worst = leftChild;
                     worstIndex = leftIndex;
                 }
                 int rightChild = leftChild + 1;
                 long rightIndex = rootIndex + rightChild;
-                if (rightChild < heapSize && betterThan(values.get(worstIndex).bytesRefView(), values.get(rightIndex).bytesRefView())) {
+                if (rightChild < heapSize && betterThan(bytesAt(worstIndex), bytesAt(rightIndex))) {
                     worst = rightChild;
                     worstIndex = rightIndex;
                 }
@@ -394,23 +420,13 @@ public class BytesRefBucketedSort implements Releasable {
         }
     }
 
-    private BreakingBytesRefBuilder clearedBytesAt(long index) {
-        BreakingBytesRefBuilder bytes = values.get(index);
-        if (bytes == null) {
-            bytes = new BreakingBytesRefBuilder(breaker, label);
-            values.set(index, bytes);
-        } else {
-            bytes.clear();
-        }
-        return bytes;
-    }
-
     @Override
     public final void close() {
-        Releasable allValues = values == null ? () -> {} : Releasables.wrap(LongStream.range(0, values.size()).mapToObj(i -> {
-            BreakingBytesRefBuilder bytes = values.get(i);
-            return bytes == null ? (Releasable) () -> {} : bytes;
-        }).toList().iterator());
-        Releasables.close(allValues, values, common);
+        if (values != null) {
+            for (long i = 0; i < values.size(); i++) {
+                Releasables.close(values.get(i));
+            }
+        }
+        Releasables.close(values, heapMode);
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/BytesRefBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/BytesRefBucketedSort.java
@@ -100,11 +100,8 @@ public class BytesRefBucketedSort implements Releasable {
     public void collect(BytesRef value, int bucket) {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
-            if (betterThan(
-                // comment to make spotless happy about line breaks
-                value,
-                bytesAt(rootIndex)
-            )) {
+            BytesRef rootValue = bytesAt(rootIndex);
+            if (betterThan(value, rootValue)) {
                 clearedBytesAt(rootIndex).append(value);
                 downHeap(rootIndex, 0, bucketSize);
             }
@@ -165,11 +162,8 @@ public class BytesRefBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            collect(
-                // comment to make spotless happy about line breaks
-                other.values.get(i) == null ? new BytesRef() : other.values.get(i).bytesRefView(),
-                groupId
-            );
+            BytesRef otherValue = other.values.get(i) == null ? new BytesRef() : other.values.get(i).bytesRefView();
+            collect(otherValue, groupId);
         }
     }
 
@@ -310,12 +304,9 @@ public class BytesRefBucketedSort implements Releasable {
         long oldMax = values.size();
         assert oldMax % bucketSize == 0;
 
-        long newSize = BigArrays.overSize(
-            // comment to make spotless happy about line breaks
-            ((long) bucket + 1) * bucketSize,
-            PageCacheRecycler.OBJECT_PAGE_SIZE,
-            org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_REF
-        );
+        int pageSize = PageCacheRecycler.OBJECT_PAGE_SIZE;
+        int bytesPerElement = org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_REF;
+        long newSize = BigArrays.overSize(((long) bucket + 1) * bucketSize, pageSize, bytesPerElement);
         // Round up to the next full bucket.
         newSize = (newSize + bucketSize - 1) / bucketSize;
         values = bigArrays.resize(values, newSize * bucketSize);
@@ -409,24 +400,21 @@ public class BytesRefBucketedSort implements Releasable {
             int leftChild = parent * 2 + 1;
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
-                if (betterThan(
-                    // comment to make spotless happy about line breaks
-                    bytesAt(worstIndex),
-                    bytesAt(leftIndex)
-                )) {
+                BytesRef worstValue = bytesAt(worstIndex);
+                BytesRef leftValue = bytesAt(leftIndex);
+                if (betterThan(worstValue, leftValue)) {
                     worst = leftChild;
                     worstIndex = leftIndex;
                 }
                 int rightChild = leftChild + 1;
                 long rightIndex = rootIndex + rightChild;
-                if (rightChild < heapSize
-                    && betterThan(
-                        // comment to make spotless happy about line breaks
-                        bytesAt(worstIndex),
-                        bytesAt(rightIndex)
-                    )) {
-                    worst = rightChild;
-                    worstIndex = rightIndex;
+                if (rightChild < heapSize) {
+                    worstValue = bytesAt(worstIndex);
+                    BytesRef rightValue = bytesAt(rightIndex);
+                    if (betterThan(worstValue, rightValue)) {
+                        worst = rightChild;
+                        worstIndex = rightIndex;
+                    }
                 }
             }
             if (worst == parent) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/BytesRefBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/BytesRefBucketedSort.java
@@ -100,7 +100,11 @@ public class BytesRefBucketedSort implements Releasable {
     public void collect(BytesRef value, int bucket) {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
-            if (betterThan(value, bytesAt(rootIndex))) {
+            if (betterThan(
+                // comment to make spotless happy about line breaks
+                value,
+                bytesAt(rootIndex)
+            )) {
                 clearedBytesAt(rootIndex).append(value);
                 downHeap(rootIndex, 0, bucketSize);
             }
@@ -161,8 +165,11 @@ public class BytesRefBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            BreakingBytesRefBuilder otherValue = other.values.get(i);
-            collect(otherValue == null ? new BytesRef() : otherValue.bytesRefView(), groupId);
+            collect(
+                // comment to make spotless happy about line breaks
+                other.values.get(i) == null ? new BytesRef() : other.values.get(i).bytesRefView(),
+                groupId
+            );
         }
     }
 
@@ -175,10 +182,7 @@ public class BytesRefBucketedSort implements Releasable {
             return blockFactory.newConstantNullBlock(selected.getPositionCount());
         }
 
-        try (
-            // comment to make spotless happy about line breaks
-            var builder = blockFactory.newBytesRefBlockBuilder(selected.getPositionCount())
-        ) {
+        try (var builder = blockFactory.newBytesRefBlockBuilder(selected.getPositionCount())) {
             for (int s = 0; s < selected.getPositionCount(); s++) {
                 int bucket = selected.getInt(s);
 
@@ -405,13 +409,22 @@ public class BytesRefBucketedSort implements Releasable {
             int leftChild = parent * 2 + 1;
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
-                if (betterThan(bytesAt(worstIndex), bytesAt(leftIndex))) {
+                if (betterThan(
+                    // comment to make spotless happy about line breaks
+                    bytesAt(worstIndex),
+                    bytesAt(leftIndex)
+                )) {
                     worst = leftChild;
                     worstIndex = leftIndex;
                 }
                 int rightChild = leftChild + 1;
                 long rightIndex = rootIndex + rightChild;
-                if (rightChild < heapSize && betterThan(bytesAt(worstIndex), bytesAt(rightIndex))) {
+                if (rightChild < heapSize
+                    && betterThan(
+                        // comment to make spotless happy about line breaks
+                        bytesAt(worstIndex),
+                        bytesAt(rightIndex)
+                    )) {
                     worst = rightChild;
                     worstIndex = rightIndex;
                 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/BytesRefBytesRefBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/BytesRefBytesRefBucketedSort.java
@@ -102,13 +102,9 @@ public class BytesRefBytesRefBucketedSort implements Releasable {
     public void collect(BytesRef value, BytesRef extraValue, int bucket) {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
-            if (betterThan(
-                // comment to make spotless happy about line breaks
-                value,
-                bytesAt(rootIndex),
-                extraValue,
-                extraBytesAt(rootIndex)
-            )) {
+            BytesRef rootValue = bytesAt(rootIndex);
+            BytesRef rootExtra = extraBytesAt(rootIndex);
+            if (betterThan(value, rootValue, extraValue, rootExtra)) {
                 clearedBytesAt(rootIndex).append(value);
                 clearedExtraBytesAt(rootIndex).append(extraValue);
                 downHeap(rootIndex, 0, bucketSize);
@@ -171,12 +167,9 @@ public class BytesRefBytesRefBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            collect(
-                // comment to make spotless happy about line breaks
-                other.values.get(i) == null ? new BytesRef() : other.values.get(i).bytesRefView(),
-                other.extraValues.get(i) == null ? new BytesRef() : other.extraValues.get(i).bytesRefView(),
-                groupId
-            );
+            BytesRef otherValue = other.values.get(i) == null ? new BytesRef() : other.values.get(i).bytesRefView();
+            BytesRef otherExtra = other.extraValues.get(i) == null ? new BytesRef() : other.extraValues.get(i).bytesRefView();
+            collect(otherValue, otherExtra, groupId);
         }
     }
 
@@ -374,12 +367,9 @@ public class BytesRefBytesRefBucketedSort implements Releasable {
         long oldMax = values.size();
         assert oldMax % bucketSize == 0;
 
-        long newSize = BigArrays.overSize(
-            // comment to make spotless happy about line breaks
-            ((long) bucket + 1) * bucketSize,
-            PageCacheRecycler.OBJECT_PAGE_SIZE,
-            org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_REF
-        );
+        int pageSize = PageCacheRecycler.OBJECT_PAGE_SIZE;
+        int bytesPerElement = org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_REF;
+        long newSize = BigArrays.overSize(((long) bucket + 1) * bucketSize, pageSize, bytesPerElement);
         // Round up to the next full bucket.
         newSize = (newSize + bucketSize - 1) / bucketSize;
         values = bigArrays.resize(values, newSize * bucketSize);
@@ -475,28 +465,25 @@ public class BytesRefBytesRefBucketedSort implements Releasable {
             int leftChild = parent * 2 + 1;
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
-                if (betterThan(
-                    // comment to make spotless happy about line breaks
-                    bytesAt(worstIndex),
-                    bytesAt(leftIndex),
-                    extraBytesAt(worstIndex),
-                    extraBytesAt(leftIndex)
-                )) {
+                BytesRef worstValue = bytesAt(worstIndex);
+                BytesRef leftValue = bytesAt(leftIndex);
+                BytesRef worstExtra = extraBytesAt(worstIndex);
+                BytesRef leftExtra = extraBytesAt(leftIndex);
+                if (betterThan(worstValue, leftValue, worstExtra, leftExtra)) {
                     worst = leftChild;
                     worstIndex = leftIndex;
                 }
                 int rightChild = leftChild + 1;
                 long rightIndex = rootIndex + rightChild;
-                if (rightChild < heapSize
-                    && betterThan(
-                        // comment to make spotless happy about line breaks
-                        bytesAt(worstIndex),
-                        bytesAt(rightIndex),
-                        extraBytesAt(worstIndex),
-                        extraBytesAt(rightIndex)
-                    )) {
-                    worst = rightChild;
-                    worstIndex = rightIndex;
+                if (rightChild < heapSize) {
+                    worstValue = bytesAt(worstIndex);
+                    BytesRef rightValue = bytesAt(rightIndex);
+                    worstExtra = extraBytesAt(worstIndex);
+                    BytesRef rightExtra = extraBytesAt(rightIndex);
+                    if (betterThan(worstValue, rightValue, worstExtra, rightExtra)) {
+                        worst = rightChild;
+                        worstIndex = rightIndex;
+                    }
                 }
             }
             if (worst == parent) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/BytesRefBytesRefBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/BytesRefBytesRefBucketedSort.java
@@ -1,0 +1,519 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data.sort;
+
+// begin generated imports
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.BitArray;
+import org.elasticsearch.common.util.ObjectArray;
+import org.elasticsearch.common.util.PageCacheRecycler;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
+import org.elasticsearch.common.util.ByteUtils;
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.core.Tuple;
+import org.elasticsearch.search.sort.BucketedSort;
+import org.elasticsearch.search.sort.SortOrder;
+
+import java.util.stream.IntStream;
+// end generated imports
+
+/**
+ * Aggregates the top N {@code BytesRef} values per bucket.
+ * See {@link BucketedSort} for more information.
+ * This class is generated. Edit @{code X-BucketedSort.java.st} instead of this file.
+ */
+public class BytesRefBytesRefBucketedSort implements Releasable {
+
+    private final BigArrays bigArrays;
+    private final CircuitBreaker breaker;
+    private final SortOrder order;
+    private final int bucketSize;
+    /**
+     * {@code true} if the bucket is in heap mode, {@code false} if
+     * it is still gathering.
+     */
+    private final BitArray heapMode;
+    /**
+     * An array containing all the values on all buckets. The structure is as follows:
+     * <p>
+     *     For each bucket, there are bucketSize elements, based on the bucket id (0, 1, 2...).
+     *     Then, for each bucket, it can be in 2 states:
+     * </p>
+     * <ul>
+     *     <li>
+     *         Gather mode: All buckets start in gather mode, and remain here while they have less than bucketSize elements.
+     *         In gather mode, the elements are stored in the array from the highest index to the lowest index.
+     *         The lowest index contains the offset to the next slot to be filled.
+     *         <p>
+     *             This allows us to insert elements in O(1) time.
+     *         </p>
+     *         <p>
+     *             When the bucketSize-th element is collected, the bucket transitions to heap mode, by heapifying its contents.
+     *         </p>
+     *     </li>
+     *     <li>
+     *         Heap mode: The bucket slots are organized as a min heap structure.
+     *         <p>
+     *             The root of the heap is the minimum value in the bucket,
+     *             which allows us to quickly discard new values that are not in the top N.
+     *         </p>
+     *     </li>
+     * </ul>
+     */
+    private ObjectArray<BreakingBytesRefBuilder> values;
+    private ObjectArray<BreakingBytesRefBuilder> extraValues;
+    public BytesRefBytesRefBucketedSort(BigArrays bigArrays, SortOrder order, int bucketSize) {
+        this.bigArrays = bigArrays;
+        this.breaker = bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST);
+        this.order = order;
+        this.bucketSize = bucketSize;
+        heapMode = new BitArray(0, bigArrays);
+
+        boolean success = false;
+        try {
+            values = bigArrays.newObjectArray(0);
+            extraValues = bigArrays.newObjectArray(0);
+            success = true;
+        } finally {
+            if (success == false) {
+                close();
+            }
+        }
+    }
+
+    /**
+     * Collects a {@code value} into a {@code bucket}.
+     * <p>
+     *     It may or may not be inserted in the heap, depending on if it is better than the current root.
+     * </p>
+     */
+    public void collect(BytesRef value, BytesRef extraValue, int bucket) {
+        long rootIndex = (long) bucket * bucketSize;
+        if (inHeapMode(bucket)) {
+            if (betterThan(
+                value,
+                bytesAt(rootIndex),
+                extraValue,
+                extraBytesAt(rootIndex)
+            )) {
+                clearedBytesAt(rootIndex).append(value);
+                clearedExtraBytesAt(rootIndex).append(extraValue);
+                downHeap(rootIndex, 0, bucketSize);
+            }
+            return;
+        }
+        // Gathering mode
+        long requiredSize = rootIndex + bucketSize;
+        if (values.size() < requiredSize) {
+            grow(bucket);
+        }
+        int next = getNextGatherOffset(rootIndex);
+        assert 0 <= next && next < bucketSize
+            : "Expected next to be in the range of valid buckets [0 <= " + next + " < " + bucketSize + "]";
+        long index = next + rootIndex;
+        clearedBytesAt(index).append(value);
+        clearedExtraBytesAt(index).append(extraValue);
+        if (next == 0) {
+            heapMode.set(bucket);
+            heapify(rootIndex, bucketSize);
+        } else {
+            setNextGatherOffset(rootIndex, next - 1);
+        }
+    }
+
+    /**
+     * The order of the sort.
+     */
+    public SortOrder getOrder() {
+        return order;
+    }
+
+    /**
+     * The number of values to store per bucket.
+     */
+    public int getBucketSize() {
+        return bucketSize;
+    }
+
+    /**
+     * Get the first and last indexes (inclusive, exclusive) of the values for a bucket.
+     * Returns [0, 0] if the bucket has never been collected.
+     */
+    private Tuple<Long, Long> getBucketValuesIndexes(int bucket) {
+        long rootIndex = (long) bucket * bucketSize;
+        if (rootIndex >= values.size()) {
+            // We've never seen this bucket.
+            return Tuple.tuple(0L, 0L);
+        }
+        long start = inHeapMode(bucket) ? rootIndex : (rootIndex + getNextGatherOffset(rootIndex) + 1);
+        long end = rootIndex + bucketSize;
+        return Tuple.tuple(start, end);
+    }
+
+    /**
+     * Merge the values from {@code other}'s {@code otherGroupId} into {@code groupId}.
+     */
+    public void merge(int groupId, BytesRefBytesRefBucketedSort other, int otherGroupId) {
+        var otherBounds = other.getBucketValuesIndexes(otherGroupId);
+
+        // TODO: This can be improved for heapified buckets by making use of the heap structures
+        for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
+            BreakingBytesRefBuilder otherValue = other.values.get(i);
+            collect(
+                otherValue == null ? new BytesRef() : otherValue.bytesRefView(),
+                other.extraValues.get(i) == null ? new BytesRef() : other.extraValues.get(i).bytesRefView(),
+                groupId
+            );
+        }
+    }
+
+    /**
+     * Creates a block with the values from the {@code selected} groups.
+     */
+    public void toBlocks(BlockFactory blockFactory, Block[] blocks, int offset, IntVector selected) {
+        // Check if the selected groups are all empty, to avoid allocating extra memory
+        if (allSelectedGroupsAreEmpty(selected)) {
+            Block constantNullBlock = blockFactory.newConstantNullBlock(selected.getPositionCount());
+            constantNullBlock.incRef();
+            blocks[offset] = constantNullBlock;
+            blocks[offset + 1] = constantNullBlock;
+            return;
+        }
+
+        try (
+            var builder = blockFactory.newBytesRefBlockBuilder(selected.getPositionCount());
+            var extraBuilder = blockFactory.newBytesRefBlockBuilder(selected.getPositionCount())
+        ) {
+            for (int s = 0; s < selected.getPositionCount(); s++) {
+                int bucket = selected.getInt(s);
+
+                var bounds = getBucketValuesIndexes(bucket);
+                var rootIndex = bounds.v1();
+                var size = bounds.v2() - bounds.v1();
+
+                if (size == 0) {
+                    builder.appendNull();
+                    extraBuilder.appendNull();
+                    continue;
+                }
+
+                if (size == 1) {
+                    appendValue(builder, rootIndex);
+                    appendExtra(extraBuilder, rootIndex);
+                    continue;
+                }
+
+                // If we are in the gathering mode, we need to heapify before sorting.
+                if (inHeapMode(bucket) == false) {
+                    heapify(rootIndex, (int) size);
+                }
+                heapSort(rootIndex, (int) size);
+
+                builder.beginPositionEntry();
+                extraBuilder.beginPositionEntry();
+                for (int i = 0; i < size; i++) {
+                    appendValue(builder, rootIndex + i);
+                    appendExtra(extraBuilder, rootIndex + i);
+                }
+                builder.endPositionEntry();
+                extraBuilder.endPositionEntry();
+            }
+            blocks[offset] = builder.build();
+            try {
+                blocks[offset + 1] = extraBuilder.build();
+            } finally {
+                if (blocks[offset + 1] == null) {
+                    blocks[offset].close();
+                    blocks[offset] = null;
+                }
+            }
+        }
+    }
+
+    private void appendExtra(org.elasticsearch.compute.data.BytesRefBlock.Builder extraBuilder, long index) {
+        BreakingBytesRefBuilder bytes = extraValues.get(index);
+        if (bytes == null) {
+            extraBuilder.appendNull();
+            return;
+        }
+        try {
+            extraBuilder.appendBytesRef(bytes.bytesRefView());
+        } finally {
+            extraValues.set(index, null);
+            Releasables.closeExpectNoException(bytes);
+        }
+    }
+
+    private BreakingBytesRefBuilder clearedExtraBytesAt(long index) {
+        BreakingBytesRefBuilder bytes = extraValues.get(index);
+        if (bytes == null) {
+            bytes = new BreakingBytesRefBuilder(breaker, "top");
+            extraValues.set(index, bytes);
+        } else {
+            bytes.clear();
+        }
+        return bytes;
+    }
+
+    private BytesRef extraBytesAt(long index) {
+        BreakingBytesRefBuilder bytes = extraValues.get(index);
+        return bytes == null ? new BytesRef() : bytes.bytesRefView();
+    }
+
+    private void appendValue(org.elasticsearch.compute.data.BytesRefBlock.Builder builder, long index) {
+        BreakingBytesRefBuilder bytes = values.get(index);
+        if (bytes == null) {
+            builder.appendNull();
+            return;
+        }
+        try {
+            builder.appendBytesRef(bytes.bytesRefView());
+        } finally {
+            values.set(index, null);
+            Releasables.closeExpectNoException(bytes);
+        }
+    }
+
+    private BreakingBytesRefBuilder clearedBytesAt(long index) {
+        BreakingBytesRefBuilder bytes = values.get(index);
+        if (bytes == null) {
+            bytes = new BreakingBytesRefBuilder(breaker, "top");
+            values.set(index, bytes);
+        } else {
+            bytes.clear();
+        }
+        return bytes;
+    }
+
+    private BytesRef bytesAt(long index) {
+        BreakingBytesRefBuilder bytes = values.get(index);
+        return bytes == null ? new BytesRef() : bytes.bytesRefView();
+    }
+
+    /**
+     * Checks if the selected groups are all empty.
+     */
+    private boolean allSelectedGroupsAreEmpty(IntVector selected) {
+        return IntStream.range(0, selected.getPositionCount()).map(selected::getInt).noneMatch(bucket -> {
+            var bounds = this.getBucketValuesIndexes(bucket);
+            var size = bounds.v2() - bounds.v1();
+            return size > 0;
+        });
+    }
+
+    /**
+     * Is this bucket a min heap {@code true} or in gathering mode {@code false}?
+     */
+    private boolean inHeapMode(int bucket) {
+        return heapMode.get(bucket);
+    }
+
+    /**
+     * Get the next index that should be "gathered" for a bucket rooted
+     * at {@code rootIndex}.
+     */
+    private int getNextGatherOffset(long rootIndex) {
+        BreakingBytesRefBuilder bytes = values.get(rootIndex);
+        assert bytes != null && bytes.length() == Integer.BYTES;
+        return ByteUtils.readIntLE(bytes.bytes(), 0);
+    }
+
+    /**
+     * Set the next index that should be "gathered" for a bucket rooted
+     * at {@code rootIndex}.
+     */
+    private void setNextGatherOffset(long rootIndex, int offset) {
+        ByteUtils.writeIntLE(offset, values.get(rootIndex).bytes(), 0);
+    }
+
+    /**
+     * {@code true} if the entry at index {@code lhs} is "better" than
+     * the entry at {@code rhs}. "Better" in this means "lower" for
+     * {@link SortOrder#ASC} and "higher" for {@link SortOrder#DESC}.
+     */
+    private boolean betterThan(BytesRef lhs, BytesRef rhs, BytesRef lhsExtra, BytesRef rhsExtra) {
+        int res = lhs.compareTo(rhs);
+        if (res != 0) {
+            return getOrder().reverseMul() * res < 0;
+        }
+        res = lhsExtra.compareTo(rhsExtra);
+        return getOrder().reverseMul() * res < 0;
+    }
+
+    /**
+     * Swap the data at two indices.
+     */
+    private void swap(long lhs, long rhs) {
+        var tmp = values.get(lhs);
+        values.set(lhs, values.get(rhs));
+        values.set(rhs, tmp);
+        var tmpExtra = extraValues.get(lhs);
+        extraValues.set(lhs, extraValues.get(rhs));
+        extraValues.set(rhs, tmpExtra);
+    }
+
+    /**
+     * Allocate storage for more buckets and store the "next gather offset"
+     * for those new buckets. We always grow the storage by whole bucket's
+     * worth of slots at a time. We never allocate space for partial buckets.
+     */
+    private void grow(int bucket) {
+        long oldMax = values.size();
+        assert oldMax % bucketSize == 0;
+
+        long newSize = BigArrays.overSize(
+            ((long) bucket + 1) * bucketSize,
+            PageCacheRecycler.OBJECT_PAGE_SIZE,
+            org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_REF
+        );
+        // Round up to the next full bucket.
+        newSize = (newSize + bucketSize - 1) / bucketSize;
+        values = bigArrays.resize(values, newSize * bucketSize);
+        // Round up to the next full bucket.
+        extraValues = bigArrays.resize(extraValues, newSize * bucketSize);
+        // Set the next gather offsets for all newly allocated buckets.
+        fillGatherOffsets(oldMax);
+    }
+
+    /**
+     * Maintain the "next gather offsets" for newly allocated buckets.
+     */
+    private void fillGatherOffsets(long startingAt) {
+        assert startingAt % bucketSize == 0;
+        int nextOffset = getBucketSize() - 1;
+        for (long bucketRoot = startingAt; bucketRoot < values.size(); bucketRoot += getBucketSize()) {
+            BreakingBytesRefBuilder bytes = values.get(bucketRoot);
+            if (bytes != null) {
+                continue;
+            }
+            bytes = new BreakingBytesRefBuilder(breaker, "top");
+            values.set(bucketRoot, bytes);
+            bytes.grow(Integer.BYTES);
+            bytes.setLength(Integer.BYTES);
+            ByteUtils.writeIntLE(nextOffset, bytes.bytes(), 0);
+        }
+    }
+
+    /**
+     * Heapify a bucket whose entries are in random order.
+     * <p>
+     * This works by validating the heap property on each node, iterating
+     * "upwards", pushing any out of order parents "down". Check out the
+     * <a href="https://en.wikipedia.org/w/index.php?title=Binary_heap&oldid=940542991#Building_a_heap">wikipedia</a>
+     * entry on binary heaps for more about this.
+     * </p>
+     * <p>
+     * While this *looks* like it could easily be {@code O(n * log n)}, it is
+     * a fairly well studied algorithm attributed to Floyd. There's
+     * been a bunch of work that puts this at {@code O(n)}, close to 1.88n worst
+     * case.
+     * </p>
+     * <ul>
+     * <li>Hayward, Ryan; McDiarmid, Colin (1991).
+     * <a href="https://web.archive.org/web/20160205023201/http://www.stats.ox.ac.uk/__data/assets/pdf_file/0015/4173/heapbuildjalg.pdf">
+     * Average Case Analysis of Heap Building byRepeated Insertion</a> J. Algorithms.
+     * <li>D.E. Knuth, ”The Art of Computer Programming, Vol. 3, Sorting and Searching”</li>
+     * </ul>
+     * @param rootIndex the index the start of the bucket
+     */
+    private void heapify(long rootIndex, int heapSize) {
+        int maxParent = heapSize / 2 - 1;
+        for (int parent = maxParent; parent >= 0; parent--) {
+            downHeap(rootIndex, parent, heapSize);
+        }
+    }
+
+    /**
+     * Sorts all the values in the heap using heap sort algorithm.
+     * This runs in {@code O(n log n)} time.
+     * @param rootIndex index of the start of the bucket
+     * @param heapSize Number of values that belong to the heap.
+     *                 Can be less than bucketSize.
+     *                 In such a case, the remaining values in range
+     *                 (rootIndex + heapSize, rootIndex + bucketSize)
+     *                 are *not* considered part of the heap.
+     */
+    private void heapSort(long rootIndex, int heapSize) {
+        while (heapSize > 0) {
+            swap(rootIndex, rootIndex + heapSize - 1);
+            heapSize--;
+            downHeap(rootIndex, 0, heapSize);
+        }
+    }
+
+    /**
+     * Correct the heap invariant of a parent and its children. This
+     * runs in {@code O(log n)} time.
+     * @param rootIndex index of the start of the bucket
+     * @param parent Index within the bucket of the parent to check.
+     *               For example, 0 is the "root".
+     * @param heapSize Number of values that belong to the heap.
+     *                 Can be less than bucketSize.
+     *                 In such a case, the remaining values in range
+     *                 (rootIndex + heapSize, rootIndex + bucketSize)
+     *                 are *not* considered part of the heap.
+     */
+    private void downHeap(long rootIndex, int parent, int heapSize) {
+        while (true) {
+            long parentIndex = rootIndex + parent;
+            int worst = parent;
+            long worstIndex = parentIndex;
+            int leftChild = parent * 2 + 1;
+            long leftIndex = rootIndex + leftChild;
+            if (leftChild < heapSize) {
+                if (betterThan(
+                    bytesAt(worstIndex),
+                    bytesAt(leftIndex),
+                    extraBytesAt(worstIndex),
+                    extraBytesAt(leftIndex)
+                )) {
+                    worst = leftChild;
+                    worstIndex = leftIndex;
+                }
+                int rightChild = leftChild + 1;
+                long rightIndex = rootIndex + rightChild;
+                if (rightChild < heapSize
+                    && betterThan(
+                        bytesAt(worstIndex),
+                        bytesAt(rightIndex),
+                        extraBytesAt(worstIndex),
+                        extraBytesAt(rightIndex)
+                    )) {
+                    worst = rightChild;
+                    worstIndex = rightIndex;
+                }
+            }
+            if (worst == parent) {
+                break;
+            }
+            swap(worstIndex, parentIndex);
+            parent = worst;
+        }
+    }
+
+    @Override
+    public final void close() {
+        if (extraValues != null) {
+            for (long i = 0; i < extraValues.size(); i++) {
+                Releasables.close(extraValues.get(i));
+            }
+        }
+        if (values != null) {
+            for (long i = 0; i < values.size(); i++) {
+                Releasables.close(values.get(i));
+            }
+        }
+        Releasables.close(values, extraValues, heapMode);
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/BytesRefBytesRefBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/BytesRefBytesRefBucketedSort.java
@@ -171,10 +171,9 @@ public class BytesRefBytesRefBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            BreakingBytesRefBuilder otherValue = other.values.get(i);
             collect(
                 // comment to make spotless happy about line breaks
-                otherValue == null ? new BytesRef() : otherValue.bytesRefView(),
+                other.values.get(i) == null ? new BytesRef() : other.values.get(i).bytesRefView(),
                 other.extraValues.get(i) == null ? new BytesRef() : other.extraValues.get(i).bytesRefView(),
                 groupId
             );
@@ -195,7 +194,6 @@ public class BytesRefBytesRefBucketedSort implements Releasable {
         }
 
         try (
-            // comment to make spotless happy about line breaks
             var builder = blockFactory.newBytesRefBlockBuilder(selected.getPositionCount());
             var extraBuilder = blockFactory.newBytesRefBlockBuilder(selected.getPositionCount())
         ) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/BytesRefBytesRefBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/BytesRefBytesRefBucketedSort.java
@@ -73,6 +73,7 @@ public class BytesRefBytesRefBucketedSort implements Releasable {
      */
     private ObjectArray<BreakingBytesRefBuilder> values;
     private ObjectArray<BreakingBytesRefBuilder> extraValues;
+
     public BytesRefBytesRefBucketedSort(BigArrays bigArrays, SortOrder order, int bucketSize) {
         this.bigArrays = bigArrays;
         this.breaker = bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST);
@@ -102,6 +103,7 @@ public class BytesRefBytesRefBucketedSort implements Releasable {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
             if (betterThan(
+                // comment to make spotless happy about line breaks
                 value,
                 bytesAt(rootIndex),
                 extraValue,
@@ -171,6 +173,7 @@ public class BytesRefBytesRefBucketedSort implements Releasable {
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
             BreakingBytesRefBuilder otherValue = other.values.get(i);
             collect(
+                // comment to make spotless happy about line breaks
                 otherValue == null ? new BytesRef() : otherValue.bytesRefView(),
                 other.extraValues.get(i) == null ? new BytesRef() : other.extraValues.get(i).bytesRefView(),
                 groupId
@@ -192,6 +195,7 @@ public class BytesRefBytesRefBucketedSort implements Releasable {
         }
 
         try (
+            // comment to make spotless happy about line breaks
             var builder = blockFactory.newBytesRefBlockBuilder(selected.getPositionCount());
             var extraBuilder = blockFactory.newBytesRefBlockBuilder(selected.getPositionCount())
         ) {
@@ -373,6 +377,7 @@ public class BytesRefBytesRefBucketedSort implements Releasable {
         assert oldMax % bucketSize == 0;
 
         long newSize = BigArrays.overSize(
+            // comment to make spotless happy about line breaks
             ((long) bucket + 1) * bucketSize,
             PageCacheRecycler.OBJECT_PAGE_SIZE,
             org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_REF
@@ -473,6 +478,7 @@ public class BytesRefBytesRefBucketedSort implements Releasable {
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
                 if (betterThan(
+                    // comment to make spotless happy about line breaks
                     bytesAt(worstIndex),
                     bytesAt(leftIndex),
                     extraBytesAt(worstIndex),
@@ -485,6 +491,7 @@ public class BytesRefBytesRefBucketedSort implements Releasable {
                 long rightIndex = rootIndex + rightChild;
                 if (rightChild < heapSize
                     && betterThan(
+                        // comment to make spotless happy about line breaks
                         bytesAt(worstIndex),
                         bytesAt(rightIndex),
                         extraBytesAt(worstIndex),

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/BytesRefDoubleBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/BytesRefDoubleBucketedSort.java
@@ -104,6 +104,7 @@ public class BytesRefDoubleBucketedSort implements Releasable {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
             if (betterThan(
+                // comment to make spotless happy about line breaks
                 value,
                 bytesAt(rootIndex),
                 extraValue,
@@ -173,6 +174,7 @@ public class BytesRefDoubleBucketedSort implements Releasable {
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
             BreakingBytesRefBuilder otherValue = other.values.get(i);
             collect(
+                // comment to make spotless happy about line breaks
                 otherValue == null ? new BytesRef() : otherValue.bytesRefView(),
                 other.extraValues.get(i),
                 groupId
@@ -194,6 +196,7 @@ public class BytesRefDoubleBucketedSort implements Releasable {
         }
 
         try (
+            // comment to make spotless happy about line breaks
             var builder = blockFactory.newBytesRefBlockBuilder(selected.getPositionCount());
             var extraBuilder = blockFactory.newDoubleBlockBuilder(selected.getPositionCount())
         ) {
@@ -345,6 +348,7 @@ public class BytesRefDoubleBucketedSort implements Releasable {
         assert oldMax % bucketSize == 0;
 
         long newSize = BigArrays.overSize(
+            // comment to make spotless happy about line breaks
             ((long) bucket + 1) * bucketSize,
             PageCacheRecycler.OBJECT_PAGE_SIZE,
             org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_REF
@@ -445,6 +449,7 @@ public class BytesRefDoubleBucketedSort implements Releasable {
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
                 if (betterThan(
+                    // comment to make spotless happy about line breaks
                     bytesAt(worstIndex),
                     bytesAt(leftIndex),
                     extraValues.get(worstIndex),
@@ -457,6 +462,7 @@ public class BytesRefDoubleBucketedSort implements Releasable {
                 long rightIndex = rootIndex + rightChild;
                 if (rightChild < heapSize
                     && betterThan(
+                        // comment to make spotless happy about line breaks
                         bytesAt(worstIndex),
                         bytesAt(rightIndex),
                         extraValues.get(worstIndex),

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/BytesRefDoubleBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/BytesRefDoubleBucketedSort.java
@@ -1,0 +1,486 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data.sort;
+
+// begin generated imports
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.BitArray;
+import org.elasticsearch.common.util.DoubleArray;
+import org.elasticsearch.common.util.ObjectArray;
+import org.elasticsearch.common.util.PageCacheRecycler;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
+import org.elasticsearch.common.util.ByteUtils;
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.core.Tuple;
+import org.elasticsearch.search.sort.BucketedSort;
+import org.elasticsearch.search.sort.SortOrder;
+
+import java.util.stream.IntStream;
+// end generated imports
+
+/**
+ * Aggregates the top N {@code BytesRef} values per bucket.
+ * See {@link BucketedSort} for more information.
+ * This class is generated. Edit @{code X-BucketedSort.java.st} instead of this file.
+ */
+public class BytesRefDoubleBucketedSort implements Releasable {
+
+    private final BigArrays bigArrays;
+    private final CircuitBreaker breaker;
+    private final SortOrder order;
+    private final int bucketSize;
+    /**
+     * {@code true} if the bucket is in heap mode, {@code false} if
+     * it is still gathering.
+     */
+    private final BitArray heapMode;
+    /**
+     * An array containing all the values on all buckets. The structure is as follows:
+     * <p>
+     *     For each bucket, there are bucketSize elements, based on the bucket id (0, 1, 2...).
+     *     Then, for each bucket, it can be in 2 states:
+     * </p>
+     * <ul>
+     *     <li>
+     *         Gather mode: All buckets start in gather mode, and remain here while they have less than bucketSize elements.
+     *         In gather mode, the elements are stored in the array from the highest index to the lowest index.
+     *         The lowest index contains the offset to the next slot to be filled.
+     *         <p>
+     *             This allows us to insert elements in O(1) time.
+     *         </p>
+     *         <p>
+     *             When the bucketSize-th element is collected, the bucket transitions to heap mode, by heapifying its contents.
+     *         </p>
+     *     </li>
+     *     <li>
+     *         Heap mode: The bucket slots are organized as a min heap structure.
+     *         <p>
+     *             The root of the heap is the minimum value in the bucket,
+     *             which allows us to quickly discard new values that are not in the top N.
+     *         </p>
+     *     </li>
+     * </ul>
+     */
+    private ObjectArray<BreakingBytesRefBuilder> values;
+    private DoubleArray extraValues;
+
+    public BytesRefDoubleBucketedSort(BigArrays bigArrays, SortOrder order, int bucketSize) {
+        this.bigArrays = bigArrays;
+        this.breaker = bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST);
+        this.order = order;
+        this.bucketSize = bucketSize;
+        heapMode = new BitArray(0, bigArrays);
+
+        boolean success = false;
+        try {
+            values = bigArrays.newObjectArray(0);
+            extraValues = bigArrays.newDoubleArray(0, false);
+            success = true;
+        } finally {
+            if (success == false) {
+                close();
+            }
+        }
+    }
+
+    /**
+     * Collects a {@code value} into a {@code bucket}.
+     * <p>
+     *     It may or may not be inserted in the heap, depending on if it is better than the current root.
+     * </p>
+     */
+    public void collect(BytesRef value, double extraValue, int bucket) {
+        long rootIndex = (long) bucket * bucketSize;
+        if (inHeapMode(bucket)) {
+            if (betterThan(
+                value,
+                bytesAt(rootIndex),
+                extraValue,
+                extraValues.get(rootIndex)
+            )) {
+                clearedBytesAt(rootIndex).append(value);
+                extraValues.set(rootIndex, extraValue);
+                downHeap(rootIndex, 0, bucketSize);
+            }
+            return;
+        }
+        // Gathering mode
+        long requiredSize = rootIndex + bucketSize;
+        if (values.size() < requiredSize) {
+            grow(bucket);
+        }
+        int next = getNextGatherOffset(rootIndex);
+        assert 0 <= next && next < bucketSize
+            : "Expected next to be in the range of valid buckets [0 <= " + next + " < " + bucketSize + "]";
+        long index = next + rootIndex;
+        clearedBytesAt(index).append(value);
+        extraValues.set(index, extraValue);
+        if (next == 0) {
+            heapMode.set(bucket);
+            heapify(rootIndex, bucketSize);
+        } else {
+            setNextGatherOffset(rootIndex, next - 1);
+        }
+    }
+
+    /**
+     * The order of the sort.
+     */
+    public SortOrder getOrder() {
+        return order;
+    }
+
+    /**
+     * The number of values to store per bucket.
+     */
+    public int getBucketSize() {
+        return bucketSize;
+    }
+
+    /**
+     * Get the first and last indexes (inclusive, exclusive) of the values for a bucket.
+     * Returns [0, 0] if the bucket has never been collected.
+     */
+    private Tuple<Long, Long> getBucketValuesIndexes(int bucket) {
+        long rootIndex = (long) bucket * bucketSize;
+        if (rootIndex >= values.size()) {
+            // We've never seen this bucket.
+            return Tuple.tuple(0L, 0L);
+        }
+        long start = inHeapMode(bucket) ? rootIndex : (rootIndex + getNextGatherOffset(rootIndex) + 1);
+        long end = rootIndex + bucketSize;
+        return Tuple.tuple(start, end);
+    }
+
+    /**
+     * Merge the values from {@code other}'s {@code otherGroupId} into {@code groupId}.
+     */
+    public void merge(int groupId, BytesRefDoubleBucketedSort other, int otherGroupId) {
+        var otherBounds = other.getBucketValuesIndexes(otherGroupId);
+
+        // TODO: This can be improved for heapified buckets by making use of the heap structures
+        for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
+            BreakingBytesRefBuilder otherValue = other.values.get(i);
+            collect(
+                otherValue == null ? new BytesRef() : otherValue.bytesRefView(),
+                other.extraValues.get(i),
+                groupId
+            );
+        }
+    }
+
+    /**
+     * Creates a block with the values from the {@code selected} groups.
+     */
+    public void toBlocks(BlockFactory blockFactory, Block[] blocks, int offset, IntVector selected) {
+        // Check if the selected groups are all empty, to avoid allocating extra memory
+        if (allSelectedGroupsAreEmpty(selected)) {
+            Block constantNullBlock = blockFactory.newConstantNullBlock(selected.getPositionCount());
+            constantNullBlock.incRef();
+            blocks[offset] = constantNullBlock;
+            blocks[offset + 1] = constantNullBlock;
+            return;
+        }
+
+        try (
+            var builder = blockFactory.newBytesRefBlockBuilder(selected.getPositionCount());
+            var extraBuilder = blockFactory.newDoubleBlockBuilder(selected.getPositionCount())
+        ) {
+            for (int s = 0; s < selected.getPositionCount(); s++) {
+                int bucket = selected.getInt(s);
+
+                var bounds = getBucketValuesIndexes(bucket);
+                var rootIndex = bounds.v1();
+                var size = bounds.v2() - bounds.v1();
+
+                if (size == 0) {
+                    builder.appendNull();
+                    extraBuilder.appendNull();
+                    continue;
+                }
+
+                if (size == 1) {
+                    appendValue(builder, rootIndex);
+                    extraBuilder.appendDouble(extraValues.get(rootIndex));
+                    continue;
+                }
+
+                // If we are in the gathering mode, we need to heapify before sorting.
+                if (inHeapMode(bucket) == false) {
+                    heapify(rootIndex, (int) size);
+                }
+                heapSort(rootIndex, (int) size);
+
+                builder.beginPositionEntry();
+                extraBuilder.beginPositionEntry();
+                for (int i = 0; i < size; i++) {
+                    appendValue(builder, rootIndex + i);
+                    extraBuilder.appendDouble(extraValues.get(rootIndex + i));
+                }
+                builder.endPositionEntry();
+                extraBuilder.endPositionEntry();
+            }
+            blocks[offset] = builder.build();
+            try {
+                blocks[offset + 1] = extraBuilder.build();
+            } finally {
+                if (blocks[offset + 1] == null) {
+                    blocks[offset].close();
+                    blocks[offset] = null;
+                }
+            }
+        }
+    }
+
+    private void appendValue(org.elasticsearch.compute.data.BytesRefBlock.Builder builder, long index) {
+        BreakingBytesRefBuilder bytes = values.get(index);
+        if (bytes == null) {
+            builder.appendNull();
+            return;
+        }
+        try {
+            builder.appendBytesRef(bytes.bytesRefView());
+        } finally {
+            values.set(index, null);
+            Releasables.closeExpectNoException(bytes);
+        }
+    }
+
+    private BreakingBytesRefBuilder clearedBytesAt(long index) {
+        BreakingBytesRefBuilder bytes = values.get(index);
+        if (bytes == null) {
+            bytes = new BreakingBytesRefBuilder(breaker, "top");
+            values.set(index, bytes);
+        } else {
+            bytes.clear();
+        }
+        return bytes;
+    }
+
+    private BytesRef bytesAt(long index) {
+        BreakingBytesRefBuilder bytes = values.get(index);
+        return bytes == null ? new BytesRef() : bytes.bytesRefView();
+    }
+
+    /**
+     * Checks if the selected groups are all empty.
+     */
+    private boolean allSelectedGroupsAreEmpty(IntVector selected) {
+        return IntStream.range(0, selected.getPositionCount()).map(selected::getInt).noneMatch(bucket -> {
+            var bounds = this.getBucketValuesIndexes(bucket);
+            var size = bounds.v2() - bounds.v1();
+            return size > 0;
+        });
+    }
+
+    /**
+     * Is this bucket a min heap {@code true} or in gathering mode {@code false}?
+     */
+    private boolean inHeapMode(int bucket) {
+        return heapMode.get(bucket);
+    }
+
+    /**
+     * Get the next index that should be "gathered" for a bucket rooted
+     * at {@code rootIndex}.
+     */
+    private int getNextGatherOffset(long rootIndex) {
+        BreakingBytesRefBuilder bytes = values.get(rootIndex);
+        assert bytes != null && bytes.length() == Integer.BYTES;
+        return ByteUtils.readIntLE(bytes.bytes(), 0);
+    }
+
+    /**
+     * Set the next index that should be "gathered" for a bucket rooted
+     * at {@code rootIndex}.
+     */
+    private void setNextGatherOffset(long rootIndex, int offset) {
+        ByteUtils.writeIntLE(offset, values.get(rootIndex).bytes(), 0);
+    }
+
+    /**
+     * {@code true} if the entry at index {@code lhs} is "better" than
+     * the entry at {@code rhs}. "Better" in this means "lower" for
+     * {@link SortOrder#ASC} and "higher" for {@link SortOrder#DESC}.
+     */
+    private boolean betterThan(BytesRef lhs, BytesRef rhs, double lhsExtra, double rhsExtra) {
+        int res = lhs.compareTo(rhs);
+        if (res != 0) {
+            return getOrder().reverseMul() * res < 0;
+        }
+        res = Double.compare(lhsExtra, rhsExtra);
+        return getOrder().reverseMul() * res < 0;
+    }
+
+    /**
+     * Swap the data at two indices.
+     */
+    private void swap(long lhs, long rhs) {
+        var tmp = values.get(lhs);
+        values.set(lhs, values.get(rhs));
+        values.set(rhs, tmp);
+        var tmpExtra = extraValues.get(lhs);
+        extraValues.set(lhs, extraValues.get(rhs));
+        extraValues.set(rhs, tmpExtra);
+    }
+
+    /**
+     * Allocate storage for more buckets and store the "next gather offset"
+     * for those new buckets. We always grow the storage by whole bucket's
+     * worth of slots at a time. We never allocate space for partial buckets.
+     */
+    private void grow(int bucket) {
+        long oldMax = values.size();
+        assert oldMax % bucketSize == 0;
+
+        long newSize = BigArrays.overSize(
+            ((long) bucket + 1) * bucketSize,
+            PageCacheRecycler.OBJECT_PAGE_SIZE,
+            org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_REF
+        );
+        // Round up to the next full bucket.
+        newSize = (newSize + bucketSize - 1) / bucketSize;
+        values = bigArrays.resize(values, newSize * bucketSize);
+        // Round up to the next full bucket.
+        extraValues = bigArrays.resize(extraValues, newSize * bucketSize);
+        // Set the next gather offsets for all newly allocated buckets.
+        fillGatherOffsets(oldMax);
+    }
+
+    /**
+     * Maintain the "next gather offsets" for newly allocated buckets.
+     */
+    private void fillGatherOffsets(long startingAt) {
+        assert startingAt % bucketSize == 0;
+        int nextOffset = getBucketSize() - 1;
+        for (long bucketRoot = startingAt; bucketRoot < values.size(); bucketRoot += getBucketSize()) {
+            BreakingBytesRefBuilder bytes = values.get(bucketRoot);
+            if (bytes != null) {
+                continue;
+            }
+            bytes = new BreakingBytesRefBuilder(breaker, "top");
+            values.set(bucketRoot, bytes);
+            bytes.grow(Integer.BYTES);
+            bytes.setLength(Integer.BYTES);
+            ByteUtils.writeIntLE(nextOffset, bytes.bytes(), 0);
+        }
+    }
+
+    /**
+     * Heapify a bucket whose entries are in random order.
+     * <p>
+     * This works by validating the heap property on each node, iterating
+     * "upwards", pushing any out of order parents "down". Check out the
+     * <a href="https://en.wikipedia.org/w/index.php?title=Binary_heap&oldid=940542991#Building_a_heap">wikipedia</a>
+     * entry on binary heaps for more about this.
+     * </p>
+     * <p>
+     * While this *looks* like it could easily be {@code O(n * log n)}, it is
+     * a fairly well studied algorithm attributed to Floyd. There's
+     * been a bunch of work that puts this at {@code O(n)}, close to 1.88n worst
+     * case.
+     * </p>
+     * <ul>
+     * <li>Hayward, Ryan; McDiarmid, Colin (1991).
+     * <a href="https://web.archive.org/web/20160205023201/http://www.stats.ox.ac.uk/__data/assets/pdf_file/0015/4173/heapbuildjalg.pdf">
+     * Average Case Analysis of Heap Building byRepeated Insertion</a> J. Algorithms.
+     * <li>D.E. Knuth, ”The Art of Computer Programming, Vol. 3, Sorting and Searching”</li>
+     * </ul>
+     * @param rootIndex the index the start of the bucket
+     */
+    private void heapify(long rootIndex, int heapSize) {
+        int maxParent = heapSize / 2 - 1;
+        for (int parent = maxParent; parent >= 0; parent--) {
+            downHeap(rootIndex, parent, heapSize);
+        }
+    }
+
+    /**
+     * Sorts all the values in the heap using heap sort algorithm.
+     * This runs in {@code O(n log n)} time.
+     * @param rootIndex index of the start of the bucket
+     * @param heapSize Number of values that belong to the heap.
+     *                 Can be less than bucketSize.
+     *                 In such a case, the remaining values in range
+     *                 (rootIndex + heapSize, rootIndex + bucketSize)
+     *                 are *not* considered part of the heap.
+     */
+    private void heapSort(long rootIndex, int heapSize) {
+        while (heapSize > 0) {
+            swap(rootIndex, rootIndex + heapSize - 1);
+            heapSize--;
+            downHeap(rootIndex, 0, heapSize);
+        }
+    }
+
+    /**
+     * Correct the heap invariant of a parent and its children. This
+     * runs in {@code O(log n)} time.
+     * @param rootIndex index of the start of the bucket
+     * @param parent Index within the bucket of the parent to check.
+     *               For example, 0 is the "root".
+     * @param heapSize Number of values that belong to the heap.
+     *                 Can be less than bucketSize.
+     *                 In such a case, the remaining values in range
+     *                 (rootIndex + heapSize, rootIndex + bucketSize)
+     *                 are *not* considered part of the heap.
+     */
+    private void downHeap(long rootIndex, int parent, int heapSize) {
+        while (true) {
+            long parentIndex = rootIndex + parent;
+            int worst = parent;
+            long worstIndex = parentIndex;
+            int leftChild = parent * 2 + 1;
+            long leftIndex = rootIndex + leftChild;
+            if (leftChild < heapSize) {
+                if (betterThan(
+                    bytesAt(worstIndex),
+                    bytesAt(leftIndex),
+                    extraValues.get(worstIndex),
+                    extraValues.get(leftIndex)
+                )) {
+                    worst = leftChild;
+                    worstIndex = leftIndex;
+                }
+                int rightChild = leftChild + 1;
+                long rightIndex = rootIndex + rightChild;
+                if (rightChild < heapSize
+                    && betterThan(
+                        bytesAt(worstIndex),
+                        bytesAt(rightIndex),
+                        extraValues.get(worstIndex),
+                        extraValues.get(rightIndex)
+                    )) {
+                    worst = rightChild;
+                    worstIndex = rightIndex;
+                }
+            }
+            if (worst == parent) {
+                break;
+            }
+            swap(worstIndex, parentIndex);
+            parent = worst;
+        }
+    }
+
+    @Override
+    public final void close() {
+        if (values != null) {
+            for (long i = 0; i < values.size(); i++) {
+                Releasables.close(values.get(i));
+            }
+        }
+        Releasables.close(values, extraValues, heapMode);
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/BytesRefDoubleBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/BytesRefDoubleBucketedSort.java
@@ -103,13 +103,9 @@ public class BytesRefDoubleBucketedSort implements Releasable {
     public void collect(BytesRef value, double extraValue, int bucket) {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
-            if (betterThan(
-                // comment to make spotless happy about line breaks
-                value,
-                bytesAt(rootIndex),
-                extraValue,
-                extraValues.get(rootIndex)
-            )) {
+            BytesRef rootValue = bytesAt(rootIndex);
+            double rootExtra = extraValues.get(rootIndex);
+            if (betterThan(value, rootValue, extraValue, rootExtra)) {
                 clearedBytesAt(rootIndex).append(value);
                 extraValues.set(rootIndex, extraValue);
                 downHeap(rootIndex, 0, bucketSize);
@@ -172,12 +168,9 @@ public class BytesRefDoubleBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            collect(
-                // comment to make spotless happy about line breaks
-                other.values.get(i) == null ? new BytesRef() : other.values.get(i).bytesRefView(),
-                other.extraValues.get(i),
-                groupId
-            );
+            BytesRef otherValue = other.values.get(i) == null ? new BytesRef() : other.values.get(i).bytesRefView();
+            double otherExtra = other.extraValues.get(i);
+            collect(otherValue, otherExtra, groupId);
         }
     }
 
@@ -345,12 +338,9 @@ public class BytesRefDoubleBucketedSort implements Releasable {
         long oldMax = values.size();
         assert oldMax % bucketSize == 0;
 
-        long newSize = BigArrays.overSize(
-            // comment to make spotless happy about line breaks
-            ((long) bucket + 1) * bucketSize,
-            PageCacheRecycler.OBJECT_PAGE_SIZE,
-            org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_REF
-        );
+        int pageSize = PageCacheRecycler.OBJECT_PAGE_SIZE;
+        int bytesPerElement = org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_REF;
+        long newSize = BigArrays.overSize(((long) bucket + 1) * bucketSize, pageSize, bytesPerElement);
         // Round up to the next full bucket.
         newSize = (newSize + bucketSize - 1) / bucketSize;
         values = bigArrays.resize(values, newSize * bucketSize);
@@ -446,28 +436,25 @@ public class BytesRefDoubleBucketedSort implements Releasable {
             int leftChild = parent * 2 + 1;
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
-                if (betterThan(
-                    // comment to make spotless happy about line breaks
-                    bytesAt(worstIndex),
-                    bytesAt(leftIndex),
-                    extraValues.get(worstIndex),
-                    extraValues.get(leftIndex)
-                )) {
+                BytesRef worstValue = bytesAt(worstIndex);
+                BytesRef leftValue = bytesAt(leftIndex);
+                double worstExtra = extraValues.get(worstIndex);
+                double leftExtra = extraValues.get(leftIndex);
+                if (betterThan(worstValue, leftValue, worstExtra, leftExtra)) {
                     worst = leftChild;
                     worstIndex = leftIndex;
                 }
                 int rightChild = leftChild + 1;
                 long rightIndex = rootIndex + rightChild;
-                if (rightChild < heapSize
-                    && betterThan(
-                        // comment to make spotless happy about line breaks
-                        bytesAt(worstIndex),
-                        bytesAt(rightIndex),
-                        extraValues.get(worstIndex),
-                        extraValues.get(rightIndex)
-                    )) {
-                    worst = rightChild;
-                    worstIndex = rightIndex;
+                if (rightChild < heapSize) {
+                    worstValue = bytesAt(worstIndex);
+                    BytesRef rightValue = bytesAt(rightIndex);
+                    worstExtra = extraValues.get(worstIndex);
+                    double rightExtra = extraValues.get(rightIndex);
+                    if (betterThan(worstValue, rightValue, worstExtra, rightExtra)) {
+                        worst = rightChild;
+                        worstIndex = rightIndex;
+                    }
                 }
             }
             if (worst == parent) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/BytesRefDoubleBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/BytesRefDoubleBucketedSort.java
@@ -172,10 +172,9 @@ public class BytesRefDoubleBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            BreakingBytesRefBuilder otherValue = other.values.get(i);
             collect(
                 // comment to make spotless happy about line breaks
-                otherValue == null ? new BytesRef() : otherValue.bytesRefView(),
+                other.values.get(i) == null ? new BytesRef() : other.values.get(i).bytesRefView(),
                 other.extraValues.get(i),
                 groupId
             );
@@ -196,7 +195,6 @@ public class BytesRefDoubleBucketedSort implements Releasable {
         }
 
         try (
-            // comment to make spotless happy about line breaks
             var builder = blockFactory.newBytesRefBlockBuilder(selected.getPositionCount());
             var extraBuilder = blockFactory.newDoubleBlockBuilder(selected.getPositionCount())
         ) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/BytesRefFloatBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/BytesRefFloatBucketedSort.java
@@ -1,0 +1,486 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data.sort;
+
+// begin generated imports
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.BitArray;
+import org.elasticsearch.common.util.FloatArray;
+import org.elasticsearch.common.util.ObjectArray;
+import org.elasticsearch.common.util.PageCacheRecycler;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
+import org.elasticsearch.common.util.ByteUtils;
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.core.Tuple;
+import org.elasticsearch.search.sort.BucketedSort;
+import org.elasticsearch.search.sort.SortOrder;
+
+import java.util.stream.IntStream;
+// end generated imports
+
+/**
+ * Aggregates the top N {@code BytesRef} values per bucket.
+ * See {@link BucketedSort} for more information.
+ * This class is generated. Edit @{code X-BucketedSort.java.st} instead of this file.
+ */
+public class BytesRefFloatBucketedSort implements Releasable {
+
+    private final BigArrays bigArrays;
+    private final CircuitBreaker breaker;
+    private final SortOrder order;
+    private final int bucketSize;
+    /**
+     * {@code true} if the bucket is in heap mode, {@code false} if
+     * it is still gathering.
+     */
+    private final BitArray heapMode;
+    /**
+     * An array containing all the values on all buckets. The structure is as follows:
+     * <p>
+     *     For each bucket, there are bucketSize elements, based on the bucket id (0, 1, 2...).
+     *     Then, for each bucket, it can be in 2 states:
+     * </p>
+     * <ul>
+     *     <li>
+     *         Gather mode: All buckets start in gather mode, and remain here while they have less than bucketSize elements.
+     *         In gather mode, the elements are stored in the array from the highest index to the lowest index.
+     *         The lowest index contains the offset to the next slot to be filled.
+     *         <p>
+     *             This allows us to insert elements in O(1) time.
+     *         </p>
+     *         <p>
+     *             When the bucketSize-th element is collected, the bucket transitions to heap mode, by heapifying its contents.
+     *         </p>
+     *     </li>
+     *     <li>
+     *         Heap mode: The bucket slots are organized as a min heap structure.
+     *         <p>
+     *             The root of the heap is the minimum value in the bucket,
+     *             which allows us to quickly discard new values that are not in the top N.
+     *         </p>
+     *     </li>
+     * </ul>
+     */
+    private ObjectArray<BreakingBytesRefBuilder> values;
+    private FloatArray extraValues;
+
+    public BytesRefFloatBucketedSort(BigArrays bigArrays, SortOrder order, int bucketSize) {
+        this.bigArrays = bigArrays;
+        this.breaker = bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST);
+        this.order = order;
+        this.bucketSize = bucketSize;
+        heapMode = new BitArray(0, bigArrays);
+
+        boolean success = false;
+        try {
+            values = bigArrays.newObjectArray(0);
+            extraValues = bigArrays.newFloatArray(0, false);
+            success = true;
+        } finally {
+            if (success == false) {
+                close();
+            }
+        }
+    }
+
+    /**
+     * Collects a {@code value} into a {@code bucket}.
+     * <p>
+     *     It may or may not be inserted in the heap, depending on if it is better than the current root.
+     * </p>
+     */
+    public void collect(BytesRef value, float extraValue, int bucket) {
+        long rootIndex = (long) bucket * bucketSize;
+        if (inHeapMode(bucket)) {
+            if (betterThan(
+                value,
+                bytesAt(rootIndex),
+                extraValue,
+                extraValues.get(rootIndex)
+            )) {
+                clearedBytesAt(rootIndex).append(value);
+                extraValues.set(rootIndex, extraValue);
+                downHeap(rootIndex, 0, bucketSize);
+            }
+            return;
+        }
+        // Gathering mode
+        long requiredSize = rootIndex + bucketSize;
+        if (values.size() < requiredSize) {
+            grow(bucket);
+        }
+        int next = getNextGatherOffset(rootIndex);
+        assert 0 <= next && next < bucketSize
+            : "Expected next to be in the range of valid buckets [0 <= " + next + " < " + bucketSize + "]";
+        long index = next + rootIndex;
+        clearedBytesAt(index).append(value);
+        extraValues.set(index, extraValue);
+        if (next == 0) {
+            heapMode.set(bucket);
+            heapify(rootIndex, bucketSize);
+        } else {
+            setNextGatherOffset(rootIndex, next - 1);
+        }
+    }
+
+    /**
+     * The order of the sort.
+     */
+    public SortOrder getOrder() {
+        return order;
+    }
+
+    /**
+     * The number of values to store per bucket.
+     */
+    public int getBucketSize() {
+        return bucketSize;
+    }
+
+    /**
+     * Get the first and last indexes (inclusive, exclusive) of the values for a bucket.
+     * Returns [0, 0] if the bucket has never been collected.
+     */
+    private Tuple<Long, Long> getBucketValuesIndexes(int bucket) {
+        long rootIndex = (long) bucket * bucketSize;
+        if (rootIndex >= values.size()) {
+            // We've never seen this bucket.
+            return Tuple.tuple(0L, 0L);
+        }
+        long start = inHeapMode(bucket) ? rootIndex : (rootIndex + getNextGatherOffset(rootIndex) + 1);
+        long end = rootIndex + bucketSize;
+        return Tuple.tuple(start, end);
+    }
+
+    /**
+     * Merge the values from {@code other}'s {@code otherGroupId} into {@code groupId}.
+     */
+    public void merge(int groupId, BytesRefFloatBucketedSort other, int otherGroupId) {
+        var otherBounds = other.getBucketValuesIndexes(otherGroupId);
+
+        // TODO: This can be improved for heapified buckets by making use of the heap structures
+        for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
+            BreakingBytesRefBuilder otherValue = other.values.get(i);
+            collect(
+                otherValue == null ? new BytesRef() : otherValue.bytesRefView(),
+                other.extraValues.get(i),
+                groupId
+            );
+        }
+    }
+
+    /**
+     * Creates a block with the values from the {@code selected} groups.
+     */
+    public void toBlocks(BlockFactory blockFactory, Block[] blocks, int offset, IntVector selected) {
+        // Check if the selected groups are all empty, to avoid allocating extra memory
+        if (allSelectedGroupsAreEmpty(selected)) {
+            Block constantNullBlock = blockFactory.newConstantNullBlock(selected.getPositionCount());
+            constantNullBlock.incRef();
+            blocks[offset] = constantNullBlock;
+            blocks[offset + 1] = constantNullBlock;
+            return;
+        }
+
+        try (
+            var builder = blockFactory.newBytesRefBlockBuilder(selected.getPositionCount());
+            var extraBuilder = blockFactory.newFloatBlockBuilder(selected.getPositionCount())
+        ) {
+            for (int s = 0; s < selected.getPositionCount(); s++) {
+                int bucket = selected.getInt(s);
+
+                var bounds = getBucketValuesIndexes(bucket);
+                var rootIndex = bounds.v1();
+                var size = bounds.v2() - bounds.v1();
+
+                if (size == 0) {
+                    builder.appendNull();
+                    extraBuilder.appendNull();
+                    continue;
+                }
+
+                if (size == 1) {
+                    appendValue(builder, rootIndex);
+                    extraBuilder.appendFloat(extraValues.get(rootIndex));
+                    continue;
+                }
+
+                // If we are in the gathering mode, we need to heapify before sorting.
+                if (inHeapMode(bucket) == false) {
+                    heapify(rootIndex, (int) size);
+                }
+                heapSort(rootIndex, (int) size);
+
+                builder.beginPositionEntry();
+                extraBuilder.beginPositionEntry();
+                for (int i = 0; i < size; i++) {
+                    appendValue(builder, rootIndex + i);
+                    extraBuilder.appendFloat(extraValues.get(rootIndex + i));
+                }
+                builder.endPositionEntry();
+                extraBuilder.endPositionEntry();
+            }
+            blocks[offset] = builder.build();
+            try {
+                blocks[offset + 1] = extraBuilder.build();
+            } finally {
+                if (blocks[offset + 1] == null) {
+                    blocks[offset].close();
+                    blocks[offset] = null;
+                }
+            }
+        }
+    }
+
+    private void appendValue(org.elasticsearch.compute.data.BytesRefBlock.Builder builder, long index) {
+        BreakingBytesRefBuilder bytes = values.get(index);
+        if (bytes == null) {
+            builder.appendNull();
+            return;
+        }
+        try {
+            builder.appendBytesRef(bytes.bytesRefView());
+        } finally {
+            values.set(index, null);
+            Releasables.closeExpectNoException(bytes);
+        }
+    }
+
+    private BreakingBytesRefBuilder clearedBytesAt(long index) {
+        BreakingBytesRefBuilder bytes = values.get(index);
+        if (bytes == null) {
+            bytes = new BreakingBytesRefBuilder(breaker, "top");
+            values.set(index, bytes);
+        } else {
+            bytes.clear();
+        }
+        return bytes;
+    }
+
+    private BytesRef bytesAt(long index) {
+        BreakingBytesRefBuilder bytes = values.get(index);
+        return bytes == null ? new BytesRef() : bytes.bytesRefView();
+    }
+
+    /**
+     * Checks if the selected groups are all empty.
+     */
+    private boolean allSelectedGroupsAreEmpty(IntVector selected) {
+        return IntStream.range(0, selected.getPositionCount()).map(selected::getInt).noneMatch(bucket -> {
+            var bounds = this.getBucketValuesIndexes(bucket);
+            var size = bounds.v2() - bounds.v1();
+            return size > 0;
+        });
+    }
+
+    /**
+     * Is this bucket a min heap {@code true} or in gathering mode {@code false}?
+     */
+    private boolean inHeapMode(int bucket) {
+        return heapMode.get(bucket);
+    }
+
+    /**
+     * Get the next index that should be "gathered" for a bucket rooted
+     * at {@code rootIndex}.
+     */
+    private int getNextGatherOffset(long rootIndex) {
+        BreakingBytesRefBuilder bytes = values.get(rootIndex);
+        assert bytes != null && bytes.length() == Integer.BYTES;
+        return ByteUtils.readIntLE(bytes.bytes(), 0);
+    }
+
+    /**
+     * Set the next index that should be "gathered" for a bucket rooted
+     * at {@code rootIndex}.
+     */
+    private void setNextGatherOffset(long rootIndex, int offset) {
+        ByteUtils.writeIntLE(offset, values.get(rootIndex).bytes(), 0);
+    }
+
+    /**
+     * {@code true} if the entry at index {@code lhs} is "better" than
+     * the entry at {@code rhs}. "Better" in this means "lower" for
+     * {@link SortOrder#ASC} and "higher" for {@link SortOrder#DESC}.
+     */
+    private boolean betterThan(BytesRef lhs, BytesRef rhs, float lhsExtra, float rhsExtra) {
+        int res = lhs.compareTo(rhs);
+        if (res != 0) {
+            return getOrder().reverseMul() * res < 0;
+        }
+        res = Float.compare(lhsExtra, rhsExtra);
+        return getOrder().reverseMul() * res < 0;
+    }
+
+    /**
+     * Swap the data at two indices.
+     */
+    private void swap(long lhs, long rhs) {
+        var tmp = values.get(lhs);
+        values.set(lhs, values.get(rhs));
+        values.set(rhs, tmp);
+        var tmpExtra = extraValues.get(lhs);
+        extraValues.set(lhs, extraValues.get(rhs));
+        extraValues.set(rhs, tmpExtra);
+    }
+
+    /**
+     * Allocate storage for more buckets and store the "next gather offset"
+     * for those new buckets. We always grow the storage by whole bucket's
+     * worth of slots at a time. We never allocate space for partial buckets.
+     */
+    private void grow(int bucket) {
+        long oldMax = values.size();
+        assert oldMax % bucketSize == 0;
+
+        long newSize = BigArrays.overSize(
+            ((long) bucket + 1) * bucketSize,
+            PageCacheRecycler.OBJECT_PAGE_SIZE,
+            org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_REF
+        );
+        // Round up to the next full bucket.
+        newSize = (newSize + bucketSize - 1) / bucketSize;
+        values = bigArrays.resize(values, newSize * bucketSize);
+        // Round up to the next full bucket.
+        extraValues = bigArrays.resize(extraValues, newSize * bucketSize);
+        // Set the next gather offsets for all newly allocated buckets.
+        fillGatherOffsets(oldMax);
+    }
+
+    /**
+     * Maintain the "next gather offsets" for newly allocated buckets.
+     */
+    private void fillGatherOffsets(long startingAt) {
+        assert startingAt % bucketSize == 0;
+        int nextOffset = getBucketSize() - 1;
+        for (long bucketRoot = startingAt; bucketRoot < values.size(); bucketRoot += getBucketSize()) {
+            BreakingBytesRefBuilder bytes = values.get(bucketRoot);
+            if (bytes != null) {
+                continue;
+            }
+            bytes = new BreakingBytesRefBuilder(breaker, "top");
+            values.set(bucketRoot, bytes);
+            bytes.grow(Integer.BYTES);
+            bytes.setLength(Integer.BYTES);
+            ByteUtils.writeIntLE(nextOffset, bytes.bytes(), 0);
+        }
+    }
+
+    /**
+     * Heapify a bucket whose entries are in random order.
+     * <p>
+     * This works by validating the heap property on each node, iterating
+     * "upwards", pushing any out of order parents "down". Check out the
+     * <a href="https://en.wikipedia.org/w/index.php?title=Binary_heap&oldid=940542991#Building_a_heap">wikipedia</a>
+     * entry on binary heaps for more about this.
+     * </p>
+     * <p>
+     * While this *looks* like it could easily be {@code O(n * log n)}, it is
+     * a fairly well studied algorithm attributed to Floyd. There's
+     * been a bunch of work that puts this at {@code O(n)}, close to 1.88n worst
+     * case.
+     * </p>
+     * <ul>
+     * <li>Hayward, Ryan; McDiarmid, Colin (1991).
+     * <a href="https://web.archive.org/web/20160205023201/http://www.stats.ox.ac.uk/__data/assets/pdf_file/0015/4173/heapbuildjalg.pdf">
+     * Average Case Analysis of Heap Building byRepeated Insertion</a> J. Algorithms.
+     * <li>D.E. Knuth, ”The Art of Computer Programming, Vol. 3, Sorting and Searching”</li>
+     * </ul>
+     * @param rootIndex the index the start of the bucket
+     */
+    private void heapify(long rootIndex, int heapSize) {
+        int maxParent = heapSize / 2 - 1;
+        for (int parent = maxParent; parent >= 0; parent--) {
+            downHeap(rootIndex, parent, heapSize);
+        }
+    }
+
+    /**
+     * Sorts all the values in the heap using heap sort algorithm.
+     * This runs in {@code O(n log n)} time.
+     * @param rootIndex index of the start of the bucket
+     * @param heapSize Number of values that belong to the heap.
+     *                 Can be less than bucketSize.
+     *                 In such a case, the remaining values in range
+     *                 (rootIndex + heapSize, rootIndex + bucketSize)
+     *                 are *not* considered part of the heap.
+     */
+    private void heapSort(long rootIndex, int heapSize) {
+        while (heapSize > 0) {
+            swap(rootIndex, rootIndex + heapSize - 1);
+            heapSize--;
+            downHeap(rootIndex, 0, heapSize);
+        }
+    }
+
+    /**
+     * Correct the heap invariant of a parent and its children. This
+     * runs in {@code O(log n)} time.
+     * @param rootIndex index of the start of the bucket
+     * @param parent Index within the bucket of the parent to check.
+     *               For example, 0 is the "root".
+     * @param heapSize Number of values that belong to the heap.
+     *                 Can be less than bucketSize.
+     *                 In such a case, the remaining values in range
+     *                 (rootIndex + heapSize, rootIndex + bucketSize)
+     *                 are *not* considered part of the heap.
+     */
+    private void downHeap(long rootIndex, int parent, int heapSize) {
+        while (true) {
+            long parentIndex = rootIndex + parent;
+            int worst = parent;
+            long worstIndex = parentIndex;
+            int leftChild = parent * 2 + 1;
+            long leftIndex = rootIndex + leftChild;
+            if (leftChild < heapSize) {
+                if (betterThan(
+                    bytesAt(worstIndex),
+                    bytesAt(leftIndex),
+                    extraValues.get(worstIndex),
+                    extraValues.get(leftIndex)
+                )) {
+                    worst = leftChild;
+                    worstIndex = leftIndex;
+                }
+                int rightChild = leftChild + 1;
+                long rightIndex = rootIndex + rightChild;
+                if (rightChild < heapSize
+                    && betterThan(
+                        bytesAt(worstIndex),
+                        bytesAt(rightIndex),
+                        extraValues.get(worstIndex),
+                        extraValues.get(rightIndex)
+                    )) {
+                    worst = rightChild;
+                    worstIndex = rightIndex;
+                }
+            }
+            if (worst == parent) {
+                break;
+            }
+            swap(worstIndex, parentIndex);
+            parent = worst;
+        }
+    }
+
+    @Override
+    public final void close() {
+        if (values != null) {
+            for (long i = 0; i < values.size(); i++) {
+                Releasables.close(values.get(i));
+            }
+        }
+        Releasables.close(values, extraValues, heapMode);
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/BytesRefFloatBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/BytesRefFloatBucketedSort.java
@@ -104,6 +104,7 @@ public class BytesRefFloatBucketedSort implements Releasable {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
             if (betterThan(
+                // comment to make spotless happy about line breaks
                 value,
                 bytesAt(rootIndex),
                 extraValue,
@@ -173,6 +174,7 @@ public class BytesRefFloatBucketedSort implements Releasable {
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
             BreakingBytesRefBuilder otherValue = other.values.get(i);
             collect(
+                // comment to make spotless happy about line breaks
                 otherValue == null ? new BytesRef() : otherValue.bytesRefView(),
                 other.extraValues.get(i),
                 groupId
@@ -194,6 +196,7 @@ public class BytesRefFloatBucketedSort implements Releasable {
         }
 
         try (
+            // comment to make spotless happy about line breaks
             var builder = blockFactory.newBytesRefBlockBuilder(selected.getPositionCount());
             var extraBuilder = blockFactory.newFloatBlockBuilder(selected.getPositionCount())
         ) {
@@ -345,6 +348,7 @@ public class BytesRefFloatBucketedSort implements Releasable {
         assert oldMax % bucketSize == 0;
 
         long newSize = BigArrays.overSize(
+            // comment to make spotless happy about line breaks
             ((long) bucket + 1) * bucketSize,
             PageCacheRecycler.OBJECT_PAGE_SIZE,
             org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_REF
@@ -445,6 +449,7 @@ public class BytesRefFloatBucketedSort implements Releasable {
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
                 if (betterThan(
+                    // comment to make spotless happy about line breaks
                     bytesAt(worstIndex),
                     bytesAt(leftIndex),
                     extraValues.get(worstIndex),
@@ -457,6 +462,7 @@ public class BytesRefFloatBucketedSort implements Releasable {
                 long rightIndex = rootIndex + rightChild;
                 if (rightChild < heapSize
                     && betterThan(
+                        // comment to make spotless happy about line breaks
                         bytesAt(worstIndex),
                         bytesAt(rightIndex),
                         extraValues.get(worstIndex),

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/BytesRefFloatBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/BytesRefFloatBucketedSort.java
@@ -172,10 +172,9 @@ public class BytesRefFloatBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            BreakingBytesRefBuilder otherValue = other.values.get(i);
             collect(
                 // comment to make spotless happy about line breaks
-                otherValue == null ? new BytesRef() : otherValue.bytesRefView(),
+                other.values.get(i) == null ? new BytesRef() : other.values.get(i).bytesRefView(),
                 other.extraValues.get(i),
                 groupId
             );
@@ -196,7 +195,6 @@ public class BytesRefFloatBucketedSort implements Releasable {
         }
 
         try (
-            // comment to make spotless happy about line breaks
             var builder = blockFactory.newBytesRefBlockBuilder(selected.getPositionCount());
             var extraBuilder = blockFactory.newFloatBlockBuilder(selected.getPositionCount())
         ) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/BytesRefFloatBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/BytesRefFloatBucketedSort.java
@@ -103,13 +103,9 @@ public class BytesRefFloatBucketedSort implements Releasable {
     public void collect(BytesRef value, float extraValue, int bucket) {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
-            if (betterThan(
-                // comment to make spotless happy about line breaks
-                value,
-                bytesAt(rootIndex),
-                extraValue,
-                extraValues.get(rootIndex)
-            )) {
+            BytesRef rootValue = bytesAt(rootIndex);
+            float rootExtra = extraValues.get(rootIndex);
+            if (betterThan(value, rootValue, extraValue, rootExtra)) {
                 clearedBytesAt(rootIndex).append(value);
                 extraValues.set(rootIndex, extraValue);
                 downHeap(rootIndex, 0, bucketSize);
@@ -172,12 +168,9 @@ public class BytesRefFloatBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            collect(
-                // comment to make spotless happy about line breaks
-                other.values.get(i) == null ? new BytesRef() : other.values.get(i).bytesRefView(),
-                other.extraValues.get(i),
-                groupId
-            );
+            BytesRef otherValue = other.values.get(i) == null ? new BytesRef() : other.values.get(i).bytesRefView();
+            float otherExtra = other.extraValues.get(i);
+            collect(otherValue, otherExtra, groupId);
         }
     }
 
@@ -345,12 +338,9 @@ public class BytesRefFloatBucketedSort implements Releasable {
         long oldMax = values.size();
         assert oldMax % bucketSize == 0;
 
-        long newSize = BigArrays.overSize(
-            // comment to make spotless happy about line breaks
-            ((long) bucket + 1) * bucketSize,
-            PageCacheRecycler.OBJECT_PAGE_SIZE,
-            org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_REF
-        );
+        int pageSize = PageCacheRecycler.OBJECT_PAGE_SIZE;
+        int bytesPerElement = org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_REF;
+        long newSize = BigArrays.overSize(((long) bucket + 1) * bucketSize, pageSize, bytesPerElement);
         // Round up to the next full bucket.
         newSize = (newSize + bucketSize - 1) / bucketSize;
         values = bigArrays.resize(values, newSize * bucketSize);
@@ -446,28 +436,25 @@ public class BytesRefFloatBucketedSort implements Releasable {
             int leftChild = parent * 2 + 1;
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
-                if (betterThan(
-                    // comment to make spotless happy about line breaks
-                    bytesAt(worstIndex),
-                    bytesAt(leftIndex),
-                    extraValues.get(worstIndex),
-                    extraValues.get(leftIndex)
-                )) {
+                BytesRef worstValue = bytesAt(worstIndex);
+                BytesRef leftValue = bytesAt(leftIndex);
+                float worstExtra = extraValues.get(worstIndex);
+                float leftExtra = extraValues.get(leftIndex);
+                if (betterThan(worstValue, leftValue, worstExtra, leftExtra)) {
                     worst = leftChild;
                     worstIndex = leftIndex;
                 }
                 int rightChild = leftChild + 1;
                 long rightIndex = rootIndex + rightChild;
-                if (rightChild < heapSize
-                    && betterThan(
-                        // comment to make spotless happy about line breaks
-                        bytesAt(worstIndex),
-                        bytesAt(rightIndex),
-                        extraValues.get(worstIndex),
-                        extraValues.get(rightIndex)
-                    )) {
-                    worst = rightChild;
-                    worstIndex = rightIndex;
+                if (rightChild < heapSize) {
+                    worstValue = bytesAt(worstIndex);
+                    BytesRef rightValue = bytesAt(rightIndex);
+                    worstExtra = extraValues.get(worstIndex);
+                    float rightExtra = extraValues.get(rightIndex);
+                    if (betterThan(worstValue, rightValue, worstExtra, rightExtra)) {
+                        worst = rightChild;
+                        worstIndex = rightIndex;
+                    }
                 }
             }
             if (worst == parent) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/BytesRefIntBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/BytesRefIntBucketedSort.java
@@ -1,0 +1,486 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data.sort;
+
+// begin generated imports
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.BitArray;
+import org.elasticsearch.common.util.IntArray;
+import org.elasticsearch.common.util.ObjectArray;
+import org.elasticsearch.common.util.PageCacheRecycler;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
+import org.elasticsearch.common.util.ByteUtils;
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.core.Tuple;
+import org.elasticsearch.search.sort.BucketedSort;
+import org.elasticsearch.search.sort.SortOrder;
+
+import java.util.stream.IntStream;
+// end generated imports
+
+/**
+ * Aggregates the top N {@code BytesRef} values per bucket.
+ * See {@link BucketedSort} for more information.
+ * This class is generated. Edit @{code X-BucketedSort.java.st} instead of this file.
+ */
+public class BytesRefIntBucketedSort implements Releasable {
+
+    private final BigArrays bigArrays;
+    private final CircuitBreaker breaker;
+    private final SortOrder order;
+    private final int bucketSize;
+    /**
+     * {@code true} if the bucket is in heap mode, {@code false} if
+     * it is still gathering.
+     */
+    private final BitArray heapMode;
+    /**
+     * An array containing all the values on all buckets. The structure is as follows:
+     * <p>
+     *     For each bucket, there are bucketSize elements, based on the bucket id (0, 1, 2...).
+     *     Then, for each bucket, it can be in 2 states:
+     * </p>
+     * <ul>
+     *     <li>
+     *         Gather mode: All buckets start in gather mode, and remain here while they have less than bucketSize elements.
+     *         In gather mode, the elements are stored in the array from the highest index to the lowest index.
+     *         The lowest index contains the offset to the next slot to be filled.
+     *         <p>
+     *             This allows us to insert elements in O(1) time.
+     *         </p>
+     *         <p>
+     *             When the bucketSize-th element is collected, the bucket transitions to heap mode, by heapifying its contents.
+     *         </p>
+     *     </li>
+     *     <li>
+     *         Heap mode: The bucket slots are organized as a min heap structure.
+     *         <p>
+     *             The root of the heap is the minimum value in the bucket,
+     *             which allows us to quickly discard new values that are not in the top N.
+     *         </p>
+     *     </li>
+     * </ul>
+     */
+    private ObjectArray<BreakingBytesRefBuilder> values;
+    private IntArray extraValues;
+
+    public BytesRefIntBucketedSort(BigArrays bigArrays, SortOrder order, int bucketSize) {
+        this.bigArrays = bigArrays;
+        this.breaker = bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST);
+        this.order = order;
+        this.bucketSize = bucketSize;
+        heapMode = new BitArray(0, bigArrays);
+
+        boolean success = false;
+        try {
+            values = bigArrays.newObjectArray(0);
+            extraValues = bigArrays.newIntArray(0, false);
+            success = true;
+        } finally {
+            if (success == false) {
+                close();
+            }
+        }
+    }
+
+    /**
+     * Collects a {@code value} into a {@code bucket}.
+     * <p>
+     *     It may or may not be inserted in the heap, depending on if it is better than the current root.
+     * </p>
+     */
+    public void collect(BytesRef value, int extraValue, int bucket) {
+        long rootIndex = (long) bucket * bucketSize;
+        if (inHeapMode(bucket)) {
+            if (betterThan(
+                value,
+                bytesAt(rootIndex),
+                extraValue,
+                extraValues.get(rootIndex)
+            )) {
+                clearedBytesAt(rootIndex).append(value);
+                extraValues.set(rootIndex, extraValue);
+                downHeap(rootIndex, 0, bucketSize);
+            }
+            return;
+        }
+        // Gathering mode
+        long requiredSize = rootIndex + bucketSize;
+        if (values.size() < requiredSize) {
+            grow(bucket);
+        }
+        int next = getNextGatherOffset(rootIndex);
+        assert 0 <= next && next < bucketSize
+            : "Expected next to be in the range of valid buckets [0 <= " + next + " < " + bucketSize + "]";
+        long index = next + rootIndex;
+        clearedBytesAt(index).append(value);
+        extraValues.set(index, extraValue);
+        if (next == 0) {
+            heapMode.set(bucket);
+            heapify(rootIndex, bucketSize);
+        } else {
+            setNextGatherOffset(rootIndex, next - 1);
+        }
+    }
+
+    /**
+     * The order of the sort.
+     */
+    public SortOrder getOrder() {
+        return order;
+    }
+
+    /**
+     * The number of values to store per bucket.
+     */
+    public int getBucketSize() {
+        return bucketSize;
+    }
+
+    /**
+     * Get the first and last indexes (inclusive, exclusive) of the values for a bucket.
+     * Returns [0, 0] if the bucket has never been collected.
+     */
+    private Tuple<Long, Long> getBucketValuesIndexes(int bucket) {
+        long rootIndex = (long) bucket * bucketSize;
+        if (rootIndex >= values.size()) {
+            // We've never seen this bucket.
+            return Tuple.tuple(0L, 0L);
+        }
+        long start = inHeapMode(bucket) ? rootIndex : (rootIndex + getNextGatherOffset(rootIndex) + 1);
+        long end = rootIndex + bucketSize;
+        return Tuple.tuple(start, end);
+    }
+
+    /**
+     * Merge the values from {@code other}'s {@code otherGroupId} into {@code groupId}.
+     */
+    public void merge(int groupId, BytesRefIntBucketedSort other, int otherGroupId) {
+        var otherBounds = other.getBucketValuesIndexes(otherGroupId);
+
+        // TODO: This can be improved for heapified buckets by making use of the heap structures
+        for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
+            BreakingBytesRefBuilder otherValue = other.values.get(i);
+            collect(
+                otherValue == null ? new BytesRef() : otherValue.bytesRefView(),
+                other.extraValues.get(i),
+                groupId
+            );
+        }
+    }
+
+    /**
+     * Creates a block with the values from the {@code selected} groups.
+     */
+    public void toBlocks(BlockFactory blockFactory, Block[] blocks, int offset, IntVector selected) {
+        // Check if the selected groups are all empty, to avoid allocating extra memory
+        if (allSelectedGroupsAreEmpty(selected)) {
+            Block constantNullBlock = blockFactory.newConstantNullBlock(selected.getPositionCount());
+            constantNullBlock.incRef();
+            blocks[offset] = constantNullBlock;
+            blocks[offset + 1] = constantNullBlock;
+            return;
+        }
+
+        try (
+            var builder = blockFactory.newBytesRefBlockBuilder(selected.getPositionCount());
+            var extraBuilder = blockFactory.newIntBlockBuilder(selected.getPositionCount())
+        ) {
+            for (int s = 0; s < selected.getPositionCount(); s++) {
+                int bucket = selected.getInt(s);
+
+                var bounds = getBucketValuesIndexes(bucket);
+                var rootIndex = bounds.v1();
+                var size = bounds.v2() - bounds.v1();
+
+                if (size == 0) {
+                    builder.appendNull();
+                    extraBuilder.appendNull();
+                    continue;
+                }
+
+                if (size == 1) {
+                    appendValue(builder, rootIndex);
+                    extraBuilder.appendInt(extraValues.get(rootIndex));
+                    continue;
+                }
+
+                // If we are in the gathering mode, we need to heapify before sorting.
+                if (inHeapMode(bucket) == false) {
+                    heapify(rootIndex, (int) size);
+                }
+                heapSort(rootIndex, (int) size);
+
+                builder.beginPositionEntry();
+                extraBuilder.beginPositionEntry();
+                for (int i = 0; i < size; i++) {
+                    appendValue(builder, rootIndex + i);
+                    extraBuilder.appendInt(extraValues.get(rootIndex + i));
+                }
+                builder.endPositionEntry();
+                extraBuilder.endPositionEntry();
+            }
+            blocks[offset] = builder.build();
+            try {
+                blocks[offset + 1] = extraBuilder.build();
+            } finally {
+                if (blocks[offset + 1] == null) {
+                    blocks[offset].close();
+                    blocks[offset] = null;
+                }
+            }
+        }
+    }
+
+    private void appendValue(org.elasticsearch.compute.data.BytesRefBlock.Builder builder, long index) {
+        BreakingBytesRefBuilder bytes = values.get(index);
+        if (bytes == null) {
+            builder.appendNull();
+            return;
+        }
+        try {
+            builder.appendBytesRef(bytes.bytesRefView());
+        } finally {
+            values.set(index, null);
+            Releasables.closeExpectNoException(bytes);
+        }
+    }
+
+    private BreakingBytesRefBuilder clearedBytesAt(long index) {
+        BreakingBytesRefBuilder bytes = values.get(index);
+        if (bytes == null) {
+            bytes = new BreakingBytesRefBuilder(breaker, "top");
+            values.set(index, bytes);
+        } else {
+            bytes.clear();
+        }
+        return bytes;
+    }
+
+    private BytesRef bytesAt(long index) {
+        BreakingBytesRefBuilder bytes = values.get(index);
+        return bytes == null ? new BytesRef() : bytes.bytesRefView();
+    }
+
+    /**
+     * Checks if the selected groups are all empty.
+     */
+    private boolean allSelectedGroupsAreEmpty(IntVector selected) {
+        return IntStream.range(0, selected.getPositionCount()).map(selected::getInt).noneMatch(bucket -> {
+            var bounds = this.getBucketValuesIndexes(bucket);
+            var size = bounds.v2() - bounds.v1();
+            return size > 0;
+        });
+    }
+
+    /**
+     * Is this bucket a min heap {@code true} or in gathering mode {@code false}?
+     */
+    private boolean inHeapMode(int bucket) {
+        return heapMode.get(bucket);
+    }
+
+    /**
+     * Get the next index that should be "gathered" for a bucket rooted
+     * at {@code rootIndex}.
+     */
+    private int getNextGatherOffset(long rootIndex) {
+        BreakingBytesRefBuilder bytes = values.get(rootIndex);
+        assert bytes != null && bytes.length() == Integer.BYTES;
+        return ByteUtils.readIntLE(bytes.bytes(), 0);
+    }
+
+    /**
+     * Set the next index that should be "gathered" for a bucket rooted
+     * at {@code rootIndex}.
+     */
+    private void setNextGatherOffset(long rootIndex, int offset) {
+        ByteUtils.writeIntLE(offset, values.get(rootIndex).bytes(), 0);
+    }
+
+    /**
+     * {@code true} if the entry at index {@code lhs} is "better" than
+     * the entry at {@code rhs}. "Better" in this means "lower" for
+     * {@link SortOrder#ASC} and "higher" for {@link SortOrder#DESC}.
+     */
+    private boolean betterThan(BytesRef lhs, BytesRef rhs, int lhsExtra, int rhsExtra) {
+        int res = lhs.compareTo(rhs);
+        if (res != 0) {
+            return getOrder().reverseMul() * res < 0;
+        }
+        res = Integer.compare(lhsExtra, rhsExtra);
+        return getOrder().reverseMul() * res < 0;
+    }
+
+    /**
+     * Swap the data at two indices.
+     */
+    private void swap(long lhs, long rhs) {
+        var tmp = values.get(lhs);
+        values.set(lhs, values.get(rhs));
+        values.set(rhs, tmp);
+        var tmpExtra = extraValues.get(lhs);
+        extraValues.set(lhs, extraValues.get(rhs));
+        extraValues.set(rhs, tmpExtra);
+    }
+
+    /**
+     * Allocate storage for more buckets and store the "next gather offset"
+     * for those new buckets. We always grow the storage by whole bucket's
+     * worth of slots at a time. We never allocate space for partial buckets.
+     */
+    private void grow(int bucket) {
+        long oldMax = values.size();
+        assert oldMax % bucketSize == 0;
+
+        long newSize = BigArrays.overSize(
+            ((long) bucket + 1) * bucketSize,
+            PageCacheRecycler.OBJECT_PAGE_SIZE,
+            org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_REF
+        );
+        // Round up to the next full bucket.
+        newSize = (newSize + bucketSize - 1) / bucketSize;
+        values = bigArrays.resize(values, newSize * bucketSize);
+        // Round up to the next full bucket.
+        extraValues = bigArrays.resize(extraValues, newSize * bucketSize);
+        // Set the next gather offsets for all newly allocated buckets.
+        fillGatherOffsets(oldMax);
+    }
+
+    /**
+     * Maintain the "next gather offsets" for newly allocated buckets.
+     */
+    private void fillGatherOffsets(long startingAt) {
+        assert startingAt % bucketSize == 0;
+        int nextOffset = getBucketSize() - 1;
+        for (long bucketRoot = startingAt; bucketRoot < values.size(); bucketRoot += getBucketSize()) {
+            BreakingBytesRefBuilder bytes = values.get(bucketRoot);
+            if (bytes != null) {
+                continue;
+            }
+            bytes = new BreakingBytesRefBuilder(breaker, "top");
+            values.set(bucketRoot, bytes);
+            bytes.grow(Integer.BYTES);
+            bytes.setLength(Integer.BYTES);
+            ByteUtils.writeIntLE(nextOffset, bytes.bytes(), 0);
+        }
+    }
+
+    /**
+     * Heapify a bucket whose entries are in random order.
+     * <p>
+     * This works by validating the heap property on each node, iterating
+     * "upwards", pushing any out of order parents "down". Check out the
+     * <a href="https://en.wikipedia.org/w/index.php?title=Binary_heap&oldid=940542991#Building_a_heap">wikipedia</a>
+     * entry on binary heaps for more about this.
+     * </p>
+     * <p>
+     * While this *looks* like it could easily be {@code O(n * log n)}, it is
+     * a fairly well studied algorithm attributed to Floyd. There's
+     * been a bunch of work that puts this at {@code O(n)}, close to 1.88n worst
+     * case.
+     * </p>
+     * <ul>
+     * <li>Hayward, Ryan; McDiarmid, Colin (1991).
+     * <a href="https://web.archive.org/web/20160205023201/http://www.stats.ox.ac.uk/__data/assets/pdf_file/0015/4173/heapbuildjalg.pdf">
+     * Average Case Analysis of Heap Building byRepeated Insertion</a> J. Algorithms.
+     * <li>D.E. Knuth, ”The Art of Computer Programming, Vol. 3, Sorting and Searching”</li>
+     * </ul>
+     * @param rootIndex the index the start of the bucket
+     */
+    private void heapify(long rootIndex, int heapSize) {
+        int maxParent = heapSize / 2 - 1;
+        for (int parent = maxParent; parent >= 0; parent--) {
+            downHeap(rootIndex, parent, heapSize);
+        }
+    }
+
+    /**
+     * Sorts all the values in the heap using heap sort algorithm.
+     * This runs in {@code O(n log n)} time.
+     * @param rootIndex index of the start of the bucket
+     * @param heapSize Number of values that belong to the heap.
+     *                 Can be less than bucketSize.
+     *                 In such a case, the remaining values in range
+     *                 (rootIndex + heapSize, rootIndex + bucketSize)
+     *                 are *not* considered part of the heap.
+     */
+    private void heapSort(long rootIndex, int heapSize) {
+        while (heapSize > 0) {
+            swap(rootIndex, rootIndex + heapSize - 1);
+            heapSize--;
+            downHeap(rootIndex, 0, heapSize);
+        }
+    }
+
+    /**
+     * Correct the heap invariant of a parent and its children. This
+     * runs in {@code O(log n)} time.
+     * @param rootIndex index of the start of the bucket
+     * @param parent Index within the bucket of the parent to check.
+     *               For example, 0 is the "root".
+     * @param heapSize Number of values that belong to the heap.
+     *                 Can be less than bucketSize.
+     *                 In such a case, the remaining values in range
+     *                 (rootIndex + heapSize, rootIndex + bucketSize)
+     *                 are *not* considered part of the heap.
+     */
+    private void downHeap(long rootIndex, int parent, int heapSize) {
+        while (true) {
+            long parentIndex = rootIndex + parent;
+            int worst = parent;
+            long worstIndex = parentIndex;
+            int leftChild = parent * 2 + 1;
+            long leftIndex = rootIndex + leftChild;
+            if (leftChild < heapSize) {
+                if (betterThan(
+                    bytesAt(worstIndex),
+                    bytesAt(leftIndex),
+                    extraValues.get(worstIndex),
+                    extraValues.get(leftIndex)
+                )) {
+                    worst = leftChild;
+                    worstIndex = leftIndex;
+                }
+                int rightChild = leftChild + 1;
+                long rightIndex = rootIndex + rightChild;
+                if (rightChild < heapSize
+                    && betterThan(
+                        bytesAt(worstIndex),
+                        bytesAt(rightIndex),
+                        extraValues.get(worstIndex),
+                        extraValues.get(rightIndex)
+                    )) {
+                    worst = rightChild;
+                    worstIndex = rightIndex;
+                }
+            }
+            if (worst == parent) {
+                break;
+            }
+            swap(worstIndex, parentIndex);
+            parent = worst;
+        }
+    }
+
+    @Override
+    public final void close() {
+        if (values != null) {
+            for (long i = 0; i < values.size(); i++) {
+                Releasables.close(values.get(i));
+            }
+        }
+        Releasables.close(values, extraValues, heapMode);
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/BytesRefIntBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/BytesRefIntBucketedSort.java
@@ -104,6 +104,7 @@ public class BytesRefIntBucketedSort implements Releasable {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
             if (betterThan(
+                // comment to make spotless happy about line breaks
                 value,
                 bytesAt(rootIndex),
                 extraValue,
@@ -173,6 +174,7 @@ public class BytesRefIntBucketedSort implements Releasable {
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
             BreakingBytesRefBuilder otherValue = other.values.get(i);
             collect(
+                // comment to make spotless happy about line breaks
                 otherValue == null ? new BytesRef() : otherValue.bytesRefView(),
                 other.extraValues.get(i),
                 groupId
@@ -194,6 +196,7 @@ public class BytesRefIntBucketedSort implements Releasable {
         }
 
         try (
+            // comment to make spotless happy about line breaks
             var builder = blockFactory.newBytesRefBlockBuilder(selected.getPositionCount());
             var extraBuilder = blockFactory.newIntBlockBuilder(selected.getPositionCount())
         ) {
@@ -345,6 +348,7 @@ public class BytesRefIntBucketedSort implements Releasable {
         assert oldMax % bucketSize == 0;
 
         long newSize = BigArrays.overSize(
+            // comment to make spotless happy about line breaks
             ((long) bucket + 1) * bucketSize,
             PageCacheRecycler.OBJECT_PAGE_SIZE,
             org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_REF
@@ -445,6 +449,7 @@ public class BytesRefIntBucketedSort implements Releasable {
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
                 if (betterThan(
+                    // comment to make spotless happy about line breaks
                     bytesAt(worstIndex),
                     bytesAt(leftIndex),
                     extraValues.get(worstIndex),
@@ -457,6 +462,7 @@ public class BytesRefIntBucketedSort implements Releasable {
                 long rightIndex = rootIndex + rightChild;
                 if (rightChild < heapSize
                     && betterThan(
+                        // comment to make spotless happy about line breaks
                         bytesAt(worstIndex),
                         bytesAt(rightIndex),
                         extraValues.get(worstIndex),

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/BytesRefIntBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/BytesRefIntBucketedSort.java
@@ -103,13 +103,9 @@ public class BytesRefIntBucketedSort implements Releasable {
     public void collect(BytesRef value, int extraValue, int bucket) {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
-            if (betterThan(
-                // comment to make spotless happy about line breaks
-                value,
-                bytesAt(rootIndex),
-                extraValue,
-                extraValues.get(rootIndex)
-            )) {
+            BytesRef rootValue = bytesAt(rootIndex);
+            int rootExtra = extraValues.get(rootIndex);
+            if (betterThan(value, rootValue, extraValue, rootExtra)) {
                 clearedBytesAt(rootIndex).append(value);
                 extraValues.set(rootIndex, extraValue);
                 downHeap(rootIndex, 0, bucketSize);
@@ -172,12 +168,9 @@ public class BytesRefIntBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            collect(
-                // comment to make spotless happy about line breaks
-                other.values.get(i) == null ? new BytesRef() : other.values.get(i).bytesRefView(),
-                other.extraValues.get(i),
-                groupId
-            );
+            BytesRef otherValue = other.values.get(i) == null ? new BytesRef() : other.values.get(i).bytesRefView();
+            int otherExtra = other.extraValues.get(i);
+            collect(otherValue, otherExtra, groupId);
         }
     }
 
@@ -345,12 +338,9 @@ public class BytesRefIntBucketedSort implements Releasable {
         long oldMax = values.size();
         assert oldMax % bucketSize == 0;
 
-        long newSize = BigArrays.overSize(
-            // comment to make spotless happy about line breaks
-            ((long) bucket + 1) * bucketSize,
-            PageCacheRecycler.OBJECT_PAGE_SIZE,
-            org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_REF
-        );
+        int pageSize = PageCacheRecycler.OBJECT_PAGE_SIZE;
+        int bytesPerElement = org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_REF;
+        long newSize = BigArrays.overSize(((long) bucket + 1) * bucketSize, pageSize, bytesPerElement);
         // Round up to the next full bucket.
         newSize = (newSize + bucketSize - 1) / bucketSize;
         values = bigArrays.resize(values, newSize * bucketSize);
@@ -446,28 +436,25 @@ public class BytesRefIntBucketedSort implements Releasable {
             int leftChild = parent * 2 + 1;
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
-                if (betterThan(
-                    // comment to make spotless happy about line breaks
-                    bytesAt(worstIndex),
-                    bytesAt(leftIndex),
-                    extraValues.get(worstIndex),
-                    extraValues.get(leftIndex)
-                )) {
+                BytesRef worstValue = bytesAt(worstIndex);
+                BytesRef leftValue = bytesAt(leftIndex);
+                int worstExtra = extraValues.get(worstIndex);
+                int leftExtra = extraValues.get(leftIndex);
+                if (betterThan(worstValue, leftValue, worstExtra, leftExtra)) {
                     worst = leftChild;
                     worstIndex = leftIndex;
                 }
                 int rightChild = leftChild + 1;
                 long rightIndex = rootIndex + rightChild;
-                if (rightChild < heapSize
-                    && betterThan(
-                        // comment to make spotless happy about line breaks
-                        bytesAt(worstIndex),
-                        bytesAt(rightIndex),
-                        extraValues.get(worstIndex),
-                        extraValues.get(rightIndex)
-                    )) {
-                    worst = rightChild;
-                    worstIndex = rightIndex;
+                if (rightChild < heapSize) {
+                    worstValue = bytesAt(worstIndex);
+                    BytesRef rightValue = bytesAt(rightIndex);
+                    worstExtra = extraValues.get(worstIndex);
+                    int rightExtra = extraValues.get(rightIndex);
+                    if (betterThan(worstValue, rightValue, worstExtra, rightExtra)) {
+                        worst = rightChild;
+                        worstIndex = rightIndex;
+                    }
                 }
             }
             if (worst == parent) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/BytesRefIntBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/BytesRefIntBucketedSort.java
@@ -172,10 +172,9 @@ public class BytesRefIntBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            BreakingBytesRefBuilder otherValue = other.values.get(i);
             collect(
                 // comment to make spotless happy about line breaks
-                otherValue == null ? new BytesRef() : otherValue.bytesRefView(),
+                other.values.get(i) == null ? new BytesRef() : other.values.get(i).bytesRefView(),
                 other.extraValues.get(i),
                 groupId
             );
@@ -196,7 +195,6 @@ public class BytesRefIntBucketedSort implements Releasable {
         }
 
         try (
-            // comment to make spotless happy about line breaks
             var builder = blockFactory.newBytesRefBlockBuilder(selected.getPositionCount());
             var extraBuilder = blockFactory.newIntBlockBuilder(selected.getPositionCount())
         ) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/BytesRefLongBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/BytesRefLongBucketedSort.java
@@ -104,6 +104,7 @@ public class BytesRefLongBucketedSort implements Releasable {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
             if (betterThan(
+                // comment to make spotless happy about line breaks
                 value,
                 bytesAt(rootIndex),
                 extraValue,
@@ -173,6 +174,7 @@ public class BytesRefLongBucketedSort implements Releasable {
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
             BreakingBytesRefBuilder otherValue = other.values.get(i);
             collect(
+                // comment to make spotless happy about line breaks
                 otherValue == null ? new BytesRef() : otherValue.bytesRefView(),
                 other.extraValues.get(i),
                 groupId
@@ -194,6 +196,7 @@ public class BytesRefLongBucketedSort implements Releasable {
         }
 
         try (
+            // comment to make spotless happy about line breaks
             var builder = blockFactory.newBytesRefBlockBuilder(selected.getPositionCount());
             var extraBuilder = blockFactory.newLongBlockBuilder(selected.getPositionCount())
         ) {
@@ -345,6 +348,7 @@ public class BytesRefLongBucketedSort implements Releasable {
         assert oldMax % bucketSize == 0;
 
         long newSize = BigArrays.overSize(
+            // comment to make spotless happy about line breaks
             ((long) bucket + 1) * bucketSize,
             PageCacheRecycler.OBJECT_PAGE_SIZE,
             org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_REF
@@ -445,6 +449,7 @@ public class BytesRefLongBucketedSort implements Releasable {
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
                 if (betterThan(
+                    // comment to make spotless happy about line breaks
                     bytesAt(worstIndex),
                     bytesAt(leftIndex),
                     extraValues.get(worstIndex),
@@ -457,6 +462,7 @@ public class BytesRefLongBucketedSort implements Releasable {
                 long rightIndex = rootIndex + rightChild;
                 if (rightChild < heapSize
                     && betterThan(
+                        // comment to make spotless happy about line breaks
                         bytesAt(worstIndex),
                         bytesAt(rightIndex),
                         extraValues.get(worstIndex),

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/BytesRefLongBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/BytesRefLongBucketedSort.java
@@ -172,10 +172,9 @@ public class BytesRefLongBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            BreakingBytesRefBuilder otherValue = other.values.get(i);
             collect(
                 // comment to make spotless happy about line breaks
-                otherValue == null ? new BytesRef() : otherValue.bytesRefView(),
+                other.values.get(i) == null ? new BytesRef() : other.values.get(i).bytesRefView(),
                 other.extraValues.get(i),
                 groupId
             );
@@ -196,7 +195,6 @@ public class BytesRefLongBucketedSort implements Releasable {
         }
 
         try (
-            // comment to make spotless happy about line breaks
             var builder = blockFactory.newBytesRefBlockBuilder(selected.getPositionCount());
             var extraBuilder = blockFactory.newLongBlockBuilder(selected.getPositionCount())
         ) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/BytesRefLongBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/BytesRefLongBucketedSort.java
@@ -103,13 +103,9 @@ public class BytesRefLongBucketedSort implements Releasable {
     public void collect(BytesRef value, long extraValue, int bucket) {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
-            if (betterThan(
-                // comment to make spotless happy about line breaks
-                value,
-                bytesAt(rootIndex),
-                extraValue,
-                extraValues.get(rootIndex)
-            )) {
+            BytesRef rootValue = bytesAt(rootIndex);
+            long rootExtra = extraValues.get(rootIndex);
+            if (betterThan(value, rootValue, extraValue, rootExtra)) {
                 clearedBytesAt(rootIndex).append(value);
                 extraValues.set(rootIndex, extraValue);
                 downHeap(rootIndex, 0, bucketSize);
@@ -172,12 +168,9 @@ public class BytesRefLongBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            collect(
-                // comment to make spotless happy about line breaks
-                other.values.get(i) == null ? new BytesRef() : other.values.get(i).bytesRefView(),
-                other.extraValues.get(i),
-                groupId
-            );
+            BytesRef otherValue = other.values.get(i) == null ? new BytesRef() : other.values.get(i).bytesRefView();
+            long otherExtra = other.extraValues.get(i);
+            collect(otherValue, otherExtra, groupId);
         }
     }
 
@@ -345,12 +338,9 @@ public class BytesRefLongBucketedSort implements Releasable {
         long oldMax = values.size();
         assert oldMax % bucketSize == 0;
 
-        long newSize = BigArrays.overSize(
-            // comment to make spotless happy about line breaks
-            ((long) bucket + 1) * bucketSize,
-            PageCacheRecycler.OBJECT_PAGE_SIZE,
-            org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_REF
-        );
+        int pageSize = PageCacheRecycler.OBJECT_PAGE_SIZE;
+        int bytesPerElement = org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_REF;
+        long newSize = BigArrays.overSize(((long) bucket + 1) * bucketSize, pageSize, bytesPerElement);
         // Round up to the next full bucket.
         newSize = (newSize + bucketSize - 1) / bucketSize;
         values = bigArrays.resize(values, newSize * bucketSize);
@@ -446,28 +436,25 @@ public class BytesRefLongBucketedSort implements Releasable {
             int leftChild = parent * 2 + 1;
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
-                if (betterThan(
-                    // comment to make spotless happy about line breaks
-                    bytesAt(worstIndex),
-                    bytesAt(leftIndex),
-                    extraValues.get(worstIndex),
-                    extraValues.get(leftIndex)
-                )) {
+                BytesRef worstValue = bytesAt(worstIndex);
+                BytesRef leftValue = bytesAt(leftIndex);
+                long worstExtra = extraValues.get(worstIndex);
+                long leftExtra = extraValues.get(leftIndex);
+                if (betterThan(worstValue, leftValue, worstExtra, leftExtra)) {
                     worst = leftChild;
                     worstIndex = leftIndex;
                 }
                 int rightChild = leftChild + 1;
                 long rightIndex = rootIndex + rightChild;
-                if (rightChild < heapSize
-                    && betterThan(
-                        // comment to make spotless happy about line breaks
-                        bytesAt(worstIndex),
-                        bytesAt(rightIndex),
-                        extraValues.get(worstIndex),
-                        extraValues.get(rightIndex)
-                    )) {
-                    worst = rightChild;
-                    worstIndex = rightIndex;
+                if (rightChild < heapSize) {
+                    worstValue = bytesAt(worstIndex);
+                    BytesRef rightValue = bytesAt(rightIndex);
+                    worstExtra = extraValues.get(worstIndex);
+                    long rightExtra = extraValues.get(rightIndex);
+                    if (betterThan(worstValue, rightValue, worstExtra, rightExtra)) {
+                        worst = rightChild;
+                        worstIndex = rightIndex;
+                    }
                 }
             }
             if (worst == parent) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/BytesRefLongBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/BytesRefLongBucketedSort.java
@@ -1,0 +1,486 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data.sort;
+
+// begin generated imports
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.BitArray;
+import org.elasticsearch.common.util.LongArray;
+import org.elasticsearch.common.util.ObjectArray;
+import org.elasticsearch.common.util.PageCacheRecycler;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
+import org.elasticsearch.common.util.ByteUtils;
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.core.Tuple;
+import org.elasticsearch.search.sort.BucketedSort;
+import org.elasticsearch.search.sort.SortOrder;
+
+import java.util.stream.IntStream;
+// end generated imports
+
+/**
+ * Aggregates the top N {@code BytesRef} values per bucket.
+ * See {@link BucketedSort} for more information.
+ * This class is generated. Edit @{code X-BucketedSort.java.st} instead of this file.
+ */
+public class BytesRefLongBucketedSort implements Releasable {
+
+    private final BigArrays bigArrays;
+    private final CircuitBreaker breaker;
+    private final SortOrder order;
+    private final int bucketSize;
+    /**
+     * {@code true} if the bucket is in heap mode, {@code false} if
+     * it is still gathering.
+     */
+    private final BitArray heapMode;
+    /**
+     * An array containing all the values on all buckets. The structure is as follows:
+     * <p>
+     *     For each bucket, there are bucketSize elements, based on the bucket id (0, 1, 2...).
+     *     Then, for each bucket, it can be in 2 states:
+     * </p>
+     * <ul>
+     *     <li>
+     *         Gather mode: All buckets start in gather mode, and remain here while they have less than bucketSize elements.
+     *         In gather mode, the elements are stored in the array from the highest index to the lowest index.
+     *         The lowest index contains the offset to the next slot to be filled.
+     *         <p>
+     *             This allows us to insert elements in O(1) time.
+     *         </p>
+     *         <p>
+     *             When the bucketSize-th element is collected, the bucket transitions to heap mode, by heapifying its contents.
+     *         </p>
+     *     </li>
+     *     <li>
+     *         Heap mode: The bucket slots are organized as a min heap structure.
+     *         <p>
+     *             The root of the heap is the minimum value in the bucket,
+     *             which allows us to quickly discard new values that are not in the top N.
+     *         </p>
+     *     </li>
+     * </ul>
+     */
+    private ObjectArray<BreakingBytesRefBuilder> values;
+    private LongArray extraValues;
+
+    public BytesRefLongBucketedSort(BigArrays bigArrays, SortOrder order, int bucketSize) {
+        this.bigArrays = bigArrays;
+        this.breaker = bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST);
+        this.order = order;
+        this.bucketSize = bucketSize;
+        heapMode = new BitArray(0, bigArrays);
+
+        boolean success = false;
+        try {
+            values = bigArrays.newObjectArray(0);
+            extraValues = bigArrays.newLongArray(0, false);
+            success = true;
+        } finally {
+            if (success == false) {
+                close();
+            }
+        }
+    }
+
+    /**
+     * Collects a {@code value} into a {@code bucket}.
+     * <p>
+     *     It may or may not be inserted in the heap, depending on if it is better than the current root.
+     * </p>
+     */
+    public void collect(BytesRef value, long extraValue, int bucket) {
+        long rootIndex = (long) bucket * bucketSize;
+        if (inHeapMode(bucket)) {
+            if (betterThan(
+                value,
+                bytesAt(rootIndex),
+                extraValue,
+                extraValues.get(rootIndex)
+            )) {
+                clearedBytesAt(rootIndex).append(value);
+                extraValues.set(rootIndex, extraValue);
+                downHeap(rootIndex, 0, bucketSize);
+            }
+            return;
+        }
+        // Gathering mode
+        long requiredSize = rootIndex + bucketSize;
+        if (values.size() < requiredSize) {
+            grow(bucket);
+        }
+        int next = getNextGatherOffset(rootIndex);
+        assert 0 <= next && next < bucketSize
+            : "Expected next to be in the range of valid buckets [0 <= " + next + " < " + bucketSize + "]";
+        long index = next + rootIndex;
+        clearedBytesAt(index).append(value);
+        extraValues.set(index, extraValue);
+        if (next == 0) {
+            heapMode.set(bucket);
+            heapify(rootIndex, bucketSize);
+        } else {
+            setNextGatherOffset(rootIndex, next - 1);
+        }
+    }
+
+    /**
+     * The order of the sort.
+     */
+    public SortOrder getOrder() {
+        return order;
+    }
+
+    /**
+     * The number of values to store per bucket.
+     */
+    public int getBucketSize() {
+        return bucketSize;
+    }
+
+    /**
+     * Get the first and last indexes (inclusive, exclusive) of the values for a bucket.
+     * Returns [0, 0] if the bucket has never been collected.
+     */
+    private Tuple<Long, Long> getBucketValuesIndexes(int bucket) {
+        long rootIndex = (long) bucket * bucketSize;
+        if (rootIndex >= values.size()) {
+            // We've never seen this bucket.
+            return Tuple.tuple(0L, 0L);
+        }
+        long start = inHeapMode(bucket) ? rootIndex : (rootIndex + getNextGatherOffset(rootIndex) + 1);
+        long end = rootIndex + bucketSize;
+        return Tuple.tuple(start, end);
+    }
+
+    /**
+     * Merge the values from {@code other}'s {@code otherGroupId} into {@code groupId}.
+     */
+    public void merge(int groupId, BytesRefLongBucketedSort other, int otherGroupId) {
+        var otherBounds = other.getBucketValuesIndexes(otherGroupId);
+
+        // TODO: This can be improved for heapified buckets by making use of the heap structures
+        for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
+            BreakingBytesRefBuilder otherValue = other.values.get(i);
+            collect(
+                otherValue == null ? new BytesRef() : otherValue.bytesRefView(),
+                other.extraValues.get(i),
+                groupId
+            );
+        }
+    }
+
+    /**
+     * Creates a block with the values from the {@code selected} groups.
+     */
+    public void toBlocks(BlockFactory blockFactory, Block[] blocks, int offset, IntVector selected) {
+        // Check if the selected groups are all empty, to avoid allocating extra memory
+        if (allSelectedGroupsAreEmpty(selected)) {
+            Block constantNullBlock = blockFactory.newConstantNullBlock(selected.getPositionCount());
+            constantNullBlock.incRef();
+            blocks[offset] = constantNullBlock;
+            blocks[offset + 1] = constantNullBlock;
+            return;
+        }
+
+        try (
+            var builder = blockFactory.newBytesRefBlockBuilder(selected.getPositionCount());
+            var extraBuilder = blockFactory.newLongBlockBuilder(selected.getPositionCount())
+        ) {
+            for (int s = 0; s < selected.getPositionCount(); s++) {
+                int bucket = selected.getInt(s);
+
+                var bounds = getBucketValuesIndexes(bucket);
+                var rootIndex = bounds.v1();
+                var size = bounds.v2() - bounds.v1();
+
+                if (size == 0) {
+                    builder.appendNull();
+                    extraBuilder.appendNull();
+                    continue;
+                }
+
+                if (size == 1) {
+                    appendValue(builder, rootIndex);
+                    extraBuilder.appendLong(extraValues.get(rootIndex));
+                    continue;
+                }
+
+                // If we are in the gathering mode, we need to heapify before sorting.
+                if (inHeapMode(bucket) == false) {
+                    heapify(rootIndex, (int) size);
+                }
+                heapSort(rootIndex, (int) size);
+
+                builder.beginPositionEntry();
+                extraBuilder.beginPositionEntry();
+                for (int i = 0; i < size; i++) {
+                    appendValue(builder, rootIndex + i);
+                    extraBuilder.appendLong(extraValues.get(rootIndex + i));
+                }
+                builder.endPositionEntry();
+                extraBuilder.endPositionEntry();
+            }
+            blocks[offset] = builder.build();
+            try {
+                blocks[offset + 1] = extraBuilder.build();
+            } finally {
+                if (blocks[offset + 1] == null) {
+                    blocks[offset].close();
+                    blocks[offset] = null;
+                }
+            }
+        }
+    }
+
+    private void appendValue(org.elasticsearch.compute.data.BytesRefBlock.Builder builder, long index) {
+        BreakingBytesRefBuilder bytes = values.get(index);
+        if (bytes == null) {
+            builder.appendNull();
+            return;
+        }
+        try {
+            builder.appendBytesRef(bytes.bytesRefView());
+        } finally {
+            values.set(index, null);
+            Releasables.closeExpectNoException(bytes);
+        }
+    }
+
+    private BreakingBytesRefBuilder clearedBytesAt(long index) {
+        BreakingBytesRefBuilder bytes = values.get(index);
+        if (bytes == null) {
+            bytes = new BreakingBytesRefBuilder(breaker, "top");
+            values.set(index, bytes);
+        } else {
+            bytes.clear();
+        }
+        return bytes;
+    }
+
+    private BytesRef bytesAt(long index) {
+        BreakingBytesRefBuilder bytes = values.get(index);
+        return bytes == null ? new BytesRef() : bytes.bytesRefView();
+    }
+
+    /**
+     * Checks if the selected groups are all empty.
+     */
+    private boolean allSelectedGroupsAreEmpty(IntVector selected) {
+        return IntStream.range(0, selected.getPositionCount()).map(selected::getInt).noneMatch(bucket -> {
+            var bounds = this.getBucketValuesIndexes(bucket);
+            var size = bounds.v2() - bounds.v1();
+            return size > 0;
+        });
+    }
+
+    /**
+     * Is this bucket a min heap {@code true} or in gathering mode {@code false}?
+     */
+    private boolean inHeapMode(int bucket) {
+        return heapMode.get(bucket);
+    }
+
+    /**
+     * Get the next index that should be "gathered" for a bucket rooted
+     * at {@code rootIndex}.
+     */
+    private int getNextGatherOffset(long rootIndex) {
+        BreakingBytesRefBuilder bytes = values.get(rootIndex);
+        assert bytes != null && bytes.length() == Integer.BYTES;
+        return ByteUtils.readIntLE(bytes.bytes(), 0);
+    }
+
+    /**
+     * Set the next index that should be "gathered" for a bucket rooted
+     * at {@code rootIndex}.
+     */
+    private void setNextGatherOffset(long rootIndex, int offset) {
+        ByteUtils.writeIntLE(offset, values.get(rootIndex).bytes(), 0);
+    }
+
+    /**
+     * {@code true} if the entry at index {@code lhs} is "better" than
+     * the entry at {@code rhs}. "Better" in this means "lower" for
+     * {@link SortOrder#ASC} and "higher" for {@link SortOrder#DESC}.
+     */
+    private boolean betterThan(BytesRef lhs, BytesRef rhs, long lhsExtra, long rhsExtra) {
+        int res = lhs.compareTo(rhs);
+        if (res != 0) {
+            return getOrder().reverseMul() * res < 0;
+        }
+        res = Long.compare(lhsExtra, rhsExtra);
+        return getOrder().reverseMul() * res < 0;
+    }
+
+    /**
+     * Swap the data at two indices.
+     */
+    private void swap(long lhs, long rhs) {
+        var tmp = values.get(lhs);
+        values.set(lhs, values.get(rhs));
+        values.set(rhs, tmp);
+        var tmpExtra = extraValues.get(lhs);
+        extraValues.set(lhs, extraValues.get(rhs));
+        extraValues.set(rhs, tmpExtra);
+    }
+
+    /**
+     * Allocate storage for more buckets and store the "next gather offset"
+     * for those new buckets. We always grow the storage by whole bucket's
+     * worth of slots at a time. We never allocate space for partial buckets.
+     */
+    private void grow(int bucket) {
+        long oldMax = values.size();
+        assert oldMax % bucketSize == 0;
+
+        long newSize = BigArrays.overSize(
+            ((long) bucket + 1) * bucketSize,
+            PageCacheRecycler.OBJECT_PAGE_SIZE,
+            org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_REF
+        );
+        // Round up to the next full bucket.
+        newSize = (newSize + bucketSize - 1) / bucketSize;
+        values = bigArrays.resize(values, newSize * bucketSize);
+        // Round up to the next full bucket.
+        extraValues = bigArrays.resize(extraValues, newSize * bucketSize);
+        // Set the next gather offsets for all newly allocated buckets.
+        fillGatherOffsets(oldMax);
+    }
+
+    /**
+     * Maintain the "next gather offsets" for newly allocated buckets.
+     */
+    private void fillGatherOffsets(long startingAt) {
+        assert startingAt % bucketSize == 0;
+        int nextOffset = getBucketSize() - 1;
+        for (long bucketRoot = startingAt; bucketRoot < values.size(); bucketRoot += getBucketSize()) {
+            BreakingBytesRefBuilder bytes = values.get(bucketRoot);
+            if (bytes != null) {
+                continue;
+            }
+            bytes = new BreakingBytesRefBuilder(breaker, "top");
+            values.set(bucketRoot, bytes);
+            bytes.grow(Integer.BYTES);
+            bytes.setLength(Integer.BYTES);
+            ByteUtils.writeIntLE(nextOffset, bytes.bytes(), 0);
+        }
+    }
+
+    /**
+     * Heapify a bucket whose entries are in random order.
+     * <p>
+     * This works by validating the heap property on each node, iterating
+     * "upwards", pushing any out of order parents "down". Check out the
+     * <a href="https://en.wikipedia.org/w/index.php?title=Binary_heap&oldid=940542991#Building_a_heap">wikipedia</a>
+     * entry on binary heaps for more about this.
+     * </p>
+     * <p>
+     * While this *looks* like it could easily be {@code O(n * log n)}, it is
+     * a fairly well studied algorithm attributed to Floyd. There's
+     * been a bunch of work that puts this at {@code O(n)}, close to 1.88n worst
+     * case.
+     * </p>
+     * <ul>
+     * <li>Hayward, Ryan; McDiarmid, Colin (1991).
+     * <a href="https://web.archive.org/web/20160205023201/http://www.stats.ox.ac.uk/__data/assets/pdf_file/0015/4173/heapbuildjalg.pdf">
+     * Average Case Analysis of Heap Building byRepeated Insertion</a> J. Algorithms.
+     * <li>D.E. Knuth, ”The Art of Computer Programming, Vol. 3, Sorting and Searching”</li>
+     * </ul>
+     * @param rootIndex the index the start of the bucket
+     */
+    private void heapify(long rootIndex, int heapSize) {
+        int maxParent = heapSize / 2 - 1;
+        for (int parent = maxParent; parent >= 0; parent--) {
+            downHeap(rootIndex, parent, heapSize);
+        }
+    }
+
+    /**
+     * Sorts all the values in the heap using heap sort algorithm.
+     * This runs in {@code O(n log n)} time.
+     * @param rootIndex index of the start of the bucket
+     * @param heapSize Number of values that belong to the heap.
+     *                 Can be less than bucketSize.
+     *                 In such a case, the remaining values in range
+     *                 (rootIndex + heapSize, rootIndex + bucketSize)
+     *                 are *not* considered part of the heap.
+     */
+    private void heapSort(long rootIndex, int heapSize) {
+        while (heapSize > 0) {
+            swap(rootIndex, rootIndex + heapSize - 1);
+            heapSize--;
+            downHeap(rootIndex, 0, heapSize);
+        }
+    }
+
+    /**
+     * Correct the heap invariant of a parent and its children. This
+     * runs in {@code O(log n)} time.
+     * @param rootIndex index of the start of the bucket
+     * @param parent Index within the bucket of the parent to check.
+     *               For example, 0 is the "root".
+     * @param heapSize Number of values that belong to the heap.
+     *                 Can be less than bucketSize.
+     *                 In such a case, the remaining values in range
+     *                 (rootIndex + heapSize, rootIndex + bucketSize)
+     *                 are *not* considered part of the heap.
+     */
+    private void downHeap(long rootIndex, int parent, int heapSize) {
+        while (true) {
+            long parentIndex = rootIndex + parent;
+            int worst = parent;
+            long worstIndex = parentIndex;
+            int leftChild = parent * 2 + 1;
+            long leftIndex = rootIndex + leftChild;
+            if (leftChild < heapSize) {
+                if (betterThan(
+                    bytesAt(worstIndex),
+                    bytesAt(leftIndex),
+                    extraValues.get(worstIndex),
+                    extraValues.get(leftIndex)
+                )) {
+                    worst = leftChild;
+                    worstIndex = leftIndex;
+                }
+                int rightChild = leftChild + 1;
+                long rightIndex = rootIndex + rightChild;
+                if (rightChild < heapSize
+                    && betterThan(
+                        bytesAt(worstIndex),
+                        bytesAt(rightIndex),
+                        extraValues.get(worstIndex),
+                        extraValues.get(rightIndex)
+                    )) {
+                    worst = rightChild;
+                    worstIndex = rightIndex;
+                }
+            }
+            if (worst == parent) {
+                break;
+            }
+            swap(worstIndex, parentIndex);
+            parent = worst;
+        }
+    }
+
+    @Override
+    public final void close() {
+        if (values != null) {
+            for (long i = 0; i < values.size(); i++) {
+                Releasables.close(values.get(i));
+            }
+        }
+        Releasables.close(values, extraValues, heapMode);
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/DoubleBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/DoubleBucketedSort.java
@@ -94,7 +94,11 @@ public class DoubleBucketedSort implements Releasable {
     public void collect(double value, int bucket) {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
-            if (betterThan(value, values.get(rootIndex))) {
+            if (betterThan(
+                // comment to make spotless happy about line breaks
+                value,
+                values.get(rootIndex)
+            )) {
                 values.set(rootIndex, value);
                 downHeap(rootIndex, 0, bucketSize);
             }
@@ -155,7 +159,11 @@ public class DoubleBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            collect(other.values.get(i), groupId);
+            collect(
+                // comment to make spotless happy about line breaks
+                other.values.get(i),
+                groupId
+            );
         }
     }
 
@@ -168,10 +176,7 @@ public class DoubleBucketedSort implements Releasable {
             return blockFactory.newConstantNullBlock(selected.getPositionCount());
         }
 
-        try (
-            // comment to make spotless happy about line breaks
-            var builder = blockFactory.newDoubleBlockBuilder(selected.getPositionCount())
-        ) {
+        try (var builder = blockFactory.newDoubleBlockBuilder(selected.getPositionCount())) {
             for (int s = 0; s < selected.getPositionCount(); s++) {
                 int bucket = selected.getInt(s);
 
@@ -357,13 +362,22 @@ public class DoubleBucketedSort implements Releasable {
             int leftChild = parent * 2 + 1;
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
-                if (betterThan(values.get(worstIndex), values.get(leftIndex))) {
+                if (betterThan(
+                    // comment to make spotless happy about line breaks
+                    values.get(worstIndex),
+                    values.get(leftIndex)
+                )) {
                     worst = leftChild;
                     worstIndex = leftIndex;
                 }
                 int rightChild = leftChild + 1;
                 long rightIndex = rootIndex + rightChild;
-                if (rightChild < heapSize && betterThan(values.get(worstIndex), values.get(rightIndex))) {
+                if (rightChild < heapSize
+                    && betterThan(
+                        // comment to make spotless happy about line breaks
+                        values.get(worstIndex),
+                        values.get(rightIndex)
+                    )) {
                     worst = rightChild;
                     worstIndex = rightIndex;
                 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/DoubleBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/DoubleBucketedSort.java
@@ -67,7 +67,6 @@ public class DoubleBucketedSort implements Releasable {
      * </ul>
      */
     private DoubleArray values;
-
     public DoubleBucketedSort(BigArrays bigArrays, SortOrder order, int bucketSize) {
         this.bigArrays = bigArrays;
         this.order = order;
@@ -264,7 +263,11 @@ public class DoubleBucketedSort implements Releasable {
         long oldMax = values.size();
         assert oldMax % bucketSize == 0;
 
-        long newSize = BigArrays.overSize(((long) bucket + 1) * bucketSize, PageCacheRecycler.DOUBLE_PAGE_SIZE, Double.BYTES);
+        long newSize = BigArrays.overSize(
+            ((long) bucket + 1) * bucketSize,
+            PageCacheRecycler.DOUBLE_PAGE_SIZE,
+            Double.BYTES
+        );
         // Round up to the next full bucket.
         newSize = (newSize + bucketSize - 1) / bucketSize;
         values = bigArrays.resize(values, newSize * bucketSize);

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/DoubleBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/DoubleBucketedSort.java
@@ -94,11 +94,8 @@ public class DoubleBucketedSort implements Releasable {
     public void collect(double value, int bucket) {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
-            if (betterThan(
-                // comment to make spotless happy about line breaks
-                value,
-                values.get(rootIndex)
-            )) {
+            double rootValue = values.get(rootIndex);
+            if (betterThan(value, rootValue)) {
                 values.set(rootIndex, value);
                 downHeap(rootIndex, 0, bucketSize);
             }
@@ -159,11 +156,8 @@ public class DoubleBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            collect(
-                // comment to make spotless happy about line breaks
-                other.values.get(i),
-                groupId
-            );
+            double otherValue = other.values.get(i);
+            collect(otherValue, groupId);
         }
     }
 
@@ -272,12 +266,9 @@ public class DoubleBucketedSort implements Releasable {
         long oldMax = values.size();
         assert oldMax % bucketSize == 0;
 
-        long newSize = BigArrays.overSize(
-            // comment to make spotless happy about line breaks
-            ((long) bucket + 1) * bucketSize,
-            PageCacheRecycler.DOUBLE_PAGE_SIZE,
-            Double.BYTES
-        );
+        int pageSize = PageCacheRecycler.DOUBLE_PAGE_SIZE;
+        int bytesPerElement = Double.BYTES;
+        long newSize = BigArrays.overSize(((long) bucket + 1) * bucketSize, pageSize, bytesPerElement);
         // Round up to the next full bucket.
         newSize = (newSize + bucketSize - 1) / bucketSize;
         values = bigArrays.resize(values, newSize * bucketSize);
@@ -362,24 +353,21 @@ public class DoubleBucketedSort implements Releasable {
             int leftChild = parent * 2 + 1;
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
-                if (betterThan(
-                    // comment to make spotless happy about line breaks
-                    values.get(worstIndex),
-                    values.get(leftIndex)
-                )) {
+                double worstValue = values.get(worstIndex);
+                double leftValue = values.get(leftIndex);
+                if (betterThan(worstValue, leftValue)) {
                     worst = leftChild;
                     worstIndex = leftIndex;
                 }
                 int rightChild = leftChild + 1;
                 long rightIndex = rootIndex + rightChild;
-                if (rightChild < heapSize
-                    && betterThan(
-                        // comment to make spotless happy about line breaks
-                        values.get(worstIndex),
-                        values.get(rightIndex)
-                    )) {
-                    worst = rightChild;
-                    worstIndex = rightIndex;
+                if (rightChild < heapSize) {
+                    worstValue = values.get(worstIndex);
+                    double rightValue = values.get(rightIndex);
+                    if (betterThan(worstValue, rightValue)) {
+                        worst = rightChild;
+                        worstIndex = rightIndex;
+                    }
                 }
             }
             if (worst == parent) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/DoubleBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/DoubleBucketedSort.java
@@ -167,7 +167,9 @@ public class DoubleBucketedSort implements Releasable {
             return blockFactory.newConstantNullBlock(selected.getPositionCount());
         }
 
-        try (var builder = blockFactory.newDoubleBlockBuilder(selected.getPositionCount())) {
+        try (
+            var builder = blockFactory.newDoubleBlockBuilder(selected.getPositionCount())
+        ) {
             for (int s = 0; s < selected.getPositionCount(); s++) {
                 int bucket = selected.getInt(s);
 

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/DoubleBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/DoubleBucketedSort.java
@@ -67,6 +67,7 @@ public class DoubleBucketedSort implements Releasable {
      * </ul>
      */
     private DoubleArray values;
+
     public DoubleBucketedSort(BigArrays bigArrays, SortOrder order, int bucketSize) {
         this.bigArrays = bigArrays;
         this.order = order;
@@ -168,6 +169,7 @@ public class DoubleBucketedSort implements Releasable {
         }
 
         try (
+            // comment to make spotless happy about line breaks
             var builder = blockFactory.newDoubleBlockBuilder(selected.getPositionCount())
         ) {
             for (int s = 0; s < selected.getPositionCount(); s++) {
@@ -266,6 +268,7 @@ public class DoubleBucketedSort implements Releasable {
         assert oldMax % bucketSize == 0;
 
         long newSize = BigArrays.overSize(
+            // comment to make spotless happy about line breaks
             ((long) bucket + 1) * bucketSize,
             PageCacheRecycler.DOUBLE_PAGE_SIZE,
             Double.BYTES

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/DoubleBytesRefBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/DoubleBytesRefBucketedSort.java
@@ -102,13 +102,9 @@ public class DoubleBytesRefBucketedSort implements Releasable {
     public void collect(double value, BytesRef extraValue, int bucket) {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
-            if (betterThan(
-                // comment to make spotless happy about line breaks
-                value,
-                values.get(rootIndex),
-                extraValue,
-                extraBytesAt(rootIndex)
-            )) {
+            double rootValue = values.get(rootIndex);
+            BytesRef rootExtra = extraBytesAt(rootIndex);
+            if (betterThan(value, rootValue, extraValue, rootExtra)) {
                 values.set(rootIndex, value);
                 clearedExtraBytesAt(rootIndex).append(extraValue);
                 downHeap(rootIndex, 0, bucketSize);
@@ -171,12 +167,9 @@ public class DoubleBytesRefBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            collect(
-                // comment to make spotless happy about line breaks
-                other.values.get(i),
-                other.extraValues.get(i) == null ? new BytesRef() : other.extraValues.get(i).bytesRefView(),
-                groupId
-            );
+            double otherValue = other.values.get(i);
+            BytesRef otherExtra = other.extraValues.get(i) == null ? new BytesRef() : other.extraValues.get(i).bytesRefView();
+            collect(otherValue, otherExtra, groupId);
         }
     }
 
@@ -342,12 +335,9 @@ public class DoubleBytesRefBucketedSort implements Releasable {
         long oldMax = values.size();
         assert oldMax % bucketSize == 0;
 
-        long newSize = BigArrays.overSize(
-            // comment to make spotless happy about line breaks
-            ((long) bucket + 1) * bucketSize,
-            PageCacheRecycler.DOUBLE_PAGE_SIZE,
-            Double.BYTES
-        );
+        int pageSize = PageCacheRecycler.DOUBLE_PAGE_SIZE;
+        int bytesPerElement = Double.BYTES;
+        long newSize = BigArrays.overSize(((long) bucket + 1) * bucketSize, pageSize, bytesPerElement);
         // Round up to the next full bucket.
         newSize = (newSize + bucketSize - 1) / bucketSize;
         values = bigArrays.resize(values, newSize * bucketSize);
@@ -434,28 +424,25 @@ public class DoubleBytesRefBucketedSort implements Releasable {
             int leftChild = parent * 2 + 1;
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
-                if (betterThan(
-                    // comment to make spotless happy about line breaks
-                    values.get(worstIndex),
-                    values.get(leftIndex),
-                    extraBytesAt(worstIndex),
-                    extraBytesAt(leftIndex)
-                )) {
+                double worstValue = values.get(worstIndex);
+                double leftValue = values.get(leftIndex);
+                BytesRef worstExtra = extraBytesAt(worstIndex);
+                BytesRef leftExtra = extraBytesAt(leftIndex);
+                if (betterThan(worstValue, leftValue, worstExtra, leftExtra)) {
                     worst = leftChild;
                     worstIndex = leftIndex;
                 }
                 int rightChild = leftChild + 1;
                 long rightIndex = rootIndex + rightChild;
-                if (rightChild < heapSize
-                    && betterThan(
-                        // comment to make spotless happy about line breaks
-                        values.get(worstIndex),
-                        values.get(rightIndex),
-                        extraBytesAt(worstIndex),
-                        extraBytesAt(rightIndex)
-                    )) {
-                    worst = rightChild;
-                    worstIndex = rightIndex;
+                if (rightChild < heapSize) {
+                    worstValue = values.get(worstIndex);
+                    double rightValue = values.get(rightIndex);
+                    worstExtra = extraBytesAt(worstIndex);
+                    BytesRef rightExtra = extraBytesAt(rightIndex);
+                    if (betterThan(worstValue, rightValue, worstExtra, rightExtra)) {
+                        worst = rightChild;
+                        worstIndex = rightIndex;
+                    }
                 }
             }
             if (worst == parent) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/DoubleBytesRefBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/DoubleBytesRefBucketedSort.java
@@ -73,6 +73,7 @@ public class DoubleBytesRefBucketedSort implements Releasable {
      */
     private DoubleArray values;
     private ObjectArray<BreakingBytesRefBuilder> extraValues;
+
     public DoubleBytesRefBucketedSort(BigArrays bigArrays, SortOrder order, int bucketSize) {
         this.bigArrays = bigArrays;
         this.breaker = bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST);
@@ -102,6 +103,7 @@ public class DoubleBytesRefBucketedSort implements Releasable {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
             if (betterThan(
+                // comment to make spotless happy about line breaks
                 value,
                 values.get(rootIndex),
                 extraValue,
@@ -188,6 +190,7 @@ public class DoubleBytesRefBucketedSort implements Releasable {
         }
 
         try (
+            // comment to make spotless happy about line breaks
             var builder = blockFactory.newDoubleBlockBuilder(selected.getPositionCount());
             var extraBuilder = blockFactory.newBytesRefBlockBuilder(selected.getPositionCount())
         ) {
@@ -337,6 +340,7 @@ public class DoubleBytesRefBucketedSort implements Releasable {
         assert oldMax % bucketSize == 0;
 
         long newSize = BigArrays.overSize(
+            // comment to make spotless happy about line breaks
             ((long) bucket + 1) * bucketSize,
             PageCacheRecycler.DOUBLE_PAGE_SIZE,
             Double.BYTES
@@ -428,6 +432,7 @@ public class DoubleBytesRefBucketedSort implements Releasable {
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
                 if (betterThan(
+                    // comment to make spotless happy about line breaks
                     values.get(worstIndex),
                     values.get(leftIndex),
                     extraBytesAt(worstIndex),
@@ -440,6 +445,7 @@ public class DoubleBytesRefBucketedSort implements Releasable {
                 long rightIndex = rootIndex + rightChild;
                 if (rightChild < heapSize
                     && betterThan(
+                        // comment to make spotless happy about line breaks
                         values.get(worstIndex),
                         values.get(rightIndex),
                         extraBytesAt(worstIndex),

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/DoubleBytesRefBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/DoubleBytesRefBucketedSort.java
@@ -1,0 +1,469 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data.sort;
+
+// begin generated imports
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.BitArray;
+import org.elasticsearch.common.util.ObjectArray;
+import org.elasticsearch.common.util.DoubleArray;
+import org.elasticsearch.common.util.PageCacheRecycler;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.core.Tuple;
+import org.elasticsearch.search.sort.BucketedSort;
+import org.elasticsearch.search.sort.SortOrder;
+
+import java.util.stream.IntStream;
+// end generated imports
+
+/**
+ * Aggregates the top N {@code double} values per bucket.
+ * See {@link BucketedSort} for more information.
+ * This class is generated. Edit @{code X-BucketedSort.java.st} instead of this file.
+ */
+public class DoubleBytesRefBucketedSort implements Releasable {
+
+    private final BigArrays bigArrays;
+    private final CircuitBreaker breaker;
+    private final SortOrder order;
+    private final int bucketSize;
+    /**
+     * {@code true} if the bucket is in heap mode, {@code false} if
+     * it is still gathering.
+     */
+    private final BitArray heapMode;
+    /**
+     * An array containing all the values on all buckets. The structure is as follows:
+     * <p>
+     *     For each bucket, there are bucketSize elements, based on the bucket id (0, 1, 2...).
+     *     Then, for each bucket, it can be in 2 states:
+     * </p>
+     * <ul>
+     *     <li>
+     *         Gather mode: All buckets start in gather mode, and remain here while they have less than bucketSize elements.
+     *         In gather mode, the elements are stored in the array from the highest index to the lowest index.
+     *         The lowest index contains the offset to the next slot to be filled.
+     *         <p>
+     *             This allows us to insert elements in O(1) time.
+     *         </p>
+     *         <p>
+     *             When the bucketSize-th element is collected, the bucket transitions to heap mode, by heapifying its contents.
+     *         </p>
+     *     </li>
+     *     <li>
+     *         Heap mode: The bucket slots are organized as a min heap structure.
+     *         <p>
+     *             The root of the heap is the minimum value in the bucket,
+     *             which allows us to quickly discard new values that are not in the top N.
+     *         </p>
+     *     </li>
+     * </ul>
+     */
+    private DoubleArray values;
+    private ObjectArray<BreakingBytesRefBuilder> extraValues;
+    public DoubleBytesRefBucketedSort(BigArrays bigArrays, SortOrder order, int bucketSize) {
+        this.bigArrays = bigArrays;
+        this.breaker = bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST);
+        this.order = order;
+        this.bucketSize = bucketSize;
+        heapMode = new BitArray(0, bigArrays);
+
+        boolean success = false;
+        try {
+            values = bigArrays.newDoubleArray(0, false);
+            extraValues = bigArrays.newObjectArray(0);
+            success = true;
+        } finally {
+            if (success == false) {
+                close();
+            }
+        }
+    }
+
+    /**
+     * Collects a {@code value} into a {@code bucket}.
+     * <p>
+     *     It may or may not be inserted in the heap, depending on if it is better than the current root.
+     * </p>
+     */
+    public void collect(double value, BytesRef extraValue, int bucket) {
+        long rootIndex = (long) bucket * bucketSize;
+        if (inHeapMode(bucket)) {
+            if (betterThan(
+                value,
+                values.get(rootIndex),
+                extraValue,
+                extraBytesAt(rootIndex)
+            )) {
+                values.set(rootIndex, value);
+                clearedExtraBytesAt(rootIndex).append(extraValue);
+                downHeap(rootIndex, 0, bucketSize);
+            }
+            return;
+        }
+        // Gathering mode
+        long requiredSize = rootIndex + bucketSize;
+        if (values.size() < requiredSize) {
+            grow(bucket);
+        }
+        int next = getNextGatherOffset(rootIndex);
+        assert 0 <= next && next < bucketSize
+            : "Expected next to be in the range of valid buckets [0 <= " + next + " < " + bucketSize + "]";
+        long index = next + rootIndex;
+        values.set(index, value);
+        clearedExtraBytesAt(index).append(extraValue);
+        if (next == 0) {
+            heapMode.set(bucket);
+            heapify(rootIndex, bucketSize);
+        } else {
+            setNextGatherOffset(rootIndex, next - 1);
+        }
+    }
+
+    /**
+     * The order of the sort.
+     */
+    public SortOrder getOrder() {
+        return order;
+    }
+
+    /**
+     * The number of values to store per bucket.
+     */
+    public int getBucketSize() {
+        return bucketSize;
+    }
+
+    /**
+     * Get the first and last indexes (inclusive, exclusive) of the values for a bucket.
+     * Returns [0, 0] if the bucket has never been collected.
+     */
+    private Tuple<Long, Long> getBucketValuesIndexes(int bucket) {
+        long rootIndex = (long) bucket * bucketSize;
+        if (rootIndex >= values.size()) {
+            // We've never seen this bucket.
+            return Tuple.tuple(0L, 0L);
+        }
+        long start = inHeapMode(bucket) ? rootIndex : (rootIndex + getNextGatherOffset(rootIndex) + 1);
+        long end = rootIndex + bucketSize;
+        return Tuple.tuple(start, end);
+    }
+
+    /**
+     * Merge the values from {@code other}'s {@code otherGroupId} into {@code groupId}.
+     */
+    public void merge(int groupId, DoubleBytesRefBucketedSort other, int otherGroupId) {
+        var otherBounds = other.getBucketValuesIndexes(otherGroupId);
+
+        // TODO: This can be improved for heapified buckets by making use of the heap structures
+        for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
+            BreakingBytesRefBuilder otherExtra = other.extraValues.get(i);
+            collect(other.values.get(i), otherExtra == null ? new BytesRef() : otherExtra.bytesRefView(), groupId);
+        }
+    }
+
+    /**
+     * Creates a block with the values from the {@code selected} groups.
+     */
+    public void toBlocks(BlockFactory blockFactory, Block[] blocks, int offset, IntVector selected) {
+        // Check if the selected groups are all empty, to avoid allocating extra memory
+        if (allSelectedGroupsAreEmpty(selected)) {
+            Block constantNullBlock = blockFactory.newConstantNullBlock(selected.getPositionCount());
+            constantNullBlock.incRef();
+            blocks[offset] = constantNullBlock;
+            blocks[offset + 1] = constantNullBlock;
+            return;
+        }
+
+        try (
+            var builder = blockFactory.newDoubleBlockBuilder(selected.getPositionCount());
+            var extraBuilder = blockFactory.newBytesRefBlockBuilder(selected.getPositionCount())
+        ) {
+            for (int s = 0; s < selected.getPositionCount(); s++) {
+                int bucket = selected.getInt(s);
+
+                var bounds = getBucketValuesIndexes(bucket);
+                var rootIndex = bounds.v1();
+                var size = bounds.v2() - bounds.v1();
+
+                if (size == 0) {
+                    builder.appendNull();
+                    extraBuilder.appendNull();
+                    continue;
+                }
+
+                if (size == 1) {
+                    builder.appendDouble(values.get(rootIndex));
+                    appendExtra(extraBuilder, rootIndex);
+                    continue;
+                }
+
+                // If we are in the gathering mode, we need to heapify before sorting.
+                if (inHeapMode(bucket) == false) {
+                    heapify(rootIndex, (int) size);
+                }
+                heapSort(rootIndex, (int) size);
+
+                builder.beginPositionEntry();
+                extraBuilder.beginPositionEntry();
+                for (int i = 0; i < size; i++) {
+                    builder.appendDouble(values.get(rootIndex + i));
+                    appendExtra(extraBuilder, rootIndex + i);
+                }
+                builder.endPositionEntry();
+                extraBuilder.endPositionEntry();
+            }
+            blocks[offset] = builder.build();
+            try {
+                blocks[offset + 1] = extraBuilder.build();
+            } finally {
+                if (blocks[offset + 1] == null) {
+                    blocks[offset].close();
+                    blocks[offset] = null;
+                }
+            }
+        }
+    }
+
+    private void appendExtra(org.elasticsearch.compute.data.BytesRefBlock.Builder extraBuilder, long index) {
+        BreakingBytesRefBuilder bytes = extraValues.get(index);
+        if (bytes == null) {
+            extraBuilder.appendNull();
+            return;
+        }
+        try {
+            extraBuilder.appendBytesRef(bytes.bytesRefView());
+        } finally {
+            extraValues.set(index, null);
+            Releasables.closeExpectNoException(bytes);
+        }
+    }
+
+    private BreakingBytesRefBuilder clearedExtraBytesAt(long index) {
+        BreakingBytesRefBuilder bytes = extraValues.get(index);
+        if (bytes == null) {
+            bytes = new BreakingBytesRefBuilder(breaker, "top");
+            extraValues.set(index, bytes);
+        } else {
+            bytes.clear();
+        }
+        return bytes;
+    }
+
+    private BytesRef extraBytesAt(long index) {
+        BreakingBytesRefBuilder bytes = extraValues.get(index);
+        return bytes == null ? new BytesRef() : bytes.bytesRefView();
+    }
+
+    /**
+     * Checks if the selected groups are all empty.
+     */
+    private boolean allSelectedGroupsAreEmpty(IntVector selected) {
+        return IntStream.range(0, selected.getPositionCount()).map(selected::getInt).noneMatch(bucket -> {
+            var bounds = this.getBucketValuesIndexes(bucket);
+            var size = bounds.v2() - bounds.v1();
+            return size > 0;
+        });
+    }
+
+    /**
+     * Is this bucket a min heap {@code true} or in gathering mode {@code false}?
+     */
+    private boolean inHeapMode(int bucket) {
+        return heapMode.get(bucket);
+    }
+
+    /**
+     * Get the next index that should be "gathered" for a bucket rooted
+     * at {@code rootIndex}.
+     */
+    private int getNextGatherOffset(long rootIndex) {
+        return (int) values.get(rootIndex);
+    }
+
+    /**
+     * Set the next index that should be "gathered" for a bucket rooted
+     * at {@code rootIndex}.
+     */
+    private void setNextGatherOffset(long rootIndex, int offset) {
+        values.set(rootIndex, offset);
+    }
+
+    /**
+     * {@code true} if the entry at index {@code lhs} is "better" than
+     * the entry at {@code rhs}. "Better" in this means "lower" for
+     * {@link SortOrder#ASC} and "higher" for {@link SortOrder#DESC}.
+     */
+    private boolean betterThan(double lhs, double rhs, BytesRef lhsExtra, BytesRef rhsExtra) {
+        int res = Double.compare(lhs, rhs);
+        if (res != 0) {
+            return getOrder().reverseMul() * res < 0;
+        }
+        res = lhsExtra.compareTo(rhsExtra);
+        return getOrder().reverseMul() * res < 0;
+    }
+
+    /**
+     * Swap the data at two indices.
+     */
+    private void swap(long lhs, long rhs) {
+        var tmp = values.get(lhs);
+        values.set(lhs, values.get(rhs));
+        values.set(rhs, tmp);
+        var tmpExtra = extraValues.get(lhs);
+        extraValues.set(lhs, extraValues.get(rhs));
+        extraValues.set(rhs, tmpExtra);
+    }
+
+    /**
+     * Allocate storage for more buckets and store the "next gather offset"
+     * for those new buckets. We always grow the storage by whole bucket's
+     * worth of slots at a time. We never allocate space for partial buckets.
+     */
+    private void grow(int bucket) {
+        long oldMax = values.size();
+        assert oldMax % bucketSize == 0;
+
+        long newSize = BigArrays.overSize(
+            ((long) bucket + 1) * bucketSize,
+            PageCacheRecycler.DOUBLE_PAGE_SIZE,
+            Double.BYTES
+        );
+        // Round up to the next full bucket.
+        newSize = (newSize + bucketSize - 1) / bucketSize;
+        values = bigArrays.resize(values, newSize * bucketSize);
+        // Round up to the next full bucket.
+        extraValues = bigArrays.resize(extraValues, newSize * bucketSize);
+        // Set the next gather offsets for all newly allocated buckets.
+        fillGatherOffsets(oldMax);
+    }
+
+    /**
+     * Maintain the "next gather offsets" for newly allocated buckets.
+     */
+    private void fillGatherOffsets(long startingAt) {
+        int nextOffset = getBucketSize() - 1;
+        for (long bucketRoot = startingAt; bucketRoot < values.size(); bucketRoot += getBucketSize()) {
+            setNextGatherOffset(bucketRoot, nextOffset);
+        }
+    }
+
+    /**
+     * Heapify a bucket whose entries are in random order.
+     * <p>
+     * This works by validating the heap property on each node, iterating
+     * "upwards", pushing any out of order parents "down". Check out the
+     * <a href="https://en.wikipedia.org/w/index.php?title=Binary_heap&oldid=940542991#Building_a_heap">wikipedia</a>
+     * entry on binary heaps for more about this.
+     * </p>
+     * <p>
+     * While this *looks* like it could easily be {@code O(n * log n)}, it is
+     * a fairly well studied algorithm attributed to Floyd. There's
+     * been a bunch of work that puts this at {@code O(n)}, close to 1.88n worst
+     * case.
+     * </p>
+     * <ul>
+     * <li>Hayward, Ryan; McDiarmid, Colin (1991).
+     * <a href="https://web.archive.org/web/20160205023201/http://www.stats.ox.ac.uk/__data/assets/pdf_file/0015/4173/heapbuildjalg.pdf">
+     * Average Case Analysis of Heap Building byRepeated Insertion</a> J. Algorithms.
+     * <li>D.E. Knuth, ”The Art of Computer Programming, Vol. 3, Sorting and Searching”</li>
+     * </ul>
+     * @param rootIndex the index the start of the bucket
+     */
+    private void heapify(long rootIndex, int heapSize) {
+        int maxParent = heapSize / 2 - 1;
+        for (int parent = maxParent; parent >= 0; parent--) {
+            downHeap(rootIndex, parent, heapSize);
+        }
+    }
+
+    /**
+     * Sorts all the values in the heap using heap sort algorithm.
+     * This runs in {@code O(n log n)} time.
+     * @param rootIndex index of the start of the bucket
+     * @param heapSize Number of values that belong to the heap.
+     *                 Can be less than bucketSize.
+     *                 In such a case, the remaining values in range
+     *                 (rootIndex + heapSize, rootIndex + bucketSize)
+     *                 are *not* considered part of the heap.
+     */
+    private void heapSort(long rootIndex, int heapSize) {
+        while (heapSize > 0) {
+            swap(rootIndex, rootIndex + heapSize - 1);
+            heapSize--;
+            downHeap(rootIndex, 0, heapSize);
+        }
+    }
+
+    /**
+     * Correct the heap invariant of a parent and its children. This
+     * runs in {@code O(log n)} time.
+     * @param rootIndex index of the start of the bucket
+     * @param parent Index within the bucket of the parent to check.
+     *               For example, 0 is the "root".
+     * @param heapSize Number of values that belong to the heap.
+     *                 Can be less than bucketSize.
+     *                 In such a case, the remaining values in range
+     *                 (rootIndex + heapSize, rootIndex + bucketSize)
+     *                 are *not* considered part of the heap.
+     */
+    private void downHeap(long rootIndex, int parent, int heapSize) {
+        while (true) {
+            long parentIndex = rootIndex + parent;
+            int worst = parent;
+            long worstIndex = parentIndex;
+            int leftChild = parent * 2 + 1;
+            long leftIndex = rootIndex + leftChild;
+            if (leftChild < heapSize) {
+                if (betterThan(
+                    values.get(worstIndex),
+                    values.get(leftIndex),
+                    extraBytesAt(worstIndex),
+                    extraBytesAt(leftIndex)
+                )) {
+                    worst = leftChild;
+                    worstIndex = leftIndex;
+                }
+                int rightChild = leftChild + 1;
+                long rightIndex = rootIndex + rightChild;
+                if (rightChild < heapSize
+                    && betterThan(
+                        values.get(worstIndex),
+                        values.get(rightIndex),
+                        extraBytesAt(worstIndex),
+                        extraBytesAt(rightIndex)
+                    )) {
+                    worst = rightChild;
+                    worstIndex = rightIndex;
+                }
+            }
+            if (worst == parent) {
+                break;
+            }
+            swap(worstIndex, parentIndex);
+            parent = worst;
+        }
+    }
+
+    @Override
+    public final void close() {
+        if (extraValues != null) {
+            for (long i = 0; i < extraValues.size(); i++) {
+                Releasables.close(extraValues.get(i));
+            }
+        }
+        Releasables.close(values, extraValues, heapMode);
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/DoubleBytesRefBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/DoubleBytesRefBucketedSort.java
@@ -171,8 +171,12 @@ public class DoubleBytesRefBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            BreakingBytesRefBuilder otherExtra = other.extraValues.get(i);
-            collect(other.values.get(i), otherExtra == null ? new BytesRef() : otherExtra.bytesRefView(), groupId);
+            collect(
+                // comment to make spotless happy about line breaks
+                other.values.get(i),
+                other.extraValues.get(i) == null ? new BytesRef() : other.extraValues.get(i).bytesRefView(),
+                groupId
+            );
         }
     }
 
@@ -190,7 +194,6 @@ public class DoubleBytesRefBucketedSort implements Releasable {
         }
 
         try (
-            // comment to make spotless happy about line breaks
             var builder = blockFactory.newDoubleBlockBuilder(selected.getPositionCount());
             var extraBuilder = blockFactory.newBytesRefBlockBuilder(selected.getPositionCount())
         ) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/DoubleDoubleBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/DoubleDoubleBucketedSort.java
@@ -166,7 +166,12 @@ public class DoubleDoubleBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            collect(other.values.get(i), other.extraValues.get(i), groupId);
+            collect(
+                // comment to make spotless happy about line breaks
+                other.values.get(i),
+                other.extraValues.get(i),
+                groupId
+            );
         }
     }
 
@@ -184,7 +189,6 @@ public class DoubleDoubleBucketedSort implements Releasable {
         }
 
         try (
-            // comment to make spotless happy about line breaks
             var builder = blockFactory.newDoubleBlockBuilder(selected.getPositionCount());
             var extraBuilder = blockFactory.newDoubleBlockBuilder(selected.getPositionCount())
         ) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/DoubleDoubleBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/DoubleDoubleBucketedSort.java
@@ -97,13 +97,9 @@ public class DoubleDoubleBucketedSort implements Releasable {
     public void collect(double value, double extraValue, int bucket) {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
-            if (betterThan(
-                // comment to make spotless happy about line breaks
-                value,
-                values.get(rootIndex),
-                extraValue,
-                extraValues.get(rootIndex)
-            )) {
+            double rootValue = values.get(rootIndex);
+            double rootExtra = extraValues.get(rootIndex);
+            if (betterThan(value, rootValue, extraValue, rootExtra)) {
                 values.set(rootIndex, value);
                 extraValues.set(rootIndex, extraValue);
                 downHeap(rootIndex, 0, bucketSize);
@@ -166,12 +162,9 @@ public class DoubleDoubleBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            collect(
-                // comment to make spotless happy about line breaks
-                other.values.get(i),
-                other.extraValues.get(i),
-                groupId
-            );
+            double otherValue = other.values.get(i);
+            double otherExtra = other.extraValues.get(i);
+            collect(otherValue, otherExtra, groupId);
         }
     }
 
@@ -307,12 +300,9 @@ public class DoubleDoubleBucketedSort implements Releasable {
         long oldMax = values.size();
         assert oldMax % bucketSize == 0;
 
-        long newSize = BigArrays.overSize(
-            // comment to make spotless happy about line breaks
-            ((long) bucket + 1) * bucketSize,
-            PageCacheRecycler.DOUBLE_PAGE_SIZE,
-            Double.BYTES
-        );
+        int pageSize = PageCacheRecycler.DOUBLE_PAGE_SIZE;
+        int bytesPerElement = Double.BYTES;
+        long newSize = BigArrays.overSize(((long) bucket + 1) * bucketSize, pageSize, bytesPerElement);
         // Round up to the next full bucket.
         newSize = (newSize + bucketSize - 1) / bucketSize;
         values = bigArrays.resize(values, newSize * bucketSize);
@@ -399,28 +389,25 @@ public class DoubleDoubleBucketedSort implements Releasable {
             int leftChild = parent * 2 + 1;
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
-                if (betterThan(
-                    // comment to make spotless happy about line breaks
-                    values.get(worstIndex),
-                    values.get(leftIndex),
-                    extraValues.get(worstIndex),
-                    extraValues.get(leftIndex)
-                )) {
+                double worstValue = values.get(worstIndex);
+                double leftValue = values.get(leftIndex);
+                double worstExtra = extraValues.get(worstIndex);
+                double leftExtra = extraValues.get(leftIndex);
+                if (betterThan(worstValue, leftValue, worstExtra, leftExtra)) {
                     worst = leftChild;
                     worstIndex = leftIndex;
                 }
                 int rightChild = leftChild + 1;
                 long rightIndex = rootIndex + rightChild;
-                if (rightChild < heapSize
-                    && betterThan(
-                        // comment to make spotless happy about line breaks
-                        values.get(worstIndex),
-                        values.get(rightIndex),
-                        extraValues.get(worstIndex),
-                        extraValues.get(rightIndex)
-                    )) {
-                    worst = rightChild;
-                    worstIndex = rightIndex;
+                if (rightChild < heapSize) {
+                    worstValue = values.get(worstIndex);
+                    double rightValue = values.get(rightIndex);
+                    worstExtra = extraValues.get(worstIndex);
+                    double rightExtra = extraValues.get(rightIndex);
+                    if (betterThan(worstValue, rightValue, worstExtra, rightExtra)) {
+                        worst = rightChild;
+                        worstIndex = rightIndex;
+                    }
                 }
             }
             if (worst == parent) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/DoubleDoubleBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/DoubleDoubleBucketedSort.java
@@ -98,6 +98,7 @@ public class DoubleDoubleBucketedSort implements Releasable {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
             if (betterThan(
+                // comment to make spotless happy about line breaks
                 value,
                 values.get(rootIndex),
                 extraValue,
@@ -183,6 +184,7 @@ public class DoubleDoubleBucketedSort implements Releasable {
         }
 
         try (
+            // comment to make spotless happy about line breaks
             var builder = blockFactory.newDoubleBlockBuilder(selected.getPositionCount());
             var extraBuilder = blockFactory.newDoubleBlockBuilder(selected.getPositionCount())
         ) {
@@ -302,6 +304,7 @@ public class DoubleDoubleBucketedSort implements Releasable {
         assert oldMax % bucketSize == 0;
 
         long newSize = BigArrays.overSize(
+            // comment to make spotless happy about line breaks
             ((long) bucket + 1) * bucketSize,
             PageCacheRecycler.DOUBLE_PAGE_SIZE,
             Double.BYTES
@@ -393,6 +396,7 @@ public class DoubleDoubleBucketedSort implements Releasable {
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
                 if (betterThan(
+                    // comment to make spotless happy about line breaks
                     values.get(worstIndex),
                     values.get(leftIndex),
                     extraValues.get(worstIndex),
@@ -405,6 +409,7 @@ public class DoubleDoubleBucketedSort implements Releasable {
                 long rightIndex = rootIndex + rightChild;
                 if (rightChild < heapSize
                     && betterThan(
+                        // comment to make spotless happy about line breaks
                         values.get(worstIndex),
                         values.get(rightIndex),
                         extraValues.get(worstIndex),

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/DoubleDoubleBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/DoubleDoubleBucketedSort.java
@@ -97,7 +97,12 @@ public class DoubleDoubleBucketedSort implements Releasable {
     public void collect(double value, double extraValue, int bucket) {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
-            if (betterThan(value, values.get(rootIndex), extraValue, extraValues.get(rootIndex))) {
+            if (betterThan(
+                value,
+                values.get(rootIndex),
+                extraValue,
+                extraValues.get(rootIndex)
+            )) {
                 values.set(rootIndex, value);
                 extraValues.set(rootIndex, extraValue);
                 downHeap(rootIndex, 0, bucketSize);
@@ -296,7 +301,11 @@ public class DoubleDoubleBucketedSort implements Releasable {
         long oldMax = values.size();
         assert oldMax % bucketSize == 0;
 
-        long newSize = BigArrays.overSize(((long) bucket + 1) * bucketSize, PageCacheRecycler.DOUBLE_PAGE_SIZE, Double.BYTES);
+        long newSize = BigArrays.overSize(
+            ((long) bucket + 1) * bucketSize,
+            PageCacheRecycler.DOUBLE_PAGE_SIZE,
+            Double.BYTES
+        );
         // Round up to the next full bucket.
         newSize = (newSize + bucketSize - 1) / bucketSize;
         values = bigArrays.resize(values, newSize * bucketSize);
@@ -383,7 +392,12 @@ public class DoubleDoubleBucketedSort implements Releasable {
             int leftChild = parent * 2 + 1;
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
-                if (betterThan(values.get(worstIndex), values.get(leftIndex), extraValues.get(worstIndex), extraValues.get(leftIndex))) {
+                if (betterThan(
+                    values.get(worstIndex),
+                    values.get(leftIndex),
+                    extraValues.get(worstIndex),
+                    extraValues.get(leftIndex)
+                )) {
                     worst = leftChild;
                     worstIndex = leftIndex;
                 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/DoubleFloatBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/DoubleFloatBucketedSort.java
@@ -97,13 +97,9 @@ public class DoubleFloatBucketedSort implements Releasable {
     public void collect(double value, float extraValue, int bucket) {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
-            if (betterThan(
-                // comment to make spotless happy about line breaks
-                value,
-                values.get(rootIndex),
-                extraValue,
-                extraValues.get(rootIndex)
-            )) {
+            double rootValue = values.get(rootIndex);
+            float rootExtra = extraValues.get(rootIndex);
+            if (betterThan(value, rootValue, extraValue, rootExtra)) {
                 values.set(rootIndex, value);
                 extraValues.set(rootIndex, extraValue);
                 downHeap(rootIndex, 0, bucketSize);
@@ -166,12 +162,9 @@ public class DoubleFloatBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            collect(
-                // comment to make spotless happy about line breaks
-                other.values.get(i),
-                other.extraValues.get(i),
-                groupId
-            );
+            double otherValue = other.values.get(i);
+            float otherExtra = other.extraValues.get(i);
+            collect(otherValue, otherExtra, groupId);
         }
     }
 
@@ -307,12 +300,9 @@ public class DoubleFloatBucketedSort implements Releasable {
         long oldMax = values.size();
         assert oldMax % bucketSize == 0;
 
-        long newSize = BigArrays.overSize(
-            // comment to make spotless happy about line breaks
-            ((long) bucket + 1) * bucketSize,
-            PageCacheRecycler.DOUBLE_PAGE_SIZE,
-            Double.BYTES
-        );
+        int pageSize = PageCacheRecycler.DOUBLE_PAGE_SIZE;
+        int bytesPerElement = Double.BYTES;
+        long newSize = BigArrays.overSize(((long) bucket + 1) * bucketSize, pageSize, bytesPerElement);
         // Round up to the next full bucket.
         newSize = (newSize + bucketSize - 1) / bucketSize;
         values = bigArrays.resize(values, newSize * bucketSize);
@@ -399,28 +389,25 @@ public class DoubleFloatBucketedSort implements Releasable {
             int leftChild = parent * 2 + 1;
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
-                if (betterThan(
-                    // comment to make spotless happy about line breaks
-                    values.get(worstIndex),
-                    values.get(leftIndex),
-                    extraValues.get(worstIndex),
-                    extraValues.get(leftIndex)
-                )) {
+                double worstValue = values.get(worstIndex);
+                double leftValue = values.get(leftIndex);
+                float worstExtra = extraValues.get(worstIndex);
+                float leftExtra = extraValues.get(leftIndex);
+                if (betterThan(worstValue, leftValue, worstExtra, leftExtra)) {
                     worst = leftChild;
                     worstIndex = leftIndex;
                 }
                 int rightChild = leftChild + 1;
                 long rightIndex = rootIndex + rightChild;
-                if (rightChild < heapSize
-                    && betterThan(
-                        // comment to make spotless happy about line breaks
-                        values.get(worstIndex),
-                        values.get(rightIndex),
-                        extraValues.get(worstIndex),
-                        extraValues.get(rightIndex)
-                    )) {
-                    worst = rightChild;
-                    worstIndex = rightIndex;
+                if (rightChild < heapSize) {
+                    worstValue = values.get(worstIndex);
+                    double rightValue = values.get(rightIndex);
+                    worstExtra = extraValues.get(worstIndex);
+                    float rightExtra = extraValues.get(rightIndex);
+                    if (betterThan(worstValue, rightValue, worstExtra, rightExtra)) {
+                        worst = rightChild;
+                        worstIndex = rightIndex;
+                    }
                 }
             }
             if (worst == parent) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/DoubleFloatBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/DoubleFloatBucketedSort.java
@@ -97,7 +97,12 @@ public class DoubleFloatBucketedSort implements Releasable {
     public void collect(double value, float extraValue, int bucket) {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
-            if (betterThan(value, values.get(rootIndex), extraValue, extraValues.get(rootIndex))) {
+            if (betterThan(
+                value,
+                values.get(rootIndex),
+                extraValue,
+                extraValues.get(rootIndex)
+            )) {
                 values.set(rootIndex, value);
                 extraValues.set(rootIndex, extraValue);
                 downHeap(rootIndex, 0, bucketSize);
@@ -296,7 +301,11 @@ public class DoubleFloatBucketedSort implements Releasable {
         long oldMax = values.size();
         assert oldMax % bucketSize == 0;
 
-        long newSize = BigArrays.overSize(((long) bucket + 1) * bucketSize, PageCacheRecycler.DOUBLE_PAGE_SIZE, Double.BYTES);
+        long newSize = BigArrays.overSize(
+            ((long) bucket + 1) * bucketSize,
+            PageCacheRecycler.DOUBLE_PAGE_SIZE,
+            Double.BYTES
+        );
         // Round up to the next full bucket.
         newSize = (newSize + bucketSize - 1) / bucketSize;
         values = bigArrays.resize(values, newSize * bucketSize);
@@ -383,7 +392,12 @@ public class DoubleFloatBucketedSort implements Releasable {
             int leftChild = parent * 2 + 1;
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
-                if (betterThan(values.get(worstIndex), values.get(leftIndex), extraValues.get(worstIndex), extraValues.get(leftIndex))) {
+                if (betterThan(
+                    values.get(worstIndex),
+                    values.get(leftIndex),
+                    extraValues.get(worstIndex),
+                    extraValues.get(leftIndex)
+                )) {
                     worst = leftChild;
                     worstIndex = leftIndex;
                 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/DoubleFloatBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/DoubleFloatBucketedSort.java
@@ -166,7 +166,12 @@ public class DoubleFloatBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            collect(other.values.get(i), other.extraValues.get(i), groupId);
+            collect(
+                // comment to make spotless happy about line breaks
+                other.values.get(i),
+                other.extraValues.get(i),
+                groupId
+            );
         }
     }
 
@@ -184,7 +189,6 @@ public class DoubleFloatBucketedSort implements Releasable {
         }
 
         try (
-            // comment to make spotless happy about line breaks
             var builder = blockFactory.newDoubleBlockBuilder(selected.getPositionCount());
             var extraBuilder = blockFactory.newFloatBlockBuilder(selected.getPositionCount())
         ) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/DoubleFloatBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/DoubleFloatBucketedSort.java
@@ -98,6 +98,7 @@ public class DoubleFloatBucketedSort implements Releasable {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
             if (betterThan(
+                // comment to make spotless happy about line breaks
                 value,
                 values.get(rootIndex),
                 extraValue,
@@ -183,6 +184,7 @@ public class DoubleFloatBucketedSort implements Releasable {
         }
 
         try (
+            // comment to make spotless happy about line breaks
             var builder = blockFactory.newDoubleBlockBuilder(selected.getPositionCount());
             var extraBuilder = blockFactory.newFloatBlockBuilder(selected.getPositionCount())
         ) {
@@ -302,6 +304,7 @@ public class DoubleFloatBucketedSort implements Releasable {
         assert oldMax % bucketSize == 0;
 
         long newSize = BigArrays.overSize(
+            // comment to make spotless happy about line breaks
             ((long) bucket + 1) * bucketSize,
             PageCacheRecycler.DOUBLE_PAGE_SIZE,
             Double.BYTES
@@ -393,6 +396,7 @@ public class DoubleFloatBucketedSort implements Releasable {
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
                 if (betterThan(
+                    // comment to make spotless happy about line breaks
                     values.get(worstIndex),
                     values.get(leftIndex),
                     extraValues.get(worstIndex),
@@ -405,6 +409,7 @@ public class DoubleFloatBucketedSort implements Releasable {
                 long rightIndex = rootIndex + rightChild;
                 if (rightChild < heapSize
                     && betterThan(
+                        // comment to make spotless happy about line breaks
                         values.get(worstIndex),
                         values.get(rightIndex),
                         extraValues.get(worstIndex),

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/DoubleIntBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/DoubleIntBucketedSort.java
@@ -98,6 +98,7 @@ public class DoubleIntBucketedSort implements Releasable {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
             if (betterThan(
+                // comment to make spotless happy about line breaks
                 value,
                 values.get(rootIndex),
                 extraValue,
@@ -183,6 +184,7 @@ public class DoubleIntBucketedSort implements Releasable {
         }
 
         try (
+            // comment to make spotless happy about line breaks
             var builder = blockFactory.newDoubleBlockBuilder(selected.getPositionCount());
             var extraBuilder = blockFactory.newIntBlockBuilder(selected.getPositionCount())
         ) {
@@ -302,6 +304,7 @@ public class DoubleIntBucketedSort implements Releasable {
         assert oldMax % bucketSize == 0;
 
         long newSize = BigArrays.overSize(
+            // comment to make spotless happy about line breaks
             ((long) bucket + 1) * bucketSize,
             PageCacheRecycler.DOUBLE_PAGE_SIZE,
             Double.BYTES
@@ -393,6 +396,7 @@ public class DoubleIntBucketedSort implements Releasable {
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
                 if (betterThan(
+                    // comment to make spotless happy about line breaks
                     values.get(worstIndex),
                     values.get(leftIndex),
                     extraValues.get(worstIndex),
@@ -405,6 +409,7 @@ public class DoubleIntBucketedSort implements Releasable {
                 long rightIndex = rootIndex + rightChild;
                 if (rightChild < heapSize
                     && betterThan(
+                        // comment to make spotless happy about line breaks
                         values.get(worstIndex),
                         values.get(rightIndex),
                         extraValues.get(worstIndex),

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/DoubleIntBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/DoubleIntBucketedSort.java
@@ -97,7 +97,12 @@ public class DoubleIntBucketedSort implements Releasable {
     public void collect(double value, int extraValue, int bucket) {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
-            if (betterThan(value, values.get(rootIndex), extraValue, extraValues.get(rootIndex))) {
+            if (betterThan(
+                value,
+                values.get(rootIndex),
+                extraValue,
+                extraValues.get(rootIndex)
+            )) {
                 values.set(rootIndex, value);
                 extraValues.set(rootIndex, extraValue);
                 downHeap(rootIndex, 0, bucketSize);
@@ -296,7 +301,11 @@ public class DoubleIntBucketedSort implements Releasable {
         long oldMax = values.size();
         assert oldMax % bucketSize == 0;
 
-        long newSize = BigArrays.overSize(((long) bucket + 1) * bucketSize, PageCacheRecycler.DOUBLE_PAGE_SIZE, Double.BYTES);
+        long newSize = BigArrays.overSize(
+            ((long) bucket + 1) * bucketSize,
+            PageCacheRecycler.DOUBLE_PAGE_SIZE,
+            Double.BYTES
+        );
         // Round up to the next full bucket.
         newSize = (newSize + bucketSize - 1) / bucketSize;
         values = bigArrays.resize(values, newSize * bucketSize);
@@ -383,7 +392,12 @@ public class DoubleIntBucketedSort implements Releasable {
             int leftChild = parent * 2 + 1;
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
-                if (betterThan(values.get(worstIndex), values.get(leftIndex), extraValues.get(worstIndex), extraValues.get(leftIndex))) {
+                if (betterThan(
+                    values.get(worstIndex),
+                    values.get(leftIndex),
+                    extraValues.get(worstIndex),
+                    extraValues.get(leftIndex)
+                )) {
                     worst = leftChild;
                     worstIndex = leftIndex;
                 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/DoubleIntBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/DoubleIntBucketedSort.java
@@ -166,7 +166,12 @@ public class DoubleIntBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            collect(other.values.get(i), other.extraValues.get(i), groupId);
+            collect(
+                // comment to make spotless happy about line breaks
+                other.values.get(i),
+                other.extraValues.get(i),
+                groupId
+            );
         }
     }
 
@@ -184,7 +189,6 @@ public class DoubleIntBucketedSort implements Releasable {
         }
 
         try (
-            // comment to make spotless happy about line breaks
             var builder = blockFactory.newDoubleBlockBuilder(selected.getPositionCount());
             var extraBuilder = blockFactory.newIntBlockBuilder(selected.getPositionCount())
         ) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/DoubleIntBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/DoubleIntBucketedSort.java
@@ -97,13 +97,9 @@ public class DoubleIntBucketedSort implements Releasable {
     public void collect(double value, int extraValue, int bucket) {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
-            if (betterThan(
-                // comment to make spotless happy about line breaks
-                value,
-                values.get(rootIndex),
-                extraValue,
-                extraValues.get(rootIndex)
-            )) {
+            double rootValue = values.get(rootIndex);
+            int rootExtra = extraValues.get(rootIndex);
+            if (betterThan(value, rootValue, extraValue, rootExtra)) {
                 values.set(rootIndex, value);
                 extraValues.set(rootIndex, extraValue);
                 downHeap(rootIndex, 0, bucketSize);
@@ -166,12 +162,9 @@ public class DoubleIntBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            collect(
-                // comment to make spotless happy about line breaks
-                other.values.get(i),
-                other.extraValues.get(i),
-                groupId
-            );
+            double otherValue = other.values.get(i);
+            int otherExtra = other.extraValues.get(i);
+            collect(otherValue, otherExtra, groupId);
         }
     }
 
@@ -307,12 +300,9 @@ public class DoubleIntBucketedSort implements Releasable {
         long oldMax = values.size();
         assert oldMax % bucketSize == 0;
 
-        long newSize = BigArrays.overSize(
-            // comment to make spotless happy about line breaks
-            ((long) bucket + 1) * bucketSize,
-            PageCacheRecycler.DOUBLE_PAGE_SIZE,
-            Double.BYTES
-        );
+        int pageSize = PageCacheRecycler.DOUBLE_PAGE_SIZE;
+        int bytesPerElement = Double.BYTES;
+        long newSize = BigArrays.overSize(((long) bucket + 1) * bucketSize, pageSize, bytesPerElement);
         // Round up to the next full bucket.
         newSize = (newSize + bucketSize - 1) / bucketSize;
         values = bigArrays.resize(values, newSize * bucketSize);
@@ -399,28 +389,25 @@ public class DoubleIntBucketedSort implements Releasable {
             int leftChild = parent * 2 + 1;
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
-                if (betterThan(
-                    // comment to make spotless happy about line breaks
-                    values.get(worstIndex),
-                    values.get(leftIndex),
-                    extraValues.get(worstIndex),
-                    extraValues.get(leftIndex)
-                )) {
+                double worstValue = values.get(worstIndex);
+                double leftValue = values.get(leftIndex);
+                int worstExtra = extraValues.get(worstIndex);
+                int leftExtra = extraValues.get(leftIndex);
+                if (betterThan(worstValue, leftValue, worstExtra, leftExtra)) {
                     worst = leftChild;
                     worstIndex = leftIndex;
                 }
                 int rightChild = leftChild + 1;
                 long rightIndex = rootIndex + rightChild;
-                if (rightChild < heapSize
-                    && betterThan(
-                        // comment to make spotless happy about line breaks
-                        values.get(worstIndex),
-                        values.get(rightIndex),
-                        extraValues.get(worstIndex),
-                        extraValues.get(rightIndex)
-                    )) {
-                    worst = rightChild;
-                    worstIndex = rightIndex;
+                if (rightChild < heapSize) {
+                    worstValue = values.get(worstIndex);
+                    double rightValue = values.get(rightIndex);
+                    worstExtra = extraValues.get(worstIndex);
+                    int rightExtra = extraValues.get(rightIndex);
+                    if (betterThan(worstValue, rightValue, worstExtra, rightExtra)) {
+                        worst = rightChild;
+                        worstIndex = rightIndex;
+                    }
                 }
             }
             if (worst == parent) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/DoubleLongBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/DoubleLongBucketedSort.java
@@ -166,7 +166,12 @@ public class DoubleLongBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            collect(other.values.get(i), other.extraValues.get(i), groupId);
+            collect(
+                // comment to make spotless happy about line breaks
+                other.values.get(i),
+                other.extraValues.get(i),
+                groupId
+            );
         }
     }
 
@@ -184,7 +189,6 @@ public class DoubleLongBucketedSort implements Releasable {
         }
 
         try (
-            // comment to make spotless happy about line breaks
             var builder = blockFactory.newDoubleBlockBuilder(selected.getPositionCount());
             var extraBuilder = blockFactory.newLongBlockBuilder(selected.getPositionCount())
         ) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/DoubleLongBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/DoubleLongBucketedSort.java
@@ -97,7 +97,12 @@ public class DoubleLongBucketedSort implements Releasable {
     public void collect(double value, long extraValue, int bucket) {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
-            if (betterThan(value, values.get(rootIndex), extraValue, extraValues.get(rootIndex))) {
+            if (betterThan(
+                value,
+                values.get(rootIndex),
+                extraValue,
+                extraValues.get(rootIndex)
+            )) {
                 values.set(rootIndex, value);
                 extraValues.set(rootIndex, extraValue);
                 downHeap(rootIndex, 0, bucketSize);
@@ -296,7 +301,11 @@ public class DoubleLongBucketedSort implements Releasable {
         long oldMax = values.size();
         assert oldMax % bucketSize == 0;
 
-        long newSize = BigArrays.overSize(((long) bucket + 1) * bucketSize, PageCacheRecycler.DOUBLE_PAGE_SIZE, Double.BYTES);
+        long newSize = BigArrays.overSize(
+            ((long) bucket + 1) * bucketSize,
+            PageCacheRecycler.DOUBLE_PAGE_SIZE,
+            Double.BYTES
+        );
         // Round up to the next full bucket.
         newSize = (newSize + bucketSize - 1) / bucketSize;
         values = bigArrays.resize(values, newSize * bucketSize);
@@ -383,7 +392,12 @@ public class DoubleLongBucketedSort implements Releasable {
             int leftChild = parent * 2 + 1;
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
-                if (betterThan(values.get(worstIndex), values.get(leftIndex), extraValues.get(worstIndex), extraValues.get(leftIndex))) {
+                if (betterThan(
+                    values.get(worstIndex),
+                    values.get(leftIndex),
+                    extraValues.get(worstIndex),
+                    extraValues.get(leftIndex)
+                )) {
                     worst = leftChild;
                     worstIndex = leftIndex;
                 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/DoubleLongBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/DoubleLongBucketedSort.java
@@ -97,13 +97,9 @@ public class DoubleLongBucketedSort implements Releasable {
     public void collect(double value, long extraValue, int bucket) {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
-            if (betterThan(
-                // comment to make spotless happy about line breaks
-                value,
-                values.get(rootIndex),
-                extraValue,
-                extraValues.get(rootIndex)
-            )) {
+            double rootValue = values.get(rootIndex);
+            long rootExtra = extraValues.get(rootIndex);
+            if (betterThan(value, rootValue, extraValue, rootExtra)) {
                 values.set(rootIndex, value);
                 extraValues.set(rootIndex, extraValue);
                 downHeap(rootIndex, 0, bucketSize);
@@ -166,12 +162,9 @@ public class DoubleLongBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            collect(
-                // comment to make spotless happy about line breaks
-                other.values.get(i),
-                other.extraValues.get(i),
-                groupId
-            );
+            double otherValue = other.values.get(i);
+            long otherExtra = other.extraValues.get(i);
+            collect(otherValue, otherExtra, groupId);
         }
     }
 
@@ -307,12 +300,9 @@ public class DoubleLongBucketedSort implements Releasable {
         long oldMax = values.size();
         assert oldMax % bucketSize == 0;
 
-        long newSize = BigArrays.overSize(
-            // comment to make spotless happy about line breaks
-            ((long) bucket + 1) * bucketSize,
-            PageCacheRecycler.DOUBLE_PAGE_SIZE,
-            Double.BYTES
-        );
+        int pageSize = PageCacheRecycler.DOUBLE_PAGE_SIZE;
+        int bytesPerElement = Double.BYTES;
+        long newSize = BigArrays.overSize(((long) bucket + 1) * bucketSize, pageSize, bytesPerElement);
         // Round up to the next full bucket.
         newSize = (newSize + bucketSize - 1) / bucketSize;
         values = bigArrays.resize(values, newSize * bucketSize);
@@ -399,28 +389,25 @@ public class DoubleLongBucketedSort implements Releasable {
             int leftChild = parent * 2 + 1;
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
-                if (betterThan(
-                    // comment to make spotless happy about line breaks
-                    values.get(worstIndex),
-                    values.get(leftIndex),
-                    extraValues.get(worstIndex),
-                    extraValues.get(leftIndex)
-                )) {
+                double worstValue = values.get(worstIndex);
+                double leftValue = values.get(leftIndex);
+                long worstExtra = extraValues.get(worstIndex);
+                long leftExtra = extraValues.get(leftIndex);
+                if (betterThan(worstValue, leftValue, worstExtra, leftExtra)) {
                     worst = leftChild;
                     worstIndex = leftIndex;
                 }
                 int rightChild = leftChild + 1;
                 long rightIndex = rootIndex + rightChild;
-                if (rightChild < heapSize
-                    && betterThan(
-                        // comment to make spotless happy about line breaks
-                        values.get(worstIndex),
-                        values.get(rightIndex),
-                        extraValues.get(worstIndex),
-                        extraValues.get(rightIndex)
-                    )) {
-                    worst = rightChild;
-                    worstIndex = rightIndex;
+                if (rightChild < heapSize) {
+                    worstValue = values.get(worstIndex);
+                    double rightValue = values.get(rightIndex);
+                    worstExtra = extraValues.get(worstIndex);
+                    long rightExtra = extraValues.get(rightIndex);
+                    if (betterThan(worstValue, rightValue, worstExtra, rightExtra)) {
+                        worst = rightChild;
+                        worstIndex = rightIndex;
+                    }
                 }
             }
             if (worst == parent) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/DoubleLongBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/DoubleLongBucketedSort.java
@@ -98,6 +98,7 @@ public class DoubleLongBucketedSort implements Releasable {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
             if (betterThan(
+                // comment to make spotless happy about line breaks
                 value,
                 values.get(rootIndex),
                 extraValue,
@@ -183,6 +184,7 @@ public class DoubleLongBucketedSort implements Releasable {
         }
 
         try (
+            // comment to make spotless happy about line breaks
             var builder = blockFactory.newDoubleBlockBuilder(selected.getPositionCount());
             var extraBuilder = blockFactory.newLongBlockBuilder(selected.getPositionCount())
         ) {
@@ -302,6 +304,7 @@ public class DoubleLongBucketedSort implements Releasable {
         assert oldMax % bucketSize == 0;
 
         long newSize = BigArrays.overSize(
+            // comment to make spotless happy about line breaks
             ((long) bucket + 1) * bucketSize,
             PageCacheRecycler.DOUBLE_PAGE_SIZE,
             Double.BYTES
@@ -393,6 +396,7 @@ public class DoubleLongBucketedSort implements Releasable {
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
                 if (betterThan(
+                    // comment to make spotless happy about line breaks
                     values.get(worstIndex),
                     values.get(leftIndex),
                     extraValues.get(worstIndex),
@@ -405,6 +409,7 @@ public class DoubleLongBucketedSort implements Releasable {
                 long rightIndex = rootIndex + rightChild;
                 if (rightChild < heapSize
                     && betterThan(
+                        // comment to make spotless happy about line breaks
                         values.get(worstIndex),
                         values.get(rightIndex),
                         extraValues.get(worstIndex),

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/FloatBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/FloatBucketedSort.java
@@ -67,7 +67,6 @@ public class FloatBucketedSort implements Releasable {
      * </ul>
      */
     private FloatArray values;
-
     public FloatBucketedSort(BigArrays bigArrays, SortOrder order, int bucketSize) {
         this.bigArrays = bigArrays;
         this.order = order;
@@ -264,7 +263,11 @@ public class FloatBucketedSort implements Releasable {
         long oldMax = values.size();
         assert oldMax % bucketSize == 0;
 
-        long newSize = BigArrays.overSize(((long) bucket + 1) * bucketSize, PageCacheRecycler.FLOAT_PAGE_SIZE, Float.BYTES);
+        long newSize = BigArrays.overSize(
+            ((long) bucket + 1) * bucketSize,
+            PageCacheRecycler.FLOAT_PAGE_SIZE,
+            Float.BYTES
+        );
         // Round up to the next full bucket.
         newSize = (newSize + bucketSize - 1) / bucketSize;
         values = bigArrays.resize(values, newSize * bucketSize);

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/FloatBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/FloatBucketedSort.java
@@ -94,11 +94,8 @@ public class FloatBucketedSort implements Releasable {
     public void collect(float value, int bucket) {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
-            if (betterThan(
-                // comment to make spotless happy about line breaks
-                value,
-                values.get(rootIndex)
-            )) {
+            float rootValue = values.get(rootIndex);
+            if (betterThan(value, rootValue)) {
                 values.set(rootIndex, value);
                 downHeap(rootIndex, 0, bucketSize);
             }
@@ -159,11 +156,8 @@ public class FloatBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            collect(
-                // comment to make spotless happy about line breaks
-                other.values.get(i),
-                groupId
-            );
+            float otherValue = other.values.get(i);
+            collect(otherValue, groupId);
         }
     }
 
@@ -272,12 +266,9 @@ public class FloatBucketedSort implements Releasable {
         long oldMax = values.size();
         assert oldMax % bucketSize == 0;
 
-        long newSize = BigArrays.overSize(
-            // comment to make spotless happy about line breaks
-            ((long) bucket + 1) * bucketSize,
-            PageCacheRecycler.FLOAT_PAGE_SIZE,
-            Float.BYTES
-        );
+        int pageSize = PageCacheRecycler.FLOAT_PAGE_SIZE;
+        int bytesPerElement = Float.BYTES;
+        long newSize = BigArrays.overSize(((long) bucket + 1) * bucketSize, pageSize, bytesPerElement);
         // Round up to the next full bucket.
         newSize = (newSize + bucketSize - 1) / bucketSize;
         values = bigArrays.resize(values, newSize * bucketSize);
@@ -362,24 +353,21 @@ public class FloatBucketedSort implements Releasable {
             int leftChild = parent * 2 + 1;
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
-                if (betterThan(
-                    // comment to make spotless happy about line breaks
-                    values.get(worstIndex),
-                    values.get(leftIndex)
-                )) {
+                float worstValue = values.get(worstIndex);
+                float leftValue = values.get(leftIndex);
+                if (betterThan(worstValue, leftValue)) {
                     worst = leftChild;
                     worstIndex = leftIndex;
                 }
                 int rightChild = leftChild + 1;
                 long rightIndex = rootIndex + rightChild;
-                if (rightChild < heapSize
-                    && betterThan(
-                        // comment to make spotless happy about line breaks
-                        values.get(worstIndex),
-                        values.get(rightIndex)
-                    )) {
-                    worst = rightChild;
-                    worstIndex = rightIndex;
+                if (rightChild < heapSize) {
+                    worstValue = values.get(worstIndex);
+                    float rightValue = values.get(rightIndex);
+                    if (betterThan(worstValue, rightValue)) {
+                        worst = rightChild;
+                        worstIndex = rightIndex;
+                    }
                 }
             }
             if (worst == parent) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/FloatBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/FloatBucketedSort.java
@@ -167,7 +167,9 @@ public class FloatBucketedSort implements Releasable {
             return blockFactory.newConstantNullBlock(selected.getPositionCount());
         }
 
-        try (var builder = blockFactory.newFloatBlockBuilder(selected.getPositionCount())) {
+        try (
+            var builder = blockFactory.newFloatBlockBuilder(selected.getPositionCount())
+        ) {
             for (int s = 0; s < selected.getPositionCount(); s++) {
                 int bucket = selected.getInt(s);
 

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/FloatBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/FloatBucketedSort.java
@@ -67,6 +67,7 @@ public class FloatBucketedSort implements Releasable {
      * </ul>
      */
     private FloatArray values;
+
     public FloatBucketedSort(BigArrays bigArrays, SortOrder order, int bucketSize) {
         this.bigArrays = bigArrays;
         this.order = order;
@@ -168,6 +169,7 @@ public class FloatBucketedSort implements Releasable {
         }
 
         try (
+            // comment to make spotless happy about line breaks
             var builder = blockFactory.newFloatBlockBuilder(selected.getPositionCount())
         ) {
             for (int s = 0; s < selected.getPositionCount(); s++) {
@@ -266,6 +268,7 @@ public class FloatBucketedSort implements Releasable {
         assert oldMax % bucketSize == 0;
 
         long newSize = BigArrays.overSize(
+            // comment to make spotless happy about line breaks
             ((long) bucket + 1) * bucketSize,
             PageCacheRecycler.FLOAT_PAGE_SIZE,
             Float.BYTES

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/FloatBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/FloatBucketedSort.java
@@ -94,7 +94,11 @@ public class FloatBucketedSort implements Releasable {
     public void collect(float value, int bucket) {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
-            if (betterThan(value, values.get(rootIndex))) {
+            if (betterThan(
+                // comment to make spotless happy about line breaks
+                value,
+                values.get(rootIndex)
+            )) {
                 values.set(rootIndex, value);
                 downHeap(rootIndex, 0, bucketSize);
             }
@@ -155,7 +159,11 @@ public class FloatBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            collect(other.values.get(i), groupId);
+            collect(
+                // comment to make spotless happy about line breaks
+                other.values.get(i),
+                groupId
+            );
         }
     }
 
@@ -168,10 +176,7 @@ public class FloatBucketedSort implements Releasable {
             return blockFactory.newConstantNullBlock(selected.getPositionCount());
         }
 
-        try (
-            // comment to make spotless happy about line breaks
-            var builder = blockFactory.newFloatBlockBuilder(selected.getPositionCount())
-        ) {
+        try (var builder = blockFactory.newFloatBlockBuilder(selected.getPositionCount())) {
             for (int s = 0; s < selected.getPositionCount(); s++) {
                 int bucket = selected.getInt(s);
 
@@ -357,13 +362,22 @@ public class FloatBucketedSort implements Releasable {
             int leftChild = parent * 2 + 1;
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
-                if (betterThan(values.get(worstIndex), values.get(leftIndex))) {
+                if (betterThan(
+                    // comment to make spotless happy about line breaks
+                    values.get(worstIndex),
+                    values.get(leftIndex)
+                )) {
                     worst = leftChild;
                     worstIndex = leftIndex;
                 }
                 int rightChild = leftChild + 1;
                 long rightIndex = rootIndex + rightChild;
-                if (rightChild < heapSize && betterThan(values.get(worstIndex), values.get(rightIndex))) {
+                if (rightChild < heapSize
+                    && betterThan(
+                        // comment to make spotless happy about line breaks
+                        values.get(worstIndex),
+                        values.get(rightIndex)
+                    )) {
                     worst = rightChild;
                     worstIndex = rightIndex;
                 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/FloatBytesRefBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/FloatBytesRefBucketedSort.java
@@ -171,8 +171,12 @@ public class FloatBytesRefBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            BreakingBytesRefBuilder otherExtra = other.extraValues.get(i);
-            collect(other.values.get(i), otherExtra == null ? new BytesRef() : otherExtra.bytesRefView(), groupId);
+            collect(
+                // comment to make spotless happy about line breaks
+                other.values.get(i),
+                other.extraValues.get(i) == null ? new BytesRef() : other.extraValues.get(i).bytesRefView(),
+                groupId
+            );
         }
     }
 
@@ -190,7 +194,6 @@ public class FloatBytesRefBucketedSort implements Releasable {
         }
 
         try (
-            // comment to make spotless happy about line breaks
             var builder = blockFactory.newFloatBlockBuilder(selected.getPositionCount());
             var extraBuilder = blockFactory.newBytesRefBlockBuilder(selected.getPositionCount())
         ) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/FloatBytesRefBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/FloatBytesRefBucketedSort.java
@@ -102,13 +102,9 @@ public class FloatBytesRefBucketedSort implements Releasable {
     public void collect(float value, BytesRef extraValue, int bucket) {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
-            if (betterThan(
-                // comment to make spotless happy about line breaks
-                value,
-                values.get(rootIndex),
-                extraValue,
-                extraBytesAt(rootIndex)
-            )) {
+            float rootValue = values.get(rootIndex);
+            BytesRef rootExtra = extraBytesAt(rootIndex);
+            if (betterThan(value, rootValue, extraValue, rootExtra)) {
                 values.set(rootIndex, value);
                 clearedExtraBytesAt(rootIndex).append(extraValue);
                 downHeap(rootIndex, 0, bucketSize);
@@ -171,12 +167,9 @@ public class FloatBytesRefBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            collect(
-                // comment to make spotless happy about line breaks
-                other.values.get(i),
-                other.extraValues.get(i) == null ? new BytesRef() : other.extraValues.get(i).bytesRefView(),
-                groupId
-            );
+            float otherValue = other.values.get(i);
+            BytesRef otherExtra = other.extraValues.get(i) == null ? new BytesRef() : other.extraValues.get(i).bytesRefView();
+            collect(otherValue, otherExtra, groupId);
         }
     }
 
@@ -342,12 +335,9 @@ public class FloatBytesRefBucketedSort implements Releasable {
         long oldMax = values.size();
         assert oldMax % bucketSize == 0;
 
-        long newSize = BigArrays.overSize(
-            // comment to make spotless happy about line breaks
-            ((long) bucket + 1) * bucketSize,
-            PageCacheRecycler.FLOAT_PAGE_SIZE,
-            Float.BYTES
-        );
+        int pageSize = PageCacheRecycler.FLOAT_PAGE_SIZE;
+        int bytesPerElement = Float.BYTES;
+        long newSize = BigArrays.overSize(((long) bucket + 1) * bucketSize, pageSize, bytesPerElement);
         // Round up to the next full bucket.
         newSize = (newSize + bucketSize - 1) / bucketSize;
         values = bigArrays.resize(values, newSize * bucketSize);
@@ -434,28 +424,25 @@ public class FloatBytesRefBucketedSort implements Releasable {
             int leftChild = parent * 2 + 1;
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
-                if (betterThan(
-                    // comment to make spotless happy about line breaks
-                    values.get(worstIndex),
-                    values.get(leftIndex),
-                    extraBytesAt(worstIndex),
-                    extraBytesAt(leftIndex)
-                )) {
+                float worstValue = values.get(worstIndex);
+                float leftValue = values.get(leftIndex);
+                BytesRef worstExtra = extraBytesAt(worstIndex);
+                BytesRef leftExtra = extraBytesAt(leftIndex);
+                if (betterThan(worstValue, leftValue, worstExtra, leftExtra)) {
                     worst = leftChild;
                     worstIndex = leftIndex;
                 }
                 int rightChild = leftChild + 1;
                 long rightIndex = rootIndex + rightChild;
-                if (rightChild < heapSize
-                    && betterThan(
-                        // comment to make spotless happy about line breaks
-                        values.get(worstIndex),
-                        values.get(rightIndex),
-                        extraBytesAt(worstIndex),
-                        extraBytesAt(rightIndex)
-                    )) {
-                    worst = rightChild;
-                    worstIndex = rightIndex;
+                if (rightChild < heapSize) {
+                    worstValue = values.get(worstIndex);
+                    float rightValue = values.get(rightIndex);
+                    worstExtra = extraBytesAt(worstIndex);
+                    BytesRef rightExtra = extraBytesAt(rightIndex);
+                    if (betterThan(worstValue, rightValue, worstExtra, rightExtra)) {
+                        worst = rightChild;
+                        worstIndex = rightIndex;
+                    }
                 }
             }
             if (worst == parent) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/FloatBytesRefBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/FloatBytesRefBucketedSort.java
@@ -73,6 +73,7 @@ public class FloatBytesRefBucketedSort implements Releasable {
      */
     private FloatArray values;
     private ObjectArray<BreakingBytesRefBuilder> extraValues;
+
     public FloatBytesRefBucketedSort(BigArrays bigArrays, SortOrder order, int bucketSize) {
         this.bigArrays = bigArrays;
         this.breaker = bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST);
@@ -102,6 +103,7 @@ public class FloatBytesRefBucketedSort implements Releasable {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
             if (betterThan(
+                // comment to make spotless happy about line breaks
                 value,
                 values.get(rootIndex),
                 extraValue,
@@ -188,6 +190,7 @@ public class FloatBytesRefBucketedSort implements Releasable {
         }
 
         try (
+            // comment to make spotless happy about line breaks
             var builder = blockFactory.newFloatBlockBuilder(selected.getPositionCount());
             var extraBuilder = blockFactory.newBytesRefBlockBuilder(selected.getPositionCount())
         ) {
@@ -337,6 +340,7 @@ public class FloatBytesRefBucketedSort implements Releasable {
         assert oldMax % bucketSize == 0;
 
         long newSize = BigArrays.overSize(
+            // comment to make spotless happy about line breaks
             ((long) bucket + 1) * bucketSize,
             PageCacheRecycler.FLOAT_PAGE_SIZE,
             Float.BYTES
@@ -428,6 +432,7 @@ public class FloatBytesRefBucketedSort implements Releasable {
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
                 if (betterThan(
+                    // comment to make spotless happy about line breaks
                     values.get(worstIndex),
                     values.get(leftIndex),
                     extraBytesAt(worstIndex),
@@ -440,6 +445,7 @@ public class FloatBytesRefBucketedSort implements Releasable {
                 long rightIndex = rootIndex + rightChild;
                 if (rightChild < heapSize
                     && betterThan(
+                        // comment to make spotless happy about line breaks
                         values.get(worstIndex),
                         values.get(rightIndex),
                         extraBytesAt(worstIndex),

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/FloatBytesRefBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/FloatBytesRefBucketedSort.java
@@ -1,0 +1,469 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data.sort;
+
+// begin generated imports
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.BitArray;
+import org.elasticsearch.common.util.ObjectArray;
+import org.elasticsearch.common.util.FloatArray;
+import org.elasticsearch.common.util.PageCacheRecycler;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.core.Tuple;
+import org.elasticsearch.search.sort.BucketedSort;
+import org.elasticsearch.search.sort.SortOrder;
+
+import java.util.stream.IntStream;
+// end generated imports
+
+/**
+ * Aggregates the top N {@code float} values per bucket.
+ * See {@link BucketedSort} for more information.
+ * This class is generated. Edit @{code X-BucketedSort.java.st} instead of this file.
+ */
+public class FloatBytesRefBucketedSort implements Releasable {
+
+    private final BigArrays bigArrays;
+    private final CircuitBreaker breaker;
+    private final SortOrder order;
+    private final int bucketSize;
+    /**
+     * {@code true} if the bucket is in heap mode, {@code false} if
+     * it is still gathering.
+     */
+    private final BitArray heapMode;
+    /**
+     * An array containing all the values on all buckets. The structure is as follows:
+     * <p>
+     *     For each bucket, there are bucketSize elements, based on the bucket id (0, 1, 2...).
+     *     Then, for each bucket, it can be in 2 states:
+     * </p>
+     * <ul>
+     *     <li>
+     *         Gather mode: All buckets start in gather mode, and remain here while they have less than bucketSize elements.
+     *         In gather mode, the elements are stored in the array from the highest index to the lowest index.
+     *         The lowest index contains the offset to the next slot to be filled.
+     *         <p>
+     *             This allows us to insert elements in O(1) time.
+     *         </p>
+     *         <p>
+     *             When the bucketSize-th element is collected, the bucket transitions to heap mode, by heapifying its contents.
+     *         </p>
+     *     </li>
+     *     <li>
+     *         Heap mode: The bucket slots are organized as a min heap structure.
+     *         <p>
+     *             The root of the heap is the minimum value in the bucket,
+     *             which allows us to quickly discard new values that are not in the top N.
+     *         </p>
+     *     </li>
+     * </ul>
+     */
+    private FloatArray values;
+    private ObjectArray<BreakingBytesRefBuilder> extraValues;
+    public FloatBytesRefBucketedSort(BigArrays bigArrays, SortOrder order, int bucketSize) {
+        this.bigArrays = bigArrays;
+        this.breaker = bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST);
+        this.order = order;
+        this.bucketSize = bucketSize;
+        heapMode = new BitArray(0, bigArrays);
+
+        boolean success = false;
+        try {
+            values = bigArrays.newFloatArray(0, false);
+            extraValues = bigArrays.newObjectArray(0);
+            success = true;
+        } finally {
+            if (success == false) {
+                close();
+            }
+        }
+    }
+
+    /**
+     * Collects a {@code value} into a {@code bucket}.
+     * <p>
+     *     It may or may not be inserted in the heap, depending on if it is better than the current root.
+     * </p>
+     */
+    public void collect(float value, BytesRef extraValue, int bucket) {
+        long rootIndex = (long) bucket * bucketSize;
+        if (inHeapMode(bucket)) {
+            if (betterThan(
+                value,
+                values.get(rootIndex),
+                extraValue,
+                extraBytesAt(rootIndex)
+            )) {
+                values.set(rootIndex, value);
+                clearedExtraBytesAt(rootIndex).append(extraValue);
+                downHeap(rootIndex, 0, bucketSize);
+            }
+            return;
+        }
+        // Gathering mode
+        long requiredSize = rootIndex + bucketSize;
+        if (values.size() < requiredSize) {
+            grow(bucket);
+        }
+        int next = getNextGatherOffset(rootIndex);
+        assert 0 <= next && next < bucketSize
+            : "Expected next to be in the range of valid buckets [0 <= " + next + " < " + bucketSize + "]";
+        long index = next + rootIndex;
+        values.set(index, value);
+        clearedExtraBytesAt(index).append(extraValue);
+        if (next == 0) {
+            heapMode.set(bucket);
+            heapify(rootIndex, bucketSize);
+        } else {
+            setNextGatherOffset(rootIndex, next - 1);
+        }
+    }
+
+    /**
+     * The order of the sort.
+     */
+    public SortOrder getOrder() {
+        return order;
+    }
+
+    /**
+     * The number of values to store per bucket.
+     */
+    public int getBucketSize() {
+        return bucketSize;
+    }
+
+    /**
+     * Get the first and last indexes (inclusive, exclusive) of the values for a bucket.
+     * Returns [0, 0] if the bucket has never been collected.
+     */
+    private Tuple<Long, Long> getBucketValuesIndexes(int bucket) {
+        long rootIndex = (long) bucket * bucketSize;
+        if (rootIndex >= values.size()) {
+            // We've never seen this bucket.
+            return Tuple.tuple(0L, 0L);
+        }
+        long start = inHeapMode(bucket) ? rootIndex : (rootIndex + getNextGatherOffset(rootIndex) + 1);
+        long end = rootIndex + bucketSize;
+        return Tuple.tuple(start, end);
+    }
+
+    /**
+     * Merge the values from {@code other}'s {@code otherGroupId} into {@code groupId}.
+     */
+    public void merge(int groupId, FloatBytesRefBucketedSort other, int otherGroupId) {
+        var otherBounds = other.getBucketValuesIndexes(otherGroupId);
+
+        // TODO: This can be improved for heapified buckets by making use of the heap structures
+        for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
+            BreakingBytesRefBuilder otherExtra = other.extraValues.get(i);
+            collect(other.values.get(i), otherExtra == null ? new BytesRef() : otherExtra.bytesRefView(), groupId);
+        }
+    }
+
+    /**
+     * Creates a block with the values from the {@code selected} groups.
+     */
+    public void toBlocks(BlockFactory blockFactory, Block[] blocks, int offset, IntVector selected) {
+        // Check if the selected groups are all empty, to avoid allocating extra memory
+        if (allSelectedGroupsAreEmpty(selected)) {
+            Block constantNullBlock = blockFactory.newConstantNullBlock(selected.getPositionCount());
+            constantNullBlock.incRef();
+            blocks[offset] = constantNullBlock;
+            blocks[offset + 1] = constantNullBlock;
+            return;
+        }
+
+        try (
+            var builder = blockFactory.newFloatBlockBuilder(selected.getPositionCount());
+            var extraBuilder = blockFactory.newBytesRefBlockBuilder(selected.getPositionCount())
+        ) {
+            for (int s = 0; s < selected.getPositionCount(); s++) {
+                int bucket = selected.getInt(s);
+
+                var bounds = getBucketValuesIndexes(bucket);
+                var rootIndex = bounds.v1();
+                var size = bounds.v2() - bounds.v1();
+
+                if (size == 0) {
+                    builder.appendNull();
+                    extraBuilder.appendNull();
+                    continue;
+                }
+
+                if (size == 1) {
+                    builder.appendFloat(values.get(rootIndex));
+                    appendExtra(extraBuilder, rootIndex);
+                    continue;
+                }
+
+                // If we are in the gathering mode, we need to heapify before sorting.
+                if (inHeapMode(bucket) == false) {
+                    heapify(rootIndex, (int) size);
+                }
+                heapSort(rootIndex, (int) size);
+
+                builder.beginPositionEntry();
+                extraBuilder.beginPositionEntry();
+                for (int i = 0; i < size; i++) {
+                    builder.appendFloat(values.get(rootIndex + i));
+                    appendExtra(extraBuilder, rootIndex + i);
+                }
+                builder.endPositionEntry();
+                extraBuilder.endPositionEntry();
+            }
+            blocks[offset] = builder.build();
+            try {
+                blocks[offset + 1] = extraBuilder.build();
+            } finally {
+                if (blocks[offset + 1] == null) {
+                    blocks[offset].close();
+                    blocks[offset] = null;
+                }
+            }
+        }
+    }
+
+    private void appendExtra(org.elasticsearch.compute.data.BytesRefBlock.Builder extraBuilder, long index) {
+        BreakingBytesRefBuilder bytes = extraValues.get(index);
+        if (bytes == null) {
+            extraBuilder.appendNull();
+            return;
+        }
+        try {
+            extraBuilder.appendBytesRef(bytes.bytesRefView());
+        } finally {
+            extraValues.set(index, null);
+            Releasables.closeExpectNoException(bytes);
+        }
+    }
+
+    private BreakingBytesRefBuilder clearedExtraBytesAt(long index) {
+        BreakingBytesRefBuilder bytes = extraValues.get(index);
+        if (bytes == null) {
+            bytes = new BreakingBytesRefBuilder(breaker, "top");
+            extraValues.set(index, bytes);
+        } else {
+            bytes.clear();
+        }
+        return bytes;
+    }
+
+    private BytesRef extraBytesAt(long index) {
+        BreakingBytesRefBuilder bytes = extraValues.get(index);
+        return bytes == null ? new BytesRef() : bytes.bytesRefView();
+    }
+
+    /**
+     * Checks if the selected groups are all empty.
+     */
+    private boolean allSelectedGroupsAreEmpty(IntVector selected) {
+        return IntStream.range(0, selected.getPositionCount()).map(selected::getInt).noneMatch(bucket -> {
+            var bounds = this.getBucketValuesIndexes(bucket);
+            var size = bounds.v2() - bounds.v1();
+            return size > 0;
+        });
+    }
+
+    /**
+     * Is this bucket a min heap {@code true} or in gathering mode {@code false}?
+     */
+    private boolean inHeapMode(int bucket) {
+        return heapMode.get(bucket);
+    }
+
+    /**
+     * Get the next index that should be "gathered" for a bucket rooted
+     * at {@code rootIndex}.
+     */
+    private int getNextGatherOffset(long rootIndex) {
+        return (int) values.get(rootIndex);
+    }
+
+    /**
+     * Set the next index that should be "gathered" for a bucket rooted
+     * at {@code rootIndex}.
+     */
+    private void setNextGatherOffset(long rootIndex, int offset) {
+        values.set(rootIndex, offset);
+    }
+
+    /**
+     * {@code true} if the entry at index {@code lhs} is "better" than
+     * the entry at {@code rhs}. "Better" in this means "lower" for
+     * {@link SortOrder#ASC} and "higher" for {@link SortOrder#DESC}.
+     */
+    private boolean betterThan(float lhs, float rhs, BytesRef lhsExtra, BytesRef rhsExtra) {
+        int res = Float.compare(lhs, rhs);
+        if (res != 0) {
+            return getOrder().reverseMul() * res < 0;
+        }
+        res = lhsExtra.compareTo(rhsExtra);
+        return getOrder().reverseMul() * res < 0;
+    }
+
+    /**
+     * Swap the data at two indices.
+     */
+    private void swap(long lhs, long rhs) {
+        var tmp = values.get(lhs);
+        values.set(lhs, values.get(rhs));
+        values.set(rhs, tmp);
+        var tmpExtra = extraValues.get(lhs);
+        extraValues.set(lhs, extraValues.get(rhs));
+        extraValues.set(rhs, tmpExtra);
+    }
+
+    /**
+     * Allocate storage for more buckets and store the "next gather offset"
+     * for those new buckets. We always grow the storage by whole bucket's
+     * worth of slots at a time. We never allocate space for partial buckets.
+     */
+    private void grow(int bucket) {
+        long oldMax = values.size();
+        assert oldMax % bucketSize == 0;
+
+        long newSize = BigArrays.overSize(
+            ((long) bucket + 1) * bucketSize,
+            PageCacheRecycler.FLOAT_PAGE_SIZE,
+            Float.BYTES
+        );
+        // Round up to the next full bucket.
+        newSize = (newSize + bucketSize - 1) / bucketSize;
+        values = bigArrays.resize(values, newSize * bucketSize);
+        // Round up to the next full bucket.
+        extraValues = bigArrays.resize(extraValues, newSize * bucketSize);
+        // Set the next gather offsets for all newly allocated buckets.
+        fillGatherOffsets(oldMax);
+    }
+
+    /**
+     * Maintain the "next gather offsets" for newly allocated buckets.
+     */
+    private void fillGatherOffsets(long startingAt) {
+        int nextOffset = getBucketSize() - 1;
+        for (long bucketRoot = startingAt; bucketRoot < values.size(); bucketRoot += getBucketSize()) {
+            setNextGatherOffset(bucketRoot, nextOffset);
+        }
+    }
+
+    /**
+     * Heapify a bucket whose entries are in random order.
+     * <p>
+     * This works by validating the heap property on each node, iterating
+     * "upwards", pushing any out of order parents "down". Check out the
+     * <a href="https://en.wikipedia.org/w/index.php?title=Binary_heap&oldid=940542991#Building_a_heap">wikipedia</a>
+     * entry on binary heaps for more about this.
+     * </p>
+     * <p>
+     * While this *looks* like it could easily be {@code O(n * log n)}, it is
+     * a fairly well studied algorithm attributed to Floyd. There's
+     * been a bunch of work that puts this at {@code O(n)}, close to 1.88n worst
+     * case.
+     * </p>
+     * <ul>
+     * <li>Hayward, Ryan; McDiarmid, Colin (1991).
+     * <a href="https://web.archive.org/web/20160205023201/http://www.stats.ox.ac.uk/__data/assets/pdf_file/0015/4173/heapbuildjalg.pdf">
+     * Average Case Analysis of Heap Building byRepeated Insertion</a> J. Algorithms.
+     * <li>D.E. Knuth, ”The Art of Computer Programming, Vol. 3, Sorting and Searching”</li>
+     * </ul>
+     * @param rootIndex the index the start of the bucket
+     */
+    private void heapify(long rootIndex, int heapSize) {
+        int maxParent = heapSize / 2 - 1;
+        for (int parent = maxParent; parent >= 0; parent--) {
+            downHeap(rootIndex, parent, heapSize);
+        }
+    }
+
+    /**
+     * Sorts all the values in the heap using heap sort algorithm.
+     * This runs in {@code O(n log n)} time.
+     * @param rootIndex index of the start of the bucket
+     * @param heapSize Number of values that belong to the heap.
+     *                 Can be less than bucketSize.
+     *                 In such a case, the remaining values in range
+     *                 (rootIndex + heapSize, rootIndex + bucketSize)
+     *                 are *not* considered part of the heap.
+     */
+    private void heapSort(long rootIndex, int heapSize) {
+        while (heapSize > 0) {
+            swap(rootIndex, rootIndex + heapSize - 1);
+            heapSize--;
+            downHeap(rootIndex, 0, heapSize);
+        }
+    }
+
+    /**
+     * Correct the heap invariant of a parent and its children. This
+     * runs in {@code O(log n)} time.
+     * @param rootIndex index of the start of the bucket
+     * @param parent Index within the bucket of the parent to check.
+     *               For example, 0 is the "root".
+     * @param heapSize Number of values that belong to the heap.
+     *                 Can be less than bucketSize.
+     *                 In such a case, the remaining values in range
+     *                 (rootIndex + heapSize, rootIndex + bucketSize)
+     *                 are *not* considered part of the heap.
+     */
+    private void downHeap(long rootIndex, int parent, int heapSize) {
+        while (true) {
+            long parentIndex = rootIndex + parent;
+            int worst = parent;
+            long worstIndex = parentIndex;
+            int leftChild = parent * 2 + 1;
+            long leftIndex = rootIndex + leftChild;
+            if (leftChild < heapSize) {
+                if (betterThan(
+                    values.get(worstIndex),
+                    values.get(leftIndex),
+                    extraBytesAt(worstIndex),
+                    extraBytesAt(leftIndex)
+                )) {
+                    worst = leftChild;
+                    worstIndex = leftIndex;
+                }
+                int rightChild = leftChild + 1;
+                long rightIndex = rootIndex + rightChild;
+                if (rightChild < heapSize
+                    && betterThan(
+                        values.get(worstIndex),
+                        values.get(rightIndex),
+                        extraBytesAt(worstIndex),
+                        extraBytesAt(rightIndex)
+                    )) {
+                    worst = rightChild;
+                    worstIndex = rightIndex;
+                }
+            }
+            if (worst == parent) {
+                break;
+            }
+            swap(worstIndex, parentIndex);
+            parent = worst;
+        }
+    }
+
+    @Override
+    public final void close() {
+        if (extraValues != null) {
+            for (long i = 0; i < extraValues.size(); i++) {
+                Releasables.close(extraValues.get(i));
+            }
+        }
+        Releasables.close(values, extraValues, heapMode);
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/FloatDoubleBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/FloatDoubleBucketedSort.java
@@ -166,7 +166,12 @@ public class FloatDoubleBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            collect(other.values.get(i), other.extraValues.get(i), groupId);
+            collect(
+                // comment to make spotless happy about line breaks
+                other.values.get(i),
+                other.extraValues.get(i),
+                groupId
+            );
         }
     }
 
@@ -184,7 +189,6 @@ public class FloatDoubleBucketedSort implements Releasable {
         }
 
         try (
-            // comment to make spotless happy about line breaks
             var builder = blockFactory.newFloatBlockBuilder(selected.getPositionCount());
             var extraBuilder = blockFactory.newDoubleBlockBuilder(selected.getPositionCount())
         ) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/FloatDoubleBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/FloatDoubleBucketedSort.java
@@ -98,6 +98,7 @@ public class FloatDoubleBucketedSort implements Releasable {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
             if (betterThan(
+                // comment to make spotless happy about line breaks
                 value,
                 values.get(rootIndex),
                 extraValue,
@@ -183,6 +184,7 @@ public class FloatDoubleBucketedSort implements Releasable {
         }
 
         try (
+            // comment to make spotless happy about line breaks
             var builder = blockFactory.newFloatBlockBuilder(selected.getPositionCount());
             var extraBuilder = blockFactory.newDoubleBlockBuilder(selected.getPositionCount())
         ) {
@@ -302,6 +304,7 @@ public class FloatDoubleBucketedSort implements Releasable {
         assert oldMax % bucketSize == 0;
 
         long newSize = BigArrays.overSize(
+            // comment to make spotless happy about line breaks
             ((long) bucket + 1) * bucketSize,
             PageCacheRecycler.FLOAT_PAGE_SIZE,
             Float.BYTES
@@ -393,6 +396,7 @@ public class FloatDoubleBucketedSort implements Releasable {
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
                 if (betterThan(
+                    // comment to make spotless happy about line breaks
                     values.get(worstIndex),
                     values.get(leftIndex),
                     extraValues.get(worstIndex),
@@ -405,6 +409,7 @@ public class FloatDoubleBucketedSort implements Releasable {
                 long rightIndex = rootIndex + rightChild;
                 if (rightChild < heapSize
                     && betterThan(
+                        // comment to make spotless happy about line breaks
                         values.get(worstIndex),
                         values.get(rightIndex),
                         extraValues.get(worstIndex),

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/FloatDoubleBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/FloatDoubleBucketedSort.java
@@ -97,7 +97,12 @@ public class FloatDoubleBucketedSort implements Releasable {
     public void collect(float value, double extraValue, int bucket) {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
-            if (betterThan(value, values.get(rootIndex), extraValue, extraValues.get(rootIndex))) {
+            if (betterThan(
+                value,
+                values.get(rootIndex),
+                extraValue,
+                extraValues.get(rootIndex)
+            )) {
                 values.set(rootIndex, value);
                 extraValues.set(rootIndex, extraValue);
                 downHeap(rootIndex, 0, bucketSize);
@@ -296,7 +301,11 @@ public class FloatDoubleBucketedSort implements Releasable {
         long oldMax = values.size();
         assert oldMax % bucketSize == 0;
 
-        long newSize = BigArrays.overSize(((long) bucket + 1) * bucketSize, PageCacheRecycler.FLOAT_PAGE_SIZE, Float.BYTES);
+        long newSize = BigArrays.overSize(
+            ((long) bucket + 1) * bucketSize,
+            PageCacheRecycler.FLOAT_PAGE_SIZE,
+            Float.BYTES
+        );
         // Round up to the next full bucket.
         newSize = (newSize + bucketSize - 1) / bucketSize;
         values = bigArrays.resize(values, newSize * bucketSize);
@@ -383,7 +392,12 @@ public class FloatDoubleBucketedSort implements Releasable {
             int leftChild = parent * 2 + 1;
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
-                if (betterThan(values.get(worstIndex), values.get(leftIndex), extraValues.get(worstIndex), extraValues.get(leftIndex))) {
+                if (betterThan(
+                    values.get(worstIndex),
+                    values.get(leftIndex),
+                    extraValues.get(worstIndex),
+                    extraValues.get(leftIndex)
+                )) {
                     worst = leftChild;
                     worstIndex = leftIndex;
                 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/FloatDoubleBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/FloatDoubleBucketedSort.java
@@ -97,13 +97,9 @@ public class FloatDoubleBucketedSort implements Releasable {
     public void collect(float value, double extraValue, int bucket) {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
-            if (betterThan(
-                // comment to make spotless happy about line breaks
-                value,
-                values.get(rootIndex),
-                extraValue,
-                extraValues.get(rootIndex)
-            )) {
+            float rootValue = values.get(rootIndex);
+            double rootExtra = extraValues.get(rootIndex);
+            if (betterThan(value, rootValue, extraValue, rootExtra)) {
                 values.set(rootIndex, value);
                 extraValues.set(rootIndex, extraValue);
                 downHeap(rootIndex, 0, bucketSize);
@@ -166,12 +162,9 @@ public class FloatDoubleBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            collect(
-                // comment to make spotless happy about line breaks
-                other.values.get(i),
-                other.extraValues.get(i),
-                groupId
-            );
+            float otherValue = other.values.get(i);
+            double otherExtra = other.extraValues.get(i);
+            collect(otherValue, otherExtra, groupId);
         }
     }
 
@@ -307,12 +300,9 @@ public class FloatDoubleBucketedSort implements Releasable {
         long oldMax = values.size();
         assert oldMax % bucketSize == 0;
 
-        long newSize = BigArrays.overSize(
-            // comment to make spotless happy about line breaks
-            ((long) bucket + 1) * bucketSize,
-            PageCacheRecycler.FLOAT_PAGE_SIZE,
-            Float.BYTES
-        );
+        int pageSize = PageCacheRecycler.FLOAT_PAGE_SIZE;
+        int bytesPerElement = Float.BYTES;
+        long newSize = BigArrays.overSize(((long) bucket + 1) * bucketSize, pageSize, bytesPerElement);
         // Round up to the next full bucket.
         newSize = (newSize + bucketSize - 1) / bucketSize;
         values = bigArrays.resize(values, newSize * bucketSize);
@@ -399,28 +389,25 @@ public class FloatDoubleBucketedSort implements Releasable {
             int leftChild = parent * 2 + 1;
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
-                if (betterThan(
-                    // comment to make spotless happy about line breaks
-                    values.get(worstIndex),
-                    values.get(leftIndex),
-                    extraValues.get(worstIndex),
-                    extraValues.get(leftIndex)
-                )) {
+                float worstValue = values.get(worstIndex);
+                float leftValue = values.get(leftIndex);
+                double worstExtra = extraValues.get(worstIndex);
+                double leftExtra = extraValues.get(leftIndex);
+                if (betterThan(worstValue, leftValue, worstExtra, leftExtra)) {
                     worst = leftChild;
                     worstIndex = leftIndex;
                 }
                 int rightChild = leftChild + 1;
                 long rightIndex = rootIndex + rightChild;
-                if (rightChild < heapSize
-                    && betterThan(
-                        // comment to make spotless happy about line breaks
-                        values.get(worstIndex),
-                        values.get(rightIndex),
-                        extraValues.get(worstIndex),
-                        extraValues.get(rightIndex)
-                    )) {
-                    worst = rightChild;
-                    worstIndex = rightIndex;
+                if (rightChild < heapSize) {
+                    worstValue = values.get(worstIndex);
+                    float rightValue = values.get(rightIndex);
+                    worstExtra = extraValues.get(worstIndex);
+                    double rightExtra = extraValues.get(rightIndex);
+                    if (betterThan(worstValue, rightValue, worstExtra, rightExtra)) {
+                        worst = rightChild;
+                        worstIndex = rightIndex;
+                    }
                 }
             }
             if (worst == parent) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/FloatFloatBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/FloatFloatBucketedSort.java
@@ -166,7 +166,12 @@ public class FloatFloatBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            collect(other.values.get(i), other.extraValues.get(i), groupId);
+            collect(
+                // comment to make spotless happy about line breaks
+                other.values.get(i),
+                other.extraValues.get(i),
+                groupId
+            );
         }
     }
 
@@ -184,7 +189,6 @@ public class FloatFloatBucketedSort implements Releasable {
         }
 
         try (
-            // comment to make spotless happy about line breaks
             var builder = blockFactory.newFloatBlockBuilder(selected.getPositionCount());
             var extraBuilder = blockFactory.newFloatBlockBuilder(selected.getPositionCount())
         ) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/FloatFloatBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/FloatFloatBucketedSort.java
@@ -97,7 +97,12 @@ public class FloatFloatBucketedSort implements Releasable {
     public void collect(float value, float extraValue, int bucket) {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
-            if (betterThan(value, values.get(rootIndex), extraValue, extraValues.get(rootIndex))) {
+            if (betterThan(
+                value,
+                values.get(rootIndex),
+                extraValue,
+                extraValues.get(rootIndex)
+            )) {
                 values.set(rootIndex, value);
                 extraValues.set(rootIndex, extraValue);
                 downHeap(rootIndex, 0, bucketSize);
@@ -296,7 +301,11 @@ public class FloatFloatBucketedSort implements Releasable {
         long oldMax = values.size();
         assert oldMax % bucketSize == 0;
 
-        long newSize = BigArrays.overSize(((long) bucket + 1) * bucketSize, PageCacheRecycler.FLOAT_PAGE_SIZE, Float.BYTES);
+        long newSize = BigArrays.overSize(
+            ((long) bucket + 1) * bucketSize,
+            PageCacheRecycler.FLOAT_PAGE_SIZE,
+            Float.BYTES
+        );
         // Round up to the next full bucket.
         newSize = (newSize + bucketSize - 1) / bucketSize;
         values = bigArrays.resize(values, newSize * bucketSize);
@@ -383,7 +392,12 @@ public class FloatFloatBucketedSort implements Releasable {
             int leftChild = parent * 2 + 1;
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
-                if (betterThan(values.get(worstIndex), values.get(leftIndex), extraValues.get(worstIndex), extraValues.get(leftIndex))) {
+                if (betterThan(
+                    values.get(worstIndex),
+                    values.get(leftIndex),
+                    extraValues.get(worstIndex),
+                    extraValues.get(leftIndex)
+                )) {
                     worst = leftChild;
                     worstIndex = leftIndex;
                 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/FloatFloatBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/FloatFloatBucketedSort.java
@@ -98,6 +98,7 @@ public class FloatFloatBucketedSort implements Releasable {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
             if (betterThan(
+                // comment to make spotless happy about line breaks
                 value,
                 values.get(rootIndex),
                 extraValue,
@@ -183,6 +184,7 @@ public class FloatFloatBucketedSort implements Releasable {
         }
 
         try (
+            // comment to make spotless happy about line breaks
             var builder = blockFactory.newFloatBlockBuilder(selected.getPositionCount());
             var extraBuilder = blockFactory.newFloatBlockBuilder(selected.getPositionCount())
         ) {
@@ -302,6 +304,7 @@ public class FloatFloatBucketedSort implements Releasable {
         assert oldMax % bucketSize == 0;
 
         long newSize = BigArrays.overSize(
+            // comment to make spotless happy about line breaks
             ((long) bucket + 1) * bucketSize,
             PageCacheRecycler.FLOAT_PAGE_SIZE,
             Float.BYTES
@@ -393,6 +396,7 @@ public class FloatFloatBucketedSort implements Releasable {
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
                 if (betterThan(
+                    // comment to make spotless happy about line breaks
                     values.get(worstIndex),
                     values.get(leftIndex),
                     extraValues.get(worstIndex),
@@ -405,6 +409,7 @@ public class FloatFloatBucketedSort implements Releasable {
                 long rightIndex = rootIndex + rightChild;
                 if (rightChild < heapSize
                     && betterThan(
+                        // comment to make spotless happy about line breaks
                         values.get(worstIndex),
                         values.get(rightIndex),
                         extraValues.get(worstIndex),

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/FloatFloatBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/FloatFloatBucketedSort.java
@@ -97,13 +97,9 @@ public class FloatFloatBucketedSort implements Releasable {
     public void collect(float value, float extraValue, int bucket) {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
-            if (betterThan(
-                // comment to make spotless happy about line breaks
-                value,
-                values.get(rootIndex),
-                extraValue,
-                extraValues.get(rootIndex)
-            )) {
+            float rootValue = values.get(rootIndex);
+            float rootExtra = extraValues.get(rootIndex);
+            if (betterThan(value, rootValue, extraValue, rootExtra)) {
                 values.set(rootIndex, value);
                 extraValues.set(rootIndex, extraValue);
                 downHeap(rootIndex, 0, bucketSize);
@@ -166,12 +162,9 @@ public class FloatFloatBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            collect(
-                // comment to make spotless happy about line breaks
-                other.values.get(i),
-                other.extraValues.get(i),
-                groupId
-            );
+            float otherValue = other.values.get(i);
+            float otherExtra = other.extraValues.get(i);
+            collect(otherValue, otherExtra, groupId);
         }
     }
 
@@ -307,12 +300,9 @@ public class FloatFloatBucketedSort implements Releasable {
         long oldMax = values.size();
         assert oldMax % bucketSize == 0;
 
-        long newSize = BigArrays.overSize(
-            // comment to make spotless happy about line breaks
-            ((long) bucket + 1) * bucketSize,
-            PageCacheRecycler.FLOAT_PAGE_SIZE,
-            Float.BYTES
-        );
+        int pageSize = PageCacheRecycler.FLOAT_PAGE_SIZE;
+        int bytesPerElement = Float.BYTES;
+        long newSize = BigArrays.overSize(((long) bucket + 1) * bucketSize, pageSize, bytesPerElement);
         // Round up to the next full bucket.
         newSize = (newSize + bucketSize - 1) / bucketSize;
         values = bigArrays.resize(values, newSize * bucketSize);
@@ -399,28 +389,25 @@ public class FloatFloatBucketedSort implements Releasable {
             int leftChild = parent * 2 + 1;
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
-                if (betterThan(
-                    // comment to make spotless happy about line breaks
-                    values.get(worstIndex),
-                    values.get(leftIndex),
-                    extraValues.get(worstIndex),
-                    extraValues.get(leftIndex)
-                )) {
+                float worstValue = values.get(worstIndex);
+                float leftValue = values.get(leftIndex);
+                float worstExtra = extraValues.get(worstIndex);
+                float leftExtra = extraValues.get(leftIndex);
+                if (betterThan(worstValue, leftValue, worstExtra, leftExtra)) {
                     worst = leftChild;
                     worstIndex = leftIndex;
                 }
                 int rightChild = leftChild + 1;
                 long rightIndex = rootIndex + rightChild;
-                if (rightChild < heapSize
-                    && betterThan(
-                        // comment to make spotless happy about line breaks
-                        values.get(worstIndex),
-                        values.get(rightIndex),
-                        extraValues.get(worstIndex),
-                        extraValues.get(rightIndex)
-                    )) {
-                    worst = rightChild;
-                    worstIndex = rightIndex;
+                if (rightChild < heapSize) {
+                    worstValue = values.get(worstIndex);
+                    float rightValue = values.get(rightIndex);
+                    worstExtra = extraValues.get(worstIndex);
+                    float rightExtra = extraValues.get(rightIndex);
+                    if (betterThan(worstValue, rightValue, worstExtra, rightExtra)) {
+                        worst = rightChild;
+                        worstIndex = rightIndex;
+                    }
                 }
             }
             if (worst == parent) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/FloatIntBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/FloatIntBucketedSort.java
@@ -166,7 +166,12 @@ public class FloatIntBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            collect(other.values.get(i), other.extraValues.get(i), groupId);
+            collect(
+                // comment to make spotless happy about line breaks
+                other.values.get(i),
+                other.extraValues.get(i),
+                groupId
+            );
         }
     }
 
@@ -184,7 +189,6 @@ public class FloatIntBucketedSort implements Releasable {
         }
 
         try (
-            // comment to make spotless happy about line breaks
             var builder = blockFactory.newFloatBlockBuilder(selected.getPositionCount());
             var extraBuilder = blockFactory.newIntBlockBuilder(selected.getPositionCount())
         ) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/FloatIntBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/FloatIntBucketedSort.java
@@ -98,6 +98,7 @@ public class FloatIntBucketedSort implements Releasable {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
             if (betterThan(
+                // comment to make spotless happy about line breaks
                 value,
                 values.get(rootIndex),
                 extraValue,
@@ -183,6 +184,7 @@ public class FloatIntBucketedSort implements Releasable {
         }
 
         try (
+            // comment to make spotless happy about line breaks
             var builder = blockFactory.newFloatBlockBuilder(selected.getPositionCount());
             var extraBuilder = blockFactory.newIntBlockBuilder(selected.getPositionCount())
         ) {
@@ -302,6 +304,7 @@ public class FloatIntBucketedSort implements Releasable {
         assert oldMax % bucketSize == 0;
 
         long newSize = BigArrays.overSize(
+            // comment to make spotless happy about line breaks
             ((long) bucket + 1) * bucketSize,
             PageCacheRecycler.FLOAT_PAGE_SIZE,
             Float.BYTES
@@ -393,6 +396,7 @@ public class FloatIntBucketedSort implements Releasable {
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
                 if (betterThan(
+                    // comment to make spotless happy about line breaks
                     values.get(worstIndex),
                     values.get(leftIndex),
                     extraValues.get(worstIndex),
@@ -405,6 +409,7 @@ public class FloatIntBucketedSort implements Releasable {
                 long rightIndex = rootIndex + rightChild;
                 if (rightChild < heapSize
                     && betterThan(
+                        // comment to make spotless happy about line breaks
                         values.get(worstIndex),
                         values.get(rightIndex),
                         extraValues.get(worstIndex),

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/FloatIntBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/FloatIntBucketedSort.java
@@ -97,7 +97,12 @@ public class FloatIntBucketedSort implements Releasable {
     public void collect(float value, int extraValue, int bucket) {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
-            if (betterThan(value, values.get(rootIndex), extraValue, extraValues.get(rootIndex))) {
+            if (betterThan(
+                value,
+                values.get(rootIndex),
+                extraValue,
+                extraValues.get(rootIndex)
+            )) {
                 values.set(rootIndex, value);
                 extraValues.set(rootIndex, extraValue);
                 downHeap(rootIndex, 0, bucketSize);
@@ -296,7 +301,11 @@ public class FloatIntBucketedSort implements Releasable {
         long oldMax = values.size();
         assert oldMax % bucketSize == 0;
 
-        long newSize = BigArrays.overSize(((long) bucket + 1) * bucketSize, PageCacheRecycler.FLOAT_PAGE_SIZE, Float.BYTES);
+        long newSize = BigArrays.overSize(
+            ((long) bucket + 1) * bucketSize,
+            PageCacheRecycler.FLOAT_PAGE_SIZE,
+            Float.BYTES
+        );
         // Round up to the next full bucket.
         newSize = (newSize + bucketSize - 1) / bucketSize;
         values = bigArrays.resize(values, newSize * bucketSize);
@@ -383,7 +392,12 @@ public class FloatIntBucketedSort implements Releasable {
             int leftChild = parent * 2 + 1;
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
-                if (betterThan(values.get(worstIndex), values.get(leftIndex), extraValues.get(worstIndex), extraValues.get(leftIndex))) {
+                if (betterThan(
+                    values.get(worstIndex),
+                    values.get(leftIndex),
+                    extraValues.get(worstIndex),
+                    extraValues.get(leftIndex)
+                )) {
                     worst = leftChild;
                     worstIndex = leftIndex;
                 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/FloatIntBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/FloatIntBucketedSort.java
@@ -97,13 +97,9 @@ public class FloatIntBucketedSort implements Releasable {
     public void collect(float value, int extraValue, int bucket) {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
-            if (betterThan(
-                // comment to make spotless happy about line breaks
-                value,
-                values.get(rootIndex),
-                extraValue,
-                extraValues.get(rootIndex)
-            )) {
+            float rootValue = values.get(rootIndex);
+            int rootExtra = extraValues.get(rootIndex);
+            if (betterThan(value, rootValue, extraValue, rootExtra)) {
                 values.set(rootIndex, value);
                 extraValues.set(rootIndex, extraValue);
                 downHeap(rootIndex, 0, bucketSize);
@@ -166,12 +162,9 @@ public class FloatIntBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            collect(
-                // comment to make spotless happy about line breaks
-                other.values.get(i),
-                other.extraValues.get(i),
-                groupId
-            );
+            float otherValue = other.values.get(i);
+            int otherExtra = other.extraValues.get(i);
+            collect(otherValue, otherExtra, groupId);
         }
     }
 
@@ -307,12 +300,9 @@ public class FloatIntBucketedSort implements Releasable {
         long oldMax = values.size();
         assert oldMax % bucketSize == 0;
 
-        long newSize = BigArrays.overSize(
-            // comment to make spotless happy about line breaks
-            ((long) bucket + 1) * bucketSize,
-            PageCacheRecycler.FLOAT_PAGE_SIZE,
-            Float.BYTES
-        );
+        int pageSize = PageCacheRecycler.FLOAT_PAGE_SIZE;
+        int bytesPerElement = Float.BYTES;
+        long newSize = BigArrays.overSize(((long) bucket + 1) * bucketSize, pageSize, bytesPerElement);
         // Round up to the next full bucket.
         newSize = (newSize + bucketSize - 1) / bucketSize;
         values = bigArrays.resize(values, newSize * bucketSize);
@@ -399,28 +389,25 @@ public class FloatIntBucketedSort implements Releasable {
             int leftChild = parent * 2 + 1;
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
-                if (betterThan(
-                    // comment to make spotless happy about line breaks
-                    values.get(worstIndex),
-                    values.get(leftIndex),
-                    extraValues.get(worstIndex),
-                    extraValues.get(leftIndex)
-                )) {
+                float worstValue = values.get(worstIndex);
+                float leftValue = values.get(leftIndex);
+                int worstExtra = extraValues.get(worstIndex);
+                int leftExtra = extraValues.get(leftIndex);
+                if (betterThan(worstValue, leftValue, worstExtra, leftExtra)) {
                     worst = leftChild;
                     worstIndex = leftIndex;
                 }
                 int rightChild = leftChild + 1;
                 long rightIndex = rootIndex + rightChild;
-                if (rightChild < heapSize
-                    && betterThan(
-                        // comment to make spotless happy about line breaks
-                        values.get(worstIndex),
-                        values.get(rightIndex),
-                        extraValues.get(worstIndex),
-                        extraValues.get(rightIndex)
-                    )) {
-                    worst = rightChild;
-                    worstIndex = rightIndex;
+                if (rightChild < heapSize) {
+                    worstValue = values.get(worstIndex);
+                    float rightValue = values.get(rightIndex);
+                    worstExtra = extraValues.get(worstIndex);
+                    int rightExtra = extraValues.get(rightIndex);
+                    if (betterThan(worstValue, rightValue, worstExtra, rightExtra)) {
+                        worst = rightChild;
+                        worstIndex = rightIndex;
+                    }
                 }
             }
             if (worst == parent) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/FloatLongBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/FloatLongBucketedSort.java
@@ -97,13 +97,9 @@ public class FloatLongBucketedSort implements Releasable {
     public void collect(float value, long extraValue, int bucket) {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
-            if (betterThan(
-                // comment to make spotless happy about line breaks
-                value,
-                values.get(rootIndex),
-                extraValue,
-                extraValues.get(rootIndex)
-            )) {
+            float rootValue = values.get(rootIndex);
+            long rootExtra = extraValues.get(rootIndex);
+            if (betterThan(value, rootValue, extraValue, rootExtra)) {
                 values.set(rootIndex, value);
                 extraValues.set(rootIndex, extraValue);
                 downHeap(rootIndex, 0, bucketSize);
@@ -166,12 +162,9 @@ public class FloatLongBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            collect(
-                // comment to make spotless happy about line breaks
-                other.values.get(i),
-                other.extraValues.get(i),
-                groupId
-            );
+            float otherValue = other.values.get(i);
+            long otherExtra = other.extraValues.get(i);
+            collect(otherValue, otherExtra, groupId);
         }
     }
 
@@ -307,12 +300,9 @@ public class FloatLongBucketedSort implements Releasable {
         long oldMax = values.size();
         assert oldMax % bucketSize == 0;
 
-        long newSize = BigArrays.overSize(
-            // comment to make spotless happy about line breaks
-            ((long) bucket + 1) * bucketSize,
-            PageCacheRecycler.FLOAT_PAGE_SIZE,
-            Float.BYTES
-        );
+        int pageSize = PageCacheRecycler.FLOAT_PAGE_SIZE;
+        int bytesPerElement = Float.BYTES;
+        long newSize = BigArrays.overSize(((long) bucket + 1) * bucketSize, pageSize, bytesPerElement);
         // Round up to the next full bucket.
         newSize = (newSize + bucketSize - 1) / bucketSize;
         values = bigArrays.resize(values, newSize * bucketSize);
@@ -399,28 +389,25 @@ public class FloatLongBucketedSort implements Releasable {
             int leftChild = parent * 2 + 1;
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
-                if (betterThan(
-                    // comment to make spotless happy about line breaks
-                    values.get(worstIndex),
-                    values.get(leftIndex),
-                    extraValues.get(worstIndex),
-                    extraValues.get(leftIndex)
-                )) {
+                float worstValue = values.get(worstIndex);
+                float leftValue = values.get(leftIndex);
+                long worstExtra = extraValues.get(worstIndex);
+                long leftExtra = extraValues.get(leftIndex);
+                if (betterThan(worstValue, leftValue, worstExtra, leftExtra)) {
                     worst = leftChild;
                     worstIndex = leftIndex;
                 }
                 int rightChild = leftChild + 1;
                 long rightIndex = rootIndex + rightChild;
-                if (rightChild < heapSize
-                    && betterThan(
-                        // comment to make spotless happy about line breaks
-                        values.get(worstIndex),
-                        values.get(rightIndex),
-                        extraValues.get(worstIndex),
-                        extraValues.get(rightIndex)
-                    )) {
-                    worst = rightChild;
-                    worstIndex = rightIndex;
+                if (rightChild < heapSize) {
+                    worstValue = values.get(worstIndex);
+                    float rightValue = values.get(rightIndex);
+                    worstExtra = extraValues.get(worstIndex);
+                    long rightExtra = extraValues.get(rightIndex);
+                    if (betterThan(worstValue, rightValue, worstExtra, rightExtra)) {
+                        worst = rightChild;
+                        worstIndex = rightIndex;
+                    }
                 }
             }
             if (worst == parent) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/FloatLongBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/FloatLongBucketedSort.java
@@ -166,7 +166,12 @@ public class FloatLongBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            collect(other.values.get(i), other.extraValues.get(i), groupId);
+            collect(
+                // comment to make spotless happy about line breaks
+                other.values.get(i),
+                other.extraValues.get(i),
+                groupId
+            );
         }
     }
 
@@ -184,7 +189,6 @@ public class FloatLongBucketedSort implements Releasable {
         }
 
         try (
-            // comment to make spotless happy about line breaks
             var builder = blockFactory.newFloatBlockBuilder(selected.getPositionCount());
             var extraBuilder = blockFactory.newLongBlockBuilder(selected.getPositionCount())
         ) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/FloatLongBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/FloatLongBucketedSort.java
@@ -97,7 +97,12 @@ public class FloatLongBucketedSort implements Releasable {
     public void collect(float value, long extraValue, int bucket) {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
-            if (betterThan(value, values.get(rootIndex), extraValue, extraValues.get(rootIndex))) {
+            if (betterThan(
+                value,
+                values.get(rootIndex),
+                extraValue,
+                extraValues.get(rootIndex)
+            )) {
                 values.set(rootIndex, value);
                 extraValues.set(rootIndex, extraValue);
                 downHeap(rootIndex, 0, bucketSize);
@@ -296,7 +301,11 @@ public class FloatLongBucketedSort implements Releasable {
         long oldMax = values.size();
         assert oldMax % bucketSize == 0;
 
-        long newSize = BigArrays.overSize(((long) bucket + 1) * bucketSize, PageCacheRecycler.FLOAT_PAGE_SIZE, Float.BYTES);
+        long newSize = BigArrays.overSize(
+            ((long) bucket + 1) * bucketSize,
+            PageCacheRecycler.FLOAT_PAGE_SIZE,
+            Float.BYTES
+        );
         // Round up to the next full bucket.
         newSize = (newSize + bucketSize - 1) / bucketSize;
         values = bigArrays.resize(values, newSize * bucketSize);
@@ -383,7 +392,12 @@ public class FloatLongBucketedSort implements Releasable {
             int leftChild = parent * 2 + 1;
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
-                if (betterThan(values.get(worstIndex), values.get(leftIndex), extraValues.get(worstIndex), extraValues.get(leftIndex))) {
+                if (betterThan(
+                    values.get(worstIndex),
+                    values.get(leftIndex),
+                    extraValues.get(worstIndex),
+                    extraValues.get(leftIndex)
+                )) {
                     worst = leftChild;
                     worstIndex = leftIndex;
                 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/FloatLongBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/FloatLongBucketedSort.java
@@ -98,6 +98,7 @@ public class FloatLongBucketedSort implements Releasable {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
             if (betterThan(
+                // comment to make spotless happy about line breaks
                 value,
                 values.get(rootIndex),
                 extraValue,
@@ -183,6 +184,7 @@ public class FloatLongBucketedSort implements Releasable {
         }
 
         try (
+            // comment to make spotless happy about line breaks
             var builder = blockFactory.newFloatBlockBuilder(selected.getPositionCount());
             var extraBuilder = blockFactory.newLongBlockBuilder(selected.getPositionCount())
         ) {
@@ -302,6 +304,7 @@ public class FloatLongBucketedSort implements Releasable {
         assert oldMax % bucketSize == 0;
 
         long newSize = BigArrays.overSize(
+            // comment to make spotless happy about line breaks
             ((long) bucket + 1) * bucketSize,
             PageCacheRecycler.FLOAT_PAGE_SIZE,
             Float.BYTES
@@ -393,6 +396,7 @@ public class FloatLongBucketedSort implements Releasable {
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
                 if (betterThan(
+                    // comment to make spotless happy about line breaks
                     values.get(worstIndex),
                     values.get(leftIndex),
                     extraValues.get(worstIndex),
@@ -405,6 +409,7 @@ public class FloatLongBucketedSort implements Releasable {
                 long rightIndex = rootIndex + rightChild;
                 if (rightChild < heapSize
                     && betterThan(
+                        // comment to make spotless happy about line breaks
                         values.get(worstIndex),
                         values.get(rightIndex),
                         extraValues.get(worstIndex),

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/IntBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/IntBucketedSort.java
@@ -94,11 +94,8 @@ public class IntBucketedSort implements Releasable {
     public void collect(int value, int bucket) {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
-            if (betterThan(
-                // comment to make spotless happy about line breaks
-                value,
-                values.get(rootIndex)
-            )) {
+            int rootValue = values.get(rootIndex);
+            if (betterThan(value, rootValue)) {
                 values.set(rootIndex, value);
                 downHeap(rootIndex, 0, bucketSize);
             }
@@ -159,11 +156,8 @@ public class IntBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            collect(
-                // comment to make spotless happy about line breaks
-                other.values.get(i),
-                groupId
-            );
+            int otherValue = other.values.get(i);
+            collect(otherValue, groupId);
         }
     }
 
@@ -272,12 +266,9 @@ public class IntBucketedSort implements Releasable {
         long oldMax = values.size();
         assert oldMax % bucketSize == 0;
 
-        long newSize = BigArrays.overSize(
-            // comment to make spotless happy about line breaks
-            ((long) bucket + 1) * bucketSize,
-            PageCacheRecycler.INT_PAGE_SIZE,
-            Integer.BYTES
-        );
+        int pageSize = PageCacheRecycler.INT_PAGE_SIZE;
+        int bytesPerElement = Integer.BYTES;
+        long newSize = BigArrays.overSize(((long) bucket + 1) * bucketSize, pageSize, bytesPerElement);
         // Round up to the next full bucket.
         newSize = (newSize + bucketSize - 1) / bucketSize;
         values = bigArrays.resize(values, newSize * bucketSize);
@@ -362,24 +353,21 @@ public class IntBucketedSort implements Releasable {
             int leftChild = parent * 2 + 1;
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
-                if (betterThan(
-                    // comment to make spotless happy about line breaks
-                    values.get(worstIndex),
-                    values.get(leftIndex)
-                )) {
+                int worstValue = values.get(worstIndex);
+                int leftValue = values.get(leftIndex);
+                if (betterThan(worstValue, leftValue)) {
                     worst = leftChild;
                     worstIndex = leftIndex;
                 }
                 int rightChild = leftChild + 1;
                 long rightIndex = rootIndex + rightChild;
-                if (rightChild < heapSize
-                    && betterThan(
-                        // comment to make spotless happy about line breaks
-                        values.get(worstIndex),
-                        values.get(rightIndex)
-                    )) {
-                    worst = rightChild;
-                    worstIndex = rightIndex;
+                if (rightChild < heapSize) {
+                    worstValue = values.get(worstIndex);
+                    int rightValue = values.get(rightIndex);
+                    if (betterThan(worstValue, rightValue)) {
+                        worst = rightChild;
+                        worstIndex = rightIndex;
+                    }
                 }
             }
             if (worst == parent) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/IntBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/IntBucketedSort.java
@@ -94,7 +94,11 @@ public class IntBucketedSort implements Releasable {
     public void collect(int value, int bucket) {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
-            if (betterThan(value, values.get(rootIndex))) {
+            if (betterThan(
+                // comment to make spotless happy about line breaks
+                value,
+                values.get(rootIndex)
+            )) {
                 values.set(rootIndex, value);
                 downHeap(rootIndex, 0, bucketSize);
             }
@@ -155,7 +159,11 @@ public class IntBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            collect(other.values.get(i), groupId);
+            collect(
+                // comment to make spotless happy about line breaks
+                other.values.get(i),
+                groupId
+            );
         }
     }
 
@@ -168,10 +176,7 @@ public class IntBucketedSort implements Releasable {
             return blockFactory.newConstantNullBlock(selected.getPositionCount());
         }
 
-        try (
-            // comment to make spotless happy about line breaks
-            var builder = blockFactory.newIntBlockBuilder(selected.getPositionCount())
-        ) {
+        try (var builder = blockFactory.newIntBlockBuilder(selected.getPositionCount())) {
             for (int s = 0; s < selected.getPositionCount(); s++) {
                 int bucket = selected.getInt(s);
 
@@ -357,13 +362,22 @@ public class IntBucketedSort implements Releasable {
             int leftChild = parent * 2 + 1;
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
-                if (betterThan(values.get(worstIndex), values.get(leftIndex))) {
+                if (betterThan(
+                    // comment to make spotless happy about line breaks
+                    values.get(worstIndex),
+                    values.get(leftIndex)
+                )) {
                     worst = leftChild;
                     worstIndex = leftIndex;
                 }
                 int rightChild = leftChild + 1;
                 long rightIndex = rootIndex + rightChild;
-                if (rightChild < heapSize && betterThan(values.get(worstIndex), values.get(rightIndex))) {
+                if (rightChild < heapSize
+                    && betterThan(
+                        // comment to make spotless happy about line breaks
+                        values.get(worstIndex),
+                        values.get(rightIndex)
+                    )) {
                     worst = rightChild;
                     worstIndex = rightIndex;
                 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/IntBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/IntBucketedSort.java
@@ -167,7 +167,9 @@ public class IntBucketedSort implements Releasable {
             return blockFactory.newConstantNullBlock(selected.getPositionCount());
         }
 
-        try (var builder = blockFactory.newIntBlockBuilder(selected.getPositionCount())) {
+        try (
+            var builder = blockFactory.newIntBlockBuilder(selected.getPositionCount())
+        ) {
             for (int s = 0; s < selected.getPositionCount(); s++) {
                 int bucket = selected.getInt(s);
 

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/IntBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/IntBucketedSort.java
@@ -67,6 +67,7 @@ public class IntBucketedSort implements Releasable {
      * </ul>
      */
     private IntArray values;
+
     public IntBucketedSort(BigArrays bigArrays, SortOrder order, int bucketSize) {
         this.bigArrays = bigArrays;
         this.order = order;
@@ -168,6 +169,7 @@ public class IntBucketedSort implements Releasable {
         }
 
         try (
+            // comment to make spotless happy about line breaks
             var builder = blockFactory.newIntBlockBuilder(selected.getPositionCount())
         ) {
             for (int s = 0; s < selected.getPositionCount(); s++) {
@@ -266,6 +268,7 @@ public class IntBucketedSort implements Releasable {
         assert oldMax % bucketSize == 0;
 
         long newSize = BigArrays.overSize(
+            // comment to make spotless happy about line breaks
             ((long) bucket + 1) * bucketSize,
             PageCacheRecycler.INT_PAGE_SIZE,
             Integer.BYTES

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/IntBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/IntBucketedSort.java
@@ -67,7 +67,6 @@ public class IntBucketedSort implements Releasable {
      * </ul>
      */
     private IntArray values;
-
     public IntBucketedSort(BigArrays bigArrays, SortOrder order, int bucketSize) {
         this.bigArrays = bigArrays;
         this.order = order;
@@ -264,7 +263,11 @@ public class IntBucketedSort implements Releasable {
         long oldMax = values.size();
         assert oldMax % bucketSize == 0;
 
-        long newSize = BigArrays.overSize(((long) bucket + 1) * bucketSize, PageCacheRecycler.INT_PAGE_SIZE, Integer.BYTES);
+        long newSize = BigArrays.overSize(
+            ((long) bucket + 1) * bucketSize,
+            PageCacheRecycler.INT_PAGE_SIZE,
+            Integer.BYTES
+        );
         // Round up to the next full bucket.
         newSize = (newSize + bucketSize - 1) / bucketSize;
         values = bigArrays.resize(values, newSize * bucketSize);

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/IntBytesRefBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/IntBytesRefBucketedSort.java
@@ -73,6 +73,7 @@ public class IntBytesRefBucketedSort implements Releasable {
      */
     private IntArray values;
     private ObjectArray<BreakingBytesRefBuilder> extraValues;
+
     public IntBytesRefBucketedSort(BigArrays bigArrays, SortOrder order, int bucketSize) {
         this.bigArrays = bigArrays;
         this.breaker = bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST);
@@ -102,6 +103,7 @@ public class IntBytesRefBucketedSort implements Releasable {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
             if (betterThan(
+                // comment to make spotless happy about line breaks
                 value,
                 values.get(rootIndex),
                 extraValue,
@@ -188,6 +190,7 @@ public class IntBytesRefBucketedSort implements Releasable {
         }
 
         try (
+            // comment to make spotless happy about line breaks
             var builder = blockFactory.newIntBlockBuilder(selected.getPositionCount());
             var extraBuilder = blockFactory.newBytesRefBlockBuilder(selected.getPositionCount())
         ) {
@@ -337,6 +340,7 @@ public class IntBytesRefBucketedSort implements Releasable {
         assert oldMax % bucketSize == 0;
 
         long newSize = BigArrays.overSize(
+            // comment to make spotless happy about line breaks
             ((long) bucket + 1) * bucketSize,
             PageCacheRecycler.INT_PAGE_SIZE,
             Integer.BYTES
@@ -428,6 +432,7 @@ public class IntBytesRefBucketedSort implements Releasable {
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
                 if (betterThan(
+                    // comment to make spotless happy about line breaks
                     values.get(worstIndex),
                     values.get(leftIndex),
                     extraBytesAt(worstIndex),
@@ -440,6 +445,7 @@ public class IntBytesRefBucketedSort implements Releasable {
                 long rightIndex = rootIndex + rightChild;
                 if (rightChild < heapSize
                     && betterThan(
+                        // comment to make spotless happy about line breaks
                         values.get(worstIndex),
                         values.get(rightIndex),
                         extraBytesAt(worstIndex),

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/IntBytesRefBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/IntBytesRefBucketedSort.java
@@ -171,8 +171,12 @@ public class IntBytesRefBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            BreakingBytesRefBuilder otherExtra = other.extraValues.get(i);
-            collect(other.values.get(i), otherExtra == null ? new BytesRef() : otherExtra.bytesRefView(), groupId);
+            collect(
+                // comment to make spotless happy about line breaks
+                other.values.get(i),
+                other.extraValues.get(i) == null ? new BytesRef() : other.extraValues.get(i).bytesRefView(),
+                groupId
+            );
         }
     }
 
@@ -190,7 +194,6 @@ public class IntBytesRefBucketedSort implements Releasable {
         }
 
         try (
-            // comment to make spotless happy about line breaks
             var builder = blockFactory.newIntBlockBuilder(selected.getPositionCount());
             var extraBuilder = blockFactory.newBytesRefBlockBuilder(selected.getPositionCount())
         ) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/IntBytesRefBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/IntBytesRefBucketedSort.java
@@ -1,0 +1,469 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data.sort;
+
+// begin generated imports
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.BitArray;
+import org.elasticsearch.common.util.ObjectArray;
+import org.elasticsearch.common.util.IntArray;
+import org.elasticsearch.common.util.PageCacheRecycler;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.core.Tuple;
+import org.elasticsearch.search.sort.BucketedSort;
+import org.elasticsearch.search.sort.SortOrder;
+
+import java.util.stream.IntStream;
+// end generated imports
+
+/**
+ * Aggregates the top N {@code int} values per bucket.
+ * See {@link BucketedSort} for more information.
+ * This class is generated. Edit @{code X-BucketedSort.java.st} instead of this file.
+ */
+public class IntBytesRefBucketedSort implements Releasable {
+
+    private final BigArrays bigArrays;
+    private final CircuitBreaker breaker;
+    private final SortOrder order;
+    private final int bucketSize;
+    /**
+     * {@code true} if the bucket is in heap mode, {@code false} if
+     * it is still gathering.
+     */
+    private final BitArray heapMode;
+    /**
+     * An array containing all the values on all buckets. The structure is as follows:
+     * <p>
+     *     For each bucket, there are bucketSize elements, based on the bucket id (0, 1, 2...).
+     *     Then, for each bucket, it can be in 2 states:
+     * </p>
+     * <ul>
+     *     <li>
+     *         Gather mode: All buckets start in gather mode, and remain here while they have less than bucketSize elements.
+     *         In gather mode, the elements are stored in the array from the highest index to the lowest index.
+     *         The lowest index contains the offset to the next slot to be filled.
+     *         <p>
+     *             This allows us to insert elements in O(1) time.
+     *         </p>
+     *         <p>
+     *             When the bucketSize-th element is collected, the bucket transitions to heap mode, by heapifying its contents.
+     *         </p>
+     *     </li>
+     *     <li>
+     *         Heap mode: The bucket slots are organized as a min heap structure.
+     *         <p>
+     *             The root of the heap is the minimum value in the bucket,
+     *             which allows us to quickly discard new values that are not in the top N.
+     *         </p>
+     *     </li>
+     * </ul>
+     */
+    private IntArray values;
+    private ObjectArray<BreakingBytesRefBuilder> extraValues;
+    public IntBytesRefBucketedSort(BigArrays bigArrays, SortOrder order, int bucketSize) {
+        this.bigArrays = bigArrays;
+        this.breaker = bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST);
+        this.order = order;
+        this.bucketSize = bucketSize;
+        heapMode = new BitArray(0, bigArrays);
+
+        boolean success = false;
+        try {
+            values = bigArrays.newIntArray(0, false);
+            extraValues = bigArrays.newObjectArray(0);
+            success = true;
+        } finally {
+            if (success == false) {
+                close();
+            }
+        }
+    }
+
+    /**
+     * Collects a {@code value} into a {@code bucket}.
+     * <p>
+     *     It may or may not be inserted in the heap, depending on if it is better than the current root.
+     * </p>
+     */
+    public void collect(int value, BytesRef extraValue, int bucket) {
+        long rootIndex = (long) bucket * bucketSize;
+        if (inHeapMode(bucket)) {
+            if (betterThan(
+                value,
+                values.get(rootIndex),
+                extraValue,
+                extraBytesAt(rootIndex)
+            )) {
+                values.set(rootIndex, value);
+                clearedExtraBytesAt(rootIndex).append(extraValue);
+                downHeap(rootIndex, 0, bucketSize);
+            }
+            return;
+        }
+        // Gathering mode
+        long requiredSize = rootIndex + bucketSize;
+        if (values.size() < requiredSize) {
+            grow(bucket);
+        }
+        int next = getNextGatherOffset(rootIndex);
+        assert 0 <= next && next < bucketSize
+            : "Expected next to be in the range of valid buckets [0 <= " + next + " < " + bucketSize + "]";
+        long index = next + rootIndex;
+        values.set(index, value);
+        clearedExtraBytesAt(index).append(extraValue);
+        if (next == 0) {
+            heapMode.set(bucket);
+            heapify(rootIndex, bucketSize);
+        } else {
+            setNextGatherOffset(rootIndex, next - 1);
+        }
+    }
+
+    /**
+     * The order of the sort.
+     */
+    public SortOrder getOrder() {
+        return order;
+    }
+
+    /**
+     * The number of values to store per bucket.
+     */
+    public int getBucketSize() {
+        return bucketSize;
+    }
+
+    /**
+     * Get the first and last indexes (inclusive, exclusive) of the values for a bucket.
+     * Returns [0, 0] if the bucket has never been collected.
+     */
+    private Tuple<Long, Long> getBucketValuesIndexes(int bucket) {
+        long rootIndex = (long) bucket * bucketSize;
+        if (rootIndex >= values.size()) {
+            // We've never seen this bucket.
+            return Tuple.tuple(0L, 0L);
+        }
+        long start = inHeapMode(bucket) ? rootIndex : (rootIndex + getNextGatherOffset(rootIndex) + 1);
+        long end = rootIndex + bucketSize;
+        return Tuple.tuple(start, end);
+    }
+
+    /**
+     * Merge the values from {@code other}'s {@code otherGroupId} into {@code groupId}.
+     */
+    public void merge(int groupId, IntBytesRefBucketedSort other, int otherGroupId) {
+        var otherBounds = other.getBucketValuesIndexes(otherGroupId);
+
+        // TODO: This can be improved for heapified buckets by making use of the heap structures
+        for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
+            BreakingBytesRefBuilder otherExtra = other.extraValues.get(i);
+            collect(other.values.get(i), otherExtra == null ? new BytesRef() : otherExtra.bytesRefView(), groupId);
+        }
+    }
+
+    /**
+     * Creates a block with the values from the {@code selected} groups.
+     */
+    public void toBlocks(BlockFactory blockFactory, Block[] blocks, int offset, IntVector selected) {
+        // Check if the selected groups are all empty, to avoid allocating extra memory
+        if (allSelectedGroupsAreEmpty(selected)) {
+            Block constantNullBlock = blockFactory.newConstantNullBlock(selected.getPositionCount());
+            constantNullBlock.incRef();
+            blocks[offset] = constantNullBlock;
+            blocks[offset + 1] = constantNullBlock;
+            return;
+        }
+
+        try (
+            var builder = blockFactory.newIntBlockBuilder(selected.getPositionCount());
+            var extraBuilder = blockFactory.newBytesRefBlockBuilder(selected.getPositionCount())
+        ) {
+            for (int s = 0; s < selected.getPositionCount(); s++) {
+                int bucket = selected.getInt(s);
+
+                var bounds = getBucketValuesIndexes(bucket);
+                var rootIndex = bounds.v1();
+                var size = bounds.v2() - bounds.v1();
+
+                if (size == 0) {
+                    builder.appendNull();
+                    extraBuilder.appendNull();
+                    continue;
+                }
+
+                if (size == 1) {
+                    builder.appendInt(values.get(rootIndex));
+                    appendExtra(extraBuilder, rootIndex);
+                    continue;
+                }
+
+                // If we are in the gathering mode, we need to heapify before sorting.
+                if (inHeapMode(bucket) == false) {
+                    heapify(rootIndex, (int) size);
+                }
+                heapSort(rootIndex, (int) size);
+
+                builder.beginPositionEntry();
+                extraBuilder.beginPositionEntry();
+                for (int i = 0; i < size; i++) {
+                    builder.appendInt(values.get(rootIndex + i));
+                    appendExtra(extraBuilder, rootIndex + i);
+                }
+                builder.endPositionEntry();
+                extraBuilder.endPositionEntry();
+            }
+            blocks[offset] = builder.build();
+            try {
+                blocks[offset + 1] = extraBuilder.build();
+            } finally {
+                if (blocks[offset + 1] == null) {
+                    blocks[offset].close();
+                    blocks[offset] = null;
+                }
+            }
+        }
+    }
+
+    private void appendExtra(org.elasticsearch.compute.data.BytesRefBlock.Builder extraBuilder, long index) {
+        BreakingBytesRefBuilder bytes = extraValues.get(index);
+        if (bytes == null) {
+            extraBuilder.appendNull();
+            return;
+        }
+        try {
+            extraBuilder.appendBytesRef(bytes.bytesRefView());
+        } finally {
+            extraValues.set(index, null);
+            Releasables.closeExpectNoException(bytes);
+        }
+    }
+
+    private BreakingBytesRefBuilder clearedExtraBytesAt(long index) {
+        BreakingBytesRefBuilder bytes = extraValues.get(index);
+        if (bytes == null) {
+            bytes = new BreakingBytesRefBuilder(breaker, "top");
+            extraValues.set(index, bytes);
+        } else {
+            bytes.clear();
+        }
+        return bytes;
+    }
+
+    private BytesRef extraBytesAt(long index) {
+        BreakingBytesRefBuilder bytes = extraValues.get(index);
+        return bytes == null ? new BytesRef() : bytes.bytesRefView();
+    }
+
+    /**
+     * Checks if the selected groups are all empty.
+     */
+    private boolean allSelectedGroupsAreEmpty(IntVector selected) {
+        return IntStream.range(0, selected.getPositionCount()).map(selected::getInt).noneMatch(bucket -> {
+            var bounds = this.getBucketValuesIndexes(bucket);
+            var size = bounds.v2() - bounds.v1();
+            return size > 0;
+        });
+    }
+
+    /**
+     * Is this bucket a min heap {@code true} or in gathering mode {@code false}?
+     */
+    private boolean inHeapMode(int bucket) {
+        return heapMode.get(bucket);
+    }
+
+    /**
+     * Get the next index that should be "gathered" for a bucket rooted
+     * at {@code rootIndex}.
+     */
+    private int getNextGatherOffset(long rootIndex) {
+        return values.get(rootIndex);
+    }
+
+    /**
+     * Set the next index that should be "gathered" for a bucket rooted
+     * at {@code rootIndex}.
+     */
+    private void setNextGatherOffset(long rootIndex, int offset) {
+        values.set(rootIndex, offset);
+    }
+
+    /**
+     * {@code true} if the entry at index {@code lhs} is "better" than
+     * the entry at {@code rhs}. "Better" in this means "lower" for
+     * {@link SortOrder#ASC} and "higher" for {@link SortOrder#DESC}.
+     */
+    private boolean betterThan(int lhs, int rhs, BytesRef lhsExtra, BytesRef rhsExtra) {
+        int res = Integer.compare(lhs, rhs);
+        if (res != 0) {
+            return getOrder().reverseMul() * res < 0;
+        }
+        res = lhsExtra.compareTo(rhsExtra);
+        return getOrder().reverseMul() * res < 0;
+    }
+
+    /**
+     * Swap the data at two indices.
+     */
+    private void swap(long lhs, long rhs) {
+        var tmp = values.get(lhs);
+        values.set(lhs, values.get(rhs));
+        values.set(rhs, tmp);
+        var tmpExtra = extraValues.get(lhs);
+        extraValues.set(lhs, extraValues.get(rhs));
+        extraValues.set(rhs, tmpExtra);
+    }
+
+    /**
+     * Allocate storage for more buckets and store the "next gather offset"
+     * for those new buckets. We always grow the storage by whole bucket's
+     * worth of slots at a time. We never allocate space for partial buckets.
+     */
+    private void grow(int bucket) {
+        long oldMax = values.size();
+        assert oldMax % bucketSize == 0;
+
+        long newSize = BigArrays.overSize(
+            ((long) bucket + 1) * bucketSize,
+            PageCacheRecycler.INT_PAGE_SIZE,
+            Integer.BYTES
+        );
+        // Round up to the next full bucket.
+        newSize = (newSize + bucketSize - 1) / bucketSize;
+        values = bigArrays.resize(values, newSize * bucketSize);
+        // Round up to the next full bucket.
+        extraValues = bigArrays.resize(extraValues, newSize * bucketSize);
+        // Set the next gather offsets for all newly allocated buckets.
+        fillGatherOffsets(oldMax);
+    }
+
+    /**
+     * Maintain the "next gather offsets" for newly allocated buckets.
+     */
+    private void fillGatherOffsets(long startingAt) {
+        int nextOffset = getBucketSize() - 1;
+        for (long bucketRoot = startingAt; bucketRoot < values.size(); bucketRoot += getBucketSize()) {
+            setNextGatherOffset(bucketRoot, nextOffset);
+        }
+    }
+
+    /**
+     * Heapify a bucket whose entries are in random order.
+     * <p>
+     * This works by validating the heap property on each node, iterating
+     * "upwards", pushing any out of order parents "down". Check out the
+     * <a href="https://en.wikipedia.org/w/index.php?title=Binary_heap&oldid=940542991#Building_a_heap">wikipedia</a>
+     * entry on binary heaps for more about this.
+     * </p>
+     * <p>
+     * While this *looks* like it could easily be {@code O(n * log n)}, it is
+     * a fairly well studied algorithm attributed to Floyd. There's
+     * been a bunch of work that puts this at {@code O(n)}, close to 1.88n worst
+     * case.
+     * </p>
+     * <ul>
+     * <li>Hayward, Ryan; McDiarmid, Colin (1991).
+     * <a href="https://web.archive.org/web/20160205023201/http://www.stats.ox.ac.uk/__data/assets/pdf_file/0015/4173/heapbuildjalg.pdf">
+     * Average Case Analysis of Heap Building byRepeated Insertion</a> J. Algorithms.
+     * <li>D.E. Knuth, ”The Art of Computer Programming, Vol. 3, Sorting and Searching”</li>
+     * </ul>
+     * @param rootIndex the index the start of the bucket
+     */
+    private void heapify(long rootIndex, int heapSize) {
+        int maxParent = heapSize / 2 - 1;
+        for (int parent = maxParent; parent >= 0; parent--) {
+            downHeap(rootIndex, parent, heapSize);
+        }
+    }
+
+    /**
+     * Sorts all the values in the heap using heap sort algorithm.
+     * This runs in {@code O(n log n)} time.
+     * @param rootIndex index of the start of the bucket
+     * @param heapSize Number of values that belong to the heap.
+     *                 Can be less than bucketSize.
+     *                 In such a case, the remaining values in range
+     *                 (rootIndex + heapSize, rootIndex + bucketSize)
+     *                 are *not* considered part of the heap.
+     */
+    private void heapSort(long rootIndex, int heapSize) {
+        while (heapSize > 0) {
+            swap(rootIndex, rootIndex + heapSize - 1);
+            heapSize--;
+            downHeap(rootIndex, 0, heapSize);
+        }
+    }
+
+    /**
+     * Correct the heap invariant of a parent and its children. This
+     * runs in {@code O(log n)} time.
+     * @param rootIndex index of the start of the bucket
+     * @param parent Index within the bucket of the parent to check.
+     *               For example, 0 is the "root".
+     * @param heapSize Number of values that belong to the heap.
+     *                 Can be less than bucketSize.
+     *                 In such a case, the remaining values in range
+     *                 (rootIndex + heapSize, rootIndex + bucketSize)
+     *                 are *not* considered part of the heap.
+     */
+    private void downHeap(long rootIndex, int parent, int heapSize) {
+        while (true) {
+            long parentIndex = rootIndex + parent;
+            int worst = parent;
+            long worstIndex = parentIndex;
+            int leftChild = parent * 2 + 1;
+            long leftIndex = rootIndex + leftChild;
+            if (leftChild < heapSize) {
+                if (betterThan(
+                    values.get(worstIndex),
+                    values.get(leftIndex),
+                    extraBytesAt(worstIndex),
+                    extraBytesAt(leftIndex)
+                )) {
+                    worst = leftChild;
+                    worstIndex = leftIndex;
+                }
+                int rightChild = leftChild + 1;
+                long rightIndex = rootIndex + rightChild;
+                if (rightChild < heapSize
+                    && betterThan(
+                        values.get(worstIndex),
+                        values.get(rightIndex),
+                        extraBytesAt(worstIndex),
+                        extraBytesAt(rightIndex)
+                    )) {
+                    worst = rightChild;
+                    worstIndex = rightIndex;
+                }
+            }
+            if (worst == parent) {
+                break;
+            }
+            swap(worstIndex, parentIndex);
+            parent = worst;
+        }
+    }
+
+    @Override
+    public final void close() {
+        if (extraValues != null) {
+            for (long i = 0; i < extraValues.size(); i++) {
+                Releasables.close(extraValues.get(i));
+            }
+        }
+        Releasables.close(values, extraValues, heapMode);
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/IntBytesRefBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/IntBytesRefBucketedSort.java
@@ -102,13 +102,9 @@ public class IntBytesRefBucketedSort implements Releasable {
     public void collect(int value, BytesRef extraValue, int bucket) {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
-            if (betterThan(
-                // comment to make spotless happy about line breaks
-                value,
-                values.get(rootIndex),
-                extraValue,
-                extraBytesAt(rootIndex)
-            )) {
+            int rootValue = values.get(rootIndex);
+            BytesRef rootExtra = extraBytesAt(rootIndex);
+            if (betterThan(value, rootValue, extraValue, rootExtra)) {
                 values.set(rootIndex, value);
                 clearedExtraBytesAt(rootIndex).append(extraValue);
                 downHeap(rootIndex, 0, bucketSize);
@@ -171,12 +167,9 @@ public class IntBytesRefBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            collect(
-                // comment to make spotless happy about line breaks
-                other.values.get(i),
-                other.extraValues.get(i) == null ? new BytesRef() : other.extraValues.get(i).bytesRefView(),
-                groupId
-            );
+            int otherValue = other.values.get(i);
+            BytesRef otherExtra = other.extraValues.get(i) == null ? new BytesRef() : other.extraValues.get(i).bytesRefView();
+            collect(otherValue, otherExtra, groupId);
         }
     }
 
@@ -342,12 +335,9 @@ public class IntBytesRefBucketedSort implements Releasable {
         long oldMax = values.size();
         assert oldMax % bucketSize == 0;
 
-        long newSize = BigArrays.overSize(
-            // comment to make spotless happy about line breaks
-            ((long) bucket + 1) * bucketSize,
-            PageCacheRecycler.INT_PAGE_SIZE,
-            Integer.BYTES
-        );
+        int pageSize = PageCacheRecycler.INT_PAGE_SIZE;
+        int bytesPerElement = Integer.BYTES;
+        long newSize = BigArrays.overSize(((long) bucket + 1) * bucketSize, pageSize, bytesPerElement);
         // Round up to the next full bucket.
         newSize = (newSize + bucketSize - 1) / bucketSize;
         values = bigArrays.resize(values, newSize * bucketSize);
@@ -434,28 +424,25 @@ public class IntBytesRefBucketedSort implements Releasable {
             int leftChild = parent * 2 + 1;
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
-                if (betterThan(
-                    // comment to make spotless happy about line breaks
-                    values.get(worstIndex),
-                    values.get(leftIndex),
-                    extraBytesAt(worstIndex),
-                    extraBytesAt(leftIndex)
-                )) {
+                int worstValue = values.get(worstIndex);
+                int leftValue = values.get(leftIndex);
+                BytesRef worstExtra = extraBytesAt(worstIndex);
+                BytesRef leftExtra = extraBytesAt(leftIndex);
+                if (betterThan(worstValue, leftValue, worstExtra, leftExtra)) {
                     worst = leftChild;
                     worstIndex = leftIndex;
                 }
                 int rightChild = leftChild + 1;
                 long rightIndex = rootIndex + rightChild;
-                if (rightChild < heapSize
-                    && betterThan(
-                        // comment to make spotless happy about line breaks
-                        values.get(worstIndex),
-                        values.get(rightIndex),
-                        extraBytesAt(worstIndex),
-                        extraBytesAt(rightIndex)
-                    )) {
-                    worst = rightChild;
-                    worstIndex = rightIndex;
+                if (rightChild < heapSize) {
+                    worstValue = values.get(worstIndex);
+                    int rightValue = values.get(rightIndex);
+                    worstExtra = extraBytesAt(worstIndex);
+                    BytesRef rightExtra = extraBytesAt(rightIndex);
+                    if (betterThan(worstValue, rightValue, worstExtra, rightExtra)) {
+                        worst = rightChild;
+                        worstIndex = rightIndex;
+                    }
                 }
             }
             if (worst == parent) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/IntDoubleBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/IntDoubleBucketedSort.java
@@ -98,6 +98,7 @@ public class IntDoubleBucketedSort implements Releasable {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
             if (betterThan(
+                // comment to make spotless happy about line breaks
                 value,
                 values.get(rootIndex),
                 extraValue,
@@ -183,6 +184,7 @@ public class IntDoubleBucketedSort implements Releasable {
         }
 
         try (
+            // comment to make spotless happy about line breaks
             var builder = blockFactory.newIntBlockBuilder(selected.getPositionCount());
             var extraBuilder = blockFactory.newDoubleBlockBuilder(selected.getPositionCount())
         ) {
@@ -302,6 +304,7 @@ public class IntDoubleBucketedSort implements Releasable {
         assert oldMax % bucketSize == 0;
 
         long newSize = BigArrays.overSize(
+            // comment to make spotless happy about line breaks
             ((long) bucket + 1) * bucketSize,
             PageCacheRecycler.INT_PAGE_SIZE,
             Integer.BYTES
@@ -393,6 +396,7 @@ public class IntDoubleBucketedSort implements Releasable {
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
                 if (betterThan(
+                    // comment to make spotless happy about line breaks
                     values.get(worstIndex),
                     values.get(leftIndex),
                     extraValues.get(worstIndex),
@@ -405,6 +409,7 @@ public class IntDoubleBucketedSort implements Releasable {
                 long rightIndex = rootIndex + rightChild;
                 if (rightChild < heapSize
                     && betterThan(
+                        // comment to make spotless happy about line breaks
                         values.get(worstIndex),
                         values.get(rightIndex),
                         extraValues.get(worstIndex),

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/IntDoubleBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/IntDoubleBucketedSort.java
@@ -97,13 +97,9 @@ public class IntDoubleBucketedSort implements Releasable {
     public void collect(int value, double extraValue, int bucket) {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
-            if (betterThan(
-                // comment to make spotless happy about line breaks
-                value,
-                values.get(rootIndex),
-                extraValue,
-                extraValues.get(rootIndex)
-            )) {
+            int rootValue = values.get(rootIndex);
+            double rootExtra = extraValues.get(rootIndex);
+            if (betterThan(value, rootValue, extraValue, rootExtra)) {
                 values.set(rootIndex, value);
                 extraValues.set(rootIndex, extraValue);
                 downHeap(rootIndex, 0, bucketSize);
@@ -166,12 +162,9 @@ public class IntDoubleBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            collect(
-                // comment to make spotless happy about line breaks
-                other.values.get(i),
-                other.extraValues.get(i),
-                groupId
-            );
+            int otherValue = other.values.get(i);
+            double otherExtra = other.extraValues.get(i);
+            collect(otherValue, otherExtra, groupId);
         }
     }
 
@@ -307,12 +300,9 @@ public class IntDoubleBucketedSort implements Releasable {
         long oldMax = values.size();
         assert oldMax % bucketSize == 0;
 
-        long newSize = BigArrays.overSize(
-            // comment to make spotless happy about line breaks
-            ((long) bucket + 1) * bucketSize,
-            PageCacheRecycler.INT_PAGE_SIZE,
-            Integer.BYTES
-        );
+        int pageSize = PageCacheRecycler.INT_PAGE_SIZE;
+        int bytesPerElement = Integer.BYTES;
+        long newSize = BigArrays.overSize(((long) bucket + 1) * bucketSize, pageSize, bytesPerElement);
         // Round up to the next full bucket.
         newSize = (newSize + bucketSize - 1) / bucketSize;
         values = bigArrays.resize(values, newSize * bucketSize);
@@ -399,28 +389,25 @@ public class IntDoubleBucketedSort implements Releasable {
             int leftChild = parent * 2 + 1;
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
-                if (betterThan(
-                    // comment to make spotless happy about line breaks
-                    values.get(worstIndex),
-                    values.get(leftIndex),
-                    extraValues.get(worstIndex),
-                    extraValues.get(leftIndex)
-                )) {
+                int worstValue = values.get(worstIndex);
+                int leftValue = values.get(leftIndex);
+                double worstExtra = extraValues.get(worstIndex);
+                double leftExtra = extraValues.get(leftIndex);
+                if (betterThan(worstValue, leftValue, worstExtra, leftExtra)) {
                     worst = leftChild;
                     worstIndex = leftIndex;
                 }
                 int rightChild = leftChild + 1;
                 long rightIndex = rootIndex + rightChild;
-                if (rightChild < heapSize
-                    && betterThan(
-                        // comment to make spotless happy about line breaks
-                        values.get(worstIndex),
-                        values.get(rightIndex),
-                        extraValues.get(worstIndex),
-                        extraValues.get(rightIndex)
-                    )) {
-                    worst = rightChild;
-                    worstIndex = rightIndex;
+                if (rightChild < heapSize) {
+                    worstValue = values.get(worstIndex);
+                    int rightValue = values.get(rightIndex);
+                    worstExtra = extraValues.get(worstIndex);
+                    double rightExtra = extraValues.get(rightIndex);
+                    if (betterThan(worstValue, rightValue, worstExtra, rightExtra)) {
+                        worst = rightChild;
+                        worstIndex = rightIndex;
+                    }
                 }
             }
             if (worst == parent) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/IntDoubleBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/IntDoubleBucketedSort.java
@@ -166,7 +166,12 @@ public class IntDoubleBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            collect(other.values.get(i), other.extraValues.get(i), groupId);
+            collect(
+                // comment to make spotless happy about line breaks
+                other.values.get(i),
+                other.extraValues.get(i),
+                groupId
+            );
         }
     }
 
@@ -184,7 +189,6 @@ public class IntDoubleBucketedSort implements Releasable {
         }
 
         try (
-            // comment to make spotless happy about line breaks
             var builder = blockFactory.newIntBlockBuilder(selected.getPositionCount());
             var extraBuilder = blockFactory.newDoubleBlockBuilder(selected.getPositionCount())
         ) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/IntDoubleBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/IntDoubleBucketedSort.java
@@ -97,7 +97,12 @@ public class IntDoubleBucketedSort implements Releasable {
     public void collect(int value, double extraValue, int bucket) {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
-            if (betterThan(value, values.get(rootIndex), extraValue, extraValues.get(rootIndex))) {
+            if (betterThan(
+                value,
+                values.get(rootIndex),
+                extraValue,
+                extraValues.get(rootIndex)
+            )) {
                 values.set(rootIndex, value);
                 extraValues.set(rootIndex, extraValue);
                 downHeap(rootIndex, 0, bucketSize);
@@ -296,7 +301,11 @@ public class IntDoubleBucketedSort implements Releasable {
         long oldMax = values.size();
         assert oldMax % bucketSize == 0;
 
-        long newSize = BigArrays.overSize(((long) bucket + 1) * bucketSize, PageCacheRecycler.INT_PAGE_SIZE, Integer.BYTES);
+        long newSize = BigArrays.overSize(
+            ((long) bucket + 1) * bucketSize,
+            PageCacheRecycler.INT_PAGE_SIZE,
+            Integer.BYTES
+        );
         // Round up to the next full bucket.
         newSize = (newSize + bucketSize - 1) / bucketSize;
         values = bigArrays.resize(values, newSize * bucketSize);
@@ -383,7 +392,12 @@ public class IntDoubleBucketedSort implements Releasable {
             int leftChild = parent * 2 + 1;
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
-                if (betterThan(values.get(worstIndex), values.get(leftIndex), extraValues.get(worstIndex), extraValues.get(leftIndex))) {
+                if (betterThan(
+                    values.get(worstIndex),
+                    values.get(leftIndex),
+                    extraValues.get(worstIndex),
+                    extraValues.get(leftIndex)
+                )) {
                     worst = leftChild;
                     worstIndex = leftIndex;
                 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/IntFloatBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/IntFloatBucketedSort.java
@@ -97,13 +97,9 @@ public class IntFloatBucketedSort implements Releasable {
     public void collect(int value, float extraValue, int bucket) {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
-            if (betterThan(
-                // comment to make spotless happy about line breaks
-                value,
-                values.get(rootIndex),
-                extraValue,
-                extraValues.get(rootIndex)
-            )) {
+            int rootValue = values.get(rootIndex);
+            float rootExtra = extraValues.get(rootIndex);
+            if (betterThan(value, rootValue, extraValue, rootExtra)) {
                 values.set(rootIndex, value);
                 extraValues.set(rootIndex, extraValue);
                 downHeap(rootIndex, 0, bucketSize);
@@ -166,12 +162,9 @@ public class IntFloatBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            collect(
-                // comment to make spotless happy about line breaks
-                other.values.get(i),
-                other.extraValues.get(i),
-                groupId
-            );
+            int otherValue = other.values.get(i);
+            float otherExtra = other.extraValues.get(i);
+            collect(otherValue, otherExtra, groupId);
         }
     }
 
@@ -307,12 +300,9 @@ public class IntFloatBucketedSort implements Releasable {
         long oldMax = values.size();
         assert oldMax % bucketSize == 0;
 
-        long newSize = BigArrays.overSize(
-            // comment to make spotless happy about line breaks
-            ((long) bucket + 1) * bucketSize,
-            PageCacheRecycler.INT_PAGE_SIZE,
-            Integer.BYTES
-        );
+        int pageSize = PageCacheRecycler.INT_PAGE_SIZE;
+        int bytesPerElement = Integer.BYTES;
+        long newSize = BigArrays.overSize(((long) bucket + 1) * bucketSize, pageSize, bytesPerElement);
         // Round up to the next full bucket.
         newSize = (newSize + bucketSize - 1) / bucketSize;
         values = bigArrays.resize(values, newSize * bucketSize);
@@ -399,28 +389,25 @@ public class IntFloatBucketedSort implements Releasable {
             int leftChild = parent * 2 + 1;
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
-                if (betterThan(
-                    // comment to make spotless happy about line breaks
-                    values.get(worstIndex),
-                    values.get(leftIndex),
-                    extraValues.get(worstIndex),
-                    extraValues.get(leftIndex)
-                )) {
+                int worstValue = values.get(worstIndex);
+                int leftValue = values.get(leftIndex);
+                float worstExtra = extraValues.get(worstIndex);
+                float leftExtra = extraValues.get(leftIndex);
+                if (betterThan(worstValue, leftValue, worstExtra, leftExtra)) {
                     worst = leftChild;
                     worstIndex = leftIndex;
                 }
                 int rightChild = leftChild + 1;
                 long rightIndex = rootIndex + rightChild;
-                if (rightChild < heapSize
-                    && betterThan(
-                        // comment to make spotless happy about line breaks
-                        values.get(worstIndex),
-                        values.get(rightIndex),
-                        extraValues.get(worstIndex),
-                        extraValues.get(rightIndex)
-                    )) {
-                    worst = rightChild;
-                    worstIndex = rightIndex;
+                if (rightChild < heapSize) {
+                    worstValue = values.get(worstIndex);
+                    int rightValue = values.get(rightIndex);
+                    worstExtra = extraValues.get(worstIndex);
+                    float rightExtra = extraValues.get(rightIndex);
+                    if (betterThan(worstValue, rightValue, worstExtra, rightExtra)) {
+                        worst = rightChild;
+                        worstIndex = rightIndex;
+                    }
                 }
             }
             if (worst == parent) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/IntFloatBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/IntFloatBucketedSort.java
@@ -98,6 +98,7 @@ public class IntFloatBucketedSort implements Releasable {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
             if (betterThan(
+                // comment to make spotless happy about line breaks
                 value,
                 values.get(rootIndex),
                 extraValue,
@@ -183,6 +184,7 @@ public class IntFloatBucketedSort implements Releasable {
         }
 
         try (
+            // comment to make spotless happy about line breaks
             var builder = blockFactory.newIntBlockBuilder(selected.getPositionCount());
             var extraBuilder = blockFactory.newFloatBlockBuilder(selected.getPositionCount())
         ) {
@@ -302,6 +304,7 @@ public class IntFloatBucketedSort implements Releasable {
         assert oldMax % bucketSize == 0;
 
         long newSize = BigArrays.overSize(
+            // comment to make spotless happy about line breaks
             ((long) bucket + 1) * bucketSize,
             PageCacheRecycler.INT_PAGE_SIZE,
             Integer.BYTES
@@ -393,6 +396,7 @@ public class IntFloatBucketedSort implements Releasable {
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
                 if (betterThan(
+                    // comment to make spotless happy about line breaks
                     values.get(worstIndex),
                     values.get(leftIndex),
                     extraValues.get(worstIndex),
@@ -405,6 +409,7 @@ public class IntFloatBucketedSort implements Releasable {
                 long rightIndex = rootIndex + rightChild;
                 if (rightChild < heapSize
                     && betterThan(
+                        // comment to make spotless happy about line breaks
                         values.get(worstIndex),
                         values.get(rightIndex),
                         extraValues.get(worstIndex),

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/IntFloatBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/IntFloatBucketedSort.java
@@ -166,7 +166,12 @@ public class IntFloatBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            collect(other.values.get(i), other.extraValues.get(i), groupId);
+            collect(
+                // comment to make spotless happy about line breaks
+                other.values.get(i),
+                other.extraValues.get(i),
+                groupId
+            );
         }
     }
 
@@ -184,7 +189,6 @@ public class IntFloatBucketedSort implements Releasable {
         }
 
         try (
-            // comment to make spotless happy about line breaks
             var builder = blockFactory.newIntBlockBuilder(selected.getPositionCount());
             var extraBuilder = blockFactory.newFloatBlockBuilder(selected.getPositionCount())
         ) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/IntFloatBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/IntFloatBucketedSort.java
@@ -97,7 +97,12 @@ public class IntFloatBucketedSort implements Releasable {
     public void collect(int value, float extraValue, int bucket) {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
-            if (betterThan(value, values.get(rootIndex), extraValue, extraValues.get(rootIndex))) {
+            if (betterThan(
+                value,
+                values.get(rootIndex),
+                extraValue,
+                extraValues.get(rootIndex)
+            )) {
                 values.set(rootIndex, value);
                 extraValues.set(rootIndex, extraValue);
                 downHeap(rootIndex, 0, bucketSize);
@@ -296,7 +301,11 @@ public class IntFloatBucketedSort implements Releasable {
         long oldMax = values.size();
         assert oldMax % bucketSize == 0;
 
-        long newSize = BigArrays.overSize(((long) bucket + 1) * bucketSize, PageCacheRecycler.INT_PAGE_SIZE, Integer.BYTES);
+        long newSize = BigArrays.overSize(
+            ((long) bucket + 1) * bucketSize,
+            PageCacheRecycler.INT_PAGE_SIZE,
+            Integer.BYTES
+        );
         // Round up to the next full bucket.
         newSize = (newSize + bucketSize - 1) / bucketSize;
         values = bigArrays.resize(values, newSize * bucketSize);
@@ -383,7 +392,12 @@ public class IntFloatBucketedSort implements Releasable {
             int leftChild = parent * 2 + 1;
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
-                if (betterThan(values.get(worstIndex), values.get(leftIndex), extraValues.get(worstIndex), extraValues.get(leftIndex))) {
+                if (betterThan(
+                    values.get(worstIndex),
+                    values.get(leftIndex),
+                    extraValues.get(worstIndex),
+                    extraValues.get(leftIndex)
+                )) {
                     worst = leftChild;
                     worstIndex = leftIndex;
                 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/IntIntBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/IntIntBucketedSort.java
@@ -97,7 +97,12 @@ public class IntIntBucketedSort implements Releasable {
     public void collect(int value, int extraValue, int bucket) {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
-            if (betterThan(value, values.get(rootIndex), extraValue, extraValues.get(rootIndex))) {
+            if (betterThan(
+                value,
+                values.get(rootIndex),
+                extraValue,
+                extraValues.get(rootIndex)
+            )) {
                 values.set(rootIndex, value);
                 extraValues.set(rootIndex, extraValue);
                 downHeap(rootIndex, 0, bucketSize);
@@ -296,7 +301,11 @@ public class IntIntBucketedSort implements Releasable {
         long oldMax = values.size();
         assert oldMax % bucketSize == 0;
 
-        long newSize = BigArrays.overSize(((long) bucket + 1) * bucketSize, PageCacheRecycler.INT_PAGE_SIZE, Integer.BYTES);
+        long newSize = BigArrays.overSize(
+            ((long) bucket + 1) * bucketSize,
+            PageCacheRecycler.INT_PAGE_SIZE,
+            Integer.BYTES
+        );
         // Round up to the next full bucket.
         newSize = (newSize + bucketSize - 1) / bucketSize;
         values = bigArrays.resize(values, newSize * bucketSize);
@@ -383,7 +392,12 @@ public class IntIntBucketedSort implements Releasable {
             int leftChild = parent * 2 + 1;
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
-                if (betterThan(values.get(worstIndex), values.get(leftIndex), extraValues.get(worstIndex), extraValues.get(leftIndex))) {
+                if (betterThan(
+                    values.get(worstIndex),
+                    values.get(leftIndex),
+                    extraValues.get(worstIndex),
+                    extraValues.get(leftIndex)
+                )) {
                     worst = leftChild;
                     worstIndex = leftIndex;
                 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/IntIntBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/IntIntBucketedSort.java
@@ -166,7 +166,12 @@ public class IntIntBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            collect(other.values.get(i), other.extraValues.get(i), groupId);
+            collect(
+                // comment to make spotless happy about line breaks
+                other.values.get(i),
+                other.extraValues.get(i),
+                groupId
+            );
         }
     }
 
@@ -184,7 +189,6 @@ public class IntIntBucketedSort implements Releasable {
         }
 
         try (
-            // comment to make spotless happy about line breaks
             var builder = blockFactory.newIntBlockBuilder(selected.getPositionCount());
             var extraBuilder = blockFactory.newIntBlockBuilder(selected.getPositionCount())
         ) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/IntIntBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/IntIntBucketedSort.java
@@ -98,6 +98,7 @@ public class IntIntBucketedSort implements Releasable {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
             if (betterThan(
+                // comment to make spotless happy about line breaks
                 value,
                 values.get(rootIndex),
                 extraValue,
@@ -183,6 +184,7 @@ public class IntIntBucketedSort implements Releasable {
         }
 
         try (
+            // comment to make spotless happy about line breaks
             var builder = blockFactory.newIntBlockBuilder(selected.getPositionCount());
             var extraBuilder = blockFactory.newIntBlockBuilder(selected.getPositionCount())
         ) {
@@ -302,6 +304,7 @@ public class IntIntBucketedSort implements Releasable {
         assert oldMax % bucketSize == 0;
 
         long newSize = BigArrays.overSize(
+            // comment to make spotless happy about line breaks
             ((long) bucket + 1) * bucketSize,
             PageCacheRecycler.INT_PAGE_SIZE,
             Integer.BYTES
@@ -393,6 +396,7 @@ public class IntIntBucketedSort implements Releasable {
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
                 if (betterThan(
+                    // comment to make spotless happy about line breaks
                     values.get(worstIndex),
                     values.get(leftIndex),
                     extraValues.get(worstIndex),
@@ -405,6 +409,7 @@ public class IntIntBucketedSort implements Releasable {
                 long rightIndex = rootIndex + rightChild;
                 if (rightChild < heapSize
                     && betterThan(
+                        // comment to make spotless happy about line breaks
                         values.get(worstIndex),
                         values.get(rightIndex),
                         extraValues.get(worstIndex),

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/IntIntBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/IntIntBucketedSort.java
@@ -97,13 +97,9 @@ public class IntIntBucketedSort implements Releasable {
     public void collect(int value, int extraValue, int bucket) {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
-            if (betterThan(
-                // comment to make spotless happy about line breaks
-                value,
-                values.get(rootIndex),
-                extraValue,
-                extraValues.get(rootIndex)
-            )) {
+            int rootValue = values.get(rootIndex);
+            int rootExtra = extraValues.get(rootIndex);
+            if (betterThan(value, rootValue, extraValue, rootExtra)) {
                 values.set(rootIndex, value);
                 extraValues.set(rootIndex, extraValue);
                 downHeap(rootIndex, 0, bucketSize);
@@ -166,12 +162,9 @@ public class IntIntBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            collect(
-                // comment to make spotless happy about line breaks
-                other.values.get(i),
-                other.extraValues.get(i),
-                groupId
-            );
+            int otherValue = other.values.get(i);
+            int otherExtra = other.extraValues.get(i);
+            collect(otherValue, otherExtra, groupId);
         }
     }
 
@@ -307,12 +300,9 @@ public class IntIntBucketedSort implements Releasable {
         long oldMax = values.size();
         assert oldMax % bucketSize == 0;
 
-        long newSize = BigArrays.overSize(
-            // comment to make spotless happy about line breaks
-            ((long) bucket + 1) * bucketSize,
-            PageCacheRecycler.INT_PAGE_SIZE,
-            Integer.BYTES
-        );
+        int pageSize = PageCacheRecycler.INT_PAGE_SIZE;
+        int bytesPerElement = Integer.BYTES;
+        long newSize = BigArrays.overSize(((long) bucket + 1) * bucketSize, pageSize, bytesPerElement);
         // Round up to the next full bucket.
         newSize = (newSize + bucketSize - 1) / bucketSize;
         values = bigArrays.resize(values, newSize * bucketSize);
@@ -399,28 +389,25 @@ public class IntIntBucketedSort implements Releasable {
             int leftChild = parent * 2 + 1;
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
-                if (betterThan(
-                    // comment to make spotless happy about line breaks
-                    values.get(worstIndex),
-                    values.get(leftIndex),
-                    extraValues.get(worstIndex),
-                    extraValues.get(leftIndex)
-                )) {
+                int worstValue = values.get(worstIndex);
+                int leftValue = values.get(leftIndex);
+                int worstExtra = extraValues.get(worstIndex);
+                int leftExtra = extraValues.get(leftIndex);
+                if (betterThan(worstValue, leftValue, worstExtra, leftExtra)) {
                     worst = leftChild;
                     worstIndex = leftIndex;
                 }
                 int rightChild = leftChild + 1;
                 long rightIndex = rootIndex + rightChild;
-                if (rightChild < heapSize
-                    && betterThan(
-                        // comment to make spotless happy about line breaks
-                        values.get(worstIndex),
-                        values.get(rightIndex),
-                        extraValues.get(worstIndex),
-                        extraValues.get(rightIndex)
-                    )) {
-                    worst = rightChild;
-                    worstIndex = rightIndex;
+                if (rightChild < heapSize) {
+                    worstValue = values.get(worstIndex);
+                    int rightValue = values.get(rightIndex);
+                    worstExtra = extraValues.get(worstIndex);
+                    int rightExtra = extraValues.get(rightIndex);
+                    if (betterThan(worstValue, rightValue, worstExtra, rightExtra)) {
+                        worst = rightChild;
+                        worstIndex = rightIndex;
+                    }
                 }
             }
             if (worst == parent) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/IntLongBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/IntLongBucketedSort.java
@@ -97,13 +97,9 @@ public class IntLongBucketedSort implements Releasable {
     public void collect(int value, long extraValue, int bucket) {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
-            if (betterThan(
-                // comment to make spotless happy about line breaks
-                value,
-                values.get(rootIndex),
-                extraValue,
-                extraValues.get(rootIndex)
-            )) {
+            int rootValue = values.get(rootIndex);
+            long rootExtra = extraValues.get(rootIndex);
+            if (betterThan(value, rootValue, extraValue, rootExtra)) {
                 values.set(rootIndex, value);
                 extraValues.set(rootIndex, extraValue);
                 downHeap(rootIndex, 0, bucketSize);
@@ -166,12 +162,9 @@ public class IntLongBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            collect(
-                // comment to make spotless happy about line breaks
-                other.values.get(i),
-                other.extraValues.get(i),
-                groupId
-            );
+            int otherValue = other.values.get(i);
+            long otherExtra = other.extraValues.get(i);
+            collect(otherValue, otherExtra, groupId);
         }
     }
 
@@ -307,12 +300,9 @@ public class IntLongBucketedSort implements Releasable {
         long oldMax = values.size();
         assert oldMax % bucketSize == 0;
 
-        long newSize = BigArrays.overSize(
-            // comment to make spotless happy about line breaks
-            ((long) bucket + 1) * bucketSize,
-            PageCacheRecycler.INT_PAGE_SIZE,
-            Integer.BYTES
-        );
+        int pageSize = PageCacheRecycler.INT_PAGE_SIZE;
+        int bytesPerElement = Integer.BYTES;
+        long newSize = BigArrays.overSize(((long) bucket + 1) * bucketSize, pageSize, bytesPerElement);
         // Round up to the next full bucket.
         newSize = (newSize + bucketSize - 1) / bucketSize;
         values = bigArrays.resize(values, newSize * bucketSize);
@@ -399,28 +389,25 @@ public class IntLongBucketedSort implements Releasable {
             int leftChild = parent * 2 + 1;
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
-                if (betterThan(
-                    // comment to make spotless happy about line breaks
-                    values.get(worstIndex),
-                    values.get(leftIndex),
-                    extraValues.get(worstIndex),
-                    extraValues.get(leftIndex)
-                )) {
+                int worstValue = values.get(worstIndex);
+                int leftValue = values.get(leftIndex);
+                long worstExtra = extraValues.get(worstIndex);
+                long leftExtra = extraValues.get(leftIndex);
+                if (betterThan(worstValue, leftValue, worstExtra, leftExtra)) {
                     worst = leftChild;
                     worstIndex = leftIndex;
                 }
                 int rightChild = leftChild + 1;
                 long rightIndex = rootIndex + rightChild;
-                if (rightChild < heapSize
-                    && betterThan(
-                        // comment to make spotless happy about line breaks
-                        values.get(worstIndex),
-                        values.get(rightIndex),
-                        extraValues.get(worstIndex),
-                        extraValues.get(rightIndex)
-                    )) {
-                    worst = rightChild;
-                    worstIndex = rightIndex;
+                if (rightChild < heapSize) {
+                    worstValue = values.get(worstIndex);
+                    int rightValue = values.get(rightIndex);
+                    worstExtra = extraValues.get(worstIndex);
+                    long rightExtra = extraValues.get(rightIndex);
+                    if (betterThan(worstValue, rightValue, worstExtra, rightExtra)) {
+                        worst = rightChild;
+                        worstIndex = rightIndex;
+                    }
                 }
             }
             if (worst == parent) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/IntLongBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/IntLongBucketedSort.java
@@ -166,7 +166,12 @@ public class IntLongBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            collect(other.values.get(i), other.extraValues.get(i), groupId);
+            collect(
+                // comment to make spotless happy about line breaks
+                other.values.get(i),
+                other.extraValues.get(i),
+                groupId
+            );
         }
     }
 
@@ -184,7 +189,6 @@ public class IntLongBucketedSort implements Releasable {
         }
 
         try (
-            // comment to make spotless happy about line breaks
             var builder = blockFactory.newIntBlockBuilder(selected.getPositionCount());
             var extraBuilder = blockFactory.newLongBlockBuilder(selected.getPositionCount())
         ) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/IntLongBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/IntLongBucketedSort.java
@@ -98,6 +98,7 @@ public class IntLongBucketedSort implements Releasable {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
             if (betterThan(
+                // comment to make spotless happy about line breaks
                 value,
                 values.get(rootIndex),
                 extraValue,
@@ -183,6 +184,7 @@ public class IntLongBucketedSort implements Releasable {
         }
 
         try (
+            // comment to make spotless happy about line breaks
             var builder = blockFactory.newIntBlockBuilder(selected.getPositionCount());
             var extraBuilder = blockFactory.newLongBlockBuilder(selected.getPositionCount())
         ) {
@@ -302,6 +304,7 @@ public class IntLongBucketedSort implements Releasable {
         assert oldMax % bucketSize == 0;
 
         long newSize = BigArrays.overSize(
+            // comment to make spotless happy about line breaks
             ((long) bucket + 1) * bucketSize,
             PageCacheRecycler.INT_PAGE_SIZE,
             Integer.BYTES
@@ -393,6 +396,7 @@ public class IntLongBucketedSort implements Releasable {
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
                 if (betterThan(
+                    // comment to make spotless happy about line breaks
                     values.get(worstIndex),
                     values.get(leftIndex),
                     extraValues.get(worstIndex),
@@ -405,6 +409,7 @@ public class IntLongBucketedSort implements Releasable {
                 long rightIndex = rootIndex + rightChild;
                 if (rightChild < heapSize
                     && betterThan(
+                        // comment to make spotless happy about line breaks
                         values.get(worstIndex),
                         values.get(rightIndex),
                         extraValues.get(worstIndex),

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/IntLongBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/IntLongBucketedSort.java
@@ -97,7 +97,12 @@ public class IntLongBucketedSort implements Releasable {
     public void collect(int value, long extraValue, int bucket) {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
-            if (betterThan(value, values.get(rootIndex), extraValue, extraValues.get(rootIndex))) {
+            if (betterThan(
+                value,
+                values.get(rootIndex),
+                extraValue,
+                extraValues.get(rootIndex)
+            )) {
                 values.set(rootIndex, value);
                 extraValues.set(rootIndex, extraValue);
                 downHeap(rootIndex, 0, bucketSize);
@@ -296,7 +301,11 @@ public class IntLongBucketedSort implements Releasable {
         long oldMax = values.size();
         assert oldMax % bucketSize == 0;
 
-        long newSize = BigArrays.overSize(((long) bucket + 1) * bucketSize, PageCacheRecycler.INT_PAGE_SIZE, Integer.BYTES);
+        long newSize = BigArrays.overSize(
+            ((long) bucket + 1) * bucketSize,
+            PageCacheRecycler.INT_PAGE_SIZE,
+            Integer.BYTES
+        );
         // Round up to the next full bucket.
         newSize = (newSize + bucketSize - 1) / bucketSize;
         values = bigArrays.resize(values, newSize * bucketSize);
@@ -383,7 +392,12 @@ public class IntLongBucketedSort implements Releasable {
             int leftChild = parent * 2 + 1;
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
-                if (betterThan(values.get(worstIndex), values.get(leftIndex), extraValues.get(worstIndex), extraValues.get(leftIndex))) {
+                if (betterThan(
+                    values.get(worstIndex),
+                    values.get(leftIndex),
+                    extraValues.get(worstIndex),
+                    extraValues.get(leftIndex)
+                )) {
                     worst = leftChild;
                     worstIndex = leftIndex;
                 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/LongBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/LongBucketedSort.java
@@ -94,11 +94,8 @@ public class LongBucketedSort implements Releasable {
     public void collect(long value, int bucket) {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
-            if (betterThan(
-                // comment to make spotless happy about line breaks
-                value,
-                values.get(rootIndex)
-            )) {
+            long rootValue = values.get(rootIndex);
+            if (betterThan(value, rootValue)) {
                 values.set(rootIndex, value);
                 downHeap(rootIndex, 0, bucketSize);
             }
@@ -159,11 +156,8 @@ public class LongBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            collect(
-                // comment to make spotless happy about line breaks
-                other.values.get(i),
-                groupId
-            );
+            long otherValue = other.values.get(i);
+            collect(otherValue, groupId);
         }
     }
 
@@ -272,12 +266,9 @@ public class LongBucketedSort implements Releasable {
         long oldMax = values.size();
         assert oldMax % bucketSize == 0;
 
-        long newSize = BigArrays.overSize(
-            // comment to make spotless happy about line breaks
-            ((long) bucket + 1) * bucketSize,
-            PageCacheRecycler.LONG_PAGE_SIZE,
-            Long.BYTES
-        );
+        int pageSize = PageCacheRecycler.LONG_PAGE_SIZE;
+        int bytesPerElement = Long.BYTES;
+        long newSize = BigArrays.overSize(((long) bucket + 1) * bucketSize, pageSize, bytesPerElement);
         // Round up to the next full bucket.
         newSize = (newSize + bucketSize - 1) / bucketSize;
         values = bigArrays.resize(values, newSize * bucketSize);
@@ -362,24 +353,21 @@ public class LongBucketedSort implements Releasable {
             int leftChild = parent * 2 + 1;
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
-                if (betterThan(
-                    // comment to make spotless happy about line breaks
-                    values.get(worstIndex),
-                    values.get(leftIndex)
-                )) {
+                long worstValue = values.get(worstIndex);
+                long leftValue = values.get(leftIndex);
+                if (betterThan(worstValue, leftValue)) {
                     worst = leftChild;
                     worstIndex = leftIndex;
                 }
                 int rightChild = leftChild + 1;
                 long rightIndex = rootIndex + rightChild;
-                if (rightChild < heapSize
-                    && betterThan(
-                        // comment to make spotless happy about line breaks
-                        values.get(worstIndex),
-                        values.get(rightIndex)
-                    )) {
-                    worst = rightChild;
-                    worstIndex = rightIndex;
+                if (rightChild < heapSize) {
+                    worstValue = values.get(worstIndex);
+                    long rightValue = values.get(rightIndex);
+                    if (betterThan(worstValue, rightValue)) {
+                        worst = rightChild;
+                        worstIndex = rightIndex;
+                    }
                 }
             }
             if (worst == parent) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/LongBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/LongBucketedSort.java
@@ -167,7 +167,9 @@ public class LongBucketedSort implements Releasable {
             return blockFactory.newConstantNullBlock(selected.getPositionCount());
         }
 
-        try (var builder = blockFactory.newLongBlockBuilder(selected.getPositionCount())) {
+        try (
+            var builder = blockFactory.newLongBlockBuilder(selected.getPositionCount())
+        ) {
             for (int s = 0; s < selected.getPositionCount(); s++) {
                 int bucket = selected.getInt(s);
 

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/LongBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/LongBucketedSort.java
@@ -67,7 +67,6 @@ public class LongBucketedSort implements Releasable {
      * </ul>
      */
     private LongArray values;
-
     public LongBucketedSort(BigArrays bigArrays, SortOrder order, int bucketSize) {
         this.bigArrays = bigArrays;
         this.order = order;
@@ -264,7 +263,11 @@ public class LongBucketedSort implements Releasable {
         long oldMax = values.size();
         assert oldMax % bucketSize == 0;
 
-        long newSize = BigArrays.overSize(((long) bucket + 1) * bucketSize, PageCacheRecycler.LONG_PAGE_SIZE, Long.BYTES);
+        long newSize = BigArrays.overSize(
+            ((long) bucket + 1) * bucketSize,
+            PageCacheRecycler.LONG_PAGE_SIZE,
+            Long.BYTES
+        );
         // Round up to the next full bucket.
         newSize = (newSize + bucketSize - 1) / bucketSize;
         values = bigArrays.resize(values, newSize * bucketSize);

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/LongBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/LongBucketedSort.java
@@ -94,7 +94,11 @@ public class LongBucketedSort implements Releasable {
     public void collect(long value, int bucket) {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
-            if (betterThan(value, values.get(rootIndex))) {
+            if (betterThan(
+                // comment to make spotless happy about line breaks
+                value,
+                values.get(rootIndex)
+            )) {
                 values.set(rootIndex, value);
                 downHeap(rootIndex, 0, bucketSize);
             }
@@ -155,7 +159,11 @@ public class LongBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            collect(other.values.get(i), groupId);
+            collect(
+                // comment to make spotless happy about line breaks
+                other.values.get(i),
+                groupId
+            );
         }
     }
 
@@ -168,10 +176,7 @@ public class LongBucketedSort implements Releasable {
             return blockFactory.newConstantNullBlock(selected.getPositionCount());
         }
 
-        try (
-            // comment to make spotless happy about line breaks
-            var builder = blockFactory.newLongBlockBuilder(selected.getPositionCount())
-        ) {
+        try (var builder = blockFactory.newLongBlockBuilder(selected.getPositionCount())) {
             for (int s = 0; s < selected.getPositionCount(); s++) {
                 int bucket = selected.getInt(s);
 
@@ -357,13 +362,22 @@ public class LongBucketedSort implements Releasable {
             int leftChild = parent * 2 + 1;
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
-                if (betterThan(values.get(worstIndex), values.get(leftIndex))) {
+                if (betterThan(
+                    // comment to make spotless happy about line breaks
+                    values.get(worstIndex),
+                    values.get(leftIndex)
+                )) {
                     worst = leftChild;
                     worstIndex = leftIndex;
                 }
                 int rightChild = leftChild + 1;
                 long rightIndex = rootIndex + rightChild;
-                if (rightChild < heapSize && betterThan(values.get(worstIndex), values.get(rightIndex))) {
+                if (rightChild < heapSize
+                    && betterThan(
+                        // comment to make spotless happy about line breaks
+                        values.get(worstIndex),
+                        values.get(rightIndex)
+                    )) {
                     worst = rightChild;
                     worstIndex = rightIndex;
                 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/LongBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/LongBucketedSort.java
@@ -67,6 +67,7 @@ public class LongBucketedSort implements Releasable {
      * </ul>
      */
     private LongArray values;
+
     public LongBucketedSort(BigArrays bigArrays, SortOrder order, int bucketSize) {
         this.bigArrays = bigArrays;
         this.order = order;
@@ -168,6 +169,7 @@ public class LongBucketedSort implements Releasable {
         }
 
         try (
+            // comment to make spotless happy about line breaks
             var builder = blockFactory.newLongBlockBuilder(selected.getPositionCount())
         ) {
             for (int s = 0; s < selected.getPositionCount(); s++) {
@@ -266,6 +268,7 @@ public class LongBucketedSort implements Releasable {
         assert oldMax % bucketSize == 0;
 
         long newSize = BigArrays.overSize(
+            // comment to make spotless happy about line breaks
             ((long) bucket + 1) * bucketSize,
             PageCacheRecycler.LONG_PAGE_SIZE,
             Long.BYTES

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/LongBytesRefBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/LongBytesRefBucketedSort.java
@@ -171,8 +171,12 @@ public class LongBytesRefBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            BreakingBytesRefBuilder otherExtra = other.extraValues.get(i);
-            collect(other.values.get(i), otherExtra == null ? new BytesRef() : otherExtra.bytesRefView(), groupId);
+            collect(
+                // comment to make spotless happy about line breaks
+                other.values.get(i),
+                other.extraValues.get(i) == null ? new BytesRef() : other.extraValues.get(i).bytesRefView(),
+                groupId
+            );
         }
     }
 
@@ -190,7 +194,6 @@ public class LongBytesRefBucketedSort implements Releasable {
         }
 
         try (
-            // comment to make spotless happy about line breaks
             var builder = blockFactory.newLongBlockBuilder(selected.getPositionCount());
             var extraBuilder = blockFactory.newBytesRefBlockBuilder(selected.getPositionCount())
         ) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/LongBytesRefBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/LongBytesRefBucketedSort.java
@@ -73,6 +73,7 @@ public class LongBytesRefBucketedSort implements Releasable {
      */
     private LongArray values;
     private ObjectArray<BreakingBytesRefBuilder> extraValues;
+
     public LongBytesRefBucketedSort(BigArrays bigArrays, SortOrder order, int bucketSize) {
         this.bigArrays = bigArrays;
         this.breaker = bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST);
@@ -102,6 +103,7 @@ public class LongBytesRefBucketedSort implements Releasable {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
             if (betterThan(
+                // comment to make spotless happy about line breaks
                 value,
                 values.get(rootIndex),
                 extraValue,
@@ -188,6 +190,7 @@ public class LongBytesRefBucketedSort implements Releasable {
         }
 
         try (
+            // comment to make spotless happy about line breaks
             var builder = blockFactory.newLongBlockBuilder(selected.getPositionCount());
             var extraBuilder = blockFactory.newBytesRefBlockBuilder(selected.getPositionCount())
         ) {
@@ -337,6 +340,7 @@ public class LongBytesRefBucketedSort implements Releasable {
         assert oldMax % bucketSize == 0;
 
         long newSize = BigArrays.overSize(
+            // comment to make spotless happy about line breaks
             ((long) bucket + 1) * bucketSize,
             PageCacheRecycler.LONG_PAGE_SIZE,
             Long.BYTES
@@ -428,6 +432,7 @@ public class LongBytesRefBucketedSort implements Releasable {
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
                 if (betterThan(
+                    // comment to make spotless happy about line breaks
                     values.get(worstIndex),
                     values.get(leftIndex),
                     extraBytesAt(worstIndex),
@@ -440,6 +445,7 @@ public class LongBytesRefBucketedSort implements Releasable {
                 long rightIndex = rootIndex + rightChild;
                 if (rightChild < heapSize
                     && betterThan(
+                        // comment to make spotless happy about line breaks
                         values.get(worstIndex),
                         values.get(rightIndex),
                         extraBytesAt(worstIndex),

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/LongBytesRefBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/LongBytesRefBucketedSort.java
@@ -1,0 +1,469 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data.sort;
+
+// begin generated imports
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.BitArray;
+import org.elasticsearch.common.util.ObjectArray;
+import org.elasticsearch.common.util.LongArray;
+import org.elasticsearch.common.util.PageCacheRecycler;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.core.Tuple;
+import org.elasticsearch.search.sort.BucketedSort;
+import org.elasticsearch.search.sort.SortOrder;
+
+import java.util.stream.IntStream;
+// end generated imports
+
+/**
+ * Aggregates the top N {@code long} values per bucket.
+ * See {@link BucketedSort} for more information.
+ * This class is generated. Edit @{code X-BucketedSort.java.st} instead of this file.
+ */
+public class LongBytesRefBucketedSort implements Releasable {
+
+    private final BigArrays bigArrays;
+    private final CircuitBreaker breaker;
+    private final SortOrder order;
+    private final int bucketSize;
+    /**
+     * {@code true} if the bucket is in heap mode, {@code false} if
+     * it is still gathering.
+     */
+    private final BitArray heapMode;
+    /**
+     * An array containing all the values on all buckets. The structure is as follows:
+     * <p>
+     *     For each bucket, there are bucketSize elements, based on the bucket id (0, 1, 2...).
+     *     Then, for each bucket, it can be in 2 states:
+     * </p>
+     * <ul>
+     *     <li>
+     *         Gather mode: All buckets start in gather mode, and remain here while they have less than bucketSize elements.
+     *         In gather mode, the elements are stored in the array from the highest index to the lowest index.
+     *         The lowest index contains the offset to the next slot to be filled.
+     *         <p>
+     *             This allows us to insert elements in O(1) time.
+     *         </p>
+     *         <p>
+     *             When the bucketSize-th element is collected, the bucket transitions to heap mode, by heapifying its contents.
+     *         </p>
+     *     </li>
+     *     <li>
+     *         Heap mode: The bucket slots are organized as a min heap structure.
+     *         <p>
+     *             The root of the heap is the minimum value in the bucket,
+     *             which allows us to quickly discard new values that are not in the top N.
+     *         </p>
+     *     </li>
+     * </ul>
+     */
+    private LongArray values;
+    private ObjectArray<BreakingBytesRefBuilder> extraValues;
+    public LongBytesRefBucketedSort(BigArrays bigArrays, SortOrder order, int bucketSize) {
+        this.bigArrays = bigArrays;
+        this.breaker = bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST);
+        this.order = order;
+        this.bucketSize = bucketSize;
+        heapMode = new BitArray(0, bigArrays);
+
+        boolean success = false;
+        try {
+            values = bigArrays.newLongArray(0, false);
+            extraValues = bigArrays.newObjectArray(0);
+            success = true;
+        } finally {
+            if (success == false) {
+                close();
+            }
+        }
+    }
+
+    /**
+     * Collects a {@code value} into a {@code bucket}.
+     * <p>
+     *     It may or may not be inserted in the heap, depending on if it is better than the current root.
+     * </p>
+     */
+    public void collect(long value, BytesRef extraValue, int bucket) {
+        long rootIndex = (long) bucket * bucketSize;
+        if (inHeapMode(bucket)) {
+            if (betterThan(
+                value,
+                values.get(rootIndex),
+                extraValue,
+                extraBytesAt(rootIndex)
+            )) {
+                values.set(rootIndex, value);
+                clearedExtraBytesAt(rootIndex).append(extraValue);
+                downHeap(rootIndex, 0, bucketSize);
+            }
+            return;
+        }
+        // Gathering mode
+        long requiredSize = rootIndex + bucketSize;
+        if (values.size() < requiredSize) {
+            grow(bucket);
+        }
+        int next = getNextGatherOffset(rootIndex);
+        assert 0 <= next && next < bucketSize
+            : "Expected next to be in the range of valid buckets [0 <= " + next + " < " + bucketSize + "]";
+        long index = next + rootIndex;
+        values.set(index, value);
+        clearedExtraBytesAt(index).append(extraValue);
+        if (next == 0) {
+            heapMode.set(bucket);
+            heapify(rootIndex, bucketSize);
+        } else {
+            setNextGatherOffset(rootIndex, next - 1);
+        }
+    }
+
+    /**
+     * The order of the sort.
+     */
+    public SortOrder getOrder() {
+        return order;
+    }
+
+    /**
+     * The number of values to store per bucket.
+     */
+    public int getBucketSize() {
+        return bucketSize;
+    }
+
+    /**
+     * Get the first and last indexes (inclusive, exclusive) of the values for a bucket.
+     * Returns [0, 0] if the bucket has never been collected.
+     */
+    private Tuple<Long, Long> getBucketValuesIndexes(int bucket) {
+        long rootIndex = (long) bucket * bucketSize;
+        if (rootIndex >= values.size()) {
+            // We've never seen this bucket.
+            return Tuple.tuple(0L, 0L);
+        }
+        long start = inHeapMode(bucket) ? rootIndex : (rootIndex + getNextGatherOffset(rootIndex) + 1);
+        long end = rootIndex + bucketSize;
+        return Tuple.tuple(start, end);
+    }
+
+    /**
+     * Merge the values from {@code other}'s {@code otherGroupId} into {@code groupId}.
+     */
+    public void merge(int groupId, LongBytesRefBucketedSort other, int otherGroupId) {
+        var otherBounds = other.getBucketValuesIndexes(otherGroupId);
+
+        // TODO: This can be improved for heapified buckets by making use of the heap structures
+        for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
+            BreakingBytesRefBuilder otherExtra = other.extraValues.get(i);
+            collect(other.values.get(i), otherExtra == null ? new BytesRef() : otherExtra.bytesRefView(), groupId);
+        }
+    }
+
+    /**
+     * Creates a block with the values from the {@code selected} groups.
+     */
+    public void toBlocks(BlockFactory blockFactory, Block[] blocks, int offset, IntVector selected) {
+        // Check if the selected groups are all empty, to avoid allocating extra memory
+        if (allSelectedGroupsAreEmpty(selected)) {
+            Block constantNullBlock = blockFactory.newConstantNullBlock(selected.getPositionCount());
+            constantNullBlock.incRef();
+            blocks[offset] = constantNullBlock;
+            blocks[offset + 1] = constantNullBlock;
+            return;
+        }
+
+        try (
+            var builder = blockFactory.newLongBlockBuilder(selected.getPositionCount());
+            var extraBuilder = blockFactory.newBytesRefBlockBuilder(selected.getPositionCount())
+        ) {
+            for (int s = 0; s < selected.getPositionCount(); s++) {
+                int bucket = selected.getInt(s);
+
+                var bounds = getBucketValuesIndexes(bucket);
+                var rootIndex = bounds.v1();
+                var size = bounds.v2() - bounds.v1();
+
+                if (size == 0) {
+                    builder.appendNull();
+                    extraBuilder.appendNull();
+                    continue;
+                }
+
+                if (size == 1) {
+                    builder.appendLong(values.get(rootIndex));
+                    appendExtra(extraBuilder, rootIndex);
+                    continue;
+                }
+
+                // If we are in the gathering mode, we need to heapify before sorting.
+                if (inHeapMode(bucket) == false) {
+                    heapify(rootIndex, (int) size);
+                }
+                heapSort(rootIndex, (int) size);
+
+                builder.beginPositionEntry();
+                extraBuilder.beginPositionEntry();
+                for (int i = 0; i < size; i++) {
+                    builder.appendLong(values.get(rootIndex + i));
+                    appendExtra(extraBuilder, rootIndex + i);
+                }
+                builder.endPositionEntry();
+                extraBuilder.endPositionEntry();
+            }
+            blocks[offset] = builder.build();
+            try {
+                blocks[offset + 1] = extraBuilder.build();
+            } finally {
+                if (blocks[offset + 1] == null) {
+                    blocks[offset].close();
+                    blocks[offset] = null;
+                }
+            }
+        }
+    }
+
+    private void appendExtra(org.elasticsearch.compute.data.BytesRefBlock.Builder extraBuilder, long index) {
+        BreakingBytesRefBuilder bytes = extraValues.get(index);
+        if (bytes == null) {
+            extraBuilder.appendNull();
+            return;
+        }
+        try {
+            extraBuilder.appendBytesRef(bytes.bytesRefView());
+        } finally {
+            extraValues.set(index, null);
+            Releasables.closeExpectNoException(bytes);
+        }
+    }
+
+    private BreakingBytesRefBuilder clearedExtraBytesAt(long index) {
+        BreakingBytesRefBuilder bytes = extraValues.get(index);
+        if (bytes == null) {
+            bytes = new BreakingBytesRefBuilder(breaker, "top");
+            extraValues.set(index, bytes);
+        } else {
+            bytes.clear();
+        }
+        return bytes;
+    }
+
+    private BytesRef extraBytesAt(long index) {
+        BreakingBytesRefBuilder bytes = extraValues.get(index);
+        return bytes == null ? new BytesRef() : bytes.bytesRefView();
+    }
+
+    /**
+     * Checks if the selected groups are all empty.
+     */
+    private boolean allSelectedGroupsAreEmpty(IntVector selected) {
+        return IntStream.range(0, selected.getPositionCount()).map(selected::getInt).noneMatch(bucket -> {
+            var bounds = this.getBucketValuesIndexes(bucket);
+            var size = bounds.v2() - bounds.v1();
+            return size > 0;
+        });
+    }
+
+    /**
+     * Is this bucket a min heap {@code true} or in gathering mode {@code false}?
+     */
+    private boolean inHeapMode(int bucket) {
+        return heapMode.get(bucket);
+    }
+
+    /**
+     * Get the next index that should be "gathered" for a bucket rooted
+     * at {@code rootIndex}.
+     */
+    private int getNextGatherOffset(long rootIndex) {
+        return (int) values.get(rootIndex);
+    }
+
+    /**
+     * Set the next index that should be "gathered" for a bucket rooted
+     * at {@code rootIndex}.
+     */
+    private void setNextGatherOffset(long rootIndex, int offset) {
+        values.set(rootIndex, offset);
+    }
+
+    /**
+     * {@code true} if the entry at index {@code lhs} is "better" than
+     * the entry at {@code rhs}. "Better" in this means "lower" for
+     * {@link SortOrder#ASC} and "higher" for {@link SortOrder#DESC}.
+     */
+    private boolean betterThan(long lhs, long rhs, BytesRef lhsExtra, BytesRef rhsExtra) {
+        int res = Long.compare(lhs, rhs);
+        if (res != 0) {
+            return getOrder().reverseMul() * res < 0;
+        }
+        res = lhsExtra.compareTo(rhsExtra);
+        return getOrder().reverseMul() * res < 0;
+    }
+
+    /**
+     * Swap the data at two indices.
+     */
+    private void swap(long lhs, long rhs) {
+        var tmp = values.get(lhs);
+        values.set(lhs, values.get(rhs));
+        values.set(rhs, tmp);
+        var tmpExtra = extraValues.get(lhs);
+        extraValues.set(lhs, extraValues.get(rhs));
+        extraValues.set(rhs, tmpExtra);
+    }
+
+    /**
+     * Allocate storage for more buckets and store the "next gather offset"
+     * for those new buckets. We always grow the storage by whole bucket's
+     * worth of slots at a time. We never allocate space for partial buckets.
+     */
+    private void grow(int bucket) {
+        long oldMax = values.size();
+        assert oldMax % bucketSize == 0;
+
+        long newSize = BigArrays.overSize(
+            ((long) bucket + 1) * bucketSize,
+            PageCacheRecycler.LONG_PAGE_SIZE,
+            Long.BYTES
+        );
+        // Round up to the next full bucket.
+        newSize = (newSize + bucketSize - 1) / bucketSize;
+        values = bigArrays.resize(values, newSize * bucketSize);
+        // Round up to the next full bucket.
+        extraValues = bigArrays.resize(extraValues, newSize * bucketSize);
+        // Set the next gather offsets for all newly allocated buckets.
+        fillGatherOffsets(oldMax);
+    }
+
+    /**
+     * Maintain the "next gather offsets" for newly allocated buckets.
+     */
+    private void fillGatherOffsets(long startingAt) {
+        int nextOffset = getBucketSize() - 1;
+        for (long bucketRoot = startingAt; bucketRoot < values.size(); bucketRoot += getBucketSize()) {
+            setNextGatherOffset(bucketRoot, nextOffset);
+        }
+    }
+
+    /**
+     * Heapify a bucket whose entries are in random order.
+     * <p>
+     * This works by validating the heap property on each node, iterating
+     * "upwards", pushing any out of order parents "down". Check out the
+     * <a href="https://en.wikipedia.org/w/index.php?title=Binary_heap&oldid=940542991#Building_a_heap">wikipedia</a>
+     * entry on binary heaps for more about this.
+     * </p>
+     * <p>
+     * While this *looks* like it could easily be {@code O(n * log n)}, it is
+     * a fairly well studied algorithm attributed to Floyd. There's
+     * been a bunch of work that puts this at {@code O(n)}, close to 1.88n worst
+     * case.
+     * </p>
+     * <ul>
+     * <li>Hayward, Ryan; McDiarmid, Colin (1991).
+     * <a href="https://web.archive.org/web/20160205023201/http://www.stats.ox.ac.uk/__data/assets/pdf_file/0015/4173/heapbuildjalg.pdf">
+     * Average Case Analysis of Heap Building byRepeated Insertion</a> J. Algorithms.
+     * <li>D.E. Knuth, ”The Art of Computer Programming, Vol. 3, Sorting and Searching”</li>
+     * </ul>
+     * @param rootIndex the index the start of the bucket
+     */
+    private void heapify(long rootIndex, int heapSize) {
+        int maxParent = heapSize / 2 - 1;
+        for (int parent = maxParent; parent >= 0; parent--) {
+            downHeap(rootIndex, parent, heapSize);
+        }
+    }
+
+    /**
+     * Sorts all the values in the heap using heap sort algorithm.
+     * This runs in {@code O(n log n)} time.
+     * @param rootIndex index of the start of the bucket
+     * @param heapSize Number of values that belong to the heap.
+     *                 Can be less than bucketSize.
+     *                 In such a case, the remaining values in range
+     *                 (rootIndex + heapSize, rootIndex + bucketSize)
+     *                 are *not* considered part of the heap.
+     */
+    private void heapSort(long rootIndex, int heapSize) {
+        while (heapSize > 0) {
+            swap(rootIndex, rootIndex + heapSize - 1);
+            heapSize--;
+            downHeap(rootIndex, 0, heapSize);
+        }
+    }
+
+    /**
+     * Correct the heap invariant of a parent and its children. This
+     * runs in {@code O(log n)} time.
+     * @param rootIndex index of the start of the bucket
+     * @param parent Index within the bucket of the parent to check.
+     *               For example, 0 is the "root".
+     * @param heapSize Number of values that belong to the heap.
+     *                 Can be less than bucketSize.
+     *                 In such a case, the remaining values in range
+     *                 (rootIndex + heapSize, rootIndex + bucketSize)
+     *                 are *not* considered part of the heap.
+     */
+    private void downHeap(long rootIndex, int parent, int heapSize) {
+        while (true) {
+            long parentIndex = rootIndex + parent;
+            int worst = parent;
+            long worstIndex = parentIndex;
+            int leftChild = parent * 2 + 1;
+            long leftIndex = rootIndex + leftChild;
+            if (leftChild < heapSize) {
+                if (betterThan(
+                    values.get(worstIndex),
+                    values.get(leftIndex),
+                    extraBytesAt(worstIndex),
+                    extraBytesAt(leftIndex)
+                )) {
+                    worst = leftChild;
+                    worstIndex = leftIndex;
+                }
+                int rightChild = leftChild + 1;
+                long rightIndex = rootIndex + rightChild;
+                if (rightChild < heapSize
+                    && betterThan(
+                        values.get(worstIndex),
+                        values.get(rightIndex),
+                        extraBytesAt(worstIndex),
+                        extraBytesAt(rightIndex)
+                    )) {
+                    worst = rightChild;
+                    worstIndex = rightIndex;
+                }
+            }
+            if (worst == parent) {
+                break;
+            }
+            swap(worstIndex, parentIndex);
+            parent = worst;
+        }
+    }
+
+    @Override
+    public final void close() {
+        if (extraValues != null) {
+            for (long i = 0; i < extraValues.size(); i++) {
+                Releasables.close(extraValues.get(i));
+            }
+        }
+        Releasables.close(values, extraValues, heapMode);
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/LongBytesRefBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/LongBytesRefBucketedSort.java
@@ -102,13 +102,9 @@ public class LongBytesRefBucketedSort implements Releasable {
     public void collect(long value, BytesRef extraValue, int bucket) {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
-            if (betterThan(
-                // comment to make spotless happy about line breaks
-                value,
-                values.get(rootIndex),
-                extraValue,
-                extraBytesAt(rootIndex)
-            )) {
+            long rootValue = values.get(rootIndex);
+            BytesRef rootExtra = extraBytesAt(rootIndex);
+            if (betterThan(value, rootValue, extraValue, rootExtra)) {
                 values.set(rootIndex, value);
                 clearedExtraBytesAt(rootIndex).append(extraValue);
                 downHeap(rootIndex, 0, bucketSize);
@@ -171,12 +167,9 @@ public class LongBytesRefBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            collect(
-                // comment to make spotless happy about line breaks
-                other.values.get(i),
-                other.extraValues.get(i) == null ? new BytesRef() : other.extraValues.get(i).bytesRefView(),
-                groupId
-            );
+            long otherValue = other.values.get(i);
+            BytesRef otherExtra = other.extraValues.get(i) == null ? new BytesRef() : other.extraValues.get(i).bytesRefView();
+            collect(otherValue, otherExtra, groupId);
         }
     }
 
@@ -342,12 +335,9 @@ public class LongBytesRefBucketedSort implements Releasable {
         long oldMax = values.size();
         assert oldMax % bucketSize == 0;
 
-        long newSize = BigArrays.overSize(
-            // comment to make spotless happy about line breaks
-            ((long) bucket + 1) * bucketSize,
-            PageCacheRecycler.LONG_PAGE_SIZE,
-            Long.BYTES
-        );
+        int pageSize = PageCacheRecycler.LONG_PAGE_SIZE;
+        int bytesPerElement = Long.BYTES;
+        long newSize = BigArrays.overSize(((long) bucket + 1) * bucketSize, pageSize, bytesPerElement);
         // Round up to the next full bucket.
         newSize = (newSize + bucketSize - 1) / bucketSize;
         values = bigArrays.resize(values, newSize * bucketSize);
@@ -434,28 +424,25 @@ public class LongBytesRefBucketedSort implements Releasable {
             int leftChild = parent * 2 + 1;
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
-                if (betterThan(
-                    // comment to make spotless happy about line breaks
-                    values.get(worstIndex),
-                    values.get(leftIndex),
-                    extraBytesAt(worstIndex),
-                    extraBytesAt(leftIndex)
-                )) {
+                long worstValue = values.get(worstIndex);
+                long leftValue = values.get(leftIndex);
+                BytesRef worstExtra = extraBytesAt(worstIndex);
+                BytesRef leftExtra = extraBytesAt(leftIndex);
+                if (betterThan(worstValue, leftValue, worstExtra, leftExtra)) {
                     worst = leftChild;
                     worstIndex = leftIndex;
                 }
                 int rightChild = leftChild + 1;
                 long rightIndex = rootIndex + rightChild;
-                if (rightChild < heapSize
-                    && betterThan(
-                        // comment to make spotless happy about line breaks
-                        values.get(worstIndex),
-                        values.get(rightIndex),
-                        extraBytesAt(worstIndex),
-                        extraBytesAt(rightIndex)
-                    )) {
-                    worst = rightChild;
-                    worstIndex = rightIndex;
+                if (rightChild < heapSize) {
+                    worstValue = values.get(worstIndex);
+                    long rightValue = values.get(rightIndex);
+                    worstExtra = extraBytesAt(worstIndex);
+                    BytesRef rightExtra = extraBytesAt(rightIndex);
+                    if (betterThan(worstValue, rightValue, worstExtra, rightExtra)) {
+                        worst = rightChild;
+                        worstIndex = rightIndex;
+                    }
                 }
             }
             if (worst == parent) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/LongDoubleBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/LongDoubleBucketedSort.java
@@ -98,6 +98,7 @@ public class LongDoubleBucketedSort implements Releasable {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
             if (betterThan(
+                // comment to make spotless happy about line breaks
                 value,
                 values.get(rootIndex),
                 extraValue,
@@ -183,6 +184,7 @@ public class LongDoubleBucketedSort implements Releasable {
         }
 
         try (
+            // comment to make spotless happy about line breaks
             var builder = blockFactory.newLongBlockBuilder(selected.getPositionCount());
             var extraBuilder = blockFactory.newDoubleBlockBuilder(selected.getPositionCount())
         ) {
@@ -302,6 +304,7 @@ public class LongDoubleBucketedSort implements Releasable {
         assert oldMax % bucketSize == 0;
 
         long newSize = BigArrays.overSize(
+            // comment to make spotless happy about line breaks
             ((long) bucket + 1) * bucketSize,
             PageCacheRecycler.LONG_PAGE_SIZE,
             Long.BYTES
@@ -393,6 +396,7 @@ public class LongDoubleBucketedSort implements Releasable {
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
                 if (betterThan(
+                    // comment to make spotless happy about line breaks
                     values.get(worstIndex),
                     values.get(leftIndex),
                     extraValues.get(worstIndex),
@@ -405,6 +409,7 @@ public class LongDoubleBucketedSort implements Releasable {
                 long rightIndex = rootIndex + rightChild;
                 if (rightChild < heapSize
                     && betterThan(
+                        // comment to make spotless happy about line breaks
                         values.get(worstIndex),
                         values.get(rightIndex),
                         extraValues.get(worstIndex),

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/LongDoubleBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/LongDoubleBucketedSort.java
@@ -97,7 +97,12 @@ public class LongDoubleBucketedSort implements Releasable {
     public void collect(long value, double extraValue, int bucket) {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
-            if (betterThan(value, values.get(rootIndex), extraValue, extraValues.get(rootIndex))) {
+            if (betterThan(
+                value,
+                values.get(rootIndex),
+                extraValue,
+                extraValues.get(rootIndex)
+            )) {
                 values.set(rootIndex, value);
                 extraValues.set(rootIndex, extraValue);
                 downHeap(rootIndex, 0, bucketSize);
@@ -296,7 +301,11 @@ public class LongDoubleBucketedSort implements Releasable {
         long oldMax = values.size();
         assert oldMax % bucketSize == 0;
 
-        long newSize = BigArrays.overSize(((long) bucket + 1) * bucketSize, PageCacheRecycler.LONG_PAGE_SIZE, Long.BYTES);
+        long newSize = BigArrays.overSize(
+            ((long) bucket + 1) * bucketSize,
+            PageCacheRecycler.LONG_PAGE_SIZE,
+            Long.BYTES
+        );
         // Round up to the next full bucket.
         newSize = (newSize + bucketSize - 1) / bucketSize;
         values = bigArrays.resize(values, newSize * bucketSize);
@@ -383,7 +392,12 @@ public class LongDoubleBucketedSort implements Releasable {
             int leftChild = parent * 2 + 1;
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
-                if (betterThan(values.get(worstIndex), values.get(leftIndex), extraValues.get(worstIndex), extraValues.get(leftIndex))) {
+                if (betterThan(
+                    values.get(worstIndex),
+                    values.get(leftIndex),
+                    extraValues.get(worstIndex),
+                    extraValues.get(leftIndex)
+                )) {
                     worst = leftChild;
                     worstIndex = leftIndex;
                 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/LongDoubleBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/LongDoubleBucketedSort.java
@@ -97,13 +97,9 @@ public class LongDoubleBucketedSort implements Releasable {
     public void collect(long value, double extraValue, int bucket) {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
-            if (betterThan(
-                // comment to make spotless happy about line breaks
-                value,
-                values.get(rootIndex),
-                extraValue,
-                extraValues.get(rootIndex)
-            )) {
+            long rootValue = values.get(rootIndex);
+            double rootExtra = extraValues.get(rootIndex);
+            if (betterThan(value, rootValue, extraValue, rootExtra)) {
                 values.set(rootIndex, value);
                 extraValues.set(rootIndex, extraValue);
                 downHeap(rootIndex, 0, bucketSize);
@@ -166,12 +162,9 @@ public class LongDoubleBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            collect(
-                // comment to make spotless happy about line breaks
-                other.values.get(i),
-                other.extraValues.get(i),
-                groupId
-            );
+            long otherValue = other.values.get(i);
+            double otherExtra = other.extraValues.get(i);
+            collect(otherValue, otherExtra, groupId);
         }
     }
 
@@ -307,12 +300,9 @@ public class LongDoubleBucketedSort implements Releasable {
         long oldMax = values.size();
         assert oldMax % bucketSize == 0;
 
-        long newSize = BigArrays.overSize(
-            // comment to make spotless happy about line breaks
-            ((long) bucket + 1) * bucketSize,
-            PageCacheRecycler.LONG_PAGE_SIZE,
-            Long.BYTES
-        );
+        int pageSize = PageCacheRecycler.LONG_PAGE_SIZE;
+        int bytesPerElement = Long.BYTES;
+        long newSize = BigArrays.overSize(((long) bucket + 1) * bucketSize, pageSize, bytesPerElement);
         // Round up to the next full bucket.
         newSize = (newSize + bucketSize - 1) / bucketSize;
         values = bigArrays.resize(values, newSize * bucketSize);
@@ -399,28 +389,25 @@ public class LongDoubleBucketedSort implements Releasable {
             int leftChild = parent * 2 + 1;
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
-                if (betterThan(
-                    // comment to make spotless happy about line breaks
-                    values.get(worstIndex),
-                    values.get(leftIndex),
-                    extraValues.get(worstIndex),
-                    extraValues.get(leftIndex)
-                )) {
+                long worstValue = values.get(worstIndex);
+                long leftValue = values.get(leftIndex);
+                double worstExtra = extraValues.get(worstIndex);
+                double leftExtra = extraValues.get(leftIndex);
+                if (betterThan(worstValue, leftValue, worstExtra, leftExtra)) {
                     worst = leftChild;
                     worstIndex = leftIndex;
                 }
                 int rightChild = leftChild + 1;
                 long rightIndex = rootIndex + rightChild;
-                if (rightChild < heapSize
-                    && betterThan(
-                        // comment to make spotless happy about line breaks
-                        values.get(worstIndex),
-                        values.get(rightIndex),
-                        extraValues.get(worstIndex),
-                        extraValues.get(rightIndex)
-                    )) {
-                    worst = rightChild;
-                    worstIndex = rightIndex;
+                if (rightChild < heapSize) {
+                    worstValue = values.get(worstIndex);
+                    long rightValue = values.get(rightIndex);
+                    worstExtra = extraValues.get(worstIndex);
+                    double rightExtra = extraValues.get(rightIndex);
+                    if (betterThan(worstValue, rightValue, worstExtra, rightExtra)) {
+                        worst = rightChild;
+                        worstIndex = rightIndex;
+                    }
                 }
             }
             if (worst == parent) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/LongDoubleBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/LongDoubleBucketedSort.java
@@ -166,7 +166,12 @@ public class LongDoubleBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            collect(other.values.get(i), other.extraValues.get(i), groupId);
+            collect(
+                // comment to make spotless happy about line breaks
+                other.values.get(i),
+                other.extraValues.get(i),
+                groupId
+            );
         }
     }
 
@@ -184,7 +189,6 @@ public class LongDoubleBucketedSort implements Releasable {
         }
 
         try (
-            // comment to make spotless happy about line breaks
             var builder = blockFactory.newLongBlockBuilder(selected.getPositionCount());
             var extraBuilder = blockFactory.newDoubleBlockBuilder(selected.getPositionCount())
         ) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/LongFloatBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/LongFloatBucketedSort.java
@@ -166,7 +166,12 @@ public class LongFloatBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            collect(other.values.get(i), other.extraValues.get(i), groupId);
+            collect(
+                // comment to make spotless happy about line breaks
+                other.values.get(i),
+                other.extraValues.get(i),
+                groupId
+            );
         }
     }
 
@@ -184,7 +189,6 @@ public class LongFloatBucketedSort implements Releasable {
         }
 
         try (
-            // comment to make spotless happy about line breaks
             var builder = blockFactory.newLongBlockBuilder(selected.getPositionCount());
             var extraBuilder = blockFactory.newFloatBlockBuilder(selected.getPositionCount())
         ) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/LongFloatBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/LongFloatBucketedSort.java
@@ -97,7 +97,12 @@ public class LongFloatBucketedSort implements Releasable {
     public void collect(long value, float extraValue, int bucket) {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
-            if (betterThan(value, values.get(rootIndex), extraValue, extraValues.get(rootIndex))) {
+            if (betterThan(
+                value,
+                values.get(rootIndex),
+                extraValue,
+                extraValues.get(rootIndex)
+            )) {
                 values.set(rootIndex, value);
                 extraValues.set(rootIndex, extraValue);
                 downHeap(rootIndex, 0, bucketSize);
@@ -296,7 +301,11 @@ public class LongFloatBucketedSort implements Releasable {
         long oldMax = values.size();
         assert oldMax % bucketSize == 0;
 
-        long newSize = BigArrays.overSize(((long) bucket + 1) * bucketSize, PageCacheRecycler.LONG_PAGE_SIZE, Long.BYTES);
+        long newSize = BigArrays.overSize(
+            ((long) bucket + 1) * bucketSize,
+            PageCacheRecycler.LONG_PAGE_SIZE,
+            Long.BYTES
+        );
         // Round up to the next full bucket.
         newSize = (newSize + bucketSize - 1) / bucketSize;
         values = bigArrays.resize(values, newSize * bucketSize);
@@ -383,7 +392,12 @@ public class LongFloatBucketedSort implements Releasable {
             int leftChild = parent * 2 + 1;
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
-                if (betterThan(values.get(worstIndex), values.get(leftIndex), extraValues.get(worstIndex), extraValues.get(leftIndex))) {
+                if (betterThan(
+                    values.get(worstIndex),
+                    values.get(leftIndex),
+                    extraValues.get(worstIndex),
+                    extraValues.get(leftIndex)
+                )) {
                     worst = leftChild;
                     worstIndex = leftIndex;
                 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/LongFloatBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/LongFloatBucketedSort.java
@@ -98,6 +98,7 @@ public class LongFloatBucketedSort implements Releasable {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
             if (betterThan(
+                // comment to make spotless happy about line breaks
                 value,
                 values.get(rootIndex),
                 extraValue,
@@ -183,6 +184,7 @@ public class LongFloatBucketedSort implements Releasable {
         }
 
         try (
+            // comment to make spotless happy about line breaks
             var builder = blockFactory.newLongBlockBuilder(selected.getPositionCount());
             var extraBuilder = blockFactory.newFloatBlockBuilder(selected.getPositionCount())
         ) {
@@ -302,6 +304,7 @@ public class LongFloatBucketedSort implements Releasable {
         assert oldMax % bucketSize == 0;
 
         long newSize = BigArrays.overSize(
+            // comment to make spotless happy about line breaks
             ((long) bucket + 1) * bucketSize,
             PageCacheRecycler.LONG_PAGE_SIZE,
             Long.BYTES
@@ -393,6 +396,7 @@ public class LongFloatBucketedSort implements Releasable {
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
                 if (betterThan(
+                    // comment to make spotless happy about line breaks
                     values.get(worstIndex),
                     values.get(leftIndex),
                     extraValues.get(worstIndex),
@@ -405,6 +409,7 @@ public class LongFloatBucketedSort implements Releasable {
                 long rightIndex = rootIndex + rightChild;
                 if (rightChild < heapSize
                     && betterThan(
+                        // comment to make spotless happy about line breaks
                         values.get(worstIndex),
                         values.get(rightIndex),
                         extraValues.get(worstIndex),

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/LongFloatBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/LongFloatBucketedSort.java
@@ -97,13 +97,9 @@ public class LongFloatBucketedSort implements Releasable {
     public void collect(long value, float extraValue, int bucket) {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
-            if (betterThan(
-                // comment to make spotless happy about line breaks
-                value,
-                values.get(rootIndex),
-                extraValue,
-                extraValues.get(rootIndex)
-            )) {
+            long rootValue = values.get(rootIndex);
+            float rootExtra = extraValues.get(rootIndex);
+            if (betterThan(value, rootValue, extraValue, rootExtra)) {
                 values.set(rootIndex, value);
                 extraValues.set(rootIndex, extraValue);
                 downHeap(rootIndex, 0, bucketSize);
@@ -166,12 +162,9 @@ public class LongFloatBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            collect(
-                // comment to make spotless happy about line breaks
-                other.values.get(i),
-                other.extraValues.get(i),
-                groupId
-            );
+            long otherValue = other.values.get(i);
+            float otherExtra = other.extraValues.get(i);
+            collect(otherValue, otherExtra, groupId);
         }
     }
 
@@ -307,12 +300,9 @@ public class LongFloatBucketedSort implements Releasable {
         long oldMax = values.size();
         assert oldMax % bucketSize == 0;
 
-        long newSize = BigArrays.overSize(
-            // comment to make spotless happy about line breaks
-            ((long) bucket + 1) * bucketSize,
-            PageCacheRecycler.LONG_PAGE_SIZE,
-            Long.BYTES
-        );
+        int pageSize = PageCacheRecycler.LONG_PAGE_SIZE;
+        int bytesPerElement = Long.BYTES;
+        long newSize = BigArrays.overSize(((long) bucket + 1) * bucketSize, pageSize, bytesPerElement);
         // Round up to the next full bucket.
         newSize = (newSize + bucketSize - 1) / bucketSize;
         values = bigArrays.resize(values, newSize * bucketSize);
@@ -399,28 +389,25 @@ public class LongFloatBucketedSort implements Releasable {
             int leftChild = parent * 2 + 1;
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
-                if (betterThan(
-                    // comment to make spotless happy about line breaks
-                    values.get(worstIndex),
-                    values.get(leftIndex),
-                    extraValues.get(worstIndex),
-                    extraValues.get(leftIndex)
-                )) {
+                long worstValue = values.get(worstIndex);
+                long leftValue = values.get(leftIndex);
+                float worstExtra = extraValues.get(worstIndex);
+                float leftExtra = extraValues.get(leftIndex);
+                if (betterThan(worstValue, leftValue, worstExtra, leftExtra)) {
                     worst = leftChild;
                     worstIndex = leftIndex;
                 }
                 int rightChild = leftChild + 1;
                 long rightIndex = rootIndex + rightChild;
-                if (rightChild < heapSize
-                    && betterThan(
-                        // comment to make spotless happy about line breaks
-                        values.get(worstIndex),
-                        values.get(rightIndex),
-                        extraValues.get(worstIndex),
-                        extraValues.get(rightIndex)
-                    )) {
-                    worst = rightChild;
-                    worstIndex = rightIndex;
+                if (rightChild < heapSize) {
+                    worstValue = values.get(worstIndex);
+                    long rightValue = values.get(rightIndex);
+                    worstExtra = extraValues.get(worstIndex);
+                    float rightExtra = extraValues.get(rightIndex);
+                    if (betterThan(worstValue, rightValue, worstExtra, rightExtra)) {
+                        worst = rightChild;
+                        worstIndex = rightIndex;
+                    }
                 }
             }
             if (worst == parent) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/LongIntBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/LongIntBucketedSort.java
@@ -166,7 +166,12 @@ public class LongIntBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            collect(other.values.get(i), other.extraValues.get(i), groupId);
+            collect(
+                // comment to make spotless happy about line breaks
+                other.values.get(i),
+                other.extraValues.get(i),
+                groupId
+            );
         }
     }
 
@@ -184,7 +189,6 @@ public class LongIntBucketedSort implements Releasable {
         }
 
         try (
-            // comment to make spotless happy about line breaks
             var builder = blockFactory.newLongBlockBuilder(selected.getPositionCount());
             var extraBuilder = blockFactory.newIntBlockBuilder(selected.getPositionCount())
         ) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/LongIntBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/LongIntBucketedSort.java
@@ -97,13 +97,9 @@ public class LongIntBucketedSort implements Releasable {
     public void collect(long value, int extraValue, int bucket) {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
-            if (betterThan(
-                // comment to make spotless happy about line breaks
-                value,
-                values.get(rootIndex),
-                extraValue,
-                extraValues.get(rootIndex)
-            )) {
+            long rootValue = values.get(rootIndex);
+            int rootExtra = extraValues.get(rootIndex);
+            if (betterThan(value, rootValue, extraValue, rootExtra)) {
                 values.set(rootIndex, value);
                 extraValues.set(rootIndex, extraValue);
                 downHeap(rootIndex, 0, bucketSize);
@@ -166,12 +162,9 @@ public class LongIntBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            collect(
-                // comment to make spotless happy about line breaks
-                other.values.get(i),
-                other.extraValues.get(i),
-                groupId
-            );
+            long otherValue = other.values.get(i);
+            int otherExtra = other.extraValues.get(i);
+            collect(otherValue, otherExtra, groupId);
         }
     }
 
@@ -307,12 +300,9 @@ public class LongIntBucketedSort implements Releasable {
         long oldMax = values.size();
         assert oldMax % bucketSize == 0;
 
-        long newSize = BigArrays.overSize(
-            // comment to make spotless happy about line breaks
-            ((long) bucket + 1) * bucketSize,
-            PageCacheRecycler.LONG_PAGE_SIZE,
-            Long.BYTES
-        );
+        int pageSize = PageCacheRecycler.LONG_PAGE_SIZE;
+        int bytesPerElement = Long.BYTES;
+        long newSize = BigArrays.overSize(((long) bucket + 1) * bucketSize, pageSize, bytesPerElement);
         // Round up to the next full bucket.
         newSize = (newSize + bucketSize - 1) / bucketSize;
         values = bigArrays.resize(values, newSize * bucketSize);
@@ -399,28 +389,25 @@ public class LongIntBucketedSort implements Releasable {
             int leftChild = parent * 2 + 1;
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
-                if (betterThan(
-                    // comment to make spotless happy about line breaks
-                    values.get(worstIndex),
-                    values.get(leftIndex),
-                    extraValues.get(worstIndex),
-                    extraValues.get(leftIndex)
-                )) {
+                long worstValue = values.get(worstIndex);
+                long leftValue = values.get(leftIndex);
+                int worstExtra = extraValues.get(worstIndex);
+                int leftExtra = extraValues.get(leftIndex);
+                if (betterThan(worstValue, leftValue, worstExtra, leftExtra)) {
                     worst = leftChild;
                     worstIndex = leftIndex;
                 }
                 int rightChild = leftChild + 1;
                 long rightIndex = rootIndex + rightChild;
-                if (rightChild < heapSize
-                    && betterThan(
-                        // comment to make spotless happy about line breaks
-                        values.get(worstIndex),
-                        values.get(rightIndex),
-                        extraValues.get(worstIndex),
-                        extraValues.get(rightIndex)
-                    )) {
-                    worst = rightChild;
-                    worstIndex = rightIndex;
+                if (rightChild < heapSize) {
+                    worstValue = values.get(worstIndex);
+                    long rightValue = values.get(rightIndex);
+                    worstExtra = extraValues.get(worstIndex);
+                    int rightExtra = extraValues.get(rightIndex);
+                    if (betterThan(worstValue, rightValue, worstExtra, rightExtra)) {
+                        worst = rightChild;
+                        worstIndex = rightIndex;
+                    }
                 }
             }
             if (worst == parent) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/LongIntBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/LongIntBucketedSort.java
@@ -98,6 +98,7 @@ public class LongIntBucketedSort implements Releasable {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
             if (betterThan(
+                // comment to make spotless happy about line breaks
                 value,
                 values.get(rootIndex),
                 extraValue,
@@ -183,6 +184,7 @@ public class LongIntBucketedSort implements Releasable {
         }
 
         try (
+            // comment to make spotless happy about line breaks
             var builder = blockFactory.newLongBlockBuilder(selected.getPositionCount());
             var extraBuilder = blockFactory.newIntBlockBuilder(selected.getPositionCount())
         ) {
@@ -302,6 +304,7 @@ public class LongIntBucketedSort implements Releasable {
         assert oldMax % bucketSize == 0;
 
         long newSize = BigArrays.overSize(
+            // comment to make spotless happy about line breaks
             ((long) bucket + 1) * bucketSize,
             PageCacheRecycler.LONG_PAGE_SIZE,
             Long.BYTES
@@ -393,6 +396,7 @@ public class LongIntBucketedSort implements Releasable {
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
                 if (betterThan(
+                    // comment to make spotless happy about line breaks
                     values.get(worstIndex),
                     values.get(leftIndex),
                     extraValues.get(worstIndex),
@@ -405,6 +409,7 @@ public class LongIntBucketedSort implements Releasable {
                 long rightIndex = rootIndex + rightChild;
                 if (rightChild < heapSize
                     && betterThan(
+                        // comment to make spotless happy about line breaks
                         values.get(worstIndex),
                         values.get(rightIndex),
                         extraValues.get(worstIndex),

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/LongIntBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/LongIntBucketedSort.java
@@ -97,7 +97,12 @@ public class LongIntBucketedSort implements Releasable {
     public void collect(long value, int extraValue, int bucket) {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
-            if (betterThan(value, values.get(rootIndex), extraValue, extraValues.get(rootIndex))) {
+            if (betterThan(
+                value,
+                values.get(rootIndex),
+                extraValue,
+                extraValues.get(rootIndex)
+            )) {
                 values.set(rootIndex, value);
                 extraValues.set(rootIndex, extraValue);
                 downHeap(rootIndex, 0, bucketSize);
@@ -296,7 +301,11 @@ public class LongIntBucketedSort implements Releasable {
         long oldMax = values.size();
         assert oldMax % bucketSize == 0;
 
-        long newSize = BigArrays.overSize(((long) bucket + 1) * bucketSize, PageCacheRecycler.LONG_PAGE_SIZE, Long.BYTES);
+        long newSize = BigArrays.overSize(
+            ((long) bucket + 1) * bucketSize,
+            PageCacheRecycler.LONG_PAGE_SIZE,
+            Long.BYTES
+        );
         // Round up to the next full bucket.
         newSize = (newSize + bucketSize - 1) / bucketSize;
         values = bigArrays.resize(values, newSize * bucketSize);
@@ -383,7 +392,12 @@ public class LongIntBucketedSort implements Releasable {
             int leftChild = parent * 2 + 1;
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
-                if (betterThan(values.get(worstIndex), values.get(leftIndex), extraValues.get(worstIndex), extraValues.get(leftIndex))) {
+                if (betterThan(
+                    values.get(worstIndex),
+                    values.get(leftIndex),
+                    extraValues.get(worstIndex),
+                    extraValues.get(leftIndex)
+                )) {
                     worst = leftChild;
                     worstIndex = leftIndex;
                 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/LongLongBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/LongLongBucketedSort.java
@@ -96,7 +96,12 @@ public class LongLongBucketedSort implements Releasable {
     public void collect(long value, long extraValue, int bucket) {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
-            if (betterThan(value, values.get(rootIndex), extraValue, extraValues.get(rootIndex))) {
+            if (betterThan(
+                value,
+                values.get(rootIndex),
+                extraValue,
+                extraValues.get(rootIndex)
+            )) {
                 values.set(rootIndex, value);
                 extraValues.set(rootIndex, extraValue);
                 downHeap(rootIndex, 0, bucketSize);
@@ -295,7 +300,11 @@ public class LongLongBucketedSort implements Releasable {
         long oldMax = values.size();
         assert oldMax % bucketSize == 0;
 
-        long newSize = BigArrays.overSize(((long) bucket + 1) * bucketSize, PageCacheRecycler.LONG_PAGE_SIZE, Long.BYTES);
+        long newSize = BigArrays.overSize(
+            ((long) bucket + 1) * bucketSize,
+            PageCacheRecycler.LONG_PAGE_SIZE,
+            Long.BYTES
+        );
         // Round up to the next full bucket.
         newSize = (newSize + bucketSize - 1) / bucketSize;
         values = bigArrays.resize(values, newSize * bucketSize);
@@ -382,7 +391,12 @@ public class LongLongBucketedSort implements Releasable {
             int leftChild = parent * 2 + 1;
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
-                if (betterThan(values.get(worstIndex), values.get(leftIndex), extraValues.get(worstIndex), extraValues.get(leftIndex))) {
+                if (betterThan(
+                    values.get(worstIndex),
+                    values.get(leftIndex),
+                    extraValues.get(worstIndex),
+                    extraValues.get(leftIndex)
+                )) {
                     worst = leftChild;
                     worstIndex = leftIndex;
                 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/LongLongBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/LongLongBucketedSort.java
@@ -165,7 +165,12 @@ public class LongLongBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            collect(other.values.get(i), other.extraValues.get(i), groupId);
+            collect(
+                // comment to make spotless happy about line breaks
+                other.values.get(i),
+                other.extraValues.get(i),
+                groupId
+            );
         }
     }
 
@@ -183,7 +188,6 @@ public class LongLongBucketedSort implements Releasable {
         }
 
         try (
-            // comment to make spotless happy about line breaks
             var builder = blockFactory.newLongBlockBuilder(selected.getPositionCount());
             var extraBuilder = blockFactory.newLongBlockBuilder(selected.getPositionCount())
         ) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/LongLongBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/LongLongBucketedSort.java
@@ -97,6 +97,7 @@ public class LongLongBucketedSort implements Releasable {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
             if (betterThan(
+                // comment to make spotless happy about line breaks
                 value,
                 values.get(rootIndex),
                 extraValue,
@@ -182,6 +183,7 @@ public class LongLongBucketedSort implements Releasable {
         }
 
         try (
+            // comment to make spotless happy about line breaks
             var builder = blockFactory.newLongBlockBuilder(selected.getPositionCount());
             var extraBuilder = blockFactory.newLongBlockBuilder(selected.getPositionCount())
         ) {
@@ -301,6 +303,7 @@ public class LongLongBucketedSort implements Releasable {
         assert oldMax % bucketSize == 0;
 
         long newSize = BigArrays.overSize(
+            // comment to make spotless happy about line breaks
             ((long) bucket + 1) * bucketSize,
             PageCacheRecycler.LONG_PAGE_SIZE,
             Long.BYTES
@@ -392,6 +395,7 @@ public class LongLongBucketedSort implements Releasable {
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
                 if (betterThan(
+                    // comment to make spotless happy about line breaks
                     values.get(worstIndex),
                     values.get(leftIndex),
                     extraValues.get(worstIndex),
@@ -404,6 +408,7 @@ public class LongLongBucketedSort implements Releasable {
                 long rightIndex = rootIndex + rightChild;
                 if (rightChild < heapSize
                     && betterThan(
+                        // comment to make spotless happy about line breaks
                         values.get(worstIndex),
                         values.get(rightIndex),
                         extraValues.get(worstIndex),

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/LongLongBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/sort/LongLongBucketedSort.java
@@ -96,13 +96,9 @@ public class LongLongBucketedSort implements Releasable {
     public void collect(long value, long extraValue, int bucket) {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
-            if (betterThan(
-                // comment to make spotless happy about line breaks
-                value,
-                values.get(rootIndex),
-                extraValue,
-                extraValues.get(rootIndex)
-            )) {
+            long rootValue = values.get(rootIndex);
+            long rootExtra = extraValues.get(rootIndex);
+            if (betterThan(value, rootValue, extraValue, rootExtra)) {
                 values.set(rootIndex, value);
                 extraValues.set(rootIndex, extraValue);
                 downHeap(rootIndex, 0, bucketSize);
@@ -165,12 +161,9 @@ public class LongLongBucketedSort implements Releasable {
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            collect(
-                // comment to make spotless happy about line breaks
-                other.values.get(i),
-                other.extraValues.get(i),
-                groupId
-            );
+            long otherValue = other.values.get(i);
+            long otherExtra = other.extraValues.get(i);
+            collect(otherValue, otherExtra, groupId);
         }
     }
 
@@ -306,12 +299,9 @@ public class LongLongBucketedSort implements Releasable {
         long oldMax = values.size();
         assert oldMax % bucketSize == 0;
 
-        long newSize = BigArrays.overSize(
-            // comment to make spotless happy about line breaks
-            ((long) bucket + 1) * bucketSize,
-            PageCacheRecycler.LONG_PAGE_SIZE,
-            Long.BYTES
-        );
+        int pageSize = PageCacheRecycler.LONG_PAGE_SIZE;
+        int bytesPerElement = Long.BYTES;
+        long newSize = BigArrays.overSize(((long) bucket + 1) * bucketSize, pageSize, bytesPerElement);
         // Round up to the next full bucket.
         newSize = (newSize + bucketSize - 1) / bucketSize;
         values = bigArrays.resize(values, newSize * bucketSize);
@@ -398,28 +388,25 @@ public class LongLongBucketedSort implements Releasable {
             int leftChild = parent * 2 + 1;
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
-                if (betterThan(
-                    // comment to make spotless happy about line breaks
-                    values.get(worstIndex),
-                    values.get(leftIndex),
-                    extraValues.get(worstIndex),
-                    extraValues.get(leftIndex)
-                )) {
+                long worstValue = values.get(worstIndex);
+                long leftValue = values.get(leftIndex);
+                long worstExtra = extraValues.get(worstIndex);
+                long leftExtra = extraValues.get(leftIndex);
+                if (betterThan(worstValue, leftValue, worstExtra, leftExtra)) {
                     worst = leftChild;
                     worstIndex = leftIndex;
                 }
                 int rightChild = leftChild + 1;
                 long rightIndex = rootIndex + rightChild;
-                if (rightChild < heapSize
-                    && betterThan(
-                        // comment to make spotless happy about line breaks
-                        values.get(worstIndex),
-                        values.get(rightIndex),
-                        extraValues.get(worstIndex),
-                        extraValues.get(rightIndex)
-                    )) {
-                    worst = rightChild;
-                    worstIndex = rightIndex;
+                if (rightChild < heapSize) {
+                    worstValue = values.get(worstIndex);
+                    long rightValue = values.get(rightIndex);
+                    worstExtra = extraValues.get(worstIndex);
+                    long rightExtra = extraValues.get(rightIndex);
+                    if (betterThan(worstValue, rightValue, worstExtra, rightExtra)) {
+                        worst = rightChild;
+                        worstIndex = rightIndex;
+                    }
                 }
             }
             if (worst == parent) {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopBytesRefBytesRefAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopBytesRefBytesRefAggregatorFunction.java
@@ -1,0 +1,291 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.List;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanVector;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.BytesRefVector;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link AggregatorFunction} implementation for {@link TopBytesRefBytesRefAggregator}.
+ * This class is generated. Edit {@code AggregatorImplementer} instead.
+ */
+public final class TopBytesRefBytesRefAggregatorFunction implements AggregatorFunction {
+  private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+      new IntermediateStateDesc("top", ElementType.BYTES_REF),
+      new IntermediateStateDesc("output", ElementType.BYTES_REF)  );
+
+  private final DriverContext driverContext;
+
+  private final TopBytesRefBytesRefAggregator.SingleState state;
+
+  private final List<Integer> channels;
+
+  private final int limit;
+
+  private final boolean ascending;
+
+  TopBytesRefBytesRefAggregatorFunction(DriverContext driverContext, List<Integer> channels,
+      int limit, boolean ascending) {
+    this.limit = limit;
+    this.ascending = ascending;
+    this.driverContext = driverContext;
+    this.channels = channels;
+    this.state = TopBytesRefBytesRefAggregator.initSingle(driverContext.bigArrays(), limit, ascending);
+  }
+
+  public static List<IntermediateStateDesc> intermediateStateDesc() {
+    return INTERMEDIATE_STATE_DESC;
+  }
+
+  @Override
+  public int intermediateBlockCount() {
+    return INTERMEDIATE_STATE_DESC.size();
+  }
+
+  @Override
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.allFalse()) {
+      // Entire page masked away
+    } else if (mask.allTrue()) {
+      addRawInputNotMasked(page);
+    } else {
+      addRawInputMasked(page, mask);
+    }
+  }
+
+  private void addRawInputMasked(Page page, BooleanVector mask) {
+    BytesRefBlock vBlock = page.getBlock(channels.get(0));
+    BytesRefBlock outputValueBlock = page.getBlock(channels.get(1));
+    BytesRefVector vVector = vBlock.asVector();
+    if (vVector == null) {
+      if (vBlock.areAllValuesNull()) {
+        /*
+         * All values are null so we can skip processing this block.
+         * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+         *       being fast without this. Likely the branch predictor is kicking
+         *       in there. But we do this anyway, just so we don't have to trust
+         *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+         *       always have long sequences of ConstantNullBlock. And this code
+         *       shows readers we've thought about this.
+         */
+        return;
+      }
+      addRawBlock(vBlock, outputValueBlock, mask);
+      return;
+    }
+    BytesRefVector outputValueVector = outputValueBlock.asVector();
+    if (outputValueVector == null) {
+      if (outputValueBlock.areAllValuesNull()) {
+        /*
+         * All values are null so we can skip processing this block.
+         * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+         *       being fast without this. Likely the branch predictor is kicking
+         *       in there. But we do this anyway, just so we don't have to trust
+         *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+         *       always have long sequences of ConstantNullBlock. And this code
+         *       shows readers we've thought about this.
+         */
+        return;
+      }
+      addRawBlock(vBlock, outputValueBlock, mask);
+      return;
+    }
+    addRawVector(vVector, outputValueVector, mask);
+  }
+
+  private void addRawInputNotMasked(Page page) {
+    BytesRefBlock vBlock = page.getBlock(channels.get(0));
+    BytesRefBlock outputValueBlock = page.getBlock(channels.get(1));
+    BytesRefVector vVector = vBlock.asVector();
+    if (vVector == null) {
+      if (vBlock.areAllValuesNull()) {
+        /*
+         * All values are null so we can skip processing this block.
+         * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+         *       being fast without this. Likely the branch predictor is kicking
+         *       in there. But we do this anyway, just so we don't have to trust
+         *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+         *       always have long sequences of ConstantNullBlock. And this code
+         *       shows readers we've thought about this.
+         */
+        return;
+      }
+      addRawBlock(vBlock, outputValueBlock);
+      return;
+    }
+    BytesRefVector outputValueVector = outputValueBlock.asVector();
+    if (outputValueVector == null) {
+      if (outputValueBlock.areAllValuesNull()) {
+        /*
+         * All values are null so we can skip processing this block.
+         * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+         *       being fast without this. Likely the branch predictor is kicking
+         *       in there. But we do this anyway, just so we don't have to trust
+         *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+         *       always have long sequences of ConstantNullBlock. And this code
+         *       shows readers we've thought about this.
+         */
+        return;
+      }
+      addRawBlock(vBlock, outputValueBlock);
+      return;
+    }
+    addRawVector(vVector, outputValueVector);
+  }
+
+  private void addRawVector(BytesRefVector vVector, BytesRefVector outputValueVector) {
+    BytesRef vScratch = new BytesRef();
+    BytesRef outputValueScratch = new BytesRef();
+    for (int valuesPosition = 0; valuesPosition < vVector.getPositionCount(); valuesPosition++) {
+      BytesRef vValue = vVector.getBytesRef(valuesPosition, vScratch);
+      BytesRef outputValueValue = outputValueVector.getBytesRef(valuesPosition, outputValueScratch);
+      TopBytesRefBytesRefAggregator.combine(state, vValue, outputValueValue);
+    }
+  }
+
+  private void addRawVector(BytesRefVector vVector, BytesRefVector outputValueVector,
+      BooleanVector mask) {
+    BytesRef vScratch = new BytesRef();
+    BytesRef outputValueScratch = new BytesRef();
+    for (int valuesPosition = 0; valuesPosition < vVector.getPositionCount(); valuesPosition++) {
+      if (mask.getBoolean(valuesPosition) == false) {
+        continue;
+      }
+      BytesRef vValue = vVector.getBytesRef(valuesPosition, vScratch);
+      BytesRef outputValueValue = outputValueVector.getBytesRef(valuesPosition, outputValueScratch);
+      TopBytesRefBytesRefAggregator.combine(state, vValue, outputValueValue);
+    }
+  }
+
+  private void addRawBlock(BytesRefBlock vBlock, BytesRefBlock outputValueBlock) {
+    BytesRef vScratch = new BytesRef();
+    BytesRef outputValueScratch = new BytesRef();
+    for (int p = 0; p < vBlock.getPositionCount(); p++) {
+      int vValueCount = vBlock.getValueCount(p);
+      if (vValueCount == 0) {
+        continue;
+      }
+      int outputValueValueCount = outputValueBlock.getValueCount(p);
+      if (outputValueValueCount == 0) {
+        continue;
+      }
+      int vStart = vBlock.getFirstValueIndex(p);
+      int vEnd = vStart + vValueCount;
+      for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
+        BytesRef vValue = vBlock.getBytesRef(vOffset, vScratch);
+        int outputValueStart = outputValueBlock.getFirstValueIndex(p);
+        int outputValueEnd = outputValueStart + outputValueValueCount;
+        for (int outputValueOffset = outputValueStart; outputValueOffset < outputValueEnd; outputValueOffset++) {
+          BytesRef outputValueValue = outputValueBlock.getBytesRef(outputValueOffset, outputValueScratch);
+          TopBytesRefBytesRefAggregator.combine(state, vValue, outputValueValue);
+        }
+      }
+    }
+  }
+
+  private void addRawBlock(BytesRefBlock vBlock, BytesRefBlock outputValueBlock,
+      BooleanVector mask) {
+    BytesRef vScratch = new BytesRef();
+    BytesRef outputValueScratch = new BytesRef();
+    for (int p = 0; p < vBlock.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
+      int vValueCount = vBlock.getValueCount(p);
+      if (vValueCount == 0) {
+        continue;
+      }
+      int outputValueValueCount = outputValueBlock.getValueCount(p);
+      if (outputValueValueCount == 0) {
+        continue;
+      }
+      int vStart = vBlock.getFirstValueIndex(p);
+      int vEnd = vStart + vValueCount;
+      for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
+        BytesRef vValue = vBlock.getBytesRef(vOffset, vScratch);
+        int outputValueStart = outputValueBlock.getFirstValueIndex(p);
+        int outputValueEnd = outputValueStart + outputValueValueCount;
+        for (int outputValueOffset = outputValueStart; outputValueOffset < outputValueEnd; outputValueOffset++) {
+          BytesRef outputValueValue = outputValueBlock.getBytesRef(outputValueOffset, outputValueScratch);
+          TopBytesRefBytesRefAggregator.combine(state, vValue, outputValueValue);
+        }
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(Page page) {
+    assert channels.size() == intermediateBlockCount();
+    assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
+    Block topUncast = page.getBlock(channels.get(0));
+    if (topUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BytesRefBlock top = (BytesRefBlock) topUncast;
+    assert top.getPositionCount() == 1;
+    Block outputUncast = page.getBlock(channels.get(1));
+    if (outputUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BytesRefBlock output = (BytesRefBlock) outputUncast;
+    assert output.getPositionCount() == 1;
+    BytesRef topScratch = new BytesRef();
+    BytesRef outputScratch = new BytesRef();
+    TopBytesRefBytesRefAggregator.combineIntermediate(state, top, output);
+  }
+
+  @Override
+  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+    state.toIntermediate(blocks, offset, driverContext);
+  }
+
+  @Override
+  public void evaluateFinal(Block[] blocks, int offset, DriverContext driverContext) {
+    blocks[offset] = TopBytesRefBytesRefAggregator.evaluateFinal(state, driverContext);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName()).append("[");
+    sb.append("channels=").append(channels);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public void close() {
+    state.close();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopBytesRefBytesRefAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopBytesRefBytesRefAggregatorFunctionSupplier.java
@@ -1,0 +1,53 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.util.List;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link AggregatorFunctionSupplier} implementation for {@link TopBytesRefBytesRefAggregator}.
+ * This class is generated. Edit {@code AggregatorFunctionSupplierImplementer} instead.
+ */
+public final class TopBytesRefBytesRefAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
+  private final int limit;
+
+  private final boolean ascending;
+
+  public TopBytesRefBytesRefAggregatorFunctionSupplier(int limit, boolean ascending) {
+    this.limit = limit;
+    this.ascending = ascending;
+  }
+
+  @Override
+  public List<IntermediateStateDesc> nonGroupingIntermediateStateDesc() {
+    return TopBytesRefBytesRefAggregatorFunction.intermediateStateDesc();
+  }
+
+  @Override
+  public List<IntermediateStateDesc> groupingIntermediateStateDesc() {
+    return TopBytesRefBytesRefGroupingAggregatorFunction.intermediateStateDesc();
+  }
+
+  @Override
+  public TopBytesRefBytesRefAggregatorFunction aggregator(DriverContext driverContext,
+      List<Integer> channels) {
+    return new TopBytesRefBytesRefAggregatorFunction(driverContext, channels, limit, ascending);
+  }
+
+  @Override
+  public TopBytesRefBytesRefGroupingAggregatorFunction groupingAggregator(
+      DriverContext driverContext, List<Integer> channels) {
+    return new TopBytesRefBytesRefGroupingAggregatorFunction(channels, driverContext, limit, ascending);
+  }
+
+  @Override
+  public String describe() {
+    return "top_byte of bytes";
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopBytesRefBytesRefGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopBytesRefBytesRefGroupingAggregatorFunction.java
@@ -1,0 +1,500 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.List;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.BytesRefVector;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntArrayBlock;
+import org.elasticsearch.compute.data.IntBigArrayBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link GroupingAggregatorFunction} implementation for {@link TopBytesRefBytesRefAggregator}.
+ * This class is generated. Edit {@code GroupingAggregatorImplementer} instead.
+ */
+public final class TopBytesRefBytesRefGroupingAggregatorFunction implements GroupingAggregatorFunction {
+  private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+      new IntermediateStateDesc("top", ElementType.BYTES_REF),
+      new IntermediateStateDesc("output", ElementType.BYTES_REF)  );
+
+  private final TopBytesRefBytesRefAggregator.GroupingState state;
+
+  private final List<Integer> channels;
+
+  private final DriverContext driverContext;
+
+  private final int limit;
+
+  private final boolean ascending;
+
+  TopBytesRefBytesRefGroupingAggregatorFunction(List<Integer> channels, DriverContext driverContext,
+      int limit, boolean ascending) {
+    this.limit = limit;
+    this.ascending = ascending;
+    this.channels = channels;
+    this.state = TopBytesRefBytesRefAggregator.initGrouping(driverContext.bigArrays(), limit, ascending);
+    this.driverContext = driverContext;
+  }
+
+  public static List<IntermediateStateDesc> intermediateStateDesc() {
+    return INTERMEDIATE_STATE_DESC;
+  }
+
+  @Override
+  public int intermediateBlockCount() {
+    return INTERMEDIATE_STATE_DESC.size();
+  }
+
+  @Override
+  public GroupingAggregatorFunction.AddInput prepareProcessRawInputPage(SeenGroupIds seenGroupIds,
+      Page page) {
+    BytesRefBlock vBlock = page.getBlock(channels.get(0));
+    BytesRefBlock outputValueBlock = page.getBlock(channels.get(1));
+    if (vBlock.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block. But we
+       * still need to track that some groups may not have been seen
+       * so that they are initialized to null when we read their values.
+       */
+      state.enableGroupIdTracking(seenGroupIds);
+      return null;
+    }
+    if (outputValueBlock.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block. But we
+       * still need to track that some groups may not have been seen
+       * so that they are initialized to null when we read their values.
+       */
+      state.enableGroupIdTracking(seenGroupIds);
+      return null;
+    }
+    BytesRefVector vVector = vBlock.asVector();
+    if (vVector == null) {
+      maybeEnableGroupIdTracking(seenGroupIds, vBlock, outputValueBlock);
+      return new GroupingAggregatorFunction.AddInput() {
+        @Override
+        public void add(int positionOffset, IntArrayBlock groupIds) {
+          addRawInput(positionOffset, groupIds, vBlock, outputValueBlock);
+        }
+
+        @Override
+        public void add(int positionOffset, IntBigArrayBlock groupIds) {
+          addRawInput(positionOffset, groupIds, vBlock, outputValueBlock);
+        }
+
+        @Override
+        public void add(int positionOffset, IntVector groupIds) {
+          addRawInput(positionOffset, groupIds, vBlock, outputValueBlock);
+        }
+
+        @Override
+        public void close() {
+        }
+      };
+    }
+    BytesRefVector outputValueVector = outputValueBlock.asVector();
+    if (outputValueVector == null) {
+      maybeEnableGroupIdTracking(seenGroupIds, vBlock, outputValueBlock);
+      return new GroupingAggregatorFunction.AddInput() {
+        @Override
+        public void add(int positionOffset, IntArrayBlock groupIds) {
+          addRawInput(positionOffset, groupIds, vBlock, outputValueBlock);
+        }
+
+        @Override
+        public void add(int positionOffset, IntBigArrayBlock groupIds) {
+          addRawInput(positionOffset, groupIds, vBlock, outputValueBlock);
+        }
+
+        @Override
+        public void add(int positionOffset, IntVector groupIds) {
+          addRawInput(positionOffset, groupIds, vBlock, outputValueBlock);
+        }
+
+        @Override
+        public void close() {
+        }
+      };
+    }
+    return new GroupingAggregatorFunction.AddInput() {
+      @Override
+      public void add(int positionOffset, IntArrayBlock groupIds) {
+        addRawInput(positionOffset, groupIds, vVector, outputValueVector);
+      }
+
+      @Override
+      public void add(int positionOffset, IntBigArrayBlock groupIds) {
+        addRawInput(positionOffset, groupIds, vVector, outputValueVector);
+      }
+
+      @Override
+      public void add(int positionOffset, IntVector groupIds) {
+        addRawInput(positionOffset, groupIds, vVector, outputValueVector);
+      }
+
+      @Override
+      public void close() {
+      }
+    };
+  }
+
+  private void addRawInput(int positionOffset, IntArrayBlock groups, BytesRefBlock vBlock,
+      BytesRefBlock outputValueBlock) {
+    BytesRef vScratch = new BytesRef();
+    BytesRef outputValueScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      if (vBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      if (outputValueBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int vStart = vBlock.getFirstValueIndex(valuesPosition);
+        int vEnd = vStart + vBlock.getValueCount(valuesPosition);
+        for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
+          BytesRef vValue = vBlock.getBytesRef(vOffset, vScratch);
+          int outputValueStart = outputValueBlock.getFirstValueIndex(valuesPosition);
+          int outputValueEnd = outputValueStart + outputValueBlock.getValueCount(valuesPosition);
+          for (int outputValueOffset = outputValueStart; outputValueOffset < outputValueEnd; outputValueOffset++) {
+            BytesRef outputValueValue = outputValueBlock.getBytesRef(outputValueOffset, outputValueScratch);
+            TopBytesRefBytesRefAggregator.combine(state, groupId, vValue, outputValueValue);
+          }
+        }
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntArrayBlock groups, BytesRefVector vVector,
+      BytesRefVector outputValueVector) {
+    BytesRef vScratch = new BytesRef();
+    BytesRef outputValueScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        BytesRef vValue = vVector.getBytesRef(valuesPosition, vScratch);
+        BytesRef outputValueValue = outputValueVector.getBytesRef(valuesPosition, outputValueScratch);
+        TopBytesRefBytesRefAggregator.combine(state, groupId, vValue, outputValueValue);
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntArrayBlock groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block topUncast = page.getBlock(channels.get(0));
+    if (topUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BytesRefBlock top = (BytesRefBlock) topUncast;
+    Block outputUncast = page.getBlock(channels.get(1));
+    if (outputUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BytesRefBlock output = (BytesRefBlock) outputUncast;
+    assert top.getPositionCount() == output.getPositionCount();
+    BytesRef topScratch = new BytesRef();
+    BytesRef outputScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int valuesPosition = groupPosition + positionOffset;
+        TopBytesRefBytesRefAggregator.combineIntermediate(state, groupId, top, output, valuesPosition);
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntBigArrayBlock groups, BytesRefBlock vBlock,
+      BytesRefBlock outputValueBlock) {
+    BytesRef vScratch = new BytesRef();
+    BytesRef outputValueScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      if (vBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      if (outputValueBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int vStart = vBlock.getFirstValueIndex(valuesPosition);
+        int vEnd = vStart + vBlock.getValueCount(valuesPosition);
+        for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
+          BytesRef vValue = vBlock.getBytesRef(vOffset, vScratch);
+          int outputValueStart = outputValueBlock.getFirstValueIndex(valuesPosition);
+          int outputValueEnd = outputValueStart + outputValueBlock.getValueCount(valuesPosition);
+          for (int outputValueOffset = outputValueStart; outputValueOffset < outputValueEnd; outputValueOffset++) {
+            BytesRef outputValueValue = outputValueBlock.getBytesRef(outputValueOffset, outputValueScratch);
+            TopBytesRefBytesRefAggregator.combine(state, groupId, vValue, outputValueValue);
+          }
+        }
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntBigArrayBlock groups, BytesRefVector vVector,
+      BytesRefVector outputValueVector) {
+    BytesRef vScratch = new BytesRef();
+    BytesRef outputValueScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        BytesRef vValue = vVector.getBytesRef(valuesPosition, vScratch);
+        BytesRef outputValueValue = outputValueVector.getBytesRef(valuesPosition, outputValueScratch);
+        TopBytesRefBytesRefAggregator.combine(state, groupId, vValue, outputValueValue);
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntBigArrayBlock groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block topUncast = page.getBlock(channels.get(0));
+    if (topUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BytesRefBlock top = (BytesRefBlock) topUncast;
+    Block outputUncast = page.getBlock(channels.get(1));
+    if (outputUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BytesRefBlock output = (BytesRefBlock) outputUncast;
+    assert top.getPositionCount() == output.getPositionCount();
+    BytesRef topScratch = new BytesRef();
+    BytesRef outputScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int valuesPosition = groupPosition + positionOffset;
+        TopBytesRefBytesRefAggregator.combineIntermediate(state, groupId, top, output, valuesPosition);
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntVector groups, BytesRefBlock vBlock,
+      BytesRefBlock outputValueBlock) {
+    BytesRef vScratch = new BytesRef();
+    BytesRef outputValueScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int valuesPosition = groupPosition + positionOffset;
+      if (vBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      if (outputValueBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      int groupId = groups.getInt(groupPosition);
+      int vStart = vBlock.getFirstValueIndex(valuesPosition);
+      int vEnd = vStart + vBlock.getValueCount(valuesPosition);
+      for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
+        BytesRef vValue = vBlock.getBytesRef(vOffset, vScratch);
+        int outputValueStart = outputValueBlock.getFirstValueIndex(valuesPosition);
+        int outputValueEnd = outputValueStart + outputValueBlock.getValueCount(valuesPosition);
+        for (int outputValueOffset = outputValueStart; outputValueOffset < outputValueEnd; outputValueOffset++) {
+          BytesRef outputValueValue = outputValueBlock.getBytesRef(outputValueOffset, outputValueScratch);
+          TopBytesRefBytesRefAggregator.combine(state, groupId, vValue, outputValueValue);
+        }
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntVector groups, BytesRefVector vVector,
+      BytesRefVector outputValueVector) {
+    BytesRef vScratch = new BytesRef();
+    BytesRef outputValueScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int valuesPosition = groupPosition + positionOffset;
+      int groupId = groups.getInt(groupPosition);
+      BytesRef vValue = vVector.getBytesRef(valuesPosition, vScratch);
+      BytesRef outputValueValue = outputValueVector.getBytesRef(valuesPosition, outputValueScratch);
+      TopBytesRefBytesRefAggregator.combine(state, groupId, vValue, outputValueValue);
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block topUncast = page.getBlock(channels.get(0));
+    if (topUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BytesRefBlock top = (BytesRefBlock) topUncast;
+    Block outputUncast = page.getBlock(channels.get(1));
+    if (outputUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BytesRefBlock output = (BytesRefBlock) outputUncast;
+    assert top.getPositionCount() == output.getPositionCount();
+    BytesRef topScratch = new BytesRef();
+    BytesRef outputScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int groupId = groups.getInt(groupPosition);
+      int valuesPosition = groupPosition + positionOffset;
+      TopBytesRefBytesRefAggregator.combineIntermediate(state, groupId, top, output, valuesPosition);
+    }
+  }
+
+  private void maybeEnableGroupIdTracking(SeenGroupIds seenGroupIds, BytesRefBlock vBlock,
+      BytesRefBlock outputValueBlock) {
+    if (vBlock.mayHaveNulls()) {
+      /*
+       * Some values in the block are null so some group ids may not
+       * be seen. We need to track which ones so we can initialize
+       * them to null when we read their values.
+       */
+      state.enableGroupIdTracking(seenGroupIds);
+    }
+    if (outputValueBlock.mayHaveNulls()) {
+      /*
+       * Some values in the block are null so some group ids may not
+       * be seen. We need to track which ones so we can initialize
+       * them to null when we read their values.
+       */
+      state.enableGroupIdTracking(seenGroupIds);
+    }
+  }
+
+  @Override
+  public void selectedMayContainUnseenGroups(SeenGroupIds seenGroupIds) {
+    state.enableGroupIdTracking(seenGroupIds);
+  }
+
+  @Override
+  public GroupingAggregatorFunction.PreparedForEvaluation prepareEvaluateIntermediate(
+      IntVector selected, GroupingAggregatorEvaluationContext ctx) {
+    return this::evaluateIntermediate;
+  }
+
+  private void evaluateIntermediate(Block[] blocks, int offset, IntVector selectedInPage) {
+    state.toIntermediate(blocks, offset, selectedInPage, driverContext);
+  }
+
+  @Override
+  public GroupingAggregatorFunction.PreparedForEvaluation prepareEvaluateFinal(IntVector selected,
+      GroupingAggregatorEvaluationContext ctx) {
+    return (blocks, offset, selectedInPage) -> evaluateFinal(blocks, offset, selectedInPage, ctx);
+  }
+
+  private void evaluateFinal(Block[] blocks, int offset, IntVector selectedInPage,
+      GroupingAggregatorEvaluationContext ctx) {
+    blocks[offset] = TopBytesRefBytesRefAggregator.evaluateFinal(state, selectedInPage, ctx);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName()).append("[");
+    sb.append("channels=").append(channels);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public void close() {
+    state.close();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopBytesRefDoubleAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopBytesRefDoubleAggregatorFunction.java
@@ -1,0 +1,287 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.List;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanVector;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.BytesRefVector;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.DoubleVector;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link AggregatorFunction} implementation for {@link TopBytesRefDoubleAggregator}.
+ * This class is generated. Edit {@code AggregatorImplementer} instead.
+ */
+public final class TopBytesRefDoubleAggregatorFunction implements AggregatorFunction {
+  private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+      new IntermediateStateDesc("top", ElementType.BYTES_REF),
+      new IntermediateStateDesc("output", ElementType.DOUBLE)  );
+
+  private final DriverContext driverContext;
+
+  private final TopBytesRefDoubleAggregator.SingleState state;
+
+  private final List<Integer> channels;
+
+  private final int limit;
+
+  private final boolean ascending;
+
+  TopBytesRefDoubleAggregatorFunction(DriverContext driverContext, List<Integer> channels,
+      int limit, boolean ascending) {
+    this.limit = limit;
+    this.ascending = ascending;
+    this.driverContext = driverContext;
+    this.channels = channels;
+    this.state = TopBytesRefDoubleAggregator.initSingle(driverContext.bigArrays(), limit, ascending);
+  }
+
+  public static List<IntermediateStateDesc> intermediateStateDesc() {
+    return INTERMEDIATE_STATE_DESC;
+  }
+
+  @Override
+  public int intermediateBlockCount() {
+    return INTERMEDIATE_STATE_DESC.size();
+  }
+
+  @Override
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.allFalse()) {
+      // Entire page masked away
+    } else if (mask.allTrue()) {
+      addRawInputNotMasked(page);
+    } else {
+      addRawInputMasked(page, mask);
+    }
+  }
+
+  private void addRawInputMasked(Page page, BooleanVector mask) {
+    BytesRefBlock vBlock = page.getBlock(channels.get(0));
+    DoubleBlock outputValueBlock = page.getBlock(channels.get(1));
+    BytesRefVector vVector = vBlock.asVector();
+    if (vVector == null) {
+      if (vBlock.areAllValuesNull()) {
+        /*
+         * All values are null so we can skip processing this block.
+         * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+         *       being fast without this. Likely the branch predictor is kicking
+         *       in there. But we do this anyway, just so we don't have to trust
+         *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+         *       always have long sequences of ConstantNullBlock. And this code
+         *       shows readers we've thought about this.
+         */
+        return;
+      }
+      addRawBlock(vBlock, outputValueBlock, mask);
+      return;
+    }
+    DoubleVector outputValueVector = outputValueBlock.asVector();
+    if (outputValueVector == null) {
+      if (outputValueBlock.areAllValuesNull()) {
+        /*
+         * All values are null so we can skip processing this block.
+         * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+         *       being fast without this. Likely the branch predictor is kicking
+         *       in there. But we do this anyway, just so we don't have to trust
+         *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+         *       always have long sequences of ConstantNullBlock. And this code
+         *       shows readers we've thought about this.
+         */
+        return;
+      }
+      addRawBlock(vBlock, outputValueBlock, mask);
+      return;
+    }
+    addRawVector(vVector, outputValueVector, mask);
+  }
+
+  private void addRawInputNotMasked(Page page) {
+    BytesRefBlock vBlock = page.getBlock(channels.get(0));
+    DoubleBlock outputValueBlock = page.getBlock(channels.get(1));
+    BytesRefVector vVector = vBlock.asVector();
+    if (vVector == null) {
+      if (vBlock.areAllValuesNull()) {
+        /*
+         * All values are null so we can skip processing this block.
+         * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+         *       being fast without this. Likely the branch predictor is kicking
+         *       in there. But we do this anyway, just so we don't have to trust
+         *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+         *       always have long sequences of ConstantNullBlock. And this code
+         *       shows readers we've thought about this.
+         */
+        return;
+      }
+      addRawBlock(vBlock, outputValueBlock);
+      return;
+    }
+    DoubleVector outputValueVector = outputValueBlock.asVector();
+    if (outputValueVector == null) {
+      if (outputValueBlock.areAllValuesNull()) {
+        /*
+         * All values are null so we can skip processing this block.
+         * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+         *       being fast without this. Likely the branch predictor is kicking
+         *       in there. But we do this anyway, just so we don't have to trust
+         *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+         *       always have long sequences of ConstantNullBlock. And this code
+         *       shows readers we've thought about this.
+         */
+        return;
+      }
+      addRawBlock(vBlock, outputValueBlock);
+      return;
+    }
+    addRawVector(vVector, outputValueVector);
+  }
+
+  private void addRawVector(BytesRefVector vVector, DoubleVector outputValueVector) {
+    BytesRef vScratch = new BytesRef();
+    for (int valuesPosition = 0; valuesPosition < vVector.getPositionCount(); valuesPosition++) {
+      BytesRef vValue = vVector.getBytesRef(valuesPosition, vScratch);
+      double outputValueValue = outputValueVector.getDouble(valuesPosition);
+      TopBytesRefDoubleAggregator.combine(state, vValue, outputValueValue);
+    }
+  }
+
+  private void addRawVector(BytesRefVector vVector, DoubleVector outputValueVector,
+      BooleanVector mask) {
+    BytesRef vScratch = new BytesRef();
+    for (int valuesPosition = 0; valuesPosition < vVector.getPositionCount(); valuesPosition++) {
+      if (mask.getBoolean(valuesPosition) == false) {
+        continue;
+      }
+      BytesRef vValue = vVector.getBytesRef(valuesPosition, vScratch);
+      double outputValueValue = outputValueVector.getDouble(valuesPosition);
+      TopBytesRefDoubleAggregator.combine(state, vValue, outputValueValue);
+    }
+  }
+
+  private void addRawBlock(BytesRefBlock vBlock, DoubleBlock outputValueBlock) {
+    BytesRef vScratch = new BytesRef();
+    for (int p = 0; p < vBlock.getPositionCount(); p++) {
+      int vValueCount = vBlock.getValueCount(p);
+      if (vValueCount == 0) {
+        continue;
+      }
+      int outputValueValueCount = outputValueBlock.getValueCount(p);
+      if (outputValueValueCount == 0) {
+        continue;
+      }
+      int vStart = vBlock.getFirstValueIndex(p);
+      int vEnd = vStart + vValueCount;
+      for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
+        BytesRef vValue = vBlock.getBytesRef(vOffset, vScratch);
+        int outputValueStart = outputValueBlock.getFirstValueIndex(p);
+        int outputValueEnd = outputValueStart + outputValueValueCount;
+        for (int outputValueOffset = outputValueStart; outputValueOffset < outputValueEnd; outputValueOffset++) {
+          double outputValueValue = outputValueBlock.getDouble(outputValueOffset);
+          TopBytesRefDoubleAggregator.combine(state, vValue, outputValueValue);
+        }
+      }
+    }
+  }
+
+  private void addRawBlock(BytesRefBlock vBlock, DoubleBlock outputValueBlock, BooleanVector mask) {
+    BytesRef vScratch = new BytesRef();
+    for (int p = 0; p < vBlock.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
+      int vValueCount = vBlock.getValueCount(p);
+      if (vValueCount == 0) {
+        continue;
+      }
+      int outputValueValueCount = outputValueBlock.getValueCount(p);
+      if (outputValueValueCount == 0) {
+        continue;
+      }
+      int vStart = vBlock.getFirstValueIndex(p);
+      int vEnd = vStart + vValueCount;
+      for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
+        BytesRef vValue = vBlock.getBytesRef(vOffset, vScratch);
+        int outputValueStart = outputValueBlock.getFirstValueIndex(p);
+        int outputValueEnd = outputValueStart + outputValueValueCount;
+        for (int outputValueOffset = outputValueStart; outputValueOffset < outputValueEnd; outputValueOffset++) {
+          double outputValueValue = outputValueBlock.getDouble(outputValueOffset);
+          TopBytesRefDoubleAggregator.combine(state, vValue, outputValueValue);
+        }
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(Page page) {
+    assert channels.size() == intermediateBlockCount();
+    assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
+    Block topUncast = page.getBlock(channels.get(0));
+    if (topUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BytesRefBlock top = (BytesRefBlock) topUncast;
+    assert top.getPositionCount() == 1;
+    Block outputUncast = page.getBlock(channels.get(1));
+    if (outputUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    DoubleBlock output = (DoubleBlock) outputUncast;
+    assert output.getPositionCount() == 1;
+    BytesRef topScratch = new BytesRef();
+    TopBytesRefDoubleAggregator.combineIntermediate(state, top, output);
+  }
+
+  @Override
+  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+    state.toIntermediate(blocks, offset, driverContext);
+  }
+
+  @Override
+  public void evaluateFinal(Block[] blocks, int offset, DriverContext driverContext) {
+    blocks[offset] = TopBytesRefDoubleAggregator.evaluateFinal(state, driverContext);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName()).append("[");
+    sb.append("channels=").append(channels);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public void close() {
+    state.close();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopBytesRefDoubleAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopBytesRefDoubleAggregatorFunctionSupplier.java
@@ -1,0 +1,53 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.util.List;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link AggregatorFunctionSupplier} implementation for {@link TopBytesRefDoubleAggregator}.
+ * This class is generated. Edit {@code AggregatorFunctionSupplierImplementer} instead.
+ */
+public final class TopBytesRefDoubleAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
+  private final int limit;
+
+  private final boolean ascending;
+
+  public TopBytesRefDoubleAggregatorFunctionSupplier(int limit, boolean ascending) {
+    this.limit = limit;
+    this.ascending = ascending;
+  }
+
+  @Override
+  public List<IntermediateStateDesc> nonGroupingIntermediateStateDesc() {
+    return TopBytesRefDoubleAggregatorFunction.intermediateStateDesc();
+  }
+
+  @Override
+  public List<IntermediateStateDesc> groupingIntermediateStateDesc() {
+    return TopBytesRefDoubleGroupingAggregatorFunction.intermediateStateDesc();
+  }
+
+  @Override
+  public TopBytesRefDoubleAggregatorFunction aggregator(DriverContext driverContext,
+      List<Integer> channels) {
+    return new TopBytesRefDoubleAggregatorFunction(driverContext, channels, limit, ascending);
+  }
+
+  @Override
+  public TopBytesRefDoubleGroupingAggregatorFunction groupingAggregator(DriverContext driverContext,
+      List<Integer> channels) {
+    return new TopBytesRefDoubleGroupingAggregatorFunction(channels, driverContext, limit, ascending);
+  }
+
+  @Override
+  public String describe() {
+    return "top_byte of doubles";
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopBytesRefDoubleGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopBytesRefDoubleGroupingAggregatorFunction.java
@@ -1,0 +1,493 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.List;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.BytesRefVector;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.DoubleVector;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntArrayBlock;
+import org.elasticsearch.compute.data.IntBigArrayBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link GroupingAggregatorFunction} implementation for {@link TopBytesRefDoubleAggregator}.
+ * This class is generated. Edit {@code GroupingAggregatorImplementer} instead.
+ */
+public final class TopBytesRefDoubleGroupingAggregatorFunction implements GroupingAggregatorFunction {
+  private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+      new IntermediateStateDesc("top", ElementType.BYTES_REF),
+      new IntermediateStateDesc("output", ElementType.DOUBLE)  );
+
+  private final TopBytesRefDoubleAggregator.GroupingState state;
+
+  private final List<Integer> channels;
+
+  private final DriverContext driverContext;
+
+  private final int limit;
+
+  private final boolean ascending;
+
+  TopBytesRefDoubleGroupingAggregatorFunction(List<Integer> channels, DriverContext driverContext,
+      int limit, boolean ascending) {
+    this.limit = limit;
+    this.ascending = ascending;
+    this.channels = channels;
+    this.state = TopBytesRefDoubleAggregator.initGrouping(driverContext.bigArrays(), limit, ascending);
+    this.driverContext = driverContext;
+  }
+
+  public static List<IntermediateStateDesc> intermediateStateDesc() {
+    return INTERMEDIATE_STATE_DESC;
+  }
+
+  @Override
+  public int intermediateBlockCount() {
+    return INTERMEDIATE_STATE_DESC.size();
+  }
+
+  @Override
+  public GroupingAggregatorFunction.AddInput prepareProcessRawInputPage(SeenGroupIds seenGroupIds,
+      Page page) {
+    BytesRefBlock vBlock = page.getBlock(channels.get(0));
+    DoubleBlock outputValueBlock = page.getBlock(channels.get(1));
+    if (vBlock.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block. But we
+       * still need to track that some groups may not have been seen
+       * so that they are initialized to null when we read their values.
+       */
+      state.enableGroupIdTracking(seenGroupIds);
+      return null;
+    }
+    if (outputValueBlock.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block. But we
+       * still need to track that some groups may not have been seen
+       * so that they are initialized to null when we read their values.
+       */
+      state.enableGroupIdTracking(seenGroupIds);
+      return null;
+    }
+    BytesRefVector vVector = vBlock.asVector();
+    if (vVector == null) {
+      maybeEnableGroupIdTracking(seenGroupIds, vBlock, outputValueBlock);
+      return new GroupingAggregatorFunction.AddInput() {
+        @Override
+        public void add(int positionOffset, IntArrayBlock groupIds) {
+          addRawInput(positionOffset, groupIds, vBlock, outputValueBlock);
+        }
+
+        @Override
+        public void add(int positionOffset, IntBigArrayBlock groupIds) {
+          addRawInput(positionOffset, groupIds, vBlock, outputValueBlock);
+        }
+
+        @Override
+        public void add(int positionOffset, IntVector groupIds) {
+          addRawInput(positionOffset, groupIds, vBlock, outputValueBlock);
+        }
+
+        @Override
+        public void close() {
+        }
+      };
+    }
+    DoubleVector outputValueVector = outputValueBlock.asVector();
+    if (outputValueVector == null) {
+      maybeEnableGroupIdTracking(seenGroupIds, vBlock, outputValueBlock);
+      return new GroupingAggregatorFunction.AddInput() {
+        @Override
+        public void add(int positionOffset, IntArrayBlock groupIds) {
+          addRawInput(positionOffset, groupIds, vBlock, outputValueBlock);
+        }
+
+        @Override
+        public void add(int positionOffset, IntBigArrayBlock groupIds) {
+          addRawInput(positionOffset, groupIds, vBlock, outputValueBlock);
+        }
+
+        @Override
+        public void add(int positionOffset, IntVector groupIds) {
+          addRawInput(positionOffset, groupIds, vBlock, outputValueBlock);
+        }
+
+        @Override
+        public void close() {
+        }
+      };
+    }
+    return new GroupingAggregatorFunction.AddInput() {
+      @Override
+      public void add(int positionOffset, IntArrayBlock groupIds) {
+        addRawInput(positionOffset, groupIds, vVector, outputValueVector);
+      }
+
+      @Override
+      public void add(int positionOffset, IntBigArrayBlock groupIds) {
+        addRawInput(positionOffset, groupIds, vVector, outputValueVector);
+      }
+
+      @Override
+      public void add(int positionOffset, IntVector groupIds) {
+        addRawInput(positionOffset, groupIds, vVector, outputValueVector);
+      }
+
+      @Override
+      public void close() {
+      }
+    };
+  }
+
+  private void addRawInput(int positionOffset, IntArrayBlock groups, BytesRefBlock vBlock,
+      DoubleBlock outputValueBlock) {
+    BytesRef vScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      if (vBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      if (outputValueBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int vStart = vBlock.getFirstValueIndex(valuesPosition);
+        int vEnd = vStart + vBlock.getValueCount(valuesPosition);
+        for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
+          BytesRef vValue = vBlock.getBytesRef(vOffset, vScratch);
+          int outputValueStart = outputValueBlock.getFirstValueIndex(valuesPosition);
+          int outputValueEnd = outputValueStart + outputValueBlock.getValueCount(valuesPosition);
+          for (int outputValueOffset = outputValueStart; outputValueOffset < outputValueEnd; outputValueOffset++) {
+            double outputValueValue = outputValueBlock.getDouble(outputValueOffset);
+            TopBytesRefDoubleAggregator.combine(state, groupId, vValue, outputValueValue);
+          }
+        }
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntArrayBlock groups, BytesRefVector vVector,
+      DoubleVector outputValueVector) {
+    BytesRef vScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        BytesRef vValue = vVector.getBytesRef(valuesPosition, vScratch);
+        double outputValueValue = outputValueVector.getDouble(valuesPosition);
+        TopBytesRefDoubleAggregator.combine(state, groupId, vValue, outputValueValue);
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntArrayBlock groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block topUncast = page.getBlock(channels.get(0));
+    if (topUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BytesRefBlock top = (BytesRefBlock) topUncast;
+    Block outputUncast = page.getBlock(channels.get(1));
+    if (outputUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    DoubleBlock output = (DoubleBlock) outputUncast;
+    assert top.getPositionCount() == output.getPositionCount();
+    BytesRef topScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int valuesPosition = groupPosition + positionOffset;
+        TopBytesRefDoubleAggregator.combineIntermediate(state, groupId, top, output, valuesPosition);
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntBigArrayBlock groups, BytesRefBlock vBlock,
+      DoubleBlock outputValueBlock) {
+    BytesRef vScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      if (vBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      if (outputValueBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int vStart = vBlock.getFirstValueIndex(valuesPosition);
+        int vEnd = vStart + vBlock.getValueCount(valuesPosition);
+        for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
+          BytesRef vValue = vBlock.getBytesRef(vOffset, vScratch);
+          int outputValueStart = outputValueBlock.getFirstValueIndex(valuesPosition);
+          int outputValueEnd = outputValueStart + outputValueBlock.getValueCount(valuesPosition);
+          for (int outputValueOffset = outputValueStart; outputValueOffset < outputValueEnd; outputValueOffset++) {
+            double outputValueValue = outputValueBlock.getDouble(outputValueOffset);
+            TopBytesRefDoubleAggregator.combine(state, groupId, vValue, outputValueValue);
+          }
+        }
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntBigArrayBlock groups, BytesRefVector vVector,
+      DoubleVector outputValueVector) {
+    BytesRef vScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        BytesRef vValue = vVector.getBytesRef(valuesPosition, vScratch);
+        double outputValueValue = outputValueVector.getDouble(valuesPosition);
+        TopBytesRefDoubleAggregator.combine(state, groupId, vValue, outputValueValue);
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntBigArrayBlock groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block topUncast = page.getBlock(channels.get(0));
+    if (topUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BytesRefBlock top = (BytesRefBlock) topUncast;
+    Block outputUncast = page.getBlock(channels.get(1));
+    if (outputUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    DoubleBlock output = (DoubleBlock) outputUncast;
+    assert top.getPositionCount() == output.getPositionCount();
+    BytesRef topScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int valuesPosition = groupPosition + positionOffset;
+        TopBytesRefDoubleAggregator.combineIntermediate(state, groupId, top, output, valuesPosition);
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntVector groups, BytesRefBlock vBlock,
+      DoubleBlock outputValueBlock) {
+    BytesRef vScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int valuesPosition = groupPosition + positionOffset;
+      if (vBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      if (outputValueBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      int groupId = groups.getInt(groupPosition);
+      int vStart = vBlock.getFirstValueIndex(valuesPosition);
+      int vEnd = vStart + vBlock.getValueCount(valuesPosition);
+      for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
+        BytesRef vValue = vBlock.getBytesRef(vOffset, vScratch);
+        int outputValueStart = outputValueBlock.getFirstValueIndex(valuesPosition);
+        int outputValueEnd = outputValueStart + outputValueBlock.getValueCount(valuesPosition);
+        for (int outputValueOffset = outputValueStart; outputValueOffset < outputValueEnd; outputValueOffset++) {
+          double outputValueValue = outputValueBlock.getDouble(outputValueOffset);
+          TopBytesRefDoubleAggregator.combine(state, groupId, vValue, outputValueValue);
+        }
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntVector groups, BytesRefVector vVector,
+      DoubleVector outputValueVector) {
+    BytesRef vScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int valuesPosition = groupPosition + positionOffset;
+      int groupId = groups.getInt(groupPosition);
+      BytesRef vValue = vVector.getBytesRef(valuesPosition, vScratch);
+      double outputValueValue = outputValueVector.getDouble(valuesPosition);
+      TopBytesRefDoubleAggregator.combine(state, groupId, vValue, outputValueValue);
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block topUncast = page.getBlock(channels.get(0));
+    if (topUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BytesRefBlock top = (BytesRefBlock) topUncast;
+    Block outputUncast = page.getBlock(channels.get(1));
+    if (outputUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    DoubleBlock output = (DoubleBlock) outputUncast;
+    assert top.getPositionCount() == output.getPositionCount();
+    BytesRef topScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int groupId = groups.getInt(groupPosition);
+      int valuesPosition = groupPosition + positionOffset;
+      TopBytesRefDoubleAggregator.combineIntermediate(state, groupId, top, output, valuesPosition);
+    }
+  }
+
+  private void maybeEnableGroupIdTracking(SeenGroupIds seenGroupIds, BytesRefBlock vBlock,
+      DoubleBlock outputValueBlock) {
+    if (vBlock.mayHaveNulls()) {
+      /*
+       * Some values in the block are null so some group ids may not
+       * be seen. We need to track which ones so we can initialize
+       * them to null when we read their values.
+       */
+      state.enableGroupIdTracking(seenGroupIds);
+    }
+    if (outputValueBlock.mayHaveNulls()) {
+      /*
+       * Some values in the block are null so some group ids may not
+       * be seen. We need to track which ones so we can initialize
+       * them to null when we read their values.
+       */
+      state.enableGroupIdTracking(seenGroupIds);
+    }
+  }
+
+  @Override
+  public void selectedMayContainUnseenGroups(SeenGroupIds seenGroupIds) {
+    state.enableGroupIdTracking(seenGroupIds);
+  }
+
+  @Override
+  public GroupingAggregatorFunction.PreparedForEvaluation prepareEvaluateIntermediate(
+      IntVector selected, GroupingAggregatorEvaluationContext ctx) {
+    return this::evaluateIntermediate;
+  }
+
+  private void evaluateIntermediate(Block[] blocks, int offset, IntVector selectedInPage) {
+    state.toIntermediate(blocks, offset, selectedInPage, driverContext);
+  }
+
+  @Override
+  public GroupingAggregatorFunction.PreparedForEvaluation prepareEvaluateFinal(IntVector selected,
+      GroupingAggregatorEvaluationContext ctx) {
+    return (blocks, offset, selectedInPage) -> evaluateFinal(blocks, offset, selectedInPage, ctx);
+  }
+
+  private void evaluateFinal(Block[] blocks, int offset, IntVector selectedInPage,
+      GroupingAggregatorEvaluationContext ctx) {
+    blocks[offset] = TopBytesRefDoubleAggregator.evaluateFinal(state, selectedInPage, ctx);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName()).append("[");
+    sb.append("channels=").append(channels);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public void close() {
+    state.close();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopBytesRefFloatAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopBytesRefFloatAggregatorFunction.java
@@ -1,0 +1,287 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.List;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanVector;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.BytesRefVector;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.FloatBlock;
+import org.elasticsearch.compute.data.FloatVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link AggregatorFunction} implementation for {@link TopBytesRefFloatAggregator}.
+ * This class is generated. Edit {@code AggregatorImplementer} instead.
+ */
+public final class TopBytesRefFloatAggregatorFunction implements AggregatorFunction {
+  private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+      new IntermediateStateDesc("top", ElementType.BYTES_REF),
+      new IntermediateStateDesc("output", ElementType.FLOAT)  );
+
+  private final DriverContext driverContext;
+
+  private final TopBytesRefFloatAggregator.SingleState state;
+
+  private final List<Integer> channels;
+
+  private final int limit;
+
+  private final boolean ascending;
+
+  TopBytesRefFloatAggregatorFunction(DriverContext driverContext, List<Integer> channels, int limit,
+      boolean ascending) {
+    this.limit = limit;
+    this.ascending = ascending;
+    this.driverContext = driverContext;
+    this.channels = channels;
+    this.state = TopBytesRefFloatAggregator.initSingle(driverContext.bigArrays(), limit, ascending);
+  }
+
+  public static List<IntermediateStateDesc> intermediateStateDesc() {
+    return INTERMEDIATE_STATE_DESC;
+  }
+
+  @Override
+  public int intermediateBlockCount() {
+    return INTERMEDIATE_STATE_DESC.size();
+  }
+
+  @Override
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.allFalse()) {
+      // Entire page masked away
+    } else if (mask.allTrue()) {
+      addRawInputNotMasked(page);
+    } else {
+      addRawInputMasked(page, mask);
+    }
+  }
+
+  private void addRawInputMasked(Page page, BooleanVector mask) {
+    BytesRefBlock vBlock = page.getBlock(channels.get(0));
+    FloatBlock outputValueBlock = page.getBlock(channels.get(1));
+    BytesRefVector vVector = vBlock.asVector();
+    if (vVector == null) {
+      if (vBlock.areAllValuesNull()) {
+        /*
+         * All values are null so we can skip processing this block.
+         * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+         *       being fast without this. Likely the branch predictor is kicking
+         *       in there. But we do this anyway, just so we don't have to trust
+         *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+         *       always have long sequences of ConstantNullBlock. And this code
+         *       shows readers we've thought about this.
+         */
+        return;
+      }
+      addRawBlock(vBlock, outputValueBlock, mask);
+      return;
+    }
+    FloatVector outputValueVector = outputValueBlock.asVector();
+    if (outputValueVector == null) {
+      if (outputValueBlock.areAllValuesNull()) {
+        /*
+         * All values are null so we can skip processing this block.
+         * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+         *       being fast without this. Likely the branch predictor is kicking
+         *       in there. But we do this anyway, just so we don't have to trust
+         *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+         *       always have long sequences of ConstantNullBlock. And this code
+         *       shows readers we've thought about this.
+         */
+        return;
+      }
+      addRawBlock(vBlock, outputValueBlock, mask);
+      return;
+    }
+    addRawVector(vVector, outputValueVector, mask);
+  }
+
+  private void addRawInputNotMasked(Page page) {
+    BytesRefBlock vBlock = page.getBlock(channels.get(0));
+    FloatBlock outputValueBlock = page.getBlock(channels.get(1));
+    BytesRefVector vVector = vBlock.asVector();
+    if (vVector == null) {
+      if (vBlock.areAllValuesNull()) {
+        /*
+         * All values are null so we can skip processing this block.
+         * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+         *       being fast without this. Likely the branch predictor is kicking
+         *       in there. But we do this anyway, just so we don't have to trust
+         *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+         *       always have long sequences of ConstantNullBlock. And this code
+         *       shows readers we've thought about this.
+         */
+        return;
+      }
+      addRawBlock(vBlock, outputValueBlock);
+      return;
+    }
+    FloatVector outputValueVector = outputValueBlock.asVector();
+    if (outputValueVector == null) {
+      if (outputValueBlock.areAllValuesNull()) {
+        /*
+         * All values are null so we can skip processing this block.
+         * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+         *       being fast without this. Likely the branch predictor is kicking
+         *       in there. But we do this anyway, just so we don't have to trust
+         *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+         *       always have long sequences of ConstantNullBlock. And this code
+         *       shows readers we've thought about this.
+         */
+        return;
+      }
+      addRawBlock(vBlock, outputValueBlock);
+      return;
+    }
+    addRawVector(vVector, outputValueVector);
+  }
+
+  private void addRawVector(BytesRefVector vVector, FloatVector outputValueVector) {
+    BytesRef vScratch = new BytesRef();
+    for (int valuesPosition = 0; valuesPosition < vVector.getPositionCount(); valuesPosition++) {
+      BytesRef vValue = vVector.getBytesRef(valuesPosition, vScratch);
+      float outputValueValue = outputValueVector.getFloat(valuesPosition);
+      TopBytesRefFloatAggregator.combine(state, vValue, outputValueValue);
+    }
+  }
+
+  private void addRawVector(BytesRefVector vVector, FloatVector outputValueVector,
+      BooleanVector mask) {
+    BytesRef vScratch = new BytesRef();
+    for (int valuesPosition = 0; valuesPosition < vVector.getPositionCount(); valuesPosition++) {
+      if (mask.getBoolean(valuesPosition) == false) {
+        continue;
+      }
+      BytesRef vValue = vVector.getBytesRef(valuesPosition, vScratch);
+      float outputValueValue = outputValueVector.getFloat(valuesPosition);
+      TopBytesRefFloatAggregator.combine(state, vValue, outputValueValue);
+    }
+  }
+
+  private void addRawBlock(BytesRefBlock vBlock, FloatBlock outputValueBlock) {
+    BytesRef vScratch = new BytesRef();
+    for (int p = 0; p < vBlock.getPositionCount(); p++) {
+      int vValueCount = vBlock.getValueCount(p);
+      if (vValueCount == 0) {
+        continue;
+      }
+      int outputValueValueCount = outputValueBlock.getValueCount(p);
+      if (outputValueValueCount == 0) {
+        continue;
+      }
+      int vStart = vBlock.getFirstValueIndex(p);
+      int vEnd = vStart + vValueCount;
+      for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
+        BytesRef vValue = vBlock.getBytesRef(vOffset, vScratch);
+        int outputValueStart = outputValueBlock.getFirstValueIndex(p);
+        int outputValueEnd = outputValueStart + outputValueValueCount;
+        for (int outputValueOffset = outputValueStart; outputValueOffset < outputValueEnd; outputValueOffset++) {
+          float outputValueValue = outputValueBlock.getFloat(outputValueOffset);
+          TopBytesRefFloatAggregator.combine(state, vValue, outputValueValue);
+        }
+      }
+    }
+  }
+
+  private void addRawBlock(BytesRefBlock vBlock, FloatBlock outputValueBlock, BooleanVector mask) {
+    BytesRef vScratch = new BytesRef();
+    for (int p = 0; p < vBlock.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
+      int vValueCount = vBlock.getValueCount(p);
+      if (vValueCount == 0) {
+        continue;
+      }
+      int outputValueValueCount = outputValueBlock.getValueCount(p);
+      if (outputValueValueCount == 0) {
+        continue;
+      }
+      int vStart = vBlock.getFirstValueIndex(p);
+      int vEnd = vStart + vValueCount;
+      for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
+        BytesRef vValue = vBlock.getBytesRef(vOffset, vScratch);
+        int outputValueStart = outputValueBlock.getFirstValueIndex(p);
+        int outputValueEnd = outputValueStart + outputValueValueCount;
+        for (int outputValueOffset = outputValueStart; outputValueOffset < outputValueEnd; outputValueOffset++) {
+          float outputValueValue = outputValueBlock.getFloat(outputValueOffset);
+          TopBytesRefFloatAggregator.combine(state, vValue, outputValueValue);
+        }
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(Page page) {
+    assert channels.size() == intermediateBlockCount();
+    assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
+    Block topUncast = page.getBlock(channels.get(0));
+    if (topUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BytesRefBlock top = (BytesRefBlock) topUncast;
+    assert top.getPositionCount() == 1;
+    Block outputUncast = page.getBlock(channels.get(1));
+    if (outputUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    FloatBlock output = (FloatBlock) outputUncast;
+    assert output.getPositionCount() == 1;
+    BytesRef topScratch = new BytesRef();
+    TopBytesRefFloatAggregator.combineIntermediate(state, top, output);
+  }
+
+  @Override
+  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+    state.toIntermediate(blocks, offset, driverContext);
+  }
+
+  @Override
+  public void evaluateFinal(Block[] blocks, int offset, DriverContext driverContext) {
+    blocks[offset] = TopBytesRefFloatAggregator.evaluateFinal(state, driverContext);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName()).append("[");
+    sb.append("channels=").append(channels);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public void close() {
+    state.close();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopBytesRefFloatAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopBytesRefFloatAggregatorFunctionSupplier.java
@@ -1,0 +1,53 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.util.List;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link AggregatorFunctionSupplier} implementation for {@link TopBytesRefFloatAggregator}.
+ * This class is generated. Edit {@code AggregatorFunctionSupplierImplementer} instead.
+ */
+public final class TopBytesRefFloatAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
+  private final int limit;
+
+  private final boolean ascending;
+
+  public TopBytesRefFloatAggregatorFunctionSupplier(int limit, boolean ascending) {
+    this.limit = limit;
+    this.ascending = ascending;
+  }
+
+  @Override
+  public List<IntermediateStateDesc> nonGroupingIntermediateStateDesc() {
+    return TopBytesRefFloatAggregatorFunction.intermediateStateDesc();
+  }
+
+  @Override
+  public List<IntermediateStateDesc> groupingIntermediateStateDesc() {
+    return TopBytesRefFloatGroupingAggregatorFunction.intermediateStateDesc();
+  }
+
+  @Override
+  public TopBytesRefFloatAggregatorFunction aggregator(DriverContext driverContext,
+      List<Integer> channels) {
+    return new TopBytesRefFloatAggregatorFunction(driverContext, channels, limit, ascending);
+  }
+
+  @Override
+  public TopBytesRefFloatGroupingAggregatorFunction groupingAggregator(DriverContext driverContext,
+      List<Integer> channels) {
+    return new TopBytesRefFloatGroupingAggregatorFunction(channels, driverContext, limit, ascending);
+  }
+
+  @Override
+  public String describe() {
+    return "top_byte of floats";
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopBytesRefFloatGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopBytesRefFloatGroupingAggregatorFunction.java
@@ -1,0 +1,493 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.List;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.BytesRefVector;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.FloatBlock;
+import org.elasticsearch.compute.data.FloatVector;
+import org.elasticsearch.compute.data.IntArrayBlock;
+import org.elasticsearch.compute.data.IntBigArrayBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link GroupingAggregatorFunction} implementation for {@link TopBytesRefFloatAggregator}.
+ * This class is generated. Edit {@code GroupingAggregatorImplementer} instead.
+ */
+public final class TopBytesRefFloatGroupingAggregatorFunction implements GroupingAggregatorFunction {
+  private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+      new IntermediateStateDesc("top", ElementType.BYTES_REF),
+      new IntermediateStateDesc("output", ElementType.FLOAT)  );
+
+  private final TopBytesRefFloatAggregator.GroupingState state;
+
+  private final List<Integer> channels;
+
+  private final DriverContext driverContext;
+
+  private final int limit;
+
+  private final boolean ascending;
+
+  TopBytesRefFloatGroupingAggregatorFunction(List<Integer> channels, DriverContext driverContext,
+      int limit, boolean ascending) {
+    this.limit = limit;
+    this.ascending = ascending;
+    this.channels = channels;
+    this.state = TopBytesRefFloatAggregator.initGrouping(driverContext.bigArrays(), limit, ascending);
+    this.driverContext = driverContext;
+  }
+
+  public static List<IntermediateStateDesc> intermediateStateDesc() {
+    return INTERMEDIATE_STATE_DESC;
+  }
+
+  @Override
+  public int intermediateBlockCount() {
+    return INTERMEDIATE_STATE_DESC.size();
+  }
+
+  @Override
+  public GroupingAggregatorFunction.AddInput prepareProcessRawInputPage(SeenGroupIds seenGroupIds,
+      Page page) {
+    BytesRefBlock vBlock = page.getBlock(channels.get(0));
+    FloatBlock outputValueBlock = page.getBlock(channels.get(1));
+    if (vBlock.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block. But we
+       * still need to track that some groups may not have been seen
+       * so that they are initialized to null when we read their values.
+       */
+      state.enableGroupIdTracking(seenGroupIds);
+      return null;
+    }
+    if (outputValueBlock.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block. But we
+       * still need to track that some groups may not have been seen
+       * so that they are initialized to null when we read their values.
+       */
+      state.enableGroupIdTracking(seenGroupIds);
+      return null;
+    }
+    BytesRefVector vVector = vBlock.asVector();
+    if (vVector == null) {
+      maybeEnableGroupIdTracking(seenGroupIds, vBlock, outputValueBlock);
+      return new GroupingAggregatorFunction.AddInput() {
+        @Override
+        public void add(int positionOffset, IntArrayBlock groupIds) {
+          addRawInput(positionOffset, groupIds, vBlock, outputValueBlock);
+        }
+
+        @Override
+        public void add(int positionOffset, IntBigArrayBlock groupIds) {
+          addRawInput(positionOffset, groupIds, vBlock, outputValueBlock);
+        }
+
+        @Override
+        public void add(int positionOffset, IntVector groupIds) {
+          addRawInput(positionOffset, groupIds, vBlock, outputValueBlock);
+        }
+
+        @Override
+        public void close() {
+        }
+      };
+    }
+    FloatVector outputValueVector = outputValueBlock.asVector();
+    if (outputValueVector == null) {
+      maybeEnableGroupIdTracking(seenGroupIds, vBlock, outputValueBlock);
+      return new GroupingAggregatorFunction.AddInput() {
+        @Override
+        public void add(int positionOffset, IntArrayBlock groupIds) {
+          addRawInput(positionOffset, groupIds, vBlock, outputValueBlock);
+        }
+
+        @Override
+        public void add(int positionOffset, IntBigArrayBlock groupIds) {
+          addRawInput(positionOffset, groupIds, vBlock, outputValueBlock);
+        }
+
+        @Override
+        public void add(int positionOffset, IntVector groupIds) {
+          addRawInput(positionOffset, groupIds, vBlock, outputValueBlock);
+        }
+
+        @Override
+        public void close() {
+        }
+      };
+    }
+    return new GroupingAggregatorFunction.AddInput() {
+      @Override
+      public void add(int positionOffset, IntArrayBlock groupIds) {
+        addRawInput(positionOffset, groupIds, vVector, outputValueVector);
+      }
+
+      @Override
+      public void add(int positionOffset, IntBigArrayBlock groupIds) {
+        addRawInput(positionOffset, groupIds, vVector, outputValueVector);
+      }
+
+      @Override
+      public void add(int positionOffset, IntVector groupIds) {
+        addRawInput(positionOffset, groupIds, vVector, outputValueVector);
+      }
+
+      @Override
+      public void close() {
+      }
+    };
+  }
+
+  private void addRawInput(int positionOffset, IntArrayBlock groups, BytesRefBlock vBlock,
+      FloatBlock outputValueBlock) {
+    BytesRef vScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      if (vBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      if (outputValueBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int vStart = vBlock.getFirstValueIndex(valuesPosition);
+        int vEnd = vStart + vBlock.getValueCount(valuesPosition);
+        for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
+          BytesRef vValue = vBlock.getBytesRef(vOffset, vScratch);
+          int outputValueStart = outputValueBlock.getFirstValueIndex(valuesPosition);
+          int outputValueEnd = outputValueStart + outputValueBlock.getValueCount(valuesPosition);
+          for (int outputValueOffset = outputValueStart; outputValueOffset < outputValueEnd; outputValueOffset++) {
+            float outputValueValue = outputValueBlock.getFloat(outputValueOffset);
+            TopBytesRefFloatAggregator.combine(state, groupId, vValue, outputValueValue);
+          }
+        }
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntArrayBlock groups, BytesRefVector vVector,
+      FloatVector outputValueVector) {
+    BytesRef vScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        BytesRef vValue = vVector.getBytesRef(valuesPosition, vScratch);
+        float outputValueValue = outputValueVector.getFloat(valuesPosition);
+        TopBytesRefFloatAggregator.combine(state, groupId, vValue, outputValueValue);
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntArrayBlock groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block topUncast = page.getBlock(channels.get(0));
+    if (topUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BytesRefBlock top = (BytesRefBlock) topUncast;
+    Block outputUncast = page.getBlock(channels.get(1));
+    if (outputUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    FloatBlock output = (FloatBlock) outputUncast;
+    assert top.getPositionCount() == output.getPositionCount();
+    BytesRef topScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int valuesPosition = groupPosition + positionOffset;
+        TopBytesRefFloatAggregator.combineIntermediate(state, groupId, top, output, valuesPosition);
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntBigArrayBlock groups, BytesRefBlock vBlock,
+      FloatBlock outputValueBlock) {
+    BytesRef vScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      if (vBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      if (outputValueBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int vStart = vBlock.getFirstValueIndex(valuesPosition);
+        int vEnd = vStart + vBlock.getValueCount(valuesPosition);
+        for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
+          BytesRef vValue = vBlock.getBytesRef(vOffset, vScratch);
+          int outputValueStart = outputValueBlock.getFirstValueIndex(valuesPosition);
+          int outputValueEnd = outputValueStart + outputValueBlock.getValueCount(valuesPosition);
+          for (int outputValueOffset = outputValueStart; outputValueOffset < outputValueEnd; outputValueOffset++) {
+            float outputValueValue = outputValueBlock.getFloat(outputValueOffset);
+            TopBytesRefFloatAggregator.combine(state, groupId, vValue, outputValueValue);
+          }
+        }
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntBigArrayBlock groups, BytesRefVector vVector,
+      FloatVector outputValueVector) {
+    BytesRef vScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        BytesRef vValue = vVector.getBytesRef(valuesPosition, vScratch);
+        float outputValueValue = outputValueVector.getFloat(valuesPosition);
+        TopBytesRefFloatAggregator.combine(state, groupId, vValue, outputValueValue);
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntBigArrayBlock groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block topUncast = page.getBlock(channels.get(0));
+    if (topUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BytesRefBlock top = (BytesRefBlock) topUncast;
+    Block outputUncast = page.getBlock(channels.get(1));
+    if (outputUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    FloatBlock output = (FloatBlock) outputUncast;
+    assert top.getPositionCount() == output.getPositionCount();
+    BytesRef topScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int valuesPosition = groupPosition + positionOffset;
+        TopBytesRefFloatAggregator.combineIntermediate(state, groupId, top, output, valuesPosition);
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntVector groups, BytesRefBlock vBlock,
+      FloatBlock outputValueBlock) {
+    BytesRef vScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int valuesPosition = groupPosition + positionOffset;
+      if (vBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      if (outputValueBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      int groupId = groups.getInt(groupPosition);
+      int vStart = vBlock.getFirstValueIndex(valuesPosition);
+      int vEnd = vStart + vBlock.getValueCount(valuesPosition);
+      for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
+        BytesRef vValue = vBlock.getBytesRef(vOffset, vScratch);
+        int outputValueStart = outputValueBlock.getFirstValueIndex(valuesPosition);
+        int outputValueEnd = outputValueStart + outputValueBlock.getValueCount(valuesPosition);
+        for (int outputValueOffset = outputValueStart; outputValueOffset < outputValueEnd; outputValueOffset++) {
+          float outputValueValue = outputValueBlock.getFloat(outputValueOffset);
+          TopBytesRefFloatAggregator.combine(state, groupId, vValue, outputValueValue);
+        }
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntVector groups, BytesRefVector vVector,
+      FloatVector outputValueVector) {
+    BytesRef vScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int valuesPosition = groupPosition + positionOffset;
+      int groupId = groups.getInt(groupPosition);
+      BytesRef vValue = vVector.getBytesRef(valuesPosition, vScratch);
+      float outputValueValue = outputValueVector.getFloat(valuesPosition);
+      TopBytesRefFloatAggregator.combine(state, groupId, vValue, outputValueValue);
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block topUncast = page.getBlock(channels.get(0));
+    if (topUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BytesRefBlock top = (BytesRefBlock) topUncast;
+    Block outputUncast = page.getBlock(channels.get(1));
+    if (outputUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    FloatBlock output = (FloatBlock) outputUncast;
+    assert top.getPositionCount() == output.getPositionCount();
+    BytesRef topScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int groupId = groups.getInt(groupPosition);
+      int valuesPosition = groupPosition + positionOffset;
+      TopBytesRefFloatAggregator.combineIntermediate(state, groupId, top, output, valuesPosition);
+    }
+  }
+
+  private void maybeEnableGroupIdTracking(SeenGroupIds seenGroupIds, BytesRefBlock vBlock,
+      FloatBlock outputValueBlock) {
+    if (vBlock.mayHaveNulls()) {
+      /*
+       * Some values in the block are null so some group ids may not
+       * be seen. We need to track which ones so we can initialize
+       * them to null when we read their values.
+       */
+      state.enableGroupIdTracking(seenGroupIds);
+    }
+    if (outputValueBlock.mayHaveNulls()) {
+      /*
+       * Some values in the block are null so some group ids may not
+       * be seen. We need to track which ones so we can initialize
+       * them to null when we read their values.
+       */
+      state.enableGroupIdTracking(seenGroupIds);
+    }
+  }
+
+  @Override
+  public void selectedMayContainUnseenGroups(SeenGroupIds seenGroupIds) {
+    state.enableGroupIdTracking(seenGroupIds);
+  }
+
+  @Override
+  public GroupingAggregatorFunction.PreparedForEvaluation prepareEvaluateIntermediate(
+      IntVector selected, GroupingAggregatorEvaluationContext ctx) {
+    return this::evaluateIntermediate;
+  }
+
+  private void evaluateIntermediate(Block[] blocks, int offset, IntVector selectedInPage) {
+    state.toIntermediate(blocks, offset, selectedInPage, driverContext);
+  }
+
+  @Override
+  public GroupingAggregatorFunction.PreparedForEvaluation prepareEvaluateFinal(IntVector selected,
+      GroupingAggregatorEvaluationContext ctx) {
+    return (blocks, offset, selectedInPage) -> evaluateFinal(blocks, offset, selectedInPage, ctx);
+  }
+
+  private void evaluateFinal(Block[] blocks, int offset, IntVector selectedInPage,
+      GroupingAggregatorEvaluationContext ctx) {
+    blocks[offset] = TopBytesRefFloatAggregator.evaluateFinal(state, selectedInPage, ctx);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName()).append("[");
+    sb.append("channels=").append(channels);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public void close() {
+    state.close();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopBytesRefIntAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopBytesRefIntAggregatorFunction.java
@@ -1,0 +1,287 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.List;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanVector;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.BytesRefVector;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link AggregatorFunction} implementation for {@link TopBytesRefIntAggregator}.
+ * This class is generated. Edit {@code AggregatorImplementer} instead.
+ */
+public final class TopBytesRefIntAggregatorFunction implements AggregatorFunction {
+  private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+      new IntermediateStateDesc("top", ElementType.BYTES_REF),
+      new IntermediateStateDesc("output", ElementType.INT)  );
+
+  private final DriverContext driverContext;
+
+  private final TopBytesRefIntAggregator.SingleState state;
+
+  private final List<Integer> channels;
+
+  private final int limit;
+
+  private final boolean ascending;
+
+  TopBytesRefIntAggregatorFunction(DriverContext driverContext, List<Integer> channels, int limit,
+      boolean ascending) {
+    this.limit = limit;
+    this.ascending = ascending;
+    this.driverContext = driverContext;
+    this.channels = channels;
+    this.state = TopBytesRefIntAggregator.initSingle(driverContext.bigArrays(), limit, ascending);
+  }
+
+  public static List<IntermediateStateDesc> intermediateStateDesc() {
+    return INTERMEDIATE_STATE_DESC;
+  }
+
+  @Override
+  public int intermediateBlockCount() {
+    return INTERMEDIATE_STATE_DESC.size();
+  }
+
+  @Override
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.allFalse()) {
+      // Entire page masked away
+    } else if (mask.allTrue()) {
+      addRawInputNotMasked(page);
+    } else {
+      addRawInputMasked(page, mask);
+    }
+  }
+
+  private void addRawInputMasked(Page page, BooleanVector mask) {
+    BytesRefBlock vBlock = page.getBlock(channels.get(0));
+    IntBlock outputValueBlock = page.getBlock(channels.get(1));
+    BytesRefVector vVector = vBlock.asVector();
+    if (vVector == null) {
+      if (vBlock.areAllValuesNull()) {
+        /*
+         * All values are null so we can skip processing this block.
+         * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+         *       being fast without this. Likely the branch predictor is kicking
+         *       in there. But we do this anyway, just so we don't have to trust
+         *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+         *       always have long sequences of ConstantNullBlock. And this code
+         *       shows readers we've thought about this.
+         */
+        return;
+      }
+      addRawBlock(vBlock, outputValueBlock, mask);
+      return;
+    }
+    IntVector outputValueVector = outputValueBlock.asVector();
+    if (outputValueVector == null) {
+      if (outputValueBlock.areAllValuesNull()) {
+        /*
+         * All values are null so we can skip processing this block.
+         * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+         *       being fast without this. Likely the branch predictor is kicking
+         *       in there. But we do this anyway, just so we don't have to trust
+         *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+         *       always have long sequences of ConstantNullBlock. And this code
+         *       shows readers we've thought about this.
+         */
+        return;
+      }
+      addRawBlock(vBlock, outputValueBlock, mask);
+      return;
+    }
+    addRawVector(vVector, outputValueVector, mask);
+  }
+
+  private void addRawInputNotMasked(Page page) {
+    BytesRefBlock vBlock = page.getBlock(channels.get(0));
+    IntBlock outputValueBlock = page.getBlock(channels.get(1));
+    BytesRefVector vVector = vBlock.asVector();
+    if (vVector == null) {
+      if (vBlock.areAllValuesNull()) {
+        /*
+         * All values are null so we can skip processing this block.
+         * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+         *       being fast without this. Likely the branch predictor is kicking
+         *       in there. But we do this anyway, just so we don't have to trust
+         *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+         *       always have long sequences of ConstantNullBlock. And this code
+         *       shows readers we've thought about this.
+         */
+        return;
+      }
+      addRawBlock(vBlock, outputValueBlock);
+      return;
+    }
+    IntVector outputValueVector = outputValueBlock.asVector();
+    if (outputValueVector == null) {
+      if (outputValueBlock.areAllValuesNull()) {
+        /*
+         * All values are null so we can skip processing this block.
+         * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+         *       being fast without this. Likely the branch predictor is kicking
+         *       in there. But we do this anyway, just so we don't have to trust
+         *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+         *       always have long sequences of ConstantNullBlock. And this code
+         *       shows readers we've thought about this.
+         */
+        return;
+      }
+      addRawBlock(vBlock, outputValueBlock);
+      return;
+    }
+    addRawVector(vVector, outputValueVector);
+  }
+
+  private void addRawVector(BytesRefVector vVector, IntVector outputValueVector) {
+    BytesRef vScratch = new BytesRef();
+    for (int valuesPosition = 0; valuesPosition < vVector.getPositionCount(); valuesPosition++) {
+      BytesRef vValue = vVector.getBytesRef(valuesPosition, vScratch);
+      int outputValueValue = outputValueVector.getInt(valuesPosition);
+      TopBytesRefIntAggregator.combine(state, vValue, outputValueValue);
+    }
+  }
+
+  private void addRawVector(BytesRefVector vVector, IntVector outputValueVector,
+      BooleanVector mask) {
+    BytesRef vScratch = new BytesRef();
+    for (int valuesPosition = 0; valuesPosition < vVector.getPositionCount(); valuesPosition++) {
+      if (mask.getBoolean(valuesPosition) == false) {
+        continue;
+      }
+      BytesRef vValue = vVector.getBytesRef(valuesPosition, vScratch);
+      int outputValueValue = outputValueVector.getInt(valuesPosition);
+      TopBytesRefIntAggregator.combine(state, vValue, outputValueValue);
+    }
+  }
+
+  private void addRawBlock(BytesRefBlock vBlock, IntBlock outputValueBlock) {
+    BytesRef vScratch = new BytesRef();
+    for (int p = 0; p < vBlock.getPositionCount(); p++) {
+      int vValueCount = vBlock.getValueCount(p);
+      if (vValueCount == 0) {
+        continue;
+      }
+      int outputValueValueCount = outputValueBlock.getValueCount(p);
+      if (outputValueValueCount == 0) {
+        continue;
+      }
+      int vStart = vBlock.getFirstValueIndex(p);
+      int vEnd = vStart + vValueCount;
+      for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
+        BytesRef vValue = vBlock.getBytesRef(vOffset, vScratch);
+        int outputValueStart = outputValueBlock.getFirstValueIndex(p);
+        int outputValueEnd = outputValueStart + outputValueValueCount;
+        for (int outputValueOffset = outputValueStart; outputValueOffset < outputValueEnd; outputValueOffset++) {
+          int outputValueValue = outputValueBlock.getInt(outputValueOffset);
+          TopBytesRefIntAggregator.combine(state, vValue, outputValueValue);
+        }
+      }
+    }
+  }
+
+  private void addRawBlock(BytesRefBlock vBlock, IntBlock outputValueBlock, BooleanVector mask) {
+    BytesRef vScratch = new BytesRef();
+    for (int p = 0; p < vBlock.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
+      int vValueCount = vBlock.getValueCount(p);
+      if (vValueCount == 0) {
+        continue;
+      }
+      int outputValueValueCount = outputValueBlock.getValueCount(p);
+      if (outputValueValueCount == 0) {
+        continue;
+      }
+      int vStart = vBlock.getFirstValueIndex(p);
+      int vEnd = vStart + vValueCount;
+      for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
+        BytesRef vValue = vBlock.getBytesRef(vOffset, vScratch);
+        int outputValueStart = outputValueBlock.getFirstValueIndex(p);
+        int outputValueEnd = outputValueStart + outputValueValueCount;
+        for (int outputValueOffset = outputValueStart; outputValueOffset < outputValueEnd; outputValueOffset++) {
+          int outputValueValue = outputValueBlock.getInt(outputValueOffset);
+          TopBytesRefIntAggregator.combine(state, vValue, outputValueValue);
+        }
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(Page page) {
+    assert channels.size() == intermediateBlockCount();
+    assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
+    Block topUncast = page.getBlock(channels.get(0));
+    if (topUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BytesRefBlock top = (BytesRefBlock) topUncast;
+    assert top.getPositionCount() == 1;
+    Block outputUncast = page.getBlock(channels.get(1));
+    if (outputUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    IntBlock output = (IntBlock) outputUncast;
+    assert output.getPositionCount() == 1;
+    BytesRef topScratch = new BytesRef();
+    TopBytesRefIntAggregator.combineIntermediate(state, top, output);
+  }
+
+  @Override
+  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+    state.toIntermediate(blocks, offset, driverContext);
+  }
+
+  @Override
+  public void evaluateFinal(Block[] blocks, int offset, DriverContext driverContext) {
+    blocks[offset] = TopBytesRefIntAggregator.evaluateFinal(state, driverContext);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName()).append("[");
+    sb.append("channels=").append(channels);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public void close() {
+    state.close();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopBytesRefIntAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopBytesRefIntAggregatorFunctionSupplier.java
@@ -1,0 +1,53 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.util.List;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link AggregatorFunctionSupplier} implementation for {@link TopBytesRefIntAggregator}.
+ * This class is generated. Edit {@code AggregatorFunctionSupplierImplementer} instead.
+ */
+public final class TopBytesRefIntAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
+  private final int limit;
+
+  private final boolean ascending;
+
+  public TopBytesRefIntAggregatorFunctionSupplier(int limit, boolean ascending) {
+    this.limit = limit;
+    this.ascending = ascending;
+  }
+
+  @Override
+  public List<IntermediateStateDesc> nonGroupingIntermediateStateDesc() {
+    return TopBytesRefIntAggregatorFunction.intermediateStateDesc();
+  }
+
+  @Override
+  public List<IntermediateStateDesc> groupingIntermediateStateDesc() {
+    return TopBytesRefIntGroupingAggregatorFunction.intermediateStateDesc();
+  }
+
+  @Override
+  public TopBytesRefIntAggregatorFunction aggregator(DriverContext driverContext,
+      List<Integer> channels) {
+    return new TopBytesRefIntAggregatorFunction(driverContext, channels, limit, ascending);
+  }
+
+  @Override
+  public TopBytesRefIntGroupingAggregatorFunction groupingAggregator(DriverContext driverContext,
+      List<Integer> channels) {
+    return new TopBytesRefIntGroupingAggregatorFunction(channels, driverContext, limit, ascending);
+  }
+
+  @Override
+  public String describe() {
+    return "top_byte of ints";
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopBytesRefIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopBytesRefIntGroupingAggregatorFunction.java
@@ -1,0 +1,492 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.List;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.BytesRefVector;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntArrayBlock;
+import org.elasticsearch.compute.data.IntBigArrayBlock;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link GroupingAggregatorFunction} implementation for {@link TopBytesRefIntAggregator}.
+ * This class is generated. Edit {@code GroupingAggregatorImplementer} instead.
+ */
+public final class TopBytesRefIntGroupingAggregatorFunction implements GroupingAggregatorFunction {
+  private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+      new IntermediateStateDesc("top", ElementType.BYTES_REF),
+      new IntermediateStateDesc("output", ElementType.INT)  );
+
+  private final TopBytesRefIntAggregator.GroupingState state;
+
+  private final List<Integer> channels;
+
+  private final DriverContext driverContext;
+
+  private final int limit;
+
+  private final boolean ascending;
+
+  TopBytesRefIntGroupingAggregatorFunction(List<Integer> channels, DriverContext driverContext,
+      int limit, boolean ascending) {
+    this.limit = limit;
+    this.ascending = ascending;
+    this.channels = channels;
+    this.state = TopBytesRefIntAggregator.initGrouping(driverContext.bigArrays(), limit, ascending);
+    this.driverContext = driverContext;
+  }
+
+  public static List<IntermediateStateDesc> intermediateStateDesc() {
+    return INTERMEDIATE_STATE_DESC;
+  }
+
+  @Override
+  public int intermediateBlockCount() {
+    return INTERMEDIATE_STATE_DESC.size();
+  }
+
+  @Override
+  public GroupingAggregatorFunction.AddInput prepareProcessRawInputPage(SeenGroupIds seenGroupIds,
+      Page page) {
+    BytesRefBlock vBlock = page.getBlock(channels.get(0));
+    IntBlock outputValueBlock = page.getBlock(channels.get(1));
+    if (vBlock.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block. But we
+       * still need to track that some groups may not have been seen
+       * so that they are initialized to null when we read their values.
+       */
+      state.enableGroupIdTracking(seenGroupIds);
+      return null;
+    }
+    if (outputValueBlock.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block. But we
+       * still need to track that some groups may not have been seen
+       * so that they are initialized to null when we read their values.
+       */
+      state.enableGroupIdTracking(seenGroupIds);
+      return null;
+    }
+    BytesRefVector vVector = vBlock.asVector();
+    if (vVector == null) {
+      maybeEnableGroupIdTracking(seenGroupIds, vBlock, outputValueBlock);
+      return new GroupingAggregatorFunction.AddInput() {
+        @Override
+        public void add(int positionOffset, IntArrayBlock groupIds) {
+          addRawInput(positionOffset, groupIds, vBlock, outputValueBlock);
+        }
+
+        @Override
+        public void add(int positionOffset, IntBigArrayBlock groupIds) {
+          addRawInput(positionOffset, groupIds, vBlock, outputValueBlock);
+        }
+
+        @Override
+        public void add(int positionOffset, IntVector groupIds) {
+          addRawInput(positionOffset, groupIds, vBlock, outputValueBlock);
+        }
+
+        @Override
+        public void close() {
+        }
+      };
+    }
+    IntVector outputValueVector = outputValueBlock.asVector();
+    if (outputValueVector == null) {
+      maybeEnableGroupIdTracking(seenGroupIds, vBlock, outputValueBlock);
+      return new GroupingAggregatorFunction.AddInput() {
+        @Override
+        public void add(int positionOffset, IntArrayBlock groupIds) {
+          addRawInput(positionOffset, groupIds, vBlock, outputValueBlock);
+        }
+
+        @Override
+        public void add(int positionOffset, IntBigArrayBlock groupIds) {
+          addRawInput(positionOffset, groupIds, vBlock, outputValueBlock);
+        }
+
+        @Override
+        public void add(int positionOffset, IntVector groupIds) {
+          addRawInput(positionOffset, groupIds, vBlock, outputValueBlock);
+        }
+
+        @Override
+        public void close() {
+        }
+      };
+    }
+    return new GroupingAggregatorFunction.AddInput() {
+      @Override
+      public void add(int positionOffset, IntArrayBlock groupIds) {
+        addRawInput(positionOffset, groupIds, vVector, outputValueVector);
+      }
+
+      @Override
+      public void add(int positionOffset, IntBigArrayBlock groupIds) {
+        addRawInput(positionOffset, groupIds, vVector, outputValueVector);
+      }
+
+      @Override
+      public void add(int positionOffset, IntVector groupIds) {
+        addRawInput(positionOffset, groupIds, vVector, outputValueVector);
+      }
+
+      @Override
+      public void close() {
+      }
+    };
+  }
+
+  private void addRawInput(int positionOffset, IntArrayBlock groups, BytesRefBlock vBlock,
+      IntBlock outputValueBlock) {
+    BytesRef vScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      if (vBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      if (outputValueBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int vStart = vBlock.getFirstValueIndex(valuesPosition);
+        int vEnd = vStart + vBlock.getValueCount(valuesPosition);
+        for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
+          BytesRef vValue = vBlock.getBytesRef(vOffset, vScratch);
+          int outputValueStart = outputValueBlock.getFirstValueIndex(valuesPosition);
+          int outputValueEnd = outputValueStart + outputValueBlock.getValueCount(valuesPosition);
+          for (int outputValueOffset = outputValueStart; outputValueOffset < outputValueEnd; outputValueOffset++) {
+            int outputValueValue = outputValueBlock.getInt(outputValueOffset);
+            TopBytesRefIntAggregator.combine(state, groupId, vValue, outputValueValue);
+          }
+        }
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntArrayBlock groups, BytesRefVector vVector,
+      IntVector outputValueVector) {
+    BytesRef vScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        BytesRef vValue = vVector.getBytesRef(valuesPosition, vScratch);
+        int outputValueValue = outputValueVector.getInt(valuesPosition);
+        TopBytesRefIntAggregator.combine(state, groupId, vValue, outputValueValue);
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntArrayBlock groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block topUncast = page.getBlock(channels.get(0));
+    if (topUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BytesRefBlock top = (BytesRefBlock) topUncast;
+    Block outputUncast = page.getBlock(channels.get(1));
+    if (outputUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    IntBlock output = (IntBlock) outputUncast;
+    assert top.getPositionCount() == output.getPositionCount();
+    BytesRef topScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int valuesPosition = groupPosition + positionOffset;
+        TopBytesRefIntAggregator.combineIntermediate(state, groupId, top, output, valuesPosition);
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntBigArrayBlock groups, BytesRefBlock vBlock,
+      IntBlock outputValueBlock) {
+    BytesRef vScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      if (vBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      if (outputValueBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int vStart = vBlock.getFirstValueIndex(valuesPosition);
+        int vEnd = vStart + vBlock.getValueCount(valuesPosition);
+        for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
+          BytesRef vValue = vBlock.getBytesRef(vOffset, vScratch);
+          int outputValueStart = outputValueBlock.getFirstValueIndex(valuesPosition);
+          int outputValueEnd = outputValueStart + outputValueBlock.getValueCount(valuesPosition);
+          for (int outputValueOffset = outputValueStart; outputValueOffset < outputValueEnd; outputValueOffset++) {
+            int outputValueValue = outputValueBlock.getInt(outputValueOffset);
+            TopBytesRefIntAggregator.combine(state, groupId, vValue, outputValueValue);
+          }
+        }
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntBigArrayBlock groups, BytesRefVector vVector,
+      IntVector outputValueVector) {
+    BytesRef vScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        BytesRef vValue = vVector.getBytesRef(valuesPosition, vScratch);
+        int outputValueValue = outputValueVector.getInt(valuesPosition);
+        TopBytesRefIntAggregator.combine(state, groupId, vValue, outputValueValue);
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntBigArrayBlock groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block topUncast = page.getBlock(channels.get(0));
+    if (topUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BytesRefBlock top = (BytesRefBlock) topUncast;
+    Block outputUncast = page.getBlock(channels.get(1));
+    if (outputUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    IntBlock output = (IntBlock) outputUncast;
+    assert top.getPositionCount() == output.getPositionCount();
+    BytesRef topScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int valuesPosition = groupPosition + positionOffset;
+        TopBytesRefIntAggregator.combineIntermediate(state, groupId, top, output, valuesPosition);
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntVector groups, BytesRefBlock vBlock,
+      IntBlock outputValueBlock) {
+    BytesRef vScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int valuesPosition = groupPosition + positionOffset;
+      if (vBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      if (outputValueBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      int groupId = groups.getInt(groupPosition);
+      int vStart = vBlock.getFirstValueIndex(valuesPosition);
+      int vEnd = vStart + vBlock.getValueCount(valuesPosition);
+      for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
+        BytesRef vValue = vBlock.getBytesRef(vOffset, vScratch);
+        int outputValueStart = outputValueBlock.getFirstValueIndex(valuesPosition);
+        int outputValueEnd = outputValueStart + outputValueBlock.getValueCount(valuesPosition);
+        for (int outputValueOffset = outputValueStart; outputValueOffset < outputValueEnd; outputValueOffset++) {
+          int outputValueValue = outputValueBlock.getInt(outputValueOffset);
+          TopBytesRefIntAggregator.combine(state, groupId, vValue, outputValueValue);
+        }
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntVector groups, BytesRefVector vVector,
+      IntVector outputValueVector) {
+    BytesRef vScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int valuesPosition = groupPosition + positionOffset;
+      int groupId = groups.getInt(groupPosition);
+      BytesRef vValue = vVector.getBytesRef(valuesPosition, vScratch);
+      int outputValueValue = outputValueVector.getInt(valuesPosition);
+      TopBytesRefIntAggregator.combine(state, groupId, vValue, outputValueValue);
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block topUncast = page.getBlock(channels.get(0));
+    if (topUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BytesRefBlock top = (BytesRefBlock) topUncast;
+    Block outputUncast = page.getBlock(channels.get(1));
+    if (outputUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    IntBlock output = (IntBlock) outputUncast;
+    assert top.getPositionCount() == output.getPositionCount();
+    BytesRef topScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int groupId = groups.getInt(groupPosition);
+      int valuesPosition = groupPosition + positionOffset;
+      TopBytesRefIntAggregator.combineIntermediate(state, groupId, top, output, valuesPosition);
+    }
+  }
+
+  private void maybeEnableGroupIdTracking(SeenGroupIds seenGroupIds, BytesRefBlock vBlock,
+      IntBlock outputValueBlock) {
+    if (vBlock.mayHaveNulls()) {
+      /*
+       * Some values in the block are null so some group ids may not
+       * be seen. We need to track which ones so we can initialize
+       * them to null when we read their values.
+       */
+      state.enableGroupIdTracking(seenGroupIds);
+    }
+    if (outputValueBlock.mayHaveNulls()) {
+      /*
+       * Some values in the block are null so some group ids may not
+       * be seen. We need to track which ones so we can initialize
+       * them to null when we read their values.
+       */
+      state.enableGroupIdTracking(seenGroupIds);
+    }
+  }
+
+  @Override
+  public void selectedMayContainUnseenGroups(SeenGroupIds seenGroupIds) {
+    state.enableGroupIdTracking(seenGroupIds);
+  }
+
+  @Override
+  public GroupingAggregatorFunction.PreparedForEvaluation prepareEvaluateIntermediate(
+      IntVector selected, GroupingAggregatorEvaluationContext ctx) {
+    return this::evaluateIntermediate;
+  }
+
+  private void evaluateIntermediate(Block[] blocks, int offset, IntVector selectedInPage) {
+    state.toIntermediate(blocks, offset, selectedInPage, driverContext);
+  }
+
+  @Override
+  public GroupingAggregatorFunction.PreparedForEvaluation prepareEvaluateFinal(IntVector selected,
+      GroupingAggregatorEvaluationContext ctx) {
+    return (blocks, offset, selectedInPage) -> evaluateFinal(blocks, offset, selectedInPage, ctx);
+  }
+
+  private void evaluateFinal(Block[] blocks, int offset, IntVector selectedInPage,
+      GroupingAggregatorEvaluationContext ctx) {
+    blocks[offset] = TopBytesRefIntAggregator.evaluateFinal(state, selectedInPage, ctx);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName()).append("[");
+    sb.append("channels=").append(channels);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public void close() {
+    state.close();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopBytesRefLongAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopBytesRefLongAggregatorFunction.java
@@ -1,0 +1,287 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.List;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanVector;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.BytesRefVector;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.LongVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link AggregatorFunction} implementation for {@link TopBytesRefLongAggregator}.
+ * This class is generated. Edit {@code AggregatorImplementer} instead.
+ */
+public final class TopBytesRefLongAggregatorFunction implements AggregatorFunction {
+  private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+      new IntermediateStateDesc("top", ElementType.BYTES_REF),
+      new IntermediateStateDesc("output", ElementType.LONG)  );
+
+  private final DriverContext driverContext;
+
+  private final TopBytesRefLongAggregator.SingleState state;
+
+  private final List<Integer> channels;
+
+  private final int limit;
+
+  private final boolean ascending;
+
+  TopBytesRefLongAggregatorFunction(DriverContext driverContext, List<Integer> channels, int limit,
+      boolean ascending) {
+    this.limit = limit;
+    this.ascending = ascending;
+    this.driverContext = driverContext;
+    this.channels = channels;
+    this.state = TopBytesRefLongAggregator.initSingle(driverContext.bigArrays(), limit, ascending);
+  }
+
+  public static List<IntermediateStateDesc> intermediateStateDesc() {
+    return INTERMEDIATE_STATE_DESC;
+  }
+
+  @Override
+  public int intermediateBlockCount() {
+    return INTERMEDIATE_STATE_DESC.size();
+  }
+
+  @Override
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.allFalse()) {
+      // Entire page masked away
+    } else if (mask.allTrue()) {
+      addRawInputNotMasked(page);
+    } else {
+      addRawInputMasked(page, mask);
+    }
+  }
+
+  private void addRawInputMasked(Page page, BooleanVector mask) {
+    BytesRefBlock vBlock = page.getBlock(channels.get(0));
+    LongBlock outputValueBlock = page.getBlock(channels.get(1));
+    BytesRefVector vVector = vBlock.asVector();
+    if (vVector == null) {
+      if (vBlock.areAllValuesNull()) {
+        /*
+         * All values are null so we can skip processing this block.
+         * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+         *       being fast without this. Likely the branch predictor is kicking
+         *       in there. But we do this anyway, just so we don't have to trust
+         *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+         *       always have long sequences of ConstantNullBlock. And this code
+         *       shows readers we've thought about this.
+         */
+        return;
+      }
+      addRawBlock(vBlock, outputValueBlock, mask);
+      return;
+    }
+    LongVector outputValueVector = outputValueBlock.asVector();
+    if (outputValueVector == null) {
+      if (outputValueBlock.areAllValuesNull()) {
+        /*
+         * All values are null so we can skip processing this block.
+         * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+         *       being fast without this. Likely the branch predictor is kicking
+         *       in there. But we do this anyway, just so we don't have to trust
+         *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+         *       always have long sequences of ConstantNullBlock. And this code
+         *       shows readers we've thought about this.
+         */
+        return;
+      }
+      addRawBlock(vBlock, outputValueBlock, mask);
+      return;
+    }
+    addRawVector(vVector, outputValueVector, mask);
+  }
+
+  private void addRawInputNotMasked(Page page) {
+    BytesRefBlock vBlock = page.getBlock(channels.get(0));
+    LongBlock outputValueBlock = page.getBlock(channels.get(1));
+    BytesRefVector vVector = vBlock.asVector();
+    if (vVector == null) {
+      if (vBlock.areAllValuesNull()) {
+        /*
+         * All values are null so we can skip processing this block.
+         * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+         *       being fast without this. Likely the branch predictor is kicking
+         *       in there. But we do this anyway, just so we don't have to trust
+         *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+         *       always have long sequences of ConstantNullBlock. And this code
+         *       shows readers we've thought about this.
+         */
+        return;
+      }
+      addRawBlock(vBlock, outputValueBlock);
+      return;
+    }
+    LongVector outputValueVector = outputValueBlock.asVector();
+    if (outputValueVector == null) {
+      if (outputValueBlock.areAllValuesNull()) {
+        /*
+         * All values are null so we can skip processing this block.
+         * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+         *       being fast without this. Likely the branch predictor is kicking
+         *       in there. But we do this anyway, just so we don't have to trust
+         *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+         *       always have long sequences of ConstantNullBlock. And this code
+         *       shows readers we've thought about this.
+         */
+        return;
+      }
+      addRawBlock(vBlock, outputValueBlock);
+      return;
+    }
+    addRawVector(vVector, outputValueVector);
+  }
+
+  private void addRawVector(BytesRefVector vVector, LongVector outputValueVector) {
+    BytesRef vScratch = new BytesRef();
+    for (int valuesPosition = 0; valuesPosition < vVector.getPositionCount(); valuesPosition++) {
+      BytesRef vValue = vVector.getBytesRef(valuesPosition, vScratch);
+      long outputValueValue = outputValueVector.getLong(valuesPosition);
+      TopBytesRefLongAggregator.combine(state, vValue, outputValueValue);
+    }
+  }
+
+  private void addRawVector(BytesRefVector vVector, LongVector outputValueVector,
+      BooleanVector mask) {
+    BytesRef vScratch = new BytesRef();
+    for (int valuesPosition = 0; valuesPosition < vVector.getPositionCount(); valuesPosition++) {
+      if (mask.getBoolean(valuesPosition) == false) {
+        continue;
+      }
+      BytesRef vValue = vVector.getBytesRef(valuesPosition, vScratch);
+      long outputValueValue = outputValueVector.getLong(valuesPosition);
+      TopBytesRefLongAggregator.combine(state, vValue, outputValueValue);
+    }
+  }
+
+  private void addRawBlock(BytesRefBlock vBlock, LongBlock outputValueBlock) {
+    BytesRef vScratch = new BytesRef();
+    for (int p = 0; p < vBlock.getPositionCount(); p++) {
+      int vValueCount = vBlock.getValueCount(p);
+      if (vValueCount == 0) {
+        continue;
+      }
+      int outputValueValueCount = outputValueBlock.getValueCount(p);
+      if (outputValueValueCount == 0) {
+        continue;
+      }
+      int vStart = vBlock.getFirstValueIndex(p);
+      int vEnd = vStart + vValueCount;
+      for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
+        BytesRef vValue = vBlock.getBytesRef(vOffset, vScratch);
+        int outputValueStart = outputValueBlock.getFirstValueIndex(p);
+        int outputValueEnd = outputValueStart + outputValueValueCount;
+        for (int outputValueOffset = outputValueStart; outputValueOffset < outputValueEnd; outputValueOffset++) {
+          long outputValueValue = outputValueBlock.getLong(outputValueOffset);
+          TopBytesRefLongAggregator.combine(state, vValue, outputValueValue);
+        }
+      }
+    }
+  }
+
+  private void addRawBlock(BytesRefBlock vBlock, LongBlock outputValueBlock, BooleanVector mask) {
+    BytesRef vScratch = new BytesRef();
+    for (int p = 0; p < vBlock.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
+      int vValueCount = vBlock.getValueCount(p);
+      if (vValueCount == 0) {
+        continue;
+      }
+      int outputValueValueCount = outputValueBlock.getValueCount(p);
+      if (outputValueValueCount == 0) {
+        continue;
+      }
+      int vStart = vBlock.getFirstValueIndex(p);
+      int vEnd = vStart + vValueCount;
+      for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
+        BytesRef vValue = vBlock.getBytesRef(vOffset, vScratch);
+        int outputValueStart = outputValueBlock.getFirstValueIndex(p);
+        int outputValueEnd = outputValueStart + outputValueValueCount;
+        for (int outputValueOffset = outputValueStart; outputValueOffset < outputValueEnd; outputValueOffset++) {
+          long outputValueValue = outputValueBlock.getLong(outputValueOffset);
+          TopBytesRefLongAggregator.combine(state, vValue, outputValueValue);
+        }
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(Page page) {
+    assert channels.size() == intermediateBlockCount();
+    assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
+    Block topUncast = page.getBlock(channels.get(0));
+    if (topUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BytesRefBlock top = (BytesRefBlock) topUncast;
+    assert top.getPositionCount() == 1;
+    Block outputUncast = page.getBlock(channels.get(1));
+    if (outputUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    LongBlock output = (LongBlock) outputUncast;
+    assert output.getPositionCount() == 1;
+    BytesRef topScratch = new BytesRef();
+    TopBytesRefLongAggregator.combineIntermediate(state, top, output);
+  }
+
+  @Override
+  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+    state.toIntermediate(blocks, offset, driverContext);
+  }
+
+  @Override
+  public void evaluateFinal(Block[] blocks, int offset, DriverContext driverContext) {
+    blocks[offset] = TopBytesRefLongAggregator.evaluateFinal(state, driverContext);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName()).append("[");
+    sb.append("channels=").append(channels);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public void close() {
+    state.close();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopBytesRefLongAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopBytesRefLongAggregatorFunctionSupplier.java
@@ -1,0 +1,53 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.util.List;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link AggregatorFunctionSupplier} implementation for {@link TopBytesRefLongAggregator}.
+ * This class is generated. Edit {@code AggregatorFunctionSupplierImplementer} instead.
+ */
+public final class TopBytesRefLongAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
+  private final int limit;
+
+  private final boolean ascending;
+
+  public TopBytesRefLongAggregatorFunctionSupplier(int limit, boolean ascending) {
+    this.limit = limit;
+    this.ascending = ascending;
+  }
+
+  @Override
+  public List<IntermediateStateDesc> nonGroupingIntermediateStateDesc() {
+    return TopBytesRefLongAggregatorFunction.intermediateStateDesc();
+  }
+
+  @Override
+  public List<IntermediateStateDesc> groupingIntermediateStateDesc() {
+    return TopBytesRefLongGroupingAggregatorFunction.intermediateStateDesc();
+  }
+
+  @Override
+  public TopBytesRefLongAggregatorFunction aggregator(DriverContext driverContext,
+      List<Integer> channels) {
+    return new TopBytesRefLongAggregatorFunction(driverContext, channels, limit, ascending);
+  }
+
+  @Override
+  public TopBytesRefLongGroupingAggregatorFunction groupingAggregator(DriverContext driverContext,
+      List<Integer> channels) {
+    return new TopBytesRefLongGroupingAggregatorFunction(channels, driverContext, limit, ascending);
+  }
+
+  @Override
+  public String describe() {
+    return "top_byte of longs";
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopBytesRefLongGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopBytesRefLongGroupingAggregatorFunction.java
@@ -1,0 +1,493 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.List;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.BytesRefVector;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntArrayBlock;
+import org.elasticsearch.compute.data.IntBigArrayBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.LongVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link GroupingAggregatorFunction} implementation for {@link TopBytesRefLongAggregator}.
+ * This class is generated. Edit {@code GroupingAggregatorImplementer} instead.
+ */
+public final class TopBytesRefLongGroupingAggregatorFunction implements GroupingAggregatorFunction {
+  private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+      new IntermediateStateDesc("top", ElementType.BYTES_REF),
+      new IntermediateStateDesc("output", ElementType.LONG)  );
+
+  private final TopBytesRefLongAggregator.GroupingState state;
+
+  private final List<Integer> channels;
+
+  private final DriverContext driverContext;
+
+  private final int limit;
+
+  private final boolean ascending;
+
+  TopBytesRefLongGroupingAggregatorFunction(List<Integer> channels, DriverContext driverContext,
+      int limit, boolean ascending) {
+    this.limit = limit;
+    this.ascending = ascending;
+    this.channels = channels;
+    this.state = TopBytesRefLongAggregator.initGrouping(driverContext.bigArrays(), limit, ascending);
+    this.driverContext = driverContext;
+  }
+
+  public static List<IntermediateStateDesc> intermediateStateDesc() {
+    return INTERMEDIATE_STATE_DESC;
+  }
+
+  @Override
+  public int intermediateBlockCount() {
+    return INTERMEDIATE_STATE_DESC.size();
+  }
+
+  @Override
+  public GroupingAggregatorFunction.AddInput prepareProcessRawInputPage(SeenGroupIds seenGroupIds,
+      Page page) {
+    BytesRefBlock vBlock = page.getBlock(channels.get(0));
+    LongBlock outputValueBlock = page.getBlock(channels.get(1));
+    if (vBlock.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block. But we
+       * still need to track that some groups may not have been seen
+       * so that they are initialized to null when we read their values.
+       */
+      state.enableGroupIdTracking(seenGroupIds);
+      return null;
+    }
+    if (outputValueBlock.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block. But we
+       * still need to track that some groups may not have been seen
+       * so that they are initialized to null when we read their values.
+       */
+      state.enableGroupIdTracking(seenGroupIds);
+      return null;
+    }
+    BytesRefVector vVector = vBlock.asVector();
+    if (vVector == null) {
+      maybeEnableGroupIdTracking(seenGroupIds, vBlock, outputValueBlock);
+      return new GroupingAggregatorFunction.AddInput() {
+        @Override
+        public void add(int positionOffset, IntArrayBlock groupIds) {
+          addRawInput(positionOffset, groupIds, vBlock, outputValueBlock);
+        }
+
+        @Override
+        public void add(int positionOffset, IntBigArrayBlock groupIds) {
+          addRawInput(positionOffset, groupIds, vBlock, outputValueBlock);
+        }
+
+        @Override
+        public void add(int positionOffset, IntVector groupIds) {
+          addRawInput(positionOffset, groupIds, vBlock, outputValueBlock);
+        }
+
+        @Override
+        public void close() {
+        }
+      };
+    }
+    LongVector outputValueVector = outputValueBlock.asVector();
+    if (outputValueVector == null) {
+      maybeEnableGroupIdTracking(seenGroupIds, vBlock, outputValueBlock);
+      return new GroupingAggregatorFunction.AddInput() {
+        @Override
+        public void add(int positionOffset, IntArrayBlock groupIds) {
+          addRawInput(positionOffset, groupIds, vBlock, outputValueBlock);
+        }
+
+        @Override
+        public void add(int positionOffset, IntBigArrayBlock groupIds) {
+          addRawInput(positionOffset, groupIds, vBlock, outputValueBlock);
+        }
+
+        @Override
+        public void add(int positionOffset, IntVector groupIds) {
+          addRawInput(positionOffset, groupIds, vBlock, outputValueBlock);
+        }
+
+        @Override
+        public void close() {
+        }
+      };
+    }
+    return new GroupingAggregatorFunction.AddInput() {
+      @Override
+      public void add(int positionOffset, IntArrayBlock groupIds) {
+        addRawInput(positionOffset, groupIds, vVector, outputValueVector);
+      }
+
+      @Override
+      public void add(int positionOffset, IntBigArrayBlock groupIds) {
+        addRawInput(positionOffset, groupIds, vVector, outputValueVector);
+      }
+
+      @Override
+      public void add(int positionOffset, IntVector groupIds) {
+        addRawInput(positionOffset, groupIds, vVector, outputValueVector);
+      }
+
+      @Override
+      public void close() {
+      }
+    };
+  }
+
+  private void addRawInput(int positionOffset, IntArrayBlock groups, BytesRefBlock vBlock,
+      LongBlock outputValueBlock) {
+    BytesRef vScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      if (vBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      if (outputValueBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int vStart = vBlock.getFirstValueIndex(valuesPosition);
+        int vEnd = vStart + vBlock.getValueCount(valuesPosition);
+        for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
+          BytesRef vValue = vBlock.getBytesRef(vOffset, vScratch);
+          int outputValueStart = outputValueBlock.getFirstValueIndex(valuesPosition);
+          int outputValueEnd = outputValueStart + outputValueBlock.getValueCount(valuesPosition);
+          for (int outputValueOffset = outputValueStart; outputValueOffset < outputValueEnd; outputValueOffset++) {
+            long outputValueValue = outputValueBlock.getLong(outputValueOffset);
+            TopBytesRefLongAggregator.combine(state, groupId, vValue, outputValueValue);
+          }
+        }
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntArrayBlock groups, BytesRefVector vVector,
+      LongVector outputValueVector) {
+    BytesRef vScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        BytesRef vValue = vVector.getBytesRef(valuesPosition, vScratch);
+        long outputValueValue = outputValueVector.getLong(valuesPosition);
+        TopBytesRefLongAggregator.combine(state, groupId, vValue, outputValueValue);
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntArrayBlock groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block topUncast = page.getBlock(channels.get(0));
+    if (topUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BytesRefBlock top = (BytesRefBlock) topUncast;
+    Block outputUncast = page.getBlock(channels.get(1));
+    if (outputUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    LongBlock output = (LongBlock) outputUncast;
+    assert top.getPositionCount() == output.getPositionCount();
+    BytesRef topScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int valuesPosition = groupPosition + positionOffset;
+        TopBytesRefLongAggregator.combineIntermediate(state, groupId, top, output, valuesPosition);
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntBigArrayBlock groups, BytesRefBlock vBlock,
+      LongBlock outputValueBlock) {
+    BytesRef vScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      if (vBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      if (outputValueBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int vStart = vBlock.getFirstValueIndex(valuesPosition);
+        int vEnd = vStart + vBlock.getValueCount(valuesPosition);
+        for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
+          BytesRef vValue = vBlock.getBytesRef(vOffset, vScratch);
+          int outputValueStart = outputValueBlock.getFirstValueIndex(valuesPosition);
+          int outputValueEnd = outputValueStart + outputValueBlock.getValueCount(valuesPosition);
+          for (int outputValueOffset = outputValueStart; outputValueOffset < outputValueEnd; outputValueOffset++) {
+            long outputValueValue = outputValueBlock.getLong(outputValueOffset);
+            TopBytesRefLongAggregator.combine(state, groupId, vValue, outputValueValue);
+          }
+        }
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntBigArrayBlock groups, BytesRefVector vVector,
+      LongVector outputValueVector) {
+    BytesRef vScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        BytesRef vValue = vVector.getBytesRef(valuesPosition, vScratch);
+        long outputValueValue = outputValueVector.getLong(valuesPosition);
+        TopBytesRefLongAggregator.combine(state, groupId, vValue, outputValueValue);
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntBigArrayBlock groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block topUncast = page.getBlock(channels.get(0));
+    if (topUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BytesRefBlock top = (BytesRefBlock) topUncast;
+    Block outputUncast = page.getBlock(channels.get(1));
+    if (outputUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    LongBlock output = (LongBlock) outputUncast;
+    assert top.getPositionCount() == output.getPositionCount();
+    BytesRef topScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int valuesPosition = groupPosition + positionOffset;
+        TopBytesRefLongAggregator.combineIntermediate(state, groupId, top, output, valuesPosition);
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntVector groups, BytesRefBlock vBlock,
+      LongBlock outputValueBlock) {
+    BytesRef vScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int valuesPosition = groupPosition + positionOffset;
+      if (vBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      if (outputValueBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      int groupId = groups.getInt(groupPosition);
+      int vStart = vBlock.getFirstValueIndex(valuesPosition);
+      int vEnd = vStart + vBlock.getValueCount(valuesPosition);
+      for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
+        BytesRef vValue = vBlock.getBytesRef(vOffset, vScratch);
+        int outputValueStart = outputValueBlock.getFirstValueIndex(valuesPosition);
+        int outputValueEnd = outputValueStart + outputValueBlock.getValueCount(valuesPosition);
+        for (int outputValueOffset = outputValueStart; outputValueOffset < outputValueEnd; outputValueOffset++) {
+          long outputValueValue = outputValueBlock.getLong(outputValueOffset);
+          TopBytesRefLongAggregator.combine(state, groupId, vValue, outputValueValue);
+        }
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntVector groups, BytesRefVector vVector,
+      LongVector outputValueVector) {
+    BytesRef vScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int valuesPosition = groupPosition + positionOffset;
+      int groupId = groups.getInt(groupPosition);
+      BytesRef vValue = vVector.getBytesRef(valuesPosition, vScratch);
+      long outputValueValue = outputValueVector.getLong(valuesPosition);
+      TopBytesRefLongAggregator.combine(state, groupId, vValue, outputValueValue);
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block topUncast = page.getBlock(channels.get(0));
+    if (topUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BytesRefBlock top = (BytesRefBlock) topUncast;
+    Block outputUncast = page.getBlock(channels.get(1));
+    if (outputUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    LongBlock output = (LongBlock) outputUncast;
+    assert top.getPositionCount() == output.getPositionCount();
+    BytesRef topScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int groupId = groups.getInt(groupPosition);
+      int valuesPosition = groupPosition + positionOffset;
+      TopBytesRefLongAggregator.combineIntermediate(state, groupId, top, output, valuesPosition);
+    }
+  }
+
+  private void maybeEnableGroupIdTracking(SeenGroupIds seenGroupIds, BytesRefBlock vBlock,
+      LongBlock outputValueBlock) {
+    if (vBlock.mayHaveNulls()) {
+      /*
+       * Some values in the block are null so some group ids may not
+       * be seen. We need to track which ones so we can initialize
+       * them to null when we read their values.
+       */
+      state.enableGroupIdTracking(seenGroupIds);
+    }
+    if (outputValueBlock.mayHaveNulls()) {
+      /*
+       * Some values in the block are null so some group ids may not
+       * be seen. We need to track which ones so we can initialize
+       * them to null when we read their values.
+       */
+      state.enableGroupIdTracking(seenGroupIds);
+    }
+  }
+
+  @Override
+  public void selectedMayContainUnseenGroups(SeenGroupIds seenGroupIds) {
+    state.enableGroupIdTracking(seenGroupIds);
+  }
+
+  @Override
+  public GroupingAggregatorFunction.PreparedForEvaluation prepareEvaluateIntermediate(
+      IntVector selected, GroupingAggregatorEvaluationContext ctx) {
+    return this::evaluateIntermediate;
+  }
+
+  private void evaluateIntermediate(Block[] blocks, int offset, IntVector selectedInPage) {
+    state.toIntermediate(blocks, offset, selectedInPage, driverContext);
+  }
+
+  @Override
+  public GroupingAggregatorFunction.PreparedForEvaluation prepareEvaluateFinal(IntVector selected,
+      GroupingAggregatorEvaluationContext ctx) {
+    return (blocks, offset, selectedInPage) -> evaluateFinal(blocks, offset, selectedInPage, ctx);
+  }
+
+  private void evaluateFinal(Block[] blocks, int offset, IntVector selectedInPage,
+      GroupingAggregatorEvaluationContext ctx) {
+    blocks[offset] = TopBytesRefLongAggregator.evaluateFinal(state, selectedInPage, ctx);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName()).append("[");
+    sb.append("channels=").append(channels);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public void close() {
+    state.close();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopDoubleBytesRefAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopDoubleBytesRefAggregatorFunction.java
@@ -1,0 +1,287 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.List;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanVector;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.BytesRefVector;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.DoubleVector;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link AggregatorFunction} implementation for {@link TopDoubleBytesRefAggregator}.
+ * This class is generated. Edit {@code AggregatorImplementer} instead.
+ */
+public final class TopDoubleBytesRefAggregatorFunction implements AggregatorFunction {
+  private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+      new IntermediateStateDesc("top", ElementType.DOUBLE),
+      new IntermediateStateDesc("output", ElementType.BYTES_REF)  );
+
+  private final DriverContext driverContext;
+
+  private final TopDoubleBytesRefAggregator.SingleState state;
+
+  private final List<Integer> channels;
+
+  private final int limit;
+
+  private final boolean ascending;
+
+  TopDoubleBytesRefAggregatorFunction(DriverContext driverContext, List<Integer> channels,
+      int limit, boolean ascending) {
+    this.limit = limit;
+    this.ascending = ascending;
+    this.driverContext = driverContext;
+    this.channels = channels;
+    this.state = TopDoubleBytesRefAggregator.initSingle(driverContext.bigArrays(), limit, ascending);
+  }
+
+  public static List<IntermediateStateDesc> intermediateStateDesc() {
+    return INTERMEDIATE_STATE_DESC;
+  }
+
+  @Override
+  public int intermediateBlockCount() {
+    return INTERMEDIATE_STATE_DESC.size();
+  }
+
+  @Override
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.allFalse()) {
+      // Entire page masked away
+    } else if (mask.allTrue()) {
+      addRawInputNotMasked(page);
+    } else {
+      addRawInputMasked(page, mask);
+    }
+  }
+
+  private void addRawInputMasked(Page page, BooleanVector mask) {
+    DoubleBlock vBlock = page.getBlock(channels.get(0));
+    BytesRefBlock outputValueBlock = page.getBlock(channels.get(1));
+    DoubleVector vVector = vBlock.asVector();
+    if (vVector == null) {
+      if (vBlock.areAllValuesNull()) {
+        /*
+         * All values are null so we can skip processing this block.
+         * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+         *       being fast without this. Likely the branch predictor is kicking
+         *       in there. But we do this anyway, just so we don't have to trust
+         *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+         *       always have long sequences of ConstantNullBlock. And this code
+         *       shows readers we've thought about this.
+         */
+        return;
+      }
+      addRawBlock(vBlock, outputValueBlock, mask);
+      return;
+    }
+    BytesRefVector outputValueVector = outputValueBlock.asVector();
+    if (outputValueVector == null) {
+      if (outputValueBlock.areAllValuesNull()) {
+        /*
+         * All values are null so we can skip processing this block.
+         * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+         *       being fast without this. Likely the branch predictor is kicking
+         *       in there. But we do this anyway, just so we don't have to trust
+         *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+         *       always have long sequences of ConstantNullBlock. And this code
+         *       shows readers we've thought about this.
+         */
+        return;
+      }
+      addRawBlock(vBlock, outputValueBlock, mask);
+      return;
+    }
+    addRawVector(vVector, outputValueVector, mask);
+  }
+
+  private void addRawInputNotMasked(Page page) {
+    DoubleBlock vBlock = page.getBlock(channels.get(0));
+    BytesRefBlock outputValueBlock = page.getBlock(channels.get(1));
+    DoubleVector vVector = vBlock.asVector();
+    if (vVector == null) {
+      if (vBlock.areAllValuesNull()) {
+        /*
+         * All values are null so we can skip processing this block.
+         * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+         *       being fast without this. Likely the branch predictor is kicking
+         *       in there. But we do this anyway, just so we don't have to trust
+         *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+         *       always have long sequences of ConstantNullBlock. And this code
+         *       shows readers we've thought about this.
+         */
+        return;
+      }
+      addRawBlock(vBlock, outputValueBlock);
+      return;
+    }
+    BytesRefVector outputValueVector = outputValueBlock.asVector();
+    if (outputValueVector == null) {
+      if (outputValueBlock.areAllValuesNull()) {
+        /*
+         * All values are null so we can skip processing this block.
+         * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+         *       being fast without this. Likely the branch predictor is kicking
+         *       in there. But we do this anyway, just so we don't have to trust
+         *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+         *       always have long sequences of ConstantNullBlock. And this code
+         *       shows readers we've thought about this.
+         */
+        return;
+      }
+      addRawBlock(vBlock, outputValueBlock);
+      return;
+    }
+    addRawVector(vVector, outputValueVector);
+  }
+
+  private void addRawVector(DoubleVector vVector, BytesRefVector outputValueVector) {
+    BytesRef outputValueScratch = new BytesRef();
+    for (int valuesPosition = 0; valuesPosition < vVector.getPositionCount(); valuesPosition++) {
+      double vValue = vVector.getDouble(valuesPosition);
+      BytesRef outputValueValue = outputValueVector.getBytesRef(valuesPosition, outputValueScratch);
+      TopDoubleBytesRefAggregator.combine(state, vValue, outputValueValue);
+    }
+  }
+
+  private void addRawVector(DoubleVector vVector, BytesRefVector outputValueVector,
+      BooleanVector mask) {
+    BytesRef outputValueScratch = new BytesRef();
+    for (int valuesPosition = 0; valuesPosition < vVector.getPositionCount(); valuesPosition++) {
+      if (mask.getBoolean(valuesPosition) == false) {
+        continue;
+      }
+      double vValue = vVector.getDouble(valuesPosition);
+      BytesRef outputValueValue = outputValueVector.getBytesRef(valuesPosition, outputValueScratch);
+      TopDoubleBytesRefAggregator.combine(state, vValue, outputValueValue);
+    }
+  }
+
+  private void addRawBlock(DoubleBlock vBlock, BytesRefBlock outputValueBlock) {
+    BytesRef outputValueScratch = new BytesRef();
+    for (int p = 0; p < vBlock.getPositionCount(); p++) {
+      int vValueCount = vBlock.getValueCount(p);
+      if (vValueCount == 0) {
+        continue;
+      }
+      int outputValueValueCount = outputValueBlock.getValueCount(p);
+      if (outputValueValueCount == 0) {
+        continue;
+      }
+      int vStart = vBlock.getFirstValueIndex(p);
+      int vEnd = vStart + vValueCount;
+      for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
+        double vValue = vBlock.getDouble(vOffset);
+        int outputValueStart = outputValueBlock.getFirstValueIndex(p);
+        int outputValueEnd = outputValueStart + outputValueValueCount;
+        for (int outputValueOffset = outputValueStart; outputValueOffset < outputValueEnd; outputValueOffset++) {
+          BytesRef outputValueValue = outputValueBlock.getBytesRef(outputValueOffset, outputValueScratch);
+          TopDoubleBytesRefAggregator.combine(state, vValue, outputValueValue);
+        }
+      }
+    }
+  }
+
+  private void addRawBlock(DoubleBlock vBlock, BytesRefBlock outputValueBlock, BooleanVector mask) {
+    BytesRef outputValueScratch = new BytesRef();
+    for (int p = 0; p < vBlock.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
+      int vValueCount = vBlock.getValueCount(p);
+      if (vValueCount == 0) {
+        continue;
+      }
+      int outputValueValueCount = outputValueBlock.getValueCount(p);
+      if (outputValueValueCount == 0) {
+        continue;
+      }
+      int vStart = vBlock.getFirstValueIndex(p);
+      int vEnd = vStart + vValueCount;
+      for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
+        double vValue = vBlock.getDouble(vOffset);
+        int outputValueStart = outputValueBlock.getFirstValueIndex(p);
+        int outputValueEnd = outputValueStart + outputValueValueCount;
+        for (int outputValueOffset = outputValueStart; outputValueOffset < outputValueEnd; outputValueOffset++) {
+          BytesRef outputValueValue = outputValueBlock.getBytesRef(outputValueOffset, outputValueScratch);
+          TopDoubleBytesRefAggregator.combine(state, vValue, outputValueValue);
+        }
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(Page page) {
+    assert channels.size() == intermediateBlockCount();
+    assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
+    Block topUncast = page.getBlock(channels.get(0));
+    if (topUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    DoubleBlock top = (DoubleBlock) topUncast;
+    assert top.getPositionCount() == 1;
+    Block outputUncast = page.getBlock(channels.get(1));
+    if (outputUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BytesRefBlock output = (BytesRefBlock) outputUncast;
+    assert output.getPositionCount() == 1;
+    BytesRef outputScratch = new BytesRef();
+    TopDoubleBytesRefAggregator.combineIntermediate(state, top, output);
+  }
+
+  @Override
+  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+    state.toIntermediate(blocks, offset, driverContext);
+  }
+
+  @Override
+  public void evaluateFinal(Block[] blocks, int offset, DriverContext driverContext) {
+    blocks[offset] = TopDoubleBytesRefAggregator.evaluateFinal(state, driverContext);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName()).append("[");
+    sb.append("channels=").append(channels);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public void close() {
+    state.close();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopDoubleBytesRefAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopDoubleBytesRefAggregatorFunctionSupplier.java
@@ -1,0 +1,53 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.util.List;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link AggregatorFunctionSupplier} implementation for {@link TopDoubleBytesRefAggregator}.
+ * This class is generated. Edit {@code AggregatorFunctionSupplierImplementer} instead.
+ */
+public final class TopDoubleBytesRefAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
+  private final int limit;
+
+  private final boolean ascending;
+
+  public TopDoubleBytesRefAggregatorFunctionSupplier(int limit, boolean ascending) {
+    this.limit = limit;
+    this.ascending = ascending;
+  }
+
+  @Override
+  public List<IntermediateStateDesc> nonGroupingIntermediateStateDesc() {
+    return TopDoubleBytesRefAggregatorFunction.intermediateStateDesc();
+  }
+
+  @Override
+  public List<IntermediateStateDesc> groupingIntermediateStateDesc() {
+    return TopDoubleBytesRefGroupingAggregatorFunction.intermediateStateDesc();
+  }
+
+  @Override
+  public TopDoubleBytesRefAggregatorFunction aggregator(DriverContext driverContext,
+      List<Integer> channels) {
+    return new TopDoubleBytesRefAggregatorFunction(driverContext, channels, limit, ascending);
+  }
+
+  @Override
+  public TopDoubleBytesRefGroupingAggregatorFunction groupingAggregator(DriverContext driverContext,
+      List<Integer> channels) {
+    return new TopDoubleBytesRefGroupingAggregatorFunction(channels, driverContext, limit, ascending);
+  }
+
+  @Override
+  public String describe() {
+    return "top_double of bytes";
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopDoubleBytesRefGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopDoubleBytesRefGroupingAggregatorFunction.java
@@ -1,0 +1,493 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.List;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.BytesRefVector;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.DoubleVector;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntArrayBlock;
+import org.elasticsearch.compute.data.IntBigArrayBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link GroupingAggregatorFunction} implementation for {@link TopDoubleBytesRefAggregator}.
+ * This class is generated. Edit {@code GroupingAggregatorImplementer} instead.
+ */
+public final class TopDoubleBytesRefGroupingAggregatorFunction implements GroupingAggregatorFunction {
+  private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+      new IntermediateStateDesc("top", ElementType.DOUBLE),
+      new IntermediateStateDesc("output", ElementType.BYTES_REF)  );
+
+  private final TopDoubleBytesRefAggregator.GroupingState state;
+
+  private final List<Integer> channels;
+
+  private final DriverContext driverContext;
+
+  private final int limit;
+
+  private final boolean ascending;
+
+  TopDoubleBytesRefGroupingAggregatorFunction(List<Integer> channels, DriverContext driverContext,
+      int limit, boolean ascending) {
+    this.limit = limit;
+    this.ascending = ascending;
+    this.channels = channels;
+    this.state = TopDoubleBytesRefAggregator.initGrouping(driverContext.bigArrays(), limit, ascending);
+    this.driverContext = driverContext;
+  }
+
+  public static List<IntermediateStateDesc> intermediateStateDesc() {
+    return INTERMEDIATE_STATE_DESC;
+  }
+
+  @Override
+  public int intermediateBlockCount() {
+    return INTERMEDIATE_STATE_DESC.size();
+  }
+
+  @Override
+  public GroupingAggregatorFunction.AddInput prepareProcessRawInputPage(SeenGroupIds seenGroupIds,
+      Page page) {
+    DoubleBlock vBlock = page.getBlock(channels.get(0));
+    BytesRefBlock outputValueBlock = page.getBlock(channels.get(1));
+    if (vBlock.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block. But we
+       * still need to track that some groups may not have been seen
+       * so that they are initialized to null when we read their values.
+       */
+      state.enableGroupIdTracking(seenGroupIds);
+      return null;
+    }
+    if (outputValueBlock.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block. But we
+       * still need to track that some groups may not have been seen
+       * so that they are initialized to null when we read their values.
+       */
+      state.enableGroupIdTracking(seenGroupIds);
+      return null;
+    }
+    DoubleVector vVector = vBlock.asVector();
+    if (vVector == null) {
+      maybeEnableGroupIdTracking(seenGroupIds, vBlock, outputValueBlock);
+      return new GroupingAggregatorFunction.AddInput() {
+        @Override
+        public void add(int positionOffset, IntArrayBlock groupIds) {
+          addRawInput(positionOffset, groupIds, vBlock, outputValueBlock);
+        }
+
+        @Override
+        public void add(int positionOffset, IntBigArrayBlock groupIds) {
+          addRawInput(positionOffset, groupIds, vBlock, outputValueBlock);
+        }
+
+        @Override
+        public void add(int positionOffset, IntVector groupIds) {
+          addRawInput(positionOffset, groupIds, vBlock, outputValueBlock);
+        }
+
+        @Override
+        public void close() {
+        }
+      };
+    }
+    BytesRefVector outputValueVector = outputValueBlock.asVector();
+    if (outputValueVector == null) {
+      maybeEnableGroupIdTracking(seenGroupIds, vBlock, outputValueBlock);
+      return new GroupingAggregatorFunction.AddInput() {
+        @Override
+        public void add(int positionOffset, IntArrayBlock groupIds) {
+          addRawInput(positionOffset, groupIds, vBlock, outputValueBlock);
+        }
+
+        @Override
+        public void add(int positionOffset, IntBigArrayBlock groupIds) {
+          addRawInput(positionOffset, groupIds, vBlock, outputValueBlock);
+        }
+
+        @Override
+        public void add(int positionOffset, IntVector groupIds) {
+          addRawInput(positionOffset, groupIds, vBlock, outputValueBlock);
+        }
+
+        @Override
+        public void close() {
+        }
+      };
+    }
+    return new GroupingAggregatorFunction.AddInput() {
+      @Override
+      public void add(int positionOffset, IntArrayBlock groupIds) {
+        addRawInput(positionOffset, groupIds, vVector, outputValueVector);
+      }
+
+      @Override
+      public void add(int positionOffset, IntBigArrayBlock groupIds) {
+        addRawInput(positionOffset, groupIds, vVector, outputValueVector);
+      }
+
+      @Override
+      public void add(int positionOffset, IntVector groupIds) {
+        addRawInput(positionOffset, groupIds, vVector, outputValueVector);
+      }
+
+      @Override
+      public void close() {
+      }
+    };
+  }
+
+  private void addRawInput(int positionOffset, IntArrayBlock groups, DoubleBlock vBlock,
+      BytesRefBlock outputValueBlock) {
+    BytesRef outputValueScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      if (vBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      if (outputValueBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int vStart = vBlock.getFirstValueIndex(valuesPosition);
+        int vEnd = vStart + vBlock.getValueCount(valuesPosition);
+        for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
+          double vValue = vBlock.getDouble(vOffset);
+          int outputValueStart = outputValueBlock.getFirstValueIndex(valuesPosition);
+          int outputValueEnd = outputValueStart + outputValueBlock.getValueCount(valuesPosition);
+          for (int outputValueOffset = outputValueStart; outputValueOffset < outputValueEnd; outputValueOffset++) {
+            BytesRef outputValueValue = outputValueBlock.getBytesRef(outputValueOffset, outputValueScratch);
+            TopDoubleBytesRefAggregator.combine(state, groupId, vValue, outputValueValue);
+          }
+        }
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntArrayBlock groups, DoubleVector vVector,
+      BytesRefVector outputValueVector) {
+    BytesRef outputValueScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        double vValue = vVector.getDouble(valuesPosition);
+        BytesRef outputValueValue = outputValueVector.getBytesRef(valuesPosition, outputValueScratch);
+        TopDoubleBytesRefAggregator.combine(state, groupId, vValue, outputValueValue);
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntArrayBlock groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block topUncast = page.getBlock(channels.get(0));
+    if (topUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    DoubleBlock top = (DoubleBlock) topUncast;
+    Block outputUncast = page.getBlock(channels.get(1));
+    if (outputUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BytesRefBlock output = (BytesRefBlock) outputUncast;
+    assert top.getPositionCount() == output.getPositionCount();
+    BytesRef outputScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int valuesPosition = groupPosition + positionOffset;
+        TopDoubleBytesRefAggregator.combineIntermediate(state, groupId, top, output, valuesPosition);
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntBigArrayBlock groups, DoubleBlock vBlock,
+      BytesRefBlock outputValueBlock) {
+    BytesRef outputValueScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      if (vBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      if (outputValueBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int vStart = vBlock.getFirstValueIndex(valuesPosition);
+        int vEnd = vStart + vBlock.getValueCount(valuesPosition);
+        for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
+          double vValue = vBlock.getDouble(vOffset);
+          int outputValueStart = outputValueBlock.getFirstValueIndex(valuesPosition);
+          int outputValueEnd = outputValueStart + outputValueBlock.getValueCount(valuesPosition);
+          for (int outputValueOffset = outputValueStart; outputValueOffset < outputValueEnd; outputValueOffset++) {
+            BytesRef outputValueValue = outputValueBlock.getBytesRef(outputValueOffset, outputValueScratch);
+            TopDoubleBytesRefAggregator.combine(state, groupId, vValue, outputValueValue);
+          }
+        }
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntBigArrayBlock groups, DoubleVector vVector,
+      BytesRefVector outputValueVector) {
+    BytesRef outputValueScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        double vValue = vVector.getDouble(valuesPosition);
+        BytesRef outputValueValue = outputValueVector.getBytesRef(valuesPosition, outputValueScratch);
+        TopDoubleBytesRefAggregator.combine(state, groupId, vValue, outputValueValue);
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntBigArrayBlock groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block topUncast = page.getBlock(channels.get(0));
+    if (topUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    DoubleBlock top = (DoubleBlock) topUncast;
+    Block outputUncast = page.getBlock(channels.get(1));
+    if (outputUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BytesRefBlock output = (BytesRefBlock) outputUncast;
+    assert top.getPositionCount() == output.getPositionCount();
+    BytesRef outputScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int valuesPosition = groupPosition + positionOffset;
+        TopDoubleBytesRefAggregator.combineIntermediate(state, groupId, top, output, valuesPosition);
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntVector groups, DoubleBlock vBlock,
+      BytesRefBlock outputValueBlock) {
+    BytesRef outputValueScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int valuesPosition = groupPosition + positionOffset;
+      if (vBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      if (outputValueBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      int groupId = groups.getInt(groupPosition);
+      int vStart = vBlock.getFirstValueIndex(valuesPosition);
+      int vEnd = vStart + vBlock.getValueCount(valuesPosition);
+      for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
+        double vValue = vBlock.getDouble(vOffset);
+        int outputValueStart = outputValueBlock.getFirstValueIndex(valuesPosition);
+        int outputValueEnd = outputValueStart + outputValueBlock.getValueCount(valuesPosition);
+        for (int outputValueOffset = outputValueStart; outputValueOffset < outputValueEnd; outputValueOffset++) {
+          BytesRef outputValueValue = outputValueBlock.getBytesRef(outputValueOffset, outputValueScratch);
+          TopDoubleBytesRefAggregator.combine(state, groupId, vValue, outputValueValue);
+        }
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntVector groups, DoubleVector vVector,
+      BytesRefVector outputValueVector) {
+    BytesRef outputValueScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int valuesPosition = groupPosition + positionOffset;
+      int groupId = groups.getInt(groupPosition);
+      double vValue = vVector.getDouble(valuesPosition);
+      BytesRef outputValueValue = outputValueVector.getBytesRef(valuesPosition, outputValueScratch);
+      TopDoubleBytesRefAggregator.combine(state, groupId, vValue, outputValueValue);
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block topUncast = page.getBlock(channels.get(0));
+    if (topUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    DoubleBlock top = (DoubleBlock) topUncast;
+    Block outputUncast = page.getBlock(channels.get(1));
+    if (outputUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BytesRefBlock output = (BytesRefBlock) outputUncast;
+    assert top.getPositionCount() == output.getPositionCount();
+    BytesRef outputScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int groupId = groups.getInt(groupPosition);
+      int valuesPosition = groupPosition + positionOffset;
+      TopDoubleBytesRefAggregator.combineIntermediate(state, groupId, top, output, valuesPosition);
+    }
+  }
+
+  private void maybeEnableGroupIdTracking(SeenGroupIds seenGroupIds, DoubleBlock vBlock,
+      BytesRefBlock outputValueBlock) {
+    if (vBlock.mayHaveNulls()) {
+      /*
+       * Some values in the block are null so some group ids may not
+       * be seen. We need to track which ones so we can initialize
+       * them to null when we read their values.
+       */
+      state.enableGroupIdTracking(seenGroupIds);
+    }
+    if (outputValueBlock.mayHaveNulls()) {
+      /*
+       * Some values in the block are null so some group ids may not
+       * be seen. We need to track which ones so we can initialize
+       * them to null when we read their values.
+       */
+      state.enableGroupIdTracking(seenGroupIds);
+    }
+  }
+
+  @Override
+  public void selectedMayContainUnseenGroups(SeenGroupIds seenGroupIds) {
+    state.enableGroupIdTracking(seenGroupIds);
+  }
+
+  @Override
+  public GroupingAggregatorFunction.PreparedForEvaluation prepareEvaluateIntermediate(
+      IntVector selected, GroupingAggregatorEvaluationContext ctx) {
+    return this::evaluateIntermediate;
+  }
+
+  private void evaluateIntermediate(Block[] blocks, int offset, IntVector selectedInPage) {
+    state.toIntermediate(blocks, offset, selectedInPage, driverContext);
+  }
+
+  @Override
+  public GroupingAggregatorFunction.PreparedForEvaluation prepareEvaluateFinal(IntVector selected,
+      GroupingAggregatorEvaluationContext ctx) {
+    return (blocks, offset, selectedInPage) -> evaluateFinal(blocks, offset, selectedInPage, ctx);
+  }
+
+  private void evaluateFinal(Block[] blocks, int offset, IntVector selectedInPage,
+      GroupingAggregatorEvaluationContext ctx) {
+    blocks[offset] = TopDoubleBytesRefAggregator.evaluateFinal(state, selectedInPage, ctx);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName()).append("[");
+    sb.append("channels=").append(channels);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public void close() {
+    state.close();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopFloatBytesRefAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopFloatBytesRefAggregatorFunction.java
@@ -1,0 +1,287 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.List;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanVector;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.BytesRefVector;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.FloatBlock;
+import org.elasticsearch.compute.data.FloatVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link AggregatorFunction} implementation for {@link TopFloatBytesRefAggregator}.
+ * This class is generated. Edit {@code AggregatorImplementer} instead.
+ */
+public final class TopFloatBytesRefAggregatorFunction implements AggregatorFunction {
+  private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+      new IntermediateStateDesc("top", ElementType.FLOAT),
+      new IntermediateStateDesc("output", ElementType.BYTES_REF)  );
+
+  private final DriverContext driverContext;
+
+  private final TopFloatBytesRefAggregator.SingleState state;
+
+  private final List<Integer> channels;
+
+  private final int limit;
+
+  private final boolean ascending;
+
+  TopFloatBytesRefAggregatorFunction(DriverContext driverContext, List<Integer> channels, int limit,
+      boolean ascending) {
+    this.limit = limit;
+    this.ascending = ascending;
+    this.driverContext = driverContext;
+    this.channels = channels;
+    this.state = TopFloatBytesRefAggregator.initSingle(driverContext.bigArrays(), limit, ascending);
+  }
+
+  public static List<IntermediateStateDesc> intermediateStateDesc() {
+    return INTERMEDIATE_STATE_DESC;
+  }
+
+  @Override
+  public int intermediateBlockCount() {
+    return INTERMEDIATE_STATE_DESC.size();
+  }
+
+  @Override
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.allFalse()) {
+      // Entire page masked away
+    } else if (mask.allTrue()) {
+      addRawInputNotMasked(page);
+    } else {
+      addRawInputMasked(page, mask);
+    }
+  }
+
+  private void addRawInputMasked(Page page, BooleanVector mask) {
+    FloatBlock vBlock = page.getBlock(channels.get(0));
+    BytesRefBlock outputValueBlock = page.getBlock(channels.get(1));
+    FloatVector vVector = vBlock.asVector();
+    if (vVector == null) {
+      if (vBlock.areAllValuesNull()) {
+        /*
+         * All values are null so we can skip processing this block.
+         * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+         *       being fast without this. Likely the branch predictor is kicking
+         *       in there. But we do this anyway, just so we don't have to trust
+         *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+         *       always have long sequences of ConstantNullBlock. And this code
+         *       shows readers we've thought about this.
+         */
+        return;
+      }
+      addRawBlock(vBlock, outputValueBlock, mask);
+      return;
+    }
+    BytesRefVector outputValueVector = outputValueBlock.asVector();
+    if (outputValueVector == null) {
+      if (outputValueBlock.areAllValuesNull()) {
+        /*
+         * All values are null so we can skip processing this block.
+         * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+         *       being fast without this. Likely the branch predictor is kicking
+         *       in there. But we do this anyway, just so we don't have to trust
+         *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+         *       always have long sequences of ConstantNullBlock. And this code
+         *       shows readers we've thought about this.
+         */
+        return;
+      }
+      addRawBlock(vBlock, outputValueBlock, mask);
+      return;
+    }
+    addRawVector(vVector, outputValueVector, mask);
+  }
+
+  private void addRawInputNotMasked(Page page) {
+    FloatBlock vBlock = page.getBlock(channels.get(0));
+    BytesRefBlock outputValueBlock = page.getBlock(channels.get(1));
+    FloatVector vVector = vBlock.asVector();
+    if (vVector == null) {
+      if (vBlock.areAllValuesNull()) {
+        /*
+         * All values are null so we can skip processing this block.
+         * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+         *       being fast without this. Likely the branch predictor is kicking
+         *       in there. But we do this anyway, just so we don't have to trust
+         *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+         *       always have long sequences of ConstantNullBlock. And this code
+         *       shows readers we've thought about this.
+         */
+        return;
+      }
+      addRawBlock(vBlock, outputValueBlock);
+      return;
+    }
+    BytesRefVector outputValueVector = outputValueBlock.asVector();
+    if (outputValueVector == null) {
+      if (outputValueBlock.areAllValuesNull()) {
+        /*
+         * All values are null so we can skip processing this block.
+         * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+         *       being fast without this. Likely the branch predictor is kicking
+         *       in there. But we do this anyway, just so we don't have to trust
+         *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+         *       always have long sequences of ConstantNullBlock. And this code
+         *       shows readers we've thought about this.
+         */
+        return;
+      }
+      addRawBlock(vBlock, outputValueBlock);
+      return;
+    }
+    addRawVector(vVector, outputValueVector);
+  }
+
+  private void addRawVector(FloatVector vVector, BytesRefVector outputValueVector) {
+    BytesRef outputValueScratch = new BytesRef();
+    for (int valuesPosition = 0; valuesPosition < vVector.getPositionCount(); valuesPosition++) {
+      float vValue = vVector.getFloat(valuesPosition);
+      BytesRef outputValueValue = outputValueVector.getBytesRef(valuesPosition, outputValueScratch);
+      TopFloatBytesRefAggregator.combine(state, vValue, outputValueValue);
+    }
+  }
+
+  private void addRawVector(FloatVector vVector, BytesRefVector outputValueVector,
+      BooleanVector mask) {
+    BytesRef outputValueScratch = new BytesRef();
+    for (int valuesPosition = 0; valuesPosition < vVector.getPositionCount(); valuesPosition++) {
+      if (mask.getBoolean(valuesPosition) == false) {
+        continue;
+      }
+      float vValue = vVector.getFloat(valuesPosition);
+      BytesRef outputValueValue = outputValueVector.getBytesRef(valuesPosition, outputValueScratch);
+      TopFloatBytesRefAggregator.combine(state, vValue, outputValueValue);
+    }
+  }
+
+  private void addRawBlock(FloatBlock vBlock, BytesRefBlock outputValueBlock) {
+    BytesRef outputValueScratch = new BytesRef();
+    for (int p = 0; p < vBlock.getPositionCount(); p++) {
+      int vValueCount = vBlock.getValueCount(p);
+      if (vValueCount == 0) {
+        continue;
+      }
+      int outputValueValueCount = outputValueBlock.getValueCount(p);
+      if (outputValueValueCount == 0) {
+        continue;
+      }
+      int vStart = vBlock.getFirstValueIndex(p);
+      int vEnd = vStart + vValueCount;
+      for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
+        float vValue = vBlock.getFloat(vOffset);
+        int outputValueStart = outputValueBlock.getFirstValueIndex(p);
+        int outputValueEnd = outputValueStart + outputValueValueCount;
+        for (int outputValueOffset = outputValueStart; outputValueOffset < outputValueEnd; outputValueOffset++) {
+          BytesRef outputValueValue = outputValueBlock.getBytesRef(outputValueOffset, outputValueScratch);
+          TopFloatBytesRefAggregator.combine(state, vValue, outputValueValue);
+        }
+      }
+    }
+  }
+
+  private void addRawBlock(FloatBlock vBlock, BytesRefBlock outputValueBlock, BooleanVector mask) {
+    BytesRef outputValueScratch = new BytesRef();
+    for (int p = 0; p < vBlock.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
+      int vValueCount = vBlock.getValueCount(p);
+      if (vValueCount == 0) {
+        continue;
+      }
+      int outputValueValueCount = outputValueBlock.getValueCount(p);
+      if (outputValueValueCount == 0) {
+        continue;
+      }
+      int vStart = vBlock.getFirstValueIndex(p);
+      int vEnd = vStart + vValueCount;
+      for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
+        float vValue = vBlock.getFloat(vOffset);
+        int outputValueStart = outputValueBlock.getFirstValueIndex(p);
+        int outputValueEnd = outputValueStart + outputValueValueCount;
+        for (int outputValueOffset = outputValueStart; outputValueOffset < outputValueEnd; outputValueOffset++) {
+          BytesRef outputValueValue = outputValueBlock.getBytesRef(outputValueOffset, outputValueScratch);
+          TopFloatBytesRefAggregator.combine(state, vValue, outputValueValue);
+        }
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(Page page) {
+    assert channels.size() == intermediateBlockCount();
+    assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
+    Block topUncast = page.getBlock(channels.get(0));
+    if (topUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    FloatBlock top = (FloatBlock) topUncast;
+    assert top.getPositionCount() == 1;
+    Block outputUncast = page.getBlock(channels.get(1));
+    if (outputUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BytesRefBlock output = (BytesRefBlock) outputUncast;
+    assert output.getPositionCount() == 1;
+    BytesRef outputScratch = new BytesRef();
+    TopFloatBytesRefAggregator.combineIntermediate(state, top, output);
+  }
+
+  @Override
+  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+    state.toIntermediate(blocks, offset, driverContext);
+  }
+
+  @Override
+  public void evaluateFinal(Block[] blocks, int offset, DriverContext driverContext) {
+    blocks[offset] = TopFloatBytesRefAggregator.evaluateFinal(state, driverContext);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName()).append("[");
+    sb.append("channels=").append(channels);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public void close() {
+    state.close();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopFloatBytesRefAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopFloatBytesRefAggregatorFunctionSupplier.java
@@ -1,0 +1,53 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.util.List;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link AggregatorFunctionSupplier} implementation for {@link TopFloatBytesRefAggregator}.
+ * This class is generated. Edit {@code AggregatorFunctionSupplierImplementer} instead.
+ */
+public final class TopFloatBytesRefAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
+  private final int limit;
+
+  private final boolean ascending;
+
+  public TopFloatBytesRefAggregatorFunctionSupplier(int limit, boolean ascending) {
+    this.limit = limit;
+    this.ascending = ascending;
+  }
+
+  @Override
+  public List<IntermediateStateDesc> nonGroupingIntermediateStateDesc() {
+    return TopFloatBytesRefAggregatorFunction.intermediateStateDesc();
+  }
+
+  @Override
+  public List<IntermediateStateDesc> groupingIntermediateStateDesc() {
+    return TopFloatBytesRefGroupingAggregatorFunction.intermediateStateDesc();
+  }
+
+  @Override
+  public TopFloatBytesRefAggregatorFunction aggregator(DriverContext driverContext,
+      List<Integer> channels) {
+    return new TopFloatBytesRefAggregatorFunction(driverContext, channels, limit, ascending);
+  }
+
+  @Override
+  public TopFloatBytesRefGroupingAggregatorFunction groupingAggregator(DriverContext driverContext,
+      List<Integer> channels) {
+    return new TopFloatBytesRefGroupingAggregatorFunction(channels, driverContext, limit, ascending);
+  }
+
+  @Override
+  public String describe() {
+    return "top_float of bytes";
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopFloatBytesRefGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopFloatBytesRefGroupingAggregatorFunction.java
@@ -1,0 +1,493 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.List;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.BytesRefVector;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.FloatBlock;
+import org.elasticsearch.compute.data.FloatVector;
+import org.elasticsearch.compute.data.IntArrayBlock;
+import org.elasticsearch.compute.data.IntBigArrayBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link GroupingAggregatorFunction} implementation for {@link TopFloatBytesRefAggregator}.
+ * This class is generated. Edit {@code GroupingAggregatorImplementer} instead.
+ */
+public final class TopFloatBytesRefGroupingAggregatorFunction implements GroupingAggregatorFunction {
+  private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+      new IntermediateStateDesc("top", ElementType.FLOAT),
+      new IntermediateStateDesc("output", ElementType.BYTES_REF)  );
+
+  private final TopFloatBytesRefAggregator.GroupingState state;
+
+  private final List<Integer> channels;
+
+  private final DriverContext driverContext;
+
+  private final int limit;
+
+  private final boolean ascending;
+
+  TopFloatBytesRefGroupingAggregatorFunction(List<Integer> channels, DriverContext driverContext,
+      int limit, boolean ascending) {
+    this.limit = limit;
+    this.ascending = ascending;
+    this.channels = channels;
+    this.state = TopFloatBytesRefAggregator.initGrouping(driverContext.bigArrays(), limit, ascending);
+    this.driverContext = driverContext;
+  }
+
+  public static List<IntermediateStateDesc> intermediateStateDesc() {
+    return INTERMEDIATE_STATE_DESC;
+  }
+
+  @Override
+  public int intermediateBlockCount() {
+    return INTERMEDIATE_STATE_DESC.size();
+  }
+
+  @Override
+  public GroupingAggregatorFunction.AddInput prepareProcessRawInputPage(SeenGroupIds seenGroupIds,
+      Page page) {
+    FloatBlock vBlock = page.getBlock(channels.get(0));
+    BytesRefBlock outputValueBlock = page.getBlock(channels.get(1));
+    if (vBlock.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block. But we
+       * still need to track that some groups may not have been seen
+       * so that they are initialized to null when we read their values.
+       */
+      state.enableGroupIdTracking(seenGroupIds);
+      return null;
+    }
+    if (outputValueBlock.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block. But we
+       * still need to track that some groups may not have been seen
+       * so that they are initialized to null when we read their values.
+       */
+      state.enableGroupIdTracking(seenGroupIds);
+      return null;
+    }
+    FloatVector vVector = vBlock.asVector();
+    if (vVector == null) {
+      maybeEnableGroupIdTracking(seenGroupIds, vBlock, outputValueBlock);
+      return new GroupingAggregatorFunction.AddInput() {
+        @Override
+        public void add(int positionOffset, IntArrayBlock groupIds) {
+          addRawInput(positionOffset, groupIds, vBlock, outputValueBlock);
+        }
+
+        @Override
+        public void add(int positionOffset, IntBigArrayBlock groupIds) {
+          addRawInput(positionOffset, groupIds, vBlock, outputValueBlock);
+        }
+
+        @Override
+        public void add(int positionOffset, IntVector groupIds) {
+          addRawInput(positionOffset, groupIds, vBlock, outputValueBlock);
+        }
+
+        @Override
+        public void close() {
+        }
+      };
+    }
+    BytesRefVector outputValueVector = outputValueBlock.asVector();
+    if (outputValueVector == null) {
+      maybeEnableGroupIdTracking(seenGroupIds, vBlock, outputValueBlock);
+      return new GroupingAggregatorFunction.AddInput() {
+        @Override
+        public void add(int positionOffset, IntArrayBlock groupIds) {
+          addRawInput(positionOffset, groupIds, vBlock, outputValueBlock);
+        }
+
+        @Override
+        public void add(int positionOffset, IntBigArrayBlock groupIds) {
+          addRawInput(positionOffset, groupIds, vBlock, outputValueBlock);
+        }
+
+        @Override
+        public void add(int positionOffset, IntVector groupIds) {
+          addRawInput(positionOffset, groupIds, vBlock, outputValueBlock);
+        }
+
+        @Override
+        public void close() {
+        }
+      };
+    }
+    return new GroupingAggregatorFunction.AddInput() {
+      @Override
+      public void add(int positionOffset, IntArrayBlock groupIds) {
+        addRawInput(positionOffset, groupIds, vVector, outputValueVector);
+      }
+
+      @Override
+      public void add(int positionOffset, IntBigArrayBlock groupIds) {
+        addRawInput(positionOffset, groupIds, vVector, outputValueVector);
+      }
+
+      @Override
+      public void add(int positionOffset, IntVector groupIds) {
+        addRawInput(positionOffset, groupIds, vVector, outputValueVector);
+      }
+
+      @Override
+      public void close() {
+      }
+    };
+  }
+
+  private void addRawInput(int positionOffset, IntArrayBlock groups, FloatBlock vBlock,
+      BytesRefBlock outputValueBlock) {
+    BytesRef outputValueScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      if (vBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      if (outputValueBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int vStart = vBlock.getFirstValueIndex(valuesPosition);
+        int vEnd = vStart + vBlock.getValueCount(valuesPosition);
+        for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
+          float vValue = vBlock.getFloat(vOffset);
+          int outputValueStart = outputValueBlock.getFirstValueIndex(valuesPosition);
+          int outputValueEnd = outputValueStart + outputValueBlock.getValueCount(valuesPosition);
+          for (int outputValueOffset = outputValueStart; outputValueOffset < outputValueEnd; outputValueOffset++) {
+            BytesRef outputValueValue = outputValueBlock.getBytesRef(outputValueOffset, outputValueScratch);
+            TopFloatBytesRefAggregator.combine(state, groupId, vValue, outputValueValue);
+          }
+        }
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntArrayBlock groups, FloatVector vVector,
+      BytesRefVector outputValueVector) {
+    BytesRef outputValueScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        float vValue = vVector.getFloat(valuesPosition);
+        BytesRef outputValueValue = outputValueVector.getBytesRef(valuesPosition, outputValueScratch);
+        TopFloatBytesRefAggregator.combine(state, groupId, vValue, outputValueValue);
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntArrayBlock groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block topUncast = page.getBlock(channels.get(0));
+    if (topUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    FloatBlock top = (FloatBlock) topUncast;
+    Block outputUncast = page.getBlock(channels.get(1));
+    if (outputUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BytesRefBlock output = (BytesRefBlock) outputUncast;
+    assert top.getPositionCount() == output.getPositionCount();
+    BytesRef outputScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int valuesPosition = groupPosition + positionOffset;
+        TopFloatBytesRefAggregator.combineIntermediate(state, groupId, top, output, valuesPosition);
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntBigArrayBlock groups, FloatBlock vBlock,
+      BytesRefBlock outputValueBlock) {
+    BytesRef outputValueScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      if (vBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      if (outputValueBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int vStart = vBlock.getFirstValueIndex(valuesPosition);
+        int vEnd = vStart + vBlock.getValueCount(valuesPosition);
+        for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
+          float vValue = vBlock.getFloat(vOffset);
+          int outputValueStart = outputValueBlock.getFirstValueIndex(valuesPosition);
+          int outputValueEnd = outputValueStart + outputValueBlock.getValueCount(valuesPosition);
+          for (int outputValueOffset = outputValueStart; outputValueOffset < outputValueEnd; outputValueOffset++) {
+            BytesRef outputValueValue = outputValueBlock.getBytesRef(outputValueOffset, outputValueScratch);
+            TopFloatBytesRefAggregator.combine(state, groupId, vValue, outputValueValue);
+          }
+        }
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntBigArrayBlock groups, FloatVector vVector,
+      BytesRefVector outputValueVector) {
+    BytesRef outputValueScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        float vValue = vVector.getFloat(valuesPosition);
+        BytesRef outputValueValue = outputValueVector.getBytesRef(valuesPosition, outputValueScratch);
+        TopFloatBytesRefAggregator.combine(state, groupId, vValue, outputValueValue);
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntBigArrayBlock groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block topUncast = page.getBlock(channels.get(0));
+    if (topUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    FloatBlock top = (FloatBlock) topUncast;
+    Block outputUncast = page.getBlock(channels.get(1));
+    if (outputUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BytesRefBlock output = (BytesRefBlock) outputUncast;
+    assert top.getPositionCount() == output.getPositionCount();
+    BytesRef outputScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int valuesPosition = groupPosition + positionOffset;
+        TopFloatBytesRefAggregator.combineIntermediate(state, groupId, top, output, valuesPosition);
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntVector groups, FloatBlock vBlock,
+      BytesRefBlock outputValueBlock) {
+    BytesRef outputValueScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int valuesPosition = groupPosition + positionOffset;
+      if (vBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      if (outputValueBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      int groupId = groups.getInt(groupPosition);
+      int vStart = vBlock.getFirstValueIndex(valuesPosition);
+      int vEnd = vStart + vBlock.getValueCount(valuesPosition);
+      for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
+        float vValue = vBlock.getFloat(vOffset);
+        int outputValueStart = outputValueBlock.getFirstValueIndex(valuesPosition);
+        int outputValueEnd = outputValueStart + outputValueBlock.getValueCount(valuesPosition);
+        for (int outputValueOffset = outputValueStart; outputValueOffset < outputValueEnd; outputValueOffset++) {
+          BytesRef outputValueValue = outputValueBlock.getBytesRef(outputValueOffset, outputValueScratch);
+          TopFloatBytesRefAggregator.combine(state, groupId, vValue, outputValueValue);
+        }
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntVector groups, FloatVector vVector,
+      BytesRefVector outputValueVector) {
+    BytesRef outputValueScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int valuesPosition = groupPosition + positionOffset;
+      int groupId = groups.getInt(groupPosition);
+      float vValue = vVector.getFloat(valuesPosition);
+      BytesRef outputValueValue = outputValueVector.getBytesRef(valuesPosition, outputValueScratch);
+      TopFloatBytesRefAggregator.combine(state, groupId, vValue, outputValueValue);
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block topUncast = page.getBlock(channels.get(0));
+    if (topUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    FloatBlock top = (FloatBlock) topUncast;
+    Block outputUncast = page.getBlock(channels.get(1));
+    if (outputUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BytesRefBlock output = (BytesRefBlock) outputUncast;
+    assert top.getPositionCount() == output.getPositionCount();
+    BytesRef outputScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int groupId = groups.getInt(groupPosition);
+      int valuesPosition = groupPosition + positionOffset;
+      TopFloatBytesRefAggregator.combineIntermediate(state, groupId, top, output, valuesPosition);
+    }
+  }
+
+  private void maybeEnableGroupIdTracking(SeenGroupIds seenGroupIds, FloatBlock vBlock,
+      BytesRefBlock outputValueBlock) {
+    if (vBlock.mayHaveNulls()) {
+      /*
+       * Some values in the block are null so some group ids may not
+       * be seen. We need to track which ones so we can initialize
+       * them to null when we read their values.
+       */
+      state.enableGroupIdTracking(seenGroupIds);
+    }
+    if (outputValueBlock.mayHaveNulls()) {
+      /*
+       * Some values in the block are null so some group ids may not
+       * be seen. We need to track which ones so we can initialize
+       * them to null when we read their values.
+       */
+      state.enableGroupIdTracking(seenGroupIds);
+    }
+  }
+
+  @Override
+  public void selectedMayContainUnseenGroups(SeenGroupIds seenGroupIds) {
+    state.enableGroupIdTracking(seenGroupIds);
+  }
+
+  @Override
+  public GroupingAggregatorFunction.PreparedForEvaluation prepareEvaluateIntermediate(
+      IntVector selected, GroupingAggregatorEvaluationContext ctx) {
+    return this::evaluateIntermediate;
+  }
+
+  private void evaluateIntermediate(Block[] blocks, int offset, IntVector selectedInPage) {
+    state.toIntermediate(blocks, offset, selectedInPage, driverContext);
+  }
+
+  @Override
+  public GroupingAggregatorFunction.PreparedForEvaluation prepareEvaluateFinal(IntVector selected,
+      GroupingAggregatorEvaluationContext ctx) {
+    return (blocks, offset, selectedInPage) -> evaluateFinal(blocks, offset, selectedInPage, ctx);
+  }
+
+  private void evaluateFinal(Block[] blocks, int offset, IntVector selectedInPage,
+      GroupingAggregatorEvaluationContext ctx) {
+    blocks[offset] = TopFloatBytesRefAggregator.evaluateFinal(state, selectedInPage, ctx);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName()).append("[");
+    sb.append("channels=").append(channels);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public void close() {
+    state.close();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopIntBytesRefAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopIntBytesRefAggregatorFunction.java
@@ -1,0 +1,287 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.List;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanVector;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.BytesRefVector;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link AggregatorFunction} implementation for {@link TopIntBytesRefAggregator}.
+ * This class is generated. Edit {@code AggregatorImplementer} instead.
+ */
+public final class TopIntBytesRefAggregatorFunction implements AggregatorFunction {
+  private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+      new IntermediateStateDesc("top", ElementType.INT),
+      new IntermediateStateDesc("output", ElementType.BYTES_REF)  );
+
+  private final DriverContext driverContext;
+
+  private final TopIntBytesRefAggregator.SingleState state;
+
+  private final List<Integer> channels;
+
+  private final int limit;
+
+  private final boolean ascending;
+
+  TopIntBytesRefAggregatorFunction(DriverContext driverContext, List<Integer> channels, int limit,
+      boolean ascending) {
+    this.limit = limit;
+    this.ascending = ascending;
+    this.driverContext = driverContext;
+    this.channels = channels;
+    this.state = TopIntBytesRefAggregator.initSingle(driverContext.bigArrays(), limit, ascending);
+  }
+
+  public static List<IntermediateStateDesc> intermediateStateDesc() {
+    return INTERMEDIATE_STATE_DESC;
+  }
+
+  @Override
+  public int intermediateBlockCount() {
+    return INTERMEDIATE_STATE_DESC.size();
+  }
+
+  @Override
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.allFalse()) {
+      // Entire page masked away
+    } else if (mask.allTrue()) {
+      addRawInputNotMasked(page);
+    } else {
+      addRawInputMasked(page, mask);
+    }
+  }
+
+  private void addRawInputMasked(Page page, BooleanVector mask) {
+    IntBlock vBlock = page.getBlock(channels.get(0));
+    BytesRefBlock outputValueBlock = page.getBlock(channels.get(1));
+    IntVector vVector = vBlock.asVector();
+    if (vVector == null) {
+      if (vBlock.areAllValuesNull()) {
+        /*
+         * All values are null so we can skip processing this block.
+         * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+         *       being fast without this. Likely the branch predictor is kicking
+         *       in there. But we do this anyway, just so we don't have to trust
+         *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+         *       always have long sequences of ConstantNullBlock. And this code
+         *       shows readers we've thought about this.
+         */
+        return;
+      }
+      addRawBlock(vBlock, outputValueBlock, mask);
+      return;
+    }
+    BytesRefVector outputValueVector = outputValueBlock.asVector();
+    if (outputValueVector == null) {
+      if (outputValueBlock.areAllValuesNull()) {
+        /*
+         * All values are null so we can skip processing this block.
+         * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+         *       being fast without this. Likely the branch predictor is kicking
+         *       in there. But we do this anyway, just so we don't have to trust
+         *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+         *       always have long sequences of ConstantNullBlock. And this code
+         *       shows readers we've thought about this.
+         */
+        return;
+      }
+      addRawBlock(vBlock, outputValueBlock, mask);
+      return;
+    }
+    addRawVector(vVector, outputValueVector, mask);
+  }
+
+  private void addRawInputNotMasked(Page page) {
+    IntBlock vBlock = page.getBlock(channels.get(0));
+    BytesRefBlock outputValueBlock = page.getBlock(channels.get(1));
+    IntVector vVector = vBlock.asVector();
+    if (vVector == null) {
+      if (vBlock.areAllValuesNull()) {
+        /*
+         * All values are null so we can skip processing this block.
+         * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+         *       being fast without this. Likely the branch predictor is kicking
+         *       in there. But we do this anyway, just so we don't have to trust
+         *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+         *       always have long sequences of ConstantNullBlock. And this code
+         *       shows readers we've thought about this.
+         */
+        return;
+      }
+      addRawBlock(vBlock, outputValueBlock);
+      return;
+    }
+    BytesRefVector outputValueVector = outputValueBlock.asVector();
+    if (outputValueVector == null) {
+      if (outputValueBlock.areAllValuesNull()) {
+        /*
+         * All values are null so we can skip processing this block.
+         * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+         *       being fast without this. Likely the branch predictor is kicking
+         *       in there. But we do this anyway, just so we don't have to trust
+         *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+         *       always have long sequences of ConstantNullBlock. And this code
+         *       shows readers we've thought about this.
+         */
+        return;
+      }
+      addRawBlock(vBlock, outputValueBlock);
+      return;
+    }
+    addRawVector(vVector, outputValueVector);
+  }
+
+  private void addRawVector(IntVector vVector, BytesRefVector outputValueVector) {
+    BytesRef outputValueScratch = new BytesRef();
+    for (int valuesPosition = 0; valuesPosition < vVector.getPositionCount(); valuesPosition++) {
+      int vValue = vVector.getInt(valuesPosition);
+      BytesRef outputValueValue = outputValueVector.getBytesRef(valuesPosition, outputValueScratch);
+      TopIntBytesRefAggregator.combine(state, vValue, outputValueValue);
+    }
+  }
+
+  private void addRawVector(IntVector vVector, BytesRefVector outputValueVector,
+      BooleanVector mask) {
+    BytesRef outputValueScratch = new BytesRef();
+    for (int valuesPosition = 0; valuesPosition < vVector.getPositionCount(); valuesPosition++) {
+      if (mask.getBoolean(valuesPosition) == false) {
+        continue;
+      }
+      int vValue = vVector.getInt(valuesPosition);
+      BytesRef outputValueValue = outputValueVector.getBytesRef(valuesPosition, outputValueScratch);
+      TopIntBytesRefAggregator.combine(state, vValue, outputValueValue);
+    }
+  }
+
+  private void addRawBlock(IntBlock vBlock, BytesRefBlock outputValueBlock) {
+    BytesRef outputValueScratch = new BytesRef();
+    for (int p = 0; p < vBlock.getPositionCount(); p++) {
+      int vValueCount = vBlock.getValueCount(p);
+      if (vValueCount == 0) {
+        continue;
+      }
+      int outputValueValueCount = outputValueBlock.getValueCount(p);
+      if (outputValueValueCount == 0) {
+        continue;
+      }
+      int vStart = vBlock.getFirstValueIndex(p);
+      int vEnd = vStart + vValueCount;
+      for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
+        int vValue = vBlock.getInt(vOffset);
+        int outputValueStart = outputValueBlock.getFirstValueIndex(p);
+        int outputValueEnd = outputValueStart + outputValueValueCount;
+        for (int outputValueOffset = outputValueStart; outputValueOffset < outputValueEnd; outputValueOffset++) {
+          BytesRef outputValueValue = outputValueBlock.getBytesRef(outputValueOffset, outputValueScratch);
+          TopIntBytesRefAggregator.combine(state, vValue, outputValueValue);
+        }
+      }
+    }
+  }
+
+  private void addRawBlock(IntBlock vBlock, BytesRefBlock outputValueBlock, BooleanVector mask) {
+    BytesRef outputValueScratch = new BytesRef();
+    for (int p = 0; p < vBlock.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
+      int vValueCount = vBlock.getValueCount(p);
+      if (vValueCount == 0) {
+        continue;
+      }
+      int outputValueValueCount = outputValueBlock.getValueCount(p);
+      if (outputValueValueCount == 0) {
+        continue;
+      }
+      int vStart = vBlock.getFirstValueIndex(p);
+      int vEnd = vStart + vValueCount;
+      for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
+        int vValue = vBlock.getInt(vOffset);
+        int outputValueStart = outputValueBlock.getFirstValueIndex(p);
+        int outputValueEnd = outputValueStart + outputValueValueCount;
+        for (int outputValueOffset = outputValueStart; outputValueOffset < outputValueEnd; outputValueOffset++) {
+          BytesRef outputValueValue = outputValueBlock.getBytesRef(outputValueOffset, outputValueScratch);
+          TopIntBytesRefAggregator.combine(state, vValue, outputValueValue);
+        }
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(Page page) {
+    assert channels.size() == intermediateBlockCount();
+    assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
+    Block topUncast = page.getBlock(channels.get(0));
+    if (topUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    IntBlock top = (IntBlock) topUncast;
+    assert top.getPositionCount() == 1;
+    Block outputUncast = page.getBlock(channels.get(1));
+    if (outputUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BytesRefBlock output = (BytesRefBlock) outputUncast;
+    assert output.getPositionCount() == 1;
+    BytesRef outputScratch = new BytesRef();
+    TopIntBytesRefAggregator.combineIntermediate(state, top, output);
+  }
+
+  @Override
+  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+    state.toIntermediate(blocks, offset, driverContext);
+  }
+
+  @Override
+  public void evaluateFinal(Block[] blocks, int offset, DriverContext driverContext) {
+    blocks[offset] = TopIntBytesRefAggregator.evaluateFinal(state, driverContext);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName()).append("[");
+    sb.append("channels=").append(channels);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public void close() {
+    state.close();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopIntBytesRefAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopIntBytesRefAggregatorFunctionSupplier.java
@@ -1,0 +1,53 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.util.List;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link AggregatorFunctionSupplier} implementation for {@link TopIntBytesRefAggregator}.
+ * This class is generated. Edit {@code AggregatorFunctionSupplierImplementer} instead.
+ */
+public final class TopIntBytesRefAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
+  private final int limit;
+
+  private final boolean ascending;
+
+  public TopIntBytesRefAggregatorFunctionSupplier(int limit, boolean ascending) {
+    this.limit = limit;
+    this.ascending = ascending;
+  }
+
+  @Override
+  public List<IntermediateStateDesc> nonGroupingIntermediateStateDesc() {
+    return TopIntBytesRefAggregatorFunction.intermediateStateDesc();
+  }
+
+  @Override
+  public List<IntermediateStateDesc> groupingIntermediateStateDesc() {
+    return TopIntBytesRefGroupingAggregatorFunction.intermediateStateDesc();
+  }
+
+  @Override
+  public TopIntBytesRefAggregatorFunction aggregator(DriverContext driverContext,
+      List<Integer> channels) {
+    return new TopIntBytesRefAggregatorFunction(driverContext, channels, limit, ascending);
+  }
+
+  @Override
+  public TopIntBytesRefGroupingAggregatorFunction groupingAggregator(DriverContext driverContext,
+      List<Integer> channels) {
+    return new TopIntBytesRefGroupingAggregatorFunction(channels, driverContext, limit, ascending);
+  }
+
+  @Override
+  public String describe() {
+    return "top_int of bytes";
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopIntBytesRefGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopIntBytesRefGroupingAggregatorFunction.java
@@ -1,0 +1,492 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.List;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.BytesRefVector;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntArrayBlock;
+import org.elasticsearch.compute.data.IntBigArrayBlock;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link GroupingAggregatorFunction} implementation for {@link TopIntBytesRefAggregator}.
+ * This class is generated. Edit {@code GroupingAggregatorImplementer} instead.
+ */
+public final class TopIntBytesRefGroupingAggregatorFunction implements GroupingAggregatorFunction {
+  private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+      new IntermediateStateDesc("top", ElementType.INT),
+      new IntermediateStateDesc("output", ElementType.BYTES_REF)  );
+
+  private final TopIntBytesRefAggregator.GroupingState state;
+
+  private final List<Integer> channels;
+
+  private final DriverContext driverContext;
+
+  private final int limit;
+
+  private final boolean ascending;
+
+  TopIntBytesRefGroupingAggregatorFunction(List<Integer> channels, DriverContext driverContext,
+      int limit, boolean ascending) {
+    this.limit = limit;
+    this.ascending = ascending;
+    this.channels = channels;
+    this.state = TopIntBytesRefAggregator.initGrouping(driverContext.bigArrays(), limit, ascending);
+    this.driverContext = driverContext;
+  }
+
+  public static List<IntermediateStateDesc> intermediateStateDesc() {
+    return INTERMEDIATE_STATE_DESC;
+  }
+
+  @Override
+  public int intermediateBlockCount() {
+    return INTERMEDIATE_STATE_DESC.size();
+  }
+
+  @Override
+  public GroupingAggregatorFunction.AddInput prepareProcessRawInputPage(SeenGroupIds seenGroupIds,
+      Page page) {
+    IntBlock vBlock = page.getBlock(channels.get(0));
+    BytesRefBlock outputValueBlock = page.getBlock(channels.get(1));
+    if (vBlock.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block. But we
+       * still need to track that some groups may not have been seen
+       * so that they are initialized to null when we read their values.
+       */
+      state.enableGroupIdTracking(seenGroupIds);
+      return null;
+    }
+    if (outputValueBlock.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block. But we
+       * still need to track that some groups may not have been seen
+       * so that they are initialized to null when we read their values.
+       */
+      state.enableGroupIdTracking(seenGroupIds);
+      return null;
+    }
+    IntVector vVector = vBlock.asVector();
+    if (vVector == null) {
+      maybeEnableGroupIdTracking(seenGroupIds, vBlock, outputValueBlock);
+      return new GroupingAggregatorFunction.AddInput() {
+        @Override
+        public void add(int positionOffset, IntArrayBlock groupIds) {
+          addRawInput(positionOffset, groupIds, vBlock, outputValueBlock);
+        }
+
+        @Override
+        public void add(int positionOffset, IntBigArrayBlock groupIds) {
+          addRawInput(positionOffset, groupIds, vBlock, outputValueBlock);
+        }
+
+        @Override
+        public void add(int positionOffset, IntVector groupIds) {
+          addRawInput(positionOffset, groupIds, vBlock, outputValueBlock);
+        }
+
+        @Override
+        public void close() {
+        }
+      };
+    }
+    BytesRefVector outputValueVector = outputValueBlock.asVector();
+    if (outputValueVector == null) {
+      maybeEnableGroupIdTracking(seenGroupIds, vBlock, outputValueBlock);
+      return new GroupingAggregatorFunction.AddInput() {
+        @Override
+        public void add(int positionOffset, IntArrayBlock groupIds) {
+          addRawInput(positionOffset, groupIds, vBlock, outputValueBlock);
+        }
+
+        @Override
+        public void add(int positionOffset, IntBigArrayBlock groupIds) {
+          addRawInput(positionOffset, groupIds, vBlock, outputValueBlock);
+        }
+
+        @Override
+        public void add(int positionOffset, IntVector groupIds) {
+          addRawInput(positionOffset, groupIds, vBlock, outputValueBlock);
+        }
+
+        @Override
+        public void close() {
+        }
+      };
+    }
+    return new GroupingAggregatorFunction.AddInput() {
+      @Override
+      public void add(int positionOffset, IntArrayBlock groupIds) {
+        addRawInput(positionOffset, groupIds, vVector, outputValueVector);
+      }
+
+      @Override
+      public void add(int positionOffset, IntBigArrayBlock groupIds) {
+        addRawInput(positionOffset, groupIds, vVector, outputValueVector);
+      }
+
+      @Override
+      public void add(int positionOffset, IntVector groupIds) {
+        addRawInput(positionOffset, groupIds, vVector, outputValueVector);
+      }
+
+      @Override
+      public void close() {
+      }
+    };
+  }
+
+  private void addRawInput(int positionOffset, IntArrayBlock groups, IntBlock vBlock,
+      BytesRefBlock outputValueBlock) {
+    BytesRef outputValueScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      if (vBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      if (outputValueBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int vStart = vBlock.getFirstValueIndex(valuesPosition);
+        int vEnd = vStart + vBlock.getValueCount(valuesPosition);
+        for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
+          int vValue = vBlock.getInt(vOffset);
+          int outputValueStart = outputValueBlock.getFirstValueIndex(valuesPosition);
+          int outputValueEnd = outputValueStart + outputValueBlock.getValueCount(valuesPosition);
+          for (int outputValueOffset = outputValueStart; outputValueOffset < outputValueEnd; outputValueOffset++) {
+            BytesRef outputValueValue = outputValueBlock.getBytesRef(outputValueOffset, outputValueScratch);
+            TopIntBytesRefAggregator.combine(state, groupId, vValue, outputValueValue);
+          }
+        }
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntArrayBlock groups, IntVector vVector,
+      BytesRefVector outputValueVector) {
+    BytesRef outputValueScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int vValue = vVector.getInt(valuesPosition);
+        BytesRef outputValueValue = outputValueVector.getBytesRef(valuesPosition, outputValueScratch);
+        TopIntBytesRefAggregator.combine(state, groupId, vValue, outputValueValue);
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntArrayBlock groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block topUncast = page.getBlock(channels.get(0));
+    if (topUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    IntBlock top = (IntBlock) topUncast;
+    Block outputUncast = page.getBlock(channels.get(1));
+    if (outputUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BytesRefBlock output = (BytesRefBlock) outputUncast;
+    assert top.getPositionCount() == output.getPositionCount();
+    BytesRef outputScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int valuesPosition = groupPosition + positionOffset;
+        TopIntBytesRefAggregator.combineIntermediate(state, groupId, top, output, valuesPosition);
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntBigArrayBlock groups, IntBlock vBlock,
+      BytesRefBlock outputValueBlock) {
+    BytesRef outputValueScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      if (vBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      if (outputValueBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int vStart = vBlock.getFirstValueIndex(valuesPosition);
+        int vEnd = vStart + vBlock.getValueCount(valuesPosition);
+        for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
+          int vValue = vBlock.getInt(vOffset);
+          int outputValueStart = outputValueBlock.getFirstValueIndex(valuesPosition);
+          int outputValueEnd = outputValueStart + outputValueBlock.getValueCount(valuesPosition);
+          for (int outputValueOffset = outputValueStart; outputValueOffset < outputValueEnd; outputValueOffset++) {
+            BytesRef outputValueValue = outputValueBlock.getBytesRef(outputValueOffset, outputValueScratch);
+            TopIntBytesRefAggregator.combine(state, groupId, vValue, outputValueValue);
+          }
+        }
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntBigArrayBlock groups, IntVector vVector,
+      BytesRefVector outputValueVector) {
+    BytesRef outputValueScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int vValue = vVector.getInt(valuesPosition);
+        BytesRef outputValueValue = outputValueVector.getBytesRef(valuesPosition, outputValueScratch);
+        TopIntBytesRefAggregator.combine(state, groupId, vValue, outputValueValue);
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntBigArrayBlock groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block topUncast = page.getBlock(channels.get(0));
+    if (topUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    IntBlock top = (IntBlock) topUncast;
+    Block outputUncast = page.getBlock(channels.get(1));
+    if (outputUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BytesRefBlock output = (BytesRefBlock) outputUncast;
+    assert top.getPositionCount() == output.getPositionCount();
+    BytesRef outputScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int valuesPosition = groupPosition + positionOffset;
+        TopIntBytesRefAggregator.combineIntermediate(state, groupId, top, output, valuesPosition);
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntVector groups, IntBlock vBlock,
+      BytesRefBlock outputValueBlock) {
+    BytesRef outputValueScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int valuesPosition = groupPosition + positionOffset;
+      if (vBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      if (outputValueBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      int groupId = groups.getInt(groupPosition);
+      int vStart = vBlock.getFirstValueIndex(valuesPosition);
+      int vEnd = vStart + vBlock.getValueCount(valuesPosition);
+      for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
+        int vValue = vBlock.getInt(vOffset);
+        int outputValueStart = outputValueBlock.getFirstValueIndex(valuesPosition);
+        int outputValueEnd = outputValueStart + outputValueBlock.getValueCount(valuesPosition);
+        for (int outputValueOffset = outputValueStart; outputValueOffset < outputValueEnd; outputValueOffset++) {
+          BytesRef outputValueValue = outputValueBlock.getBytesRef(outputValueOffset, outputValueScratch);
+          TopIntBytesRefAggregator.combine(state, groupId, vValue, outputValueValue);
+        }
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntVector groups, IntVector vVector,
+      BytesRefVector outputValueVector) {
+    BytesRef outputValueScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int valuesPosition = groupPosition + positionOffset;
+      int groupId = groups.getInt(groupPosition);
+      int vValue = vVector.getInt(valuesPosition);
+      BytesRef outputValueValue = outputValueVector.getBytesRef(valuesPosition, outputValueScratch);
+      TopIntBytesRefAggregator.combine(state, groupId, vValue, outputValueValue);
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block topUncast = page.getBlock(channels.get(0));
+    if (topUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    IntBlock top = (IntBlock) topUncast;
+    Block outputUncast = page.getBlock(channels.get(1));
+    if (outputUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BytesRefBlock output = (BytesRefBlock) outputUncast;
+    assert top.getPositionCount() == output.getPositionCount();
+    BytesRef outputScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int groupId = groups.getInt(groupPosition);
+      int valuesPosition = groupPosition + positionOffset;
+      TopIntBytesRefAggregator.combineIntermediate(state, groupId, top, output, valuesPosition);
+    }
+  }
+
+  private void maybeEnableGroupIdTracking(SeenGroupIds seenGroupIds, IntBlock vBlock,
+      BytesRefBlock outputValueBlock) {
+    if (vBlock.mayHaveNulls()) {
+      /*
+       * Some values in the block are null so some group ids may not
+       * be seen. We need to track which ones so we can initialize
+       * them to null when we read their values.
+       */
+      state.enableGroupIdTracking(seenGroupIds);
+    }
+    if (outputValueBlock.mayHaveNulls()) {
+      /*
+       * Some values in the block are null so some group ids may not
+       * be seen. We need to track which ones so we can initialize
+       * them to null when we read their values.
+       */
+      state.enableGroupIdTracking(seenGroupIds);
+    }
+  }
+
+  @Override
+  public void selectedMayContainUnseenGroups(SeenGroupIds seenGroupIds) {
+    state.enableGroupIdTracking(seenGroupIds);
+  }
+
+  @Override
+  public GroupingAggregatorFunction.PreparedForEvaluation prepareEvaluateIntermediate(
+      IntVector selected, GroupingAggregatorEvaluationContext ctx) {
+    return this::evaluateIntermediate;
+  }
+
+  private void evaluateIntermediate(Block[] blocks, int offset, IntVector selectedInPage) {
+    state.toIntermediate(blocks, offset, selectedInPage, driverContext);
+  }
+
+  @Override
+  public GroupingAggregatorFunction.PreparedForEvaluation prepareEvaluateFinal(IntVector selected,
+      GroupingAggregatorEvaluationContext ctx) {
+    return (blocks, offset, selectedInPage) -> evaluateFinal(blocks, offset, selectedInPage, ctx);
+  }
+
+  private void evaluateFinal(Block[] blocks, int offset, IntVector selectedInPage,
+      GroupingAggregatorEvaluationContext ctx) {
+    blocks[offset] = TopIntBytesRefAggregator.evaluateFinal(state, selectedInPage, ctx);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName()).append("[");
+    sb.append("channels=").append(channels);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public void close() {
+    state.close();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopLongBytesRefAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopLongBytesRefAggregatorFunction.java
@@ -1,0 +1,287 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.List;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanVector;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.BytesRefVector;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.LongVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link AggregatorFunction} implementation for {@link TopLongBytesRefAggregator}.
+ * This class is generated. Edit {@code AggregatorImplementer} instead.
+ */
+public final class TopLongBytesRefAggregatorFunction implements AggregatorFunction {
+  private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+      new IntermediateStateDesc("top", ElementType.LONG),
+      new IntermediateStateDesc("output", ElementType.BYTES_REF)  );
+
+  private final DriverContext driverContext;
+
+  private final TopLongBytesRefAggregator.SingleState state;
+
+  private final List<Integer> channels;
+
+  private final int limit;
+
+  private final boolean ascending;
+
+  TopLongBytesRefAggregatorFunction(DriverContext driverContext, List<Integer> channels, int limit,
+      boolean ascending) {
+    this.limit = limit;
+    this.ascending = ascending;
+    this.driverContext = driverContext;
+    this.channels = channels;
+    this.state = TopLongBytesRefAggregator.initSingle(driverContext.bigArrays(), limit, ascending);
+  }
+
+  public static List<IntermediateStateDesc> intermediateStateDesc() {
+    return INTERMEDIATE_STATE_DESC;
+  }
+
+  @Override
+  public int intermediateBlockCount() {
+    return INTERMEDIATE_STATE_DESC.size();
+  }
+
+  @Override
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.allFalse()) {
+      // Entire page masked away
+    } else if (mask.allTrue()) {
+      addRawInputNotMasked(page);
+    } else {
+      addRawInputMasked(page, mask);
+    }
+  }
+
+  private void addRawInputMasked(Page page, BooleanVector mask) {
+    LongBlock vBlock = page.getBlock(channels.get(0));
+    BytesRefBlock outputValueBlock = page.getBlock(channels.get(1));
+    LongVector vVector = vBlock.asVector();
+    if (vVector == null) {
+      if (vBlock.areAllValuesNull()) {
+        /*
+         * All values are null so we can skip processing this block.
+         * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+         *       being fast without this. Likely the branch predictor is kicking
+         *       in there. But we do this anyway, just so we don't have to trust
+         *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+         *       always have long sequences of ConstantNullBlock. And this code
+         *       shows readers we've thought about this.
+         */
+        return;
+      }
+      addRawBlock(vBlock, outputValueBlock, mask);
+      return;
+    }
+    BytesRefVector outputValueVector = outputValueBlock.asVector();
+    if (outputValueVector == null) {
+      if (outputValueBlock.areAllValuesNull()) {
+        /*
+         * All values are null so we can skip processing this block.
+         * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+         *       being fast without this. Likely the branch predictor is kicking
+         *       in there. But we do this anyway, just so we don't have to trust
+         *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+         *       always have long sequences of ConstantNullBlock. And this code
+         *       shows readers we've thought about this.
+         */
+        return;
+      }
+      addRawBlock(vBlock, outputValueBlock, mask);
+      return;
+    }
+    addRawVector(vVector, outputValueVector, mask);
+  }
+
+  private void addRawInputNotMasked(Page page) {
+    LongBlock vBlock = page.getBlock(channels.get(0));
+    BytesRefBlock outputValueBlock = page.getBlock(channels.get(1));
+    LongVector vVector = vBlock.asVector();
+    if (vVector == null) {
+      if (vBlock.areAllValuesNull()) {
+        /*
+         * All values are null so we can skip processing this block.
+         * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+         *       being fast without this. Likely the branch predictor is kicking
+         *       in there. But we do this anyway, just so we don't have to trust
+         *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+         *       always have long sequences of ConstantNullBlock. And this code
+         *       shows readers we've thought about this.
+         */
+        return;
+      }
+      addRawBlock(vBlock, outputValueBlock);
+      return;
+    }
+    BytesRefVector outputValueVector = outputValueBlock.asVector();
+    if (outputValueVector == null) {
+      if (outputValueBlock.areAllValuesNull()) {
+        /*
+         * All values are null so we can skip processing this block.
+         * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+         *       being fast without this. Likely the branch predictor is kicking
+         *       in there. But we do this anyway, just so we don't have to trust
+         *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+         *       always have long sequences of ConstantNullBlock. And this code
+         *       shows readers we've thought about this.
+         */
+        return;
+      }
+      addRawBlock(vBlock, outputValueBlock);
+      return;
+    }
+    addRawVector(vVector, outputValueVector);
+  }
+
+  private void addRawVector(LongVector vVector, BytesRefVector outputValueVector) {
+    BytesRef outputValueScratch = new BytesRef();
+    for (int valuesPosition = 0; valuesPosition < vVector.getPositionCount(); valuesPosition++) {
+      long vValue = vVector.getLong(valuesPosition);
+      BytesRef outputValueValue = outputValueVector.getBytesRef(valuesPosition, outputValueScratch);
+      TopLongBytesRefAggregator.combine(state, vValue, outputValueValue);
+    }
+  }
+
+  private void addRawVector(LongVector vVector, BytesRefVector outputValueVector,
+      BooleanVector mask) {
+    BytesRef outputValueScratch = new BytesRef();
+    for (int valuesPosition = 0; valuesPosition < vVector.getPositionCount(); valuesPosition++) {
+      if (mask.getBoolean(valuesPosition) == false) {
+        continue;
+      }
+      long vValue = vVector.getLong(valuesPosition);
+      BytesRef outputValueValue = outputValueVector.getBytesRef(valuesPosition, outputValueScratch);
+      TopLongBytesRefAggregator.combine(state, vValue, outputValueValue);
+    }
+  }
+
+  private void addRawBlock(LongBlock vBlock, BytesRefBlock outputValueBlock) {
+    BytesRef outputValueScratch = new BytesRef();
+    for (int p = 0; p < vBlock.getPositionCount(); p++) {
+      int vValueCount = vBlock.getValueCount(p);
+      if (vValueCount == 0) {
+        continue;
+      }
+      int outputValueValueCount = outputValueBlock.getValueCount(p);
+      if (outputValueValueCount == 0) {
+        continue;
+      }
+      int vStart = vBlock.getFirstValueIndex(p);
+      int vEnd = vStart + vValueCount;
+      for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
+        long vValue = vBlock.getLong(vOffset);
+        int outputValueStart = outputValueBlock.getFirstValueIndex(p);
+        int outputValueEnd = outputValueStart + outputValueValueCount;
+        for (int outputValueOffset = outputValueStart; outputValueOffset < outputValueEnd; outputValueOffset++) {
+          BytesRef outputValueValue = outputValueBlock.getBytesRef(outputValueOffset, outputValueScratch);
+          TopLongBytesRefAggregator.combine(state, vValue, outputValueValue);
+        }
+      }
+    }
+  }
+
+  private void addRawBlock(LongBlock vBlock, BytesRefBlock outputValueBlock, BooleanVector mask) {
+    BytesRef outputValueScratch = new BytesRef();
+    for (int p = 0; p < vBlock.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
+      int vValueCount = vBlock.getValueCount(p);
+      if (vValueCount == 0) {
+        continue;
+      }
+      int outputValueValueCount = outputValueBlock.getValueCount(p);
+      if (outputValueValueCount == 0) {
+        continue;
+      }
+      int vStart = vBlock.getFirstValueIndex(p);
+      int vEnd = vStart + vValueCount;
+      for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
+        long vValue = vBlock.getLong(vOffset);
+        int outputValueStart = outputValueBlock.getFirstValueIndex(p);
+        int outputValueEnd = outputValueStart + outputValueValueCount;
+        for (int outputValueOffset = outputValueStart; outputValueOffset < outputValueEnd; outputValueOffset++) {
+          BytesRef outputValueValue = outputValueBlock.getBytesRef(outputValueOffset, outputValueScratch);
+          TopLongBytesRefAggregator.combine(state, vValue, outputValueValue);
+        }
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(Page page) {
+    assert channels.size() == intermediateBlockCount();
+    assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
+    Block topUncast = page.getBlock(channels.get(0));
+    if (topUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    LongBlock top = (LongBlock) topUncast;
+    assert top.getPositionCount() == 1;
+    Block outputUncast = page.getBlock(channels.get(1));
+    if (outputUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BytesRefBlock output = (BytesRefBlock) outputUncast;
+    assert output.getPositionCount() == 1;
+    BytesRef outputScratch = new BytesRef();
+    TopLongBytesRefAggregator.combineIntermediate(state, top, output);
+  }
+
+  @Override
+  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+    state.toIntermediate(blocks, offset, driverContext);
+  }
+
+  @Override
+  public void evaluateFinal(Block[] blocks, int offset, DriverContext driverContext) {
+    blocks[offset] = TopLongBytesRefAggregator.evaluateFinal(state, driverContext);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName()).append("[");
+    sb.append("channels=").append(channels);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public void close() {
+    state.close();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopLongBytesRefAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopLongBytesRefAggregatorFunctionSupplier.java
@@ -1,0 +1,53 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.util.List;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link AggregatorFunctionSupplier} implementation for {@link TopLongBytesRefAggregator}.
+ * This class is generated. Edit {@code AggregatorFunctionSupplierImplementer} instead.
+ */
+public final class TopLongBytesRefAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
+  private final int limit;
+
+  private final boolean ascending;
+
+  public TopLongBytesRefAggregatorFunctionSupplier(int limit, boolean ascending) {
+    this.limit = limit;
+    this.ascending = ascending;
+  }
+
+  @Override
+  public List<IntermediateStateDesc> nonGroupingIntermediateStateDesc() {
+    return TopLongBytesRefAggregatorFunction.intermediateStateDesc();
+  }
+
+  @Override
+  public List<IntermediateStateDesc> groupingIntermediateStateDesc() {
+    return TopLongBytesRefGroupingAggregatorFunction.intermediateStateDesc();
+  }
+
+  @Override
+  public TopLongBytesRefAggregatorFunction aggregator(DriverContext driverContext,
+      List<Integer> channels) {
+    return new TopLongBytesRefAggregatorFunction(driverContext, channels, limit, ascending);
+  }
+
+  @Override
+  public TopLongBytesRefGroupingAggregatorFunction groupingAggregator(DriverContext driverContext,
+      List<Integer> channels) {
+    return new TopLongBytesRefGroupingAggregatorFunction(channels, driverContext, limit, ascending);
+  }
+
+  @Override
+  public String describe() {
+    return "top_long of bytes";
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopLongBytesRefGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopLongBytesRefGroupingAggregatorFunction.java
@@ -1,0 +1,493 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.List;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.BytesRefVector;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntArrayBlock;
+import org.elasticsearch.compute.data.IntBigArrayBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.LongVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link GroupingAggregatorFunction} implementation for {@link TopLongBytesRefAggregator}.
+ * This class is generated. Edit {@code GroupingAggregatorImplementer} instead.
+ */
+public final class TopLongBytesRefGroupingAggregatorFunction implements GroupingAggregatorFunction {
+  private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+      new IntermediateStateDesc("top", ElementType.LONG),
+      new IntermediateStateDesc("output", ElementType.BYTES_REF)  );
+
+  private final TopLongBytesRefAggregator.GroupingState state;
+
+  private final List<Integer> channels;
+
+  private final DriverContext driverContext;
+
+  private final int limit;
+
+  private final boolean ascending;
+
+  TopLongBytesRefGroupingAggregatorFunction(List<Integer> channels, DriverContext driverContext,
+      int limit, boolean ascending) {
+    this.limit = limit;
+    this.ascending = ascending;
+    this.channels = channels;
+    this.state = TopLongBytesRefAggregator.initGrouping(driverContext.bigArrays(), limit, ascending);
+    this.driverContext = driverContext;
+  }
+
+  public static List<IntermediateStateDesc> intermediateStateDesc() {
+    return INTERMEDIATE_STATE_DESC;
+  }
+
+  @Override
+  public int intermediateBlockCount() {
+    return INTERMEDIATE_STATE_DESC.size();
+  }
+
+  @Override
+  public GroupingAggregatorFunction.AddInput prepareProcessRawInputPage(SeenGroupIds seenGroupIds,
+      Page page) {
+    LongBlock vBlock = page.getBlock(channels.get(0));
+    BytesRefBlock outputValueBlock = page.getBlock(channels.get(1));
+    if (vBlock.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block. But we
+       * still need to track that some groups may not have been seen
+       * so that they are initialized to null when we read their values.
+       */
+      state.enableGroupIdTracking(seenGroupIds);
+      return null;
+    }
+    if (outputValueBlock.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block. But we
+       * still need to track that some groups may not have been seen
+       * so that they are initialized to null when we read their values.
+       */
+      state.enableGroupIdTracking(seenGroupIds);
+      return null;
+    }
+    LongVector vVector = vBlock.asVector();
+    if (vVector == null) {
+      maybeEnableGroupIdTracking(seenGroupIds, vBlock, outputValueBlock);
+      return new GroupingAggregatorFunction.AddInput() {
+        @Override
+        public void add(int positionOffset, IntArrayBlock groupIds) {
+          addRawInput(positionOffset, groupIds, vBlock, outputValueBlock);
+        }
+
+        @Override
+        public void add(int positionOffset, IntBigArrayBlock groupIds) {
+          addRawInput(positionOffset, groupIds, vBlock, outputValueBlock);
+        }
+
+        @Override
+        public void add(int positionOffset, IntVector groupIds) {
+          addRawInput(positionOffset, groupIds, vBlock, outputValueBlock);
+        }
+
+        @Override
+        public void close() {
+        }
+      };
+    }
+    BytesRefVector outputValueVector = outputValueBlock.asVector();
+    if (outputValueVector == null) {
+      maybeEnableGroupIdTracking(seenGroupIds, vBlock, outputValueBlock);
+      return new GroupingAggregatorFunction.AddInput() {
+        @Override
+        public void add(int positionOffset, IntArrayBlock groupIds) {
+          addRawInput(positionOffset, groupIds, vBlock, outputValueBlock);
+        }
+
+        @Override
+        public void add(int positionOffset, IntBigArrayBlock groupIds) {
+          addRawInput(positionOffset, groupIds, vBlock, outputValueBlock);
+        }
+
+        @Override
+        public void add(int positionOffset, IntVector groupIds) {
+          addRawInput(positionOffset, groupIds, vBlock, outputValueBlock);
+        }
+
+        @Override
+        public void close() {
+        }
+      };
+    }
+    return new GroupingAggregatorFunction.AddInput() {
+      @Override
+      public void add(int positionOffset, IntArrayBlock groupIds) {
+        addRawInput(positionOffset, groupIds, vVector, outputValueVector);
+      }
+
+      @Override
+      public void add(int positionOffset, IntBigArrayBlock groupIds) {
+        addRawInput(positionOffset, groupIds, vVector, outputValueVector);
+      }
+
+      @Override
+      public void add(int positionOffset, IntVector groupIds) {
+        addRawInput(positionOffset, groupIds, vVector, outputValueVector);
+      }
+
+      @Override
+      public void close() {
+      }
+    };
+  }
+
+  private void addRawInput(int positionOffset, IntArrayBlock groups, LongBlock vBlock,
+      BytesRefBlock outputValueBlock) {
+    BytesRef outputValueScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      if (vBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      if (outputValueBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int vStart = vBlock.getFirstValueIndex(valuesPosition);
+        int vEnd = vStart + vBlock.getValueCount(valuesPosition);
+        for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
+          long vValue = vBlock.getLong(vOffset);
+          int outputValueStart = outputValueBlock.getFirstValueIndex(valuesPosition);
+          int outputValueEnd = outputValueStart + outputValueBlock.getValueCount(valuesPosition);
+          for (int outputValueOffset = outputValueStart; outputValueOffset < outputValueEnd; outputValueOffset++) {
+            BytesRef outputValueValue = outputValueBlock.getBytesRef(outputValueOffset, outputValueScratch);
+            TopLongBytesRefAggregator.combine(state, groupId, vValue, outputValueValue);
+          }
+        }
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntArrayBlock groups, LongVector vVector,
+      BytesRefVector outputValueVector) {
+    BytesRef outputValueScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        long vValue = vVector.getLong(valuesPosition);
+        BytesRef outputValueValue = outputValueVector.getBytesRef(valuesPosition, outputValueScratch);
+        TopLongBytesRefAggregator.combine(state, groupId, vValue, outputValueValue);
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntArrayBlock groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block topUncast = page.getBlock(channels.get(0));
+    if (topUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    LongBlock top = (LongBlock) topUncast;
+    Block outputUncast = page.getBlock(channels.get(1));
+    if (outputUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BytesRefBlock output = (BytesRefBlock) outputUncast;
+    assert top.getPositionCount() == output.getPositionCount();
+    BytesRef outputScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int valuesPosition = groupPosition + positionOffset;
+        TopLongBytesRefAggregator.combineIntermediate(state, groupId, top, output, valuesPosition);
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntBigArrayBlock groups, LongBlock vBlock,
+      BytesRefBlock outputValueBlock) {
+    BytesRef outputValueScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      if (vBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      if (outputValueBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int vStart = vBlock.getFirstValueIndex(valuesPosition);
+        int vEnd = vStart + vBlock.getValueCount(valuesPosition);
+        for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
+          long vValue = vBlock.getLong(vOffset);
+          int outputValueStart = outputValueBlock.getFirstValueIndex(valuesPosition);
+          int outputValueEnd = outputValueStart + outputValueBlock.getValueCount(valuesPosition);
+          for (int outputValueOffset = outputValueStart; outputValueOffset < outputValueEnd; outputValueOffset++) {
+            BytesRef outputValueValue = outputValueBlock.getBytesRef(outputValueOffset, outputValueScratch);
+            TopLongBytesRefAggregator.combine(state, groupId, vValue, outputValueValue);
+          }
+        }
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntBigArrayBlock groups, LongVector vVector,
+      BytesRefVector outputValueVector) {
+    BytesRef outputValueScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        long vValue = vVector.getLong(valuesPosition);
+        BytesRef outputValueValue = outputValueVector.getBytesRef(valuesPosition, outputValueScratch);
+        TopLongBytesRefAggregator.combine(state, groupId, vValue, outputValueValue);
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntBigArrayBlock groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block topUncast = page.getBlock(channels.get(0));
+    if (topUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    LongBlock top = (LongBlock) topUncast;
+    Block outputUncast = page.getBlock(channels.get(1));
+    if (outputUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BytesRefBlock output = (BytesRefBlock) outputUncast;
+    assert top.getPositionCount() == output.getPositionCount();
+    BytesRef outputScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int valuesPosition = groupPosition + positionOffset;
+        TopLongBytesRefAggregator.combineIntermediate(state, groupId, top, output, valuesPosition);
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntVector groups, LongBlock vBlock,
+      BytesRefBlock outputValueBlock) {
+    BytesRef outputValueScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int valuesPosition = groupPosition + positionOffset;
+      if (vBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      if (outputValueBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      int groupId = groups.getInt(groupPosition);
+      int vStart = vBlock.getFirstValueIndex(valuesPosition);
+      int vEnd = vStart + vBlock.getValueCount(valuesPosition);
+      for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
+        long vValue = vBlock.getLong(vOffset);
+        int outputValueStart = outputValueBlock.getFirstValueIndex(valuesPosition);
+        int outputValueEnd = outputValueStart + outputValueBlock.getValueCount(valuesPosition);
+        for (int outputValueOffset = outputValueStart; outputValueOffset < outputValueEnd; outputValueOffset++) {
+          BytesRef outputValueValue = outputValueBlock.getBytesRef(outputValueOffset, outputValueScratch);
+          TopLongBytesRefAggregator.combine(state, groupId, vValue, outputValueValue);
+        }
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntVector groups, LongVector vVector,
+      BytesRefVector outputValueVector) {
+    BytesRef outputValueScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int valuesPosition = groupPosition + positionOffset;
+      int groupId = groups.getInt(groupPosition);
+      long vValue = vVector.getLong(valuesPosition);
+      BytesRef outputValueValue = outputValueVector.getBytesRef(valuesPosition, outputValueScratch);
+      TopLongBytesRefAggregator.combine(state, groupId, vValue, outputValueValue);
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block topUncast = page.getBlock(channels.get(0));
+    if (topUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    LongBlock top = (LongBlock) topUncast;
+    Block outputUncast = page.getBlock(channels.get(1));
+    if (outputUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BytesRefBlock output = (BytesRefBlock) outputUncast;
+    assert top.getPositionCount() == output.getPositionCount();
+    BytesRef outputScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int groupId = groups.getInt(groupPosition);
+      int valuesPosition = groupPosition + positionOffset;
+      TopLongBytesRefAggregator.combineIntermediate(state, groupId, top, output, valuesPosition);
+    }
+  }
+
+  private void maybeEnableGroupIdTracking(SeenGroupIds seenGroupIds, LongBlock vBlock,
+      BytesRefBlock outputValueBlock) {
+    if (vBlock.mayHaveNulls()) {
+      /*
+       * Some values in the block are null so some group ids may not
+       * be seen. We need to track which ones so we can initialize
+       * them to null when we read their values.
+       */
+      state.enableGroupIdTracking(seenGroupIds);
+    }
+    if (outputValueBlock.mayHaveNulls()) {
+      /*
+       * Some values in the block are null so some group ids may not
+       * be seen. We need to track which ones so we can initialize
+       * them to null when we read their values.
+       */
+      state.enableGroupIdTracking(seenGroupIds);
+    }
+  }
+
+  @Override
+  public void selectedMayContainUnseenGroups(SeenGroupIds seenGroupIds) {
+    state.enableGroupIdTracking(seenGroupIds);
+  }
+
+  @Override
+  public GroupingAggregatorFunction.PreparedForEvaluation prepareEvaluateIntermediate(
+      IntVector selected, GroupingAggregatorEvaluationContext ctx) {
+    return this::evaluateIntermediate;
+  }
+
+  private void evaluateIntermediate(Block[] blocks, int offset, IntVector selectedInPage) {
+    state.toIntermediate(blocks, offset, selectedInPage, driverContext);
+  }
+
+  @Override
+  public GroupingAggregatorFunction.PreparedForEvaluation prepareEvaluateFinal(IntVector selected,
+      GroupingAggregatorEvaluationContext ctx) {
+    return (blocks, offset, selectedInPage) -> evaluateFinal(blocks, offset, selectedInPage, ctx);
+  }
+
+  private void evaluateFinal(Block[] blocks, int offset, IntVector selectedInPage,
+      GroupingAggregatorEvaluationContext ctx) {
+    blocks[offset] = TopLongBytesRefAggregator.evaluateFinal(state, selectedInPage, ctx);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName()).append("[");
+    sb.append("channels=").append(channels);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public void close() {
+    state.close();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-SampleAggregator.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-SampleAggregator.java.st
@@ -127,7 +127,7 @@ class Sample$Type$Aggregator {
 
         private GroupingState(BigArrays bigArrays, int limit) {
             CircuitBreaker breaker = bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST);
-            this.sort = new BytesRefBucketedSort(breaker, "sample", bigArrays, SortOrder.ASC, limit);
+            this.sort = new BytesRefBucketedSort(bigArrays, SortOrder.ASC, limit);
             boolean success = false;
             try {
                 this.bytesRefBuilder = new BreakingBytesRefBuilder(breaker, "sample");

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-TopAggregator.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-TopAggregator.java.st
@@ -77,7 +77,14 @@ $endif$
         state.add(groupId, v$if(hasOutputField)$, outputValue$endif$);
     }
 
-    public static void combineIntermediate(GroupingState state, int groupId, $Type$Block values, $if(hasOutputField)$$OutputFieldType$Block outputValues, $endif$int position) {
+    public static void combineIntermediate(
+        // comment to make spotless happy about line breaks
+        GroupingState state,
+        int groupId,
+        $Type$Block values,
+        $if(hasOutputField)$$OutputFieldType$Block outputValues,$endif$
+        int position
+    ) {
         int start = values.getFirstValueIndex(position);
         int end = start + values.getValueCount(position);
 $if(hasOutputField && OutputFieldBytesRef)$

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-TopAggregator.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-TopAggregator.java.st
@@ -51,14 +51,17 @@ class Top$Name$$OutputFieldName$Aggregator {
     public static void combineIntermediate(SingleState state, $Type$Block values$if(hasOutputField)$, $OutputFieldType$Block outputValues$endif$) {
         int start = values.getFirstValueIndex(0);
         int end = start + values.getValueCount(0);
+$if(hasOutputField && OutputFieldBytesRef)$
+        var outputScratch = new BytesRef();
+$endif$
 $if(BytesRef || Ip)$
         var scratch = new BytesRef();
         for (int i = start; i < end; i++) {
-            combine(state, values.get$Type$(i, scratch)$if(hasOutputField)$, outputValues.get$OutputFieldType$(i)$endif$);
+            combine(state, values.get$Type$(i, scratch)$if(hasOutputField)$, $if(OutputFieldBytesRef)$outputValues.getBytesRef(i, outputScratch)$else$outputValues.get$OutputFieldType$(i)$endif$$endif$);
         }
 $else$
         for (int i = start; i < end; i++) {
-            combine(state, values.get$Type$(i)$if(hasOutputField)$, outputValues.get$OutputFieldType$(i)$endif$);
+            combine(state, values.get$Type$(i)$if(hasOutputField)$, $if(OutputFieldBytesRef)$outputValues.getBytesRef(i, outputScratch)$else$outputValues.get$OutputFieldType$(i)$endif$$endif$);
         }
 $endif$
     }
@@ -78,14 +81,17 @@ $endif$
     public static void combineIntermediate(GroupingState state, int groupId, $Type$Block values, $if(hasOutputField)$$OutputFieldType$Block outputValues, $endif$int position) {
         int start = values.getFirstValueIndex(position);
         int end = start + values.getValueCount(position);
+$if(hasOutputField && OutputFieldBytesRef)$
+        var outputScratch = new BytesRef();
+$endif$
 $if(BytesRef || Ip)$
         var scratch = new BytesRef();
         for (int i = start; i < end; i++) {
-            combine(state, groupId, values.get$Type$(i, scratch)$if(hasOutputField)$, outputValues.get$OutputFieldType$(i)$endif$);
+            combine(state, groupId, values.get$Type$(i, scratch)$if(hasOutputField)$, $if(OutputFieldBytesRef)$outputValues.getBytesRef(i, outputScratch)$else$outputValues.get$OutputFieldType$(i)$endif$$endif$);
         }
 $else$
         for (int i = start; i < end; i++) {
-            combine(state, groupId, values.get$Type$(i)$if(hasOutputField)$, outputValues.get$OutputFieldType$(i)$endif$);
+            combine(state, groupId, values.get$Type$(i)$if(hasOutputField)$, $if(OutputFieldBytesRef)$outputValues.getBytesRef(i, outputScratch)$else$outputValues.get$OutputFieldType$(i)$endif$$endif$);
         }
 $endif$
     }
@@ -98,7 +104,7 @@ $endif$
         private final $Name$$OutputFieldName$BucketedSort sort;
 
         private GroupingState(BigArrays bigArrays, int limit, boolean ascending) {
-$if(BytesRef)$
+$if(BytesRef && !hasOutputField)$
             // TODO pass the breaker in from the DriverContext
             CircuitBreaker breaker = bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST);
             this.sort = new BytesRefBucketedSort(breaker, "top", bigArrays, ascending ? SortOrder.ASC : SortOrder.DESC, limit);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-TopAggregator.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-TopAggregator.java.st
@@ -9,7 +9,6 @@ package org.elasticsearch.compute.aggregation;
 
 // begin generated imports
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
@@ -104,13 +103,7 @@ $endif$
         private final $Name$$OutputFieldName$BucketedSort sort;
 
         private GroupingState(BigArrays bigArrays, int limit, boolean ascending) {
-$if(BytesRef && !hasOutputField)$
-            // TODO pass the breaker in from the DriverContext
-            CircuitBreaker breaker = bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST);
-            this.sort = new BytesRefBucketedSort(breaker, "top", bigArrays, ascending ? SortOrder.ASC : SortOrder.DESC, limit);
-$else$
             this.sort = new $Name$$OutputFieldName$BucketedSort(bigArrays, ascending ? SortOrder.ASC : SortOrder.DESC, limit);
-$endif$
         }
 
         public void add(int groupId, $type$ value$if(hasOutputField)$, $OutputFieldtype$ outputValue$endif$) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/sort/X-BucketedSort.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/sort/X-BucketedSort.java.st
@@ -143,30 +143,25 @@ $endif$
     public void collect($type$ value, $if(hasExtra)$$Extratype$ extraValue, $endif$int bucket) {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
-$if(hasExtra)$
             if (betterThan(
                 // comment to make spotless happy about line breaks
                 value,
-                $if(BytesRef)$bytesAt(rootIndex)$else$values.get(rootIndex)$endif$,
+                $if(BytesRef)$bytesAt(rootIndex)$else$values.get(rootIndex)$endif$$if(hasExtra)$,
                 extraValue,
                 $if(ExtraBytesRef)$extraBytesAt(rootIndex)$else$extraValues.get(rootIndex)$endif$
+$else$
+$endif$
             )) {
 $if(BytesRef)$
                 clearedBytesAt(rootIndex).append(value);
 $else$
                 values.set(rootIndex, value);
 $endif$
+$if(hasExtra)$
 $if(ExtraBytesRef)$
                 clearedExtraBytesAt(rootIndex).append(extraValue);
 $else$
                 extraValues.set(rootIndex, extraValue);
-$endif$
-$else$
-            if (betterThan(value, $if(BytesRef)$bytesAt(rootIndex)$else$values.get(rootIndex)$endif$)) {
-$if(BytesRef)$
-                clearedBytesAt(rootIndex).append(value);
-$else$
-                values.set(rootIndex, value);
 $endif$
 $endif$
                 downHeap(rootIndex, 0, bucketSize);
@@ -239,35 +234,12 @@ $endif$
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-$if(hasExtra)$
-$if(BytesRef)$
-            BreakingBytesRefBuilder otherValue = other.values.get(i);
             collect(
                 // comment to make spotless happy about line breaks
-                otherValue == null ? new BytesRef() : otherValue.bytesRefView(),
-$if(ExtraBytesRef)$
-                other.extraValues.get(i) == null ? new BytesRef() : other.extraValues.get(i).bytesRefView(),
-$else$
-                other.extraValues.get(i),
-$endif$
+                $if(BytesRef)$other.values.get(i) == null ? new BytesRef() : other.values.get(i).bytesRefView()$else$other.values.get(i)$endif$$if(hasExtra)$,
+                $if(ExtraBytesRef)$other.extraValues.get(i) == null ? new BytesRef() : other.extraValues.get(i).bytesRefView()$else$other.extraValues.get(i)$endif$$endif$,
                 groupId
             );
-$else$
-$if(ExtraBytesRef)$
-            BreakingBytesRefBuilder otherExtra = other.extraValues.get(i);
-            collect(other.values.get(i), otherExtra == null ? new BytesRef() : otherExtra.bytesRefView(), groupId);
-$else$
-            collect(other.values.get(i), other.extraValues.get(i), groupId);
-$endif$
-$endif$
-$else$
-$if(BytesRef)$
-            BreakingBytesRefBuilder otherValue = other.values.get(i);
-            collect(otherValue == null ? new BytesRef() : otherValue.bytesRefView(), groupId);
-$else$
-            collect(other.values.get(i), groupId);
-$endif$
-$endif$
         }
     }
 
@@ -286,17 +258,8 @@ $if(hasExtra)$
         }
 
         try (
-            // comment to make spotless happy about line breaks
-$if(BytesRef)$
-            var builder = blockFactory.newBytesRefBlockBuilder(selected.getPositionCount());
-$else$
             var builder = blockFactory.new$Type$BlockBuilder(selected.getPositionCount());
-$endif$
-$if(ExtraBytesRef)$
-            var extraBuilder = blockFactory.newBytesRefBlockBuilder(selected.getPositionCount())
-$else$
             var extraBuilder = blockFactory.new$ExtraType$BlockBuilder(selected.getPositionCount())
-$endif$
         ) {
             for (int s = 0; s < selected.getPositionCount(); s++) {
                 int bucket = selected.getInt(s);
@@ -370,14 +333,7 @@ $else$
             return blockFactory.newConstantNullBlock(selected.getPositionCount());
         }
 
-        try (
-            // comment to make spotless happy about line breaks
-$if(BytesRef)$
-            var builder = blockFactory.newBytesRefBlockBuilder(selected.getPositionCount())
-$else$
-            var builder = blockFactory.new$Type$BlockBuilder(selected.getPositionCount())
-$endif$
-        ) {
+        try (var builder = blockFactory.new$Type$BlockBuilder(selected.getPositionCount())) {
             for (int s = 0; s < selected.getPositionCount(); s++) {
                 int bucket = selected.getInt(s);
 
@@ -687,42 +643,30 @@ $endif$
             int leftChild = parent * 2 + 1;
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
-$if(hasExtra)$
                 if (betterThan(
                     // comment to make spotless happy about line breaks
                     $if(BytesRef)$bytesAt(worstIndex)$else$values.get(worstIndex)$endif$,
-                    $if(BytesRef)$bytesAt(leftIndex)$else$values.get(leftIndex)$endif$,
+                    $if(BytesRef)$bytesAt(leftIndex)$else$values.get(leftIndex)$endif$$if(hasExtra)$,
                     $if(ExtraBytesRef)$extraBytesAt(worstIndex)$else$extraValues.get(worstIndex)$endif$,
                     $if(ExtraBytesRef)$extraBytesAt(leftIndex)$else$extraValues.get(leftIndex)$endif$
+$else$
+$endif$
                 )) {
-$else$
-$if(BytesRef)$
-                if (betterThan(bytesAt(worstIndex), bytesAt(leftIndex))) {
-$else$
-                if (betterThan(values.get(worstIndex), values.get(leftIndex))) {
-$endif$
-$endif$
                     worst = leftChild;
                     worstIndex = leftIndex;
                 }
                 int rightChild = leftChild + 1;
                 long rightIndex = rootIndex + rightChild;
-$if(hasExtra)$
                 if (rightChild < heapSize
                     && betterThan(
                         // comment to make spotless happy about line breaks
                         $if(BytesRef)$bytesAt(worstIndex)$else$values.get(worstIndex)$endif$,
-                        $if(BytesRef)$bytesAt(rightIndex)$else$values.get(rightIndex)$endif$,
+                        $if(BytesRef)$bytesAt(rightIndex)$else$values.get(rightIndex)$endif$$if(hasExtra)$,
                         $if(ExtraBytesRef)$extraBytesAt(worstIndex)$else$extraValues.get(worstIndex)$endif$,
                         $if(ExtraBytesRef)$extraBytesAt(rightIndex)$else$extraValues.get(rightIndex)$endif$
+$else$
+$endif$
                     )) {
-$else$
-$if(BytesRef)$
-                if (rightChild < heapSize && betterThan(bytesAt(worstIndex), bytesAt(rightIndex))) {
-$else$
-                if (rightChild < heapSize && betterThan(values.get(worstIndex), values.get(rightIndex))) {
-$endif$
-$endif$
                     worst = rightChild;
                     worstIndex = rightIndex;
                 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/sort/X-BucketedSort.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/sort/X-BucketedSort.java.st
@@ -95,11 +95,14 @@ $endif$
 $if(hasExtra)$
 $if(ExtraBytesRef)$
     private ObjectArray<BreakingBytesRefBuilder> extraValues;
+
 $else$
     private $ExtraArray$ extraValues;
-$endif$
-$endif$
 
+$endif$
+$else$
+
+$endif$
     public $Name$$ExtraName$BucketedSort(BigArrays bigArrays, SortOrder order, int bucketSize) {
         this.bigArrays = bigArrays;
 $if(BytesRef || ExtraBytesRef)$
@@ -142,6 +145,7 @@ $endif$
         if (inHeapMode(bucket)) {
 $if(hasExtra)$
             if (betterThan(
+                // comment to make spotless happy about line breaks
                 value,
                 $if(BytesRef)$bytesAt(rootIndex)$else$values.get(rootIndex)$endif$,
                 extraValue,
@@ -239,6 +243,7 @@ $if(hasExtra)$
 $if(BytesRef)$
             BreakingBytesRefBuilder otherValue = other.values.get(i);
             collect(
+                // comment to make spotless happy about line breaks
                 otherValue == null ? new BytesRef() : otherValue.bytesRefView(),
 $if(ExtraBytesRef)$
                 other.extraValues.get(i) == null ? new BytesRef() : other.extraValues.get(i).bytesRefView(),
@@ -281,6 +286,7 @@ $if(hasExtra)$
         }
 
         try (
+            // comment to make spotless happy about line breaks
 $if(BytesRef)$
             var builder = blockFactory.newBytesRefBlockBuilder(selected.getPositionCount());
 $else$
@@ -365,6 +371,7 @@ $else$
         }
 
         try (
+            // comment to make spotless happy about line breaks
 $if(BytesRef)$
             var builder = blockFactory.newBytesRefBlockBuilder(selected.getPositionCount())
 $else$
@@ -571,6 +578,7 @@ $endif$
         assert oldMax % bucketSize == 0;
 
         long newSize = BigArrays.overSize(
+            // comment to make spotless happy about line breaks
             ((long) bucket + 1) * bucketSize,
             $if(BytesRef)$PageCacheRecycler.OBJECT_PAGE_SIZE$else$PageCacheRecycler.$TYPE$_PAGE_SIZE$endif$,
             $if(BytesRef)$org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_REF$else$$BYTES$$endif$
@@ -681,6 +689,7 @@ $endif$
             if (leftChild < heapSize) {
 $if(hasExtra)$
                 if (betterThan(
+                    // comment to make spotless happy about line breaks
                     $if(BytesRef)$bytesAt(worstIndex)$else$values.get(worstIndex)$endif$,
                     $if(BytesRef)$bytesAt(leftIndex)$else$values.get(leftIndex)$endif$,
                     $if(ExtraBytesRef)$extraBytesAt(worstIndex)$else$extraValues.get(worstIndex)$endif$,
@@ -701,6 +710,7 @@ $endif$
 $if(hasExtra)$
                 if (rightChild < heapSize
                     && betterThan(
+                        // comment to make spotless happy about line breaks
                         $if(BytesRef)$bytesAt(worstIndex)$else$values.get(worstIndex)$endif$,
                         $if(BytesRef)$bytesAt(rightIndex)$else$values.get(rightIndex)$endif$,
                         $if(ExtraBytesRef)$extraBytesAt(worstIndex)$else$extraValues.get(worstIndex)$endif$,

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/sort/X-BucketedSort.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/sort/X-BucketedSort.java.st
@@ -158,8 +158,12 @@ $else$
                 extraValues.set(rootIndex, extraValue);
 $endif$
 $else$
-            if (betterThan(value, values.get(rootIndex))) {
+            if (betterThan(value, $if(BytesRef)$bytesAt(rootIndex)$else$values.get(rootIndex)$endif$)) {
+$if(BytesRef)$
+                clearedBytesAt(rootIndex).append(value);
+$else$
                 values.set(rootIndex, value);
+$endif$
 $endif$
                 downHeap(rootIndex, 0, bucketSize);
             }
@@ -252,7 +256,12 @@ $else$
 $endif$
 $endif$
 $else$
+$if(BytesRef)$
+            BreakingBytesRefBuilder otherValue = other.values.get(i);
+            collect(otherValue == null ? new BytesRef() : otherValue.bytesRefView(), groupId);
+$else$
             collect(other.values.get(i), groupId);
+$endif$
 $endif$
         }
     }
@@ -355,7 +364,13 @@ $else$
             return blockFactory.newConstantNullBlock(selected.getPositionCount());
         }
 
-        try (var builder = blockFactory.new$Type$BlockBuilder(selected.getPositionCount())) {
+        try (
+$if(BytesRef)$
+            var builder = blockFactory.newBytesRefBlockBuilder(selected.getPositionCount())
+$else$
+            var builder = blockFactory.new$Type$BlockBuilder(selected.getPositionCount())
+$endif$
+        ) {
             for (int s = 0; s < selected.getPositionCount(); s++) {
                 int bucket = selected.getInt(s);
 
@@ -369,7 +384,11 @@ $else$
                 }
 
                 if (size == 1) {
+$if(BytesRef)$
+                    appendValue(builder, rootIndex);
+$else$
                     builder.append$Type$(values.get(rootIndex));
+$endif$
                     continue;
                 }
 
@@ -381,7 +400,11 @@ $else$
 
                 builder.beginPositionEntry();
                 for (int i = 0; i < size; i++) {
+$if(BytesRef)$
+                    appendValue(builder, rootIndex + i);
+$else$
                     builder.append$Type$(values.get(rootIndex + i));
+$endif$
                 }
                 builder.endPositionEntry();
             }
@@ -664,7 +687,11 @@ $if(hasExtra)$
                     $if(ExtraBytesRef)$extraBytesAt(leftIndex)$else$extraValues.get(leftIndex)$endif$
                 )) {
 $else$
+$if(BytesRef)$
+                if (betterThan(bytesAt(worstIndex), bytesAt(leftIndex))) {
+$else$
                 if (betterThan(values.get(worstIndex), values.get(leftIndex))) {
+$endif$
 $endif$
                     worst = leftChild;
                     worstIndex = leftIndex;
@@ -680,7 +707,11 @@ $if(hasExtra)$
                         $if(ExtraBytesRef)$extraBytesAt(rightIndex)$else$extraValues.get(rightIndex)$endif$
                     )) {
 $else$
+$if(BytesRef)$
+                if (rightChild < heapSize && betterThan(bytesAt(worstIndex), bytesAt(rightIndex))) {
+$else$
                 if (rightChild < heapSize && betterThan(values.get(worstIndex), values.get(rightIndex))) {
+$endif$
 $endif$
                     worst = rightChild;
                     worstIndex = rightIndex;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/sort/X-BucketedSort.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/sort/X-BucketedSort.java.st
@@ -8,16 +8,31 @@
 package org.elasticsearch.compute.data.sort;
 
 // begin generated imports
+$if(BytesRef || ExtraBytesRef)$
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+$endif$
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.BitArray;
-$if(hasExtra && !(long && Extralong))$
+$if(hasExtra && !ExtraBytesRef && !(long && Extralong))$
 import org.elasticsearch.common.util.$ExtraType$Array;
 $endif$
+$if(BytesRef || ExtraBytesRef)$
+import org.elasticsearch.common.util.ObjectArray;
+$endif$
+$if(!BytesRef)$
 import org.elasticsearch.common.util.$Type$Array;
+$endif$
 import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.IntVector;
+$if(BytesRef || ExtraBytesRef)$
+import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
+$endif$
+$if(BytesRef)$
+import org.elasticsearch.common.util.ByteUtils;
+$endif$
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.Tuple;
@@ -35,6 +50,9 @@ import java.util.stream.IntStream;
 public class $Name$$ExtraName$BucketedSort implements Releasable {
 
     private final BigArrays bigArrays;
+$if(BytesRef || ExtraBytesRef)$
+    private final CircuitBreaker breaker;
+$endif$
     private final SortOrder order;
     private final int bucketSize;
     /**
@@ -69,25 +87,41 @@ public class $Name$$ExtraName$BucketedSort implements Releasable {
      *     </li>
      * </ul>
      */
-$if(hasExtra)$
-    private $Array$ values;
-    private $ExtraArray$ extraValues;
-
+$if(BytesRef)$
+    private ObjectArray<BreakingBytesRefBuilder> values;
 $else$
     private $Array$ values;
+$endif$
+$if(hasExtra)$
+$if(ExtraBytesRef)$
+    private ObjectArray<BreakingBytesRefBuilder> extraValues;
+$else$
+    private $ExtraArray$ extraValues;
+$endif$
 $endif$
 
     public $Name$$ExtraName$BucketedSort(BigArrays bigArrays, SortOrder order, int bucketSize) {
         this.bigArrays = bigArrays;
+$if(BytesRef || ExtraBytesRef)$
+        this.breaker = bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST);
+$endif$
         this.order = order;
         this.bucketSize = bucketSize;
         heapMode = new BitArray(0, bigArrays);
 
         boolean success = false;
         try {
+$if(BytesRef)$
+            values = bigArrays.newObjectArray(0);
+$else$
             values = bigArrays.new$Type$Array(0, false);
+$endif$
 $if(hasExtra)$
+$if(ExtraBytesRef)$
+            extraValues = bigArrays.newObjectArray(0);
+$else$
             extraValues = bigArrays.new$ExtraType$Array(0, false);
+$endif$
 $endif$
             success = true;
         } finally {
@@ -106,10 +140,26 @@ $endif$
     public void collect($type$ value, $if(hasExtra)$$Extratype$ extraValue, $endif$int bucket) {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
-            if (betterThan(value, values.get(rootIndex)$if(hasExtra)$, extraValue, extraValues.get(rootIndex)$endif$)) {
-                values.set(rootIndex, value);
 $if(hasExtra)$
+            if (betterThan(
+                value,
+                $if(BytesRef)$bytesAt(rootIndex)$else$values.get(rootIndex)$endif$,
+                extraValue,
+                $if(ExtraBytesRef)$extraBytesAt(rootIndex)$else$extraValues.get(rootIndex)$endif$
+            )) {
+$if(BytesRef)$
+                clearedBytesAt(rootIndex).append(value);
+$else$
+                values.set(rootIndex, value);
+$endif$
+$if(ExtraBytesRef)$
+                clearedExtraBytesAt(rootIndex).append(extraValue);
+$else$
                 extraValues.set(rootIndex, extraValue);
+$endif$
+$else$
+            if (betterThan(value, values.get(rootIndex))) {
+                values.set(rootIndex, value);
 $endif$
                 downHeap(rootIndex, 0, bucketSize);
             }
@@ -124,9 +174,17 @@ $endif$
         assert 0 <= next && next < bucketSize
             : "Expected next to be in the range of valid buckets [0 <= " + next + " < " + bucketSize + "]";
         long index = next + rootIndex;
+$if(BytesRef)$
+        clearedBytesAt(index).append(value);
+$else$
         values.set(index, value);
+$endif$
 $if(hasExtra)$
+$if(ExtraBytesRef)$
+        clearedExtraBytesAt(index).append(extraValue);
+$else$
         extraValues.set(index, extraValue);
+$endif$
 $endif$
         if (next == 0) {
             heapMode.set(bucket);
@@ -173,7 +231,29 @@ $endif$
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            collect(other.values.get(i), $if(hasExtra)$other.extraValues.get(i), $endif$groupId);
+$if(hasExtra)$
+$if(BytesRef)$
+            BreakingBytesRefBuilder otherValue = other.values.get(i);
+            collect(
+                otherValue == null ? new BytesRef() : otherValue.bytesRefView(),
+$if(ExtraBytesRef)$
+                other.extraValues.get(i) == null ? new BytesRef() : other.extraValues.get(i).bytesRefView(),
+$else$
+                other.extraValues.get(i),
+$endif$
+                groupId
+            );
+$else$
+$if(ExtraBytesRef)$
+            BreakingBytesRefBuilder otherExtra = other.extraValues.get(i);
+            collect(other.values.get(i), otherExtra == null ? new BytesRef() : otherExtra.bytesRefView(), groupId);
+$else$
+            collect(other.values.get(i), other.extraValues.get(i), groupId);
+$endif$
+$endif$
+$else$
+            collect(other.values.get(i), groupId);
+$endif$
         }
     }
 
@@ -192,8 +272,16 @@ $if(hasExtra)$
         }
 
         try (
+$if(BytesRef)$
+            var builder = blockFactory.newBytesRefBlockBuilder(selected.getPositionCount());
+$else$
             var builder = blockFactory.new$Type$BlockBuilder(selected.getPositionCount());
+$endif$
+$if(ExtraBytesRef)$
+            var extraBuilder = blockFactory.newBytesRefBlockBuilder(selected.getPositionCount())
+$else$
             var extraBuilder = blockFactory.new$ExtraType$BlockBuilder(selected.getPositionCount())
+$endif$
         ) {
             for (int s = 0; s < selected.getPositionCount(); s++) {
                 int bucket = selected.getInt(s);
@@ -209,8 +297,16 @@ $if(hasExtra)$
                 }
 
                 if (size == 1) {
+$if(BytesRef)$
+                    appendValue(builder, rootIndex);
+$else$
                     builder.append$Type$(values.get(rootIndex));
+$endif$
+$if(ExtraBytesRef)$
+                    appendExtra(extraBuilder, rootIndex);
+$else$
                     extraBuilder.append$ExtraType$(extraValues.get(rootIndex));
+$endif$
                     continue;
                 }
 
@@ -223,8 +319,16 @@ $if(hasExtra)$
                 builder.beginPositionEntry();
                 extraBuilder.beginPositionEntry();
                 for (int i = 0; i < size; i++) {
+$if(BytesRef)$
+                    appendValue(builder, rootIndex + i);
+$else$
                     builder.append$Type$(values.get(rootIndex + i));
+$endif$
+$if(ExtraBytesRef)$
+                    appendExtra(extraBuilder, rootIndex + i);
+$else$
                     extraBuilder.append$ExtraType$(extraValues.get(rootIndex + i));
+$endif$
                 }
                 builder.endPositionEntry();
                 extraBuilder.endPositionEntry();
@@ -286,6 +390,70 @@ $else$
     }
 $endif$
 
+$if(ExtraBytesRef)$
+    private void appendExtra(org.elasticsearch.compute.data.BytesRefBlock.Builder extraBuilder, long index) {
+        BreakingBytesRefBuilder bytes = extraValues.get(index);
+        if (bytes == null) {
+            extraBuilder.appendNull();
+            return;
+        }
+        try {
+            extraBuilder.appendBytesRef(bytes.bytesRefView());
+        } finally {
+            extraValues.set(index, null);
+            Releasables.closeExpectNoException(bytes);
+        }
+    }
+
+    private BreakingBytesRefBuilder clearedExtraBytesAt(long index) {
+        BreakingBytesRefBuilder bytes = extraValues.get(index);
+        if (bytes == null) {
+            bytes = new BreakingBytesRefBuilder(breaker, "top");
+            extraValues.set(index, bytes);
+        } else {
+            bytes.clear();
+        }
+        return bytes;
+    }
+
+    private BytesRef extraBytesAt(long index) {
+        BreakingBytesRefBuilder bytes = extraValues.get(index);
+        return bytes == null ? new BytesRef() : bytes.bytesRefView();
+    }
+
+$endif$
+$if(BytesRef)$
+    private void appendValue(org.elasticsearch.compute.data.BytesRefBlock.Builder builder, long index) {
+        BreakingBytesRefBuilder bytes = values.get(index);
+        if (bytes == null) {
+            builder.appendNull();
+            return;
+        }
+        try {
+            builder.appendBytesRef(bytes.bytesRefView());
+        } finally {
+            values.set(index, null);
+            Releasables.closeExpectNoException(bytes);
+        }
+    }
+
+    private BreakingBytesRefBuilder clearedBytesAt(long index) {
+        BreakingBytesRefBuilder bytes = values.get(index);
+        if (bytes == null) {
+            bytes = new BreakingBytesRefBuilder(breaker, "top");
+            values.set(index, bytes);
+        } else {
+            bytes.clear();
+        }
+        return bytes;
+    }
+
+    private BytesRef bytesAt(long index) {
+        BreakingBytesRefBuilder bytes = values.get(index);
+        return bytes == null ? new BytesRef() : bytes.bytesRefView();
+    }
+
+$endif$
     /**
      * Checks if the selected groups are all empty.
      */
@@ -309,7 +477,11 @@ $endif$
      * at {@code rootIndex}.
      */
     private int getNextGatherOffset(long rootIndex) {
-$if(int)$
+$if(BytesRef)$
+        BreakingBytesRefBuilder bytes = values.get(rootIndex);
+        assert bytes != null && bytes.length() == Integer.BYTES;
+        return ByteUtils.readIntLE(bytes.bytes(), 0);
+$elseif(int)$
         return values.get(rootIndex);
 $else$
         return (int) values.get(rootIndex);
@@ -321,7 +493,11 @@ $endif$
      * at {@code rootIndex}.
      */
     private void setNextGatherOffset(long rootIndex, int offset) {
+$if(BytesRef)$
+        ByteUtils.writeIntLE(offset, values.get(rootIndex).bytes(), 0);
+$else$
         values.set(rootIndex, offset);
+$endif$
     }
 
     /**
@@ -330,12 +506,20 @@ $endif$
      * {@link SortOrder#ASC} and "higher" for {@link SortOrder#DESC}.
      */
     private boolean betterThan($type$ lhs, $type$ rhs$if(hasExtra)$, $Extratype$ lhsExtra, $Extratype$ rhsExtra$endif$) {
+$if(BytesRef)$
+        int res = lhs.compareTo(rhs);
+$else$
         int res = $Wrapper$.compare(lhs, rhs);
+$endif$
 $if(hasExtra)$
         if (res != 0) {
             return getOrder().reverseMul() * res < 0;
         }
+$if(ExtraBytesRef)$
+        res = lhsExtra.compareTo(rhsExtra);
+$else$
         res = $ExtraWrapper$.compare(lhsExtra, rhsExtra);
+$endif$
 $endif$
         return getOrder().reverseMul() * res < 0;
     }
@@ -363,7 +547,11 @@ $endif$
         long oldMax = values.size();
         assert oldMax % bucketSize == 0;
 
-        long newSize = BigArrays.overSize(((long) bucket + 1) * bucketSize, PageCacheRecycler.$TYPE$_PAGE_SIZE, $BYTES$);
+        long newSize = BigArrays.overSize(
+            ((long) bucket + 1) * bucketSize,
+            $if(BytesRef)$PageCacheRecycler.OBJECT_PAGE_SIZE$else$PageCacheRecycler.$TYPE$_PAGE_SIZE$endif$,
+            $if(BytesRef)$org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_REF$else$$BYTES$$endif$
+        );
         // Round up to the next full bucket.
         newSize = (newSize + bucketSize - 1) / bucketSize;
         values = bigArrays.resize(values, newSize * bucketSize);
@@ -379,10 +567,26 @@ $endif$
      * Maintain the "next gather offsets" for newly allocated buckets.
      */
     private void fillGatherOffsets(long startingAt) {
+$if(BytesRef)$
+        assert startingAt % bucketSize == 0;
+        int nextOffset = getBucketSize() - 1;
+        for (long bucketRoot = startingAt; bucketRoot < values.size(); bucketRoot += getBucketSize()) {
+            BreakingBytesRefBuilder bytes = values.get(bucketRoot);
+            if (bytes != null) {
+                continue;
+            }
+            bytes = new BreakingBytesRefBuilder(breaker, "top");
+            values.set(bucketRoot, bytes);
+            bytes.grow(Integer.BYTES);
+            bytes.setLength(Integer.BYTES);
+            ByteUtils.writeIntLE(nextOffset, bytes.bytes(), 0);
+        }
+$else$
         int nextOffset = getBucketSize() - 1;
         for (long bucketRoot = startingAt; bucketRoot < values.size(); bucketRoot += getBucketSize()) {
             setNextGatherOffset(bucketRoot, nextOffset);
         }
+$endif$
     }
 
     /**
@@ -452,7 +656,16 @@ $endif$
             int leftChild = parent * 2 + 1;
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
-                if (betterThan(values.get(worstIndex), values.get(leftIndex)$if(hasExtra)$, extraValues.get(worstIndex), extraValues.get(leftIndex)$endif$)) {
+$if(hasExtra)$
+                if (betterThan(
+                    $if(BytesRef)$bytesAt(worstIndex)$else$values.get(worstIndex)$endif$,
+                    $if(BytesRef)$bytesAt(leftIndex)$else$values.get(leftIndex)$endif$,
+                    $if(ExtraBytesRef)$extraBytesAt(worstIndex)$else$extraValues.get(worstIndex)$endif$,
+                    $if(ExtraBytesRef)$extraBytesAt(leftIndex)$else$extraValues.get(leftIndex)$endif$
+                )) {
+$else$
+                if (betterThan(values.get(worstIndex), values.get(leftIndex))) {
+$endif$
                     worst = leftChild;
                     worstIndex = leftIndex;
                 }
@@ -461,10 +674,10 @@ $endif$
 $if(hasExtra)$
                 if (rightChild < heapSize
                     && betterThan(
-                        values.get(worstIndex),
-                        values.get(rightIndex),
-                        extraValues.get(worstIndex),
-                        extraValues.get(rightIndex)
+                        $if(BytesRef)$bytesAt(worstIndex)$else$values.get(worstIndex)$endif$,
+                        $if(BytesRef)$bytesAt(rightIndex)$else$values.get(rightIndex)$endif$,
+                        $if(ExtraBytesRef)$extraBytesAt(worstIndex)$else$extraValues.get(worstIndex)$endif$,
+                        $if(ExtraBytesRef)$extraBytesAt(rightIndex)$else$extraValues.get(rightIndex)$endif$
                     )) {
 $else$
                 if (rightChild < heapSize && betterThan(values.get(worstIndex), values.get(rightIndex))) {
@@ -483,6 +696,20 @@ $endif$
 
     @Override
     public final void close() {
+$if(ExtraBytesRef)$
+        if (extraValues != null) {
+            for (long i = 0; i < extraValues.size(); i++) {
+                Releasables.close(extraValues.get(i));
+            }
+        }
+$endif$
+$if(BytesRef)$
+        if (values != null) {
+            for (long i = 0; i < values.size(); i++) {
+                Releasables.close(values.get(i));
+            }
+        }
+$endif$
         Releasables.close(values, $if(hasExtra)$extraValues, $endif$heapMode);
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/sort/X-BucketedSort.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/sort/X-BucketedSort.java.st
@@ -143,15 +143,11 @@ $endif$
     public void collect($type$ value, $if(hasExtra)$$Extratype$ extraValue, $endif$int bucket) {
         long rootIndex = (long) bucket * bucketSize;
         if (inHeapMode(bucket)) {
-            if (betterThan(
-                // comment to make spotless happy about line breaks
-                value,
-                $if(BytesRef)$bytesAt(rootIndex)$else$values.get(rootIndex)$endif$$if(hasExtra)$,
-                extraValue,
-                $if(ExtraBytesRef)$extraBytesAt(rootIndex)$else$extraValues.get(rootIndex)$endif$
-$else$
+            $type$ rootValue = $if(BytesRef)$bytesAt(rootIndex)$else$values.get(rootIndex)$endif$;
+$if(hasExtra)$
+            $Extratype$ rootExtra = $if(ExtraBytesRef)$extraBytesAt(rootIndex)$else$extraValues.get(rootIndex)$endif$;
 $endif$
-            )) {
+            if (betterThan(value, rootValue$if(hasExtra)$, extraValue, rootExtra$endif$)) {
 $if(BytesRef)$
                 clearedBytesAt(rootIndex).append(value);
 $else$
@@ -234,12 +230,19 @@ $endif$
 
         // TODO: This can be improved for heapified buckets by making use of the heap structures
         for (long i = otherBounds.v1(); i < otherBounds.v2(); i++) {
-            collect(
-                // comment to make spotless happy about line breaks
-                $if(BytesRef)$other.values.get(i) == null ? new BytesRef() : other.values.get(i).bytesRefView()$else$other.values.get(i)$endif$$if(hasExtra)$,
-                $if(ExtraBytesRef)$other.extraValues.get(i) == null ? new BytesRef() : other.extraValues.get(i).bytesRefView()$else$other.extraValues.get(i)$endif$$endif$,
-                groupId
-            );
+$if(BytesRef)$
+            $type$ otherValue = other.values.get(i) == null ? new BytesRef() : other.values.get(i).bytesRefView();
+$else$
+            $type$ otherValue = other.values.get(i);
+$endif$
+$if(hasExtra)$
+$if(ExtraBytesRef)$
+            $Extratype$ otherExtra = other.extraValues.get(i) == null ? new BytesRef() : other.extraValues.get(i).bytesRefView();
+$else$
+            $Extratype$ otherExtra = other.extraValues.get(i);
+$endif$
+$endif$
+            collect(otherValue$if(hasExtra)$, otherExtra$endif$, groupId);
         }
     }
 
@@ -533,12 +536,9 @@ $endif$
         long oldMax = values.size();
         assert oldMax % bucketSize == 0;
 
-        long newSize = BigArrays.overSize(
-            // comment to make spotless happy about line breaks
-            ((long) bucket + 1) * bucketSize,
-            $if(BytesRef)$PageCacheRecycler.OBJECT_PAGE_SIZE$else$PageCacheRecycler.$TYPE$_PAGE_SIZE$endif$,
-            $if(BytesRef)$org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_REF$else$$BYTES$$endif$
-        );
+        int pageSize = $if(BytesRef)$PageCacheRecycler.OBJECT_PAGE_SIZE$else$PageCacheRecycler.$TYPE$_PAGE_SIZE$endif$;
+        int bytesPerElement = $BYTES$;
+        long newSize = BigArrays.overSize(((long) bucket + 1) * bucketSize, pageSize, bytesPerElement);
         // Round up to the next full bucket.
         newSize = (newSize + bucketSize - 1) / bucketSize;
         values = bigArrays.resize(values, newSize * bucketSize);
@@ -643,32 +643,29 @@ $endif$
             int leftChild = parent * 2 + 1;
             long leftIndex = rootIndex + leftChild;
             if (leftChild < heapSize) {
-                if (betterThan(
-                    // comment to make spotless happy about line breaks
-                    $if(BytesRef)$bytesAt(worstIndex)$else$values.get(worstIndex)$endif$,
-                    $if(BytesRef)$bytesAt(leftIndex)$else$values.get(leftIndex)$endif$$if(hasExtra)$,
-                    $if(ExtraBytesRef)$extraBytesAt(worstIndex)$else$extraValues.get(worstIndex)$endif$,
-                    $if(ExtraBytesRef)$extraBytesAt(leftIndex)$else$extraValues.get(leftIndex)$endif$
-$else$
+                $type$ worstValue = $if(BytesRef)$bytesAt(worstIndex)$else$values.get(worstIndex)$endif$;
+                $type$ leftValue = $if(BytesRef)$bytesAt(leftIndex)$else$values.get(leftIndex)$endif$;
+$if(hasExtra)$
+                $Extratype$ worstExtra = $if(ExtraBytesRef)$extraBytesAt(worstIndex)$else$extraValues.get(worstIndex)$endif$;
+                $Extratype$ leftExtra = $if(ExtraBytesRef)$extraBytesAt(leftIndex)$else$extraValues.get(leftIndex)$endif$;
 $endif$
-                )) {
+                if (betterThan(worstValue, leftValue$if(hasExtra)$, worstExtra, leftExtra$endif$)) {
                     worst = leftChild;
                     worstIndex = leftIndex;
                 }
                 int rightChild = leftChild + 1;
                 long rightIndex = rootIndex + rightChild;
-                if (rightChild < heapSize
-                    && betterThan(
-                        // comment to make spotless happy about line breaks
-                        $if(BytesRef)$bytesAt(worstIndex)$else$values.get(worstIndex)$endif$,
-                        $if(BytesRef)$bytesAt(rightIndex)$else$values.get(rightIndex)$endif$$if(hasExtra)$,
-                        $if(ExtraBytesRef)$extraBytesAt(worstIndex)$else$extraValues.get(worstIndex)$endif$,
-                        $if(ExtraBytesRef)$extraBytesAt(rightIndex)$else$extraValues.get(rightIndex)$endif$
-$else$
+                if (rightChild < heapSize) {
+                    worstValue = $if(BytesRef)$bytesAt(worstIndex)$else$values.get(worstIndex)$endif$;
+                    $type$ rightValue = $if(BytesRef)$bytesAt(rightIndex)$else$values.get(rightIndex)$endif$;
+$if(hasExtra)$
+                    worstExtra = $if(ExtraBytesRef)$extraBytesAt(worstIndex)$else$extraValues.get(worstIndex)$endif$;
+                    $Extratype$ rightExtra = $if(ExtraBytesRef)$extraBytesAt(rightIndex)$else$extraValues.get(rightIndex)$endif$;
 $endif$
-                    )) {
-                    worst = rightChild;
-                    worstIndex = rightIndex;
+                    if (betterThan(worstValue, rightValue$if(hasExtra)$, worstExtra, rightExtra$endif$)) {
+                        worst = rightChild;
+                        worstIndex = rightIndex;
+                    }
                 }
             }
             if (worst == parent) {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/sort/BytesRefBucketedSortTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/sort/BytesRefBucketedSortTests.java
@@ -9,8 +9,6 @@ package org.elasticsearch.compute.data.sort;
 
 import org.apache.lucene.document.InetAddressPoint;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.breaker.CircuitBreaker;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BytesRefBlock;
@@ -27,14 +25,7 @@ import static org.hamcrest.Matchers.equalTo;
 public class BytesRefBucketedSortTests extends BucketedSortTestCase<BytesRefBucketedSort, BytesRef> {
     @Override
     protected BytesRefBucketedSort build(SortOrder sortOrder, int bucketSize) {
-        BigArrays bigArrays = bigArrays();
-        return new BytesRefBucketedSort(
-            bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST),
-            "test",
-            bigArrays,
-            sortOrder,
-            bucketSize
-        );
+        return new BytesRefBucketedSort(bigArrays(), sortOrder, bucketSize);
     }
 
     @Override

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/expression/function/AbstractFunctionTestCase.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/expression/function/AbstractFunctionTestCase.java
@@ -952,7 +952,7 @@ public abstract class AbstractFunctionTestCase extends ESTestCase {
     }
 
     public static DriverContext driverContext(List<CircuitBreaker> breakers) {
-        BigArrays bigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, ByteSizeValue.ofMb(256)).withCircuitBreaking();
+        BigArrays bigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, ByteSizeValue.ofMb(512)).withCircuitBreaking();
         breakers.add(bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST));
         return new DriverContext(bigArrays, BlockFactory.builder(bigArrays).build(), null);
     }

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats_top.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats_top.csv-spec
@@ -431,3 +431,81 @@ FROM employees
 shortest_employee:integer | tallest_employee:integer
 10020                     | 10094
 ;
+
+fieldNumericOutputFieldKeyword
+required_capability: agg_top_with_output_field_string
+
+FROM employees
+| STATS top_names = TOP(salary, 3, "desc", first_name)
+;
+
+top_names:keyword
+[Otmar, Moss, Tzvetan]
+;
+
+fieldKeywordOutputFieldNumeric
+required_capability: agg_top_with_output_field_string
+
+FROM employees
+| STATS top_salaries = TOP(first_name, 3, "asc", salary)
+;
+
+top_salaries:integer
+[44307, 38645, 60335]
+;
+
+fieldKeywordOutputFieldKeyword
+required_capability: agg_top_with_output_field_string
+
+FROM employees
+| STATS top_last_names = TOP(first_name, 3, "desc", last_name)
+;
+
+top_last_names:keyword
+[Nyanchama, Rosen, Berztiss]
+;
+
+fieldNumericOutputFieldKeywordGrouping
+required_capability: agg_top_with_output_field_string
+
+FROM employees
+| STATS top_names = TOP(salary, 3, "desc", first_name) BY gender
+| SORT gender
+| KEEP gender, top_names
+;
+
+gender:keyword | top_names:keyword
+F              | [Tzvetan, Divier, Valter]
+M              | [Otmar, Moss, Remzi]
+null           | [Lillian, Kazuhito, Cristinel]
+;
+
+fieldKeywordOutputFieldNumericGrouping
+required_capability: agg_top_with_output_field
+
+FROM employees
+| STATS top_salaries = TOP(first_name, 3, "desc", salary) BY gender
+| SORT gender
+| KEEP gender, top_salaries
+;
+
+gender:keyword | top_salaries:integer
+F              | [32272, 37112, 73578]
+M              | [42716, 50128, 28336]
+null           | [48942, 31120, 73717]
+;
+
+fieldKeywordOutputFieldKeywordGrouping
+required_capability: agg_top_with_output_field_string
+
+FROM employees
+| STATS top_last_names = TOP(first_name, 3, "desc", last_name) BY gender
+| SORT gender
+| KEEP gender, top_last_names
+;
+
+gender:keyword | top_last_names:keyword
+F              | [Eugenio, Meriste, Sullins]
+M              | [Nyanchama, Rosen, Berztiss]
+null           | [Bridgland, Sluis, Haddadi]
+;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats_top.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats_top.csv-spec
@@ -481,7 +481,7 @@ null           | [Lillian, Kazuhito, Cristinel]
 ;
 
 fieldKeywordOutputFieldNumericGrouping
-required_capability: agg_top_with_output_field
+required_capability: agg_top_with_output_field_string
 
 FROM employees
 | STATS top_salaries = TOP(first_name, 3, "desc", salary) BY gender

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats_top.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats_top.csv-spec
@@ -433,7 +433,7 @@ shortest_employee:integer | tallest_employee:integer
 ;
 
 fieldNumericOutputFieldKeyword
-required_capability: agg_top_with_output_field_string
+required_capability: fn_top_output_field_string
 
 FROM employees
 | STATS top_names = TOP(salary, 3, "desc", first_name)
@@ -444,7 +444,7 @@ top_names:keyword
 ;
 
 fieldKeywordOutputFieldNumeric
-required_capability: agg_top_with_output_field_string
+required_capability: fn_top_output_field_string
 
 FROM employees
 | STATS top_salaries = TOP(first_name, 3, "asc", salary)
@@ -455,7 +455,7 @@ top_salaries:integer
 ;
 
 fieldKeywordOutputFieldKeyword
-required_capability: agg_top_with_output_field_string
+required_capability: fn_top_output_field_string
 
 FROM employees
 | STATS top_last_names = TOP(first_name, 3, "desc", last_name)
@@ -466,7 +466,7 @@ top_last_names:keyword
 ;
 
 fieldNumericOutputFieldKeywordGrouping
-required_capability: agg_top_with_output_field_string
+required_capability: fn_top_output_field_string
 
 FROM employees
 | STATS top_names = TOP(salary, 3, "desc", first_name) BY gender
@@ -481,7 +481,7 @@ null           | [Lillian, Kazuhito, Cristinel]
 ;
 
 fieldKeywordOutputFieldNumericGrouping
-required_capability: agg_top_with_output_field_string
+required_capability: fn_top_output_field_string
 
 FROM employees
 | STATS top_salaries = TOP(first_name, 3, "desc", salary) BY gender
@@ -496,7 +496,7 @@ null           | [48942, 31120, 73717]
 ;
 
 fieldKeywordOutputFieldKeywordGrouping
-required_capability: agg_top_with_output_field_string
+required_capability: fn_top_output_field_string
 
 FROM employees
 | STATS top_last_names = TOP(first_name, 3, "desc", last_name) BY gender

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -3194,11 +3194,6 @@ public class EsqlCapabilities {
          */
         FIX_TS_BLOCK_LOADER_PASSTHROUGH_ALIASING,
 
-        /**
-         * Support for {@code keyword} and {@code text} fields in {@code TOP} aggregation with outputField.
-         */
-        AGG_TOP_WITH_OUTPUT_FIELD_STRING,
-
         // Last capability should still have a comma for fewer merge conflicts when adding new ones :)
         // This comment prevents the semicolon from being on the previous capability when Spotless formats the file.
         ;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -3194,6 +3194,11 @@ public class EsqlCapabilities {
          */
         FIX_TS_BLOCK_LOADER_PASSTHROUGH_ALIASING,
 
+        /**
+         * Support for {@code keyword} and {@code text} fields in {@code TOP} aggregation with outputField.
+         */
+        AGG_TOP_WITH_OUTPUT_FIELD_STRING,
+
         // Last capability should still have a comma for fewer merge conflicts when adding new ones :)
         // This comment prevents the semicolon from being on the previous capability when Spotless formats the file.
         ;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Top.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Top.java
@@ -13,22 +13,31 @@ import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.compute.aggregation.AggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.TopBooleanAggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.TopBytesRefAggregatorFunctionSupplier;
+import org.elasticsearch.compute.aggregation.TopBytesRefBytesRefAggregatorFunctionSupplier;
+import org.elasticsearch.compute.aggregation.TopBytesRefDoubleAggregatorFunctionSupplier;
+import org.elasticsearch.compute.aggregation.TopBytesRefFloatAggregatorFunctionSupplier;
+import org.elasticsearch.compute.aggregation.TopBytesRefIntAggregatorFunctionSupplier;
+import org.elasticsearch.compute.aggregation.TopBytesRefLongAggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.TopDoubleAggregatorFunctionSupplier;
+import org.elasticsearch.compute.aggregation.TopDoubleBytesRefAggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.TopDoubleDoubleAggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.TopDoubleFloatAggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.TopDoubleIntAggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.TopDoubleLongAggregatorFunctionSupplier;
+import org.elasticsearch.compute.aggregation.TopFloatBytesRefAggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.TopFloatDoubleAggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.TopFloatFloatAggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.TopFloatIntAggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.TopFloatLongAggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.TopIntAggregatorFunctionSupplier;
+import org.elasticsearch.compute.aggregation.TopIntBytesRefAggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.TopIntDoubleAggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.TopIntFloatAggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.TopIntIntAggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.TopIntLongAggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.TopIpAggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.TopLongAggregatorFunctionSupplier;
+import org.elasticsearch.compute.aggregation.TopLongBytesRefAggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.TopLongDoubleAggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.TopLongFloatAggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.TopLongIntAggregatorFunctionSupplier;
@@ -107,7 +116,7 @@ public class Top extends AggregateFunction
         @Param(
             optional = true,
             name = "outputField",
-            type = { "double", "integer", "long", "date" },
+            type = { "double", "integer", "long", "date", "keyword", "text" },
             description = "The extra field that, if present, will be the output of the TOP call instead of `field`."
                 + "{applies_to}`stack: ga 9.3`"
         ) Expression outputField
@@ -196,23 +205,25 @@ public class Top extends AggregateFunction
             typeResolution = typeResolution.and(
                 isType(
                     outputField(),
-                    dt -> dt == DataType.DATETIME || (dt.isNumeric() && dt != DataType.UNSIGNED_LONG),
+                    dt -> dt == DataType.DATETIME || (dt.isNumeric() && dt != DataType.UNSIGNED_LONG) || DataType.isString(dt),
                     sourceText(),
                     FOURTH,
                     "date",
-                    "numeric except unsigned_long or counter types"
+                    "numeric except unsigned_long or counter types",
+                    "string"
                 )
             )
                 .and(
                     isType(
                         field(),
-                        dt -> dt == DataType.DATETIME || (dt.isNumeric() && dt != DataType.UNSIGNED_LONG),
+                        dt -> dt == DataType.DATETIME || (dt.isNumeric() && dt != DataType.UNSIGNED_LONG) || DataType.isString(dt),
                         "when fourth argument is set, ",
                         sourceText(),
                         FIRST,
                         false,
                         "date",
-                        "numeric except unsigned_long or counter types"
+                        "numeric except unsigned_long or counter types",
+                        "string"
                     )
                 );
         }
@@ -361,7 +372,31 @@ public class Top extends AggregateFunction
             Map.entry(Tuple.tuple(DataType.DOUBLE, DataType.INTEGER), TopDoubleIntAggregatorFunctionSupplier::new),
             Map.entry(Tuple.tuple(DataType.DOUBLE, DataType.LONG), TopDoubleLongAggregatorFunctionSupplier::new),
             Map.entry(Tuple.tuple(DataType.DOUBLE, DataType.FLOAT), TopDoubleFloatAggregatorFunctionSupplier::new),
-            Map.entry(Tuple.tuple(DataType.DOUBLE, DataType.DOUBLE), TopDoubleDoubleAggregatorFunctionSupplier::new)
+            Map.entry(Tuple.tuple(DataType.DOUBLE, DataType.DOUBLE), TopDoubleDoubleAggregatorFunctionSupplier::new),
+            Map.entry(Tuple.tuple(DataType.LONG, DataType.KEYWORD), TopLongBytesRefAggregatorFunctionSupplier::new),
+            Map.entry(Tuple.tuple(DataType.LONG, DataType.TEXT), TopLongBytesRefAggregatorFunctionSupplier::new),
+            Map.entry(Tuple.tuple(DataType.DATETIME, DataType.KEYWORD), TopLongBytesRefAggregatorFunctionSupplier::new),
+            Map.entry(Tuple.tuple(DataType.DATETIME, DataType.TEXT), TopLongBytesRefAggregatorFunctionSupplier::new),
+            Map.entry(Tuple.tuple(DataType.INTEGER, DataType.KEYWORD), TopIntBytesRefAggregatorFunctionSupplier::new),
+            Map.entry(Tuple.tuple(DataType.INTEGER, DataType.TEXT), TopIntBytesRefAggregatorFunctionSupplier::new),
+            Map.entry(Tuple.tuple(DataType.DOUBLE, DataType.KEYWORD), TopDoubleBytesRefAggregatorFunctionSupplier::new),
+            Map.entry(Tuple.tuple(DataType.DOUBLE, DataType.TEXT), TopDoubleBytesRefAggregatorFunctionSupplier::new),
+            Map.entry(Tuple.tuple(DataType.FLOAT, DataType.KEYWORD), TopFloatBytesRefAggregatorFunctionSupplier::new),
+            Map.entry(Tuple.tuple(DataType.FLOAT, DataType.TEXT), TopFloatBytesRefAggregatorFunctionSupplier::new),
+            Map.entry(Tuple.tuple(DataType.KEYWORD, DataType.INTEGER), TopBytesRefIntAggregatorFunctionSupplier::new),
+            Map.entry(Tuple.tuple(DataType.TEXT, DataType.INTEGER), TopBytesRefIntAggregatorFunctionSupplier::new),
+            Map.entry(Tuple.tuple(DataType.KEYWORD, DataType.LONG), TopBytesRefLongAggregatorFunctionSupplier::new),
+            Map.entry(Tuple.tuple(DataType.TEXT, DataType.LONG), TopBytesRefLongAggregatorFunctionSupplier::new),
+            Map.entry(Tuple.tuple(DataType.KEYWORD, DataType.DATETIME), TopBytesRefLongAggregatorFunctionSupplier::new),
+            Map.entry(Tuple.tuple(DataType.TEXT, DataType.DATETIME), TopBytesRefLongAggregatorFunctionSupplier::new),
+            Map.entry(Tuple.tuple(DataType.KEYWORD, DataType.FLOAT), TopBytesRefFloatAggregatorFunctionSupplier::new),
+            Map.entry(Tuple.tuple(DataType.TEXT, DataType.FLOAT), TopBytesRefFloatAggregatorFunctionSupplier::new),
+            Map.entry(Tuple.tuple(DataType.KEYWORD, DataType.DOUBLE), TopBytesRefDoubleAggregatorFunctionSupplier::new),
+            Map.entry(Tuple.tuple(DataType.TEXT, DataType.DOUBLE), TopBytesRefDoubleAggregatorFunctionSupplier::new),
+            Map.entry(Tuple.tuple(DataType.KEYWORD, DataType.KEYWORD), TopBytesRefBytesRefAggregatorFunctionSupplier::new),
+            Map.entry(Tuple.tuple(DataType.KEYWORD, DataType.TEXT), TopBytesRefBytesRefAggregatorFunctionSupplier::new),
+            Map.entry(Tuple.tuple(DataType.TEXT, DataType.KEYWORD), TopBytesRefBytesRefAggregatorFunctionSupplier::new),
+            Map.entry(Tuple.tuple(DataType.TEXT, DataType.TEXT), TopBytesRefBytesRefAggregatorFunctionSupplier::new)
         );
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Top.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Top.java
@@ -87,7 +87,10 @@ public class Top extends AggregateFunction
         SurrogateExpression,
         PostOptimizationVerificationAware {
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(Expression.class, "Top", Top::new);
-    public static final FunctionDefinition DEFINITION = FunctionDefinition.def(Top.class).quaternary(Top::new).name("top");
+    public static final FunctionDefinition DEFINITION = FunctionDefinition.def(Top.class)
+        .quaternary(Top::new)
+        .capabilities("output_field_string")
+        .name("top");
 
     private static final String ORDER_ASC = "ASC";
     private static final String ORDER_DESC = "DESC";

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/TopErrorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/TopErrorTests.java
@@ -80,17 +80,17 @@ public class TopErrorTests extends ErrorsForCasesWithoutExamplesTestCase {
                 return equalTo(
                     "fourth argument of ["
                         + sourceForSignature(signature)
-                        + "] must be [date or numeric except unsigned_long or counter types], found value [] type ["
+                        + "] must be [date, numeric except unsigned_long or counter types or string], found value [] type ["
                         + signature.get(3).typeName()
                         + "]"
                 );
             }
             DataType first = signature.getFirst();
-            if (first != DataType.DATETIME && first.isNumeric() == false) {
+            if (first != DataType.DATETIME && first.isNumeric() == false && DataType.isString(first) == false) {
                 return equalTo(
                     "when fourth argument is set, first argument of ["
                         + sourceForSignature(signature)
-                        + "] must be [date or numeric except unsigned_long or counter types], found value [] type ["
+                        + "] must be [date, numeric except unsigned_long or counter types or string], found value [] type ["
                         + first.typeName()
                         + "]"
                 );

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/TopTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/TopTests.java
@@ -67,14 +67,18 @@ public class TopTests extends AbstractAggregationTestCase {
                     MultiRowTestCaseSupplier.intCases(rows, rows, Integer.MIN_VALUE, Integer.MAX_VALUE, true),
                     MultiRowTestCaseSupplier.longCases(rows, rows, Long.MIN_VALUE, Long.MAX_VALUE, true),
                     MultiRowTestCaseSupplier.doubleCases(rows, rows, -Double.MAX_VALUE, Double.MAX_VALUE, true),
-                    MultiRowTestCaseSupplier.dateCases(rows, rows)
+                    MultiRowTestCaseSupplier.dateCases(rows, rows),
+                    MultiRowTestCaseSupplier.stringCases(rows, rows, DataType.KEYWORD),
+                    MultiRowTestCaseSupplier.stringCases(rows, rows, DataType.TEXT)
                 ).flatMap(List::stream).toList();
                 for (var fieldCaseSupplier : fieldCaseSuppliers) {
                     List<TestCaseSupplier.TypedDataSupplier> outputFieldCaseSuppliers = Stream.of(
                         MultiRowTestCaseSupplier.intCases(rows, rows, Integer.MIN_VALUE, Integer.MAX_VALUE, true),
                         MultiRowTestCaseSupplier.longCases(rows, rows, Long.MIN_VALUE, Long.MAX_VALUE, true),
                         MultiRowTestCaseSupplier.doubleCases(rows, rows, -Double.MAX_VALUE, Double.MAX_VALUE, true),
-                        MultiRowTestCaseSupplier.dateCases(rows, rows)
+                        MultiRowTestCaseSupplier.dateCases(rows, rows),
+                        MultiRowTestCaseSupplier.stringCases(rows, rows, DataType.KEYWORD),
+                        MultiRowTestCaseSupplier.stringCases(rows, rows, DataType.TEXT)
                     ).flatMap(List::stream).toList();
                     for (var outputFieldCaseSupplier : outputFieldCaseSuppliers) {
                         if (fieldCaseSupplier.name().equals(outputFieldCaseSupplier.name())) {
@@ -356,7 +360,7 @@ public class TopTests extends AbstractAggregationTestCase {
             dataTypes.add(outputFieldSupplier.type());
         }
 
-        DataType expectedType = outputFieldSupplied ? outputFieldSupplier.type() : fieldSupplier.type();
+        DataType expectedType = outputFieldSupplied ? outputFieldSupplier.type().noText() : fieldSupplier.type();
         String name = fieldSupplier.name() + ", " + limitCaseSupplier.name() + ", " + order;
         if (outputFieldSupplied) {
             name += ", " + outputFieldSupplier.name();


### PR DESCRIPTION
fixes https://github.com/elastic/elasticsearch/issues/151751

The most significant changes are in `X-BucketedSort.java.st`, which now has `BytesRef` support.

Additionally, the hard-rolled `BytesRefBucketedSort` can now be generated too, and therefore is removed.