### PR TITLE
[ES|QL] Subquery scoped lookup index resolution

### DIFF
--- a/docs/changelog/151830.yaml
+++ b/docs/changelog/151830.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 151830
+summary: Subquery scoped lookup index resolution
+type: bug

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterSubqueryIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterSubqueryIT.java
@@ -7,6 +7,9 @@
 
 package org.elasticsearch.xpack.esql.action;
 
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.query.RangeQueryBuilder;
 import org.elasticsearch.xpack.esql.VerificationException;
 import org.junit.Before;
@@ -20,6 +23,8 @@ import java.util.List;
 import java.util.Locale;
 
 import static org.elasticsearch.core.TimeValue.timeValueSeconds;
+import static org.elasticsearch.index.mapper.DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.getValuesList;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
@@ -493,6 +498,145 @@ public class CrossClusterSubqueryIT extends AbstractCrossClusterTestCase {
         }
     }
 
+    public void testSubqueryWithLookupJoinIndicesExistOnAllClustersReferencedBySubqueries() {
+        populateLookupIndex(REMOTE_CLUSTER_1, "values_lookup_1", 10);
+        populateLookupIndex(REMOTE_CLUSTER_2, "values_lookup_2", 10);
+        populateLookupIndex(LOCAL_CLUSTER, "values_lookup", 10);
+        populateLookupIndex(REMOTE_CLUSTER_1, "values_lookup", 10);
+        populateLookupIndex(REMOTE_CLUSTER_2, "values_lookup", 10);
+
+        String query = """
+            FROM
+                logs-*,
+                (FROM cluster-a:logs-* metadata _index
+                 | where v > 1
+                 | LOOKUP JOIN values_lookup_1 on v == lookup_key),
+                (FROM remote-b:logs-* metadata _index
+                 | where v > 1
+                 | LOOKUP JOIN values_lookup_2 on v == lookup_key),
+                (FROM logs-*, *:logs-* metadata _index
+                 | where v > 1
+                 | LOOKUP JOIN values_lookup on v == lookup_key)
+                metadata _index
+            | WHERE v < 5
+            | EVAL lookup_tag = coalesce(lookup_tag, "local")
+            | KEEP tag, v, _index, lookup_tag
+            | SORT tag, v, _index
+            """;
+
+        try (EsqlQueryResponse resp = runQuery(query, randomBoolean())) {
+            var columns = resp.columns().stream().map(ColumnInfoImpl::name).toList();
+            assertThat(columns, hasItems("tag", "v", "_index", "lookup_tag"));
+
+            List<List<Object>> values = getValuesList(resp);
+            List<List<Object>> expected = List.of(
+                List.of("local", 0L, LOCAL_INDEX, "local"),
+                List.of("local", 1L, LOCAL_INDEX, "local"),
+                List.of("local", 2L, LOCAL_INDEX, "local"),
+                List.of("local", 2L, LOCAL_INDEX, "local"),
+                List.of("local", 3L, LOCAL_INDEX, "local"),
+                List.of("local", 3L, LOCAL_INDEX, "local"),
+                List.of("local", 4L, LOCAL_INDEX, "local"),
+                List.of("local", 4L, LOCAL_INDEX, "local"),
+                List.of("remote", 4L, REMOTE_CLUSTER_1_INDEX, REMOTE_CLUSTER_1),
+                List.of("remote", 4L, REMOTE_CLUSTER_1_INDEX, REMOTE_CLUSTER_1),
+                List.of("remote", 4L, REMOTE_CLUSTER_2_INDEX, REMOTE_CLUSTER_2),
+                List.of("remote", 4L, REMOTE_CLUSTER_2_INDEX, REMOTE_CLUSTER_2)
+
+            );
+            assertEquals(expected, values);
+
+            EsqlExecutionInfo executionInfo = resp.getExecutionInfo();
+            assertCCSExecutionInfoDetails(executionInfo);
+        }
+    }
+
+    /**
+     * A {@code LOOKUP JOIN} inside a subquery references a lookup index that does not exist on any cluster referenced by the subquery. A
+     * completely missing lookup index is an analysis-time error - index resolution returns an invalid resolution ("Unknown index"), which
+     * short-circuits before the skip-vs-error decision is reached. The behavior is therefore independent of {@code skip_unavailable}: the
+     * query always fails with a {@link VerificationException}, identically for {@code skip_unavailable=true} and {@code false}, same
+     * behavior as CrossClusterLookupJoinIT.testLookupJoinMissingRemoteIndex. This test runs every case under both settings to capture that
+     * the behavior does not change.
+     */
+    public void testSubqueryWithLookupJoinMissingLookupIndexOnSomeClusters() {
+        // values_lookup exists only on cluster-a; missing_lookup is never created, so it is absent from every cluster.
+        populateLookupIndex(REMOTE_CLUSTER_1, "values_lookup_1", 10);
+        populateLookupIndex(REMOTE_CLUSTER_2, "values_lookup_2", 10);
+
+        // (1) lookup join in a subquery scoped to a single remote cluster: missing only on that cluster.
+        VerificationException ex = expectThrows(VerificationException.class, () -> runQuery("""
+            FROM
+                logs-*,
+                (FROM cluster-a:logs-* metadata _index | LOOKUP JOIN missing_lookup ON v == lookup_key)
+            """, randomBoolean()));
+        assertThat(ex.getMessage(), containsString("Unknown index [cluster-a:missing_lookup]"));
+
+        // (2) lookup join in a subquery scoped to the local cluster: missing locally.
+        ex = expectThrows(VerificationException.class, () -> runQuery("""
+            FROM
+                cluster-a:logs-*,
+                (FROM logs-* metadata _index | LOOKUP JOIN missing_lookup ON v == lookup_key)
+            """, randomBoolean()));
+        assertThat(ex.getMessage(), containsString("Unknown index [missing_lookup]"));
+
+        // (3) two remote subqueries joining the same missing lookup index: the lookup is scoped to both remotes, so the missing
+        // index is reported for both clusters.
+        ex = expectThrows(VerificationException.class, () -> runQuery("""
+            FROM
+                logs-*,
+                (FROM cluster-a:logs-* metadata _index | LOOKUP JOIN missing_lookup ON v == lookup_key),
+                (FROM remote-b:logs-* metadata _index | LOOKUP JOIN missing_lookup ON v == lookup_key)
+            """, randomBoolean()));
+        assertThat(ex.getMessage(), containsString("Unknown index [cluster-a:missing_lookup,remote-b:missing_lookup]"));
+
+        // (4) one subquery uses an existing lookup index (values_lookup on remote-b), the sibling subquery references the missing
+        // lookup index: the missing index fails the query, but it is reported only for remote-b because that is the only cluster
+        // relevant to its LOOKUP JOIN - cluster-a is not queried for missing_lookup since it belongs to the sibling subquery.
+        ex = expectThrows(VerificationException.class, () -> runQuery("""
+            FROM
+                (FROM remote-b:logs-* metadata _index | LOOKUP JOIN values_lookup_2 ON v == lookup_key),
+                (FROM remote-b:logs-* metadata _index | LOOKUP JOIN missing_lookup ON v == lookup_key)
+            """, randomBoolean()));
+        assertThat(
+            ex.getMessage(),
+            allOf(containsString("Unknown index [remote-b:missing_lookup]"), not(containsString("cluster-a:missing_lookup")))
+        );
+
+        // (5) one subquery on local, plus a remote subquery whose lookup index is missing.
+        ex = expectThrows(VerificationException.class, () -> runQuery("""
+            FROM
+                (FROM logs-*),
+                (FROM cluster-a:logs-* metadata _index | LOOKUP JOIN missing_lookup ON v == lookup_key)
+            """, randomBoolean()));
+        assertThat(ex.getMessage(), containsString("Unknown index [cluster-a:missing_lookup]"));
+
+        // (6) lookup index missing on remote-b, but exists on cluster-a
+        // cluster-a has skipUnavailable=false by default
+        String query = """
+            FROM
+                (FROM logs-*),
+                (FROM *:logs-* metadata _index | LOOKUP JOIN values_lookup_2 ON v == lookup_key)
+            """;
+
+        ex = expectThrows(VerificationException.class, () -> runQuery(query, randomBoolean()));
+        assertThat(ex.getMessage(), containsString("lookup index [values_lookup_2] is not available in remote cluster [cluster-a]"));
+        // validate the behavior of skipUnavailable on cluster-a, lookup index exists on remote-b but not on cluster-a
+        try {
+            setSkipUnavailable(REMOTE_CLUSTER_1, true);
+            try (EsqlQueryResponse resp = runQuery(query, randomBoolean())) {
+                List<List<Object>> values = getValuesList(resp);
+                assertThat(values, hasSize(20)); // 10 docs from local cluster, 10 from remote-b
+                EsqlExecutionInfo executionInfo = resp.getExecutionInfo();
+                assertClusterEsqlExecutionInfo(executionInfo, LOCAL_CLUSTER, EsqlExecutionInfo.Cluster.Status.SUCCESSFUL);
+                assertClusterEsqlExecutionInfo(executionInfo, REMOTE_CLUSTER_1, EsqlExecutionInfo.Cluster.Status.SKIPPED);
+                assertClusterEsqlExecutionInfo(executionInfo, REMOTE_CLUSTER_2, EsqlExecutionInfo.Cluster.Status.SUCCESSFUL);
+            }
+        } finally {
+            setSkipUnavailable(REMOTE_CLUSTER_1, false);
+        }
+    }
+
     public void testSubqueryWithLookupJoinInMainQuery() {
         assumeTrue(
             "Requires subquery in FROM command with implicit LIMIT removed",
@@ -645,6 +789,284 @@ public class CrossClusterSubqueryIT extends AbstractCrossClusterTestCase {
                  | FORK (WHERE v > 5) (WHERE v < 3))
             """, randomBoolean()));
         assertThat(ex.getMessage(), containsString("FORK inside subquery is not supported"));
+    }
+
+    public void testSubqueryWithRow() {
+        assumeTrue("Requires ROW as a subquery source", EsqlCapabilities.Cap.SUBQUERY_WITH_ROW.isEnabled());
+
+        try (EsqlQueryResponse resp = runQuery("""
+            FROM
+                (FROM logs-* | STATS c = count(*) | EVAL cluster = "local"),
+                (FROM *:logs-* | STATS c = count(*) | EVAL cluster = "remote"),
+                (ROW c = TO_LONG(99), cluster = "row")
+            | KEEP c, cluster
+            | SORT cluster
+            """, randomBoolean())) {
+            var columns = resp.columns().stream().map(ColumnInfoImpl::name).toList();
+            assertThat(columns, hasItems("c", "cluster"));
+
+            List<List<Object>> values = getValuesList(resp);
+            List<List<Object>> expected = List.of(List.of(10L, "local"), List.of(20L, "remote"), List.of(99L, "row"));
+            assertEquals(expected, values);
+
+            EsqlExecutionInfo executionInfo = resp.getExecutionInfo();
+            assertCCSExecutionInfoDetails(executionInfo);
+        }
+
+        try (EsqlQueryResponse resp = runQuery("""
+            FROM
+                (FROM logs-* | WHERE v < 2 | KEEP tag, v),
+                (FROM *:logs-* | WHERE v < 1 | KEEP tag, v),
+                (ROW tag = "row", v = TO_LONG(100))
+            | KEEP tag, v
+            | SORT tag, v
+            """, randomBoolean())) {
+            var columns = resp.columns().stream().map(ColumnInfoImpl::name).toList();
+            assertThat(columns, hasItems("tag", "v"));
+
+            List<List<Object>> values = getValuesList(resp);
+            List<List<Object>> expected = List.of(
+                List.of("local", 0L),
+                List.of("local", 1L),
+                List.of("remote", 0L),
+                List.of("remote", 0L),
+                List.of("row", 100L)
+            );
+            assertEquals(expected, values);
+
+            EsqlExecutionInfo executionInfo = resp.getExecutionInfo();
+            assertCCSExecutionInfoDetails(executionInfo);
+        }
+    }
+
+    public void testSubqueryWithRowAndLookupJoinInSubquery() {
+        assumeTrue("Requires ROW as a subquery source", EsqlCapabilities.Cap.SUBQUERY_WITH_ROW.isEnabled());
+        populateLookupIndex(LOCAL_CLUSTER, "values_lookup", 10);
+        populateLookupIndex(REMOTE_CLUSTER_1, "values_lookup", 10);
+        populateLookupIndex(REMOTE_CLUSTER_2, "values_lookup", 10);
+
+        try (EsqlQueryResponse resp = runQuery("""
+            FROM
+                (FROM logs-* | where v == 6 | LOOKUP JOIN values_lookup on v == lookup_key),
+                (FROM *:logs-* | where v == 4 | LOOKUP JOIN values_lookup on v == lookup_key),
+                (ROW v = TO_LONG(4), tag = "row" | LOOKUP JOIN values_lookup on v == lookup_key)
+            | KEEP tag, v, lookup_tag
+            | SORT tag, v, lookup_tag
+            """, randomBoolean())) {
+            var columns = resp.columns().stream().map(ColumnInfoImpl::name).toList();
+            assertThat(columns, hasItems("tag", "v", "lookup_tag"));
+
+            List<List<Object>> values = getValuesList(resp);
+            List<List<Object>> expected = List.of(
+                List.of("local", 6L, "local"),
+                List.of("remote", 4L, REMOTE_CLUSTER_1),
+                List.of("remote", 4L, REMOTE_CLUSTER_2),
+                List.of("row", 4L, "local")
+            );
+            assertEquals(expected, values);
+
+            EsqlExecutionInfo executionInfo = resp.getExecutionInfo();
+            assertCCSExecutionInfoDetails(executionInfo);
+        }
+    }
+
+    public void testSubqueryWithRowAndLookupJoinMissingLookupIndex() {
+        assumeTrue("Requires ROW as a subquery source", EsqlCapabilities.Cap.SUBQUERY_WITH_ROW.isEnabled());
+
+        VerificationException ex = expectThrows(VerificationException.class, () -> runQuery("""
+            FROM
+                cluster-a:logs-*,
+                (ROW v = TO_LONG(4) | LOOKUP JOIN missing_lookup ON v == lookup_key)
+            """, randomBoolean()));
+        assertThat(ex.getMessage(), containsString("Unknown index [missing_lookup]"));
+    }
+
+    public void testSubqueryWithTimeSeries() {
+        assumeTrue("Requires TS as a subquery source", EsqlCapabilities.Cap.SUBQUERY_WITH_TS.isEnabled());
+        populateTimeSeriesIndex(LOCAL_CLUSTER, "metrics");
+        populateTimeSeriesIndex(REMOTE_CLUSTER_1, "metrics");
+        populateTimeSeriesIndex(REMOTE_CLUSTER_2, "metrics");
+
+        try (EsqlQueryResponse resp = runQuery("""
+            FROM
+                (TS metrics | STATS m = max(cpu) | EVAL cluster = "local"),
+                (TS cluster-a:metrics | STATS m = max(cpu) | EVAL cluster = "cluster-a"),
+                (TS remote-b:metrics | STATS m = max(cpu) | EVAL cluster = "remote-b")
+            | KEEP cluster, m
+            | SORT cluster
+            """, randomBoolean())) {
+            var columns = resp.columns().stream().map(ColumnInfoImpl::name).toList();
+            assertThat(columns, hasItems("cluster", "m"));
+
+            List<List<Object>> values = getValuesList(resp);
+            List<List<Object>> expected = List.of(List.of(REMOTE_CLUSTER_1, 6.0), List.of("local", 6.0), List.of(REMOTE_CLUSTER_2, 6.0));
+            assertEquals(expected, values);
+
+            EsqlExecutionInfo executionInfo = resp.getExecutionInfo();
+            assertCCSExecutionInfoDetails(executionInfo);
+        }
+
+        try (EsqlQueryResponse resp = runQuery("""
+            FROM
+                (TS metrics | WHERE host == "h1" | STATS m = max(cpu) | EVAL cluster = "local"),
+                (TS cluster-a:metrics | WHERE host == "h1" | STATS m = max(cpu) | EVAL cluster = "cluster-a"),
+                (TS remote-b:metrics | WHERE host == "h1" | STATS m = max(cpu) | EVAL cluster = "remote-b")
+            | KEEP cluster, m
+            | SORT cluster
+            """, randomBoolean())) {
+            var columns = resp.columns().stream().map(ColumnInfoImpl::name).toList();
+            assertThat(columns, hasItems("cluster", "m"));
+
+            List<List<Object>> values = getValuesList(resp);
+            List<List<Object>> expected = List.of(List.of(REMOTE_CLUSTER_1, 3.0), List.of("local", 3.0), List.of(REMOTE_CLUSTER_2, 3.0));
+            assertEquals(expected, values);
+
+            EsqlExecutionInfo executionInfo = resp.getExecutionInfo();
+            assertCCSExecutionInfoDetails(executionInfo);
+        }
+    }
+
+    public void testSubqueryWithTimeSeriesAndLookupJoinInSubquery() {
+        assumeTrue("Requires TS as a subquery source", EsqlCapabilities.Cap.SUBQUERY_WITH_TS.isEnabled());
+        populateTimeSeriesIndex(REMOTE_CLUSTER_1, "metrics");
+        populateTimeSeriesIndex(REMOTE_CLUSTER_2, "metrics");
+        populateLookupIndex(REMOTE_CLUSTER_1, "values_lookup", 10);
+        populateLookupIndex(REMOTE_CLUSTER_2, "values_lookup", 10);
+
+        try (EsqlQueryResponse resp = runQuery("""
+            FROM
+                (TS cluster-a:metrics
+                 | WHERE host == "h1"
+                 | EVAL key = TO_LONG(cpu)
+                 | LOOKUP JOIN values_lookup ON key == lookup_key
+                 | KEEP cluster_tag, key, lookup_tag),
+                (TS remote-b:metrics
+                 | WHERE host == "h1"
+                 | EVAL key = TO_LONG(cpu)
+                 | LOOKUP JOIN values_lookup ON key == lookup_key
+                 | KEEP cluster_tag, key, lookup_tag)
+            | SORT cluster_tag, key
+            """, randomBoolean())) {
+            var columns = resp.columns().stream().map(ColumnInfoImpl::name).toList();
+            assertThat(columns, hasItems("cluster_tag", "key", "lookup_tag"));
+
+            List<List<Object>> values = getValuesList(resp);
+            List<List<Object>> expected = List.of(
+                List.of(REMOTE_CLUSTER_1, 1L, REMOTE_CLUSTER_1),
+                List.of(REMOTE_CLUSTER_1, 2L, REMOTE_CLUSTER_1),
+                List.of(REMOTE_CLUSTER_1, 3L, REMOTE_CLUSTER_1),
+                List.of(REMOTE_CLUSTER_2, 1L, REMOTE_CLUSTER_2),
+                List.of(REMOTE_CLUSTER_2, 2L, REMOTE_CLUSTER_2),
+                List.of(REMOTE_CLUSTER_2, 3L, REMOTE_CLUSTER_2)
+            );
+            assertEquals(expected, values);
+
+            EsqlExecutionInfo executionInfo = resp.getExecutionInfo();
+            assertCCSExecutionInfoDetails(executionInfo);
+        }
+    }
+
+    public void testSubqueryWithTimeSeriesAndLookupJoinIndicesExistOnAllClustersReferencedByTheSubquery() {
+        assumeTrue("Requires TS as a subquery source", EsqlCapabilities.Cap.SUBQUERY_WITH_TS.isEnabled());
+        populateTimeSeriesIndex(REMOTE_CLUSTER_1, "metrics");
+        populateTimeSeriesIndex(REMOTE_CLUSTER_2, "metrics");
+        populateLookupIndex(REMOTE_CLUSTER_1, "values_lookup_1", 10);
+        populateLookupIndex(REMOTE_CLUSTER_2, "values_lookup_2", 10);
+
+        try (EsqlQueryResponse resp = runQuery("""
+            FROM
+                (TS cluster-a:metrics
+                 | WHERE host == "h1"
+                 | EVAL key = TO_LONG(cpu)
+                 | LOOKUP JOIN values_lookup_1 ON key == lookup_key
+                 | KEEP cluster_tag, key, lookup_tag),
+                (TS remote-b:metrics
+                 | WHERE host == "h1"
+                 | EVAL key = TO_LONG(cpu)
+                 | LOOKUP JOIN values_lookup_2 ON key == lookup_key
+                 | KEEP cluster_tag, key, lookup_tag)
+            | SORT cluster_tag, key
+            """, randomBoolean())) {
+            var columns = resp.columns().stream().map(ColumnInfoImpl::name).toList();
+            assertThat(columns, hasItems("cluster_tag", "key", "lookup_tag"));
+
+            List<List<Object>> values = getValuesList(resp);
+            List<List<Object>> expected = List.of(
+                List.of(REMOTE_CLUSTER_1, 1L, REMOTE_CLUSTER_1),
+                List.of(REMOTE_CLUSTER_1, 2L, REMOTE_CLUSTER_1),
+                List.of(REMOTE_CLUSTER_1, 3L, REMOTE_CLUSTER_1),
+                List.of(REMOTE_CLUSTER_2, 1L, REMOTE_CLUSTER_2),
+                List.of(REMOTE_CLUSTER_2, 2L, REMOTE_CLUSTER_2),
+                List.of(REMOTE_CLUSTER_2, 3L, REMOTE_CLUSTER_2)
+            );
+            assertEquals(expected, values);
+
+            EsqlExecutionInfo executionInfo = resp.getExecutionInfo();
+            assertCCSExecutionInfoDetails(executionInfo);
+        }
+    }
+
+    public void testSubqueryWithTimeSeriesAndLookupJoinMissingLookupIndexOnClustersReferencedByTheSubquery() {
+        assumeTrue("Requires TS as a subquery source", EsqlCapabilities.Cap.SUBQUERY_WITH_TS.isEnabled());
+        populateTimeSeriesIndex(REMOTE_CLUSTER_1, "metrics");
+        populateTimeSeriesIndex(REMOTE_CLUSTER_2, "metrics");
+
+        // (1) TS subquery scoped to a single remote cluster: the missing lookup is reported only for that cluster.
+        VerificationException ex = expectThrows(VerificationException.class, () -> runQuery("""
+            FROM
+                (TS cluster-a:metrics
+                 | EVAL key = TO_LONG(cpu)
+                 | LOOKUP JOIN missing_lookup ON key == lookup_key)
+            """, randomBoolean()));
+        assertThat(ex.getMessage(), containsString("Unknown index [cluster-a:missing_lookup]"));
+
+        // (2) two TS subqueries joining the same missing lookup index: the lookup is scoped to both remotes.
+        ex = expectThrows(VerificationException.class, () -> runQuery("""
+            FROM
+                (TS cluster-a:metrics
+                 | EVAL key = TO_LONG(cpu)
+                 | LOOKUP JOIN missing_lookup ON key == lookup_key),
+                (TS remote-b:metrics
+                 | EVAL key = TO_LONG(cpu)
+                 | LOOKUP JOIN missing_lookup ON key == lookup_key)
+            """, randomBoolean()));
+        assertThat(ex.getMessage(), containsString("Unknown index [cluster-a:missing_lookup,remote-b:missing_lookup]"));
+    }
+
+    private void populateTimeSeriesIndex(String clusterAlias, String indexName) {
+        String clusterTag = Strings.isEmpty(clusterAlias) ? "local" : clusterAlias;
+        Settings settings = Settings.builder()
+            .put("mode", "time_series")
+            .putList("routing_path", List.of("host"))
+            .put("index.number_of_shards", randomIntBetween(1, 3))
+            .build();
+        Client client = client(clusterAlias);
+        assertAcked(
+            client.admin()
+                .indices()
+                .prepareCreate(indexName)
+                .setSettings(settings)
+                .setMapping(
+                    "@timestamp",
+                    "type=date",
+                    "host",
+                    "type=keyword,time_series_dimension=true",
+                    "cluster_tag",
+                    "type=keyword",
+                    "cpu",
+                    "type=double,time_series_metric=gauge"
+                )
+        );
+        long timestamp = DEFAULT_DATE_TIME_FORMATTER.parseMillis("2024-04-15T00:00:00Z");
+        for (String host : List.of("h1", "h2")) {
+            double base = host.equals("h1") ? 1.0 : 4.0;
+            for (int i = 0; i < 3; i++) {
+                client.prepareIndex(indexName)
+                    .setSource("@timestamp", timestamp + i * 1000L, "host", host, "cluster_tag", clusterTag, "cpu", base + i)
+                    .get();
+            }
+        }
+        client.admin().indices().prepareRefresh(indexName).get();
     }
 
     static void assertClusterEsqlExecutionInfo(

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -1193,7 +1193,15 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                 }
                 config = new JoinConfig(type, leftKeys, rightKeys, joinOnConditions);
 
-                return new LookupJoin(join.source(), join.left(), join.right(), config, join.isRemote() || context.includesRemoteIndices());
+                // A LOOKUP JOIN runs remotely only when its left input actually reaches remote data nodes, i.e. the left subtree reads
+                // from a (non-lookup) index. A sourceless left side (e.g. a ROW subquery) keeps its data on the coordinator, so its lookup
+                // must run locally even when other parts of the query touch remote clusters; marking it remote would route it to data
+                // nodes that have no rows for it and produce a data node plan without concrete indices.
+                boolean leftReadsFromIndices = join.left()
+                    .anyMatch(p -> p instanceof EsRelation relation && relation.indexMode() != IndexMode.LOOKUP);
+                boolean isRemote = join.isRemote() || (context.includesRemoteIndices() && leftReadsFromIndices);
+
+                return new LookupJoin(join.source(), join.left(), join.right(), config, isRemote);
             } else {
                 // everything else is unsupported for now
                 UnresolvedAttribute errorAttribute = new UnresolvedAttribute(join.source(), "unsupported", "Unsupported join type");

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/PreAnalyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/PreAnalyzer.java
@@ -24,15 +24,18 @@ import org.elasticsearch.xpack.esql.plan.IndexPattern;
 import org.elasticsearch.xpack.esql.plan.LinkedIndexPattern;
 import org.elasticsearch.xpack.esql.plan.logical.Enrich;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.plan.logical.Subquery;
 import org.elasticsearch.xpack.esql.plan.logical.TimeSeriesAggregate;
 import org.elasticsearch.xpack.esql.plan.logical.UnresolvedExternalRelation;
 import org.elasticsearch.xpack.esql.plan.logical.UnresolvedRelation;
 import org.elasticsearch.xpack.esql.plan.logical.ViewShadowRelation;
 import org.elasticsearch.xpack.esql.plan.logical.inference.InferencePlan;
+import org.elasticsearch.xpack.esql.plan.logical.join.AbstractSubqueryJoin;
 import org.elasticsearch.xpack.esql.plan.logical.promql.PromqlCommand;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -52,6 +55,12 @@ public class PreAnalyzer {
         Map<IndexPattern, IndexMode> indexes,
         List<Enrich> enriches,
         List<IndexPattern> lookupIndices,
+        // Maps each lookup index pattern to the main (non-lookup) index patterns its LOOKUP JOIN must be resolvable against. A lookup
+        // nested inside a subquery maps to that subquery's main patterns; a lookup in the main query (which runs after the subqueries are
+        // unioned) maps to the whole query's main patterns - the union of the top-level main FROM and every subquery's main patterns. This
+        // lets index resolution require the lookup index only on the relevant clusters rather than on every cluster involved in the overall
+        // query. A lookup index that resolves to an empty set of main patterns is treated as referencing all clusters.
+        Map<IndexPattern, Set<IndexPattern>> lookupIndexPatternsToMainAndSubqueryIndexPatterns,
         Set<LinkedIndexPattern> linkedIndices,  // CPS only, patterns from local view names that could match remote indices
         boolean useAggregateMetricDoubleWhenNotSupported,
         boolean useDenseVectorWhenNotSupported,
@@ -63,6 +72,7 @@ public class PreAnalyzer {
             Map.of(),
             List.of(),
             List.of(),
+            Map.of(),
             Set.of(),
             false,
             false,
@@ -96,6 +106,10 @@ public class PreAnalyzer {
                 );
             }
         });
+
+        Map<IndexPattern, Set<IndexPattern>> lookupIndexPatternsToMainAndSubqueryIndexPatterns = mapLookupIndicesToSubqueryMainPatterns(
+            plan
+        );
 
         // CPS: collect ViewShadowRelation patterns. Shadows live as siblings of the
         // strict UnresolvedRelation inside per-resolution-level ViewUnionAlls (see ViewResolver).
@@ -181,6 +195,7 @@ public class PreAnalyzer {
             indexes,
             unresolvedEnriches,
             lookupIndices,
+            lookupIndexPatternsToMainAndSubqueryIndexPatterns,
             linkedIndexPatterns,
             useAggregateMetricDoubleWhenNotSupported.get(),
             useDenseVectorWhenNotSupported.get(),
@@ -188,6 +203,165 @@ public class PreAnalyzer {
             icebergPaths,
             inferenceIds
         );
+    }
+
+    /**
+     * Associates each lookup index with the main (non-lookup) index patterns its {@code LOOKUP JOIN} must be resolvable against.
+     * <p>
+     * A {@code LOOKUP JOIN} only needs its lookup index to exist on the clusters whose data actually reaches the join. By recording, per
+     * lookup index, the relevant main index patterns, index resolution can later limit the lookup index requirement to just those clusters
+     * instead of every cluster in the overall query.
+     * <p>
+     * The query is processed as a tree of <em>scopes</em>: the whole query is the outermost scope and each {@link Subquery} introduces a
+     * nested scope. A scope's main patterns are the main {@link UnresolvedRelation}s it directly owns plus the main patterns of every scope
+     * nested within it, because those nested subqueries' outputs are unioned into this scope before any of this scope's own
+     * {@code LOOKUP JOIN}s run. Each lookup index is associated with the main patterns of the scope that <em>directly</em> contains it - so
+     * a deeply nested lookup is scoped to its own (inner) data, while a main-query lookup spans the whole query. The same lookup index name
+     * can appear in more than one scope; when that happens the entries are merged by union, because the lookup index must then be present
+     * on the clusters of all of them.
+     * <p>
+     * An {@code IN}/{@code NOT IN} subquery (resolved into an {@link AbstractSubqueryJoin}: {@code SemiJoin}/{@code AntiJoin}/
+     * {@code MarkJoin}) is treated differently from a {@code FROM} {@link Subquery}. Its right side is an independent scope - lookups
+     * inside it are scoped to that subquery's own main patterns - but its data only filters the enclosing scope's rows; it is never unioned
+     * into the enclosing scope. Its main patterns are therefore <em>not</em> folded into the enclosing scope, so a lookup in the enclosing
+     * scope is never required on the (possibly remote) clusters referenced only inside the {@code IN}/{@code NOT IN} subquery.
+     */
+    private static Map<IndexPattern, Set<IndexPattern>> mapLookupIndicesToSubqueryMainPatterns(LogicalPlan plan) {
+        Map<IndexPattern, Set<IndexPattern>> lookupIndexPatternsToMainPatterns = new HashMap<>();
+        collectScopeMainPatterns(plan, lookupIndexPatternsToMainPatterns);
+        return lookupIndexPatternsToMainPatterns;
+    }
+
+    /**
+     * Processes a single scope - the whole query, the body of one {@link Subquery}, or the right side of one {@link AbstractSubqueryJoin}
+     * ({@code IN}/{@code NOT IN} subquery) - recording every lookup index directly in that scope against the scope's main patterns, and
+     * returns those main patterns so the enclosing scope can fold them into its own.
+     * <p>
+     * The scope's main patterns are the main relations it directly owns (those not below a nested {@link Subquery} or
+     * {@link AbstractSubqueryJoin}) together with the main patterns of every nested {@code FROM} subquery, because a {@code FROM}
+     * subquery's output is unioned into this scope before this scope's own {@code LOOKUP JOIN}s run. The main patterns of a nested
+     * {@code IN}/{@code NOT IN} subquery are deliberately excluded: that subquery only filters this scope's rows, its data is never unioned
+     * in, so it must not pull this scope's lookups onto the clusters it references.
+     */
+    private static Set<IndexPattern> collectScopeMainPatterns(
+        LogicalPlan scopeRoot,
+        Map<IndexPattern, Set<IndexPattern>> lookupIndexPatternsToMainPatterns
+    ) {
+        Set<IndexPattern> directMainPatterns = new HashSet<>();
+        Set<IndexPattern> directLookupPatterns = new HashSet<>();
+        List<Subquery> nestedSubqueries = new ArrayList<>();
+        List<LogicalPlan> inSubqueries = new ArrayList<>();
+        collectScopeNodes(scopeRoot, directMainPatterns, directLookupPatterns, nestedSubqueries, inSubqueries);
+
+        // This scope's main patterns include its directly-owned mains plus every nested FROM subquery's main patterns (those nested
+        // outputs are unioned into this scope before this scope's own lookups run). IN/NOT IN subqueries are intentionally not folded in.
+        Set<IndexPattern> scopeMainPatterns = new HashSet<>(directMainPatterns);
+        for (Subquery nestedSubquery : nestedSubqueries) {
+            scopeMainPatterns.addAll(collectScopeMainPatterns(nestedSubquery.plan(), lookupIndexPatternsToMainPatterns));
+        }
+
+        // IN/NOT IN subqueries are independent scopes: process them so their own nested lookups get scoped to their own main patterns, but
+        // discard the returned main patterns - a lookup in this scope must not be required on the clusters referenced only inside them.
+        for (LogicalPlan inSubquery : inSubqueries) {
+            collectScopeMainPatterns(inSubquery, lookupIndexPatternsToMainPatterns);
+        }
+
+        // The lookups directly in this scope run on this scope's (unioned) data, so they map to this scope's main patterns.
+        mergeLookupToMainPatterns(lookupIndexPatternsToMainPatterns, directLookupPatterns, scopeMainPatterns);
+
+        return scopeMainPatterns;
+    }
+
+    /**
+     * Walks a single scope rooted at {@code node}, classifying the nodes it owns into this scope's main / lookup relations and the nested
+     * scopes it introduces, stopping at each scope boundary:
+     * <ul>
+     *   <li>an {@link UnresolvedRelation} is a leaf collected as a main or lookup pattern of this scope;</li>
+     *   <li>a {@link Subquery} ({@code FROM} subquery) is a nested folding scope - it is recorded but not descended into, so its relations
+     *   are processed by the recursive call on its body;</li>
+     *   <li>an {@link AbstractSubqueryJoin} ({@code IN}/{@code NOT IN} subquery) is split: its left side continues this scope (descended
+     *   here), while its right side is the independent, non-folding subquery scope recorded in {@code inSubqueries};</li>
+     *   <li>any other node stays within this scope, so the walk descends into all of its children.</li>
+     * </ul>
+     */
+    private static void collectScopeNodes(
+        LogicalPlan node,
+        Set<IndexPattern> directMainPatterns,
+        Set<IndexPattern> directLookupPatterns,
+        List<Subquery> nestedSubqueries,
+        List<LogicalPlan> inSubqueries
+    ) {
+        if (node instanceof UnresolvedRelation relation) {
+            collectMainOrLookupPattern(relation, directMainPatterns, directLookupPatterns);
+        } else if (node instanceof Subquery subquery) {
+            nestedSubqueries.add(subquery);
+        } else if (node instanceof AbstractSubqueryJoin subqueryJoin) {
+            // The left side is the main query the IN/NOT IN filter applies to (same scope); the right side is the independent subquery.
+            inSubqueries.add(subqueryJoin.right());
+            collectScopeNodes(subqueryJoin.left(), directMainPatterns, directLookupPatterns, nestedSubqueries, inSubqueries);
+        } else {
+            for (LogicalPlan child : node.children()) {
+                collectScopeNodes(child, directMainPatterns, directLookupPatterns, nestedSubqueries, inSubqueries);
+            }
+        }
+    }
+
+    private static void collectMainOrLookupPattern(
+        UnresolvedRelation relation,
+        Set<IndexPattern> mainPatterns,
+        Set<IndexPattern> lookupPatterns
+    ) {
+        if (relation.indexMode() == IndexMode.LOOKUP) {
+            lookupPatterns.add(relation.indexPattern());
+        } else {
+            mainPatterns.add(relation.indexPattern());
+        }
+    }
+
+    /**
+     * Records, for a single scope, the association from each of that scope's {@code lookupPatterns} to that scope's {@code mainPatterns},
+     * accumulating into {@code lookupIndexPatternsToMainPatterns} across all scopes.
+     * <p>
+     * For every lookup index in the scope, {@link Map#merge} inserts {@code mainPatterns} the first time the lookup index is seen, and
+     * unions it with the already-recorded patterns when the same lookup index also appears in another scope (so the lookup index is
+     * required on the clusters of <em>all</em> scopes that use it).
+     * <p>
+     * Worked example for the query:
+     * <pre>{@code
+     *   FROM main0,                                                  // top-level main FROM
+     *     (FROM m1 | LOOKUP JOIN lk1 ON f),                          // subquery A
+     *     (FROM m2, m3 | LOOKUP JOIN lk1 ON f | LOOKUP JOIN lk2 ON g)   // subquery B
+     *   | LOOKUP JOIN lk0 ON h                                       // main-query lookup
+     * }</pre>
+     * The subqueries are merged first; the main-query lookup is then merged against the whole query's main patterns - the union of the
+     * top-level main FROM and every subquery's main patterns:
+     * <pre>{@code
+     *   // subquery A:  mainPatterns={m1},      lookupPatterns={lk1}
+     *   merge(lk1, {m1})     -> { lk1={m1} }
+     *
+     *   // subquery B:  mainPatterns={m2, m3},  lookupPatterns={lk1, lk2}
+     *   merge(lk1, {m2, m3}) -> { lk1={m1, m2, m3} }              // lk1 already present: union with existing {m1}
+     *   merge(lk2, {m2, m3}) -> { lk1={m1, m2, m3}, lk2={m2, m3} }
+     *
+     *   // main query:  lookupPatterns={lk0}, mainPatterns={main0} + {m1} + {m2, m3} = {main0, m1, m2, m3}
+     *   merge(lk0, {main0, m1, m2, m3}) -> { lk1={m1, m2, m3}, lk2={m2, m3}, lk0={main0, m1, m2, m3} }
+     * }</pre>
+     * Final result: {@code { lk0={main0, m1, m2, m3}, lk1={m1, m2, m3}, lk2={m2, m3} }}. lk0 (a main-query lookup) spans every main
+     * pattern because it runs on the unioned output; lk1 spans both subqueries' main patterns because it is used in both; lk2 is scoped to
+     * subquery B's main patterns only.
+     */
+    private static void mergeLookupToMainPatterns(
+        Map<IndexPattern, Set<IndexPattern>> lookupIndexPatternsToMainPatterns,
+        Set<IndexPattern> lookupPatterns,
+        Set<IndexPattern> mainPatterns
+    ) {
+        for (IndexPattern lookupPattern : lookupPatterns) {
+            lookupIndexPatternsToMainPatterns.merge(lookupPattern, mainPatterns, (existing, added) -> {
+                Set<IndexPattern> merged = new HashSet<>(existing);
+                merged.addAll(added);
+                return merged;
+            });
+        }
     }
 
     private static String inferenceId(InferencePlan<?> plan) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlCCSUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlCCSUtils.java
@@ -168,11 +168,23 @@ public class EsqlCCSUtils {
         }
     }
 
-    static String createQualifiedLookupIndexExpressionFromAvailableClusters(EsqlExecutionInfo executionInfo, String localPattern) {
+    /**
+     * Builds the qualified field-caps expression for a lookup index, restricted to the clusters that actually need it.
+     * <p>
+     * A {@code LOOKUP JOIN} only requires its lookup index on the clusters whose data reaches the join - for a lookup nested in a
+     * subquery these are the clusters of that subquery's main {@code FROM}, and for a lookup in the main query these are all running
+     * clusters (see {@code relevantClustersForLookupIndex}). Qualifying the expression to exactly those clusters means a lookup index that
+     * is missing from a cluster which does not feed the join is never queried there, so it is not spuriously reported as unknown.
+     */
+    static String createQualifiedLookupIndexExpressionFromAvailableClusters(
+        EsqlExecutionInfo executionInfo,
+        Set<String> relevantClusters,
+        String localPattern
+    ) {
         if (executionInfo.getClusters().isEmpty()) {
             return localPattern;
         }
-        return executionInfo.getRunningClusterAliases()
+        return relevantClusters.stream()
             .map(clusterAlias -> RemoteClusterAware.buildRemoteIndexName(clusterAlias, localPattern))
             .collect(joining(","));
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
@@ -1269,64 +1269,63 @@ public class EsqlSession {
                 }
             }
             return r;
-        })
-            .<PreAnalysisResult>andThen((l, r) -> preAnalyzeLookupIndices(preAnalysis.lookupIndices().iterator(), r, executionInfo, l))
-            .andThenApply(r -> {
-                executionInfo.queryProfile().indicesResolutionMarker().stop();
-                return r;
-            })
-            .<PreAnalysisResult>andThen((l, r) -> preAnalyzeExternalSources(parsed, preAnalysis, r, l))
-            .<PreAnalysisResult>andThen((l, r) -> {
-                // Do not update PreAnalysisResult.minimumTransportVersion, that's already been determined during main index resolution.
-                executionInfo.queryProfile().enrichResolutionMarker().start();
-                enrichPolicyResolver.resolvePolicies(
-                    preAnalysis.enriches(),
-                    executionInfo,
-                    r.minimumTransportVersion(),
-                    l.delegateFailureAndWrap((ll, enrichResolution) -> {
-                        executionInfo.queryProfile().enrichResolutionMarker().stop();
-                        ll.onResponse(r.withEnrichResolution(enrichResolution));
-                    })
-                );
-            })
-            .<PreAnalysisResult>andThen((l, r) -> {
-                executionInfo.queryProfile().inferenceResolutionMarker().start();
-                inferenceService.resolveInferenceIds(preAnalysis.inferenceIds(), l.delegateFailureAndWrap((ll, inferenceResolution) -> {
-                    executionInfo.queryProfile().inferenceResolutionMarker().stop();
-                    ll.onResponse(r.withInferenceResolution(inferenceResolution));
-                }));
-            })
-            .<Versioned<LogicalPlan>>andThen((l, r) -> {
-                analyzeWithRetry(
-                    parsed,
-                    nullify ? UnmappedResolution.NULLIFY : unmappedResolution,
-                    configuration,
-                    executionInfo,
-                    description,
-                    requestFilter,
-                    timestampBounds,
-                    preAnalysis,
-                    r,
-                    l
-                );
-            })
-            .addListener(logicalPlanListener);
+        }).<PreAnalysisResult>andThen((l, r) -> preAnalyzeLookupIndices(preAnalysis, r, executionInfo, l)).andThenApply(r -> {
+            executionInfo.queryProfile().indicesResolutionMarker().stop();
+            return r;
+        }).<PreAnalysisResult>andThen((l, r) -> preAnalyzeExternalSources(parsed, preAnalysis, r, l)).<PreAnalysisResult>andThen((l, r) -> {
+            // Do not update PreAnalysisResult.minimumTransportVersion, that's already been determined during main index resolution.
+            executionInfo.queryProfile().enrichResolutionMarker().start();
+            enrichPolicyResolver.resolvePolicies(
+                preAnalysis.enriches(),
+                executionInfo,
+                r.minimumTransportVersion(),
+                l.delegateFailureAndWrap((ll, enrichResolution) -> {
+                    executionInfo.queryProfile().enrichResolutionMarker().stop();
+                    ll.onResponse(r.withEnrichResolution(enrichResolution));
+                })
+            );
+        }).<PreAnalysisResult>andThen((l, r) -> {
+            executionInfo.queryProfile().inferenceResolutionMarker().start();
+            inferenceService.resolveInferenceIds(preAnalysis.inferenceIds(), l.delegateFailureAndWrap((ll, inferenceResolution) -> {
+                executionInfo.queryProfile().inferenceResolutionMarker().stop();
+                ll.onResponse(r.withInferenceResolution(inferenceResolution));
+            }));
+        }).<Versioned<LogicalPlan>>andThen((l, r) -> {
+            analyzeWithRetry(
+                parsed,
+                nullify ? UnmappedResolution.NULLIFY : unmappedResolution,
+                configuration,
+                executionInfo,
+                description,
+                requestFilter,
+                timestampBounds,
+                preAnalysis,
+                r,
+                l
+            );
+        }).addListener(logicalPlanListener);
     }
 
     /**
      * Perform a field caps request for each lookup index. Does not update the minimum transport version.
      */
     private void preAnalyzeLookupIndices(
-        Iterator<IndexPattern> lookupIndices,
+        PreAnalyzer.PreAnalysis preAnalysis,
         PreAnalysisResult preAnalysisResult,
         EsqlExecutionInfo executionInfo,
         ActionListener<PreAnalysisResult> listener
     ) {
-        forAll(lookupIndices, preAnalysisResult, (lookupIndex, r, l) -> preAnalyzeLookupIndex(lookupIndex, r, executionInfo, l), listener);
+        forAll(
+            preAnalysis.lookupIndices().iterator(),
+            preAnalysisResult,
+            (lookupIndex, r, l) -> preAnalyzeLookupIndex(lookupIndex, preAnalysis, r, executionInfo, l),
+            listener
+        );
     }
 
     private void preAnalyzeLookupIndex(
         IndexPattern lookupIndexPattern,
+        PreAnalyzer.PreAnalysis preAnalysis,
         PreAnalysisResult result,
         EsqlExecutionInfo executionInfo,
         ActionListener<PreAnalysisResult> listener
@@ -1339,19 +1338,71 @@ public class EsqlSession {
             ThreadPool.Names.SEARCH_COORDINATION,
             ThreadPool.Names.SYSTEM_READ
         );
+        // The lookup index only has to be present on the clusters referenced by the scope that contains the LOOKUP JOIN - either the
+        // enclosing subquery or, for a lookup that is not nested in a subquery, the whole query's main FROM.
+        Set<String> relevantClusters = relevantClustersForLookupIndex(lookupIndexPattern, preAnalysis, result, executionInfo);
         // No need to update the minimum transport version in the PreAnalysisResult,
         // it should already have been determined during the main index resolution.
         executionInfo.queryProfile().incFieldCapsCalls();
         indexResolver.resolveLookupIndices(
-            EsqlCCSUtils.createQualifiedLookupIndexExpressionFromAvailableClusters(executionInfo, localPattern),
+            EsqlCCSUtils.createQualifiedLookupIndexExpressionFromAvailableClusters(executionInfo, relevantClusters, localPattern),
             result.wildcardJoinIndices().contains(localPattern) ? IndexResolver.ALL_FIELDS : result.fieldNames,
             // We use the minimum version determined in the main index resolution, because for remote LOOKUP JOIN, we're only considering
             // remote lookup indices in the field caps request - but the coordinating cluster must be considered, too!
             // The main index resolution should already have taken the version of the coordinating cluster into account and this should
             // be reflected in result.minimumTransportVersion().
             result.minimumTransportVersion(),
-            listener.map(indexResolution -> receiveLookupIndexResolution(result, localPattern, executionInfo, indexResolution))
+            listener.map(
+                indexResolution -> receiveLookupIndexResolution(result, localPattern, relevantClusters, executionInfo, indexResolution)
+            )
         );
+    }
+
+    /**
+     * The set of clusters that must contain the given lookup index. When the LOOKUP JOIN lives inside a subquery, only the clusters
+     * referenced by that subquery's main FROM are relevant; the lookup index does not need to exist on clusters that are only referenced
+     * by sibling subqueries. When the lookup is not nested in a subquery, the clusters of the whole query's main FROM are relevant.
+     * <p>
+     * A lookup whose scope has no main patterns is fed only by coordinator-only data (e.g. a {@code ROW} subquery): its {@code LOOKUP JOIN}
+     * executes on the local coordinator, so the lookup index is relevant on the local cluster only - never on the remote clusters that feed
+     * the main FROM or sibling subqueries.
+     */
+    private static Set<String> relevantClustersForLookupIndex(
+        IndexPattern lookupIndexPattern,
+        PreAnalyzer.PreAnalysis preAnalysis,
+        PreAnalysisResult result,
+        EsqlExecutionInfo executionInfo
+    ) {
+        // A sourceless query (e.g. ROW ... | LOOKUP JOIN) has no main FROM and therefore no clusters in the execution info. Both the
+        // lookup index expression construction and the resolution handling special-case the empty-cluster scenario, so the relevant
+        // clusters are unused; return early to avoid querying the running clusters, which asserts a non-empty cluster map.
+        if (executionInfo.getClusters().isEmpty()) {
+            return Set.of();
+        }
+        Set<String> runningClusters = executionInfo.getRunningClusterAliases().collect(toSet());
+        Set<IndexPattern> mainPatterns = preAnalysis.lookupIndexPatternsToMainAndSubqueryIndexPatterns().get(lookupIndexPattern);
+        if (mainPatterns == null) {
+            // Defensive: a lookup that could not be associated with any scope. Fall back to requiring it on all running clusters.
+            return runningClusters;
+        }
+        if (mainPatterns.isEmpty()) {
+            // The lookup is fed only by coordinator-only data (a ROW subquery), so it runs on the local coordinator and must be resolved
+            // against the local cluster only. Resolving it on the remote clusters that feed sibling scopes would spuriously report it as
+            // an unknown index qualified with a cluster alias it never touches.
+            return Set.of(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY);
+        }
+        Set<String> relevantClusters = new HashSet<>();
+        for (IndexPattern mainPattern : mainPatterns) {
+            IndexResolution mainResolution = result.indexResolution().get(mainPattern);
+            if (mainResolution != null && mainResolution.isValid() && mainResolution.get() != null) {
+                for (String clusterAlias : mainResolution.get().originalIndices().keySet()) {
+                    if (runningClusters.contains(clusterAlias)) {
+                        relevantClusters.add(clusterAlias);
+                    }
+                }
+            }
+        }
+        return relevantClusters;
     }
 
     /**
@@ -1430,6 +1481,7 @@ public class EsqlSession {
     private PreAnalysisResult receiveLookupIndexResolution(
         PreAnalysisResult result,
         String index,
+        Set<String> relevantClusters,
         EsqlExecutionInfo executionInfo,
         IndexResolution lookupIndexResolution
     ) {
@@ -1475,10 +1527,15 @@ public class EsqlSession {
             return result.addLookupIndexResolution(index, lookupIndexResolution);
         }
 
-        // Collect resolved clusters from the index resolution, verify that each cluster has a single resolution for the lookup index
+        // Collect resolved clusters from the index resolution, verify that each cluster has a single resolution for the lookup index.
+        // Only the clusters referenced by the subquery that contains this LOOKUP JOIN are considered (for a lookup that is not scoped to
+        // a subquery, these are all the running clusters); indices resolved on clusters that only belong to sibling subqueries are ignored.
         Map<String, String> clustersWithResolvedIndices = new HashMap<>(lookupIndexResolution.resolvedIndices().size());
         lookupIndexResolution.get().indexNameWithModes().forEach((indexName, indexMode) -> {
             String clusterAlias = RemoteClusterAware.splitIndexName(indexName).getClusterGroupingKey();
+            if (relevantClusters.contains(clusterAlias) == false) {
+                return;
+            }
             // Check that all indices are in lookup mode
             if (indexMode != IndexMode.LOOKUP) {
                 skipClusterOrError(
@@ -1508,9 +1565,9 @@ public class EsqlSession {
             }
         });
 
-        // These are clusters that are still in the running, we need to have the index on all of them
-        // Verify that all active clusters have the lookup index resolved
-        executionInfo.getRunningClusterAliases().forEach(clusterAlias -> {
+        // We only need the lookup index on the clusters referenced by the subquery that contains this LOOKUP JOIN (for a lookup that is
+        // not scoped to a subquery, these are all the running clusters). Verify that each of those clusters has the lookup index resolved.
+        relevantClusters.forEach(clusterAlias -> {
             if (clustersWithResolvedIndices.containsKey(clusterAlias) == false) {
                 // Missing cluster resolution
                 skipClusterOrError(clusterAlias, executionInfo, findFailure(lookupIndexResolution.failures(), index, clusterAlias));

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/PreAnalyzerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/PreAnalyzerTests.java
@@ -8,16 +8,22 @@
 package org.elasticsearch.xpack.esql.analysis;
 
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
+import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.expression.function.FunctionDefinition;
 import org.elasticsearch.xpack.esql.expression.function.inference.InferenceFunction;
+import org.elasticsearch.xpack.esql.plan.IndexPattern;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.TEST_FUNCTION_REGISTRY;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.TEST_PARSER;
+import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 
 public class PreAnalyzerTests extends ESTestCase {
@@ -112,5 +118,493 @@ public class PreAnalyzerTests extends ESTestCase {
     private void assertCollectInferenceIds(PreAnalyzer preAnalyzer, String query, List<String> expectedInferenceIds) {
         List<String> inferenceIds = preAnalyzer.preAnalyze(TEST_PARSER.parseQuery(query)).inferenceIds();
         assertThat(inferenceIds, containsInAnyOrder(expectedInferenceIds.toArray(new String[0])));
+    }
+
+    /**
+     * A LOOKUP JOIN that is not nested inside a subquery is part of the whole query's main FROM, so its lookup index must be associated
+     * with the top-level main index pattern(s) (rather than being absent from the map). The main FROM may target remote clusters; those
+     * are preserved verbatim in the main pattern. The lookup index itself is always local - remote clusters are not allowed on the
+     * right-hand side of a LOOKUP JOIN.
+     */
+    public void testTopLevelLookupIndexMapsToMainPattern() {
+        // Single main pattern.
+        assertLookupToMainPatterns("FROM logs | LOOKUP JOIN lookup_index ON f1", Map.of("lookup_index", Set.of("logs")));
+
+        // A comma-separated FROM is a single index pattern, so the lookup is associated with that whole pattern.
+        assertLookupToMainPatterns("FROM logs,more | LOOKUP JOIN lookup_index ON f1", Map.of("lookup_index", Set.of("logs,more")));
+
+        // A remote main FROM is kept cluster-qualified in the main pattern; the (local) lookup index is associated with it.
+        assertLookupToMainPatterns(
+            "FROM remote_cluster:logs | LOOKUP JOIN lookup_index ON f1",
+            Map.of("lookup_index", Set.of("remote_cluster:logs"))
+        );
+
+        // A mix of local and remote (wildcard) clusters in the main FROM is a single comma-separated pattern.
+        assertLookupToMainPatterns("FROM logs,*:logs | LOOKUP JOIN lookup_index ON f1", Map.of("lookup_index", Set.of("logs,*:logs")));
+
+        // Several top-level lookup joins against a remote main FROM are each associated with the same top-level main pattern.
+        assertLookupToMainPatterns(
+            "FROM *:logs | LOOKUP JOIN lookup_a ON f1 | LOOKUP JOIN lookup_b ON f2",
+            Map.of("lookup_a", Set.of("*:logs"), "lookup_b", Set.of("*:logs"))
+        );
+    }
+
+    /**
+     * A LOOKUP JOIN in the main query (not nested in a subquery) runs after the subqueries' outputs are unioned with the top-level main
+     * FROM, so its lookup index must exist on every cluster the query touches. It is therefore associated with both the top-level main
+     * index pattern and every subquery's (here remote) main index pattern.
+     */
+    public void testMainQueryLookupIndexMapsToMainAndSubqueryPatterns() {
+        // Top-level main FROM plus remote subqueries: the main-query lookup spans the top-level main pattern and both subqueries' remote
+        // main patterns.
+        assertLookupToMainPatterns(
+            "FROM main_index, (FROM cluster-a:index1), (FROM cluster-b:index2) | LOOKUP JOIN lookup_index ON f",
+            Map.of("lookup_index", Set.of("main_index", "cluster-a:index1", "cluster-b:index2"))
+        );
+
+        // No top-level main FROM (only remote subqueries): the main-query lookup spans both subqueries' remote main patterns.
+        assertLookupToMainPatterns(
+            "FROM (FROM cluster-a:index1), (FROM cluster-b:index2) | LOOKUP JOIN lookup_index ON f",
+            Map.of("lookup_index", Set.of("cluster-a:index1", "cluster-b:index2"))
+        );
+    }
+
+    /**
+     * Nested subqueries are rejected later by the verifier, but pre-analysis still runs on the parsed plan. Each lookup index is scoped to
+     * the main patterns of the scope that directly contains it: a scope's main patterns are its directly-owned mains plus every nested
+     * subquery's mains (those are unioned into the scope before its own lookups run). So a main-query LOOKUP JOIN spans the whole query, an
+     * outer subquery's lookup spans that subquery (including its nested subquery's mains), and a deeply nested lookup is scoped to its own
+     * inner data only.
+     */
+    public void testMainQueryLookupIncludesNestedSubqueryMainPatterns() {
+        // Main patterns only (no lookup joins inside the subqueries): the main-query lookup spans the top-level main and every (nested)
+        // subquery main.
+        assertLookupToMainPatterns(
+            "FROM idxA, (FROM idxB, (FROM idxC)) | LOOKUP JOIN lkTop ON f",
+            Map.of("lkTop", Set.of("idxA", "idxB", "idxC"))
+        );
+
+        // Remote clusters, with a LOOKUP JOIN inside each subquery level plus one in the main query:
+        // - lookup_c is inside the nested subquery and only sees cluster-c:idxC (it runs before any union), so it is scoped to that alone;
+        // - lookup_b is inside the outer subquery, which unions cluster-b:idxB with the nested subquery's output, so it spans both
+        // cluster-b:idxB and cluster-c:idxC;
+        // - main_lookup runs after the whole-query union and spans every main pattern (cluster-a:idxA plus both nested subquery mains).
+        assertLookupToMainPatterns(
+            """
+                FROM cluster-a:idxA,
+                  (FROM cluster-b:idxB,
+                     (FROM cluster-c:idxC | LOOKUP JOIN lookup_c ON g)
+                   | LOOKUP JOIN lookup_b ON f)
+                | LOOKUP JOIN main_lookup ON h
+                """,
+            Map.of(
+                "lookup_c",
+                Set.of("cluster-c:idxC"),
+                "lookup_b",
+                Set.of("cluster-b:idxB", "cluster-c:idxC"),
+                "main_lookup",
+                Set.of("cluster-a:idxA", "cluster-b:idxB", "cluster-c:idxC")
+            )
+        );
+    }
+
+    /**
+     * Subqueries that each contain a LOOKUP JOIN, with a top-level main FROM present. Each subquery's lookup index is associated with
+     * that subquery's own main patterns; the top-level main FROM contributes no mapping of its own (it has no lookup join). When the two
+     * subqueries join against the same lookup index, that index is associated with the union of both subqueries' main patterns. A LOOKUP
+     * JOIN in the main query (outside the subqueries) runs on the unioned output and so spans the whole query's main patterns.
+     */
+    public void testSubqueriesWithLookupJoinsAndMainIndexPattern() {
+        // A different lookup index in each subquery: each is scoped to its own subquery's main pattern. main_index is not a key in the
+        // map (it has no lookup join) and does not leak into either lookup's main patterns.
+        assertLookupToMainPatterns("""
+            FROM main_index,
+              (FROM cluster-a:logs | LOOKUP JOIN lookup_a ON f),
+              (FROM cluster-b:logs | LOOKUP JOIN lookup_b ON g)
+            """, Map.of("lookup_a", Set.of("cluster-a:logs"), "lookup_b", Set.of("cluster-b:logs")));
+
+        // The same lookup index in both subqueries: associated with the union of both subqueries' main patterns.
+        assertLookupToMainPatterns("""
+            FROM main_index,
+              (FROM cluster-a:logs | LOOKUP JOIN shared_lookup ON f),
+              (FROM cluster-b:logs | LOOKUP JOIN shared_lookup ON g)
+            """, Map.of("shared_lookup", Set.of("cluster-a:logs", "cluster-b:logs")));
+
+        // An extra LOOKUP JOIN in the main query (outside the subqueries): main_lookup spans the whole query's main patterns (the top-level
+        // main FROM plus both subqueries' main patterns), while each in-subquery lookup stays scoped to its own subquery.
+        assertLookupToMainPatterns(
+            """
+                FROM main_index,
+                  (FROM cluster-a:logs | LOOKUP JOIN lookup_a ON f),
+                  (FROM cluster-b:logs | LOOKUP JOIN lookup_b ON g)
+                | LOOKUP JOIN main_lookup ON h
+                """,
+            Map.of(
+                "lookup_a",
+                Set.of("cluster-a:logs"),
+                "lookup_b",
+                Set.of("cluster-b:logs"),
+                "main_lookup",
+                Set.of("main_index", "cluster-a:logs", "cluster-b:logs")
+            )
+        );
+
+        // The same index joined both inside a subquery and in the main query: required on that subquery's clusters (from the in-subquery
+        // join) unioned with the whole query's clusters (from the main-query join), which is the whole query's main patterns.
+        assertLookupToMainPatterns("""
+            FROM main_index,
+              (FROM cluster-a:logs | LOOKUP JOIN shared_lookup ON f),
+              (FROM cluster-b:logs)
+            | LOOKUP JOIN shared_lookup ON h
+            """, Map.of("shared_lookup", Set.of("main_index", "cluster-a:logs", "cluster-b:logs")));
+    }
+
+    /**
+     * Subqueries that each contain a LOOKUP JOIN, with no top-level main FROM (the whole query is made up entirely of subqueries). The
+     * in-subquery mappings are the same as when a main FROM is present, because the top-level main FROM never contributes a lookup
+     * mapping in these queries. A LOOKUP JOIN in the main query (outside the subqueries) runs on the unioned output and so spans every
+     * subquery's main pattern.
+     */
+    public void testSubqueriesWithLookupJoinsAndNoMainIndexPattern() {
+        // A different lookup index in each subquery.
+        assertLookupToMainPatterns("""
+            FROM
+              (FROM cluster-a:logs | LOOKUP JOIN lookup_a ON f),
+              (FROM cluster-b:logs | LOOKUP JOIN lookup_b ON g)
+            """, Map.of("lookup_a", Set.of("cluster-a:logs"), "lookup_b", Set.of("cluster-b:logs")));
+
+        // The same lookup index in both subqueries: associated with the union of both subqueries' main patterns.
+        assertLookupToMainPatterns("""
+            FROM
+              (FROM cluster-a:logs | LOOKUP JOIN shared_lookup ON f),
+              (FROM cluster-b:logs | LOOKUP JOIN shared_lookup ON g)
+            """, Map.of("shared_lookup", Set.of("cluster-a:logs", "cluster-b:logs")));
+
+        // An extra LOOKUP JOIN in the main query (outside the subqueries), with no top-level main FROM: main_lookup spans both subqueries'
+        // main patterns, while each in-subquery lookup stays scoped to its own subquery.
+        assertLookupToMainPatterns(
+            """
+                FROM
+                  (FROM cluster-a:logs | LOOKUP JOIN lookup_a ON f),
+                  (FROM cluster-b:logs | LOOKUP JOIN lookup_b ON g)
+                | LOOKUP JOIN main_lookup ON h
+                """,
+            Map.of(
+                "lookup_a",
+                Set.of("cluster-a:logs"),
+                "lookup_b",
+                Set.of("cluster-b:logs"),
+                "main_lookup",
+                Set.of("cluster-a:logs", "cluster-b:logs")
+            )
+        );
+    }
+
+    /**
+     * An {@code IN}/{@code NOT IN} subquery (a {@code SemiJoin}/{@code AntiJoin}) only filters the rows of the enclosing query; its data is
+     * never unioned in. So a {@code LOOKUP JOIN} inside the subquery is scoped to that subquery's own main patterns, and a
+     * {@code LOOKUP JOIN} in the enclosing query is scoped to the enclosing query's main patterns only - it is never required on the
+     * (possibly remote) clusters referenced solely inside the {@code IN}/{@code NOT IN} subquery.
+     */
+    public void testInSubqueryLookupsScopedToSubquery() {
+        assumeTrue("Requires IN subquery support", EsqlCapabilities.Cap.WHERE_IN_SUBQUERY_WITHOUT_VIEW.isEnabled());
+
+        // IN subquery (SemiJoin): the lookup inside the subquery is scoped to the subquery's remote main pattern, while the main-query
+        // lookup is scoped to the main FROM only - it does not pick up cluster-a referenced inside the IN subquery.
+        assertInSubqueryLookupToMainPatterns("""
+            FROM main_index
+            | WHERE f IN (FROM cluster-a:logs | LOOKUP JOIN sub_lookup ON g)
+            | LOOKUP JOIN main_lookup ON h
+            """, Map.of("sub_lookup", Set.of("cluster-a:logs"), "main_lookup", Set.of("main_index")));
+
+        // NOT IN subquery (AntiJoin): same scoping as IN.
+        assertInSubqueryLookupToMainPatterns("""
+            FROM main_index
+            | WHERE f NOT IN (FROM cluster-a:logs | LOOKUP JOIN sub_lookup ON g)
+            | LOOKUP JOIN main_lookup ON h
+            """, Map.of("sub_lookup", Set.of("cluster-a:logs"), "main_lookup", Set.of("main_index")));
+
+        // The enclosing query is itself a union of FROM subqueries: the main-query lookup spans those FROM subqueries' main patterns (they
+        // are unioned in) but still excludes cluster-a referenced only inside the IN subquery.
+        assertInSubqueryLookupToMainPatterns("""
+            FROM main_index, (FROM cluster-b:logs)
+            | WHERE f IN (FROM cluster-a:logs)
+            | LOOKUP JOIN main_lookup ON h
+            """, Map.of("main_lookup", Set.of("main_index", "cluster-b:logs")));
+
+        assertInSubqueryLookupToMainPatterns("""
+            FROM main_index, (FROM cluster-b:logs)
+            | WHERE f IN (FROM cluster-a:logs | LOOKUP JOIN sub_lookup ON g)
+            | LOOKUP JOIN main_lookup ON h
+            """, Map.of("main_lookup", Set.of("main_index", "cluster-b:logs"), "sub_lookup", Set.of("cluster-a:logs")));
+
+        // The IN subquery body is itself a union of remote FROM subqueries: the lookup inside it spans both of those remote main patterns,
+        // while the main-query lookup stays scoped to the main FROM.
+        assertInSubqueryLookupToMainPatterns("""
+            FROM main_index
+            | WHERE f IN (FROM (FROM cluster-a:logs), (FROM cluster-b:logs) | LOOKUP JOIN sub_lookup ON g)
+            | LOOKUP JOIN main_lookup ON h
+            """, Map.of("sub_lookup", Set.of("cluster-a:logs", "cluster-b:logs"), "main_lookup", Set.of("main_index")));
+
+        assertInSubqueryLookupToMainPatterns("""
+            FROM main_index, (FROM cluster-b:logs)
+            | WHERE f IN (FROM (FROM cluster-a:logs), (FROM cluster-b:logs) | LOOKUP JOIN sub_lookup ON g)
+            | LOOKUP JOIN main_lookup ON h
+            """, Map.of("main_lookup", Set.of("main_index", "cluster-b:logs"), "sub_lookup", Set.of("cluster-a:logs", "cluster-b:logs")));
+
+        assertInSubqueryLookupToMainPatterns(
+            """
+                FROM main_index, (FROM cluster-b:logs)
+                | WHERE f IN (FROM
+                                  (FROM cluster-a:logs | LOOKUP JOIN sub_lookup_a ON a),
+                                  (FROM cluster-b:logs | LOOKUP JOIN sub_lookup_b ON b)
+                              | LOOKUP JOIN sub_lookup ON g)
+                | LOOKUP JOIN main_lookup ON h
+                """,
+            Map.of(
+                "main_lookup",
+                Set.of("main_index", "cluster-b:logs"),
+                "sub_lookup",
+                Set.of("cluster-a:logs", "cluster-b:logs"),
+                "sub_lookup_a",
+                Set.of("cluster-a:logs"),
+                "sub_lookup_b",
+                Set.of("cluster-b:logs")
+            )
+        );
+
+        // The same lookup index used both in the main query and inside the IN subquery must exist on the clusters of both scopes, so it is
+        // associated with the union of the main FROM and the IN subquery's main pattern.
+        assertInSubqueryLookupToMainPatterns("""
+            FROM main_index
+            | WHERE f IN (FROM cluster-a:logs | LOOKUP JOIN shared_lookup ON g)
+            | LOOKUP JOIN shared_lookup ON h
+            """, Map.of("shared_lookup", Set.of("main_index", "cluster-a:logs")));
+    }
+
+    /**
+     * Nested {@code IN}/{@code NOT IN} subqueries: each subquery is an independent scope whose data is never unioned into the scope that
+     * filters on it. So a lookup is scoped to the main patterns of the {@code IN}/{@code NOT IN} subquery (or main query) that directly
+     * contains it, and never to the clusters referenced only inside a more deeply nested {@code IN}/{@code NOT IN} subquery.
+     */
+    public void testNestedInSubqueryLookupsScopedIndependently() {
+        assumeTrue("Requires IN subquery support", EsqlCapabilities.Cap.WHERE_IN_SUBQUERY_WITHOUT_VIEW.isEnabled());
+
+        // An IN subquery nested inside another IN subquery, each with its own LOOKUP JOIN, plus a main-query LOOKUP JOIN:
+        // - inner_lookup sits in the innermost IN subquery and is scoped to cluster-b:logs only;
+        // - outer_lookup sits in the outer IN subquery and is scoped to cluster-a:logs only (the inner IN subquery is not unioned in);
+        // - main_lookup is in the main query and is scoped to main_index only (neither IN subquery is unioned in).
+        assertInSubqueryLookupToMainPatterns(
+            """
+                FROM main_index
+                | WHERE f IN (
+                    FROM cluster-a:logs
+                    | WHERE g IN (FROM cluster-b:logs | LOOKUP JOIN inner_lookup ON p)
+                    | LOOKUP JOIN outer_lookup ON q
+                  )
+                | LOOKUP JOIN main_lookup ON h
+                """,
+            Map.of("inner_lookup", Set.of("cluster-b:logs"), "outer_lookup", Set.of("cluster-a:logs"), "main_lookup", Set.of("main_index"))
+        );
+
+        // Two sibling IN/NOT IN subqueries (two WHERE clauses), each with its own lookup: each lookup is scoped to its own subquery's
+        // remote main pattern, and the main-query lookup remains scoped to the main FROM only.
+        assertInSubqueryLookupToMainPatterns("""
+            FROM main_index
+            | WHERE f IN (FROM cluster-a:logs | LOOKUP JOIN lookup_a ON g)
+            | WHERE k NOT IN (FROM cluster-b:logs | LOOKUP JOIN lookup_b ON m)
+            | LOOKUP JOIN main_lookup ON h
+            """, Map.of("lookup_a", Set.of("cluster-a:logs"), "lookup_b", Set.of("cluster-b:logs"), "main_lookup", Set.of("main_index")));
+
+        // An IN subquery embedded in an OR (a MarkJoin) is scoped exactly like a SemiJoin/AntiJoin: the lookup inside it stays on the
+        // subquery's clusters and the main-query lookup excludes them.
+        assertInSubqueryLookupToMainPatterns("""
+            FROM main_index
+            | WHERE f IN (FROM cluster-a:logs | LOOKUP JOIN sub_lookup ON g) OR h > 1
+            | LOOKUP JOIN main_lookup ON k
+            """, Map.of("sub_lookup", Set.of("cluster-a:logs"), "main_lookup", Set.of("main_index")));
+    }
+
+    /**
+     * A {@code ROW} command is a valid subquery source inside a {@code FROM}. A {@code ROW} subquery is sourceless - it produces no
+     * {@link org.elasticsearch.xpack.esql.plan.logical.UnresolvedRelation} - so it contributes no main index patterns (and therefore no
+     * clusters) to the scope it is unioned into. A main-query {@code LOOKUP JOIN} therefore gains nothing from a sibling {@code ROW}
+     * subquery, whether the main FROM is local or remote, and a {@code LOOKUP JOIN} nested inside a {@code ROW} subquery is scoped to an
+     * empty set of main patterns (treated as "all clusters" downstream, which the session resolves to the local coordinator).
+     */
+    public void testRowSubqueryInFromContributesNoMainPatterns() {
+        assumeTrue("Requires ROW subquery support", EsqlCapabilities.Cap.SUBQUERY_WITH_ROW.isEnabled());
+
+        // A ROW subquery is a sourceless union member, so the main-query lookup spans only the top-level main FROM.
+        assertLookupToMainPatterns(
+            "FROM main_index, (ROW x = 1) | LOOKUP JOIN main_lookup ON f",
+            Map.of("main_lookup", Set.of("main_index"))
+        );
+        // Same shape against a remote main FROM: the ROW still contributes no cluster, so the lookup spans only the remote main.
+        assertLookupToMainPatterns(
+            "FROM cluster-a:main_index, (ROW x = 1) | LOOKUP JOIN main_lookup ON f",
+            Map.of("main_lookup", Set.of("cluster-a:main_index"))
+        );
+
+        // No top-level main FROM, only a ROW subquery: the whole query has no main patterns, so the main-query lookup maps to the empty
+        // set (which downstream means "all clusters").
+        assertLookupToMainPatterns("FROM (ROW x = 1) | LOOKUP JOIN main_lookup ON x", Map.of("main_lookup", Set.of()));
+
+        // A LOOKUP JOIN inside the ROW subquery is scoped to the ROW subquery's (empty) main patterns; the main-query lookup still spans
+        // only the top-level main FROM.
+        assertLookupToMainPatterns(
+            "FROM main_index, (ROW x = 1 | LOOKUP JOIN sub_lookup ON x) | LOOKUP JOIN main_lookup ON f",
+            Map.of("sub_lookup", Set.of(), "main_lookup", Set.of("main_index"))
+        );
+        // Same shape against a remote main FROM: the nested ROW lookup never picks up that remote cluster (it stays empty), while the
+        // main-query lookup spans only the remote main FROM.
+        assertLookupToMainPatterns(
+            "FROM cluster-a:main_index, (ROW x = 1 | LOOKUP JOIN sub_lookup ON x) | LOOKUP JOIN main_lookup ON f",
+            Map.of("sub_lookup", Set.of(), "main_lookup", Set.of("cluster-a:main_index"))
+        );
+    }
+
+    /**
+     * A {@code ROW} command is also a valid {@code IN}/{@code NOT IN} subquery source. As with any {@code IN}/{@code NOT IN} subquery it is
+     * an independent scope whose data only filters the enclosing rows and is never unioned in; being sourceless it also contributes no main
+     * patterns (and no clusters) of its own. So a {@code LOOKUP JOIN} inside the {@code ROW} subquery is scoped to an empty set, and a
+     * {@code LOOKUP JOIN} in the enclosing query stays scoped to the enclosing main FROM, whether that main is local or remote.
+     */
+    public void testRowSubqueryInWhereInScopedIndependently() {
+        assumeTrue("Requires IN subquery support", EsqlCapabilities.Cap.WHERE_IN_SUBQUERY_WITHOUT_VIEW.isEnabled());
+        assumeTrue("Requires ROW subquery support", EsqlCapabilities.Cap.SUBQUERY_WITH_ROW.isEnabled());
+
+        // IN subquery (SemiJoin) with a ROW body: the main-query lookup is scoped to the main FROM only.
+        assertInSubqueryLookupToMainPatterns(
+            "FROM main_index | WHERE f IN (ROW x = 1) | LOOKUP JOIN main_lookup ON h",
+            Map.of("main_lookup", Set.of("main_index"))
+        );
+        // Same shape against a remote main FROM: scoped to the remote main only.
+        assertInSubqueryLookupToMainPatterns(
+            "FROM cluster-a:main_index | WHERE f IN (ROW x = 1) | LOOKUP JOIN main_lookup ON h",
+            Map.of("main_lookup", Set.of("cluster-a:main_index"))
+        );
+
+        // NOT IN subquery (AntiJoin) with a ROW body: same scoping as IN, against both a local and a remote main FROM.
+        assertInSubqueryLookupToMainPatterns(
+            "FROM main_index | WHERE f NOT IN (ROW x = 1) | LOOKUP JOIN main_lookup ON h",
+            Map.of("main_lookup", Set.of("main_index"))
+        );
+        assertInSubqueryLookupToMainPatterns(
+            "FROM cluster-a:main_index | WHERE f NOT IN (ROW x = 1) | LOOKUP JOIN main_lookup ON h",
+            Map.of("main_lookup", Set.of("cluster-a:main_index"))
+        );
+
+        // A LOOKUP JOIN inside the ROW IN subquery is scoped to the subquery's (empty) main patterns; the main-query lookup excludes it
+        // and stays scoped to the enclosing main FROM - shown here against both a local and a remote main.
+        assertInSubqueryLookupToMainPatterns(
+            "FROM main_index | WHERE f IN (ROW x = 1 | LOOKUP JOIN sub_lookup ON x) | LOOKUP JOIN main_lookup ON h",
+            Map.of("sub_lookup", Set.of(), "main_lookup", Set.of("main_index"))
+        );
+        assertInSubqueryLookupToMainPatterns(
+            "FROM cluster-a:main_index | WHERE f IN (ROW x = 1 | LOOKUP JOIN sub_lookup ON x) | LOOKUP JOIN main_lookup ON h",
+            Map.of("sub_lookup", Set.of(), "main_lookup", Set.of("cluster-a:main_index"))
+        );
+    }
+
+    /**
+     * A {@code TS} (time-series) command is a valid subquery source inside a {@code FROM}. Its index produces an
+     * {@link org.elasticsearch.xpack.esql.plan.logical.UnresolvedRelation} just like a {@code FROM}, so a {@code TS} subquery contributes
+     * its index pattern to the enclosing scope's main patterns (its output is unioned in). A main-query {@code LOOKUP JOIN} therefore spans
+     * the {@code TS} subquery's index, and a {@code LOOKUP JOIN} nested inside the {@code TS} subquery is scoped to that subquery's index.
+     */
+    public void testTimeSeriesSubqueryInFromMapsToMainPattern() {
+        assumeTrue("Requires TS subquery support", EsqlCapabilities.Cap.SUBQUERY_WITH_TS.isEnabled());
+
+        // A TS subquery is unioned into the main query: the main-query lookup spans both the top-level main FROM and the TS index.
+        assertLookupToMainPatterns(
+            "FROM main_index, (TS metrics_index) | LOOKUP JOIN main_lookup ON f",
+            Map.of("main_lookup", Set.of("main_index", "metrics_index"))
+        );
+        // Same shape across clusters: a remote main FROM and a TS subquery on a different remote cluster - the lookup spans both.
+        assertLookupToMainPatterns(
+            "FROM cluster-a:main_index, (TS remote-b:metrics) | LOOKUP JOIN main_lookup ON f",
+            Map.of("main_lookup", Set.of("cluster-a:main_index", "remote-b:metrics"))
+        );
+
+        // No top-level main FROM, only a remote TS subquery: the main-query lookup spans the TS subquery's remote index.
+        assertLookupToMainPatterns(
+            "FROM (TS cluster-a:metrics) | LOOKUP JOIN main_lookup ON f",
+            Map.of("main_lookup", Set.of("cluster-a:metrics"))
+        );
+
+        // A LOOKUP JOIN inside the TS subquery is scoped to that subquery's remote main pattern; the main-query lookup spans both the
+        // local main FROM and the remote TS index.
+        assertLookupToMainPatterns(
+            "FROM main_index, (TS cluster-a:metrics | LOOKUP JOIN sub_lookup ON f) | LOOKUP JOIN main_lookup ON h",
+            Map.of("sub_lookup", Set.of("cluster-a:metrics"), "main_lookup", Set.of("main_index", "cluster-a:metrics"))
+        );
+    }
+
+    /**
+     * A {@code TS} command is also a valid {@code IN}/{@code NOT IN} subquery source. As an {@code IN}/{@code NOT IN} subquery it is an
+     * independent scope whose data only filters the enclosing rows and is never unioned in, so a {@code LOOKUP JOIN} inside the {@code TS}
+     * subquery is scoped to the {@code TS} index alone while a {@code LOOKUP JOIN} in the enclosing query stays scoped to the enclosing
+     * main FROM - it never picks up the (possibly remote) clusters referenced only inside the {@code TS} IN subquery.
+     */
+    public void testTimeSeriesSubqueryInWhereInScopedToSubquery() {
+        assumeTrue("Requires IN subquery support", EsqlCapabilities.Cap.WHERE_IN_SUBQUERY_WITHOUT_VIEW.isEnabled());
+        assumeTrue("Requires TS in IN subquery support", EsqlCapabilities.Cap.WHERE_IN_SUBQUERY_WITH_TS.isEnabled());
+
+        // IN subquery (SemiJoin) with a TS body and a nested LOOKUP JOIN: sub_lookup is scoped to the TS remote index, while the
+        // main-query lookup is scoped to the main FROM only - it does not pick up the cluster referenced inside the IN subquery.
+        assertInSubqueryLookupToMainPatterns(
+            "FROM main_index | WHERE f IN (TS cluster-a:metrics | LOOKUP JOIN sub_lookup ON g) | LOOKUP JOIN main_lookup ON h",
+            Map.of("sub_lookup", Set.of("cluster-a:metrics"), "main_lookup", Set.of("main_index"))
+        );
+        // Same shape against a remote enclosing main on a different cluster: the main-query lookup stays scoped to remote-b only and
+        // never picks up cluster-a, which is referenced solely inside the IN subquery.
+        assertInSubqueryLookupToMainPatterns(
+            "FROM remote-b:main_index | WHERE f IN (TS cluster-a:metrics | LOOKUP JOIN sub_lookup ON g) | LOOKUP JOIN main_lookup ON h",
+            Map.of("sub_lookup", Set.of("cluster-a:metrics"), "main_lookup", Set.of("remote-b:main_index"))
+        );
+
+        // NOT IN subquery (AntiJoin) with a TS body: same scoping as IN, against both a local and a remote enclosing main FROM.
+        assertInSubqueryLookupToMainPatterns(
+            "FROM main_index | WHERE f NOT IN (TS cluster-a:metrics | LOOKUP JOIN sub_lookup ON g) | LOOKUP JOIN main_lookup ON h",
+            Map.of("sub_lookup", Set.of("cluster-a:metrics"), "main_lookup", Set.of("main_index"))
+        );
+        assertInSubqueryLookupToMainPatterns(
+            "FROM remote-b:main_index | WHERE f NOT IN (TS cluster-a:metrics | LOOKUP JOIN sub_lookup ON g) | LOOKUP JOIN main_lookup ON h",
+            Map.of("sub_lookup", Set.of("cluster-a:metrics"), "main_lookup", Set.of("remote-b:main_index"))
+        );
+    }
+
+    public void testNoLookupIndexProducesEmptyMap() {
+        var preAnalysis = new PreAnalyzer().preAnalyze(TEST_PARSER.parseQuery("FROM logs | WHERE f1 > 1"));
+        assertThat(preAnalysis.lookupIndexPatternsToMainAndSubqueryIndexPatterns(), anEmptyMap());
+    }
+
+    private static void assertLookupToMainPatterns(String query, Map<String, Set<String>> expected) {
+        assertLookupToMainPatterns(TEST_PARSER.parseQuery(query), expected);
+    }
+
+    /**
+     * Resolves {@code IN}/{@code NOT IN} subqueries into {@link org.elasticsearch.xpack.esql.plan.logical.join.AbstractSubqueryJoin}
+     * nodes (as the session does before pre-analysis) and then asserts the lookup-to-main-pattern mapping. The parser only emits
+     * {@code InSubquery} expressions, so the join nodes that {@link PreAnalyzer} reasons about only exist after this resolution step.
+     */
+    private static void assertInSubqueryLookupToMainPatterns(String query, Map<String, Set<String>> expected) {
+        assertLookupToMainPatterns(InSubqueryResolver.resolve(TEST_PARSER.parseQuery(query)), expected);
+    }
+
+    private static void assertLookupToMainPatterns(LogicalPlan plan, Map<String, Set<String>> expected) {
+        Map<IndexPattern, Set<IndexPattern>> actual = new PreAnalyzer().preAnalyze(plan)
+            .lookupIndexPatternsToMainAndSubqueryIndexPatterns();
+
+        assertThat(actual.keySet(), containsInAnyOrder(expected.keySet().stream().map(PreAnalyzerTests::pattern).toArray()));
+        expected.forEach((lookup, mainPatterns) -> {
+            Set<IndexPattern> actualMainPatterns = actual.get(pattern(lookup));
+            assertThat(actualMainPatterns, containsInAnyOrder(mainPatterns.stream().map(PreAnalyzerTests::pattern).toArray()));
+        });
+    }
+
+    private static IndexPattern pattern(String indexPattern) {
+        return new IndexPattern(Source.EMPTY, indexPattern);
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/session/EsqlCCSUtilsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/session/EsqlCCSUtilsTests.java
@@ -64,83 +64,66 @@ public class EsqlCCSUtilsTests extends ESTestCase {
     private final String REMOTE2_ALIAS = "remote2";
 
     public void testCreateQualifiedLookupIndexExpressionFromAvailableClusters() {
+        // A cross-cluster query with the local cluster plus two remotes; the lookup expression is qualified only against the clusters
+        // that are relevant to the LOOKUP JOIN (its enclosing scope), regardless of which other clusters are running.
+        EsqlExecutionInfo executionInfo = createEsqlExecutionInfo(true);
+        executionInfo.swapCluster(
+            LOCAL_CLUSTER_ALIAS,
+            (k, v) -> createEsqlExecutionInfoCluster(LOCAL_CLUSTER_ALIAS, "", false, EsqlExecutionInfo.Cluster.Status.RUNNING)
+        );
+        executionInfo.swapCluster(
+            REMOTE1_ALIAS,
+            (k, v) -> createEsqlExecutionInfoCluster(REMOTE1_ALIAS, "", true, EsqlExecutionInfo.Cluster.Status.RUNNING)
+        );
+        executionInfo.swapCluster(
+            REMOTE2_ALIAS,
+            (k, v) -> createEsqlExecutionInfoCluster(REMOTE2_ALIAS, "", true, EsqlExecutionInfo.Cluster.Status.RUNNING)
+        );
 
-        // no clusters marked as skipped
-        {
-            EsqlExecutionInfo executionInfo = createEsqlExecutionInfo(true);
-            executionInfo.swapCluster(
-                LOCAL_CLUSTER_ALIAS,
-                (k, v) -> createEsqlExecutionInfoCluster(LOCAL_CLUSTER_ALIAS, "", false, EsqlExecutionInfo.Cluster.Status.RUNNING)
-            );
-            executionInfo.swapCluster(
-                REMOTE1_ALIAS,
-                (k, v) -> createEsqlExecutionInfoCluster(REMOTE1_ALIAS, "", true, EsqlExecutionInfo.Cluster.Status.RUNNING)
-            );
-            executionInfo.swapCluster(
-                REMOTE2_ALIAS,
-                (k, v) -> createEsqlExecutionInfoCluster(REMOTE2_ALIAS, "", true, EsqlExecutionInfo.Cluster.Status.RUNNING)
-            );
-            assertIndexPattern(
-                EsqlCCSUtils.createQualifiedLookupIndexExpressionFromAvailableClusters(executionInfo, "lookup"),
-                containsInAnyOrder("lookup", REMOTE1_ALIAS + ":lookup", REMOTE2_ALIAS + ":lookup")
-            );
-        }
-        // one cluster marked as skipped
-        {
-            EsqlExecutionInfo executionInfo = createEsqlExecutionInfo(true);
-            executionInfo.swapCluster(
-                LOCAL_CLUSTER_ALIAS,
-                (k, v) -> createEsqlExecutionInfoCluster(LOCAL_CLUSTER_ALIAS, "", false, EsqlExecutionInfo.Cluster.Status.RUNNING)
-            );
-            executionInfo.swapCluster(
-                REMOTE1_ALIAS,
-                (k, v) -> createEsqlExecutionInfoCluster(REMOTE1_ALIAS, "", true, EsqlExecutionInfo.Cluster.Status.RUNNING)
-            );
-            executionInfo.swapCluster(
-                REMOTE2_ALIAS,
-                (k, v) -> createEsqlExecutionInfoCluster(REMOTE2_ALIAS, "", true, EsqlExecutionInfo.Cluster.Status.SKIPPED)
-            );
-            assertIndexPattern(
-                EsqlCCSUtils.createQualifiedLookupIndexExpressionFromAvailableClusters(executionInfo, "lookup"),
-                containsInAnyOrder("lookup", REMOTE1_ALIAS + ":lookup")
-            );
-        }
-        // all remotes marked as skipped
-        {
-            EsqlExecutionInfo executionInfo = createEsqlExecutionInfo(true);
-            executionInfo.swapCluster(
-                LOCAL_CLUSTER_ALIAS,
-                (k, v) -> createEsqlExecutionInfoCluster(LOCAL_CLUSTER_ALIAS, "", false, EsqlExecutionInfo.Cluster.Status.RUNNING)
-            );
-            executionInfo.swapCluster(
-                REMOTE1_ALIAS,
-                (k, v) -> createEsqlExecutionInfoCluster(REMOTE1_ALIAS, "", true, EsqlExecutionInfo.Cluster.Status.SKIPPED)
-            );
-            executionInfo.swapCluster(
-                REMOTE2_ALIAS,
-                (k, v) -> createEsqlExecutionInfoCluster(REMOTE2_ALIAS, "", true, EsqlExecutionInfo.Cluster.Status.SKIPPED)
-            );
-            assertIndexPattern(
-                EsqlCCSUtils.createQualifiedLookupIndexExpressionFromAvailableClusters(executionInfo, "lookup"),
-                containsInAnyOrder("lookup")
-            );
-        }
-        // all remotes are skipped and no local
-        {
-            EsqlExecutionInfo executionInfo = createEsqlExecutionInfo(true);
-            executionInfo.swapCluster(
-                REMOTE1_ALIAS,
-                (k, v) -> createEsqlExecutionInfoCluster(REMOTE1_ALIAS, "", true, EsqlExecutionInfo.Cluster.Status.SKIPPED)
-            );
-            executionInfo.swapCluster(
-                REMOTE2_ALIAS,
-                (k, v) -> createEsqlExecutionInfoCluster(REMOTE2_ALIAS, "", true, EsqlExecutionInfo.Cluster.Status.SKIPPED)
-            );
-            assertIndexPattern(
-                EsqlCCSUtils.createQualifiedLookupIndexExpressionFromAvailableClusters(executionInfo, "lookup"),
-                containsInAnyOrder()
-            );
-        }
+        // all clusters relevant
+        assertIndexPattern(
+            EsqlCCSUtils.createQualifiedLookupIndexExpressionFromAvailableClusters(
+                executionInfo,
+                Set.of(LOCAL_CLUSTER_ALIAS, REMOTE1_ALIAS, REMOTE2_ALIAS),
+                "lookup"
+            ),
+            containsInAnyOrder("lookup", REMOTE1_ALIAS + ":lookup", REMOTE2_ALIAS + ":lookup")
+        );
+
+        // only local + one remote relevant: the other remote is not queried even though it is running
+        assertIndexPattern(
+            EsqlCCSUtils.createQualifiedLookupIndexExpressionFromAvailableClusters(
+                executionInfo,
+                Set.of(LOCAL_CLUSTER_ALIAS, REMOTE1_ALIAS),
+                "lookup"
+            ),
+            containsInAnyOrder("lookup", REMOTE1_ALIAS + ":lookup")
+        );
+
+        // only a single remote relevant
+        assertIndexPattern(
+            EsqlCCSUtils.createQualifiedLookupIndexExpressionFromAvailableClusters(executionInfo, Set.of(REMOTE2_ALIAS), "lookup"),
+            containsInAnyOrder(REMOTE2_ALIAS + ":lookup")
+        );
+
+        // only the local cluster relevant
+        assertIndexPattern(
+            EsqlCCSUtils.createQualifiedLookupIndexExpressionFromAvailableClusters(executionInfo, Set.of(LOCAL_CLUSTER_ALIAS), "lookup"),
+            containsInAnyOrder("lookup")
+        );
+
+        // no relevant clusters
+        assertIndexPattern(
+            EsqlCCSUtils.createQualifiedLookupIndexExpressionFromAvailableClusters(executionInfo, Set.of(), "lookup"),
+            containsInAnyOrder()
+        );
+
+        // local-only query (no clusters tracked in executionInfo): always the bare local pattern
+        EsqlExecutionInfo localOnly = createEsqlExecutionInfo(true);
+        assertIndexPattern(
+            EsqlCCSUtils.createQualifiedLookupIndexExpressionFromAvailableClusters(localOnly, Set.of(), "lookup"),
+            containsInAnyOrder("lookup")
+        );
     }
 
     private static void assertIndexPattern(String indexPattern, Matcher<Iterable<? extends String>> matcher) {


### PR DESCRIPTION
**Problem**

Previously, `ES|QL` resolved every lookup index against all running clusters in the query. With subqueries, this was too strict: a `LOOKUP JOIN` nested inside one subquery would be required to exist on clusters that are only referenced by sibling subqueries (or the top-level FROM), causing "Unknown index" `VerificationException` or the clusters referenced by sibling subqueries to be skipped even though those clusters never feed the join.

**Change**

Index resolution now scopes each lookup index to only the clusters that actually need it.

`PreAnalyzer` — Builds a new map, `lookupIndexPatternsToMainAndSubqueryIndexPatterns`, associating each lookup index pattern with the main (non-lookup) `FROM` patterns its `LOOKUP JOIN` must be resolvable against:
- The query is walked as a tree of scopes (the whole query plus each Subquery).
- A scope's main patterns = the main relations it directly owns + the main patterns of every nested FROM subquery (whose output is unioned in before this scope's joins run).
- A lookup nested in a subquery is scoped to that subquery's data; a main-query lookup spans the whole query's union of main patterns.
- IN/NOT IN subqueries (`SemiJoin`/`AntiJoin`/`MarkJoin`) are independent scopes — their own nested lookups are scoped to their own patterns, but their patterns are not folded into the enclosing scope (they filter rows, they aren't unioned in).
- The same lookup name across scopes is merged by union.

`EsqlSession` — `preAnalyzeLookupIndex` now computes relevantClustersForLookupIndex(...) from the scope map: it maps the lookup's main patterns to the clusters their resolutions landed on (intersected with running clusters). The field-caps expression, the per-cluster resolution check, and the "missing on cluster" verification all use this restricted cluster set instead of all running clusters. Coordinator-only scopes (e.g. `ROW` ... | LOOKUP JOIN, no main FROM) resolve against the local cluster only.

`EsqlCCSUtils` — `createQualifiedLookupIndexExpressionFromAvailableClusters` takes an explicit relevantClusters set and qualifies the lookup expression to exactly those clusters.

`Analyzer` — A `LOOKUP JOIN` is now marked remote only when its left subtree actually reads from a (non-lookup) index. A sourceless left side (e.g. a ROW subquery) keeps its data on the coordinator, so its lookup runs locally even when other parts of the query touch remote clusters — avoiding a data-node plan with no concrete indices.

Behavior note: a lookup index that is missing from every cluster remains an analysis-time `VerificationException`, independent of skip_unavailable.

**Tests**

- CrossClusterSubqueryIT — new CCS integration tests covering lookups per-subquery, lookups missing on some clusters, and skip_unavailable interactions.
- PreAnalyzerTests — new unit tests for the scope-to-main-pattern mapping.
- EsqlCCSUtilsTests — updated for the new relevantClusters parameter.