### PR TITLE
[Search] Add `project_routing` support to the `_terms_enum` API

### DIFF
--- a/docs/changelog/151926.yaml
+++ b/docs/changelog/151926.yaml
@@ -1,0 +1,6 @@
+area: Search
+issues:
+  - 151331
+pr: 151926
+summary: "Add `project_routing` support to the `_terms_enum` API"
+type: enhancement

--- a/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/xpack/core/termsenum/TermsEnumProjectRoutingDisallowedInNonCpsEnvIT.java
+++ b/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/xpack/core/termsenum/TermsEnumProjectRoutingDisallowedInNonCpsEnvIT.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.core.termsenum;
+
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.xpack.core.LocalStateCompositeXPackPlugin;
+import org.elasticsearch.xpack.core.XPackSettings;
+import org.hamcrest.Matchers;
+
+import java.io.IOException;
+import java.util.Collection;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+
+/**
+ * Validates that the {@code _terms_enum} API rejects a {@code project_routing} parameter when the node is not running in
+ * cross-project-search mode ({@code serverless.cross_project.enabled} is off). In that case
+ * {@link org.elasticsearch.xpack.core.termsenum.action.TermsEnumRequest#validate()} returns a validation error because the
+ * request's indices options do not resolve a cross-project index expression.
+ */
+@ESIntegTestCase.ClusterScope(
+    scope = ESIntegTestCase.Scope.TEST,
+    supportsDedicatedMasters = false,
+    numDataNodes = 1,
+    numClientNodes = 0
+)
+public class TermsEnumProjectRoutingDisallowedInNonCpsEnvIT extends ESIntegTestCase {
+
+    @Override
+    protected boolean addMockHttpTransport() {
+        return false;
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return CollectionUtils.appendToCopyNoNullElements(super.nodePlugins(), LocalStateCompositeXPackPlugin.class);
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal, otherSettings))
+            .put(XPackSettings.SECURITY_ENABLED.getKey(), false)
+            .build();
+    }
+
+    public void testDisallowProjectRouting() throws IOException {
+        String index = "test";
+        assertAcked(indicesAdmin().prepareCreate(index).setMapping("foo", "type=keyword"));
+        prepareIndex(index).setSource("foo", "foo").get();
+        indicesAdmin().prepareRefresh(index).get();
+
+        Request request = new Request("POST", "/" + index + "/_terms_enum");
+        request.setJsonEntity("""
+            {
+              "field": "foo",
+              "project_routing": "_alias:_origin"
+            }
+            """);
+
+        ResponseException err = expectThrows(ResponseException.class, () -> getRestClient().performRequest(request));
+        assertThat(err.toString(), Matchers.containsString("Unknown key for a VALUE_STRING in [project_routing]"));
+    }
+}

