### PR TITLE
Simplify gradle testkit setup on windows

### DIFF
--- a/build-tools-internal/build.gradle
+++ b/build-tools-internal/build.gradle
@@ -378,6 +378,13 @@ tasks.register("integTest", Test) {
   testClassesDirs = sourceSets.integTest.output.classesDirs
   classpath = sourceSets.integTest.runtimeClasspath
   useJUnitPlatform()
+  // On Windows the default tmpdir may resolve to an 8.3 short-form path (e.g. BUILDK~1) when
+  // the username is longer than 8 characters. Gradle TestKit passes this path to the nested
+  // Gradle daemon, which can cause daemon startup failures. Use a stable path without
+  // short-name aliases to avoid this.
+  if (org.gradle.internal.os.OperatingSystem.current().isWindows()) {
+    systemProperty 'java.io.tmpdir', 'C:/Temp'
+  }
 }
 
 tasks.named("check").configure { dependsOn("integTest") }

--- a/build-tools/src/testFixtures/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy
+++ b/build-tools/src/testFixtures/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy
@@ -15,6 +15,7 @@ import com.github.tomakehurst.wiremock.WireMockServer
 
 import org.apache.commons.io.FileUtils
 import org.apache.commons.io.IOUtils
+import org.elasticsearch.gradle.OS
 import org.elasticsearch.gradle.internal.test.BuildConfigurationAwareGradleRunner
 import org.elasticsearch.gradle.internal.test.InternalAwareGradleRunner
 import org.elasticsearch.gradle.internal.test.NormalizeOutputGradleRunner
@@ -114,6 +115,14 @@ abstract class AbstractGradleFuncTest extends Specification {
     }
 
     GradleRunner gradleRunner(File projectDir, Object... arguments) {
+        def args = arguments.collect { it.toString() } + "--full-stacktrace"
+        // On Windows, Gradle daemon startup can fail with "Connection reset by peer" when the
+        // TestKit-spawned daemon crashes before completing the handshake (e.g. due to Windows
+        // Defender scanning new JVM processes or 8.3 short-path issues). Running without a daemon
+        // eliminates the TCP socket communication between TestKit and the daemon entirely.
+        if (OS.current() == OS.WINDOWS) {
+            args += "--no-daemon"
+        }
         return new NormalizeOutputGradleRunner(
             new BuildConfigurationAwareGradleRunner(
                     new InternalAwareGradleRunner(
@@ -127,7 +136,7 @@ abstract class AbstractGradleFuncTest extends Specification {
                                 .forwardOutput()
             ), configurationCacheCompatible,
                 buildApiRestrictionsDisabled)
-        ).withArguments(arguments.collect { it.toString() } + "--full-stacktrace")
+        ).withArguments(args)
     }
 
     def assertOutputContains(String givenOutput, String expected) {

--- a/build-tools/src/testFixtures/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy
+++ b/build-tools/src/testFixtures/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy
@@ -116,13 +116,6 @@ abstract class AbstractGradleFuncTest extends Specification {
 
     GradleRunner gradleRunner(File projectDir, Object... arguments) {
         def args = arguments.collect { it.toString() } + "--full-stacktrace"
-        // On Windows, Gradle daemon startup can fail with "Connection reset by peer" when the
-        // TestKit-spawned daemon crashes before completing the handshake (e.g. due to Windows
-        // Defender scanning new JVM processes or 8.3 short-path issues). Running without a daemon
-        // eliminates the TCP socket communication between TestKit and the daemon entirely.
-        if (OS.current() == OS.WINDOWS) {
-            args += "--no-daemon"
-        }
         return new NormalizeOutputGradleRunner(
             new BuildConfigurationAwareGradleRunner(
                     new InternalAwareGradleRunner(


### PR DESCRIPTION
We saw issues with testkit gradle daemon failing to setup a socket connection.