### PR TITLE
PromQL: Fix absent_over_time output

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-absent-over-time.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-absent-over-time.csv-spec
@@ -20,18 +20,31 @@ false                    | two         | 2024-05-10T00:20:00.000Z
 false                    | two         | 2024-05-10T00:22:00.000Z
 ;
 
-absent_over_time_events_received_promql-Ignore
+absent_over_time_events_received_promql
 required_capability: promql_command_v0
 required_capability: fix_promql_time_bucket_v2
+required_capability: fix_promql_absent_over_time_output
 
 PROMQL index=k8s step=2m is_absent=(max by (pod) (absent_over_time(events_received{cluster="prod",pod="two"}[2m])))
 | SORT step | LIMIT 10;
 ignoreOrder:true
 
 is_absent:double | step:datetime            | pod:keyword
-1.0              | 2024-05-10T00:10:00.000Z | two
 1.0              | 2024-05-10T00:12:00.000Z | two
-1.0              | 2024-05-10T00:18:00.000Z | two
+1.0              | 2024-05-10T00:14:00.000Z | two
+1.0              | 2024-05-10T00:20:00.000Z | two
+;
+
+absent_over_time_promql_returns_one_for_absent_range
+required_capability: promql_command_v0
+required_capability: fix_promql_time_bucket_v2
+required_capability: fix_promql_absent_over_time_output
+
+PROMQL index=k8s step=2m start="2024-05-10T00:12:00.000Z" end="2024-05-10T00:12:00.000Z" is_absent=(max by (pod) (absent_over_time(events_received{cluster="prod",pod="two"}[2m])))
+| SORT step;
+
+is_absent:double | step:datetime            | pod:keyword
+1.0              | 2024-05-10T00:12:00.000Z | two
 ;
 
 absent_over_time_of_long
@@ -53,20 +66,12 @@ false             | staging         | 2024-05-10T00:20:00.000Z
 absent_over_time_of_long_promql
 required_capability: promql_command_v0
 required_capability: fix_promql_time_bucket_v2
+required_capability: fix_promql_absent_over_time_output
 
 PROMQL index=k8s step=10m is_absent=(max by (cluster) (absent_over_time(network.bytes_in[10m])))
 | SORT cluster, step | LIMIT 10;
 
 is_absent:double | step:datetime            | cluster:keyword
-0.0              | 2024-05-10T00:10:00.000Z | prod
-0.0              | 2024-05-10T00:20:00.000Z | prod
-0.0              | 2024-05-10T00:30:00.000Z | prod
-0.0              | 2024-05-10T00:10:00.000Z | qa
-0.0              | 2024-05-10T00:20:00.000Z | qa
-0.0              | 2024-05-10T00:30:00.000Z | qa
-0.0              | 2024-05-10T00:10:00.000Z | staging
-0.0              | 2024-05-10T00:20:00.000Z | staging
-0.0              | 2024-05-10T00:30:00.000Z | staging
 ;
 
 absent_over_time_of_long_promql_collapsed
@@ -74,15 +79,13 @@ required_capability: promql_command_v0
 required_capability: ts_collapse
 required_capability: fix_promql_time_bucket_v2
 required_capability: fix_tstep_bucket_rounding
+required_capability: fix_promql_absent_over_time_output
 
 PROMQL index=k8s step=10m start="2024-05-10T00:00:00.000Z" end="2024-05-10T00:20:00.000Z" is_absent=(max by (cluster) (absent_over_time(network.bytes_in[10m])))
 | TS_COLLAPSE
 | SORT cluster;
 
 is_absent:double  | step:datetime                                                                                  | cluster:keyword
-[0.0, 0.0]       | [2024-05-10T00:10:00.000Z, 2024-05-10T00:20:00.000Z]                                        | prod
-[0.0, 0.0]       | [2024-05-10T00:10:00.000Z, 2024-05-10T00:20:00.000Z]                                        | qa
-[0.0, 0.0]       | [2024-05-10T00:10:00.000Z, 2024-05-10T00:20:00.000Z]                                        | staging
 ;
 
 absent_over_time_of_boolean
@@ -104,20 +107,12 @@ false              | staging         | 2024-05-10T00:20:00.000Z
 absent_over_time_of_boolean_promql
 required_capability: promql_command_v0
 required_capability: fix_promql_time_bucket_v2