--- a/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/xpack/core/termsenum/TermsEnumProjectRoutingIT.java
+++ b/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/xpack/core/termsenum/TermsEnumProjectRoutingIT.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.core.termsenum;
+
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.rest.ObjectPath;
+import org.elasticsearch.xpack.core.LocalStateCompositeXPackPlugin;
+import org.elasticsearch.xpack.core.XPackSettings;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Validates that the {@code _terms_enum} API accepts a {@code project_routing} parameter when the node runs in
+ * cross-project-search mode ({@code serverless.cross_project.enabled} is on). With cross-project mode enabled,
+ * {@link org.elasticsearch.xpack.core.termsenum.rest.RestTermsEnumAction} flips the request's indices options to resolve a
+ * cross-project index expression, so {@link org.elasticsearch.xpack.core.termsenum.action.TermsEnumRequest#validate()}
+ * passes and the request executes locally, returning the indexed terms.
+ * <p>
+ * This test validates only that {@code project_routing} is <em>accepted</em> and that the request <em>executes locally</em>
+ * under cross-project-enabled mode. It does NOT exercise true multi-project routing, which is performed only by the
+ * closed-source serverless {@code ProjectRoutingResolver} (absent here, a no-op in this repository) — the same limitation
+ * under which the transform/ml cross-project-search integration tests operate.
+ */
+@ESIntegTestCase.ClusterScope(
+    scope = ESIntegTestCase.Scope.TEST,
+    supportsDedicatedMasters = false,
+    numDataNodes = 1,
+    numClientNodes = 0
+)
+public class TermsEnumProjectRoutingIT extends ESIntegTestCase {
+
+    @Override
+    protected boolean addMockHttpTransport() {
+        return false;
+    }
+
+    /**
+     * Registers the {@code serverless.cross_project.enabled} node setting, which only exists in the closed-source serverless
+     * distribution. Copied verbatim from the transform/ml cross-project-search integration tests.
+     */
+    public static class CpsPlugin extends Plugin {
+        @Override
+        public List<Setting<?>> getSettings() {
+            return List.of(Setting.boolSetting("serverless.cross_project.enabled", false, Setting.Property.NodeScope));
+        }
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        final List<Class<? extends Plugin>> plugins = new ArrayList<>(super.nodePlugins());
+        plugins.add(LocalStateCompositeXPackPlugin.class);
+        plugins.add(CpsPlugin.class);
+        return plugins;
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal, otherSettings))
+            .put(XPackSettings.SECURITY_ENABLED.getKey(), false)
+            .put("serverless.cross_project.enabled", true)
+            .build();
+    }
+
+    public void testProjectRoutingAcceptedAndExecutesLocally() throws IOException {
+        String index = "test";
+        assertAcked(indicesAdmin().prepareCreate(index).setMapping("foo", "type=keyword"));
+        prepareIndex(index).setSource("foo", "foo").get();
+        prepareIndex(index).setSource("foo", "foobar").get();
+        indicesAdmin().prepareRefresh(index).get();
+
+        Request request = new Request("POST", "/" + index + "/_terms_enum");
+        request.setJsonEntity("""
+            {
+              "field": "foo",
+              "project_routing": "_alias:_origin"
+            }
+            """);
+
+        Response response = getRestClient().performRequest(request);
+        assertThat(response.getStatusLine().getStatusCode(), equalTo(200));
+
+        ObjectPath objectPath = ObjectPath.createFromResponse(response);
+        List<String> terms = objectPath.evaluate("terms");
+        assertThat(terms, containsInAnyOrder("foo", "foobar"));
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackPlugin.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackPlugin.java
@@ -376,7 +376,7 @@ public class XPackPlugin extends XPackClientPlugin
         List<RestHandler> handlers = new ArrayList<>();
         handlers.add(new RestXPackInfoAction());
         handlers.add(new RestXPackUsageAction());
-        handlers.add(new RestTermsEnumAction());
+        handlers.add(new RestTermsEnumAction(restHandlersServices.crossProjectModeDecider()));
         handlers.add(new RestGetLicenseAction());
         handlers.add(new RestPutLicenseAction());
         handlers.add(new RestDeleteLicenseAction());

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/termsenum/action/TermsEnumAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/termsenum/action/TermsEnumAction.java
@@ -28,6 +28,7 @@ public class TermsEnumAction extends ActionType<TermsEnumResponse> {
 
     static final ParseField INDEX_FILTER = new ParseField("index_filter");
     static final ParseField TIMEOUT = new ParseField("timeout");
+    static final ParseField PROJECT_ROUTING = new ParseField("project_routing");
 
     private TermsEnumAction() {
         super(NAME);
@@ -53,5 +54,6 @@ public class TermsEnumAction extends ActionType<TermsEnumResponse> {
             ObjectParser.ValueType.STRING
         );
         PARSER.declareObject(TermsEnumRequest::indexFilter, (p, context) -> parseTopLevelQuery(p), INDEX_FILTER);
+        PARSER.declareString(TermsEnumRequest::projectRouting, PROJECT_ROUTING);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/termsenum/action/TermsEnumRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/termsenum/action/TermsEnumRequest.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.core.termsenum.action;
 
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.ResolvedIndexExpressions;
 import org.elasticsearch.action.ValidateActions;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.support.IndicesOptions;
@@ -18,6 +19,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.search.crossproject.TargetProjects;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 
@@ -42,6 +44,11 @@ public final class TermsEnumRequest extends BroadcastRequest<TermsEnumRequest> i
     private int size = DEFAULT_SIZE;
     private boolean caseInsensitive;
     private QueryBuilder indexFilter;
+    private String projectRouting;
+    @Nullable
+    private ResolvedIndexExpressions resolvedIndexExpressions = null;
+    @Nullable
+    private transient TargetProjects resolvedTargetProjects = null;
 
     public TermsEnumRequest() {
         this(Strings.EMPTY_ARRAY);
@@ -134,12 +141,62 @@ public final class TermsEnumRequest extends BroadcastRequest<TermsEnumRequest> i
                 validationException = ValidateActions.addValidationError("Timeout cannot be > 1 minute", validationException);
             }
         }
+        if (projectRouting != null && indicesOptions().resolveCrossProjectIndexExpression() == false) {
+            validationException = ValidateActions.addValidationError(
+                "Unknown key for a VALUE_STRING in [project_routing]",
+                validationException
+            );
+        }
         return validationException;
     }
 
     @Override
     public boolean allowsRemoteIndices() {
         return true;
+    }
+
+    @Override
+    public boolean allowsCrossProject() {
+        return true;
+    }
+
+    @Override
+    public void setResolvedIndexExpressions(ResolvedIndexExpressions expressions) {
+        this.resolvedIndexExpressions = expressions;
+    }
+
+    @Override
+    @Nullable
+    public ResolvedIndexExpressions getResolvedIndexExpressions() {
+        return resolvedIndexExpressions;
+    }
+
+    @Override
+    public void setResolvedTargetProjects(TargetProjects targetProjects) {
+        this.resolvedTargetProjects = targetProjects;
+    }
+
+    @Override
+    @Nullable
+    public TargetProjects getResolvedTargetProjects() {
+        return resolvedTargetProjects;
+    }
+
+    /**
+     * Scopes the terms enum request to the projects matching the provided cross-project routing expression.
+     */
+    public TermsEnumRequest projectRouting(@Nullable String projectRouting) {
+        if (this.projectRouting != null) {
+            throw new IllegalArgumentException("project_routing is already set to [" + this.projectRouting + "]");
+        }
+        this.projectRouting = projectRouting;
+        return this;
+    }
+
+    @Override
+    @Nullable
+    public String getProjectRouting() {
+        return projectRouting;
     }
 
     /**

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/termsenum/rest/RestTermsEnumAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/termsenum/rest/RestTermsEnumAction.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.core.termsenum.rest;
 
+import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.rest.BaseRestHandler;
@@ -13,6 +14,7 @@ import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.Scope;
 import org.elasticsearch.rest.ServerlessScope;
 import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.search.crossproject.CrossProjectModeDecider;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.termsenum.action.TermsEnumAction;
 import org.elasticsearch.xpack.core.termsenum.action.TermsEnumRequest;
@@ -25,6 +27,12 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
 
 @ServerlessScope(Scope.PUBLIC)
 public class RestTermsEnumAction extends BaseRestHandler {
+
+    private final CrossProjectModeDecider crossProjectModeDecider;
+
+    public RestTermsEnumAction(CrossProjectModeDecider crossProjectModeDecider) {
+        this.crossProjectModeDecider = crossProjectModeDecider;
+    }
 
     @Override
     public List<Route> routes() {
@@ -43,6 +51,13 @@ public class RestTermsEnumAction extends BaseRestHandler {
                 parser,
                 Strings.splitStringByCommaToArray(request.param("index"))
             );
+            if (crossProjectModeDecider.crossProjectEnabled() && termEnumRequest.allowsCrossProject()) {
+                termEnumRequest.indicesOptions(
+                    IndicesOptions.builder(termEnumRequest.indicesOptions())
+                        .crossProjectModeOptions(new IndicesOptions.CrossProjectModeOptions(true))
+                        .build()
+                );
+            }
             return channel -> client.execute(TermsEnumAction.INSTANCE, termEnumRequest, new RestToXContentListener<>(channel));
         }
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/termsenum/TermsEnumRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/termsenum/TermsEnumRequestTests.java
@@ -31,6 +31,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 
+import static org.hamcrest.Matchers.containsString;
+
 public class TermsEnumRequestTests extends AbstractXContentSerializingTestCase<TermsEnumRequest> {
     private NamedXContentRegistry xContentRegistry;
     private NamedWriteableRegistry namedWriteableRegistry;
@@ -149,5 +151,22 @@ public class TermsEnumRequestTests extends AbstractXContentSerializingTestCase<T
             "prefix string larger than 32766 characters, which is the maximum allowed term length for keyword fields.",
             validationException.validationErrors().get(0)
         );
+    }
+
+    public void testProjectRoutingAllowedInCpsMode() {
+        TermsEnumRequest request = new TermsEnumRequest("idx").field("f");
+        // indices options that resolve a cross-project index expression mirror what RestTermsEnumAction sets in CPS mode
+        request.indicesOptions(IndicesOptions.CPS_LENIENT_EXPAND_OPEN);
+        request.projectRouting("_alias:_origin");
+        assertNull(request.validate());
+    }
+
+    public void testProjectRoutingRejectedWithoutCpsMode() {
+        TermsEnumRequest request = new TermsEnumRequest("idx").field("f");
+        // default indices options do not resolve a cross-project index expression, so project_routing is not allowed
+        request.projectRouting("_alias:_origin");
+        ActionRequestValidationException validationException = request.validate();
+        assertNotNull(validationException);
+        assertThat(validationException.getMessage(), containsString("Unknown key for a VALUE_STRING in [project_routing]"));
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/termsenum/action/RestTermsEnumActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/termsenum/action/RestTermsEnumActionTests.java
@@ -21,6 +21,7 @@ import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.search.SearchModule;
+import org.elasticsearch.search.crossproject.CrossProjectModeDecider;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskManager;
 import org.elasticsearch.telemetry.TelemetryProvider;
@@ -59,7 +60,7 @@ public class RestTermsEnumActionTests extends ESTestCase {
         usageService,
         TelemetryProvider.NOOP
     );
-    private static RestTermsEnumAction action = new RestTermsEnumAction();
+    private static RestTermsEnumAction action = new RestTermsEnumAction(CrossProjectModeDecider.NOOP);
 
     /**
      * Configures {@link NodeClient} to stub {@link TermsEnumAction} transport action.

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/termsenum/action/RestTermsEnumActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/termsenum/action/RestTermsEnumActionTests.java
@@ -41,10 +41,12 @@ import org.junit.BeforeClass;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.Collections.emptyMap;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 
 public class RestTermsEnumActionTests extends ESTestCase {
@@ -63,6 +65,12 @@ public class RestTermsEnumActionTests extends ESTestCase {
     private static RestTermsEnumAction action = new RestTermsEnumAction(CrossProjectModeDecider.NOOP);
 
     /**
+     * Captures the {@link TermsEnumRequest} that the stubbed transport action receives so tests can assert how
+     * {@link RestTermsEnumAction} prepared it (e.g. whether cross-project index expression resolution was enabled).
+     */
+    private static final AtomicReference<TermsEnumRequest> capturedRequest = new AtomicReference<>();
+
+    /**
      * Configures {@link NodeClient} to stub {@link TermsEnumAction} transport action.
      * <p>
      * This lower level of execution is out of the scope of this test.
@@ -78,7 +86,9 @@ public class RestTermsEnumActionTests extends ESTestCase {
             EsExecutors.DIRECT_EXECUTOR_SERVICE
         ) {
             @Override
-            protected void doExecute(Task task, ActionRequest request, ActionListener<ActionResponse> listener) {}
+            protected void doExecute(Task task, ActionRequest request, ActionListener<ActionResponse> listener) {
+                capturedRequest.set((TermsEnumRequest) request);
+            }
         };
 
         final Map<ActionType<?>, TransportAction<?, ?>> actions = new HashMap<>();
@@ -162,6 +172,48 @@ public class RestTermsEnumActionTests extends ESTestCase {
         assertThat(channel.responses().get(), equalTo(0));
         assertThat(channel.errors().get(), equalTo(1));
         assertThat(channel.capturedResponse().content().utf8ToString(), containsString("field cannot be null"));
+    }
+
+    public void testRestTermEnumActionCrossProjectEnabled() throws Exception {
+        // GIVEN a REST handler whose decider has cross-project mode enabled
+        final RestTermsEnumAction crossProjectAction = new RestTermsEnumAction(
+            new CrossProjectModeDecider(Settings.builder().put("serverless.cross_project.enabled", true).build())
+        );
+
+        capturedRequest.set(null);
+        final RestRequest request = createRestRequest("""
+            {
+              "field": "a"
+            }""");
+        final FakeRestChannel channel = new FakeRestChannel(request, true);
+
+        // WHEN the handler prepares and executes the request (no route registration, direct dispatch)
+        crossProjectAction.handleRequest(request, channel, client);
+
+        // THEN the executed request resolves a cross-project index expression
+        assertThat(channel.errors().get(), equalTo(0));
+        assertNotNull(capturedRequest.get());
+        assertThat(capturedRequest.get().indicesOptions().resolveCrossProjectIndexExpression(), is(true));
+    }
+
+    public void testRestTermEnumActionCrossProjectDisabled() throws Exception {
+        // GIVEN a REST handler whose decider leaves cross-project mode disabled (the NOOP control)
+        final RestTermsEnumAction nonCrossProjectAction = new RestTermsEnumAction(CrossProjectModeDecider.NOOP);
+
+        capturedRequest.set(null);
+        final RestRequest request = createRestRequest("""
+            {
+              "field": "a"
+            }""");
+        final FakeRestChannel channel = new FakeRestChannel(request, true);
+
+        // WHEN the handler prepares and executes the request (no route registration, direct dispatch)
+        nonCrossProjectAction.handleRequest(request, channel, client);
+
+        // THEN the executed request does not resolve a cross-project index expression
+        assertThat(channel.errors().get(), equalTo(0));
+        assertNotNull(capturedRequest.get());
+        assertThat(capturedRequest.get().indicesOptions().resolveCrossProjectIndexExpression(), is(false));
     }
 
     private RestRequest createRestRequest(String content) {


### PR DESCRIPTION
Resolves #151331.

`_terms_enum` currently does not support `project_routing`, which makes it inconsistent with the cross-project request routing used by other APIs. Adding support lets clients scope term enum requests to the intended project and avoid cross-project ambiguity.

This supersedes #151791, which I was not able to reopen as the author after it was closed. It carries the same change plus the integration tests requested there.

### Tests
- `TermsEnumProjectRoutingDisallowedInNonCpsEnvIT` (internalClusterTest): `_terms_enum` with `project_routing` is rejected outside cross-project mode.
- `TermsEnumProjectRoutingIT` (internalClusterTest): with `serverless.cross_project.enabled`, the request is accepted and runs against a local index.
- `TermsEnumRequestTests`: both `validate()` branches (accepted in cross-project mode, rejected otherwise).
- `RestTermsEnumActionTests`: the REST handler flips on cross-project mode when it is enabled.

These do not exercise true multi-project routing, since `ProjectRoutingResolver` is a no-op in the open source build (the real resolver ships with serverless), so `_alias:_origin` resolves to the local project. That is the same scope the existing transform and ml cross-project integration tests cover.

- [x] I have signed the [contributor license agreement](https://www.elastic.co/contributor-agreement).
- [x] I have followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md).
- [x] The pull request targets `main`.
- [x] This is not a class submission.
