### PR TITLE
Increase client timeout in multi_node.EsqlSpecIT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -635,21 +635,6 @@ tests:
 - class: org.elasticsearch.xpack.searchablesnapshots.cache.blob.SearchableSnapshotsBlobStoreCacheMaintenanceIntegTests
   method: testCleanUpMigratedSystemIndexAfterIndicesAreDeleted
   issue: https://github.com/elastic/elasticsearch/issues/151732
-- class: org.elasticsearch.simdvec.internal.vectorization.ES93BinaryQuantizedVectorScorerTests
-  method: testBulkScore {p0=SNAP p1=DOT_PRODUCT}
-  issue: https://github.com/elastic/elasticsearch/issues/151735
-- class: org.elasticsearch.simdvec.internal.vectorization.ES93BinaryQuantizedVectorScorerTests
-  method: testBulkScore {p0=MMAP p1=DOT_PRODUCT}
-  issue: https://github.com/elastic/elasticsearch/issues/151736
-- class: org.elasticsearch.simdvec.internal.vectorization.ES93BinaryQuantizedVectorScorerTests
-  method: testBulkScore {p0=SNAP p1=COSINE}
-  issue: https://github.com/elastic/elasticsearch/issues/151737
-- class: org.elasticsearch.simdvec.internal.vectorization.ES93BinaryQuantizedVectorScorerTests
-  method: testBulkScore {p0=MMAP p1=COSINE}
-  issue: https://github.com/elastic/elasticsearch/issues/151738
-- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
-  method: test {csv-spec:in_subquery.inSubqueryWithEvalInsideInSubquery}
-  issue: https://github.com/elastic/elasticsearch/issues/151761
 - class: org.elasticsearch.xpack.stateless.cluster.coordination.BlobStoreSyncDirectoryTests
   method: testCloseCancelsOnGoingUploads
   issue: https://github.com/elastic/elasticsearch/issues/151622

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -554,9 +554,6 @@ tests:
 - class: org.elasticsearch.index.engine.ThreadPoolMergeExecutorServiceDiskSpaceTests
   method: testUnavailableBudgetBlocksNewMergeTasksFromStartingExecution
   issue: https://github.com/elastic/elasticsearch/issues/151330
-- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
-  method: test {csv-spec:stats.maxOfHalfFloat}
-  issue: https://github.com/elastic/elasticsearch/issues/151357
 - class: org.elasticsearch.xpack.esql.plugin.CanMatchIT
   method: testAliasFilters
   issue: https://github.com/elastic/elasticsearch/issues/151367
@@ -587,9 +584,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.multi_node.GenerativeIT
   method: test {feature:SUBQUERIES}
   issue: https://github.com/elastic/elasticsearch/issues/149681
-- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
-  method: test {csv-spec:date_nanos.implicit casting to nanos, date plus time to millis, equality test}
-  issue: https://github.com/elastic/elasticsearch/issues/151536
 - class: org.elasticsearch.xpack.logsdb.LogsdbRestIT
   method: testSyntheticSourceRuntimeFieldQueries
   issue: https://github.com/elastic/elasticsearch/issues/151546
@@ -608,18 +602,12 @@ tests:
 - class: org.elasticsearch.datastreams.lifecycle.ExplainDataStreamLifecycleIT
   method: testExplainFailuresLifecycle
   issue: https://github.com/elastic/elasticsearch/issues/151602
-- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
-  method: test {csv-spec:metric_temporality.tdigestAggsByTBucket}
-  issue: https://github.com/elastic/elasticsearch/issues/151613
 - class: org.elasticsearch.xpack.stateless.StatelessMergePreWarmingIT
   method: testMergePreWarmingFailureDoesNotFailTheEngine
   issue: https://github.com/elastic/elasticsearch/issues/151618
 - class: org.elasticsearch.gradle.internal.precommit.PomValidationPrecommitPluginFuncTest
   method: detects missing POM elements and reports structured problems
   issue: https://github.com/elastic/elasticsearch/issues/151636
-- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
-  method: test {csv-spec:lookup-join.byteEqualsLong}
-  issue: https://github.com/elastic/elasticsearch/issues/151650
 - class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
   method: test {yaml=scroll/10_basic/Basic scroll}
   issue: https://github.com/elastic/elasticsearch/issues/151698
@@ -659,9 +647,6 @@ tests:
 - class: org.elasticsearch.simdvec.internal.vectorization.ES93BinaryQuantizedVectorScorerTests
   method: testBulkScore {p0=MMAP p1=COSINE}
   issue: https://github.com/elastic/elasticsearch/issues/151738
-- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
-  method: test {csv-spec:in_subquery.inSubqueryWithEvalInsideInSubquery}
-  issue: https://github.com/elastic/elasticsearch/issues/151761
 - class: org.elasticsearch.xpack.stateless.cluster.coordination.BlobStoreSyncDirectoryTests
   method: testCloseCancelsOnGoingUploads
   issue: https://github.com/elastic/elasticsearch/issues/151622

--- a/x-pack/plugin/esql/qa/server/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/multi_node/EsqlSpecIT.java
+++ b/x-pack/plugin/esql/qa/server/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/multi_node/EsqlSpecIT.java
@@ -7,7 +7,9 @@
 
 package org.elasticsearch.xpack.esql.qa.multi_node;
 
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.xpack.esql.CsvSpecReader.CsvTestCase;
 import org.elasticsearch.xpack.esql.CsvTestUtils;
 import org.elasticsearch.xpack.esql.qa.rest.EsqlSpecTestCase;
@@ -23,6 +25,11 @@ public class EsqlSpecIT extends EsqlSpecTestCase {
     public static ElasticsearchCluster cluster = Clusters.testCluster(CSV_DATA_PATH, spec -> {
         spec.plugin("inference-service-test").settings(nodeSpec -> LOGGING_CLUSTER_SETTINGS);
     });
+
+    @Override
+    protected Settings restClientSettings() {
+        return Settings.builder().put(super.restClientSettings()).put(ESRestTestCase.CLIENT_SOCKET_TIMEOUT, "3m").build();
+    }
 
     @Override
     protected Path getCsvDataPath() {


### PR DESCRIPTION
Use a longer client socket timeout in `multi_node.EsqlSpecIT` as requests can take more than the default 60s.

Fixes #151357, fixes #151536, fixes #151613, fixes #151650, fixes #151761