### PR TITLE
Fix SemanticFieldFieldsApiIT release mode tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -644,12 +644,6 @@ tests:
 - class: org.elasticsearch.xpack.stateless.commits.StatelessFileDeletionIT
   method: testDeleteIndexAfterRecovery
   issue: https://github.com/elastic/elasticsearch/issues/151884
-- class: org.elasticsearch.xpack.inference.integration.SemanticFieldFieldsApiIT
-  method: testFetchingMixedTextAndImageChunks
-  issue: https://github.com/elastic/elasticsearch/issues/151928
-- class: org.elasticsearch.xpack.inference.integration.SemanticFieldFieldsApiIT
-  method: testFetchingMixedTextAndImageValues
-  issue: https://github.com/elastic/elasticsearch/issues/151929
 - class: org.elasticsearch.xpack.stateless.cache.SearchCommitPrefetcherIT
   method: testSearchNodePrefetchesOnlyLatestGenerationOnFirstCommitNotification
   issue: https://github.com/elastic/elasticsearch/issues/151992

--- a/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/integration/IntegrationTestUtils.java
+++ b/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/integration/IntegrationTestUtils.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.inference.integration;
 
+import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -62,14 +63,16 @@ public class IntegrationTestUtils {
     }
 
     public static void deleteInferenceEndpoint(Client client, TaskType taskType, String inferenceId) {
-        assertAcked(
-            safeGet(
+        try {
+            assertAcked(
                 client.execute(
                     DeleteInferenceEndpointAction.INSTANCE,
                     new DeleteInferenceEndpointAction.Request(inferenceId, taskType, true, false)
-                )
-            )
-        );
+                ).actionGet(TEST_REQUEST_TIMEOUT)
+            );
+        } catch (ResourceNotFoundException e) {
+            // The inference endpoint does not exist; nothing to delete.
+        }
     }
 
     public static void deleteIndex(Client client, String indexName) {

--- a/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/integration/SemanticFieldFieldsApiIT.java
+++ b/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/integration/SemanticFieldFieldsApiIT.java
@@ -78,12 +78,14 @@ public class SemanticFieldFieldsApiIT extends ESIntegTestCase {
 
     @Before
     public void setup() throws Exception {
+        assumeTrue("Semantic field feature flag is enabled", SemanticFieldMapper.SEMANTIC_FIELD_FEATURE_FLAG.isEnabled());
         IntegrationTestUtils.createInferenceEndpoint(client(), TaskType.EMBEDDING, INFERENCE_ID, EMBEDDING_SERVICE_SETTINGS);
         createIndex();
     }
 
     @After
     public void cleanUp() {
+        assumeTrue("Semantic field feature flag is enabled", SemanticFieldMapper.SEMANTIC_FIELD_FEATURE_FLAG.isEnabled());
         IntegrationTestUtils.deleteIndex(client(), indexName);
         IntegrationTestUtils.deleteInferenceEndpoint(client(), TaskType.EMBEDDING, INFERENCE_ID);
     }

--- a/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/integration/SemanticFieldFieldsApiIT.java
+++ b/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/integration/SemanticFieldFieldsApiIT.java
@@ -85,7 +85,6 @@ public class SemanticFieldFieldsApiIT extends ESIntegTestCase {
 
     @After
     public void cleanUp() {
-        assumeTrue("Semantic field feature flag is enabled", SemanticFieldMapper.SEMANTIC_FIELD_FEATURE_FLAG.isEnabled());
         IntegrationTestUtils.deleteIndex(client(), indexName);
         IntegrationTestUtils.deleteInferenceEndpoint(client(), TaskType.EMBEDDING, INFERENCE_ID);
     }


### PR DESCRIPTION
`SemanticFieldFieldsApiIT` tests were failing in release mode because they depend on the `semantic` field, which is behind a feature flag that isn't active in that mode.

This PR fixes the issue by gating the tests on the feature flag. `deleteInferenceEndpoint` has also been updated to ignore when the inference endpoint doesn't exist, to handle the case when the inference endpoint was not created (such as when the `@Before` method is skipped :wink:).

Fixes https://github.com/elastic/elasticsearch/issues/151928
Fixes https://github.com/elastic/elasticsearch/issues/151929