### PR TITLE
Treat ConnectException as an unknown capability during mixed-version runs

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -575,9 +575,6 @@ tests:
 - class: org.elasticsearch.xpack.stateless.StatelessHollowIndexShardsIT
   method: testRelocateHollowShards
   issue: https://github.com/elastic/elasticsearch/issues/151410
-- class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
-  method: test {p0=esql/160_union_types/load four indices with single conversion function TO_IP}
-  issue: https://github.com/elastic/elasticsearch/issues/151413
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
   method: test {feature:SUBQUERIES}
   issue: https://github.com/elastic/elasticsearch/issues/149681

--- a/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestExecutionContext.java
+++ b/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestExecutionContext.java
@@ -30,6 +30,7 @@ import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.net.ConnectException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -346,6 +347,12 @@ public class ClientYamlTestExecutionContext {
                 return Optional.empty(); // we don't know, the capabilities API is unsupported
             }
             throw new UncheckedIOException(responseException);
+        } catch (ConnectException connectException) {
+            // The capabilities API is probed on each node individually, so a single transiently unreachable node (e.g. one that is
+            // restarting in a mixed-version cluster) would otherwise hard-fail the test with "Connection refused". Treat it as an
+            // unknown result instead: capability-gated tests degrade to being skipped rather than erroring on a flaky connection.
+            logger.warn(() -> "could not reach node while checking capability " + params, connectException);
+            return Optional.empty();
         } catch (IOException ioException) {
             throw new UncheckedIOException(ioException);
         }


### PR DESCRIPTION
The capabilities API is queried against each cluster node individually. In mixed-version BWC runs a node that is briefly unreachable (e.g. restarting) surfaces as `java.net.ConnectException: Connection refused`, which previously wrapped into `UncheckedIOException` and hard-failed the surrounding test. This change catches `ConnectException` in `ClientYamlTestExecutionContext#checkCapability`, logs a warning, and returns `Optional.empty()` so capability-gated tests degrade to a skip rather than an error.

The corresponding mute entry for `EsqlClientYamlIT#test {p0=esql/160_union_types/load four indices with single conversion function TO_IP}` is removed from `muted-tests.yml`, since the underlying flakiness is now handled at the runner level.

Resolves #151413

- [x] I have signed the [contributor license agreement](https://www.elastic.co/contributor-agreement).
- [x] I have followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md).
- [x] The pull request targets `main`.
- [x] This is not a class submission.