### PR TITLE
PromQL: Add support for increase on histograms

### DIFF
--- a/docs/changelog/152065.yaml
+++ b/docs/changelog/152065.yaml
@@ -1,0 +1,5 @@
+area: PromQL
+issues: []
+pr: 152065
+summary: "PromQL: Add support for increase on histograms"
+type: enhancement

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/promql-native-histogram-support.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/promql-native-histogram-support.csv-spec
@@ -86,3 +86,85 @@ result:double         | step:datetime            | _timeseries:keyword
 0.0011946046511627907 | 2025-09-25T00:02:00.000Z | "{""instance"":""instance-1""}"
 0.007390242424242424  | 2025-09-25T00:02:00.000Z | "{""instance"":""instance-2""}"
 ;
+
+///////////////////////////////////////////////////////////////////////////////
+// histogram_count with increase on exponential histograms
+// Uses same time range as ES|QL TS test "timeseriesAllAggsFilteredAndBucketed"
+// (TRANGE 00:30:00-01:00:00, TBUCKET 10m) so results should match COUNT column.
+///////////////////////////////////////////////////////////////////////////////
+
+histogram_count_increase_exp_histo_single_bucket
+required_capability: promql_increase_on_histogram
+PROMQL index=exp_histo_sample step=2h start="2025-09-25T02:00:00.000Z" end="2025-09-25T02:00:00.000Z" result=(histogram_count(increase(responseTime{instance="instance-1"}[2h])));
+
+result:double | step:datetime            | _timeseries:keyword
+3250.0        | 2025-09-25T02:00:00.000Z | "{""instance"":""instance-1""}"
+;
+
+histogram_count_increase_exp_histo_all_instances
+required_capability: promql_increase_on_histogram
+PROMQL index=exp_histo_sample step=2h start="2025-09-25T02:00:00.000Z" end="2025-09-25T02:00:00.000Z" result=(histogram_count(increase(responseTime{instance=~"instance-.*"}[2h])))
+| SORT _timeseries;
+
+result:double | step:datetime            | _timeseries:keyword
+8841.0        | 2025-09-25T02:00:00.000Z | "{""instance"":""instance-0""}"
+3250.0        | 2025-09-25T02:00:00.000Z | "{""instance"":""instance-1""}"
+3380.0        | 2025-09-25T02:00:00.000Z | "{""instance"":""instance-2""}"
+;
+
+histogram_count_increase_exp_histo_multi_step
+required_capability: promql_increase_on_histogram
+PROMQL index=exp_histo_sample step=30m start="2025-09-25T00:30:00.000Z" end="2025-09-25T01:30:00.000Z" result=(histogram_count(increase(responseTime{instance="instance-1"}[30m])))
+| SORT step;
+
+result:double | step:datetime            | _timeseries:keyword
+1126.0        | 2025-09-25T00:30:00.000Z | "{""instance"":""instance-1""}"
+890.0         | 2025-09-25T01:00:00.000Z | "{""instance"":""instance-1""}"
+919.0         | 2025-09-25T01:30:00.000Z | "{""instance"":""instance-1""}"
+;
+
+///////////////////////////////////////////////////////////////////////////////
+// histogram_sum with increase on exponential histograms
+///////////////////////////////////////////////////////////////////////////////
+
+histogram_sum_increase_exp_histo_single_bucket
+required_capability: promql_increase_on_histogram
+PROMQL index=exp_histo_sample step=2h start="2025-09-25T02:00:00.000Z" end="2025-09-25T02:00:00.000Z" result=(histogram_sum(increase(responseTime{instance="instance-1"}[2h])));
+
+result:double     | step:datetime            | _timeseries:keyword
+36.19848400000001 | 2025-09-25T02:00:00.000Z | "{""instance"":""instance-1""}"
+;
+
+histogram_sum_increase_exp_histo_all_instances
+required_capability: promql_increase_on_histogram
+PROMQL index=exp_histo_sample step=2h start="2025-09-25T02:00:00.000Z" end="2025-09-25T02:00:00.000Z" result=(histogram_sum(increase(responseTime{instance=~"instance-.*"}[2h])))
+| SORT _timeseries;
+
+result:double      | step:datetime            | _timeseries:keyword
+1472.744209000001  | 2025-09-25T02:00:00.000Z | "{""instance"":""instance-0""}"
+36.19848400000001  | 2025-09-25T02:00:00.000Z | "{""instance"":""instance-1""}"
+27.706021000000007 | 2025-09-25T02:00:00.000Z | "{""instance"":""instance-2""}"
+;
+
+///////////////////////////////////////////////////////////////////////////////
+// histogram_avg with increase on exponential histograms
+///////////////////////////////////////////////////////////////////////////////
+
+histogram_avg_increase_exp_histo_single_bucket
+required_capability: promql_increase_on_histogram
+PROMQL index=exp_histo_sample step=2h start="2025-09-25T02:00:00.000Z" end="2025-09-25T02:00:00.000Z" result=(histogram_avg(increase(responseTime{instance="instance-1"}[2h])));
+
+result:double        | step:datetime            | _timeseries:keyword
+0.011137995076923079 | 2025-09-25T02:00:00.000Z | "{""instance"":""instance-1""}"
+;
+
+histogram_avg_increase_exp_histo_all_instances
+required_capability: promql_increase_on_histogram
+PROMQL index=exp_histo_sample step=2h start="2025-09-25T02:00:00.000Z" end="2025-09-25T02:00:00.000Z" result=(histogram_avg(increase(responseTime{instance=~"instance-.*"}[2h])))
+| SORT _timeseries;
+
+result:double        | step:datetime            | _timeseries:keyword
+0.16658117961769042  | 2025-09-25T02:00:00.000Z | "{""instance"":""instance-0""}"
+0.011137995076923079 | 2025-09-25T02:00:00.000Z | "{""instance"":""instance-1""}"
+0.008197047633136096 | 2025-09-25T02:00:00.000Z | "{""instance"":""instance-2""}"
+;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -3170,6 +3170,11 @@ public class EsqlCapabilities {
         PROMQL_HISTOGRAM_SUM_COUNT_AVG,
 
         /**
+         * Support for PromQL {@code increase()} on exponential histograms.
+         */
+        PROMQL_INCREASE_ON_HISTOGRAM,
+
+        /**
          * Support for the {@code HIGHLIGHT} command. Part A: parsing and plan-shape only; execution
          * throws "not implemented yet". Snapshot-only.
          */

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Increase.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Increase.java
@@ -57,7 +57,11 @@ public class Increase extends TimeSeriesAggregateFunction implements OptionalArg
         .ternary(Increase::createWithImplicitTemporality)
         .name("increase");
     public static final PromqlFunctionDefinition PROMQL_DEFINITION = PromqlFunctionDefinition.def()
-        .withinSeries(Increase::createWithImplicitTemporality)
+        .withinSeries(
+            (source, field, window, timestamp) -> field.resolved() && field.dataType().isHistogram()
+                ? new HistogramMergeOverTime(source, field, window, timestamp)
+                : createWithImplicitTemporality(source, field, window, timestamp)
+        )
         .counterSupport(PromqlFunctionDefinition.CounterSupport.REQUIRED)
         .description("Calculates the increase in the time series in the range vector, adjusting for counter resets.")
         .example("increase(http_requests_total[5m])")

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/PromqlFunctionCall.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/PromqlFunctionCall.java
@@ -113,7 +113,7 @@ public abstract sealed class PromqlFunctionCall extends UnaryPlan implements Pro
             // PromQL accepts any numeric range vector. ES|QL distinguishes counter from gauge types
             // internally, so plain numerics are wrapped with to_counter() for counter-required
             // functions and counter metrics are wrapped with to_gauge() for gauge-only functions.
-            if (target != null && target.resolved()) {
+            if (target != null && target.resolved() && target.dataType().isHistogram() == false) {
                 var counterSupport = definition.counterSupport();
                 if (counterSupport == PromqlFunctionDefinition.CounterSupport.REQUIRED && DataType.isCounter(target.dataType()) == false) {
                     target = new ToCounter(source(), target);


### PR DESCRIPTION
Part of https://github.com/elastic/elasticsearch/issues/150074.

Adds support for `increase` on exponential histograms. We simply wire it to use our `merge_over_time` ES|QL function, which does what is semantically expected: `increase` yields a histogram approximating all raw samples that have fallen into the specific time range. Because `merge_over_time` handles temporality, `increase` in `PromQL` also automatically will handle the temporality.