### PR TITLE
Size PrefetchingCentroidIterator depth by visit ratio

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/ES920DiskBBQVectorsReader.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/ES920DiskBBQVectorsReader.java
@@ -59,9 +59,12 @@ public class ES920DiskBBQVectorsReader extends IVFVectorsReader<IVFVectorsReader
         );
     }
 
-    public CentroidIterator getPostingListPrefetchIterator(CentroidIterator centroidIterator, IndexInput postingListSlice)
-        throws IOException {
-        return new PrefetchingCentroidIterator(centroidIterator, postingListSlice);
+    public CentroidIterator getPostingListPrefetchIterator(
+        CentroidIterator centroidIterator,
+        IndexInput postingListSlice,
+        long maxPrefetchBytes
+    ) throws IOException {
+        return new PrefetchingCentroidIterator(centroidIterator, postingListSlice, maxPrefetchBytes);
     }
 
     @Override
@@ -121,7 +124,8 @@ public class ES920DiskBBQVectorsReader extends IVFVectorsReader<IVFVectorsReader
                 globalCentroidDp
             );
         }
-        return getPostingListPrefetchIterator(centroidIterator, postingListSlice);
+        final long maxPrefetchBytes = prefetchByteBudget(visitRatio, fieldEntry.postingListLength());
+        return getPostingListPrefetchIterator(centroidIterator, postingListSlice, maxPrefetchBytes);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/IVFVectorsReader.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/IVFVectorsReader.java
@@ -147,6 +147,21 @@ public abstract class IVFVectorsReader<E extends IVFVectorsReader.FieldEntry> ex
         return values.size();
     }
 
