### PR TITLE
Refactor TimeSeriesMetadataFieldBlockLoader

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -51,19 +52,28 @@ public final class MappingLookup {
 
     private final CacheKey cacheKey = new CacheKey();
 
-    /** Full field name to mapper */
+    // field name to mapper
     private final Map<String, Mapper> fieldMappers;
     private final Map<String, ObjectMapper> objectMappers;
-    private final Map<String, InferenceFieldMetadata> inferenceFields;
-    private final Set<String> syntheticVectorFields;
+
+    // views
+    private final Map<String, InferenceFieldMetadata> indexInferenceFields;
+    private final Map<String, NamedAnalyzer> indexAnalyzers;
+    private final List<FieldMapper> indexTimeScriptMappers;
+    private final Set<String> indexSyntheticVectorFields;
+    private final Set<FieldMapper> indexMetricFieldMappers;
+    private final Set<FieldMapper> indexDimensionFieldMappers;
+
+    // stats
+    private final int totalFieldsCount;
     private final int runtimeFieldMappersCount;
+
+    // lookup
     private final NestedLookup nestedLookup;
     private final FieldTypeLookup fieldTypeLookup;
     private final FieldTypeLookup indexTimeLookup;  // for index-time scripts, a lookup that does not include runtime fields
-    private final Map<String, NamedAnalyzer> indexAnalyzers;
-    private final List<FieldMapper> indexTimeScriptMappers;
+
     private final Mapping mapping;
-    private final int totalFieldsCount;
     private final IndexMode indexMode;
 
     // cached booleans from the _source field mapper
@@ -186,6 +196,8 @@ public final class MappingLookup {
 
         final Map<String, NamedAnalyzer> indexAnalyzers = new HashMap<>();
         final List<FieldMapper> indexTimeScriptMappers = new ArrayList<>();
+        final Set<FieldMapper> dimensionMappers = new LinkedHashSet<>();
+        final Set<FieldMapper> metricMappers = new LinkedHashSet<>();
         for (FieldMapper mapper : mappers) {
             if (objects.containsKey(mapper.fullPath())) {
                 throw new MapperParsingException("Field [" + mapper.fullPath() + "] is defined both as an object and a field");
@@ -196,6 +208,13 @@ public final class MappingLookup {
             indexAnalyzers.putAll(mapper.indexAnalyzers());
             if (mapper.hasScript()) {
                 indexTimeScriptMappers.add(mapper);
+            }
+            MappedFieldType fieldType = mapper.fieldType();
+            if (fieldType.isDimension()) {
+                dimensionMappers.add(mapper);
+            }
+            if (fieldType.getMetricType() != null) {
+                metricMappers.add(mapper);
             }
         }
 
@@ -213,7 +232,7 @@ public final class MappingLookup {
         this.fieldTypeLookup = new FieldTypeLookup(mappers, aliasMappers, passThroughSources, runtimeFields);
 
         Map<String, InferenceFieldMetadata> inferenceFields = new HashMap<>();
-        List<String> syntheticVectorFields = new ArrayList<>();
+        Set<String> syntheticVectorFields = new LinkedHashSet<>();
         for (FieldMapper mapper : mappers) {
             if (mapper instanceof InferenceFieldMapper inferenceFieldMapper) {
                 inferenceFields.put(mapper.fullPath(), inferenceFieldMapper.getMetadata(fieldTypeLookup.sourcePaths(mapper.fullPath())));
@@ -222,8 +241,8 @@ public final class MappingLookup {
                 syntheticVectorFields.add(mapper.fullPath());
             }
         }
-        this.inferenceFields = Map.copyOf(inferenceFields);
-        this.syntheticVectorFields = Set.copyOf(syntheticVectorFields);
+        this.indexInferenceFields = Collections.unmodifiableMap(inferenceFields);
+        this.indexSyntheticVectorFields = Collections.unmodifiableSet(syntheticVectorFields);
 
         if (runtimeFields.isEmpty()) {
             // without runtime fields this is the same as the field type lookup
@@ -232,11 +251,13 @@ public final class MappingLookup {
             this.indexTimeLookup = new FieldTypeLookup(mappers, aliasMappers, passThroughSources, Collections.emptyList());
         }
         // make all fields into compact+fast immutable maps
-        this.fieldMappers = Map.copyOf(fieldMappers);
-        this.objectMappers = Map.copyOf(objects);
+        this.fieldMappers = Collections.unmodifiableMap(fieldMappers);
+        this.indexDimensionFieldMappers = Collections.unmodifiableSet(dimensionMappers);
+        this.indexMetricFieldMappers = Collections.unmodifiableSet(metricMappers);
+        this.objectMappers = Collections.unmodifiableMap(objects);
         this.runtimeFieldMappersCount = runtimeFields.size();
-        this.indexAnalyzers = Map.copyOf(indexAnalyzers);
-        this.indexTimeScriptMappers = List.copyOf(indexTimeScriptMappers);
+        this.indexAnalyzers = Collections.unmodifiableMap(indexAnalyzers);
+        this.indexTimeScriptMappers = Collections.unmodifiableList(indexTimeScriptMappers);
         this.indexMode = indexMode;
 
         runtimeFields.stream().flatMap(RuntimeField::asMappedFieldTypes).map(MappedFieldType::name).forEach(this::validateDoesNotShadow);
@@ -319,6 +340,24 @@ public final class MappingLookup {
         return fieldMappers.values();
     }
 
+    /**
+     * Returns the set of dimension field mappers, pre-computed at mapping construction time.
+     * The returned set is unordered; callers that need a stable order must sort it themselves.
+     * Field name ordering does not affect {@code _timeseries} JSON content: synthetic source
+     * reconstructs field order from the mapping, and stored source preserves the original document order.
+     */
+    public Set<FieldMapper> indexDimensionFieldMappers() {
+        return indexDimensionFieldMappers;
+    }
+
+    /**
+     * Returns the set of metric field mappers, pre-computed at mapping construction time.
+     * The returned set is unordered; see {@link #indexDimensionFieldMappers()} for ordering notes.
+     */
+    public Set<FieldMapper> indexMetricFieldMappers() {
+        return indexMetricFieldMappers;
+    }
+
     void checkLimits(IndexSettings settings) {
         checkFieldLimit(settings.getMappingTotalFieldsLimit());
         checkObjectDepthLimit(settings.getMappingDepthLimit());
@@ -352,11 +391,7 @@ public final class MappingLookup {
     }
 
     private void checkDimensionFieldLimit(long limit) {
-        long dimensionFieldCount = fieldMappers.values()
-            .stream()
-            .filter(m -> m instanceof FieldMapper && ((FieldMapper) m).fieldType().isDimension())
-            .count();
-        if (dimensionFieldCount > limit) {
+        if (indexDimensionFieldMappers.size() > limit) {
             throw new IllegalArgumentException("Limit of total dimension fields [" + limit + "] has been exceeded");
         }
     }
@@ -424,11 +459,11 @@ public final class MappingLookup {
      * Returns a map containing all fields that require to run inference (through the {@link InferenceService} prior to indexation.
      */
     public Map<String, InferenceFieldMetadata> inferenceFields() {
-        return inferenceFields;
+        return indexInferenceFields;
     }
 
     public Set<String> syntheticVectorFields() {
-        return syntheticVectorFields;
+        return indexSyntheticVectorFields;
     }
 
     public NestedLookup nestedLookup() {

--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceFieldMapper.java
@@ -368,7 +368,7 @@ public class SourceFieldMapper extends MetadataFieldMapper {
             if (enabled) {
                 var config = blContext.blockLoaderFunctionConfig();
                 if (config instanceof BlockLoaderFunctionConfig.TimeSeriesMetadata tsm) {
-                    return new TimeSeriesMetadataFieldBlockLoader(blContext, tsm.loadMetrics());
+                    return new TimeSeriesMetadataFieldBlockLoader(blContext, tsm.loadMetricFields());
                 }
                 return new SourceFieldBlockLoader();
             }

--- a/server/src/main/java/org/elasticsearch/index/mapper/TimeSeriesMetadataFieldBlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TimeSeriesMetadataFieldBlockLoader.java
@@ -12,10 +12,8 @@ package org.elasticsearch.index.mapper;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.util.IOFunction;
-import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.mapper.blockloader.BlockLoaderFunctionConfig;
@@ -29,18 +27,48 @@ import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Set;
 
 /**
- * Load {@code _timeseries} into blocks.
+ * Loads {@code _timeseries} metadata into blocks.
  */
 public final class TimeSeriesMetadataFieldBlockLoader implements BlockLoader {
 
     private final Set<String> metadataFields;
 
     public TimeSeriesMetadataFieldBlockLoader(MappedFieldType.BlockLoaderContext context, boolean loadMetrics) {
-        this.metadataFields = timeSeriesMetadata(context, loadMetrics);
+        this.metadataFields = lookupTimeSeriesMetadataFieldNames(context, loadMetrics);
+    }
+
+    private static Set<String> lookupTimeSeriesMetadataFieldNames(MappedFieldType.BlockLoaderContext context, boolean loadMetrics) {
+        assert context.blockLoaderFunctionConfig() instanceof BlockLoaderFunctionConfig.TimeSeriesMetadata;
+
+        if (context.indexSettings().getMode() != IndexMode.TIME_SERIES) {
+            throw new IllegalStateException("TimeSeriesMetadataFieldBlockLoader requires index mode: [ " + IndexMode.TIME_SERIES + " ]");
+        }
+
+        var config = (BlockLoaderFunctionConfig.TimeSeriesMetadata) context.blockLoaderFunctionConfig();
+        MappingLookup mappingLookup = context.mappingLookup();
+
+        var dimensionIndex = mappingLookup.indexDimensionFieldMappers();
+
+        var result = new LinkedHashSet<String>(dimensionIndex.size());
+        for (var mapper : dimensionIndex) {
+            result.add(mapper.fieldType().name());
+        }
+
+        for (var skip : config.skipFieldNames()) {
+            result.remove(skip);
+        }
+
+        if (loadMetrics) {
+            // Metrics are disjoint from dimensions by TSDB mapping validation and are never excluded.
+            for (FieldMapper mapper : mappingLookup.indexMetricFieldMappers()) {
+                result.add(mapper.fieldType().name());
+            }
+        }
+
+        return result;
     }
 
     @Override
@@ -55,7 +83,7 @@ public final class TimeSeriesMetadataFieldBlockLoader implements BlockLoader {
 
     @Override
     public RowStrideReader rowStrideReader(CircuitBreaker breaker, LeafReaderContext context) throws IOException {
-        return new TimeSeries(breaker);
+        return new TimeSeriesReader(breaker);
     }
 
     @Override
@@ -73,37 +101,40 @@ public final class TimeSeriesMetadataFieldBlockLoader implements BlockLoader {
 
     @Override
     public SortedSetDocValues ordinals(LeafReaderContext context) {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException("_timeseries metadata does not support ordinals");
     }
 
-    private static class TimeSeries extends BlockStoredFieldsReader {
-        protected TimeSeries(CircuitBreaker breaker) {
+    @Override
+    public String toString() {
+        return "TimeSeriesMetadata";
+    }
+
+    private static final class TimeSeriesReader extends BlockStoredFieldsReader {
+        private TimeSeriesReader(CircuitBreaker breaker) {
             super(breaker);
         }
 
-        @Override
-        public void read(int docId, StoredFields storedFields, Builder builder) throws IOException {
-            // TODO support appending BytesReference
-            ((BytesRefBuilder) builder).appendBytesRef(toJson(storedFields.source()).toBytesRef());
-        }
-
         /**
-         * The {@code _timeseries} keyword column is documented to contain a JSON-encoded object with the dimension
-         * key/value pairs identifying each group. {@link Source#internalSourceRef()} returns bytes in whatever XContent
-         * type the underlying {@code _source} happens to use: synthetic source always reconstructs as JSON, but stored
-         * source preserves the original encoding (e.g. CBOR for documents written via the Prometheus remote-write
-         * endpoint, which builds {@link org.elasticsearch.xcontent.XContentFactory#cborBuilder} requests). Normalize
-         * to JSON so the value is a valid keyword regardless of how {@code _source} is stored. When the underlying
-         * encoding is already JSON we return the bytes unchanged to avoid a parser/builder round-trip.
+         * Returns source bytes normalized to JSON.
+         *
+         * The {@code _timeseries} keyword column is documented as a JSON-encoded object containing
+         * the dimension key/value pairs that identify a time series. Synthetic source already
+         * reconstructs as JSON, but stored source preserves the original content type. For example,
+         * documents written through the Prometheus remote-write endpoint may be stored as CBOR.
+         *
+         * If the source is already JSON, this method returns the original bytes to avoid an
+         * unnecessary parser/builder round trip.
          */
         private static BytesReference toJson(Source source) throws IOException {
             BytesReference bytes = source.internalSourceRef();
-            XContentType type = source.sourceContentType();
-            if (type == XContentType.JSON) {
+            XContentType contentType = source.sourceContentType();
+
+            if (contentType == XContentType.JSON) {
                 return bytes;
             }
+
             try (
-                XContentParser parser = XContentHelper.createParserNotCompressed(XContentParserConfiguration.EMPTY, bytes, type);
+                XContentParser parser = XContentHelper.createParserNotCompressed(XContentParserConfiguration.EMPTY, bytes, contentType);
                 XContentBuilder json = XContentFactory.jsonBuilder()
             ) {
                 parser.nextToken();
@@ -113,55 +144,14 @@ public final class TimeSeriesMetadataFieldBlockLoader implements BlockLoader {
         }
 
         @Override
+        public void read(int docId, StoredFields storedFields, Builder builder) throws IOException {
+            // TODO: support appending BytesReference directly.
+            ((BytesRefBuilder) builder).appendBytesRef(toJson(storedFields.source()).toBytesRef());
+        }
+
+        @Override
         public String toString() {
             return "BlockStoredFieldsReader.TimeSeries";
         }
-    }
-
-    private Set<String> timeSeriesMetadata(MappedFieldType.BlockLoaderContext ctx, boolean loadMetrics) {
-        if (ctx.indexSettings().getMode() != IndexMode.TIME_SERIES) {
-            throw new IllegalStateException("The TimeSeriesMetadataFieldBlockLoader cannot be used in non-time series mode.");
-        }
-
-        assert ctx.blockLoaderFunctionConfig() instanceof BlockLoaderFunctionConfig.TimeSeriesMetadata;
-        var config = (BlockLoaderFunctionConfig.TimeSeriesMetadata) ctx.blockLoaderFunctionConfig();
-
-        if (loadMetrics == false) {
-            IndexMetadata indexMetadata = ctx.indexSettings().getIndexMetadata();
-            List<String> dimensionFieldsFromSettings = indexMetadata.getTimeSeriesDimensions();
-            // The settings shortcut lists dimensions by name and excludes WITHOUT fields via an exact-name removal.
-            // It cannot honor exclusions when an entry is a wildcard (e.g. a passthrough dimension recorded as
-            // "labels.*"), because a concrete field name like "labels.le" never matches the literal "labels.*".
-            // In that case fall through to the mapping-based enumeration below, which resolves the wildcard to
-            // concrete dimension fields and can drop the excluded ones by name.
-            if (dimensionFieldsFromSettings != null
-                && dimensionFieldsFromSettings.isEmpty() == false
-                && (config.withoutFields().isEmpty() || dimensionFieldsFromSettings.stream().noneMatch(Regex::isSimpleMatchPattern))) {
-                Set<String> result = new LinkedHashSet<>(dimensionFieldsFromSettings);
-                result.removeAll(config.withoutFields());
-                return result;
-            }
-        }
-
-        Set<String> result = new LinkedHashSet<>();
-        MappingLookup mappingLookup = ctx.mappingLookup();
-        for (Mapper mapper : mappingLookup.fieldMappers()) {
-            if (mapper instanceof FieldMapper fieldMapper) {
-                MappedFieldType fieldType = fieldMapper.fieldType();
-                if (fieldType.isDimension() && config.withoutFields().contains(fieldType.name()) == false) {
-                    result.add(fieldType.name());
-                }
-                if (loadMetrics && fieldType.getMetricType() != null) {
-                    result.add(fieldType.name());
-                }
-            }
-        }
-
-        return result;
-    }
-
-    @Override
-    public String toString() {
-        return "TimeSeriesMetadata";
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/blockloader/BlockLoaderFunctionConfig.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/blockloader/BlockLoaderFunctionConfig.java
@@ -33,7 +33,7 @@ public interface BlockLoaderFunctionConfig {
      * Configuration for loading time-series metadata fields from {@code _source}.
      * Controls which field types to include (dimensions, metrics, or both) and which dimensions to exclude.
      */
-    record TimeSeriesMetadata(boolean loadMetrics, Set<String> withoutFields) implements BlockLoaderFunctionConfig {
+    record TimeSeriesMetadata(boolean loadMetricFields, Set<String> skipFieldNames) implements BlockLoaderFunctionConfig {
         @Override
         public Function function() {
             return Function.TIME_SERIES_METADATA;

--- a/server/src/test/java/org/elasticsearch/index/mapper/TimeSeriesMetadataFieldBlockLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TimeSeriesMetadataFieldBlockLoaderTests.java
@@ -188,24 +188,6 @@ public class TimeSeriesMetadataFieldBlockLoaderTests extends MapperServiceTestCa
         assertThat(sourcePaths(loader), equalTo(Set.of("labels.__name__", "labels.instance")));
     }
 
-    /**
-     * With no exclusions the wildcard {@code index.dimensions} shortcut is still honored as-is, since there is
-     * nothing to remove and the source filter understands the {@code labels.*} pattern.
-     */
-    public void testWildcardDimensionSettingUsedWhenNothingExcluded() throws IOException {
-        Settings settings = Settings.builder()
-            .put(TSDB_PROMETHEUS_LIKE_SETTINGS)
-            .putList(IndexMetadata.INDEX_DIMENSIONS.getKey(), "labels.*")
-            .build();
-        BlockLoader loader = createBlockLoader(
-            settings,
-            PROMETHEUS_LIKE_MAPPING,
-            new BlockLoaderFunctionConfig.TimeSeriesMetadata(false, Set.of())
-        );
-        assertThat(loader, instanceOf(TimeSeriesMetadataFieldBlockLoader.class));
-        assertThat(sourcePaths(loader), equalTo(Set.of("labels.*")));
-    }
-
     public void testNoConfigReturnSourceBlockLoader() throws IOException {
         MapperService mapperService = createMapperService(TSDB_SYNTHETIC_SETTINGS, MAPPING);
         BlockLoader loader = mapperService.documentMapper()
@@ -281,7 +263,7 @@ public class TimeSeriesMetadataFieldBlockLoaderTests extends MapperServiceTestCa
     }
 
     /**
-     * Verify that the `withoutFields` parameter correctly excludes labels from the output.
+     * Verify that the `skipFieldNames` parameter correctly excludes labels from the output.
      * When using PromQL's `without(instance)` clause, the `instance` label must not appear
      * in the emitted `_timeseries` JSON.
      */
@@ -308,6 +290,47 @@ public class TimeSeriesMetadataFieldBlockLoaderTests extends MapperServiceTestCa
         @SuppressWarnings("unchecked")
         Map<String, Object> labels = (Map<String, Object>) parsed.get("labels");
         assertThat(labels, equalTo(Map.of("__name__", "go_gc_cleanups_executed_cleanups_total", "job", "prometheus")));
+    }
+
+    /**
+     * Excluding all dimensions must produce an empty source-paths set (single global series).
+     */
+    public void testWithoutAllDimensionsYieldsEmptySourcePaths() throws IOException {
+        BlockLoader loader = createBlockLoader(
+            TSDB_SYNTHETIC_SETTINGS,
+            MAPPING,
+            new BlockLoaderFunctionConfig.TimeSeriesMetadata(false, Set.of("host", "env", "region"))
+        );
+        assertThat(loader, instanceOf(TimeSeriesMetadataFieldBlockLoader.class));
+        assertThat(sourcePaths(loader), equalTo(Set.of()));
+    }
+
+    /**
+     * An unknown field in skipFieldNames must be silently ignored: the exclusion simply
+     * does not match any dimension and the full dimension set is returned.
+     */
+    public void testWithoutUnknownFieldIsIgnored() throws IOException {
+        BlockLoader loader = createBlockLoader(
+            TSDB_SYNTHETIC_SETTINGS,
+            MAPPING,
+            new BlockLoaderFunctionConfig.TimeSeriesMetadata(false, Set.of("does_not_exist"))
+        );
+        assertThat(loader, instanceOf(TimeSeriesMetadataFieldBlockLoader.class));
+        assertThat(sourcePaths(loader), equalTo(Set.of("host", "env", "region")));
+    }
+
+    /**
+     * loadMetricFields=true with a non-empty exclusion set: the excluded dimension must be absent from
+     * source paths while metrics remain unaffected.
+     */
+    public void testExcludedDimensionsWithMetricsAndExclusion() throws IOException {
+        BlockLoader loader = createBlockLoader(
+            TSDB_SYNTHETIC_SETTINGS,
+            MAPPING,
+            new BlockLoaderFunctionConfig.TimeSeriesMetadata(true, Set.of("host"))
+        );
+        assertThat(loader, instanceOf(TimeSeriesMetadataFieldBlockLoader.class));
+        assertThat(sourcePaths(loader), equalTo(Set.of("env", "region", "cpu", "request_count")));
     }
 
     /**

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerInSubqueryTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerInSubqueryTests.java
@@ -3401,7 +3401,7 @@ public class AnalyzerInSubqueryTests extends ESTestCase {
         assertThat(semiJoin.config().leftFields().get(0).name(), equalTo("cluster"));
         assertThat(semiJoin.config().rightFields().get(0).name(), equalTo("cluster"));
 
-        // Only the outer (left-hand) k8s relation should carry the lowered `_timeseries` attribute with the expected withoutFields; the
+        // Only the outer (left-hand) k8s relation should carry the lowered `_timeseries` attribute with the expected skipFieldNames; the
         // right-hand subquery relation must not be polluted. The outer aggregate uses sum() (not a TS-required function) so the left
         // relation's index mode is rewritten to STANDARD; the subquery uses rate() and so its relation stays TIME_SERIES.
         assertK8sRelationWithTimeseriesWithout(semiJoin.left(), IndexMode.STANDARD, Set.of("pod", "region"));
@@ -3705,7 +3705,7 @@ public class AnalyzerInSubqueryTests extends ESTestCase {
 
     /**
      * Asserts that the given plan is the k8s TS source relation and that it carries a lowered {@code _timeseries}
-     * {@code TimeSeriesMetadataAttribute} with the expected {@code withoutFields}. {@code TranslateTimeSeriesWithout} injects this
+     * {@code TimeSeriesMetadataAttribute} with the expected {@code skipFieldNames}. {@code TranslateTimeSeriesWithout} injects this
      * attribute only into the main (left-hand) TS source feeding the outer aggregate, never into the subquery (right-hand) relation.
      */
     private static void assertK8sRelationWithTimeseriesWithout(


### PR DESCRIPTION
## Summary

- Adds pre-computed `indexDimensionFieldMappers()` / `indexMetricFieldMappers()` views to `MappingLookup`, built once at mapping construction time so callers get an O(1) set instead of iterating all field mappers
- Renames `BlockLoaderFunctionConfig.TimeSeriesMetadata` fields to be more descriptive: `loadMetrics` → `loadMetricFields`, `withoutFields` → `skipFieldNames`
- Restructures `TimeSeriesMetadataFieldBlockLoader` to use the new `MappingLookup` accessors, removing the now-unnecessary settings-based shortcut that failed silently for wildcard dimension paths (e.g. `labels.*`)

This is a pure refactor — no functional change to the `_timeseries` block loader output.

## Test plan

- [ ] `./gradlew :server:test --tests '*.TimeSeriesMetadataFieldBlockLoaderTests'`
- [ ] `./gradlew :server:test --tests '*.MappingLookupTests'`