### PR TITLE
Fix BlobStoreSyncDirectoryTests.testCloseCancelsOnGoingUploads 

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -632,9 +632,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
   method: test {csv-spec:in_subquery.inSubqueryWithEvalInsideInSubquery}
   issue: https://github.com/elastic/elasticsearch/issues/151761
-- class: org.elasticsearch.xpack.stateless.cluster.coordination.BlobStoreSyncDirectoryTests
-  method: testCloseCancelsOnGoingUploads
-  issue: https://github.com/elastic/elasticsearch/issues/151622
 - class: org.elasticsearch.xpack.stateless.CorruptionIT
   method: testConcurrentOperations
   issue: https://github.com/elastic/elasticsearch/issues/151779

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/cluster/coordination/BlobStoreSyncDirectoryTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/cluster/coordination/BlobStoreSyncDirectoryTests.java
@@ -319,7 +319,12 @@ public class BlobStoreSyncDirectoryTests extends ESTestCase {
             dir.close();
             blockExecutionLatch.countDown();
 
-            assertThrows(Exception.class, syncFuture::get);
+            try {
+                syncFuture.get();
+            } catch (Exception ignored) {
+                // there's a controlled race, in most cases an exception will be thrown. If a `sync()` method executes when `dir.close()`
+                // executes it may not throw an exception, but it will eventually cancel uploads anyway.
+            }
             assertThat(uploadedFiles, is(empty()));
         }
     }


### PR DESCRIPTION
There is a race in the sync method that I think we can accept. 

The method asks for files to upload first and then queues the uploads for these files.

When the underlying Lucene dir is closed, there may be an ongoing `sync()` method already running. 

If the `close()` happens before listing files to upload - an exception will be throw. If it will be after, we rely on a check in each upload task. 

In both case we are successfully preventing the file uploads and we do want to validate both scenarios in the test.

Closes #151622 