### PR TITLE
[ESQL] Bound and cancel external-source resolution

### DIFF
--- a/docs/changelog/152021.yaml
+++ b/docs/changelog/152021.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 960
+pr: 152021
+summary: Bound and cancel external-source resolution
+type: enhancement

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
@@ -88,6 +88,8 @@ public class ExternalSourceResolver {
 
     private static final int MAX_PARALLEL_METADATA_READS = 16;
 
+    private static final String RESOLUTION_CANCELLED_MESSAGE = "ES|QL external source resolution cancelled";
+
     /**
      * Returns a config suitable for passing to a storage provider: merges the {@link #DATASOURCE_CONFIG_KEY}
      * sub-map (data-source auth/connection settings) into the top level so that the provider can
@@ -192,7 +194,7 @@ public class ExternalSourceResolver {
      */
     private void throwIfCancelled() {
         if (isCancelled()) {
-            throw new TaskCancelledException("ES|QL external source resolution cancelled");
+            throw new TaskCancelledException(RESOLUTION_CANCELLED_MESSAGE);
         }
     }
 
@@ -207,7 +209,7 @@ public class ExternalSourceResolver {
     private boolean reportIfCancelled(String path, ActionListener<?> listener) {
         if (isCancelled()) {
             LOGGER.debug("External source resolution cancelled for [{}]", path);
-            listener.onFailure(new TaskCancelledException("ES|QL external source resolution cancelled"));
+            listener.onFailure(new TaskCancelledException(RESOLUTION_CANCELLED_MESSAGE));
             return true;
         }
         return false;
@@ -232,6 +234,11 @@ public class ExternalSourceResolver {
             return;
         }
 
+        // Resolution runs on the SEARCH pool and a wide multi-file resolve pins this worker on the
+        // BoundedParallelGather latch while it dispatches up to MAX_PARALLEL_METADATA_READS more SEARCH
+        // tasks (join pattern). This is an accepted tradeoff: the rework bounds submission so a saturated
+        // pool now fails fast via running-slot rejection rather than deadlocking on a flooded queue.
+        // Moving resolution off SEARCH entirely is left as a possible follow-up.
         executor.execute(() -> {
             try {
                 Map<String, ExternalSourceResolution.ResolvedSource> resolved = Maps.newHashMapWithExpectedSize(paths.size());

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
+import org.elasticsearch.tasks.TaskCancelledException;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.ExternalMetadataAttribute;
 import org.elasticsearch.xpack.esql.core.expression.Nullability;
@@ -45,6 +46,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executor;
+import java.util.function.BooleanSupplier;
 
 /**
  * Resolver for external data sources (Iceberg tables, Parquet files, etc.).
@@ -134,6 +136,14 @@ public class ExternalSourceResolver {
     private final Settings settings;
     private final ExternalSourceCacheService cacheService;
 
+    /**
+     * Supplier consulted before each per-file footer read so that an in-flight resolution of a large
+     * glob aborts promptly when the originating query is cancelled. {@code null} means "never cancelled"
+     * (used by tests and call sites that do not carry a {@code CancellableTask}).
+     */
+    @Nullable
+    private final BooleanSupplier isCancelled;
+
     /** Coordinator-side accessor used by EsqlSession to reconcile data-node-captured source stats post-query. */
     public ExternalSourceCacheService cacheService() {
         return cacheService;
@@ -153,10 +163,54 @@ public class ExternalSourceResolver {
         Settings settings,
         @Nullable ExternalSourceCacheService cacheService
     ) {
+        this(executor, dataSourceModule, settings, cacheService, null);
+    }
+
+    public ExternalSourceResolver(
+        Executor executor,
+        DataSourceModule dataSourceModule,
+        Settings settings,
+        @Nullable ExternalSourceCacheService cacheService,
+        @Nullable BooleanSupplier isCancelled
+    ) {
         this.executor = executor;
         this.dataSourceModule = dataSourceModule;
         this.settings = settings;
         this.cacheService = cacheService;
+        this.isCancelled = isCancelled;
+    }
+
+    /** Returns {@code true} when the originating query has been cancelled. Safe to call when no supplier is wired. */
+    private boolean isCancelled() {
+        return isCancelled != null && isCancelled.getAsBoolean();
+    }
+
+    /**
+     * Throws {@link TaskCancelledException} if the originating query has been cancelled, so that an in-flight
+     * resolution of a large glob aborts promptly. Called both before doing storage I/O and (defensively) when a
+     * per-file read fails while the query is cancelled, so cancellation is never masked as a partial-stats result.
+     */
+    private void throwIfCancelled() {
+        if (isCancelled()) {
+            throw new TaskCancelledException("ES|QL external source resolution cancelled");
+        }
+    }
+
+    /**
+     * If the originating query has been cancelled, reports a clean {@link TaskCancelledException} to {@code listener}
+     * and returns {@code true}; otherwise returns {@code false}. Used in the resolution failure path so that a footer
+     * read which failed <em>because</em> the query was cancelled mid-flight surfaces as cancellation rather than as a
+     * generic resolution error. Such a failure can arrive wrapped — {@code resolveSingleSource} wraps reader failures
+     * in {@link IllegalArgumentException} and the schema cache wraps loader failures in {@code ExecutionException} —
+     * so the cancellation state is consulted directly rather than matched on the exception type.
+     */
+    private boolean reportIfCancelled(String path, ActionListener<?> listener) {
+        if (isCancelled()) {
+            LOGGER.debug("External source resolution cancelled for [{}]", path);
+            listener.onFailure(new TaskCancelledException("ES|QL external source resolution cancelled"));
+            return true;
+        }
+        return false;
     }
 
     public void resolve(
@@ -191,11 +245,27 @@ public class ExternalSourceResolver {
                         ExternalSourceResolution.ResolvedSource resolvedSource = resolveSource(path, config, hints, hivePartitioning);
                         resolved.put(path, resolvedSource);
                         LOGGER.debug("Successfully resolved external source: {}", path);
+                    } catch (TaskCancelledException e) {
+                        // Surface cancellation unwrapped so the client sees a clean cancellation (4xx) rather
+                        // than a generic "Failed to resolve external source" wrapper (500).
+                        LOGGER.debug("External source resolution cancelled for [{}]", path);
+                        listener.onFailure(e);
+                        return;
                     } catch (IllegalArgumentException | UnsupportedOperationException e) {
+                        // A footer read (e.g. the FFW anchor or a single-file source) can fail because the query was
+                        // cancelled mid-read; surface that as cancellation rather than a bad-request/unsupported error.
+                        if (reportIfCancelled(path, listener)) {
+                            return;
+                        }
                         LOGGER.error("Failed to resolve external source [{}]: {}", path, e.getMessage(), e);
                         listener.onFailure(e);
                         return;
                     } catch (Exception e) {
+                        // Same guard for wrapped failures (e.g. the schema cache wraps a cancelled anchor read in
+                        // ExecutionException): a cancelled query must not surface as a generic 500.
+                        if (reportIfCancelled(path, listener)) {
+                            return;
+                        }
                         LOGGER.error("Failed to resolve external source [{}]: {}", path, e.getMessage(), e);
                         String exceptionMessage = e.getMessage();
                         String errorDetail = exceptionMessage != null ? exceptionMessage : e.getClass().getSimpleName();
@@ -219,6 +289,10 @@ public class ExternalSourceResolver {
         boolean hivePartitioning
     ) throws Exception {
         LOGGER.debug("Resolving external source: path=[{}]", path);
+
+        // A query cancelled before resolution starts must do no storage I/O at all: bail before glob
+        // expansion, cache listing, or any footer read.
+        throwIfCancelled();
 
         if (GlobExpander.isMultiFile(path)) {
             return resolveMultiFileSource(path, config, hints, hivePartitioning);
@@ -328,6 +402,9 @@ public class ExternalSourceResolver {
 
         StoragePath anchorPath = listing.path(anchor);
         long anchorMtime = listing.lastModifiedMillis(anchor);
+
+        // Glob expansion / cache listing above can be slow on wide globs; re-check before the anchor footer read.
+        throwIfCancelled();
 
         ExternalSourceMetadata extMetadata;
         if (cacheable) {
@@ -587,6 +664,7 @@ public class ExternalSourceResolver {
         }
 
         List<Map.Entry<StoragePath, SourceMetadata>> entries = BoundedParallelGather.gather(indices, i -> {
+            throwIfCancelled();
             StoragePath filePath = fileList.path(i);
             SourceMetadata meta = cacheable
                 ? cachedResolveSingleSource(filePath, fileList.lastModifiedMillis(i), config)
@@ -652,13 +730,18 @@ public class ExternalSourceResolver {
         }
         List<SourceMetadata> allMeta;
         try {
-            allMeta = BoundedParallelGather.gather(
-                paths,
-                filePath -> resolveSingleSource(filePath.toString(), config),
-                MAX_PARALLEL_METADATA_READS,
-                executor
-            );
+            allMeta = BoundedParallelGather.gather(paths, filePath -> {
+                throwIfCancelled();
+                return resolveSingleSource(filePath.toString(), config);
+            }, MAX_PARALLEL_METADATA_READS, executor);
+        } catch (TaskCancelledException e) {
+            // Cancellation is not a "could not aggregate stats" condition — propagate it so the query
+            // aborts promptly instead of silently degrading to partial stats and continuing.
+            throw e;
         } catch (Exception e) {
+            // If the query was cancelled, a read may have failed for that reason; surface cancellation
+            // rather than masking it as partial stats.
+            throwIfCancelled();
             LOGGER.debug(() -> "Failed to read per-file stats in parallel, will use partial stats: " + e.getMessage());
             return null;
         }
@@ -676,6 +759,8 @@ public class ExternalSourceResolver {
         int fileCount = listing.fileCount();
         List<Map<String, Object>> perFileStats = new ArrayList<>(fileCount);
         for (int i = 0; i < fileCount; i++) {
+            // Cancellation is checked before the per-file try so it is never swallowed as "partial stats".
+            throwIfCancelled();
             StoragePath filePath = listing.path(i);
             long mtime = listing.lastModifiedMillis(i);
             String formatType = detectFormatType(filePath);
@@ -690,7 +775,14 @@ public class ExternalSourceResolver {
                     return null;
                 }
                 perFileStats.add(fileMeta);
+            } catch (TaskCancelledException e) {
+                // A bare cancellation (e.g. from a cache wait point) must abort, not degrade to partial stats.
+                throw e;
             } catch (Exception e) {
+                // The schema cache wraps loader failures in ExecutionException, so a cancellation observed
+                // while reading a footer can arrive wrapped here; re-check the supplier so it surfaces as
+                // cancellation rather than being masked as partial stats.
+                throwIfCancelled();
                 LOGGER.debug(() -> "Failed to get cached stats for [" + filePath + "], will use partial stats: " + e.getMessage());
                 return null;
             }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/utils/BoundedParallelGather.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/utils/BoundedParallelGather.java
@@ -7,32 +7,43 @@
 
 package org.elasticsearch.xpack.esql.datasources.utils;
 
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.util.concurrent.ThrottledTaskRunner;
 import org.elasticsearch.core.CheckedFunction;
+import org.elasticsearch.core.Releasable;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Applies a function to a list of items with bounded parallelism, collecting results in input order.
  *
- * <p>Dispatches work to the provided executor with a semaphore to cap the number of concurrent
- * in-flight calls. Blocks the calling thread until all items complete (join pattern), then
- * returns the results in the same order as the input list.
+ * <p>Work is routed through a {@link ThrottledTaskRunner}, which submits at most {@code maxConcurrency}
+ * runnables to the provided executor at any one time and holds the remaining items in its own in-memory
+ * FIFO queue. This bounds <em>submission</em>, not just execution: a large input list can never overflow
+ * a bounded executor queue (e.g. the {@code SEARCH} pool), so it can only ever fail fast on a genuine
+ * running-slot rejection — never flood the pool with thousands of enqueued tasks. The calling thread
+ * blocks until all items complete (join pattern), then returns the results in the same order as the
+ * input list. If the calling thread is interrupted while waiting, it short-circuits the not-yet-started
+ * items and still drains the in-flight ones before failing, so no task is left running against the
+ * executor once {@code gather} returns.
  *
- * <p>Fast-fail semantics: once any item throws, remaining not-yet-started items are skipped.
- * The first exception is re-thrown after all in-flight tasks complete. Additional exceptions
- * from other tasks are suppressed onto the first.
+ * <p>Fast-fail semantics: once any item throws, remaining not-yet-started items are skipped (they are
+ * still dequeued by the runner but short-circuit before invoking the function). The first exception is
+ * re-thrown after all tasks settle. Additional exceptions from other tasks are suppressed onto the first.
+ * A running-slot rejection from the executor (surfaced via {@link ActionListener#onFailure}) is recorded
+ * the same way, so the call fails fast and cleanly rather than hanging.
  *
  * <p>For zero or one items, the function is executed inline on the calling thread — no thread
  * dispatch occurs. This avoids executor overhead for the common trivial case.
  */
 public final class BoundedParallelGather {
+
+    private static final String TASK_RUNNER_NAME = "bounded-parallel-gather";
 
     private BoundedParallelGather() {}
 
@@ -47,8 +58,9 @@ public final class BoundedParallelGather {
      * @param <T>            input type
      * @param <R>            result type
      * @return a list of results in the same order as {@code items}
-     * @throws Exception     the first exception thrown by any invocation of {@code fn},
-     *                       with remaining exceptions suppressed onto it
+     * @throws Exception     the first exception thrown by any invocation of {@code fn} (or by the
+     *                       executor when rejecting a running slot), with remaining exceptions
+     *                       suppressed onto it
      */
     public static <T, R> List<R> gather(List<T> items, CheckedFunction<T, R, Exception> fn, int maxConcurrency, Executor executor)
         throws Exception {
@@ -66,48 +78,71 @@ public final class BoundedParallelGather {
             return List.of(fn.apply(items.get(0)));
         }
 
-        Semaphore semaphore = new Semaphore(Math.min(size, maxConcurrency));
+        Object[] results = new Object[size];
         AtomicBoolean failed = new AtomicBoolean(false);
         AtomicReference<Exception> firstError = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(size);
 
-        @SuppressWarnings("unchecked")
-        CompletableFuture<R>[] futures = (CompletableFuture<R>[]) new CompletableFuture<?>[size];
+        // The runner only ever dispatches up to maxConcurrency runnables to the executor, so enqueue
+        // rejection is impossible. Any rejection here is a running-slot rejection (the executor is
+        // already saturated by real work) and arrives per-task via onFailure.
+        ThrottledTaskRunner runner = new ThrottledTaskRunner(TASK_RUNNER_NAME, Math.min(size, maxConcurrency), executor);
 
         for (int i = 0; i < size; i++) {
-            T item = items.get(i);
-            futures[i] = CompletableFuture.supplyAsync(() -> {
-                if (failed.get()) {
-                    return null;
-                }
-                try {
-                    semaphore.acquire();
-                    try {
-                        if (failed.get()) {
-                            return null;
+            final int idx = i;
+            final T item = items.get(i);
+            runner.enqueueTask(new ActionListener<>() {
+                @Override
+                public void onResponse(Releasable releasable) {
+                    // Closing the releasable lets the runner dispatch the next queued task; do it
+                    // before counting down so a freed slot is observed promptly.
+                    try (releasable) {
+                        if (failed.get() == false) {
+                            try {
+                                results[idx] = fn.apply(item);
+                            } catch (Exception e) {
+                                recordError(failed, firstError, e);
+                            }
                         }
-                        return fn.apply(item);
                     } finally {
-                        semaphore.release();
+                        latch.countDown();
                     }
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    Exception wrapped = new RuntimeException("Interrupted while processing item", e);
-                    recordError(failed, firstError, wrapped);
-                    throw new CompletionException(wrapped);
-                } catch (Exception e) {
-                    recordError(failed, firstError, e);
-                    if (e instanceof RuntimeException re) {
-                        throw re;
-                    }
-                    throw new CompletionException(e);
                 }
-            }, executor);
+
+                @Override
+                public void onFailure(Exception e) {
+                    // Reached when the executor rejects this running slot (EsAbortPolicy routes the
+                    // rejection here rather than throwing out of enqueueTask). The runner closes the
+                    // releasable for this path itself, so we only record and release the latch.
+                    try {
+                        recordError(failed, firstError, e);
+                    } finally {
+                        latch.countDown();
+                    }
+                }
+            });
         }
 
-        try {
-            CompletableFuture.allOf(futures).join();
-        } catch (CompletionException ignored) {
-            // The real error is in firstError; we will rethrow below.
+        // Block until every enqueued task has settled. If the calling thread is interrupted we must NOT
+        // return early: the tasks are already enqueued/running on the executor and would otherwise keep
+        // reading footers (and writing into the shared results array) after this method has returned,
+        // breaking the synchronous contract. Instead, record the interruption (which sets the failed flag
+        // so not-yet-started tasks short-circuit and the queue drains without doing more work), keep
+        // waiting for the in-flight tasks to settle, then restore the interrupt status and fail. The
+        // runner guarantees every enqueued task completes via onResponse/onFailure, so the latch always
+        // reaches zero.
+        boolean interrupted = false;
+        while (true) {
+            try {
+                latch.await();
+                break;
+            } catch (InterruptedException e) {
+                interrupted = true;
+                recordError(failed, firstError, new RuntimeException("Interrupted while gathering results", e));
+            }
+        }
+        if (interrupted) {
+            Thread.currentThread().interrupt();
         }
 
         Exception error = firstError.get();
@@ -115,18 +150,13 @@ public final class BoundedParallelGather {
             throw error;
         }
 
-        List<R> results = new ArrayList<>(size);
-        for (CompletableFuture<R> future : futures) {
-            // All futures are complete at this point; get() will not block and
-            // will not throw because firstError is null (all succeeded).
-            try {
-                results.add(future.get());
-            } catch (Exception e) {
-                // Should not happen since firstError is null, but propagate defensively.
-                throw new RuntimeException("Unexpected error collecting gather results", e);
-            }
+        List<R> resultList = new ArrayList<>(size);
+        for (Object result : results) {
+            @SuppressWarnings("unchecked")
+            R typed = (R) result;
+            resultList.add(typed);
         }
-        return results;
+        return resultList;
     }
 
     private static void recordError(AtomicBoolean failed, AtomicReference<Exception> firstError, Exception e) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/utils/BoundedParallelGather.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/utils/BoundedParallelGather.java
@@ -38,6 +38,12 @@ import java.util.concurrent.atomic.AtomicReference;
  * A running-slot rejection from the executor (surfaced via {@link ActionListener#onFailure}) is recorded
  * the same way, so the call fails fast and cleanly rather than hanging.
  *
+ * <p>Fast-fail granularity is per slot, not per call: an item whose {@code fn} invocation is already in
+ * progress when the failure (or a cancellation observed inside {@code fn}) is seen runs to completion —
+ * at most {@code maxConcurrency} such calls can be in flight. Only items that have not yet started are
+ * skipped. A caller that aborts via a cancellation check inside {@code fn} therefore stops promptly, but
+ * up to one already-started call per slot may still finish before {@code gather} returns.
+ *
  * <p>For zero or one items, the function is executed inline on the calling thread — no thread
  * dispatch occurs. This avoids executor overhead for the common trivial case.
  */

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/execution/PlanExecutor.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/execution/PlanExecutor.java
@@ -42,6 +42,7 @@ import org.elasticsearch.xpack.esql.view.ViewResolver;
 
 import java.util.List;
 import java.util.function.BiConsumer;
+import java.util.function.BooleanSupplier;
 
 import static org.elasticsearch.action.ActionListener.wrap;
 
@@ -98,6 +99,7 @@ public class PlanExecutor {
         IndicesExpressionGrouper indicesExpressionGrouper,
         EsqlSession.PlanRunner planRunner,
         TransportActionServices services,
+        BooleanSupplier cancellation,
         ActionListener<Versioned<Result>> listener
     ) {
         final PlanTelemetry planTelemetry = new PlanTelemetry(functionRegistry);
@@ -107,7 +109,8 @@ public class PlanExecutor {
             services.transportService().getThreadPool().executor(org.elasticsearch.threadpool.ThreadPool.Names.SEARCH),
             dataSourceModule,
             services.clusterService().getSettings(),
-            cacheService
+            cacheService,
+            cancellation
         );
         final var session = new EsqlSession(
             sessionId,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlQueryAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlQueryAction.java
@@ -351,6 +351,7 @@ public class TransportEsqlQueryAction extends HandledTransportAction<EsqlQueryRe
             remoteClusterService,
             planRunner,
             services,
+            ((CancellableTask) task)::isCancelled,
             ActionListener.wrap(result -> {
                 recordCCSTelemetry(task, executionInfo, request, null);
                 planExecutor.metrics().recordTook(executionInfo.overallTook().millis());

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolverTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolverTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.CloseableIterator;
+import org.elasticsearch.tasks.TaskCancelledException;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
@@ -41,6 +42,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.StorageProviderFactory;
 
 import java.io.InputStream;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -51,10 +53,13 @@ import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BooleanSupplier;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.lessThan;
 
 /**
  * Tests for {@link ExternalSourceResolver} multi-file schema resolution behavior.
@@ -568,6 +573,197 @@ public class ExternalSourceResolverTests extends ESTestCase {
 
         Exception e = expectThrows(RuntimeException.class, () -> resolveMultiFile("s3://bucket/data/*.parquet", schemasByPath, List.of()));
         assertTrue(e.getMessage().contains("Glob pattern matched no files"));
+    }
+
+    // ===== Cancellation =====
+
+    /**
+     * A multi-file resolve must abort with {@link TaskCancelledException} when the originating query is
+     * cancelled mid-flight, and must stop reading further per-file footers rather than scanning the whole
+     * glob. The resolver runs on the DIRECT executor here, so footer reads happen sequentially and the
+     * cancellation flag (flipped after a couple of reads) deterministically short-circuits the rest.
+     */
+    public void testMultiFileResolveCancellationStopsReadingFooters() {
+        int fileCount = 5;
+        int cancelAfter = 2;
+        List<Attribute> schema = List.of(attr("x", DataType.INTEGER));
+
+        Map<String, List<Attribute>> schemasByPath = new HashMap<>();
+        List<StorageEntry> listing = new ArrayList<>();
+        for (int i = 0; i < fileCount; i++) {
+            String path = "s3://bucket/data/f" + i + ".parquet";
+            schemasByPath.put(path, schema);
+            listing.add(entry(path, 100 + i));
+        }
+
+        Map<String, List<StorageEntry>> listingsByPrefix = new HashMap<>();
+        listingsByPrefix.put(StoragePath.of("s3://bucket/data/*.parquet").patternPrefix().toString(), listing);
+
+        AtomicInteger reads = new AtomicInteger(0);
+        // Flip cancellation once a couple of footers have been read.
+        BooleanSupplier isCancelled = () -> reads.get() >= cancelAfter;
+
+        ExternalSourceResolver resolver = createResolverWithCancellation(schemasByPath, listingsByPrefix, isCancelled, reads);
+        PlainActionFuture<ExternalSourceResolution> future = new PlainActionFuture<>();
+        resolver.resolve(List.of("s3://bucket/data/*.parquet"), Map.of(), future);
+
+        // Cancellation surfaces unwrapped (not wrapped in a generic "Failed to resolve external source").
+        expectThrows(TaskCancelledException.class, future::actionGet);
+        assertThat(
+            "cancellation must stop the resolver before reading every footer; read " + reads.get() + " of " + fileCount,
+            reads.get(),
+            lessThan(fileCount)
+        );
+    }
+
+    /**
+     * A query already cancelled before resolution starts must perform no footer reads at all: the early
+     * cancellation check at the top of {@code resolveSource} aborts before glob expansion, cache listing, or
+     * any footer read. Surfaces as {@link TaskCancelledException} with a footer read count of exactly zero.
+     */
+    public void testResolveCancelledUpFrontReadsNoFooters() {
+        int fileCount = 4;
+        List<Attribute> schema = List.of(attr("x", DataType.INTEGER));
+
+        Map<String, List<Attribute>> schemasByPath = new HashMap<>();
+        List<StorageEntry> listing = new ArrayList<>();
+        for (int i = 0; i < fileCount; i++) {
+            String path = "s3://bucket/data/f" + i + ".parquet";
+            schemasByPath.put(path, schema);
+            listing.add(entry(path, 100 + i));
+        }
+
+        Map<String, List<StorageEntry>> listingsByPrefix = new HashMap<>();
+        listingsByPrefix.put(StoragePath.of("s3://bucket/data/*.parquet").patternPrefix().toString(), listing);
+
+        AtomicInteger reads = new AtomicInteger(0);
+        ExternalSourceResolver resolver = createResolverWithCancellation(schemasByPath, listingsByPrefix, () -> true, reads);
+        PlainActionFuture<ExternalSourceResolution> future = new PlainActionFuture<>();
+        resolver.resolve(List.of("s3://bucket/data/*.parquet"), Map.of(), future);
+
+        expectThrows(TaskCancelledException.class, future::actionGet);
+        assertEquals("a query cancelled before resolution must read zero footers", 0, reads.get());
+    }
+
+    /**
+     * Cancellation observed while reading a footer on the cacheable FIRST_FILE_WINS stats path must surface as
+     * {@link TaskCancelledException}, not be masked as a partial-stats result. The schema cache wraps loader
+     * failures in an {@code ExecutionException}, so the resolver cannot rely on the exception type alone — it
+     * re-checks cancellation in its partial-stats fallback. Here the format reader flips the cancellation flag
+     * and fails the second file's footer read; the resolve must abort with {@code TaskCancelledException} rather
+     * than complete with partial (anchor-only) stats.
+     */
+    public void testCachedMultiFileResolveSurfacesCancellationObservedMidRead() throws Exception {
+        int fileCount = 2;
+        List<Attribute> schema = List.of(attr("x", DataType.INTEGER));
+
+        Map<String, List<Attribute>> schemasByPath = new HashMap<>();
+        Map<String, Long> rowCountsByPath = new HashMap<>();
+        List<StorageEntry> listing = new ArrayList<>();
+        for (int i = 0; i < fileCount; i++) {
+            String path = "s3://bucket/data/f" + i + ".parquet";
+            schemasByPath.put(path, schema);
+            rowCountsByPath.put(path, 10L);
+            listing.add(entry(path, 100 + i));
+        }
+
+        Map<String, List<StorageEntry>> listingsByPrefix = new HashMap<>();
+        listingsByPrefix.put(StoragePath.of("s3://bucket/data/*.parquet").patternPrefix().toString(), listing);
+
+        AtomicInteger reads = new AtomicInteger(0);
+        AtomicBoolean cancelled = new AtomicBoolean(false);
+        // The lex-smallest file (f0) is the anchor; f1 is therefore only read inside the aggregate loop. Fail
+        // f1's footer read with the query already flipped to cancelled, simulating a read that aborts because the
+        // client cancelled mid-flight — exercising the partial-stats fallback's cancellation re-check.
+        String failOnPathSuffix = "f1.parquet";
+
+        Settings cacheSettings = Settings.builder()
+            .put("esql.source.cache.size", "10mb")
+            .put("esql.source.cache.enabled", true)
+            .put("esql.source.cache.schema.ttl", "5m")
+            .put("esql.source.cache.listing.ttl", "30s")
+            .build();
+
+        try (ExternalSourceCacheService cacheService = new ExternalSourceCacheService(cacheSettings)) {
+            ExternalSourceResolver resolver = createCachedResolverFailingMidRead(
+                schemasByPath,
+                rowCountsByPath,
+                listingsByPrefix,
+                cacheService,
+                cancelled,
+                reads,
+                failOnPathSuffix
+            );
+            PlainActionFuture<ExternalSourceResolution> future = new PlainActionFuture<>();
+            resolver.resolve(
+                List.of("s3://bucket/data/*.parquet"),
+                Map.of("s3://bucket/data/*.parquet", new HashMap<>(configFor(FormatReader.SchemaResolution.FIRST_FILE_WINS))),
+                future
+            );
+
+            // Without the cancellation re-check the wrapped failure would degrade to partial stats and the resolve
+            // would succeed; instead it must surface cancellation.
+            expectThrows(TaskCancelledException.class, future::actionGet);
+            assertTrue("the failing footer read must have flipped the query to cancelled", cancelled.get());
+        }
+    }
+
+    /**
+     * Cancellation observed while reading the FIRST_FILE_WINS anchor footer (before the per-file aggregate loop is
+     * even reached) must surface as {@link TaskCancelledException}, not as a generic resolution error. The anchor
+     * read happens outside the aggregate loop and the cache wraps the failure in an {@code ExecutionException}, so
+     * the resolver re-checks cancellation in its failure path. Here the format reader fails the anchor (lex-smallest)
+     * file's footer read with the query already flipped to cancelled.
+     */
+    public void testCachedMultiFileResolveSurfacesCancellationDuringAnchorRead() throws Exception {
+        int fileCount = 2;
+        List<Attribute> schema = List.of(attr("x", DataType.INTEGER));
+
+        Map<String, List<Attribute>> schemasByPath = new HashMap<>();
+        Map<String, Long> rowCountsByPath = new HashMap<>();
+        List<StorageEntry> listing = new ArrayList<>();
+        for (int i = 0; i < fileCount; i++) {
+            String path = "s3://bucket/data/f" + i + ".parquet";
+            schemasByPath.put(path, schema);
+            rowCountsByPath.put(path, 10L);
+            listing.add(entry(path, 100 + i));
+        }
+
+        Map<String, List<StorageEntry>> listingsByPrefix = new HashMap<>();
+        listingsByPrefix.put(StoragePath.of("s3://bucket/data/*.parquet").patternPrefix().toString(), listing);
+
+        AtomicInteger reads = new AtomicInteger(0);
+        AtomicBoolean cancelled = new AtomicBoolean(false);
+        // f0 is the lex-smallest file, hence the FFW anchor read that runs before the aggregate loop.
+        String failOnPathSuffix = "f0.parquet";
+
+        Settings cacheSettings = Settings.builder()
+            .put("esql.source.cache.size", "10mb")
+            .put("esql.source.cache.enabled", true)
+            .put("esql.source.cache.schema.ttl", "5m")
+            .put("esql.source.cache.listing.ttl", "30s")
+            .build();
+
+        try (ExternalSourceCacheService cacheService = new ExternalSourceCacheService(cacheSettings)) {
+            ExternalSourceResolver resolver = createCachedResolverFailingMidRead(
+                schemasByPath,
+                rowCountsByPath,
+                listingsByPrefix,
+                cacheService,
+                cancelled,
+                reads,
+                failOnPathSuffix
+            );
+            PlainActionFuture<ExternalSourceResolution> future = new PlainActionFuture<>();
+            resolver.resolve(
+                List.of("s3://bucket/data/*.parquet"),
+                Map.of("s3://bucket/data/*.parquet", new HashMap<>(configFor(FormatReader.SchemaResolution.FIRST_FILE_WINS))),
+                future
+            );
+
+            expectThrows(TaskCancelledException.class, future::actionGet);
+            assertTrue("the failing anchor read must have flipped the query to cancelled", cancelled.get());
+        }
     }
 
     // ===== Single-file resolution returns a resolved singleton FileList =====
@@ -1636,6 +1832,208 @@ public class ExternalSourceResolverTests extends ESTestCase {
                 return new Configured<>(provider, Set.copyOf(config.keySet()));
             }
         };
+    }
+
+    /**
+     * Builds a resolver wired with an {@code isCancelled} supplier and a format reader that counts footer
+     * reads, so cancellation behavior can be observed end-to-end. Runs on the DIRECT executor so reads are
+     * sequential and deterministic.
+     */
+    private ExternalSourceResolver createResolverWithCancellation(
+        Map<String, List<Attribute>> schemasByPath,
+        Map<String, List<StorageEntry>> listingsByPrefix,
+        BooleanSupplier isCancelled,
+        AtomicInteger readCounter
+    ) {
+        NoConfigFormatReader formatReader = new NoConfigFormatReader() {
+            @Override
+            public SourceMetadata metadata(StorageObject object) {
+                readCounter.incrementAndGet();
+                String path = object.path().toString();
+                List<Attribute> schema = schemasByPath.get(path);
+                if (schema == null) {
+                    throw new IllegalArgumentException("No schema configured for path: " + path);
+                }
+                return new StubSourceMetadata(path, schema);
+            }
+
+            @Override
+            public CloseableIterator<Page> read(StorageObject object, FormatReadContext context) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public String formatName() {
+                return "parquet";
+            }
+
+            @Override
+            public List<String> fileExtensions() {
+                return List.of(".parquet");
+            }
+
+            @Override
+            public void close() {}
+        };
+        StubStorageProvider storageProvider = new StubStorageProvider(listingsByPrefix, schemasByPath);
+
+        DataSourcePlugin plugin = new DataSourcePlugin() {
+            @Override
+            public Set<String> supportedSchemes() {
+                return Set.of("s3");
+            }
+
+            @Override
+            public Set<FormatSpec> formatSpecs() {
+                return Set.of(FormatSpec.of("parquet", ".parquet"));
+            }
+
+            @Override
+            public Map<String, StorageProviderFactory> storageProviders(Settings settings) {
+                return Map.of("s3", stubStorageProviderFactory(storageProvider));
+            }
+
+            @Override
+            public Map<String, FormatReaderFactory> formatReaders(Settings settings) {
+                return Map.of("parquet", (s, bf) -> formatReader);
+            }
+        };
+
+        List<DataSourcePlugin> plugins = List.of(plugin);
+        DataSourceCapabilities capabilities = DataSourceCapabilities.build(plugins);
+        DataSourceModule module = new DataSourceModule(
+            plugins,
+            capabilities,
+            Settings.EMPTY,
+            blockFactory,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
+            new DataSourceCredentials(),
+            () -> false
+        );
+
+        return new ExternalSourceResolver(EsExecutors.DIRECT_EXECUTOR_SERVICE, module, Settings.EMPTY, null, isCancelled);
+    }
+
+    /**
+     * Builds a cacheable resolver whose format reader returns per-file row-count statistics, counts footer reads,
+     * and on the {@code failOnRead}-th read flips {@code cancelled} to {@code true} before throwing — modelling a
+     * footer read that aborts because the originating query was cancelled mid-flight. The resolver's cancellation
+     * supplier is wired to {@code cancelled}, so the partial-stats fallback can re-observe the cancellation.
+     */
+    private ExternalSourceResolver createCachedResolverFailingMidRead(
+        Map<String, List<Attribute>> schemasByPath,
+        Map<String, Long> rowCountsByPath,
+        Map<String, List<StorageEntry>> listingsByPrefix,
+        ExternalSourceCacheService cacheService,
+        AtomicBoolean cancelled,
+        AtomicInteger readCounter,
+        String failOnPathSuffix
+    ) {
+        NoConfigFormatReader formatReader = new NoConfigFormatReader() {
+            @Override
+            public SourceMetadata metadata(StorageObject object) {
+                readCounter.incrementAndGet();
+                if (object.path().toString().endsWith(failOnPathSuffix)) {
+                    cancelled.set(true);
+                    throw new IllegalStateException("footer read failed after cancellation");
+                }
+                String path = object.path().toString();
+                List<Attribute> schema = schemasByPath.get(path);
+                if (schema == null) {
+                    throw new IllegalArgumentException("No schema configured for path: " + path);
+                }
+                Long rowCount = rowCountsByPath.get(path);
+                return new SourceMetadata() {
+                    @Override
+                    public List<Attribute> schema() {
+                        return schema;
+                    }
+
+                    @Override
+                    public String sourceType() {
+                        return "parquet";
+                    }
+
+                    @Override
+                    public String location() {
+                        return path;
+                    }
+
+                    @Override
+                    public Optional<SourceStatistics> statistics() {
+                        if (rowCount == null) {
+                            return Optional.empty();
+                        }
+                        return Optional.of(new SourceStatistics() {
+                            @Override
+                            public OptionalLong rowCount() {
+                                return OptionalLong.of(rowCount);
+                            }
+
+                            @Override
+                            public OptionalLong sizeInBytes() {
+                                return OptionalLong.empty();
+                            }
+                        });
+                    }
+                };
+            }
+
+            @Override
+            public CloseableIterator<Page> read(StorageObject object, FormatReadContext context) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public String formatName() {
+                return "parquet";
+            }
+
+            @Override
+            public List<String> fileExtensions() {
+                return List.of(".parquet");
+            }
+
+            @Override
+            public void close() {}
+        };
+        StubStorageProvider storageProvider = new StubStorageProvider(listingsByPrefix, schemasByPath);
+
+        DataSourcePlugin plugin = new DataSourcePlugin() {
+            @Override
+            public Set<String> supportedSchemes() {
+                return Set.of("s3");
+            }
+
+            @Override
+            public Set<FormatSpec> formatSpecs() {
+                return Set.of(FormatSpec.of("parquet", ".parquet"));
+            }
+
+            @Override
+            public Map<String, StorageProviderFactory> storageProviders(Settings settings) {
+                return Map.of("s3", stubStorageProviderFactory(storageProvider));
+            }
+
+            @Override
+            public Map<String, FormatReaderFactory> formatReaders(Settings settings) {
+                return Map.of("parquet", (s, bf) -> formatReader);
+            }
+        };
+
+        List<DataSourcePlugin> plugins = List.of(plugin);
+        DataSourceCapabilities capabilities = DataSourceCapabilities.build(plugins);
+        DataSourceModule module = new DataSourceModule(
+            plugins,
+            capabilities,
+            Settings.EMPTY,
+            blockFactory,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
+            new DataSourceCredentials(),
+            () -> false
+        );
+
+        return new ExternalSourceResolver(EsExecutors.DIRECT_EXECUTOR_SERVICE, module, Settings.EMPTY, cacheService, cancelled::get);
     }
 
     private ExternalSourceResolver createResolverWithCache(

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/utils/BoundedParallelGatherTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/utils/BoundedParallelGatherTests.java
@@ -7,6 +7,12 @@
 
 package org.elasticsearch.xpack.esql.datasources.utils;
 
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
+import org.elasticsearch.common.util.concurrent.EsThreadPoolExecutor;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.tasks.TaskCancelledException;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.ArrayList;
@@ -15,7 +21,13 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 public class BoundedParallelGatherTests extends ESTestCase {
 
@@ -159,6 +171,236 @@ public class BoundedParallelGatherTests extends ESTestCase {
             expectThrows(IllegalArgumentException.class, () -> BoundedParallelGather.gather(List.of(1, 2), item -> item, 0, executor));
         } finally {
             executor.shutdown();
+        }
+    }
+
+    /**
+     * Regression for #960: with a {@code SEARCH}-style bounded executor whose queue is far smaller than the
+     * number of items, the gather must not overflow the queue. Because submission (not just execution) is
+     * bounded, the executor never sees more than {@code maxConcurrency} runnables at once, so no
+     * {@link EsRejectedExecutionException} is thrown and every result is still produced in order.
+     */
+    public void testBoundedExecutorIsNeverFlooded() throws Exception {
+        int itemCount = 100;
+        int maxConcurrency = 4;
+        // Queue capacity == maxConcurrency, far smaller than itemCount. The old eager-submit implementation
+        // would push all 100 runnables onto this queue at once and overflow it.
+        EsThreadPoolExecutor executor = EsExecutors.newFixed(
+            "test-no-flood",
+            maxConcurrency,
+            maxConcurrency,
+            EsExecutors.daemonThreadFactory("test", "no-flood"),
+            new ThreadContext(Settings.EMPTY),
+            EsExecutors.TaskTrackingConfig.DO_NOT_TRACK
+        );
+        try {
+            AtomicInteger inFlight = new AtomicInteger(0);
+            AtomicInteger peakConcurrency = new AtomicInteger(0);
+
+            List<Integer> items = new ArrayList<>();
+            for (int i = 0; i < itemCount; i++) {
+                items.add(i);
+            }
+
+            List<Integer> results = BoundedParallelGather.gather(items, item -> {
+                int current = inFlight.incrementAndGet();
+                peakConcurrency.accumulateAndGet(current, Math::max);
+                Thread.sleep(1);
+                inFlight.decrementAndGet();
+                return item * 2;
+            }, maxConcurrency, executor);
+
+            assertEquals(itemCount, results.size());
+            for (int i = 0; i < itemCount; i++) {
+                assertEquals(Integer.valueOf(i * 2), results.get(i));
+            }
+            assertThat(
+                "peak in-flight " + peakConcurrency.get() + " must never exceed maxConcurrency " + maxConcurrency,
+                peakConcurrency.get(),
+                lessThanOrEqualTo(maxConcurrency)
+            );
+        } finally {
+            terminate(executor);
+        }
+    }
+
+    /**
+     * When the executor is already saturated by real work and rejects a running slot, the rejection must be
+     * surfaced cleanly: the call fails fast by throwing the {@link EsRejectedExecutionException} (rather than
+     * hanging on a latch that never completes). A pool of size 1 with a zero-length queue, whose single
+     * worker is occupied by an unrelated blocking task, rejects every gather task via {@code EsAbortPolicy}.
+     */
+    public void testRunningSlotRejectionSurfacesCleanly() throws Exception {
+        int maxConcurrency = 4;
+        EsThreadPoolExecutor executor = EsExecutors.newFixed(
+            "test-reject",
+            1,
+            0,
+            EsExecutors.daemonThreadFactory("test", "reject"),
+            new ThreadContext(Settings.EMPTY),
+            EsExecutors.TaskTrackingConfig.DO_NOT_TRACK
+        );
+        CountDownLatch workerBusy = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+        try {
+            // Occupy the single worker thread for the whole gather call so every gather task is rejected.
+            executor.execute(() -> {
+                workerBusy.countDown();
+                try {
+                    release.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            });
+            assertTrue("blocking task did not start", workerBusy.await(10, TimeUnit.SECONDS));
+
+            AtomicInteger startedCount = new AtomicInteger(0);
+            List<Integer> items = List.of(0, 1, 2, 3);
+
+            EsRejectedExecutionException thrown = expectThrows(
+                EsRejectedExecutionException.class,
+                () -> BoundedParallelGather.gather(items, item -> {
+                    startedCount.incrementAndGet();
+                    return item;
+                }, maxConcurrency, executor)
+            );
+            assertNotNull(thrown);
+            // Every task was rejected before it could run, and the call returned (no hang) by throwing.
+            assertEquals("no task should run while the executor is saturated", 0, startedCount.get());
+        } finally {
+            release.countDown();
+            terminate(executor);
+        }
+    }
+
+    /**
+     * Cancellation rides the existing fast-fail path: the gather primitive has no task knowledge, so a
+     * cancelled query is modelled by a function that throws once a flag flips (exactly what
+     * {@code ExternalSourceResolver}'s functions do). Once one item throws, the {@code failed} flag must
+     * short-circuit the not-yet-started items and the thrown exception must propagate to the caller.
+     */
+    public void testCancellationShortCircuitsRemainingItems() throws Exception {
+        int itemCount = 100;
+        int maxConcurrency = 4;
+        AtomicBoolean cancelled = new AtomicBoolean(false);
+        AtomicInteger startedCount = new AtomicInteger(0);
+
+        EsThreadPoolExecutor executor = EsExecutors.newFixed(
+            "test-cancel",
+            maxConcurrency,
+            maxConcurrency,
+            EsExecutors.daemonThreadFactory("test", "cancel"),
+            new ThreadContext(Settings.EMPTY),
+            EsExecutors.TaskTrackingConfig.DO_NOT_TRACK
+        );
+        try {
+            List<Integer> items = new ArrayList<>();
+            for (int i = 0; i < itemCount; i++) {
+                items.add(i);
+            }
+
+            TaskCancelledException thrown = expectThrows(TaskCancelledException.class, () -> BoundedParallelGather.gather(items, item -> {
+                // Mirror ExternalSourceResolver's fns: check cancellation first, before doing any work.
+                if (cancelled.get()) {
+                    throw new TaskCancelledException("cancelled");
+                }
+                if (startedCount.incrementAndGet() == 5) {
+                    cancelled.set(true); // flip mid-flight, after a few items have started
+                }
+                Thread.sleep(5);
+                return item;
+            }, maxConcurrency, executor));
+
+            assertEquals("cancelled", thrown.getMessage());
+            assertThat(
+                "cancellation must stop new items from starting; started " + startedCount.get() + " of " + itemCount,
+                startedCount.get(),
+                lessThan(itemCount)
+            );
+        } finally {
+            terminate(executor);
+        }
+    }
+
+    /**
+     * If the calling thread is interrupted while waiting for results, {@code gather} must not abandon the
+     * tasks it already submitted: they are running on the executor and would keep doing work (and writing
+     * into the shared results array) after the method returned. The fix marks failure (so not-yet-started
+     * items short-circuit), drains the in-flight tasks, restores the interrupt status, and then fails.
+     * <p>
+     * The two in-flight tasks are pinned on a latch so the calling thread is forced to actually wait for
+     * them: a correct implementation does not return until they settle (asserted via {@code gatherReturned}),
+     * whereas the old implementation returned immediately on interrupt leaving them running.
+     */
+    public void testInterruptDrainsInFlightTasksBeforeFailing() throws Exception {
+        int itemCount = 20;
+        int maxConcurrency = 2;
+        EsThreadPoolExecutor executor = EsExecutors.newFixed(
+            "test-interrupt",
+            maxConcurrency,
+            maxConcurrency,
+            EsExecutors.daemonThreadFactory("test", "interrupt"),
+            new ThreadContext(Settings.EMPTY),
+            EsExecutors.TaskTrackingConfig.DO_NOT_TRACK
+        );
+
+        AtomicInteger started = new AtomicInteger(0);
+        AtomicInteger completed = new AtomicInteger(0);
+        CountDownLatch firstTaskRunning = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+        AtomicReference<Throwable> thrown = new AtomicReference<>();
+        AtomicBoolean interruptFlagOnReturn = new AtomicBoolean(false);
+        AtomicBoolean gatherReturned = new AtomicBoolean(false);
+
+        List<Integer> items = new ArrayList<>();
+        for (int i = 0; i < itemCount; i++) {
+            items.add(i);
+        }
+
+        Thread caller = new Thread(() -> {
+            try {
+                BoundedParallelGather.gather(items, item -> {
+                    started.incrementAndGet();
+                    firstTaskRunning.countDown();
+                    // Pin the in-flight slot until the test releases it, so the calling thread is forced to
+                    // wait (drain) for this task rather than abandon it when interrupted.
+                    release.await();
+                    completed.incrementAndGet();
+                    return item;
+                }, maxConcurrency, executor);
+            } catch (Throwable t) {
+                thrown.set(t);
+            } finally {
+                interruptFlagOnReturn.set(Thread.currentThread().isInterrupted());
+                gatherReturned.set(true);
+            }
+        }, "gather-caller");
+
+        try {
+            caller.start();
+            assertTrue("first task did not start", firstTaskRunning.await(10, TimeUnit.SECONDS));
+            // Interrupt the calling thread while it is blocked waiting for results.
+            caller.interrupt();
+
+            // With the in-flight tasks still pinned, a correct gather must keep draining and must NOT have
+            // returned yet (the buggy version returned immediately on interrupt, abandoning the tasks).
+            Thread.sleep(200);
+            assertFalse("gather must drain in-flight tasks before returning on interrupt", gatherReturned.get());
+            assertEquals("pinned in-flight tasks must not have completed yet", 0, completed.get());
+
+            // Release the pinned tasks so the in-flight ones finish and the runner drains the rest.
+            release.countDown();
+            caller.join(TimeUnit.SECONDS.toMillis(10));
+            assertFalse("gather caller thread should have finished", caller.isAlive());
+
+            assertNotNull("gather must fail when the calling thread is interrupted", thrown.get());
+            assertTrue("interrupt status must be restored on the calling thread", interruptFlagOnReturn.get());
+            // Drain contract: every task that started also settled before gather returned — none was abandoned.
+            assertEquals("all started tasks must settle before gather returns", started.get(), completed.get());
+            assertThat("fast-fail must short-circuit some not-yet-started items", started.get(), lessThan(itemCount));
+        } finally {
+            release.countDown();
+            terminate(executor);
         }
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/telemetry/PlanExecutorMetricsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/telemetry/PlanExecutorMetricsTests.java
@@ -241,6 +241,7 @@ public class PlanExecutorMetricsTests extends ESTestCase {
                     groupIndicesByCluster,
                     runPhase,
                     MOCK_TRANSPORT_ACTION_SERVICES,
+                    () -> false,
                     new ActionListener<>() {
                         @Override
                         public void onResponse(Versioned<Result> result) {
@@ -278,6 +279,7 @@ public class PlanExecutorMetricsTests extends ESTestCase {
                     groupIndicesByCluster,
                     runPhase,
                     MOCK_TRANSPORT_ACTION_SERVICES,
+                    () -> false,
                     new ActionListener<>() {
                         @Override
                         public void onResponse(Versioned<Result> result) {}
@@ -624,6 +626,7 @@ public class PlanExecutorMetricsTests extends ESTestCase {
                 groupIndicesByCluster,
                 runPhase,
                 MOCK_TRANSPORT_ACTION_SERVICES,
+                () -> false,
                 listener
             );
         }


### PR DESCRIPTION
Rework `BoundedParallelGather` to submit at most `maxConcurrency` tasks via `ThrottledTaskRunner` instead of flooding the executor queue, and drain in-flight tasks on interrupt before failing so no footer read outlives the gather call.

Plumb query cancellation through `PlanExecutor` and `ExternalSourceResolver` so a cancelled query aborts glob expansion, the `FIRST_FILE_WINS` anchor read, and per-file footer reads promptly, surfacing `TaskCancelledException` instead of masking it as partial stats or a generic 500.

### Notes
- Resolution runs on the `SEARCH` pool, and a wide multi-file resolve pins one `SEARCH` worker on the `BoundedParallelGather` latch (join pattern) while it dispatches up to `MAX_PARALLEL_METADATA_READS` more `SEARCH` tasks. This is pre-existing and an accepted tradeoff: bounding submission means a saturated pool now fails fast via running-slot rejection rather than deadlocking on a flooded queue. Moving resolution off `SEARCH` is a possible follow-up.
- Cancellation short-circuits not-yet-started items; an already in-flight footer read (at most one per slot) still runs to completion before `gather` returns.

Closes #960