+required_capability: fix_promql_absent_over_time_output
 
 PROMQL index=k8s step=10m is_absent=(max by (cluster) (absent_over_time(network.eth0.up[10m])))
 | SORT step, cluster | LIMIT 10;
 
 is_absent:double | step:datetime            | cluster:keyword
-0.0              | 2024-05-10T00:10:00.000Z | prod
-0.0              | 2024-05-10T00:10:00.000Z | qa
-0.0              | 2024-05-10T00:10:00.000Z | staging
-0.0              | 2024-05-10T00:20:00.000Z | prod
-0.0              | 2024-05-10T00:20:00.000Z | qa
-0.0              | 2024-05-10T00:20:00.000Z | staging
-0.0              | 2024-05-10T00:30:00.000Z | prod
-0.0              | 2024-05-10T00:30:00.000Z | qa
-0.0              | 2024-05-10T00:30:00.000Z | staging
 ;
 
 absent_over_time_of_date_nanos
@@ -187,20 +182,12 @@ false                  | staging         | 2024-05-10T00:20:00.000Z
 absent_over_time_of_integer_promql
 required_capability: promql_command_v0
 required_capability: fix_promql_time_bucket_v2
+required_capability: fix_promql_absent_over_time_output
 
 PROMQL index=k8s step=10m is_absent=(max by (cluster) (absent_over_time(network.eth0.currently_connected_clients[10m])))
 | SORT step, cluster | LIMIT 10;
 
 is_absent:double | step:datetime            | cluster:keyword
-0.0              | 2024-05-10T00:10:00.000Z | prod
-0.0              | 2024-05-10T00:10:00.000Z | qa
-0.0              | 2024-05-10T00:10:00.000Z | staging
-0.0              | 2024-05-10T00:20:00.000Z | prod
-0.0              | 2024-05-10T00:20:00.000Z | qa
-0.0              | 2024-05-10T00:20:00.000Z | staging
-0.0              | 2024-05-10T00:30:00.000Z | prod
-0.0              | 2024-05-10T00:30:00.000Z | qa
-0.0              | 2024-05-10T00:30:00.000Z | staging
 ;
 
 absent_over_time_of_text
@@ -335,20 +322,12 @@ false              | staging         | 2024-05-10T00:20:00.000Z
 absent_over_time_with_filtering_promql
 required_capability: promql_command_v0
 required_capability: fix_promql_time_bucket_v2
+required_capability: fix_promql_absent_over_time_output
 
 PROMQL index=k8s step=10m is_absent=(max by (cluster) (absent_over_time(network.bytes_in{pod!="three"}[10m])))
 | SORT step, cluster | LIMIT 10;
 
 is_absent:double | step:datetime            | cluster:keyword
