### PR TITLE
Increase DocsClientYamlTestSuiteIT suite timeout to 60 minutes

### DIFF
--- a/docs/src/yamlRestTest/java/org/elasticsearch/smoketest/DocsClientYamlTestSuiteIT.java
+++ b/docs/src/yamlRestTest/java/org/elasticsearch/smoketest/DocsClientYamlTestSuiteIT.java
@@ -58,7 +58,6 @@ import static java.util.Collections.singletonMap;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 import static org.hamcrest.Matchers.is;
 
-//The default 40 minutes timeout isn't always enough, but Darwin CI hosts are incredibly slow...
 @TimeoutSuite(millis = 60 * TimeUnits.MINUTE)
 public class DocsClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
 

--- a/docs/src/yamlRestTest/java/org/elasticsearch/smoketest/DocsClientYamlTestSuiteIT.java
+++ b/docs/src/yamlRestTest/java/org/elasticsearch/smoketest/DocsClientYamlTestSuiteIT.java
@@ -58,8 +58,8 @@ import static java.util.Collections.singletonMap;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 import static org.hamcrest.Matchers.is;
 
-//The default 20 minutes timeout isn't always enough, but Darwin CI hosts are incredibly slow...
-@TimeoutSuite(millis = 40 * TimeUnits.MINUTE)
+//The default 40 minutes timeout isn't always enough, but Darwin CI hosts are incredibly slow...
+@TimeoutSuite(millis = 60 * TimeUnits.MINUTE)
 public class DocsClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
 
     public DocsClientYamlTestSuiteIT(@Name("yaml") ClientYamlTestCandidate testCandidate) {


### PR DESCRIPTION
Raises `@TimeoutSuite` on `DocsClientYamlTestSuiteIT` from **40** to **60** minutes to reduce intermittent `Test abandoned because suite timeout was reached` failures.

The suite runs all doc snippets in one JVM serially. When it exceeds 40 minutes, randomizedtesting abandons whichever snippet is running and blames it (e.g. `bool-query/line_134`). The failure is flaky: the `encryption-at-rest` periodic step passes on most runs and only tips over the budget occasionally (#139860, #145512, #145268). Bumping the timeout adds headroom; **60 min** matches the existing Windows override in `ElasticsearchTestBasePlugin`.

Closes: #150929
Closes: #139860
Closes: #145512
Closes: #145268