### PR TITLE
Downsampling speedup for labels

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/fielddata/FieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/FieldData.java
@@ -344,7 +344,27 @@ public enum FieldData {
      * NOTE: this is slow!
      */
     public static BinaryDocValues toString(final SortedDocValues values) {
-        return new AbstractBinaryDocValues() {
+        return new BinaryDocValues() {
+
+            @Override
+            public int docID() {
+                return values.docID();
+            }
+
+            @Override
+            public int nextDoc() throws IOException {
+                return values.nextDoc();
+            }
+
+            @Override
+            public int advance(int target) throws IOException {
+                return values.advance(target);
+            }
+
+            @Override
+            public long cost() {
+                return values.cost();
+            }
 
             @Override
             public BytesRef binaryValue() throws IOException {

--- a/server/src/main/java/org/elasticsearch/index/fielddata/SortedBinaryDocValues.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/SortedBinaryDocValues.java
@@ -27,10 +27,12 @@ public abstract class SortedBinaryDocValues {
     private final DocIdSetIterator docIdIterator;
 
     /**
-     * @param docIdSetIterator, the {@link DocIdSetIterator} that backs this instance.
+     * @param docIdSetIterator, the {@link DocIdSetIterator} that backs this instance. If the docIdSetIterator is an
+     *                          {@link AbstractBinaryDocValues} then we do not use it because it explicitly does not support
+     *                          the parts of the {@link DocIdSetIterator} interface.
      */
     public SortedBinaryDocValues(@Nullable DocIdSetIterator docIdSetIterator) {
-        this.docIdIterator = docIdSetIterator;
+        this.docIdIterator = docIdSetIterator instanceof AbstractBinaryDocValues ? null : docIdSetIterator;
     }
 
     /**

--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/AbstractFieldDownsampler.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/AbstractFieldDownsampler.java
@@ -65,6 +65,20 @@ abstract class AbstractFieldDownsampler<T> implements DownsampleFieldSerializer 
         return state == State.BUCKET_COMPLETED;
     }
 
+    protected static int lowerBound(int[] values, int from, int to, int target) {
+        int low = from;
+        int high = to;
+        while (low < high) {
+            int mid = (low + high) >>> 1;
+            if (values[mid] < target) {
+                low = mid + 1;
+            } else {
+                high = mid;
+            }
+        }
+        return low;
+    }
+
     /**
      * @return the leaf reader that will retrieve the doc values for this field.
      */

--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/LastValueFieldDownsampler.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/LastValueFieldDownsampler.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.downsample;
 
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.internal.hppc.IntArrayList;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.index.fielddata.FormattedDocValues;
 import org.elasticsearch.index.fielddata.IndexFieldData;
@@ -29,6 +30,12 @@ class LastValueFieldDownsampler extends AbstractFieldDownsampler<FormattedDocVal
 
     private final MappedFieldType fieldType;
     Object lastValue = null;
+
+    // Downsamplers are shared across leaf collectors, but doc-values iterators are leaf-local and forward-only.
+    // Keep the active iterator and read its docID() when switching back to it instead of storing per-leaf positions.
+    private DocIdSetIterator leafDocIdIterator;
+    private int leafDocIdIteratorDoc = -1;
+    private boolean leafIteratorExhausted;
 
     LastValueFieldDownsampler(String name, MappedFieldType fieldType, IndexFieldData<?> fieldData) {
         super(name, fieldData);
@@ -63,9 +70,25 @@ class LastValueFieldDownsampler extends AbstractFieldDownsampler<FormattedDocVal
 
     @Override
     public void collect(FormattedDocValues docValues, IntArrayList docIdBuffer) throws IOException {
-        if (isDone()) {
+        if (isDone() || docIdBuffer.isEmpty()) {
             return;
         }
+
+        DocIdSetIterator docIdIterator = docValues.docIdIterator();
+        if (docIdIterator == null) {
+            collectUsingAdvanceExact(docValues, docIdBuffer);
+            return;
+        }
+
+        resetLeafIteratorStateIfNeeded(docIdIterator);
+        if (leafIteratorExhausted) {
+            return;
+        }
+
+        collectUsingDocIdIterator(docValues, docIdBuffer);
+    }
+
+    private void collectUsingAdvanceExact(FormattedDocValues docValues, IntArrayList docIdBuffer) throws IOException {
         for (int i = 0; i < docIdBuffer.size() && isDone() == false; i++) {
             int docId = docIdBuffer.get(i);
             if (docValues.advanceExact(docId) == false) {
@@ -73,6 +96,91 @@ class LastValueFieldDownsampler extends AbstractFieldDownsampler<FormattedDocVal
             }
             collectCurrentValues(docValues);
         }
+    }
+
+    private void resetLeafIteratorStateIfNeeded(DocIdSetIterator docIdIterator) {
+        if (leafDocIdIterator != docIdIterator) {
+            // If we see a previously used iterator again, its own docID() is the last position for that leaf.
+            leafDocIdIterator = docIdIterator;
+            leafDocIdIteratorDoc = docIdIterator.docID();
+            leafIteratorExhausted = leafDocIdIteratorDoc == DocIdSetIterator.NO_MORE_DOCS;
+        }
+    }
+
+    /**
+     * Collects buffered docs by intersecting the ordered buffer with the numeric doc-values iterator.
+     * <p>
+     * This path is used only when the field exposes a {@link DocIdSetIterator}. The iterator is leaf-local
+     * and forward-only, so we never try to rewind it. When collection later returns to a previously seen
+     * leaf, {@link #resetLeafIteratorStateIfNeeded(DocIdSetIterator)} reads the iterator's own
+     * {@link DocIdSetIterator#docID()} and resumes from that position.
+     *
+     * <pre>
+     * buffered doc ids:  [ 3 ][ 7 ][ 9 ][ 15 ]
+     * doc-values docs:   [ 1 ][ 3 ][ 8 ][ 9 ][ 20 ]
+     *
+     * 1. Advance the doc-values iterator to the first buffered doc or beyond.
+     *
+     *    buffered doc ids:  [ 3 ][ 7 ][ 9 ][ 15 ]
+     *                         ^
+     *    doc-values docs:   [ 1 ][ 3 ][ 8 ][ 9 ][ 20 ]
+     *                         ^
+     *
+     * 2. Keep comparing the current doc-values doc to the current buffered target:
+     *
+     *    current doc &lt; target doc  -> advance doc-values to target doc
+     *    current doc == target doc -> collect current values, then move to the next buffered target
+     *    current doc &gt; target doc  -> binary-search the next buffered target that is >= current doc
+     *
+     * If the iterator is exhausted, the leaf is marked exhausted and later collections for the same iterator
+     * return without touching doc values. This turns the problem into a forward-only merge instead of probing
+     * every buffered doc with {@code advanceExact(docId)}.
+     * </pre>
+     */
+    private void collectUsingDocIdIterator(FormattedDocValues docValues, IntArrayList docIdBuffer) throws IOException {
+        int bufferedDocCount = docIdBuffer.size();
+        int[] bufferedDocIds = docIdBuffer.buffer;
+        if (leafDocIdIteratorDoc > bufferedDocIds[bufferedDocCount - 1]) {
+            return;
+        }
+
+        int firstBufferedDocId = bufferedDocIds[0];
+        if (leafDocIdIteratorDoc < firstBufferedDocId) {
+            // advance to the closest doc that >= firstBufferedDocId
+            advanceLeafDocIdIterator(firstBufferedDocId);
+            if (leafIteratorExhausted) {
+                return;
+            }
+        }
+
+        // find the closest index in bufferedDocIds that points to a doc that is >= leafDocIdIteratorDoc
+        int index = lowerBound(bufferedDocIds, 0, bufferedDocCount, leafDocIdIteratorDoc);
+        while (index < bufferedDocCount && leafIteratorExhausted == false && isDone() == false) {
+            int targetDocId = bufferedDocIds[index];
+            if (leafDocIdIteratorDoc < targetDocId) {
+                // advance to the closest doc that is >= targetDocId
+                advanceLeafDocIdIterator(targetDocId);
+                continue;
+            }
+
+            // found the intersection (means that the particular field exists for the current doc)
+            if (leafDocIdIteratorDoc == targetDocId) {
+                collectCurrentValues(docValues);
+                index++;
+                if (index < bufferedDocCount && isDone() == false) {
+                    advanceLeafDocIdIterator(bufferedDocIds[index]);
+                }
+                continue;
+            }
+
+            // move to the next buffered doc, which is the closest to the next doc of the particular field
+            index = lowerBound(bufferedDocIds, index + 1, bufferedDocCount, leafDocIdIteratorDoc);
+        }
+    }
+
+    private void advanceLeafDocIdIterator(int targetDocId) throws IOException {
+        leafDocIdIteratorDoc = leafDocIdIterator.advance(targetDocId);
+        leafIteratorExhausted = leafDocIdIteratorDoc == DocIdSetIterator.NO_MORE_DOCS;
     }
 
     @Override

--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/NumericMetricFieldDownsampler.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/NumericMetricFieldDownsampler.java
@@ -158,20 +158,6 @@ abstract sealed class NumericMetricFieldDownsampler extends AbstractFieldDownsam
         leafIteratorExhausted = leafDocIdIteratorDoc == DocIdSetIterator.NO_MORE_DOCS;
     }
 
-    private static int lowerBound(int[] values, int from, int to, int target) {
-        int low = from;
-        int high = to;
-        while (low < high) {
-            int mid = (low + high) >>> 1;
-            if (values[mid] < target) {
-                low = mid + 1;
-            } else {
-                high = mid;
-            }
-        }
-        return low;
-    }
-
     @Override
     public SortedNumericDoubleValues getLeaf(LeafReaderContext context) {
         LeafNumericFieldData numericFieldData = (LeafNumericFieldData) fieldData.load(context);

--- a/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/DimensionFieldDownsamplerTests.java
+++ b/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/DimensionFieldDownsamplerTests.java
@@ -16,7 +16,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Iterator;
 
-import static org.elasticsearch.xpack.downsample.LastValueFieldDownsamplerTests.createValuesInstance;
+import static org.elasticsearch.xpack.downsample.FormattedDocValuesTestUtils.createValuesInstance;
 import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;

--- a/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/FormattedDocValuesTestUtils.java
+++ b/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/FormattedDocValuesTestUtils.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.downsample;
+
+import org.apache.lucene.internal.hppc.IntArrayList;
+import org.apache.lucene.internal.hppc.IntObjectHashMap;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.elasticsearch.index.fielddata.FormattedDocValues;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+final class FormattedDocValuesTestUtils {
+
+    private FormattedDocValuesTestUtils() {}
+
+    static FormattedDocValues withDocIdIterator(IntArrayList docIdsWithValues, Object[] values) {
+        if (docIdsWithValues.size() != values.length) {
+            throw new IllegalArgumentException("doc ids and values must have the same length");
+        }
+
+        final IntObjectHashMap<Object> docIdToValue = IntObjectHashMap.from(docIdsWithValues.toArray(), values);
+        final int[] sortedDocIds = docIdsWithValues.toArray();
+        final int[] currentDocId = new int[] { -1 };
+        final DocIdSetIterator docIdIterator = docIdIterator(sortedDocIds, currentDocId, null);
+
+        return new FormattedDocValues() {
+            @Override
+            public boolean advanceExact(int target) {
+                currentDocId[0] = target;
+                return docIdToValue.containsKey(target);
+            }
+
+            @Override
+            public int docValueCount() {
+                return 1;
+            }
+
+            @Override
+            public Object nextValue() {
+                return docIdToValue.get(currentDocId[0]);
+            }
+
+            @Override
+            public DocIdSetIterator docIdIterator() {
+                return docIdIterator;
+            }
+        };
+    }
+
+    static FormattedDocValues withDocIdIterator(IntArrayList sortedDocIdsWithValues, FormattedDocValues delegate) {
+        final int[] sortedDocIds = sortedDocIdsWithValues.toArray();
+        final int[] currentDocId = new int[] { -1 };
+        final DocIdSetIterator docIdIterator = docIdIterator(sortedDocIds, currentDocId, null);
+
+        return new FormattedDocValues() {
+            @Override
+            public boolean advanceExact(int target) throws IOException {
+                return delegate.advanceExact(target);
+            }
+
+            @Override
+            public int docValueCount() throws IOException {
+                return delegate.docValueCount();
+            }
+
+            @Override
+            public Object nextValue() throws IOException {
+                return delegate.nextValue();
+            }
+
+            @Override
+            public DocIdSetIterator docIdIterator() {
+                return docIdIterator;
+            }
+        };
+    }
+
+    static TrackingFormattedDocValues trackingWithDocIdIterator(IntArrayList docIdsWithValues, Object[] values) {
+        if (docIdsWithValues.size() != values.length) {
+            throw new IllegalArgumentException("doc ids and values must have the same length");
+        }
+
+        final IntObjectHashMap<Object> docIdToValue = IntObjectHashMap.from(docIdsWithValues.toArray(), values);
+        final int[] sortedDocIds = docIdsWithValues.toArray();
+        Arrays.sort(sortedDocIds);
+        final int[] currentDocId = new int[] { -1 };
+        final int[] advanceCalls = new int[] { 0 };
+        final int[] advanceExactCalls = new int[] { 0 };
+        final DocIdSetIterator docIdIterator = docIdIterator(sortedDocIds, currentDocId, advanceCalls);
+
+        return new TrackingFormattedDocValues(docIdIterator, docIdToValue, currentDocId, advanceCalls, advanceExactCalls);
+    }
+
+    private static DocIdSetIterator docIdIterator(int[] sortedDocIds, int[] currentDocId, int[] advanceCalls) {
+        return new DocIdSetIterator() {
+            @Override
+            public int advance(int target) {
+                if (advanceCalls != null) {
+                    advanceCalls[0]++;
+                }
+                if (currentDocId[0] != -1 && currentDocId[0] != NO_MORE_DOCS && target <= currentDocId[0]) {
+                    throw new IllegalArgumentException(
+                        "advance target [" + target + "] must be greater than current doc [" + currentDocId[0] + "]"
+                    );
+                }
+                for (int docId : sortedDocIds) {
+                    if (docId >= target) {
+                        currentDocId[0] = docId;
+                        return docId;
+                    }
+                }
+                currentDocId[0] = NO_MORE_DOCS;
+                return NO_MORE_DOCS;
+            }
+
+            @Override
+            public int nextDoc() {
+                if (currentDocId[0] == NO_MORE_DOCS) {
+                    return NO_MORE_DOCS;
+                }
+                return advance(currentDocId[0] + 1);
+            }
+
+            @Override
+            public int docID() {
+                return currentDocId[0];
+            }
+
+            @Override
+            public long cost() {
+                return sortedDocIds.length;
+            }
+        };
+    }
+
+    static final class TrackingFormattedDocValues implements FormattedDocValues {
+        private final IntObjectHashMap<Object> docIdToValue;
+        private final int[] currentDocId;
+        private final int[] advanceCalls;
+        private final int[] advanceExactCalls;
+        private final DocIdSetIterator docIdIterator;
+
+        private TrackingFormattedDocValues(
+            DocIdSetIterator docIdIterator,
+            IntObjectHashMap<Object> docIdToValue,
+            int[] currentDocId,
+            int[] advanceCalls,
+            int[] advanceExactCalls
+        ) {
+            this.docIdIterator = docIdIterator;
+            this.docIdToValue = docIdToValue;
+            this.currentDocId = currentDocId;
+            this.advanceCalls = advanceCalls;
+            this.advanceExactCalls = advanceExactCalls;
+        }
+
+        @Override
+        public boolean advanceExact(int target) {
+            advanceExactCalls[0]++;
+            currentDocId[0] = target;
+            return docIdToValue.containsKey(target);
+        }
+
+        @Override
+        public int docValueCount() {
+            return 1;
+        }
+
+        @Override
+        public Object nextValue() {
+            return docIdToValue.get(currentDocId[0]);
+        }
+
+        @Override
+        public DocIdSetIterator docIdIterator() {
+            return docIdIterator;
+        }
+
+        int advanceCalls() {
+            return advanceCalls[0];
+        }
+
+        int advanceExactCalls() {
+            return advanceExactCalls[0];
+        }
+    }
+
+    public enum DocValuesType {
+        WITH_ITERATOR,
+        WITHOUT_ITERATOR
+    }
+
+    static <T> FormattedDocValues createValuesInstance(IntArrayList docIdBuffer, T[] values) {
+        return new FormattedDocValues() {
+
+            final IntObjectHashMap<T> docIdToValue = IntObjectHashMap.from(docIdBuffer.toArray(), values);
+
+            int currentDocId = -1;
+
+            @Override
+            public boolean advanceExact(int target) {
+                currentDocId = target;
+                return docIdToValue.containsKey(target);
+            }
+
+            @Override
+            public T nextValue() {
+                return docIdToValue.get(currentDocId);
+            }
+
+            @Override
+            public int docValueCount() {
+                return 1;
+            }
+        };
+    }
+}

--- a/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/LastValueFieldDownsamplerTests.java
+++ b/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/LastValueFieldDownsamplerTests.java
@@ -7,8 +7,9 @@
 
 package org.elasticsearch.xpack.downsample;
 
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
 import org.apache.lucene.internal.hppc.IntArrayList;
-import org.apache.lucene.internal.hppc.IntObjectHashMap;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.index.fielddata.FormattedDocValues;
@@ -19,6 +20,7 @@ import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.aggregations.AggregatorTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xpack.downsample.FormattedDocValuesTestUtils.DocValuesType;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -27,16 +29,36 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import static org.elasticsearch.xpack.downsample.FormattedDocValuesTestUtils.trackingWithDocIdIterator;
+import static org.elasticsearch.xpack.downsample.FormattedDocValuesTestUtils.withDocIdIterator;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
 
 public class LastValueFieldDownsamplerTests extends AggregatorTestCase {
 
+    private final DocValuesType docValuesType;
+
+    public LastValueFieldDownsamplerTests(DocValuesType docValuesType) {
+        this.docValuesType = docValuesType;
+    }
+
+    @ParametersFactory(shuffle = false)
+    public static List<Object[]> iteratorTypes() {
+        return List.of(new Object[] { DocValuesType.WITH_ITERATOR }, new Object[] { DocValuesType.WITHOUT_ITERATOR });
+    }
+
+    private FormattedDocValues getValues(IntArrayList docIdBuffer, Object[] values) {
+        return switch (docValuesType) {
+            case WITH_ITERATOR -> withDocIdIterator(docIdBuffer, values);
+            case WITHOUT_ITERATOR -> FormattedDocValuesTestUtils.createValuesInstance(docIdBuffer, values);
+        };
+    }
+
     public void testLastValueKeyword() throws IOException {
         LastValueFieldDownsampler lastValueFieldProducer = new LastValueFieldDownsampler(randomAlphanumericOfLength(10), null, null);
         assertThat(lastValueFieldProducer.lastValue(), nullValue());
         var docIdBuffer = IntArrayList.from(0, 1, 2);
-        var values = createValuesInstance(docIdBuffer, new String[] { "aaa", "bbb", "ccc" });
+        var values = getValues(docIdBuffer, new String[] { "aaa", "bbb", "ccc" });
         lastValueFieldProducer.collect(values, docIdBuffer);
         assertThat(lastValueFieldProducer.lastValue(), equalTo("aaa"));
         assertThat(lastValueFieldProducer.isDone(), equalTo(true));
@@ -49,7 +71,7 @@ public class LastValueFieldDownsamplerTests extends AggregatorTestCase {
         LastValueFieldDownsampler lastValueFieldProducer = new LastValueFieldDownsampler(randomAlphanumericOfLength(10), null, null);
         assertThat(lastValueFieldProducer.lastValue(), nullValue());
         var docIdBuffer = IntArrayList.from(0, 1, 2);
-        var values = createValuesInstance(docIdBuffer, new Double[] { 10.20D, 17.30D, 12.60D });
+        var values = getValues(docIdBuffer, new Double[] { 10.20D, 17.30D, 12.60D });
         lastValueFieldProducer.collect(values, docIdBuffer);
         assertThat(lastValueFieldProducer.lastValue(), equalTo(10.20D));
         assertThat(lastValueFieldProducer.isDone(), equalTo(true));
@@ -62,7 +84,7 @@ public class LastValueFieldDownsamplerTests extends AggregatorTestCase {
         LastValueFieldDownsampler lastValueFieldProducer = new LastValueFieldDownsampler(randomAlphanumericOfLength(10), null, null);
         assertThat(lastValueFieldProducer.lastValue(), nullValue());
         var docIdBuffer = IntArrayList.from(0, 1, 2);
-        var values = createValuesInstance(docIdBuffer, new Integer[] { 10, 17, 12 });
+        var values = getValues(docIdBuffer, new Integer[] { 10, 17, 12 });
         lastValueFieldProducer.collect(values, docIdBuffer);
         assertThat(lastValueFieldProducer.lastValue(), equalTo(10));
         assertThat(lastValueFieldProducer.isDone(), equalTo(true));
@@ -75,7 +97,7 @@ public class LastValueFieldDownsamplerTests extends AggregatorTestCase {
         LastValueFieldDownsampler lastValueFieldProducer = new LastValueFieldDownsampler(randomAlphanumericOfLength(10), null, null);
         assertThat(lastValueFieldProducer.lastValue(), nullValue());
         var docIdBuffer = IntArrayList.from(0, 1, 2);
-        var values = createValuesInstance(docIdBuffer, new Long[] { 10L, 17L, 12L });
+        var values = getValues(docIdBuffer, new Long[] { 10L, 17L, 12L });
         lastValueFieldProducer.collect(values, docIdBuffer);
         assertThat(lastValueFieldProducer.lastValue(), equalTo(10L));
         assertThat(lastValueFieldProducer.isDone(), equalTo(true));
@@ -88,7 +110,7 @@ public class LastValueFieldDownsamplerTests extends AggregatorTestCase {
         LastValueFieldDownsampler lastValueFieldProducer = new LastValueFieldDownsampler(randomAlphanumericOfLength(10), null, null);
         assertThat(lastValueFieldProducer.lastValue(), nullValue());
         var docIdBuffer = IntArrayList.from(0, 1, 2);
-        var values = createValuesInstance(docIdBuffer, new Boolean[] { true, false, false });
+        var values = getValues(docIdBuffer, new Boolean[] { true, false, false });
         lastValueFieldProducer.collect(values, docIdBuffer);
         assertThat(lastValueFieldProducer.lastValue(), equalTo(true));
         assertThat(lastValueFieldProducer.isDone(), equalTo(true));
@@ -100,7 +122,7 @@ public class LastValueFieldDownsamplerTests extends AggregatorTestCase {
     public void testLastValueMultiValue() throws IOException {
         var docIdBuffer = IntArrayList.from(0);
         Boolean[] multiValue = new Boolean[] { true, false };
-        var values = new FormattedDocValues() {
+        var innerValues = new FormattedDocValues() {
 
             Iterator<Boolean> iterator = Arrays.stream(multiValue).iterator();
 
@@ -120,13 +142,15 @@ public class LastValueFieldDownsamplerTests extends AggregatorTestCase {
             }
         };
 
-        values.iterator = Arrays.stream(multiValue).iterator();
+        var values = docValuesType == DocValuesType.WITH_ITERATOR ? withDocIdIterator(docIdBuffer, innerValues) : innerValues;
+
+        innerValues.iterator = Arrays.stream(multiValue).iterator();
         LastValueFieldDownsampler multiLastValueProducer = new LastValueFieldDownsampler(randomAlphanumericOfLength(10), null, null);
         assertThat(multiLastValueProducer.lastValue(), nullValue());
         multiLastValueProducer.collect(values, docIdBuffer);
         assertThat(multiLastValueProducer.lastValue(), equalTo(multiValue));
         // Ensure we read all the available values
-        assertThat(values.iterator.hasNext(), equalTo(false));
+        assertThat(innerValues.iterator.hasNext(), equalTo(false));
         multiLastValueProducer.reset();
         assertThat(multiLastValueProducer.lastValue(), nullValue());
     }
@@ -139,7 +163,7 @@ public class LastValueFieldDownsamplerTests extends AggregatorTestCase {
         assertEquals(1, fieldCounts.formattedValueFields());
 
         var bytes = List.of("a\0value_a", "b\0value_b", "c\0value_c", "d\0value_d");
-        var docValues = new FormattedDocValues() {
+        var innerDocValues = new FormattedDocValues() {
 
             Iterator<String> iterator = bytes.iterator();
 
@@ -158,6 +182,10 @@ public class LastValueFieldDownsamplerTests extends AggregatorTestCase {
                 return iterator.next();
             }
         };
+
+        var docValues = docValuesType == DocValuesType.WITH_ITERATOR
+            ? withDocIdIterator(IntArrayList.from(1), innerDocValues)
+            : innerDocValues;
 
         downsampler.collect(docValues, IntArrayList.from(1));
         assertFalse(downsampler.isEmpty());
@@ -178,29 +206,39 @@ public class LastValueFieldDownsamplerTests extends AggregatorTestCase {
         assertNull(downsampler.lastValue());
     }
 
-    static <T> FormattedDocValues createValuesInstance(IntArrayList docIdBuffer, T[] values) {
-        return new FormattedDocValues() {
+    public void testLastValueWithDocIdIterator() throws IOException {
+        assumeTrue("This test is relevant only for doc values with iterator", docValuesType == DocValuesType.WITH_ITERATOR);
+        var producer = new LastValueFieldDownsampler(randomAlphanumericOfLength(10), null, null);
+        var docIdBuffer = IntArrayList.from(0, 1, 2, 3, 4, 5);
+        var valuesInstance = trackingWithDocIdIterator(IntArrayList.from(1, 4), new String[] { "value_1", "value_4" });
+        producer.collect(valuesInstance, docIdBuffer);
 
-            final IntObjectHashMap<T> docIdToValue = IntObjectHashMap.from(docIdBuffer.toArray(), values);
+        assertThat(producer.isDone(), equalTo(true));
+        assertThat(producer.lastValue(), equalTo("value_1"));
+        assertThat(valuesInstance.advanceCalls(), equalTo(1));
+        assertThat(valuesInstance.advanceExactCalls(), equalTo(0));
 
-            int currentDocId = -1;
+        // A reset should not influence an exhausted leaf
+        boolean isReset = randomBoolean();
+        if (isReset) {
+            producer.reset();
+        }
+        assertThat(producer.isEmpty(), equalTo(isReset));
 
-            @Override
-            public boolean advanceExact(int target) throws IOException {
-                currentDocId = target;
-                return docIdToValue.containsKey(target);
-            }
+        producer.collect(valuesInstance, IntArrayList.from(6, 7));
+        assertThat(valuesInstance.advanceCalls(), equalTo(1));
+        assertThat(valuesInstance.advanceExactCalls(), equalTo(0));
+        assertThat(producer.isEmpty(), equalTo(isReset));
 
-            @Override
-            public T nextValue() throws IOException {
-                return docIdToValue.get(currentDocId);
-            }
+        producer.reset();
+        // A second leaf should be processed separetely
+        var secondLeafValues = trackingWithDocIdIterator(IntArrayList.from(4), new String[] { "value_4" });
+        producer.collect(secondLeafValues, IntArrayList.from(4, 5));
 
-            @Override
-            public int docValueCount() {
-                return 1;
-            }
-        };
+        assertFalse(producer.isEmpty());
+        assertThat(producer.lastValue(), equalTo("value_4"));
+        assertEquals(1, secondLeafValues.advanceCalls());
+        assertEquals(0, secondLeafValues.advanceExactCalls());
     }
 
     private static MappedFieldType createDummyFlattenedFieldType() {


### PR DESCRIPTION
Use docId iterator when collecting labels using the `LastValueFieldDownsampler `

Follow up of https://github.com/elastic/elasticsearch/pull/144553
