### PR TITLE
[Inference] Add requires org.apache.commons.lang3 to module-info

### DIFF
--- a/docs/changelog/151794.yaml
+++ b/docs/changelog/151794.yaml
@@ -1,0 +1,5 @@
+area: Inference
+issues: []
+pr: 151794
+summary: "[Inference] Add requires org.apache.commons.lang3 to module-info"
+type: upgrade

--- a/x-pack/plugin/inference/src/main/java/module-info.java
+++ b/x-pack/plugin/inference/src/main/java/module-info.java
@@ -35,6 +35,7 @@ module org.elasticsearch.inference {
     requires org.elasticsearch.logging;
     requires org.elasticsearch.sslconfig;
     requires org.apache.commons.text;
+    requires org.apache.commons.lang3;
     requires software.amazon.awssdk.services.sagemakerruntime;
     requires com.azure.identity;
     requires com.azure.core;


### PR DESCRIPTION
The inference plugin is a named JPMS module and uses `commons-text`, which internally calls `org.apache.commons.lang3.Validate`. The module declared `requires org.apache.commons.text` but not `requires org.apache.commons.lang3`.

This stayed latent while `commons-lang3` was `3.9` (an automatic module,resolved for free). After #150242 bumped it to `3.20.0` — which ships a real `module-info.class` and is therefore an explicit module — it is no longer readable without an explicit `requires`, so the inference path throws a fatal `NoClassDefFoundError: org/apache/commons/lang3/Validate`, halting the node. 