### PR TITLE
Refactor: unify prefix_properties into a single per-prefix map

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mapping/70_columnar_prefix_dynamic_properties.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mapping/70_columnar_prefix_dynamic_properties.yml
@@ -63,7 +63,7 @@ setup:
       indices.get_mapping:
         index: test_columnar_single_prefix
   - match: { test_columnar_single_prefix.mappings.dynamic: "true" }
-  - match: { test_columnar_single_prefix.mappings.prefix_properties.dynamic.attributes: "false" }
+  - match: { test_columnar_single_prefix.mappings.prefix_properties.attributes.dynamic: "false" }
   - is_true: test_columnar_single_prefix.mappings.properties.attributes\.host
 
   # Unknown field under dynamic:false prefix is silently dropped; known field is indexed
@@ -121,9 +121,9 @@ setup:
       indices.get_mapping:
         index: test_columnar_multi_prefix
   - match: { test_columnar_multi_prefix.mappings.dynamic: "true" }
-  - match: { test_columnar_multi_prefix.mappings.prefix_properties.dynamic.attributes: "false" }
-  - match: { test_columnar_multi_prefix.mappings.prefix_properties.dynamic.resource: "strict" }
-  - match: { test_columnar_multi_prefix.mappings.prefix_properties.dynamic.metrics: "true" }
+  - match: { test_columnar_multi_prefix.mappings.prefix_properties.attributes.dynamic: "false" }
+  - match: { test_columnar_multi_prefix.mappings.prefix_properties.resource.dynamic: "strict" }
+  - match: { test_columnar_multi_prefix.mappings.prefix_properties.metrics.dynamic: "true" }
 
   # dynamic:false drops unknown; dynamic:true auto-maps unknown; known fields always indexed
   - do:
@@ -178,13 +178,13 @@ setup:
             index.mode: columnar
           mappings:
             prefix_properties:
-              dynamic:
-                attributes: "runtime"
+              attributes:
+                dynamic: "runtime"
             properties:
               attributes.host:
                 type: keyword
   - match: { error.type: "mapper_parsing_exception" }
-  - match: { error.reason: "/\\[prefix_properties\\.dynamic\\].does.not.support.\\[runtime\\]/" }
+  - match: { error.reason: "/\\[prefix_properties\\.attributes\\.dynamic\\].does.not.support.\\[runtime\\]/" }
 
 ---
 "columnar: runtime is rejected":
@@ -227,11 +227,12 @@ setup:
   - do:
       indices.get_mapping:
         index: test_columnar_nested_prefix
-  # The full dotted path "a.b" is stored as a literal key in prefix_properties.dynamic;
+  # The full dotted path "a.b" is stored as a literal key in prefix_properties;
   # matching the whole object confirms it is "a.b" and not a nested "a" -> "b" structure.
   - match:
-      test_columnar_nested_prefix.mappings.prefix_properties.dynamic:
-        a.b: "strict"
+      test_columnar_nested_prefix.mappings.prefix_properties:
+        a.b:
+          dynamic: "strict"
 
   # Known field under a.b.c is indexed successfully
   - do:
@@ -296,8 +297,8 @@ setup:
   - do:
       indices.get_mapping:
         index: test_columnar_merge_prefix
-  - match: { test_columnar_merge_prefix.mappings.prefix_properties.dynamic.attributes: "false" }
-  - match: { test_columnar_merge_prefix.mappings.prefix_properties.dynamic.resource: "strict" }
+  - match: { test_columnar_merge_prefix.mappings.prefix_properties.attributes.dynamic: "false" }
+  - match: { test_columnar_merge_prefix.mappings.prefix_properties.resource.dynamic: "strict" }
 
   # dynamic:false drops unknown under attributes after merge
   - do:
@@ -394,7 +395,7 @@ setup:
       indices.get_mapping:
         index: test_logsdb_columnar_single_prefix
   - match: { test_logsdb_columnar_single_prefix.mappings.dynamic: "true" }
-  - match: { test_logsdb_columnar_single_prefix.mappings.prefix_properties.dynamic.attributes: "false" }
+  - match: { test_logsdb_columnar_single_prefix.mappings.prefix_properties.attributes.dynamic: "false" }
 
   # Unknown field under dynamic:false prefix is silently dropped; known field is indexed
   - do:
@@ -453,9 +454,9 @@ setup:
       indices.get_mapping:
         index: test_logsdb_columnar_multi_prefix
   - match: { test_logsdb_columnar_multi_prefix.mappings.dynamic: "true" }
-  - match: { test_logsdb_columnar_multi_prefix.mappings.prefix_properties.dynamic.attributes: "false" }
-  - match: { test_logsdb_columnar_multi_prefix.mappings.prefix_properties.dynamic.resource: "strict" }
-  - match: { test_logsdb_columnar_multi_prefix.mappings.prefix_properties.dynamic.metrics: "true" }
+  - match: { test_logsdb_columnar_multi_prefix.mappings.prefix_properties.attributes.dynamic: "false" }
+  - match: { test_logsdb_columnar_multi_prefix.mappings.prefix_properties.resource.dynamic: "strict" }
+  - match: { test_logsdb_columnar_multi_prefix.mappings.prefix_properties.metrics.dynamic: "true" }
 
   # dynamic:false drops unknown; dynamic:true auto-maps unknown; known fields always indexed
   - do:
@@ -513,9 +514,10 @@ setup:
           mappings:
             dynamic: "true"
             prefix_properties:
-              dynamic:
-                attributes: "false"
-                resource: "strict"
+              attributes:
+                dynamic: "false"
+              resource:
+                dynamic: "strict"
             properties:
               attributes.host:
                 type: keyword
@@ -526,8 +528,8 @@ setup:
       indices.get_mapping:
         index: test_columnar_prefix_props_input
   - match: { test_columnar_prefix_props_input.mappings.dynamic: "true" }
