### PR TITLE
Catch unreachable bundled JPMS modules at build time

### DIFF
--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/precommit/JavaModulePrecommitPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/precommit/JavaModulePrecommitPluginFuncTest.groovy
@@ -95,6 +95,164 @@ class JavaModulePrecommitPluginFuncTest extends AbstractGradleInternalPluginFunc
         result.task(":validateModule").outcome == TaskOutcome.SUCCESS
     }
 
+    def "detects explicit bundled module not reachable from module graph"() {
+        given:
+        // Simulate a plugin project: add a resolveableCompileOnly configuration (normally applied
+        // by BasePluginBuildPlugin via CompileOnlyResolvePlugin) so the plugin wires bundledClasspath.
+        buildFile << """
+        configurations {
+            resolveableCompileOnly {
+                canBeResolved = true
+                canBeConsumed = false
+                extendsFrom configurations.compileOnly
+            }
+        }
+        tasks.named('compileJava') {
+            options.compilerArgs.addAll(['--module-version', '${ES_VERSION}'])
+        }
+        dependencies {
+            // An explicit-module JAR built by the sibling subproject; it is bundled (implementation)
+            // but intentionally omitted from module-info requires to trigger the check.
+            implementation project(':mylib')
+        }
+        """
+        settingsFile << "include ':mylib'"
+        file("mylib/build.gradle").text = "plugins { id 'java' }"
+        file("mylib/src/main/java/module-info.java").text = "module com.example.mylib { }"
+        file("mylib/src/main/java/com/example/mylib/Lib.java").text = """
+        package com.example.mylib;
+        public class Lib {}
+        """
+        file("src/main/java/module-info.java").text = """
+        module org.elasticsearch.testmodule {
+            // intentionally missing: requires com.example.mylib;
+        }
+        """
+        file("src/main/java/org/elasticsearch/testmodule/Dummy.java").text = """
+        package org.elasticsearch.testmodule;
+        public class Dummy {}
+        """
+
+        when:
+        def result = gradleRunner("validateModule").buildAndFail()
+
+        then:
+        result.task(":validateModule").outcome == TaskOutcome.FAILED
+
+        and: "problems report flags the unreachable bundled module"
+        assertProblemsReportContains("unreachable-bundled-module")
+        assertProblemsReportSeverity("unreachable-bundled-module", "ERROR")
+    }
+
+    def "passes when explicit bundled module is declared in requires"() {
+        given:
+        buildFile << """
+        configurations {
+            resolveableCompileOnly {
+                canBeResolved = true
+                canBeConsumed = false
+                extendsFrom configurations.compileOnly
+            }
+        }
+        tasks.named('compileJava') {
+            options.compilerArgs.addAll(['--module-version', '${ES_VERSION}'])
+        }
+        dependencies {
+            implementation project(':mylib')
+        }
+        """
+        settingsFile << "include ':mylib'"
+        file("mylib/build.gradle").text = "plugins { id 'java' }"
+        file("mylib/src/main/java/module-info.java").text = "module com.example.mylib { }"
+        file("mylib/src/main/java/com/example/mylib/Lib.java").text = """
+        package com.example.mylib;
+        public class Lib {}
+        """
+        file("src/main/java/module-info.java").text = """
+        module org.elasticsearch.testmodule {
+            requires com.example.mylib;
+        }
+        """
+        file("src/main/java/org/elasticsearch/testmodule/Dummy.java").text = """
+        package org.elasticsearch.testmodule;
+        public class Dummy {}
+        """
+
+        when:
+        def result = gradleRunner("validateModule").build()
+
+        then:
+        result.task(":validateModule").outcome == TaskOutcome.SUCCESS
+    }
+
+    def "skips resolution check for non-plugin modular projects (no resolveableCompileOnly)"() {
+        given:
+        // No resolveableCompileOnly → bundledClasspath stays null → resolution check is skipped.
+        buildFile << """
+        tasks.named('compileJava') {
+            options.compilerArgs.addAll(['--module-version', '${ES_VERSION}'])
+        }
+        """
+        file("src/main/java/module-info.java").text = """
+        module org.elasticsearch.testmodule {
+        }
+        """
+        file("src/main/java/org/elasticsearch/testmodule/Dummy.java").text = """
+        package org.elasticsearch.testmodule;
+        public class Dummy {}
+        """
+
+        when:
+        def result = gradleRunner("validateModule").build()
+
+        then:
+        result.task(":validateModule").outcome == TaskOutcome.SUCCESS
+    }
+
+    def "allowedUnreachable suppresses the check for a named module"() {
+        given:
+        buildFile << """
+        configurations {
+            resolveableCompileOnly {
+                canBeResolved = true
+                canBeConsumed = false
+                extendsFrom configurations.compileOnly
+            }
+        }
+        tasks.named('compileJava') {
+            options.compilerArgs.addAll(['--module-version', '${ES_VERSION}'])
+        }
+        dependencies {
+            implementation project(':mylib')
+        }
+        tasks.named('validateModule') {
+            allowedUnreachable.add('com.example.mylib')
+        }
+        """
+        settingsFile << "include ':mylib'"
+        file("mylib/build.gradle").text = "plugins { id 'java' }"
+        file("mylib/src/main/java/module-info.java").text = "module com.example.mylib { }"
+        file("mylib/src/main/java/com/example/mylib/Lib.java").text = """
+        package com.example.mylib;
+        public class Lib {}
+        """
+        file("src/main/java/module-info.java").text = """
+        module org.elasticsearch.testmodule {
+            // com.example.mylib intentionally omitted but suppressed via allowedUnreachable
+        }
+        """
+        file("src/main/java/org/elasticsearch/testmodule/Dummy.java").text = """
+        package org.elasticsearch.testmodule;
+        public class Dummy {}
+        """
+
+        when:
+        def result = gradleRunner("validateModule").build()
+
+        then:
+        result.task(":validateModule").outcome == TaskOutcome.SUCCESS
+    }
+
     def "problems have solutions in report"() {
         given:
         buildFile << """

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/JavaModulePrecommitPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/JavaModulePrecommitPlugin.java
@@ -9,10 +9,12 @@
 
 package org.elasticsearch.gradle.internal.precommit;
 
+import org.elasticsearch.gradle.dependencies.CompileOnlyResolvePlugin;
 import org.elasticsearch.gradle.internal.conventions.precommit.PrecommitPlugin;
 import org.elasticsearch.gradle.util.GradleUtils;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
+import org.gradle.api.file.FileCollection;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskProvider;
@@ -28,9 +30,20 @@ public class JavaModulePrecommitPlugin extends PrecommitPlugin {
             SourceSet mainSourceSet = GradleUtils.getJavaSourceSets(project).findByName(SourceSet.MAIN_SOURCE_SET_NAME);
             t.dependsOn(mainSourceSet.getClassesTaskName());
             t.getSrcDirs().set(project.provider(() -> mainSourceSet.getAllSource().getSrcDirs()));
-            t.setClasspath(project.getConfigurations().getByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME));
             t.setClassesDirs(mainSourceSet.getOutput().getClassesDirs());
             t.setResourcesDirs(mainSourceSet.getOutput().getResourcesDir());
+
+            // Wire module-resolution inputs for plugin projects that bundle their own jars.
+            // BasePluginBuildPlugin registers "resolveableCompileOnly" (a resolvable mirror of
+            // compileOnly) for every ES plugin. When present, bundled jars = runtimeClasspath
+            // minus resolveableCompileOnly, mirroring the formula in BasePluginBuildPlugin.createBundleSpec.
+            var configs = project.getConfigurations();
+            var provided = configs.findByName(CompileOnlyResolvePlugin.RESOLVEABLE_COMPILE_ONLY_CONFIGURATION_NAME);
+            if (provided != null) {
+                FileCollection runtime = configs.getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME);
+                t.setBundledClasspath(runtime.minus(provided));
+                t.setProvidedClasspath(provided);
+            }
         });
         return task;
     }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/JavaModulePrecommitTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/JavaModulePrecommitTask.java
@@ -21,6 +21,7 @@ import org.gradle.api.problems.ProblemReporter;
 import org.gradle.api.problems.Problems;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.api.tasks.Classpath;
+import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
@@ -30,9 +31,13 @@ import org.gradle.api.tasks.TaskAction;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.lang.module.Configuration;
+import java.lang.module.FindException;
 import java.lang.module.ModuleDescriptor;
 import java.lang.module.ModuleFinder;
 import java.lang.module.ModuleReference;
+import java.lang.module.ResolutionException;
+import java.lang.module.ResolvedModule;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -52,17 +57,23 @@ public class JavaModulePrecommitTask extends PrecommitTask {
     private static final String expectedVersion = VersionProperties.getElasticsearch();
 
     private final SetProperty<File> srcDirs;
+    private final SetProperty<String> allowedUnreachable;
     private final ProblemReporter problemReporter;
 
     private FileCollection classesDirs;
 
-    private FileCollection classpath;
+    /** Bundled plugin jars: runtimeClasspath minus resolveableCompileOnly. Null for non-plugin projects. */
+    private FileCollection bundledClasspath;
+
+    /** Provided (compile-only) jars: resolveableCompileOnly. Null for non-plugin projects. */
+    private FileCollection providedClasspath;
 
     private File resourcesDir;
 
     @Inject
     public JavaModulePrecommitTask(ObjectFactory objectFactory, Problems problems) {
         srcDirs = objectFactory.setProperty(File.class);
+        allowedUnreachable = objectFactory.setProperty(String.class);
         this.problemReporter = problems.getReporter();
     }
 
@@ -95,14 +106,31 @@ public class JavaModulePrecommitTask extends PrecommitTask {
         return srcDirs;
     }
 
+    @org.gradle.api.tasks.Optional
     @Classpath
     @InputFiles
-    public FileCollection getClasspath() {
-        return classpath;
+    public FileCollection getBundledClasspath() {
+        return bundledClasspath;
     }
 
-    public void setClasspath(FileCollection classpath) {
-        this.classpath = classpath;
+    public void setBundledClasspath(FileCollection bundledClasspath) {
+        this.bundledClasspath = bundledClasspath;
+    }
+
+    @org.gradle.api.tasks.Optional
+    @Classpath
+    @InputFiles
+    public FileCollection getProvidedClasspath() {
+        return providedClasspath;
+    }
+
+    public void setProvidedClasspath(FileCollection providedClasspath) {
+        this.providedClasspath = providedClasspath;
+    }
+
+    @Input
+    public SetProperty<String> getAllowedUnreachable() {
+        return allowedUnreachable;
     }
 
     @TaskAction
@@ -116,6 +144,9 @@ public class JavaModulePrecommitTask extends PrecommitTask {
         checkModuleVersion(mod, problems);
         checkModuleNamePrefix(mod, problems);
         checkModuleServices(mod, problems);
+        if (bundledClasspath != null && bundledClasspath.isEmpty() == false) {
+            checkModuleResolution(mod, problems);
+        }
         if (problems.isEmpty() == false) {
             throw problemReporter.throwing(
                 new GradleException(
@@ -204,6 +235,105 @@ public class JavaModulePrecommitTask extends PrecommitTask {
                 throw new UncheckedIOException(e);
             }
         }
+    }
+
+    private void checkModuleResolution(ModuleReference mref, List<Problem> problems) {
+        getLogger().info("{} checking module resolution for {}", getPath(), mref.descriptor().name());
+        String rootName = mref.descriptor().name();
+
+        // The observable universe: bundled jars + provided (compile-only) jars + the plugin's own classes.
+        // This mirrors what PluginsLoader puts in its after-finder, plus the parent-layer modules
+        // (server, core) that would be in the runtime parent layer but must be findable for
+        // resolution of the plugin's own requires to succeed.
+        List<Path> observablePaths = new ArrayList<>();
+        observablePaths.add(getClassesDirs().getSingleFile().toPath());
+        List<Path> bundledJarPaths = new ArrayList<>();
+        for (File f : bundledClasspath) {
+            if (f.isFile() && f.getName().endsWith(".jar")) {
+                Path p = f.toPath();
+                observablePaths.add(p);
+                bundledJarPaths.add(p);
+            }
+        }
+        if (providedClasspath != null) {
+            for (File f : providedClasspath) {
+                if (f.isFile() && f.getName().endsWith(".jar")) {
+                    observablePaths.add(f.toPath());
+                }
+            }
+        }
+
+        Set<String> allowed = getAllowedUnreachable().get();
+        try {
+            List<String> unreachable = findUnreachableBundledModules(
+                rootName,
+                observablePaths.toArray(Path[]::new),
+                bundledJarPaths,
+                allowed
+            );
+            for (String moduleName : unreachable) {
+                problems.add(
+                    problemReporter.create(
+                        ProblemId.create(
+                            "unreachable-bundled-module",
+                            "Unreachable bundled module",
+                            ElasticsearchBuildProblems.JAVA_MODULE
+                        ),
+                        spec -> spec.contextualLabel(
+                            "Bundled module '" + moduleName + "' is an explicit JPMS module but is not reachable from '" + rootName + "'"
+                        ).solution("Add 'requires " + moduleName + ";' to module-info.java, or remove the unused dependency")
+                    )
+                );
+            }
+        } catch (FindException | ResolutionException e) {
+            problems.add(
+                problemReporter.create(
+                    ProblemId.create("module-resolution-failed", "Module resolution failed", ElasticsearchBuildProblems.JAVA_MODULE),
+                    spec -> spec.contextualLabel("Module resolution failed for '" + rootName + "': " + e.getMessage())
+                        .solution("Check that all required modules are present in the classpath")
+                )
+            );
+        }
+    }
+
+    /**
+     * Returns the names of bundled explicit JPMS modules that are not reachable from {@code rootName}
+     * in the module graph resolved over {@code observablePaths}.
+     *
+     * <p>Automatic modules are excluded from the result: when any automatic module is resolved the
+     * JPMS resolver pulls in all observable automatic modules automatically, so they are never the
+     * source of a missing-requires bug. Only explicit modules (those with a real {@code module-info})
+     * can be silently dropped from the graph when nothing declares {@code requires} for them.
+     *
+     * <p>Extracted as a package-private static to enable unit testing without Gradle infrastructure.
+     */
+    static List<String> findUnreachableBundledModules(
+        String rootName,
+        Path[] observablePaths,
+        Iterable<Path> bundledJarPaths,
+        Set<String> allowed
+    ) {
+        Configuration cfg = Configuration.resolveAndBind(
+            ModuleFinder.of(),
+            List.of(ModuleLayer.boot().configuration()),
+            ModuleFinder.of(observablePaths),
+            Set.of(rootName)
+        );
+        Set<String> resolved = cfg.modules().stream().map(ResolvedModule::name).collect(toSet());
+
+        List<String> unreachable = new ArrayList<>();
+        for (Path jar : bundledJarPaths) {
+            ModuleFinder.of(jar)
+                .findAll()
+                .stream()
+                .map(ModuleReference::descriptor)
+                .filter(d -> d.isAutomatic() == false)
+                .map(ModuleDescriptor::name)
+                .filter(n -> resolved.contains(n) == false)
+                .filter(n -> allowed.contains(n) == false)
+                .forEach(unreachable::add);
+        }
+        return unreachable;
     }
 
     private static boolean hasModuleInfoDotJava(SetProperty<File> srcDirs) {


### PR DESCRIPTION
# Catch unreachable bundled JPMS modules at build time

## Motivation

PR #151794 fixed a node-fatal `NoClassDefFoundError` in the inference plugin caused by a
missing `requires org.apache.commons.lang3` in its `module-info.java`. The root cause is a
JPMS gap that neither `javac` nor the existing `validateModule` precommit check detected:

- `javac` only validates that types **directly referenced in a module's own source** are
  readable. Because the inference plugin never imports `commons-lang3` types directly
  (only `commons-text` does, internally), compilation succeeded.
- `validateModule` checked module version, name prefix, and `provides`/services
  declarations, but never attempted to resolve the module graph.

The upgrade of `commons-lang3` from 3.9 to 3.20.0 turned it from an *automatic* module
(no `module-info.class`) into an *explicit* named module (has `module-info.class`). This
changed the resolution semantics: automatic modules are pulled into the graph for free when
any other automatic module is present; explicit modules are only included when something
explicitly `requires` them. Nothing did, so `commons-lang3` was silently absent from the
plugin's module graph at runtime.

## What this PR does

Extends `validateModule` to replicate the runtime module resolution that
`PluginsLoader.createModuleLayer` performs, and fail if any **bundled, explicit** JPMS
module is not reachable in the resolved graph.

### Why automatic modules are not checked

When any automatic module is resolved, the JPMS resolver includes **all observable
automatic modules** in the graph. So a bundled automatic module can never be silently
absent. Only explicit modules (those with a real `module-info.class`) can be dropped from
the graph when nothing `requires` them — and only for explicit modules is a missing
`requires` a latent `NoClassDefFoundError`.

### The check algorithm

For plugin projects (those that bundle their own jars, identified by the presence of the
`resolveableCompileOnly` Gradle configuration registered by `BasePluginBuildPlugin`):

1. **Bundled jars** = `runtimeClasspath` minus `resolveableCompileOnly` — exactly the set
   of jars that end up in the plugin's bundle directory at runtime. This mirrors the
   formula already used in `BasePluginBuildPlugin.createBundleSpec` and
   `TestBuildInfoPlugin`.

2. **Provided jars** = `resolveableCompileOnly` — jars provided by the parent layer at
   runtime (`:server`, x-pack `core`, Lucene, etc.). These are included in the observable
   universe for resolution so that the plugin's direct `requires` on server-side modules
   can be satisfied, but they are not checked for reachability.

3. `Configuration.resolveAndBind` is called with the same parameters as
   `PluginsLoader.createModuleLayer`: empty before-finder, `ModuleLayer.boot()` as parent,
   all observable paths (bundled + provided + the plugin's own compiled classes) in the
   after-finder, and the plugin's module name as the root.

4. Any bundled jar whose module is an **explicit** named module and whose name is **absent**
   from the resolved configuration is reported as `unreachable-bundled-module` with a
   suggestion to add `requires <name>;` to `module-info.java`.

### Escape hatch

`allowedUnreachable` (`SetProperty<String>` on the task) lets individual module names be
suppressed. This is intended only for cases where the code path that uses the library is
provably unreachable at runtime (similar reasoning to `NotEntitledException` suppressions).
Note that `allowedUnreachable` and removing the dependency from the build entirely have
**identical runtime behavior**: in both cases the classes are inaccessible and
`NoClassDefFoundError` results if the code path is ever reached. The difference is that
`allowedUnreachable` leaves a zombie JAR in the bundle; exclusion from the build is
preferred when feasible.

Non-plugin modular projects (libraries, `:server`) are unaffected: the check is a no-op
when `resolveableCompileOnly` is absent.

## Files changed

- `build-tools-internal/.../precommit/JavaModulePrecommitTask.java` — adds
  `bundledClasspath`, `providedClasspath`, `allowedUnreachable` inputs; adds
  `checkModuleResolution` and the package-private `findUnreachableBundledModules` static
  helper (extracted for testability without the Gradle test-kit); removes the previously
  dead `classpath` input.
- `build-tools-internal/.../precommit/JavaModulePrecommitPlugin.java` — wires the new
  inputs via `runtimeClasspath.minus(resolveableCompileOnly)` when the plugin project has
  `resolveableCompileOnly`; removes the `compileClasspath` wiring that was never read.
- `build-tools-internal/.../precommit/JavaModulePrecommitPluginFuncTest.groovy` — four new
  test scenarios: detects a missing `requires`, passes when `requires` is present, is a
  no-op for non-plugin modular projects, and respects `allowedUnreachable`.

## Pre-existing issues surfaced

Running `validateModule` against the current `main` after this change reveals three latent
issues in the inference plugin (unrelated to the original `commons-lang3` fix):

```
Bundled module 'java.xml.bind' is not reachable from 'org.elasticsearch.inference'
Bundled module 'org.objectweb.asm' is not reachable from 'org.elasticsearch.inference'
Bundled module 'org.cryptomator.siv' is not reachable from 'org.elasticsearch.inference'
```

All three follow the same pattern: they are explicit named modules that are depended on
by **automatic modules** in the inference bundle (respectively: `msal4j` uses JAXB,
`json-smart` uses ASM, `nimbus-jose-jwt` uses SIV-mode crypto). Because automatic modules
cannot declare `requires` in a `module-info`, these explicit modules are absent from the
module graph. If the relevant code paths are exercised at runtime (SAML-based auth, JSON
accessor generation, Azure SIV key wrapping), a `NoClassDefFoundError` results.

These need to be triaged in a follow-up: either add the corresponding `requires`
declarations to the inference `module-info.java`, or exclude the transitive dependencies if
those code paths are provably unreachable.
