### PR TITLE
[Search] Add `project_routing` support to the `_terms_enum` API

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackPlugin.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackPlugin.java
@@ -376,7 +376,7 @@ public class XPackPlugin extends XPackClientPlugin
         List<RestHandler> handlers = new ArrayList<>();
         handlers.add(new RestXPackInfoAction());
         handlers.add(new RestXPackUsageAction());
-        handlers.add(new RestTermsEnumAction());
+        handlers.add(new RestTermsEnumAction(restHandlersServices.crossProjectModeDecider()));
         handlers.add(new RestGetLicenseAction());
         handlers.add(new RestPutLicenseAction());
         handlers.add(new RestDeleteLicenseAction());

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/termsenum/action/TermsEnumAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/termsenum/action/TermsEnumAction.java
@@ -28,6 +28,7 @@ public class TermsEnumAction extends ActionType<TermsEnumResponse> {
 
     static final ParseField INDEX_FILTER = new ParseField("index_filter");
     static final ParseField TIMEOUT = new ParseField("timeout");
+    static final ParseField PROJECT_ROUTING = new ParseField("project_routing");
 
     private TermsEnumAction() {
         super(NAME);
@@ -53,5 +54,6 @@ public class TermsEnumAction extends ActionType<TermsEnumResponse> {
             ObjectParser.ValueType.STRING
         );
         PARSER.declareObject(TermsEnumRequest::indexFilter, (p, context) -> parseTopLevelQuery(p), INDEX_FILTER);
+        PARSER.declareString(TermsEnumRequest::projectRouting, PROJECT_ROUTING);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/termsenum/action/TermsEnumRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/termsenum/action/TermsEnumRequest.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.core.termsenum.action;
 
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.ResolvedIndexExpressions;
 import org.elasticsearch.action.ValidateActions;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.support.IndicesOptions;
@@ -18,6 +19,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.search.crossproject.TargetProjects;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 
@@ -42,6 +44,11 @@ public final class TermsEnumRequest extends BroadcastRequest<TermsEnumRequest> i
     private int size = DEFAULT_SIZE;
     private boolean caseInsensitive;
     private QueryBuilder indexFilter;
+    private String projectRouting;
+    @Nullable
+    private ResolvedIndexExpressions resolvedIndexExpressions = null;
+    @Nullable
+    private transient TargetProjects resolvedTargetProjects = null;
 
     public TermsEnumRequest() {
         this(Strings.EMPTY_ARRAY);
@@ -134,12 +141,62 @@ public final class TermsEnumRequest extends BroadcastRequest<TermsEnumRequest> i
                 validationException = ValidateActions.addValidationError("Timeout cannot be > 1 minute", validationException);
             }
         }
+        if (projectRouting != null && indicesOptions().resolveCrossProjectIndexExpression() == false) {
+            validationException = ValidateActions.addValidationError(
+                "Unknown key for a VALUE_STRING in [project_routing]",
+                validationException
+            );
+        }
         return validationException;
     }
 
     @Override
     public boolean allowsRemoteIndices() {
         return true;
+    }
+
+    @Override
+    public boolean allowsCrossProject() {
+        return true;
+    }
+
+    @Override
+    public void setResolvedIndexExpressions(ResolvedIndexExpressions expressions) {
+        this.resolvedIndexExpressions = expressions;
+    }
+
+    @Override
+    @Nullable
+    public ResolvedIndexExpressions getResolvedIndexExpressions() {
+        return resolvedIndexExpressions;
+    }
+
+    @Override
+    public void setResolvedTargetProjects(TargetProjects targetProjects) {
+        this.resolvedTargetProjects = targetProjects;
+    }
+
+    @Override
+    @Nullable
+    public TargetProjects getResolvedTargetProjects() {
+        return resolvedTargetProjects;
+    }
+
+    /**
+     * Scopes the terms enum request to the projects matching the provided cross-project routing expression.
+     */
+    public TermsEnumRequest projectRouting(@Nullable String projectRouting) {
+        if (this.projectRouting != null) {
+            throw new IllegalArgumentException("project_routing is already set to [" + this.projectRouting + "]");
+        }
+        this.projectRouting = projectRouting;
+        return this;
+    }
+
+    @Override
+    @Nullable
+    public String getProjectRouting() {
+        return projectRouting;
     }
 
     /**

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/termsenum/rest/RestTermsEnumAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/termsenum/rest/RestTermsEnumAction.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.core.termsenum.rest;
 
+import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.rest.BaseRestHandler;
@@ -13,6 +14,7 @@ import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.Scope;
 import org.elasticsearch.rest.ServerlessScope;
 import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.search.crossproject.CrossProjectModeDecider;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.termsenum.action.TermsEnumAction;
 import org.elasticsearch.xpack.core.termsenum.action.TermsEnumRequest;
@@ -25,6 +27,12 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
 
 @ServerlessScope(Scope.PUBLIC)
 public class RestTermsEnumAction extends BaseRestHandler {
+
+    private final CrossProjectModeDecider crossProjectModeDecider;
+
+    public RestTermsEnumAction(CrossProjectModeDecider crossProjectModeDecider) {
+        this.crossProjectModeDecider = crossProjectModeDecider;
+    }
 
     @Override
     public List<Route> routes() {
@@ -43,6 +51,13 @@ public class RestTermsEnumAction extends BaseRestHandler {
                 parser,
                 Strings.splitStringByCommaToArray(request.param("index"))
             );
+            if (crossProjectModeDecider.crossProjectEnabled() && termEnumRequest.allowsCrossProject()) {
+                termEnumRequest.indicesOptions(
+                    IndicesOptions.builder(termEnumRequest.indicesOptions())
+                        .crossProjectModeOptions(new IndicesOptions.CrossProjectModeOptions(true))
+                        .build()
+                );
+            }
             return channel -> client.execute(TermsEnumAction.INSTANCE, termEnumRequest, new RestToXContentListener<>(channel));
         }
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/termsenum/action/RestTermsEnumActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/termsenum/action/RestTermsEnumActionTests.java
@@ -21,6 +21,7 @@ import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.search.SearchModule;
+import org.elasticsearch.search.crossproject.CrossProjectModeDecider;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskManager;
 import org.elasticsearch.telemetry.TelemetryProvider;
@@ -59,7 +60,7 @@ public class RestTermsEnumActionTests extends ESTestCase {
         usageService,
         TelemetryProvider.NOOP
     );
-    private static RestTermsEnumAction action = new RestTermsEnumAction();
+    private static RestTermsEnumAction action = new RestTermsEnumAction(CrossProjectModeDecider.NOOP);
 
     /**
      * Configures {@link NodeClient} to stub {@link TermsEnumAction} transport action.


### PR DESCRIPTION
Resolves #151331.

`_terms_enum` currently does not support `project_routing`, which makes it inconsistent with cross-project request routing used by other APIs. Adding support would let clients scope term enum requests to the intended project and avoid cross-project ambiguity.

- [x] I have signed the [contributor license agreement](https://www.elastic.co/contributor-agreement).
- [x] I have followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md).
- [x] The pull request targets `main`.
- [x] This is not a class submission.