### PR TITLE
[Test] Fix SharedBlobCacheWarmingServiceIT.testCacheIsWarmedOnUnhollowing

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -593,9 +593,6 @@ tests:
 - class: org.elasticsearch.index.store.BytesReadHeaderIT
   method: testMultiSearchSetsBytesReadHeader
   issue: https://github.com/elastic/elasticsearch/issues/151595
-- class: org.elasticsearch.xpack.stateless.cache.SharedBlobCacheWarmingServiceIT
-  method: testCacheIsWarmedOnUnhollowing
-  issue: https://github.com/elastic/elasticsearch/issues/151600
 - class: org.elasticsearch.datastreams.lifecycle.ExplainDataStreamLifecycleIT
   method: testExplainFailuresLifecycle
   issue: https://github.com/elastic/elasticsearch/issues/151602

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/cache/SharedBlobCacheWarmingServiceIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/cache/SharedBlobCacheWarmingServiceIT.java
@@ -656,6 +656,10 @@ public class SharedBlobCacheWarmingServiceIT extends AbstractStatelessPluginInte
             metadataContainsReplicatedRanges.set(blobStoreCacheDirectory.metadataContainsReplicatedRanges());
         });
 
+        // Block until warming completes so that the recovery thread's engine.refresh("unhollowing") cannot race
+        // a concurrent cache fill against the warming tasks, which would leave the prewarmed bytes metric at zero.
+        getSharedBlobCacheWarmingService(indexNodeB).setAwaitWarmingForIndexingRecovery(true);
+
         // Trigger unhollowing
         final int moreDocs = randomIntBetween(6, 10);
         logger.info("--> ingesting {} more docs to unhollow the shard", moreDocs);


### PR DESCRIPTION
The fire-and-forget warming can lose a race against engine.refresh ("unhollowing"), which pre-populates the same cache regions and leaves the prewarmed-bytes metric at zero. Block until warming completes, matching the pattern already used in the same test class.

Closes #151600