### PR TITLE
[9.4] Fix flaky test on geometry simplification of complex geometries (#151554)

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/geo/GeometryTestUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/geo/GeometryTestUtils.java
@@ -238,6 +238,11 @@ public class GeometryTestUtils {
         return geometry.apply(hasAlt);
     }
 
+    public static Geometry randomGeometryWithoutCircle(boolean hasAlt, int maxPoints) {
+        var pointCounter = new GeometryPointCountVisitor();
+        return randomValueOtherThanMany(g -> g.visit(pointCounter) > maxPoints, () -> randomGeometryWithoutCircle(0, hasAlt));
+    }
+
     public static Geometry randomGeometryWithoutCircle(int level, boolean hasAlt) {
         @SuppressWarnings("unchecked")
         Function<Boolean, Geometry> geometry = ESTestCase.randomFrom(

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/TestCaseSupplier.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/TestCaseSupplier.java
@@ -1513,11 +1513,40 @@ public record TestCaseSupplier(String name, List<DataType> types, Supplier<TestC
         );
     }
 
+    /**
+     * Like {@link #geoShapeCases(Supplier)} but rejects geometries with more than {@code maxPoints}
+     * vertices. Use this when the operation under test has a JVM-stack-depth sensitivity to geometry
+     * complexity (e.g. recursive JTS simplification algorithms).
+     */
+    public static List<TypedDataSupplier> geoShapeCases(Supplier<Boolean> hasAlt, int maxPoints) {
+        return List.of(
+            new TypedDataSupplier(
+                "<geo_shape>",
+                () -> GEO.asWkb(GeometryTestUtils.randomGeometryWithoutCircle(hasAlt.get(), maxPoints)),
+                DataType.GEO_SHAPE
+            )
+        );
+    }
+
     public static List<TypedDataSupplier> cartesianShapeCases(Supplier<Boolean> hasAlt) {
         return List.of(
             new TypedDataSupplier(
                 "<cartesian_shape>",
                 () -> CARTESIAN.asWkb(ShapeTestUtils.randomGeometry(hasAlt.get())),
+                DataType.CARTESIAN_SHAPE
+            )
+        );
+    }
+
+    /**
+     * Like {@link #cartesianShapeCases(Supplier)} but rejects geometries with more than
+     * {@code maxPoints} vertices.
+     */
+    public static List<TypedDataSupplier> cartesianShapeCases(Supplier<Boolean> hasAlt, int maxPoints) {
+        return List.of(
+            new TypedDataSupplier(
+                "<cartesian_shape>",
+                () -> CARTESIAN.asWkb(ShapeTestUtils.randomGeometry(hasAlt.get(), maxPoints)),
                 DataType.CARTESIAN_SHAPE
             )
         );

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/AbstractSpatialGeometryTransformTestCase.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/AbstractSpatialGeometryTransformTestCase.java
@@ -60,12 +60,20 @@ public abstract class AbstractSpatialGeometryTransformTestCase extends AbstractS
         return 100;
     }
 
+    /**
+     * Maximum vertex count for randomly-generated shapes used in these tests. Geometry transform
+     * operations such as ST_SIMPLIFY and ST_SIMPLIFYPRESERVETOPOLOGY rely on JTS algorithms that
+     * use recursion proportional to vertex count (e.g. {@code TaggedLineStringSimplifier}), so we
+     * cap complexity to avoid {@link StackOverflowError} in multithreaded test execution.
+     */
+    private static final int MAX_TEST_GEOMETRY_POINTS = 100;
+
     public static TestCaseSupplier.TypedDataSupplier testCaseSupplier(DataType dataType) {
         return switch (dataType) {
             case GEO_POINT -> TestCaseSupplier.geoPointCases(() -> false).getFirst();
-            case GEO_SHAPE -> TestCaseSupplier.geoShapeCases(() -> false).getFirst();
+            case GEO_SHAPE -> TestCaseSupplier.geoShapeCases(() -> false, MAX_TEST_GEOMETRY_POINTS).getFirst();
             case CARTESIAN_POINT -> TestCaseSupplier.cartesianPointCases(() -> false).getFirst();
-            case CARTESIAN_SHAPE -> TestCaseSupplier.cartesianShapeCases(() -> false).getFirst();
+            case CARTESIAN_SHAPE -> TestCaseSupplier.cartesianShapeCases(() -> false, MAX_TEST_GEOMETRY_POINTS).getFirst();
             default -> throw new IllegalArgumentException("Unsupported datatype: " + dataType);
         };
     }
@@ -183,7 +191,7 @@ public abstract class AbstractSpatialGeometryTransformTestCase extends AbstractS
             Geometry jtsGeometry = UNSPECIFIED.wkbToJtsGeometry(wkb);
             Geometry result = jtsOp.apply(jtsGeometry, parameter);
             return UNSPECIFIED.jtsGeometryToWkb(result);
-        } catch (Exception e) {
+        } catch (Exception | StackOverflowError e) {
             throw new AssumptionViolatedException("Skipping invalid test case");
         }
     }


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Fix flaky test on geometry simplification of complex geometries (#151554)