+    /**
+     * Computes the number of posting list bytes to keep prefetched ahead of the consumer for a query,
+     * used to size {@link PrefetchingCentroidIterator}'s prefetch depth. This mirrors the vector visit
+     * budget ({@code maxVectorVisited = 2 * visitRatio * numVectors}) but expressed in posting list
+     * bytes, because the iterator only has posting list byte lengths available to decide how deeply to
+     * prefetch. The factor of two accounts for SOAR vectors, matching {@code maxVectorVisited}.
+     *
+     * @param visitRatio the fraction of vectors the query is expected to visit
+     * @param postingListLength the total byte length of the field's posting lists
+     * @return the target number of posting list bytes to prefetch ahead
+     */
+    protected static long prefetchByteBudget(float visitRatio, long postingListLength) {
+        return (long) (2.0 * visitRatio * postingListLength);
+    }
+
     protected static IndexInput openDataInput(
         SegmentReadState state,
         int versionMeta,
@@ -535,6 +550,10 @@ public abstract class IVFVectorsReader<E extends IVFVectorsReader.FieldEntry> ex
 
         public int numCentroids() {
             return numCentroids;
+        }
+
+        public long postingListLength() {
+            return postingListLength;
         }
 
         public float[] globalCentroid() {

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/PrefetchingCentroidIterator.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/PrefetchingCentroidIterator.java
@@ -12,67 +12,64 @@ package org.elasticsearch.index.codec.vectors.diskbbq;
 import org.apache.lucene.store.IndexInput;
 
 import java.io.IOException;
+import java.util.ArrayDeque;
 
 /**
- * A configurable iterator that prefetches posting lists ahead of consumption
- * to optimize disk I/O performance. This iterator wraps another CentroidIterator
- * and maintains a configurable buffer of prefetched posting list locations.
+ * A {@link CentroidIterator} that prefetches upcoming posting lists ahead of consumption so that
+ * disk / blob-cache I/O overlaps with scoring. This iterator wraps another {@link CentroidIterator}
+ * and keeps a buffer of prefetched posting list locations.
  *
- * The iterator is not thread-safe and is designed for single-threaded access.
+ * <p>Rather than prefetching a fixed number of posting lists, the depth is derived from the
+ * iterator's own state: the iterator keeps issuing prefetch hints until the cumulative byte length
+ * of the posting lists that have been prefetched but not yet returned reaches {@code maxPrefetchBytes}.
+ * This naturally adapts the prefetch depth to the size of the posting lists &mdash; many small lists
+ * or only a few large ones &mdash; while the byte budget bounds how far ahead we read so we do not
+ * eagerly fetch posting lists the query is unlikely to score. At least one posting list is always
+ * prefetched ahead, preserving the previous behaviour when the budget is too small to cover even a
+ * single list.
+ *
+ * <p>The iterator is not thread-safe and is designed for single-threaded access.
  */
 public final class PrefetchingCentroidIterator implements CentroidIterator {
 
     private final CentroidIterator delegate;
     private final IndexInput postingListSlice;
-    private final int prefetchAhead;
+    private final long maxPrefetchBytes;
 
-    // Ring buffer for prefetched offsets and lengths
-    private final PostingMetadata[] prefetchBuffer;
-    private int readIndex = 0;  // Where we read from buffer
-    private int writeIndex = 0; // Where we write to buffer
-    private int bufferCount = 0; // Number of elements in buffer
+    // Buffer of prefetched-but-not-yet-returned posting lists, kept in iteration order.
+    private final ArrayDeque<PostingMetadata> prefetchBuffer = new ArrayDeque<>();
+    // Cumulative byte length of the posting lists currently held in the buffer.
+    private long bytesInFlight = 0;
 
     /**
-     * Creates a prefetching iterator with default prefetch depth of 1.
+     * Creates a prefetching iterator.
      *
      * @param delegate the underlying centroid iterator
      * @param postingListSlice the index input for posting lists
+     * @param maxPrefetchBytes the target number of posting list bytes to keep prefetched ahead of the
+     *                         consumer; negative values are treated as zero, in which case a single
+     *                         posting list is prefetched ahead
      * @throws IOException if prefetching fails during initialization
      */
-    public PrefetchingCentroidIterator(CentroidIterator delegate, IndexInput postingListSlice) throws IOException {
-        this(delegate, postingListSlice, 1);
-    }
-
-    /**
-     * Creates a prefetching iterator with configurable prefetch depth.
-     *
-     * @param delegate the underlying centroid iterator
-     * @param postingListSlice the index input for posting lists
-     * @param prefetchAhead number of posting lists to prefetch ahead (must be &gt;= 1)
-     * @throws IOException if prefetching fails during initialization
-     * @throws IllegalArgumentException if {@code prefetchAhead < 1}
-     */
-    public PrefetchingCentroidIterator(CentroidIterator delegate, IndexInput postingListSlice, int prefetchAhead) throws IOException {
-        if (prefetchAhead < 1) {
-            throw new IllegalArgumentException("prefetchAhead must be at least 1, got: " + prefetchAhead);
-        }
+    public PrefetchingCentroidIterator(CentroidIterator delegate, IndexInput postingListSlice, long maxPrefetchBytes) throws IOException {
         this.delegate = delegate;
         this.postingListSlice = postingListSlice;
-        this.prefetchAhead = prefetchAhead;
-        this.prefetchBuffer = new PostingMetadata[prefetchAhead];
-        // Initialize buffer by prefetching up to prefetchAhead elements
+        this.maxPrefetchBytes = Math.max(maxPrefetchBytes, 0);
+        // Initialize the buffer by prefetching ahead up to the configured byte budget.
         fillBuffer();
     }
 
     /**
-     * Fills the prefetch buffer up to the configured capacity.
+     * Tops up the prefetch buffer, issuing a prefetch hint for each newly buffered posting list.
+     * Always buffers at least one posting list (so {@link #hasNext()} can make progress) and then
+     * continues until the in-flight byte window reaches the configured budget or the delegate is
+     * exhausted.
      */
     private void fillBuffer() throws IOException {
-        while (bufferCount < prefetchAhead && delegate.hasNext()) {
+        while (delegate.hasNext() && (prefetchBuffer.isEmpty() || bytesInFlight < maxPrefetchBytes)) {
             PostingMetadata offsetAndLength = delegate.nextPosting();
-            prefetchBuffer[writeIndex] = offsetAndLength;
-            writeIndex = (writeIndex + 1) % prefetchAhead;
-            bufferCount++;
+            prefetchBuffer.addLast(offsetAndLength);
+            bytesInFlight += offsetAndLength.length();
 
             // Trigger prefetch
             postingListSlice.prefetch(offsetAndLength.offset(), offsetAndLength.length());
@@ -81,30 +78,21 @@ public final class PrefetchingCentroidIterator implements CentroidIterator {
 
     @Override
     public boolean hasNext() {
-        return bufferCount > 0;
+        return prefetchBuffer.isEmpty() == false;
     }
 
     @Override
     public PostingMetadata nextPosting() throws IOException {
-        if (bufferCount == 0) {
+        if (prefetchBuffer.isEmpty()) {
             throw new IllegalStateException("No more elements available");
         }
 
         // Get the next element from buffer
-        PostingMetadata result = prefetchBuffer[readIndex];
-        readIndex = (readIndex + 1) % prefetchAhead;
-        bufferCount--;
+        PostingMetadata result = prefetchBuffer.pollFirst();
+        bytesInFlight -= result.length();
 
-        // Try to fill buffer with one more element
-        if (delegate.hasNext()) {
-            PostingMetadata offsetAndLength = delegate.nextPosting();
-            prefetchBuffer[writeIndex] = offsetAndLength;
-            writeIndex = (writeIndex + 1) % prefetchAhead;
-            bufferCount++;
-
-            // Trigger prefetch for the newly added element
-            postingListSlice.prefetch(offsetAndLength.offset(), offsetAndLength.length());
-        }
+        // Top up the buffer, prefetching any newly revealed posting lists.
+        fillBuffer();
 
         return result;
     }

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/es94/ES940DiskBBQVectorsReader.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/es94/ES940DiskBBQVectorsReader.java
@@ -73,10 +73,9 @@ public class ES940DiskBBQVectorsReader extends IVFVectorsReader<ES940DiskBBQVect
         );
     }
 
-    CentroidIterator getPostingListPrefetchIterator(CentroidIterator centroidIterator, IndexInput postingListSlice) throws IOException {
-        // TODO we may want to prefetch more than one postings list, however, we will likely want to place a limit
-        // so we don't bother prefetching many lists we won't end up scoring
-        return new PrefetchingCentroidIterator(centroidIterator, postingListSlice);
+    CentroidIterator getPostingListPrefetchIterator(CentroidIterator centroidIterator, IndexInput postingListSlice, long maxPrefetchBytes)
+        throws IOException {
+        return new PrefetchingCentroidIterator(centroidIterator, postingListSlice, maxPrefetchBytes);
     }
 
     private void ensureCompatibleEncoding(IndexInput metaInput, ES940DiskBBQVectorsFormat.QuantEncoding quantEncoding)
@@ -195,7 +194,8 @@ public class ES940DiskBBQVectorsReader extends IVFVectorsReader<ES940DiskBBQVect
                 bulkSize
             );
         }
-        return getPostingListPrefetchIterator(centroidIterator, postingListSlice);
+        final long maxPrefetchBytes = prefetchByteBudget(visitRatio, fieldEntry.postingListLength());
+        return getPostingListPrefetchIterator(centroidIterator, postingListSlice, maxPrefetchBytes);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/next/ESNextDiskBBQVectorsReader.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/next/ESNextDiskBBQVectorsReader.java
@@ -79,10 +79,9 @@ public class ESNextDiskBBQVectorsReader extends IVFVectorsReader<ESNextDiskBBQVe
         );
     }
 
-    CentroidIterator getPostingListPrefetchIterator(CentroidIterator centroidIterator, IndexInput postingListSlice) throws IOException {
-        // TODO we may want to prefetch more than one postings list, however, we will likely want to place a limit
-        // so we don't bother prefetching many lists we won't end up scoring
-        return new PrefetchingCentroidIterator(centroidIterator, postingListSlice);
+    CentroidIterator getPostingListPrefetchIterator(CentroidIterator centroidIterator, IndexInput postingListSlice, long maxPrefetchBytes)
+        throws IOException {
+        return new PrefetchingCentroidIterator(centroidIterator, postingListSlice, maxPrefetchBytes);
     }
 
     @Override
@@ -197,7 +196,8 @@ public class ESNextDiskBBQVectorsReader extends IVFVectorsReader<ESNextDiskBBQVe
                 bulkSize
             );
         }
-        return getPostingListPrefetchIterator(centroidIterator, postingListSlice);
+        final long maxPrefetchBytes = prefetchByteBudget(visitRatio, fieldEntry.postingListLength());
+        return getPostingListPrefetchIterator(centroidIterator, postingListSlice, maxPrefetchBytes);
     }
 
     private FixedBitSet getCentroidFilter(

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/diskbbq/PrefetchingCentroidIteratorTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/diskbbq/PrefetchingCentroidIteratorTests.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.vectors.diskbbq;
+
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FilterIndexInput;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PrefetchingCentroidIteratorTests extends ESTestCase {
+
+    /**
+     * With a budget large enough to cover every posting list, all posting lists are prefetched up
+     * front (in a single pass) and then returned, in order, exactly once each.
+     */
+    public void testReturnsAllPostingsInOrderAndPrefetchesEachOnce() throws IOException {
+        List<PostingMetadata> postings = postings(8, 100);
+        try (Directory dir = new ByteBuffersDirectory(); RecordingIndexInput recording = openRecordingInput(dir)) {
+            // budget covers every posting list with room to spare
+            long budget = 100L * postings.size() + 1;
+            PrefetchingCentroidIterator it = new PrefetchingCentroidIterator(listIterator(postings), recording, budget);
+
+            // everything was prefetched while constructing the iterator
+            assertEquals(postings.size(), recording.prefetches.size());
+
+            List<PostingMetadata> returned = drain(it);
+            assertEquals(postings, returned);
+            assertPrefetchesMatch(postings, recording.prefetches);
+        }
+    }
+
+    /**
+     * A non-positive budget still prefetches exactly one posting list ahead of the consumer,
+     * preserving the original prefetch-by-one behaviour.
+     */
+    public void testZeroBudgetPrefetchesOneAhead() throws IOException {
+        List<PostingMetadata> postings = postings(5, 100);
+        try (Directory dir = new ByteBuffersDirectory(); RecordingIndexInput recording = openRecordingInput(dir)) {
+            PrefetchingCentroidIterator it = new PrefetchingCentroidIterator(listIterator(postings), recording, 0);
+
+            // only the first posting list is prefetched before any is consumed
+            assertEquals(1, recording.prefetches.size());
+
+            int consumed = 0;
+            while (it.hasNext()) {
+                it.nextPosting();
+                consumed++;
+                // we stay exactly one posting list ahead until the delegate is exhausted
+                assertEquals(Math.min(consumed + 1, postings.size()), recording.prefetches.size());
+            }
+            assertEquals(postings.size(), consumed);
+        }
+    }
+
+    /**
+     * The prefetch depth adapts to the byte budget: the iterator keeps prefetching ahead until the
+     * in-flight posting list bytes reach the budget, then maintains that window as it advances.
+     */
+    public void testPrefetchDepthAdaptsToByteBudget() throws IOException {
+        int length = 100;
+        List<PostingMetadata> postings = postings(10, length);
+        try (Directory dir = new ByteBuffersDirectory(); RecordingIndexInput recording = openRecordingInput(dir)) {
+            // budget spans between 2 and 3 posting lists, so we prefetch 3 ahead (smallest window >= budget)
+            long budget = 250;
+            PrefetchingCentroidIterator it = new PrefetchingCentroidIterator(listIterator(postings), recording, budget);
+
+            assertEquals(3, recording.prefetches.size());
+
+            // consuming one posting list drops below the budget again and pulls in exactly one more
+            it.nextPosting();
+            assertEquals(4, recording.prefetches.size());
+
+            List<PostingMetadata> returned = new ArrayList<>();
+            returned.add(postings.get(0));
+            returned.addAll(drain(it));
+            assertEquals(postings, returned);
+            assertPrefetchesMatch(postings, recording.prefetches);
+        }
+    }
+
+    public void testEmptyDelegate() throws IOException {
+        try (Directory dir = new ByteBuffersDirectory(); RecordingIndexInput recording = openRecordingInput(dir)) {
+            PrefetchingCentroidIterator it = new PrefetchingCentroidIterator(listIterator(List.of()), recording, randomLongBudget());
+            assertFalse(it.hasNext());
+            assertTrue(recording.prefetches.isEmpty());
+            expectThrows(IllegalStateException.class, it::nextPosting);
+        }
+    }
+
+    public void testNextOnExhaustedIteratorThrows() throws IOException {
+        List<PostingMetadata> postings = postings(3, 100);
+        try (Directory dir = new ByteBuffersDirectory(); RecordingIndexInput recording = openRecordingInput(dir)) {
+            PrefetchingCentroidIterator it = new PrefetchingCentroidIterator(listIterator(postings), recording, randomLongBudget());
+            drain(it);
+            assertFalse(it.hasNext());
+            expectThrows(IllegalStateException.class, it::nextPosting);
+        }
+    }
+
+    private long randomLongBudget() {
+        return randomFrom(0L, 1L, 100L, 1024L, Long.MAX_VALUE);
+    }
+
+    private static List<PostingMetadata> postings(int count, int length) {
+        List<PostingMetadata> postings = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            postings.add(new PostingMetadata((long) i * length, length, i, i));
+        }
+        return postings;
+    }
+
+    private static List<PostingMetadata> drain(PrefetchingCentroidIterator it) throws IOException {
+        List<PostingMetadata> returned = new ArrayList<>();
+        while (it.hasNext()) {
+            returned.add(it.nextPosting());
+        }
+        return returned;
+    }
+
+    private static void assertPrefetchesMatch(List<PostingMetadata> expected, List<long[]> prefetches) {
+        assertEquals(expected.size(), prefetches.size());
+        for (int i = 0; i < expected.size(); i++) {
+            assertEquals("prefetch offset at " + i, expected.get(i).offset(), prefetches.get(i)[0]);
+            assertEquals("prefetch length at " + i, expected.get(i).length(), prefetches.get(i)[1]);
+        }
+    }
+
+    private static CentroidIterator listIterator(List<PostingMetadata> postings) {
+        return new CentroidIterator() {
+            private int idx = 0;
+
+            @Override
+            public boolean hasNext() {
+                return idx < postings.size();
+            }
+
+            @Override
+            public PostingMetadata nextPosting() {
+                return postings.get(idx++);
+            }
+        };
+    }
+
+    private static RecordingIndexInput openRecordingInput(Directory dir) throws IOException {
+        try (IndexOutput out = dir.createOutput("postings", IOContext.DEFAULT)) {
+            out.writeByte((byte) 0);
+        }
+        return new RecordingIndexInput(dir.openInput("postings", IOContext.DEFAULT));
+    }
+
+    /**
+     * Wraps a real {@link IndexInput} and records the arguments of every {@link #prefetch} call so the
+     * test can assert which posting lists were prefetched, and in what order.
+     */
+    private static class RecordingIndexInput extends FilterIndexInput {
+        final List<long[]> prefetches = new ArrayList<>();
+
+        RecordingIndexInput(IndexInput in) {
+            super("recording", in);
+        }
+
+        @Override
+        public void prefetch(long offset, long length) throws IOException {
+            prefetches.add(new long[] { offset, length });
+        }
+    }
+}


### PR DESCRIPTION
The `PrefetchingCentroidIterator` previously prefetched a hard-coded single posting list ahead of the consumer, which is too shallow now that serverless turns a local file cache miss into a remote blob cache load. This change replaces the fixed-depth ring buffer with a byte-budget driven deque: the iterator keeps issuing prefetch hints until the cumulative byte length of buffered posting lists reaches a target, so depth adapts naturally to posting list sizes.

The budget is derived from the same `2 * visitRatio` factor that sizes the vector visit budget, but expressed in posting list bytes via a new `prefetchByteBudget` helper on `IVFVectorsReader`. `ES920DiskBBQVectorsReader`, `ES940DiskBBQVectorsReader`, and `ESNextDiskBBQVectorsReader` now compute the budget from `visitRatio` and `fieldEntry.postingListLength()` and pass it through to the iterator. A non-positive budget still prefetches one list ahead, preserving the prior behaviour. New unit tests in `PrefetchingCentroidIteratorTests` cover the budget-driven depth, zero-budget fallback, empty delegate, and exhaustion.

Resolves #151343

- [x] I have signed the [contributor license agreement](https://www.elastic.co/contributor-agreement).
- [x] I have followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md).
- [x] The pull request targets `main`.
- [x] This is not a class submission.