### PR TITLE
Track BCCs pending upload

### DIFF
--- a/docs/changelog/152078.yaml
+++ b/docs/changelog/152078.yaml
@@ -1,0 +1,5 @@
+area: Engine
+issues: []
+pr: 152078
+summary: Track BCCs pending upload
+type: enhancement

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/commits/VirtualBatchedCompoundCommitsIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/commits/VirtualBatchedCompoundCommitsIT.java
@@ -106,6 +106,8 @@ import static org.elasticsearch.xpack.stateless.commits.HollowShardsService.SETT
 import static org.elasticsearch.xpack.stateless.commits.HollowShardsService.STATELESS_HOLLOW_INDEX_SHARDS_ENABLED;
 import static org.elasticsearch.xpack.stateless.commits.StatelessCommitService.BCC_ELAPSED_TIME_BEFORE_FREEZE_HISTOGRAM_METRIC;
 import static org.elasticsearch.xpack.stateless.commits.StatelessCommitService.BCC_NUMBER_COMMITS_HISTOGRAM_METRIC;
+import static org.elasticsearch.xpack.stateless.commits.StatelessCommitService.BCC_ON_DISK_COUNT_METRIC;
+import static org.elasticsearch.xpack.stateless.commits.StatelessCommitService.BCC_ON_DISK_SIZE_METRIC;
 import static org.elasticsearch.xpack.stateless.commits.StatelessCommitService.BCC_TOTAL_SIZE_HISTOGRAM_METRIC;
 import static org.elasticsearch.xpack.stateless.commits.StatelessCommitService.STATELESS_UPLOAD_MAX_AMOUNT_COMMITS;
 import static org.elasticsearch.xpack.stateless.commits.StatelessCommitService.STATELESS_UPLOAD_MAX_SIZE;
@@ -1333,8 +1335,17 @@ public class VirtualBatchedCompoundCommitsIT extends AbstractStatelessPluginInte
             if (randomBoolean() || i == numberCommits - 1) {
                 final VirtualBatchedCompoundCommit virtualBcc = statelessCommitService.getCurrentVirtualBcc(shardId);
                 final long minAge = threadPool.relativeTimeInMillis() - virtualBcc.getCreationTimeInMillis();
+                metricsPlugin.collect();
+                assertThat(getLastLongGaugeValue(BCC_ON_DISK_COUNT_METRIC, metricsPlugin), greaterThanOrEqualTo(1L));
+                assertThat(
+                    getLastLongGaugeValue(BCC_ON_DISK_SIZE_METRIC, metricsPlugin),
+                    greaterThanOrEqualTo(virtualBcc.getTotalSizeInBytes())
+                );
                 // Trigger upload
                 flush(indexName);
+                metricsPlugin.collect();
+                assertThat(getLastLongGaugeValue(BCC_ON_DISK_COUNT_METRIC, metricsPlugin), equalTo(0L));
+                assertThat(getLastLongGaugeValue(BCC_ON_DISK_SIZE_METRIC, metricsPlugin), equalTo(0L));
 
                 final List<Measurement> sizeMeasurements = metricsPlugin.getLongHistogramMeasurement(BCC_TOTAL_SIZE_HISTOGRAM_METRIC);
                 assertThat(sizeMeasurements, hasSize(1));

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/commits/StatelessCommitService.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/commits/StatelessCommitService.java
@@ -64,6 +64,7 @@ import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.indices.recovery.RecoveryCommitTooNewException;
 import org.elasticsearch.telemetry.TelemetryProvider;
 import org.elasticsearch.telemetry.metric.LongHistogram;
+import org.elasticsearch.telemetry.metric.LongWithAttributes;
 import org.elasticsearch.threadpool.Scheduler;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.ConnectTransportException;
@@ -82,6 +83,7 @@ import org.elasticsearch.xpack.stateless.utils.WaitForVersion;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -211,6 +213,8 @@ public class StatelessCommitService extends AbstractLifecycleComponent implement
     public static final String BCC_TOTAL_SIZE_HISTOGRAM_METRIC = "es.bcc.total_size_in_megabytes.histogram";
     public static final String BCC_NUMBER_COMMITS_HISTOGRAM_METRIC = "es.bcc.number_of_commits.histogram";
     public static final String BCC_ELAPSED_TIME_BEFORE_FREEZE_HISTOGRAM_METRIC = "es.bcc.elapsed_time_before_freeze.histogram";
+    public static final String BCC_ON_DISK_COUNT_METRIC = "es.bcc.on_disk.total";
+    public static final String BCC_ON_DISK_SIZE_METRIC = "es.bcc.on_disk.size";
 
     private final ClusterService clusterService;
     private final ObjectStoreService objectStoreService;
@@ -342,6 +346,35 @@ public class StatelessCommitService extends AbstractLifecycleComponent implement
                 "Histogram for elapsed time in milliseconds of batched compound commits before freezing",
                 "ms"
             );
