### PR TITLE
Mute ip_location MixedClusterEsqlSpecIT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -695,3 +695,6 @@ tests:
 - class: org.elasticsearch.xpack.inference.integration.SemanticFieldFieldsApiIT
   method: testFetchingMixedTextAndImageValues
   issue: https://github.com/elastic/elasticsearch/issues/151929
+- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
+  method: test {csv-spec:ip_location.*}
+  issue: https://github.com/elastic/elasticsearch/issues/151950


### PR DESCRIPTION
The PR at https://github.com/elastic/elasticsearch/pull/149421 appears to cause MixedClusterEsqlSpecIT to fail.

Failing command:

```
./gradlew ":x-pack:plugin:esql:qa:server:mixed-cluster:bcUpgradeTest" -Dtests.class="org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT" -Dtests.method="test {csv-spec:ip_location.withCountryDatabase}" -Dtests.seed=2B6234A9E6C6CDEB -Dtests.bwc.main.version=9.5.0-SNAPSHOT -Dtests.bwc.refspec.main=f8a5240641e409ca874a9b7af217a1f618141f18 -Dtests.locale=et-Latn-EE -Dtests.timezone=Africa/Kigali -Druntime.java=26
```

Error:

```
Line 2:3: org.elasticsearch.xpack.esql.evaluator.command.IpLocationFunctionBridge$IpLocationDatabaseUnavailableException: IP location database [GeoLite2-Country.mmdb] is not available on this node"
```

This PR mutes the tests, while another PR does a more proper fix. See https://github.com/elastic/elasticsearch/pull/151894