### PR TITLE
[9.4] [Inference] Add requires org.apache.commons.lang3 to module-info (#151794)

### DIFF
--- a/docs/changelog/151794.yaml
+++ b/docs/changelog/151794.yaml
@@ -1,0 +1,5 @@
+area: Inference
+issues: []
+pr: 151794
+summary: "[Inference] Add requires org.apache.commons.lang3 to module-info"
+type: upgrade

--- a/x-pack/plugin/inference/src/main/java/module-info.java
+++ b/x-pack/plugin/inference/src/main/java/module-info.java
@@ -35,6 +35,7 @@ module org.elasticsearch.inference {
     requires org.elasticsearch.logging;
     requires org.elasticsearch.sslconfig;
     requires org.apache.commons.text;
+    requires org.apache.commons.lang3;
     requires software.amazon.awssdk.services.sagemakerruntime;
     requires com.azure.identity;
     requires com.azure.core;


### PR DESCRIPTION
Backports the following commits to 9.4:
 - [Inference] Add requires org.apache.commons.lang3 to module-info (#151794)