### PR TITLE
[9.3] Pin JDK TransformerFactory in Gradle func tests (#151954)

### DIFF
--- a/build-tools/src/testFixtures/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy
+++ b/build-tools/src/testFixtures/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy
@@ -71,7 +71,18 @@ abstract class AbstractGradleFuncTest extends Specification {
             minimumCompilerJava = 21
         """
         propertiesFile <<
-            "org.gradle.java.installations.fromEnv=JAVA_HOME,RUNTIME_JAVA_HOME,JAVA15_HOME,JAVA14_HOME,JAVA13_HOME,JAVA12_HOME,JAVA11_HOME,JAVA8_HOME"
+            "org.gradle.java.installations.fromEnv=JAVA_HOME,RUNTIME_JAVA_HOME,JAVA15_HOME,JAVA14_HOME,JAVA13_HOME,JAVA12_HOME,JAVA11_HOME,JAVA8_HOME\n"
+        // Pin the JAXP TransformerFactory to the JDK built-in implementation.
+        // The plugin-under-test classpath injected via GradleRunner#withPluginClasspath transitively
+        // contains Saxon-HE (pulled in by the nmcp publishing plugin), which registers itself as a
+        // javax.xml.transform.TransformerFactory service provider. Whether the JDK's FactoryFinder
+        // picks up that service registration depends on non-deterministic classpath/ServiceLoader
+        // ordering, so on some platforms (e.g. CI) Gradle's internal XmlFactories resolves to
+        // net.sf.saxon.TransformerFactoryImpl, which the Gradle core classloader cannot load,
+        // failing GenerateMavenPom with a TransformerFactoryConfigurationError. Forcing the JDK
+        // default keeps POM generation deterministic across environments.
+        propertiesFile <<
+            "systemProp.javax.xml.transform.TransformerFactory=com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl"
 
         def nativeLibsProject = subProject(":libs:native:native-libraries")
         nativeLibsProject << """


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Pin JDK TransformerFactory in Gradle func tests (#151954)](https://github.com/elastic/elasticsearch/pull/151954)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)