### PR TITLE
[9.4] Make AzureClientProvider shutdown synchronous (#151920)

### DIFF
--- a/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureClientProvider.java
+++ b/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureClientProvider.java
@@ -15,7 +15,6 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.resolver.DefaultAddressResolverGroup;
 import reactor.core.publisher.Mono;
-import reactor.core.publisher.SignalType;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 import reactor.netty.resources.ConnectionProvider;
@@ -43,6 +42,7 @@ import org.elasticsearch.common.blobstore.OperationPurpose;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.FutureUtils;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.repositories.azure.executors.ReactorScheduledExecutorService;
 import org.elasticsearch.rest.RestStatus;
@@ -54,6 +54,7 @@ import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.repositories.azure.AzureRepositoryPlugin.NETTY_EVENT_LOOP_THREAD_POOL_NAME;
 import static org.elasticsearch.repositories.azure.AzureRepositoryPlugin.REPOSITORY_THREAD_POOL_NAME;
@@ -258,22 +259,21 @@ class AzureClientProvider extends AbstractLifecycleComponent {
     protected void doStop() {
         closed = true;
         // Dispose of the connection provider first and wait for it to complete before we close the event loop.
-        connectionProvider.disposeLater()
-            .timeout(Duration.ofSeconds(10))    // Limit how long we wait for the connection provider to close
-            .doFinally(signalType -> {
-                if (signalType != SignalType.ON_COMPLETE) {
-                    logger.info("Got unexpected signal type disposing connection provider: {}", signalType);
-                }
-                // Now safe to shut down the event loop
-                eventLoopGroup.shutdownGracefully().addListener(future -> {
-                    if (future.isSuccess() == false) {
-                        logger.warn("Error shutting down Azure event loop, but resetting schedulers anyway", future.cause());
-                    }
-                    // Now everything is shut down, reset the factory to clear any cached schedulers
-                    Schedulers.resetFactory();
-                });
-            })
-            .subscribe(null, throwable -> logger.warn("Error shutting down connection provider", throwable));
+        try {
+            connectionProvider.disposeLater().block(Duration.ofSeconds(5));
+        } catch (RuntimeException e) {
+            logger.warn("Error disposing connection provider", e);
+        } finally {
+            // Now it's safe to shut down the event loop
+            try {
+                FutureUtils.get(eventLoopGroup.shutdownGracefully(), 5, TimeUnit.SECONDS);
+            } catch (RuntimeException e) {
+                logger.warn("Error shutting down event loop group", e);
+            } finally {
+                // Now everything is shut down, reset the factory to clear any cached schedulers
+                Schedulers.resetFactory();
+            }
+        }
     }
 
     @Override

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -242,9 +242,6 @@ tests:
   method: "builds distribution from branches via archives extractedAssemble [bwcDistVersion: 8.2.1, bwcProject: major3, expectedAssembleTaskName:
     extractedAssemble, #2]"
   issue: https://github.com/elastic/elasticsearch/issues/150410
-- class: org.elasticsearch.repositories.azure.AzureBlobContainerTests
-  method: testCanConfigureReadTimeout
-  issue: https://github.com/elastic/elasticsearch/issues/151022
 - class: org.elasticsearch.cluster.routing.allocation.decider.WriteLoadConstraintDeciderIT
   method: testMaxQueueLatencyMetricIsPublished
   issue: https://github.com/elastic/elasticsearch/issues/146283


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Make AzureClientProvider shutdown synchronous (#151920)

Fixes #151022