### PR TITLE
[9.3] Fix flaky SearchWithRandomDisconnectsIT.testSearchWithRandomDisconnects (#147868)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -193,9 +193,6 @@ tests:
 - class: org.elasticsearch.xpack.inference.external.http.sender.RequestExecutorServiceTests
   method: testChangingCapacity_DoesNotRejectsOverflowTasks_BecauseOfQueueFull
   issue: https://github.com/elastic/elasticsearch/issues/137823
-- class: org.elasticsearch.search.basic.SearchWithRandomDisconnectsIT
-  method: testSearchWithRandomDisconnects
-  issue: https://github.com/elastic/elasticsearch/issues/138128
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeMetricsIT
   method: test
   issue: https://github.com/elastic/elasticsearch/issues/138311

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/basic/SearchWithRandomDisconnectsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/basic/SearchWithRandomDisconnectsIT.java
@@ -16,6 +16,7 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ListenableFuture;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.discovery.AbstractDisruptionTestCase;
 import org.elasticsearch.index.IndexModule;
 import org.elasticsearch.index.IndexSettings;
@@ -97,7 +98,7 @@ public class SearchWithRandomDisconnectsIT extends AbstractDisruptionTestCase {
         for (PlainActionFuture<Void> future : futures) {
             future.get();
         }
-        ensureGreen(DISRUPTION_HEALING_OVERHEAD, indexNames);
+        ensureGreen(new TimeValue(DISRUPTION_HEALING_OVERHEAD.millis() + 2000L * indexNames.length), indexNames);
         assertAcked(indicesAdmin().prepareDelete(indexNames));
     }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Fix flaky SearchWithRandomDisconnectsIT.testSearchWithRandomDisconnects (#147868)](https://github.com/elastic/elasticsearch/pull/147868)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

Closes #151925