### PR TITLE
[Gradle] Run CheckForbiddenApisTask in a toolchain-matched forked process

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaBasePlugin.java
@@ -13,7 +13,6 @@ import groovy.lang.Closure;
 
 import org.elasticsearch.gradle.internal.conventions.precommit.PrecommitTaskPlugin;
 import org.elasticsearch.gradle.internal.info.BuildParameterExtension;
-import org.elasticsearch.gradle.internal.precommit.CheckForbiddenApisTask;
 import org.elasticsearch.gradle.internal.test.MutedTestPlugin;
 import org.elasticsearch.gradle.internal.test.TestUtil;
 import org.elasticsearch.gradle.test.SystemPropertyCommandLineArgumentProvider;
@@ -132,15 +131,6 @@ public class ElasticsearchJavaBasePlugin implements Plugin<Project> {
             compileTask.getOptions().getRelease().set(releaseVersionProviderFromCompileTask(project, compileTask));
         });
 
-        // Run the forbidden-apis checker in a forked process matching the compile toolchain,
-        // so that signature resolution uses the correct JDK bootclasspath (e.g. JDK 22+
-        // signatures like MemorySegment#getString cannot be resolved in a JDK 21 daemon).
-        project.getTasks().withType(CheckForbiddenApisTask.class).configureEach(t -> {
-            t.getJavaLauncher().set(javaToolchains.launcherFor(spec -> {
-                spec.getLanguageVersion().set(JavaLanguageVersion.of(buildParams.getMinimumRuntimeVersion().getMajorVersion()));
-                spec.getVendor().set(JvmVendorSpec.ORACLE);
-            }));
-        });
     }
 
     /**

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaBasePlugin.java
@@ -13,6 +13,7 @@ import groovy.lang.Closure;
 
 import org.elasticsearch.gradle.internal.conventions.precommit.PrecommitTaskPlugin;
 import org.elasticsearch.gradle.internal.info.BuildParameterExtension;
+import org.elasticsearch.gradle.internal.precommit.CheckForbiddenApisTask;
 import org.elasticsearch.gradle.internal.test.MutedTestPlugin;
 import org.elasticsearch.gradle.internal.test.TestUtil;
 import org.elasticsearch.gradle.test.SystemPropertyCommandLineArgumentProvider;
@@ -129,6 +130,16 @@ public class ElasticsearchJavaBasePlugin implements Plugin<Project> {
         project.getTasks().withType(GroovyCompile.class).configureEach(compileTask -> {
             // TODO: this probably shouldn't apply to groovy at all?
             compileTask.getOptions().getRelease().set(releaseVersionProviderFromCompileTask(project, compileTask));
+        });
+
+        // Run the forbidden-apis checker in a forked process matching the compile toolchain,
+        // so that signature resolution uses the correct JDK bootclasspath (e.g. JDK 22+
+        // signatures like MemorySegment#getString cannot be resolved in a JDK 21 daemon).
+        project.getTasks().withType(CheckForbiddenApisTask.class).configureEach(t -> {
+            t.getJavaLauncher().set(javaToolchains.launcherFor(spec -> {
+                spec.getLanguageVersion().set(JavaLanguageVersion.of(buildParams.getMinimumRuntimeVersion().getMajorVersion()));
+                spec.getVendor().set(JvmVendorSpec.ORACLE);
+            }));
         });
     }
 

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/CheckForbiddenApisTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/CheckForbiddenApisTask.java
@@ -39,6 +39,7 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.PathSensitive;
@@ -49,6 +50,7 @@ import org.gradle.api.tasks.VerificationException;
 import org.gradle.api.tasks.VerificationTask;
 import org.gradle.api.tasks.util.PatternFilterable;
 import org.gradle.api.tasks.util.PatternSet;
+import org.gradle.jvm.toolchain.JavaLauncher;
 import org.gradle.workers.WorkAction;
 import org.gradle.workers.WorkParameters;
 import org.gradle.workers.WorkQueue;
@@ -262,6 +264,17 @@ public abstract class CheckForbiddenApisTask extends DefaultTask implements Patt
     }
 
     /**
+     * Optional Java toolchain launcher. When set, the forbidden-apis checker runs in a
+     * forked process using this launcher's JVM, so signature resolution uses that JVM's
+     * bootclasspath. This should match the project's compile toolchain (set automatically
+     * by {@link org.elasticsearch.gradle.internal.ElasticsearchJavaBasePlugin}). When
+     * absent the checker falls back to running in the Gradle daemon ({@code noIsolation}).
+     */
+    @Nested
+    @Optional
+    public abstract Property<JavaLauncher> getJavaLauncher();
+
+    /**
      * The default compiler target version used to expand references to bundled JDK signatures.
      * E.g., if you use "jdk-deprecated", it will expand to this version.
      * This setting should be identical to the target version used in the compiler task.
@@ -379,7 +392,15 @@ public abstract class CheckForbiddenApisTask extends DefaultTask implements Patt
     /** Executes the forbidden apis task. */
     @TaskAction
     public void checkForbidden() {
-        WorkQueue workQueue = getWorkerExecutor().noIsolation();
+        WorkQueue workQueue;
+        if (getJavaLauncher().isPresent()) {
+            File javaExecutable = getJavaLauncher().get().getExecutablePath().getAsFile();
+            workQueue = getWorkerExecutor().processIsolation(
+                spec -> spec.forkOptions(opts -> opts.executable(javaExecutable))
+            );
+        } else {
+            workQueue = getWorkerExecutor().noIsolation();
+        }
         workQueue.submit(ForbiddenApisCheckWorkAction.class, parameters -> {
             parameters.getClasspath().setFrom(getClasspath());
             parameters.getClassDirectories().setFrom(getClassesDirs());

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/CheckForbiddenApisTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/CheckForbiddenApisTask.java
@@ -395,9 +395,7 @@ public abstract class CheckForbiddenApisTask extends DefaultTask implements Patt
         WorkQueue workQueue;
         if (getJavaLauncher().isPresent()) {
             File javaExecutable = getJavaLauncher().get().getExecutablePath().getAsFile();
-            workQueue = getWorkerExecutor().processIsolation(
-                spec -> spec.forkOptions(opts -> opts.executable(javaExecutable))
-            );
+            workQueue = getWorkerExecutor().processIsolation(spec -> spec.forkOptions(opts -> opts.executable(javaExecutable)));
         } else {
             workQueue = getWorkerExecutor().noIsolation();
         }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/CheckForbiddenApisTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/CheckForbiddenApisTask.java
@@ -266,9 +266,9 @@ public abstract class CheckForbiddenApisTask extends DefaultTask implements Patt
     /**
      * Optional Java toolchain launcher. When set, the forbidden-apis checker runs in a
      * forked process using this launcher's JVM, so signature resolution uses that JVM's
-     * bootclasspath. This should match the project's compile toolchain (set automatically
-     * by {@link org.elasticsearch.gradle.internal.ElasticsearchJavaBasePlugin}). When
-     * absent the checker falls back to running in the Gradle daemon ({@code noIsolation}).
+     * bootclasspath. {@link ForbiddenApisPrecommitPlugin} sets this when the project's
+     * minimum runtime differs from the Gradle daemon JVM. When absent the checker falls
+     * back to running in the Gradle daemon ({@code noIsolation}).
      */
     @Nested
     @Optional

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ForbiddenApisPrecommitPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ForbiddenApisPrecommitPlugin.java
@@ -12,20 +12,33 @@ package org.elasticsearch.gradle.internal.precommit;
 import org.elasticsearch.gradle.internal.ExportElasticsearchBuildResourcesTask;
 import org.elasticsearch.gradle.internal.conventions.precommit.PrecommitPlugin;
 import org.elasticsearch.gradle.internal.info.BuildParameterExtension;
+import org.gradle.api.JavaVersion;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.plugins.JavaBasePlugin;
 import org.gradle.api.specs.Specs;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskProvider;
+import org.gradle.jvm.toolchain.JavaLanguageVersion;
+import org.gradle.jvm.toolchain.JavaToolchainService;
+import org.gradle.jvm.toolchain.JvmVendorSpec;
 
 import java.io.File;
 import java.util.Set;
+
+import javax.inject.Inject;
 
 import static de.thetaphi.forbiddenapis.gradle.ForbiddenApisPlugin.FORBIDDEN_APIS_TASK_NAME;
 import static org.elasticsearch.gradle.internal.precommit.CheckForbiddenApisTask.BUNDLED_SIGNATURE_DEFAULTS;
 
 public class ForbiddenApisPrecommitPlugin extends PrecommitPlugin {
+
+    private final JavaToolchainService javaToolchains;
+
+    @Inject
+    public ForbiddenApisPrecommitPlugin(JavaToolchainService javaToolchains) {
+        this.javaToolchains = javaToolchains;
+    }
 
     @Override
     public TaskProvider<? extends Task> createTask(Project project) {
@@ -34,7 +47,7 @@ public class ForbiddenApisPrecommitPlugin extends PrecommitPlugin {
         // Create a convenience task for all checks (this does not conflict with extension, as it has higher priority in DSL):
         var forbiddenTask = project.getTasks()
             .register(FORBIDDEN_APIS_TASK_NAME, task -> { task.setDescription("Runs forbidden-apis checks."); });
-
+        
         TaskProvider<ExportElasticsearchBuildResourcesTask> resourcesTask = project.getTasks()
             .register("forbiddenApisResources", ExportElasticsearchBuildResourcesTask.class);
         File resourcesDir = project.getLayout().getBuildDirectory().dir("forbidden-apis-config").get().getAsFile();
@@ -67,6 +80,12 @@ public class ForbiddenApisPrecommitPlugin extends PrecommitPlugin {
                     )
                 );
                 t.getSuppressAnnotations().set(Set.of("**.SuppressForbidden"));
+                if (buildParams.getMinimumRuntimeVersion().equals(JavaVersion.current()) == false) {
+                    t.getJavaLauncher().set(javaToolchains.launcherFor(spec -> {
+                        spec.getLanguageVersion().set(JavaLanguageVersion.of(buildParams.getMinimumRuntimeVersion().getMajorVersion()));
+                        spec.getVendor().set(JvmVendorSpec.ORACLE);
+                    }));
+                }
                 if (t.getName().endsWith("Test")) {
                     t.setSignaturesFiles(
                         t.getSignaturesFiles()

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ForbiddenApisPrecommitPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ForbiddenApisPrecommitPlugin.java
@@ -47,7 +47,7 @@ public class ForbiddenApisPrecommitPlugin extends PrecommitPlugin {
         // Create a convenience task for all checks (this does not conflict with extension, as it has higher priority in DSL):
         var forbiddenTask = project.getTasks()
             .register(FORBIDDEN_APIS_TASK_NAME, task -> { task.setDescription("Runs forbidden-apis checks."); });
-        
+
         TaskProvider<ExportElasticsearchBuildResourcesTask> resourcesTask = project.getTasks()
             .register("forbiddenApisResources", ExportElasticsearchBuildResourcesTask.class);
         File resourcesDir = project.getLayout().getBuildDirectory().dir("forbidden-apis-config").get().getAsFile();


### PR DESCRIPTION
CheckForbiddenApisTask used noIsolation(), so the forbidden-apis
library resolved method signatures against the Gradle daemon's own
bootclasspath. This makes signature resolution depend on the daemon
JDK rather than the project's configured toolchain.

Add an optional JavaLauncher property to CheckForbiddenApisTask and
use processIsolation with that launcher's java executable when one is
configured. Keep the noIsolation() path as a backward-compatible
fallback.

Wire the launcher from ElasticsearchJavaBasePlugin using the same
minimumRuntimeVersion + Oracle toolchain spec already used for
compilation and javadocs, so compiler, javadoc, and forbidden-apis
checks all resolve against the same JDK.