### PR TITLE
Bugfix: `TimeSeriesMetadataFieldBlockLoader` ignores passthrough fields

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -56,6 +57,8 @@ public final class MappingLookup {
     private final Map<String, ObjectMapper> objectMappers;
     private final Map<String, InferenceFieldMetadata> inferenceFields;
     private final Set<String> syntheticVectorFields;
+    private final Set<FieldMapper> indexDimensionFieldMappers;
+    private final Set<FieldMapper> indexMetricFieldMappers;
     private final int runtimeFieldMappersCount;
     private final NestedLookup nestedLookup;
     private final FieldTypeLookup fieldTypeLookup;
@@ -186,6 +189,8 @@ public final class MappingLookup {
 
         final Map<String, NamedAnalyzer> indexAnalyzers = new HashMap<>();
         final List<FieldMapper> indexTimeScriptMappers = new ArrayList<>();
+        final Set<FieldMapper> dimensionMappers = new LinkedHashSet<>();
+        final Set<FieldMapper> metricMappers = new LinkedHashSet<>();
         for (FieldMapper mapper : mappers) {
             if (objects.containsKey(mapper.fullPath())) {
                 throw new MapperParsingException("Field [" + mapper.fullPath() + "] is defined both as an object and a field");
@@ -196,6 +201,13 @@ public final class MappingLookup {
             indexAnalyzers.putAll(mapper.indexAnalyzers());
             if (mapper.hasScript()) {
                 indexTimeScriptMappers.add(mapper);
+            }
+            MappedFieldType fieldType = mapper.fieldType();
+            if (fieldType.isDimension()) {
+                dimensionMappers.add(mapper);
+            }
+            if (fieldType.getMetricType() != null) {
+                metricMappers.add(mapper);
             }
         }
 
@@ -240,6 +252,8 @@ public final class MappingLookup {
         }
         // make all fields into compact+fast immutable maps
         this.fieldMappers = Map.copyOf(fieldMappers);
+        this.indexDimensionFieldMappers = Collections.unmodifiableSet(dimensionMappers);
+        this.indexMetricFieldMappers = Collections.unmodifiableSet(metricMappers);
         this.objectMappers = Map.copyOf(objects);
         this.runtimeFieldMappersCount = runtimeFields.size();
         this.indexAnalyzers = Map.copyOf(indexAnalyzers);
@@ -324,6 +338,20 @@ public final class MappingLookup {
      */
     public Iterable<Mapper> fieldMappers() {
         return fieldMappers.values();
+    }
+
+    /**
+     * Returns the set of field mappers marked as time-series dimensions, in insertion order.
+     */
+    public Set<FieldMapper> indexDimensionFieldMappers() {
+        return indexDimensionFieldMappers;
+    }
+
+    /**
+     * Returns the set of field mappers that carry a time-series metric type, in insertion order.
+     */
+    public Set<FieldMapper> indexMetricFieldMappers() {
+        return indexMetricFieldMappers;
     }
 
     void checkLimits(IndexSettings settings) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/TimeSeriesMetadataFieldBlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TimeSeriesMetadataFieldBlockLoader.java
@@ -12,10 +12,8 @@ package org.elasticsearch.index.mapper;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.util.IOFunction;
-import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.mapper.blockloader.BlockLoaderFunctionConfig;
@@ -29,7 +27,6 @@ import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Set;
 
 /**
@@ -125,35 +122,25 @@ public final class TimeSeriesMetadataFieldBlockLoader implements BlockLoader {
 
         assert ctx.blockLoaderFunctionConfig() instanceof BlockLoaderFunctionConfig.TimeSeriesMetadata;
         var config = (BlockLoaderFunctionConfig.TimeSeriesMetadata) ctx.blockLoaderFunctionConfig();
+        MappingLookup mappingLookup = ctx.mappingLookup();
 
-        if (loadMetrics == false) {
-            IndexMetadata indexMetadata = ctx.indexSettings().getIndexMetadata();
-            List<String> dimensionFieldsFromSettings = indexMetadata.getTimeSeriesDimensions();
-            // The settings shortcut lists dimensions by name and excludes WITHOUT fields via an exact-name removal.
-            // It cannot honor exclusions when an entry is a wildcard (e.g. a passthrough dimension recorded as
-            // "labels.*"), because a concrete field name like "labels.le" never matches the literal "labels.*".
-            // In that case fall through to the mapping-based enumeration below, which resolves the wildcard to
-            // concrete dimension fields and can drop the excluded ones by name.
-            if (dimensionFieldsFromSettings != null
-                && dimensionFieldsFromSettings.isEmpty() == false
-                && (config.withoutFields().isEmpty() || dimensionFieldsFromSettings.stream().noneMatch(Regex::isSimpleMatchPattern))) {
-                Set<String> result = new LinkedHashSet<>(dimensionFieldsFromSettings);
-                result.removeAll(config.withoutFields());
-                return result;
-            }
+        Set<FieldMapper> dimensionIndex = mappingLookup.indexDimensionFieldMappers();
+        Set<String> result = new LinkedHashSet<>(dimensionIndex.size());
+        for (FieldMapper mapper : dimensionIndex) {
+            result.add(mapper.fieldType().name());
         }
 
-        Set<String> result = new LinkedHashSet<>();
-        MappingLookup mappingLookup = ctx.mappingLookup();
-        for (Mapper mapper : mappingLookup.fieldMappers()) {
-            if (mapper instanceof FieldMapper fieldMapper) {
-                MappedFieldType fieldType = fieldMapper.fieldType();
-                if (fieldType.isDimension() && config.withoutFields().contains(fieldType.name()) == false) {
-                    result.add(fieldType.name());
-                }
-                if (loadMetrics && fieldType.getMetricType() != null) {
-                    result.add(fieldType.name());
-                }
+        for (String skip : config.withoutFields()) {
+            // Resolve each name to its concrete field name so that passthrough aliases
+            // like "cpu" -> "attributes.cpu" are matched correctly.
+            var ft = mappingLookup.getFieldType(skip);
+            result.remove(ft != null ? ft.name() : skip);
+        }
+
+        if (loadMetrics) {
+            // Metrics are disjoint from dimensions by TSDB mapping validation and are never excluded.
+            for (FieldMapper mapper : mappingLookup.indexMetricFieldMappers()) {
+                result.add(mapper.fieldType().name());
             }
         }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/TimeSeriesMetadataFieldBlockLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TimeSeriesMetadataFieldBlockLoaderTests.java
@@ -226,24 +226,6 @@ public class TimeSeriesMetadataFieldBlockLoaderTests extends MapperServiceTestCa
         assertThat(sourcePaths(loader), equalTo(Set.of("labels.__name__", "labels.instance")));
     }
 
-    /**
-     * With no exclusions the wildcard {@code index.dimensions} shortcut is still honored as-is, since there is
-     * nothing to remove and the source filter understands the {@code labels.*} pattern.
-     */
-    public void testWildcardDimensionSettingUsedWhenNothingExcluded() throws IOException {
-        Settings settings = Settings.builder()
-            .put(TSDB_PROMETHEUS_LIKE_SETTINGS)
-            .putList(IndexMetadata.INDEX_DIMENSIONS.getKey(), "labels.*")
-            .build();
-        BlockLoader loader = createBlockLoader(
-            settings,
-            PROMETHEUS_LIKE_MAPPING,
-            new BlockLoaderFunctionConfig.TimeSeriesMetadata(false, Set.of())
-        );
-        assertThat(loader, instanceOf(TimeSeriesMetadataFieldBlockLoader.class));
-        assertThat(sourcePaths(loader), equalTo(Set.of("labels.*")));
-    }
-
     public void testNoConfigReturnSourceBlockLoader() throws IOException {
         MapperService mapperService = createMapperService(TSDB_SYNTHETIC_SETTINGS, MAPPING);
         BlockLoader loader = mapperService.documentMapper()

--- a/server/src/test/java/org/elasticsearch/index/mapper/TimeSeriesMetadataFieldBlockLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TimeSeriesMetadataFieldBlockLoaderTests.java
@@ -72,6 +72,12 @@ public class TimeSeriesMetadataFieldBlockLoaderTests extends MapperServiceTestCa
      */
     private static final Settings TSDB_PROMETHEUS_LIKE_SETTINGS = tsdbSettings(SourceFieldMapper.Mode.STORED, "labels.*");
 
+    /**
+     * OTel-like TSDB index: an {@code attributes} passthrough object. Dimension fields show up under
+     * {@code attributes.*} and also as root-level aliases. Synthetic source (JSON) is used.
+     */
+    private static final Settings TSDB_OTEL_LIKE_SETTINGS = tsdbSettings(null, "attributes.*");
+
     private static final String MAPPING = """
         {
           "_doc": {
@@ -83,6 +89,38 @@ public class TimeSeriesMetadataFieldBlockLoaderTests extends MapperServiceTestCa
               "cpu": { "type": "double", "time_series_metric": "gauge" },
               "request_count": { "type": "long", "time_series_metric": "counter" },
               "message": { "type": "keyword" }
+            }
+          }
+        }
+        """;
+
+    /**
+     * OTel TSDB index: an {@code attributes} {@code passthrough} object marked as
+     * {@code time_series_dimension: true}, plus a non-dimension metric under {@code metrics}. Dimension
+     * fields are exposed both under their concrete path ({@code attributes.cpu}) and as root-level aliases
+     * ({@code cpu}). Stored source is not configured here, so synthetic source (JSON) is used.
+     */
+    private static final String OTEL_LIKE_MAPPING = """
+        {
+          "_doc": {
+            "properties": {
+              "@timestamp": { "type": "date" },
+              "attributes": {
+                "type": "passthrough",
+                "priority": 10,
+                "time_series_dimension": true,
+                "properties": {
+                  "cpu": { "type": "keyword" },
+                  "state": { "type": "keyword" }
+                }
+              },
+              "metrics": {
+                "type": "passthrough",
+                "priority": 20,
+                "properties": {
+                  "system.cpu.time": { "type": "double", "time_series_metric": "gauge" }
+                }
+              }
             }
           }
         }
@@ -308,6 +346,94 @@ public class TimeSeriesMetadataFieldBlockLoaderTests extends MapperServiceTestCa
         @SuppressWarnings("unchecked")
         Map<String, Object> labels = (Map<String, Object>) parsed.get("labels");
         assertThat(labels, equalTo(Map.of("__name__", "go_gc_cleanups_executed_cleanups_total", "job", "prometheus")));
+    }
+
+    /**
+     * Regression test for OTel passthrough alias exclusion (GitHub issue #151540). PromQL
+     * {@code without(cpu)} passes the short alias name {@code "cpu"} in {@code withoutFields}. The block
+     * loader must resolve the alias to the concrete dimension path {@code "attributes.cpu"} (via
+     * {@link MappingLookup#getFieldType}) so the exclusion actually matches and the dimension is dropped from
+     * the {@code _timeseries} source paths. Before the fix, {@code "cpu" != "attributes.cpu"} caused the
+     * exclusion to silently no-op, leaking the label.
+     */
+    public void testOtelPassthroughAliasExcludedByShortName() throws IOException {
+        BlockLoader loader = createBlockLoader(
+            TSDB_OTEL_LIKE_SETTINGS,
+            OTEL_LIKE_MAPPING,
+            new BlockLoaderFunctionConfig.TimeSeriesMetadata(false, Set.of("cpu"))
+        );
+        assertThat(loader, instanceOf(TimeSeriesMetadataFieldBlockLoader.class));
+        assertThat(sourcePaths(loader), equalTo(Set.of("attributes.state")));
+    }
+
+    /**
+     * Prometheus-style passthrough: {@code labels.job} is exposed as the short alias {@code job} at the
+     * root level. Passing {@code "job"} in withoutFields must resolve to {@code "labels.job"} and exclude
+     * it, leaving only {@code labels.__name__} and {@code labels.instance}.
+     */
+    public void testPrometheusPassthroughAliasExcludedByShortName() throws IOException {
+        BlockLoader loader = createBlockLoader(
+            TSDB_PROMETHEUS_LIKE_SETTINGS,
+            PROMETHEUS_LIKE_MAPPING,
+            new BlockLoaderFunctionConfig.TimeSeriesMetadata(false, Set.of("job"))
+        );
+        assertThat(loader, instanceOf(TimeSeriesMetadataFieldBlockLoader.class));
+        assertThat(sourcePaths(loader), equalTo(Set.of("labels.__name__", "labels.instance")));
+    }
+
+    /**
+     * Excluding all dimensions must produce an empty source-paths set (single global series).
+     */
+    public void testWithoutAllDimensionsYieldsEmptySourcePaths() throws IOException {
+        BlockLoader loader = createBlockLoader(
+            TSDB_SYNTHETIC_SETTINGS,
+            MAPPING,
+            new BlockLoaderFunctionConfig.TimeSeriesMetadata(false, Set.of("host", "env", "region"))
+        );
+        assertThat(loader, instanceOf(TimeSeriesMetadataFieldBlockLoader.class));
+        assertThat(sourcePaths(loader), equalTo(Set.of()));
+    }
+
+    /**
+     * An unknown field in withoutFields must be silently ignored: the exclusion simply
+     * does not match any dimension and the full dimension set is returned.
+     */
+    public void testWithoutUnknownFieldIsIgnored() throws IOException {
+        BlockLoader loader = createBlockLoader(
+            TSDB_SYNTHETIC_SETTINGS,
+            MAPPING,
+            new BlockLoaderFunctionConfig.TimeSeriesMetadata(false, Set.of("does_not_exist"))
+        );
+        assertThat(loader, instanceOf(TimeSeriesMetadataFieldBlockLoader.class));
+        assertThat(sourcePaths(loader), equalTo(Set.of("host", "env", "region")));
+    }
+
+    /**
+     * loadMetricFields=true with a non-empty exclusion set: the excluded dimension must be absent from
+     * source paths while metrics remain unaffected.
+     */
+    public void testExcludedDimensionsWithMetricsAndExclusion() throws IOException {
+        BlockLoader loader = createBlockLoader(
+            TSDB_SYNTHETIC_SETTINGS,
+            MAPPING,
+            new BlockLoaderFunctionConfig.TimeSeriesMetadata(true, Set.of("host"))
+        );
+        assertThat(loader, instanceOf(TimeSeriesMetadataFieldBlockLoader.class));
+        assertThat(sourcePaths(loader), equalTo(Set.of("env", "region", "cpu", "request_count")));
+    }
+
+    /**
+     * Complement of {@link #testOtelPassthroughAliasExcludedByShortName}: passing the concrete field name
+     * {@code "attributes.cpu"} directly must also work, and it already did before the fix (regression guard).
+     */
+    public void testOtelPassthroughConcreteNameExcludesCorrectly() throws IOException {
+        BlockLoader loader = createBlockLoader(
+            TSDB_OTEL_LIKE_SETTINGS,
+            OTEL_LIKE_MAPPING,
+            new BlockLoaderFunctionConfig.TimeSeriesMetadata(false, Set.of("attributes.cpu"))
+        );
+        assertThat(loader, instanceOf(TimeSeriesMetadataFieldBlockLoader.class));
+        assertThat(sourcePaths(loader), equalTo(Set.of("attributes.state")));
     }
 
     /**

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
@@ -223,6 +223,10 @@ public class CsvTestsDataLoader {
             "promql_histogram_no_le.csv",
             "promql_histogram_no_le-settings.json"
         ).withRequiredCapabilities(EsqlCapabilities.Cap.PROMQL_HISTOGRAM_QUANTILE),
+        new TestDataset("otel-metrics", "otel-metrics-mappings.json", "k8s-otel.csv", "otel-metrics-settings.json")
+            .withRequiredCapabilities(EsqlCapabilities.Cap.FIX_TS_BLOCK_LOADER_PASSTHROUGH_ALIASING),
+        new TestDataset("prom-metrics", "prom-metrics-mappings.json", "k8s-prometheus-remote-write.csv", "prom-metrics-settings.json")
+            .withRequiredCapabilities(EsqlCapabilities.Cap.FIX_TS_BLOCK_LOADER_PASSTHROUGH_ALIASING),
         new TestDataset("distances"),
         new TestDataset("addresses"),
         new TestDataset("addresses").withIndex("addresses_no_continent")

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/TestAnalyzer.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/TestAnalyzer.java
@@ -22,6 +22,10 @@ import org.elasticsearch.xpack.esql.common.Failures;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.querydsl.QueryDslTimestampBoundsExtractor.TimestampBounds;
 import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.type.DateEsField;
+import org.elasticsearch.xpack.esql.core.type.EsField;
+import org.elasticsearch.xpack.esql.core.type.KeywordEsField;
 import org.elasticsearch.xpack.esql.datasources.ExternalSourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.ExternalSourceResolution;
 import org.elasticsearch.xpack.esql.datasources.ExternalSourceResolver;
@@ -292,6 +296,48 @@ public class TestAnalyzer {
      */
     public TestAnalyzer addK8sDownsampled() {
         return addIndex("k8s", "k8s-downsampled-mappings.json", IndexMode.TIME_SERIES);
+    }
+
+    /**
+     * Adds the otel-metrics index, built programmatically to mirror what IndexResolver produces for a real
+     * OTel TSDB index. In a real OTel index both the root-level alias (e.g. {@code cpu}) and the concrete
+     * passthrough field (e.g. {@code attributes.cpu}) have {@code isAlias=false}; the mapping here reflects
+     * that to keep tests consistent with production behaviour.
+     */
+    public TestAnalyzer addOtelMetrics() {
+        LinkedHashMap<String, EsField> attributesChildren = new LinkedHashMap<>();
+        attributesChildren.put("cpu", new KeywordEsField("cpu", Map.of(), true, 0, false, false, EsField.TimeSeriesFieldType.DIMENSION));
+        attributesChildren.put(
+            "state",
+            new KeywordEsField("state", Map.of(), true, 0, false, false, EsField.TimeSeriesFieldType.DIMENSION)
+        );
+
+        LinkedHashMap<String, EsField> resourceAttributesChildren = new LinkedHashMap<>();
+        resourceAttributesChildren.put(
+            "host.name",
+            new KeywordEsField("host.name", Map.of(), true, 0, false, false, EsField.TimeSeriesFieldType.DIMENSION)
+        );
+
+        LinkedHashMap<String, EsField> metricsChildren = new LinkedHashMap<>();
+        metricsChildren.put(
+            "system.cpu.time",
+            new EsField("system.cpu.time", DataType.DOUBLE, Map.of(), true, EsField.TimeSeriesFieldType.METRIC)
+        );
+
+        LinkedHashMap<String, EsField> mapping = new LinkedHashMap<>();
+        mapping.put("@timestamp", DateEsField.dateEsField("@timestamp", Map.of(), true, EsField.TimeSeriesFieldType.NONE));
+        mapping.put("attributes", new EsField("attributes", DataType.OBJECT, attributesChildren, false, EsField.TimeSeriesFieldType.NONE));
+        mapping.put("cpu", new KeywordEsField("cpu", Map.of(), true, 0, false, false, EsField.TimeSeriesFieldType.DIMENSION));
+        mapping.put("state", new KeywordEsField("state", Map.of(), true, 0, false, false, EsField.TimeSeriesFieldType.DIMENSION));
+        mapping.put(
+            "resource.attributes",
+            new EsField("resource.attributes", DataType.OBJECT, resourceAttributesChildren, false, EsField.TimeSeriesFieldType.NONE)
+        );
+        mapping.put("host.name", new KeywordEsField("host.name", Map.of(), true, 0, false, false, EsField.TimeSeriesFieldType.DIMENSION));
+        mapping.put("metrics", new EsField("metrics", DataType.OBJECT, metricsChildren, false, EsField.TimeSeriesFieldType.NONE));
+
+        EsIndex otelMetrics = new EsIndex("otel-metrics", mapping, Map.of("otel-metrics", IndexMode.TIME_SERIES), Map.of(), Map.of());
+        return addIndex(otelMetrics);
     }
 
     /**

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/data/k8s-otel.csv
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/data/k8s-otel.csv
@@ -1,0 +1,5 @@
+@timestamp:date,attributes.cpu:keyword,attributes.state:keyword,metrics.cpu_time:double
+2024-05-10T00:58:01.000Z,user,active,10.0
+2024-05-10T00:58:02.000Z,user,idle,2.0
+2024-05-10T00:58:03.000Z,system,active,5.0
+2024-05-10T00:58:04.000Z,system,idle,1.0

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/data/k8s-prometheus-remote-write.csv
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/data/k8s-prometheus-remote-write.csv
@@ -1,0 +1,5 @@
+@timestamp:date,labels.cpu:keyword,labels.state:keyword,metrics.cpu_time:double
+2024-05-10T00:58:01.000Z,user,active,10.0
+2024-05-10T00:58:02.000Z,user,idle,2.0
+2024-05-10T00:58:03.000Z,system,active,5.0
+2024-05-10T00:58:04.000Z,system,idle,1.0

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/index/mappings/otel-metrics-mappings.json
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/index/mappings/otel-metrics-mappings.json
@@ -1,0 +1,28 @@
+{
+  "properties": {
+    "@timestamp": {
+      "type": "date"
+    },
+    "attributes": {
+      "type": "passthrough",
+      "priority": 10,
+      "time_series_dimension": true,
+      "properties": {
+        "cpu": {
+          "type": "keyword"
+        },
+        "state": {
+          "type": "keyword"
+        }
+      }
+    },
+    "metrics": {
+      "properties": {
+        "cpu_time": {
+          "type": "double",
+          "time_series_metric": "gauge"
+        }
+      }
+    }
+  }
+}

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/index/mappings/prom-metrics-mappings.json
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/index/mappings/prom-metrics-mappings.json
@@ -1,0 +1,28 @@
+{
+  "properties": {
+    "@timestamp": {
+      "type": "date"
+    },
+    "labels": {
+      "type": "passthrough",
+      "priority": 10,
+      "time_series_dimension": true,
+      "properties": {
+        "cpu": {
+          "type": "keyword"
+        },
+        "state": {
+          "type": "keyword"
+        }
+      }
+    },
+    "metrics": {
+      "properties": {
+        "cpu_time": {
+          "type": "double",
+          "time_series_metric": "gauge"
+        }
+      }
+    }
+  }
+}

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/index/settings/otel-metrics-settings.json
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/index/settings/otel-metrics-settings.json
@@ -1,0 +1,10 @@
+{
+  "index": {
+    "mode": "time_series",
+    "routing_path": ["attributes.*"],
+    "time_series": {
+      "start_time": "2024-05-10T00:00:00Z",
+      "end_time": "2024-05-20T00:00:00Z"
+    }
+  }
+}

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/index/settings/prom-metrics-settings.json
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/index/settings/prom-metrics-settings.json
@@ -1,0 +1,10 @@
+{
+  "index": {
+    "mode": "time_series",
+    "routing_path": ["labels.*"],
+    "time_series": {
+      "start_time": "2024-05-10T00:00:00Z",
+      "end_time": "2024-05-20T00:00:00Z"
+    }
+  }
+}

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/otel-metrics-promql-without.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/otel-metrics-promql-without.csv-spec
@@ -1,0 +1,226 @@
+// Regression tests for PromQL and ES|QL `without` on TSDB indices that use passthrough objects.
+// Covers both OTel-style (attributes.*) and Prometheus-style (labels.*) passthrough mappings.
+// Before the fix, without(cpu) was a no-op: the plan passed the short alias name "cpu" to
+// the _timeseries block loader, but the loader compared against the concrete field name
+// "attributes.cpu" / "labels.cpu" and the exclusion never matched.
+// https://github.com/elastic/elasticsearch/issues/151540
+
+
+// without(cpu) must exclude the `attributes.cpu` passthrough dimension from the
+// _timeseries series key. Before the fix, `cpu` and `state` both appeared in the key.
+without_otel_attribute_cpu_excludes_from_timeseries
+required_capability: promql_command_v0
+required_capability: fix_promql_time_bucket_v2
+required_capability: promql_nested_aggregates
+required_capability: promql_without_grouping
+required_capability: fix_ts_block_loader_passthrough_aliasing
+PROMQL index=otel-metrics step=1h result=(sum without (cpu) (metrics.cpu_time))
+| EVAL has_cpu = _timeseries LIKE "*cpu*"
+| KEEP result, _timeseries, has_cpu
+| SORT result;
+
+result:double | _timeseries:keyword                        | has_cpu:boolean
+3.0           | "{""attributes"":{""state"":""idle""}}"    | false
+15.0          | "{""attributes"":{""state"":""active""}}"  | false
+;
+
+
+// without(state) must exclude the `attributes.state` passthrough dimension.
+without_otel_attribute_state_excludes_from_timeseries
+required_capability: promql_command_v0
+required_capability: fix_promql_time_bucket_v2
+required_capability: promql_nested_aggregates
+required_capability: promql_without_grouping
+required_capability: fix_ts_block_loader_passthrough_aliasing
+PROMQL index=otel-metrics step=1h result=(sum without (state) (metrics.cpu_time))
+| EVAL has_state = _timeseries LIKE "*state*"
+| KEEP result, _timeseries, has_state
+| SORT result;
+
+result:double | _timeseries:keyword                        | has_state:boolean
+6.0           | "{""attributes"":{""cpu"":""system""}}"    | false
+12.0          | "{""attributes"":{""cpu"":""user""}}"      | false
+;
+
+
+sum_without_otel_cpu
+required_capability: promql_command_v0
+required_capability: fix_promql_time_bucket_v2
+required_capability: promql_nested_aggregates
+required_capability: promql_without_grouping
+required_capability: fix_ts_block_loader_passthrough_aliasing
+PROMQL index=otel-metrics step=1h result=(sum without (cpu) (metrics.cpu_time))
+| SORT result;
+
+result:double | step:datetime            | _timeseries:keyword
+3.0           | 2024-05-10T01:00:00.000Z | "{""attributes"":{""state"":""idle""}}"
+15.0          | 2024-05-10T01:00:00.000Z | "{""attributes"":{""state"":""active""}}"
+;
+
+
+sum_without_otel_state
+required_capability: promql_command_v0
+required_capability: fix_promql_time_bucket_v2
+required_capability: promql_nested_aggregates
+required_capability: promql_without_grouping
+required_capability: fix_ts_block_loader_passthrough_aliasing
+PROMQL index=otel-metrics step=1h result=(sum without (state) (metrics.cpu_time))
+| SORT result;
+
+result:double | step:datetime            | _timeseries:keyword
+6.0           | 2024-05-10T01:00:00.000Z | "{""attributes"":{""cpu"":""system""}}"
+12.0          | 2024-05-10T01:00:00.000Z | "{""attributes"":{""cpu"":""user""}}"
+;
+
+
+// sum by (state) is the "by" baseline equivalent to sum without (cpu).
+sum_by_state_baseline_for_without_cpu
+required_capability: promql_command_v0
+required_capability: fix_promql_time_bucket_v2
+required_capability: promql_nested_aggregates
+required_capability: promql_without_grouping
+required_capability: fix_ts_block_loader_passthrough_aliasing
+PROMQL index=otel-metrics step=1h result=(sum by (state) (metrics.cpu_time))
+| SORT result;
+
+result:double | step:datetime            | state:keyword
+3.0           | 2024-05-10T01:00:00.000Z | idle
+15.0          | 2024-05-10T01:00:00.000Z | active
+;
+
+
+// without(cpu) must exclude the `labels.cpu` passthrough dimension.
+without_prom_label_cpu_excludes_from_timeseries
+required_capability: promql_command_v0
+required_capability: fix_promql_time_bucket_v2
+required_capability: promql_nested_aggregates
+required_capability: promql_without_grouping
+required_capability: fix_ts_block_loader_passthrough_aliasing
+PROMQL index=prom-metrics step=1h result=(sum without (cpu) (metrics.cpu_time))
+| EVAL has_cpu = _timeseries LIKE "*cpu*"
+| KEEP result, _timeseries, has_cpu
+| SORT result;
+
+result:double | _timeseries:keyword                     | has_cpu:boolean
+3.0           | "{""labels"":{""state"":""idle""}}"     | false
+15.0          | "{""labels"":{""state"":""active""}}"   | false
+;
+
+
+// without(state) must exclude the `labels.state` passthrough dimension.
+without_prom_label_state_excludes_from_timeseries
+required_capability: promql_command_v0
+required_capability: fix_promql_time_bucket_v2
+required_capability: promql_nested_aggregates
+required_capability: promql_without_grouping
+required_capability: fix_ts_block_loader_passthrough_aliasing
+PROMQL index=prom-metrics step=1h result=(sum without (state) (metrics.cpu_time))
+| EVAL has_state = _timeseries LIKE "*state*"
+| KEEP result, _timeseries, has_state
+| SORT result;
+
+result:double | _timeseries:keyword                     | has_state:boolean
+6.0           | "{""labels"":{""cpu"":""system""}}"     | false
+12.0          | "{""labels"":{""cpu"":""user""}}"       | false
+;
+
+
+sum_without_prom_cpu
+required_capability: promql_command_v0
+required_capability: fix_promql_time_bucket_v2
+required_capability: promql_nested_aggregates
+required_capability: promql_without_grouping
+required_capability: fix_ts_block_loader_passthrough_aliasing
+PROMQL index=prom-metrics step=1h result=(sum without (cpu) (metrics.cpu_time))
+| SORT result;
+
+result:double | step:datetime            | _timeseries:keyword
+3.0           | 2024-05-10T01:00:00.000Z | "{""labels"":{""state"":""idle""}}"
+15.0          | 2024-05-10T01:00:00.000Z | "{""labels"":{""state"":""active""}}"
+;
+
+
+sum_without_prom_state
+required_capability: promql_command_v0
+required_capability: fix_promql_time_bucket_v2
+required_capability: promql_nested_aggregates
+required_capability: promql_without_grouping
+required_capability: fix_ts_block_loader_passthrough_aliasing
+PROMQL index=prom-metrics step=1h result=(sum without (state) (metrics.cpu_time))
+| SORT result;
+
+result:double | step:datetime            | _timeseries:keyword
+6.0           | 2024-05-10T01:00:00.000Z | "{""labels"":{""cpu"":""system""}}"
+12.0          | 2024-05-10T01:00:00.000Z | "{""labels"":{""cpu"":""user""}}"
+;
+
+
+sum_by_state_baseline_for_without_cpu_prom
+required_capability: promql_command_v0
+required_capability: fix_promql_time_bucket_v2
+required_capability: promql_nested_aggregates
+required_capability: promql_without_grouping
+required_capability: fix_ts_block_loader_passthrough_aliasing
+PROMQL index=prom-metrics step=1h result=(sum by (state) (metrics.cpu_time))
+| SORT result;
+
+result:double | step:datetime            | state:keyword
+3.0           | 2024-05-10T01:00:00.000Z | idle
+15.0          | 2024-05-10T01:00:00.000Z | active
+;
+
+
+esql_without_otel_attribute_cpu
+required_capability: ts_command_v0
+required_capability: esql_without_grouping
+required_capability: fix_ts_block_loader_passthrough_aliasing
+TS otel-metrics
+| STATS result = sum(metrics.cpu_time) BY WITHOUT(cpu)
+| SORT result;
+
+result:double | _timeseries:keyword
+3.0           | "{""attributes"":{""state"":""idle""}}"
+15.0          | "{""attributes"":{""state"":""active""}}"
+;
+
+
+esql_without_otel_attribute_state
+required_capability: ts_command_v0
+required_capability: esql_without_grouping
+required_capability: fix_ts_block_loader_passthrough_aliasing
+TS otel-metrics
+| STATS result = sum(metrics.cpu_time) BY WITHOUT(state)
+| SORT result;
+
+result:double | _timeseries:keyword
+6.0           | "{""attributes"":{""cpu"":""system""}}"
+12.0          | "{""attributes"":{""cpu"":""user""}}"
+;
+
+
+esql_without_prom_label_cpu
+required_capability: ts_command_v0
+required_capability: esql_without_grouping
+required_capability: fix_ts_block_loader_passthrough_aliasing
+TS prom-metrics
+| STATS result = sum(metrics.cpu_time) BY WITHOUT(cpu)
+| SORT result;
+
+result:double | _timeseries:keyword
+3.0           | "{""labels"":{""state"":""idle""}}"
+15.0          | "{""labels"":{""state"":""active""}}"
+;
+
+
+esql_without_prom_label_state
+required_capability: ts_command_v0
+required_capability: esql_without_grouping
+required_capability: fix_ts_block_loader_passthrough_aliasing
+TS prom-metrics
+| STATS result = sum(metrics.cpu_time) BY WITHOUT(state)
+| SORT result;
+
+result:double | _timeseries:keyword
+6.0           | "{""labels"":{""cpu"":""system""}}"
+12.0          | "{""labels"":{""cpu"":""user""}}"
+;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -3169,6 +3169,14 @@ public class EsqlCapabilities {
          */
         PROMQL_HISTOGRAM_QUANTILE_IMPLICIT_LE,
 
+        /**
+         * Fix for PromQL {@code without} and ES|QL {@code TS_WITHOUT}: passthrough alias names (e.g. OTel
+         * {@code cpu} for the concrete dimension {@code attributes.cpu}) are now correctly resolved in the
+         * {@code _timeseries} block loader so excluded labels are actually removed from the series key.
+         * https://github.com/elastic/elasticsearch/issues/151540
+         */
+        FIX_TS_BLOCK_LOADER_PASSTHROUGH_ALIASING,
+
         // Last capability should still have a comma for fewer merge conflicts when adding new ones :)
         // This comment prevents the semicolon from being on the previous capability when Spotless formats the file.
         ;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/AbstractPromqlPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/AbstractPromqlPlanOptimizerTests.java
@@ -34,6 +34,7 @@ public abstract class AbstractPromqlPlanOptimizerTests extends AbstractLogicalPl
 
     protected static TestAnalyzer tsAnalyzer() {
         return analyzerWithEnrichPolicies().addK8s()
+            .addOtelMetrics()
             .addEmptyIndex()
             .unmappedResolution(UnmappedResolution.NULLIFY)
             .minimumTransportVersion(TimeSeriesCollapse.TS_COLLAPSE);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlPlanWithoutGroupingTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlPlanWithoutGroupingTests.java
@@ -361,6 +361,52 @@ public class PromqlPlanWithoutGroupingTests extends AbstractPromqlPlanOptimizerT
         planPromql("PROMQL index=k8s step=1h result=(sum(avg_over_time(network.cost[1h])) without (pod, region))");
     }
 
+    /**
+     * Regression test for OTel passthrough alias exclusion: {@code without(cpu)} on an OTel TSDB index must
+     * resolve the short label name {@code cpu} to the concrete passthrough dimension {@code attributes.cpu},
+     * so the {@code _timeseries} block loader receives the concrete field name and correctly excludes it.
+     * Before the fix, the plan passed {@code "cpu"} in {@code excludedFields()} but the block loader compared
+     * against {@code "attributes.cpu"} (the concrete field name) and the exclusion never matched.
+     */
+    public void testWithoutOtelAttributeShortNameExcludesConcretePassthroughDimension() {
+        var plan = logicalOptimizerWithLatestVersion.optimize(
+            planPromql("PROMQL index=otel-metrics step=1h result=(sum without (cpu) (metrics.system.cpu.time))", false)
+        );
+
+        var timeSeriesMetadata = plan.collect(EsRelation.class)
+            .stream()
+            .flatMap(relation -> relation.output().stream())
+            .filter(TimeSeriesMetadataAttribute.class::isInstance)
+            .map(TimeSeriesMetadataAttribute.class::cast)
+            .findFirst()
+            .orElse(null);
+        assertNotNull(timeSeriesMetadata);
+        assertThat(timeSeriesMetadata.excludedFields(), hasItem("cpu"));
+    }
+
+    /**
+     * Regression test for OTel resource-attributes passthrough alias exclusion. The plan-level fix does not
+     * strip {@code resource.attributes.} prefix, so {@code excludedFields()} contains {@code "host.name"} (the
+     * short root-level alias). The block loader fix resolves the alias to the concrete dimension
+     * {@code resource.attributes.host.name} via {@code MappingLookup.getFieldType}, ensuring the exclusion
+     * actually matches the dimension the loader enumerates.
+     */
+    public void testWithoutResourceAttributeShortNameExcludesConcretePassthroughDimension() {
+        var plan = logicalOptimizerWithLatestVersion.optimize(
+            planPromql("PROMQL index=otel-metrics step=1h result=(sum without (host.name) (metrics.system.cpu.time))", false)
+        );
+
+        var timeSeriesMetadata = plan.collect(EsRelation.class)
+            .stream()
+            .flatMap(relation -> relation.output().stream())
+            .filter(TimeSeriesMetadataAttribute.class::isInstance)
+            .map(TimeSeriesMetadataAttribute.class::cast)
+            .findFirst()
+            .orElse(null);
+        assertNotNull(timeSeriesMetadata);
+        assertThat(timeSeriesMetadata.excludedFields(), hasItem("host.name"));
+    }
+
     public void testWithoutTrailingCommaPlans() {
         planPromql("PROMQL index=k8s step=1h result=(sum without (pod, region,) (avg_over_time(network.cost[1h])))");
     }


### PR DESCRIPTION
## What

`TimeSeriesMetadataFieldBlockLoader` takes `L = withoutFields` and loads metadata blob with fields except `L`.

When `L` contains [passthrough](https://www.elastic.co/docs/reference/elasticsearch/mapping-reference/passthrough) aliases which are passed to PromQL's `without(cpu)` or ESQL's `TS_WITHOUT(cpu)` query, it sees name as if it is not a passthrough alias e.g. `cpu` instead of `attributes.cpu` or `labels.cpu` and silently ignores the exclusion.

## Fix

To fix the bug we have to resolve `L` names via `MappingLookup` to bring names to canonical form on shard level lookup table. It adds up to `|L|` hash lookups to each per shard per query.

Closes #151540