### PR TITLE
Gate jdk.incubator.vector test arg to JDK 21-24

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchTestBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchTestBasePlugin.java
@@ -113,6 +113,10 @@ public abstract class ElasticsearchTestBasePlugin implements Plugin<Project> {
             });
             test.getJvmArgumentProviders().add(nonInputProperties);
             test.getExtensions().add("nonInputProperties", nonInputProperties);
+            test.getJvmArgumentProviders().add(() -> {
+                int javaFeature = Integer.parseInt(test.getJavaVersion().getMajorVersion());
+                return javaFeature >= 21 && javaFeature <= 24 ? List.of("--add-modules=jdk.incubator.vector") : List.of();
+            });
 
             test.setWorkingDir(project.file(project.getBuildDir() + "/testrun/" + test.getName().replace("#", "_")));
             test.setMaxParallelForks(Integer.parseInt(System.getProperty("tests.jvms", buildParams.get().getDefaultParallel().toString())));
@@ -137,7 +141,6 @@ public abstract class ElasticsearchTestBasePlugin implements Plugin<Project> {
                 // Needed by UninitializedArrays to reflectively access jdk.internal.misc.Unsafe
                 "--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED",
                 "--enable-native-access=ALL-UNNAMED",
-                "--add-modules=jdk.incubator.vector",
                 "-XX:+HeapDumpOnOutOfMemoryError",
                 "-XX:-UseGCOverheadLimit"
             );


### PR DESCRIPTION
ElasticsearchTestBasePlugin unconditionally added
--add-modules=jdk.incubator.vector to every Test task JVM.
That worked while tests ran on JDKs where the incubator module
still existed, but newer toolchain paths now execute some inner
build tests on JDK 25 where the module was removed.

This caused test JVM startup to fail during boot-layer
initialization with:

  java.lang.module.FindException:
  Module jdk.incubator.vector not found

Fix it by moving the flag to a lazy JVM argument provider and only
emitting it when the test JVM feature version is between 21 and 24
inclusive. That preserves existing behavior where the module exists
and avoids breaking JDK 25 test launches.