### PR TITLE
Fix StatelessMergePreWarmingIT. testMergePreWarmingFailureDoesNotFailTheEngine

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -611,9 +611,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
   method: test {csv-spec:metric_temporality.tdigestAggsByTBucket}
   issue: https://github.com/elastic/elasticsearch/issues/151613
-- class: org.elasticsearch.xpack.stateless.StatelessMergePreWarmingIT
-  method: testMergePreWarmingFailureDoesNotFailTheEngine
-  issue: https://github.com/elastic/elasticsearch/issues/151618
 - class: org.elasticsearch.gradle.internal.precommit.PomValidationPrecommitPluginFuncTest
   method: detects missing POM elements and reports structured problems
   issue: https://github.com/elastic/elasticsearch/issues/151636

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/StatelessMergePreWarmingIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/StatelessMergePreWarmingIT.java
@@ -181,15 +181,12 @@ public class StatelessMergePreWarmingIT extends AbstractStatelessPluginIntegTest
                 long position,
                 long length
             ) throws IOException {
-                logger.info("---> blob name {} and thread {}", blobName, Thread.currentThread().getName());
                 assert (blobName.equals(bccToUpload)
                     && Thread.currentThread().getName().contains(StatelessPlugin.PREWARM_THREAD_POOL)) == false
                     : "Unexpected read from the pre-warmed thread";
                 return super.blobContainerReadBlob(originalSupplier, purpose, blobName, position, length);
             }
         });
-
-        logger.info("---> bcc to upload {}", bccToUpload);
 
         var flushFuture = indicesAdmin().prepareFlush(indexName).execute();
 
@@ -214,11 +211,6 @@ public class StatelessMergePreWarmingIT extends AbstractStatelessPluginIntegTest
         // Let the upload continue and wait until it finishes
         blockUploadLatch.countDown();
         flushFuture.actionGet();
-        logger.info("---> upload done");
-
-        Thread.sleep(3000);
-
-        logger.info("---> Update request starts");
 
         // Send an update request that would require reading from the cache
         var updateBulkRequest = new BulkRequest();

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/StatelessMergePreWarmingIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/StatelessMergePreWarmingIT.java
@@ -14,6 +14,7 @@ import org.apache.lucene.index.SegmentInfos;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.update.UpdateRequest;
+import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider;
 import org.elasticsearch.common.CheckedSupplier;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.blobstore.OperationPurpose;
@@ -43,6 +44,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFa
 import static org.elasticsearch.xpack.stateless.StatelessMergeIT.blockMergePool;
 import static org.elasticsearch.xpack.stateless.commits.StatelessCommitService.STATELESS_UPLOAD_MAX_AMOUNT_COMMITS;
 import static org.elasticsearch.xpack.stateless.commits.StatelessCommitService.STATELESS_UPLOAD_MAX_SIZE;
+import static org.hamcrest.Matchers.greaterThan;
 
 public class StatelessMergePreWarmingIT extends AbstractStatelessPluginIntegTestCase {
 
@@ -196,14 +198,18 @@ public class StatelessMergePreWarmingIT extends AbstractStatelessPluginIntegTest
         internalCluster().getInstances(StatelessPlugin.SharedBlobCacheServiceSupplier.class)
             .forEach(sharedBlobCacheServiceSupplier -> sharedBlobCacheServiceSupplier.get().forceEvict(entry -> true));
 
-        // This prevents the shard to be allocated if the shard fails due to a bug in the tested code
+        // This prevents the shard from being re-allocated if the engine fails due to a bug in the tested code
         client().admin()
             .indices()
             .prepareUpdateSettings(indexName)
-            .setSettings(Settings.builder().put("index.routing.allocation.exclude._name", indexNode));
+            .setSettings(Settings.builder().put(EnableAllocationDecider.INDEX_ROUTING_ALLOCATION_ENABLE_SETTING.getKey(), "none"))
+            .execute();
 
-        // Let the merge proceed and wait until the merge pre-warming kicks in
+        final var previousMergeCount = getTotalMergeCount(indexName);
+
+        // Let the merge proceed, then wait until it finishes.
         unblockMergePoolLatch.countDown();
+        assertBusy(() -> assertThat(getTotalMergeCount(indexName), greaterThan(previousMergeCount)));
 
         // Let the upload continue and wait until it finishes
         blockUploadLatch.countDown();
@@ -227,4 +233,7 @@ public class StatelessMergePreWarmingIT extends AbstractStatelessPluginIntegTest
         ensureGreen(indexName);
     }
 
+    private long getTotalMergeCount(String indexName) {
+        return indicesAdmin().prepareStats(indexName).setMerge(true).get().getIndices().get(indexName).getPrimaries().merge.getTotal();
+    }
 }

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/StatelessMergePreWarmingIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/StatelessMergePreWarmingIT.java
@@ -179,12 +179,15 @@ public class StatelessMergePreWarmingIT extends AbstractStatelessPluginIntegTest
                 long position,
                 long length
             ) throws IOException {
+                logger.info("---> blob name {} and thread {}", blobName, Thread.currentThread().getName());
                 assert (blobName.equals(bccToUpload)
                     && Thread.currentThread().getName().contains(StatelessPlugin.PREWARM_THREAD_POOL)) == false
                     : "Unexpected read from the pre-warmed thread";
                 return super.blobContainerReadBlob(originalSupplier, purpose, blobName, position, length);
             }
         });
+
+        logger.info("---> bcc to upload {}", bccToUpload);
 
         var flushFuture = indicesAdmin().prepareFlush(indexName).execute();
 
