### PR TITLE
[9.4] Fix libs/build.gradle subprojects scope and processor precommit

### DIFF
--- a/libs/build.gradle
+++ b/libs/build.gradle
@@ -7,37 +7,29 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-configure(childProjects.values()) {
+subprojects {
 
   apply plugin: 'base'
 
   /*
    * Although these libs are local to Elasticsearch, they can conflict with other similarly
    * named libraries when downloaded into a single directory via maven. Here we set the
-   * name of all libs to begin with the "elasticsearch-" prefix. Additionally, subprojects
-   * of libs begin with their parents artifactId.
+   * name of all libs to begin with the "elasticsearch-" prefix, followed by all path
+   * segments below :libs joined with dashes.
+   * e.g. :libs:foreign-library          -> elasticsearch-foreign-library
+   *      :libs:entitlement:tools:common -> elasticsearch-entitlement-tools-common
    */
-  def baseProject = project
-  def baseArtifactId = "elasticsearch-${it.name}"
   base {
-    archivesName = baseArtifactId
-  }
-  subprojects {
-    apply plugin: 'base'
-
-    def subArtifactId = baseArtifactId
-    def currentProject = project
-    while (currentProject != baseProject) {
-      subArtifactId += "-${currentProject.name}"
-      currentProject = currentProject.parent
-    }
-    base {
-      archivesName = subArtifactId
-    }
+    archivesName = "elasticsearch-${project.path.substring(':libs:'.length()).replace(':', '-')}"
   }
 
-  // log4j is a hack, and not really a full elasticsearch built jar
-  if (project.name != 'log4j') {
+  // log4j is a hack, and not really a full elasticsearch built jar.
+  // native-libraries only repackages prebuilt native binaries (zstd/vec/parquet) and publishes
+  // them through a custom `default` directory artifact; applying elasticsearch.build (and thus the
+  // java plugin) replaces that artifact with java variants, so the distribution's `platform/` copy
+  // resolves an empty jar instead of the extracted .so/.dylib files. See libs/native/libraries.
+  def nonBuildLibs = ['log4j', 'native-libraries']
+  if (false == nonBuildLibs.contains(project.name)) {
 
     /*
      * All subprojects are java projects using Elasticsearch's standard build

--- a/libs/entitlement/qa/src/javaRestTest/java/org/elasticsearch/entitlement/qa/EntitlementsAllowedViaOverrideIT.java
+++ b/libs/entitlement/qa/src/javaRestTest/java/org/elasticsearch/entitlement/qa/EntitlementsAllowedViaOverrideIT.java
@@ -35,7 +35,7 @@ public class EntitlementsAllowedViaOverrideIT extends AbstractEntitlementsIT {
                     - path: %s
                       mode: read
             """, ENTITLEMENT_QA_TEST_MODULE_NAME, tempDir.resolve("read_dir"));
-        var encodedPolicyOverride = new String(Base64.getEncoder().encode(policyOverride.getBytes(StandardCharsets.UTF_8)));
+        var encodedPolicyOverride = Base64.getEncoder().encodeToString(policyOverride.getBytes(StandardCharsets.UTF_8));
         return Map.of("es.entitlements.policy." + ENTITLEMENT_TEST_PLUGIN_NAME, encodedPolicyOverride);
     }
 

--- a/libs/entitlement/qa/src/javaRestTest/java/org/elasticsearch/entitlement/qa/EntitlementsTestRule.java
+++ b/libs/entitlement/qa/src/javaRestTest/java/org/elasticsearch/entitlement/qa/EntitlementsTestRule.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.entitlement.qa;
 
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.cluster.local.PluginInstallSpec;
 import org.elasticsearch.test.cluster.util.resource.Resource;
@@ -29,6 +30,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 
+@SuppressForbidden(reason = "TemporaryFolder.getRoot() returns java.io.File; System.out used for test setup debug logging")
 class EntitlementsTestRule implements TestRule {
 
     // entitlements that test methods may use, see EntitledActions
@@ -87,6 +89,7 @@ class EntitlementsTestRule implements TestRule {
         testDir = new TemporaryFolder();
         var tempDirSetup = new ExternalResource() {
             @Override
+            @SuppressForbidden(reason = "TemporaryFolder.getRoot() returns java.io.File")
             protected void before() throws Throwable {
                 Path testPath = testDir.getRoot().toPath();
                 Files.createDirectory(testPath.resolve("read_dir"));


### PR DESCRIPTION
Backport of #151720 to 9.4.

**Note:** Changes to `libs/foreign-library/processor` are not included — that module does not exist on this branch.