### PR TITLE
[CI] Use Adoptium JDK 17 for example-plugin test clusters on Ubuntu 24.04

### DIFF
--- a/build-tools/src/main/java/org/elasticsearch/gradle/util/OsUtils.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/util/OsUtils.java
@@ -41,7 +41,7 @@ public final class OsUtils {
         return version.after("0.0.0") && version.onOrBefore("8.10.4") && isUbuntu2404OrLater();
     }
 
-    private static boolean isUbuntu2404OrLater() {
+    public static boolean isUbuntu2404OrLater() {
         try {
             if (OS.current() != OS.LINUX) {
                 return false;

--- a/plugins/examples/build.gradle
+++ b/plugins/examples/build.gradle
@@ -1,4 +1,7 @@
 import org.elasticsearch.gradle.VersionProperties
+import org.elasticsearch.gradle.util.OsUtils
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.gradle.jvm.toolchain.JvmVendorSpec
 
 buildscript {
   repositories {
@@ -18,6 +21,19 @@ subprojects {
   java {
     sourceCompatibility = 17
     targetCompatibility = 17
+  }
+
+  // Oracle JDK 17 is incompatible with Ubuntu 24.04+ (kernel >= 6.14) due to a cgroup v2 change
+  // that causes a NullPointerException on JVM startup. Use Adoptium JDK 17, which has the fix,
+  // as the runtime JDK for all test clusters on affected systems.
+  plugins.withId('elasticsearch.testclusters') { testClustersPlugin ->
+    if (OsUtils.isUbuntu2404OrLater()) {
+      def adoptium17 = javaToolchains.launcherFor {
+        languageVersion = JavaLanguageVersion.of(17)
+        vendor = JvmVendorSpec.ADOPTIUM
+      }
+      testClustersPlugin.setRuntimeJava(adoptium17.map { it.metadata.installationPath.asFile })
+    }
   }
 
   repositories {


### PR DESCRIPTION
Oracle JDK 17 crashes on startup with a NullPointerException in the cgroup
v2 detection code on Ubuntu 24.04 (kernel >= 6.14). The existing workaround
in example-plugins.sh references $HOME/.java/adoptopenjdk17 which does not
exist on current CI agents (JDKs are now provisioned under ~/.gradle/jdks/).

Fix this by configuring every subproject that applies
elasticsearch.testclusters to use Adoptium JDK 17 via Gradle's toolchain
service when isUbuntu2404OrLater() is true. Gradle resolves the JDK from
~/.gradle/jdks/eclipse_adoptium-17-* which is pre-populated by the agent
image build, so no resolver download is needed at runtime.

OsUtils.isUbuntu2404OrLater() is promoted from private to public so the
Groovy build script can call it directly.