### PR TITLE
[Gradle] Pin JDK TransformerFactory in Gradle func tests

### DIFF
--- a/build-tools/src/testFixtures/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy
+++ b/build-tools/src/testFixtures/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy
@@ -71,7 +71,18 @@ abstract class AbstractGradleFuncTest extends Specification {
             minimumCompilerJava = 21
         """
         propertiesFile <<
-            "org.gradle.java.installations.fromEnv=JAVA_HOME,RUNTIME_JAVA_HOME,JAVA15_HOME,JAVA14_HOME,JAVA13_HOME,JAVA12_HOME,JAVA11_HOME,JAVA8_HOME"
+            "org.gradle.java.installations.fromEnv=JAVA_HOME,RUNTIME_JAVA_HOME,JAVA15_HOME,JAVA14_HOME,JAVA13_HOME,JAVA12_HOME,JAVA11_HOME,JAVA8_HOME\n"
+        // Pin the JAXP TransformerFactory to the JDK built-in implementation.
+        // The plugin-under-test classpath injected via GradleRunner#withPluginClasspath transitively
+        // contains Saxon-HE (pulled in by the nmcp publishing plugin), which registers itself as a
+        // javax.xml.transform.TransformerFactory service provider. Whether the JDK's FactoryFinder
+        // picks up that service registration depends on non-deterministic classpath/ServiceLoader
+        // ordering, so on some platforms (e.g. CI) Gradle's internal XmlFactories resolves to
+        // net.sf.saxon.TransformerFactoryImpl, which the Gradle core classloader cannot load,
+        // failing GenerateMavenPom with a TransformerFactoryConfigurationError. Forcing the JDK
+        // default keeps POM generation deterministic across environments.
+        propertiesFile <<
+            "systemProp.javax.xml.transform.TransformerFactory=com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl"
 
         def nativeLibsProject = subProject(":libs:native:native-libraries")
         // Stub mirrors the real producer: a dedicated `nativeLibs` consumable variant that


### PR DESCRIPTION
## Problem

`PublishPluginFuncTest` fails intermittently (reliably on Linux CI, but passes on macOS locally) with:

```
> Task :generatePomFileForElasticPublication FAILED
  Provider net.sf.saxon.TransformerFactoryImpl not found
Caused by: javax.xml.transform.TransformerFactoryConfigurationError: Provider net.sf.saxon.TransformerFactoryImpl not found
Caused by: java.lang.ClassNotFoundException: net/sf/saxon/TransformerFactoryImpl
	at org.gradle.internal.xml.XmlFactories.newTransformerFactory(XmlFactories.java:74)
	at org.gradle.api.publish.maven.tasks.GenerateMavenPom.doGenerate(GenerateMavenPom.java:104)
```

## Root cause

The plugin-under-test classpath injected via `GradleRunner#withPluginClasspath()` transitively contains **Saxon-HE** (pulled in by the `nmcp` publishing plugin). Saxon registers itself as a `javax.xml.transform.TransformerFactory` service provider via `META-INF/services`.

Whether the JDK's `FactoryFinder` picks up that service registration depends on non-deterministic classpath/`ServiceLoader` ordering. On some platforms (e.g. CI) Gradle's internal `XmlFactories.newTransformerFactory()` resolves to `net.sf.saxon.TransformerFactoryImpl`, which the Gradle **core** classloader cannot load (Saxon lives in the isolated plugin classloader) — so `GenerateMavenPom` fails. The real build is unaffected because Saxon is not visible to the core classloader there.

## Fix

Force the JDK built-in `TransformerFactory` in the generated func-test build via `gradle.properties`, the [Gradle-documented workaround](https://github.com/gradle/gradle/issues/26672) for legacy XML providers leaking onto the build classpath. This makes POM generation deterministic across environments.

Surfaced by the build scan: https://gradle-enterprise.elastic.co/s/pxmkkzkxm27ta