@@ -205,6 +208,11 @@ public class StatelessMergePreWarmingIT extends AbstractStatelessPluginIntegTest
         // Let the upload continue and wait until it finishes
         blockUploadLatch.countDown();
         flushFuture.actionGet();
+        logger.info("---> upload done");
+
+        Thread.sleep(3000);
+
+        logger.info("---> Update request starts");
 
         // Send an update request that would require reading from the cache
         var updateBulkRequest = new BulkRequest();

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/engine/IndexEngine.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/engine/IndexEngine.java
@@ -989,12 +989,6 @@ public class IndexEngine extends InternalEngine {
                 cacheWarmingService.warmCacheForMerge(merge.getId(), shardId, store, merge.getMerge(), fileName -> {
                     BatchedCompoundCommit latestUploadedBcc = statelessCommitService.getLatestUploadedBcc(shardId);
                     BlobLocation blobLocation = statelessCommitService.getBlobLocation(shardId, fileName);
-                    logger.info("--> merge file name {} and latest uploaded bcc {}", fileName, latestUploadedBcc);
-                    try {
-                        Thread.sleep(100);
-                    } catch (InterruptedException e) {
-                        throw new AssertionError(e);
-                    }
                     if (blobLocation != null && latestUploadedBcc != null) {
                         // Only return the location if the file is uploaded as we don't want to try warming an un-uploaded file
                         if (blobLocation.getBatchedCompoundCommitTermAndGeneration()

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/engine/IndexEngine.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/engine/IndexEngine.java
@@ -989,6 +989,12 @@ public class IndexEngine extends InternalEngine {
                 cacheWarmingService.warmCacheForMerge(merge.getId(), shardId, store, merge.getMerge(), fileName -> {
                     BatchedCompoundCommit latestUploadedBcc = statelessCommitService.getLatestUploadedBcc(shardId);
                     BlobLocation blobLocation = statelessCommitService.getBlobLocation(shardId, fileName);
+                    logger.info("--> merge file name {} and latest uploaded bcc {}", fileName, latestUploadedBcc);
+                    try {
+                        Thread.sleep(100);
+                    } catch (InterruptedException e) {
+                        throw new AssertionError(e);
+                    }
                     if (blobLocation != null && latestUploadedBcc != null) {
                         // Only return the location if the file is uploaded as we don't want to try warming an un-uploaded file
                         if (blobLocation.getBatchedCompoundCommitTermAndGeneration()


### PR DESCRIPTION
**Root cause analysis**

For context, the PR that introduced this test: https://github.com/elastic/elasticsearch-serverless/pull/3571

From failure logs ([build](https://gradle-enterprise.elastic.co/s/f7tcdl2me6vo2)):
```
WARNING: Uncaught exception in thread: Thread[#588,elasticsearch[node_t0][stateless_prewarm][T#1],5,TGRP-StatelessMergePreWarmingIT] 
java.lang.AssertionError: Unexpected read from the pre-warmed thread |  
at __randomizedtesting.SeedInfo.seed([2A03A2C71E0D52D3]:0)
```

The test unblocks the merge pool and released the upload latch in immediate succession, with no synchronization between them. Because `latestUploadedBcc` is evaluated per file inside the `blobLocationResolver` lambda: https://github.com/elastic/elasticsearch/blob/be25e8a86070669a5f85095e4caaa1edc88d4250/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/engine/IndexEngine.java#L990

if the upload completes before `beforeMerge` finished iterating over files, the merge can see the freshly uploaded BCC and permit those files for pre-warming, tripping the assertion.

The resulting `AssertionError` is uncaught. If my understanding is correct, the pre-warmer can then hold on the cache region indefinitely which causes the update operation to get stuck waiting for a dead thread:
```
"elasticsearch[node_t0][write][T#2]" ID=576 WAITING on org.elasticsearch.action.support.PlainActionFuture$Sync@4e9f6546
	at java.base@26.0.1/jdk.internal.misc.Unsafe.park(Native Method)
	- waiting on org.elasticsearch.action.support.PlainActionFuture$Sync@4e9f6546
	at java.base@26.0.1/java.util.concurrent.locks.LockSupport.park(LockSupport.java:223)
	at java.base@26.0.1/java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(AbstractQueuedSynchronizer.java:790)
	at java.base@26.0.1/java.util.concurrent.locks.AbstractQueuedSynchronizer.acquireSharedInterruptibly(AbstractQueuedSynchronizer.java:1139)
	at app//org.elasticsearch.action.support.PlainActionFuture$Sync.get(PlainActionFuture.java:265)
	at app//org.elasticsearch.action.support.PlainActionFuture.get(PlainActionFuture.java:96)
	at app//org.elasticsearch.blobcache.shared.SharedBlobCacheService$CacheFile.recordWait(SharedBlobCacheService.java:1733)
	at app//org.elasticsearch.blobcache.shared.SharedBlobCacheService$CacheFile.populateAndRead(SharedBlobCacheService.java:1568)
	at app//org.elasticsearch.xpack.stateless.cache.reader.CacheFileReader.doRead(CacheFileReader.java:236)
	at app//org.elasticsearch.xpack.stateless.cache.reader.CacheFileReader.read(CacheFileReader.java:204)
```

Reproed on [157a2e5](https://github.com/elastic/elasticsearch/pull/151823/commits/157a2e5fdd838ba4c4d53bd14c3d6a2de00ec59d) (https://gradle-enterprise.elastic.co/s/rxjwf55aoc2yg)

**Fix**

The fix waits for the merge to fully complete (via checking `IndicesStats.merge.getTotal()`) before releasing the upload latch, ensuring that `warmCacheForMerge` always runs while the upload is still in flight.

Closes https://github.com/elastic/elasticsearch/issues/151618
