### PR TITLE
Fix DivTests overflow in scalar/vector division

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/DivTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/DivTests.java
@@ -216,13 +216,19 @@ public class DivTests extends AbstractScalarFunctionTestCase {
                 .withWarning("Line 1:1: java.lang.ArithmeticException: / by zero");
         }));
 
-        suppliers.addAll(
-            denseVectorScalarCases(
-                "Div",
-                (v, s) -> v.stream().map(f -> f / (Float) DataTypeConverter.convert(s, FLOAT)).toList(),
-                (s, v) -> v.stream().map(f -> ((Float) DataTypeConverter.convert(s, FLOAT) / f)).toList()
-            )
-        );
+        suppliers.addAll(denseVectorScalarCases("Div", (v, s) -> {
+            Float sf = (Float) DataTypeConverter.convert(s, FLOAT);
+            List<Float> result = v.stream().map(f -> f / sf).toList();
+            // If the scalar denominator is zero or any element overflows to Infinity/NaN,
+            // the evaluator throws ArithmeticException and returns null for the whole vector
+            return result.stream().anyMatch(f -> Float.isInfinite(f) || Float.isNaN(f)) ? null : result;
+        }, (s, v) -> {
+            Float sf = (Float) DataTypeConverter.convert(s, FLOAT);
+            List<Float> result = v.stream().map(f -> sf / f).toList();
+            // Large scalars (e.g. randomInt/randomLong) divided by near-zero vector elements
+            // can overflow to Infinity; the evaluator throws and returns null for the whole vector
+            return result.stream().anyMatch(f -> Float.isInfinite(f) || Float.isNaN(f)) ? null : result;
+        }));
 
         // Overflows
         suppliers.addAll(


### PR DESCRIPTION
When dividing a large random scalar by a near-zero vector element, `divDenseVectorElements` throws `ArithmeticException` and the evaluator returns null for the whole vector. The test case supplier was computing the expected value naively, which could include `Infinity` or `NaN`, causing the assertion to fail against the null result.

This commit fixes the expected-value computation in the `denseVectorScalarCases` lambdas to return null when any element would be non-finite, aligning the expected value with evaluator behaviour.

Fixes #151114, #151115, and #151116

This is a backport of #152032
