### PR TITLE
[ES|QL] Allow expressions in SPARKLINE argument (#150506)

### DIFF
--- a/docs/changelog/151953.yaml
+++ b/docs/changelog/151953.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 150506
+pr: 151953
+summary: Allow expressions over aggregates in SPARKLINE
+type: bug

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats_sparkline.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats_sparkline.csv-spec
@@ -295,6 +295,36 @@ s:long | t:null
 1      | null
 ;
 
+sparklineWithCountPlusConstant
+required_capability: fn_sparkline_expressions
+FROM employees
+| STATS sparkline = SPARKLINE(COUNT(*)+1, hire_date, 20, "1985-01-01T00:00:00Z", "1985-12-31T00:00:00Z")
+;
+
+sparkline:long
+[0, 3, 0, 0, 2, 0, 2, 0, 2, 3, 5, 0]
+;
+
+sparklineWithMaxPlusConstant
+required_capability: fn_sparkline_expressions
+FROM employees
+| STATS sparkline = SPARKLINE(MAX(salary)+1, hire_date, 20, "1985-01-01T00:00:00Z", "1985-12-31T00:00:00Z")
+;
+
+sparkline:integer
+[0, 66175, 0, 0, 44818, 0, 62406, 0, 49096, 54330, 75000, 0]
+;
+
+sparklineWithSumOfTwoAggregates
+required_capability: fn_sparkline_expressions
+FROM employees
+| STATS sparkline = SPARKLINE(MAX(salary)+MIN(salary), hire_date, 20, "1985-01-01T00:00:00Z", "1985-12-31T00:00:00Z")
+;
+
+sparkline:integer
+[0, 92610, 0, 0, 89634, 0, 124810, 0, 98190, 103064, 108955, 0]
+;
+
 sparklineComplexWithGroupingMapped
 required_capability: fn_sparkline_nested
 FROM employees

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Sparkline.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Sparkline.java
@@ -14,6 +14,7 @@ import org.elasticsearch.compute.operator.SparklineGenerateEmptyBucketsOperator;
 import org.elasticsearch.xpack.esql.capabilities.PostAnalysisVerificationAware;
 import org.elasticsearch.xpack.esql.common.Failure;
 import org.elasticsearch.xpack.esql.common.Failures;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
@@ -96,7 +97,8 @@ public class Sparkline extends AggregateFunction implements AggregateMetricDoubl
             "null_alongside", // Fix for null aggs (e.g. COUNT_DISTINCT(null)) paired with SPARKLINE
             "reject_mv", // Rejects multi-valued aggregates (TOP, SAMPLE, VALUES) as first argument
             "duplicate_surrogates", // Fix for surrogate aggs appearing both inside and outside SPARKLINE
-            "nested" // Fix for more SPARKLINE nested in another expression
+            "nested", // Fix for more SPARKLINE nested in another expression
+            "expressions" // Accepts expressions over aggregates as first argument (e.g. COUNT()+1, MIN(a)+MIN(b))
         )
         .name("sparkline");
 
@@ -156,7 +158,7 @@ public class Sparkline extends AggregateFunction implements AggregateMetricDoubl
         TypeResolution fieldNullCheck = isNotNull(field(), sourceText(), FIRST);
         if (fieldNullCheck.unresolved()) {
             return fieldNullCheck;
-        } else if (field() instanceof AggregateFunction == false) {
+        } else if (field().anyMatch(AggregateFunction.class::isInstance) == false) {
             return new TypeResolution(
                 LoggerMessageFormat.format(
                     null,
@@ -164,6 +166,16 @@ public class Sparkline extends AggregateFunction implements AggregateMetricDoubl
                     sourceText(),
                     field().sourceText(),
                     field().dataType().typeName()
+                )
+            );
+        } else if (hasAttributeOutsideAggregate(field())) {
+            return new TypeResolution(
+                LoggerMessageFormat.format(
+                    null,
+                    "first argument of [{}] must aggregate to a single value; every field referenced in [{}] must be inside "
+                        + "an aggregate function (grouping keys included)",
+                    sourceText(),
+                    field().sourceText()
                 )
             );
         }
