### PR TITLE
Use ObjectParser for Amazon Bedrock service settings

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AmazonBedrockService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AmazonBedrockService.java
@@ -232,6 +232,11 @@ public class AmazonBedrockService extends SenderService<AmazonBedrockModel> {
     }
 
     @Override
+    public boolean usesParserForServiceSettings() {
+        return true;
+    }
+
+    @Override
     public Model updateModelWithEmbeddingDetails(Model model, int embeddingSize) {
         if (model instanceof AmazonBedrockEmbeddingsModel embeddingsModel) {
             var serviceSettings = embeddingsModel.getServiceSettings();

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AmazonBedrockServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AmazonBedrockServiceSettings.java
@@ -49,8 +49,8 @@ public abstract class AmazonBedrockServiceSettings extends FilteredXContentObjec
     public static <B extends AmazonBedrockServiceSettings.Builder<? extends AmazonBedrockServiceSettings>> void declareCommonFields(
         AbstractObjectParser<B, ConfigurationParseContext> parser
     ) {
-        parser.declareString(AmazonBedrockServiceSettings.Builder::setModel, new ParseField(MODEL_FIELD));
         parser.declareString(AmazonBedrockServiceSettings.Builder::setRegion, new ParseField(REGION_FIELD));
+        parser.declareString(AmazonBedrockServiceSettings.Builder::setModel, new ParseField(MODEL_FIELD));
         parser.declareString(AmazonBedrockServiceSettings.Builder::setProvider, new ParseField(PROVIDER_FIELD));
         parser.declareObject(
             AmazonBedrockServiceSettings.Builder::setRateLimitSettings,
@@ -83,17 +83,17 @@ public abstract class AmazonBedrockServiceSettings extends FilteredXContentObjec
      * @param <T> the task-specific settings type produced by {@link #build(String, String, String, RateLimitSettings)}
      */
     public abstract static class Builder<T extends AmazonBedrockServiceSettings> {
-        private String model;
         private String region;
+        private String model;
         private String provider;
         private RateLimitSettings rateLimitSettings;
 
-        public void setModel(String model) {
-            this.model = model;
-        }
-
         public void setRegion(String region) {
             this.region = region;
+        }
+
+        public void setModel(String model) {
+            this.model = model;
         }
 
         public void setProvider(String provider) {
@@ -104,13 +104,13 @@ public abstract class AmazonBedrockServiceSettings extends FilteredXContentObjec
             this.rateLimitSettings = rateLimitSettings;
         }
 
-        public abstract T build(String model, String region, String provider, RateLimitSettings rateLimitSettings);
+        protected abstract T build(String region, String model, String provider, RateLimitSettings rateLimitSettings);
 
         public final T build() {
-            validateStringIsNotNullOrEmpty(model, MODEL_FIELD);
             validateStringIsNotNullOrEmpty(region, REGION_FIELD);
+            validateStringIsNotNullOrEmpty(model, MODEL_FIELD);
             validateStringIsNotNullOrEmpty(provider, PROVIDER_FIELD);
-            return build(model, region, provider, rateLimitSettings);
+            return build(region, model, provider, rateLimitSettings);
         }
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AmazonBedrockServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AmazonBedrockServiceSettings.java
@@ -7,10 +7,13 @@
 
 package org.elasticsearch.xpack.inference.services.amazonbedrock;
 
+import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.ServiceSettings;
@@ -18,23 +21,18 @@ import org.elasticsearch.xcontent.AbstractObjectParser;
 import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
-import org.elasticsearch.xpack.inference.services.amazonbedrock.embeddings.AmazonBedrockEmbeddingsServiceSettings;
-import org.elasticsearch.xpack.inference.services.llama.LlamaServiceSettings;
 import org.elasticsearch.xpack.inference.services.settings.DefaultSecretSettings;
 import org.elasticsearch.xpack.inference.services.settings.FilteredXContentObject;
 import org.elasticsearch.xpack.inference.services.settings.RateLimitSettings;
 
 import java.io.IOException;
-import java.net.URI;
 import java.util.EnumSet;
 import java.util.Map;
 import java.util.Objects;
 
 import static org.elasticsearch.xpack.inference.common.parser.StringParser.validateStringIsNotNullOrEmpty;
-import static org.elasticsearch.xpack.inference.services.ServiceFields.MODEL_ID;
-import static org.elasticsearch.xpack.inference.services.ServiceFields.URL;
-import static org.elasticsearch.xpack.inference.services.ServiceUtils.createUri;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractRequiredEnum;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractRequiredString;
 import static org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockConstants.MODEL_FIELD;
@@ -46,7 +44,7 @@ public abstract class AmazonBedrockServiceSettings extends FilteredXContentObjec
     protected static final String AMAZON_BEDROCK_BASE_NAME = "amazon_bedrock";
 
     /**
-     * Registers the common Llama service-settings fields (model_id, url, rate_limit) onto the given parser.
+     * Registers the common Bedrock service-settings fields (model, region, provider, rate_limit) onto the given parser.
      */
     public static <B extends AmazonBedrockServiceSettings.Builder<? extends AmazonBedrockServiceSettings>> void declareCommonFields(
         AbstractObjectParser<B, ConfigurationParseContext> parser
@@ -113,6 +111,26 @@ public abstract class AmazonBedrockServiceSettings extends FilteredXContentObjec
             validateStringIsNotNullOrEmpty(region, REGION_FIELD);
             validateStringIsNotNullOrEmpty(provider, PROVIDER_FIELD);
             return build(model, region, provider, rateLimitSettings);
+        }
+    }
+
+    /**
+     * Creates a {@link AmazonBedrockServiceSettings} from a map of settings using the given parser.
+     *
+     * @param map     the map to parse
+     * @param context the context in which the parsing is done
+     * @param parser  the parser to use for parsing the settings
+     * @return the created {@link AmazonBedrockServiceSettings}
+     */
+    public static <T extends AmazonBedrockServiceSettings> T fromMap(
+        Map<String, Object> map,
+        ConfigurationParseContext context,
+        ObjectParser<? extends AmazonBedrockServiceSettings.Builder<T>, ConfigurationParseContext> parser
+    ) {
+        try (var xParser = XContentHelper.mapToXContentParser(XContentParserConfiguration.EMPTY, map)) {
+            return parser.apply(xParser, context).build();
+        } catch (IOException e) {
+            throw new ElasticsearchParseException("Failed to parse [{}]", e, ModelConfigurations.SERVICE_SETTINGS);
         }
     }
 
@@ -218,17 +236,58 @@ public abstract class AmazonBedrockServiceSettings extends FilteredXContentObjec
     }
 
     @Override
+    public String toString() {
+        return Strings.toString(this);
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (o == null || getClass() != o.getClass()) return false;
         AmazonBedrockServiceSettings that = (AmazonBedrockServiceSettings) o;
         return Objects.equals(region, that.region)
             && Objects.equals(model, that.model)
-            && provider == that.provider
+            && Objects.equals(provider, that.provider)
             && Objects.equals(rateLimitSettings, that.rateLimitSettings);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(region, model, provider, rateLimitSettings);
+    }
+
+    /**
+     * Registers the common Bedrock fields that may be changed by an update request. Only {@code rate_limit} is mutable; the
+     * immutable fields (such as {@code model}, {@code region} and {@code provider}) are intentionally not declared so that a strict update
+     * parser rejects attempts to change them.
+     */
+    public static void declareCommonUpdatableFields(AbstractObjectParser<? extends CommonUpdate, Void> parser) {
+        parser.declareObject(
+            CommonUpdate::setRateLimitSettings,
+            // A null default preserves "no change" semantics for updates: an empty or value-less rate_limit object leaves the existing
+            // rate limit untouched in CommonUpdate#mergedRateLimitSettings.
+            (p, c) -> RateLimitSettings.createParser(false, null).apply(p, null),
+            new ParseField(RateLimitSettings.FIELD_NAME)
+        );
+    }
+
+    /**
+     * Common fields parsed from an update request. Because settings are immutable, each subclass builds the new instance itself,
+     * calling {@link #mergedRateLimitSettings(AmazonBedrockServiceSettings)} to resolve the shared fields.
+     */
+    public static class CommonUpdate {
+
+        protected RateLimitSettings rateLimitSettings;
+
+        private void setRateLimitSettings(@Nullable RateLimitSettings rateLimitSettings) {
+            this.rateLimitSettings = rateLimitSettings;
+        }
+
+        /**
+         * Resolves the rate limit settings to use after applying this update: the value supplied by the update if present, otherwise
+         * the value carried by the existing settings.
+         */
+        protected RateLimitSettings mergedRateLimitSettings(AmazonBedrockServiceSettings existing) {
+            return Objects.requireNonNullElse(this.rateLimitSettings, existing.rateLimitSettings());
+        }
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AmazonBedrockServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AmazonBedrockServiceSettings.java
@@ -35,9 +35,11 @@ import java.util.Objects;
 import static org.elasticsearch.xpack.inference.common.parser.StringParser.validateStringIsNotNullOrEmpty;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractRequiredEnum;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractRequiredString;
+import static org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockConstants.ACCESS_KEY_FIELD;
 import static org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockConstants.MODEL_FIELD;
 import static org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockConstants.PROVIDER_FIELD;
 import static org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockConstants.REGION_FIELD;
+import static org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockConstants.SECRET_KEY_FIELD;
 
 public abstract class AmazonBedrockServiceSettings extends FilteredXContentObject implements ServiceSettings {
 
@@ -59,9 +61,10 @@ public abstract class AmazonBedrockServiceSettings extends FilteredXContentObjec
             (p, c) -> RateLimitSettings.createParser(c == ConfigurationParseContext.PERSISTENT, DEFAULT_RATE_LIMIT_SETTINGS).apply(p, null),
             new ParseField(RateLimitSettings.FIELD_NAME)
         );
-        // api_key appears in the same JSON block as service settings in REST requests; DefaultSecretSettings extracts it separately.
-        // Declare it here as a no-op so the strict REQUEST parser does not reject it as an unknown field.
-        parser.declareString((b, v) -> {}, new ParseField(DefaultSecretSettings.API_KEY));
+        // access_key/secret_key appear in the same JSON block as service settings in REST requests; DefaultSecretSettings extracts them
+        // separately. Declare it here as a no-op so the strict REQUEST parser does not reject it as an unknown field.
+        parser.declareString((b, v) -> {}, new ParseField(ACCESS_KEY_FIELD));
+        parser.declareString((b, v) -> {}, new ParseField(SECRET_KEY_FIELD));
     }
 
     protected final String region;

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AmazonBedrockServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AmazonBedrockServiceSettings.java
@@ -80,7 +80,8 @@ public abstract class AmazonBedrockServiceSettings extends FilteredXContentObjec
      * Accumulates the parsed common fields and assembles a {@link AmazonBedrockServiceSettings}, enforcing that the required fields are
      * present. Task-specific builders extend this and contribute their own fields.
      *
-     * @param <T> the task-specific settings type produced by {@link #build(String, String, String, RateLimitSettings)}
+     * @param <T> the task-specific settings type produced by {@link #build(String, String, String, RateLimitSettings,
+     * ConfigurationParseContext)}
      */
     public abstract static class Builder<T extends AmazonBedrockServiceSettings> {
         private String region;
@@ -104,13 +105,19 @@ public abstract class AmazonBedrockServiceSettings extends FilteredXContentObjec
             this.rateLimitSettings = rateLimitSettings;
         }
 
-        protected abstract T build(String region, String model, String provider, RateLimitSettings rateLimitSettings);
+        protected abstract T build(
+            String region,
+            String model,
+            String provider,
+            RateLimitSettings rateLimitSettings,
+            ConfigurationParseContext context
+        );
 
-        public final T build() {
+        public final T build(ConfigurationParseContext context) {
             validateStringIsNotNullOrEmpty(region, REGION_FIELD);
             validateStringIsNotNullOrEmpty(model, MODEL_FIELD);
             validateStringIsNotNullOrEmpty(provider, PROVIDER_FIELD);
-            return build(region, model, provider, rateLimitSettings);
+            return build(region, model, provider, rateLimitSettings, context);
         }
     }
 
@@ -128,7 +135,7 @@ public abstract class AmazonBedrockServiceSettings extends FilteredXContentObjec
         ObjectParser<? extends AmazonBedrockServiceSettings.Builder<T>, ConfigurationParseContext> parser
     ) {
         try (var xParser = XContentHelper.mapToXContentParser(XContentParserConfiguration.EMPTY, map)) {
-            return parser.apply(xParser, context).build();
+            return parser.apply(xParser, context).build(context);
         } catch (IOException e) {
             throw new ElasticsearchParseException("Failed to parse [{}]", e, ModelConfigurations.SERVICE_SETTINGS);
         }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AmazonBedrockServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AmazonBedrockServiceSettings.java
@@ -14,16 +14,27 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.ServiceSettings;
+import org.elasticsearch.xcontent.AbstractObjectParser;
+import org.elasticsearch.xcontent.ObjectParser;
+import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
+import org.elasticsearch.xpack.inference.services.amazonbedrock.embeddings.AmazonBedrockEmbeddingsServiceSettings;
+import org.elasticsearch.xpack.inference.services.llama.LlamaServiceSettings;
+import org.elasticsearch.xpack.inference.services.settings.DefaultSecretSettings;
 import org.elasticsearch.xpack.inference.services.settings.FilteredXContentObject;
 import org.elasticsearch.xpack.inference.services.settings.RateLimitSettings;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.EnumSet;
 import java.util.Map;
 import java.util.Objects;
 
+import static org.elasticsearch.xpack.inference.common.parser.StringParser.validateStringIsNotNullOrEmpty;
+import static org.elasticsearch.xpack.inference.services.ServiceFields.MODEL_ID;
+import static org.elasticsearch.xpack.inference.services.ServiceFields.URL;
+import static org.elasticsearch.xpack.inference.services.ServiceUtils.createUri;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractRequiredEnum;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractRequiredString;
 import static org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockConstants.MODEL_FIELD;
@@ -33,6 +44,27 @@ import static org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBed
 public abstract class AmazonBedrockServiceSettings extends FilteredXContentObject implements ServiceSettings {
 
     protected static final String AMAZON_BEDROCK_BASE_NAME = "amazon_bedrock";
+
+    /**
+     * Registers the common Llama service-settings fields (model_id, url, rate_limit) onto the given parser.
+     */
+    public static <B extends AmazonBedrockServiceSettings.Builder<? extends AmazonBedrockServiceSettings>> void declareCommonFields(
+        AbstractObjectParser<B, ConfigurationParseContext> parser
+    ) {
+        parser.declareString(AmazonBedrockServiceSettings.Builder::setModel, new ParseField(MODEL_FIELD));
+        parser.declareString(AmazonBedrockServiceSettings.Builder::setRegion, new ParseField(REGION_FIELD));
+        parser.declareString(AmazonBedrockServiceSettings.Builder::setProvider, new ParseField(PROVIDER_FIELD));
+        parser.declareObject(
+            AmazonBedrockServiceSettings.Builder::setRateLimitSettings,
+            // An explicitly empty rate_limit object ({}) resolves to the default rate limit rather than null, so the setter is never
+            // invoked with null.
+            (p, c) -> RateLimitSettings.createParser(c == ConfigurationParseContext.PERSISTENT, DEFAULT_RATE_LIMIT_SETTINGS).apply(p, null),
+            new ParseField(RateLimitSettings.FIELD_NAME)
+        );
+        // api_key appears in the same JSON block as service settings in REST requests; DefaultSecretSettings extracts it separately.
+        // Declare it here as a no-op so the strict REQUEST parser does not reject it as an unknown field.
+        parser.declareString((b, v) -> {}, new ParseField(DefaultSecretSettings.API_KEY));
+    }
 
     protected final String region;
     protected final String model;
@@ -45,6 +77,44 @@ public abstract class AmazonBedrockServiceSettings extends FilteredXContentObjec
     // decent throughput without exceeding the minimal for _most_ items. The user should consult
     // the table above if using a model that might have a lesser limit (e.g. Anthropic Claude 3.5)
     protected static final RateLimitSettings DEFAULT_RATE_LIMIT_SETTINGS = new RateLimitSettings(240);
+
+    /**
+     * Accumulates the parsed common fields and assembles a {@link AmazonBedrockServiceSettings}, enforcing that the required fields are
+     * present. Task-specific builders extend this and contribute their own fields.
+     *
+     * @param <T> the task-specific settings type produced by {@link #build(String, String, String, RateLimitSettings)}
+     */
+    public abstract static class Builder<T extends AmazonBedrockServiceSettings> {
+        private String model;
+        private String region;
+        private String provider;
+        private RateLimitSettings rateLimitSettings;
+
+        public void setModel(String model) {
+            this.model = model;
+        }
+
+        public void setRegion(String region) {
+            this.region = region;
+        }
+
+        public void setProvider(String provider) {
+            this.provider = provider;
+        }
+
+        public void setRateLimitSettings(RateLimitSettings rateLimitSettings) {
+            this.rateLimitSettings = rateLimitSettings;
+        }
+
+        public abstract T build(String model, String region, String provider, RateLimitSettings rateLimitSettings);
+
+        public final T build() {
+            validateStringIsNotNullOrEmpty(model, MODEL_FIELD);
+            validateStringIsNotNullOrEmpty(region, REGION_FIELD);
+            validateStringIsNotNullOrEmpty(provider, PROVIDER_FIELD);
+            return build(model, region, provider, rateLimitSettings);
+        }
+    }
 
     protected static AmazonBedrockCommonSettings fromMap(
         Map<String, Object> map,
@@ -145,5 +215,20 @@ public abstract class AmazonBedrockServiceSettings extends FilteredXContentObjec
         builder.field(MODEL_FIELD, model);
         builder.field(PROVIDER_FIELD, provider.name());
         rateLimitSettings.toXContent(builder, params);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        AmazonBedrockServiceSettings that = (AmazonBedrockServiceSettings) o;
+        return Objects.equals(region, that.region)
+            && Objects.equals(model, that.model)
+            && provider == that.provider
+            && Objects.equals(rateLimitSettings, that.rateLimitSettings);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(region, model, provider, rateLimitSettings);
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AmazonBedrockServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AmazonBedrockServiceSettings.java
@@ -23,7 +23,6 @@ import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
-import org.elasticsearch.xpack.inference.services.settings.DefaultSecretSettings;
 import org.elasticsearch.xpack.inference.services.settings.FilteredXContentObject;
 import org.elasticsearch.xpack.inference.services.settings.RateLimitSettings;
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AmazonBedrockServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AmazonBedrockServiceSettings.java
@@ -22,6 +22,7 @@ import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
+import org.elasticsearch.xpack.inference.common.parser.StatefulValue;
 import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
 import org.elasticsearch.xpack.inference.services.settings.FilteredXContentObject;
 import org.elasticsearch.xpack.inference.services.settings.RateLimitSettings;
@@ -31,6 +32,7 @@ import java.util.EnumSet;
 import java.util.Map;
 import java.util.Objects;
 
+import static org.elasticsearch.xpack.inference.common.parser.StatefulValue.applyUpdate;
 import static org.elasticsearch.xpack.inference.common.parser.StringParser.validateStringIsNotNullOrEmpty;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractRequiredEnum;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractRequiredString;
@@ -143,26 +145,6 @@ public abstract class AmazonBedrockServiceSettings extends FilteredXContentObjec
         }
     }
 
-    protected static AmazonBedrockCommonSettings fromMap(
-        Map<String, Object> map,
-        ValidationException validationException,
-        ConfigurationParseContext context
-    ) {
-        var model = extractRequiredString(map, MODEL_FIELD, ModelConfigurations.SERVICE_SETTINGS, validationException);
-        var region = extractRequiredString(map, REGION_FIELD, ModelConfigurations.SERVICE_SETTINGS, validationException);
-        var provider = extractRequiredEnum(
-            map,
-            PROVIDER_FIELD,
-            ModelConfigurations.SERVICE_SETTINGS,
-            AmazonBedrockProvider::fromString,
-            EnumSet.allOf(AmazonBedrockProvider.class),
-            validationException
-        );
-        var rateLimitSettings = RateLimitSettings.of(map, DEFAULT_RATE_LIMIT_SETTINGS, validationException, context);
-
-        return new AmazonBedrockCommonSettings(region, model, provider, rateLimitSettings);
-    }
-
     protected AmazonBedrockCommonSettings updateCommonSettings(
         Map<String, Object> serviceSettings,
         ValidationException validationException
@@ -270,12 +252,12 @@ public abstract class AmazonBedrockServiceSettings extends FilteredXContentObjec
      * parser rejects attempts to change them.
      */
     public static void declareCommonUpdatableFields(AbstractObjectParser<? extends CommonUpdate, Void> parser) {
-        parser.declareObject(
-            CommonUpdate::setRateLimitSettings,
-            // A null default preserves "no change" semantics for updates: an empty or value-less rate_limit object leaves the existing
-            // rate limit untouched in CommonUpdate#mergedRateLimitSettings.
-            (p, c) -> RateLimitSettings.createParser(false, null).apply(p, null),
-            new ParseField(RateLimitSettings.FIELD_NAME)
+        StatefulValue.declareNullable(
+            parser,
+            (update, value) -> update.rateLimitSettings = value,
+            (p) -> RateLimitSettings.createParser(false, null).apply(p, null),
+            new ParseField(RateLimitSettings.FIELD_NAME),
+            ObjectParser.ValueType.OBJECT_OR_NULL
         );
     }
 
@@ -285,18 +267,14 @@ public abstract class AmazonBedrockServiceSettings extends FilteredXContentObjec
      */
     public static class CommonUpdate {
 
-        protected RateLimitSettings rateLimitSettings;
-
-        private void setRateLimitSettings(@Nullable RateLimitSettings rateLimitSettings) {
-            this.rateLimitSettings = rateLimitSettings;
-        }
+        protected StatefulValue<RateLimitSettings> rateLimitSettings;
 
         /**
-         * Resolves the rate limit settings to use after applying this update: the value supplied by the update if present, otherwise
-         * the value carried by the existing settings.
+         * Resolves the rate limit settings to use after applying the update following the tri-state convention: an omitted field keeps
+         * the current value, an explicit null resets the field to the default rate limit, and a present value replaces the current one.
          */
         protected RateLimitSettings mergedRateLimitSettings(AmazonBedrockServiceSettings existing) {
-            return Objects.requireNonNullElse(this.rateLimitSettings, existing.rateLimitSettings());
+            return applyUpdate(rateLimitSettings, existing.rateLimitSettings(), DEFAULT_RATE_LIMIT_SETTINGS);
         }
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AmazonBedrockServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AmazonBedrockServiceSettings.java
@@ -264,7 +264,7 @@ public abstract class AmazonBedrockServiceSettings extends FilteredXContentObjec
      */
     public static class CommonUpdate {
 
-        protected StatefulValue<RateLimitSettings> rateLimitSettings;
+        protected StatefulValue<RateLimitSettings> rateLimitSettings = StatefulValue.undefined();;
 
         /**
          * Resolves the rate limit settings to use after applying the update following the tri-state convention: an omitted field keeps

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AmazonBedrockServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AmazonBedrockServiceSettings.java
@@ -84,7 +84,7 @@ public abstract class AmazonBedrockServiceSettings extends FilteredXContentObjec
      * Accumulates the parsed common fields and assembles a {@link AmazonBedrockServiceSettings}, enforcing that the required fields are
      * present. Task-specific builders extend this and contribute their own fields.
      *
-     * @param <T> the task-specific settings type produced by {@link #build(String, String, String, RateLimitSettings,
+     * @param <T> the task-specific settings type produced by {@link #build(String, String, AmazonBedrockProvider, RateLimitSettings,
      * ConfigurationParseContext)}
      */
     public abstract static class Builder<T extends AmazonBedrockServiceSettings> {
@@ -112,7 +112,7 @@ public abstract class AmazonBedrockServiceSettings extends FilteredXContentObjec
         protected abstract T build(
             String region,
             String model,
-            String provider,
+            AmazonBedrockProvider provider,
             RateLimitSettings rateLimitSettings,
             ConfigurationParseContext context
         );
@@ -121,7 +121,7 @@ public abstract class AmazonBedrockServiceSettings extends FilteredXContentObjec
             validateStringIsNotNullOrEmpty(region, REGION_FIELD);
             validateStringIsNotNullOrEmpty(model, MODEL_FIELD);
             validateStringIsNotNullOrEmpty(provider, PROVIDER_FIELD);
-            return build(region, model, provider, rateLimitSettings, context);
+            return build(region, model, AmazonBedrockProvider.fromString(provider), rateLimitSettings, context);
         }
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AmazonBedrockServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AmazonBedrockServiceSettings.java
@@ -28,14 +28,11 @@ import org.elasticsearch.xpack.inference.services.settings.FilteredXContentObjec
 import org.elasticsearch.xpack.inference.services.settings.RateLimitSettings;
 
 import java.io.IOException;
-import java.util.EnumSet;
 import java.util.Map;
 import java.util.Objects;
 
 import static org.elasticsearch.xpack.inference.common.parser.StatefulValue.applyUpdate;
 import static org.elasticsearch.xpack.inference.common.parser.StringParser.validateStringIsNotNullOrEmpty;
-import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractRequiredEnum;
-import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractRequiredString;
 import static org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockConstants.ACCESS_KEY_FIELD;
 import static org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockConstants.MODEL_FIELD;
 import static org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockConstants.PROVIDER_FIELD;

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AmazonBedrockServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AmazonBedrockServiceSettings.java
@@ -78,7 +78,7 @@ public abstract class AmazonBedrockServiceSettings extends FilteredXContentObjec
     // setting this to 240 requests per minute (4 requests / sec) is a sane default for us as it should be enough for
     // decent throughput without exceeding the minimal for _most_ items. The user should consult
     // the table above if using a model that might have a lesser limit (e.g. Anthropic Claude 3.5)
-    protected static final RateLimitSettings DEFAULT_RATE_LIMIT_SETTINGS = new RateLimitSettings(240);
+    public static final RateLimitSettings DEFAULT_RATE_LIMIT_SETTINGS = new RateLimitSettings(240);
 
     /**
      * Accumulates the parsed common fields and assembles a {@link AmazonBedrockServiceSettings}, enforcing that the required fields are

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AmazonBedrockServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AmazonBedrockServiceSettings.java
@@ -264,7 +264,7 @@ public abstract class AmazonBedrockServiceSettings extends FilteredXContentObjec
      */
     public static class CommonUpdate {
 
-        protected StatefulValue<RateLimitSettings> rateLimitSettings = StatefulValue.undefined();;
+        protected StatefulValue<RateLimitSettings> rateLimitSettings = StatefulValue.undefined();
 
         /**
          * Resolves the rate limit settings to use after applying the update following the tri-state convention: an omitted field keeps

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/completion/AmazonBedrockChatCompletionServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/completion/AmazonBedrockChatCompletionServiceSettings.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.inference.services.amazonbedrock.completion;
 
 import org.elasticsearch.ElasticsearchParseException;
-import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.inference.ModelConfigurations;
@@ -68,9 +67,9 @@ public class AmazonBedrockChatCompletionServiceSettings extends AmazonBedrockSer
     public static class Builder extends AmazonBedrockServiceSettings.Builder<AmazonBedrockChatCompletionServiceSettings> {
 
         @Override
-        public AmazonBedrockChatCompletionServiceSettings build(
-            String model,
+        protected AmazonBedrockChatCompletionServiceSettings build(
             String region,
+            String model,
             String provider,
             RateLimitSettings rateLimitSettings
         ) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/completion/AmazonBedrockChatCompletionServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/completion/AmazonBedrockChatCompletionServiceSettings.java
@@ -21,10 +21,9 @@ import org.elasticsearch.xpack.inference.services.settings.RateLimitSettings;
 
 import java.io.IOException;
 import java.util.Map;
-import java.util.Objects;
 
 /**
- * Represents the settings for a Amazon Bedrock chat completion service. Extends {@link AmazonBedrockChatCompletionServiceSettings}, which
+ * Represents the settings for an Amazon Bedrock chat completion service. Extends {@link AmazonBedrockChatCompletionServiceSettings}, which
  * carries the model ID, region, provider, and rate limit settings shared across all Bedrock tasks. Chat completion adds no settings of its
  * own.
  */
@@ -85,7 +84,7 @@ public class AmazonBedrockChatCompletionServiceSettings extends AmazonBedrockSer
 
     /**
      * Parses an update request, which may only contain the mutable {@code rate_limit} field. Including any immutable field (such as
-     * {@code model}, {@code region} or {@code provider} causes the strict parser to reject the request.
+     * {@code model}, {@code region} or {@code provider}) causes the strict parser to reject the request.
      */
     private static class Update extends AmazonBedrockServiceSettings.CommonUpdate {
         private static final ObjectParser<Update, Void> PARSER = new ObjectParser<>(ModelConfigurations.SERVICE_SETTINGS, Update::new);
@@ -134,23 +133,6 @@ public class AmazonBedrockChatCompletionServiceSettings extends AmazonBedrockSer
     protected XContentBuilder toXContentFragmentOfExposedFields(XContentBuilder builder, Params params) throws IOException {
         super.addXContentFragmentOfExposedFields(builder, params);
         return builder;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        AmazonBedrockChatCompletionServiceSettings that = (AmazonBedrockChatCompletionServiceSettings) o;
-
-        return Objects.equals(region, that.region)
-            && Objects.equals(provider, that.provider)
-            && Objects.equals(model, that.model)
-            && Objects.equals(rateLimitSettings, that.rateLimitSettings);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(super.hashCode());
     }
 
     @Override

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/completion/AmazonBedrockChatCompletionServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/completion/AmazonBedrockChatCompletionServiceSettings.java
@@ -7,9 +7,14 @@
 
 package org.elasticsearch.xpack.inference.services.amazonbedrock.completion;
 
+import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.inference.ModelConfigurations;
+import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
 import org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockProvider;
 import org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockServiceSettings;
@@ -19,6 +24,11 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
 
+/**
+ * Represents the settings for a Amazon Bedrock chat completion service. Extends {@link AmazonBedrockChatCompletionServiceSettings}, which
+ * carries the model ID, region, provider, and rate limit settings shared across all Bedrock tasks. Chat completion adds no settings of its
+ * own.
+ */
 public class AmazonBedrockChatCompletionServiceSettings extends AmazonBedrockServiceSettings {
     public static final String NAME = "amazon_bedrock_chat_completion_service_settings";
 
@@ -26,18 +36,72 @@ public class AmazonBedrockChatCompletionServiceSettings extends AmazonBedrockSer
         Map<String, Object> serviceSettings,
         ConfigurationParseContext context
     ) {
-        var validationException = new ValidationException();
+        var parser = context == ConfigurationParseContext.REQUEST ? REQUEST_PARSER : PERSISTENT_PARSER;
+        return AmazonBedrockServiceSettings.fromMap(serviceSettings, context, parser);
+    }
 
-        var commonSettings = AmazonBedrockServiceSettings.fromMap(serviceSettings, validationException, context);
+    private static final ObjectParser<Builder, ConfigurationParseContext> REQUEST_PARSER = createParser(false);
+    private static final ObjectParser<Builder, ConfigurationParseContext> PERSISTENT_PARSER = createParser(true);
 
-        validationException.throwIfValidationErrorsExist();
-
-        return new AmazonBedrockChatCompletionServiceSettings(
-            commonSettings.region(),
-            commonSettings.model(),
-            commonSettings.provider(),
-            commonSettings.rateLimitSettings()
+    /**
+     * Creates an {@link ObjectParser} for the Amazon Bedrock chat completion service settings.
+     *
+     * @param ignoreUnknownFields whether the parser should tolerate unknown fields. This is {@code false} for request parsing (so that
+     *                            unexpected fields are rejected) and {@code true} for persisted configuration (so that fields written by
+     *                            other versions are tolerated).
+     * @return the parser
+     */
+    static ObjectParser<Builder, ConfigurationParseContext> createParser(boolean ignoreUnknownFields) {
+        ObjectParser<Builder, ConfigurationParseContext> parser = new ObjectParser<>(
+            ModelConfigurations.SERVICE_SETTINGS,
+            ignoreUnknownFields,
+            Builder::new
         );
+        AmazonBedrockServiceSettings.declareCommonFields(parser);
+        return parser;
+    }
+
+    /**
+     * Builds a {@link AmazonBedrockChatCompletionServiceSettings} from the common Bedrock fields, enforcing that the required fields are
+     * present.
+     */
+    public static class Builder extends AmazonBedrockServiceSettings.Builder<AmazonBedrockChatCompletionServiceSettings> {
+
+        @Override
+        public AmazonBedrockChatCompletionServiceSettings build(
+            String model,
+            String region,
+            String provider,
+            RateLimitSettings rateLimitSettings
+        ) {
+            return new AmazonBedrockChatCompletionServiceSettings(
+                region,
+                model,
+                AmazonBedrockProvider.fromString(provider),
+                rateLimitSettings
+            );
+        }
+    }
+
+    /**
+     * Parses an update request, which may only contain the mutable {@code rate_limit} field. Including any immutable field (such as
+     * {@code model}, {@code region} or {@code provider) causes the strict parser to reject the request.
+     */
+    private static class Update extends AmazonBedrockServiceSettings.CommonUpdate {
+        private static final ObjectParser<Update, Void> PARSER = new ObjectParser<>(ModelConfigurations.SERVICE_SETTINGS, Update::new);
+
+        static {
+            AmazonBedrockServiceSettings.declareCommonUpdatableFields(PARSER);
+        }
+
+        public AmazonBedrockChatCompletionServiceSettings mergeInto(AmazonBedrockChatCompletionServiceSettings existing) {
+            return new AmazonBedrockChatCompletionServiceSettings(
+                existing.region(),
+                existing.modelId(),
+                existing.provider(),
+                mergedRateLimitSettings(existing)
+            );
+        }
     }
 
     public AmazonBedrockChatCompletionServiceSettings(
@@ -85,20 +149,11 @@ public class AmazonBedrockChatCompletionServiceSettings extends AmazonBedrockSer
     }
 
     @Override
-    public int hashCode() {
-        return Objects.hash(region, model, provider, rateLimitSettings);
-    }
-
-    @Override
     public AmazonBedrockChatCompletionServiceSettings updateServiceSettings(Map<String, Object> serviceSettings) {
-        var validationException = new ValidationException();
-        var updatedCommonSettings = updateCommonSettings(serviceSettings, validationException);
-        validationException.throwIfValidationErrorsExist();
-        return new AmazonBedrockChatCompletionServiceSettings(
-            updatedCommonSettings.region(),
-            updatedCommonSettings.model(),
-            updatedCommonSettings.provider(),
-            updatedCommonSettings.rateLimitSettings()
-        );
+        try (var xParser = XContentHelper.mapToXContentParser(XContentParserConfiguration.EMPTY, serviceSettings)) {
+            return Update.PARSER.apply(xParser, null).mergeInto(this);
+        } catch (IOException e) {
+            throw new ElasticsearchParseException("Failed to parse Amazon Bedrock chat completion service settings update", e);
+        }
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/completion/AmazonBedrockChatCompletionServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/completion/AmazonBedrockChatCompletionServiceSettings.java
@@ -85,7 +85,7 @@ public class AmazonBedrockChatCompletionServiceSettings extends AmazonBedrockSer
 
     /**
      * Parses an update request, which may only contain the mutable {@code rate_limit} field. Including any immutable field (such as
-     * {@code model}, {@code region} or {@code provider) causes the strict parser to reject the request.
+     * {@code model}, {@code region} or {@code provider} causes the strict parser to reject the request.
      */
     private static class Update extends AmazonBedrockServiceSettings.CommonUpdate {
         private static final ObjectParser<Update, Void> PARSER = new ObjectParser<>(ModelConfigurations.SERVICE_SETTINGS, Update::new);

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/completion/AmazonBedrockChatCompletionServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/completion/AmazonBedrockChatCompletionServiceSettings.java
@@ -149,6 +149,11 @@ public class AmazonBedrockChatCompletionServiceSettings extends AmazonBedrockSer
     }
 
     @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode());
+    }
+
+    @Override
     public AmazonBedrockChatCompletionServiceSettings updateServiceSettings(Map<String, Object> serviceSettings) {
         try (var xParser = XContentHelper.mapToXContentParser(XContentParserConfiguration.EMPTY, serviceSettings)) {
             return Update.PARSER.apply(xParser, null).mergeInto(this);

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/completion/AmazonBedrockChatCompletionServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/completion/AmazonBedrockChatCompletionServiceSettings.java
@@ -71,7 +71,8 @@ public class AmazonBedrockChatCompletionServiceSettings extends AmazonBedrockSer
             String region,
             String model,
             String provider,
-            RateLimitSettings rateLimitSettings
+            RateLimitSettings rateLimitSettings,
+            ConfigurationParseContext context
         ) {
             return new AmazonBedrockChatCompletionServiceSettings(
                 region,

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/completion/AmazonBedrockChatCompletionServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/completion/AmazonBedrockChatCompletionServiceSettings.java
@@ -73,12 +73,7 @@ public class AmazonBedrockChatCompletionServiceSettings extends AmazonBedrockSer
             RateLimitSettings rateLimitSettings,
             ConfigurationParseContext context
         ) {
-            return new AmazonBedrockChatCompletionServiceSettings(
-                region,
-                model,
-                provider,
-                rateLimitSettings
-            );
+            return new AmazonBedrockChatCompletionServiceSettings(region, model, provider, rateLimitSettings);
         }
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/completion/AmazonBedrockChatCompletionServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/completion/AmazonBedrockChatCompletionServiceSettings.java
@@ -69,14 +69,14 @@ public class AmazonBedrockChatCompletionServiceSettings extends AmazonBedrockSer
         protected AmazonBedrockChatCompletionServiceSettings build(
             String region,
             String model,
-            String provider,
+            AmazonBedrockProvider provider,
             RateLimitSettings rateLimitSettings,
             ConfigurationParseContext context
         ) {
             return new AmazonBedrockChatCompletionServiceSettings(
                 region,
                 model,
-                AmazonBedrockProvider.fromString(provider),
+                provider,
                 rateLimitSettings
             );
         }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/embeddings/AmazonBedrockEmbeddingsServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/embeddings/AmazonBedrockEmbeddingsServiceSettings.java
@@ -7,9 +7,11 @@
 
 package org.elasticsearch.xpack.inference.services.amazonbedrock.embeddings;
 
+import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
 import org.elasticsearch.inference.ModelConfigurations;
@@ -17,11 +19,14 @@ import org.elasticsearch.inference.SimilarityMeasure;
 import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xpack.inference.common.parser.EnumParser;
 import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
 import org.elasticsearch.xpack.inference.services.ServiceFields;
 import org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockProvider;
 import org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockServiceSettings;
+import org.elasticsearch.xpack.inference.services.llama.LlamaServiceSettings;
+import org.elasticsearch.xpack.inference.services.llama.embeddings.LlamaEmbeddingsServiceSettings;
 import org.elasticsearch.xpack.inference.services.settings.RateLimitSettings;
 
 import java.io.IOException;
@@ -56,8 +61,9 @@ public class AmazonBedrockEmbeddingsServiceSettings extends AmazonBedrockService
             Builder::new
         );
         AmazonBedrockServiceSettings.declareCommonFields(parser);
-        parser.declareInt(Builder::setDimensions, new ParseField(DIMENSIONS));
+        // dimensions and dimensions_set_by_user cannot be updated via request
         if (isPersistentContext) {
+            parser.declareInt(Builder::setDimensions, new ParseField(DIMENSIONS));
             parser.declareBoolean(Builder::setDimensionsSetByUser, new ParseField(DIMENSIONS_SET_BY_USER));
         }
         parser.declareString(Builder::setSimilarity, EnumParser::parseSimilarity, new ParseField(SIMILARITY));
@@ -168,27 +174,11 @@ public class AmazonBedrockEmbeddingsServiceSettings extends AmazonBedrockService
 
     @Override
     public AmazonBedrockEmbeddingsServiceSettings updateServiceSettings(Map<String, Object> serviceSettings) {
-        var validationException = new ValidationException();
-        var updatedCommonSettings = updateCommonSettings(serviceSettings, validationException);
-
-        var extractedMaxTokens = extractOptionalPositiveInteger(
-            serviceSettings,
-            MAX_INPUT_TOKENS,
-            ModelConfigurations.SERVICE_SETTINGS,
-            validationException
-        );
-
-        validationException.throwIfValidationErrorsExist();
-        return new AmazonBedrockEmbeddingsServiceSettings(
-            updatedCommonSettings.region(),
-            updatedCommonSettings.model(),
-            updatedCommonSettings.provider(),
-            this.dimensions,
-            this.dimensionsSetByUser,
-            extractedMaxTokens != null ? extractedMaxTokens : this.maxInputTokens,
-            this.similarity,
-            updatedCommonSettings.rateLimitSettings()
-        );
+        try (var xParser = XContentHelper.mapToXContentParser(XContentParserConfiguration.EMPTY, serviceSettings)) {
+            return Update.PARSER.apply(xParser, null).mergeInto(this);
+        } catch (IOException e) {
+            throw new ElasticsearchParseException("Failed to parse Llama embeddings service settings update", e);
+        }
     }
 
     @Override
@@ -218,7 +208,7 @@ public class AmazonBedrockEmbeddingsServiceSettings extends AmazonBedrockService
      */
     public static class Builder extends AmazonBedrockServiceSettings.Builder<AmazonBedrockEmbeddingsServiceSettings> {
         private Integer dimensions;
-        private Boolean dimensionsSetByUser;
+        private Boolean dimensionsSetByUser = Boolean.FALSE;
         private SimilarityMeasure similarity;
         private Integer maxInputTokens;
 
@@ -254,10 +244,46 @@ public class AmazonBedrockEmbeddingsServiceSettings extends AmazonBedrockService
                 AmazonBedrockProvider.fromString(provider),
                 dimensions,
                 // Set the dimensionsSetByUser flag only if we're parsing the request and dimensions was populated by the user
-                context == ConfigurationParseContext.REQUEST && dimensions != null ? dimensionsSetByUser : false,
+                dimensionsSetByUser,
                 maxInputTokens,
                 similarity,
                 rateLimitSettings
+            );
+        }
+    }
+
+    /**
+     * Parses an update request, which may only contain the mutable {@code max_input_tokens} and {@code rate_limit} fields. Including any
+     * immutable field (such as {@code region}, {@code model}, {@code provider}, {@code dimensions}, or {@code similarity}) causes the
+     * strict parser to reject the request.
+     */
+    private static class Update extends AmazonBedrockServiceSettings.CommonUpdate {
+
+        private static final ObjectParser<Update, Void> PARSER = new ObjectParser<>(ModelConfigurations.SERVICE_SETTINGS, Update::new);
+
+        static {
+            declareCommonUpdatableFields(PARSER);
+            PARSER.declareInt(Update::setMaxInputTokens, new ParseField(MAX_INPUT_TOKENS));
+        }
+
+        private Integer maxInputTokens;
+
+        private void setMaxInputTokens(Integer maxInputTokens) {
+            validatePositiveInteger(maxInputTokens, MAX_INPUT_TOKENS);
+            this.maxInputTokens = maxInputTokens;
+        }
+
+        public AmazonBedrockEmbeddingsServiceSettings mergeInto(AmazonBedrockEmbeddingsServiceSettings existing) {
+            var updatedMaxInputTokens = this.maxInputTokens != null ? this.maxInputTokens : existing.maxInputTokens();
+            return new AmazonBedrockEmbeddingsServiceSettings(
+                existing.region(),
+                existing.modelId(),
+                existing.provider(),
+                existing.dimensions(),
+                existing.dimensionsSetByUser(),
+                updatedMaxInputTokens,
+                existing.similarity(),
+                mergedRateLimitSettings(existing)
             );
         }
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/embeddings/AmazonBedrockEmbeddingsServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/embeddings/AmazonBedrockEmbeddingsServiceSettings.java
@@ -30,6 +30,7 @@ import java.util.Objects;
 
 import static org.elasticsearch.xpack.inference.common.parser.NumberParser.validatePositiveInteger;
 import static org.elasticsearch.xpack.inference.services.ServiceFields.DIMENSIONS;
+import static org.elasticsearch.xpack.inference.services.ServiceFields.DIMENSIONS_SET_BY_USER;
 import static org.elasticsearch.xpack.inference.services.ServiceFields.MAX_INPUT_TOKENS;
 import static org.elasticsearch.xpack.inference.services.ServiceFields.SIMILARITY;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractOptionalPositiveInteger;
@@ -43,19 +44,22 @@ public class AmazonBedrockEmbeddingsServiceSettings extends AmazonBedrockService
     /**
      * Creates an {@link ObjectParser} for the Llama embeddings service settings.
      *
-     * @param ignoreUnknownFields whether the parser should tolerate unknown fields. This is {@code false} for request parsing (so that
+     * @param isPersistentContext whether the parser is applied to the persistent state. This is {@code false} for request parsing (so that
      *                            unexpected fields are rejected) and {@code true} for persisted configuration (so that fields written by
      *                            other versions are tolerated).
      * @return the parser
      */
-    static ObjectParser<Builder, ConfigurationParseContext> createParser(boolean ignoreUnknownFields) {
+    static ObjectParser<Builder, ConfigurationParseContext> createParser(boolean isPersistentContext) {
         ObjectParser<Builder, ConfigurationParseContext> parser = new ObjectParser<>(
             ModelConfigurations.SERVICE_SETTINGS,
-            ignoreUnknownFields,
+            isPersistentContext,
             Builder::new
         );
         AmazonBedrockServiceSettings.declareCommonFields(parser);
         parser.declareInt(Builder::setDimensions, new ParseField(DIMENSIONS));
+        if (isPersistentContext) {
+            parser.declareBoolean(Builder::setDimensionsSetByUser, new ParseField(DIMENSIONS_SET_BY_USER));
+        }
         parser.declareString(Builder::setSimilarity, EnumParser::parseSimilarity, new ParseField(SIMILARITY));
         parser.declareInt(Builder::setMaxInputTokens, new ParseField(MAX_INPUT_TOKENS));
         return parser;
@@ -214,12 +218,17 @@ public class AmazonBedrockEmbeddingsServiceSettings extends AmazonBedrockService
      */
     public static class Builder extends AmazonBedrockServiceSettings.Builder<AmazonBedrockEmbeddingsServiceSettings> {
         private Integer dimensions;
+        private Boolean dimensionsSetByUser;
         private SimilarityMeasure similarity;
         private Integer maxInputTokens;
 
         public void setDimensions(Integer dimensions) {
             validatePositiveInteger(dimensions, DIMENSIONS);
             this.dimensions = dimensions;
+        }
+
+        public void setDimensionsSetByUser(Boolean dimensionsSetByUser) {
+            this.dimensionsSetByUser = dimensionsSetByUser;
         }
 
         public void setSimilarity(SimilarityMeasure similarity) {
@@ -236,14 +245,16 @@ public class AmazonBedrockEmbeddingsServiceSettings extends AmazonBedrockService
             String region,
             String model,
             String provider,
-            RateLimitSettings rateLimitSettings
+            RateLimitSettings rateLimitSettings,
+            ConfigurationParseContext context
         ) {
             return new AmazonBedrockEmbeddingsServiceSettings(
                 region,
                 model,
                 AmazonBedrockProvider.fromString(provider),
                 dimensions,
-                false,
+                // Set the dimensionsSetByUser flag only if we're parsing the request and dimensions was populated by the user
+                context == ConfigurationParseContext.REQUEST && dimensions != null ? dimensionsSetByUser : false,
                 maxInputTokens,
                 similarity,
                 rateLimitSettings

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/embeddings/AmazonBedrockEmbeddingsServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/embeddings/AmazonBedrockEmbeddingsServiceSettings.java
@@ -14,11 +14,12 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.SimilarityMeasure;
+import org.elasticsearch.xcontent.ObjectParser;
+import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xpack.core.inference.InferenceUtils;
+import org.elasticsearch.xpack.inference.common.parser.EnumParser;
 import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
 import org.elasticsearch.xpack.inference.services.ServiceFields;
-import org.elasticsearch.xpack.inference.services.ServiceUtils;
 import org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockProvider;
 import org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockServiceSettings;
 import org.elasticsearch.xpack.inference.services.settings.RateLimitSettings;
@@ -27,15 +28,38 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
 
+import static org.elasticsearch.xpack.inference.common.parser.NumberParser.validatePositiveInteger;
 import static org.elasticsearch.xpack.inference.services.ServiceFields.DIMENSIONS;
 import static org.elasticsearch.xpack.inference.services.ServiceFields.MAX_INPUT_TOKENS;
 import static org.elasticsearch.xpack.inference.services.ServiceFields.SIMILARITY;
-import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractOptionalBoolean;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractOptionalPositiveInteger;
-import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractSimilarity;
 
 public class AmazonBedrockEmbeddingsServiceSettings extends AmazonBedrockServiceSettings {
     public static final String NAME = "amazon_bedrock_embeddings_service_settings";
+
+    private static final ObjectParser<Builder, ConfigurationParseContext> REQUEST_PARSER = createParser(false);
+    private static final ObjectParser<Builder, ConfigurationParseContext> PERSISTENT_PARSER = createParser(true);
+
+    /**
+     * Creates an {@link ObjectParser} for the Llama embeddings service settings.
+     *
+     * @param ignoreUnknownFields whether the parser should tolerate unknown fields. This is {@code false} for request parsing (so that
+     *                            unexpected fields are rejected) and {@code true} for persisted configuration (so that fields written by
+     *                            other versions are tolerated).
+     * @return the parser
+     */
+    static ObjectParser<Builder, ConfigurationParseContext> createParser(boolean ignoreUnknownFields) {
+        ObjectParser<Builder, ConfigurationParseContext> parser = new ObjectParser<>(
+            ModelConfigurations.SERVICE_SETTINGS,
+            ignoreUnknownFields,
+            Builder::new
+        );
+        AmazonBedrockServiceSettings.declareCommonFields(parser);
+        parser.declareInt(Builder::setDimensions, new ParseField(DIMENSIONS));
+        parser.declareString(Builder::setSimilarity, EnumParser::parseSimilarity, new ParseField(SIMILARITY));
+        parser.declareInt(Builder::setMaxInputTokens, new ParseField(MAX_INPUT_TOKENS));
+        return parser;
+    }
 
     private final Integer dimensions;
     private final Boolean dimensionsSetByUser;
@@ -43,57 +67,8 @@ public class AmazonBedrockEmbeddingsServiceSettings extends AmazonBedrockService
     private final SimilarityMeasure similarity;
 
     public static AmazonBedrockEmbeddingsServiceSettings fromMap(Map<String, Object> map, ConfigurationParseContext context) {
-        var validationException = new ValidationException();
-
-        var baseSettings = AmazonBedrockServiceSettings.fromMap(map, validationException, context);
-        var similarity = extractSimilarity(map, ModelConfigurations.SERVICE_SETTINGS, validationException);
-
-        var maxInputTokens = extractOptionalPositiveInteger(
-            map,
-            MAX_INPUT_TOKENS,
-            ModelConfigurations.SERVICE_SETTINGS,
-            validationException
-        );
-        var dimensions = extractOptionalPositiveInteger(map, DIMENSIONS, ModelConfigurations.SERVICE_SETTINGS, validationException);
-
-        var dimensionsSetByUser = extractOptionalBoolean(map, ServiceFields.DIMENSIONS_SET_BY_USER, validationException);
-
-        switch (context) {
-            case REQUEST -> {
-                if (dimensionsSetByUser != null) {
-                    validationException.addValidationError(
-                        ServiceUtils.invalidSettingError(ServiceFields.DIMENSIONS_SET_BY_USER, ModelConfigurations.SERVICE_SETTINGS)
-                    );
-                }
-
-                if (dimensions != null) {
-                    validationException.addValidationError(
-                        ServiceUtils.invalidSettingError(DIMENSIONS, ModelConfigurations.SERVICE_SETTINGS)
-                    );
-                }
-                dimensionsSetByUser = false;
-            }
-            case PERSISTENT -> {
-                if (dimensionsSetByUser == null) {
-                    validationException.addValidationError(
-                        InferenceUtils.missingSettingErrorMsg(ServiceFields.DIMENSIONS_SET_BY_USER, ModelConfigurations.SERVICE_SETTINGS)
-                    );
-                }
-            }
-        }
-
-        validationException.throwIfValidationErrorsExist();
-
-        return new AmazonBedrockEmbeddingsServiceSettings(
-            baseSettings.region(),
-            baseSettings.model(),
-            baseSettings.provider(),
-            dimensions,
-            dimensionsSetByUser,
-            maxInputTokens,
-            similarity,
-            baseSettings.rateLimitSettings()
-        );
+        var parser = context == ConfigurationParseContext.REQUEST ? REQUEST_PARSER : PERSISTENT_PARSER;
+        return AmazonBedrockServiceSettings.fromMap(map, context, parser);
     }
 
     public AmazonBedrockEmbeddingsServiceSettings(StreamInput in) throws IOException {
@@ -230,6 +205,50 @@ public class AmazonBedrockEmbeddingsServiceSettings extends AmazonBedrockService
 
     @Override
     public int hashCode() {
-        return Objects.hash(region, model, provider, dimensions, dimensionsSetByUser, maxInputTokens, similarity, rateLimitSettings);
+        return Objects.hash(super.hashCode(), dimensions, dimensionsSetByUser, maxInputTokens, similarity);
     }
+
+    /**
+     * Accumulates the embeddings-specific fields on top of the common Llama fields and builds a
+     * {@link AmazonBedrockEmbeddingsServiceSettings}, enforcing that {@code dimensions} and {@code max_input_tokens} are positive.
+     */
+    public static class Builder extends AmazonBedrockServiceSettings.Builder<AmazonBedrockEmbeddingsServiceSettings> {
+        private Integer dimensions;
+        private SimilarityMeasure similarity;
+        private Integer maxInputTokens;
+
+        public void setDimensions(Integer dimensions) {
+            validatePositiveInteger(dimensions, DIMENSIONS);
+            this.dimensions = dimensions;
+        }
+
+        public void setSimilarity(SimilarityMeasure similarity) {
+            this.similarity = similarity;
+        }
+
+        public void setMaxInputTokens(Integer maxInputTokens) {
+            validatePositiveInteger(maxInputTokens, MAX_INPUT_TOKENS);
+            this.maxInputTokens = maxInputTokens;
+        }
+
+        @Override
+        protected AmazonBedrockEmbeddingsServiceSettings build(
+            String region,
+            String model,
+            String provider,
+            RateLimitSettings rateLimitSettings
+        ) {
+            return new AmazonBedrockEmbeddingsServiceSettings(
+                region,
+                model,
+                AmazonBedrockProvider.fromString(provider),
+                dimensions,
+                false,
+                maxInputTokens,
+                similarity,
+                rateLimitSettings
+            );
+        }
+    }
+
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/embeddings/AmazonBedrockEmbeddingsServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/embeddings/AmazonBedrockEmbeddingsServiceSettings.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.inference.services.amazonbedrock.embeddings;
 
 import org.elasticsearch.ElasticsearchParseException;
-import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentHelper;
@@ -25,8 +24,6 @@ import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
 import org.elasticsearch.xpack.inference.services.ServiceFields;
 import org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockProvider;
 import org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockServiceSettings;
-import org.elasticsearch.xpack.inference.services.llama.LlamaServiceSettings;
-import org.elasticsearch.xpack.inference.services.llama.embeddings.LlamaEmbeddingsServiceSettings;
 import org.elasticsearch.xpack.inference.services.settings.RateLimitSettings;
 
 import java.io.IOException;
@@ -38,7 +35,6 @@ import static org.elasticsearch.xpack.inference.services.ServiceFields.DIMENSION
 import static org.elasticsearch.xpack.inference.services.ServiceFields.DIMENSIONS_SET_BY_USER;
 import static org.elasticsearch.xpack.inference.services.ServiceFields.MAX_INPUT_TOKENS;
 import static org.elasticsearch.xpack.inference.services.ServiceFields.SIMILARITY;
-import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractOptionalPositiveInteger;
 
 public class AmazonBedrockEmbeddingsServiceSettings extends AmazonBedrockServiceSettings {
     public static final String NAME = "amazon_bedrock_embeddings_service_settings";

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/embeddings/AmazonBedrockEmbeddingsServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/embeddings/AmazonBedrockEmbeddingsServiceSettings.java
@@ -239,7 +239,6 @@ public class AmazonBedrockEmbeddingsServiceSettings extends AmazonBedrockService
                 model,
                 provider,
                 dimensions,
-                // Set the dimensionsSetByUser flag only if we're parsing the request and dimensions was populated by the user
                 dimensionsSetByUser,
                 maxInputTokens,
                 similarity,

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/embeddings/AmazonBedrockEmbeddingsServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/embeddings/AmazonBedrockEmbeddingsServiceSettings.java
@@ -214,7 +214,7 @@ public class AmazonBedrockEmbeddingsServiceSettings extends AmazonBedrockService
         }
 
         public void setDimensionsSetByUser(Boolean dimensionsSetByUser) {
-            this.dimensionsSetByUser = dimensionsSetByUser;
+            this.dimensionsSetByUser = Objects.requireNonNullElse(dimensionsSetByUser, Boolean.FALSE);
         }
 
         public void setSimilarity(SimilarityMeasure similarity) {
@@ -230,14 +230,14 @@ public class AmazonBedrockEmbeddingsServiceSettings extends AmazonBedrockService
         protected AmazonBedrockEmbeddingsServiceSettings build(
             String region,
             String model,
-            String provider,
+            AmazonBedrockProvider provider,
             RateLimitSettings rateLimitSettings,
             ConfigurationParseContext context
         ) {
             return new AmazonBedrockEmbeddingsServiceSettings(
                 region,
                 model,
-                AmazonBedrockProvider.fromString(provider),
+                provider,
                 dimensions,
                 // Set the dimensionsSetByUser flag only if we're parsing the request and dimensions was populated by the user
                 dimensionsSetByUser,

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/embeddings/AmazonBedrockEmbeddingsServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/embeddings/AmazonBedrockEmbeddingsServiceSettings.java
@@ -43,7 +43,7 @@ public class AmazonBedrockEmbeddingsServiceSettings extends AmazonBedrockService
     private static final ObjectParser<Builder, ConfigurationParseContext> PERSISTENT_PARSER = createParser(true);
 
     /**
-     * Creates an {@link ObjectParser} for the Llama embeddings service settings.
+     * Creates an {@link ObjectParser} for the Bedrock embeddings service settings.
      *
      * @param isPersistentContext whether the parser is applied to the persistent state. This is {@code false} for request parsing (so that
      *                            unexpected fields are rejected) and {@code true} for persisted configuration (so that fields written by
@@ -173,7 +173,7 @@ public class AmazonBedrockEmbeddingsServiceSettings extends AmazonBedrockService
         try (var xParser = XContentHelper.mapToXContentParser(XContentParserConfiguration.EMPTY, serviceSettings)) {
             return Update.PARSER.apply(xParser, null).mergeInto(this);
         } catch (IOException e) {
-            throw new ElasticsearchParseException("Failed to parse Llama embeddings service settings update", e);
+            throw new ElasticsearchParseException("Failed to parse Bedrock embeddings service settings update", e);
         }
     }
 
@@ -199,7 +199,7 @@ public class AmazonBedrockEmbeddingsServiceSettings extends AmazonBedrockService
     }
 
     /**
-     * Accumulates the embeddings-specific fields on top of the common Llama fields and builds a
+     * Accumulates the embeddings-specific fields on top of the common Bedrock fields and builds a
      * {@link AmazonBedrockEmbeddingsServiceSettings}, enforcing that {@code dimensions} and {@code max_input_tokens} are positive.
      */
     public static class Builder extends AmazonBedrockServiceSettings.Builder<AmazonBedrockEmbeddingsServiceSettings> {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AbstractAmazonBedrockServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AbstractAmazonBedrockServiceSettingsTests.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference.services.amazonbedrock;
+
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.inference.ModelConfigurations;
+import org.elasticsearch.inference.SimilarityMeasure;
+import org.elasticsearch.test.AbstractBWCSerializationTestCase;
+import org.elasticsearch.xcontent.XContentParseException;
+import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
+import org.elasticsearch.xpack.inference.services.settings.RateLimitSettings;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockConstants.MODEL_FIELD;
+import static org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockConstants.PROVIDER_FIELD;
+import static org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockConstants.REGION_FIELD;
+import static org.elasticsearch.xpack.inference.services.contextualai.ContextualAiRerankTestFixtures.DEFAULT_RATE_LIMIT;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Base test case for {@link AmazonBedrockServiceSettings} subclasses. Holds the assertions for the fields common to every Bedrock task
+ * (model identity, endpoint URL, and rate limiting) so they are exercised once for each task type instead of being duplicated in
+ * every concrete settings test. Task-specific tests live in the concrete subclasses.
+ */
+public abstract class AbstractAmazonBedrockServiceSettingsTests<T extends AmazonBedrockServiceSettings> extends AbstractBWCSerializationTestCase<T> {
+
+    public static final String TEST_REGION = "test-region";
+    private static final String INITIAL_TEST_REGION = "initial-test-region";
+    public static final String TEST_MODEL_ID = "test-model-id";
+    private static final String INITIAL_TEST_MODEL_ID = "initial-test-model-id";
+    public static final AmazonBedrockProvider TEST_PROVIDER = AmazonBedrockProvider.AMAZONTITAN;
+    private static final AmazonBedrockProvider INITIAL_TEST_PROVIDER = AmazonBedrockProvider.AI21LABS;
+    public static final int TEST_RATE_LIMIT = 20;
+    private static final int INITIAL_TEST_RATE_LIMIT = 30;
+
+    /**
+     * Parses a settings instance from a settings map, mirroring the concrete subclass's {@code fromMap} entry point.
+     */
+    protected abstract T fromMap(Map<String, Object> map, ConfigurationParseContext context);
+
+    /**
+     * Builds a settings map populated with only the common fields, leaving any task-specific fields unset.
+     */
+    protected abstract Map<String, Object> buildCommonServiceSettingsMap(
+        @Nullable String region,
+        @Nullable String model,
+        @Nullable String provider,
+        @Nullable Integer rateLimit
+    );
+
+    /**
+     * Creates a settings instance with the given common fields and defaults (typically {@code null}) for any task-specific fields.
+     */
+    protected abstract T createServiceSettings(String region, String model, String provider, RateLimitSettings rateLimitSettings);
+
+    /**
+     * The task-specific immutable fields an update request must reject, in addition to the common {@code model_id} and {@code url}
+     * fields. Subclasses override this when they declare additional immutable fields.
+     */
+    protected List<String> additionalImmutableFields() {
+        return List.of();
+    }
+
+    public void testFromMap_OnlyMandatoryFields_UsesDefaultValues_Success() {
+        var serviceSettings = fromMap(
+            buildCommonServiceSettingsMap(TEST_REGION, TEST_MODEL_ID, TEST_PROVIDER.toString(), TEST_RATE_LIMIT),
+            randomFrom(ConfigurationParseContext.values())
+        );
+
+        assertThat(serviceSettings, is(createServiceSettings(TEST_REGION, TEST_MODEL_ID, TEST_PROVIDER.toString(), new RateLimitSettings(DEFAULT_RATE_LIMIT))));
+    }
+
+    public void testFromMap_EmptyRateLimitObject_UsesDefaultValue() {
+        var map = buildCommonServiceSettingsMap(TEST_REGION, TEST_MODEL_ID, TEST_PROVIDER.toString(), null);
+        map.put(RateLimitSettings.FIELD_NAME, new HashMap<>());
+
+        var serviceSettings = fromMap(map, randomFrom(ConfigurationParseContext.values()));
+
+        assertThat(serviceSettings, is(createServiceSettings(TEST_REGION, TEST_MODEL_ID, TEST_PROVIDER.toString(), new RateLimitSettings(DEFAULT_RATE_LIMIT))));
+    }
+
+    public void testFromMap_NoRegion_ThrowsException() {
+        var thrownException = expectThrows(
+            IllegalArgumentException.class,
+            () -> fromMap(
+                buildCommonServiceSettingsMap(null, TEST_MODEL_ID, TEST_PROVIDER.toString(), TEST_RATE_LIMIT),
+                randomFrom(ConfigurationParseContext.values())
+            )
+        );
+
+        assertThat(
+            thrownException.getMessage(),
+            is(
+                Strings.format(
+                    "[%s] does not contain the required setting [%s]",
+                    ModelConfigurations.SERVICE_SETTINGS, REGION_FIELD
+                )
+            )
+        );
+    }
+
+    public void testFromMap_NoModel_ThrowsException() {
+        var thrownException = expectThrows(
+            IllegalArgumentException.class,
+            () -> fromMap(
+                buildCommonServiceSettingsMap(TEST_REGION, null, TEST_PROVIDER.toString(), TEST_RATE_LIMIT),
+                randomFrom(ConfigurationParseContext.values())
+            )
+        );
+
+        assertThat(
+            thrownException.getMessage(),
+            is(
+                Strings.format(
+                    "[%s] does not contain the required setting [%s]",
+                    ModelConfigurations.SERVICE_SETTINGS, MODEL_FIELD
+                )
+            )
+        );
+    }
+
+    public void testFromMap_NoProvider_ThrowsException() {
+        var thrownException = expectThrows(
+            IllegalArgumentException.class,
+            () -> fromMap(
+                buildCommonServiceSettingsMap(TEST_REGION, TEST_MODEL_ID, null, TEST_RATE_LIMIT),
+                randomFrom(ConfigurationParseContext.values())
+            )
+        );
+
+        assertThat(
+            thrownException.getMessage(),
+            is(
+                Strings.format(
+                    "[%s] does not contain the required setting [%s]",
+                    ModelConfigurations.SERVICE_SETTINGS, PROVIDER_FIELD
+                )
+            )
+        );
+    }
+
+    public void testUpdateServiceSettings_RateLimit_IsUpdated() {
+        var originalServiceSettings = createServiceSettings(
+            INITIAL_TEST_REGION,
+            INITIAL_TEST_MODEL_ID,
+            INITIAL_TEST_PROVIDER.toString(),
+            new RateLimitSettings(INITIAL_TEST_RATE_LIMIT)
+        );
+        var updatedServiceSettings = originalServiceSettings.updateServiceSettings(
+            new HashMap<>(Map.of(RateLimitSettings.FIELD_NAME, Map.of(RateLimitSettings.REQUESTS_PER_MINUTE_FIELD, TEST_RATE_LIMIT)))
+        );
+
+        assertThat(
+            updatedServiceSettings,
+            is(createServiceSettings(INITIAL_TEST_REGION, INITIAL_TEST_MODEL_ID, INITIAL_TEST_PROVIDER.toString(), new RateLimitSettings(TEST_RATE_LIMIT)))
+        );
+    }
+
+    public void testUpdateServiceSettings_EmptyMap_DoesNotChangeSettings() {
+        var originalServiceSettings = createServiceSettings(
+            INITIAL_TEST_REGION,
+            INITIAL_TEST_MODEL_ID,
+            INITIAL_TEST_PROVIDER.toString(),
+            new RateLimitSettings(INITIAL_TEST_RATE_LIMIT)
+        );
+        assertThat(originalServiceSettings.updateServiceSettings(new HashMap<>()), is(originalServiceSettings));
+    }
+
+    public void testUpdateServiceSettings_EmptyRateLimitObject_DoesNotChangeSettings() {
+        var originalServiceSettings = createServiceSettings(
+            INITIAL_TEST_REGION,
+            INITIAL_TEST_MODEL_ID,
+            INITIAL_TEST_PROVIDER.toString(),
+            new RateLimitSettings(INITIAL_TEST_RATE_LIMIT)
+        );
+        var updatedServiceSettings = originalServiceSettings.updateServiceSettings(
+            new HashMap<>(Map.of(RateLimitSettings.FIELD_NAME, new HashMap<>()))
+        );
+
+        assertThat(updatedServiceSettings, is(originalServiceSettings));
+    }
+
+    public void testUpdateServiceSettings_GivenImmutableFields_ThrowsException() {
+        var serviceSettings = createServiceSettings(
+            INITIAL_TEST_REGION,
+            INITIAL_TEST_MODEL_ID,
+            INITIAL_TEST_PROVIDER.toString(),
+            new RateLimitSettings(INITIAL_TEST_RATE_LIMIT)
+        );
+
+        var immutableFields = new ArrayList<>(List.of(REGION_FIELD, MODEL_FIELD, PROVIDER_FIELD));
+        immutableFields.addAll(additionalImmutableFields());
+        for (String immutableField : immutableFields) {
+            var e = expectThrows(
+                XContentParseException.class,
+                () -> serviceSettings.updateServiceSettings(new HashMap<>(Map.of(immutableField, "value")))
+            );
+            assertThat(
+                e.getMessage(),
+                endsWith(Strings.format("[%s] unknown field [%s]", ModelConfigurations.SERVICE_SETTINGS, immutableField))
+            );
+        }
+    }
+}

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AbstractAmazonBedrockServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AbstractAmazonBedrockServiceSettingsTests.java
@@ -10,7 +10,6 @@ package org.elasticsearch.xpack.inference.services.amazonbedrock;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.ModelConfigurations;
-import org.elasticsearch.inference.SimilarityMeasure;
 import org.elasticsearch.test.AbstractBWCSerializationTestCase;
 import org.elasticsearch.xcontent.XContentParseException;
 import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
@@ -33,7 +32,8 @@ import static org.hamcrest.Matchers.is;
  * (model identity, endpoint URL, and rate limiting) so they are exercised once for each task type instead of being duplicated in
  * every concrete settings test. Task-specific tests live in the concrete subclasses.
  */
-public abstract class AbstractAmazonBedrockServiceSettingsTests<T extends AmazonBedrockServiceSettings> extends AbstractBWCSerializationTestCase<T> {
+public abstract class AbstractAmazonBedrockServiceSettingsTests<T extends AmazonBedrockServiceSettings> extends
+    AbstractBWCSerializationTestCase<T> {
 
     public static final String TEST_REGION = "test-region";
     private static final String INITIAL_TEST_REGION = "initial-test-region";
@@ -78,7 +78,10 @@ public abstract class AbstractAmazonBedrockServiceSettingsTests<T extends Amazon
             randomFrom(ConfigurationParseContext.values())
         );
 
-        assertThat(serviceSettings, is(createServiceSettings(TEST_REGION, TEST_MODEL_ID, TEST_PROVIDER.toString(), new RateLimitSettings(DEFAULT_RATE_LIMIT))));
+        assertThat(
+            serviceSettings,
+            is(createServiceSettings(TEST_REGION, TEST_MODEL_ID, TEST_PROVIDER.toString(), new RateLimitSettings(DEFAULT_RATE_LIMIT)))
+        );
     }
 
     public void testFromMap_EmptyRateLimitObject_UsesDefaultValue() {
@@ -87,7 +90,10 @@ public abstract class AbstractAmazonBedrockServiceSettingsTests<T extends Amazon
 
         var serviceSettings = fromMap(map, randomFrom(ConfigurationParseContext.values()));
 
-        assertThat(serviceSettings, is(createServiceSettings(TEST_REGION, TEST_MODEL_ID, TEST_PROVIDER.toString(), new RateLimitSettings(DEFAULT_RATE_LIMIT))));
+        assertThat(
+            serviceSettings,
+            is(createServiceSettings(TEST_REGION, TEST_MODEL_ID, TEST_PROVIDER.toString(), new RateLimitSettings(DEFAULT_RATE_LIMIT)))
+        );
     }
 
     public void testFromMap_NoRegion_ThrowsException() {
@@ -101,12 +107,7 @@ public abstract class AbstractAmazonBedrockServiceSettingsTests<T extends Amazon
 
         assertThat(
             thrownException.getMessage(),
-            is(
-                Strings.format(
-                    "[%s] does not contain the required setting [%s]",
-                    ModelConfigurations.SERVICE_SETTINGS, REGION_FIELD
-                )
-            )
+            is(Strings.format("[%s] does not contain the required setting [%s]", ModelConfigurations.SERVICE_SETTINGS, REGION_FIELD))
         );
     }
 
@@ -121,12 +122,7 @@ public abstract class AbstractAmazonBedrockServiceSettingsTests<T extends Amazon
 
         assertThat(
             thrownException.getMessage(),
-            is(
-                Strings.format(
-                    "[%s] does not contain the required setting [%s]",
-                    ModelConfigurations.SERVICE_SETTINGS, MODEL_FIELD
-                )
-            )
+            is(Strings.format("[%s] does not contain the required setting [%s]", ModelConfigurations.SERVICE_SETTINGS, MODEL_FIELD))
         );
     }
 
@@ -141,12 +137,7 @@ public abstract class AbstractAmazonBedrockServiceSettingsTests<T extends Amazon
 
         assertThat(
             thrownException.getMessage(),
-            is(
-                Strings.format(
-                    "[%s] does not contain the required setting [%s]",
-                    ModelConfigurations.SERVICE_SETTINGS, PROVIDER_FIELD
-                )
-            )
+            is(Strings.format("[%s] does not contain the required setting [%s]", ModelConfigurations.SERVICE_SETTINGS, PROVIDER_FIELD))
         );
     }
 
@@ -163,7 +154,14 @@ public abstract class AbstractAmazonBedrockServiceSettingsTests<T extends Amazon
 
         assertThat(
             updatedServiceSettings,
-            is(createServiceSettings(INITIAL_TEST_REGION, INITIAL_TEST_MODEL_ID, INITIAL_TEST_PROVIDER.toString(), new RateLimitSettings(TEST_RATE_LIMIT)))
+            is(
+                createServiceSettings(
+                    INITIAL_TEST_REGION,
+                    INITIAL_TEST_MODEL_ID,
+                    INITIAL_TEST_PROVIDER.toString(),
+                    new RateLimitSettings(TEST_RATE_LIMIT)
+                )
+            )
         );
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AbstractAmazonBedrockServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AbstractAmazonBedrockServiceSettingsTests.java
@@ -35,13 +35,13 @@ public abstract class AbstractAmazonBedrockServiceSettingsTests<T extends Amazon
     AbstractBWCSerializationTestCase<T> {
 
     public static final String TEST_REGION = "test-region";
-    private static final String INITIAL_TEST_REGION = "initial-test-region";
+    protected static final String INITIAL_TEST_REGION = "initial-test-region";
     public static final String TEST_MODEL_ID = "test-model-id";
-    private static final String INITIAL_TEST_MODEL_ID = "initial-test-model-id";
+    protected static final String INITIAL_TEST_MODEL_ID = "initial-test-model-id";
     public static final AmazonBedrockProvider TEST_PROVIDER = AmazonBedrockProvider.AMAZONTITAN;
-    private static final AmazonBedrockProvider INITIAL_TEST_PROVIDER = AmazonBedrockProvider.AI21LABS;
+    protected static final AmazonBedrockProvider INITIAL_TEST_PROVIDER = AmazonBedrockProvider.AI21LABS;
     public static final int TEST_RATE_LIMIT = 20;
-    private static final int INITIAL_TEST_RATE_LIMIT = 30;
+    protected static final int INITIAL_TEST_RATE_LIMIT = 30;
     private static final int DEFAULT_RATE_LIMIT = 240;
 
     /**
@@ -62,7 +62,7 @@ public abstract class AbstractAmazonBedrockServiceSettingsTests<T extends Amazon
     /**
      * Creates a settings instance with the given common fields and defaults (typically {@code null}) for any task-specific fields.
      */
-    protected abstract T createServiceSettings(String region, String model, String provider, RateLimitSettings rateLimitSettings);
+    protected abstract T createServiceSettings(String region, String model, AmazonBedrockProvider provider, RateLimitSettings rateLimitSettings);
 
     /**
      * The task-specific immutable fields an update request must reject, in addition to the common {@code region}, {@code model} and
@@ -80,7 +80,7 @@ public abstract class AbstractAmazonBedrockServiceSettingsTests<T extends Amazon
 
         assertThat(
             serviceSettings,
-            is(createServiceSettings(TEST_REGION, TEST_MODEL_ID, TEST_PROVIDER.toString(), new RateLimitSettings(DEFAULT_RATE_LIMIT)))
+            is(createServiceSettings(TEST_REGION, TEST_MODEL_ID, TEST_PROVIDER, new RateLimitSettings(DEFAULT_RATE_LIMIT)))
         );
     }
 
@@ -92,7 +92,7 @@ public abstract class AbstractAmazonBedrockServiceSettingsTests<T extends Amazon
 
         assertThat(
             serviceSettings,
-            is(createServiceSettings(TEST_REGION, TEST_MODEL_ID, TEST_PROVIDER.toString(), new RateLimitSettings(DEFAULT_RATE_LIMIT)))
+            is(createServiceSettings(TEST_REGION, TEST_MODEL_ID, TEST_PROVIDER, new RateLimitSettings(DEFAULT_RATE_LIMIT)))
         );
     }
 
@@ -145,7 +145,7 @@ public abstract class AbstractAmazonBedrockServiceSettingsTests<T extends Amazon
         var originalServiceSettings = createServiceSettings(
             INITIAL_TEST_REGION,
             INITIAL_TEST_MODEL_ID,
-            INITIAL_TEST_PROVIDER.toString(),
+            INITIAL_TEST_PROVIDER,
             new RateLimitSettings(INITIAL_TEST_RATE_LIMIT)
         );
         var updatedServiceSettings = originalServiceSettings.updateServiceSettings(
@@ -158,7 +158,7 @@ public abstract class AbstractAmazonBedrockServiceSettingsTests<T extends Amazon
                 createServiceSettings(
                     INITIAL_TEST_REGION,
                     INITIAL_TEST_MODEL_ID,
-                    INITIAL_TEST_PROVIDER.toString(),
+                    INITIAL_TEST_PROVIDER,
                     new RateLimitSettings(TEST_RATE_LIMIT)
                 )
             )
@@ -169,7 +169,7 @@ public abstract class AbstractAmazonBedrockServiceSettingsTests<T extends Amazon
         var originalServiceSettings = createServiceSettings(
             INITIAL_TEST_REGION,
             INITIAL_TEST_MODEL_ID,
-            INITIAL_TEST_PROVIDER.toString(),
+            INITIAL_TEST_PROVIDER,
             new RateLimitSettings(INITIAL_TEST_RATE_LIMIT)
         );
         assertThat(originalServiceSettings.updateServiceSettings(new HashMap<>()), is(originalServiceSettings));
@@ -179,7 +179,7 @@ public abstract class AbstractAmazonBedrockServiceSettingsTests<T extends Amazon
         var originalServiceSettings = createServiceSettings(
             INITIAL_TEST_REGION,
             INITIAL_TEST_MODEL_ID,
-            INITIAL_TEST_PROVIDER.toString(),
+            INITIAL_TEST_PROVIDER,
             new RateLimitSettings(INITIAL_TEST_RATE_LIMIT)
         );
         var updatedServiceSettings = originalServiceSettings.updateServiceSettings(
@@ -193,7 +193,7 @@ public abstract class AbstractAmazonBedrockServiceSettingsTests<T extends Amazon
         var serviceSettings = createServiceSettings(
             INITIAL_TEST_REGION,
             INITIAL_TEST_MODEL_ID,
-            INITIAL_TEST_PROVIDER.toString(),
+            INITIAL_TEST_PROVIDER,
             new RateLimitSettings(INITIAL_TEST_RATE_LIMIT)
         );
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AbstractAmazonBedrockServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AbstractAmazonBedrockServiceSettingsTests.java
@@ -23,7 +23,6 @@ import java.util.Map;
 import static org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockConstants.MODEL_FIELD;
 import static org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockConstants.PROVIDER_FIELD;
 import static org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockConstants.REGION_FIELD;
-import static org.elasticsearch.xpack.inference.services.contextualai.ContextualAiRerankTestFixtures.DEFAULT_RATE_LIMIT;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.is;
 
@@ -43,6 +42,7 @@ public abstract class AbstractAmazonBedrockServiceSettingsTests<T extends Amazon
     private static final AmazonBedrockProvider INITIAL_TEST_PROVIDER = AmazonBedrockProvider.AI21LABS;
     public static final int TEST_RATE_LIMIT = 20;
     private static final int INITIAL_TEST_RATE_LIMIT = 30;
+    private static final int DEFAULT_RATE_LIMIT = 240;
 
     /**
      * Parses a settings instance from a settings map, mirroring the concrete subclass's {@code fromMap} entry point.
@@ -65,8 +65,8 @@ public abstract class AbstractAmazonBedrockServiceSettingsTests<T extends Amazon
     protected abstract T createServiceSettings(String region, String model, String provider, RateLimitSettings rateLimitSettings);
 
     /**
-     * The task-specific immutable fields an update request must reject, in addition to the common {@code model_id} and {@code url}
-     * fields. Subclasses override this when they declare additional immutable fields.
+     * The task-specific immutable fields an update request must reject, in addition to the common {@code region}, {@code model} and
+     * {@code provider} fields. Subclasses override this when they declare additional immutable fields.
      */
     protected List<String> additionalImmutableFields() {
         return List.of();
@@ -74,7 +74,7 @@ public abstract class AbstractAmazonBedrockServiceSettingsTests<T extends Amazon
 
     public void testFromMap_OnlyMandatoryFields_UsesDefaultValues_Success() {
         var serviceSettings = fromMap(
-            buildCommonServiceSettingsMap(TEST_REGION, TEST_MODEL_ID, TEST_PROVIDER.toString(), TEST_RATE_LIMIT),
+            buildCommonServiceSettingsMap(TEST_REGION, TEST_MODEL_ID, TEST_PROVIDER.toString(), DEFAULT_RATE_LIMIT),
             randomFrom(ConfigurationParseContext.values())
         );
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AbstractAmazonBedrockServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AbstractAmazonBedrockServiceSettingsTests.java
@@ -62,7 +62,12 @@ public abstract class AbstractAmazonBedrockServiceSettingsTests<T extends Amazon
     /**
      * Creates a settings instance with the given common fields and defaults (typically {@code null}) for any task-specific fields.
      */
-    protected abstract T createServiceSettings(String region, String model, AmazonBedrockProvider provider, RateLimitSettings rateLimitSettings);
+    protected abstract T createServiceSettings(
+        String region,
+        String model,
+        AmazonBedrockProvider provider,
+        RateLimitSettings rateLimitSettings
+    );
 
     /**
      * The task-specific immutable fields an update request must reject, in addition to the common {@code region}, {@code model} and

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AbstractAmazonBedrockServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AbstractAmazonBedrockServiceSettingsTests.java
@@ -170,7 +170,7 @@ public abstract class AbstractAmazonBedrockServiceSettingsTests<T extends Amazon
         );
     }
 
-    public void testUpdateServiceSettings_EmptyMap_DoesNotChangeSettings() {
+    public void testUpdateServiceSettings_EmptyMap_UsesDefaultValue() {
         var originalServiceSettings = createServiceSettings(
             INITIAL_TEST_REGION,
             INITIAL_TEST_MODEL_ID,
@@ -178,20 +178,6 @@ public abstract class AbstractAmazonBedrockServiceSettingsTests<T extends Amazon
             new RateLimitSettings(INITIAL_TEST_RATE_LIMIT)
         );
         assertThat(originalServiceSettings.updateServiceSettings(new HashMap<>()), is(originalServiceSettings));
-    }
-
-    public void testUpdateServiceSettings_EmptyRateLimitObject_DoesNotChangeSettings() {
-        var originalServiceSettings = createServiceSettings(
-            INITIAL_TEST_REGION,
-            INITIAL_TEST_MODEL_ID,
-            INITIAL_TEST_PROVIDER,
-            new RateLimitSettings(INITIAL_TEST_RATE_LIMIT)
-        );
-        var updatedServiceSettings = originalServiceSettings.updateServiceSettings(
-            new HashMap<>(Map.of(RateLimitSettings.FIELD_NAME, new HashMap<>()))
-        );
-
-        assertThat(updatedServiceSettings, is(originalServiceSettings));
     }
 
     public void testUpdateServiceSettings_GivenImmutableFields_ThrowsException() {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AbstractAmazonBedrockServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AbstractAmazonBedrockServiceSettingsTests.java
@@ -170,7 +170,7 @@ public abstract class AbstractAmazonBedrockServiceSettingsTests<T extends Amazon
         );
     }
 
-    public void testUpdateServiceSettings_EmptyMap_UsesDefaultValue() {
+    public void testUpdateServiceSettings_EmptyMap_DoesNotChangeSettings() {
         var originalServiceSettings = createServiceSettings(
             INITIAL_TEST_REGION,
             INITIAL_TEST_MODEL_ID,

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AbstractAmazonBedrockServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AbstractAmazonBedrockServiceSettingsTests.java
@@ -23,8 +23,10 @@ import java.util.Map;
 import static org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockConstants.MODEL_FIELD;
 import static org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockConstants.PROVIDER_FIELD;
 import static org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockConstants.REGION_FIELD;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
 
 /**
  * Base test case for {@link AmazonBedrockServiceSettings} subclasses. Holds the assertions for the fields common to every Bedrock task
@@ -143,6 +145,21 @@ public abstract class AbstractAmazonBedrockServiceSettingsTests<T extends Amazon
         assertThat(
             thrownException.getMessage(),
             is(Strings.format("[%s] does not contain the required setting [%s]", ModelConfigurations.SERVICE_SETTINGS, PROVIDER_FIELD))
+        );
+    }
+
+    public void testFromMap_InvalidProvider_ThrowsException() {
+        var thrownException = expectThrows(
+            IllegalArgumentException.class,
+            () -> fromMap(
+                buildCommonServiceSettingsMap(TEST_REGION, TEST_MODEL_ID, "invalid_provider", TEST_RATE_LIMIT),
+                randomFrom(ConfigurationParseContext.values())
+            )
+        );
+
+        assertThat(
+            thrownException.getMessage(),
+            containsString("No enum constant")
         );
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AbstractAmazonBedrockServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AbstractAmazonBedrockServiceSettingsTests.java
@@ -26,7 +26,6 @@ import static org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBed
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.startsWith;
 
 /**
  * Base test case for {@link AmazonBedrockServiceSettings} subclasses. Holds the assertions for the fields common to every Bedrock task
@@ -157,10 +156,7 @@ public abstract class AbstractAmazonBedrockServiceSettingsTests<T extends Amazon
             )
         );
 
-        assertThat(
-            thrownException.getMessage(),
-            containsString("No enum constant")
-        );
+        assertThat(thrownException.getMessage(), containsString("No enum constant"));
     }
 
     public void testUpdateServiceSettings_RateLimit_IsUpdated() {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AmazonBedrockServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AmazonBedrockServiceTests.java
@@ -7,8 +7,6 @@
 
 package org.elasticsearch.xpack.inference.services.amazonbedrock;
 
-import org.elasticsearch.xcontent.XContentParseException;
-
 import software.amazon.awssdk.services.bedrockruntime.model.BedrockRuntimeException;
 
 import org.elasticsearch.ElasticsearchException;
@@ -16,7 +14,6 @@ import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.action.support.PlainActionFuture;
-import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
@@ -42,6 +39,7 @@ import org.elasticsearch.inference.UnparsedModel;
 import org.elasticsearch.inference.completion.ContentString;
 import org.elasticsearch.inference.completion.Message;
 import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xcontent.XContentParseException;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.results.ChatCompletionResults;
 import org.elasticsearch.xpack.core.inference.results.ChunkedInferenceEmbedding;

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AmazonBedrockServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AmazonBedrockServiceTests.java
@@ -370,11 +370,8 @@ public class AmazonBedrockServiceTests extends InferenceServiceTestCase {
             );
 
             ActionListener<Model> modelVerificationListener = ActionTestUtils.assertNoSuccessListener(e -> {
-                assertThat(e, instanceOf(ElasticsearchStatusException.class));
-                assertThat(
-                    e.getMessage(),
-                    is("Configuration contains settings [{extra_key=value}] unknown to the [amazonbedrock] service")
-                );
+                assertThat(e, instanceOf(XContentParseException.class));
+                assertThat(e.getMessage(), containsString("[service_settings] unknown field [extra_key]"));
             });
 
             service.parseRequestConfig(INFERENCE_ID_VALUE, TaskType.TEXT_EMBEDDING, config, modelVerificationListener);
@@ -395,10 +392,16 @@ public class AmazonBedrockServiceTests extends InferenceServiceTestCase {
 
         taskSettingsMap.put("extra_key", "value");
 
-        assertParseRequestConfigThrowsWhenExtraKeyPresent(
+        ActionListener<Model> modelVerificationListener = ActionTestUtils.assertNoSuccessListener(e -> {
+            assertThat(e, instanceOf(ElasticsearchStatusException.class));
+            assertThat(e.getMessage(), is("Configuration contains settings [{extra_key=value}] unknown to the [amazonbedrock] service"));
+        });
+
+        service.parseRequestConfig(
+            INFERENCE_ID_VALUE,
             taskType,
-            service,
-            getRequestConfigMap(settingsMap, taskSettingsMap, secretSettingsMap)
+            getRequestConfigMap(settingsMap, taskSettingsMap, secretSettingsMap),
+            modelVerificationListener
         );
     }
 
@@ -416,10 +419,16 @@ public class AmazonBedrockServiceTests extends InferenceServiceTestCase {
 
         secretSettingsMap.put("extra_key", "value");
 
-        assertParseRequestConfigThrowsWhenExtraKeyPresent(
+        ActionListener<Model> modelVerificationListener = ActionTestUtils.assertNoSuccessListener(e -> {
+            assertThat(e, instanceOf(XContentParseException.class));
+            assertThat(e.getMessage(), containsString("[service_settings] unknown field [extra_key]"));
+        });
+
+        service.parseRequestConfig(
+            INFERENCE_ID_VALUE,
             taskType,
-            service,
-            getRequestConfigMap(settingsMap, taskSettingsMap, secretSettingsMap)
+            getRequestConfigMap(settingsMap, taskSettingsMap, secretSettingsMap),
+            modelVerificationListener
         );
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AmazonBedrockServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AmazonBedrockServiceTests.java
@@ -7,6 +7,8 @@
 
 package org.elasticsearch.xpack.inference.services.amazonbedrock;
 
+import org.elasticsearch.xcontent.XContentParseException;
+
 import software.amazon.awssdk.services.bedrockruntime.model.BedrockRuntimeException;
 
 import org.elasticsearch.ElasticsearchException;
@@ -429,8 +431,8 @@ public class AmazonBedrockServiceTests extends InferenceServiceTestCase {
         Map<String, Object> config
     ) {
         ActionListener<Model> modelVerificationListener = ActionTestUtils.assertNoSuccessListener(e -> {
-            assertThat(e, instanceOf(ElasticsearchStatusException.class));
-            assertThat(e.getMessage(), is("Configuration contains settings [{extra_key=value}] unknown to the [amazonbedrock] service"));
+            assertThat(e, instanceOf(XContentParseException.class));
+            assertThat(e.getMessage(), containsString("[service_settings] unknown field [extra_key]"));
         });
 
         service.parseRequestConfig(INFERENCE_ID_VALUE, taskType, config, modelVerificationListener);
@@ -496,8 +498,8 @@ public class AmazonBedrockServiceTests extends InferenceServiceTestCase {
     public void testParseRequestConfig_ForEmbeddingsTask_DimensionsIsNotAllowed() throws IOException {
         try (var service = createAmazonBedrockService()) {
             ActionListener<Model> modelVerificationListener = ActionTestUtils.assertNoSuccessListener(exception -> {
-                assertThat(exception, instanceOf(ValidationException.class));
-                assertThat(exception.getMessage(), containsString("[service_settings] does not allow the setting [dimensions]"));
+                assertThat(exception, instanceOf(XContentParseException.class));
+                assertThat(exception.getMessage(), containsString("[service_settings] unknown field [dimensions]"));
             });
 
             service.parseRequestConfig(

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/completion/AmazonBedrockChatCompletionServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/completion/AmazonBedrockChatCompletionServiceSettingsTests.java
@@ -10,141 +10,29 @@ package org.elasticsearch.xpack.inference.services.amazonbedrock.completion;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
-import org.elasticsearch.xcontent.XContentParseException;
-import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.ml.AbstractBWCWireSerializationTestCase;
-import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
 import org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockProvider;
 import org.elasticsearch.xpack.inference.services.settings.RateLimitSettings;
 import org.elasticsearch.xpack.inference.services.settings.RateLimitSettingsTests;
 
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
+import static org.elasticsearch.xpack.inference.services.amazonbedrock.AbstractAmazonBedrockServiceSettingsTests.TEST_MODEL_ID;
+import static org.elasticsearch.xpack.inference.services.amazonbedrock.AbstractAmazonBedrockServiceSettingsTests.TEST_PROVIDER;
+import static org.elasticsearch.xpack.inference.services.amazonbedrock.AbstractAmazonBedrockServiceSettingsTests.TEST_RATE_LIMIT;
+import static org.elasticsearch.xpack.inference.services.amazonbedrock.AbstractAmazonBedrockServiceSettingsTests.TEST_REGION;
 import static org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockConstants.MODEL_FIELD;
 import static org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockConstants.PROVIDER_FIELD;
 import static org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockConstants.REGION_FIELD;
-import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.is;
 
 public class AmazonBedrockChatCompletionServiceSettingsTests extends AbstractBWCWireSerializationTestCase<
     AmazonBedrockChatCompletionServiceSettings> {
-    private static final String TEST_REGION = "test-region";
-    private static final String INITIAL_TEST_REGION = "initial-test-region";
-    private static final String TEST_MODEL_ID = "test-model-id";
-    private static final String INITIAL_TEST_MODEL_ID = "initial-test-model-id";
-    private static final AmazonBedrockProvider TEST_PROVIDER = AmazonBedrockProvider.AMAZONTITAN;
-    private static final AmazonBedrockProvider INITIAL_TEST_PROVIDER = AmazonBedrockProvider.AI21LABS;
-    private static final int TEST_RATE_LIMIT = 20;
-    private static final int INITIAL_TEST_RATE_LIMIT = 30;
-
-    public void testUpdateServiceSettings_RateLimit_IsUpdated() {
-        var originalServiceSettings = new AmazonBedrockChatCompletionServiceSettings(
-            INITIAL_TEST_REGION,
-            INITIAL_TEST_MODEL_ID,
-            INITIAL_TEST_PROVIDER,
-            new RateLimitSettings(INITIAL_TEST_RATE_LIMIT)
-        );
-        var updatedServiceSettings = originalServiceSettings.updateServiceSettings(
-            new HashMap<>(Map.of(RateLimitSettings.FIELD_NAME, Map.of(RateLimitSettings.REQUESTS_PER_MINUTE_FIELD, TEST_RATE_LIMIT)))
-        );
-
-        assertThat(
-            updatedServiceSettings,
-            is(
-                new AmazonBedrockChatCompletionServiceSettings(
-                    INITIAL_TEST_REGION,
-                    INITIAL_TEST_MODEL_ID,
-                    INITIAL_TEST_PROVIDER,
-                    new RateLimitSettings(TEST_RATE_LIMIT)
-                )
-            )
-        );
-    }
-
-    public void testUpdateServiceSettings_EmptyRateLimitObject_DoesNotChangeSettings() {
-        var originalServiceSettings = new AmazonBedrockChatCompletionServiceSettings(
-            INITIAL_TEST_REGION,
-            INITIAL_TEST_MODEL_ID,
-            INITIAL_TEST_PROVIDER,
-            new RateLimitSettings(INITIAL_TEST_RATE_LIMIT)
-        );
-        var updatedServiceSettings = originalServiceSettings.updateServiceSettings(
-            new HashMap<>(Map.of(RateLimitSettings.FIELD_NAME, new HashMap<>()))
-        );
-
-        assertThat(updatedServiceSettings, is(originalServiceSettings));
-    }
-
-    public void testUpdateServiceSettings_GivenImmutableFields_ThrowsException() {
-        var serviceSettings = new AmazonBedrockChatCompletionServiceSettings(
-            INITIAL_TEST_REGION,
-            INITIAL_TEST_MODEL_ID,
-            INITIAL_TEST_PROVIDER,
-            new RateLimitSettings(INITIAL_TEST_RATE_LIMIT)
-        );
-        for (String immutableField : List.of(REGION_FIELD, MODEL_FIELD, PROVIDER_FIELD)) {
-            var e = expectThrows(
-                XContentParseException.class,
-                () -> serviceSettings.updateServiceSettings(new HashMap<>(Map.of(immutableField, "value")))
-            );
-            assertThat(
-                e.getMessage(),
-                endsWith(Strings.format("[%s] unknown field [%s]", ModelConfigurations.SERVICE_SETTINGS, immutableField))
-            );
-        }
-    }
-
-    private static HashMap<String, Object> createChatCompletionRequestSettingsMap(
-        String region,
-        String modelId,
-        String provider,
-        int rateLimit
-    ) {
-        var newSettingsMap = createChatCompletionRequestSettingsMap(region, modelId, provider);
-        newSettingsMap.put(RateLimitSettings.FIELD_NAME, new HashMap<>(Map.of(RateLimitSettings.REQUESTS_PER_MINUTE_FIELD, rateLimit)));
-        return newSettingsMap;
-    }
-
-    public void testFromMap_Request_CreatesSettingsCorrectly() {
-        var serviceSettings = AmazonBedrockChatCompletionServiceSettings.fromMap(
-            createChatCompletionRequestSettingsMap(TEST_REGION, TEST_MODEL_ID, TEST_PROVIDER.toString()),
-            ConfigurationParseContext.REQUEST
-        );
-
-        assertThat(serviceSettings, is(new AmazonBedrockChatCompletionServiceSettings(TEST_REGION, TEST_MODEL_ID, TEST_PROVIDER, null)));
-    }
-
-    public void testFromMap_RequestWithRateLimit_CreatesSettingsCorrectly() {
-        var settingsMap = createChatCompletionRequestSettingsMap(TEST_REGION, TEST_MODEL_ID, TEST_PROVIDER.toString(), TEST_RATE_LIMIT);
-
-        var serviceSettings = AmazonBedrockChatCompletionServiceSettings.fromMap(settingsMap, ConfigurationParseContext.REQUEST);
-
-        assertThat(
-            serviceSettings,
-            is(
-                new AmazonBedrockChatCompletionServiceSettings(
-                    TEST_REGION,
-                    TEST_MODEL_ID,
-                    TEST_PROVIDER,
-                    new RateLimitSettings(TEST_RATE_LIMIT)
-                )
-            )
-        );
-    }
-
-    public void testFromMap_Persistent_CreatesSettingsCorrectly() {
-        var settingsMap = createChatCompletionRequestSettingsMap(TEST_REGION, TEST_MODEL_ID, TEST_PROVIDER.toString());
-        var serviceSettings = AmazonBedrockChatCompletionServiceSettings.fromMap(settingsMap, ConfigurationParseContext.PERSISTENT);
-
-        assertThat(serviceSettings, is(new AmazonBedrockChatCompletionServiceSettings(TEST_REGION, TEST_MODEL_ID, TEST_PROVIDER, null)));
-    }
 
     public void testToXContent_WritesAllValues() throws IOException {
         var entity = new AmazonBedrockChatCompletionServiceSettings(

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/completion/AmazonBedrockChatCompletionServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/completion/AmazonBedrockChatCompletionServiceSettingsTests.java
@@ -47,10 +47,10 @@ public class AmazonBedrockChatCompletionServiceSettingsTests extends AbstractAma
     protected AmazonBedrockChatCompletionServiceSettings createServiceSettings(
         String region,
         String model,
-        String provider,
+        AmazonBedrockProvider provider,
         RateLimitSettings rateLimitSettings
     ) {
-        return new AmazonBedrockChatCompletionServiceSettings(region, model, AmazonBedrockProvider.fromString(provider), rateLimitSettings);
+        return new AmazonBedrockChatCompletionServiceSettings(region, model, provider, rateLimitSettings);
     }
 
     @Override

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/completion/AmazonBedrockChatCompletionServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/completion/AmazonBedrockChatCompletionServiceSettingsTests.java
@@ -10,8 +10,11 @@ package org.elasticsearch.xpack.inference.services.amazonbedrock.completion;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
+import org.elasticsearch.xcontent.XContentParseException;
+import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.ml.AbstractBWCWireSerializationTestCase;
 import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
@@ -21,11 +24,13 @@ import org.elasticsearch.xpack.inference.services.settings.RateLimitSettingsTest
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockConstants.MODEL_FIELD;
 import static org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockConstants.PROVIDER_FIELD;
 import static org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockConstants.REGION_FIELD;
+import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.is;
 
 public class AmazonBedrockChatCompletionServiceSettingsTests extends AbstractBWCWireSerializationTestCase<
@@ -39,7 +44,7 @@ public class AmazonBedrockChatCompletionServiceSettingsTests extends AbstractBWC
     private static final int TEST_RATE_LIMIT = 20;
     private static final int INITIAL_TEST_RATE_LIMIT = 30;
 
-    public void testUpdateServiceSettings_AllFields_OnlyMutableFieldsAreUpdated() {
+    public void testUpdateServiceSettings_RateLimit_IsUpdated() {
         var originalServiceSettings = new AmazonBedrockChatCompletionServiceSettings(
             INITIAL_TEST_REGION,
             INITIAL_TEST_MODEL_ID,
@@ -47,7 +52,7 @@ public class AmazonBedrockChatCompletionServiceSettingsTests extends AbstractBWC
             new RateLimitSettings(INITIAL_TEST_RATE_LIMIT)
         );
         var updatedServiceSettings = originalServiceSettings.updateServiceSettings(
-            createChatCompletionRequestSettingsMap(TEST_REGION, TEST_MODEL_ID, TEST_PROVIDER.toString(), TEST_RATE_LIMIT)
+            new HashMap<>(Map.of(RateLimitSettings.FIELD_NAME, Map.of(RateLimitSettings.REQUESTS_PER_MINUTE_FIELD, TEST_RATE_LIMIT)))
         );
 
         assertThat(
@@ -63,16 +68,37 @@ public class AmazonBedrockChatCompletionServiceSettingsTests extends AbstractBWC
         );
     }
 
-    public void testUpdateServiceSettings_EmptyMap_DoesNotChangeSettings() {
+    public void testUpdateServiceSettings_EmptyRateLimitObject_DoesNotChangeSettings() {
         var originalServiceSettings = new AmazonBedrockChatCompletionServiceSettings(
             INITIAL_TEST_REGION,
             INITIAL_TEST_MODEL_ID,
             INITIAL_TEST_PROVIDER,
             new RateLimitSettings(INITIAL_TEST_RATE_LIMIT)
         );
-        var updatedServiceSettings = originalServiceSettings.updateServiceSettings(new HashMap<>());
+        var updatedServiceSettings = originalServiceSettings.updateServiceSettings(
+            new HashMap<>(Map.of(RateLimitSettings.FIELD_NAME, new HashMap<>()))
+        );
 
         assertThat(updatedServiceSettings, is(originalServiceSettings));
+    }
+
+    public void testUpdateServiceSettings_GivenImmutableFields_ThrowsException() {
+        var serviceSettings = new AmazonBedrockChatCompletionServiceSettings(
+            INITIAL_TEST_REGION,
+            INITIAL_TEST_MODEL_ID,
+            INITIAL_TEST_PROVIDER,
+            new RateLimitSettings(INITIAL_TEST_RATE_LIMIT)
+        );
+        for (String immutableField : List.of(REGION_FIELD, MODEL_FIELD, PROVIDER_FIELD)) {
+            var e = expectThrows(
+                XContentParseException.class,
+                () -> serviceSettings.updateServiceSettings(new HashMap<>(Map.of(immutableField, "value")))
+            );
+            assertThat(
+                e.getMessage(),
+                endsWith(Strings.format("[%s] unknown field [%s]", ModelConfigurations.SERVICE_SETTINGS, immutableField))
+            );
+        }
     }
 
     private static HashMap<String, Object> createChatCompletionRequestSettingsMap(

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/completion/AmazonBedrockChatCompletionServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/completion/AmazonBedrockChatCompletionServiceSettingsTests.java
@@ -10,10 +10,13 @@ package org.elasticsearch.xpack.inference.services.amazonbedrock.completion;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
+import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentType;
-import org.elasticsearch.xpack.core.ml.AbstractBWCWireSerializationTestCase;
+import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
+import org.elasticsearch.xpack.inference.services.amazonbedrock.AbstractAmazonBedrockServiceSettingsTests;
 import org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockProvider;
 import org.elasticsearch.xpack.inference.services.settings.RateLimitSettings;
 import org.elasticsearch.xpack.inference.services.settings.RateLimitSettingsTests;
@@ -22,17 +25,40 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.elasticsearch.xpack.inference.services.amazonbedrock.AbstractAmazonBedrockServiceSettingsTests.TEST_MODEL_ID;
-import static org.elasticsearch.xpack.inference.services.amazonbedrock.AbstractAmazonBedrockServiceSettingsTests.TEST_PROVIDER;
-import static org.elasticsearch.xpack.inference.services.amazonbedrock.AbstractAmazonBedrockServiceSettingsTests.TEST_RATE_LIMIT;
-import static org.elasticsearch.xpack.inference.services.amazonbedrock.AbstractAmazonBedrockServiceSettingsTests.TEST_REGION;
 import static org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockConstants.MODEL_FIELD;
 import static org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockConstants.PROVIDER_FIELD;
 import static org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockConstants.REGION_FIELD;
 import static org.hamcrest.Matchers.is;
 
-public class AmazonBedrockChatCompletionServiceSettingsTests extends AbstractBWCWireSerializationTestCase<
+public class AmazonBedrockChatCompletionServiceSettingsTests extends AbstractAmazonBedrockServiceSettingsTests<
     AmazonBedrockChatCompletionServiceSettings> {
+
+    @Override
+    protected AmazonBedrockChatCompletionServiceSettings fromMap(Map<String, Object> map, ConfigurationParseContext context) {
+        return AmazonBedrockChatCompletionServiceSettings.fromMap(map, context);
+    }
+
+    @Override
+    protected Map<String, Object> buildCommonServiceSettingsMap(String region, String model, String provider, Integer rateLimit) {
+        return buildServiceSettingsMap(region, model, provider, rateLimit);
+    }
+
+    @Override
+    protected AmazonBedrockChatCompletionServiceSettings createServiceSettings(
+        String region,
+        String model,
+        String provider,
+        RateLimitSettings rateLimitSettings
+    ) {
+        return new AmazonBedrockChatCompletionServiceSettings(region, model, AmazonBedrockProvider.fromString(provider), rateLimitSettings);
+    }
+
+    @Override
+    protected AmazonBedrockChatCompletionServiceSettings doParseInstance(XContentParser parser) throws IOException {
+        return AmazonBedrockChatCompletionServiceSettings.createParser(true)
+            .apply(parser, ConfigurationParseContext.PERSISTENT)
+            .build(ConfigurationParseContext.PERSISTENT);
+    }
 
     public void testToXContent_WritesAllValues() throws IOException {
         var entity = new AmazonBedrockChatCompletionServiceSettings(
@@ -108,4 +134,27 @@ public class AmazonBedrockChatCompletionServiceSettingsTests extends AbstractBWC
             RateLimitSettingsTests.createRandom()
         );
     }
+
+    public static Map<String, Object> buildServiceSettingsMap(
+        @Nullable String region,
+        @Nullable String model,
+        @Nullable String provider,
+        @Nullable Integer rateLimit
+    ) {
+        var map = new HashMap<String, Object>();
+        if (region != null) {
+            map.put(REGION_FIELD, region);
+        }
+        if (model != null) {
+            map.put(MODEL_FIELD, model);
+        }
+        if (provider != null) {
+            map.put(PROVIDER_FIELD, provider);
+        }
+        if (rateLimit != null) {
+            map.put(RateLimitSettings.FIELD_NAME, new HashMap<>(Map.of(RateLimitSettings.REQUESTS_PER_MINUTE_FIELD, rateLimit)));
+        }
+        return map;
+    }
+
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/embeddings/AmazonBedrockEmbeddingsServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/embeddings/AmazonBedrockEmbeddingsServiceSettingsTests.java
@@ -82,6 +82,9 @@ public class AmazonBedrockEmbeddingsServiceSettingsTests extends AbstractAmazonB
     }
 
     public void testUpdateServiceSettings_AllFields_OnlyMutableFieldsAreUpdated() {
+        var settingsMap = new HashMap<String, Object>();
+        settingsMap.put(ServiceFields.MAX_INPUT_TOKENS, TEST_MAX_INPUT_TOKENS);
+        settingsMap.put(RateLimitSettings.FIELD_NAME, new HashMap<>(Map.of(RateLimitSettings.REQUESTS_PER_MINUTE_FIELD, TEST_RATE_LIMIT)));
         var originalServiceSettings = new AmazonBedrockEmbeddingsServiceSettings(
             INITIAL_TEST_REGION,
             INITIAL_TEST_MODEL_ID,
@@ -92,18 +95,7 @@ public class AmazonBedrockEmbeddingsServiceSettingsTests extends AbstractAmazonB
             INITIAL_TEST_SIMILARITY,
             new RateLimitSettings(INITIAL_TEST_RATE_LIMIT)
         );
-        var updatedServiceSettings = originalServiceSettings.updateServiceSettings(
-            createEmbeddingsRequestSettingsMap(
-                TEST_REGION,
-                TEST_MODEL_ID,
-                TEST_PROVIDER.toString(),
-                TEST_DIMENSIONS,
-                TEST_DIMENSIONS_SET_BY_USER,
-                TEST_MAX_INPUT_TOKENS,
-                TEST_SIMILARITY,
-                TEST_RATE_LIMIT
-            )
-        );
+        var updatedServiceSettings = originalServiceSettings.updateServiceSettings(settingsMap);
 
         assertThat(
             updatedServiceSettings,
@@ -226,53 +218,6 @@ public class AmazonBedrockEmbeddingsServiceSettingsTests extends AbstractAmazonB
                     null
                 )
             )
-        );
-    }
-
-    public void testFromMap_Request_DimensionsSetByUser_ShouldThrowWhenPresent() {
-        var settingsMap = createEmbeddingsRequestSettingsMap(
-            TEST_REGION,
-            TEST_MODEL_ID,
-            TEST_PROVIDER.toString(),
-            null,
-            true,
-            TEST_MAX_INPUT_TOKENS,
-            TEST_SIMILARITY
-        );
-
-        var thrownException = expectThrows(
-            ValidationException.class,
-            () -> AmazonBedrockEmbeddingsServiceSettings.fromMap(settingsMap, ConfigurationParseContext.REQUEST)
-        );
-
-        MatcherAssert.assertThat(
-            thrownException.getMessage(),
-            containsString(
-                Strings.format("Validation Failed: 1: [service_settings] does not allow the setting [%s];", DIMENSIONS_SET_BY_USER)
-            )
-        );
-    }
-
-    public void testFromMap_Request_Dimensions_ShouldThrowWhenPresent() {
-        var settingsMap = createEmbeddingsRequestSettingsMap(
-            TEST_REGION,
-            TEST_MODEL_ID,
-            TEST_PROVIDER.toString(),
-            TEST_DIMENSIONS,
-            null,
-            null,
-            null,
-            TEST_RATE_LIMIT
-        );
-
-        var thrownException = expectThrows(
-            ValidationException.class,
-            () -> AmazonBedrockEmbeddingsServiceSettings.fromMap(settingsMap, ConfigurationParseContext.REQUEST)
-        );
-
-        MatcherAssert.assertThat(
-            thrownException.getMessage(),
-            containsString(Strings.format("[service_settings] does not allow the setting [%s]", DIMENSIONS))
         );
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/embeddings/AmazonBedrockEmbeddingsServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/embeddings/AmazonBedrockEmbeddingsServiceSettingsTests.java
@@ -12,14 +12,16 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.SimilarityMeasure;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
+import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentType;
-import org.elasticsearch.xpack.core.ml.AbstractBWCWireSerializationTestCase;
 import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
 import org.elasticsearch.xpack.inference.services.ServiceFields;
+import org.elasticsearch.xpack.inference.services.amazonbedrock.AbstractAmazonBedrockServiceSettingsTests;
 import org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockProvider;
 import org.elasticsearch.xpack.inference.services.settings.RateLimitSettings;
 import org.elasticsearch.xpack.inference.services.settings.RateLimitSettingsTests;
@@ -38,16 +40,11 @@ import static org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBed
 import static org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockConstants.PROVIDER_FIELD;
 import static org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockConstants.REGION_FIELD;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.is;
 
-public class AmazonBedrockEmbeddingsServiceSettingsTests extends AbstractBWCWireSerializationTestCase<
+public class AmazonBedrockEmbeddingsServiceSettingsTests extends AbstractAmazonBedrockServiceSettingsTests<
     AmazonBedrockEmbeddingsServiceSettings> {
-    private static final String TEST_REGION = "test-region";
-    private static final String INITIAL_TEST_REGION = "initial-test-region";
-    private static final String TEST_MODEL_ID = "test-model-id";
-    private static final String INITIAL_TEST_MODEL_ID = "initial-test-model-id";
-    private static final AmazonBedrockProvider TEST_PROVIDER = AmazonBedrockProvider.AMAZONTITAN;
-    private static final AmazonBedrockProvider INITIAL_TEST_PROVIDER = AmazonBedrockProvider.AI21LABS;
     public static final boolean TEST_DIMENSIONS_SET_BY_USER = false;
     public static final boolean INITIAL_TEST_DIMENSIONS_SET_BY_USER = true;
     private static final int TEST_DIMENSIONS = 1536;
@@ -56,8 +53,33 @@ public class AmazonBedrockEmbeddingsServiceSettingsTests extends AbstractBWCWire
     private static final int INITIAL_TEST_MAX_INPUT_TOKENS = 1024;
     private static final SimilarityMeasure TEST_SIMILARITY = SimilarityMeasure.COSINE;
     private static final SimilarityMeasure INITIAL_TEST_SIMILARITY = SimilarityMeasure.DOT_PRODUCT;
-    private static final int TEST_RATE_LIMIT = 20;
-    private static final int INITIAL_TEST_RATE_LIMIT = 30;
+
+    @Override
+    protected AmazonBedrockEmbeddingsServiceSettings fromMap(Map<String, Object> map, ConfigurationParseContext context) {
+        return AmazonBedrockEmbeddingsServiceSettings.fromMap(map, context);
+    }
+
+    @Override
+    protected Map<String, Object> buildCommonServiceSettingsMap(String region, String model, String provider, Integer rateLimit) {
+        return buildServiceSettingsMap(region, model, provider, null, null, null, null, rateLimit);
+    }
+
+    @Override
+    protected AmazonBedrockEmbeddingsServiceSettings createServiceSettings(
+        String region,
+        String model,
+        AmazonBedrockProvider provider,
+        RateLimitSettings rateLimitSettings
+    ) {
+        return new AmazonBedrockEmbeddingsServiceSettings(region, model, provider, null, false, null, null, rateLimitSettings);
+    }
+
+    @Override
+    protected AmazonBedrockEmbeddingsServiceSettings doParseInstance(XContentParser parser) throws IOException {
+        return AmazonBedrockEmbeddingsServiceSettings.createParser(true)
+            .apply(parser, ConfigurationParseContext.PERSISTENT)
+            .build(ConfigurationParseContext.PERSISTENT);
+    }
 
     public void testUpdateServiceSettings_AllFields_OnlyMutableFieldsAreUpdated() {
         var originalServiceSettings = new AmazonBedrockEmbeddingsServiceSettings(
@@ -268,13 +290,24 @@ public class AmazonBedrockEmbeddingsServiceSettingsTests extends AbstractBWCWire
         );
 
         var thrownException = expectThrows(
-            ValidationException.class,
+            IllegalArgumentException.class,
             () -> AmazonBedrockEmbeddingsServiceSettings.fromMap(settingsMap, ConfigurationParseContext.REQUEST)
         );
 
-        MatcherAssert.assertThat(
+        assertThat(
             thrownException.getMessage(),
-            containsString(Strings.format("[%s] must be a positive integer", MAX_INPUT_TOKENS))
+            endsWith(Strings.format("[%s] failed to parse field [%s]", ModelConfigurations.SERVICE_SETTINGS, MAX_INPUT_TOKENS))
+        );
+        assertThat(
+            thrownException.getCause().getMessage(),
+            is(
+                Strings.format(
+                    "[%s] Invalid value [%d]. [%s] must be a positive integer",
+                    ModelConfigurations.SERVICE_SETTINGS,
+                    maxInputTokens,
+                    MAX_INPUT_TOKENS
+                )
+            )
         );
     }
 
@@ -317,6 +350,35 @@ public class AmazonBedrockEmbeddingsServiceSettingsTests extends AbstractBWCWire
         );
     }
 
+    public void testFromMap_PersistentContext_DoesNotThrowException_WhenDimensionsSetByUserIsNull() {
+        var settingsMap = createEmbeddingsRequestSettingsMap(
+            TEST_REGION,
+            TEST_MODEL_ID,
+            TEST_PROVIDER.toString(),
+            TEST_DIMENSIONS,
+            null,
+            TEST_MAX_INPUT_TOKENS,
+            TEST_SIMILARITY
+        );
+        var serviceSettings = AmazonBedrockEmbeddingsServiceSettings.fromMap(settingsMap, ConfigurationParseContext.PERSISTENT);
+
+        assertThat(
+            serviceSettings,
+            is(
+                new AmazonBedrockEmbeddingsServiceSettings(
+                    TEST_REGION,
+                    TEST_MODEL_ID,
+                    TEST_PROVIDER,
+                    TEST_DIMENSIONS,
+                    false,
+                    TEST_MAX_INPUT_TOKENS,
+                    TEST_SIMILARITY,
+                    null
+                )
+            )
+        );
+    }
+
     public void testFromMap_PersistentContext_DoesNotThrowException_WhenSimilarityIsPresent() {
         var settingsMap = createEmbeddingsRequestSettingsMap(
             TEST_REGION,
@@ -343,29 +405,6 @@ public class AmazonBedrockEmbeddingsServiceSettingsTests extends AbstractBWCWire
                     null
                 )
             )
-        );
-    }
-
-    public void testFromMap_PersistentContext_ThrowsException_WhenDimensionsSetByUserIsNull() {
-        var settingsMap = createEmbeddingsRequestSettingsMap(
-            TEST_REGION,
-            TEST_MODEL_ID,
-            TEST_PROVIDER.toString(),
-            TEST_DIMENSIONS,
-            null,
-            null,
-            null,
-            TEST_RATE_LIMIT
-        );
-
-        var exception = expectThrows(
-            ValidationException.class,
-            () -> AmazonBedrockEmbeddingsServiceSettings.fromMap(settingsMap, ConfigurationParseContext.PERSISTENT)
-        );
-
-        assertThat(
-            exception.getMessage(),
-            containsString("Validation Failed: 1: [service_settings] does not contain the required setting [dimensions_set_by_user];")
         );
     }
 
@@ -515,6 +554,7 @@ public class AmazonBedrockEmbeddingsServiceSettingsTests extends AbstractBWCWire
         }
 
         if (maxTokens != null) {
+            System.out.println("Setting max_tokens to " + maxTokens);
             map.put(ServiceFields.MAX_INPUT_TOKENS, maxTokens);
         }
 
@@ -592,4 +632,43 @@ public class AmazonBedrockEmbeddingsServiceSettingsTests extends AbstractBWCWire
     private static SimilarityMeasure randomSimilarityOrNull() {
         return randomFrom(new SimilarityMeasure[] { null, randomSimilarityMeasure() });
     }
+
+    public static Map<String, Object> buildServiceSettingsMap(
+        @Nullable String region,
+        @Nullable String model,
+        @Nullable String provider,
+        @Nullable String dimensions,
+        @Nullable Boolean dimensionsSetByUser,
+        @Nullable Integer maxInputTokens,
+        @Nullable String similarity,
+        @Nullable Integer rateLimit
+    ) {
+        var map = new HashMap<String, Object>();
+        if (region != null) {
+            map.put(REGION_FIELD, region);
+        }
+        if (model != null) {
+            map.put(MODEL_FIELD, model);
+        }
+        if (provider != null) {
+            map.put(PROVIDER_FIELD, provider);
+        }
+        if (dimensions != null) {
+            map.put(DIMENSIONS, dimensions);
+        }
+        if (dimensionsSetByUser != null) {
+            map.put(DIMENSIONS_SET_BY_USER, dimensionsSetByUser);
+        }
+        if (maxInputTokens != null) {
+            map.put(MAX_INPUT_TOKENS, maxInputTokens);
+        }
+        if (similarity != null) {
+            map.put(SIMILARITY, similarity);
+        }
+        if (rateLimit != null) {
+            map.put(RateLimitSettings.FIELD_NAME, new HashMap<>(Map.of(RateLimitSettings.REQUESTS_PER_MINUTE_FIELD, rateLimit)));
+        }
+        return map;
+    }
+
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/embeddings/AmazonBedrockEmbeddingsServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/embeddings/AmazonBedrockEmbeddingsServiceSettingsTests.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.inference.services.amazonbedrock.embeddings;
 
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.ModelConfigurations;
@@ -25,7 +24,6 @@ import org.elasticsearch.xpack.inference.services.amazonbedrock.AbstractAmazonBe
 import org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockProvider;
 import org.elasticsearch.xpack.inference.services.settings.RateLimitSettings;
 import org.elasticsearch.xpack.inference.services.settings.RateLimitSettingsTests;
-import org.hamcrest.MatcherAssert;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -39,7 +37,6 @@ import static org.elasticsearch.xpack.inference.services.ServiceFields.SIMILARIT
 import static org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockConstants.MODEL_FIELD;
 import static org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockConstants.PROVIDER_FIELD;
 import static org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockConstants.REGION_FIELD;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.is;
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/embeddings/AmazonBedrockEmbeddingsServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/embeddings/AmazonBedrockEmbeddingsServiceSettingsTests.java
@@ -111,6 +111,56 @@ public class AmazonBedrockEmbeddingsServiceSettingsTests extends AbstractAmazonB
         );
     }
 
+    public void testUpdateServiceSettings_Request_Dimensions_ShouldThrowWhenPresent() {
+        var settingsMap = new HashMap<String, Object>();
+        settingsMap.put(DIMENSIONS, TEST_DIMENSIONS);
+        var originalServiceSettings = new AmazonBedrockEmbeddingsServiceSettings(
+            INITIAL_TEST_REGION,
+            INITIAL_TEST_MODEL_ID,
+            INITIAL_TEST_PROVIDER,
+            INITIAL_TEST_DIMENSIONS,
+            INITIAL_TEST_DIMENSIONS_SET_BY_USER,
+            INITIAL_TEST_MAX_INPUT_TOKENS,
+            INITIAL_TEST_SIMILARITY,
+            new RateLimitSettings(INITIAL_TEST_RATE_LIMIT)
+        );
+
+        var thrownException = expectThrows(
+            IllegalArgumentException.class,
+            () -> originalServiceSettings.updateServiceSettings(settingsMap)
+        );
+
+        assertThat(
+            thrownException.getMessage(),
+            endsWith(Strings.format("[%s] unknown field [%s]", ModelConfigurations.SERVICE_SETTINGS, DIMENSIONS))
+        );
+    }
+
+    public void testUpdateServiceSettings_Request_DimensionsSetByUser_ShouldThrowWhenPresent() {
+        var settingsMap = new HashMap<String, Object>();
+        settingsMap.put(DIMENSIONS_SET_BY_USER, Boolean.TRUE);
+        var originalServiceSettings = new AmazonBedrockEmbeddingsServiceSettings(
+            INITIAL_TEST_REGION,
+            INITIAL_TEST_MODEL_ID,
+            INITIAL_TEST_PROVIDER,
+            INITIAL_TEST_DIMENSIONS,
+            INITIAL_TEST_DIMENSIONS_SET_BY_USER,
+            INITIAL_TEST_MAX_INPUT_TOKENS,
+            INITIAL_TEST_SIMILARITY,
+            new RateLimitSettings(INITIAL_TEST_RATE_LIMIT)
+        );
+
+        var thrownException = expectThrows(
+            IllegalArgumentException.class,
+            () -> originalServiceSettings.updateServiceSettings(settingsMap)
+        );
+
+        assertThat(
+            thrownException.getMessage(),
+            endsWith(Strings.format("[%s] unknown field [%s]", ModelConfigurations.SERVICE_SETTINGS, DIMENSIONS_SET_BY_USER))
+        );
+    }
+
     public void testUpdateServiceSettings_EmptyMap_DoesNotChangeSettings() {
         var originalServiceSettings = new AmazonBedrockEmbeddingsServiceSettings(
             INITIAL_TEST_REGION,

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/embeddings/AmazonBedrockEmbeddingsServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/embeddings/AmazonBedrockEmbeddingsServiceSettingsTests.java
@@ -165,36 +165,6 @@ public class AmazonBedrockEmbeddingsServiceSettingsTests extends AbstractAmazonB
         );
     }
 
-    public void testUpdateServiceSettings_EmptyMap_UsesDefaultValue() {
-        var originalServiceSettings = new AmazonBedrockEmbeddingsServiceSettings(
-            INITIAL_TEST_REGION,
-            INITIAL_TEST_MODEL_ID,
-            INITIAL_TEST_PROVIDER,
-            INITIAL_TEST_DIMENSIONS,
-            INITIAL_TEST_DIMENSIONS_SET_BY_USER,
-            INITIAL_TEST_MAX_INPUT_TOKENS,
-            INITIAL_TEST_SIMILARITY,
-            new RateLimitSettings(INITIAL_TEST_RATE_LIMIT)
-        );
-        var updatedServiceSettings = originalServiceSettings.updateServiceSettings(new HashMap<>());
-
-        assertThat(
-            updatedServiceSettings,
-            is(
-                new AmazonBedrockEmbeddingsServiceSettings(
-                    INITIAL_TEST_REGION,
-                    INITIAL_TEST_MODEL_ID,
-                    INITIAL_TEST_PROVIDER,
-                    INITIAL_TEST_DIMENSIONS,
-                    INITIAL_TEST_DIMENSIONS_SET_BY_USER,
-                    INITIAL_TEST_MAX_INPUT_TOKENS,
-                    INITIAL_TEST_SIMILARITY,
-                    DEFAULT_RATE_LIMIT_SETTINGS
-                )
-            )
-        );
-    }
-
     public void testFromMap_Request_CreatesSettingsCorrectly() {
         var serviceSettings = AmazonBedrockEmbeddingsServiceSettings.fromMap(
             createEmbeddingsRequestSettingsMap(

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/embeddings/AmazonBedrockEmbeddingsServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/embeddings/AmazonBedrockEmbeddingsServiceSettingsTests.java
@@ -39,7 +39,6 @@ import static org.elasticsearch.xpack.inference.services.ServiceFields.SIMILARIT
 import static org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockConstants.MODEL_FIELD;
 import static org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockConstants.PROVIDER_FIELD;
 import static org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockConstants.REGION_FIELD;
-import static org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockServiceSettings.DEFAULT_RATE_LIMIT_SETTINGS;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.is;

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/embeddings/AmazonBedrockEmbeddingsServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/embeddings/AmazonBedrockEmbeddingsServiceSettingsTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.inference.services.amazonbedrock.embeddings;
 
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.ModelConfigurations;
@@ -16,6 +17,7 @@ import org.elasticsearch.inference.SimilarityMeasure;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
+import org.elasticsearch.xcontent.XContentParseException;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
@@ -24,6 +26,7 @@ import org.elasticsearch.xpack.inference.services.amazonbedrock.AbstractAmazonBe
 import org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockProvider;
 import org.elasticsearch.xpack.inference.services.settings.RateLimitSettings;
 import org.elasticsearch.xpack.inference.services.settings.RateLimitSettingsTests;
+import org.hamcrest.MatcherAssert;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -37,6 +40,8 @@ import static org.elasticsearch.xpack.inference.services.ServiceFields.SIMILARIT
 import static org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockConstants.MODEL_FIELD;
 import static org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockConstants.PROVIDER_FIELD;
 import static org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockConstants.REGION_FIELD;
+import static org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockServiceSettings.DEFAULT_RATE_LIMIT_SETTINGS;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.is;
 
@@ -161,7 +166,7 @@ public class AmazonBedrockEmbeddingsServiceSettingsTests extends AbstractAmazonB
         );
     }
 
-    public void testUpdateServiceSettings_EmptyMap_DoesNotChangeSettings() {
+    public void testUpdateServiceSettings_EmptyMap_UsesDefaultValue() {
         var originalServiceSettings = new AmazonBedrockEmbeddingsServiceSettings(
             INITIAL_TEST_REGION,
             INITIAL_TEST_MODEL_ID,
@@ -174,7 +179,16 @@ public class AmazonBedrockEmbeddingsServiceSettingsTests extends AbstractAmazonB
         );
         var updatedServiceSettings = originalServiceSettings.updateServiceSettings(new HashMap<>());
 
-        assertThat(updatedServiceSettings, is(originalServiceSettings));
+        assertThat(updatedServiceSettings, is(new AmazonBedrockEmbeddingsServiceSettings(
+            INITIAL_TEST_REGION,
+            INITIAL_TEST_MODEL_ID,
+            INITIAL_TEST_PROVIDER,
+            INITIAL_TEST_DIMENSIONS,
+            INITIAL_TEST_DIMENSIONS_SET_BY_USER,
+            INITIAL_TEST_MAX_INPUT_TOKENS,
+            INITIAL_TEST_SIMILARITY,
+            DEFAULT_RATE_LIMIT_SETTINGS
+        )));
     }
 
     public void testFromMap_Request_CreatesSettingsCorrectly() {
@@ -205,6 +219,53 @@ public class AmazonBedrockEmbeddingsServiceSettingsTests extends AbstractAmazonB
                     null
                 )
             )
+        );
+    }
+
+    public void testFromMap_Request_DimensionsSetByUser_ShouldThrowWhenPresent() {
+        var settingsMap = createEmbeddingsRequestSettingsMap(
+            TEST_REGION,
+            TEST_MODEL_ID,
+            TEST_PROVIDER.toString(),
+            null,
+            true,
+            TEST_MAX_INPUT_TOKENS,
+            TEST_SIMILARITY
+        );
+
+        var thrownException = expectThrows(
+            XContentParseException.class,
+            () -> AmazonBedrockEmbeddingsServiceSettings.fromMap(settingsMap, ConfigurationParseContext.REQUEST)
+        );
+
+        MatcherAssert.assertThat(
+            thrownException.getMessage(),
+            containsString(
+                Strings.format("[service_settings] unknown field [%s]", DIMENSIONS_SET_BY_USER)
+            )
+        );
+    }
+
+    public void testFromMap_Request_Dimensions_ShouldThrowWhenPresent() {
+        var settingsMap = createEmbeddingsRequestSettingsMap(
+            TEST_REGION,
+            TEST_MODEL_ID,
+            TEST_PROVIDER.toString(),
+            TEST_DIMENSIONS,
+            null,
+            null,
+            null,
+            TEST_RATE_LIMIT
+        );
+
+        var thrownException = expectThrows(
+            XContentParseException.class,
+            () -> AmazonBedrockEmbeddingsServiceSettings.fromMap(settingsMap, ConfigurationParseContext.REQUEST)
+        );
+
+        MatcherAssert.assertThat(
+            thrownException.getMessage(),
+            containsString(Strings.format("[service_settings] unknown field [%s]", DIMENSIONS))
         );
     }
 
@@ -546,7 +607,6 @@ public class AmazonBedrockEmbeddingsServiceSettingsTests extends AbstractAmazonB
         }
 
         if (maxTokens != null) {
-            System.out.println("Setting max_tokens to " + maxTokens);
             map.put(ServiceFields.MAX_INPUT_TOKENS, maxTokens);
         }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/embeddings/AmazonBedrockEmbeddingsServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/embeddings/AmazonBedrockEmbeddingsServiceSettingsTests.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.inference.services.amazonbedrock.embeddings;
 
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.ModelConfigurations;
@@ -179,16 +178,21 @@ public class AmazonBedrockEmbeddingsServiceSettingsTests extends AbstractAmazonB
         );
         var updatedServiceSettings = originalServiceSettings.updateServiceSettings(new HashMap<>());
 
-        assertThat(updatedServiceSettings, is(new AmazonBedrockEmbeddingsServiceSettings(
-            INITIAL_TEST_REGION,
-            INITIAL_TEST_MODEL_ID,
-            INITIAL_TEST_PROVIDER,
-            INITIAL_TEST_DIMENSIONS,
-            INITIAL_TEST_DIMENSIONS_SET_BY_USER,
-            INITIAL_TEST_MAX_INPUT_TOKENS,
-            INITIAL_TEST_SIMILARITY,
-            DEFAULT_RATE_LIMIT_SETTINGS
-        )));
+        assertThat(
+            updatedServiceSettings,
+            is(
+                new AmazonBedrockEmbeddingsServiceSettings(
+                    INITIAL_TEST_REGION,
+                    INITIAL_TEST_MODEL_ID,
+                    INITIAL_TEST_PROVIDER,
+                    INITIAL_TEST_DIMENSIONS,
+                    INITIAL_TEST_DIMENSIONS_SET_BY_USER,
+                    INITIAL_TEST_MAX_INPUT_TOKENS,
+                    INITIAL_TEST_SIMILARITY,
+                    DEFAULT_RATE_LIMIT_SETTINGS
+                )
+            )
+        );
     }
 
     public void testFromMap_Request_CreatesSettingsCorrectly() {
@@ -240,9 +244,7 @@ public class AmazonBedrockEmbeddingsServiceSettingsTests extends AbstractAmazonB
 
         MatcherAssert.assertThat(
             thrownException.getMessage(),
-            containsString(
-                Strings.format("[service_settings] unknown field [%s]", DIMENSIONS_SET_BY_USER)
-            )
+            containsString(Strings.format("[service_settings] unknown field [%s]", DIMENSIONS_SET_BY_USER))
         );
     }
 


### PR DESCRIPTION
Refactor Amazon Bedrock service settings in Inference API to use ObjectParser.

Closes https://github.com/elastic/search-team/issues/14763
Closes https://github.com/elastic/search-team/issues/14764

Reworks Amazon Bedrock (`completion` and `embeddings`) service-settings parsing to use the standard `ObjectParser` + `Builder` pattern instead of hand-rolled, `ValidationException`-based map extraction. Common logic is pulled up into a new shared base class so the two task types no longer duplicate parsing, serialization, update, and field-storage code.

### Changes
- **New `AmazonBedrockServiceSettings` base class** holding the fields shared by all Bedrock tasks (`region`, `model`, `provider`, `rate_limit`) plus the shared `ObjectParser`/`Builder`, XContent, stream serialization, and update machinery. `AmazonBedrockChatCompletionServiceSettings` and `AmazonBedrockEmbeddingsServiceSettings` now extend it and contribute only their own fields.
- **`ObjectParser`-based parsing** for both settings types, replacing manual `extractRequiredString`/`extractSimilarity`/etc. Required fields and defaults are enforced in `Builder.build()`, and separate strict (request) vs. lenient (persistent) parsers handle unknown fields.
- **New `EnumParser` helper** (`common/parser`) for parsing enum values (e.g. embeddings `similarity`) within an object-parser context with user-friendly error messages.
- **`AmazonBedrockService.usesParserForServiceSettings()`** now returns `true`.

Tested create/read/update paths locally with both inference types.