### PR TITLE
[8.19] Clarify Outlook Cloud shared mailbox sync behavior (#151956)

### DIFF
--- a/docs/reference/connector/docs/connectors-outlook.asciidoc
+++ b/docs/reference/connector/docs/connectors-outlook.asciidoc
@@ -168,6 +168,7 @@ The connector syncs the following objects and entities:
 ====
 * Content from files bigger than 10 MB won't be extracted. (Self-managed connectors can use the <<es-connectors-content-extraction-local, self-managed local extraction service>> to handle larger binary files.)
 * Permissions are not synced. *All documents* indexed to an Elastic deployment will be visible to *all users with access* to that Elastic Deployment.
+* For Outlook Cloud (Office 365), the connector only discovers mailboxes belonging to *enabled* directory users (`accountEnabled = true`) that have an email address. *Shared mailboxes are not synced by default*, because their backing Entra ID account has sign-in disabled. To sync a shared mailbox, enable sign-in for its account in Entra ID (this may require assigning a license).
 ====
 
 [discrete#es-connectors-outlook-sync-types]
@@ -383,6 +384,7 @@ The connector syncs the following objects and entities:
 ====
 * Content from files bigger than 10 MB won't be extracted by default. You can use the <<es-connectors-content-extraction-local, self-managed local extraction service>> to handle larger binary files.
 * Permissions are not synced. *All documents* indexed to an Elastic deployment will be visible to *all users with access* to that Elastic Deployment.
+* For Outlook Cloud (Office 365), the connector only discovers mailboxes belonging to *enabled* directory users (`accountEnabled = true`) that have an email address. *Shared mailboxes are not synced by default*, because their backing Entra ID account has sign-in disabled. To sync a shared mailbox, enable sign-in for its account in Entra ID (this may require assigning a license).
 ====
 
 [discrete#es-connectors-outlook-client-sync-types]


### PR DESCRIPTION
Document that the Outlook Cloud connector only discovers enabled, mail-enabled directory users, so shared mailboxes are not synced by default. Note the workaround of enabling sign-in for the account.
Backport of https://github.com/elastic/elasticsearch/pull/151956 to 8.19