@@ -209,9 +221,31 @@ public class Sparkline extends AggregateFunction implements AggregateMetricDoubl
         }
     }
 
+    /**
+     * Returns {@code true} if the expression contains an {@link Attribute} that is not enclosed in an
+     * {@link AggregateFunction}. Such an attribute is a per-row value, so the expression would not
+     * aggregate to the single value a sparkline data point requires (e.g. {@code salary + 1} as opposed
+     * to {@code MIN(salary) + 1}). Aggregate functions are treated as leaves: anything inside them is
+     * already aggregated and need not be inspected.
+     */
+    private static boolean hasAttributeOutsideAggregate(Expression e) {
+        if (e instanceof AggregateFunction) {
+            return false;
+        }
+        if (e instanceof Attribute) {
+            return true;
+        }
+        for (Expression child : e.children()) {
+            if (hasAttributeOutsideAggregate(child)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     @Override
     public void postAnalysisVerification(Failures failures) {
-        if (field() instanceof Top || field() instanceof Sample || field() instanceof Values) {
+        if (field().anyMatch(e -> e instanceof Top || e instanceof Sample || e instanceof Values)) {
             failures.add(
                 new Failure(
                     this,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceSparklineAggregate.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceSparklineAggregate.java
@@ -202,17 +202,25 @@ public class ReplaceSparklineAggregate extends OptimizerRules.ParameterizedOptim
 
         ParserUtils.Stats firstPhaseStats = ParserUtils.buildStats(source, firstPhaseGroupings, firstPhaseAggregates);
         Aggregate aggregate = new Aggregate(plan.source(), dateBucketEval, firstPhaseStats.groupings(), firstPhaseStats.aggregates());
-        // Since this rule has to occur after PropogateInlineEvals to work with INLINE STATS, we don't get surrogate substitution
-        // to handle inner aggregates that are SurrogateExpressions (e.g., AVG → Div(Sum, Count)). We apply the substitution here to ensure
-        // that any inner aggregates are properly replaced with their surrogates in the first phase plan.
-        LogicalPlan phase1Plan = new SubstituteSurrogateAggregations().apply(aggregate);
-        // For the same reason, ReplaceAggregateNestedExpressionWithEval has already run and will not run again. Apply it here so
-        // that non-trivial scalar expressions in the inner aggregate's field (e.g. SUM(SIN(salary))) are extracted into a preceding
-        // Eval, ensuring the physical planner assigns a correctly-typed channel to the aggregator.
-        // Use locally-unique synthetic names: the same surrogate may also appear standalone in this STATS (e.g. WEIGHTED_AVG used both
-        // directly and inside SPARKLINE), in which case its inner expression was already extracted into an identically-named synthetic
-        // Eval by the global pass. Reusing that name here would make one of the two extractions be dropped by output-attribute merging,
-        // leaving a dangling reference.
+        // The aggregate-handling rules from the main Substitutions batch (see LogicalPlanOptimizer#substitutions) ran before this rule
+        // (it lives after PropagateInlineEvals) and will not run again, yet the first-phase Aggregate we just built embeds the inner
+        // aggregation (Sparkline.field(), e.g. COUNT()+1) which those rules never saw. Re-apply just the inner-aggregation lowering subset
+        // of that batch so the inner aggregation is lowered like an ordinary STATS:
+        // 1. extract scalar expressions nested inside an aggregate (e.g. SUM(SIN(salary))) into a preceding Eval;
+        // 2. extract aggregates wrapped in a top-level expression (e.g. COUNT()+1, MIN(a)+MIN(b)) into naked aggs plus a following Eval;
+        // 3. expand surrogate aggregates (e.g. AVG -> Div(Sum, Count)). This must run after step 2 so that a surrogate hidden inside an
+        // expression (e.g. AVG(x)+1) is first exposed as a naked top-level agg and only then expanded;
+        // 4. re-extract any scalar expressions surfaced by surrogate expansion, using locally-unique synthetic names to avoid collisions
+        // when the same surrogate also appears standalone in this STATS (e.g. WEIGHTED_AVG used both directly and inside SPARKLINE).
+        // This is a subset, not a verbatim copy, of the main batch: RewriteSumOfExpressionPlusConstant (a SUM(x +/- c) optimization) and
+        // SubstituteFilteredExpression are intentionally left out -- the former is optional and the latter already ran in the main batch,
+        // so any SPARKLINE WHERE filter is already attached to the inner aggregate. The main batch also runs
+        // SubstituteSurrogateAggregations twice for a CCS/bwc reason that does not apply to this freshly built local Aggregate, so a
+        // single pass is enough here. Without steps 2-3 the physical planner cannot assign a correctly-typed channel to an aggregate that
+        // is part of an expression.
+        LogicalPlan phase1Plan = new ReplaceAggregateNestedExpressionWithEval().apply(aggregate);
+        phase1Plan = new ReplaceAggregateAggExpressionWithEval().apply(phase1Plan);
+        phase1Plan = new SubstituteSurrogateAggregations().apply(phase1Plan);
         phase1Plan = new ReplaceAggregateNestedExpressionWithEval(true).apply(phase1Plan);
         return new FirstPhaseAggregateData(phase1Plan, sparklineValueAliases, toPartialAliases, originalAggFuncs, dateBucketAttr);
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceSparklineAggregate.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceSparklineAggregate.java
@@ -203,17 +203,25 @@ public class ReplaceSparklineAggregate extends OptimizerRules.ParameterizedOptim
 
         ParserUtils.Stats firstPhaseStats = ParserUtils.buildStats(source, firstPhaseGroupings, firstPhaseAggregates);
         Aggregate aggregate = new Aggregate(plan.source(), dateBucketEval, firstPhaseStats.groupings(), firstPhaseStats.aggregates());
-        // Since this rule has to occur after PropogateInlineEvals to work with INLINE STATS, we don't get surrogate substitution
-        // to handle inner aggregates that are SurrogateExpressions (e.g., AVG → Div(Sum, Count)). We apply the substitution here to ensure
-        // that any inner aggregates are properly replaced with their surrogates in the first phase plan.
-        LogicalPlan phase1Plan = new SubstituteSurrogateAggregations().apply(aggregate);
-        // For the same reason, ReplaceAggregateNestedExpressionWithEval has already run and will not run again. Apply it here so
-        // that non-trivial scalar expressions in the inner aggregate's field (e.g. SUM(SIN(salary))) are extracted into a preceding
-        // Eval, ensuring the physical planner assigns a correctly-typed channel to the aggregator.
-        // Use locally-unique synthetic names: the same surrogate may also appear standalone in this STATS (e.g. WEIGHTED_AVG used both
-        // directly and inside SPARKLINE), in which case its inner expression was already extracted into an identically-named synthetic
-        // Eval by the global pass. Reusing that name here would make one of the two extractions be dropped by output-attribute merging,
-        // leaving a dangling reference.
+        // The aggregate-handling rules from the main Substitutions batch (see LogicalPlanOptimizer#substitutions) ran before this rule
+        // (it lives after PropagateInlineEvals) and will not run again, yet the first-phase Aggregate we just built embeds the inner
+        // aggregation (Sparkline.field(), e.g. COUNT()+1) which those rules never saw. Re-apply just the inner-aggregation lowering subset
+        // of that batch so the inner aggregation is lowered like an ordinary STATS:
+        // 1. extract scalar expressions nested inside an aggregate (e.g. SUM(SIN(salary))) into a preceding Eval;
+        // 2. extract aggregates wrapped in a top-level expression (e.g. COUNT()+1, MIN(a)+MIN(b)) into naked aggs plus a following Eval;
+        // 3. expand surrogate aggregates (e.g. AVG -> Div(Sum, Count)). This must run after step 2 so that a surrogate hidden inside an
+        // expression (e.g. AVG(x)+1) is first exposed as a naked top-level agg and only then expanded;
+        // 4. re-extract any scalar expressions surfaced by surrogate expansion, using locally-unique synthetic names to avoid collisions
+        // when the same surrogate also appears standalone in this STATS (e.g. WEIGHTED_AVG used both directly and inside SPARKLINE).
+        // This is a subset, not a verbatim copy, of the main batch: RewriteSumOfExpressionPlusConstant (a SUM(x +/- c) optimization) and
+        // SubstituteFilteredExpression are intentionally left out -- the former is optional and the latter already ran in the main batch,
+        // so any SPARKLINE WHERE filter is already attached to the inner aggregate. The main batch also runs
+        // SubstituteSurrogateAggregations twice for a CCS/bwc reason that does not apply to this freshly built local Aggregate, so a
+        // single pass is enough here. Without steps 2-3 the physical planner cannot assign a correctly-typed channel to an aggregate that
+        // is part of an expression.
+        LogicalPlan phase1Plan = new ReplaceAggregateNestedExpressionWithEval().apply(aggregate);
+        phase1Plan = new ReplaceAggregateAggExpressionWithEval().apply(phase1Plan);
+        phase1Plan = new SubstituteSurrogateAggregations().apply(phase1Plan);
         phase1Plan = new ReplaceAggregateNestedExpressionWithEval(true).apply(phase1Plan);
         return new FirstPhaseAggregateData(phase1Plan, sparklineValueAliases, toPartialAliases, originalAggFuncs, dateBucketAttr);
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
@@ -1870,6 +1870,36 @@ public class VerifierTests extends ESTestCase {
         );
     }
 
+    public void testSparklineAcceptsExpressionsOverAggregates() {
+        String sparklineArgs = "hire_date, 10, \"2024-01-01\", \"2024-02-01\"";
+        // should not throw
+        defaultAnalyzer().query("from test | stats s = SPARKLINE(COUNT()+1, " + sparklineArgs + ")");
+        defaultAnalyzer().query("from test | stats s = SPARKLINE(MIN(salary)+MIN(emp_no), " + sparklineArgs + ")");
+        defaultAnalyzer().query("from test | stats s = SPARKLINE(AVG(salary)*2, " + sparklineArgs + ")");
+    }
+
+    public void testSparklineRejectsExpressionsWithBareFields() {
+        String sparklineArgs = "hire_date, 10, \"2024-01-01\", \"2024-02-01\"";
+        // no aggregate at all in the expression
+        defaultAnalyzer().error(
+            "from test | stats s = SPARKLINE(salary+1, " + sparklineArgs + ")",
+            containsString("must be an aggregate function")
+        );
+        // contains an aggregate but also a bare field outside it
+        defaultAnalyzer().error(
+            "from test | stats s = SPARKLINE(MIN(salary)+emp_no, " + sparklineArgs + ")",
+            containsString("must aggregate to a single value; every field referenced in")
+        );
+    }
+
+    public void testSparklineRejectsMultiValuedAggsInsideExpressions() {
+        String sparklineArgs = "hire_date, 10, \"2024-01-01\", \"2024-02-01\"";
+        defaultAnalyzer().error(
+            "from test | stats s = SPARKLINE(TOP(avg_worked_seconds, 3, \"asc\")+1, " + sparklineArgs + ")",
+            containsString("must be a single-valued aggregate function")
+        );
+    }
+
     public void testWeightedAvg() {
         defaultAnalyzer().error(
             "row v = [1, 2, 3] | stats w_avg = weighted_avg(v, null)",

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
@@ -1921,6 +1921,36 @@ public class VerifierTests extends ESTestCase {
         );
     }
 
+    public void testSparklineAcceptsExpressionsOverAggregates() {
+        String sparklineArgs = "hire_date, 10, \"2024-01-01\", \"2024-02-01\"";
+        // should not throw
+        defaultAnalyzer().query("from test | stats s = SPARKLINE(COUNT()+1, " + sparklineArgs + ")");
+        defaultAnalyzer().query("from test | stats s = SPARKLINE(MIN(salary)+MIN(emp_no), " + sparklineArgs + ")");
+        defaultAnalyzer().query("from test | stats s = SPARKLINE(AVG(salary)*2, " + sparklineArgs + ")");
+    }
+
+    public void testSparklineRejectsExpressionsWithBareFields() {
+        String sparklineArgs = "hire_date, 10, \"2024-01-01\", \"2024-02-01\"";
+        // no aggregate at all in the expression
+        defaultAnalyzer().error(
+            "from test | stats s = SPARKLINE(salary+1, " + sparklineArgs + ")",
+            containsString("must be an aggregate function")
+        );
+        // contains an aggregate but also a bare field outside it
+        defaultAnalyzer().error(
+            "from test | stats s = SPARKLINE(MIN(salary)+emp_no, " + sparklineArgs + ")",
+            containsString("must aggregate to a single value; every field referenced in")
+        );
+    }
+
+    public void testSparklineRejectsMultiValuedAggsInsideExpressions() {
+        String sparklineArgs = "hire_date, 10, \"2024-01-01\", \"2024-02-01\"";
+        defaultAnalyzer().error(
+            "from test | stats s = SPARKLINE(TOP(avg_worked_seconds, 3, \"asc\")+1, " + sparklineArgs + ")",
+            containsString("must be a single-valued aggregate function")
+        );
+    }
+
     public void testWeightedAvg() {
         defaultAnalyzer().error(
             "row v = [1, 2, 3] | stats w_avg = weighted_avg(v, null)",

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/SparklineValidationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/SparklineValidationTests.java
@@ -8,10 +8,13 @@
 package org.elasticsearch.xpack.esql.expression.function.aggregate;
 
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.EsqlTestUtils;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Add;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Mul;
 
 import java.util.Locale;
 
@@ -35,6 +38,79 @@ public class SparklineValidationTests extends ESTestCase {
         );
         assertTrue(s.typeResolved().unresolved());
         assertThat(s.typeResolved().message(), equalTo("first argument of [] must be an aggregate function, found value [] type [double]"));
+    }
+
+    public void testFieldIsExpressionContainingAggregate() {
+        Sparkline s = sparkline(
+            new Add(Source.synthetic(""), validAggField(), new Literal(Source.synthetic(""), 1, DataType.INTEGER), EsqlTestUtils.TEST_CFG),
+            validKey(),
+            validBuckets(),
+            validFrom(),
+            validTo()
+        );
+        assertTrue(s.typeResolved().resolved());
+    }
+
+    public void testFieldIsExpressionOverMultipleAggregates() {
+        Sparkline s = sparkline(
+            new Add(
+                Source.synthetic(""),
+                validAggField(),
+                new Min(Source.synthetic(""), field("g", DataType.DOUBLE)),
+                EsqlTestUtils.TEST_CFG
+            ),
+            validKey(),
+            validBuckets(),
+            validFrom(),
+            validTo()
+        );
+        assertTrue(s.typeResolved().resolved());
+    }
+
+    public void testFieldIsAggregateTimesConstant() {
+        Sparkline s = sparkline(
+            new Mul(Source.synthetic(""), validAggField(), new Literal(Source.synthetic(""), 2, DataType.INTEGER)),
+            validKey(),
+            validBuckets(),
+            validFrom(),
+            validTo()
+        );
+        assertTrue(s.typeResolved().resolved());
+    }
+
+    public void testFieldExpressionWithoutAggregate() {
+        Sparkline s = sparkline(
+            new Add(
+                Source.synthetic(""),
+                field("f", DataType.DOUBLE),
+                new Literal(Source.synthetic(""), 1, DataType.INTEGER),
+                EsqlTestUtils.TEST_CFG
+            ),
+            validKey(),
+            validBuckets(),
+            validFrom(),
+            validTo()
+        );
+        assertTrue(s.typeResolved().unresolved());
+        assertThat(s.typeResolved().message(), equalTo("first argument of [] must be an aggregate function, found value [] type [double]"));
+    }
+
+    public void testFieldExpressionWithBareFieldOutsideAggregate() {
+        Sparkline s = sparkline(
+            new Add(Source.synthetic(""), validAggField(), field("g", DataType.DOUBLE), EsqlTestUtils.TEST_CFG),
+            validKey(),
+            validBuckets(),
+            validFrom(),
+            validTo()
+        );
+        assertTrue(s.typeResolved().unresolved());
+        assertThat(
+            s.typeResolved().message(),
+            equalTo(
+                "first argument of [] must aggregate to a single value; every field referenced in [] must be inside "
+                    + "an aggregate function (grouping keys included)"
+            )
+        );
     }
 
     public void testFieldWrongType() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceSparklineAggregateTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceSparklineAggregateTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.xpack.esql.core.expression.Expressions;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.AggregateFunction;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Count;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.FromPartial;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Sum;
@@ -42,6 +43,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
 public class ReplaceSparklineAggregateTests extends AbstractLogicalPlanOptimizerTests {
@@ -166,6 +168,28 @@ public class ReplaceSparklineAggregateTests extends AbstractLogicalPlanOptimizer
         );
     }
 
+    public void testSparklineWithExpressionOverAggregate() {
+        LogicalPlan plan = plan("from test | stats s = sparkline(count(*)+1, hire_date, 10, \"2024-01-01\", \"2024-12-31\")");
+        assertThat(collect(plan, SparklineGenerateEmptyBuckets.class), hasSize(1));
+        // count(*)+1 must be lowered: no aggregate may remain buried inside an expression in any STATS
+        assertNoAggregateBuriedInExpression(plan);
+        // the naked count survived the rewrite
+        assertThat(collectAggregateFunctions(plan), hasItem(instanceOf(Count.class)));
+    }
+
+    public void testSparklineWithSurrogateAggregateExpression() {
+        // AVG is a surrogate (Div(Sum, Count)); avg(salary)+1 exercises the
+        // ReplaceAggregateAggExpressionWithEval-before-SubstituteSurrogateAggregations ordering: the surrogate must first be
+        // exposed as a naked top-level agg, then expanded.
+        LogicalPlan plan = plan("from test | stats s = sparkline(avg(salary)+1, hire_date, 10, \"2024-01-01\", \"2024-12-31\")");
+        assertThat(collect(plan, SparklineGenerateEmptyBuckets.class), hasSize(1));
+        assertNoAggregateBuriedInExpression(plan);
+        // AVG expanded into naked Sum and Count
+        List<AggregateFunction> aggs = collectAggregateFunctions(plan);
+        assertThat(aggs, hasItem(instanceOf(Sum.class)));
+        assertThat(aggs, hasItem(instanceOf(Count.class)));
+    }
+
     public void testBucketCountExceedsLimit() {
         var e = expectThrows(IllegalArgumentException.class, () -> plan("""
             from test | stats s = sparkline(count(*), hire_date, 101, "2024-01-01", "2024-12-31")
@@ -198,6 +222,39 @@ public class ReplaceSparklineAggregateTests extends AbstractLogicalPlanOptimizer
                     s2 = sparkline(max(salary), hire_date, 10, "2024-01-01", "2024-06-30")
             """));
         assertThat(e.getMessage(), containsString("All SPARKLINE functions in a single STATS command must share the same"));
+    }
+
+    private static <T extends LogicalPlan> List<T> collect(LogicalPlan plan, Class<T> cls) {
+        List<T> found = new ArrayList<>();
+        plan.forEachDown(cls, found::add);
+        return found;
+    }
+
+    private static List<AggregateFunction> collectAggregateFunctions(LogicalPlan plan) {
+        List<AggregateFunction> found = new ArrayList<>();
+        plan.forEachExpressionDown(AggregateFunction.class, found::add);
+        return found;
+    }
+
+    /**
+     * Asserts that no STATS in the plan still holds an aggregate function buried inside an expression
+     * (e.g. {@code COUNT()+1}); every aggregate must have been lifted into a naked agg with the
+     * surrounding arithmetic pushed into a following {@code EVAL}. Otherwise the physical planner
+     * cannot assign a channel to it.
+     */
+    private static void assertNoAggregateBuriedInExpression(LogicalPlan plan) {
+        plan.forEachDown(Aggregate.class, agg -> {
+            for (NamedExpression ne : agg.aggregates()) {
+                Expression unwrapped = Alias.unwrap(ne);
+                if (unwrapped instanceof AggregateFunction == false) {
+                    assertThat(
+                        "aggregate function must not remain buried inside expression [" + ne + "]",
+                        unwrapped.anyMatch(AggregateFunction.class::isInstance),
+                        is(false)
+                    );
+                }
+            }
+        });
     }
 
     private void validateSparklineGenerateEmptyBuckets(SparklineGenerateEmptyBuckets sparkline, List<String> sparklineAggregateNames) {


### PR DESCRIPTION
`SPARKLINE`'s first argument currently has to be a bare aggregate function, so

```esql
FROM ... | STATS s = SPARKLINE(COUNT()+1, @timestamp, 20, "...", "...")
```

fails analysis with *"first argument ... must be an aggregate function, found value [COUNT()+1]"* — even though every other aggregate happily accepts expressions over aggregates (`SUM(x)+1`, `MIN(a)+MIN(b)`, `AVG(x)*2`). This PR lifts that restriction.

Closes https://github.com/elastic/elasticsearch/issues/150506

### What changed

- **Validation** (`Sparkline#resolveType`): accept the first argument when it *contains* an aggregate, and reject it only when a field is referenced outside an aggregate, so the value still collapses to a single number per bucket. The multi-valued-aggregate guard (`TOP`/`SAMPLE`/`VALUES`) now walks the whole expression, so `TOP(x)+1` stays rejected.
- **Lowering** (`ReplaceSparklineAggregate`): the first-phase aggregate now re-applies the same inner-aggregation lowering the main optimizer batch uses (extract nested expressions → pull aggregates out of a wrapping expression → expand surrogates). `COUNT()+1` becomes a naked `COUNT()` plus a following `EVAL`, which the physical planner can assign a channel to.

### Testing

Coverage at every layer — unit (`SparklineValidationTests`), analyzer (`VerifierTests`), optimizer (`ReplaceSparklineAggregateTests`), and end-to-end (`stats_sparkline.csv-spec`) — for accepted (`COUNT()+1`, `MIN(a)+MIN(b)`, `AVG(x)*2`) and rejected (bare field, multi-valued agg inside an expression) cases. The `AVG(x)+1` case specifically pins the rule ordering: a surrogate must be pulled out of the expression *before* it's expanded.

### Notes

- **Grouping keys**: a bare grouping-key reference inside the expression (e.g. `SPARKLINE(MAX(salary)+languages, ...) BY languages`) is rejected — `resolveType` has no grouping context, so it can't tell a grouping key from any other field. This is stricter than plain `STATS`; happy to revisit if that's not the desired behavior.
- **Empty buckets**: the arithmetic applies to populated buckets only — `COUNT()+1` yields `[0, 3, 0, ...]`, i.e. gap-filled buckets stay `0`, consistent with how all sparklines fill gaps.