### PR TITLE
[CI] Mute TransportVersionGenerationFuncTest

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -665,3 +665,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
   method: test {csv-spec:views.wildcardExcludeNestedEmployeeViewsNoFalseCircularReference}
   issue: https://github.com/elastic/elasticsearch/issues/151811
+- class: org.elasticsearch.gradle.internal.transport.TransportVersionGenerationFuncTest
+  method: name can be found from staged definition
+  issue: https://github.com/elastic/elasticsearch/issues/150299


### PR DESCRIPTION
Resolves #150299.

Mutes `TransportVersionGenerationFuncTest` (method "name can be found from staged definition"), which is failing in CI.

- [x] I have signed the [contributor license agreement](https://www.elastic.co/contributor-agreement).
- [x] I have followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md).
- [x] The pull request targets `main`.
- [x] This is not a class submission.