### PR TITLE
Fix int8_hnsw rabbit vector to prevent BWC flakiness in KNN similarity test

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/41_knn_search_byte_quantized_bfloat16.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/41_knn_search_byte_quantized_bfloat16.yml
@@ -62,7 +62,7 @@ setup:
         id: "3"
         body:
           name: rabbit.jpg
-          vector: [1.0, 222.6, -26.0, 29.6, -312.0]
+          vector: [0.25, 55.65, -6.5, 7.4, -78.0]
           another_vector: [-0.5, 11.0, 0, 12, 111.0]
   # Flush in order to provoke a merge later
   - do:


### PR DESCRIPTION
## Summary

Follow-up to #151778 which fixed the rabbit vector in both `41_knn_search_byte_quantized_bfloat16.yml` and `42_knn_search_int8_flat_bfloat16.yml`.

The previous fix used `[1.0, 222.6, -26.0, 29.6, -312.0]` for both files. This works for `int8_flat` (file 42) because the "KNN Vector similarity search only" test there is gated behind `lucene_10_4_upgrade` and Lucene 10.4's `OptimizedScalarQuantizer` handles the wider quantile range. However, for `int8_hnsw` (file 41), that test has **no `requires` guard** and runs on 9.3.6 BWC nodes where the old `ScalarQuantizer` computes alpha ≈ 4.82, giving moose an approximate L2² ≈ 116 — exceeding the `similarity: 10.51` threshold (≤ 110.46) and incorrectly excluding moose from results.

**Root cause:** The rabbit vector `[1.0, 222.6, -26.0, 29.6, -312.0]` extends the segment's quantile range beyond cow's dominant `[-200, 300]` bounds. On 9.3.6 the coarser alpha value introduces enough quantization error to push moose's approximate L2² just over the threshold.

**Fix:** Halve the rabbit vector to `[0.25, 55.65, -6.5, 7.4, -78.0]` in file 41 only. Every component stays within cow's range, so alpha ≈ 3.94 regardless of node version, giving moose an approximate L2² ≈ 77 — safely below the threshold. The cosine test is unaffected since cosine similarity is scale-invariant.

## Test plan

- [x] `ClientYamlTestSuiteIT` for `search.vectors/41_knn_search_byte_quantized_bfloat16` passes locally
- [x] `ClientYamlTestSuiteIT` for `search.vectors/42_knn_search_int8_flat_bfloat16` passes locally (unchanged)
- [ ] `MixedClusterClientYamlTestSuiteIT` for `search.vectors/41_knn_search_byte_quantized_bfloat16/KNN Vector similarity search only` — this is the originally flaky test

🤖 Generated with [Claude Code](https://claude.com/claude-code)