-0.0              | 2024-05-10T00:10:00.000Z | prod
-0.0              | 2024-05-10T00:10:00.000Z | qa
-0.0              | 2024-05-10T00:10:00.000Z | staging
-0.0              | 2024-05-10T00:20:00.000Z | prod
-0.0              | 2024-05-10T00:20:00.000Z | qa
-0.0              | 2024-05-10T00:20:00.000Z | staging
-0.0              | 2024-05-10T00:30:00.000Z | prod
-0.0              | 2024-05-10T00:30:00.000Z | qa
-0.0              | 2024-05-10T00:30:00.000Z | staging
 ;
 
 absent_over_time_older_than_10d

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -2317,6 +2317,12 @@ public class EsqlCapabilities {
         PROMQL_ABSENT_LABEL_MATCHING,
 
         /**
+         * Fix PromQL {@code absent_over_time()} to return {@code 1.0} only for absent ranges and no row when samples exist.
+         * https://github.com/elastic/elasticsearch/issues/151973
+         */
+        FIX_PROMQL_ABSENT_OVER_TIME_OUTPUT,
+
+        /**
          * Support for the {@code TS_COLLAPSE} pipe command, which collapses PromQL results
          * into one multi-valued row per series.
          */

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/AbsentOverTime.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/AbsentOverTime.java
@@ -22,6 +22,7 @@ import org.elasticsearch.xpack.esql.expression.function.FunctionDefinition;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.FunctionType;
 import org.elasticsearch.xpack.esql.expression.function.Param;
+import org.elasticsearch.xpack.esql.expression.function.scalar.conditional.Case;
 import org.elasticsearch.xpack.esql.expression.promql.function.PromqlFunctionDefinition;
 
 import java.io.IOException;
@@ -41,7 +42,7 @@ public class AbsentOverTime extends TimeSeriesAggregateFunction implements Aggre
         .binary(AbsentOverTime::new)
         .name("absent_over_time");
     public static final PromqlFunctionDefinition PROMQL_DEFINITION = PromqlFunctionDefinition.def()
-        .withinSeriesOverTime(AbsentOverTime::new)
+        .withinSeriesOverTime(AbsentOverTime::promqlAbsentOverTime)
         .counterSupport(PromqlFunctionDefinition.CounterSupport.SUPPORTED)
         .description("Returns 1 if the range vector has no elements, otherwise returns an empty vector.")
         .example("absent_over_time(nonexistent_metric[5m])")
@@ -98,6 +99,10 @@ public class AbsentOverTime extends TimeSeriesAggregateFunction implements Aggre
 
     public AbsentOverTime(Source source, Expression field, Expression filter, Expression window) {
         super(source, field, filter, window, List.of());
+    }
+
+    private static Expression promqlAbsentOverTime(Source source, Expression field, Expression filter, Expression window) {
+        return new Case(source, new AbsentOverTime(source, field, filter, window), List.of(Literal.fromDouble(source, 1.0)));
     }
 
     private AbsentOverTime(StreamInput in) throws IOException {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlPlanFunctionCallTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlPlanFunctionCallTests.java
@@ -15,12 +15,14 @@ import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.FoldContext;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.AbsentOverTime;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Avg;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.LastOverTime;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Percentile;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.PercentileOverTime;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Rate;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Sum;
+import org.elasticsearch.xpack.esql.expression.function.scalar.conditional.Case;
 import org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToCounter;
 import org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToGauge;
 import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNotNull;
@@ -35,6 +37,7 @@ import org.elasticsearch.xpack.esql.plan.logical.TimeSeriesAggregate;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.as;
@@ -86,6 +89,48 @@ public class PromqlPlanFunctionCallTests extends AbstractPromqlPlanOptimizerTest
             as(percentile.percentile().fold(FoldContext.small()), Double.class),
             equalTo(expectedPercentile)
         );
+    }
+
+    public void testAbsentOverTimePromqlReturnsNullWhenRangeIsPresent() {
+        var window = Literal.timeDuration(Source.EMPTY, Duration.ofMinutes(5));
+        var ctx = new PromqlFunctionRegistry.PromqlContext(Literal.NULL, window, Literal.NULL, EsqlTestUtils.TEST_CFG);
+        Expression built = PromqlFunctionRegistry.INSTANCE.buildEsqlFunction(
+            "absent_over_time",
+            Source.EMPTY,
+            Literal.fromDouble(Source.EMPTY, 1.0),
+            ctx,
+            List.of()
+        );
+
+        Case absentOrNull = as(built, Case.class);
+        assertThat(absentOrNull.children(), hasSize(2));
+        AbsentOverTime absent = as(absentOrNull.children().get(0), AbsentOverTime.class);
+        assertThat(absent.window().fold(FoldContext.small()), equalTo(Duration.ofMinutes(5)));
+        assertThat(as(absentOrNull.children().get(1), Literal.class).value(), equalTo(1.0));
+    }
+
+    public void testAbsentOverTimePromqlFiltersNullOutput() {
+        LogicalPlan plan = planPromql(
+            "PROMQL index=k8s step=10m is_absent=(max by (cluster) (absent_over_time(network.bytes_in[10m])))",
+            false
+        );
+        assertTrue(plan.resolved());
+
+        IsNotNull valueFilter = plan.collect(Filter.class)
+            .stream()
+            .map(Filter::condition)
+            .filter(IsNotNull.class::isInstance)
+            .map(IsNotNull.class::cast)
+            .filter(notNull -> notNull.field() instanceof Attribute attr && attr.name().equals("is_absent"))
+            .findFirst()
+            .orElseThrow();
+        assertThat(as(valueFilter.field(), Attribute.class).name(), equalTo("is_absent"));
+
+        List<Case> cases = new ArrayList<>();
+        plan.forEachExpressionDown(Case.class, cases::add);
+        assertThat(cases, hasSize(1));
+        assertThat(cases.getFirst().children(), hasSize(2));
+        assertThat(as(cases.getFirst().children().get(1), Literal.class).value(), equalTo(1.0));
     }
 
     public void testRound() {


### PR DESCRIPTION
This PR fixes `absent_over_time` in PromQL to match Prometheus semantics. 

Closes #151973