### PR TITLE
Fix GeoLineDecomposer infinite loop on extreme longitude values

### DIFF
--- a/docs/changelog/152067.yaml
+++ b/docs/changelog/152067.yaml
@@ -1,0 +1,6 @@
+pr: 152067
+summary: Reject extreme or non-finite coordinates in GeoLineDecomposer to prevent OOM
+area: Geo
+type: bug
+issues:
+ - 152066

--- a/server/src/main/java/org/elasticsearch/common/geo/GeoLineDecomposer.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeoLineDecomposer.java
@@ -6,7 +6,6 @@
  * your election, the "Elastic License 2.0", the "GNU Affero General Public
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
-
 package org.elasticsearch.common.geo;
 
 import org.elasticsearch.geometry.Line;
@@ -60,8 +59,20 @@ class GeoLineDecomposer {
         double[] lats = new double[lons.length];
 
         for (int i = 0; i < lons.length; i++) {
-            double[] lonLat = new double[] { line.getX(i), line.getY(i) };
-            normalizePoint(lonLat, false, true);
+            double x = line.getX(i);
+            double y = line.getY(i);
+            // Reject non-finite values and longitudes beyond a conservative safety threshold.
+            // Cross-dateline encodings use continuous longitude sequences (e.g. lon=200 for
+            // -160° wrapped), so values moderately above ±180 are legitimate. However, values
+            // of magnitude ~1e19 drive the anti-meridian loop to ~1e17 iterations, exhausting
+            // the heap. 1e6° is a conservative upper bound that keeps the worst-case iteration
+            // count under ~3000 while rejecting any plausible data-corruption value.
+            if (Double.isFinite(x) == false || Double.isFinite(y) == false || Math.abs(x) > 1e6) {
+                throw new IllegalArgumentException(
+                    "invalid LineString coordinate at index " + i + ": [" + x + ", " + y + "]");
+            }
+            double[] lonLat = new double[] {x, y};
+            normalizePoint(lonLat,false, true);
             lons[i] = lonLat[0];
             lats[i] = lonLat[1];
         }
@@ -138,7 +149,7 @@ class GeoLineDecomposer {
     private static double calculateShift(double lon, boolean include180) {
         double normalized = GeoUtils.centeredModulus(lon, 360);
         double shift = Math.round(normalized - lon);
-        if (include180 == false && normalized == 180.0) {
+        if (!include180 && normalized == 180.0) {
             shift = shift - 360;
         }
         return shift;

--- a/server/src/test/java/org/elasticsearch/common/geo/GeoLineDecomposerTests.java
+++ b/server/src/test/java/org/elasticsearch/common/geo/GeoLineDecomposerTests.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.common.geo;
+
+import org.elasticsearch.geometry.Line;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class GeoLineDecomposerTests extends ESTestCase {
+
+    public void testEmptyLineIsNoOp() {
+        List<Line> collector = new ArrayList<>();
+        GeoLineDecomposer.decomposeLine(Line.EMPTY, collector);
+        assertEquals(0, collector.size());
+    }
+
+    public void testSimpleLineIsKeptAsSingleSegment() {
+        Line line = new Line(new double[] { 10, 20, 30 }, new double[] { 1, 2, 3 });
+        List<Line> collector = new ArrayList<>();
+        GeoLineDecomposer.decomposeLine(line, collector);
+        assertEquals(1, collector.size());
+        assertArrayEquals(new double[] { 10, 20, 30 }, collector.get(0).getX(), 0.0);
+        assertArrayEquals(new double[] { 1, 2, 3 }, collector.get(0).getY(), 0.0);
+    }
+
+    public void testCrossingDatelineIsSplit() {
+        Line line = new Line(new double[] { 160, 200 }, new double[] { 10, 20 });
+        List<Line> collector = new ArrayList<>();
+        GeoLineDecomposer.decomposeLine(line, collector);
+        assertEquals(2, collector.size());
+        assertArrayEquals(new double[] { 160, 180 }, collector.get(0).getX(), 0.0);
+        assertArrayEquals(new double[] { -180, -160 }, collector.get(1).getX(), 0.0);
+    }
+
+    /**
+     * Longitudes in (180, 360] and multi-revolution encodings up to ±1e6 are legitimate
+     * cross-dateline inputs (e.g. lon=200 == -160 wrapped, lon=900 == -180+180*3).
+     * The validator must not reject them.
+     */
+    public void testAllowsLongitudeUpTo360() {
+        List<Line> collector = new ArrayList<>();
+        GeoLineDecomposer.decomposeLine(new Line(new double[] { 10, 200 }, new double[] { 1, 2 }), collector);
+        assertFalse(collector.isEmpty());
+    }
+
+    public void testAllowsMultiRevolutionLongitude() {
+        // lon=900 = 2.5 revolutions, still a legitimate cross-dateline encoding
+        List<Line> collector = new ArrayList<>();
+        GeoLineDecomposer.decomposeLine(new Line(new double[] { 10, 900 }, new double[] { 1, 2 }), collector);
+        assertFalse(collector.isEmpty());
+    }
+
+    /**
+     * Reproduces the OOM seen in the field: a LineString whose second longitude is a corrupted
+     * value (~-4.14e19) drives the dateline-decomposing loop to add hundreds of millions of
+     * 2-point Lines before exiting (~350 million objects, 24 GB retained, node OOMed in ~3s).
+     * The fix must reject the document fast with an IllegalArgumentException.
+     */
+    public void testRejectsExtremeLongitude() {
+        Line line = new Line(
+            new double[] { 116.5037459137329, -4.142431633325595e19 },
+            new double[] { 39.793895444619, 71.0 }
+        );
+        IllegalArgumentException ex = expectThrows(
+            IllegalArgumentException.class,
+            () -> GeoLineDecomposer.decomposeLine(line, new ArrayList<>())
+        );
+        assertTrue(ex.getMessage(), ex.getMessage().startsWith("invalid LineString coordinate"));
+    }
+
+    public void testRejectsNonFiniteCoordinates() {
+        for (double bad : new double[] { Double.NaN, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY }) {
+            expectThrows(IllegalArgumentException.class, () ->
+                GeoLineDecomposer.decomposeLine(new Line(new double[] { bad, 10 }, new double[] { 1, 2 }), new ArrayList<>()));
+            expectThrows(IllegalArgumentException.class, () ->
+                GeoLineDecomposer.decomposeLine(new Line(new double[] { 10, 20 }, new double[] { bad, 2 }), new ArrayList<>()));
+        }
+    }
+
+    public void testRejectsLongitudeBeyondOneMillion() {
+        expectThrows(IllegalArgumentException.class, () ->
+            GeoLineDecomposer.decomposeLine(new Line(new double[] { 10, 1e6 + 1 }, new double[] { 1, 2 }), new ArrayList<>()));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #152066

A `geo_shape` LineString with a corrupted longitude value (magnitude ~1e19) causes `GeoLineDecomposer.decompose` to loop indefinitely, exhausting the heap and crashing the node. **One malformed document can bring down an entire node within seconds.**

## Root cause

The `decompose` loop has three branches. Branch B fires when `intersection(lons[i-1]+shift, lons[i]+shift)` returns a valid `t ∈ (0,1)`. For `|lons[i]| ~ 1e19`, this is always true — the two endpoints straddle every anti-meridian crossing. Branch B rewrites `lons[i-1]` to `±180 - shift` and calls `collector.add(...)` but **never increments `i`**. Each iteration steps `shift` by 360°; convergence would need `|lons[1] - lons[0]| / 360 ≈ 1.15e17` iterations. In a production incident the heap was exhausted at **~350 million `Line` objects (24 GB retained)**, with the node OOMing in ~3 seconds on a 512 MB heap.

## Fix

Add a coordinate check at the `decomposeLine` entry point. Reject:
- Non-finite values (`NaN`, `±Inf`)
- `|lon| > 1e6°` — a conservative safety threshold. Cross-dateline encodings legitimately use continuous longitude sequences beyond ±180° (e.g. `lon=200` for -160° wrapped), so simply rejecting anything above 180 would be incorrect. `1e6°` keeps the worst-case iteration count under ~3000 while rejecting any plausible data-corruption value. The exact threshold is open to discussion — the key constraint is that it must be finite and bounded enough to prevent unbounded loop growth.

A malformed document now fails fast with HTTP 400 instead of crashing the node.

## Testing

New test class `GeoLineDecomposerTests` with 7 cases:
- Normal line kept as single segment
- Dateline crossing correctly split into 2 segments
- `lon=200` (legitimate wrapped value) accepted
- `lon=900` (multi-revolution cross-dateline encoding) accepted
- Extreme longitude from production heap dump (`-4.14e19`) → `IllegalArgumentException`
- `NaN` / `±Inf` → `IllegalArgumentException`
- `|lon| > 1e6` → `IllegalArgumentException`

## Checklist

- [x] Signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)
- [x] Follows [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)
- [x] Tested locally
- [x] PR targets `main`