### PR TITLE
Entitlement: skip defineHiddenClass tests on Java < 21

### DIFF
--- a/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/JvmActions.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/JvmActions.java
@@ -115,12 +115,12 @@ class JvmActions {
         MethodHandles.lookup().defineClass(new byte[0]);
     }
 
-    @EntitlementTest(expectedAccess = ES_MODULES_ONLY, expectedExceptionIfDenied = IllegalAccessException.class)
+    @EntitlementTest(expectedAccess = ES_MODULES_ONLY, expectedExceptionIfDenied = IllegalAccessException.class, fromJavaVersion = 21)
     static void defineHiddenClass() throws IllegalAccessException {
         MethodHandles.lookup().defineHiddenClass(new byte[0], false);
     }
 
-    @EntitlementTest(expectedAccess = ES_MODULES_ONLY, expectedExceptionIfDenied = IllegalAccessException.class)
+    @EntitlementTest(expectedAccess = ES_MODULES_ONLY, expectedExceptionIfDenied = IllegalAccessException.class, fromJavaVersion = 21)
     static void defineHiddenClassWithClassData() throws IllegalAccessException {
         MethodHandles.lookup().defineHiddenClassWithClassData(new byte[0], "data", false);
     }


### PR DESCRIPTION
## Summary

`ClassLoaderInstrumentation` deliberately skips instrumenting `defineHiddenClass` and `defineHiddenClassWithClassData` on Java < 21 (because on Java 17, the JVM routes all lambda creation through the public `defineHiddenClass` method). However, the corresponding `JvmActions` test methods were not similarly gated.

On Java 17 without instrumentation, the actual JVM call proceeds with empty/invalid class bytes, throwing `ClassFormatError` (an `Error`, not `Exception`). This escapes `RestEntitlementsCheckAction`'s `catch (Exception e)` block, Netty receives an uncaught `Error`, the connection closes abruptly, and the ES server crashes — causing all subsequent tests to fail with connection errors.

The fix adds `fromJavaVersion = 21` to both test methods, consistent with how `VersionSpecificNetworkChecks.createInetAddressResolverProvider` is gated at `fromJavaVersion = 18`.

Closes #151807
Closes #151808