### PR TITLE
Fix TopNOperatorTests#testSplitOnSize

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -527,9 +527,6 @@ tests:
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=index/100_field_name_length_limit/Test field name length limit synthetic source}
   issue: https://github.com/elastic/elasticsearch/issues/151117
-- class: org.elasticsearch.compute.operator.topn.TopNOperatorTests
-  method: testSplitOnSize
-  issue: https://github.com/elastic/elasticsearch/issues/151118
 - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
   method: test {csv-spec:change_point.values null column}
   issue: https://github.com/elastic/elasticsearch/issues/151132

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/TopNOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/TopNOperatorTests.java
@@ -2138,7 +2138,10 @@ public class TopNOperatorTests extends OperatorTestCase {
 
     public void testSplitOnSize() {
         int topCount = 50;
-        long jumboPageBytes = randomJumboPageBytes();
+        // When building blocks, we over-allocate to minimize resizing and copying. With
+        // paged structures like BytesRefBlock, this can result in multiple pages. To avoid
+        // over-emitting in this test, require the jumbo page to be at least two pages.
+        long jumboPageBytes = Math.max(randomJumboPageBytes(), PageCacheRecycler.PAGE_SIZE_IN_BYTES * 2);
         int byteLength = Math.max(10, Math.toIntExact(jumboPageBytes / 10));
         logger.info("byteLength {}", byteLength);
         int inputPageRows = 10;


### PR DESCRIPTION
When building blocks, we over-allocate to minimize resizing and copying. With
paged structures like BytesRefBlock, this can result in multiple pages. To avoid
over-emitting in this test, require the jumbo page to be at least two pages.

Closes #151118