### PR TITLE
[Slices] Add support for all slices in DenseVectorFieldMapper

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
@@ -3458,12 +3458,7 @@ public class DenseVectorFieldMapper extends FieldMapper {
         @Nullable
         private static BytesRef[] extractSliceRouting(@Nullable String sliceRouting, boolean sliceEnabled) {
             if (sliceRouting == null) {
-                if (sliceEnabled) {
-                    throw new IllegalArgumentException(
-                        "[" + SliceIndexing.PARAM_NAME + "] is required for KNN queries when [index.slice.enabled] is true"
-                    );
-                }
-                return null;
+                return sliceEnabled ? new BytesRef[0] : null;
             }
             String[] sliceValues = Strings.splitStringByCommaToArray(sliceRouting.trim());
             if (sliceValues.length == 0) {

--- a/server/src/main/java/org/elasticsearch/search/vectors/IVFKnnFloatSlicedVectorQuery.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/IVFKnnFloatSlicedVectorQuery.java
@@ -48,7 +48,7 @@ public class IVFKnnFloatSlicedVectorQuery extends IVFKnnFloatVectorQuery {
      * @param filter the filter to apply to the results
      * @param visitRatio the ratio of vectors to score for the IVF search strategy
      * @param sliceField the field used for slicing the index
-     * @param sliceIds the slices to be search
+     * @param sliceIds the slices to be searched. If the array is empty, all slices are searched
      */
     public IVFKnnFloatSlicedVectorQuery(
         String field,
@@ -64,7 +64,6 @@ public class IVFKnnFloatSlicedVectorQuery extends IVFKnnFloatVectorQuery {
         super(field, query, k, numCands, filter, visitRatio, queryConfigResolver);
         this.sliceField = Objects.requireNonNull(sliceField);
         this.sliceIds = Objects.requireNonNull(sliceIds);
-        assert sliceIds.length > 0;
     }
 
     @Override
@@ -97,9 +96,14 @@ public class IVFKnnFloatSlicedVectorQuery extends IVFKnnFloatVectorQuery {
         }
         // Get ordinals sorted so we can share the iterator of the filter if it exists. Note that it means tht in case
         // of filters, we cannot process slices in parallel as the iterator needs to be consume in order.
-        final int[] ords = sliceToSortedOrds(sortedDocValues, sliceIds);
-        if (ords.length == 0) {
-            return NO_RESULTS;
+        final int[] ords;
+        if (sliceIds.length > 0) {
+            ords = sliceToSortedOrds(sortedDocValues, sliceIds);
+            if (ords.length == 0) {
+                return NO_RESULTS;
+            }
+        } else {
+            ords = null;
         }
         final DocValuesSkipper skipper = ctx.reader().getDocValuesSkipper(sliceField);
         if (skipper == null) {
@@ -134,19 +138,36 @@ public class IVFKnnFloatSlicedVectorQuery extends IVFKnnFloatVectorQuery {
             docIdIteratorSupplier = null;
             costSupplier = null;
         }
-        for (int i = 0; i < ords.length; i++) {
-            assert i == 0 || ords[i - 1] < ords[i];
-            approximateSearchForOneSlice(
-                sortedDocValues,
-                skipper,
-                ords[i],
-                knnCollector,
-                docIdIteratorSupplier,
-                costSupplier,
-                liveDocs,
-                maxDoc,
-                ctx
-            );
+        if (ords != null) {
+            for (int i = 0; i < ords.length; i++) {
+                assert i == 0 || ords[i - 1] < ords[i];
+                approximateSearchForOneSlice(
+                    sortedDocValues,
+                    skipper,
+                    ords[i],
+                    knnCollector,
+                    docIdIteratorSupplier,
+                    costSupplier,
+                    liveDocs,
+                    maxDoc,
+                    ctx
+                );
+            }
+        } else {
+            int numOrds = sortedDocValues.getValueCount();
+            for (int i = 0; i < numOrds; i++) {
+                approximateSearchForOneSlice(
+                    sortedDocValues,
+                    skipper,
+                    i,
+                    knnCollector,
+                    docIdIteratorSupplier,
+                    costSupplier,
+                    liveDocs,
+                    maxDoc,
+                    ctx
+                );
+            }
         }
         TopDocs results = knnCollector instanceof BulkKnnCollector bulkKnnCollector
             ? bulkKnnCollector.unsortedTopK()

--- a/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldTypeTests.java
@@ -29,6 +29,7 @@ import org.elasticsearch.search.vectors.DiversifyingChildrenIVFKnnFloatVectorQue
 import org.elasticsearch.search.vectors.DiversifyingParentBlockQuery;
 import org.elasticsearch.search.vectors.ESKnnByteVectorQuery;
 import org.elasticsearch.search.vectors.ESKnnFloatVectorQuery;
+import org.elasticsearch.search.vectors.IVFKnnFloatSlicedVectorQuery;
 import org.elasticsearch.search.vectors.IVFKnnFloatVectorQuery;
 import org.elasticsearch.search.vectors.RescoreKnnVectorQuery;
 import org.elasticsearch.search.vectors.VectorData;
@@ -946,34 +947,36 @@ public class DenseVectorFieldTypeTests extends FieldTypeTestCase {
             "s1"
         );
         if (parentFilter == null) {
-            assertThat(query, instanceOf(IVFKnnFloatVectorQuery.class));
+            assertThat(query, instanceOf(IVFKnnFloatSlicedVectorQuery.class));
         } else {
             assertThat(query, instanceOf(DiversifyingChildrenIVFKnnFloatSlicedVectorQuery.class));
         }
         assertThat(query.toString("ignored"), containsString("_routing=[s1]"));
     }
 
-    public void testBBQIVFRejectsMissingSliceForKnnWhenSliceEnabled() {
+    public void testBBQIVFUsesSlicedQueryForAllSliceRouting() {
         BitSetProducer parentFilter = random().nextBoolean() ? null : context -> null;
         DenseVectorFieldType fieldType = createBBQIVFFloatFieldType();
-        IllegalArgumentException exception = expectThrows(
-            IllegalArgumentException.class,
-            () -> fieldType.createKnnQuery(
-                VectorData.fromFloats(testQueryVector(64)),
-                5,
-                10,
-                10f,
-                null,
-                null,
-                null,
-                parentFilter,
-                randomFrom(DenseVectorFieldMapper.FilterHeuristic.values()),
-                randomBoolean(),
-                true,
-                null
-            )
+        Query query = fieldType.createKnnQuery(
+            VectorData.fromFloats(testQueryVector(64)),
+            5,
+            10,
+            10f,
+            null,
+            null,
+            null,
+            parentFilter,
+            randomFrom(DenseVectorFieldMapper.FilterHeuristic.values()),
+            randomBoolean(),
+            true,
+            null
         );
-        assertThat(exception.getMessage(), containsString("[_slice] is required for KNN queries when [index.slice.enabled] is true"));
+        if (parentFilter == null) {
+            assertThat(query, instanceOf(IVFKnnFloatSlicedVectorQuery.class));
+        } else {
+            assertThat(query, instanceOf(DiversifyingChildrenIVFKnnFloatSlicedVectorQuery.class));
+        }
+        assertThat(query.toString("ignored"), containsString("_routing=[]"));
     }
 
     public void testBBQIVFFallsBackWhenSliceRoutingMissingAndSliceDisabled() {

--- a/server/src/test/java/org/elasticsearch/search/vectors/IVFKnnFloatSlicedVectorQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/search/vectors/IVFKnnFloatSlicedVectorQueryTests.java
@@ -273,6 +273,15 @@ public class IVFKnnFloatSlicedVectorQueryTests extends AbstractIVFKnnVectorQuery
                         TopDocs topDocs = getTopDocs(searcher, expectedDocs, vector, filterQuery, querySlices);
                         assertTopDocs(applyFilter, expectedDocs, topDocs, reader, filterField, filterValue, querySlices);
                     }
+                    {
+                        // all slices
+                        int expectedDocs = 0;
+                        for (int j = 0; j < numSlices; j++) {
+                            expectedDocs += applyFilter ? docsPerSliceFiltered[j] : docsPerSlice[j];
+                        }
+                        TopDocs topDocs = getTopDocs(searcher, expectedDocs, vector, filterQuery);
+                        assertEquals(expectedDocs, topDocs.scoreDocs.length);
+                    }
                     // invalid slice
                     TopDocs topDocs = getTopDocs(searcher, 0, vector, filterQuery, -1);
                     assertEquals(0, topDocs.scoreDocs.length);
@@ -281,13 +290,20 @@ public class IVFKnnFloatSlicedVectorQueryTests extends AbstractIVFKnnVectorQuery
         }
     }
 
-    private TopDocs getTopDocs(IndexSearcher searcher, int expectedDocs, float[] vector, Query filterQuery, int... slice)
+    private TopDocs getTopDocs(IndexSearcher searcher, int expectedDocs, float[] vector, Query filterQuery, int... slices)
         throws IOException {
-        BytesRef[] sliceRef = new BytesRef[slice.length];
-        for (int i = 0; i < slice.length; i++) {
-            sliceRef[i] = new BytesRef("" + slice[i]);
+        BytesRef[] sliceRef;
+        int k;
+        if (slices != null) {
+            sliceRef = new BytesRef[slices.length];
+            for (int i = 0; i < slices.length; i++) {
+                sliceRef[i] = new BytesRef("" + slices[i]);
+            }
+            k = 2 * Math.max(1, expectedDocs);
+        } else {
+            sliceRef = null;
+            k = expectedDocs;
         }
-        int k = 2 * Math.max(1, expectedDocs);
         Query kvq = new IVFKnnFloatSlicedVectorQuery("vector", vector, k, k, filterQuery, 1.0f, testResolver(), SLICE_FIELD, sliceRef);
         return searcher.search(kvq, k);
     }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/47_knn_search_bbq_disk_slice.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/47_knn_search_bbq_disk_slice.yml
@@ -129,6 +129,26 @@ setup:
   - match: { hits.hits.1._id: "2" }
   - match: { hits.hits.2._id: "3" }
   - match: { hits.hits.3._id: "4" }
+
+---
+"KNN search with _all":
+  - do:
+      search:
+        index: bbq_disk_slice
+        _slice: _all
+        body:
+          knn:
+            field: vector
+            query_vector: [0.707107, 0.707107, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+            k: 4
+            num_candidates: 10
+
+  - match: { hits.total.value: 4 }
+  - length: { hits.hits: 4 }
+  - match: { hits.hits.0._id: "1" }
+  - match: { hits.hits.1._id: "2" }
+  - match: { hits.hits.2._id: "3" }
+  - match: { hits.hits.3._id: "4" }
 ---
 "Search without _slice is rejected on slice-enabled index":
   - do:
@@ -138,6 +158,7 @@ setup:
         body:
           query:
             match_all: {}
+
 ---
 "KNN search requires _slice when slice indexing is enabled":
   - do:
@@ -150,19 +171,7 @@ setup:
             query_vector: [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
             k: 1
             num_candidates: 10
----
-"KNN search rejects _slice=_all":
-  - do:
-      catch: /\[_slice\] is required for KNN queries when \[index.slice.enabled\] is true/
-      search:
-        index: bbq_disk_slice
-        _slice: _all
-        body:
-          knn:
-            field: vector
-            query_vector: [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
-            k: 1
-            num_candidates: 10
+
 ---
 "Index requires _slice when slice indexing is enabled":
   - do:


### PR DESCRIPTION
In the case we will iterate over all ordinals and search using the same collector.