-  - match: { test_columnar_prefix_props_input.mappings.prefix_properties.dynamic.attributes: "false" }
-  - match: { test_columnar_prefix_props_input.mappings.prefix_properties.dynamic.resource: "strict" }
+  - match: { test_columnar_prefix_props_input.mappings.prefix_properties.attributes.dynamic: "false" }
+  - match: { test_columnar_prefix_props_input.mappings.prefix_properties.resource.dynamic: "strict" }
 
   # dynamic:false drops unknown under attributes
   - do:

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
@@ -63,7 +63,7 @@ final class FieldTypeLookup {
         Collection<FieldAliasMapper> fieldAliasMappers,
         Collection<PassThroughFieldSource> passThroughSources,
         Collection<RuntimeField> runtimeFields,
-        Map<String, Integer> passthroughByPrefix
+        Map<String, PrefixProperties> prefixProperties
     ) {
 
         final Map<String, MappedFieldType> fullNameToFieldType = new HashMap<>();
@@ -72,11 +72,11 @@ final class FieldTypeLookup {
         final Map<String, Set<String>> fieldToCopiedFields = new HashMap<>();
         final Set<String> copiedFields = new HashSet<>();
 
-        // For strict columnar mode: build prefix→fieldType with priority-conflict resolution so that
+        // For strict columnar mode: build alias→fieldType with priority-conflict resolution so that
         // short-name aliases can be registered for flat fields that originated from passthrough objects.
         // Conflicts (same alias from two passthroughs) are resolved by keeping the highest priority.
-        Map<String, Integer> ptAliasPriorities = passthroughByPrefix.isEmpty() ? Map.of() : new HashMap<>();
-        Map<String, MappedFieldType> ptAliasTypes = passthroughByPrefix.isEmpty() ? Map.of() : new HashMap<>();
+        Map<String, Integer> ptAliasPriorities = new HashMap<>();
+        Map<String, MappedFieldType> ptAliasTypes = new HashMap<>();
 
         for (FieldMapper fieldMapper : fieldMappers) {
             String fieldName = fieldMapper.fullPath();
@@ -97,12 +97,15 @@ final class FieldTypeLookup {
                 }
                 fieldToCopiedFields.get(targetField).add(fieldName);
             }
-            if (passthroughByPrefix.isEmpty() == false) {
-                for (Map.Entry<String, Integer> ptEntry : passthroughByPrefix.entrySet()) {
+            if (prefixProperties.isEmpty() == false) {
+                for (Map.Entry<String, PrefixProperties> ptEntry : prefixProperties.entrySet()) {
+                    Integer priority = ptEntry.getValue().passthrough();
+                    if (priority == null) {
+                        continue;
+                    }
                     String ptPrefix = ptEntry.getKey() + ".";
                     if (fieldName.startsWith(ptPrefix)) {
                         String alias = fieldName.substring(ptPrefix.length());
-                        int priority = ptEntry.getValue();
                         Integer existing = ptAliasPriorities.get(alias);
                         if (existing == null || priority > existing) {
                             ptAliasPriorities.put(alias, priority);

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
@@ -210,8 +210,8 @@ public final class MappingLookup {
 
         PassThroughObjectMapper.checkForDuplicatePriorities(passThroughSources);
         final Collection<RuntimeField> runtimeFields = mapping.getRoot().runtimeFields();
-        final Map<String, Integer> passthroughByPrefix = mapping.getRoot().getPassthroughByPrefix();
-        this.fieldTypeLookup = new FieldTypeLookup(mappers, aliasMappers, passThroughSources, runtimeFields, passthroughByPrefix);
+        final Map<String, PrefixProperties> prefixProperties = mapping.getRoot().getPrefixProperties();
+        this.fieldTypeLookup = new FieldTypeLookup(mappers, aliasMappers, passThroughSources, runtimeFields, prefixProperties);
 
         Map<String, InferenceFieldMetadata> inferenceFields = new HashMap<>();
         List<String> syntheticVectorFields = new ArrayList<>();
@@ -235,7 +235,7 @@ public final class MappingLookup {
                 aliasMappers,
                 passThroughSources,
                 Collections.emptyList(),
-                passthroughByPrefix
+                prefixProperties
             );
         }
         // make all fields into compact+fast immutable maps

--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -132,18 +132,11 @@ public class ObjectMapper extends Mapper {
         protected Dynamic dynamic;
         protected final List<Mapper.Builder> mappersBuilders = new ArrayList<>();
         /**
-         * Accumulates per-prefix {@code dynamic} values captured during auto-flattening in strict columnar mode.
+         * Accumulates per-prefix settings captured during auto-flattening in strict columnar mode.
          * Populated by {@link #flattenBuildersIfNeeded} when {@link MapperBuilderContext#isStrictColumnar()} is true.
          * Read by {@link RootObjectMapper.Builder#build} to persist the entries so they survive round-trips.
          */
-        protected final Map<String, Dynamic> dynamicByPrefix = new HashMap<>();
-        /**
-         * Accumulates per-prefix passthrough priorities captured during auto-flattening in strict columnar mode.
-         * Populated by {@link #asFlattenedFieldBuilders} when the flattened child is a {@link PassThroughObjectMapper.Builder}.
-         * Read by {@link RootObjectMapper.Builder#build} and persisted under {@code prefix_properties.passthrough} so that
-         * root-level field aliases can be reconstructed by {@link FieldTypeLookup} after a mapping round-trip.
-         */
-        protected final Map<String, Integer> passThroughByPrefix = new HashMap<>();
+        protected final Map<String, PrefixProperties> prefixProperties = new HashMap<>();
 
         public Builder(String name) {
             this(name, Defaults.SUBOBJECTS);
@@ -364,13 +357,7 @@ public class ObjectMapper extends Mapper {
             Map<String, Mapper.Builder> map = new HashMap<>();
             for (Mapper.Builder builder : builders) {
                 if (subobjects.value() == Subobjects.DISABLED && builder instanceof ObjectMapper.Builder objectMapperBuilder) {
-                    objectMapperBuilder.asFlattenedFieldBuilders(
-                        builderContext,
-                        map,
-                        new ContentPath(),
-                        this.dynamicByPrefix,
-                        this.passThroughByPrefix
-                    );
+                    objectMapperBuilder.asFlattenedFieldBuilders(builderContext, map, new ContentPath(), this.prefixProperties);
                 } else {
                     Mapper.Builder existing = map.get(builder.leafName());
                     if (existing != null) {
@@ -387,34 +374,33 @@ public class ObjectMapper extends Mapper {
          * with dotted paths reflecting the hierarchy. Works entirely at the builder level,
          * avoiding the need to build an intermediate ObjectMapper.
          *
-         * @param parentContext    the builder context of the parent object (used for full-path error messages)
-         * @param result           the map to collect flattened field builders into
-         * @param path             tracks the relative path for field renaming
-         * @param dynamicCollector      accumulates per-prefix {@code dynamic} values in strict columnar mode;
-         *                              must be the root builder's {@code dynamicByPrefix} map so all entries
-         *                              from the full nested hierarchy land in one place
-         * @param passThroughCollector  accumulates per-prefix passthrough priorities in strict columnar mode;
-         *                              must be the root builder's {@code passThroughByPrefix} map
+         * @param parentContext the builder context of the parent object (used for full-path error messages)
+         * @param result        the map to collect flattened field builders into
+         * @param path          tracks the relative path for field renaming
+         * @param collector     accumulates per-prefix settings in strict columnar mode;
+         *                      must be the root builder's {@code prefixProperties} map so all entries
+         *                      from the full nested hierarchy land in one place
          */
         private void asFlattenedFieldBuilders(
             MapperBuilderContext parentContext,
             Map<String, Mapper.Builder> result,
             ContentPath path,
-            Map<String, Dynamic> dynamicCollector,
-            Map<String, Integer> passThroughCollector
+            Map<String, PrefixProperties> collector
         ) {
             String fullName = parentContext.buildFullName(path.pathAsText(leafName()));
             ensureBuilderFlattenable(parentContext, fullName);
-            if (parentContext.isStrictColumnar() && dynamic != null) {
-                dynamicCollector.put(fullName, dynamic);
-            }
-            if (parentContext.isStrictColumnar() && this instanceof PassThroughObjectMapper.Builder ptBuilder) {
-                passThroughCollector.put(fullName, ptBuilder.priority);
+            if (parentContext.isStrictColumnar()) {
+                if (dynamic != null) {
+                    collector.merge(fullName, new PrefixProperties(dynamic, null), PrefixProperties::merge);
+                }
+                if (this instanceof PassThroughObjectMapper.Builder ptBuilder) {
+                    collector.merge(fullName, new PrefixProperties(null, ptBuilder.priority), PrefixProperties::merge);
+                }
             }
             path.add(leafName());
             for (Mapper.Builder childBuilder : mappersBuilders) {
                 if (childBuilder instanceof ObjectMapper.Builder objectMapperBuilder) {
-                    objectMapperBuilder.asFlattenedFieldBuilders(parentContext, result, path, dynamicCollector, passThroughCollector);
+                    objectMapperBuilder.asFlattenedFieldBuilders(parentContext, result, path, collector);
                 } else if (childBuilder instanceof FieldMapper.Builder fieldMapperBuilder) {
                     fieldMapperBuilder.setLeafName(path.pathAsText(fieldMapperBuilder.leafName()));
                     result.put(fieldMapperBuilder.leafName(), fieldMapperBuilder);
@@ -425,7 +411,7 @@ public class ObjectMapper extends Mapper {
 
         private void ensureBuilderFlattenable(MapperBuilderContext context, String fullName) {
             // In strict columnar mode, objects with a different dynamic than the parent are allowed;
-            // their declared dynamic is captured in dynamicByPrefix for index-time resolution.
+            // their declared dynamic is captured in prefixProperties for index-time resolution.
             if (dynamic != null && context.getDynamic() != dynamic && context.isStrictColumnar() == false) {
                 throwAutoFlatteningException(
                     fullName,

--- a/server/src/main/java/org/elasticsearch/index/mapper/PrefixProperties.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/PrefixProperties.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.mapper;
+
+/**
+ * Per-prefix object settings captured during auto-flattening in strict columnar mode.
+ * Stored under {@code prefix_properties} in the mapping source, keyed by the full dotted
+ * path of the declared object mapper (e.g. {@code "attributes"}, {@code "resource.sub"}).
+ *
+ * <p>Each facet is nullable — a {@code null} value means the corresponding property was
+ * not declared for this prefix. {@link #merge} prefers the incoming non-null value for
+ * each facet, preserving the existing value when the incoming one is absent.
+ *
+ * @param dynamic     the explicit {@link ObjectMapper.Dynamic} setting for this prefix,
+ *                    or {@code null} if the prefix does not declare an explicit dynamic value
+ * @param passthrough the passthrough priority for this prefix (from a {@link PassThroughObjectMapper}),
+ *                    or {@code null} if the prefix is not a passthrough object
+ */
+record PrefixProperties(ObjectMapper.Dynamic dynamic, Integer passthrough) {
+
+    /**
+     * Merges {@code incoming} into {@code existing}, preferring non-null incoming facets.
+     * This mirrors the semantics of the old per-map {@code putAll} updates: each facet is
+     * independent and the incoming mapping always wins when it supplies a value.
+     */
+    static PrefixProperties merge(PrefixProperties existing, PrefixProperties incoming) {
+        return new PrefixProperties(
+            incoming.dynamic != null ? incoming.dynamic : existing.dynamic,
+            incoming.passthrough != null ? incoming.passthrough : existing.passthrough
+        );
+    }
+
+    /** Returns {@code true} if all facets are {@code null} (this entry carries no information). */
+    boolean isEmpty() {
+        return dynamic == null && passthrough == null;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
@@ -178,16 +178,17 @@ public class RootObjectMapper extends ObjectMapper {
                 // Transfer per-prefix settings parsed from the stored source (prefix_properties key).
                 // When re-parsing a stored flat mapping there are no ObjectMapper.Builder children for
                 // asFlattenedFieldBuilders to harvest, so processField writes directly into the incoming
-                // builder's maps; we copy them here to ensure they are not lost.
-                this.dynamicByPrefix.putAll(rootMergeWith.dynamicByPrefix);
-                this.passThroughByPrefix.putAll(rootMergeWith.passThroughByPrefix);
+                // builder's map; we merge them here to ensure they are not lost.
+                for (Map.Entry<String, PrefixProperties> e : rootMergeWith.prefixProperties.entrySet()) {
+                    this.prefixProperties.merge(e.getKey(), e.getValue(), PrefixProperties::merge);
+                }
             }
         }
 
         @Override
         public RootObjectMapper build(MapperBuilderContext context) {
             // Build child mappers first so that flattenBuildersIfNeeded has a chance to populate
-            // dynamicByPrefix and passThroughByPrefix before we pass them to the RootObjectMapper constructor.
+            // prefixProperties before we pass them to the RootObjectMapper constructor.
             Map<String, Mapper> mappers = buildMappers(context.createChildContext(null, dynamic));
             return new RootObjectMapper(
                 leafName(),
@@ -196,8 +197,7 @@ public class RootObjectMapper extends ObjectMapper {
                 sourceKeepMode,
                 dynamic,
                 mappers,
-                dynamicByPrefix,
-                passThroughByPrefix,
+                prefixProperties,
                 new HashMap<>(runtimeFields),
                 dynamicDateTimeFormatters,
                 dynamicTemplates,
@@ -217,22 +217,14 @@ public class RootObjectMapper extends ObjectMapper {
     private final RootObjectMapperNamespaceValidator namespaceValidator;
     private final boolean sliceEnabled;
     /**
-     * Per-prefix {@code dynamic} settings captured during auto-flattening in strict columnar mode.
+     * Per-prefix settings captured during auto-flattening in strict columnar mode.
      * Keys are the full dotted paths of declared object mappers (e.g. {@code "attributes"},
-     * {@code "resource.sub"}); values are their explicit {@code dynamic} setting. Kept in sorted key
-     * order for longest-prefix resolution and deterministic serialization. Empty for
+     * {@code "resource.sub"}); values hold any combination of {@link PrefixProperties#dynamic}
+     * and {@link PrefixProperties#passthrough} settings for that prefix. Kept in sorted key order
+     * for longest-prefix resolution and deterministic serialization. Empty for
      * non-strict-columnar indices.
      */
-    private final NavigableMap<String, Dynamic> dynamicByPrefix;
-    /**
-     * Per-prefix passthrough priorities captured during auto-flattening in strict columnar mode.
-     * Keys are the full dotted paths of declared passthrough mappers (e.g. {@code "attributes"},
-     * {@code "resource.attributes"}); values are their {@code priority}. Kept in sorted key order
-     * for deterministic serialization. Persisted under {@code prefix_properties.passthrough} so that
-     * {@link FieldTypeLookup} can reconstruct root-level field aliases after a mapping round-trip.
-     * Empty for non-strict-columnar indices.
-     */
-    private final NavigableMap<String, Integer> passthroughByPrefix;
+    private final NavigableMap<String, PrefixProperties> prefixProperties;
 
     RootObjectMapper(
         String name,
@@ -241,8 +233,7 @@ public class RootObjectMapper extends ObjectMapper {
         Optional<SourceKeepMode> sourceKeepMode,
         Dynamic dynamic,
         Map<String, Mapper> mappers,
-        Map<String, Dynamic> dynamicByPrefix,
-        Map<String, Integer> passthroughByPrefix,
+        Map<String, PrefixProperties> prefixProperties,
         Map<String, RuntimeField> runtimeFields,
         Explicit<DateFormatter[]> dynamicDateTimeFormatters,
         Explicit<DynamicTemplate[]> dynamicTemplates,
@@ -259,8 +250,7 @@ public class RootObjectMapper extends ObjectMapper {
         this.numericDetection = numericDetection;
         this.namespaceValidator = namespaceValidator == null ? new DefaultRootObjectMapperNamespaceValidator() : namespaceValidator;
         this.sliceEnabled = sliceEnabled;
-        this.dynamicByPrefix = Collections.unmodifiableNavigableMap(new TreeMap<>(dynamicByPrefix));
-        this.passthroughByPrefix = Collections.unmodifiableNavigableMap(new TreeMap<>(passthroughByPrefix));
+        this.prefixProperties = Collections.unmodifiableNavigableMap(new TreeMap<>(prefixProperties));
     }
 
     @Override
@@ -282,8 +272,7 @@ public class RootObjectMapper extends ObjectMapper {
             sourceKeepMode,
             dynamic,
             Map.of(),
-            dynamicByPrefix,
-            passthroughByPrefix,
+            prefixProperties,
             Map.of(),
             dynamicDateTimeFormatters,
             dynamicTemplates,
@@ -348,7 +337,7 @@ public class RootObjectMapper extends ObjectMapper {
      * @return the resolved dynamic value
      */
     public Dynamic resolveDynamic(String fullPath, Dynamic fallback) {
-        if (dynamicByPrefix.isEmpty()) {
+        if (prefixProperties.isEmpty()) {
             return fallback;
         }
         // headMap(fullPath, inclusive=true) limits candidates to prefixes <= fullPath in sort order.
@@ -356,23 +345,21 @@ public class RootObjectMapper extends ObjectMapper {
         // A prefix matches if it is exactly fullPath or a dotted ancestor of fullPath.
         // TODO: for large prefix sets a trie would reduce scan cost; acceptable for now given the
         // small number of prefixes expected in practice.
-        for (Map.Entry<String, Dynamic> entry : dynamicByPrefix.headMap(fullPath, true).descendingMap().entrySet()) {
+        for (Map.Entry<String, PrefixProperties> entry : prefixProperties.headMap(fullPath, true).descendingMap().entrySet()) {
+            if (entry.getValue().dynamic() == null) {
+                continue; // passthrough-only prefix; skip to find an ancestor that has dynamic set
+            }
             String prefix = entry.getKey();
             if (fullPath.equals(prefix) || fullPath.startsWith(prefix + ".")) {
-                return entry.getValue();
+                return entry.getValue().dynamic();
             }
         }
         return fallback;
     }
 
-    // package-private accessor used in tests
-    Map<String, Dynamic> getDynamicByPrefix() {
-        return dynamicByPrefix;
-    }
-
-    // package-private accessor used by MappingLookup → FieldTypeLookup for prefix-based alias resolution
-    Map<String, Integer> getPassthroughByPrefix() {
-        return passthroughByPrefix;
+    // package-private accessor used by tests and MappingLookup → FieldTypeLookup for prefix-based resolution
+    Map<String, PrefixProperties> getPrefixProperties() {
+        return prefixProperties;
     }
 
     @Override
@@ -416,31 +403,26 @@ public class RootObjectMapper extends ObjectMapper {
             builder.endObject();
         }
 
-        if (dynamicByPrefix.isEmpty() == false || passthroughByPrefix.isEmpty() == false) {
+        if (prefixProperties.isEmpty() == false) {
             // Keys are in sorted order (guaranteed by the NavigableMap field type) for deterministic
             // serialization: the mapping source is byte-compared across nodes, so output order must
             // be stable.
             //
             // "prefix_properties" is an umbrella for per-prefix object settings in strict columnar
-            // mode. To add a new facet (e.g. "enabled") without a stored-format migration: add a
-            // Builder collector to ObjectMapper.Builder (mirror dynamicByPrefix), populate it in
-            // asFlattenedFieldBuilders gated on isStrictColumnar(), store it as a NavigableMap on
-            // RootObjectMapper, serialize/parse it here under prefix_properties.<facet>, and copy
-            // it in Builder#merge via putAll. For "enabled", also turn the enabled=false throw in
-            // ensureBuilderFlattenable into a capture (as was done for heterogeneous dynamic).
-            // Follow-ups tracked in #151524.
+            // mode. Each entry is keyed by the full dotted prefix path and holds its facets as an
+            // object (e.g. {"dynamic": "strict", "passthrough": 1}). To add a new facet (e.g.
+            // "enabled"): add it to the {@link PrefixProperties} record, populate it in
+            // asFlattenedFieldBuilders gated on isStrictColumnar(), serialize/parse it in the loop
+            // below, and propagate it in PrefixProperties#merge. Follow-ups in #151524.
             builder.startObject("prefix_properties");
-            if (dynamicByPrefix.isEmpty() == false) {
-                builder.startObject("dynamic");
-                for (Map.Entry<String, Dynamic> entry : dynamicByPrefix.entrySet()) {
-                    builder.field(entry.getKey(), entry.getValue().name().toLowerCase(Locale.ROOT));
+            for (Map.Entry<String, PrefixProperties> entry : prefixProperties.entrySet()) {
+                PrefixProperties pp = entry.getValue();
+                builder.startObject(entry.getKey());
+                if (pp.dynamic() != null) {
+                    builder.field("dynamic", pp.dynamic().name().toLowerCase(Locale.ROOT));
                 }
-                builder.endObject();
-            }
-            if (passthroughByPrefix.isEmpty() == false) {
-                builder.startObject("passthrough");
-                for (Map.Entry<String, Integer> entry : passthroughByPrefix.entrySet()) {
-                    builder.field(entry.getKey(), entry.getValue());
+                if (pp.passthrough() != null) {
+                    builder.field("passthrough", pp.passthrough());
                 }
                 builder.endObject();
             }
@@ -651,23 +633,24 @@ public class RootObjectMapper extends ObjectMapper {
             if ((fieldNode instanceof Map) == false) {
                 throw new MapperParsingException("[prefix_properties] must be an object");
             }
-            Object dynamicNode = ((Map<String, Object>) fieldNode).get("dynamic");
-            if (dynamicNode != null) {
-                if ((dynamicNode instanceof Map) == false) {
-                    throw new MapperParsingException("[prefix_properties.dynamic] must be an object");
+            for (Map.Entry<String, Object> prefixEntry : ((Map<String, Object>) fieldNode).entrySet()) {
+                String prefix = prefixEntry.getKey();
+                Object prefixNode = prefixEntry.getValue();
+                if ((prefixNode instanceof Map) == false) {
+                    throw new MapperParsingException("[prefix_properties." + prefix + "] must be an object");
                 }
-                for (Map.Entry<String, Object> entry : ((Map<String, Object>) dynamicNode).entrySet()) {
-                    builder.dynamicByPrefix.put(entry.getKey(), parsePrefixDynamic(entry.getKey(), entry.getValue()));
+                Map<String, Object> facets = (Map<String, Object>) prefixNode;
+                Dynamic dynamic = null;
+                Integer passthrough = null;
+                Object dynamicVal = facets.get("dynamic");
+                if (dynamicVal != null) {
+                    dynamic = parsePrefixDynamic(prefix, dynamicVal);
                 }
-            }
-            Object passthroughNode = ((Map<String, Object>) fieldNode).get("passthrough");
-            if (passthroughNode != null) {
-                if ((passthroughNode instanceof Map) == false) {
-                    throw new MapperParsingException("[prefix_properties.passthrough] must be an object");
+                Object passthroughVal = facets.get("passthrough");
+                if (passthroughVal != null) {
+                    passthrough = parsePrefixPassthrough(prefix, passthroughVal);
                 }
-                for (Map.Entry<String, Object> entry : ((Map<String, Object>) passthroughNode).entrySet()) {
-                    builder.passThroughByPrefix.put(entry.getKey(), parsePrefixPassthrough(entry.getKey(), entry.getValue()));
-                }
+                builder.prefixProperties.put(prefix, new PrefixProperties(dynamic, passthrough));
             }
             return true;
         }
@@ -675,22 +658,22 @@ public class RootObjectMapper extends ObjectMapper {
     }
 
     /**
-     * Parses a {@code dynamic} value for use in {@code prefix_properties.dynamic}.
+     * Parses a {@code dynamic} value for use in {@code prefix_properties.<prefix>.dynamic}.
      * Accepts {@code true}, {@code false}, and {@code strict} (case-insensitive).
      * {@code runtime} is explicitly rejected because it is not supported in strict columnar mode.
      */
     private static Dynamic parsePrefixDynamic(String key, Object value) {
         if (value instanceof String == false) {
-            throw new MapperParsingException("[prefix_properties.dynamic." + key + "] must be a string value");
+            throw new MapperParsingException("[prefix_properties." + key + ".dynamic] must be a string value");
         }
         String str = (String) value;
         if (str.equalsIgnoreCase("runtime")) {
-            throw new MapperParsingException("[prefix_properties.dynamic] does not support [runtime] at key [" + key + "]");
+            throw new MapperParsingException("[prefix_properties." + key + ".dynamic] does not support [runtime]");
         }
         try {
             return Dynamic.valueOf(str.toUpperCase(Locale.ROOT));
         } catch (IllegalArgumentException e) {
-            throw new MapperParsingException("unknown [prefix_properties.dynamic] value: [" + str + "] at key [" + key + "]");
+            throw new MapperParsingException("unknown value [" + str + "] for [prefix_properties." + key + ".dynamic]");
         }
     }
 
@@ -704,7 +687,7 @@ public class RootObjectMapper extends ObjectMapper {
         try {
             return Integer.parseInt(String.valueOf(value));
         } catch (NumberFormatException e) {
-            throw new MapperParsingException("[prefix_properties.passthrough." + key + "] must be an integer value");
+            throw new MapperParsingException("[prefix_properties." + key + ".passthrough] must be an integer value");
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/FieldTypeLookupTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FieldTypeLookupTests.java
@@ -621,10 +621,10 @@ public class FieldTypeLookupTests extends ESTestCase {
         assertNull(lookup.get("status"));
     }
 
-    // --- prefix_properties.passthrough-based alias resolution (strict columnar mode path) ---
+    // --- prefix_properties-based alias resolution (strict columnar mode path) ---
 
     /**
-     * When {@code passthroughByPrefix} is populated (strict columnar mode), flat fields whose names
+     * When {@code prefixProperties} is populated (strict columnar mode), flat fields whose names
      * start with a passthrough prefix get short-name root aliases so queries can omit the prefix.
      */
     public void testPrefixBasedAliasForPassthroughByPrefix() {
@@ -636,7 +636,7 @@ public class FieldTypeLookupTests extends ESTestCase {
             List.of(),
             List.of(),
             List.of(),
-            Map.of("attributes", 1)
+            Map.of("attributes", new PrefixProperties(null, 1))
         );
 
         assertSame(envField.fieldType(), lookup.get("env"));
@@ -653,7 +653,13 @@ public class FieldTypeLookupTests extends ESTestCase {
     public void testPrefixBasedAliasMultiSegmentPrefix() {
         MockFieldMapper deepField = new MockFieldMapper("path.to.my.field");
 
-        FieldTypeLookup lookup = new FieldTypeLookup(List.of(deepField), List.of(), List.of(), List.of(), Map.of("path.to", 0));
+        FieldTypeLookup lookup = new FieldTypeLookup(
+            List.of(deepField),
+            List.of(),
+            List.of(),
+            List.of(),
+            Map.of("path.to", new PrefixProperties(null, 0))
+        );
 
         // alias is everything after "path.to." — "my.field", not just "field"
         assertSame(deepField.fieldType(), lookup.get("my.field"));
@@ -672,7 +678,7 @@ public class FieldTypeLookupTests extends ESTestCase {
             List.of(),
             List.of(),
             List.of(),
-            Map.of("attributes", 1, "resource", 2)
+            Map.of("attributes", new PrefixProperties(null, 1), "resource", new PrefixProperties(null, 2))
         );
 
         // resource has priority 2 > 1, so resource.env wins for alias "env"
@@ -680,14 +686,14 @@ public class FieldTypeLookupTests extends ESTestCase {
     }
 
     /**
-     * When no {@code passthroughByPrefix} is provided (empty map), no prefix-based aliases are created.
+     * When no {@code prefixProperties} is provided (empty map), no prefix-based aliases are created.
      */
     public void testNoPrefixBasedAliasWhenPassthroughByPrefixEmpty() {
         MockFieldMapper envField = new MockFieldMapper("attributes.env");
 
         FieldTypeLookup lookup = new FieldTypeLookup(List.of(envField), List.of(), List.of(), List.of(), Map.of());
 
-        assertNull("empty passthroughByPrefix must not create aliases", lookup.get("env"));
+        assertNull("empty prefixProperties must not create aliases", lookup.get("env"));
     }
 
     /**
@@ -702,7 +708,7 @@ public class FieldTypeLookupTests extends ESTestCase {
             List.of(),
             List.of(),
             List.of(),
-            Map.of("attributes", 1)
+            Map.of("attributes", new PrefixProperties(null, 1))
         );
 
         assertSame(rootEnv.fieldType(), lookup.get("env"));

--- a/server/src/test/java/org/elasticsearch/index/mapper/ObjectMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ObjectMapperTests.java
@@ -846,8 +846,8 @@ public class ObjectMapperTests extends MapperServiceTestCase {
             assertNotNull(mapperService.fieldType("resource.service"));
             // Prefix→dynamic map is populated
             RootObjectMapper root = mapperService.mappingLookup().getMapping().getRoot();
-            assertEquals(ObjectMapper.Dynamic.FALSE, root.getDynamicByPrefix().get("attributes"));
-            assertEquals(ObjectMapper.Dynamic.STRICT, root.getDynamicByPrefix().get("resource"));
+            assertEquals(ObjectMapper.Dynamic.FALSE, root.getPrefixProperties().get("attributes").dynamic());
+            assertEquals(ObjectMapper.Dynamic.STRICT, root.getPrefixProperties().get("resource").dynamic());
         }
     }
 
@@ -874,8 +874,8 @@ public class ObjectMapperTests extends MapperServiceTestCase {
                 b.endObject();
             }));
             RootObjectMapper root = mapperService.mappingLookup().getMapping().getRoot();
-            assertEquals(ObjectMapper.Dynamic.FALSE, root.getDynamicByPrefix().get("foo"));
-            assertEquals(ObjectMapper.Dynamic.TRUE, root.getDynamicByPrefix().get("foo.bar"));
+            assertEquals(ObjectMapper.Dynamic.FALSE, root.getPrefixProperties().get("foo").dynamic());
+            assertEquals(ObjectMapper.Dynamic.TRUE, root.getPrefixProperties().get("foo.bar").dynamic());
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/PassThroughObjectMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/PassThroughObjectMapperTests.java
@@ -289,7 +289,7 @@ public class PassThroughObjectMapperTests extends MapperServiceTestCase {
     /**
      * In columnar/logsdb_columnar mode passthrough objects are auto-flattened: their child fields are
      * stored as flat dotted names at root level and the passthrough's prefix+priority are captured in
-     * {@code prefix_properties.passthrough}. {@link FieldTypeLookup} then reconstructs root-level
+     * {@code prefix_properties}. {@link FieldTypeLookup} then reconstructs root-level
      * aliases so that queries can omit the passthrough prefix.
      */
     public void testPassThroughAliasesInColumnarMode() throws IOException {
@@ -309,12 +309,12 @@ public class PassThroughObjectMapperTests extends MapperServiceTestCase {
             // The concrete dotted path must be reachable
             assertNotNull("attributes.env should be a concrete field [" + indexMode + "]", mapperService.fieldType("attributes.env"));
 
-            // The root-level alias must exist via prefix_properties.passthrough
+            // The root-level alias must exist via prefix_properties
             assertNotNull("root alias 'env' should exist via passthrough [" + indexMode + "]", mapperService.fieldType("env"));
 
-            // The passthroughByPrefix map must be populated on the root
-            Map<String, Integer> ptByPrefix = mapperService.mappingLookup().getMapping().getRoot().getPassthroughByPrefix();
-            assertEquals(Integer.valueOf(1), ptByPrefix.get("attributes"));
+            // The prefixProperties map must be populated on the root
+            Map<String, PrefixProperties> pp = mapperService.mappingLookup().getMapping().getRoot().getPrefixProperties();
+            assertEquals(Integer.valueOf(1), pp.get("attributes").passthrough());
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/RootObjectMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RootObjectMapperTests.java
@@ -787,16 +787,16 @@ public class RootObjectMapperTests extends MapperServiceTestCase {
             String mappingJson2 = Strings.toString(mapperService2.documentMapper().mapping());
             assertEquals("prefix_properties must survive round-trip serialization for " + indexMode, mappingJson1, mappingJson2);
 
-            // The stored mapping must contain prefix_properties.dynamic in the expected nested shape
+            // The stored mapping must contain prefix_properties in the expected prefix-keyed shape
             assertThat(mappingJson1, containsString("prefix_properties"));
-            assertThat(mappingJson1, containsString("\"prefix_properties\":{\"dynamic\":{"));
-            assertThat(mappingJson1, containsString("\"attributes\":\"false\""));
-            assertThat(mappingJson1, containsString("\"resource\":\"strict\""));
+            assertThat(mappingJson1, containsString("\"prefix_properties\":{\"attributes\":{"));
+            assertThat(mappingJson1, containsString("\"dynamic\":\"false\""));
+            assertThat(mappingJson1, containsString("\"dynamic\":\"strict\""));
 
-            // The dynamic_by_prefix map must be populated on re-parsed root
+            // The prefixProperties map must be populated on re-parsed root
             RootObjectMapper root2 = mapperService2.mappingLookup().getMapping().getRoot();
-            assertEquals(ObjectMapper.Dynamic.FALSE, root2.getDynamicByPrefix().get("attributes"));
-            assertEquals(ObjectMapper.Dynamic.STRICT, root2.getDynamicByPrefix().get("resource"));
+            assertEquals(ObjectMapper.Dynamic.FALSE, root2.getPrefixProperties().get("attributes").dynamic());
+            assertEquals(ObjectMapper.Dynamic.STRICT, root2.getPrefixProperties().get("resource").dynamic());
         }
     }
 
@@ -829,8 +829,8 @@ public class RootObjectMapperTests extends MapperServiceTestCase {
             }));
 
             RootObjectMapper root = mapperService.documentMapper().mapping().getRoot();
-            assertEquals(ObjectMapper.Dynamic.FALSE, root.getDynamicByPrefix().get("attributes"));
-            assertEquals(ObjectMapper.Dynamic.STRICT, root.getDynamicByPrefix().get("resource"));
+            assertEquals(ObjectMapper.Dynamic.FALSE, root.getPrefixProperties().get("attributes").dynamic());
+            assertEquals(ObjectMapper.Dynamic.STRICT, root.getPrefixProperties().get("resource").dynamic());
         }
     }
 
@@ -866,13 +866,13 @@ public class RootObjectMapperTests extends MapperServiceTestCase {
             assertEquals(
                 "dynamic update on a prefix should be allowed (consistent with object dynamic mutability)",
                 ObjectMapper.Dynamic.STRICT,
-                root.getDynamicByPrefix().get("attributes")
+                root.getPrefixProperties().get("attributes").dynamic()
             );
         }
     }
 
     /**
-     * Verifies that {@code prefix_properties.passthrough} entries survive a serialization/deserialization
+     * Verifies that {@code prefix_properties} passthrough entries survive a serialization/deserialization
      * round-trip so that {@link FieldTypeLookup} can reconstruct root-level aliases after index restart.
      */
     public void testPassthroughByPrefixSerializationRoundTrip() throws Exception {
@@ -901,23 +901,23 @@ public class RootObjectMapperTests extends MapperServiceTestCase {
             // Re-parse and re-serialize — must be identical
             MapperService mapperService2 = createMapperService(settings, mappingJson1);
             String mappingJson2 = Strings.toString(mapperService2.documentMapper().mapping());
-            assertEquals("prefix_properties.passthrough must survive round-trip for " + indexMode, mappingJson1, mappingJson2);
+            assertEquals("prefix_properties passthrough must survive round-trip for " + indexMode, mappingJson1, mappingJson2);
 
-            // The stored mapping must contain prefix_properties.passthrough
+            // The stored mapping must contain prefix_properties in the prefix-keyed shape
             assertThat(mappingJson1, containsString("\"prefix_properties\""));
             assertThat(mappingJson1, containsString("\"passthrough\""));
-            assertThat(mappingJson1, containsString("\"attributes\":1"));
-            assertThat(mappingJson1, containsString("\"resource.attributes\":2"));
+            assertThat(mappingJson1, containsString("\"attributes\":{"));
+            assertThat(mappingJson1, containsString("\"resource.attributes\":{"));
 
             // The map must be populated on the re-parsed root
             RootObjectMapper root2 = mapperService2.mappingLookup().getMapping().getRoot();
-            assertEquals(Integer.valueOf(1), root2.getPassthroughByPrefix().get("attributes"));
-            assertEquals(Integer.valueOf(2), root2.getPassthroughByPrefix().get("resource.attributes"));
+            assertEquals(Integer.valueOf(1), root2.getPrefixProperties().get("attributes").passthrough());
+            assertEquals(Integer.valueOf(2), root2.getPrefixProperties().get("resource.attributes").passthrough());
         }
     }
 
     /**
-     * Verifies that a merge update adds a new passthrough prefix entry to {@code prefix_properties.passthrough}.
+     * Verifies that a merge update adds a new passthrough prefix entry to {@code prefix_properties}.
      */
     public void testPassthroughByPrefixMergeAddsEntry() throws Exception {
         assumeTrue("columnar index mode requires snapshot build", IndexMode.COLUMNAR_FEATURE_FLAG.isEnabled());
@@ -945,8 +945,8 @@ public class RootObjectMapperTests extends MapperServiceTestCase {
             }));
 
             RootObjectMapper root = mapperService.documentMapper().mapping().getRoot();
-            assertEquals(Integer.valueOf(1), root.getPassthroughByPrefix().get("attributes"));
-            assertEquals(Integer.valueOf(2), root.getPassthroughByPrefix().get("resource"));
+            assertEquals(Integer.valueOf(1), root.getPrefixProperties().get("attributes").passthrough());
+            assertEquals(Integer.valueOf(2), root.getPrefixProperties().get("resource").passthrough());
         }
     }
 }

--- a/x-pack/plugin/logsdb/src/yamlRestTest/resources/rest-api-spec/test/32_columnar_passthrough.yml
+++ b/x-pack/plugin/logsdb/src/yamlRestTest/resources/rest-api-spec/test/32_columnar_passthrough.yml
@@ -47,8 +47,8 @@ setup:
   - do:
       indices.get_mapping:
         index: test_columnar_passthrough_basic
-  - match: { test_columnar_passthrough_basic.mappings.prefix_properties.passthrough.attributes: 1 }
-  - match: { test_columnar_passthrough_basic.mappings.prefix_properties.dynamic.attributes: "true" }
+  - match: { test_columnar_passthrough_basic.mappings.prefix_properties.attributes.passthrough: 1 }
+  - match: { test_columnar_passthrough_basic.mappings.prefix_properties.attributes.dynamic: "true" }
   # Child field is flattened to a dotted name at root level; the passthrough object itself is gone
   - is_true: test_columnar_passthrough_basic.mappings.properties.attributes\.env
   - is_false: test_columnar_passthrough_basic.mappings.properties.attributes
@@ -101,7 +101,7 @@ setup:
   - do:
       indices.get_mapping:
         index: test_columnar_passthrough_object_notation
-  - match: { test_columnar_passthrough_object_notation.mappings.prefix_properties.passthrough.attributes: 1 }
+  - match: { test_columnar_passthrough_object_notation.mappings.prefix_properties.attributes.passthrough: 1 }
   - is_true: test_columnar_passthrough_object_notation.mappings.properties.attributes\.service
   - is_false: test_columnar_passthrough_object_notation.mappings.properties.attributes
 
@@ -149,8 +149,8 @@ setup:
   - do:
       indices.get_mapping:
         index: test_columnar_passthrough_priority
-  - match: { test_columnar_passthrough_priority.mappings.prefix_properties.passthrough.attributes: 1 }
-  - match: { test_columnar_passthrough_priority.mappings.prefix_properties.passthrough.resource: 2 }
+  - match: { test_columnar_passthrough_priority.mappings.prefix_properties.attributes.passthrough: 1 }
+  - match: { test_columnar_passthrough_priority.mappings.prefix_properties.resource.passthrough: 2 }
   - is_true: test_columnar_passthrough_priority.mappings.properties.attributes\.region
   - is_true: test_columnar_passthrough_priority.mappings.properties.resource\.region
   - is_false: test_columnar_passthrough_priority.mappings.properties.attributes
@@ -206,7 +206,7 @@ setup:
   - do:
       indices.get_mapping:
         index: test_columnar_passthrough_concrete_wins
-  - match: { test_columnar_passthrough_concrete_wins.mappings.prefix_properties.passthrough.attributes: 1 }
+  - match: { test_columnar_passthrough_concrete_wins.mappings.prefix_properties.attributes.passthrough: 1 }
   - is_true: test_columnar_passthrough_concrete_wins.mappings.properties.env
   - is_true: test_columnar_passthrough_concrete_wins.mappings.properties.attributes\.env
   - is_false: test_columnar_passthrough_concrete_wins.mappings.properties.attributes
@@ -252,11 +252,10 @@ setup:
         index: test_columnar_passthrough_dotted_prefix
   # The full dotted name is stored as a flat literal key — not as nested structure
   - match:
-      test_columnar_passthrough_dotted_prefix.mappings.prefix_properties.passthrough:
-        resource.attributes: 1
-  - match:
-      test_columnar_passthrough_dotted_prefix.mappings.prefix_properties.dynamic:
-        resource.attributes: "true"
+      test_columnar_passthrough_dotted_prefix.mappings.prefix_properties:
+        resource.attributes:
+          passthrough: 1
+          dynamic: "true"
   - is_true: test_columnar_passthrough_dotted_prefix.mappings.properties.resource\.attributes\.env
   - is_false: test_columnar_passthrough_dotted_prefix.mappings.properties.resource\.attributes
 
@@ -286,9 +285,10 @@ setup:
             index.mode: columnar
           mappings:
             prefix_properties:
-              passthrough:
-                attributes: 1
-                resource: 2
+              attributes:
+                passthrough: 1
+              resource:
+                passthrough: 2
             properties:
               attributes.env:
                 type: keyword
@@ -298,8 +298,8 @@ setup:
   - do:
       indices.get_mapping:
         index: test_columnar_passthrough_body_input
-  - match: { test_columnar_passthrough_body_input.mappings.prefix_properties.passthrough.attributes: 1 }
-  - match: { test_columnar_passthrough_body_input.mappings.prefix_properties.passthrough.resource: 2 }
+  - match: { test_columnar_passthrough_body_input.mappings.prefix_properties.attributes.passthrough: 1 }
+  - match: { test_columnar_passthrough_body_input.mappings.prefix_properties.resource.passthrough: 2 }
   - is_true: test_columnar_passthrough_body_input.mappings.properties.attributes\.env
   - is_true: test_columnar_passthrough_body_input.mappings.properties.resource\.service
   - is_false: test_columnar_passthrough_body_input.mappings.properties.attributes
@@ -352,8 +352,8 @@ setup:
   - do:
       indices.get_mapping:
         index: test_columnar_passthrough_merge
-  - match: { test_columnar_passthrough_merge.mappings.prefix_properties.passthrough.attributes: 1 }
-  - is_false: test_columnar_passthrough_merge.mappings.prefix_properties.passthrough.resource
+  - match: { test_columnar_passthrough_merge.mappings.prefix_properties.attributes.passthrough: 1 }
+  - is_false: test_columnar_passthrough_merge.mappings.prefix_properties.resource
   - is_true: test_columnar_passthrough_merge.mappings.properties.attributes\.env
   - is_false: test_columnar_passthrough_merge.mappings.properties.attributes
 
@@ -372,8 +372,8 @@ setup:
   - do:
       indices.get_mapping:
         index: test_columnar_passthrough_merge
-  - match: { test_columnar_passthrough_merge.mappings.prefix_properties.passthrough.attributes: 1 }
-  - match: { test_columnar_passthrough_merge.mappings.prefix_properties.passthrough.resource: 2 }
+  - match: { test_columnar_passthrough_merge.mappings.prefix_properties.attributes.passthrough: 1 }
+  - match: { test_columnar_passthrough_merge.mappings.prefix_properties.resource.passthrough: 2 }
   - is_true: test_columnar_passthrough_merge.mappings.properties.attributes\.env
   - is_true: test_columnar_passthrough_merge.mappings.properties.resource\.service
   - is_false: test_columnar_passthrough_merge.mappings.properties.attributes
@@ -390,13 +390,13 @@ setup:
             index.mode: columnar
           mappings:
             prefix_properties:
-              passthrough:
-                attributes: "not-a-number"
+              attributes:
+                passthrough: "not-a-number"
             properties:
               attributes.env:
                 type: keyword
   - match: { error.type: "mapper_parsing_exception" }
-  - match: { error.reason: "/\\[prefix_properties\\.passthrough\\.attributes\\].must.be.an.integer.value/" }
+  - match: { error.reason: "/\\[prefix_properties\\.attributes\\.passthrough\\].must.be.an.integer.value/" }
 
 ---
 "logsdb_columnar: no prefix_properties when no passthrough objects":
@@ -437,8 +437,8 @@ setup:
   - do:
       indices.get_mapping:
         index: test_logsdb_columnar_passthrough_basic
-  - match: { test_logsdb_columnar_passthrough_basic.mappings.prefix_properties.passthrough.attributes: 1 }
-  - match: { test_logsdb_columnar_passthrough_basic.mappings.prefix_properties.dynamic.attributes: "true" }
+  - match: { test_logsdb_columnar_passthrough_basic.mappings.prefix_properties.attributes.passthrough: 1 }
+  - match: { test_logsdb_columnar_passthrough_basic.mappings.prefix_properties.attributes.dynamic: "true" }
   - is_true: test_logsdb_columnar_passthrough_basic.mappings.properties.attributes\.env
   - is_false: test_logsdb_columnar_passthrough_basic.mappings.properties.attributes
 
@@ -485,8 +485,8 @@ setup:
   - do:
       indices.get_mapping:
         index: test_logsdb_columnar_passthrough_priority
-  - match: { test_logsdb_columnar_passthrough_priority.mappings.prefix_properties.passthrough.attributes: 1 }
-  - match: { test_logsdb_columnar_passthrough_priority.mappings.prefix_properties.passthrough.resource: 2 }
+  - match: { test_logsdb_columnar_passthrough_priority.mappings.prefix_properties.attributes.passthrough: 1 }
+  - match: { test_logsdb_columnar_passthrough_priority.mappings.prefix_properties.resource.passthrough: 2 }
   - is_true: test_logsdb_columnar_passthrough_priority.mappings.properties.attributes\.region
   - is_true: test_logsdb_columnar_passthrough_priority.mappings.properties.resource\.region
   - is_false: test_logsdb_columnar_passthrough_priority.mappings.properties.attributes
@@ -520,8 +520,8 @@ setup:
             index.mode: logsdb_columnar
           mappings:
             prefix_properties:
-              passthrough:
-                attributes: 1
+              attributes:
+                passthrough: 1
             properties:
               attributes.env:
                 type: keyword
@@ -529,7 +529,7 @@ setup:
   - do:
       indices.get_mapping:
         index: test_logsdb_columnar_passthrough_body_input
-  - match: { test_logsdb_columnar_passthrough_body_input.mappings.prefix_properties.passthrough.attributes: 1 }
+  - match: { test_logsdb_columnar_passthrough_body_input.mappings.prefix_properties.attributes.passthrough: 1 }
   - is_true: test_logsdb_columnar_passthrough_body_input.mappings.properties.attributes\.env
   - is_false: test_logsdb_columnar_passthrough_body_input.mappings.properties.attributes
 
@@ -582,8 +582,8 @@ setup:
   - do:
       indices.get_mapping:
         index: test_logsdb_columnar_passthrough_merge
-  - match: { test_logsdb_columnar_passthrough_merge.mappings.prefix_properties.passthrough.attributes: 1 }
-  - match: { test_logsdb_columnar_passthrough_merge.mappings.prefix_properties.passthrough.resource: 2 }
+  - match: { test_logsdb_columnar_passthrough_merge.mappings.prefix_properties.attributes.passthrough: 1 }
+  - match: { test_logsdb_columnar_passthrough_merge.mappings.prefix_properties.resource.passthrough: 2 }
   - is_true: test_logsdb_columnar_passthrough_merge.mappings.properties.attributes\.env
   - is_true: test_logsdb_columnar_passthrough_merge.mappings.properties.resource\.service
   - is_false: test_logsdb_columnar_passthrough_merge.mappings.properties.attributes


### PR DESCRIPTION
## Summary

PRs #151581 and #151681 introduced `prefix_properties` with two parallel maps keyed by facet type:
- `prefix_properties.dynamic.<prefix>`
- `prefix_properties.passthrough.<prefix>`

This PR consolidates them into a single map keyed by prefix path, where each entry holds all facets as a nested object:

**Before:**
```json
"prefix_properties": {
  "dynamic":     { "attributes": "false", "resource": "strict" },
  "passthrough": { "attributes": 1 }
}
```

**After:**
```json
"prefix_properties": {
  "attributes": { "dynamic": "false", "passthrough": 1 },
  "resource":   { "dynamic": "strict" }
}
```

**Changes:**
- New `PrefixProperties` record (package-private) holding `@Nullable Dynamic dynamic` and `@Nullable Integer passthrough`, with a `merge` function
- `ObjectMapper.Builder`: two collector maps → one `Map<String, PrefixProperties>`
- `RootObjectMapper`: two `NavigableMap` fields → one; updated serialization, parsing, and `resolveDynamic` (skips entries with null `dynamic`)
- `FieldTypeLookup`, `MappingLookup`: updated to use the new type
- All unit tests and YAML REST tests updated to the new path format (`prefix_properties.<prefix>.dynamic` instead of `prefix_properties.dynamic.<prefix>`)

No functional or behavioral changes.

This also unblocks the parallel branch that adds an `enabled` facet — it now adds one field to the record instead of a third parallel map.

## Test plan

- [ ] `RootObjectMapperTests`, `FieldTypeLookupTests`, `PassThroughObjectMapperTests`, `ObjectMapperTests` — all pass
- [ ] YAML REST test `mapping/70_columnar_prefix_dynamic_properties`
- [ ] YAML REST test `logsdb/32_columnar_passthrough`