### PR TITLE
Clarify Outlook Cloud shared mailbox sync behavior

### DIFF
--- a/docs/reference/search-connectors/es-connectors-outlook.md
+++ b/docs/reference/search-connectors/es-connectors-outlook.md
@@ -287,6 +287,7 @@ The connector syncs the following objects and entities:
 ::::{note}
 * Content from files bigger than 10 MB won’t be extracted by default. You can use the [self-managed local extraction service](/reference/search-connectors/es-connectors-content-extraction.md#es-connectors-content-extraction-local) to handle larger binary files.
 * Permissions are not synced. **All documents** indexed to an Elastic deployment will be visible to **all users with access** to that Elastic Deployment.
+* For Outlook Cloud (Office 365), the connector only discovers mailboxes belonging to **enabled** directory users (`accountEnabled = true`) that have an email address. **Shared mailboxes are not synced by default**, because their backing Entra ID account has sign-in disabled. To sync a shared mailbox, enable sign-in for its account in Entra ID (this may require assigning a license).
 
 ::::
 


### PR DESCRIPTION
## Fixes https://github.com/elastic/docs-content/issues/1828

Document that the Outlook Cloud connector only discovers enabled, mail-enabled directory users, so shared mailboxes are not synced by default. Note the workaround of enabling sign-in for the account.