+        var meterRegistry = telemetryProvider.getMeterRegistry();
+        meterRegistry.registerLongGauge(
+            BCC_ON_DISK_COUNT_METRIC,
+            "Total number of batched compound commits with local data on disk on this node",
+            "count",
+            () -> new LongWithAttributes(getBccOnDiskCount(shardsCommitsStates.values()))
+        );
+        meterRegistry.registerLongGauge(
+            BCC_ON_DISK_SIZE_METRIC,
+            "Total size in bytes of batched compound commits with local data on disk on this node",
+            "bytes",
+            () -> new LongWithAttributes(getBccOnDiskSizeInBytes(shardsCommitsStates.values()))
+        );
+    }
+
+    private static long getBccOnDiskCount(Collection<ShardCommitState> shardCommitStates) {
+        long count = 0;
+        for (ShardCommitState commitState : shardCommitStates) {
+            count += commitState.getBccOnDiskCount();
+        }
+        return count;
+    }
+
+    private static long getBccOnDiskSizeInBytes(Collection<ShardCommitState> shardCommitStates) {
+        long sizeInBytes = 0;
+        for (ShardCommitState commitState : shardCommitStates) {
+            sizeInBytes += commitState.getBccOnDiskSizeInBytes();
+        }
+        return sizeInBytes;
     }
 
     public boolean useReplicatedRanges() {
@@ -1245,6 +1278,7 @@ public class StatelessCommitService extends AbstractLifecycleComponent implement
         // uploaded which is then removed from pendingUploadBccGenerations.
         private volatile VirtualBatchedCompoundCommit currentVirtualBcc = null;
         private final Map<Long, VirtualBatchedCompoundCommit> pendingUploadBccGenerations = new ConcurrentHashMap<>();
+        private volatile long pendingUploadTotalSizeInBytes;
         private volatile BatchedCompoundCommit latestUploadedBcc = null;
         // NOTE When moving a VBCC through its lifecycle, we must update it first in the new state before remove it from the old state.
         // That is, we must first add it to the `pendingUploadBccGenerations` before un-assigning it from `currentVirtualBcc`,
@@ -1346,6 +1380,15 @@ public class StatelessCommitService extends AbstractLifecycleComponent implement
 
         public ShardLocalCommitsTracker shardLocalCommitsTracker() {
             return shardLocalCommitsTracker;
+        }
+
+        public int getBccOnDiskCount() {
+            return (this.currentVirtualBcc == null ? 0 : 1) + this.pendingUploadBccGenerations.size();
+        }
+
+        public long getBccOnDiskSizeInBytes() {
+            var current = this.currentVirtualBcc;
+            return (current == null ? 0 : current.getTotalSizeInBytes()) + pendingUploadTotalSizeInBytes;
         }
 
         /**
@@ -1816,6 +1859,7 @@ public class StatelessCommitService extends AbstractLifecycleComponent implement
                 assert previous == null : "expected null, but got " + previous;
                 // reset after add to pending list so that vbcc is always visible as either pending or current
                 currentVirtualBcc = null;
+                pendingUploadTotalSizeInBytes += expectedVirtualBcc.getTotalSizeInBytes();
                 logger.trace(
                     () -> Strings.format(
                         "%s reset current VBCC generation [%s] after freeze",
@@ -2001,7 +2045,10 @@ public class StatelessCommitService extends AbstractLifecycleComponent implement
                 if (newBccGeneration <= getMaxUploadedBccGeneration()) {
                     if (isUpload) {
                         // Remove the BCC from the pending list regardless just in case
-                        pendingUploadBccGenerations.remove(newBccGeneration);
+                        var removed = pendingUploadBccGenerations.remove(newBccGeneration);
+                        if (removed != null) {
+                            pendingUploadTotalSizeInBytes -= removed.getTotalSizeInBytes();
+                        }
                     }
                     assert false
                         : "out of order BCC generation ["
@@ -2065,6 +2112,7 @@ public class StatelessCommitService extends AbstractLifecycleComponent implement
                     // Remove the BCC from the pending list *after* upload consumers but *before* generation listeners are fired
                     var removed = pendingUploadBccGenerations.remove(newBccGeneration);
                     assert removed != null : newBccGeneration + "not found";
+                    pendingUploadTotalSizeInBytes -= removed.getTotalSizeInBytes();
                 }
                 if (generationListeners != null) {
                     List<Tuple<Long, ActionListener<Void>>> listenersToReregister = null;

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/commits/StatelessCommitService.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/commits/StatelessCommitService.java
@@ -976,13 +976,19 @@ public class StatelessCommitService extends AbstractLifecycleComponent implement
         if (bccUploadSlowLogThresholdMillis <= 0 || uploadResult.totalUploadTimeMs() < bccUploadSlowLogThresholdMillis) {
             return;
         }
+
+        final ShardId shardId = virtualBcc.getShardId();
+        // The BCC has not yet been marked as uploaded so we need to remove one
+        final int generationQueueSize = this.shardsCommitsStates.get(shardId).getPendingUploadCount() - 1;
+
         final var message = new ESLogMessage(
-            "{} batched compound commit [{}] upload took [{}]ms over [{}] attempt(s): {}",
-            virtualBcc.getShardId(),
+            "{} batched compound commit [{}] upload took [{}]ms over [{}] attempt(s): {} ( remaining BCCs in the generation queue: {} )",
+            shardId,
             virtualBcc.getPrimaryTermAndGeneration().generation(),
             uploadResult.totalUploadTimeMs(),
             uploadResult.uploadAttempts(),
-            uploadResult.attemptsToLogString()
+            uploadResult.attemptsToLogString(),
+            generationQueueSize
         ).field("elasticsearch.primary.bcc_upload_time", uploadResult.totalUploadTimeMs())
             .field("elasticsearch.primary.bcc_upload_attempts", uploadResult.uploadAttempts())
             .field("elasticsearch.primary.bcc_generation_queue_time", uploadResult.totalGenerationQueueWaitMs())
@@ -1382,8 +1388,12 @@ public class StatelessCommitService extends AbstractLifecycleComponent implement
             return shardLocalCommitsTracker;
         }
 
+        public int getPendingUploadCount() {
+            return this.pendingUploadBccGenerations.size();
+        }
+
         public int getBccOnDiskCount() {
-            return (this.currentVirtualBcc == null ? 0 : 1) + this.pendingUploadBccGenerations.size();
+            return (this.currentVirtualBcc == null ? 0 : 1) + getPendingUploadCount();
         }
 
         public long getBccOnDiskSizeInBytes() {
@@ -2111,8 +2121,11 @@ public class StatelessCommitService extends AbstractLifecycleComponent implement
                 if (isUpload) {
                     // Remove the BCC from the pending list *after* upload consumers but *before* generation listeners are fired
                     var removed = pendingUploadBccGenerations.remove(newBccGeneration);
-                    assert removed != null : newBccGeneration + "not found";
-                    pendingUploadTotalSizeInBytes -= removed.getTotalSizeInBytes();
+                    if (removed != null) {
+                        pendingUploadTotalSizeInBytes -= removed.getTotalSizeInBytes();
+                    } else {
+                        assert false : newBccGeneration + "not found";
+                    }
                 }
                 if (generationListeners != null) {
                     List<Tuple<Long, ActionListener<Void>>> listenersToReregister = null;


### PR DESCRIPTION
This patch add metrics that expose the amount of BCCs on disk (`es.bcc.on_disk.total`) as well as their total size (`es.bcc.on_disk.size`). This expose the amount of backlog that a node can accumulate when the upload cannot keep up with the writes. This backlog can also impact memory usage as StatelessCommitService hold a certain amount of data structures to keep track of the files. 

The patch also adds the number of BCCs still waiting on the generation queue to the slow upload log to help assessing the time needed before the queue can return to a reasonable size. 