### PR TITLE
[Inference] Add requires org.apache.commons.lang3 to module-info

### DIFF
--- a/docs/changelog/151794.yaml
+++ b/docs/changelog/151794.yaml
@@ -1,0 +1,5 @@
+area: Inference
+issues: []
+pr: 151794
+summary: "[Inference] Add requires org.apache.commons.lang3 to module-info"
+type: upgrade

--- a/x-pack/plugin/inference/src/main/java/module-info.java
+++ b/x-pack/plugin/inference/src/main/java/module-info.java
@@ -35,6 +35,7 @@ module org.elasticsearch.inference {
     requires org.elasticsearch.logging;
     requires org.elasticsearch.sslconfig;
     requires org.apache.commons.text;
+    requires org.apache.commons.lang3;
     requires software.amazon.awssdk.services.sagemakerruntime;
     requires com.azure.identity;
     requires com.azure.core;


### PR DESCRIPTION
Cherry picking the commit from this PR: https://github.com/elastic/elasticsearch/pull/151794 to add the `requires` line to fix the issue.