### PR TITLE
[9.4] Wait on readiness service on start (#102325)

### DIFF
--- a/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
@@ -52,6 +52,7 @@ import org.elasticsearch.node.Node;
 import org.elasticsearch.node.NodeValidationException;
 import org.elasticsearch.plugins.PluginBundle;
 import org.elasticsearch.plugins.PluginsLoader;
+import org.elasticsearch.readiness.ReadinessService;
 import org.elasticsearch.rest.MethodHandlers;
 import org.elasticsearch.transport.RequestHandlerRegistry;
 
@@ -450,6 +451,10 @@ class Elasticsearch {
 
         INSTANCE.start();
 
+        if (ReadinessService.enabled(bootstrap.environment())) {
+            waitForNodeReady(INSTANCE.node.injector().getInstance(ReadinessService.class));
+        }
+
         if (bootstrap.args().daemonize()) {
             LogConfigurator.removeConsoleAppender();
         }
@@ -536,6 +541,17 @@ class Elasticsearch {
                     + org.apache.lucene.util.Version.LATEST
                     + "]"
             );
+        }
+    }
+
+    static void waitForNodeReady(ReadinessService readinessService) {
+        CountDownLatch ready = new CountDownLatch(1);
+        readinessService.addBoundAddressListener(address -> ready.countDown());
+        try {
+            ready.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new ElasticsearchException("Interrupted while waiting for node to be ready", e);
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/bootstrap/ElasticsearchTests.java
+++ b/server/src/test/java/org/elasticsearch/bootstrap/ElasticsearchTests.java
@@ -9,15 +9,22 @@
 
 package org.elasticsearch.bootstrap;
 
+import org.elasticsearch.common.transport.BoundTransportAddress;
+import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.entitlement.runtime.policy.Policy;
 import org.elasticsearch.entitlement.runtime.policy.Scope;
 import org.elasticsearch.entitlement.runtime.policy.entitlements.InboundNetworkEntitlement;
 import org.elasticsearch.entitlement.runtime.policy.entitlements.LoadNativeLibrariesEntitlement;
 import org.elasticsearch.entitlement.runtime.policy.entitlements.OutboundNetworkEntitlement;
+import org.elasticsearch.readiness.ReadinessService;
 import org.elasticsearch.test.ESTestCase;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.Map.entry;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -65,5 +72,56 @@ public class ElasticsearchTests extends ESTestCase {
         assertThat(pluginsWithNativeAccess.keySet(), containsInAnyOrder("plugin-with-native", "another-plugin-with-native"));
         assertThat(pluginsWithNativeAccess.get("plugin-with-native"), containsInAnyOrder("module.a"));
         assertThat(pluginsWithNativeAccess.get("another-plugin-with-native"), containsInAnyOrder("module.a2", "module.b2"));
+    }
+
+    public void testWaitForNodeReadyBlocksUntilReady() throws Exception {
+        CountDownLatch listenerRegistered = new CountDownLatch(1);
+        AtomicReference<ReadinessService.BoundAddressListener> capturedListener = new AtomicReference<>();
+
+        ReadinessService service = new ReadinessService(null, null) {
+            @Override
+            public synchronized void addBoundAddressListener(BoundAddressListener listener) {
+                capturedListener.set(listener);
+                listenerRegistered.countDown();
+            }
+        };
+
+        Thread waiter = new Thread(() -> Elasticsearch.waitForNodeReady(service), "test-waiter");
+        waiter.start();
+        try {
+            assertTrue("listener should be registered", listenerRegistered.await(10, java.util.concurrent.TimeUnit.SECONDS));
+            assertTrue("waitForNodeReady should be blocking", waiter.isAlive());
+
+            capturedListener.get().addressBound(mockBoundAddress());
+
+            waiter.join(10_000);
+            assertFalse("waitForNodeReady should have returned after readiness fired", waiter.isAlive());
+        } finally {
+            // ensure the thread is not left stuck if the test fails partway through
+            if (capturedListener.get() != null) {
+                capturedListener.get().addressBound(mockBoundAddress());
+            }
+            waiter.join(5_000);
+        }
+    }
+
+    public void testWaitForNodeReadyWhenAlreadyReady() throws Exception {
+        BoundTransportAddress address = mockBoundAddress();
+
+        // Simulates a service that is already ready: fires the listener immediately on registration
+        ReadinessService service = new ReadinessService(null, null) {
+            @Override
+            public synchronized void addBoundAddressListener(BoundAddressListener listener) {
+                listener.addressBound(address);
+            }
+        };
+
+        // Should return without blocking; if it hangs the test will time out
+        Elasticsearch.waitForNodeReady(service);
+    }
+
+    private static BoundTransportAddress mockBoundAddress() throws UnknownHostException {
+        TransportAddress ta = new TransportAddress(InetAddress.getLoopbackAddress(), 9200);
+        return new BoundTransportAddress(new TransportAddress[] { ta }, ta);
     }
 }


### PR DESCRIPTION
Backport of #102325 to 9.4.

Node.start() currently does not return until the node is serving http. However, other parts of the system may not be quite ready. For example, file settings may not have been applied, and we may not yet have a master node. The readiness service's purpose is to identify when the node is actually ready for serving requests.

This commit adjusts the end of startup to wait on the readiness service being ready. The ramifications are that the main Elasticsearch thread will not exit until the node is actually ready to serve requests, and the cli will not exit (when in daemon mode) until the node is ready.

closes #136955